### PR TITLE
docs: document coven pc and the prompt-first tui

### DIFF
--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -60,7 +60,14 @@ From a project directory:
 coven
 ```
 
-The default command opens the beginner-friendly TUI. Choose **Start here** or run the explicit checks:
+The default command opens the prompt-first TUI. You can either:
+
+- type a task directly and press Enter (e.g. `fix the failing tests` or a slash command like `/run codex fix the failing tests`);
+- select a menu item with arrow keys or its single-key shortcut and press Enter;
+- press `h` or type `/help` to see natural-language and slash-command examples;
+- press `Ctrl+C` or `Esc` to quit.
+
+If you prefer to run the explicit setup checks:
 
 ```sh
 coven doctor
@@ -149,6 +156,36 @@ Use `restart` when the socket or daemon state looks stale:
 ```sh
 coven daemon restart
 ```
+
+## Diagnostics and relief
+
+`coven pc` is a macOS-first system diagnostics and relief tool surfaced through the Coven CLI. All read operations are side-effect free.
+
+Inspect:
+
+```sh
+coven pc                  # full report: CPU, memory, disk, top processes
+coven pc status           # one-line health summary with 🟢/🟡/🔴 indicators
+coven pc status --json    # machine-readable health summary
+coven pc top --n 10       # top-N processes by CPU usage
+coven pc disk             # disk usage breakdown
+```
+
+Relief operations mutate system state and require an explicit `--confirm` gate:
+
+```sh
+coven pc kill <pid> --confirm     # SIGTERM with PID identity re-check
+coven pc cache clear --confirm    # clear ~/Library/Caches + /Library/Caches
+```
+
+Safety constraints in v1:
+
+- All write operations require `--confirm`. There is no bypass path.
+- Termination is SIGTERM only. No SIGKILL.
+- Process identity is re-checked immediately before SIGTERM to prevent PID reuse.
+- Cache clear uses a hardcoded path list. No glob expansion.
+- Process arguments are redacted by default; pass `--verbose` to inspect them.
+- No `sudo`, no LaunchAgent mutation, no system service control.
 
 ## Contributor verification loop
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -36,6 +36,10 @@ The OpenCoven local runtime substrate and command-line product.
 
 The user-facing command.
 
+## `coven pc`
+
+macOS-first system diagnostics and relief subcommand. Reports CPU, memory, disk, and top processes. Write operations (process kill, cache clear) are gated behind `--confirm`.
+
 ## `COVEN_HOME`
 
 The local directory where Coven stores daemon/socket/database state when configured. Runtime state should not be committed to source control.
@@ -67,6 +71,14 @@ The explicit repository or project boundary for a session.
 ## PTY
 
 Pseudoterminal. Coven uses PTYs so harnesses behave like terminal-native tools while their output can still be recorded and replayed.
+
+## Prompt-first TUI
+
+The default `coven` and `coven tui` interface. Accepts free-form task text or slash commands like `/run codex <task>` as input, alongside arrow-key menu navigation.
+
+## Relief
+
+Write-side operations in `coven pc` that mutate system state (process termination, cache deletion). Always require an explicit `--confirm` flag.
 
 ## Sacrifice
 


### PR DESCRIPTION
## Summary

Closes the doc drift introduced by the two features merged this week:

- `coven pc` diagnostics and relief subcommand (6dfdbf3)
- prompt-first `coven tui` (0d4aa42)

## Changes

**`docs/GETTING-STARTED.md`**

- Rewrote the *First run* section to describe the prompt-first TUI input field, the `/help` slash command, and `Ctrl+C` / `Esc` quit behaviour, alongside the existing menu navigation.
- Added a new *Diagnostics and relief* section between *Stop the daemon* and *Contributor verification loop*. Covers the five read subcommands (`pc`, `pc status`, `pc top`, `pc disk`, `pc status --json`), the two `--confirm`-gated relief operations (`pc kill`, `pc cache clear`), and the v1 safety constraints from the commit message (SIGTERM-only, PID re-check, no `sudo`, no LaunchAgent mutation, hardcoded cache path list, argv redaction by default).

**`docs/GLOSSARY.md`**

- Added `coven pc` entry.
- Added *Prompt-first TUI* entry.
- Added *Relief* entry for the write-side `coven pc` operations.

## Why

The roadmap's *Now (Coven)* line is "Maintain public documentation alignment with CLI/API surface." Both features above are user-facing surface that landed without docs. This PR closes that gap.

## Verification

- Markdown rendered locally; no broken cross-references.
- No code or test changes.