### PR TITLE
Potential fix for code scanning alert no. 5: Cleartext logging of sensitive information

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1478,7 +1478,7 @@ fn summon_session_command(session_id: &str) -> Result<()> {
 
     if session.archived_at.is_some() {
         store::summon_session(&conn, session_id, &current_timestamp())?;
-        eprintln!("summoned session {session_id} from the archive");
+        eprintln!("summoned session from the archive");
     }
 
     attach_session(session_id)


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/5](https://github.com/OpenCoven/coven/security/code-scanning/5)

To fix this without changing functional behavior, stop printing the raw `session_id` in the flagged stderr message. Keep the action notification, but remove sensitive/untrusted interpolation. This preserves command behavior (session is still summoned and attached) while eliminating cleartext exposure in stderr/log capture.

Best single change in `crates/coven-cli/src/main.rs`:
- In `summon_session_command`, replace the `eprintln!` at line 1481:
  - from: `eprintln!("summoned session {session_id} from the archive");`
  - to: `eprintln!("summoned session from the archive");`

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
