### PR TITLE
test: smoke daemon ritual flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Prefer copy/paste commands?
 cd /path/to/your/project
 coven doctor
 coven daemon start
+coven daemon restart
 coven run codex "fix the failing tests"
 coven run claude "polish this UI"
 coven sessions
@@ -101,6 +102,7 @@ Coven is the local harness substrate for OpenCoven. It does not replace your cod
 | `coven doctor` | Detect supported harness CLIs and print install hints |
 | `coven daemon start` | Start the local Coven daemon |
 | `coven daemon status` | Show daemon health, pid, and socket path |
+| `coven daemon restart` | Restart the local daemon and rebind the socket |
 | `coven daemon stop` | Stop the local daemon |
 | `coven run <harness> <prompt>` | Launch a project-scoped harness session |
 | `coven run <harness> <prompt> --cwd <path>` | Launch from a cwd inside the project root |

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -3,11 +3,12 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 #[cfg(unix)]
 use std::io::{BufRead, BufReader, Read};
 #[cfg(unix)]
-use std::os::unix::net::UnixListener;
+use std::os::unix::net::{UnixListener, UnixStream};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -288,20 +289,129 @@ pub fn clear_status(coven_home: &Path) -> Result<bool> {
 }
 
 pub fn stop_background_server(coven_home: &Path) -> Result<bool> {
+    stop_background_server_with_controller(coven_home, &SystemDaemonStopController)
+}
+
+trait DaemonStopController {
+    fn signal_term(&self, pid: u32) -> Result<()>;
+    fn pid_is_alive(&self, pid: u32) -> bool;
+    fn wait_for_exit(&self, pid: u32, timeout: Duration) -> bool;
+    fn status_matches_running_daemon(&self, status: &DaemonStatus) -> bool;
+}
+
+struct SystemDaemonStopController;
+
+impl DaemonStopController for SystemDaemonStopController {
+    fn signal_term(&self, pid: u32) -> Result<()> {
+        #[cfg(unix)]
+        {
+            let output = Command::new("kill")
+                .arg("-TERM")
+                .arg(pid.to_string())
+                .stdin(Stdio::null())
+                .output()
+                .with_context(|| format!("failed to signal Coven daemon pid {pid}"))?;
+            if output.status.success() {
+                Ok(())
+            } else {
+                anyhow::bail!(
+                    "failed to signal Coven daemon pid {pid}: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                )
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = pid;
+            Ok(())
+        }
+    }
+
+    fn pid_is_alive(&self, pid: u32) -> bool {
+        #[cfg(unix)]
+        {
+            Command::new("kill")
+                .arg("-0")
+                .arg(pid.to_string())
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|status| status.success())
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = pid;
+            false
+        }
+    }
+
+    fn wait_for_exit(&self, pid: u32, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        while Instant::now() < deadline {
+            if !self.pid_is_alive(pid) {
+                return true;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        !self.pid_is_alive(pid)
+    }
+
+    fn status_matches_running_daemon(&self, status: &DaemonStatus) -> bool {
+        #[cfg(unix)]
+        {
+            daemon_health_reports_pid(&status.socket, status.pid).unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = status;
+            true
+        }
+    }
+}
+
+fn stop_background_server_with_controller(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+) -> Result<bool> {
     let status = read_status(coven_home)?;
     let Some(status) = status else {
         return Ok(false);
     };
 
-    #[cfg(unix)]
-    {
-        let _ = Command::new("kill")
-            .arg("-TERM")
-            .arg(status.pid.to_string())
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
+    if !controller.status_matches_running_daemon(&status) {
+        if controller.pid_is_alive(status.pid) {
+            anyhow::bail!(
+                "Coven daemon pid {} could not be verified through its socket; not signaling or clearing daemon status",
+                status.pid
+            );
+        }
+        clear_status(coven_home)?;
+        let socket = daemon_socket_path(coven_home);
+        if socket.exists() {
+            std::fs::remove_file(&socket)
+                .with_context(|| format!("failed to remove daemon socket {}", socket.display()))?;
+        }
+        return Ok(true);
+    }
+
+    match controller.signal_term(status.pid) {
+        Ok(()) => {
+            if !controller.wait_for_exit(status.pid, Duration::from_secs(2)) {
+                anyhow::bail!(
+                    "Coven daemon pid {} did not exit after SIGTERM; not clearing daemon status",
+                    status.pid
+                );
+            }
+        }
+        Err(error) if controller.pid_is_alive(status.pid) => {
+            anyhow::bail!(
+                "failed to stop Coven daemon pid {}; not clearing daemon status: {error}",
+                status.pid
+            );
+        }
+        Err(_) => {}
     }
 
     clear_status(coven_home)?;
@@ -311,6 +421,32 @@ pub fn stop_background_server(coven_home: &Path) -> Result<bool> {
             .with_context(|| format!("failed to remove daemon socket {}", socket.display()))?;
     }
     Ok(true)
+}
+
+#[cfg(unix)]
+fn daemon_health_reports_pid(socket: &str, expected_pid: u32) -> Result<bool> {
+    let mut stream = UnixStream::connect(socket)
+        .with_context(|| format!("failed to connect to Coven daemon socket {socket}"))?;
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: coven\r\n\r\n")
+        .context("failed to write Coven health request")?;
+    stream
+        .shutdown(std::net::Shutdown::Write)
+        .context("failed to finish Coven health request")?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .context("failed to read Coven health response")?;
+    let Some((_, body)) = response.split_once("\r\n\r\n") else {
+        return Ok(false);
+    };
+    let body: Value =
+        serde_json::from_str(body).context("failed to parse Coven health response")?;
+    Ok(body
+        .get("daemon")
+        .and_then(|daemon| daemon.get("pid"))
+        .and_then(Value::as_u64)
+        .is_some_and(|pid| pid == u64::from(expected_pid)))
 }
 
 #[cfg(unix)]
@@ -569,6 +705,120 @@ mod tests {
         assert_eq!(read_status(temp_dir.path())?, None);
         assert!(!clear_status(temp_dir.path())?);
         Ok(())
+    }
+
+    #[test]
+    fn stop_background_server_keeps_status_when_existing_daemon_survives() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_status(temp_dir.path(), &status)?;
+
+        let error = stop_background_server_with_controller(
+            temp_dir.path(),
+            &FakeStopController {
+                pid_alive: true,
+                exited_after_signal: false,
+                signal_error: None,
+                verified_daemon: true,
+                signaled: std::sync::Arc::default(),
+            },
+        )
+        .expect_err("stop should refuse to clear status while pid is alive");
+
+        assert!(error.to_string().contains("did not exit"));
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
+    #[test]
+    fn stop_background_server_clears_stale_status_when_pid_is_gone() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_status(temp_dir.path(), &status)?;
+
+        assert!(stop_background_server_with_controller(
+            temp_dir.path(),
+            &FakeStopController {
+                pid_alive: false,
+                exited_after_signal: false,
+                signal_error: Some("No such process".to_string()),
+                verified_daemon: false,
+                signaled: std::sync::Arc::default(),
+            },
+        )?);
+
+        assert_eq!(read_status(temp_dir.path())?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn stop_background_server_refuses_unverified_live_pid_without_signaling() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+        };
+        write_status(temp_dir.path(), &status)?;
+        let controller = FakeStopController {
+            pid_alive: true,
+            exited_after_signal: true,
+            signal_error: None,
+            verified_daemon: false,
+            signaled: std::sync::Arc::default(),
+        };
+
+        let error = stop_background_server_with_controller(temp_dir.path(), &controller)
+            .expect_err("stop should not signal an unverified live pid");
+
+        assert!(error.to_string().contains("could not be verified"));
+        assert_eq!(*controller.signaled.lock().unwrap(), 0);
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
+    struct FakeStopController {
+        pid_alive: bool,
+        exited_after_signal: bool,
+        signal_error: Option<String>,
+        verified_daemon: bool,
+        signaled: std::sync::Arc<std::sync::Mutex<usize>>,
+    }
+
+    impl DaemonStopController for FakeStopController {
+        fn signal_term(&self, _pid: u32) -> Result<()> {
+            *self.signaled.lock().unwrap() += 1;
+            match &self.signal_error {
+                Some(error) => anyhow::bail!(error.clone()),
+                None => Ok(()),
+            }
+        }
+
+        fn pid_is_alive(&self, _pid: u32) -> bool {
+            self.pid_alive
+        }
+
+        fn wait_for_exit(&self, _pid: u32, _timeout: std::time::Duration) -> bool {
+            self.exited_after_signal
+        }
+
+        fn status_matches_running_daemon(&self, _status: &DaemonStatus) -> bool {
+            self.verified_daemon
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1271,8 +1271,7 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
             let was_running = daemon::stop_background_server(&home)?;
             let current_exe =
                 std::env::current_exe().context("failed to resolve current executable")?;
-            let status =
-                daemon::start_background_server(&home, &current_exe, current_timestamp())?;
+            let status = daemon::start_background_server(&home, &current_exe, current_timestamp())?;
             if was_running {
                 println!(
                     "coven daemon status=restarted pid={} socket={}",

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1268,14 +1268,22 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
             );
         }
         DaemonCommand::Restart => {
-            let _ = daemon::stop_background_server(&home)?;
+            let was_running = daemon::stop_background_server(&home)?;
             let current_exe =
                 std::env::current_exe().context("failed to resolve current executable")?;
-            let status = daemon::start_background_server(&home, &current_exe, current_timestamp())?;
-            println!(
-                "coven daemon status=running pid={} socket={}",
-                status.pid, status.socket
-            );
+            let status =
+                daemon::start_background_server(&home, &current_exe, current_timestamp())?;
+            if was_running {
+                println!(
+                    "coven daemon status=restarted pid={} socket={}",
+                    status.pid, status.socket
+                );
+            } else {
+                println!(
+                    "coven daemon status=running pid={} socket={}",
+                    status.pid, status.socket
+                );
+            }
         }
         DaemonCommand::Status => match daemon::read_status(&home)? {
             Some(status) => {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -120,6 +120,7 @@ enum PatchCommand {
 #[derive(Subcommand, Debug)]
 enum DaemonCommand {
     Start,
+    Restart,
     Status,
     Stop,
     #[command(hide = true)]
@@ -1266,6 +1267,16 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 status.pid, status.socket
             );
         }
+        DaemonCommand::Restart => {
+            let _ = daemon::stop_background_server(&home)?;
+            let current_exe =
+                std::env::current_exe().context("failed to resolve current executable")?;
+            let status = daemon::start_background_server(&home, &current_exe, current_timestamp())?;
+            println!(
+                "coven daemon status=running pid={} socket={}",
+                status.pid, status.socket
+            );
+        }
         DaemonCommand::Status => match daemon::read_status(&home)? {
             Some(status) => {
                 let health = api::health_response(Some(status.clone()));
@@ -1893,8 +1904,8 @@ mod tests {
     }
 
     #[test]
-    fn cli_accepts_daemon_start_status_stop_and_hidden_serve_commands() {
-        for subcommand in ["start", "status", "stop", "serve"] {
+    fn cli_accepts_daemon_start_status_stop_restart_and_hidden_serve_commands() {
+        for subcommand in ["start", "status", "stop", "restart", "serve"] {
             let cli = Cli::parse_from(["coven", "daemon", subcommand]);
             match cli.command {
                 Some(Command::Daemon { .. }) => {}

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -55,6 +55,19 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
         "fake codex complete: smoke replay",
     )?;
 
+    let restart = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
+    assert_success("daemon restart", &restart);
+    assert_stdout_contains("daemon restart", &restart, "status=running");
+    wait_for_daemon_health(&coven_home)?;
+
+    let restarted_status = run_coven(&coven, &coven_home, &path, &["daemon", "status"])?;
+    assert_success("daemon restarted status", &restarted_status);
+    assert_stdout_contains(
+        "daemon restarted status",
+        &restarted_status,
+        "status=running",
+    );
+
     let attach = run_coven(&coven, &coven_home, &path, &["attach", &replay_session])?;
     assert_success("attach replay", &attach);
     assert_stdout_contains(

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -57,7 +57,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
 
     let restart = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
     assert_success("daemon restart", &restart);
-    assert_stdout_contains("daemon restart", &restart, "status=running");
+    assert_stdout_contains("daemon restart", &restart, "status=restarted");
     wait_for_daemon_health(&coven_home)?;
 
     let restarted_status = run_coven(&coven, &coven_home, &path, &["daemon", "status"])?;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,7 +77,7 @@ flowchart TD
 
 - `coven` and `coven tui` open the beginner-friendly slash-command palette.
 - `coven doctor` checks store/project/harness readiness and prints next steps.
-- `coven daemon start/status/stop` manages the local daemon.
+- `coven daemon start/status/restart/stop` manages the local daemon.
 - `coven run codex|claude <prompt>` launches a project-scoped PTY session.
 - `coven sessions` opens the human session browser in a terminal; `--plain` keeps scriptable output.
 - Session browser actions surface readable choices: **Rejoin**, **View Log**, **Summon**, **Archive**, and **Sacrifice**.

--- a/docs/OPERATIONAL-MODEL.md
+++ b/docs/OPERATIONAL-MODEL.md
@@ -45,7 +45,7 @@ The Rust CLI/daemon should stay narrow and boring:
 - `coven sessions` opens the interactive session browser in terminals and prints table output for scripts/pipes.
 - `coven attach` replays and follows Coven-managed event output.
 - `coven archive`, `coven summon`, and `coven sacrifice --yes` manage completed session history without making users memorize ids in the TUI path.
-- `coven daemon start/status/stop` manages one local daemon state directory.
+- `coven daemon start/status/restart/stop` manages one local daemon state directory.
 - The daemon exposes a small local API over `<covenHome>/coven.sock`.
 - SQLite stores session metadata, archive state, and append-only event history.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ Shipped:
 - Rust CLI command named `coven`.
 - Beginner-friendly `coven` / `coven tui` entrypoint.
 - `coven doctor` setup checks.
-- Local daemon lifecycle: `coven daemon start/status/stop`.
+- Local daemon lifecycle: `coven daemon start/status/restart/stop`.
 - Project-root and cwd boundary guard.
 - Built-in Codex and Claude Code harness adapters.
 - PTY-backed `coven run codex|claude <prompt>` sessions.
@@ -49,6 +49,7 @@ Shipped:
 - Versioned `v1` daemon API contract for external clients.
 - Compatibility tests for the external OpenClaw bridge against versioned daemon responses.
 - First-run recovery hints for missing Codex or Claude Code CLIs.
+- Real CLI smoke coverage for daemon restart, attach replay, kill, archive, summon, and sacrifice flows.
 - Published npm wrapper packages:
   - `@opencoven/cli`
   - `@opencoven/cli-macos`
@@ -63,7 +64,6 @@ Now:
 
 Next:
 
-- Add stronger real-world smoke tests for daemon restart, attach, kill, archive, summon, and sacrifice flows.
 - Improve install verification across macOS and Linux package paths.
 - Turn the MVP checklist into linked GitHub issues/milestones.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,7 @@ coven
 coven tui
 coven doctor
 coven daemon start
+coven daemon restart
 coven run codex "fix tests"
 coven run claude "polish this UI"
 coven sessions


### PR DESCRIPTION
## Summary
- add real CLI smoke coverage for daemon restart before replaying persisted session output
- add `coven daemon restart` as the user-facing restart path
- update README/docs/roadmap to reflect restart and shipped smoke coverage

## Verification
- watched the smoke test fail first because `coven daemon restart` did not exist
- `cargo fmt --check`
- `cargo test --workspace --locked` — 111 unit + 1 smoke passed
- `cargo clippy --workspace --all-targets -- -D warnings`
- `npx --yes -p vitest@4.1.5 vitest run src/*.test.ts` — 84 passed
- `python3 scripts/check-secrets.py`
- `git diff --check`