### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -143,8 +143,8 @@ def main() -> int:
         print("Secret guard found possible sensitive values. Values are intentionally redacted.", file=sys.stderr)
         for path, line, rule in current:
             print(f"current:{path}:{line}:{rule}", file=sys.stderr)
-        for sha, path, line, rule in history:
-            print(f"history:{sha}:{path}:{line}:{rule}", file=sys.stderr)
+        if history:
+            print(f"history findings: {len(history)} entries (details redacted)", file=sys.stderr)
         return 1
     print("Secret guard passed: no current-tree or history findings.")
     return 0


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/1](https://github.com/OpenCoven/coven/security/code-scanning/1)

To fix this cleanly without changing core behavior, keep detection logic unchanged but reduce logging detail for history findings in `main()`:

- Continue printing per-file details for `current` findings (already low risk and useful in CI).
- Replace per-item `history` logging (`history:{sha}:{path}:{line}:{rule}`) with a single aggregate/redacted summary count.
- Keep exit codes and scanning behavior exactly the same.

**File/region to change:** `scripts/check-secrets.py`, in `main()` around lines 146–147.

No new imports, dependencies, or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
