### PR TITLE
Potential fix for code scanning alert no. 6: Cleartext logging of sensitive information

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1497,7 +1497,7 @@ fn sacrifice_session_command(session_id: &str, yes: bool) -> Result<()> {
     }
 
     store::sacrifice_session(&conn, session_id)?;
-    println!("sacrificed session {session_id}; its event log was permanently deleted");
+    println!("sacrificed session; its event log was permanently deleted");
     Ok(())
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/6](https://github.com/OpenCoven/coven/security/code-scanning/6)

General fix: avoid printing raw sensitive/untrusted identifiers in log/console output. Replace them with a redacted or non-reversible representation, while keeping the operational message.

Best single fix here (minimal functional impact): change the success message in `sacrifice_session_command` to omit the raw `session_id`. This keeps user feedback (“sacrificed session … permanently deleted”) but removes the sensitive value from stdout. No new imports, methods, or dependencies are required.

Change location:
- File: `crates/coven-cli/src/main.rs`
- Region: `sacrifice_session_command`, line 1500 in provided snippet
- Edit: replace interpolated `{session_id}` with a redacted constant phrase.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
