### PR TITLE
Add Coven-side comux demo session JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ coven run claude "polish this UI"
 coven sessions
 coven sessions --all
 coven sessions --plain
+coven sessions --json
 ```
 
-`coven doctor` checks whether supported local harness CLIs are available. `coven run` creates a project-scoped session record, validates the working directory, and launches the selected harness through Coven-managed PTY execution. In a terminal, `coven sessions` opens a human session browser where you can select work and choose visible actions like **Rejoin**, **View Log**, **Summon**, **Archive**, and **Sacrifice** without copying IDs; use `--plain` for scripts or table output.
+`coven doctor` checks whether supported local harness CLIs are available. `coven run` creates a project-scoped session record, validates the working directory, and launches the selected harness through Coven-managed PTY execution. In a terminal, `coven sessions` opens a human session browser where you can select work and choose visible actions like **Rejoin**, **View Log**, **Summon**, **Archive**, and **Sacrifice** without copying IDs; use `--plain` for scripts or `--json` for client discovery.
 
 Coven also provides a rescue loop for OpenClaw contributors and users:
 
@@ -117,6 +118,7 @@ OpenCoven is an open ecosystem for persistent AI familiars: named agents with me
 | `coven sessions --all` | Browse active and archived sessions in a terminal; print all when piped |
 | `coven sessions --manage` | Force the interactive session browser |
 | `coven sessions --plain` | Force plain table output for scripts/copying |
+| `coven sessions --json` | Print a JSON `sessions` array for clients such as comux |
 | `coven attach <session-id>` | Replay/follow session output and forward input |
 | `coven summon <session-id>` | Restore an archived session, then replay/follow it |
 | `coven archive <session-id>` | Hide a non-running session from the active list while preserving events |
@@ -126,7 +128,7 @@ Session rituals are intentionally explicit. **Archive** is reversible and keeps 
 
 ## Local API
 
-The daemon exposes a small versioned HTTP API over a Unix socket for first-party and external clients. The current public contract is **`v1`**; new clients should use the `/api/v1` prefix.
+The daemon exposes a small versioned HTTP API over a Unix socket for first-party and external clients. The current public contract is **`coven.daemon.v1`** served under the `/api/v1` prefix.
 
 Coven's current auth posture is same-user local access over `<covenHome>/coven.sock`. It does not use daemon OAuth, JWTs, bearer tokens, API keys, or browser cookies; provider auth stays with the harness CLIs such as Codex and Claude Code. See [`docs/AUTH.md`](docs/AUTH.md) before adding a new client, dashboard, remote bridge, or browser-facing transport.
 
@@ -143,7 +145,7 @@ Coven's current auth posture is same-user local access over `<covenHome>/coven.s
 
 Treat the socket API as the product contract. Clients may validate for UX, but the Rust daemon remains the authority boundary. See [`docs/API.md`](docs/API.md) for compatibility rules.
 
-Current stable contract: [`docs/API-CONTRACT.md`](docs/API-CONTRACT.md). `GET /api/v1/health` exposes `apiVersion: "v1"` and `supportedApiVersions: ["v1"]` for client handshakes.
+Current stable contract: [`docs/API-CONTRACT.md`](docs/API-CONTRACT.md). `GET /api/v1/health` exposes the named contract `apiVersion: "coven.daemon.v1"` and machine-readable capabilities for client handshakes.
 
 ## Requirements
 
@@ -180,6 +182,7 @@ Coven is the room where harnesses run. The clients decide how to present and rou
 - [Concepts](docs/CONCEPTS.md)
 - [Glossary](docs/GLOSSARY.md)
 - [Public roadmap](docs/ROADMAP.md)
+- [comux + Coven demo loop](docs/COMUX-DEMO-LOOP.md)
 - [Product spec](docs/PRODUCT-SPEC.md)
 - [Architecture diagrams](docs/ARCHITECTURE.md)
 - [Session lifecycle](docs/SESSION-LIFECYCLE.md)

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -81,6 +81,8 @@ enum Command {
         manage: bool,
         #[arg(long, help = "Print a plain table instead of the session browser")]
         plain: bool,
+        #[arg(long, help = "Print sessions as JSON for clients such as comux")]
+        json: bool,
     },
     #[command(about = "Replay/follow a session and forward input to live daemon sessions")]
     Attach { session_id: String },
