### PR TITLE
Potential fix for code scanning alert no. 4: Cleartext logging of sensitive information

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1463,7 +1463,9 @@ fn archive_session_command(session_id: &str) -> Result<()> {
 
     store::archive_session(&conn, session_id, &current_timestamp())?;
     println!("archived session");
-    println!("Summon it later with `coven summon <session-id>` or view it with `coven sessions --all`.");
+    println!(
+        "Summon it later with `coven summon SESSION_ID` (replace SESSION_ID with one from `coven sessions --all`)."
+    );
     Ok(())
 }
 
@@ -1517,8 +1519,8 @@ fn attach_session(session_id: &str) -> Result<()> {
     };
 
     eprintln!(
-        "attached to session {} status={} harness={} title={} ",
-        session.id, session.status, session.harness, session.title
+        "attached to session status={} harness={} title={} ",
+        session.status, session.harness, session.title
     );
 
     maybe_spawn_input_forwarder(home.clone(), session_id.to_string());

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1462,10 +1462,8 @@ fn archive_session_command(session_id: &str) -> Result<()> {
     }
 
     store::archive_session(&conn, session_id, &current_timestamp())?;
-    println!("archived session {session_id}");
-    println!(
-        "Summon it later with `coven summon {session_id}` or view it with `coven sessions --all`."
-    );
+    println!("archived session");
+    println!("Summon it later with `coven summon <session-id>` or view it with `coven sessions --all`.");
     Ok(())
 }
 
@@ -1478,7 +1476,7 @@ fn summon_session_command(session_id: &str) -> Result<()> {
 
     if session.archived_at.is_some() {
         store::summon_session(&conn, session_id, &current_timestamp())?;
-        eprintln!("summoned session {session_id} from the archive");
+        eprintln!("summoned session from the archive");
     }
 
     attach_session(session_id)


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/4](https://github.com/OpenCoven/coven/security/code-scanning/4)

General fix: do not print untrusted/sensitive identifiers verbatim in logs or terminal status messages. Prefer generic messages, or sanitize/redact identifiers before output.

Best minimal fix without changing behavior materially: update the affected user messages in `crates/coven-cli/src/main.rs` to remove direct interpolation of `session_id` in the archive/summon messages. Keep actionable guidance, but without echoing the ID. This avoids cleartext disclosure while preserving command flow and functionality.

Edits needed in `crates/coven-cli/src/main.rs`:
- In `archive_session_command`, replace:
  - `println!("archived session {session_id}");`
  - and the follow-up line containing ``coven summon {session_id}``
  with generic text that does not include the ID.
- In `summon_session_command`, replace:
  - `eprintln!("summoned session {session_id} from the archive");`
  with generic text.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
