### PR TITLE
Add JSON sessions output

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -77,6 +77,8 @@ enum Command {
     Sessions {
         #[arg(long, help = "Include archived sessions")]
         all: bool,
+        #[arg(long, help = "Print sessions as JSON for local integrations")]
+        json: bool,
         #[arg(long, help = "Open the interactive session action browser")]
         manage: bool,
         #[arg(long, help = "Print a plain table instead of the session browser")]
@@ -151,7 +153,12 @@ fn main() -> Result<()> {
             title,
             detach,
         }) => run_session(&harness, &prompt, cwd.as_deref(), title.as_deref(), detach),
-        Some(Command::Sessions { all, manage, plain }) => run_sessions_command(all, manage, plain),
+        Some(Command::Sessions {
+            all,
+            json,
+            manage,
+            plain,
+        }) => run_sessions_command(all, json, manage, plain),
         Some(Command::Attach { session_id }) => attach_session(&session_id),
         Some(Command::Summon { session_id }) => summon_session_command(&session_id),
         Some(Command::Archive { session_id }) => archive_session_command(&session_id),
@@ -584,7 +591,16 @@ fn run_guided_harness_session() -> Result<()> {
     run_session(&harness, &[prompt], None, title.as_deref(), false)
 }
 
-fn run_sessions_command(include_archived: bool, manage: bool, plain: bool) -> Result<()> {
+fn run_sessions_command(
+    include_archived: bool,
+    json: bool,
+    manage: bool,
+    plain: bool,
+) -> Result<()> {
+    if json {
+        return list_sessions_json(include_archived);
+    }
+
     match sessions_command_mode(
         io::stdin().is_terminal(),
         io::stdout().is_terminal(),
@@ -1622,6 +1638,18 @@ fn run_session(
     }
 }
 
+fn list_sessions_json(include_archived: bool) -> Result<()> {
+    let store_path = coven_store_path()?;
+    let conn = store::open_store(&store_path)?;
+    let sessions = if include_archived {
+        store::list_sessions_including_archived(&conn)?
+    } else {
+        store::list_sessions(&conn)?
+    };
+    println!("{}", format_sessions_json(&sessions)?);
+    Ok(())
+}
+
 fn list_sessions(include_archived: bool) -> Result<()> {
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
@@ -1950,6 +1978,10 @@ fn format_session_line(session: &store::SessionRecord) -> String {
     )
 }
 
+fn format_sessions_json(sessions: &[store::SessionRecord]) -> Result<String> {
+    serde_json::to_string(sessions).context("failed to serialize sessions as JSON")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2228,10 +2260,32 @@ mod tests {
     fn cli_accepts_coven_session_ritual_verbs() {
         let sessions = Cli::parse_from(["coven", "sessions", "--all"]);
         match sessions.command {
-            Some(Command::Sessions { all, manage, plain }) => {
+            Some(Command::Sessions {
+                all,
+                json,
+                manage,
+                plain,
+            }) => {
+                assert!(all);
+                assert!(!json);
+                assert!(!manage);
+                assert!(!plain);
+            }
+            other => panic!("expected sessions command, got {other:?}"),
+        }
+
+        let json = Cli::parse_from(["coven", "sessions", "--json", "--all"]);
+        match json.command {
+            Some(Command::Sessions {
+                all,
+                manage,
+                plain,
+                json,
+            }) => {
                 assert!(all);
                 assert!(!manage);
                 assert!(!plain);
+                assert!(json);
             }
             other => panic!("expected sessions command, got {other:?}"),
         }
@@ -2435,6 +2489,29 @@ mod tests {
             format_session_line(&session),
             "550e8400-e29b-41d4-a716-446655440000 created    codex    active   A useful session"
         );
+    }
+
+    #[test]
+    fn format_sessions_json_includes_archived_metadata_for_integrations() -> Result<()> {
+        let sessions = vec![store::SessionRecord {
+            id: "session-1".to_string(),
+            project_root: "/tmp/project".to_string(),
+            harness: "codex".to_string(),
+            title: "A useful session".to_string(),
+            status: "completed".to_string(),
+            exit_code: Some(0),
+            archived_at: Some("2026-04-27T07:00:00Z".to_string()),
+            created_at: "2026-04-27T06:00:00Z".to_string(),
+            updated_at: "2026-04-27T06:10:00Z".to_string(),
+        }];
+
+        let parsed: serde_json::Value = serde_json::from_str(&format_sessions_json(&sessions)?)?;
+
+        assert_eq!(parsed[0]["id"], "session-1");
+        assert_eq!(parsed[0]["project_root"], "/tmp/project");
+        assert_eq!(parsed[0]["status"], "completed");
+        assert_eq!(parsed[0]["archived_at"], "2026-04-27T07:00:00Z");
+        Ok(())
     }
 
     #[test]

--- a/docs/CLIENT-INTEGRATION.md
+++ b/docs/CLIENT-INTEGRATION.md
@@ -105,6 +105,8 @@ A native control room can make Coven easier to operate by showing:
 - logs and traces;
 - docs and troubleshooting links.
 
+Use `coven sessions --json` for active sessions and `coven sessions --json --all` when the client needs archived records too. The JSON shape is the same `SessionRecord` shape exposed by the daemon API, including `project_root`, `status`, `created_at`, `updated_at`, and nullable `archived_at`.
+
 The control room should still use the same socket API and capability handshake as other clients.
 
 ## Desktop automation adapters

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -130,6 +130,8 @@ For scripts or copy/paste workflows:
 ```sh
 coven sessions --plain
 coven sessions --all --plain
+coven sessions --json
+coven sessions --json --all
 ```
 
 ## Attach, archive, summon, and sacrifice

--- a/docs/SESSION-LIFECYCLE.md
+++ b/docs/SESSION-LIFECYCLE.md
@@ -48,6 +48,7 @@ For a completed session, attach acts like a log viewer. For a running session, a
 
 - In an interactive terminal, it opens the session browser.
 - When piped or run with `--plain`, it prints table output.
+- `--json` prints machine-readable session records for local clients.
 - `--all` includes archived sessions.
 - `--manage` forces the browser.
 


### PR DESCRIPTION
## Summary
- add `coven sessions --json` and `coven sessions --json --all` for local clients such as Comux
- emit the existing `SessionRecord` JSON shape, including nullable `archived_at` for archived session visibility
- document JSON sessions usage for scripts and desktop/control-room integrations

Refs BunsDev/comux#6

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p coven-cli cli_accepts_coven_session_ritual_verbs`
- `cargo test -p coven-cli format_sessions_json_includes_archived_metadata_for_integrations`
- `cargo test -p coven-cli`
- `tmp=$(mktemp -d); COVEN_HOME="$tmp" cargo run -q -p coven-cli -- sessions --json --all; rm -rf "$tmp"`