### PR TITLE
cast: phase 2 — Cast-native attach with follower-backed transcript

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -631,6 +631,10 @@ pub(crate) fn summon_only_command(session_id: &str) -> Result<store::SessionReco
     if session.archived_at.is_some() {
         store::summon_session(&conn, session_id, &current_timestamp())?;
         eprintln!("summoned session from the archive");
+        let Some(session) = store::get_session(&conn, session_id)? else {
+            anyhow::bail!("session `{session_id}` not found");
+        };
+        return Ok(session);
     }
 
     Ok(session)

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -613,6 +613,15 @@ fn archive_session_command(session_id: &str) -> Result<()> {
 }
 
 fn summon_session_command(session_id: &str) -> Result<()> {
+    summon_only_command(session_id)?;
+    attach_session(session_id)
+}
+
+/// Un-archive a session if needed, without attaching. Returns the session
+/// record so callers (Cast's attach dispatcher) can decide what to do next.
+/// Pulled out of `summon_session_command` so the Cast TUI path can summon
+/// then re-enter through Cast's follower instead of the legacy attach loop.
+pub(crate) fn summon_only_command(session_id: &str) -> Result<store::SessionRecord> {
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
     let Some(session) = store::get_session(&conn, session_id)? else {
@@ -624,7 +633,7 @@ fn summon_session_command(session_id: &str) -> Result<()> {
         eprintln!("summoned session from the archive");
     }
 
-    attach_session(session_id)
+    Ok(session)
 }
 
 fn sacrifice_session_command(session_id: &str, yes: bool) -> Result<()> {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -327,6 +327,21 @@ pub fn list_events(conn: &Connection, session_id: &str) -> Result<Vec<EventRecor
     list_events_with_options(conn, session_id, &EventsQueryOptions::default())
 }
 
+pub fn event_kind_exists(conn: &Connection, session_id: &str, kind: &str) -> Result<bool> {
+    use rusqlite::OptionalExtension;
+
+    let exists = conn
+        .query_row(
+            "SELECT 1 FROM events WHERE session_id = ?1 AND kind = ?2 LIMIT 1",
+            params![session_id, kind],
+            |_| Ok(()),
+        )
+        .optional()
+        .context("failed to query event kind existence")?
+        .is_some();
+    Ok(exists)
+}
+
 pub fn list_events_with_options(
     conn: &Connection,
     session_id: &str,
@@ -689,6 +704,31 @@ mod tests {
 
         assert_eq!(tail.len(), 2);
         assert!(tail[0].seq > after_seq);
+        Ok(())
+    }
+
+    #[test]
+    fn event_kind_exists_detects_kind_without_loading_event_payloads() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_json_event(
+            &conn,
+            "session-1",
+            "output",
+            &serde_json::json!({ "data": "hello" }),
+            "2026-04-27T06:01:00Z",
+        )?;
+        insert_json_event(
+            &conn,
+            "session-1",
+            "cast.summary",
+            &serde_json::json!({ "status": "completed", "exitCode": 0 }),
+            "2026-04-27T06:02:00Z",
+        )?;
+
+        assert!(!event_kind_exists(&conn, "session-1", "input")?);
+        assert!(event_kind_exists(&conn, "session-1", "cast.summary")?);
         Ok(())
     }
 

--- a/crates/coven-cli/src/tui/cast/attach.rs
+++ b/crates/coven-cli/src/tui/cast/attach.rs
@@ -1,0 +1,287 @@
+//! Cast attach helpers.
+//!
+//! Phase 2 lets the user re-enter a previously-launched session through the
+//! same follower the launch path uses. The pure helpers in this module decode
+//! the `cast.summary` event Cast wrote at the end of the original run so the
+//! attach outcome card can describe what already happened — and tell the
+//! launch-side writer when a summary already exists so it does not double-log.
+
+use serde_json::Value;
+
+use crate::store;
+
+/// Event kind Cast writes when a launched session finishes. See
+/// `shell::write_cast_summary_event` for the producer side.
+pub(crate) const CAST_SUMMARY_KIND: &str = "cast.summary";
+
+/// Decoded `cast.summary` event. All fields are optional because Cast may
+/// have written a partial payload (e.g. an older Cast that didn't record
+/// `headline`), and the renderer should degrade gracefully.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct CastAttachSummary {
+    pub(crate) request: Option<String>,
+    pub(crate) headline: Option<String>,
+    pub(crate) harness: Option<String>,
+    pub(crate) status: Option<String>,
+    pub(crate) exit_code: Option<i32>,
+}
+
+/// Return the most recent `cast.summary` event from `events`, decoded. Cast
+/// only writes one summary per session today, but the helper returns the
+/// last one so re-runs (which append) remain readable.
+pub(crate) fn find_cast_summary(events: &[store::EventRecord]) -> Option<CastAttachSummary> {
+    events
+        .iter()
+        .rev()
+        .find(|event| event.kind == CAST_SUMMARY_KIND)
+        .map(decode_summary)
+}
+
+/// True when at least one `cast.summary` event has been recorded for this
+/// session. Producers use this to keep the summary writer idempotent.
+pub(crate) fn summary_already_recorded(events: &[store::EventRecord]) -> bool {
+    events.iter().any(|event| event.kind == CAST_SUMMARY_KIND)
+}
+
+/// One-line outcome-card note describing what Cast saw on the prior run.
+/// Returns `None` when none of the fields are populated, so the caller can
+/// skip the note entirely instead of printing an empty bullet.
+pub(crate) fn format_summary_note(summary: &CastAttachSummary) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(status) = &summary.status {
+        match summary.exit_code {
+            Some(code) => parts.push(format!("status `{status}` (exit code {code})")),
+            None => parts.push(format!("status `{status}`")),
+        }
+    } else if let Some(code) = summary.exit_code {
+        parts.push(format!("exit code {code}"));
+    }
+    if let Some(harness) = &summary.harness {
+        parts.push(format!("harness {harness}"));
+    }
+    if let Some(request) = summary.request.as_ref().or(summary.headline.as_ref()) {
+        let trimmed = first_chars(request, 60);
+        parts.push(format!("request `{trimmed}`"));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(format!("Prior Cast summary: {}.", parts.join(", ")))
+    }
+}
+
+fn decode_summary(event: &store::EventRecord) -> CastAttachSummary {
+    let payload = match serde_json::from_str::<Value>(&event.payload_json) {
+        Ok(value) => value,
+        Err(_) => return CastAttachSummary::default(),
+    };
+    CastAttachSummary {
+        request: payload
+            .get("request")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        headline: payload
+            .get("headline")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        harness: payload
+            .get("harness")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        status: payload
+            .get("status")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        exit_code: payload
+            .get("exitCode")
+            .and_then(Value::as_i64)
+            .map(|v| v as i32)
+            .or_else(|| {
+                payload
+                    .get("exit_code")
+                    .and_then(Value::as_i64)
+                    .map(|v| v as i32)
+            }),
+    }
+}
+
+fn first_chars(value: &str, limit: usize) -> String {
+    let count = value.chars().count();
+    if count <= limit {
+        return value.to_string();
+    }
+    let mut out: String = value.chars().take(limit.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary_event(seq: i64, payload: serde_json::Value) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: CAST_SUMMARY_KIND.to_string(),
+            payload_json: payload.to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    fn output_event(seq: i64, data: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: "output".to_string(),
+            payload_json: serde_json::json!({ "data": data }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn find_cast_summary_returns_none_when_no_summary_event_exists() {
+        let events = vec![output_event(1, "hello\n"), output_event(2, "bye\n")];
+        assert!(find_cast_summary(&events).is_none());
+    }
+
+    #[test]
+    fn find_cast_summary_decodes_request_status_and_exit_code() {
+        let events = vec![
+            output_event(1, "working\n"),
+            summary_event(
+                2,
+                serde_json::json!({
+                    "request": "fix the failing tests",
+                    "headline": "Cast a project-scoped spell",
+                    "harness": "codex",
+                    "status": "completed",
+                    "exitCode": 0,
+                }),
+            ),
+        ];
+
+        let summary = find_cast_summary(&events).expect("summary should be decoded");
+        assert_eq!(summary.request.as_deref(), Some("fix the failing tests"));
+        assert_eq!(summary.harness.as_deref(), Some("codex"));
+        assert_eq!(summary.status.as_deref(), Some("completed"));
+        assert_eq!(summary.exit_code, Some(0));
+    }
+
+    #[test]
+    fn find_cast_summary_accepts_snake_case_exit_code() {
+        let events = vec![summary_event(
+            1,
+            serde_json::json!({ "status": "failed", "exit_code": 137 }),
+        )];
+
+        let summary = find_cast_summary(&events).expect("summary should be decoded");
+        assert_eq!(summary.exit_code, Some(137));
+    }
+
+    #[test]
+    fn find_cast_summary_returns_most_recent_when_multiple_exist() {
+        let events = vec![
+            summary_event(1, serde_json::json!({ "status": "failed", "exitCode": 1 })),
+            output_event(2, "retrying\n"),
+            summary_event(
+                3,
+                serde_json::json!({ "status": "completed", "exitCode": 0 }),
+            ),
+        ];
+
+        let summary = find_cast_summary(&events).expect("summary should be decoded");
+        assert_eq!(summary.status.as_deref(), Some("completed"));
+        assert_eq!(summary.exit_code, Some(0));
+    }
+
+    #[test]
+    fn find_cast_summary_yields_default_summary_for_malformed_payload() {
+        let mut event = summary_event(1, serde_json::json!({}));
+        event.payload_json = "not json".to_string();
+        let events = vec![event];
+
+        let summary = find_cast_summary(&events).expect("summary should still be returned");
+        assert_eq!(summary, CastAttachSummary::default());
+    }
+
+    #[test]
+    fn summary_already_recorded_only_true_when_summary_event_present() {
+        let only_output = vec![output_event(1, "hi\n")];
+        assert!(!summary_already_recorded(&only_output));
+
+        let with_summary = vec![
+            output_event(1, "hi\n"),
+            summary_event(2, serde_json::json!({ "status": "completed" })),
+        ];
+        assert!(summary_already_recorded(&with_summary));
+    }
+
+    #[test]
+    fn format_summary_note_returns_none_for_empty_summary() {
+        assert_eq!(
+            format_summary_note(&CastAttachSummary::default()),
+            None,
+            "an empty summary should yield no note"
+        );
+    }
+
+    #[test]
+    fn format_summary_note_shows_status_exit_code_harness_and_request() {
+        let summary = CastAttachSummary {
+            request: Some("fix the failing tests".to_string()),
+            headline: Some("Cast a project-scoped spell".to_string()),
+            harness: Some("codex".to_string()),
+            status: Some("completed".to_string()),
+            exit_code: Some(0),
+        };
+
+        let note = format_summary_note(&summary).expect("note should be produced");
+        assert!(note.contains("Prior Cast summary"));
+        assert!(note.contains("status `completed`"));
+        assert!(note.contains("exit code 0"));
+        assert!(note.contains("harness codex"));
+        assert!(note.contains("request `fix the failing tests`"));
+    }
+
+    #[test]
+    fn format_summary_note_falls_back_to_headline_when_request_missing() {
+        let summary = CastAttachSummary {
+            request: None,
+            headline: Some("Cast a project-scoped spell".to_string()),
+            ..Default::default()
+        };
+
+        let note = format_summary_note(&summary).expect("note should be produced");
+        assert!(note.contains("request `Cast a project-scoped spell`"));
+    }
+
+    #[test]
+    fn format_summary_note_truncates_long_request_with_ellipsis() {
+        let long_request = "a".repeat(120);
+        let summary = CastAttachSummary {
+            request: Some(long_request),
+            ..Default::default()
+        };
+
+        let note = format_summary_note(&summary).expect("note should be produced");
+        assert!(
+            note.contains('…'),
+            "long request should be truncated with ellipsis: {note}"
+        );
+    }
+
+    #[test]
+    fn format_summary_note_handles_status_without_exit_code() {
+        let summary = CastAttachSummary {
+            status: Some("interrupted".to_string()),
+            ..Default::default()
+        };
+
+        let note = format_summary_note(&summary).expect("note should be produced");
+        assert!(note.contains("status `interrupted`"));
+        assert!(!note.contains("exit code"));
+    }
+}

--- a/crates/coven-cli/src/tui/cast/attach.rs
+++ b/crates/coven-cli/src/tui/cast/attach.rs
@@ -3,8 +3,7 @@
 //! Phase 2 lets the user re-enter a previously-launched session through the
 //! same follower the launch path uses. The pure helpers in this module decode
 //! the `cast.summary` event Cast wrote at the end of the original run so the
-//! attach outcome card can describe what already happened — and tell the
-//! launch-side writer when a summary already exists so it does not double-log.
+//! attach outcome card can describe what already happened.
 
 use serde_json::Value;
 
@@ -35,12 +34,6 @@ pub(crate) fn find_cast_summary(events: &[store::EventRecord]) -> Option<CastAtt
         .rev()
         .find(|event| event.kind == CAST_SUMMARY_KIND)
         .map(decode_summary)
-}
-
-/// True when at least one `cast.summary` event has been recorded for this
-/// session. Producers use this to keep the summary writer idempotent.
-pub(crate) fn summary_already_recorded(events: &[store::EventRecord]) -> bool {
-    events.iter().any(|event| event.kind == CAST_SUMMARY_KIND)
 }
 
 /// One-line outcome-card note describing what Cast saw on the prior run.
@@ -205,18 +198,6 @@ mod tests {
 
         let summary = find_cast_summary(&events).expect("summary should still be returned");
         assert_eq!(summary, CastAttachSummary::default());
-    }
-
-    #[test]
-    fn summary_already_recorded_only_true_when_summary_event_present() {
-        let only_output = vec![output_event(1, "hi\n")];
-        assert!(!summary_already_recorded(&only_output));
-
-        let with_summary = vec![
-            output_event(1, "hi\n"),
-            summary_event(2, serde_json::json!({ "status": "completed" })),
-        ];
-        assert!(summary_already_recorded(&with_summary));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -10,6 +10,7 @@
 //! all remain the authority. Cast is orchestration and presentation: it
 //! never bypasses the daemon and never invents a second runtime.
 
+pub(crate) mod attach;
 pub(crate) mod follow;
 pub(crate) mod gate;
 pub(crate) mod intent;
@@ -22,6 +23,7 @@ use anyhow::Result;
 
 use crate::harness;
 
+pub(crate) use attach::{find_cast_summary, format_summary_note, summary_already_recorded};
 pub(crate) use follow::{follow_until_exit, CastSessionExit, FollowerObserver, FollowerPacer};
 pub(crate) use gate::{evaluate_gate, GateOutcome};
 pub(crate) use intent::{parse_spell, CastHarness, CastIntent};

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 
 use crate::harness;
 
-pub(crate) use attach::{find_cast_summary, format_summary_note, summary_already_recorded};
+pub(crate) use attach::{find_cast_summary, format_summary_note};
 pub(crate) use follow::{follow_until_exit, CastSessionExit, FollowerObserver, FollowerPacer};
 pub(crate) use gate::{evaluate_gate, GateOutcome};
 pub(crate) use intent::{parse_spell, CastHarness, CastIntent};

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -827,14 +827,17 @@ fn attach_via_daemon(
     }
 
     let mut observer = TranscriptObserver::new(io::stdout());
-    let exit = if is_live {
+    let (exit, replay_summary_note) = if is_live {
         let mut pacer = SleepPacer::new(Duration::from_millis(250));
-        Some(follow_until_exit(
-            &mut client,
-            &session.id,
-            &mut observer,
-            &mut pacer,
-        )?)
+        (
+            Some(follow_until_exit(
+                &mut client,
+                &session.id,
+                &mut observer,
+                &mut pacer,
+            )?),
+            None,
+        )
     } else {
         // For completed sessions, drain the historical event log once. The
         // follower observer renders the transcript exactly as it did on the
@@ -858,13 +861,7 @@ fn attach_via_daemon(
     // the summary themselves, so showing it again would only echo the exit
     // line we already printed.
     if !is_live {
-        let history = client.list_events(ChatEventQuery {
-            session_id: &session.id,
-            after_seq: None,
-            limit: None,
-        })?;
-        if let Some(note) = cast::find_cast_summary(&history).and_then(|s| format_summary_note(&s))
-        {
+        if let Some(note) = replay_summary_note {
             notes.push(note);
         }
     }
@@ -906,17 +903,19 @@ fn attach_via_daemon(
 
 /// Drain the historical event log for a non-running session through the same
 /// observer the live follower uses. Returns the decoded exit if the replay
-/// contains an `exit` event so the outcome card can show the original status.
+/// contains an `exit` event so the outcome card can show the original status,
+/// plus the rendered `cast.summary` note (if present) from the same event set.
 fn replay_completed_session(
     client: &mut dyn ChatClient,
     session_id: &str,
     observer: &mut dyn FollowerObserver,
-) -> Result<Option<CastSessionExit>> {
+) -> Result<(Option<CastSessionExit>, Option<String>)> {
     let records = client.list_events(ChatEventQuery {
         session_id,
         after_seq: None,
         limit: None,
     })?;
+    let summary_note = cast::find_cast_summary(&records).and_then(|s| format_summary_note(&s));
 
     let mut exit = None;
     for record in records {
@@ -933,7 +932,7 @@ fn replay_completed_session(
             cast::follow::CastFollowEvent::Other { kind } => observer.on_other(kind),
         }
     }
-    Ok(exit)
+    Ok((exit, summary_note))
 }
 
 fn format_exit_summary(exit: &CastSessionExit) -> String {
@@ -1541,6 +1540,23 @@ mod attach_tests {
         }
     }
 
+    fn cast_summary_event(seq: i64, request: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: "cast.summary".to_string(),
+            payload_json: serde_json::json!({
+                "request": request,
+                "status": "completed",
+                "exitCode": 0,
+                "harness": "codex"
+            })
+            .to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
     #[test]
     fn attach_origin_verb_labels_distinguish_attach_from_summon() {
         assert_eq!(AttachOrigin::Attach.verb_past(), "Attached to");
@@ -1557,7 +1573,7 @@ mod attach_tests {
         let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut observer = TranscriptObserver::new(&mut buffer);
 
-        let exit =
+        let (exit, summary_note) =
             replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
 
         let rendered = String::from_utf8(buffer.into_inner()).unwrap();
@@ -1577,6 +1593,10 @@ mod attach_tests {
         let exit = exit.expect("replay should surface the recorded exit");
         assert_eq!(exit.status, "completed");
         assert_eq!(exit.exit_code, Some(0));
+        assert!(
+            summary_note.is_none(),
+            "no summary note without cast.summary"
+        );
 
         let queries = client.queries.borrow();
         assert_eq!(queries.len(), 1, "one full-history fetch is enough");
@@ -1592,7 +1612,7 @@ mod attach_tests {
         let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut observer = TranscriptObserver::new(&mut buffer);
 
-        let exit =
+        let (exit, summary_note) =
             replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
 
         assert!(
@@ -1606,5 +1626,31 @@ mod attach_tests {
             !rendered.contains("[Cast:"),
             "no Cast exit banner without an exit event: {rendered:?}"
         );
+        assert!(
+            summary_note.is_none(),
+            "no summary note without cast.summary"
+        );
+    }
+
+    #[test]
+    fn replay_completed_session_returns_cast_summary_note_from_same_history_fetch() {
+        let mut client = ReplayClient::new(vec![
+            output_event(1, "hello\n"),
+            cast_summary_event(2, "fix tests"),
+            exit_event(3, "completed", Some(0)),
+        ]);
+        let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let mut observer = TranscriptObserver::new(&mut buffer);
+
+        let (exit, summary_note) =
+            replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
+
+        assert_eq!(exit.and_then(|v| v.exit_code), Some(0));
+        let note = summary_note.expect("summary note should be rendered");
+        assert!(note.contains("Prior Cast summary"));
+        assert!(note.contains("request `fix tests`"));
+
+        let queries = client.queries.borrow();
+        assert_eq!(queries.len(), 1, "summary note should reuse replay history");
     }
 }

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -13,17 +13,17 @@ use crossterm::{
 use uuid::Uuid;
 
 use super::cast::{
-    self, evaluate_gate, follow_until_exit, render_cast_frame_for_terminal, render_outcome,
-    render_plan_intro, CastIntent, CastOutcome, CastPlan, CastSessionExit, FollowerObserver,
-    FollowerPacer, GateOutcome, SafetyDecision,
+    self, evaluate_gate, follow_until_exit, format_summary_note, render_cast_frame_for_terminal,
+    render_outcome, render_plan_intro, summary_already_recorded, CastIntent, CastOutcome, CastPlan,
+    CastSessionExit, FollowerObserver, FollowerPacer, GateOutcome, SafetyDecision,
 };
-use super::chat::client::{ChatClient, DaemonChatClient, LaunchRequest};
+use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
 use super::{is_key_press, sessions};
 use crate::{
     archive_session_command, attach_session, coven_home_dir, coven_store_path, current_timestamp,
     daemon, default_harness_id, project, prompt_for_optional_line, prompt_for_required_line,
     run_daemon_command, run_doctor, run_patch_openclaw, run_session, sacrifice_session_command,
-    store, summon_session_command, theme, DaemonCommand,
+    store, summon_only_command, theme, DaemonCommand, RUNNING_SESSION_STATUS,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -355,28 +355,13 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             }
         }
         CastIntent::AttachSession { session_id } => {
-            attach_session(&session_id)?;
-            CastOutcome {
-                request: request_text,
-                launched: Some(format!("Attached to session {session_id}")),
-                session_id: Some(session_id),
-                next_step: Some(
-                    "Detach with Ctrl+C; the session keeps running under the daemon.".to_string(),
-                ),
-                notes: vec![],
-            }
+            attach_via_cast(&plan, &session_id, &request_text, AttachOrigin::Attach)?
         }
         CastIntent::SummonSession { session_id } => {
-            summon_session_command(&session_id)?;
-            CastOutcome {
-                request: request_text,
-                launched: Some(format!("Summoned session {session_id}")),
-                session_id: Some(session_id),
-                next_step: Some(
-                    "The session is now active again — attach to follow it.".to_string(),
-                ),
-                notes: vec![],
-            }
+            // Un-archive first (cheap, no follower), then re-enter through Cast
+            // so the resumed session also gets the Cast transcript / summary.
+            summon_only_command(&session_id)?;
+            attach_via_cast(&plan, &session_id, &request_text, AttachOrigin::Summon)?
         }
         CastIntent::ArchiveSession { session_id } => {
             archive_session_command(&session_id)?;
@@ -734,6 +719,14 @@ fn write_cast_summary_event(
 ) -> Result<()> {
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
+    // Cast attach replays existing events through the same follower, which
+    // would re-trigger the summary writer at the end. Skip the write when a
+    // summary already exists so the ledger keeps exactly one `cast.summary`
+    // per session.
+    let existing = store::list_events(&conn, session_id)?;
+    if summary_already_recorded(&existing) {
+        return Ok(());
+    }
     let payload = serde_json::json!({
         "request": plan.raw_spell,
         "headline": plan.headline,
@@ -748,6 +741,192 @@ fn write_cast_summary_event(
         &payload,
         &current_timestamp(),
     )
+}
+
+/// What brought the user into this attach. Affects the outcome card's
+/// `launched` label so the user can tell the two flows apart.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AttachOrigin {
+    Attach,
+    Summon,
+}
+
+impl AttachOrigin {
+    fn verb_past(self) -> &'static str {
+        match self {
+            AttachOrigin::Attach => "Attached to",
+            AttachOrigin::Summon => "Summoned and attached to",
+        }
+    }
+}
+
+/// Cast-native attach. Live sessions stream through the follower with the
+/// same `afterSeq` cursor the launch path uses (so no duplicate output) and
+/// accept follow-up input from stdin. Completed sessions replay their full
+/// event log through the same observer so the user sees the same transcript
+/// shape, then surface any existing `cast.summary` in the outcome card.
+///
+/// Falls back to the legacy `attach_session` loop when the daemon is not
+/// reachable; the outcome card explains why the follower was skipped.
+fn attach_via_cast(
+    plan: &CastPlan,
+    session_id: &str,
+    request_text: &str,
+    origin: AttachOrigin,
+) -> Result<CastOutcome> {
+    match daemon_runtime_state()? {
+        DaemonRuntimeState::Running => attach_via_daemon(plan, session_id, request_text, origin),
+        DaemonRuntimeState::NotReady(reason) => {
+            attach_session(session_id)?;
+            Ok(CastOutcome {
+                request: request_text.to_string(),
+                launched: Some(format!(
+                    "{} session {session_id} (legacy attach fallback)",
+                    origin.verb_past()
+                )),
+                session_id: Some(session_id.to_string()),
+                next_step: Some(
+                    "Start the daemon for streamed transcripts: `coven daemon start`.".to_string(),
+                ),
+                notes: vec![format!("Cast event follower skipped: {reason}.")],
+            })
+        }
+    }
+}
+
+fn attach_via_daemon(
+    plan: &CastPlan,
+    session_id: &str,
+    request_text: &str,
+    origin: AttachOrigin,
+) -> Result<CastOutcome> {
+    let mut client = DaemonChatClient::default();
+    let session = client
+        .get_session(session_id)
+        .with_context(|| format!("Cast could not look up session `{session_id}` via the daemon"))?;
+
+    println!();
+    println!(
+        "Cast transcript — session {} ({}). Press Enter at any time to send input.",
+        session.id, session.harness
+    );
+
+    let is_live = session.status == RUNNING_SESSION_STATUS;
+    if is_live {
+        // Mirror the launch path: forward stdin lines into the daemon for
+        // follow-up input while the follower streams output. The thread is
+        // detached and exits when stdin closes.
+        maybe_spawn_cast_input_forwarder(coven_home_dir()?, session.id.clone());
+    }
+
+    let mut observer = TranscriptObserver::new(io::stdout());
+    let exit = if is_live {
+        let mut pacer = SleepPacer::new(Duration::from_millis(250));
+        Some(follow_until_exit(
+            &mut client,
+            &session.id,
+            &mut observer,
+            &mut pacer,
+        )?)
+    } else {
+        // For completed sessions, drain the historical event log once. The
+        // follower observer renders the transcript exactly as it did on the
+        // original run and reports the exit when it lands in the replay.
+        replay_completed_session(&mut client, &session.id, &mut observer)?
+    };
+
+    if is_live {
+        if let Some(exit) = exit.as_ref() {
+            // Idempotent — skips when a `cast.summary` already exists.
+            write_cast_summary_event(&session.id, plan, &session.harness, exit)?;
+        }
+    }
+
+    let mut notes = plan_outcome_notes(plan);
+    if let Some(exit) = exit.as_ref() {
+        notes.push(format_exit_summary(exit));
+    }
+    // For completed/replayed sessions, surface the original Cast summary so
+    // the user can see what the prior run was about. Live attaches just wrote
+    // the summary themselves, so showing it again would only echo the exit
+    // line we already printed.
+    if !is_live {
+        let history = client.list_events(ChatEventQuery {
+            session_id: &session.id,
+            after_seq: None,
+            limit: None,
+        })?;
+        if let Some(note) = cast::find_cast_summary(&history).and_then(|s| format_summary_note(&s))
+        {
+            notes.push(note);
+        }
+    }
+
+    let launched = if is_live {
+        format!(
+            "{} live session {} via daemon",
+            origin.verb_past(),
+            session.id
+        )
+    } else {
+        format!(
+            "{} completed session {} (replayed via daemon)",
+            origin.verb_past(),
+            session.id
+        )
+    };
+
+    let next_step = if is_live {
+        Some(format!(
+            "Run `coven attach {}` later to revisit; events are durable.",
+            session.id
+        ))
+    } else {
+        Some(format!(
+            "Run `coven sessions` to manage this session, or `/sacrifice {}` to delete it.",
+            session.id
+        ))
+    };
+
+    Ok(CastOutcome {
+        request: request_text.to_string(),
+        launched: Some(launched),
+        session_id: Some(session.id),
+        next_step,
+        notes,
+    })
+}
+
+/// Drain the historical event log for a non-running session through the same
+/// observer the live follower uses. Returns the decoded exit if the replay
+/// contains an `exit` event so the outcome card can show the original status.
+fn replay_completed_session(
+    client: &mut dyn ChatClient,
+    session_id: &str,
+    observer: &mut dyn FollowerObserver,
+) -> Result<Option<CastSessionExit>> {
+    let records = client.list_events(ChatEventQuery {
+        session_id,
+        after_seq: None,
+        limit: None,
+    })?;
+
+    let mut exit = None;
+    for record in records {
+        let decoded = cast::follow::decode_event(&record);
+        match &decoded {
+            cast::follow::CastFollowEvent::Output(chunk) => observer.on_output(chunk),
+            cast::follow::CastFollowEvent::Exit { status, exit_code } => {
+                observer.on_exit(status, *exit_code);
+                exit = Some(CastSessionExit {
+                    status: status.clone(),
+                    exit_code: *exit_code,
+                });
+            }
+            cast::follow::CastFollowEvent::Other { kind } => observer.on_other(kind),
+        }
+    }
+    Ok(exit)
 }
 
 fn format_exit_summary(exit: &CastSessionExit) -> String {
@@ -1274,4 +1453,151 @@ pub(crate) fn move_magical_tui_selection(current: usize, direction: MagicalTuiMo
 #[cfg(test)]
 pub(crate) fn render_frame_plain_for_test(selection: usize) -> String {
     render_magical_tui_frame_plain(selection)
+}
+
+#[cfg(test)]
+mod attach_tests {
+    use std::cell::RefCell;
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::tui::chat::client::LaunchRequest;
+
+    /// Stub client that returns a canned event log on every `list_events` call
+    /// and records which session id was queried. Mirrors the stub in
+    /// `cast::follow` tests but kept local to shell.rs so the wiring (not the
+    /// already-tested decode pipeline) is what's under test here.
+    struct ReplayClient {
+        events: Vec<store::EventRecord>,
+        queries: RefCell<Vec<String>>,
+    }
+
+    impl ReplayClient {
+        fn new(events: Vec<store::EventRecord>) -> Self {
+            Self {
+                events,
+                queries: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ChatClient for ReplayClient {
+        fn launch_session(&mut self, _request: LaunchRequest) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn get_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {
+            self.queries.borrow_mut().push(query.session_id.to_string());
+            Ok(self.events.clone())
+        }
+
+        fn send_input(&mut self, _session_id: &str, _data: &str) -> Result<()> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn kill_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised by replay tests")
+        }
+    }
+
+    fn output_event(seq: i64, data: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: "output".to_string(),
+            payload_json: serde_json::json!({ "data": data }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    fn exit_event(seq: i64, status: &str, exit_code: Option<i32>) -> store::EventRecord {
+        let payload = match exit_code {
+            Some(code) => serde_json::json!({ "status": status, "exitCode": code }),
+            None => serde_json::json!({ "status": status }),
+        };
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "session-1".to_string(),
+            kind: "exit".to_string(),
+            payload_json: payload.to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn attach_origin_verb_labels_distinguish_attach_from_summon() {
+        assert_eq!(AttachOrigin::Attach.verb_past(), "Attached to");
+        assert_eq!(AttachOrigin::Summon.verb_past(), "Summoned and attached to");
+    }
+
+    #[test]
+    fn replay_completed_session_streams_full_transcript_into_observer() {
+        let mut client = ReplayClient::new(vec![
+            output_event(1, "hello\n"),
+            output_event(2, "world\n"),
+            exit_event(3, "completed", Some(0)),
+        ]);
+        let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let mut observer = TranscriptObserver::new(&mut buffer);
+
+        let exit =
+            replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
+
+        let rendered = String::from_utf8(buffer.into_inner()).unwrap();
+        assert!(
+            rendered.contains("hello"),
+            "transcript missing first chunk: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("world"),
+            "transcript missing second chunk"
+        );
+        assert!(
+            rendered.contains("[Cast: session completed (exit code 0)]"),
+            "transcript should include Cast exit banner: {rendered:?}"
+        );
+
+        let exit = exit.expect("replay should surface the recorded exit");
+        assert_eq!(exit.status, "completed");
+        assert_eq!(exit.exit_code, Some(0));
+
+        let queries = client.queries.borrow();
+        assert_eq!(queries.len(), 1, "one full-history fetch is enough");
+        assert_eq!(queries[0], "session-1");
+    }
+
+    #[test]
+    fn replay_completed_session_returns_none_when_no_exit_event_in_log() {
+        let mut client = ReplayClient::new(vec![
+            output_event(1, "still going\n"),
+            output_event(2, "no exit yet\n"),
+        ]);
+        let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
+        let mut observer = TranscriptObserver::new(&mut buffer);
+
+        let exit =
+            replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
+
+        assert!(
+            exit.is_none(),
+            "replay must not invent an exit when the log has none"
+        );
+        let rendered = String::from_utf8(buffer.into_inner()).unwrap();
+        assert!(rendered.contains("still going"));
+        assert!(rendered.contains("no exit yet"));
+        assert!(
+            !rendered.contains("[Cast:"),
+            "no Cast exit banner without an exit event: {rendered:?}"
+        );
+    }
 }

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -805,13 +805,21 @@ fn attach_via_daemon(
         .get_session(session_id)
         .with_context(|| format!("Cast could not look up session `{session_id}` via the daemon"))?;
 
-    println!();
-    println!(
-        "Cast transcript — session {} ({}). Press Enter at any time to send input.",
-        session.id, session.harness
-    );
-
     let is_live = session.status == RUNNING_SESSION_STATUS;
+
+    println!();
+    if is_live {
+        println!(
+            "Cast transcript — session {} ({}). Press Enter at any time to send input.",
+            session.id, session.harness
+        );
+    } else {
+        println!(
+            "Cast transcript — session {} ({}) replay.",
+            session.id, session.harness
+        );
+    }
+
     if is_live {
         // Mirror the launch path: forward stdin lines into the daemon for
         // follow-up input while the follower streams output. The thread is

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -14,8 +14,8 @@ use uuid::Uuid;
 
 use super::cast::{
     self, evaluate_gate, follow_until_exit, format_summary_note, render_cast_frame_for_terminal,
-    render_outcome, render_plan_intro, summary_already_recorded, CastIntent, CastOutcome, CastPlan,
-    CastSessionExit, FollowerObserver, FollowerPacer, GateOutcome, SafetyDecision,
+    render_outcome, render_plan_intro, CastIntent, CastOutcome, CastPlan, CastSessionExit,
+    FollowerObserver, FollowerPacer, GateOutcome, SafetyDecision,
 };
 use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
 use super::{is_key_press, sessions};
@@ -723,8 +723,7 @@ fn write_cast_summary_event(
     // would re-trigger the summary writer at the end. Skip the write when a
     // summary already exists so the ledger keeps exactly one `cast.summary`
     // per session.
-    let existing = store::list_events(&conn, session_id)?;
-    if summary_already_recorded(&existing) {
+    if store::event_kind_exists(&conn, session_id, "cast.summary")? {
         return Ok(());
     }
     let payload = serde_json::json!({


### PR DESCRIPTION
PR #93 already shipped the Cast event follower, transcript renderer, exit summary, `cast.summary` event writer, and stdin forwarding for *newly launched* sessions. The remaining Phase 2 gap was `/attach` and `/summon`: those still routed through the legacy `attach_session` loop in main.rs, which uses a HashSet<String> for dedup and reads from the SQLite store directly — bypassing the daemon's `/events` endpoint and `afterSeq` cursor.

This commit closes the gap.

New `cast/attach.rs`:
- `CastAttachSummary` + `find_cast_summary` decode the most recent `cast.summary` event from a session's history so the attach outcome can describe what the prior run did.
- `summary_already_recorded` lets the launch-side writer skip a duplicate summary when attach replays existing events through the same follower.
- `format_summary_note` renders the decoded summary as a one-line outcome card note (status, exit code, harness, request — truncated to 60 chars).

`shell.rs` wiring:
- New `attach_via_cast` dispatcher: live sessions stream through `follow_until_exit` with the same `afterSeq` cursor as launches and accept stdin forwarding; completed sessions replay the full event log through the same `TranscriptObserver` so the user sees the transcript shape they'd see at original launch, then surface the prior `cast.summary` in the outcome.
- Falls back to the legacy `attach_session` loop when the daemon isn't running, with an outcome note explaining the fallback.
- `write_cast_summary_event` is now idempotent — guards against double-logging when an attach replay reaches the exit event a second time.
- New `AttachOrigin` enum distinguishes `/attach` from `/summon` in the outcome card's `launched` label.

`main.rs`:
- Extract `summon_only_command` from `summon_session_command` so Cast can un-archive without dragging in the legacy attach loop. The top-level `coven summon` CLI behaviour is unchanged.

Tests: 14 new (11 in `cast::attach`, 3 in `shell::attach_tests` covering AttachOrigin labels and `replay_completed_session` over a stub client). Total: 275 unit + 4 smoke tests pass. cargo fmt clean, clippy clean, diff --check clean. Non-interactive `coven` smoke renders the Cast frame and exits 0.