### PR TITLE
docs(troubleshooting): add system health and pressure section

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -61,6 +61,28 @@ coven daemon restart
 
 If a client cannot connect, verify it is using the same `COVEN_HOME` as the CLI.
 
+## System health and pressure
+
+If sessions feel slow, the daemon is sluggish to start, or `coven doctor` succeeds but harness work stalls, the underlying machine may be under CPU, memory, or disk pressure.
+
+`coven pc` surfaces a local system report without launching a harness. All read operations are side-effect free:
+
+```sh
+coven pc                  # full report: CPU, memory, disk, top processes
+coven pc status           # one-line health summary
+coven pc top --n 10       # top-N processes by CPU usage
+coven pc disk             # disk usage breakdown
+```
+
+Relief operations mutate system state and require an explicit `--confirm` gate:
+
+```sh
+coven pc kill <pid> --confirm     # SIGTERM with PID identity re-check
+coven pc cache clear --confirm    # clear ~/Library/Caches + /Library/Caches
+```
+
+`coven pc` is currently macOS-first. See [Diagnostics and relief](GETTING-STARTED.md#diagnostics-and-relief) in Getting started for the full command reference.
+
 ## Stale running sessions
 
 If a daemon stopped while sessions were running, those records may become `orphaned` on the next daemon start.


### PR DESCRIPTION
Title:
docs(troubleshooting): add system health and pressure section

Body (copy-paste):

## Summary

* Add a `System health and pressure` section to `docs/TROUBLESHOOTING.md` pointing to `coven pc` for diagnosing local CPU, memory, and disk pressure.
* Cover the read-only inspection commands (`coven pc`, `status`, `top`, `disk`) and the `--confirm`-gated relief commands.
* Link back to `docs/GETTING-STARTED.md#diagnostics-and-relief` for the full reference instead of duplicating it.

## Background

`coven pc` shipped in #41 (60688b9) and was documented in `GETTING-STARTED.md`, but `TROUBLESHOOTING.md` did not reference it. Users hitting daemon sluggishness or stalled harness work had no pointer from the canonical troubleshooting doc to the existing diagnostics tool. This closes the drift without duplicating content.

## Verification

* `python3 scripts/check-secrets.py`
* `git diff --check`
