### PR TITLE
Potential fix for code scanning alert no. 2: Cleartext logging of sensitive information

### DIFF
--- a/crates/coven-cli/src/patch.rs
+++ b/crates/coven-cli/src/patch.rs
@@ -198,12 +198,11 @@ pub fn summarize_patch_plan(request: &PatchOpenClawRequest) -> String {
 pub fn summarize_patch_report(report: &PatchOpenClawReport) -> String {
     format!(
         "Coven patch status: {status}\n\
-        Session: {session_id}\n\
+        Session: [redacted]\n\
         Changed files:{changed_files}\
         Verification:{verification}\
         Nothing was committed or pushed.",
         status = report.status,
-        session_id = report.session_id,
         changed_files = format_report_list(&report.changed_files, "none"),
         verification = format_report_list(&report.verification, "not run")
     )


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/2](https://github.com/OpenCoven/coven/security/code-scanning/2)

To fix this without changing core behavior, keep generating and using `session_id` internally, but stop including the raw value in the human-readable report string. The best single change is in `crates/coven-cli/src/patch.rs` inside `summarize_patch_report`: replace the `Session: {session_id}` line with a non-sensitive message (for example, `Session: [redacted]`). This preserves report structure and avoids leaking the identifier via `println!` in `main.rs`.

No new imports, dependencies, or API changes are required. We only modify formatting in the existing function so callers remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
