### PR TITLE
fix: publish macOS npm package name

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -21,7 +21,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  COVEN_NPM_TARGET: darwin-arm64
+  COVEN_NPM_TARGET: macos
 
 jobs:
   verify:
@@ -46,7 +46,7 @@ jobs:
       matrix:
         include:
           # v0 proves the wrapper end-to-end on Val's MB Black / macOS arm64 first.
-          - npm-target: darwin-arm64
+          - npm-target: macos
             rust-target: aarch64-apple-darwin
             runner: macos-latest
             binary: coven
@@ -73,10 +73,10 @@ jobs:
           node-version: 24
       - uses: actions/download-artifact@v6
         with:
-          name: coven-darwin-arm64
+          name: coven-macos
           path: target/aarch64-apple-darwin/release
       - run: chmod +x target/aarch64-apple-darwin/release/coven
-      - run: node scripts/publish-npm.mjs --target=darwin-arm64 --skip-build --dry-run
+      - run: node scripts/publish-npm.mjs --target=macos --skip-build --dry-run
 
   npm-publish:
     name: npm publish manual
@@ -92,7 +92,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - uses: actions/download-artifact@v6
         with:
-          name: coven-darwin-arm64
+          name: coven-macos
           path: target/aarch64-apple-darwin/release
       - run: chmod +x target/aarch64-apple-darwin/release/coven
       - name: Validate manual publish version
@@ -105,7 +105,7 @@ jobs:
             echo "Refusing to publish placeholder version ${{ inputs.version }}" >&2
             exit 1
           fi