@@ -151,7 +153,12 @@ fn main() -> Result<()> {
             title,
             detach,
         }) => run_session(&harness, &prompt, cwd.as_deref(), title.as_deref(), detach),
-        Some(Command::Sessions { all, manage, plain }) => run_sessions_command(all, manage, plain),
+        Some(Command::Sessions {
+            all,
+            manage,
+            plain,
+            json,
+        }) => run_sessions_command(all, manage, plain, json),
         Some(Command::Attach { session_id }) => attach_session(&session_id),
         Some(Command::Summon { session_id }) => summon_session_command(&session_id),
         Some(Command::Archive { session_id }) => archive_session_command(&session_id),
@@ -217,6 +224,7 @@ enum SessionBrowserActionKind {
 enum SessionsCommandMode {
     Browser,
     List,
+    Json,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -584,15 +592,22 @@ fn run_guided_harness_session() -> Result<()> {
     run_session(&harness, &[prompt], None, title.as_deref(), false)
 }
 
-fn run_sessions_command(include_archived: bool, manage: bool, plain: bool) -> Result<()> {
+fn run_sessions_command(
+    include_archived: bool,
+    manage: bool,
+    plain: bool,
+    json: bool,
+) -> Result<()> {
     match sessions_command_mode(
         io::stdin().is_terminal(),
         io::stdout().is_terminal(),
         manage,
         plain,
+        json,
     ) {
         SessionsCommandMode::Browser => run_session_browser(include_archived),
-        SessionsCommandMode::List => list_sessions(include_archived),
+        SessionsCommandMode::List => list_sessions_plain(include_archived),
+        SessionsCommandMode::Json => list_sessions_json(include_archived),
     }
 }
 
@@ -601,8 +616,11 @@ fn sessions_command_mode(
     stdout_terminal: bool,
     manage: bool,
     plain: bool,
+    json: bool,
 ) -> SessionsCommandMode {
-    if plain {
+    if json {
+        SessionsCommandMode::Json
+    } else if plain {
         SessionsCommandMode::List
     } else if manage || (stdin_terminal && stdout_terminal) {
         SessionsCommandMode::Browser
@@ -1622,7 +1640,7 @@ fn run_session(
     }
 }
 
-fn list_sessions(include_archived: bool) -> Result<()> {
+fn list_sessions_plain(include_archived: bool) -> Result<()> {
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
     let sessions = if include_archived {
@@ -1669,6 +1687,19 @@ fn list_sessions(include_archived: bool) -> Result<()> {
         println!("  coven sacrifice <session-id> --yes  # permanently delete non-running session");
     }
 
+    Ok(())
+}
+
+fn list_sessions_json(include_archived: bool) -> Result<()> {
+    let store_path = coven_store_path()?;
+    let conn = store::open_store(&store_path)?;
+    let sessions = if include_archived {
+        store::list_sessions_including_archived(&conn)?
+    } else {
+        store::list_sessions(&conn)?
+    };
+
+    println!("{}", render_sessions_json(&sessions)?);
     Ok(())
 }
 
@@ -1950,6 +1981,11 @@ fn format_session_line(session: &store::SessionRecord) -> String {
     )
 }
 
+fn render_sessions_json(sessions: &[store::SessionRecord]) -> Result<String> {
+    serde_json::to_string_pretty(&serde_json::json!({ "sessions": sessions }))
+        .context("failed to serialize sessions as JSON")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2228,10 +2264,16 @@ mod tests {
     fn cli_accepts_coven_session_ritual_verbs() {
         let sessions = Cli::parse_from(["coven", "sessions", "--all"]);
         match sessions.command {
-            Some(Command::Sessions { all, manage, plain }) => {
+            Some(Command::Sessions {
+                all,
+                manage,
+                plain,
+                json,
+            }) => {
                 assert!(all);
                 assert!(!manage);
                 assert!(!plain);
+                assert!(!json);
             }
             other => panic!("expected sessions command, got {other:?}"),
         }
@@ -2242,6 +2284,12 @@ mod tests {
                 assert!(manage);
                 assert!(plain);
             }
+            other => panic!("expected sessions command, got {other:?}"),
+        }
+
+        let json = Cli::parse_from(["coven", "sessions", "--json"]);
+        match json.command {
+            Some(Command::Sessions { json, .. }) => assert!(json),
             other => panic!("expected sessions command, got {other:?}"),
         }
 
@@ -2270,20 +2318,24 @@ mod tests {
     #[test]
     fn sessions_command_opens_browser_for_humans_and_plain_tables_for_scripts() {
         assert_eq!(
-            sessions_command_mode(true, true, false, false),
+            sessions_command_mode(true, true, false, false, false),
             SessionsCommandMode::Browser
         );
         assert_eq!(
-            sessions_command_mode(false, true, false, false),
+            sessions_command_mode(false, true, false, false, false),
             SessionsCommandMode::List
         );
         assert_eq!(
-            sessions_command_mode(false, false, true, false),
+            sessions_command_mode(false, false, true, false, false),
             SessionsCommandMode::Browser
         );
         assert_eq!(
-            sessions_command_mode(true, true, true, true),
+            sessions_command_mode(true, true, true, true, false),
             SessionsCommandMode::List
+        );
+        assert_eq!(
+            sessions_command_mode(true, true, true, true, true),
+            SessionsCommandMode::Json
         );
     }
 
@@ -2435,6 +2487,30 @@ mod tests {
             format_session_line(&session),
             "550e8400-e29b-41d4-a716-446655440000 created    codex    active   A useful session"
         );
+    }
+
+    #[test]
+    fn render_sessions_json_prints_client_friendly_session_array() -> Result<()> {
+        let session = store::SessionRecord {
+            id: "session-1".to_string(),
+            project_root: "/tmp/project".to_string(),
+            harness: "codex".to_string(),
+            title: "Demo loop".to_string(),
+            status: "running".to_string(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-05-14T07:00:00Z".to_string(),
+            updated_at: "2026-05-14T07:00:01Z".to_string(),
+        };
+
+        let rendered = render_sessions_json(&[session])?;
+        let body: serde_json::Value = serde_json::from_str(&rendered)?;
+
+        assert_eq!(body["sessions"][0]["id"], "session-1");
+        assert_eq!(body["sessions"][0]["project_root"], "/tmp/project");
+        assert_eq!(body["sessions"][0]["harness"], "codex");
+        assert_eq!(body["sessions"][0]["status"], "running");
+        Ok(())
     }
 
     #[test]

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,7 @@ See [Authentication and local access](AUTH.md) for the current auth posture. In 
 
 ## Versioning
 
-The current public API contract is **`v1`**.
+The current public API contract is the named **`coven.daemon.v1`** contract served under the `/api/v1` route prefix.
 
 Versioned clients should use the `/api/v1` prefix:
 
@@ -35,9 +35,15 @@ Unknown `/api/<version>/...` prefixes fail closed with an `unsupported API versi
 
 ```json
 {
-  "apiVersion": "v1",
-  "supportedApiVersions": ["v1"],
   "ok": true,
+  "apiVersion": "coven.daemon.v1",
+  "covenVersion": "0.0.0",
+  "capabilities": {
+    "sessions": true,
+    "events": true,
+    "eventCursor": "sequence",
+    "structuredErrors": true
+  },
   "daemon": {
     "pid": 12345,
     "startedAt": "2026-05-09T12:00:00Z",

--- a/docs/CLIENT-INTEGRATION.md
+++ b/docs/CLIENT-INTEGRATION.md
@@ -9,7 +9,7 @@ Talk to Coven through the local socket API. Do not duplicate Coven's path, harne
 Recommended handshake:
 
 1. Call `GET /api/v1/health`.
-2. Confirm `supportedApiVersions` includes `v1`.
+2. Confirm `apiVersion === "coven.daemon.v1"` and the needed `capabilities` fields are available.
 3. Call `GET /api/v1/capabilities` if using control-plane actions.
 4. Use versioned `/api/v1/...` routes only.
 
@@ -47,6 +47,7 @@ Good comux responsibilities:
 - launch sessions from visible project/worktree context;
 - open sessions in panes;
 - attach/rejoin live work;
+- read `coven sessions --json` for simple local discovery when daemon-level control is unnecessary;
 - show logs and artifacts;
 - help review diffs;
 - help merge, PR, archive, or clean up explicitly.

--- a/docs/COMUX-DEMO-LOOP.md
+++ b/docs/COMUX-DEMO-LOOP.md
@@ -1,0 +1,79 @@
+# comux + Coven Demo Loop
+
+This is the Coven-side contract for making Coven-managed Codex and Claude Code sessions visible in comux.
+
+## Loop
+
+1. Open the target repository in comux.
+2. Start Coven if needed:
+
+   ```sh
+   coven daemon start
+   ```
+
+3. Launch a Coven-backed session from the same repository:
+
+   ```sh
+   coven run codex "fix the failing tests"
+   coven run claude "review the diff"
+   ```
+
+4. Let comux discover sessions through either supported client path:
+   - `coven sessions --json` for simple local CLI discovery.
+   - `GET /api/v1/sessions` after `GET /api/v1/health` for daemon clients.
+5. Open the session as a visible comux pane, or attach manually:
+
+   ```sh
+   coven attach <session-id>
+   ```
+
+6. Inspect files, diffs, and session output from comux.
+7. Merge, create a PR, archive, summon, sacrifice, or clean up explicitly after verification.
+
+## CLI discovery
+
+`coven sessions --json` prints a stable object with a `sessions` array. Records use the same snake_case field names as the daemon API:
+
+```json
+{
+  "sessions": [
+    {
+      "id": "session-1",
+      "project_root": "/repo",
+      "harness": "codex",
+      "title": "Fix the tests",
+      "status": "running",
+      "exit_code": null,
+      "archived_at": null,
+      "created_at": "2026-05-14T07:00:00Z",
+      "updated_at": "2026-05-14T07:00:01Z"
+    }
+  ]
+}
+```
+
+Use `--all --json` when archived sessions should remain visible.
+
+## Daemon discovery
+
+Daemon clients should use the versioned socket API:
+
+1. `GET /api/v1/health`
+2. Verify `apiVersion === "coven.daemon.v1"` and `capabilities.sessions === true`.
+3. `GET /api/v1/sessions`
+4. Filter sessions by verified project root before showing them in a project-scoped UI.
+
+The daemon socket defaults to `~/.coven/coven.sock`. The daemon remains the authority for project roots, cwd, harness ids, live-session checks, input, kill requests, archive state, and destructive deletion rules.
+
+## Unavailable states
+
+Clients should keep their core UI usable when Coven is missing or stopped:
+
+- CLI missing: show install guidance for `@opencoven/cli`.
+- Daemon stopped or socket missing: suggest `coven daemon start`.
+- Harness missing: suggest `coven doctor`.
+- Unsupported API version: ask the user to update Coven or the client.
+
+## Roadmap
+
+The broader OpenCoven roadmap remains the public tracking point for the end-to-end demo: [ROADMAP.md](ROADMAP.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The guiding promise: OpenCoven turns AI from a blank chatbox into a living works
 - [Concepts](CONCEPTS.md) — core nouns: harness, project root, session, daemon, client, control plane, and rituals.
 - [Glossary](GLOSSARY.md) — short definitions for recurring product and architecture terms.
 - [Public roadmap](ROADMAP.md) — community-facing progress snapshot across Coven, comux, and integrations.
+- [comux + Coven demo loop](COMUX-DEMO-LOOP.md) — Coven-side CLI/API contract for the visible comux cockpit flow.
 - [Product spec](PRODUCT-SPEC.md) — what Coven is and what belongs in MVP.
 - [Architecture diagrams](ARCHITECTURE.md) — runtime topology, session lifecycle, and authority boundary diagrams.
 - [Session lifecycle](SESSION-LIFECYCLE.md) — launch, attach/replay, archive, summon, sacrifice, orphan recovery, and events.


### PR DESCRIPTION
## Summary
- add `coven sessions --json` for comux/local client session discovery
- document the comux + Coven demo loop from the Coven side
- align public client/API docs with the current `coven.daemon.v1` health handshake

## Verification
- `cargo fmt --check`
- `cargo test -p coven-cli sessions`
- `tmp=$(mktemp -d) && COVEN_HOME="$tmp" cargo run -p coven-cli -- sessions --json`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`

Does not close BunsDev/comux#5; this is the Coven-side support PR.
