### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete multi-character sanitization

### DIFF
--- a/docs/scripts/docs-site/build.mjs
+++ b/docs/scripts/docs-site/build.mjs
@@ -252,10 +252,24 @@ function decodeHtml(value) {
 }
 
 function stripTags(value) {
-  return decodeHtml(String(value))
-    .replace(/[<>]/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
+  const decoded = decodeHtml(String(value));
+  let result = '';
+  let inTag = false;
+  for (let i = 0; i < decoded.length; i++) {
+    const ch = decoded[i];
+    if (ch === '<') {
+      inTag = true;
+    } else if (ch === '>') {
+      if (inTag) {
+        inTag = false;
+      } else {
+        result += ch;
+      }
+    } else if (!inTag) {
+      result += ch;
+    }
+  }
+  return result.replace(/\s+/g, ' ').trim();
 }
 
 function collectToc(html) {

--- a/docs/scripts/docs-site/build.mjs
+++ b/docs/scripts/docs-site/build.mjs
@@ -252,7 +252,10 @@ function decodeHtml(value) {
 }
 
 function stripTags(value) {
-  return decodeHtml(String(value).replace(/<[^>]*>/g, '')).replace(/\s+/g, ' ').trim();
+  return decodeHtml(String(value))
+    .replace(/[<>]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 function collectToc(html) {


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/8](https://github.com/OpenCoven/coven/security/code-scanning/8)

Use a robust, character-level neutralization approach instead of trying to remove whole tags with a single multi-character regex pass.  
Best fix here (without changing intended functionality): decode entities first, then strip angle brackets (`<` and `>`) directly, then normalize whitespace. This avoids the “re-appearing unsafe token” issue tied to multi-character tag matching and still produces clean plain-text titles.

Edit only `docs/scripts/docs-site/build.mjs`, replacing the body of `stripTags` at the shown region (line ~255). No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
