### PR TITLE
feat(coven-pc): add `coven pc` diagnostics and relief subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,13 +196,40 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
+ "dirs-next",
  "portable-pty",
  "rusqlite",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "uuid",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -254,6 +281,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +315,12 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -333,6 +387,17 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -395,7 +460,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -466,6 +531,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +605,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -639,12 +722,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -855,13 +969,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -937,7 +1066,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1074,6 +1203,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1140,6 +1288,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winreg"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,6 +11,20 @@
 
 A system where agents, tools, and workflows converge under intentional orchestration.
 
+OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity. It moves AI beyond disposable chat sessions and toward durable, personal, intelligible systems that people can own, customize, and collaborate with over time.
+
+The value should be instantly clear: OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to the user.
+
+### Vision
+Most AI today feels temporary: a user opens a chat, explains context, gets a response, and starts over. OpenCoven is built around a different future: AI that can stay.
+
+The next generation of AI should be durable, personal systems that remember what matters, understand their purpose, use tools, collaborate with other agents, and grow alongside the people and projects they serve.
+
+OpenCoven brings structure to the magic by combining memory, identity, orchestration, local execution, tool access, and multi-agent collaboration into an open framework people can inspect, customize, and own.
+
+### Philosophy
+A familiar is not a faceless bot. It has a name, purpose, memory, toolset, voice, role, and place in a larger workflow. It should feel personal without pretending to be human, powerful without becoming opaque, and extensible without collapsing into chaos.
+
 ### Brand Traits
 - **Arcane, but precise** — mystical without chaos
 - **Technical, not gimmicky** — substance over flair

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 </p>
 
 <p align="center">
+  OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to you.
+</p>
+
+<p align="center">
   <a href="https://github.com/OpenCoven/coven/issues"><strong>Issues</strong></a>
   ·
   <a href="https://discord.gg/opencoven"><strong>Discord</strong></a>
@@ -82,6 +86,8 @@ If OpenClaw breaks, Coven gives you a predictable repair room: choose a repo, ch
 ## What it does
 
 Coven is the local harness substrate for OpenCoven. It does not replace your coding agent, your UI, or OpenClaw. It gives them a shared room where project work can happen visibly and safely.
+
+OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity. Coven provides the local runtime layer for that vision: project-scoped sessions, harness-neutral execution, inspectable history, and explicit authority boundaries.
 
 - **Project-root boundaries** — every launch is tied to an explicit repository/project root.
 - **Harness-neutral runtime** — v0 focuses on Codex and Claude Code, with a clean adapter path for future harnesses.

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -20,6 +20,8 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+sysinfo = "0.30"
+dirs-next = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -23,6 +23,7 @@ mod daemon;
 mod harness;
 mod openclaw_repo;
 mod patch;
+mod pc;
 mod project;
 mod pty_runner;
 mod store;
@@ -96,6 +97,11 @@ enum Command {
         #[command(subcommand)]
         command: PatchCommand,
     },
+    #[command(about = "Diagnose and relieve macOS system pressure")]
+    Pc {
+        #[command(subcommand)]
+        command: Option<pc::PcCommand>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -149,6 +155,7 @@ fn main() -> Result<()> {
         Some(Command::Archive { session_id }) => archive_session_command(&session_id),
         Some(Command::Sacrifice { session_id, yes }) => sacrifice_session_command(&session_id, yes),
         Some(Command::Patch { command }) => run_patch_command(command),
+        Some(Command::Pc { command }) => pc::run_pc_command(command),
     }
 }
 

