### PR TITLE
fix(api): reject non-integer limit and afterSeq with structured 400

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -382,11 +382,35 @@ fn list_session_events(coven_home: &Path, session_id: &str, query: &str) -> Resu
         );
     }
 
-    let after_seq = query_param(query, "afterSeq").and_then(|v| v.parse::<i64>().ok());
+    let after_seq = match query_param(query, "afterSeq") {
+        Some(v) => match v.parse::<i64>() {
+            Ok(n) => Some(n),
+            Err(_) => {
+                return api_error(
+                    400,
+                    "invalid_request",
+                    "afterSeq must be an integer.",
+                    Some(json!({ "afterSeq": v })),
+                );
+            }
+        },
+        None => None,
+    };
     let after_event_id = query_param(query, "afterEventId").map(str::to_string);
-    let limit = query_param(query, "limit")
-        .and_then(|v| v.parse::<i64>().ok())
-        .map(|l| l.clamp(1, MAX_EVENTS_LIMIT));
+    let limit = match query_param(query, "limit") {
+        Some(v) => match v.parse::<i64>() {
+            Ok(n) => Some(n.clamp(1, MAX_EVENTS_LIMIT)),
+            Err(_) => {
+                return api_error(
+                    400,
+                    "invalid_request",
+                    "limit must be an integer.",
+                    Some(json!({ "limit": v })),
+                );
+            }
+        },
+        None => None,
+    };
 
     let opts = store::EventsQueryOptions {
         after_seq,
@@ -1209,6 +1233,42 @@ mod tests {
 
         assert_eq!(response.status, 400);
         assert!(response.body.contains(r#""code":"invalid_request""#));
+        Ok(())
+    }
+
+    #[test]
+    fn events_endpoint_returns_structured_error_for_non_integer_limit() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        let response = handle_request(
+            "GET",
+            "/events?sessionId=session-1&limit=foo",
+            temp_dir.path(),
+            None,
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""code":"invalid_request""#));
+        assert!(response.body.contains(r#""limit":"foo""#));
+        Ok(())
+    }
+
+    #[test]
+    fn events_endpoint_returns_structured_error_for_non_integer_after_seq() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        let response = handle_request(
+            "GET",
+            "/events?sessionId=session-1&afterSeq=foo",
+            temp_dir.path(),
+            None,
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""code":"invalid_request""#));
+        assert!(response.body.contains(r#""afterSeq":"foo""#));
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -372,16 +372,6 @@ fn session_not_live_response(session_id: &str) -> Result<ApiResponse> {
 }
 
 fn list_session_events(coven_home: &Path, session_id: &str, query: &str) -> Result<ApiResponse> {
-    let conn = store::open_store(&store_path(coven_home))?;
-    if store::get_session(&conn, session_id)?.is_none() {
-        return api_error(
-            404,
-            "session_not_found",
-            "Session was not found.",
-            Some(json!({ "sessionId": session_id })),
-        );
-    }
-
     let after_seq = match query_param(query, "afterSeq") {
         Some(v) => match v.parse::<i64>() {
             Ok(n) => Some(n),
@@ -411,6 +401,16 @@ fn list_session_events(coven_home: &Path, session_id: &str, query: &str) -> Resu
         },
         None => None,
     };
+
+    let conn = store::open_store(&store_path(coven_home))?;
+    if store::get_session(&conn, session_id)?.is_none() {
+        return api_error(
+            404,
+            "session_not_found",
+            "Session was not found.",
+            Some(json!({ "sessionId": session_id })),
+        );
+    }
 
     let opts = store::EventsQueryOptions {
         after_seq,
@@ -1262,6 +1262,38 @@ mod tests {
         let response = handle_request(
             "GET",
             "/events?sessionId=session-1&afterSeq=foo",
+            temp_dir.path(),
+            None,
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""code":"invalid_request""#));
+        assert!(response.body.contains(r#""afterSeq":"foo""#));
+        Ok(())
+    }
+
+    #[test]
+    fn events_endpoint_validates_limit_before_session_lookup() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let response = handle_request(
+            "GET",
+            "/events?sessionId=ghost&limit=foo",
+            temp_dir.path(),
+            None,
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""code":"invalid_request""#));
+        assert!(response.body.contains(r#""limit":"foo""#));
+        Ok(())
+    }
+
+    #[test]
+    fn events_endpoint_validates_after_seq_before_session_lookup() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let response = handle_request(
+            "GET",
+            "/events?sessionId=ghost&afterSeq=foo",
             temp_dir.path(),
             None,
         )?;


### PR DESCRIPTION
## Summary

* Return `400 invalid_request` from `GET /api/v1/events` when `limit` or `afterSeq` cannot be parsed as an integer.
* Echo the offending value in the structured error `details` so clients can surface a clear message.
* Preserve the existing clamping behavior for in-range integer limits.

## Root Cause

`list_session_events` in `crates/coven-cli/src/api.rs` used `.parse::<i64>().ok()` for both `limit` and `afterSeq`, so malformed values silently fell back to defaults instead of returning a client error. That made typos like `limit=abc` indistinguishable from omitted parameters. The existing `events_endpoint_returns_structured_error_for_missing_session_id` test already exercises that contract for a missing `sessionId`.

## Scope

Out-of-range and negative integer values are intentionally left as a separate concern. The current numeric clamp from 1 to `MAX_EVENTS_LIMIT` is preserved for syntactically valid input. A follow-up can decide whether `limit=-1` or `limit=0` should also reject with `invalid_request`.

## Verification

* `cargo fmt --check`
* `cargo clippy --workspace --all-targets -- -D warnings`
* `cargo test --workspace --locked` (144 passed, 0 failed; 4 smoke tests pass)
* `cargo test -p coven-cli events_endpoint_returns_structured_error` (4 passed, including the 2 new tests)
