### PR TITLE
fix(cli): print full session ids in plain sessions output

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -36,6 +36,7 @@ const DEFAULT_SESSION_STATUS: &str = "created";
 const RUNNING_SESSION_STATUS: &str = "running";
 const FAILED_SESSION_STATUS: &str = "failed";
 const DEFAULT_TITLE_CHARS: usize = 48;
+const PLAIN_SESSION_ID_COLUMN_WIDTH: usize = 36;
 
 #[derive(Parser, Debug)]
 #[command(name = "coven")]
@@ -1642,12 +1643,20 @@ fn list_sessions(include_archived: bool) -> Result<()> {
         println!("  coven sessions --all");
     } else {
         println!(
-            "{:<12} {:<10} {:<8} {:<8} TITLE",
-            "SESSION", "STATUS", "HARNESS", "RITUAL"
+            "{:<id_width$} {:<10} {:<8} {:<8} TITLE",
+            "SESSION",
+            "STATUS",
+            "HARNESS",
+            "RITUAL",
+            id_width = PLAIN_SESSION_ID_COLUMN_WIDTH
         );
         println!(
-            "{:<12} {:<10} {:<8} {:<8} -----",
-            "-------", "------", "-------", "------"
+            "{:<id_width$} {:<10} {:<8} {:<8} -----",
+            "-------",
+            "------",
+            "-------",
+            "------",
+            id_width = PLAIN_SESSION_ID_COLUMN_WIDTH
         );
         for session in sessions {
             println!("{}", format_session_line(&session));
@@ -1925,15 +1934,19 @@ fn coven_home_from_env(coven_home: Option<OsString>, home: Option<OsString>) -> 
 }
 
 fn format_session_line(session: &store::SessionRecord) -> String {
-    let short_id = first_chars(&session.id, 12);
     let ritual = if session.archived_at.is_some() {
         "archived"
     } else {
         "active"
     };
     format!(
-        "{:<12} {:<10} {:<8} {:<8} {}",
-        short_id, session.status, session.harness, ritual, session.title
+        "{:<id_width$} {:<10} {:<8} {:<8} {}",
+        session.id,
+        session.status,
+        session.harness,
+        ritual,
+        session.title,
+        id_width = PLAIN_SESSION_ID_COLUMN_WIDTH
     )
 }
 
@@ -2407,7 +2420,7 @@ mod tests {
     #[test]
     fn format_session_line_prints_id_status_harness_and_title() {
         let session = store::SessionRecord {
-            id: "session-id".to_string(),
+            id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
             project_root: "/tmp/project".to_string(),
             harness: "codex".to_string(),
             title: "A useful session".to_string(),
@@ -2420,7 +2433,7 @@ mod tests {
 
         assert_eq!(
             format_session_line(&session),
-            "session-id   created    codex    active   A useful session"
+            "550e8400-e29b-41d4-a716-446655440000 created    codex    active   A useful session"
         );
     }
 

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -140,7 +140,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
 
     let active_sessions = run_coven(&coven, &coven_home, &path, &["sessions", "--plain"])?;
     assert_success("active sessions", &active_sessions);
-    assert_stdout_not_contains("active sessions", &active_sessions, &kill_session[..12]);
+    assert_stdout_not_contains("active sessions", &active_sessions, &kill_session);
 
     let archived_sessions = run_coven(
         &coven,
@@ -149,7 +149,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
         &["sessions", "--all", "--plain"],
     )?;
     assert_success("archived sessions", &archived_sessions);
-    assert_stdout_contains("archived sessions", &archived_sessions, &kill_session[..12]);
+    assert_stdout_contains("archived sessions", &archived_sessions, &kill_session);
     assert_stdout_contains("archived sessions", &archived_sessions, "archived");
 
     let summon = run_coven(&coven, &coven_home, &path, &["summon", &kill_session])?;
@@ -157,7 +157,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
 
     let restored_sessions = run_coven(&coven, &coven_home, &path, &["sessions", "--plain"])?;
     assert_success("restored sessions", &restored_sessions);
-    assert_stdout_contains("restored sessions", &restored_sessions, &kill_session[..12]);
+    assert_stdout_contains("restored sessions", &restored_sessions, &kill_session);
     assert_stdout_contains("restored sessions", &restored_sessions, "active");
 
     let sacrifice = run_coven(
@@ -176,11 +176,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
         &["sessions", "--all", "--plain"],
     )?;
     assert_success("all sessions after sacrifice", &all_sessions);
-    assert_stdout_not_contains(
-        "all sessions after sacrifice",
-        &all_sessions,
-        &kill_session[..12],
-    );
+    assert_stdout_not_contains("all sessions after sacrifice", &all_sessions, &kill_session);
 
     let stop = run_coven(&coven, &coven_home, &path, &["daemon", "stop"])?;
     assert_success("daemon stop", &stop);


### PR DESCRIPTION
Summary:
- `coven sessions --plain` now emits copy/paste-safe full session IDs.

Root-cause analysis:
- The plain sessions formatter truncated IDs via `first_chars(..., 12)` while follow-up verbs require exact IDs.

Security:
- No truncated-ID acceptance is added; exact matching remains required for state-changing/destructive commands.

Verification:
- `cargo fmt --check`
- `cargo test -p coven-cli`

Closes #43