--- a/crates/coven-cli/src/pc/diagnostics.rs
+++ b/crates/coven-cli/src/pc/diagnostics.rs
@@ -1,0 +1,109 @@
+use anyhow::Result;
+use sysinfo::{Disks, Pid, System};
+
+#[derive(Debug)]
+pub struct SystemSnapshot {
+    pub cpu_usage_pct: f32,
+    pub memory_used_mb: u64,
+    pub memory_total_mb: u64,
+    pub swap_used_mb: u64,
+    pub swap_total_mb: u64,
+    pub uptime_secs: u64,
+    pub processes: Vec<ProcessInfo>,
+    pub disks: Vec<DiskInfo>,
+}
+
+#[derive(Debug)]
+pub struct ProcessInfo {
+    pub pid: u32,
+    pub name: String,
+    pub cpu_pct: f32,
+    pub memory_mb: u64,
+    /// Full argv — only included when verbose is requested
+    pub argv: Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+pub struct DiskInfo {
+    pub mount: String,
+    pub total_gb: f64,
+    pub available_gb: f64,
+    pub used_pct: f32,
+}
+
+pub fn snapshot(verbose: bool) -> Result<SystemSnapshot> {
+    let mut sys = System::new_all();
+    // Sleep the minimum interval so CPU usage is meaningful
+    std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+    sys.refresh_all();
+
+    let cpu_usage_pct = sys.global_cpu_info().cpu_usage();
+    let memory_used_mb = sys.used_memory() / 1024 / 1024;
+    let memory_total_mb = sys.total_memory() / 1024 / 1024;
+    let swap_used_mb = sys.used_swap() / 1024 / 1024;
+    let swap_total_mb = sys.total_swap() / 1024 / 1024;
+    let uptime_secs = System::uptime();
+
+    let mut processes: Vec<ProcessInfo> = sys
+        .processes()
+        .iter()
+        .map(|(pid, p)| ProcessInfo {
+            pid: pid.as_u32(),
+            name: p.name().to_string(),
+            cpu_pct: p.cpu_usage(),
+            memory_mb: p.memory() / 1024 / 1024,
+            argv: if verbose {
+                Some(p.cmd().to_vec())
+            } else {
+                None
+            },
+        })
+        .collect();
+
+    // Sort by CPU descending
+    processes.sort_by(|a, b| {
+        b.cpu_pct
+            .partial_cmp(&a.cpu_pct)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let disk_list = Disks::new_with_refreshed_list();
+    let disks: Vec<DiskInfo> = disk_list
+        .iter()
+        .map(|d| {
+            let total = d.total_space() as f64 / 1024.0 / 1024.0 / 1024.0;
+            let avail = d.available_space() as f64 / 1024.0 / 1024.0 / 1024.0;
+            let used_pct = if total > 0.0 {
+                ((total - avail) / total * 100.0) as f32
+            } else {
+                0.0
+            };
+            DiskInfo {
+                mount: d.mount_point().to_string_lossy().to_string(),
+                total_gb: total,
+                available_gb: avail,
+                used_pct,
+            }
+        })
+        .collect();
+
+    Ok(SystemSnapshot {
+        cpu_usage_pct,
+        memory_used_mb,
+        memory_total_mb,
+        swap_used_mb,
+        swap_total_mb,
+        uptime_secs,
+        processes,
+        disks,
+    })
+}
+
+/// Look up a process name for pre-signal identity verification.
+#[allow(dead_code)]
+pub fn process_name_for_pid(pid: u32) -> Option<String> {
+    let mut sys = System::new();
+    let pid_key = Pid::from_u32(pid);
+    sys.refresh_process(pid_key);
+    sys.process(pid_key).map(|p| p.name().to_string())
+}

--- a/crates/coven-cli/src/pc/display.rs
+++ b/crates/coven-cli/src/pc/display.rs
@@ -1,0 +1,160 @@
+use crate::pc::diagnostics::{DiskInfo, ProcessInfo, SystemSnapshot};
+
+pub enum OutputFormat {
+    Compact,
+    Json,
+    Verbose,
+}
+
+fn health_indicator(pct: f32, warn: f32, crit: f32) -> &'static str {
+    if pct >= crit {
+        "🔴"
+    } else if pct >= warn {
+        "🟡"
+    } else {
+        "🟢"
+    }
+}
+
+pub fn print_status(snap: &SystemSnapshot, _format: &OutputFormat) {
+    let cpu_ind = health_indicator(snap.cpu_usage_pct, 70.0, 90.0);
+    let mem_pct = if snap.memory_total_mb > 0 {
+        snap.memory_used_mb as f32 / snap.memory_total_mb as f32 * 100.0
+    } else {
+        0.0
+    };
+    let mem_ind = health_indicator(mem_pct, 70.0, 90.0);
+    println!(
+        "{cpu_ind} CPU {:.1}%  {mem_ind} RAM {}/{} MB  uptime {}",
+        snap.cpu_usage_pct,
+        snap.memory_used_mb,
+        snap.memory_total_mb,
+        format_uptime(snap.uptime_secs),
+    );
+}
+
+pub fn print_full(snap: &SystemSnapshot, format: &OutputFormat) {
+    match format {
+        OutputFormat::Json => print_json(snap),
+        OutputFormat::Compact | OutputFormat::Verbose => print_human(snap, format),
+    }
+}
+
+fn print_human(snap: &SystemSnapshot, format: &OutputFormat) {
+    println!("── System ──────────────────────────────────");
+    let cpu_ind = health_indicator(snap.cpu_usage_pct, 70.0, 90.0);
+    println!("  {cpu_ind} CPU      {:.1}%", snap.cpu_usage_pct);
+
+    let mem_pct = if snap.memory_total_mb > 0 {
+        snap.memory_used_mb as f32 / snap.memory_total_mb as f32 * 100.0
+    } else {
+        0.0
+    };
+    let mem_ind = health_indicator(mem_pct, 70.0, 90.0);
+    println!(
+        "  {mem_ind} Memory   {} / {} MB  ({:.0}%)",
+        snap.memory_used_mb, snap.memory_total_mb, mem_pct,
+    );
+
+    if snap.swap_total_mb > 0 {
+        let swap_pct = snap.swap_used_mb as f32 / snap.swap_total_mb as f32 * 100.0;
+        let swap_ind = health_indicator(swap_pct, 50.0, 80.0);
+        println!(
+            "  {swap_ind} Swap     {} / {} MB  ({:.0}%)",
+            snap.swap_used_mb, snap.swap_total_mb, swap_pct,
+        );
+    }
+    println!("  ⏱  Uptime   {}", format_uptime(snap.uptime_secs));
+
+    println!("\n── Disk ────────────────────────────────────");
+    for disk in &snap.disks {
+        print_disk(disk);
+    }
+
+    println!("\n── Top Processes (by CPU) ──────────────────");
+    for proc in snap.processes.iter().take(10) {
+        print_proc(proc, format);
+    }
+}
+
+fn print_disk(d: &DiskInfo) {
+    let ind = health_indicator(d.used_pct, 80.0, 95.0);
+    println!(
+        "  {ind} {}  {:.1} GB used / {:.1} GB total  ({:.0}%)",
+        d.mount,
+        d.total_gb - d.available_gb,
+        d.total_gb,
+        d.used_pct,
+    );
+}
+
+fn print_proc(p: &ProcessInfo, format: &OutputFormat) {
+    let base = format!(
+        "  PID {:>6}  CPU {:>5.1}%  MEM {:>5} MB  {}",
+        p.pid, p.cpu_pct, p.memory_mb, p.name,
+    );
+    if let (OutputFormat::Verbose, Some(argv)) = (format, &p.argv) {
+        println!("{}  [{}]", base, argv.join(" "));
+    } else {
+        println!("{base}");
+    }
+}
+
+pub fn print_top(snap: &SystemSnapshot, n: usize, format: &OutputFormat) {
+    println!("── Top {} Processes (by CPU) ────────────────", n);
+    for proc in snap.processes.iter().take(n) {
+        print_proc(proc, format);
+    }
+}
+
+pub fn print_disk_usage(snap: &SystemSnapshot) {
+    println!("── Disk Usage ──────────────────────────────");
+    for disk in &snap.disks {
+        print_disk(disk);
+    }
+}
+
+fn print_json(snap: &SystemSnapshot) {
+    // Minimal JSON output — no external serde dependency needed for this simple shape
+    println!("{{");
+    println!("  \"cpu_usage_pct\": {:.2},", snap.cpu_usage_pct);
+    println!("  \"memory_used_mb\": {},", snap.memory_used_mb);
+    println!("  \"memory_total_mb\": {},", snap.memory_total_mb);
+    println!("  \"swap_used_mb\": {},", snap.swap_used_mb);
+    println!("  \"swap_total_mb\": {},", snap.swap_total_mb);
+    println!("  \"uptime_secs\": {},", snap.uptime_secs);
+    println!("  \"processes\": [");
+    let procs: Vec<_> = snap.processes.iter().take(20).collect();
+    for (i, p) in procs.iter().enumerate() {
+        let comma = if i + 1 < procs.len() { "," } else { "" };
+        // Redact argv in JSON output too (verbose-only)
+        println!(
+            "    {{\"pid\": {}, \"name\": {:?}, \"cpu_pct\": {:.2}, \"memory_mb\": {}}}{}",
+            p.pid, p.name, p.cpu_pct, p.memory_mb, comma
+        );
+    }
+    println!("  ],");
+    println!("  \"disks\": [");
+    for (i, d) in snap.disks.iter().enumerate() {
+        let comma = if i + 1 < snap.disks.len() { "," } else { "" };
+        println!(
+            "    {{\"mount\": {:?}, \"total_gb\": {:.2}, \"available_gb\": {:.2}, \"used_pct\": {:.1}}}{}",
+            d.mount, d.total_gb, d.available_gb, d.used_pct, comma
+        );
+    }
+    println!("  ]");
+    println!("}}");
+}
+
+fn format_uptime(secs: u64) -> String {
+    let days = secs / 86400;
+    let hours = (secs % 86400) / 3600;
+    let mins = (secs % 3600) / 60;
+    if days > 0 {
+        format!("{days}d {hours}h {mins}m")
+    } else if hours > 0 {
+        format!("{hours}h {mins}m")
+    } else {
+        format!("{mins}m")
+    }
+}

--- a/crates/coven-cli/src/pc/mod.rs
+++ b/crates/coven-cli/src/pc/mod.rs
@@ -1,0 +1,111 @@
+pub mod diagnostics;
+pub mod display;
+pub mod relief;
+
+use anyhow::Result;
+use clap::Subcommand;
+
+use crate::pc::display::OutputFormat;
+
+#[derive(Subcommand, Debug)]
+pub enum PcCommand {
+    #[command(about = "One-line health summary")]
+    Status {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
+    #[command(about = "Top processes by CPU and memory usage")]
+    Top {
+        #[arg(long, default_value = "10", help = "Number of processes to show")]
+        n: usize,
+        #[arg(long, help = "Include full command-line arguments")]
+        verbose: bool,
+    },
+    #[command(about = "Disk usage breakdown")]
+    Disk,
+    #[command(about = "Kill a process by PID (requires --confirm)")]
+    Kill {
+        #[arg(help = "Process ID to terminate")]
+        pid: u32,
+        #[arg(long, help = "Required: confirm you intend to terminate this process")]
+        confirm: bool,
+    },
+    #[command(about = "Clear user and system caches (requires --confirm)")]
+    Cache {
+        #[command(subcommand)]
+        command: CacheCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CacheCommand {
+    #[command(about = "Clear ~/Library/Caches and /Library/Caches (requires --confirm)")]
+    Clear {
+        #[arg(long, help = "Required: confirm you intend to clear caches")]
+        confirm: bool,
+    },
+}
+
+pub fn run_pc_command(command: Option<PcCommand>) -> Result<()> {
+    match command {
+        None => {
+            // Full report
+            let snap = diagnostics::snapshot(false)?;
+            display::print_full(&snap, &OutputFormat::Compact);
+        }
+        Some(PcCommand::Status { json }) => {
+            let snap = diagnostics::snapshot(false)?;
+            let fmt = if json {
+                OutputFormat::Json
+            } else {
+                OutputFormat::Compact
+            };
+            display::print_status(&snap, &fmt);
+        }
+        Some(PcCommand::Top { n, verbose }) => {
+            let snap = diagnostics::snapshot(verbose)?;
+            let fmt = if verbose {
+                OutputFormat::Verbose
+            } else {
+                OutputFormat::Compact
+            };
+            display::print_top(&snap, n, &fmt);
+        }
+        Some(PcCommand::Disk) => {
+            let snap = diagnostics::snapshot(false)?;
+            display::print_disk_usage(&snap);
+        }
+        Some(PcCommand::Kill { pid, confirm }) => {
+            relief::kill_by_pid(pid, confirm)?;
+        }
+        Some(PcCommand::Cache {
+            command: CacheCommand::Clear { confirm },
+        }) => {
+            relief::clear_caches(confirm)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kill_requires_confirm() {
+        let err = relief::kill_by_pid(99999999, false).unwrap_err();
+        assert!(err.to_string().contains("--confirm"));
+    }
+
+    #[test]
+    fn test_cache_clear_requires_confirm() {
+        let err = relief::clear_caches(false).unwrap_err();
+        assert!(err.to_string().contains("--confirm"));
+    }
+
+    #[test]
+    fn test_snapshot_returns_data() {
+        let snap = diagnostics::snapshot(false).expect("snapshot should succeed");
+        assert!(snap.memory_total_mb > 0);
+    }
+}

--- a/crates/coven-cli/src/pc/relief.rs
+++ b/crates/coven-cli/src/pc/relief.rs
@@ -1,0 +1,109 @@
+use anyhow::{bail, Result};
+use std::path::PathBuf;
+use sysinfo::{Pid, Signal, System};
+
+/// Hardcoded cache directories eligible for clearing. Never uses glob expansion.
+const USER_CACHE_DIRS: &[&str] = &["Library/Caches"];
+const SYSTEM_CACHE_DIR: &str = "/Library/Caches";
+
+/// Kill a process by PID. Requires --confirm flag at the CLI layer.
+/// Uses SIGTERM only (no SIGKILL in v1). Re-checks PID identity before signaling.
+pub fn kill_by_pid(pid: u32, confirm: bool) -> Result<()> {
+    if !confirm {
+        bail!("Refusing to kill process {pid} without --confirm. Add --confirm to proceed.");
+    }
+
+    let mut sys = System::new_all();
+    sys.refresh_all();
+
+    let pid_key = Pid::from_u32(pid);
+    let name = sys
+        .process(pid_key)
+        .map(|p| p.name().to_string())
+        .ok_or_else(|| anyhow::anyhow!("No process found with PID {pid}"))?;
+
+    eprintln!("Sending SIGTERM to PID {pid} ({name})...");
+
+    // Re-check identity immediately before signaling to avoid PID reuse mistakes
+    sys.refresh_process(pid_key);
+    let proc = sys
+        .process(pid_key)
+        .ok_or_else(|| anyhow::anyhow!("Process {pid} disappeared before signal could be sent"))?;
+
+    // Verify name still matches
+    let current_name = proc.name().to_string();
+    if current_name != name {
+        bail!(
+            "PID {pid} identity changed ({name} → {current_name}). Refusing to signal to avoid PID reuse mistake."
+        );
+    }
+
+    let sent = proc.kill_with(Signal::Term);
+    match sent {
+        Some(true) => {
+            println!("SIGTERM sent to PID {pid} ({name}).");
+            Ok(())
+        }
+        Some(false) | None => {
+            bail!("Failed to send SIGTERM to PID {pid} ({name}). Check permissions.");
+        }
+    }
+}
+
+/// Clear user and system caches. Requires --confirm flag at the CLI layer.
+/// Only removes contents of the hardcoded list above.
+pub fn clear_caches(confirm: bool) -> Result<()> {
+    if !confirm {
+        bail!("Refusing to clear caches without --confirm. Add --confirm to proceed.");
+    }
+
+    let home = dirs_next::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+
+    let mut cleared = 0usize;
+    let mut errors = 0usize;
+
+    for rel in USER_CACHE_DIRS {
+        let path = home.join(rel);
+        clear_directory_contents(&path, &mut cleared, &mut errors);
+    }
+
+    // System cache (may need elevated privs — best-effort)
+    let sys_cache = PathBuf::from(SYSTEM_CACHE_DIR);
+    clear_directory_contents(&sys_cache, &mut cleared, &mut errors);
+
+    if errors > 0 {
+        println!(
+            "Cache clear: removed {cleared} item(s), {errors} error(s) (some may require elevated privileges)."
+        );
+    } else {
+        println!("Cache clear: removed {cleared} item(s).");
+    }
+
+    Ok(())
+}
+
+fn clear_directory_contents(path: &PathBuf, cleared: &mut usize, errors: &mut usize) {
+    if !path.exists() {
+        return;
+    }
+    let entries = match std::fs::read_dir(path) {
+        Ok(e) => e,
+        Err(_) => {
+            *errors += 1;
+            return;
+        }
+    };
+    for entry in entries.flatten() {
+        let entry_path = entry.path();
+        let result = if entry_path.is_dir() {
+            std::fs::remove_dir_all(&entry_path)
+        } else {
+            std::fs::remove_file(&entry_path)
+        };
+        match result {
+            Ok(()) => *cleared += 1,
+            Err(_) => *errors += 1,
+        }
+    }
+}

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -6,6 +6,20 @@ The canonical OpenCoven brand system lives in [`../DESIGN.md`](../DESIGN.md). Im
 
 OpenCoven should feel like **collective intelligence + controlled power**: arcane but precise, technical not gimmicky, powerful not loud, minimal but symbolic.
 
+## Positioning
+
+OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity.
+
+Most AI today feels temporary. You open a chat, explain your context, get a response, and start over. OpenCoven is built around a different future: AI that can **stay**.
+
+OpenCoven gives builders a way to create durable AI systems that remember what matters, understand their purpose, use tools, collaborate with other agents, and remain understandable over time. Each familiar can have a name, a voice, a memory, a toolset, a role, and a place in a larger workflow.
+
+The philosophy is simple: AI should be powerful without becoming opaque, personal without pretending to be human, and extensible without collapsing into chaos. OpenCoven brings structure to the magic through memory, identity, orchestration, local execution, tool access, and multi-agent collaboration.
+
+Use this as the high-level brand promise:
+
+> OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to you.
+
 ## Brand asset pack
 
 | Asset | Purpose |

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,10 @@
 
 This directory holds the product and architecture notes for Coven, the OpenCoven harness substrate.
 
+OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity. Coven is the local harness substrate that helps those systems run inside explicit project boundaries.
+
+The guiding promise: OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to the user.
+
 ## Start here
 
 - [Public roadmap](ROADMAP.md) — community-facing progress snapshot across Coven, comux, and integrations.
@@ -34,6 +38,7 @@ Keep these docs aligned with VMUX-style clarity while staying specific to OpenCo
 - Concrete quick-start commands.
 - Explicit local trust boundary.
 - Clear relationship to comux and OpenClaw.
+- Consistent OpenCoven positioning: persistent familiars, user-owned systems, memory, identity, tools, orchestration, and multi-agent collaboration.
 - Be precise about npm status: packages are published for early adopters, but Coven is still an early local-first MVP.
 
 ## Canonical language

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,8 @@ Node package wrapper for the native **Coven** CLI.
 
 Coven is the OpenCoven harness substrate: a local Rust CLI/daemon for project-scoped Codex, Claude Code, and future harness sessions.
 
+OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to you. Coven is the local command layer for running those agent workflows inside explicit project boundaries.
+
 ```bash
 npx @opencoven/cli
 ```

--- a/skills/opencoven-design/SKILL.md
+++ b/skills/opencoven-design/SKILL.md
@@ -1,445 +1,373 @@
 ---
-name: OpenCoven Design System
-description: Opinionated design constraints for OpenCoven harness interfaces, cockpit UIs, and agent-built components
-style: Dark
-accent: Violet
-grid: 4px
-framework: Lit/React
+name: opencoven-design
+description: Agent-operable design constraints for OpenCoven, Coven, harness cockpits, docs, and integration surfaces
+style: dark
+accent: violet
+source_of_truth: DESIGN.md
 ---
 
-# OpenCoven Design System
+# OpenCoven Design Skill
 
-Opinionated UI constraints for building consistent, dense, command-first interfaces for the OpenCoven harness ecosystem (comux, OpenMeow, OpenClaw integrations).
+Use this skill when designing or implementing OpenCoven/Coven interfaces, docs pages, diagrams, package README visuals, native companion surfaces, or agent-built UI components.
 
-## Colors
+OpenCoven should feel like collective intelligence plus controlled power: arcane but precise, technical not gimmicky, powerful not loud, minimal but symbolic.
 
-**Semantic Tokens:**
+Core positioning: OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity. It turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to the user.
 
+## Source Of Truth
+
+Read these local files before changing brand or UI behavior:
+
+- `DESIGN.md` - canonical brand and design system
+- `docs/BRAND.md` - brand asset index and usage summary
+- `docs/BRANDING-ADHERENCE.md` - current exceptions, risks, and hardening checklist
+- `brand/docs/BRAND-USAGE.md` - contributor PR checklist
+- `brand/ui/color-tokens.css` - canonical CSS color tokens
+- `brand/ui/typography.css` - canonical typography tokens
+
+Do not invent a separate design system. If this skill conflicts with `DESIGN.md`, follow `DESIGN.md` and update this skill.
+
+## Brand Position
+
+Build for harness operators and developers, not a marketing toy.
+
+- The default feeling is a quiet command cockpit.
+- The product promise is durable AI systems that can stay: remember what matters, understand their purpose, use tools, coordinate with other agents, and remain understandable over time.
+- A familiar is not a faceless bot. It has a name, purpose, memory, toolset, voice, role, and place in a larger workflow.
+- Keep the philosophy clear: powerful without becoming opaque, personal without pretending to be human, extensible without collapsing into chaos.
+- Mystical symbolism is allowed only when it supports identity: sigil, trident, flame, crescents, nodes, execution paths.
+- Interfaces should be dense, legible, and repeatable under daily use.
+- Copy should be direct and capable. Avoid hype, jokes, and vague AI language.
+- Use `OpenCoven` for the ecosystem/org and `Coven` for the CLI/daemon/product.
+- The command is always `coven`, never `opencoven`.
+
+## Color Tokens
+
+Use the repo tokens, not arbitrary hex values.
+
+```css
+--oc-black: #000000;
+--oc-white: #ffffff;
+
+--oc-purple-1: #6E4BFF;
+--oc-purple-2: #8A63FF;
+--oc-purple-3: #A78BFF;
+--oc-purple-glow: #7C5CFF;
+
+--oc-accent-blue: #0A84FF;
+--oc-danger: #FF3B30;
+--oc-success: #30D158;
+
+--oc-surface-0: var(--oc-black);
+--oc-surface-1: #050507;
+--oc-surface-2: #080812;
+--oc-border-subtle: rgba(255, 255, 255, 0.08);
+--oc-border-strong: rgba(255, 255, 255, 0.14);
+--oc-text: rgba(255, 255, 255, 0.94);
+--oc-text-muted: rgba(255, 255, 255, 0.64);
+--oc-text-faint: rgba(255, 255, 255, 0.42);
 ```
-# Foundation (Grayscale)
-surface-0:        #000000  (pure black, backgrounds)
-surface-1:        #0d0d0d  (raised, very dark)
-surface-2:        #1a1a1a  (cards, panels)
-surface-3:        #262626  (borders, dividers)
-surface-4:        #333333  (hover states)
 
-text-primary:     #ffffff  (main text)
-text-secondary:   #b3b3b3  (secondary, muted)
-text-tertiary:    #808080  (very muted, hints)
-text-inverse:     #000000  (on accent backgrounds)
+### Color Rules
 
-border-primary:   #333333  (dividers, outlines)
-border-secondary: #1f1f1f  (subtle dividers)
-border-focus:     #7c3aed  (focused elements)
+- Use black and white for roughly 90 percent of the composition.
+- Reserve purple for identity, primary CTAs, focus, selected state, execution paths, and small highlights.
+- Use `--oc-accent-blue` only for documented actionable/system states. Do not make blue the brand accent.
+- Use `--oc-danger` for destructive actions and hard errors.
+- Use `--oc-success` for completion, connected, passing, and healthy states.
+- Keep text WCAG AA contrast on every surface.
 
-# Accent (Violet)
-accent-primary:   #7c3aed  (interactive, highlights, focus)
-accent-secondary: #6d28d9  (hover state)
-accent-dark:      #5b21b6  (active/pressed)
-accent-light:     #a78bfa  (light overlays, secondary accent)
+## Signature Treatments
 
-# Semantic
-success:          #10b981  (confirmations, positive)
-warning:          #f59e0b  (cautions, warnings)
-error:            #ef4444  (destructive, errors)
-info:             #7c3aed  (same as accent-primary)
+Gradients and glow are allowed, but only as controlled brand moments.
+
+```css
+--oc-gradient-signature: linear-gradient(135deg, var(--oc-purple-1), var(--oc-purple-3));
+--oc-radial-glow: radial-gradient(circle, rgba(138, 99, 255, 0.28) 0%, rgba(138, 99, 255, 0) 68%);
+--oc-focus-ring: 0 0 0 2px rgba(124, 92, 255, 0.52), 0 0 32px rgba(124, 92, 255, 0.28);
+--oc-hover-glow: 0 0 36px rgba(124, 92, 255, 0.26);
 ```
+
+Use signature treatment for:
+
+- Primary logo and hero/OG assets
+- Focus rings and interactive affordances
+- Hover glow on CTAs or selected execution paths
+- Subtle radial glow behind the sigil
+
+Do not use gradients or glows for:
+
+- General cards
+- Tables
+- Dense cockpit panels
+- Documentation diagrams, except small path highlights
+- Decorative page backgrounds
 
 ## Typography
 
-**Font Stack:**
-```
---font-primary:   -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", sans-serif
---font-mono:      "Courier New", monospace, "SF Mono"
+Use the repo typography tokens.
+
+```css
+--oc-font-ui: Inter, "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+--oc-font-display: Satoshi, "Neue Montreal", Geist, Inter, "SF Pro Display", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+--oc-font-mono: "SF Mono", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+
+--oc-tracking-heading: -0.02em;
+--oc-tracking-hero: -0.055em;
+--oc-tracking-label: 0.14em;
+--oc-line-body: 1.4;
+--oc-line-heading: 1.2;
 ```
 
-**Scale (rem units):**
+### Typography Rules
+
+- Use UI font for product surfaces, controls, tables, body text, and docs prose.
+- Use display font for hero headlines and major product headings only.
+- Use mono font for commands, session IDs, logs, event streams, diffs, paths, hashes, and API payloads.
+- Keep body line height at 1.4 and headings at 1.2.
+- Avoid all-caps except for compact labels, badges, and nav group headings.
+- Do not add playful, cursive, serif, or decorative fonts.
+
+## Spacing And Shape
+
+- Base spacing is a 4px grid.
+- Dense cockpit UIs should favor 4px, 8px, 12px, and 16px increments.
+- Documentation and landing pages may use more breathing room, but still stay on grid.
+- Cards and panels should use restrained radii: 4px to 8px unless a platform style requires otherwise.
+- Do not nest cards inside cards.
+- Use borders and alignment before shadows.
+
+Recommended dimensions:
+
 ```
-text-xs:          0.75rem  (10px, labels, tags)
-text-sm:          0.875rem (14px, secondary text)
-text-base:        1rem     (16px, body text)
-text-lg:          1.125rem (18px, section headings)
-text-xl:          1.25rem  (20px, modal titles)
-text-2xl:         1.5rem   (24px, page titles)
-text-mono:        0.875rem (monospace for code, logs, terminal output)
+Button heights: 24px compact, 32px standard, 40px large
+Input height: 32px standard
+Table rows: 32px dense, 40px comfortable
+Sidebar: 280px standard, 320px expanded
+Modal: 400px compact, 500px standard, 600px wide
+Icon grid: 24px or 32px
 ```
 
-**Weights:**
-```
-font-normal:      400
-font-medium:      500  (labels, highlights)
-font-semibold:    600  (headings, emphasis)
-font-bold:        700  (page titles only)
-```
+## Layout Patterns
 
-**Text Styles:**
-```
-heading-1:        text-2xl, font-bold, line-height: 1.3
-heading-2:        text-xl, font-semibold, line-height: 1.4
-heading-3:        text-lg, font-semibold, line-height: 1.4
-body:             text-base, font-normal, line-height: 1.6
-caption:          text-xs, font-normal, line-height: 1.5
-code:             text-mono, font-normal, background: surface-2, padding: 0.25rem 0.5rem
-```
+### Harness Cockpit
 
-## Spacing
+Use for session managers, operator dashboards, run queues, agent control rooms, and debug tools.
 
-**Grid:** 4px base unit
+- Left navigation or lane rail, main work area, optional right inspector.
+- Dense rows with clear status badges.
+- Mono identifiers for sessions, agents, tools, commits, ports, and paths.
+- Explicit empty, loading, error, and disconnected states.
+- No oversized marketing hero inside operational UI.
 
-**Scale:**
-```
-0:    0px
-0.5:  2px   (micro-spacing)
-1:    4px   (base)
-1.5:  6px   (compact)
-2:    8px   (standard, default margins)
-3:    12px  (comfortable)
-4:    16px  (section spacing)
-6:    24px  (major breaks)
-8:    32px  (page-level spacing)
-12:   48px  (full-page gutters)
-```
+### Session Browser
 
-**Layout Gutters:**
-```
---gutter-page:    1.5rem  (24px, outer margins)
---gutter-section: 1rem    (16px, section breaks)
---gutter-compact: 0.5rem  (8px, dense cockpit mode)
-```
+Use tab-like navigation for long-lived work.
 
-## Borders
+- Tabs or session pills show active work.
+- Preserve browser-like history where relevant: back, forward, reopen, recent sessions.
+- Active session should be obvious through border, text, and selected state, not color alone.
+- Destructive session actions should be visible but gated.
+- Use product ritual labels exactly where they exist: **Rejoin**, **View Log**, **Summon**, **Archive**, and **Sacrifice**.
+- **Archive** is reversible and keeps the ledger.
+- **Summon** restores an archived session to the active list.
+- **Sacrifice** is permanent, refuses running sessions, and requires explicit confirmation such as `--yes` or typed confirmation.
+- In terminal UIs, `coven sessions` should favor a human browser; `coven sessions --plain` stays scriptable.
 
-**Radius Scale:**
-```
-radius-none:      0px
-radius-sm:        2px   (subtle corners, tight components)
-radius-md:        4px   (standard, cards, buttons)
-radius-lg:        6px   (modals, popovers)
-radius-xl:        8px   (large surfaces)
-radius-full:      9999px (badges, avatars)
-```
+### Documentation And Landing
 
-**Width Scale:**
-```
-border-1:         1px   (standard)
-border-2:         2px   (focus rings, emphasis)
-border-3:         3px   (destructive confirmation)
-```
+- Landing hero: black foundation, centered sigil, restrained purple glow, literal OpenCoven/Coven offer.
+- Docs: calm technical rhythm, readable code blocks, no decorative clutter.
+- Diagrams: nodes, paths, monoline icons, purple execution highlights.
+- Keep the next section visible below a landing hero on normal mobile and desktop viewports.
+- Be honest about early MVP status where relevant. Do not imply production maturity beyond the docs.
 
-**Focus Rings:**
-```
-focus-ring:       2px solid accent-primary, offset 2px
-focus-ring-error: 2px solid error, offset 2px
-```
+### Repair And Trust Surfaces
 
-## Layout
-
-**Viewport Breakpoints:**
-```
-mobile:   0px     (phones)
-tablet:   768px   (iPad, small tablets)
-desktop:  1024px  (laptop)
-wide:     1440px  (ultrawide)
-```
-
-**Container Patterns:**
-```
-page-max-width:   1400px
-sidebar-width:    280px  (or 320px in detail view)
-modal-width:      500px  (standard), 600px (wide), 400px (compact)
-drawer-width:     400px
-
-# Cockpit-style dense layout
-dense-columns:    8-12 columns, 4px gaps (terminal-like grid)
-```
-
-**Component Layout:**
-```
-button-height:    32px    (standard), 24px (compact), 40px (large)
-input-height:     32px
-card-padding:     16px    (standard), 12px (compact)
-table-row-height: 40px    (comfortable), 32px (dense)
-```
+- Repair flows should show selected repo root, branch, dirty files, untracked files, harness, and verification profile before launch.
+- Dirty repos require a visible warning and confirmation.
+- v0 repair flows never commit, push, or operate outside the selected repo root.
+- Treat the Rust CLI/daemon as the authority boundary for project-root validation, PTY lifecycle, socket API, input/kill, and persistence.
+- Clients may improve UX, but they must not visually imply authority they do not have.
 
 ## Components
 
-**Button:**
-```
-Sizes:
-  - small:   height 24px, padding 4px 12px, text-xs, rounded-sm
-  - default: height 32px, padding 8px 16px, text-sm, rounded-md
-  - large:   height 40px, padding 12px 20px, text-base, rounded-md
+### Buttons
 
-Variants:
-  - primary:   background accent-primary, text white, border none
-  - secondary: background surface-2, text text-primary, border 1px border-primary
-  - outline:   background transparent, border 2px accent-primary, text accent-primary
-  - ghost:     background transparent, border none, text text-primary (hover: background surface-2)
-  - danger:    background error, text white, border none
-  
-States:
-  - default:   as specified
-  - hover:     darken 5%, cursor pointer
-  - active:    darken 10%, border-focus 2px
-  - disabled:  opacity 50%, cursor not-allowed
-  - loading:   spinner, opacity 70%, cursor wait
-```
+- Primary: purple accent, white text, restrained hover glow.
+- Secondary: dark surface, subtle border, white or muted text.
+- Ghost: transparent, clear hover surface.
+- Danger: danger token, explicit label, confirmation for irreversible actions.
+- Icon buttons should use familiar icons and tooltips when meaning is not obvious.
+- Hover should not scale layout.
 
-**Input / TextArea:**
-```
-Sizing:
-  - height 32px, padding 8px 12px
-  - border 1px border-primary, radius-md
-  - background surface-2, text text-primary
+### Inputs
 
-States:
-  - focus:     border-2 accent-primary, outline none, shadow: inset 0 0 0 3px accent-light (opacity 20%)
-  - hover:     border-primary 1px (darken)
-  - error:     border-2 error
-  - disabled:  background surface-1, text-tertiary, cursor not-allowed
-  - readonly:  background surface-1, text-secondary
+- Dark surface, subtle border, clear placeholder color.
+- Focus must use visible purple ring or equivalent tokenized focus treatment.
+- Error state must include border and text message.
+- Disabled and readonly states must be visually distinct.
 
-Placeholder: color text-tertiary
-```
+### Panels And Cards
 
-**Card / Panel:**
-```
-Background:     surface-2
-Border:         1px border-primary, radius-md
-Padding:        16px (standard), 12px (compact)
-Shadow:         none (dark mode: no shadows)
-Dividers:       1px border-secondary between sections
-```
+- Use for real grouped content, repeated items, modals, and framed tools.
+- Background: `--oc-surface-1` or `--oc-surface-2`.
+- Border: `--oc-border-subtle` or `--oc-border-strong`.
+- Prefer dividers and alignment over shadows.
+- Do not use glass-heavy blur.
 
-**Table:**
-```
-Header:
-  - background surface-3
-  - font semibold, text-xs, text-secondary
-  - padding 8px 12px, align left
-  
-Row:
-  - height 40px (comfortable), 32px (dense)
-  - border-bottom 1px border-secondary
-  - padding 8px 12px
-  
-Cells:
-  - text-secondary by default
-  - hover: background surface-1 (very subtle)
-  
-Alternating rows: no striping (maintain dense clarity)
-```
+### Tables And Lists
 
-**Modal / Dialog:**
-```
-Backdrop:       background black, opacity 50%
-Container:      background surface-0, border 1px border-primary, radius-lg
-Header:         padding 16px, heading-2, border-bottom 1px border-secondary
-Body:           padding 16px
-Footer:         padding 12px 16px, border-top 1px border-secondary, text-right buttons
+- Header labels should be compact, muted, and scannable.
+- Rows should support hover, selected, focused, loading, and error states.
+- Use mono for machine data.
+- Avoid zebra striping unless density requires it.
 
-Close button:   top-right corner, 24px square, icon ghost
-```
+### Badges
 
-**Badge / Tag:**
-```
-Padding:        2px 8px
-Radius:         radius-full
-Font:           text-xs, font-medium
-Colors:         background surface-3, text text-primary (default)
-                background accent-light, text text-inverse (accent)
-                background error, text white (danger)
-```
+- Use badges for run status, agent state, verification result, branch state, auth state, and risk level.
+- Keep badges compact.
+- Pair color with text, never color alone.
 
-**Sidebar / Navigation:**
-```
-Width:         280px (standard), 320px (expanded)
-Background:    surface-1
-Item height:   40px
-Item padding:  8px 12px
-Item radius:   radius-sm
-Item hover:    background surface-2
-Item active:   background accent-secondary, text accent-light, left-border 3px accent-primary
-Dividers:      1px border-secondary
-Section title: text-xs, font-semibold, text-tertiary, padding-top 12px, padding-left 12px
-```
+### Modals And Confirmations
 
-**Session / Tab-like Pattern:**
-```
-Tab container:  background surface-1, border-bottom 1px border-secondary
-Tab:            padding 8px 16px, height 36px, border-bottom 2px transparent
-Tab hover:      background surface-2
-Tab active:     border-bottom-color accent-primary, text accent-light
-Session pill:   background surface-2, padding 4px 12px, radius-sm, text-xs, border 1px border-secondary
-Session active: background accent-secondary, text accent-light
-```
+- Use modals for irreversible or high-risk choices.
+- Dialog copy should name the action and affected resource.
+- Prefer archive/stop/disable before delete where the product supports recovery.
+- Danger action must not be the default focused action.
 
-## Interactive States
+## Interaction States
 
-**Hover:**
-```
-Buttons:         opacity +10%, color darken 5%
-Cards:           background lighten 1%, border border-secondary
-Links:           text accent-light, underline
-```
+Every interactive element needs these states:
 
-**Focus:**
-```
-All interactive: 2px solid accent-primary outline, offset 2px, radius-sm
-Text inputs:     inset shadow 0 0 0 3px accent-light (opacity 20%)
-Keyboard:        always visible (do not :focus { outline: none; })
-```
+- Default
+- Hover
+- Active or pressed
+- Focus visible
+- Disabled
+- Loading or pending where async work exists
+- Error where user recovery is possible
 
-**Disabled:**
-```
-Buttons:         opacity 50%, cursor not-allowed
-Inputs:          opacity 50%, background surface-1, cursor not-allowed
-Text:            text-tertiary
-```
+Keyboard navigation must remain visible. Never remove focus indicators without a tokenized replacement.
 
-**Active / Pressed:**
-```
-Buttons:         background darker variant, scale 98%, shadow none
-Toggles:         background accent-dark, border accent-primary
-```
+## Motion
 
-**Error State:**
-```
-Input border:    2px error
-Input shadow:    inset 0 0 0 3px error (opacity 10%)
-Text message:    text-xs, color error, margin-top 4px
-```
+- Motion should clarify state changes, not decorate the page.
+- Standard transition: 150ms to 250ms.
+- Page or path drawing motion may run 600ms to 1200ms when it explains graph/execution flow.
+- Respect `prefers-reduced-motion`.
+- Hover glow is preferred over scale for brand CTAs.
+- Do not animate body text or cause layout shift.
 
-## Animation
+## Iconography
 
-**Timing:**
-```
-quick:      150ms  (hover states, tooltips)
-normal:     250ms  (modals, transitions)
-slow:       400ms  (page-level, complex animations)
-```
+- Use monoweight, geometric, slightly sharp icons.
+- Use existing icons from `brand/icons/` when possible.
+- Use trident tips, crescents, flame curves, nodes, and connection lines only as meaningful motifs.
+- Avoid emoji and whimsical icons in system UI.
+- Test logo and icon legibility at 24px minimum.
 
-**Easing:**
-```
-ease-in-out: cubic-bezier(0.4, 0, 0.2, 1)  (standard)
-ease-out:    cubic-bezier(0, 0, 0.2, 1)    (exits)
-ease-in:     cubic-bezier(0.4, 0, 1, 1)    (enters)
-```
+## Logo Rules
 
-**Transitions:**
-```
-color:         250ms ease-in-out
-background:    250ms ease-in-out
-border:        250ms ease-in-out
-opacity:       150ms ease-in-out
-transform:     200ms ease-out (scale, translate only)
+- Hero and social: `brand/logo/opencoven-logo.svg` or canonical social assets.
+- Small dark UI: `brand/logo/opencoven-white.svg`.
+- Light backgrounds or print: `brand/logo/opencoven-black.svg`.
+- Technical diagrams: `brand/logo/opencoven-monoline.svg`.
+- Preserve aspect ratio and clear space.
+- Do not create new logo variants.
+
+## Accessibility
+
+- Hit targets should be large enough for pointer use: 32px minimum for dense tools, 40px preferred for primary actions.
+- Do not rely on color alone for status, risk, or selection.
+- Keep focus order predictable through rails, tabs, tables, dialogs, and inspectors.
+- Modals must trap focus while open and restore focus when closed.
+- Every icon-only control needs an accessible name and tooltip where helpful.
+
+## Verification
+
+Before claiming a UI or brand change follows this skill:
+
+- Check changed colors against `brand/ui/color-tokens.css`.
+- Check typography against `brand/ui/typography.css`.
+- Inspect desktop and mobile layouts when a visual surface changed.
+- Verify focus, hover, disabled, loading, empty, and error states for touched interactive components.
+- Run the smallest relevant project gate: typecheck, lint, build, screenshot, or direct visual inspection.
+- Record intentional exceptions in `docs/BRANDING-ADHERENCE.md`.
+
+## MUST
+
+- Use `DESIGN.md` and `brand/ui/*.css` as source of truth.
+- Build dark-first on pure black foundations.
+- Keep UI technical, minimal, and symbolic.
+- Use `OpenCoven`, `Coven`, and `coven` with their exact product meanings.
+- Keep purple controlled and meaningful.
+- Use tokenized colors and typography.
+- Provide visible focus states.
+- Provide empty, loading, disabled, error, and success states where applicable.
+- Gate destructive actions.
+- Preserve Archive/Summon/Sacrifice semantics in session UI.
+- Respect the Rust daemon as the authority boundary in trust-sensitive UI.
+- Keep dense operator surfaces scannable.
+- Use mono for operational data.
+
+## SHOULD
+
+- Use borders and spacing before shadows.
+- Prefer tabs, rails, split panes, inspectors, and command surfaces for harness workflows.
+- Use status badges for session/agent/tool state.
+- Keep page copy short and concrete.
+- Use diagrams to explain orchestration only when they clarify relationships.
+- Document any intentional exception in `docs/BRANDING-ADHERENCE.md`.
+
+## NEVER
+
+- Do not use light mode as the primary OpenCoven experience.
+- Do not use random gradients, noise textures, bokeh, or decorative blobs.
+- Do not overuse purple; it should feel intentional, not saturated.
+- Do not use blue, green, or red as brand accents.
+- Do not hide focus rings.
+- Do not use heavy blur/glass effects.
+- Do not use shadows as the main structure.
+- Do not make marketing heroes inside operator tools.
+- Do not add playful fonts, emoji UI, or novelty iconography.
+- Do not place text over complex backgrounds.
+- Do not create orphan color values when a token exists.
+
+## Prompt Pattern
+
+Use this pattern when assigning UI work to an agent:
+
+```markdown
+Build [surface/component] for OpenCoven.
+Follow skills/opencoven-design/SKILL.md and the canonical brand files:
+- DESIGN.md
+- brand/ui/color-tokens.css
+- brand/ui/typography.css
+
+The surface must include:
+- [required states]
+- [required interactions]
+- [data density / layout constraints]
+
+Do not invent new colors, logo variants, or decorative effects.
+Return changed files, verification run, and any brand exceptions.
 ```
 
-**Reduced Motion:**
-```
-@media (prefers-reduced-motion: reduce):
-  - all animations → 0ms (instant)
-  - all transitions → 0ms (instant)
-  - no transforms → instant repositioning
-```
+## Review Checklist
 
-## MUST (Absolute Requirements)
-
-- **DO use pure black (#000000) for backgrounds**, not #111111 or #1a1a1a elsewhere
-- **DO use violet accent (#7c3aed) for all focus rings and primary CTAs**
-- **DO NOT use random gradients or shadow effects** — flat design only
-- **DO use the exact font stack** (system fonts, then Courier for monospace)
-- **DO apply 4px grid spacing consistently** — all margins/padding in multiples of 4px
-- **DO preserve focus rings at all times** — keyboard navigation must be visible
-- **DO use the semantic color tokens exactly** — no arbitrary color values
-- **DO handle destructive actions with error color (#ef4444) and confirmation gates**
-- **DO maintain session/browser UI patterns** — tabs, history, forward/back paradigms where applicable
-- **DO NOT strip disabled or readonly states** — always show UI feedback for unavailable actions
-
-## SHOULD (Strong Recommendations)
-
-- **Prefer flat design over bevels, shadows, or 3D effects**
-- **Use dense layouts (cockpit-style) in admin/operator UIs** — tight grids, minimal spacing
-- **Apply the monospace font to code, logs, terminal output, and API responses**
-- **Use border-secondary (#1f1f1f) for subtle internal dividers, not border-primary**
-- **Consider table row heights: 40px for comfortable reading, 32px for dense data**
-- **Follow the text hierarchy:** heading-1 for page title, heading-2 for sections, heading-3 for subsections
-- **Animate transitions smoothly** (250ms default) when state changes, but respect reduced-motion
-- **Ensure modals and popovers have clear stacking** (backdrop, container, content layers)
-- **Use badges and tags for status/metadata** — prefer inline pills over separate UI elements
-- **Build sidebar navigation with clear active states** — always show current location
-
-## NEVER (Explicit Prohibitions)
-
-- **NEVER use light backgrounds or light mode styling** — pure dark theme only
-- **NEVER apply random colors, gradients, or glow effects** — violates the Coven aesthetic
-- **NEVER hide focus indicators** (no `outline: none` without replacement)
-- **NEVER use shadows as primary design elements** — flat only
-- **NEVER place text on complex backgrounds** — maintain contrast, flat backgrounds only
-- **NEVER use Comic Sans, cursive, or decorative fonts** — system fonts only
-- **NEVER break the 4px grid** — all spacing must be multiples of 4px
-- **NEVER skip error states or disabled states** — all interactive elements must show feedback
-- **NEVER hide destructive actions** — make them explicit with color + confirmation
-- **NEVER use emojis or whimsical icons in system UI** — stay professional and minimal
-- **NEVER apply animations to text transitions** — animate only position, opacity, and scale
-- **NEVER use blue, green, or red as primary accents** — violet (#7c3aed) only
-
-## Usage
-
-### In Prompts
-When building UI components, reference this skill:
-
-```
-You are building a Coven cockpit interface. Follow the OpenCoven Design System SKILL.md exactly.
-Build a session manager card showing:
-- Session ID (monospace)
-- Status badge (success/warning/error)
-- Delete button (destructive, confirmation required)
-```
-
-### In Code
-Include the design tokens at the top of your CSS/JS:
-
-```css
-:root {
-  --color-surface-0: #000000;
-  --color-surface-1: #0d0d0d;
-  --color-accent-primary: #7c3aed;
-  --font-primary: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "Courier New", monospace;
-  --grid: 4px;
-}
-```
-
-### In Design Tools
-- **Figma:** Create component library matching these specs
-- **Lit/React:** Build styled components using these tokens
-- **Tailwind:** Extend config with Coven colors, spacing, and typography
-
-## Examples
-
-**Dense Dashboard (Cockpit Mode):**
-- Sidebar (280px) + main content (flex)
-- 4px grid spacing throughout
-- Row height 32px
-- Monospace for data cells
-- Accent-colored status badges
-
-**Modal with Destructive Action:**
-- Header with title, close button
-- Body with content
-- Footer with Cancel (secondary) + Delete (danger, 2px red border)
-- Confirmation: "Are you sure?" dialog required
-
-**Session List:**
-- Tab-like pills showing active session
-- Each row: session ID (monospace), status (badge), actions (buttons)
-- Hover: subtle background change, no animation
-- Delete: error-colored, opens confirmation modal
+- Colors come from `--oc-*` tokens or documented semantic aliases.
+- Typography uses `--oc-font-ui`, `--oc-font-display`, or `--oc-font-mono`.
+- Purple is limited to identity, focus, selected state, CTAs, and execution highlights.
+- Hover states glow or change border/surface; they do not scale layout.
+- Dense tools are scannable and not card-heavy.
+- Destructive actions are explicit and gated.
+- Focus, disabled, loading, empty, and error states are present.
+- Logo variant matches the surface.
+- Any exception is documented in `docs/BRANDING-ADHERENCE.md`.
 
 ---
 
-**Reviewed by:** Sage (Research) + Coven Team  
-**Last Updated:** 2026-05-10  
-**Version:** 1.0.0  
-**License:** MIT (OpenCoven)
+Last updated: 2026-05-10
+Version: 1.1.0
+License: MIT

--- a/skills/opencoven-design/metadata.json
+++ b/skills/opencoven-design/metadata.json
@@ -1,17 +1,17 @@
 {
-  "name": "OpenCoven Design System",
-  "description": "Opinionated design constraints for OpenCoven harness interfaces, cockpit UIs, and agent-built components",
-  "style": "Dark",
-  "accent": "Violet",
+  "name": "opencoven-design",
+  "description": "Agent-operable design constraints for OpenCoven, Coven, harness cockpits, docs, and integration surfaces",
+  "style": "dark",
+  "accent": "violet",
   "grid": "4px",
-  "framework": "Lit/React",
-  "version": "1.0.0",
+  "sourceOfTruth": "DESIGN.md",
+  "version": "1.1.0",
   "author": "OpenCoven Team",
   "license": "MIT",
-  "tags": ["design", "ui", "constraints", "dark-mode", "cockpit"],
+  "tags": ["design", "ui", "constraints", "dark-mode", "cockpit", "brand"],
   "colors": {
     "foundation": "black",
     "accent": "violet",
-    "palette": "87-color semantic system"
+    "palette": "OpenCoven --oc-* token system"
   }
 }


### PR DESCRIPTION
## Summary

Adds `coven pc` — a macOS-first system diagnostics and relief tool built into the Coven CLI.

## Commands

```
coven pc                          # full report: CPU, memory, disk, top processes
coven pc status [--json]          # one-line health summary with 🟢/🟡/🔴 indicators
coven pc top [--n N] [--verbose]  # top processes by CPU
coven pc disk                     # disk usage breakdown
coven pc kill <pid> --confirm     # SIGTERM with PID identity re-check
coven pc cache clear --confirm    # clear ~/Library/Caches + /Library/Caches
```

## Safety model

- All read ops: no side effects, no approval gate
- All write/kill ops: require explicit `--confirm` flag — no bypass path
- Process kill uses PID only — no shell interpolation, no pgrep
- Identity re-checked immediately before SIGTERM to prevent PID reuse mistakes
- No SIGKILL in v1 — SIGTERM only
- Cache clear uses hardcoded path list only — no glob expansion
- argv redacted by default; exposed only behind `--verbose`
- No sudo, no LaunchAgent mutation, no system service control in v1

## Files

- `crates/coven-cli/src/pc/mod.rs` — subcommand + clap wiring
- `crates/coven-cli/src/pc/diagnostics.rs` — read-only system info (sysinfo 0.30)
- `crates/coven-cli/src/pc/relief.rs` — write ops with confirm gates
- `crates/coven-cli/src/pc/display.rs` — compact/json/verbose output
- `crates/coven-cli/Cargo.toml` — added sysinfo 0.30, dirs-next 2

## Verification

- `cargo check` ✅
- `cargo test -p coven-cli` 3/3 ✅
- `cargo fmt --check` ✅
- `cargo clippy -D warnings` ✅

Co-authored-by: Nova <nova@opencoven.ai>