-      - run: node scripts/publish-npm.mjs --target=darwin-arm64 --skip-build --publish
+      - run: node scripts/publish-npm.mjs --target=macos --skip-build --publish
         env:
           COVEN_NPM_VERSION: ${{ inputs.version }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/npm/coven-platform-template/README.md
+++ b/npm/coven-platform-template/README.md
@@ -1,3 +1,3 @@
 # Native Coven CLI package
 
-This package contains one platform-specific Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select the right optional dependency for your OS and CPU.
+This package contains the macOS Apple Silicon Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select this optional dependency on supported macOS systems.

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -13,4 +13,4 @@ The wrapper installs platform-specific native packages through `optionalDependen
 
 ## v0 platform scope
 
-The first publishing proof targets `@opencoven/cli-darwin-arm64` (macOS Apple Silicon). Other platform packages are listed for the stable package contract and will be filled out by follow-up release work. Installing on any other platform will result in a missing-platform-package error until those packages are published.
+The first publishing proof targets `@opencoven/cli-macos` for macOS Apple Silicon. Other platforms are intentionally not advertised yet; installing on unsupported platforms will report that only macOS Apple Silicon is available in v0.

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -5,11 +5,7 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 
 const PLATFORM_PACKAGES = {
-  'darwin-arm64': '@opencoven/cli-darwin-arm64',
-  'darwin-x64': '@opencoven/cli-darwin-x64',
-  'linux-arm64': '@opencoven/cli-linux-arm64',
-  'linux-x64': '@opencoven/cli-linux-x64',
-  'win32-x64': '@opencoven/cli-win32-x64'
+  'darwin-arm64': '@opencoven/cli-macos'
 };
 
 const binaryName = process.platform === 'win32' ? 'coven.exe' : 'coven';
@@ -23,7 +19,7 @@ function wrapperVersion() {
 function resolveBinary() {
   if (!packageName) {
     throw new Error(
-      `Unsupported platform ${platformKey}. Coven publishes native packages for: ${Object.keys(PLATFORM_PACKAGES).join(', ')}.`
+      `Unsupported platform ${platformKey}. Coven v0 publishes native npm packages for macOS Apple Silicon only.`
     );
   }
 
@@ -31,7 +27,7 @@ function resolveBinary() {
     return require.resolve(`${packageName}/bin/${binaryName}`);
   } catch (error) {
     throw new Error(
-      `Could not find native Coven package ${packageName}. Reinstall @opencoven/cli so npm can install the optional dependency for ${platformKey}. Original error: ${error.message}`
+      `Could not find native Coven package ${packageName}. Reinstall @opencoven/cli so npm can install the macOS optional dependency. Original error: ${error.message}`
     );
   }
 }

--- a/npm/coven/package.json
+++ b/npm/coven/package.json
@@ -17,11 +17,7 @@
     "url": "git+https://github.com/OpenCoven/coven.git"
   },
   "optionalDependencies": {
-    "@opencoven/cli-darwin-arm64": "0.0.0",
-    "@opencoven/cli-darwin-x64": "0.0.0",
-    "@opencoven/cli-linux-arm64": "0.0.0",
-    "@opencoven/cli-linux-x64": "0.0.0",
-    "@opencoven/cli-win32-x64": "0.0.0"
+    "@opencoven/cli-macos": "0.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { releaseVersion, validatePublishVersion } from './publish-npm.mjs';
+import { releaseVersion, targetPackageName, validatePublishVersion } from './publish-npm.mjs';
 
 test('releaseVersion prefers explicit COVEN_NPM_VERSION and strips a leading v', () => {
   assert.equal(
@@ -28,4 +28,8 @@ test('validatePublishVersion allows dry-run with placeholder version', () => {
 
 test('validatePublishVersion allows real publish with explicit release version', () => {
   assert.doesNotThrow(() => validatePublishVersion('1.2.3', false));
+});
+
+test('macOS target publishes under human-facing native package name', () => {
+  assert.equal(targetPackageName('macos'), '@opencoven/cli-macos');
 });

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -9,40 +9,12 @@ const repoRoot = path.resolve(__dirname, '..');
 const distRoot = path.join(repoRoot, 'npm', 'dist');
 
 const targets = {
-  'darwin-arm64': {
-    packageName: '@opencoven/cli-darwin-arm64',
+  macos: {
+    packageName: '@opencoven/cli-macos',
     os: 'darwin',
     cpu: 'arm64',
     rustTarget: 'aarch64-apple-darwin',
     binaryName: 'coven'
-  },
-  'darwin-x64': {
-    packageName: '@opencoven/cli-darwin-x64',
-    os: 'darwin',
-    cpu: 'x64',
-    rustTarget: 'x86_64-apple-darwin',
-    binaryName: 'coven'
-  },
-  'linux-x64': {
-    packageName: '@opencoven/cli-linux-x64',
-    os: 'linux',
-    cpu: 'x64',
-    rustTarget: 'x86_64-unknown-linux-gnu',
-    binaryName: 'coven'
-  },
-  'linux-arm64': {
-    packageName: '@opencoven/cli-linux-arm64',
-    os: 'linux',
-    cpu: 'arm64',
-    rustTarget: 'aarch64-unknown-linux-gnu',
-    binaryName: 'coven'
-  },
-  'win32-x64': {
-    packageName: '@opencoven/cli-win32-x64',
-    os: 'win32',
-    cpu: 'x64',
-    rustTarget: 'x86_64-pc-windows-msvc',
-    binaryName: 'coven.exe'
   }
 };
 
@@ -58,7 +30,7 @@ function main() {
     return found ? found.slice(prefix.length) : undefined;
   };
 
-  const targetName = optionValue('--target') ?? process.env.COVEN_NPM_TARGET ?? `${process.platform}-${process.arch}`;
+  const targetName = optionValue('--target') ?? process.env.COVEN_NPM_TARGET ?? defaultTargetName(process.platform, process.arch);
   const dryRun = args.has('--dry-run') || !args.has('--publish');
   const skipBuild = args.has('--skip-build');
   const version = releaseVersion(process.env, wrapperPackageVersion());
@@ -146,6 +118,17 @@ export function releaseVersion(env = process.env, packageVersion = wrapperPackag
   }
 
   return packageVersion;
+}
+
+export function targetPackageName(targetName) {
+  return targets[targetName]?.packageName;
+}
+
+export function defaultTargetName(platform, arch) {
+  if (platform === 'darwin' && arch === 'arm64') {
+    return 'macos';
+  }
+  return `${platform}-${arch}`;
 }
 
 export function validatePublishVersion(version, dryRun) {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -131,6 +131,20 @@ export function defaultTargetName(platform, arch) {
   return `${platform}-${arch}`;
 }
 
+if ('NODE_TEST_CONTEXT' in process.env) {
+  const assert = await import('node:assert/strict');
+  const { test } = await import('node:test');
+
+  test('defaultTargetName maps darwin arm64 to macos', () => {
+    assert.strictEqual(defaultTargetName('darwin', 'arm64'), 'macos');
+  });
+
+  test('defaultTargetName falls back to platform-arch for non-special cases', () => {
+    assert.strictEqual(defaultTargetName('linux', 'x64'), 'linux-x64');
+    assert.strictEqual(defaultTargetName('darwin', 'x64'), 'darwin-x64');
+  });
+}
+
 export function validatePublishVersion(version, dryRun) {
   if (!dryRun && version === '0.0.0') {
     throw new Error('Refusing real npm publish with placeholder version 0.0.0. Set COVEN_NPM_VERSION or run from a v* tag.');


### PR DESCRIPTION
## Summary

Renames the public native npm package from the technical `@opencoven/cli-darwin-arm64` identity to the human-facing `@opencoven/cli-macos` before first publish.

## Changes

- Wrapper package now depends only on `@opencoven/cli-macos`.
- Native package generation publishes `@opencoven/cli-macos` while keeping npm constraints `os: darwin` and `cpu: arm64`.
- Release workflow uses the `macos` npm target/artifact name.
- Docs now advertise macOS Apple Silicon only for v0, without listing unsupported platform packages.

## Verification

- `cargo fmt --check` ✅
- `cargo test --workspace --locked` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `node --check scripts/publish-npm.mjs` ✅
- `node --check npm/coven/bin/coven.js` ✅
- `node --test scripts/publish-npm-test.mjs` ✅
- `node scripts/publish-npm.mjs --target=macos --skip-build --dry-run` ✅
- package smoke install from packed tarballs and `coven --version` ✅
- `python3 scripts/check-secrets-test.py` ✅
- `python3 scripts/check-secrets.py` ✅
- `git diff --check` ✅

`@opencoven/cli-macos` is not currently published on npm, so the rename is safe before first release.
