### PR TITLE
Potential fix for code scanning alert no. 7: Double escaping or unescaping

### DIFF
--- a/docs/scripts/docs-site/build.mjs
+++ b/docs/scripts/docs-site/build.mjs
@@ -244,11 +244,11 @@ function renderMintlifyBlocks(markdown) {
 
 function decodeHtml(value) {
   return String(value)
-    .replaceAll('&amp;', '&')
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')
     .replaceAll('&quot;', '"')
-    .replaceAll('&#39;', "'");
+    .replaceAll('&#39;', "'")
+    .replaceAll('&amp;', '&');
 }
 
 function stripTags(value) {

--- a/docs/scripts/docs-site/build.mjs
+++ b/docs/scripts/docs-site/build.mjs
@@ -243,6 +243,8 @@ function renderMintlifyBlocks(markdown) {
 }
 
 function decodeHtml(value) {
+  // Decode &amp; last so that sequences like &amp;lt; decode to &lt; (not <),
+  // preventing double-unescaping of HTML entities.
   return String(value)
     .replaceAll('&lt;', '<')
     .replaceAll('&gt;', '>')


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/7](https://github.com/OpenCoven/coven/security/code-scanning/7)

To fix this safely without changing intended functionality, keep the same custom decoding logic but reorder replacements so `&amp;` is decoded last.  
That preserves expected decoding of normal entities while preventing double-unescape of sequences like `&amp;lt;`.

**Change location:** `docs/scripts/docs-site/build.mjs`, in `decodeHtml(value)` (lines 245–252 in the snippet).  
**Implementation detail:** Move `.replaceAll('&amp;', '&')` to the end of the replacement chain. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
