### PR TITLE
feat: add Windows npm package wiring

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -53,6 +53,10 @@ jobs:
             rust-target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
             binary: coven
+          - npm-target: windows
+            rust-target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            binary: coven.exe
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -84,10 +88,17 @@ jobs:
           name: coven-linux-x64
           path: target/x86_64-unknown-linux-gnu/release
       - run: chmod +x target/x86_64-unknown-linux-gnu/release/coven
+      - uses: actions/download-artifact@v8
+        with:
+          name: coven-windows
+          path: target/${{ format('{0}-{1}-{2}-{3}', 'x86_64', 'pc', 'windows', 'msvc') }}/release
       - run: node scripts/publish-npm.mjs --target=macos --skip-build --dry-run
         env:
           COVEN_NPM_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper
+        env:
+          COVEN_NPM_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
+      - run: node scripts/publish-npm.mjs --target=windows --skip-build --dry-run --skip-wrapper
         env:
           COVEN_NPM_VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
 
@@ -113,6 +124,10 @@ jobs:
           name: coven-linux-x64
           path: target/x86_64-unknown-linux-gnu/release
       - run: chmod +x target/x86_64-unknown-linux-gnu/release/coven
+      - uses: actions/download-artifact@v8
+        with:
+          name: coven-windows
+          path: target/${{ format('{0}-{1}-{2}-{3}', 'x86_64', 'pc', 'windows', 'msvc') }}/release
       - name: Validate manual publish version
         run: |
           if [ -z "${{ inputs.version }}" ]; then
