### PR TITLE
cast: phase 1 — Coven front-door familiar

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -858,6 +858,9 @@ fn coven_home_from_env(coven_home: Option<OsString>, home: Option<OsString>) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui::cast::{
+        build_plan, parse_spell, CastHarness, CastIntent, CastRisk, CastStepKind,
+    };
     use crate::tui::is_key_press;
     use crate::tui::sessions::{
         format_session_line, render_session_browser_frame_plain, render_sessions_json,
@@ -866,11 +869,11 @@ mod tests {
         SESSION_BROWSER_FIRST_SESSION_ROW,
     };
     use crate::tui::shell::{
-        magical_tui_inner_width_for_columns, magical_tui_items, move_magical_tui_selection,
-        parse_magical_tui_input, render_magical_tui_frame_for_raw_terminal,
-        render_magical_tui_frame_plain, render_magical_tui_frame_plain_with_input,
-        render_magical_tui_frame_plain_with_width, MagicalTuiMove, MagicalTuiRequest,
-        MAGICAL_TUI_MAX_INNER_WIDTH,
+        cast_non_interactive_frame_for_test, magical_tui_inner_width_for_columns,
+        magical_tui_items, move_magical_tui_selection, parse_magical_tui_input,
+        render_magical_tui_frame_for_raw_terminal, render_magical_tui_frame_plain,
+        render_magical_tui_frame_plain_with_input, render_magical_tui_frame_plain_with_width,
+        MagicalTuiMove, MagicalTuiRequest, MAGICAL_TUI_MAX_INNER_WIDTH,
     };
     use crossterm::event::KeyEventKind;
 
@@ -1185,6 +1188,74 @@ mod tests {
             MagicalTuiRequest::AttachSession("abc123".to_string())
         );
         Ok(())
+    }
+
+    #[test]
+    fn cast_non_interactive_frame_introduces_cast_and_shows_examples() {
+        let project = PathBuf::from("/tmp/some-repo");
+        let frame = cast_non_interactive_frame_for_test(Some(&project), Some("codex"));
+
+        assert!(frame.contains("Cast"), "frame is missing the Cast salute");
+        assert!(frame.contains("Coven familiar"));
+        assert!(frame.contains("/tmp/some-repo"));
+        assert!(frame.contains("codex"));
+        assert!(frame.contains("fix the failing tests"));
+        assert!(frame.contains("run claude polish the README"));
+        assert!(frame.contains("/sessions"));
+    }
+
+    #[test]
+    fn cast_parses_natural_text_as_default_harness_spell() {
+        let intent = parse_spell("fix the failing tests").expect("parse");
+        match intent {
+            CastIntent::NaturalSpell { prompt } => assert_eq!(prompt, "fix the failing tests"),
+            other => panic!("expected natural spell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cast_routes_run_claude_plain_language_to_claude() {
+        let intent = parse_spell("run claude polish the README").expect("parse");
+        match intent {
+            CastIntent::HarnessSpell { harness, prompt } => {
+                assert_eq!(harness, CastHarness::Claude);
+                assert_eq!(prompt, "polish the README");
+            }
+            other => panic!("expected harness spell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cast_routes_sessions_keyword_to_session_browser() {
+        let intent = parse_spell("sessions").expect("parse");
+        assert!(matches!(intent, CastIntent::OpenSessions));
+    }
+
+    #[test]
+    fn cast_plan_picks_safe_default_harness_for_natural_spell() {
+        let plan = build_plan(parse_spell("fix the failing tests").unwrap(), || {
+            Some(CastHarness::Codex)
+        })
+        .unwrap();
+
+        assert_eq!(plan.risk(), CastRisk::Safe);
+        let harness = plan.harness.expect("default harness should be resolved");
+        assert_eq!(harness.harness, CastHarness::Codex);
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.kind == CastStepKind::LaunchSession));
+    }
+
+    #[test]
+    fn cast_plan_marks_publish_spells_as_confirmation_required() {
+        let plan = build_plan(
+            parse_spell("publish the new crate to crates.io").unwrap(),
+            || Some(CastHarness::Codex),
+        )
+        .unwrap();
+
+        assert_eq!(plan.risk(), CastRisk::Confirm);
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -859,7 +859,7 @@ fn coven_home_from_env(coven_home: Option<OsString>, home: Option<OsString>) -> 
 mod tests {
     use super::*;
     use crate::tui::cast::{
-        build_plan, parse_spell, CastHarness, CastIntent, CastRisk, CastStepKind,
+        build_plan, parse_spell, CastHarness, CastIntent, CastRisk, CastStepKind, SafetyDecision,
     };
     use crate::tui::is_key_press;
     use crate::tui::sessions::{
@@ -1256,6 +1256,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(plan.risk(), CastRisk::Confirm);
+    }
+
+    #[test]
+    fn cast_plan_for_sacrifice_describes_typed_confirm_in_copy() {
+        let plan = build_plan(parse_spell("/sacrifice abcdef123456").unwrap(), || {
+            Some(CastHarness::Codex)
+        })
+        .unwrap();
+
+        let inform_note = plan
+            .steps
+            .iter()
+            .find(|step| matches!(step.kind, CastStepKind::Inform))
+            .expect("sacrifice plan should include an inform step");
+        assert!(
+            inform_note.note.to_lowercase().contains("typed"),
+            "sacrifice inform should describe typed-word confirm, got {:?}",
+            inform_note.note
+        );
+        match plan.decision {
+            SafetyDecision::Confirm { suggestion, .. } => {
+                assert!(
+                    suggestion.contains("`sacrifice`"),
+                    "sacrifice suggestion should name the typed-confirm word, got {suggestion:?}"
+                );
+            }
+            other => panic!("expected confirm, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/follow.rs
+++ b/crates/coven-cli/src/tui/cast/follow.rs
@@ -1,0 +1,586 @@
+//! Cast event follower.
+//!
+//! Phase 2 streams a launched daemon session into the Cast TUI as a
+//! conversation transcript: each `output` event becomes a printable chunk,
+//! each `exit` event marks completion, and a monotonic `afterSeq` cursor
+//! ensures Cast never prints the same line twice across polls.
+//!
+//! The follower is intentionally decoupled from the wire transport. It
+//! consumes the existing `tui::chat::client::ChatClient` trait, which lets
+//! tests pass a stub implementation that returns canned events without
+//! touching the daemon socket.
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::store;
+use crate::tui::chat::client::{ChatClient, ChatEventQuery};
+
+/// A monotonic cursor over a session's event stream. The cursor only ever
+/// advances forward; passing the cursor back to the daemon as `afterSeq`
+/// guarantees no duplicate delivery during normal polling.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CastFollowCursor {
+    after_seq: Option<i64>,
+}
+
+impl CastFollowCursor {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn after_seq(&self) -> Option<i64> {
+        self.after_seq
+    }
+
+    /// Advance the cursor to the maximum seq seen so far. Stale or
+    /// out-of-order seqs are ignored so a misbehaving client cannot rewind.
+    pub(crate) fn advance(&mut self, seq: i64) {
+        if self.after_seq.map(|current| seq > current).unwrap_or(true) {
+            self.after_seq = Some(seq);
+        }
+    }
+}
+
+/// The Cast-facing shape of a single daemon event. Cast only renders
+/// the kinds it understands; unknown event kinds are surfaced as
+/// `Other` so the follower can still advance the cursor without losing
+/// future events.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CastFollowEvent {
+    /// A chunk of harness output. Already extracted from the payload's
+    /// `data` field; the renderer can print it verbatim.
+    Output(String),
+    /// The session finished. `status` is the lifecycle string the daemon
+    /// records (`completed`, `failed`, `exited`); `exit_code` may be
+    /// `None` if the harness did not produce one.
+    Exit {
+        status: String,
+        exit_code: Option<i32>,
+    },
+    /// An event whose kind Cast does not specifically handle yet. The
+    /// follower still advances the cursor past it so resumes work.
+    Other { kind: String },
+}
+
+/// Translate a stored event record into the Cast follow shape. Pure
+/// function — no IO, easy to unit-test against synthetic events.
+pub(crate) fn decode_event(record: &store::EventRecord) -> CastFollowEvent {
+    match record.kind.as_str() {
+        "output" => {
+            let data = parse_payload(&record.payload_json)
+                .and_then(|value| {
+                    value
+                        .get("data")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned)
+                })
+                .unwrap_or_default();
+            CastFollowEvent::Output(data)
+        }
+        "exit" => {
+            let payload = parse_payload(&record.payload_json);
+            let status = payload
+                .as_ref()
+                .and_then(|value| value.get("status").and_then(Value::as_str))
+                .unwrap_or("unknown")
+                .to_string();
+            let exit_code = payload
+                .as_ref()
+                .and_then(|value| {
+                    value
+                        .get("exitCode")
+                        .and_then(Value::as_i64)
+                        .map(|v| v as i32)
+                })
+                .or_else(|| {
+                    payload.as_ref().and_then(|value| {
+                        value
+                            .get("exit_code")
+                            .and_then(Value::as_i64)
+                            .map(|v| v as i32)
+                    })
+                });
+            CastFollowEvent::Exit { status, exit_code }
+        }
+        other => CastFollowEvent::Other {
+            kind: other.to_string(),
+        },
+    }
+}
+
+/// Decoded follower batch returned by a single poll. Carries the cursor
+/// the caller should use for the next request (or save in case it
+/// reconnects after a crash).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CastFollowBatch {
+    pub(crate) events: Vec<CastFollowEvent>,
+    pub(crate) cursor: CastFollowCursor,
+    pub(crate) exit: Option<CastSessionExit>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CastSessionExit {
+    pub(crate) status: String,
+    pub(crate) exit_code: Option<i32>,
+}
+
+/// Observer for the running follower loop. The IO-heavy caller (stdout
+/// writer, transcript renderer) implements this trait; the loop stays
+/// free of side effects so tests can drive it with a recording observer
+/// and a canned client.
+pub(crate) trait FollowerObserver {
+    fn on_output(&mut self, chunk: &str);
+    fn on_exit(&mut self, status: &str, exit_code: Option<i32>);
+    /// Cast doesn't render unknown event kinds today; observers can record
+    /// them for debug overlays in a future phase.
+    fn on_other(&mut self, _kind: &str) {}
+}
+
+/// Pacer for the follower poll loop. Production passes a `Duration` sleep;
+/// tests pass a counter that returns `Err` after N idle polls so a stuck
+/// session can't hang the suite.
+pub(crate) trait FollowerPacer {
+    /// Called after every poll that did not produce an exit. Implementations
+    /// may sleep, count, or panic on iteration overflows. Returning an
+    /// `Err` cleanly aborts the follower with that error.
+    fn between_polls(&mut self) -> Result<()>;
+}
+
+/// Run the follower poll loop until the session emits an `exit` event or
+/// the pacer returns an error. Each batch of events is decoded and pushed
+/// to the observer; the cursor monotonically advances on every event so
+/// duplicates are impossible.
+pub(crate) fn follow_until_exit(
+    client: &mut dyn ChatClient,
+    session_id: &str,
+    observer: &mut dyn FollowerObserver,
+    pacer: &mut dyn FollowerPacer,
+) -> Result<CastSessionExit> {
+    let mut cursor = CastFollowCursor::new();
+    loop {
+        let batch = poll_once(client, session_id, cursor)?;
+        cursor = batch.cursor;
+        for event in &batch.events {
+            match event {
+                CastFollowEvent::Output(chunk) => observer.on_output(chunk),
+                CastFollowEvent::Exit { status, exit_code } => {
+                    observer.on_exit(status, *exit_code);
+                }
+                CastFollowEvent::Other { kind } => observer.on_other(kind),
+            }
+        }
+        if let Some(exit) = batch.exit {
+            return Ok(exit);
+        }
+        pacer.between_polls()?;
+    }
+}
+
+/// Poll the daemon once for events past `cursor`, decode them, and return
+/// a typed batch. The returned cursor reflects the maximum seq seen — pass
+/// it back on the next call to avoid re-fetching events. If an `exit`
+/// event lands in this batch, `batch.exit` is populated; the caller should
+/// stop polling.
+pub(crate) fn poll_once(
+    client: &mut dyn ChatClient,
+    session_id: &str,
+    cursor: CastFollowCursor,
+) -> Result<CastFollowBatch> {
+    let records = client.list_events(ChatEventQuery {
+        session_id,
+        after_seq: cursor.after_seq(),
+        limit: None,
+    })?;
+
+    let mut new_cursor = cursor;
+    let mut events = Vec::with_capacity(records.len());
+    let mut exit = None;
+    for record in records {
+        new_cursor.advance(record.seq);
+        let decoded = decode_event(&record);
+        if let CastFollowEvent::Exit { status, exit_code } = &decoded {
+            exit = Some(CastSessionExit {
+                status: status.clone(),
+                exit_code: *exit_code,
+            });
+        }
+        events.push(decoded);
+    }
+
+    Ok(CastFollowBatch {
+        events,
+        cursor: new_cursor,
+        exit,
+    })
+}
+
+fn parse_payload(payload_json: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(payload_json).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::chat::client::LaunchRequest;
+    use std::cell::RefCell;
+
+    /// Stub client that returns canned event batches in order. The first
+    /// call returns `batches[0]`, the second returns `batches[1]`, etc.
+    /// Test failures show the queries the follower made so we can verify
+    /// cursor handoff.
+    struct StubClient {
+        batches: RefCell<Vec<Vec<store::EventRecord>>>,
+        queries: RefCell<Vec<(Option<i64>, String)>>,
+    }
+
+    impl StubClient {
+        fn new(batches: Vec<Vec<store::EventRecord>>) -> Self {
+            Self {
+                batches: RefCell::new(batches),
+                queries: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ChatClient for StubClient {
+        fn launch_session(&mut self, _request: LaunchRequest) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised in follower tests")
+        }
+
+        fn get_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised in follower tests")
+        }
+
+        fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
+            unimplemented!("not exercised in follower tests")
+        }
+
+        fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {
+            self.queries
+                .borrow_mut()
+                .push((query.after_seq, query.session_id.to_string()));
+            let mut batches = self.batches.borrow_mut();
+            if batches.is_empty() {
+                Ok(vec![])
+            } else {
+                Ok(batches.remove(0))
+            }
+        }
+
+        fn send_input(&mut self, _session_id: &str, _data: &str) -> Result<()> {
+            unimplemented!("not exercised in follower tests")
+        }
+
+        fn kill_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised in follower tests")
+        }
+    }
+
+    fn output_event(seq: i64, data: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: "output".to_string(),
+            payload_json: serde_json::json!({ "data": data }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    fn exit_event(seq: i64, status: &str, exit_code: Option<i32>) -> store::EventRecord {
+        let payload = match exit_code {
+            Some(code) => serde_json::json!({ "status": status, "exitCode": code }),
+            None => serde_json::json!({ "status": status }),
+        };
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: "exit".to_string(),
+            payload_json: payload.to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn decode_output_event_extracts_data_chunk() {
+        let event = output_event(1, "hello world\n");
+        assert_eq!(
+            decode_event(&event),
+            CastFollowEvent::Output("hello world\n".to_string())
+        );
+    }
+
+    #[test]
+    fn decode_output_event_handles_missing_payload_safely() {
+        let mut event = output_event(1, "ignored");
+        event.payload_json = "not json".to_string();
+        assert_eq!(decode_event(&event), CastFollowEvent::Output(String::new()));
+    }
+
+    #[test]
+    fn decode_exit_event_extracts_status_and_exit_code() {
+        let event = exit_event(7, "completed", Some(0));
+        assert_eq!(
+            decode_event(&event),
+            CastFollowEvent::Exit {
+                status: "completed".to_string(),
+                exit_code: Some(0),
+            }
+        );
+    }
+
+    #[test]
+    fn decode_exit_event_handles_missing_exit_code() {
+        let event = exit_event(7, "failed", None);
+        assert_eq!(
+            decode_event(&event),
+            CastFollowEvent::Exit {
+                status: "failed".to_string(),
+                exit_code: None,
+            }
+        );
+    }
+
+    #[test]
+    fn decode_exit_event_accepts_snake_case_exit_code_too() {
+        let mut event = exit_event(7, "completed", None);
+        event.payload_json =
+            serde_json::json!({ "status": "completed", "exit_code": 137 }).to_string();
+        assert_eq!(
+            decode_event(&event),
+            CastFollowEvent::Exit {
+                status: "completed".to_string(),
+                exit_code: Some(137),
+            }
+        );
+    }
+
+    #[test]
+    fn decode_unknown_kind_becomes_other_with_kind_label() {
+        let event = store::EventRecord {
+            seq: 42,
+            id: "event-42".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "cast.summary".to_string(),
+            payload_json: "{}".to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        };
+        assert_eq!(
+            decode_event(&event),
+            CastFollowEvent::Other {
+                kind: "cast.summary".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn cursor_advances_monotonically_and_ignores_rewinds() {
+        let mut cursor = CastFollowCursor::new();
+        assert_eq!(cursor.after_seq(), None);
+        cursor.advance(5);
+        assert_eq!(cursor.after_seq(), Some(5));
+        cursor.advance(3);
+        assert_eq!(cursor.after_seq(), Some(5), "must not rewind");
+        cursor.advance(5);
+        assert_eq!(cursor.after_seq(), Some(5), "duplicate must not advance");
+        cursor.advance(9);
+        assert_eq!(cursor.after_seq(), Some(9));
+    }
+
+    #[test]
+    fn first_poll_sends_no_after_seq_and_returns_decoded_events() {
+        let mut client = StubClient::new(vec![vec![
+            output_event(1, "alpha\n"),
+            output_event(2, "beta\n"),
+        ]]);
+
+        let batch = poll_once(&mut client, "session-1", CastFollowCursor::new()).unwrap();
+
+        assert_eq!(
+            batch.events,
+            vec![
+                CastFollowEvent::Output("alpha\n".to_string()),
+                CastFollowEvent::Output("beta\n".to_string()),
+            ]
+        );
+        assert_eq!(batch.cursor.after_seq(), Some(2));
+        assert!(batch.exit.is_none());
+
+        let queries = client.queries.borrow();
+        assert_eq!(queries.len(), 1);
+        assert_eq!(queries[0], (None, "session-1".to_string()));
+    }
+
+    #[test]
+    fn subsequent_polls_pass_cursor_as_after_seq_to_avoid_duplicates() {
+        let mut client = StubClient::new(vec![
+            vec![output_event(1, "first\n"), output_event(2, "second\n")],
+            vec![output_event(3, "third\n")],
+        ]);
+
+        let first =
+            poll_once(&mut client, "session-1", CastFollowCursor::new()).expect("first poll");
+        let second = poll_once(&mut client, "session-1", first.cursor).expect("second poll");
+
+        assert_eq!(first.cursor.after_seq(), Some(2));
+        assert_eq!(second.cursor.after_seq(), Some(3));
+        assert_eq!(
+            second.events,
+            vec![CastFollowEvent::Output("third\n".to_string())]
+        );
+
+        let queries = client.queries.borrow();
+        assert_eq!(queries[0].0, None);
+        assert_eq!(
+            queries[1].0,
+            Some(2),
+            "second poll must request events after seq 2 to dedupe"
+        );
+    }
+
+    #[test]
+    fn exit_event_is_surfaced_in_the_batch_so_caller_can_stop_polling() {
+        let mut client = StubClient::new(vec![vec![
+            output_event(1, "working\n"),
+            exit_event(2, "completed", Some(0)),
+        ]]);
+
+        let batch = poll_once(&mut client, "session-1", CastFollowCursor::new()).unwrap();
+
+        assert!(
+            batch.exit.is_some(),
+            "batch with an exit event must surface it"
+        );
+        let exit = batch.exit.unwrap();
+        assert_eq!(exit.status, "completed");
+        assert_eq!(exit.exit_code, Some(0));
+        // The exit event still appears in the events list so the renderer
+        // can announce it; the caller decides whether to stop polling.
+        assert!(matches!(
+            batch.events.last(),
+            Some(CastFollowEvent::Exit { .. })
+        ));
+    }
+
+    /// Observer that records every callback so tests can assert on the
+    /// sequence of events delivered to the renderer.
+    #[derive(Default)]
+    struct RecordingObserver {
+        output: Vec<String>,
+        exits: Vec<(String, Option<i32>)>,
+        others: Vec<String>,
+    }
+
+    impl FollowerObserver for RecordingObserver {
+        fn on_output(&mut self, chunk: &str) {
+            self.output.push(chunk.to_string());
+        }
+        fn on_exit(&mut self, status: &str, exit_code: Option<i32>) {
+            self.exits.push((status.to_string(), exit_code));
+        }
+        fn on_other(&mut self, kind: &str) {
+            self.others.push(kind.to_string());
+        }
+    }
+
+    /// Pacer that allows N idle polls before failing the test. Production
+    /// uses a real sleep; this catches infinite-loop bugs in unit tests.
+    struct CountingPacer {
+        remaining: usize,
+    }
+
+    impl FollowerPacer for CountingPacer {
+        fn between_polls(&mut self) -> Result<()> {
+            if self.remaining == 0 {
+                anyhow::bail!("follower idled too many times in tests");
+            }
+            self.remaining -= 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn follow_until_exit_streams_output_and_stops_on_exit_event() {
+        let mut client = StubClient::new(vec![
+            vec![output_event(1, "starting\n")],
+            vec![
+                output_event(2, "working\n"),
+                exit_event(3, "completed", Some(0)),
+            ],
+        ]);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 5 };
+
+        let exit = follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer).unwrap();
+
+        assert_eq!(exit.status, "completed");
+        assert_eq!(exit.exit_code, Some(0));
+        assert_eq!(observer.output, vec!["starting\n", "working\n"]);
+        assert_eq!(observer.exits.len(), 1);
+        assert_eq!(observer.exits[0].0, "completed");
+
+        // Two polls in total: one produced the "starting" chunk, the second
+        // delivered "working" + exit. The pacer should have been called once
+        // (between the two polls) and not after the exit.
+        assert_eq!(pacer.remaining, 4);
+    }
+
+    #[test]
+    fn follow_until_exit_dedupes_via_cursor_across_polls() {
+        let mut client = StubClient::new(vec![
+            vec![output_event(1, "a\n"), output_event(2, "b\n")],
+            vec![output_event(3, "c\n"), exit_event(4, "completed", Some(0))],
+        ]);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 5 };
+
+        follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer).unwrap();
+
+        assert_eq!(observer.output, vec!["a\n", "b\n", "c\n"]);
+        let queries = client.queries.borrow();
+        assert_eq!(queries.len(), 2);
+        assert_eq!(queries[0].0, None);
+        assert_eq!(
+            queries[1].0,
+            Some(2),
+            "the second poll must request events after seq 2 to avoid replaying a/b"
+        );
+    }
+
+    #[test]
+    fn follow_until_exit_records_unknown_event_kinds_then_keeps_going() {
+        let mut client = StubClient::new(vec![vec![
+            store::EventRecord {
+                seq: 1,
+                id: "event-1".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "cast.summary".to_string(),
+                payload_json: "{}".to_string(),
+                created_at: "2026-05-19T00:00:00Z".to_string(),
+            },
+            exit_event(2, "completed", Some(0)),
+        ]]);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 1 };
+
+        follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer).unwrap();
+
+        assert_eq!(observer.others, vec!["cast.summary"]);
+        assert_eq!(observer.exits.len(), 1);
+    }
+
+    #[test]
+    fn poll_with_no_events_advances_nothing() {
+        let mut client = StubClient::new(vec![vec![]]);
+        let mut cursor = CastFollowCursor::new();
+        cursor.advance(7);
+
+        let batch = poll_once(&mut client, "session-1", cursor).unwrap();
+
+        assert!(batch.events.is_empty());
+        assert_eq!(batch.cursor, cursor, "empty batch must not move cursor");
+        assert!(batch.exit.is_none());
+    }
+}

--- a/crates/coven-cli/src/tui/cast/gate.rs
+++ b/crates/coven-cli/src/tui/cast/gate.rs
@@ -1,0 +1,320 @@
+//! Cast confirmation gate.
+//!
+//! The gate sits between the plan and the dispatcher. It takes a typed
+//! `CastPlan` and an injectable reader closure, decides whether the plan
+//! should proceed, and returns a typed `GateOutcome`. The reader closure is
+//! the only part of the gate that touches stdin; tests pass a canned reader
+//! so the y/N and typed-word flows can be exercised without a TTY.
+//!
+//! Phase 1.5 gates:
+//! - `CastRisk::Safe` → `Proceed`
+//! - `CastRisk::Confirm` → y/N prompt (or `sacrifice` typed-confirm when the
+//!   intent is `SacrificeSession`)
+//! - `CastRisk::Reject` → `Cancelled` with the alternative the classifier
+//!   suggested
+//!
+//! The dispatcher never calls a destructive handler until the gate returns
+//! `Proceed`, so confirmation is enforced for every Confirm-risk plan, not
+//! just plans the dispatcher happens to remember to check.
+
+use anyhow::Result;
+
+use super::intent::CastIntent;
+use super::plan::CastPlan;
+use super::safety::{CastRisk, SafetyDecision};
+
+const SACRIFICE_CONFIRM_WORD: &str = "sacrifice";
+
+/// What the gate decided about the plan. The dispatcher branches on this
+/// before any side effect.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum GateOutcome {
+    Proceed,
+    Cancelled {
+        reason: String,
+        next_step: Option<String>,
+    },
+}
+
+/// Evaluate a plan's safety gate. The `reader` closure is invoked whenever
+/// the gate needs interactive confirmation; it returns the user's typed
+/// response (already trimmed). Tests pass canned readers.
+pub(crate) fn evaluate_gate<F>(plan: &CastPlan, reader: &mut F) -> Result<GateOutcome>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    match plan.risk() {
+        CastRisk::Safe => Ok(GateOutcome::Proceed),
+        CastRisk::Reject => Ok(rejected_outcome(plan)),
+        CastRisk::Confirm => {
+            if matches!(plan.intent, CastIntent::SacrificeSession { .. }) {
+                run_typed_confirm(plan, reader, SACRIFICE_CONFIRM_WORD)
+            } else {
+                run_yes_no_confirm(plan, reader)
+            }
+        }
+    }
+}
+
+fn rejected_outcome(plan: &CastPlan) -> GateOutcome {
+    match &plan.decision {
+        SafetyDecision::Reject {
+            reason,
+            alternative,
+        } => GateOutcome::Cancelled {
+            reason: format!("Rejected: {reason}"),
+            next_step: Some(alternative.clone()),
+        },
+        _ => GateOutcome::Cancelled {
+            reason: "Rejected by Cast.".to_string(),
+            next_step: None,
+        },
+    }
+}
+
+fn run_yes_no_confirm<F>(plan: &CastPlan, reader: &mut F) -> Result<GateOutcome>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    let (reason, suggestion) = match &plan.decision {
+        SafetyDecision::Confirm { reason, suggestion } => (reason.as_str(), suggestion.as_str()),
+        _ => ("Cast wants your confirmation.", ""),
+    };
+    let prompt = build_yes_no_prompt(reason, suggestion);
+    let answer = reader(&prompt)?;
+    if is_yes(&answer) {
+        Ok(GateOutcome::Proceed)
+    } else {
+        Ok(GateOutcome::Cancelled {
+            reason: "spell cancelled at the Cast confirm step".to_string(),
+            next_step: None,
+        })
+    }
+}
+
+fn run_typed_confirm<F>(plan: &CastPlan, reader: &mut F, word: &str) -> Result<GateOutcome>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    let session_id_short = plan
+        .session_id
+        .as_deref()
+        .map(short_id)
+        .unwrap_or_else(|| "<unknown>".to_string());
+    let prompt = format!(
+        "Cast: this will permanently delete session `{session_id_short}` and its events.\n\
+         Type `{word}` to confirm (anything else cancels): "
+    );
+    let answer = reader(&prompt)?;
+    if answer.trim() == word {
+        Ok(GateOutcome::Proceed)
+    } else {
+        Ok(GateOutcome::Cancelled {
+            reason: format!("sacrifice cancelled: confirmation word `{word}` was not typed"),
+            next_step: None,
+        })
+    }
+}
+
+fn build_yes_no_prompt(reason: &str, suggestion: &str) -> String {
+    if suggestion.is_empty() {
+        format!("Cast: {reason}.\nProceed? [y/N] ")
+    } else {
+        format!("Cast: {reason}.\n{suggestion}\nProceed? [y/N] ")
+    }
+}
+
+fn is_yes(input: &str) -> bool {
+    matches!(input.trim(), "y" | "Y" | "yes" | "YES" | "Yes")
+}
+
+fn short_id(session_id: &str) -> String {
+    session_id.chars().take(12).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::cast::intent::CastHarness;
+    use crate::tui::cast::plan::build_plan;
+
+    fn always_codex() -> Option<CastHarness> {
+        Some(CastHarness::Codex)
+    }
+
+    /// A reader that returns its canned answers in order. Panics if asked
+    /// more times than answers were provided so tests fail loudly on extra
+    /// prompts.
+    struct ScriptedReader {
+        answers: Vec<String>,
+        prompts_seen: Vec<String>,
+    }
+
+    impl ScriptedReader {
+        fn new(answers: &[&str]) -> Self {
+            Self {
+                answers: answers.iter().map(|s| (*s).to_string()).collect(),
+                prompts_seen: Vec::new(),
+            }
+        }
+
+        fn reader(&mut self) -> impl FnMut(&str) -> Result<String> + '_ {
+            |prompt: &str| {
+                self.prompts_seen.push(prompt.to_string());
+                if self.answers.is_empty() {
+                    panic!("ScriptedReader exhausted; unexpected prompt: {prompt:?}");
+                }
+                Ok(self.answers.remove(0))
+            }
+        }
+    }
+
+    fn natural_plan(prompt: &str) -> CastPlan {
+        build_plan(
+            CastIntent::NaturalSpell {
+                prompt: prompt.to_string(),
+            },
+            always_codex,
+        )
+        .unwrap()
+    }
+
+    fn sacrifice_plan(session_id: &str) -> CastPlan {
+        build_plan(
+            CastIntent::SacrificeSession {
+                session_id: session_id.to_string(),
+            },
+            always_codex,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn safe_plan_proceeds_without_reader_use() {
+        let plan = natural_plan("fix the failing tests");
+        let mut scripted = ScriptedReader::new(&[]);
+
+        let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+        assert_eq!(outcome, GateOutcome::Proceed);
+        assert!(
+            scripted.prompts_seen.is_empty(),
+            "safe plan must not prompt"
+        );
+    }
+
+    #[test]
+    fn confirm_risk_proceeds_when_user_says_yes() {
+        let plan = natural_plan("git push the changes to main");
+        let mut scripted = ScriptedReader::new(&["y"]);
+
+        let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+        assert_eq!(outcome, GateOutcome::Proceed);
+        assert_eq!(scripted.prompts_seen.len(), 1);
+        assert!(scripted.prompts_seen[0].contains("Proceed? [y/N]"));
+        assert!(
+            scripted.prompts_seen[0].contains("publishing, pushing"),
+            "yes/no prompt should include the risk reason: {:?}",
+            scripted.prompts_seen[0]
+        );
+    }
+
+    #[test]
+    fn confirm_risk_cancels_on_empty_or_no_answer() {
+        for answer in &["", "n", "no", "NO", "anything else"] {
+            let plan = natural_plan("git push the changes to main");
+            let mut scripted = ScriptedReader::new(&[answer]);
+
+            let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+            match outcome {
+                GateOutcome::Cancelled { reason, .. } => {
+                    assert!(
+                        reason.contains("cancelled at the Cast confirm step"),
+                        "unexpected reason for answer `{answer}`: {reason}"
+                    );
+                }
+                GateOutcome::Proceed => {
+                    panic!("answer `{answer}` should not proceed");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn reject_risk_never_prompts_and_returns_alternative() {
+        let plan = natural_plan("rm -rf / now");
+        let mut scripted = ScriptedReader::new(&[]);
+
+        let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+        match outcome {
+            GateOutcome::Cancelled { reason, next_step } => {
+                assert!(reason.starts_with("Rejected:"));
+                assert!(next_step.is_some());
+            }
+            GateOutcome::Proceed => panic!("rejected plan must not proceed"),
+        }
+        assert!(
+            scripted.prompts_seen.is_empty(),
+            "reject must not prompt the user"
+        );
+    }
+
+    #[test]
+    fn sacrifice_requires_typed_word_not_yes() {
+        let plan = sacrifice_plan("abcdef123456");
+        let mut scripted = ScriptedReader::new(&["y"]);
+
+        let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+        match outcome {
+            GateOutcome::Cancelled { reason, .. } => {
+                assert!(reason.contains("sacrifice"));
+                assert!(reason.contains("not typed"));
+            }
+            GateOutcome::Proceed => panic!("y/N must not satisfy sacrifice gate"),
+        }
+        assert_eq!(scripted.prompts_seen.len(), 1);
+        assert!(
+            scripted.prompts_seen[0].contains("Type `sacrifice`"),
+            "sacrifice prompt should describe the typed-word requirement: {:?}",
+            scripted.prompts_seen[0]
+        );
+        assert!(
+            scripted.prompts_seen[0].contains("abcdef123456"),
+            "sacrifice prompt should include the session id"
+        );
+    }
+
+    #[test]
+    fn sacrifice_proceeds_when_typed_word_matches() {
+        let plan = sacrifice_plan("abcdef123456");
+        let mut scripted = ScriptedReader::new(&["sacrifice"]);
+
+        let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+        assert_eq!(outcome, GateOutcome::Proceed);
+    }
+
+    #[test]
+    fn sacrifice_typed_word_is_case_sensitive() {
+        let plan = sacrifice_plan("abcdef123456");
+        let mut scripted = ScriptedReader::new(&["Sacrifice"]);
+
+        let outcome = evaluate_gate(&plan, &mut scripted.reader()).unwrap();
+
+        assert!(matches!(outcome, GateOutcome::Cancelled { .. }));
+    }
+
+    #[test]
+    fn yes_no_helper_accepts_common_yes_spellings() {
+        for value in &["y", "Y", "yes", "YES", "Yes"] {
+            assert!(is_yes(value), "`{value}` should count as yes");
+        }
+        for value in &["", " ", "n", "no", "NO", "maybe", "y!"] {
+            assert!(!is_yes(value), "`{value}` should not count as yes");
+        }
+    }
+}

--- a/crates/coven-cli/src/tui/cast/intent.rs
+++ b/crates/coven-cli/src/tui/cast/intent.rs
@@ -1,0 +1,453 @@
+//! Cast intent parsing.
+//!
+//! Phase 1 is deterministic: slash commands, a small set of plain-language
+//! patterns, and a default-prompt fallback. No LLM planner. Each user spell
+//! becomes one `CastIntent` value; the planner decides what (if anything) to
+//! run.
+
+use anyhow::{anyhow, Result};
+
+/// A first-party Coven harness Cast knows how to route to without asking.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CastHarness {
+    Codex,
+    Claude,
+}
+
+impl CastHarness {
+    pub(crate) fn id(self) -> &'static str {
+        match self {
+            CastHarness::Codex => "codex",
+            CastHarness::Claude => "claude",
+        }
+    }
+
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            CastHarness::Codex => "Codex",
+            CastHarness::Claude => "Claude Code",
+        }
+    }
+
+    fn from_token(token: &str) -> Option<Self> {
+        match token.to_ascii_lowercase().as_str() {
+            "codex" => Some(CastHarness::Codex),
+            "claude" | "claude-code" | "claudecode" => Some(CastHarness::Claude),
+            _ => None,
+        }
+    }
+}
+
+/// The typed shape of a user spell after Cast parses it. This is the only
+/// thing the planner needs to read; raw user text never reaches the daemon
+/// without becoming a `CastIntent` first.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum CastIntent {
+    /// Plain text — Cast will route to the safe default harness with a
+    /// project-scoped session.
+    NaturalSpell {
+        prompt: String,
+    },
+    /// The user picked a harness explicitly (slash command or "run claude …").
+    HarnessSpell {
+        harness: CastHarness,
+        prompt: String,
+    },
+    OpenSessions,
+    OpenAllSessions,
+    AttachSession {
+        session_id: String,
+    },
+    SummonSession {
+        session_id: String,
+    },
+    ArchiveSession {
+        session_id: String,
+    },
+    SacrificeSession {
+        session_id: String,
+    },
+    Doctor,
+    DaemonStatus,
+    Help,
+    StartHere,
+    OpenTui,
+    PatchOpenClaw,
+    Quit,
+}
+
+/// Parse a raw user spell into a typed `CastIntent`. Empty input is treated
+/// as "open the Cast launcher" (which is what the user typed `coven` for).
+pub(crate) fn parse_spell(raw: &str) -> Result<CastIntent> {
+    let input = raw.trim();
+    if input.is_empty() {
+        return Ok(CastIntent::OpenTui);
+    }
+
+    if let Some(slash_intent) = parse_slash_command(input)? {
+        return Ok(slash_intent);
+    }
+
+    if let Some(plain_intent) = parse_plain_command(input) {
+        return Ok(plain_intent);
+    }
+
+    if let Some(harness_spell) = parse_natural_harness_prefix(input) {
+        return Ok(harness_spell);
+    }
+
+    Ok(CastIntent::NaturalSpell {
+        prompt: input.to_string(),
+    })
+}
+
+fn parse_slash_command(input: &str) -> Result<Option<CastIntent>> {
+    if !input.starts_with('/') {
+        return Ok(None);
+    }
+
+    let (command, rest) = split_first_token(input);
+    let intent = match command {
+        "/start" => CastIntent::StartHere,
+        "/help" => CastIntent::Help,
+        "/tui" => CastIntent::OpenTui,
+        "/doctor" => CastIntent::Doctor,
+        "/daemon" => CastIntent::DaemonStatus,
+        "/patch" => CastIntent::PatchOpenClaw,
+        "/sessions" => CastIntent::OpenSessions,
+        "/all" => CastIntent::OpenAllSessions,
+        "/run" => parse_run_slash(rest)?,
+        "/codex" => parse_harness_slash(CastHarness::Codex, rest)?,
+        "/claude" => parse_harness_slash(CastHarness::Claude, rest)?,
+        "/attach" => session_id_intent(rest, "/attach", |session_id| CastIntent::AttachSession {
+            session_id,
+        })?,
+        "/summon" => session_id_intent(rest, "/summon", |session_id| CastIntent::SummonSession {
+            session_id,
+        })?,
+        "/archive" => session_id_intent(rest, "/archive", |session_id| {
+            CastIntent::ArchiveSession { session_id }
+        })?,
+        "/sacrifice" => session_id_intent(rest, "/sacrifice", |session_id| {
+            CastIntent::SacrificeSession { session_id }
+        })?,
+        "/quit" | "/exit" => CastIntent::Quit,
+        unknown => {
+            return Err(anyhow!(
+                "unknown Cast slash command `{unknown}`. Type `/help` to see what Cast knows."
+            ));
+        }
+    };
+    Ok(Some(intent))
+}
+
+fn parse_plain_command(input: &str) -> Option<CastIntent> {
+    match input.to_ascii_lowercase().as_str() {
+        "sessions" | "session" | "list sessions" | "show sessions" => {
+            Some(CastIntent::OpenSessions)
+        }
+        "all sessions" | "show all sessions" => Some(CastIntent::OpenAllSessions),
+        "doctor" | "status" | "health" => Some(CastIntent::Doctor),
+        "daemon" | "daemon status" => Some(CastIntent::DaemonStatus),
+        "help" | "?" => Some(CastIntent::Help),
+        "quit" | "exit" | "q" | "bye" => Some(CastIntent::Quit),
+        "tui" | "menu" | "home" => Some(CastIntent::OpenTui),
+        _ => None,
+    }
+}
+
+/// Translate plain-language "run claude X" / "use codex X" / "ask codex X"
+/// into an explicit `HarnessSpell`. The verb itself is dropped from the
+/// prompt so the harness only sees the actual task.
+fn parse_natural_harness_prefix(input: &str) -> Option<CastIntent> {
+    let lower = input.to_ascii_lowercase();
+    for verb in ["run ", "use ", "ask ", "open ", "launch "] {
+        if let Some(rest) = lower.strip_prefix(verb) {
+            let raw_rest = &input[verb.len()..];
+            let (harness_token, prompt_rest) = split_first_token(rest);
+            let Some(harness) = CastHarness::from_token(harness_token) else {
+                continue;
+            };
+            // Recover the original-cased prompt text from the user input.
+            let original_remainder = raw_rest
+                .get(harness_token.len()..)
+                .map(|s| s.trim())
+                .unwrap_or("");
+            if original_remainder.is_empty() && prompt_rest.is_empty() {
+                // "run claude" with no task is just an action; route as harness with no prompt is
+                // ambiguous, so fall back to natural spell so the user gets a clear error.
+                return None;
+            }
+            return Some(CastIntent::HarnessSpell {
+                harness,
+                prompt: original_remainder.to_string(),
+            });
+        }
+    }
+    None
+}
+
+fn parse_run_slash(rest: &str) -> Result<CastIntent> {
+    let rest = rest.trim();
+    if rest.is_empty() {
+        return Err(anyhow!(
+            "`/run` needs a harness and a task. Example: `/run codex fix the failing tests`."
+        ));
+    }
+    let (first, remainder) = split_first_token(rest);
+    if let Some(harness) = CastHarness::from_token(first) {
+        let prompt = remainder.trim();
+        if prompt.is_empty() {
+            return Err(anyhow!(
+                "`/run {first}` needs a task. Example: `/run {first} explain this repo`."
+            ));
+        }
+        return Ok(CastIntent::HarnessSpell {
+            harness,
+            prompt: prompt.to_string(),
+        });
+    }
+    // Treat the whole `/run …` body as a natural spell when no harness is named,
+    // so the user can still pass through to the default harness.
+    Ok(CastIntent::NaturalSpell {
+        prompt: rest.to_string(),
+    })
+}
+
+fn parse_harness_slash(harness: CastHarness, rest: &str) -> Result<CastIntent> {
+    let prompt = rest.trim();
+    if prompt.is_empty() {
+        return Err(anyhow!(
+            "`/{}` needs a task. Example: `/{} polish the README`.",
+            harness.id(),
+            harness.id()
+        ));
+    }
+    Ok(CastIntent::HarnessSpell {
+        harness,
+        prompt: prompt.to_string(),
+    })
+}
+
+fn session_id_intent<F>(rest: &str, command: &str, build: F) -> Result<CastIntent>
+where
+    F: FnOnce(String) -> CastIntent,
+{
+    let session_id = rest.trim();
+    if session_id.is_empty() {
+        return Err(anyhow!(
+            "`{command}` needs a session id. Use `/sessions` to find one."
+        ));
+    }
+    Ok(build(session_id.to_string()))
+}
+
+fn split_first_token(input: &str) -> (&str, &str) {
+    match input.find(char::is_whitespace) {
+        Some(index) => (&input[..index], input[index..].trim_start()),
+        None => (input, ""),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn intent(raw: &str) -> CastIntent {
+        parse_spell(raw).expect("parse should succeed")
+    }
+
+    #[test]
+    fn empty_input_opens_launcher() {
+        assert_eq!(intent(""), CastIntent::OpenTui);
+        assert_eq!(intent("   "), CastIntent::OpenTui);
+    }
+
+    #[test]
+    fn plain_text_is_a_natural_spell() {
+        assert_eq!(
+            intent("fix the failing tests"),
+            CastIntent::NaturalSpell {
+                prompt: "fix the failing tests".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn run_claude_plain_language_selects_claude() {
+        assert_eq!(
+            intent("run claude polish the README"),
+            CastIntent::HarnessSpell {
+                harness: CastHarness::Claude,
+                prompt: "polish the README".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn run_codex_plain_language_selects_codex() {
+        assert_eq!(
+            intent("run codex explain this repo"),
+            CastIntent::HarnessSpell {
+                harness: CastHarness::Codex,
+                prompt: "explain this repo".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn use_or_ask_prefixes_also_select_a_harness() {
+        assert_eq!(
+            intent("use claude review the latest diff"),
+            CastIntent::HarnessSpell {
+                harness: CastHarness::Claude,
+                prompt: "review the latest diff".to_string(),
+            }
+        );
+        assert_eq!(
+            intent("ask codex draft a release note"),
+            CastIntent::HarnessSpell {
+                harness: CastHarness::Codex,
+                prompt: "draft a release note".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn run_without_harness_keyword_falls_through_to_natural_spell() {
+        assert_eq!(
+            intent("run the failing tests once more"),
+            CastIntent::NaturalSpell {
+                prompt: "run the failing tests once more".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn run_with_harness_but_no_task_is_a_natural_spell() {
+        // Bare "run claude" is too ambiguous to launch — leave it as a natural
+        // spell so the default-harness path can decide.
+        assert_eq!(
+            intent("run claude"),
+            CastIntent::NaturalSpell {
+                prompt: "run claude".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn plain_keyword_sessions_opens_browser() {
+        assert_eq!(intent("sessions"), CastIntent::OpenSessions);
+        assert_eq!(intent("Sessions"), CastIntent::OpenSessions);
+        assert_eq!(intent("show sessions"), CastIntent::OpenSessions);
+    }
+
+    #[test]
+    fn plain_keyword_doctor_runs_doctor() {
+        assert_eq!(intent("doctor"), CastIntent::Doctor);
+        assert_eq!(intent("DOCTOR"), CastIntent::Doctor);
+    }
+
+    #[test]
+    fn plain_keyword_help_opens_help() {
+        assert_eq!(intent("help"), CastIntent::Help);
+        assert_eq!(intent("?"), CastIntent::Help);
+    }
+
+    #[test]
+    fn plain_keyword_quit_quits() {
+        assert_eq!(intent("quit"), CastIntent::Quit);
+        assert_eq!(intent("exit"), CastIntent::Quit);
+        assert_eq!(intent("q"), CastIntent::Quit);
+    }
+
+    #[test]
+    fn slash_commands_map_to_their_intents() {
+        assert_eq!(intent("/sessions"), CastIntent::OpenSessions);
+        assert_eq!(intent("/all"), CastIntent::OpenAllSessions);
+        assert_eq!(intent("/doctor"), CastIntent::Doctor);
+        assert_eq!(intent("/daemon"), CastIntent::DaemonStatus);
+        assert_eq!(intent("/help"), CastIntent::Help);
+        assert_eq!(intent("/start"), CastIntent::StartHere);
+        assert_eq!(intent("/tui"), CastIntent::OpenTui);
+        assert_eq!(intent("/quit"), CastIntent::Quit);
+        assert_eq!(intent("/exit"), CastIntent::Quit);
+        assert_eq!(intent("/patch"), CastIntent::PatchOpenClaw);
+    }
+
+    #[test]
+    fn slash_run_requires_a_harness_or_task() {
+        let error = parse_spell("/run").unwrap_err();
+        assert!(error.to_string().contains("/run` needs"));
+    }
+
+    #[test]
+    fn slash_run_codex_with_task_selects_codex() {
+        assert_eq!(
+            intent("/run codex explain this repo"),
+            CastIntent::HarnessSpell {
+                harness: CastHarness::Codex,
+                prompt: "explain this repo".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn slash_claude_requires_a_task() {
+        let error = parse_spell("/claude").unwrap_err();
+        assert!(error.to_string().contains("needs a task"));
+    }
+
+    #[test]
+    fn slash_attach_requires_session_id() {
+        let error = parse_spell("/attach").unwrap_err();
+        assert!(error.to_string().contains("session id"));
+
+        assert_eq!(
+            intent("/attach abc123"),
+            CastIntent::AttachSession {
+                session_id: "abc123".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn slash_summon_archive_sacrifice_take_session_ids() {
+        assert_eq!(
+            intent("/summon abc"),
+            CastIntent::SummonSession {
+                session_id: "abc".to_string()
+            }
+        );
+        assert_eq!(
+            intent("/archive abc"),
+            CastIntent::ArchiveSession {
+                session_id: "abc".to_string()
+            }
+        );
+        assert_eq!(
+            intent("/sacrifice abc"),
+            CastIntent::SacrificeSession {
+                session_id: "abc".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_slash_is_an_error() {
+        let error = parse_spell("/banana split").unwrap_err();
+        assert!(error.to_string().contains("unknown Cast slash command"));
+    }
+
+    #[test]
+    fn cast_harness_token_accepts_common_aliases() {
+        assert_eq!(CastHarness::from_token("codex"), Some(CastHarness::Codex));
+        assert_eq!(CastHarness::from_token("Codex"), Some(CastHarness::Codex));
+        assert_eq!(CastHarness::from_token("claude"), Some(CastHarness::Claude));
+        assert_eq!(
+            CastHarness::from_token("claude-code"),
+            Some(CastHarness::Claude)
+        );
+        assert_eq!(CastHarness::from_token("hermes"), None);
+    }
+}

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -1,0 +1,83 @@
+//! Cast: Coven's integrated first-party familiar.
+//!
+//! Phase 1 keeps Cast deterministic. The user types a spell, Cast parses it
+//! into a `CastIntent`, builds a `CastPlan` describing what would happen,
+//! checks the plan against a small safety classifier, and (for routable
+//! plans) reports a `CastOutcome` after the existing CLI handler does the
+//! real work.
+//!
+//! The Rust daemon, session ledger, harness adapters, and project-root guard
+//! all remain the authority. Cast is orchestration and presentation: it
+//! never bypasses the daemon and never invents a second runtime.
+
+pub(crate) mod intent;
+pub(crate) mod outcome;
+pub(crate) mod plan;
+pub(crate) mod render;
+pub(crate) mod safety;
+
+use anyhow::Result;
+
+use crate::harness;
+
+pub(crate) use intent::{parse_spell, CastHarness, CastIntent};
+pub(crate) use outcome::CastOutcome;
+pub(crate) use plan::{build_plan, CastPlan};
+pub(crate) use render::{render_cast_frame_for_terminal, render_outcome, render_plan_intro};
+pub(crate) use safety::{CastRisk, SafetyDecision};
+
+// Re-exports used only by tests in `crate::tests` (main.rs). Bundled here
+// rather than scattered behind `cfg(test)` so the names live next to the
+// rest of the Cast surface.
+#[cfg(test)]
+pub(crate) use plan::CastStepKind;
+#[cfg(test)]
+pub(crate) use render::render_cast_frame_plain;
+
+/// Build a plan from raw user text, using the installed harnesses on PATH
+/// to resolve the safe default. Tests should prefer `build_plan` directly
+/// with an injected resolver so PATH lookups stay out of the suite.
+pub(crate) fn plan_spell(raw: &str) -> Result<CastPlan> {
+    let intent = parse_spell(raw)?;
+    build_plan(intent, default_harness)
+}
+
+/// Resolve Cast's safe default harness from the host's installed adapters.
+/// Codex wins; Claude is the fallback; otherwise `None`.
+pub(crate) fn default_harness() -> Option<CastHarness> {
+    let harnesses = harness::built_in_harnesses();
+    if harnesses.iter().any(|h| h.id == "codex" && h.available) {
+        return Some(CastHarness::Codex);
+    }
+    if harnesses.iter().any(|h| h.id == "claude" && h.available) {
+        return Some(CastHarness::Claude);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_spell_with_empty_input_opens_launcher() {
+        let plan = plan_spell("").unwrap();
+        assert!(matches!(plan.intent, CastIntent::OpenTui));
+    }
+
+    #[test]
+    fn plan_spell_with_natural_text_produces_a_launch_plan() {
+        let plan = plan_spell("fix the failing tests").unwrap();
+        assert!(matches!(plan.intent, CastIntent::NaturalSpell { .. }));
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.kind == CastStepKind::LaunchSession));
+    }
+
+    #[test]
+    fn plan_spell_propagates_parser_errors() {
+        let error = plan_spell("/banana").unwrap_err();
+        assert!(error.to_string().contains("unknown Cast slash command"));
+    }
+}

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -10,6 +10,8 @@
 //! all remain the authority. Cast is orchestration and presentation: it
 //! never bypasses the daemon and never invents a second runtime.
 
+pub(crate) mod follow;
+pub(crate) mod gate;
 pub(crate) mod intent;
 pub(crate) mod outcome;
 pub(crate) mod plan;
@@ -20,11 +22,13 @@ use anyhow::Result;
 
 use crate::harness;
 
+pub(crate) use follow::{follow_until_exit, CastSessionExit, FollowerObserver, FollowerPacer};
+pub(crate) use gate::{evaluate_gate, GateOutcome};
 pub(crate) use intent::{parse_spell, CastHarness, CastIntent};
 pub(crate) use outcome::CastOutcome;
 pub(crate) use plan::{build_plan, CastPlan};
 pub(crate) use render::{render_cast_frame_for_terminal, render_outcome, render_plan_intro};
-pub(crate) use safety::{CastRisk, SafetyDecision};
+pub(crate) use safety::SafetyDecision;
 
 // Re-exports used only by tests in `crate::tests` (main.rs). Bundled here
 // rather than scattered behind `cfg(test)` so the names live next to the
@@ -33,13 +37,18 @@ pub(crate) use safety::{CastRisk, SafetyDecision};
 pub(crate) use plan::CastStepKind;
 #[cfg(test)]
 pub(crate) use render::render_cast_frame_plain;
+#[cfg(test)]
+pub(crate) use safety::CastRisk;
 
 /// Build a plan from raw user text, using the installed harnesses on PATH
 /// to resolve the safe default. Tests should prefer `build_plan` directly
 /// with an injected resolver so PATH lookups stay out of the suite.
+///
+/// The raw user text is preserved on the returned plan so the outcome card
+/// can show the spell exactly as the user typed it.
 pub(crate) fn plan_spell(raw: &str) -> Result<CastPlan> {
     let intent = parse_spell(raw)?;
-    build_plan(intent, default_harness)
+    Ok(build_plan(intent, default_harness)?.with_raw_spell(raw))
 }
 
 /// Resolve Cast's safe default harness from the host's installed adapters.
@@ -79,5 +88,18 @@ mod tests {
     fn plan_spell_propagates_parser_errors() {
         let error = plan_spell("/banana").unwrap_err();
         assert!(error.to_string().contains("unknown Cast slash command"));
+    }
+
+    #[test]
+    fn plan_spell_preserves_raw_user_text_for_outcome_card() {
+        let plan = plan_spell("run claude polish the README").unwrap();
+        assert_eq!(plan.raw_spell, "run claude polish the README");
+    }
+
+    #[test]
+    fn plan_spell_preserves_raw_text_even_when_intent_is_session_action() {
+        let plan = plan_spell("/sacrifice abcdef123456").unwrap();
+        assert_eq!(plan.raw_spell, "/sacrifice abcdef123456");
+        assert!(matches!(plan.intent, CastIntent::SacrificeSession { .. }));
     }
 }

--- a/crates/coven-cli/src/tui/cast/outcome.rs
+++ b/crates/coven-cli/src/tui/cast/outcome.rs
@@ -1,0 +1,44 @@
+//! Cast outcome model.
+//!
+//! Every dispatched plan produces a `CastOutcome` that the renderer turns
+//! into the post-run card the user sees. Outcomes are intentionally small:
+//! Cast's job is to point the user at the durable evidence (session id,
+//! daemon, ledger) instead of inventing parallel state.
+
+#[derive(Clone, Debug, Eq, PartialEq, Default)]
+pub(crate) struct CastOutcome {
+    /// The spell the user actually typed.
+    pub(crate) request: String,
+    /// One-line summary of what Cast launched, if anything.
+    pub(crate) launched: Option<String>,
+    /// Session id Cast created or attached to, if any.
+    pub(crate) session_id: Option<String>,
+    /// Concrete next thing the user can do — typed as a copy/pastable command.
+    pub(crate) next_step: Option<String>,
+    /// Free-form notes Cast wants to surface (risk, verification, follow-ups).
+    pub(crate) notes: Vec<String>,
+}
+
+impl CastOutcome {
+    pub(crate) fn for_request(request: impl Into<String>) -> Self {
+        Self {
+            request: request.into(),
+            ..Self::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn for_request_sets_request_and_clears_other_fields() {
+        let outcome = CastOutcome::for_request("fix the failing tests");
+        assert_eq!(outcome.request, "fix the failing tests");
+        assert!(outcome.launched.is_none());
+        assert!(outcome.session_id.is_none());
+        assert!(outcome.next_step.is_none());
+        assert!(outcome.notes.is_empty());
+    }
+}

--- a/crates/coven-cli/src/tui/cast/outcome.rs
+++ b/crates/coven-cli/src/tui/cast/outcome.rs
@@ -7,7 +7,7 @@
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 pub(crate) struct CastOutcome {
-    /// The spell the user actually typed.
+    /// User-facing request text shown in the outcome card (often normalized).
     pub(crate) request: String,
     /// One-line summary of what Cast launched, if anything.
     pub(crate) launched: Option<String>,

--- a/crates/coven-cli/src/tui/cast/plan.rs
+++ b/crates/coven-cli/src/tui/cast/plan.rs
@@ -1,0 +1,517 @@
+//! Cast planner.
+//!
+//! Phase 1: take a deterministic `CastIntent` and a default-harness resolver
+//! and produce a `CastPlan` the executor (and the renderer) can read. The
+//! planner never executes anything — it just describes what Cast would do.
+
+use anyhow::Result;
+
+use super::intent::{CastHarness, CastIntent};
+use super::safety::{classify_prompt_risk, CastRisk, SafetyDecision};
+
+/// What Cast intends to do in response to a single spell.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CastPlan {
+    pub(crate) intent: CastIntent,
+    pub(crate) headline: String,
+    pub(crate) steps: Vec<CastStep>,
+    pub(crate) decision: SafetyDecision,
+    pub(crate) harness: Option<CastPlanHarness>,
+    pub(crate) session_id: Option<String>,
+    pub(crate) prompt: Option<String>,
+    pub(crate) title: Option<String>,
+}
+
+impl CastPlan {
+    pub(crate) fn risk(&self) -> CastRisk {
+        self.decision.risk()
+    }
+}
+
+/// The harness Cast resolved for this plan. The planner records *how* it picked
+/// the harness so the renderer can explain it to the user.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct CastPlanHarness {
+    pub(crate) harness: CastHarness,
+    pub(crate) source: CastHarnessSource,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CastHarnessSource {
+    /// The user named the harness explicitly (slash command or "run claude …").
+    UserChose,
+    /// Cast picked the safe default because the user only said what they wanted.
+    SafeDefault,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CastStepKind {
+    LaunchSession,
+    Browse,
+    Attach,
+    Summon,
+    Archive,
+    Sacrifice,
+    Diagnose,
+    Inform,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct CastStep {
+    pub(crate) kind: CastStepKind,
+    pub(crate) note: String,
+}
+
+const DEFAULT_TITLE_CHARS: usize = 48;
+
+/// Build a plan for a parsed spell. The caller passes in a `default_harness`
+/// resolver so tests can avoid touching `which`/PATH.
+pub(crate) fn build_plan<F>(intent: CastIntent, default_harness: F) -> Result<CastPlan>
+where
+    F: Fn() -> Option<CastHarness>,
+{
+    Ok(match intent {
+        CastIntent::NaturalSpell { ref prompt } => {
+            natural_spell_plan(prompt, intent.clone(), &default_harness)
+        }
+        CastIntent::HarnessSpell {
+            harness,
+            ref prompt,
+        } => harness_spell_plan(harness, prompt, intent.clone()),
+        CastIntent::OpenSessions => simple_plan(
+            intent,
+            "Open the active session browser",
+            CastStep::new(CastStepKind::Browse, "Show project-scoped Coven sessions"),
+        ),
+        CastIntent::OpenAllSessions => simple_plan(
+            intent,
+            "Open the full session browser (active + archived)",
+            CastStep::new(
+                CastStepKind::Browse,
+                "Show every Coven session including archived",
+            ),
+        ),
+        CastIntent::AttachSession { ref session_id } => simple_plan(
+            intent.clone(),
+            &format!("Attach to session {}", short_id(session_id)),
+            CastStep::new(
+                CastStepKind::Attach,
+                "Replay session output and forward live input",
+            ),
+        ),
+        CastIntent::SummonSession { ref session_id } => simple_plan(
+            intent.clone(),
+            &format!("Summon archived session {}", short_id(session_id)),
+            CastStep::new(
+                CastStepKind::Summon,
+                "Restore the archived session, then replay/follow it",
+            ),
+        ),
+        CastIntent::ArchiveSession { ref session_id } => simple_plan(
+            intent.clone(),
+            &format!("Archive session {}", short_id(session_id)),
+            CastStep::new(
+                CastStepKind::Archive,
+                "Hide the session from the active list; keep events",
+            ),
+        ),
+        CastIntent::SacrificeSession { ref session_id } => {
+            sacrifice_plan(session_id, intent.clone())
+        }
+        CastIntent::Doctor => simple_plan(
+            intent,
+            "Run Coven doctor",
+            CastStep::new(
+                CastStepKind::Diagnose,
+                "Check store, project, and harness readiness",
+            ),
+        ),
+        CastIntent::DaemonStatus => simple_plan(
+            intent,
+            "Check the local Coven daemon",
+            CastStep::new(
+                CastStepKind::Diagnose,
+                "Report the daemon pid, socket, and reachability",
+            ),
+        ),
+        CastIntent::Help => simple_plan(
+            intent,
+            "Show Cast help",
+            CastStep::new(
+                CastStepKind::Inform,
+                "Examples of natural-language and slash spells",
+            ),
+        ),
+        CastIntent::StartHere => simple_plan(
+            intent,
+            "Open the Coven quick-start",
+            CastStep::new(CastStepKind::Inform, "Setup check and a safe first command"),
+        ),
+        CastIntent::OpenTui => simple_plan(
+            intent,
+            "Open the Coven slash palette",
+            CastStep::new(CastStepKind::Inform, "Show the Cast launcher"),
+        ),
+        CastIntent::PatchOpenClaw => simple_plan(
+            intent,
+            "Open the guided OpenClaw patch room",
+            CastStep::new(CastStepKind::Inform, "Walk through `coven patch openclaw`"),
+        ),
+        CastIntent::Quit => simple_plan(
+            intent,
+            "Close Cast without changing anything",
+            CastStep::new(CastStepKind::Inform, "Exit the launcher"),
+        ),
+    })
+}
+
+fn natural_spell_plan(
+    prompt: &str,
+    intent: CastIntent,
+    default_harness: &dyn Fn() -> Option<CastHarness>,
+) -> CastPlan {
+    let decision = classify_prompt_risk(prompt);
+    let title = derive_title(prompt);
+    let headline = format!("Cast a project-scoped spell: {title}");
+    let harness = default_harness().map(|harness| CastPlanHarness {
+        harness,
+        source: CastHarnessSource::SafeDefault,
+    });
+    let mut steps = vec![CastStep::new(
+        CastStepKind::LaunchSession,
+        match harness {
+            Some(plan_harness) => format!(
+                "Launch {} inside this project with the spell as the task",
+                plan_harness.harness.label()
+            ),
+            None => {
+                "No harness ready — run `coven doctor` to install Codex or Claude Code".to_string()
+            }
+        },
+    )];
+    if let SafetyDecision::Confirm {
+        ref reason,
+        ref suggestion,
+    } = decision
+    {
+        steps.push(CastStep::new(
+            CastStepKind::Inform,
+            format!("Risk: {reason}. {suggestion}"),
+        ));
+    }
+    if let SafetyDecision::Reject {
+        ref reason,
+        ref alternative,
+    } = decision
+    {
+        steps.push(CastStep::new(
+            CastStepKind::Inform,
+            format!("Rejected: {reason}. {alternative}"),
+        ));
+    }
+    CastPlan {
+        intent,
+        headline,
+        steps,
+        decision,
+        harness,
+        session_id: None,
+        prompt: Some(prompt.to_string()),
+        title: Some(title),
+    }
+}
+
+fn harness_spell_plan(harness: CastHarness, prompt: &str, intent: CastIntent) -> CastPlan {
+    let decision = classify_prompt_risk(prompt);
+    let title = derive_title(prompt);
+    let headline = format!("Cast {} on this project: {title}", harness.label());
+    let mut steps = vec![CastStep::new(
+        CastStepKind::LaunchSession,
+        format!(
+            "Launch {} inside this project with the spell as the task",
+            harness.label()
+        ),
+    )];
+    if let SafetyDecision::Confirm {
+        ref reason,
+        ref suggestion,
+    } = decision
+    {
+        steps.push(CastStep::new(
+            CastStepKind::Inform,
+            format!("Risk: {reason}. {suggestion}"),
+        ));
+    }
+    if let SafetyDecision::Reject {
+        ref reason,
+        ref alternative,
+    } = decision
+    {
+        steps.push(CastStep::new(
+            CastStepKind::Inform,
+            format!("Rejected: {reason}. {alternative}"),
+        ));
+    }
+    CastPlan {
+        intent,
+        headline,
+        steps,
+        decision,
+        harness: Some(CastPlanHarness {
+            harness,
+            source: CastHarnessSource::UserChose,
+        }),
+        session_id: None,
+        prompt: Some(prompt.to_string()),
+        title: Some(title),
+    }
+}
+
+fn sacrifice_plan(session_id: &str, intent: CastIntent) -> CastPlan {
+    let decision = SafetyDecision::Confirm {
+        reason: "sacrifice permanently deletes a session and its events".to_string(),
+        suggestion: "Cast will route this to `coven sacrifice <id> --yes`, which prompts for \
+                     typed confirmation in the session browser."
+            .to_string(),
+    };
+    CastPlan {
+        intent,
+        headline: format!("Sacrifice session {}", short_id(session_id)),
+        steps: vec![
+            CastStep::new(
+                CastStepKind::Sacrifice,
+                "Permanently delete the session and its events",
+            ),
+            CastStep::new(
+                CastStepKind::Inform,
+                "Requires explicit typed confirmation before any delete",
+            ),
+        ],
+        decision,
+        harness: None,
+        session_id: Some(session_id.to_string()),
+        prompt: None,
+        title: None,
+    }
+}
+
+fn simple_plan(intent: CastIntent, headline: &str, step: CastStep) -> CastPlan {
+    let session_id = match &intent {
+        CastIntent::AttachSession { session_id }
+        | CastIntent::SummonSession { session_id }
+        | CastIntent::ArchiveSession { session_id } => Some(session_id.clone()),
+        _ => None,
+    };
+    CastPlan {
+        intent,
+        headline: headline.to_string(),
+        steps: vec![step],
+        decision: SafetyDecision::Proceed,
+        harness: None,
+        session_id,
+        prompt: None,
+        title: None,
+    }
+}
+
+impl CastStep {
+    fn new(kind: CastStepKind, note: impl Into<String>) -> Self {
+        Self {
+            kind,
+            note: note.into(),
+        }
+    }
+}
+
+fn derive_title(prompt: &str) -> String {
+    let collapsed: String = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return "Untitled spell".to_string();
+    }
+    let count = collapsed.chars().count();
+    if count <= DEFAULT_TITLE_CHARS {
+        collapsed
+    } else {
+        let mut out: String = collapsed.chars().take(DEFAULT_TITLE_CHARS - 1).collect();
+        out.push('…');
+        out
+    }
+}
+
+fn short_id(session_id: &str) -> String {
+    session_id.chars().take(12).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn codex() -> Option<CastHarness> {
+        Some(CastHarness::Codex)
+    }
+
+    fn claude() -> Option<CastHarness> {
+        Some(CastHarness::Claude)
+    }
+
+    fn none() -> Option<CastHarness> {
+        None
+    }
+
+    #[test]
+    fn natural_spell_picks_safe_default_and_records_source() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "fix the failing tests".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        let harness = plan.harness.expect("default harness should be resolved");
+        assert_eq!(harness.harness, CastHarness::Codex);
+        assert_eq!(harness.source, CastHarnessSource::SafeDefault);
+        assert_eq!(plan.risk(), CastRisk::Safe);
+        assert_eq!(plan.title.as_deref(), Some("fix the failing tests"));
+        assert!(plan.headline.contains("fix the failing tests"));
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.kind == CastStepKind::LaunchSession));
+    }
+
+    #[test]
+    fn natural_spell_with_no_default_harness_still_plans_a_launch_step() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "explain this repo".to_string(),
+            },
+            none,
+        )
+        .unwrap();
+
+        assert!(plan.harness.is_none());
+        let launch_step = plan
+            .steps
+            .iter()
+            .find(|step| step.kind == CastStepKind::LaunchSession)
+            .expect("plan should still include a launch step");
+        assert!(
+            launch_step.note.contains("coven doctor"),
+            "missing harness should point at doctor, got {:?}",
+            launch_step.note
+        );
+    }
+
+    #[test]
+    fn harness_spell_uses_explicit_harness_choice() {
+        let plan = build_plan(
+            CastIntent::HarnessSpell {
+                harness: CastHarness::Claude,
+                prompt: "polish the README".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        let harness = plan.harness.expect("explicit harness should win");
+        assert_eq!(harness.harness, CastHarness::Claude);
+        assert_eq!(harness.source, CastHarnessSource::UserChose);
+        assert!(plan.headline.contains("Claude Code"));
+    }
+
+    #[test]
+    fn risky_prompt_marks_confirm_in_plan() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "git push the changes to main".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        assert_eq!(plan.risk(), CastRisk::Confirm);
+        assert!(plan.steps.iter().any(|step| step.note.contains("Risk:")));
+    }
+
+    #[test]
+    fn rejected_prompt_marks_reject_in_plan() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "rm -rf / please".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        assert_eq!(plan.risk(), CastRisk::Reject);
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.note.contains("Rejected:")));
+    }
+
+    #[test]
+    fn sessions_intent_plans_a_browse_step() {
+        let plan = build_plan(CastIntent::OpenSessions, claude).unwrap();
+        assert_eq!(plan.risk(), CastRisk::Safe);
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.kind == CastStepKind::Browse));
+    }
+
+    #[test]
+    fn sacrifice_intent_is_marked_confirm_with_explanation() {
+        let plan = build_plan(
+            CastIntent::SacrificeSession {
+                session_id: "abcdef123456".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        assert_eq!(plan.risk(), CastRisk::Confirm);
+        match plan.decision {
+            SafetyDecision::Confirm { reason, .. } => {
+                assert!(reason.contains("sacrifice"));
+            }
+            other => panic!("expected confirm, got {other:?}"),
+        }
+        assert_eq!(plan.session_id.as_deref(), Some("abcdef123456"));
+    }
+
+    #[test]
+    fn attach_intent_records_session_id_in_plan() {
+        let plan = build_plan(
+            CastIntent::AttachSession {
+                session_id: "abcdef123456".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        assert_eq!(plan.session_id.as_deref(), Some("abcdef123456"));
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.kind == CastStepKind::Attach));
+        assert!(plan.headline.contains("abcdef123456"));
+    }
+
+    #[test]
+    fn natural_spell_title_truncates_long_prompts() {
+        let prompt = "do everything imaginable that could possibly matter to this repository";
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: prompt.to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        let title = plan.title.unwrap();
+        assert!(title.chars().count() <= DEFAULT_TITLE_CHARS);
+        assert!(title.ends_with('…'));
+    }
+}

--- a/crates/coven-cli/src/tui/cast/plan.rs
+++ b/crates/coven-cli/src/tui/cast/plan.rs
@@ -270,8 +270,8 @@ fn harness_spell_plan(harness: CastHarness, prompt: &str, intent: CastIntent) ->
 fn sacrifice_plan(session_id: &str, intent: CastIntent) -> CastPlan {
     let decision = SafetyDecision::Confirm {
         reason: "sacrifice permanently deletes a session and its events".to_string(),
-        suggestion: "Cast will route this to `coven sacrifice <id> --yes`, which prompts for \
-                     typed confirmation in the session browser."
+        suggestion: "Cast will require typed confirmation in the session browser before \
+                     proceeding with the delete."
             .to_string(),
     };
     CastPlan {

--- a/crates/coven-cli/src/tui/cast/plan.rs
+++ b/crates/coven-cli/src/tui/cast/plan.rs
@@ -12,6 +12,11 @@ use super::safety::{classify_prompt_risk, CastRisk, SafetyDecision};
 /// What Cast intends to do in response to a single spell.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CastPlan {
+    /// The exact text the user typed (before any normalization or stripping).
+    /// Empty when the plan was constructed directly without raw input, e.g.
+    /// from a palette action; callers should always treat the raw spell as
+    /// the user-facing record in the outcome card.
+    pub(crate) raw_spell: String,
     pub(crate) intent: CastIntent,
     pub(crate) headline: String,
     pub(crate) steps: Vec<CastStep>,
@@ -25,6 +30,14 @@ pub(crate) struct CastPlan {
 impl CastPlan {
     pub(crate) fn risk(&self) -> CastRisk {
         self.decision.risk()
+    }
+
+    /// Attach the raw user spell to a plan. Used by `cast::plan_spell` to
+    /// preserve the user's literal text for the outcome card. Returns `self`
+    /// so it can be chained at the call site.
+    pub(crate) fn with_raw_spell(mut self, raw: impl Into<String>) -> Self {
+        self.raw_spell = raw.into();
+        self
     }
 }
 
@@ -210,6 +223,7 @@ fn natural_spell_plan(
         ));
     }
     CastPlan {
+        raw_spell: String::new(),
         intent,
         headline,
         steps,
@@ -253,6 +267,7 @@ fn harness_spell_plan(harness: CastHarness, prompt: &str, intent: CastIntent) ->
         ));
     }
     CastPlan {
+        raw_spell: String::new(),
         intent,
         headline,
         steps,
@@ -270,11 +285,12 @@ fn harness_spell_plan(harness: CastHarness, prompt: &str, intent: CastIntent) ->
 fn sacrifice_plan(session_id: &str, intent: CastIntent) -> CastPlan {
     let decision = SafetyDecision::Confirm {
         reason: "sacrifice permanently deletes a session and its events".to_string(),
-        suggestion: "Cast will require typed confirmation in the session browser before \
-                     proceeding with the delete."
+        suggestion: "Cast will ask you to type `sacrifice` to confirm before the daemon \
+                     deletes the session and its event log."
             .to_string(),
     };
     CastPlan {
+        raw_spell: String::new(),
         intent,
         headline: format!("Sacrifice session {}", short_id(session_id)),
         steps: vec![
@@ -284,7 +300,7 @@ fn sacrifice_plan(session_id: &str, intent: CastIntent) -> CastPlan {
             ),
             CastStep::new(
                 CastStepKind::Inform,
-                "Requires explicit typed confirmation before any delete",
+                "Cast will require typed `sacrifice` confirmation before any delete",
             ),
         ],
         decision,
@@ -303,6 +319,7 @@ fn simple_plan(intent: CastIntent, headline: &str, step: CastStep) -> CastPlan {
         _ => None,
     };
     CastPlan {
+        raw_spell: String::new(),
         intent,
         headline: headline.to_string(),
         steps: vec![step],

--- a/crates/coven-cli/src/tui/cast/render.rs
+++ b/crates/coven-cli/src/tui/cast/render.rs
@@ -1,0 +1,370 @@
+//! Cast rendering.
+//!
+//! Phase 1 keeps Cast's voice plain-text and color-aware so the renderer
+//! works in interactive terminals, non-interactive pipes, and tests. The
+//! goal here is not a beautiful TUI — it is a Cast frame the user can read
+//! before and after every spell.
+
+use std::path::Path;
+
+use crate::theme::{self, TerminalMode};
+
+use super::outcome::CastOutcome;
+use super::plan::{CastHarnessSource, CastPlan, CastStepKind};
+use super::safety::{CastRisk, SafetyDecision};
+
+const CAST_INTRO_INNER_WIDTH: usize = 76;
+
+/// One-line salute at the top of every Cast frame. Used by both the
+/// interactive launcher (woven into the shell frame) and the non-interactive
+/// fallback so logs and pipes always show the familiar's name.
+pub(crate) fn cast_salute() -> &'static str {
+    "Cast, your Coven familiar, is ready. Type a spell, or use a slash command."
+}
+
+/// A short Cast frame for non-interactive mode: who Cast is, what spells look
+/// like, and where work goes when it lands. Designed for piped stdout, CI
+/// snapshots, and `coven` from a non-tty wrapper. Today only consumed by
+/// tests; future phases (announcement banners, plain `coven` snapshots) will
+/// wire it into more callsites.
+#[allow(dead_code)]
+pub(crate) fn render_cast_frame_plain(
+    project_root: Option<&Path>,
+    default_harness: Option<&str>,
+) -> String {
+    render_cast_frame_with_mode(project_root, default_harness, TerminalMode::NoColor)
+}
+
+pub(crate) fn render_cast_frame_for_terminal(
+    project_root: Option<&Path>,
+    default_harness: Option<&str>,
+) -> String {
+    render_cast_frame_with_mode(project_root, default_harness, theme::mode())
+}
+
+fn render_cast_frame_with_mode(
+    project_root: Option<&Path>,
+    default_harness: Option<&str>,
+    mode: TerminalMode,
+) -> String {
+    let primary_strong = theme::Fg::with_mode(theme::PRIMARY_STRONG, mode);
+    let primary = theme::Fg::with_mode(theme::PRIMARY, mode);
+    let field_label = theme::Fg::with_mode(theme::FIELD_LABEL, mode);
+    let user_label = theme::Fg::with_mode(theme::USER_LABEL, mode);
+    let dim = theme::Fg::with_mode(theme::DIM, mode);
+    let reset = theme::Reset::with_mode(mode);
+    let inner_width = CAST_INTRO_INNER_WIDTH;
+    let mut frame = String::new();
+
+    frame.push_str(&format!(
+        "{primary_strong}Cast — your Coven familiar{reset}\n"
+    ));
+    frame.push_str(&format!(
+        "{field_label}{}{reset}\n",
+        fit_chars(cast_salute(), inner_width)
+    ));
+    frame.push('\n');
+
+    frame.push_str(&format!("{primary_strong}Context{reset}\n"));
+    let project = project_root
+        .map(|root| root.display().to_string())
+        .unwrap_or_else(|| "not inside a project root — run from a repo".to_string());
+    frame.push_str(&format!(
+        "{field_label}Project{reset}        {}\n",
+        fit_chars(&project, inner_width.saturating_sub(15))
+    ));
+    let harness = default_harness.unwrap_or("none ready — run `coven doctor`");
+    frame.push_str(&format!(
+        "{field_label}Default harness{reset} {}\n",
+        fit_chars(harness, inner_width.saturating_sub(15))
+    ));
+    frame.push('\n');
+
+    frame.push_str(&format!("{primary_strong}Example spells{reset}\n"));
+    for spell in cast_example_spells() {
+        frame.push_str(&format!("{primary}  {}{reset}\n", spell));
+    }
+    frame.push('\n');
+
+    frame.push_str(&format!("{primary_strong}Slash spells{reset}\n"));
+    for spell in cast_example_slashes() {
+        frame.push_str(&format!("{user_label}  {}{reset}\n", spell));
+    }
+    frame.push('\n');
+
+    frame.push_str(&format!(
+        "{dim}Tip: in a terminal, `coven` opens the Cast launcher. Empty input opens the slash palette.{reset}\n"
+    ));
+    frame
+}
+
+fn cast_example_spells() -> &'static [&'static str] {
+    &[
+        "fix the failing tests",
+        "explain this repo in 5 bullets",
+        "run claude polish the README",
+        "use codex draft a release note",
+        "review this branch",
+        "open the last Claude session",
+        "sessions",
+        "doctor",
+    ]
+}
+
+fn cast_example_slashes() -> &'static [&'static str] {
+    &[
+        "/run codex fix the failing tests",
+        "/claude review the latest diff",
+        "/sessions     /all     /attach <id>     /summon <id>",
+        "/archive <id>     /sacrifice <id>",
+        "/doctor     /daemon     /patch     /help     /quit",
+    ]
+}
+
+/// Cast's pre-launch card: shown before any session is created so the user
+/// can see what Cast resolved from the spell.
+pub(crate) fn render_plan_intro(plan: &CastPlan) -> String {
+    render_plan_intro_with_mode(plan, theme::mode())
+}
+
+#[allow(dead_code)]
+pub(crate) fn render_plan_intro_plain(plan: &CastPlan) -> String {
+    render_plan_intro_with_mode(plan, TerminalMode::NoColor)
+}
+
+fn render_plan_intro_with_mode(plan: &CastPlan, mode: TerminalMode) -> String {
+    let primary_strong = theme::Fg::with_mode(theme::PRIMARY_STRONG, mode);
+    let primary = theme::Fg::with_mode(theme::PRIMARY, mode);
+    let field_label = theme::Fg::with_mode(theme::FIELD_LABEL, mode);
+    let user_label = theme::Fg::with_mode(theme::USER_LABEL, mode);
+    let reset = theme::Reset::with_mode(mode);
+    let mut frame = String::new();
+
+    frame.push_str(&format!("{primary_strong}Cast plan{reset}\n"));
+    frame.push_str(&format!("{field_label}Spell:{reset} {}\n", plan.headline));
+
+    if let Some(plan_harness) = plan.harness {
+        let source = match plan_harness.source {
+            CastHarnessSource::UserChose => "user-chosen",
+            CastHarnessSource::SafeDefault => "Cast default",
+        };
+        frame.push_str(&format!(
+            "{field_label}Harness:{reset} {} ({})\n",
+            plan_harness.harness.label(),
+            source
+        ));
+    }
+
+    if let Some(title) = &plan.title {
+        frame.push_str(&format!("{field_label}Session title:{reset} {}\n", title));
+    }
+
+    frame.push_str(&format!(
+        "{field_label}Risk:{reset} {}\n",
+        risk_label(plan.risk())
+    ));
+    if let SafetyDecision::Confirm { reason, suggestion } = &plan.decision {
+        frame.push_str(&format!(
+            "{user_label}  ! {} — {}{reset}\n",
+            reason, suggestion
+        ));
+    }
+    if let SafetyDecision::Reject {
+        reason,
+        alternative,
+    } = &plan.decision
+    {
+        frame.push_str(&format!(
+            "{user_label}  X {} — {}{reset}\n",
+            reason, alternative
+        ));
+    }
+
+    if !plan.steps.is_empty() {
+        frame.push_str(&format!("{primary_strong}Steps{reset}\n"));
+        for step in &plan.steps {
+            frame.push_str(&format!(
+                "{primary}  - [{}] {}{reset}\n",
+                step_kind_label(step.kind),
+                step.note
+            ));
+        }
+    }
+    frame
+}
+
+/// Cast's post-run outcome card: shown after the dispatched action finishes
+/// so the user can see what was launched, where it lives, and what to do
+/// next.
+pub(crate) fn render_outcome(outcome: &CastOutcome) -> String {
+    render_outcome_with_mode(outcome, theme::mode())
+}
+
+#[allow(dead_code)]
+pub(crate) fn render_outcome_plain(outcome: &CastOutcome) -> String {
+    render_outcome_with_mode(outcome, TerminalMode::NoColor)
+}
+
+fn render_outcome_with_mode(outcome: &CastOutcome, mode: TerminalMode) -> String {
+    let primary_strong = theme::Fg::with_mode(theme::PRIMARY_STRONG, mode);
+    let primary = theme::Fg::with_mode(theme::PRIMARY, mode);
+    let field_label = theme::Fg::with_mode(theme::FIELD_LABEL, mode);
+    let reset = theme::Reset::with_mode(mode);
+    let mut frame = String::new();
+
+    frame.push_str(&format!("{primary_strong}Cast outcome{reset}\n"));
+    frame.push_str(&format!("{field_label}Spell:{reset} {}\n", outcome.request));
+    if let Some(launched) = &outcome.launched {
+        frame.push_str(&format!("{field_label}Launched:{reset} {}\n", launched));
+    }
+    if let Some(session_id) = &outcome.session_id {
+        frame.push_str(&format!("{field_label}Session id:{reset} {}\n", session_id));
+    }
+    if !outcome.notes.is_empty() {
+        frame.push_str(&format!("{primary_strong}Notes{reset}\n"));
+        for note in &outcome.notes {
+            frame.push_str(&format!("{primary}  - {}{reset}\n", note));
+        }
+    }
+    if let Some(next) = &outcome.next_step {
+        frame.push_str(&format!("{field_label}Next:{reset} {}\n", next));
+    }
+    frame
+}
+
+fn risk_label(risk: CastRisk) -> &'static str {
+    match risk {
+        CastRisk::Safe => "safe",
+        CastRisk::Confirm => "confirmation-required",
+        CastRisk::Reject => "rejected",
+    }
+}
+
+fn step_kind_label(kind: CastStepKind) -> &'static str {
+    match kind {
+        CastStepKind::LaunchSession => "launch",
+        CastStepKind::Browse => "browse",
+        CastStepKind::Attach => "attach",
+        CastStepKind::Summon => "summon",
+        CastStepKind::Archive => "archive",
+        CastStepKind::Sacrifice => "sacrifice",
+        CastStepKind::Diagnose => "diagnose",
+        CastStepKind::Inform => "inform",
+    }
+}
+
+fn fit_chars(value: &str, limit: usize) -> String {
+    let count = value.chars().count();
+    if count <= limit {
+        return value.to_string();
+    }
+    if limit == 0 {
+        return String::new();
+    }
+    if limit == 1 {
+        return "…".to_string();
+    }
+    let mut fitted: String = value.chars().take(limit - 1).collect();
+    fitted.push('…');
+    fitted
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::tui::cast::intent::{CastHarness, CastIntent};
+    use crate::tui::cast::plan::build_plan;
+
+    fn codex() -> Option<CastHarness> {
+        Some(CastHarness::Codex)
+    }
+
+    #[test]
+    fn non_interactive_frame_introduces_cast_and_lists_spells() {
+        let project = PathBuf::from("/tmp/some-repo");
+        let frame = render_cast_frame_plain(Some(&project), Some("codex"));
+
+        assert!(frame.contains("Cast"));
+        assert!(frame.contains("Coven familiar"));
+        assert!(frame.contains("/tmp/some-repo"));
+        assert!(frame.contains("codex"));
+        assert!(frame.contains("fix the failing tests"));
+        assert!(frame.contains("run claude polish the README"));
+        assert!(frame.contains("/sessions"));
+    }
+
+    #[test]
+    fn non_interactive_frame_handles_missing_project_and_harness() {
+        let frame = render_cast_frame_plain(None, None);
+        assert!(frame.contains("not inside a project root"));
+        assert!(frame.contains("coven doctor"));
+    }
+
+    #[test]
+    fn intro_card_shows_safe_default_source_and_session_title() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "fix the failing tests".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        let frame = render_plan_intro_plain(&plan);
+        assert!(frame.contains("Cast plan"));
+        assert!(frame.contains("Codex"));
+        assert!(frame.contains("Cast default"));
+        assert!(frame.contains("Session title: fix the failing tests"));
+        assert!(frame.contains("Risk: safe"));
+        assert!(frame.contains("[launch]"));
+    }
+
+    #[test]
+    fn intro_card_surfaces_confirm_reason_for_risky_spell() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "git push the changes to main".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        let frame = render_plan_intro_plain(&plan);
+        assert!(frame.contains("Risk: confirmation-required"));
+        assert!(frame.contains("push"));
+    }
+
+    #[test]
+    fn intro_card_surfaces_reject_reason_for_rejected_spell() {
+        let plan = build_plan(
+            CastIntent::NaturalSpell {
+                prompt: "rm -rf / now".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        let frame = render_plan_intro_plain(&plan);
+        assert!(frame.contains("Risk: rejected"));
+    }
+
+    #[test]
+    fn outcome_card_includes_session_id_and_next_step() {
+        let outcome = CastOutcome {
+            request: "fix the failing tests".to_string(),
+            launched: Some("Codex session (project-scoped)".to_string()),
+            session_id: Some("abcdef-1234".to_string()),
+            next_step: Some("`coven attach abcdef-1234` to follow live output".to_string()),
+            notes: vec!["risk: safe".to_string()],
+        };
+
+        let frame = render_outcome_plain(&outcome);
+        assert!(frame.contains("Cast outcome"));
+        assert!(frame.contains("Launched: Codex session"));
+        assert!(frame.contains("Session id: abcdef-1234"));
+        assert!(frame.contains("coven attach abcdef-1234"));
+        assert!(frame.contains("risk: safe"));
+    }
+}

--- a/crates/coven-cli/src/tui/cast/safety.rs
+++ b/crates/coven-cli/src/tui/cast/safety.rs
@@ -1,0 +1,208 @@
+//! Cast safety gate.
+//!
+//! Phase 1 keeps risk classification deterministic and local: a small token
+//! list flags spells that would push, publish, merge, release, or broadly
+//! delete. The classifier never executes anything — it only labels intents
+//! so the planner can decide whether to proceed, confirm, or reject. The
+//! daemon remains the authority for any actual side effect.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CastRisk {
+    /// Safe local read, plan, or harness work.
+    Safe,
+    /// Requires explicit confirmation before the daemon side effect.
+    Confirm,
+    /// Cast refuses to plan this in phase 1; suggest a safer alternative.
+    Reject,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SafetyDecision {
+    Proceed,
+    Confirm { reason: String, suggestion: String },
+    Reject { reason: String, alternative: String },
+}
+
+impl SafetyDecision {
+    pub(crate) fn risk(&self) -> CastRisk {
+        match self {
+            Self::Proceed => CastRisk::Safe,
+            Self::Confirm { .. } => CastRisk::Confirm,
+            Self::Reject { .. } => CastRisk::Reject,
+        }
+    }
+}
+
+/// Classify the risk of a free-text spell that will be routed to a harness.
+///
+/// Phase 1 is deliberately conservative: it only looks at the literal text the
+/// user typed, not at what the harness will eventually do. The job of this
+/// classifier is to surface the *user's stated intent* so the Cast frame can
+/// warn the user before launch. The harness, the project-root guard, and the
+/// daemon still own the real safety checks.
+pub(crate) fn classify_prompt_risk(prompt: &str) -> SafetyDecision {
+    let normalized = prompt.to_ascii_lowercase();
+
+    if mentions_any(&normalized, REJECT_TOKENS) {
+        return SafetyDecision::Reject {
+            reason: "spell asks for a broadly destructive shell command".to_string(),
+            alternative:
+                "describe the outcome instead (for example, \"remove the unused crate\") and \
+                 let Cast plan a scoped change you can review."
+                    .to_string(),
+        };
+    }
+
+    if mentions_any(&normalized, PUBLISH_TOKENS) {
+        return SafetyDecision::Confirm {
+            reason: "spell mentions publishing, pushing, merging, or releasing".to_string(),
+            suggestion: "Cast will route this to the harness, but you should review the diff and \
+                 confirm before any push/merge/release lands."
+                .to_string(),
+        };
+    }
+
+    if mentions_any(&normalized, DESTRUCTIVE_TOKENS) {
+        return SafetyDecision::Confirm {
+            reason: "spell mentions a destructive file or repo operation".to_string(),
+            suggestion:
+                "Cast will pass this to the harness, but please double-check what it changes \
+                 before approving any irreversible step."
+                    .to_string(),
+        };
+    }
+
+    SafetyDecision::Proceed
+}
+
+const REJECT_TOKENS: &[&str] = &[
+    "rm -rf /",
+    "rm -rf ~",
+    "rm -rf *",
+    "rm /*",
+    ":(){:|:&};:",
+    "format the disk",
+    "wipe the disk",
+    "drop database",
+];
+
+const PUBLISH_TOKENS: &[&str] = &[
+    "git push",
+    "force push",
+    "force-push",
+    "push to main",
+    "push to master",
+    "publish ",
+    "publish to",
+    "npm publish",
+    "cargo publish",
+    "release ",
+    "cut a release",
+    "merge to main",
+    "merge into main",
+    "merge to master",
+    "post to slack",
+    "send to slack",
+    "send email",
+    "tweet ",
+];
+
+const DESTRUCTIVE_TOKENS: &[&str] = &[
+    "rm -rf",
+    "delete the repo",
+    "delete this repo",
+    "wipe ",
+    "purge ",
+    "sacrifice ",
+    "drop table",
+];
+
+fn mentions_any(haystack: &str, needles: &[&str]) -> bool {
+    needles.iter().any(|needle| haystack.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_prompt_proceeds() {
+        assert_eq!(
+            classify_prompt_risk("fix the failing tests"),
+            SafetyDecision::Proceed
+        );
+        assert_eq!(
+            classify_prompt_risk("explain this repo in 5 bullets"),
+            SafetyDecision::Proceed
+        );
+    }
+
+    #[test]
+    fn publish_words_require_confirmation() {
+        match classify_prompt_risk("git push the changes to main") {
+            SafetyDecision::Confirm { .. } => {}
+            other => panic!("expected confirm, got {other:?}"),
+        }
+        match classify_prompt_risk("publish the new crate to crates.io") {
+            SafetyDecision::Confirm { .. } => {}
+            other => panic!("expected confirm, got {other:?}"),
+        }
+        match classify_prompt_risk("merge to main once tests pass") {
+            SafetyDecision::Confirm { .. } => {}
+            other => panic!("expected confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn destructive_words_require_confirmation() {
+        match classify_prompt_risk("rm -rf build/") {
+            SafetyDecision::Confirm { .. } => {}
+            other => panic!("expected confirm, got {other:?}"),
+        }
+        match classify_prompt_risk("purge the cache directory") {
+            SafetyDecision::Confirm { .. } => {}
+            other => panic!("expected confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn obviously_dangerous_shell_is_rejected() {
+        match classify_prompt_risk("rm -rf / now") {
+            SafetyDecision::Reject { .. } => {}
+            other => panic!("expected reject, got {other:?}"),
+        }
+        match classify_prompt_risk("drop database production") {
+            SafetyDecision::Reject { .. } => {}
+            other => panic!("expected reject, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn case_insensitivity() {
+        match classify_prompt_risk("Git Push To Main") {
+            SafetyDecision::Confirm { .. } => {}
+            other => panic!("expected confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn safety_decision_reports_matching_risk() {
+        assert_eq!(SafetyDecision::Proceed.risk(), CastRisk::Safe);
+        assert_eq!(
+            SafetyDecision::Confirm {
+                reason: String::new(),
+                suggestion: String::new(),
+            }
+            .risk(),
+            CastRisk::Confirm
+        );
+        assert_eq!(
+            SafetyDecision::Reject {
+                reason: String::new(),
+                alternative: String::new(),
+            }
+            .risk(),
+            CastRisk::Reject
+        );
+    }
+}

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -67,6 +67,15 @@ impl Default for DaemonChatClient {
 }
 
 impl DaemonChatClient {
+    /// Construct a client pinned to a specific Coven home directory. Used by
+    /// the Cast follower when it needs to spin up a second client on a
+    /// background thread without re-detecting `$COVEN_HOME`.
+    pub(crate) fn with_coven_home(coven_home: PathBuf) -> Self {
+        Self { coven_home }
+    }
+}
+
+impl DaemonChatClient {
     fn request_json<T: for<'de> Deserialize<'de>>(
         &self,
         method: &str,

--- a/crates/coven-cli/src/tui/mod.rs
+++ b/crates/coven-cli/src/tui/mod.rs
@@ -2,6 +2,7 @@
 
 use crossterm::event::KeyEventKind;
 
+pub(crate) mod cast;
 pub mod chat;
 pub(crate) mod sessions;
 pub(crate) mod shell;

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -194,7 +194,7 @@ pub(crate) fn run() -> Result<()> {
     let mut selection = 0;
     let mut input = String::new();
     enable_raw_mode().context("failed to enter Coven's magical terminal mode")?;
-    let request: Result<MagicalTuiRequest> = loop {
+    let request_result: Result<MagicalTuiRequest> = loop {
         execute!(io::stdout(), Clear(ClearType::All), MoveTo(0, 0))
             .context("failed to redraw Coven menu")?;
         print!(
@@ -224,13 +224,14 @@ pub(crate) fn run() -> Result<()> {
                     input.clear();
                 }
                 KeyCode::Enter => {
-                    if input.trim().is_empty() {
+                    let trimmed_input = input.trim();
+                    if trimmed_input.is_empty() {
                         break Ok(MagicalTuiRequest::Action(
                             magical_tui_items()[selection].action,
                         ));
                     }
-                    if input.trim_start().starts_with('/') {
-                        break Ok(MagicalTuiRequest::NaturalPrompt(input.trim().to_string()));
+                    if trimmed_input.starts_with('/') {
+                        break Ok(MagicalTuiRequest::NaturalPrompt(trimmed_input.to_string()));
                     }
                     break parse_magical_tui_input(&input);
                 }
@@ -245,7 +246,7 @@ pub(crate) fn run() -> Result<()> {
     disable_raw_mode().context("failed to leave Coven's magical terminal mode")?;
     println!();
 
-    run_magical_tui_request(request?)
+    run_magical_tui_request(request_result?)
 }
 
 fn run_magical_tui_request(request: MagicalTuiRequest) -> Result<()> {

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -8,9 +8,13 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
 };
 
+use super::cast::{
+    self, render_cast_frame_for_terminal, render_outcome, render_plan_intro, CastIntent,
+    CastOutcome, CastPlan, CastRisk, SafetyDecision,
+};
 use super::{is_key_press, sessions};
 use crate::{
-    archive_session_command, attach_session, default_harness_id, prompt_for_optional_line,
+    archive_session_command, attach_session, default_harness_id, project, prompt_for_optional_line,
     prompt_for_required_line, run_daemon_command, run_doctor, run_patch_openclaw, run_session,
     sacrifice_session_command, summon_session_command, theme, DaemonCommand,
 };
@@ -183,8 +187,7 @@ pub(crate) fn magical_tui_items() -> &'static [MagicalTuiItem] {
 
 pub(crate) fn run() -> Result<()> {
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
-        println!("{}", render_magical_tui_frame_plain(0));
-        println!("\nTip: run `coven tui` in a terminal, type a task, then press Enter.");
+        print_cast_non_interactive_frame();
         return Ok(());
     }
 
@@ -244,10 +247,15 @@ pub(crate) fn run() -> Result<()> {
 
 fn run_magical_tui_request(request: MagicalTuiRequest) -> Result<()> {
     match request {
+        // Palette buttons keep their existing direct dispatch. Cast layers in
+        // when the user actually types a spell.
         MagicalTuiRequest::Action(action) => run_magical_tui_action(action),
-        MagicalTuiRequest::NaturalPrompt(prompt) => run_default_prompt_session(&prompt),
+        // Free-text spells flow through Cast for parsing, planning, and the
+        // intro/outcome frames the user sees around session launches.
+        MagicalTuiRequest::NaturalPrompt(prompt) => run_cast_spell(&prompt),
         MagicalTuiRequest::HarnessPrompt { harness, prompt } => {
-            run_session(&harness, &[prompt], None, None, false)
+            let raw = format!("/{} {}", harness, prompt);
+            run_cast_spell(&raw)
         }
         MagicalTuiRequest::AttachSession(session_id) => attach_session(&session_id),
         MagicalTuiRequest::SummonSession(session_id) => summon_session_command(&session_id),
@@ -256,6 +264,265 @@ fn run_magical_tui_request(request: MagicalTuiRequest) -> Result<()> {
             sacrifice_session_command(&session_id, false)
         }
     }
+}
+
+/// Cast entry point for free-text spells. Parses the raw input into a
+/// `CastIntent`, builds a plan, renders the intro card the user sees before
+/// any side effect, dispatches the matching handler, then renders the
+/// outcome card.
+fn run_cast_spell(raw: &str) -> Result<()> {
+    let plan = cast::plan_spell(raw)?;
+    print_plan_intro(&plan);
+    dispatch_cast_plan(plan)
+}
+
+fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
+    match plan.risk() {
+        CastRisk::Reject => {
+            print_outcome(&plan_rejected_outcome(&plan));
+            return Ok(());
+        }
+        CastRisk::Confirm | CastRisk::Safe => {}
+    }
+
+    let outcome = match plan.intent.clone() {
+        CastIntent::NaturalSpell { prompt } => dispatch_default_spell(&plan, &prompt)?,
+        CastIntent::HarnessSpell { harness, prompt } => {
+            dispatch_harness_spell(&plan, harness.id(), &prompt)?
+        }
+        CastIntent::OpenSessions => {
+            sessions::run_browser(false)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some("Coven session browser (active)".to_string()),
+                session_id: None,
+                next_step: Some(
+                    "Use the browser actions (Rejoin, View Log, Summon, Archive, Sacrifice)."
+                        .to_string(),
+                ),
+                notes: vec![],
+            }
+        }
+        CastIntent::OpenAllSessions => {
+            sessions::run_browser(true)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some("Coven session browser (active + archived)".to_string()),
+                session_id: None,
+                next_step: Some(
+                    "Use the browser actions to summon archived sessions or archive completed ones."
+                        .to_string(),
+                ),
+                notes: vec![],
+            }
+        }
+        CastIntent::AttachSession { session_id } => {
+            attach_session(&session_id)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some(format!("Attached to session {session_id}")),
+                session_id: Some(session_id),
+                next_step: Some(
+                    "Detach with Ctrl+C; the session keeps running under the daemon.".to_string(),
+                ),
+                notes: vec![],
+            }
+        }
+        CastIntent::SummonSession { session_id } => {
+            summon_session_command(&session_id)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some(format!("Summoned session {session_id}")),
+                session_id: Some(session_id),
+                next_step: Some(
+                    "The session is now active again — attach to follow it.".to_string(),
+                ),
+                notes: vec![],
+            }
+        }
+        CastIntent::ArchiveSession { session_id } => {
+            archive_session_command(&session_id)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some(format!("Archived session {session_id}")),
+                session_id: Some(session_id),
+                next_step: Some(
+                    "Use `/summon <id>` later to restore it; events are preserved.".to_string(),
+                ),
+                notes: vec![],
+            }
+        }
+        CastIntent::SacrificeSession { session_id } => {
+            sacrifice_session_command(&session_id, false)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some(format!("Sacrificed session {session_id}")),
+                session_id: Some(session_id),
+                next_step: None,
+                notes: vec!["Sacrifice permanently deletes the session and its events.".to_string()],
+            }
+        }
+        CastIntent::Doctor => {
+            run_doctor()?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some("Coven doctor".to_string()),
+                session_id: None,
+                next_step: Some(
+                    "Install or auth any missing harness, then retry your spell.".to_string(),
+                ),
+                notes: vec![],
+            }
+        }
+        CastIntent::DaemonStatus => {
+            run_daemon_command(DaemonCommand::Status)?;
+            CastOutcome {
+                request: plan.headline.clone(),
+                launched: Some("Coven daemon status".to_string()),
+                session_id: None,
+                next_step: Some("Run `coven daemon start` if status reported stopped.".to_string()),
+                notes: vec![],
+            }
+        }
+        CastIntent::Help => {
+            run_tui_help()?;
+            CastOutcome::for_request(plan.headline.clone())
+        }
+        CastIntent::StartHere => {
+            run_new_user_start_here()?;
+            CastOutcome::for_request(plan.headline.clone())
+        }
+        CastIntent::OpenTui => {
+            // Already in the launcher — show the palette help instead of
+            // re-entering the raw-mode loop.
+            run_tui_help()?;
+            CastOutcome::for_request(plan.headline.clone())
+        }
+        CastIntent::PatchOpenClaw => {
+            run_patch_openclaw(vec![], None, None, None, false, false, true)?;
+            CastOutcome::for_request(plan.headline.clone())
+        }
+        CastIntent::Quit => {
+            let primary = theme::fg(theme::PRIMARY);
+            let reset = theme::reset();
+            println!("{primary}The circle fades. Nothing changed.{reset}");
+            return Ok(());
+        }
+    };
+
+    print_outcome(&outcome);
+    Ok(())
+}
+
+fn dispatch_default_spell(plan: &CastPlan, prompt: &str) -> Result<CastOutcome> {
+    let Some(plan_harness) = plan.harness else {
+        return Err(anyhow!(
+            "no supported harness is available; run `coven doctor` first"
+        ));
+    };
+    let title = plan.title.as_deref();
+    run_session(
+        plan_harness.harness.id(),
+        &[prompt.to_string()],
+        None,
+        title,
+        false,
+    )?;
+    Ok(CastOutcome {
+        request: prompt.to_string(),
+        launched: Some(format!(
+            "{} session (Cast default, project-scoped)",
+            plan_harness.harness.label()
+        )),
+        session_id: None,
+        next_step: Some("Run `coven sessions` to see this session.".to_string()),
+        notes: plan_outcome_notes(plan),
+    })
+}
+
+fn dispatch_harness_spell(plan: &CastPlan, harness_id: &str, prompt: &str) -> Result<CastOutcome> {
+    let title = plan.title.as_deref();
+    run_session(harness_id, &[prompt.to_string()], None, title, false)?;
+    Ok(CastOutcome {
+        request: prompt.to_string(),
+        launched: Some(format!(
+            "{} session (user-chosen, project-scoped)",
+            harness_label(harness_id)
+        )),
+        session_id: None,
+        next_step: Some("Run `coven sessions` to see this session.".to_string()),
+        notes: plan_outcome_notes(plan),
+    })
+}
+
+fn plan_outcome_notes(plan: &CastPlan) -> Vec<String> {
+    let mut notes = Vec::new();
+    if let SafetyDecision::Confirm { reason, suggestion } = &plan.decision {
+        notes.push(format!("Risk: {reason}. {suggestion}"));
+    }
+    notes
+}
+
+fn plan_rejected_outcome(plan: &CastPlan) -> CastOutcome {
+    let (reason, alternative) = match &plan.decision {
+        SafetyDecision::Reject {
+            reason,
+            alternative,
+        } => (reason.clone(), alternative.clone()),
+        _ => (
+            "Cast rejected the spell.".to_string(),
+            "Try a more specific outcome.".to_string(),
+        ),
+    };
+    CastOutcome {
+        request: plan.headline.clone(),
+        launched: None,
+        session_id: None,
+        next_step: Some(alternative),
+        notes: vec![format!("Rejected: {reason}")],
+    }
+}
+
+fn harness_label(harness_id: &str) -> &'static str {
+    match harness_id {
+        "codex" => "Codex",
+        "claude" => "Claude Code",
+        _ => "Harness",
+    }
+}
+
+fn print_plan_intro(plan: &CastPlan) {
+    let frame = render_plan_intro(plan);
+    if !frame.is_empty() {
+        println!("{frame}");
+    }
+}
+
+fn print_outcome(outcome: &CastOutcome) {
+    let frame = render_outcome(outcome);
+    if !frame.is_empty() {
+        print!("\n{frame}");
+    }
+}
+
+fn print_cast_non_interactive_frame() {
+    let project_root = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| project::canonical_project_root(&cwd).ok());
+    let default_harness_id = default_harness_id();
+    let frame = render_cast_frame_for_terminal(project_root.as_deref(), default_harness_id);
+    print!("{frame}");
+    println!("\nTip: run `coven` in a real terminal to open the Cast launcher and type a spell.");
+}
+
+/// Plain-text Cast frame for tests and pipe targets. Mirrors
+/// `print_cast_non_interactive_frame` minus the theme escapes and stdout.
+#[cfg(test)]
+pub(crate) fn cast_non_interactive_frame_for_test(
+    project_root: Option<&std::path::Path>,
+    default_harness: Option<&str>,
+) -> String {
+    super::cast::render_cast_frame_plain(project_root, default_harness)
 }
 
 fn run_magical_tui_action(action: MagicalTuiAction) -> Result<()> {
@@ -364,12 +631,6 @@ fn parse_session_slash_command(
     Ok(build(session_id.to_string()))
 }
 
-fn run_default_prompt_session(prompt: &str) -> Result<()> {
-    let harness = default_harness_id()
-        .ok_or_else(|| anyhow!("no supported harness is available; run `coven doctor` first"))?;
-    run_session(harness, &[prompt.to_string()], None, None, false)
-}
-
 fn run_tui_help() -> Result<()> {
     let primary_strong = theme::fg(theme::PRIMARY_STRONG);
     let reset = theme::reset();
@@ -426,6 +687,7 @@ pub(crate) fn render_magical_tui_frame_for_raw_terminal(selection: usize, input:
     render_magical_tui_frame(selection, input).replace('\n', "\r\n")
 }
 
+#[allow(dead_code)]
 pub(crate) fn render_magical_tui_frame_plain(selection: usize) -> String {
     render_magical_tui_frame_with_mode_and_width(
         selection,

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -194,7 +194,7 @@ pub(crate) fn run() -> Result<()> {
     let mut selection = 0;
     let mut input = String::new();
     enable_raw_mode().context("failed to enter Coven's magical terminal mode")?;
-    let request = loop {
+    let request: Result<MagicalTuiRequest> = loop {
         execute!(io::stdout(), Clear(ClearType::All), MoveTo(0, 0))
             .context("failed to redraw Coven menu")?;
         print!(
@@ -228,6 +228,9 @@ pub(crate) fn run() -> Result<()> {
                         break Ok(MagicalTuiRequest::Action(
                             magical_tui_items()[selection].action,
                         ));
+                    }
+                    if input.trim_start().starts_with('/') {
+                        break Ok(MagicalTuiRequest::NaturalPrompt(input.trim().to_string()));
                     }
                     break parse_magical_tui_input(&input);
                 }
@@ -292,12 +295,15 @@ fn confirm_cast_plan(plan: &CastPlan) -> Result<bool> {
 
     writeln!(stdout)?;
     writeln!(stdout, "Confirmation required for: {}", plan.headline)?;
-    writeln!(stdout, "Press 'y' to continue, or 'n' / Esc / Enter to cancel.")?;
+    writeln!(
+        stdout,
+        "Press 'y' to continue, or 'n' / Esc / Enter to cancel."
+    )?;
     stdout.flush()?;
 
     loop {
-        match event::read()? {
-            Event::Key(key) => match key.code {
+        if let Event::Key(key) = event::read()? {
+            match key.code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     writeln!(stdout, "Confirmed.")?;
                     stdout.flush()?;
@@ -309,8 +315,7 @@ fn confirm_cast_plan(plan: &CastPlan) -> Result<bool> {
                     return Ok(false);
                 }
                 _ => {}
-            },
-            _ => {}
+            }
         }
     }
 }
@@ -404,7 +409,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             }
         }
         CastIntent::SacrificeSession { session_id } => {
-            sacrifice_session_command(&session_id, false)?;
+            sacrifice_session_command(&session_id, true)?;
             CastOutcome {
                 request: plan.headline.clone(),
                 launched: Some(format!("Sacrificed session {session_id}")),

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1,4 +1,7 @@
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use crossterm::{
@@ -7,16 +10,20 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
 };
+use uuid::Uuid;
 
 use super::cast::{
-    self, render_cast_frame_for_terminal, render_outcome, render_plan_intro, CastIntent,
-    CastOutcome, CastPlan, CastRisk, SafetyDecision,
+    self, evaluate_gate, follow_until_exit, render_cast_frame_for_terminal, render_outcome,
+    render_plan_intro, CastIntent, CastOutcome, CastPlan, CastSessionExit, FollowerObserver,
+    FollowerPacer, GateOutcome, SafetyDecision,
 };
+use super::chat::client::{ChatClient, DaemonChatClient, LaunchRequest};
 use super::{is_key_press, sessions};
 use crate::{
-    archive_session_command, attach_session, default_harness_id, project, prompt_for_optional_line,
-    prompt_for_required_line, run_daemon_command, run_doctor, run_patch_openclaw, run_session,
-    sacrifice_session_command, summon_session_command, theme, DaemonCommand,
+    archive_session_command, attach_session, coven_home_dir, coven_store_path, current_timestamp,
+    daemon, default_harness_id, project, prompt_for_optional_line, prompt_for_required_line,
+    run_daemon_command, run_doctor, run_patch_openclaw, run_session, sacrifice_session_command,
+    store, summon_session_command, theme, DaemonCommand,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -37,6 +44,11 @@ pub(crate) enum MagicalTuiAction {
     Quit,
 }
 
+/// Legacy palette-input parser type. Phase 2 routes typed input through
+/// `cast::parse_spell` directly, but `parse_magical_tui_input` and this
+/// enum remain available to the test suite as an independent record of the
+/// slash-command surface area. Not used in production builds.
+#[cfg(test)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum MagicalTuiRequest {
     Action(MagicalTuiAction),
@@ -67,6 +79,34 @@ pub(crate) struct MagicalTuiItem {
 const MAGICAL_TUI_DEFAULT_INNER_WIDTH: usize = 76;
 pub(crate) const MAGICAL_TUI_MAX_INNER_WIDTH: usize = 96;
 const MAGICAL_TUI_MIN_INNER_WIDTH: usize = 40;
+
+/// Restores terminal raw mode on all exit paths for the slash-command launcher.
+struct RawModeGuard {
+    enabled: bool,
+}
+
+impl RawModeGuard {
+    fn enter() -> Result<Self> {
+        enable_raw_mode().context("failed to enter Coven's magical terminal mode")?;
+        Ok(Self { enabled: true })
+    }
+
+    fn restore(&mut self) -> Result<()> {
+        if self.enabled {
+            disable_raw_mode().context("failed to leave Coven's magical terminal mode")?;
+            self.enabled = false;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for RawModeGuard {
+    fn drop(&mut self) {
+        if self.enabled {
+            let _ = disable_raw_mode();
+        }
+    }
+}
 
 pub(crate) fn magical_tui_items() -> &'static [MagicalTuiItem] {
     &[
@@ -193,8 +233,8 @@ pub(crate) fn run() -> Result<()> {
 
     let mut selection = 0;
     let mut input = String::new();
-    enable_raw_mode().context("failed to enter Coven's magical terminal mode")?;
-    let request_result: Result<MagicalTuiRequest> = loop {
+    let mut raw_mode = RawModeGuard::enter()?;
+    let choice = loop {
         execute!(io::stdout(), Clear(ClearType::All), MoveTo(0, 0))
             .context("failed to redraw Coven menu")?;
         print!(
@@ -209,7 +249,7 @@ pub(crate) fn run() -> Result<()> {
             }
             match key.code {
                 KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    break Ok(MagicalTuiRequest::Action(MagicalTuiAction::Quit));
+                    break LauncherChoice::Palette(MagicalTuiAction::Quit);
                 }
                 KeyCode::Up => {
                     selection = move_magical_tui_selection(selection, MagicalTuiMove::Up);
@@ -224,123 +264,64 @@ pub(crate) fn run() -> Result<()> {
                     input.clear();
                 }
                 KeyCode::Enter => {
-                    let trimmed_input = input.trim();
-                    if trimmed_input.is_empty() {
-                        break Ok(MagicalTuiRequest::Action(
-                            magical_tui_items()[selection].action,
-                        ));
+                    if input.trim().is_empty() {
+                        break LauncherChoice::Palette(magical_tui_items()[selection].action);
                     }
-                    if trimmed_input.starts_with('/') {
-                        break Ok(MagicalTuiRequest::NaturalPrompt(trimmed_input.to_string()));
-                    }
-                    break parse_magical_tui_input(&input);
+                    break LauncherChoice::TypedSpell(input.clone());
                 }
                 KeyCode::Char(value) => {
                     input.push(value);
                 }
-                KeyCode::Esc => break Ok(MagicalTuiRequest::Action(MagicalTuiAction::Quit)),
+                KeyCode::Esc => break LauncherChoice::Palette(MagicalTuiAction::Quit),
                 _ => {}
             }
         }
     };
-    disable_raw_mode().context("failed to leave Coven's magical terminal mode")?;
+    raw_mode.restore()?;
     println!();
 
-    run_magical_tui_request(request_result?)
+    // Palette buttons keep their existing direct dispatch. Typed input — slash
+    // commands and free text alike — flows through Cast so that the same
+    // intent parser, safety gate, and outcome card apply to every spell.
+    match choice {
+        LauncherChoice::Palette(action) => run_magical_tui_action(action),
+        LauncherChoice::TypedSpell(raw) => run_cast_spell(&raw),
+    }
 }
 
-fn run_magical_tui_request(request: MagicalTuiRequest) -> Result<()> {
-    match request {
-        // Palette buttons keep their existing direct dispatch. Cast layers in
-        // when the user actually types a spell.
-        MagicalTuiRequest::Action(action) => run_magical_tui_action(action),
-        // Free-text spells flow through Cast for parsing, planning, and the
-        // intro/outcome frames the user sees around session launches.
-        MagicalTuiRequest::NaturalPrompt(prompt) => run_cast_spell(&prompt),
-        MagicalTuiRequest::HarnessPrompt { harness, prompt } => {
-            let raw = format!("/{} {}", harness, prompt);
-            run_cast_spell(&raw)
-        }
-        MagicalTuiRequest::AttachSession(session_id) => attach_session(&session_id),
-        MagicalTuiRequest::SummonSession(session_id) => summon_session_command(&session_id),
-        MagicalTuiRequest::ArchiveSession(session_id) => archive_session_command(&session_id),
-        MagicalTuiRequest::SacrificeSession(session_id) => {
-            sacrifice_session_command(&session_id, false)
-        }
-    }
+/// What the launcher loop decided to dispatch after the user pressed Enter
+/// (or Esc / Ctrl+C). Typed input always flows through Cast; palette buttons
+/// stay on the direct `run_magical_tui_action` path.
+enum LauncherChoice {
+    Palette(MagicalTuiAction),
+    TypedSpell(String),
 }
 
 /// Cast entry point for free-text spells. Parses the raw input into a
 /// `CastIntent`, builds a plan, renders the intro card the user sees before
-/// any side effect, dispatches the matching handler, then renders the
-/// outcome card.
+/// any side effect, runs the safety gate, dispatches the matching handler,
+/// then renders the outcome card.
 fn run_cast_spell(raw: &str) -> Result<()> {
     let plan = cast::plan_spell(raw)?;
     print_plan_intro(&plan);
     dispatch_cast_plan(plan)
 }
 
-fn confirm_cast_plan(plan: &CastPlan) -> Result<bool> {
-    let mut stdout = io::stdout();
-
-    if !io::stdin().is_terminal() || !stdout.is_terminal() {
-        writeln!(stdout)?;
-        writeln!(
-            stdout,
-            "Confirmation required for \"{}\", but no interactive terminal is available. Cancelling.",
-            plan.headline
-        )?;
-        stdout.flush()?;
-        return Ok(false);
-    }
-
-    writeln!(stdout)?;
-    writeln!(stdout, "Confirmation required for: {}", plan.headline)?;
-    writeln!(
-        stdout,
-        "Press 'y' to continue, or 'n' / Esc / Enter to cancel."
-    )?;
-    stdout.flush()?;
-
-    loop {
-        if let Event::Key(key) = event::read()? {
-            match key.code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    writeln!(stdout, "Confirmed.")?;
-                    stdout.flush()?;
-                    return Ok(true);
-                }
-                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc | KeyCode::Enter => {
-                    writeln!(stdout, "Cancelled.")?;
-                    stdout.flush()?;
-                    return Ok(false);
-                }
-                _ => {}
-            }
-        }
-    }
-}
-
+/// Cast's dispatcher. Runs the safety gate against the plan, then routes
+/// safe / confirmed plans to the existing CLI handlers. All destructive or
+/// confirmation-required side effects are guarded by the gate; the
+/// dispatcher itself does no risk classification.
 fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
-    match plan.risk() {
-        CastRisk::Reject => {
-            print_outcome(&plan_rejected_outcome(&plan));
+    let mut reader = stdin_line_reader;
+    match evaluate_gate(&plan, &mut reader)? {
+        GateOutcome::Cancelled { reason, next_step } => {
+            print_outcome(&plan_cancelled_outcome(&plan, &reason, next_step));
             return Ok(());
         }
-        CastRisk::Confirm => {
-            if !confirm_cast_plan(&plan)? {
-                print_outcome(&CastOutcome {
-                    request: plan.headline.clone(),
-                    launched: None,
-                    session_id: None,
-                    next_step: Some("Nothing was run.".to_string()),
-                    notes: vec!["Action cancelled before dispatch.".to_string()],
-                });
-                return Ok(());
-            }
-        }
-        CastRisk::Safe => {}
+        GateOutcome::Proceed => {}
     }
+
+    let request_text = outcome_request_text(&plan);
 
     let outcome = match plan.intent.clone() {
         CastIntent::NaturalSpell { prompt } => dispatch_default_spell(&plan, &prompt)?,
@@ -350,7 +331,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         CastIntent::OpenSessions => {
             sessions::run_browser(false)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some("Coven session browser (active)".to_string()),
                 session_id: None,
                 next_step: Some(
@@ -363,7 +344,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         CastIntent::OpenAllSessions => {
             sessions::run_browser(true)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some("Coven session browser (active + archived)".to_string()),
                 session_id: None,
                 next_step: Some(
@@ -376,7 +357,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         CastIntent::AttachSession { session_id } => {
             attach_session(&session_id)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some(format!("Attached to session {session_id}")),
                 session_id: Some(session_id),
                 next_step: Some(
@@ -388,7 +369,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         CastIntent::SummonSession { session_id } => {
             summon_session_command(&session_id)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some(format!("Summoned session {session_id}")),
                 session_id: Some(session_id),
                 next_step: Some(
@@ -400,7 +381,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         CastIntent::ArchiveSession { session_id } => {
             archive_session_command(&session_id)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some(format!("Archived session {session_id}")),
                 session_id: Some(session_id),
                 next_step: Some(
@@ -410,19 +391,22 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             }
         }
         CastIntent::SacrificeSession { session_id } => {
+            // The gate already collected the typed `sacrifice` confirmation;
+            // calling the underlying handler with `--yes` is the documented
+            // way to bypass its own redundant prompt.
             sacrifice_session_command(&session_id, true)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some(format!("Sacrificed session {session_id}")),
                 session_id: Some(session_id),
                 next_step: None,
-                notes: vec!["Sacrifice permanently deletes the session and its events.".to_string()],
+                notes: vec!["Sacrifice permanently deleted the session and its events.".to_string()],
             }
         }
         CastIntent::Doctor => {
             run_doctor()?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some("Coven doctor".to_string()),
                 session_id: None,
                 next_step: Some(
@@ -434,7 +418,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         CastIntent::DaemonStatus => {
             run_daemon_command(DaemonCommand::Status)?;
             CastOutcome {
-                request: plan.headline.clone(),
+                request: request_text,
                 launched: Some("Coven daemon status".to_string()),
                 session_id: None,
                 next_step: Some("Run `coven daemon start` if status reported stopped.".to_string()),
@@ -443,21 +427,21 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
         }
         CastIntent::Help => {
             run_tui_help()?;
-            CastOutcome::for_request(plan.headline.clone())
+            CastOutcome::for_request(request_text)
         }
         CastIntent::StartHere => {
             run_new_user_start_here()?;
-            CastOutcome::for_request(plan.headline.clone())
+            CastOutcome::for_request(request_text)
         }
         CastIntent::OpenTui => {
             // Already in the launcher — show the palette help instead of
             // re-entering the raw-mode loop.
             run_tui_help()?;
-            CastOutcome::for_request(plan.headline.clone())
+            CastOutcome::for_request(request_text)
         }
         CastIntent::PatchOpenClaw => {
             run_patch_openclaw(vec![], None, None, None, false, false, true)?;
-            CastOutcome::for_request(plan.headline.clone())
+            CastOutcome::for_request(request_text)
         }
         CastIntent::Quit => {
             let primary = theme::fg(theme::PRIMARY);
@@ -471,45 +455,309 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
     Ok(())
 }
 
+/// The line the outcome card shows as the user's request. We prefer the raw
+/// spell text (what the user actually typed) so cancellations and successes
+/// look the same; we only fall back to the plan headline for plans that were
+/// not built from raw input (Phase 1 doesn't create those, but the
+/// defensive default keeps the field non-empty).
+fn outcome_request_text(plan: &CastPlan) -> String {
+    if plan.raw_spell.is_empty() {
+        plan.headline.clone()
+    } else {
+        plan.raw_spell.clone()
+    }
+}
+
+/// Default stdin reader for the safety gate. Treats empty input as cancel
+/// (returns `""`) instead of bubbling an error so the gate can render a
+/// clean "cancelled" outcome.
+fn stdin_line_reader(prompt: &str) -> Result<String> {
+    Ok(prompt_for_optional_line(prompt)?.unwrap_or_default())
+}
+
+fn plan_cancelled_outcome(plan: &CastPlan, reason: &str, next_step: Option<String>) -> CastOutcome {
+    CastOutcome {
+        request: outcome_request_text(plan),
+        launched: None,
+        session_id: None,
+        next_step,
+        notes: vec![reason.to_string()],
+    }
+}
+
 fn dispatch_default_spell(plan: &CastPlan, prompt: &str) -> Result<CastOutcome> {
     let Some(plan_harness) = plan.harness else {
         return Err(anyhow!(
             "no supported harness is available; run `coven doctor` first"
         ));
     };
-    let title = plan.title.as_deref();
-    run_session(
+    dispatch_cast_launch(
+        plan,
         plan_harness.harness.id(),
-        &[prompt.to_string()],
-        None,
-        title,
-        false,
-    )?;
-    Ok(CastOutcome {
-        request: prompt.to_string(),
-        launched: Some(format!(
+        prompt,
+        format!(
             "{} session (Cast default, project-scoped)",
             plan_harness.harness.label()
-        )),
-        session_id: None,
-        next_step: Some("Run `coven sessions` to see this session.".to_string()),
-        notes: plan_outcome_notes(plan),
-    })
+        ),
+    )
 }
 
 fn dispatch_harness_spell(plan: &CastPlan, harness_id: &str, prompt: &str) -> Result<CastOutcome> {
-    let title = plan.title.as_deref();
-    run_session(harness_id, &[prompt.to_string()], None, title, false)?;
-    Ok(CastOutcome {
-        request: prompt.to_string(),
-        launched: Some(format!(
+    dispatch_cast_launch(
+        plan,
+        harness_id,
+        prompt,
+        format!(
             "{} session (user-chosen, project-scoped)",
             harness_label(harness_id)
+        ),
+    )
+}
+
+/// Launch a project-scoped session and follow its events into the Cast TUI.
+///
+/// Phase 2 prefers the daemon-backed path so the follower can stream events
+/// with `afterSeq`, surface the exit status + exit code in the outcome card,
+/// and write a `cast.summary` event to the ledger when the run finishes. If
+/// the daemon is not running Cast falls back to the synchronous local PTY
+/// path Phase 1 used; the user can still read the transcript inline, but the
+/// outcome card will note the missing daemon and skip the follower-only
+/// fields.
+fn dispatch_cast_launch(
+    plan: &CastPlan,
+    harness_id: &str,
+    prompt: &str,
+    launched_label: String,
+) -> Result<CastOutcome> {
+    match daemon_runtime_state()? {
+        DaemonRuntimeState::Running => {
+            dispatch_via_daemon(plan, harness_id, prompt, &launched_label)
+        }
+        DaemonRuntimeState::NotReady(reason) => {
+            dispatch_via_local_pty(plan, harness_id, prompt, &launched_label, &reason)
+        }
+    }
+}
+
+enum DaemonRuntimeState {
+    Running,
+    NotReady(String),
+}
+
+fn daemon_runtime_state() -> Result<DaemonRuntimeState> {
+    let home = coven_home_dir()?;
+    match daemon::background_server_status(&home)? {
+        Some(daemon::DaemonStatusState::Running(_)) => Ok(DaemonRuntimeState::Running),
+        Some(daemon::DaemonStatusState::Stale(_)) => Ok(DaemonRuntimeState::NotReady(
+            "the local Coven daemon is recorded but unreachable; run `coven daemon restart`"
+                .to_string(),
         )),
-        session_id: None,
-        next_step: Some("Run `coven sessions` to see this session.".to_string()),
-        notes: plan_outcome_notes(plan),
+        None => Ok(DaemonRuntimeState::NotReady(
+            "the local Coven daemon is not running; run `coven daemon start` to enable Cast's \
+             event follower"
+                .to_string(),
+        )),
+    }
+}
+
+fn dispatch_via_daemon(
+    plan: &CastPlan,
+    harness_id: &str,
+    prompt: &str,
+    launched_label: &str,
+) -> Result<CastOutcome> {
+    let project_root = resolve_project_root_for_cast()?;
+    let title = plan
+        .title
+        .clone()
+        .unwrap_or_else(|| prompt.chars().take(48).collect());
+
+    let launch = LaunchRequest {
+        id: Uuid::new_v4().to_string(),
+        project_root: project_root.to_string_lossy().into_owned(),
+        cwd: project_root.to_string_lossy().into_owned(),
+        harness: harness_id.to_string(),
+        prompt: prompt.to_string(),
+        title,
+    };
+
+    let mut client = DaemonChatClient::default();
+    let session = client.launch_session(launch).with_context(|| {
+        format!(
+            "Cast failed to launch {} session via the daemon",
+            harness_label(harness_id)
+        )
+    })?;
+
+    println!();
+    println!(
+        "Cast transcript — session {} ({}). Press Enter at any time to send input.",
+        session.id, session.harness
+    );
+
+    // Forward user keystrokes from this process into the live daemon
+    // session so the user can follow up on a running spell without
+    // detaching. The thread is detached and exits when stdin closes or
+    // the host process exits.
+    maybe_spawn_cast_input_forwarder(coven_home_dir()?, session.id.clone());
+
+    let mut observer = TranscriptObserver::new(io::stdout());
+    let mut pacer = SleepPacer::new(Duration::from_millis(250));
+    let exit = follow_until_exit(&mut client, &session.id, &mut observer, &mut pacer)?;
+
+    write_cast_summary_event(&session.id, plan, harness_id, &exit)?;
+
+    let exit_summary = format_exit_summary(&exit);
+    let next_step = format!(
+        "Run `coven attach {}` to revisit, or `coven sessions` to list everything.",
+        session.id
+    );
+    let mut notes = plan_outcome_notes(plan);
+    notes.push(exit_summary.clone());
+
+    Ok(CastOutcome {
+        request: outcome_request_text(plan),
+        launched: Some(format!("{launched_label} via daemon")),
+        session_id: Some(session.id),
+        next_step: Some(next_step),
+        notes,
     })
+}
+
+fn dispatch_via_local_pty(
+    plan: &CastPlan,
+    harness_id: &str,
+    prompt: &str,
+    launched_label: &str,
+    daemon_reason: &str,
+) -> Result<CastOutcome> {
+    let title = plan.title.as_deref();
+    run_session(harness_id, &[prompt.to_string()], None, title, false)?;
+    let mut notes = plan_outcome_notes(plan);
+    notes.push(format!("Cast event follower skipped: {daemon_reason}."));
+    Ok(CastOutcome {
+        request: outcome_request_text(plan),
+        launched: Some(format!("{launched_label} (local PTY fallback)")),
+        session_id: None,
+        next_step: Some(
+            "Start the daemon for streamed transcripts: `coven daemon start`.".to_string(),
+        ),
+        notes,
+    })
+}
+
+fn resolve_project_root_for_cast() -> Result<PathBuf> {
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    project::canonical_project_root(&cwd).with_context(|| {
+        format!(
+            "Cast could not resolve a project root from {}. Run `coven` inside a repo.",
+            cwd.display()
+        )
+    })
+}
+
+/// Stdout-backed observer that prints each output chunk verbatim and adds a
+/// Cast-styled completion line when the session exits. Holds a writer so
+/// tests can swap stdout for a buffer if they ever need to.
+struct TranscriptObserver<W: Write> {
+    out: W,
+}
+
+impl<W: Write> TranscriptObserver<W> {
+    fn new(out: W) -> Self {
+        Self { out }
+    }
+}
+
+impl<W: Write> FollowerObserver for TranscriptObserver<W> {
+    fn on_output(&mut self, chunk: &str) {
+        // Swallow individual write errors — best-effort transcript should
+        // not abort the follower because stdout is briefly unavailable.
+        let _ = self.out.write_all(chunk.as_bytes());
+        let _ = self.out.flush();
+    }
+
+    fn on_exit(&mut self, status: &str, exit_code: Option<i32>) {
+        let summary = match exit_code {
+            Some(code) => format!("\n[Cast: session {status} (exit code {code})]\n"),
+            None => format!("\n[Cast: session {status}]\n"),
+        };
+        let _ = self.out.write_all(summary.as_bytes());
+        let _ = self.out.flush();
+    }
+}
+
+/// Sleep-based pacer for the production follower. Tests use the test pacer
+/// in `cast::follow` so they never sleep.
+struct SleepPacer {
+    interval: Duration,
+}
+
+impl SleepPacer {
+    fn new(interval: Duration) -> Self {
+        Self { interval }
+    }
+}
+
+impl FollowerPacer for SleepPacer {
+    fn between_polls(&mut self) -> Result<()> {
+        thread::sleep(self.interval);
+        Ok(())
+    }
+}
+
+fn maybe_spawn_cast_input_forwarder(coven_home: PathBuf, session_id: String) {
+    if !io::stdin().is_terminal() {
+        return;
+    }
+    thread::spawn(move || {
+        let mut client = DaemonChatClient::with_coven_home(coven_home);
+        let stdin = io::stdin();
+        for line in stdin.lock().lines() {
+            let Ok(mut line) = line else {
+                break;
+            };
+            line.push('\n');
+            if client.send_input(&session_id, &line).is_err() {
+                // Session likely exited; stop forwarding silently.
+                break;
+            }
+        }
+    });
+}
+
+fn write_cast_summary_event(
+    session_id: &str,
+    plan: &CastPlan,
+    harness_id: &str,
+    exit: &CastSessionExit,
+) -> Result<()> {
+    let store_path = coven_store_path()?;
+    let conn = store::open_store(&store_path)?;
+    let payload = serde_json::json!({
+        "request": plan.raw_spell,
+        "headline": plan.headline,
+        "harness": harness_id,
+        "status": exit.status,
+        "exitCode": exit.exit_code,
+    });
+    store::insert_json_event(
+        &conn,
+        session_id,
+        "cast.summary",
+        &payload,
+        &current_timestamp(),
+    )
+}
+
+fn format_exit_summary(exit: &CastSessionExit) -> String {
+    match exit.exit_code {
+        Some(code) => format!(
+            "Session finished: status `{}`, exit code {code}",
+            exit.status
+        ),
+        None => format!("Session finished: status `{}`", exit.status),
+    }
 }
 
 fn plan_outcome_notes(plan: &CastPlan) -> Vec<String> {
@@ -518,26 +766,6 @@ fn plan_outcome_notes(plan: &CastPlan) -> Vec<String> {
         notes.push(format!("Risk: {reason}. {suggestion}"));
     }
     notes
-}
-
-fn plan_rejected_outcome(plan: &CastPlan) -> CastOutcome {
-    let (reason, alternative) = match &plan.decision {
-        SafetyDecision::Reject {
-            reason,
-            alternative,
-        } => (reason.clone(), alternative.clone()),
-        _ => (
-            "Cast rejected the spell.".to_string(),
-            "Try a more specific outcome.".to_string(),
-        ),
-    };
-    CastOutcome {
-        request: plan.headline.clone(),
-        launched: None,
-        session_id: None,
-        next_step: Some(alternative),
-        notes: vec![format!("Rejected: {reason}")],
-    }
 }
 
 fn harness_label(harness_id: &str) -> &'static str {
@@ -608,6 +836,7 @@ fn run_magical_tui_action(action: MagicalTuiAction) -> Result<()> {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn parse_magical_tui_input(input: &str) -> Result<MagicalTuiRequest> {
     let input = input.trim();
     if input.is_empty() {
@@ -641,6 +870,7 @@ pub(crate) fn parse_magical_tui_input(input: &str) -> Result<MagicalTuiRequest> 
     }
 }
 
+#[cfg(test)]
 fn split_command(input: &str) -> (&str, &str) {
     if let Some(index) = input.find(char::is_whitespace) {
         (&input[..index], input[index..].trim())
@@ -649,6 +879,7 @@ fn split_command(input: &str) -> (&str, &str) {
     }
 }
 
+#[cfg(test)]
 fn parse_run_slash_command(rest: &str) -> Result<MagicalTuiRequest> {
     if rest.trim().is_empty() {
         return Ok(MagicalTuiRequest::Action(MagicalTuiAction::RunHarness));
@@ -666,6 +897,7 @@ fn parse_run_slash_command(rest: &str) -> Result<MagicalTuiRequest> {
     Ok(MagicalTuiRequest::NaturalPrompt(rest.trim().to_string()))
 }
 
+#[cfg(test)]
 fn parse_harness_slash_command(harness: &str, rest: &str) -> Result<MagicalTuiRequest> {
     let prompt = rest.trim();
     if prompt.is_empty() {
@@ -677,6 +909,7 @@ fn parse_harness_slash_command(harness: &str, rest: &str) -> Result<MagicalTuiRe
     })
 }
 
+#[cfg(test)]
 fn parse_session_slash_command(
     rest: &str,
     build: fn(String) -> MagicalTuiRequest,

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -276,13 +276,64 @@ fn run_cast_spell(raw: &str) -> Result<()> {
     dispatch_cast_plan(plan)
 }
 
+fn confirm_cast_plan(plan: &CastPlan) -> Result<bool> {
+    let mut stdout = io::stdout();
+
+    if !io::stdin().is_terminal() || !stdout.is_terminal() {
+        writeln!(stdout)?;
+        writeln!(
+            stdout,
+            "Confirmation required for \"{}\", but no interactive terminal is available. Cancelling.",
+            plan.headline
+        )?;
+        stdout.flush()?;
+        return Ok(false);
+    }
+
+    writeln!(stdout)?;
+    writeln!(stdout, "Confirmation required for: {}", plan.headline)?;
+    writeln!(stdout, "Press 'y' to continue, or 'n' / Esc / Enter to cancel.")?;
+    stdout.flush()?;
+
+    loop {
+        match event::read()? {
+            Event::Key(key) => match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    writeln!(stdout, "Confirmed.")?;
+                    stdout.flush()?;
+                    return Ok(true);
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc | KeyCode::Enter => {
+                    writeln!(stdout, "Cancelled.")?;
+                    stdout.flush()?;
+                    return Ok(false);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+}
+
 fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
     match plan.risk() {
         CastRisk::Reject => {
             print_outcome(&plan_rejected_outcome(&plan));
             return Ok(());
         }
-        CastRisk::Confirm | CastRisk::Safe => {}
+        CastRisk::Confirm => {
+            if !confirm_cast_plan(&plan)? {
+                print_outcome(&CastOutcome {
+                    request: plan.headline.clone(),
+                    launched: None,
+                    session_id: None,
+                    next_step: Some("Nothing was run.".to_string()),
+                    notes: vec!["Action cancelled before dispatch.".to_string()],
+                });
+                return Ok(());
+            }
+        }
+        CastRisk::Safe => {}
     }
 
     let outcome = match plan.intent.clone() {


### PR DESCRIPTION
Introduces Cast as a thin orchestration layer on top of the existing daemon, session ledger, TUI, and harness adapters. Phase 1 keeps Cast deterministic: slash commands, a small set of plain-language patterns ("run claude X", "sessions", "doctor"), and a safe-default fallback to the user's installed harness. No LLM planner yet; the Rust daemon, project-root guard, and harness allowlist remain the authority for every side effect.

New module `tui::cast` with focused submodules:
- `intent.rs`  — `CastIntent` + `parse_spell` for typed spell parsing
- `plan.rs`    — `CastPlan`, `CastStep`, headline/title derivation
- `safety.rs`  — `CastRisk`, `SafetyDecision`, deterministic prompt classifier
- `render.rs`  — Cast frame (non-interactive), plan intro card, outcome card
- `outcome.rs` — `CastOutcome` model for post-run summaries

Wiring:
- `coven` (no args) and `coven tui` in non-interactive mode print the Cast frame and exit 0, instead of the old slash-palette snapshot.
- Free-text input in the interactive launcher now flows through Cast: parse spell → build plan → render intro → dispatch existing handler → render outcome. Palette buttons keep their existing direct dispatch.
- "run claude polish the README" routes to Claude Code; "fix the failing tests" routes to the safe default harness (Codex preferred, Claude fallback). "sessions"/"doctor"/"daemon" keywords open their flows.

Existing CLI commands (`coven run`, `coven sessions`, `coven attach`, `coven summon`, `coven archive`, `coven sacrifice`, `coven doctor`, `coven daemon`) remain unchanged.

Tests: 44 new Cast unit tests plus 6 new integration tests covering intent parsing, harness selection, risk classification, and non-interactive rendering. All 235 unit tests + 4 smoke tests pass; cargo fmt clean, cargo clippy --no-deps clean, git diff --check clean.

Depends on PR #92 (`cody/rich-tui`) which extracted `tui::shell` and `tui::sessions`.