### PR TITLE
docs(contributing): add first checkout path for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,24 @@ Coven is built as a small, boring Rust authority layer with TypeScript integrati
 - Node.js 18+ and `pnpm` for package/plugin work
 - A supported harness CLI for manual smoke tests, usually Codex or Claude Code
 
+## Contributor First 10 Minutes
+
+Use this path for a fresh source checkout before opening a docs or code PR:
+
+```bash
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build --workspace
+cargo run -p coven-cli -- doctor
+cargo test -p coven-cli --test smoke -- --nocapture
+```
+
+A healthy first pass means the workspace builds, `doctor` prints the local store/project/harness status, and the smoke test passes. It is okay if `doctor` reports Codex or Claude Code as missing as long as it gives install/setup guidance; install and authenticate a real harness only before running manual `coven run ...` sessions.
+
+The smoke test is safe for first-time contributors because it uses an isolated temporary `COVEN_HOME` and injects a fake `codex` executable into `PATH`. It does not require private Codex or Claude credentials.
+
+After this first pass, use the fuller local loop below. For product context, start with the [README](README.md) and [Getting started](docs/GETTING-STARTED.md) guide.
+
 ## Local Development
 
 1. Build the workspace:


### PR DESCRIPTION
Add a short "Contributor First 10 Minutes" section to the Coven contributing guide.

This gives new contributors a concrete fresh-checkout path before opening a docs or code PR: clone the repo, build the workspace, run `doctor`, and run the contributor-safe smoke test. The wording stays grounded in commands verified locally and calls out that the smoke test uses an isolated temporary `COVEN_HOME` with a fake `codex` executable, so it does not require private Codex or Claude credentials.

This is scoped to the docs/onboarding help-wanted lane without changing roadmap state, adding new docs, or claiming Linux-specific verification.

Local verification:
- `git diff --check`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p coven-cli --test smoke -- --nocapture`
- `python scripts/check-secrets.py`