@@ -124,6 +139,10 @@ jobs:
             exit 1
           fi
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper
+        env:
+          COVEN_NPM_VERSION: ${{ inputs.version }}
+          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
+      - run: node scripts/publish-npm.mjs --target=windows --skip-build --publish --skip-wrapper
         env:
           COVEN_NPM_VERSION: ${{ inputs.version }}
           NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cargo build --workspace
 cargo run -p coven-cli -- doctor
 ```
 
-Current npm package latest: `0.0.10` for `@opencoven/cli`, `@opencoven/cli-macos`, and `@opencoven/cli-linux-x64`.
+Current npm package latest: `0.0.10` for `@opencoven/cli`, `@opencoven/cli-macos`, and `@opencoven/cli-linux-x64`. Windows x64 release wiring is staged for the next package release as `@opencoven/cli-windows`.
 
 ## Quick Start
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,5 +90,6 @@ The npm wrapper packages are live for early adopters:
 - `@opencoven/cli`
 - `@opencoven/cli-macos`
 - `@opencoven/cli-linux-x64`
+- `@opencoven/cli-windows` once the next Windows-enabled release is published
 
-The source package versions stay template-like in the repo; release workflow dispatch supplies the published version and builds platform packages. As of the current documentation pass, npm latest is `0.0.10` for all three packages.
+The source package versions stay template-like in the repo; release workflow dispatch supplies the published version and builds platform packages. As of the current documentation pass, npm latest is `0.0.10` for the wrapper plus macOS/Linux packages; Windows x64 release wiring is staged for the next package release.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,7 @@ Shipped:
 - Compatibility tests for the external OpenClaw bridge against versioned daemon responses.
 - First-run recovery hints for missing Codex or Claude Code CLIs.
 - Real CLI smoke coverage for daemon restart, attach replay, kill, archive, summon, and sacrifice flows.
+- Install verification and release wiring for macOS, Linux x64, and Windows x64 npm package paths.
 - Published npm wrapper packages:
   - `@opencoven/cli`
   - `@opencoven/cli-macos`
@@ -64,7 +65,6 @@ Now:
 
 Next:
 
-- Improve install verification across macOS and Linux package paths.
 - Turn the MVP checklist into linked GitHub issues/milestones.
 
 Later:

--- a/npm/coven-platform-template/README.md
+++ b/npm/coven-platform-template/README.md
@@ -2,4 +2,4 @@
 
 This package contains one platform-specific Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select this optional dependency on supported systems.
 
-Linux x64 builds target glibc-based distributions. Alpine Linux is not supported.
+Linux x64 builds target glibc-based distributions. Alpine Linux is not supported. Windows builds target x64 Windows.

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -20,5 +20,6 @@ Current early-adopter packages target:
 
 - `@opencoven/cli-macos` for macOS Apple Silicon
 - `@opencoven/cli-linux-x64` for glibc-based Linux x64 distributions
+- `@opencoven/cli-windows` for Windows x64, starting with the next release that includes Windows artifacts
 
 Alpine Linux is not supported.

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -6,7 +6,8 @@ const require = createRequire(import.meta.url);
 
 const PLATFORM_PACKAGES = {
   'darwin-arm64': '@opencoven/cli-macos',
-  'linux-x64': '@opencoven/cli-linux-x64'
+  'linux-x64': '@opencoven/cli-linux-x64',
+  'win32-x64': '@opencoven/cli-windows'
 };
 
 const binaryName = process.platform === 'win32' ? 'coven.exe' : 'coven';
@@ -20,7 +21,7 @@ function wrapperVersion() {
 function resolveBinary() {
   if (!packageName) {
     throw new Error(
-      `Unsupported platform ${platformKey}. Coven v0 publishes native npm packages for macOS Apple Silicon and glibc-based Linux x64.`
+      `Unsupported platform ${platformKey}. Coven v0 publishes native npm packages for macOS Apple Silicon, glibc-based Linux x64, and Windows x64.`
     );
   }
 
@@ -28,7 +29,7 @@ function resolveBinary() {
     return require.resolve(`${packageName}/bin/${binaryName}`);
   } catch (error) {
     throw new Error(
-      `Could not find native Coven package ${packageName}. Reinstall @opencoven/cli so npm can install the optional dependency for ${platformKey}. Linux x64 support requires a glibc-based distribution; Alpine is not supported. Original error: ${error.message}`
+      `Could not find native Coven package ${packageName}. Reinstall @opencoven/cli so npm can install the optional dependency for ${platformKey}. Linux x64 support requires a glibc-based distribution; Alpine is not supported. Windows support requires x64 Windows. Original error: ${error.message}`
     );
   }
 }

--- a/npm/coven/package.json
+++ b/npm/coven/package.json
@@ -18,7 +18,8 @@
   },
   "optionalDependencies": {
     "@opencoven/cli-macos": "0.0.0",
-    "@opencoven/cli-linux-x64": "0.0.0"
+    "@opencoven/cli-linux-x64": "0.0.0",
+    "@opencoven/cli-windows": "0.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,4 +41,4 @@ Session rituals use Coven language while staying safe: archive hides old work wi
 
 ## Status
 
-This wrapper is live for early adopters. The current published npm latest is `0.0.10` for `@opencoven/cli`, `@opencoven/cli-macos`, and `@opencoven/cli-linux-x64`. Coven itself is still an early local-first MVP, so command/API compatibility should be tracked in the repo docs and release notes.
+This wrapper is live for early adopters. The current published npm latest is `0.0.10` for `@opencoven/cli`, `@opencoven/cli-macos`, and `@opencoven/cli-linux-x64`; Windows x64 release wiring is staged as `@opencoven/cli-windows` for the next package release. Coven itself is still an early local-first MVP, so command/API compatibility should be tracked in the repo docs and release notes.

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion } from './publish-npm.mjs';
+import { defaultTargetName, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion } from './publish-npm.mjs';
 
 test('releaseVersion prefers explicit COVEN_NPM_VERSION and strips a leading v', () => {
   assert.equal(
@@ -39,10 +39,24 @@ test('linux x64 target publishes under linux native package name', () => {
   assert.equal(targetPackageName('linux-x64'), '@opencoven/cli-linux-x64');
 });
 
+test('windows target publishes under windows native package name', () => {
+  assert.equal(targetPackageName('windows'), '@opencoven/cli-windows');
+});
+
+test('defaultTargetName maps win32 x64 to windows', () => {
+  assert.equal(defaultTargetName('win32', 'x64'), 'windows');
+});
+
 test('wrapper declares linux x64 native package as an optional dependency', () => {
   const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
   const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
   assert.equal(packageJson.optionalDependencies['@opencoven/cli-linux-x64'], '0.0.0');
+});
+
+test('wrapper declares windows native package as an optional dependency', () => {
+  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  assert.equal(packageJson.optionalDependencies['@opencoven/cli-windows'], '0.0.0');
 });
 
 test('wrapper binary maps linux x64 to linux native package and documents glibc requirement', () => {
@@ -50,6 +64,13 @@ test('wrapper binary maps linux x64 to linux native package and documents glibc 
   const bin = readFileSync(binPath, 'utf8');
   assert.match(bin, /'linux-x64': '@opencoven\/cli-linux-x64'/);
   assert.match(bin, /glibc-based Linux x64/);
+});
+
+test('wrapper binary maps windows x64 to windows native package and exe binary', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const bin = readFileSync(binPath, 'utf8');
+  assert.match(bin, /'win32-x64': '@opencoven\/cli-windows'/);
+  assert.match(bin, /process\.platform === 'win32' \? 'coven\.exe' : 'coven'/);
 });
 
 test('release workflow builds and dry-runs linux x64 package', () => {
@@ -62,6 +83,20 @@ test('release workflow builds and dry-runs linux x64 package', () => {
   assert.match(workflow, /rust-target: x86_64-unknown-linux-gnu/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=linux-x64 --skip-build --publish --skip-wrapper/);
+});
+
+test('release workflow builds and dry-runs windows package', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /npm-target: windows/);
+  assert.match(workflow, /rust-target: x86_64-pc-windows-msvc/);
+  assert.match(workflow, /runner: windows-latest/);
+  assert.match(workflow, /binary: coven\.exe/);
+  assert.match(workflow, /node scripts\/publish-npm\.mjs --target=windows --skip-build --dry-run --skip-wrapper/);
+  assert.match(workflow, /node scripts\/publish-npm\.mjs --target=windows --skip-build --publish --skip-wrapper/);
 });
 
 test('publishEnv preserves setup-node NODE_AUTH_TOKEN when NPM_TOKEN is absent', () => {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -22,6 +22,13 @@ const targets = {
     cpu: 'x64',
     rustTarget: 'x86_64-unknown-linux-gnu',
     binaryName: 'coven'
+  },
+  windows: {
+    packageName: '@opencoven/cli-windows',
+    os: 'win32',
+    cpu: 'x64',
+    rustTarget: 'x86_64-pc-windows-msvc',
+    binaryName: 'coven.exe'
   }
 };
 
@@ -137,6 +144,9 @@ export function defaultTargetName(platform, arch) {
   if (platform === 'darwin' && arch === 'arm64') {
     return 'macos';
   }
+  if (platform === 'win32' && arch === 'x64') {
+    return 'windows';
+  }
   return `${platform}-${arch}`;
 }
 
@@ -151,6 +161,10 @@ if ('NODE_TEST_CONTEXT' in process.env) {
   test('defaultTargetName falls back to platform-arch for non-special cases', () => {
     assert.strictEqual(defaultTargetName('linux', 'x64'), 'linux-x64');
     assert.strictEqual(defaultTargetName('darwin', 'x64'), 'darwin-x64');
+  });
+
+  test('defaultTargetName maps win32 x64 to windows', () => {
+    assert.strictEqual(defaultTargetName('win32', 'x64'), 'windows');
   });
 }
 


### PR DESCRIPTION
## Summary
- add `@opencoven/cli-windows` as the Windows x64 optional native package
- map `win32-x64` to the Windows package and `coven.exe` in the wrapper
- extend npm release workflow dry-run/manual publish wiring to build and package Windows artifacts
- update install docs/roadmap for macOS, Linux x64, and Windows x64 package paths

## Verification
- `cargo fmt --check`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `node --test scripts/publish-npm-test.mjs`
- local publish dry-runs for macOS, Linux x64, and Windows x64 with fake binaries
- `npx --yes -p vitest@4.1.5 vitest run src/*.test.ts` in `packages/openclaw-coven`
- `python3 scripts/check-secrets.py`
- `git diff --check`