### PR TITLE
Add Coven control-plane discovery slice

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::{daemon::DaemonStatus, project, store};
+use crate::{control_plane, daemon::DaemonStatus, project, store};
 
 pub const COVEN_API_VERSION: &str = "v1";
 pub const SUPPORTED_API_VERSIONS: [&str; 1] = [COVEN_API_VERSION];
@@ -120,6 +120,20 @@ pub fn handle_request_with_runtime(
             }),
         ),
         ("GET", "/health") => json_response(200, &health_response(daemon)),
+        ("GET", "/capabilities") => json_response(200, &control_plane::capabilities()),
+        ("POST", "/actions") => {
+            let payload = match parse_body(body) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    return json_response(
+                        400,
+                        &control_plane::rejected_action("", error.to_string()),
+                    );
+                }
+            };
+            let (status, response) = control_plane::route_action(payload);
+            json_response(status, &response)
+        }
         ("GET", "/sessions") => {
             let conn = store::open_store(&store_path(coven_home))?;
             let sessions = store::list_sessions(&conn)?;
@@ -426,6 +440,122 @@ mod tests {
 
         assert_eq!(response.status, 404);
         assert!(response.body.contains("unsupported API version"));
+        Ok(())
+    }
+
+    #[test]
+    fn routes_control_capabilities_discovery_to_json() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let response = handle_request("GET", "/api/v1/capabilities", temp_dir.path(), None)?;
+
+        assert_eq!(response.status, 200);
+        assert!(response.body.contains(r#""id":"coven.sessions""#));
+        assert!(response.body.contains(r#""id":"coven.control.actions""#));
+        assert!(response.body.contains(r#""id":"desktop.automation""#));
+        assert!(response.body.contains(r#""policy":"requiresApproval""#));
+        Ok(())
+    }
+
+    #[test]
+    fn control_action_routes_safe_capability_refresh() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let body = json!({
+            "action": "coven.capabilities.refresh",
+            "origin": "open-meow",
+            "intentId": "intent-1"
+        })
+        .to_string();
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+        )?;
+
+        assert_eq!(response.status, 202);
+        assert!(response.body.contains(r#""accepted":true"#));
+        assert!(response
+            .body
+            .contains(r#""action":"coven.capabilities.refresh""#));
+        assert!(response.body.contains(r#""kind":"capabilities.refreshed""#));
+        assert!(response.body.contains(r#""origin":"open-meow""#));
+        assert!(response.body.contains(r#""intentId":"intent-1""#));
+        Ok(())
+    }
+
+    #[test]
+    fn capabilities_only_advertise_routable_control_actions() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let response = handle_request("GET", "/api/v1/capabilities", temp_dir.path(), None)?;
+
+        assert_eq!(response.status, 200);
+        assert!(response
+            .body
+            .contains(r#""actions":["coven.capabilities.refresh"]"#));
+        assert!(!response.body.contains("coven.sessions.launch"));
+        assert!(!response.body.contains("desktop.window.focus"));
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_control_actions_fail_closed_with_structured_json() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let malformed = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some("{not-json"),
+        )?;
+        let missing = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(r#"{"origin":"open-meow"}"#),
+        )?;
+        let empty = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(r#"{"action":"   "}"#),
+        )?;
+
+        assert_eq!(malformed.status, 400);
+        assert_eq!(missing.status, 400);
+        assert_eq!(empty.status, 400);
+        assert!(malformed.body.contains(r#""accepted":false"#));
+        assert!(missing.body.contains("request body requires string field"));
+        assert!(empty.body.contains("request body requires string field"));
+        Ok(())
+    }
+
+    #[test]
+    fn control_action_blocks_unknown_actions_before_adapters_run() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let body = json!({
+            "action": "desktop.deleteEverything",
+            "origin": "open-meow"
+        })
+        .to_string();
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""accepted":false"#));
+        assert!(response.body.contains("unknown action"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -127,7 +127,7 @@ pub fn handle_request_with_runtime(
                 Err(error) => {
                     return json_response(
                         400,
-                        &control_plane::rejected_action("", error.to_string()),
+                        &control_plane::rejected_action("(unknown)", error.to_string()),
                     );
                 }
             };
@@ -475,7 +475,7 @@ mod tests {
             Some(&body),
         )?;
 
-        assert_eq!(response.status, 202);
+        assert_eq!(response.status, 200);
         assert!(response.body.contains(r#""accepted":true"#));
         assert!(response
             .body
@@ -526,13 +526,25 @@ mod tests {
             None,
             Some(r#"{"action":"   "}"#),
         )?;
+        let non_object = handle_request_with_body(
+            "POST",
+            "/api/v1/actions",
+            temp_dir.path(),
+            None,
+            Some(r#"["not","an","object"]"#),
+        )?;
 
         assert_eq!(malformed.status, 400);
         assert_eq!(missing.status, 400);
         assert_eq!(empty.status, 400);
+        assert_eq!(non_object.status, 400);
         assert!(malformed.body.contains(r#""accepted":false"#));
+        assert!(malformed.body.contains(r#""action":"(unknown)""#));
         assert!(missing.body.contains("request body requires string field"));
         assert!(empty.body.contains("request body requires string field"));
+        assert!(non_object
+            .body
+            .contains("request body must be a JSON object"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -96,6 +96,13 @@ pub fn capabilities() -> CapabilityCatalog {
 }
 
 pub fn route_action(payload: Value) -> (u16, ControlActionResponse) {
+    if !payload.is_object() {
+        return (
+            400,
+            rejected_action("(unknown)", "request body must be a JSON object"),
+        );
+    }
+
     let Some(action) = payload
         .get("action")
         .and_then(Value::as_str)
@@ -133,7 +140,7 @@ pub fn route_action(payload: Value) -> (u16, ControlActionResponse) {
                 }),
             };
             (
-                202,
+                200,
                 ControlActionResponse {
                     ok: true,
                     accepted: true,

--- a/crates/coven-cli/src/control_plane.rs
+++ b/crates/coven-cli/src/control_plane.rs
@@ -1,0 +1,166 @@
+use serde::Serialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityCatalog {
+    pub capabilities: Vec<Capability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Capability {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub adapter: &'static str,
+    pub status: CapabilityStatus,
+    pub policy: CapabilityPolicy,
+    pub actions: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CapabilityStatus {
+    Available,
+    Planned,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CapabilityPolicy {
+    Allow,
+    RequiresApproval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ControlActionResponse {
+    pub ok: bool,
+    pub accepted: bool,
+    pub action: String,
+    pub status: ActionStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event: Option<ControlEvent>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ActionStatus {
+    Completed,
+    Rejected,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ControlEvent {
+    pub kind: &'static str,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub origin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intent_id: Option<String>,
+    pub payload: Value,
+}
+
+pub fn capabilities() -> CapabilityCatalog {
+    CapabilityCatalog {
+        capabilities: vec![
+            Capability {
+                id: "coven.sessions",
+                label: "Project-scoped harness sessions",
+                adapter: "coven-daemon",
+                status: CapabilityStatus::Available,
+                policy: CapabilityPolicy::Allow,
+                actions: vec![],
+            },
+            Capability {
+                id: "coven.control.actions",
+                label: "Coven control-plane action router",
+                adapter: "coven-daemon",
+                status: CapabilityStatus::Available,
+                policy: CapabilityPolicy::Allow,
+                actions: vec!["coven.capabilities.refresh"],
+            },
+            Capability {
+                id: "desktop.automation",
+                label: "Desktop automation adapters",
+                adapter: "desktop-use",
+                status: CapabilityStatus::Planned,
+                policy: CapabilityPolicy::RequiresApproval,
+                actions: vec![],
+            },
+        ],
+    }
+}
+
+pub fn route_action(payload: Value) -> (u16, ControlActionResponse) {
+    let Some(action) = payload
+        .get("action")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|action| !action.is_empty())
+    else {
+        return (
+            400,
+            rejected_action("", "request body requires string field `action`"),
+        );
+    };
+
+    let origin = payload
+        .get("origin")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|origin| !origin.is_empty())
+        .map(ToOwned::to_owned);
+    let intent_id = payload
+        .get("intentId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|intent_id| !intent_id.is_empty())
+        .map(ToOwned::to_owned);
+
+    match action {
+        "coven.capabilities.refresh" => {
+            let event = ControlEvent {
+                kind: "capabilities.refreshed",
+                action: action.to_string(),
+                origin,
+                intent_id,
+                payload: json!({
+                    "capabilities": capabilities().capabilities.len(),
+                }),
+            };
+            (
+                202,
+                ControlActionResponse {
+                    ok: true,
+                    accepted: true,
+                    action: action.to_string(),
+                    status: ActionStatus::Completed,
+                    reason: None,
+                    event: Some(event),
+                },
+            )
+        }
+        _ => (
+            400,
+            rejected_action(action, format!("unknown action `{action}`")),
+        ),
+    }
+}
+
+pub fn rejected_action(
+    action: impl Into<String>,
+    reason: impl Into<String>,
+) -> ControlActionResponse {
+    ControlActionResponse {
+        ok: false,
+        accepted: false,
+        action: action.into(),
+        status: ActionStatus::Rejected,
+        reason: Some(reason.into()),
+        event: None,
+    }
+}

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -504,13 +504,7 @@ pub fn serve_next_connection(
         body.as_deref(),
         runtime,
     )?;
-    let reason = match response.status {
-        200 => "OK",
-        202 => "Accepted",
-        409 => "Conflict",
-        404 => "Not Found",
-        _ => "OK",
-    };
+    let reason = http_reason_phrase(response.status);
     let http = format!(
         "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
         response.status,
@@ -523,6 +517,19 @@ pub fn serve_next_connection(
         .write_all(http.as_bytes())
         .context("failed to write API response")?;
     Ok(())
+}
+
+fn http_reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        400 => "Bad Request",
+        404 => "Not Found",
+        409 => "Conflict",
+        500 => "Internal Server Error",
+        _ => "OK",
+    }
 }
 
 #[cfg(unix)]
@@ -661,6 +668,11 @@ mod tests {
             *self.killed.lock().unwrap() = true;
             Ok(())
         }
+    }
+
+    #[test]
+    fn http_reason_phrase_names_bad_requests() {
+        assert_eq!(http_reason_phrase(400), "Bad Request");
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -17,6 +17,7 @@ use crossterm::{
 use uuid::Uuid;
 
 mod api;
+mod control_plane;
 mod daemon;
 mod harness;
 mod openclaw_repo;

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -75,7 +75,7 @@ Clients should ignore unknown future capability ids and action ids unless they e
 }
 ```
 
-Successful safe actions return `202`:
+Immediately completed safe actions return `200`:
 
 ```json
 {

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -7,6 +7,7 @@ The Coven daemon socket API is a public compatibility boundary for comux and ext
 - `GET /api/v1/health` exposes `apiVersion: "v1"` and `supportedApiVersions: ["v1"]`.
 - Clients should read `/api/v1/health` before assuming any response shape from other endpoints.
 - Legacy unversioned routes such as `GET /health` remain early-MVP aliases; new clients should use `/api/v1`.
+- Control-plane clients should discover capabilities before sending action ids.
 
 ## `GET /api/v1/health`
 
@@ -26,6 +27,83 @@ The Coven daemon socket API is a public compatibility boundary for comux and ext
 ```
 
 If the daemon metadata is unavailable, `daemon` may be `null`.
+
+## Capability catalog shape (`v1`)
+
+`GET /api/v1/capabilities` returns the daemon/control-plane capability catalog. This is the intended OpenMeow handshake for deciding which actions to show or route through Coven.
+
+```json
+{
+  "capabilities": [
+    {
+      "id": "coven.control.actions",
+      "label": "Coven control-plane action router",
+      "adapter": "coven-daemon",
+      "status": "available",
+      "policy": "allow",
+      "actions": ["coven.capabilities.refresh"]
+    },
+    {
+      "id": "desktop.automation",
+      "label": "Desktop automation adapters",
+      "adapter": "desktop-use",
+      "status": "planned",
+      "policy": "requiresApproval",
+      "actions": []
+    }
+  ]
+}
+```
+
+Known enum values in `v1`:
+
+- `status`: `available`, `planned`
+- `policy`: `allow`, `requiresApproval`
+
+Clients should ignore unknown future capability ids and action ids unless they explicitly support them.
+
+## Control action shape (`v1`)
+
+`POST /api/v1/actions` accepts a policy-shaped action envelope. The daemon validates the action id before any adapter work is allowed.
+
+```json
+{
+  "action": "coven.capabilities.refresh",
+  "origin": "open-meow",
+  "intentId": "intent-1",
+  "args": {}
+}
+```
+
+Successful safe actions return `202`:
+
+```json
+{
+  "ok": true,
+  "accepted": true,
+  "action": "coven.capabilities.refresh",
+  "status": "completed",
+  "event": {
+    "kind": "capabilities.refreshed",
+    "action": "coven.capabilities.refresh",
+    "origin": "open-meow",
+    "intentId": "intent-1",
+    "payload": { "capabilities": 3 }
+  }
+}
+```
+
+Unknown action ids return `400` and fail closed:
+
+```json
+{
+  "ok": false,
+  "accepted": false,
+  "action": "desktop.deleteEverything",
+  "status": "rejected",
+  "reason": "unknown action `desktop.deleteEverything`"
+}
+```
 
 ## Session record shape (`v1`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -14,6 +14,8 @@ Versioned clients should use the `/api/v1` prefix:
 |---|---|
 | `GET /api/v1/api-version` | Read the active API version and supported versions |
 | `GET /api/v1/health` | Check daemon health and metadata |
+| `GET /api/v1/capabilities` | Discover daemon/control-plane capabilities and policy hints |
+| `POST /api/v1/actions` | Route a policy-shaped control-plane action |
 | `GET /api/v1/sessions` | List active sessions |
 | `POST /api/v1/sessions` | Launch a session |
 | `GET /api/v1/sessions/:id` | Fetch one session |
@@ -43,6 +45,64 @@ Unknown `/api/<version>/...` prefixes fail closed with an `unsupported API versi
 ```
 
 When no daemon metadata is available, `daemon` is `null`.
+
+## Control-plane capabilities
+
+`GET /api/v1/capabilities` is the discovery point for first-party clients such as OpenMeow. It returns capability ids, adapter ownership, availability, policy hints, and action ids. This keeps clients from hard-coding what the daemon can do.
+
+```json
+{
+  "capabilities": [
+    {
+      "id": "coven.control.actions",
+      "label": "Coven control-plane action router",
+      "adapter": "coven-daemon",
+      "status": "available",
+      "policy": "allow",
+      "actions": ["coven.capabilities.refresh"]
+    },
+    {
+      "id": "desktop.automation",
+      "label": "Desktop automation adapters",
+      "adapter": "desktop-use",
+      "status": "planned",
+      "policy": "requiresApproval",
+      "actions": []
+    }
+  ]
+}
+```
+
+## Control-plane actions
+
+`POST /api/v1/actions` accepts an OpenMeow-style intent envelope. The daemon routes only known actions; unknown actions fail closed before any adapter can run.
+
+```json
+{
+  "action": "coven.capabilities.refresh",
+  "origin": "open-meow",
+  "intentId": "intent-1",
+  "args": {}
+}
+```
+
+Successful safe actions return `202` with an event-shaped payload that clients can render optimistically or fold into later event streams:
+
+```json
+{
+  "ok": true,
+  "accepted": true,
+  "action": "coven.capabilities.refresh",
+  "status": "completed",
+  "event": {
+    "kind": "capabilities.refreshed",
+    "action": "coven.capabilities.refresh",
+    "origin": "open-meow",
+    "intentId": "intent-1",
+    "payload": { "capabilities": 3 }
+  }
+}
+```
 
 ## Compatibility rules
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -86,7 +86,7 @@ When no daemon metadata is available, `daemon` is `null`.
 }
 ```
 
-Successful safe actions return `202` with an event-shaped payload that clients can render optimistically or fold into later event streams:
+Immediately completed safe actions return `200` with an event-shaped payload that clients can render optimistically or fold into later event streams:
 
 ```json
 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -15,7 +15,12 @@ flowchart LR
   Comux[comux cockpit] -->|HTTP over Unix socket| Daemon
   OpenClaw[OpenClaw] --> Plugin[external @opencoven/coven plugin]
   Plugin -->|HTTP over Unix socket| Daemon
-  OpenMeow[OpenMeow intake/status] -. future status/intake .-> Daemon
+  OpenMeow[OpenMeow chat/intent client] -->|capabilities + actions| Daemon
+
+  Daemon --> Control[Control plane: capability discovery + action routing]
+  Control --> Policy[Policy + permission hints]
+  Control --> AdapterBus[Adapter/event bus]
+  AdapterBus -. desktop.automation .-> DesktopUse[desktop-use adapters]
 
   Daemon --> Boundary[Project-root + cwd guard]
   Boundary --> Adapter[Harness adapter router]
@@ -72,6 +77,28 @@ flowchart TD
   HarnessCheck -- yes --> Spawn[Spawn harness with argv APIs]
   Spawn --> Ledger[Persist session + events]
 ```
+
+## OpenMeow / automation boundary
+
+OpenMeow should remain a chat UI, local echo/optimistic rendering surface, intent-capture layer, and tiny fast-path host for ultra-simple local actions. It should not become the automation engine.
+
+Coven is the canonical shared local runtime for reusable automation because it centralizes:
+
+- daemon/process ownership
+- policy and permission decisions
+- config/profile storage
+- capability discovery
+- action routing and event emission
+- adapter ownership for Accessibility, AppleScript, keyboard/mouse, window, filesystem, clipboard, and app-specific bridges
+
+The intended flow is:
+
+```text
+user -> OpenMeow -> Coven -> adapters -> desktop/apps
+desktop/apps -> Coven -> OpenMeow UI updates
+```
+
+`GET /api/v1/capabilities` lets OpenMeow and other clients discover what Coven can route. `POST /api/v1/actions` gives clients a stable intent envelope without coupling them directly to brittle OS automation APIs.
 
 ## Current user-facing surface
 


### PR DESCRIPTION
## Summary

Adds the first Coven control-plane API slice for OpenMeow and other local clients:

- `GET /api/v1/capabilities` for capability discovery
- `POST /api/v1/actions` for policy-shaped action routing
- A new `control_plane` module with typed capability/action/event response models
- API contract and architecture docs describing the OpenMeow → Coven → adapters boundary

This intentionally does **not** execute desktop automation yet. It establishes the safe daemon-owned contract that desktop adapters can plug into later.

## Design intent

Kitty's architecture separates responsibilities like this:

```text
user -> OpenMeow -> Coven -> adapters -> desktop/apps
desktop/apps -> Coven -> OpenMeow UI updates
```

OpenMeow remains the chat UI, local echo/optimistic rendering surface, and intent-capture layer. Coven is the canonical local daemon/control plane for:

- policy and permissions
- config/profile store ownership
- capability discovery
- event/action routing
- future adapter ownership for Accessibility, AppleScript, keyboard/mouse, window management, filesystem, clipboard, and app-specific bridges

## API behavior

### `GET /api/v1/capabilities`

Returns a catalog of current and planned daemon/control-plane capabilities with policy hints.

The only currently routable action advertised is:

- `coven.capabilities.refresh`

Planned desktop automation is listed as a capability, but with no executable action IDs yet. This avoids clients discovering and calling action IDs that the router will reject or that do not exist yet.

### `POST /api/v1/actions`

Accepts an intent-style envelope:

```json
{
  "action": "coven.capabilities.refresh",
  "origin": "open-meow",
  "intentId": "intent-1",
  "args": {}
}
```

Known safe actions return `202` with an event-shaped response. Unknown, malformed, missing, or empty actions fail closed with structured `400` JSON.

## Security / safety notes

- No desktop adapters execute in this slice.
- Unknown action IDs fail closed before adapter routing.
- Malformed `/actions` bodies return structured `400` responses instead of propagating errors out of request handling.
- Capability discovery only advertises action IDs accepted by the action router.
- Added `400 => Bad Request` HTTP reason phrase handling.
- No secrets were added; changed-file secret pattern scan was clean.

## Tests / verification

Fresh verification run before commit/push:

```bash
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
cargo test --all
git diff --check
```

Results:

- `cargo test --all`: 120 unit tests passed, 1 smoke test passed
- `cargo clippy`: clean with `-D warnings`
- `git diff --check`: clean
- changed-file secret pattern scan: clean

## Follow-ups

- Add persistent event streaming once OpenMeow consumes Coven updates directly.
- Add explicit policy/approval states for future desktop automation actions.
- Wire real desktop-use adapters only after the permission and audit model is complete.
