### PR TITLE
feat: add npm wrapper publishing scaffold

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,111 @@
+name: Release npm packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to npm for real. Requires npm-publish environment approval.'
+        required: true
+        default: false
+        type: boolean
+      version:
+        description: 'Release version to publish, without a leading v. Required when publish=true.'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  COVEN_NPM_TARGET: darwin-arm64
+
+jobs:
+  verify:
+    name: Release gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - run: cargo fmt --check
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace --locked
+      - run: python3 scripts/check-secrets.py
+
+  build-platform:
+    name: Build ${{ matrix.npm-target }}
+    runs-on: ${{ matrix.runner }}
+    needs: verify
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # v0 proves the wrapper end-to-end on Val's MB Black / macOS arm64 first.
+          - npm-target: darwin-arm64
+            rust-target: aarch64-apple-darwin
+            runner: macos-latest
+            binary: coven
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+      - run: cargo build --release --target ${{ matrix.rust-target }}
+      - uses: actions/upload-artifact@v5
+        with:
+          name: coven-${{ matrix.npm-target }}
+          path: target/${{ matrix.rust-target }}/release/${{ matrix.binary }}
+          if-no-files-found: error
+
+  npm-dry-run:
+    name: npm publish dry-run
+    runs-on: ubuntu-latest
+    needs: build-platform
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: actions/download-artifact@v6
+        with:
+          name: coven-darwin-arm64
+          path: target/aarch64-apple-darwin/release
+      - run: chmod +x target/aarch64-apple-darwin/release/coven
+      - run: node scripts/publish-npm.mjs --target=darwin-arm64 --skip-build --dry-run
+
+  npm-publish:
+    name: npm publish manual
+    runs-on: ubuntu-latest
+    needs: build-platform
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+      - uses: actions/download-artifact@v6
+        with:
+          name: coven-darwin-arm64
+          path: target/aarch64-apple-darwin/release
+      - run: chmod +x target/aarch64-apple-darwin/release/coven
+      - name: Validate manual publish version
+        run: |
+          if [ -z "${{ inputs.version }}" ]; then
+            echo "workflow_dispatch publish requires a non-placeholder version input" >&2
+            exit 1
+          fi
+          if [ "${{ inputs.version }}" = "0.0.0" ] || [ "${{ inputs.version }}" = "v0.0.0" ]; then
+            echo "Refusing to publish placeholder version ${{ inputs.version }}" >&2
+            exit 1
+          fi
+      - run: node scripts/publish-npm.mjs --target=darwin-arm64 --skip-build --publish
+        env:
+          COVEN_NPM_VERSION: ${{ inputs.version }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 node_modules/
 packages/*/node_modules/
 *.tgz
+
+/npm/dist/

--- a/npm/coven-platform-template/README.md
+++ b/npm/coven-platform-template/README.md
@@ -1,0 +1,3 @@
+# Native Coven CLI package
+
+This package contains one platform-specific Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select the right optional dependency for your OS and CPU.

--- a/npm/coven-platform-template/package.json.tpl
+++ b/npm/coven-platform-template/package.json.tpl
@@ -1,0 +1,17 @@
+{
+  "name": "__PACKAGE_NAME__",
+  "version": "__VERSION__",
+  "private": false,
+  "description": "Native Coven CLI binary for __OS__/__CPU__.",
+  "os": ["__OS__"],
+  "cpu": ["__CPU__"],
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenCoven/coven.git"
+  }
+}

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -1,0 +1,16 @@
+# @opencoven/cli
+
+Node wrapper for the native Coven Rust CLI.
+
+After an approved v0 release is published for macOS Apple Silicon:
+
+```sh
+npm install -g @opencoven/cli
+coven doctor
+```
+
+The wrapper installs platform-specific native packages through `optionalDependencies` and runs the matching `coven` binary for your OS and CPU. No Rust toolchain is required for end users after a supported package is published.
+
+## v0 platform scope
+
+The first publishing proof targets `@opencoven/cli-darwin-arm64` (macOS Apple Silicon). Other platform packages are listed for the stable package contract and will be filled out by follow-up release work. Installing on any other platform will result in a missing-platform-package error until those packages are published.

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+const PLATFORM_PACKAGES = {
+  'darwin-arm64': '@opencoven/cli-darwin-arm64',
+  'darwin-x64': '@opencoven/cli-darwin-x64',
+  'linux-arm64': '@opencoven/cli-linux-arm64',
+  'linux-x64': '@opencoven/cli-linux-x64',
+  'win32-x64': '@opencoven/cli-win32-x64'
+};
+
+const binaryName = process.platform === 'win32' ? 'coven.exe' : 'coven';
+const platformKey = `${process.platform}-${process.arch}`;
+const packageName = PLATFORM_PACKAGES[platformKey];
+
+function wrapperVersion() {
+  return require('../package.json').version;
+}
+
+function resolveBinary() {
+  if (!packageName) {
+    throw new Error(
+      `Unsupported platform ${platformKey}. Coven publishes native packages for: ${Object.keys(PLATFORM_PACKAGES).join(', ')}.`
+    );
+  }
+
+  try {
+    return require.resolve(`${packageName}/bin/${binaryName}`);
+  } catch (error) {
+    throw new Error(
+      `Could not find native Coven package ${packageName}. Reinstall @opencoven/cli so npm can install the optional dependency for ${platformKey}. Original error: ${error.message}`
+    );
+  }
+}
+
+let binary;
+try {
+  binary = resolveBinary();
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+if (args.length === 1 && (args[0] === '--version' || args[0] === '-V')) {
+  console.log(wrapperVersion());
+  process.exit(0);
+}
+
+const child = spawn(binary, args, {
+  stdio: 'inherit',
+  windowsHide: false
+});
+
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    if (!child.killed) {
+      child.kill(signal);
+    }
+  });
+}
+
+child.on('error', (error) => {
+  console.error(`Failed to launch Coven binary at ${binary}: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/npm/coven/package.json
+++ b/npm/coven/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@opencoven/cli",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Coven CLI wrapper for the native Rust binary.",
+  "type": "module",
+  "bin": {
+    "coven": "bin/coven.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenCoven/coven.git"
+  },
+  "optionalDependencies": {
+    "@opencoven/cli-darwin-arm64": "0.0.0",
+    "@opencoven/cli-darwin-x64": "0.0.0",
+    "@opencoven/cli-linux-arm64": "0.0.0",
+    "@opencoven/cli-linux-x64": "0.0.0",
+    "@opencoven/cli-win32-x64": "0.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { releaseVersion, validatePublishVersion } from './publish-npm.mjs';
+
+test('releaseVersion prefers explicit COVEN_NPM_VERSION and strips a leading v', () => {
+  assert.equal(
+    releaseVersion({ COVEN_NPM_VERSION: 'v1.2.3', GITHUB_REF_NAME: 'v9.9.9' }, '0.0.0'),
+    '1.2.3'
+  );
+});
+
+test('releaseVersion falls back to tag ref for tag-triggered dry runs', () => {
+  assert.equal(releaseVersion({ GITHUB_REF_NAME: 'v2.0.1' }, '0.0.0'), '2.0.1');
+});
+
+test('releaseVersion falls back to package placeholder for local dry runs', () => {
+  assert.equal(releaseVersion({}, '0.0.0'), '0.0.0');
+});
+
+test('validatePublishVersion rejects real publish with placeholder version', () => {
+  assert.throws(() => validatePublishVersion('0.0.0', false), /Refusing real npm publish/);
+});
+
+test('validatePublishVersion allows dry-run with placeholder version', () => {
+  assert.doesNotThrow(() => validatePublishVersion('0.0.0', true));
+});
+
+test('validatePublishVersion allows real publish with explicit release version', () => {
+  assert.doesNotThrow(() => validatePublishVersion('1.2.3', false));
+});

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+const distRoot = path.join(repoRoot, 'npm', 'dist');
+
+const targets = {
+  'darwin-arm64': {
+    packageName: '@opencoven/cli-darwin-arm64',
+    os: 'darwin',
+    cpu: 'arm64',
+    rustTarget: 'aarch64-apple-darwin',
+    binaryName: 'coven'
+  },
+  'darwin-x64': {
+    packageName: '@opencoven/cli-darwin-x64',
+    os: 'darwin',
+    cpu: 'x64',
+    rustTarget: 'x86_64-apple-darwin',
+    binaryName: 'coven'
+  },
+  'linux-x64': {
+    packageName: '@opencoven/cli-linux-x64',
+    os: 'linux',
+    cpu: 'x64',
+    rustTarget: 'x86_64-unknown-linux-gnu',
+    binaryName: 'coven'
+  },
+  'linux-arm64': {
+    packageName: '@opencoven/cli-linux-arm64',
+    os: 'linux',
+    cpu: 'arm64',
+    rustTarget: 'aarch64-unknown-linux-gnu',
+    binaryName: 'coven'
+  },
+  'win32-x64': {
+    packageName: '@opencoven/cli-win32-x64',
+    os: 'win32',
+    cpu: 'x64',
+    rustTarget: 'x86_64-pc-windows-msvc',
+    binaryName: 'coven.exe'
+  }
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+function main() {
+  const args = new Set(process.argv.slice(2));
+  const optionValue = (name) => {
+    const prefix = `${name}=`;
+    const found = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+    return found ? found.slice(prefix.length) : undefined;
+  };
+
+  const targetName = optionValue('--target') ?? process.env.COVEN_NPM_TARGET ?? `${process.platform}-${process.arch}`;
+  const dryRun = args.has('--dry-run') || !args.has('--publish');
+  const skipBuild = args.has('--skip-build');
+  const version = releaseVersion(process.env, wrapperPackageVersion());
+  const target = targets[targetName];
+
+  if (!target) {
+    fail(`Unsupported npm target ${targetName}. Known targets: ${Object.keys(targets).join(', ')}`);
+  }
+
+  validatePublishVersion(version, dryRun);
+  if (!dryRun && process.env.NPM_TOKEN === undefined) {
+    fail('Refusing real npm publish without NPM_TOKEN. Prefer --dry-run until Val manually approves publishing.');
+  }
+
+  if (!skipBuild) {
+    run('cargo', ['build', '--release', '--target', target.rustTarget]);
+  }
+
+  const binaryPath = path.join(repoRoot, 'target', target.rustTarget, 'release', target.binaryName);
+  if (!existsSync(binaryPath)) {
+    fail(`Built binary not found at ${binaryPath}`);
+  }
+
+  rmSync(distRoot, { recursive: true, force: true });
+  mkdirSync(distRoot, { recursive: true });
+
+  const platformDir = writePlatformPackage(targetName, target, binaryPath, version);
+  const wrapperDir = writeWrapperPackage(version);
+
+  run('npm', ['publish', dryRun ? '--dry-run' : '--access', dryRun ? undefined : 'public'].filter(Boolean), {
+    cwd: platformDir,
+    env: publishEnv(dryRun)
+  });
+  run('npm', ['publish', dryRun ? '--dry-run' : '--access', dryRun ? undefined : 'public'].filter(Boolean), {
+    cwd: wrapperDir,
+    env: publishEnv(dryRun)
+  });
+
+  console.log(`Prepared npm packages in ${distRoot}`);
+  console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${target.packageName} and @opencoven/cli at version ${version}.`);
+}
+
+function writePlatformPackage(targetName, target, binaryPath, version) {
+  const outDir = path.join(distRoot, targetName);
+  const binDir = path.join(outDir, 'bin');
+  mkdirSync(binDir, { recursive: true });
+
+  const template = readFileSync(path.join(repoRoot, 'npm', 'coven-platform-template', 'package.json.tpl'), 'utf8');
+  const packageJson = template
+    .replaceAll('__PACKAGE_NAME__', target.packageName)
+    .replaceAll('__VERSION__', version)
+    .replaceAll('__OS__', target.os)
+    .replaceAll('__CPU__', target.cpu);
+
+  writeFileSync(path.join(outDir, 'package.json'), `${packageJson.trim()}\n`);
+  cpSync(path.join(repoRoot, 'npm', 'coven-platform-template', 'README.md'), path.join(outDir, 'README.md'));
+  cpSync(binaryPath, path.join(binDir, target.binaryName));
+  chmodSync(path.join(binDir, target.binaryName), 0o755);
+  return outDir;
+}
+
+function writeWrapperPackage(version) {
+  const outDir = path.join(distRoot, 'coven');
+  cpSync(path.join(repoRoot, 'npm', 'coven'), outDir, { recursive: true });
+  const packagePath = path.join(outDir, 'package.json');
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  packageJson.version = version;
+  for (const packageName of Object.keys(packageJson.optionalDependencies)) {
+    packageJson.optionalDependencies[packageName] = version;
+  }
+  writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  chmodSync(path.join(outDir, 'bin', 'coven.js'), 0o755);
+  return outDir;
+}
+
+export function releaseVersion(env = process.env, packageVersion = wrapperPackageVersion()) {
+  const fromEnv = env.COVEN_NPM_VERSION;
+  if (fromEnv) {
+    return fromEnv.replace(/^v/, '');
+  }
+
+  const githubRef = env.GITHUB_REF_NAME;
+  if (githubRef?.startsWith('v')) {
+    return githubRef.slice(1);
+  }
+
+  return packageVersion;
+}
+
+export function validatePublishVersion(version, dryRun) {
+  if (!dryRun && version === '0.0.0') {
+    throw new Error('Refusing real npm publish with placeholder version 0.0.0. Set COVEN_NPM_VERSION or run from a v* tag.');
+  }
+}
+
+function wrapperPackageVersion() {
+  const wrapperPackage = JSON.parse(readFileSync(path.join(repoRoot, 'npm', 'coven', 'package.json'), 'utf8'));
+  return wrapperPackage.version;
+}
+
+function run(command, args, options = {}) {
+  const printable = [command, ...args].join(' ');
+  console.log(`$ ${printable}`);
+  const result = spawnSync(command, args, {
+    cwd: options.cwd ?? repoRoot,
+    env: options.env ?? process.env,
+    stdio: 'inherit'
+  });
+  if (result.error) {
+    fail(`${printable} failed: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    fail(`${printable} exited with ${result.status}`);
+  }
+}
+
+function publishEnv(dryRun) {
+  if (dryRun) {
+    return process.env;
+  }
+  return {
+    ...process.env,
+    NODE_AUTH_TOKEN: process.env.NPM_TOKEN
+  };
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}


### PR DESCRIPTION
DO NOT MERGE — Val will publish manually.

## Summary

Wires up npm packaging for the Coven Rust CLI using the esbuild/biome/swc/turbo-style wrapper + optional native packages pattern.

Package layout:

- `npm/coven` — main wrapper package `@opencoven/coven`
  - `bin/coven.js` resolves the platform package via `require.resolve(...)`
  - forwards argv/stdio/exit code with `child_process.spawn`
  - prints a clear unsupported/missing-platform-package error
  - exposes `bin: { "coven": "bin/coven.js" }`
  - lists platform packages in exact-version `optionalDependencies`
- `npm/coven-platform-template` — template for generated native packages
- `scripts/publish-npm.mjs` — builds the Rust CLI, generates npm package dirs under ignored `npm/dist`, and runs `npm publish --dry-run` by default
- `.github/workflows/release-npm.yml` — tag-triggered darwin-arm64 build + dry-run publish; real publish is workflow_dispatch-only and gated on the `npm-publish` environment

## Tested

Rust / repo gates:

- `cargo fmt --check` ✅
- `cargo test --workspace --locked` ✅ — 88 passed
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `git diff --check` ✅

Node / npm smoke:

- `node --check npm/coven/bin/coven.js` ✅
- `node --check scripts/publish-npm.mjs` ✅
- `node scripts/publish-npm.mjs --target=darwin-arm64 --dry-run` ✅
- Local linked platform-package smoke:
  - `node npm/coven/bin/coven.js --version` → `0.0.0` ✅
  - `node npm/coven/bin/coven.js doctor` → listed Codex and Claude Code ✅

Dry-run publish output highlights:

- `@opencoven/coven-darwin-arm64@0.0.0`
  - files: `README.md`, `bin/coven`, `package.json`
  - package size: `1.6 MB`
  - unpacked size: `3.5 MB`
  - total files: `3`
- `@opencoven/coven@0.0.0`
  - files: `README.md`, `bin/coven.js`, `package.json`
  - package size: `1.5 kB`
  - unpacked size: `3.2 kB`
  - total files: `3`

## Notes

- No real `npm publish` was run.
- Versions remain `0.0.0`; release-time versions flow from `COVEN_NPM_VERSION` or git tag names in the publish script.
- This PR targets `feat/coven-patch-openclaw` instead of `main` because current `origin/main` has only the first OpenClaw patch commit and fails the required clippy gate with pre-existing dead-code errors. Against `feat/coven-patch-openclaw`, the required Rust gates pass and this diff stays wrapper-only.

## Deferred

- Linux x64 / Linux arm64 / Windows x64 native build jobs and package proofs.
- macOS x64 build proof.
- Full multi-target CI release matrix once the darwin-arm64 package path is accepted.
- Real npm publish — Val will run/approve that manually.
