### PR TITLE
fix: enforce Coven API launch boundaries

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::{daemon::DaemonStatus, store};
+use crate::{daemon::DaemonStatus, project, store};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -155,11 +155,10 @@ fn launch_session(
 
 fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
     let project_root = required_string(&payload, "projectRoot")?;
-    let cwd = payload
-        .get("cwd")
-        .and_then(Value::as_str)
-        .unwrap_or(&project_root)
-        .to_string();
+    let cwd = payload.get("cwd").and_then(Value::as_str);
+    let canonical_project_root = project::canonical_project_root(Path::new(&project_root))
+        .context("failed to resolve projectRoot")?;
+    let canonical_cwd = project::resolve_inside_root(&canonical_project_root, cwd.map(Path::new))?;
     let harness = required_string(&payload, "harness")?;
     let prompt = required_string(&payload, "prompt")?;
     let title = payload
@@ -171,8 +170,8 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
 
     Ok(SessionLaunch {
         id: Uuid::new_v4().to_string(),
-        project_root,
-        cwd,
+        project_root: canonical_project_root.to_string_lossy().into_owned(),
+        cwd: canonical_cwd.to_string_lossy().into_owned(),
         harness,
         prompt,
         title,
@@ -389,16 +388,25 @@ mod tests {
     #[test]
     fn launch_request_invokes_runtime_and_persists_running_session() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        let cwd = project_root.join("app");
+        std::fs::create_dir_all(&cwd)?;
         let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "cwd": cwd,
+            "harness": "codex",
+            "prompt": "hello coven",
+            "title": "Demo"
+        })
+        .to_string();
 
         let response = handle_request_with_runtime(
             "POST",
             "/sessions",
             temp_dir.path(),
             None,
-            Some(
-                r#"{"projectRoot":"/repo","cwd":"/repo/app","harness":"codex","prompt":"hello coven","title":"Demo"}"#,
-            ),
+            Some(&body),
             &runtime,
         )?;
         let list = handle_request("GET", "/sessions", temp_dir.path(), None)?;
@@ -408,6 +416,14 @@ mod tests {
         assert_eq!(runtime.launches.borrow().len(), 1);
         assert_eq!(runtime.launches.borrow()[0].harness, "codex");
         assert_eq!(runtime.launches.borrow()[0].prompt, "hello coven");
+        assert_eq!(
+            runtime.launches.borrow()[0].project_root,
+            project_root.canonicalize()?.to_string_lossy()
+        );
+        assert_eq!(
+            runtime.launches.borrow()[0].cwd,
+            cwd.canonicalize()?.to_string_lossy()
+        );
         assert!(list.body.contains(r#""title":"Demo""#));
         Ok(())
     }
@@ -415,14 +431,22 @@ mod tests {
     #[test]
     fn launch_request_persists_failed_status_when_runtime_launch_fails() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
         let runtime = FailingLaunchRuntime;
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "prompt": "hello"
+        })
+        .to_string();
 
         let error = handle_request_with_runtime(
             "POST",
             "/sessions",
             temp_dir.path(),
             None,
-            Some(r#"{"projectRoot":"/repo","harness":"codex","prompt":"hello"}"#),
+            Some(&body),
             &runtime,
         )
         .unwrap_err();
@@ -430,6 +454,40 @@ mod tests {
 
         assert!(error.to_string().contains("launch failed"));
         assert!(sessions.body.contains(r#""status":"failed""#));
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_rejects_cwd_outside_project_root() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        let outside = temp_dir.path().join("outside");
+        std::fs::create_dir_all(&project_root)?;
+        std::fs::create_dir_all(&outside)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "cwd": outside,
+            "harness": "codex",
+            "prompt": "hello"
+        })
+        .to_string();
+
+        let error = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("outside the Coven project root"),
+            "unexpected error: {error:?}"
+        );
+        assert!(runtime.launches.borrow().is_empty());
         Ok(())
     }
 

--- a/docs/MVP-PLAN.md
+++ b/docs/MVP-PLAN.md
@@ -1395,6 +1395,14 @@ Prefer showing Coven sessions as external managed panes rather than replacing na
 
 Test that comux refuses to display sessions outside the current project root.
 
+- [x] **Step 3.5: Add project-scoped Coven launch from comux bridge**
+
+Comux can now send `coven.sessions.launch` through its daemon protocol. The bridge validates harness/prompt input, resolves `cwd` inside the active comux project root, calls Coven `POST /sessions`, and rejects any returned session whose project root is outside the comux project scope.
+
+- [x] **Step 3.6: Enforce Coven API launch boundaries**
+
+Coven now canonicalizes `projectRoot` and resolves `cwd` with the same `resolve_inside_root` guard used by the direct CLI before daemon/API launches reach the runtime.
+
 - [x] **Step 4: Commit**
 
 ```bash
@@ -1480,8 +1488,9 @@ Use a simple milestone board until the repo exists. Once created, mirror this in
 ### Milestone 6: comux bridge
 
 - [x] comux lists Coven sessions
+- [x] comux launches Coven sessions through the local API
 - [x] comux attaches or opens Coven session view
-- [x] comux preserves project boundary
+- [x] comux preserves project boundary for list/open/launch
 
 ### Milestone 7: OpenClaw bridge — external plugin
 
@@ -1557,3 +1566,5 @@ Current repo status after initial implementation passes:
 - Future-harness proof slice documented Hermes CLI observations in `docs/FUTURE-HARNESSES.md` and refactored the adapter seam so future CLIs can declare fixed prefix args before the prompt without adding unsupported harness ids prematurely.
 - npm wrapper package scaffold exists at `packages/cli`; local verification confirms `node packages/cli/bin/coven.js doctor` invokes the `coven` binary, and `npm pack --dry-run` includes only package metadata, README, and bin shim.
 - Comux now has Coven session protocol types and a project-scoped fake-client bridge helper; tests prove sessions outside the current project root are filtered out. Committed in `BunsDev/comux` as `1fe3a21 feat: add coven session bridge types`.
+- Comux follow-up branch `coven-comux-launch` adds `coven.sessions.launch`, a bridge helper that validates launch input and scopes `cwd` to the active comux project before calling Coven `POST /sessions`; focused tests cover in-scope launch and out-of-scope rejection.
+- Coven follow-up branch `coven-api-launch-boundary` closes the matching daemon/API safety gap: `POST /sessions` now canonicalizes `projectRoot`, resolves `cwd` through `resolve_inside_root`, and rejects out-of-root launches before runtime invocation.


### PR DESCRIPTION
## Summary
- Canonicalize `projectRoot` for `POST /sessions`
- Resolve optional `cwd` through `project::resolve_inside_root` before persisting or launching
- Update the MVP plan to record the comux launch bridge and matching Coven API boundary guard

## Test Plan
- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --locked
- [x] cargo build --workspace --locked