### PR TITLE
cast(phase 5): sequential goal flow with deterministic sub-prompting

### DIFF
--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod gate;
 pub(crate) mod intent;
 pub(crate) mod outcome;
 pub(crate) mod plan;
+pub(crate) mod quest;
 pub(crate) mod render;
 pub(crate) mod safety;
 
@@ -29,7 +30,14 @@ pub(crate) use gate::{evaluate_gate, GateOutcome};
 pub(crate) use intent::{parse_spell, CastHarness, CastIntent};
 pub(crate) use outcome::CastOutcome;
 pub(crate) use plan::{build_plan, CastPlan};
+#[allow(unused_imports)]
+pub(crate) use quest::{
+    advance as advance_quest, compose_sub_prompt, quest_from_goal, set_phase_sub_prompt,
+    skip_phase, Quest, QuestHandoff, QuestPhase, QuestPhaseStatus, QuestPhaseSummary,
+};
 pub(crate) use render::{render_cast_frame_for_terminal, render_outcome, render_plan_intro};
+#[allow(unused_imports)]
+pub(crate) use render::render_quest_handoff;
 pub(crate) use safety::SafetyDecision;
 
 // Re-exports used only by tests in `crate::tests` (main.rs). Bundled here

--- a/crates/coven-cli/src/tui/cast/quest.rs
+++ b/crates/coven-cli/src/tui/cast/quest.rs
@@ -135,7 +135,13 @@ pub(crate) fn quest_from_goal(goal: &str, default_harness: Option<CastHarness>) 
 
 fn default_phase_set(goal: &str, harness: Option<CastHarness>) -> Vec<QuestPhase> {
     vec![
-        new_phase("design", "Scope the work", DESIGN_PHASE_TEMPLATE, goal, harness),
+        new_phase(
+            "design",
+            "Scope the work",
+            DESIGN_PHASE_TEMPLATE,
+            goal,
+            harness,
+        ),
         new_phase(
             "implement",
             "Make the change",
@@ -203,14 +209,16 @@ pub(crate) fn compose_sub_prompt(phase: &QuestPhase, quest_goal: &str) -> String
 pub(crate) fn advance(quest: &mut Quest, summary: QuestPhaseSummary) -> Option<usize> {
     let current = quest.current_index()?;
     let from_name = quest.phases[current].name.clone();
+    let failed = phase_failed(&summary);
     let prior_status_label = phase_status_label(&summary);
-    let reason = handoff_reason(&from_name, &prior_status_label);
+    let reason = handoff_reason(&from_name, &prior_status_label, failed);
     let carried = summary.carried_context.clone();
 
     quest.phases[current].status = QuestPhaseStatus::Complete(summary);
-    quest.cursor = current + 1;
+    let next_index = next_pending_index(quest, current + 1);
+    quest.cursor = next_index.unwrap_or(quest.phases.len());
 
-    let next_index = quest.current_index()?;
+    let next_index = next_index?;
     let goal = quest.goal.clone();
     let next = &mut quest.phases[next_index];
     next.handoff = Some(QuestHandoff {
@@ -265,7 +273,7 @@ pub(crate) fn skip_phase(quest: &mut Quest, index: usize, reason: String) -> Res
     }
     phase.status = QuestPhaseStatus::Skipped { reason };
     if quest.cursor == index {
-        quest.cursor = index + 1;
+        quest.cursor = next_pending_index(quest, index + 1).unwrap_or(quest.phases.len());
     }
     Ok(())
 }
@@ -283,12 +291,21 @@ fn phase_status_label(summary: &QuestPhaseSummary) -> String {
     }
 }
 
-fn handoff_reason(from_phase: &str, prior_status_label: &str) -> String {
-    let lower = prior_status_label.to_ascii_lowercase();
-    let failed = lower.starts_with("failed")
-        || lower.contains("error")
-        || lower.contains("exit 1")
-        || lower.contains("interrupted");
+fn phase_failed(summary: &QuestPhaseSummary) -> bool {
+    if let Some(code) = summary.exit_code {
+        if code != 0 {
+            return true;
+        }
+    }
+    summary.exit_status.as_deref().is_some_and(|status| {
+        matches!(
+            status.trim().to_ascii_lowercase().as_str(),
+            "failed" | "error" | "interrupted"
+        )
+    })
+}
+
+fn handoff_reason(from_phase: &str, prior_status_label: &str, failed: bool) -> String {
     if failed {
         format!(
             "Phase `{from_phase}` finished with `{prior_status_label}` — incorporate the failure context before continuing."
@@ -312,6 +329,13 @@ fn derive_quest_title(goal: &str) -> String {
     let mut out: String = collapsed.chars().take(QUEST_TITLE_CHARS - 1).collect();
     out.push('…');
     out
+}
+
+fn next_pending_index(quest: &Quest, start: usize) -> Option<usize> {
+    quest.phases[start..]
+        .iter()
+        .position(|phase| matches!(phase.status, QuestPhaseStatus::Pending))
+        .map(|offset| start + offset)
 }
 
 #[cfg(test)]
@@ -344,7 +368,9 @@ mod tests {
                 phase.name
             );
             assert!(
-                phase.sub_prompt.contains("rename the legacy `cody` module to `cast`"),
+                phase
+                    .sub_prompt
+                    .contains("rename the legacy `cody` module to `cast`"),
                 "phase `{}` sub_prompt should include the user goal verbatim, got:\n{}",
                 phase.name,
                 phase.sub_prompt
@@ -384,7 +410,11 @@ mod tests {
             },
         );
 
-        assert_eq!(next, Some(1), "cursor should advance to the implement phase");
+        assert_eq!(
+            next,
+            Some(1),
+            "cursor should advance to the implement phase"
+        );
         assert_eq!(q.cursor, 1);
         assert!(matches!(q.phases[0].status, QuestPhaseStatus::Complete(_)));
         assert!(matches!(q.phases[1].status, QuestPhaseStatus::Pending));
@@ -491,12 +521,41 @@ mod tests {
                 ..QuestPhaseSummary::default()
             },
         );
-        // Implement completes; cursor lands on the skipped verify (2). The
-        // next `current()` call shows verify as skipped so the shell can
-        // jump past it without re-prompting.
+        // Implement completes; verify is skipped, so there is no further
+        // pending work and the quest cursor exhausts.
+        assert!(q.is_complete());
+        assert_eq!(q.cursor, q.phases.len());
+        assert!(q.current().is_none());
+        assert!(matches!(
+            q.phases[2].status,
+            QuestPhaseStatus::Skipped { .. }
+        ));
+    }
+
+    #[test]
+    fn advance_skips_over_skipped_phases_and_preserves_skip_reason() {
+        let mut q = quest("publish a release");
+        skip_phase(&mut q, 1, "implementation already done".to_string()).unwrap();
+
+        let next = advance(
+            &mut q,
+            QuestPhaseSummary {
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                ..QuestPhaseSummary::default()
+            },
+        );
+
+        assert_eq!(
+            next,
+            Some(2),
+            "advance should jump to the next pending phase"
+        );
         assert_eq!(q.cursor, 2);
-        let current = q.current().expect("verify exists");
-        assert!(matches!(current.status, QuestPhaseStatus::Skipped { .. }));
+        assert!(matches!(
+            q.phases[1].status,
+            QuestPhaseStatus::Skipped { ref reason } if reason == "implementation already done"
+        ));
     }
 
     #[test]
@@ -522,6 +581,26 @@ mod tests {
 
         let label = phase_status_label(&QuestPhaseSummary::default());
         assert_eq!(label, "complete");
+    }
+
+    #[test]
+    fn non_zero_exit_codes_use_failure_handoff_reason() {
+        let mut q = quest("verify build");
+        advance(
+            &mut q,
+            QuestPhaseSummary {
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(2),
+                ..QuestPhaseSummary::default()
+            },
+        );
+
+        let handoff = q.phases[1].handoff.as_ref().expect("handoff attached");
+        assert!(
+            handoff.reason.contains("incorporate the failure context"),
+            "non-zero exit codes must produce failure framing, got: {}",
+            handoff.reason
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/quest.rs
+++ b/crates/coven-cli/src/tui/cast/quest.rs
@@ -1,0 +1,534 @@
+//! Cast quest flow — deterministic sub-prompting for sequential goals.
+//!
+//! Phase 5 takes a high-level user goal and decomposes it into an ordered
+//! `Quest` of structured phases. Each [`QuestPhase`] owns a concrete
+//! `sub_prompt`: the literal text Cast would hand to a harness if the user
+//! approves it right now. After a phase finishes, the caller records a
+//! [`QuestPhaseSummary`] and calls [`advance`]; the next pending phase
+//! receives a [`QuestHandoff`] describing what changed and *why* its
+//! sub-prompt was updated.
+//!
+//! The composer is intentionally deterministic and local-first. No LLM
+//! planner is invoked inside Cast — sub-prompts are assembled from
+//! structured templates plus the recorded prior-phase outcome. That makes
+//! every handoff inspectable, reproducible in tests, and overridable by the
+//! user before the harness sees it.
+//!
+//! Integration boundary: this module is pure. The Cast shell wires the
+//! quest into its existing gate / follow / outcome surfaces; `quest.rs`
+//! does no IO and never reaches the daemon directly. Until the shell
+//! integration lands, the surface is exercised only by the in-module test
+//! suite — `#![allow(dead_code)]` keeps the warning noise off the seam.
+
+#![allow(dead_code)]
+
+use anyhow::{anyhow, Result};
+
+use super::intent::CastHarness;
+
+/// A sequential goal Cast is guiding the user through. Owns the original
+/// user request and an ordered list of [`QuestPhase`]s. `cursor` points at
+/// the next phase that has not yet completed or been skipped.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Quest {
+    pub(crate) title: String,
+    pub(crate) goal: String,
+    pub(crate) phases: Vec<QuestPhase>,
+    pub(crate) cursor: usize,
+}
+
+/// One scoped phase. `template` is the structured base prompt; `sub_prompt`
+/// is the currently-resolved text Cast would hand to the harness. The two
+/// diverge after a handoff (which appends carried context) or a manual
+/// `set_phase_sub_prompt` edit.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct QuestPhase {
+    pub(crate) name: String,
+    pub(crate) goal: String,
+    pub(crate) harness: Option<CastHarness>,
+    pub(crate) template: String,
+    pub(crate) sub_prompt: String,
+    pub(crate) status: QuestPhaseStatus,
+    pub(crate) handoff: Option<QuestHandoff>,
+    pub(crate) edited_by_user: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum QuestPhaseStatus {
+    Pending,
+    Running { session_id: String },
+    Complete(QuestPhaseSummary),
+    Skipped { reason: String },
+}
+
+/// Structured outcome of a single phase. Cast feeds this into the next
+/// phase's handoff so the visible sub-prompt update stays reproducible.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct QuestPhaseSummary {
+    pub(crate) session_id: Option<String>,
+    pub(crate) exit_status: Option<String>,
+    pub(crate) exit_code: Option<i32>,
+    /// Bulletable facts extracted from the run that should be carried into
+    /// the next sub-prompt (file paths touched, IDs minted, tests run).
+    pub(crate) carried_context: Vec<String>,
+}
+
+/// What Cast tells the next phase about the prior one. `reason` is
+/// rendered verbatim on the handoff card so the user can read why the
+/// sub-prompt changed before approving it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct QuestHandoff {
+    pub(crate) from_phase: String,
+    pub(crate) prior_status: String,
+    pub(crate) reason: String,
+    pub(crate) carried_context: Vec<String>,
+}
+
+impl Quest {
+    pub(crate) fn current_index(&self) -> Option<usize> {
+        if self.cursor < self.phases.len() {
+            Some(self.cursor)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn current(&self) -> Option<&QuestPhase> {
+        self.current_index().map(|idx| &self.phases[idx])
+    }
+
+    pub(crate) fn is_complete(&self) -> bool {
+        self.cursor >= self.phases.len()
+    }
+}
+
+const DESIGN_PHASE_TEMPLATE: &str =
+    "Design the smallest viable change for the goal. Produce: a short approach summary, the file or surface boundaries you will touch, and a list of risks or open questions. Do not write code yet. Goal: {goal}.";
+
+const IMPLEMENT_PHASE_TEMPLATE: &str =
+    "Implement the change agreed in the prior design phase. Stay within the named boundaries. Run any existing tests touching the change. Goal: {goal}.";
+
+const VERIFY_PHASE_TEMPLATE: &str =
+    "Verify the implementation: re-run the touched tests, sanity-check the diff, and surface any regression or follow-up. Do not push or merge. Goal: {goal}.";
+
+const QUEST_TITLE_CHARS: usize = 60;
+
+/// Build a fresh quest from a free-text goal. The default template is the
+/// Design → Implement → Verify rhythm that fits most repository work; each
+/// phase starts pending with a concrete `sub_prompt` already composed so
+/// the user can read what Cast would delegate.
+pub(crate) fn quest_from_goal(goal: &str, default_harness: Option<CastHarness>) -> Quest {
+    let trimmed = goal.trim();
+    let title = derive_quest_title(trimmed);
+    let mut quest = Quest {
+        title,
+        goal: trimmed.to_string(),
+        phases: default_phase_set(trimmed, default_harness),
+        cursor: 0,
+    };
+    let goal = quest.goal.clone();
+    for phase in &mut quest.phases {
+        phase.sub_prompt = compose_sub_prompt(phase, &goal);
+    }
+    quest
+}
+
+fn default_phase_set(goal: &str, harness: Option<CastHarness>) -> Vec<QuestPhase> {
+    vec![
+        new_phase("design", "Scope the work", DESIGN_PHASE_TEMPLATE, goal, harness),
+        new_phase(
+            "implement",
+            "Make the change",
+            IMPLEMENT_PHASE_TEMPLATE,
+            goal,
+            harness,
+        ),
+        new_phase(
+            "verify",
+            "Confirm the change",
+            VERIFY_PHASE_TEMPLATE,
+            goal,
+            harness,
+        ),
+    ]
+}
+
+fn new_phase(
+    name: &str,
+    role: &str,
+    template: &str,
+    goal: &str,
+    harness: Option<CastHarness>,
+) -> QuestPhase {
+    QuestPhase {
+        name: name.to_string(),
+        goal: format!("{role} for: {goal}"),
+        harness,
+        template: template.to_string(),
+        sub_prompt: String::new(),
+        status: QuestPhaseStatus::Pending,
+        handoff: None,
+        edited_by_user: false,
+    }
+}
+
+/// Compose `phase.sub_prompt` from its template plus any attached handoff.
+/// Pure: same inputs always yield the same output, which is what makes the
+/// handoff card honest.
+pub(crate) fn compose_sub_prompt(phase: &QuestPhase, quest_goal: &str) -> String {
+    let mut out = phase.template.replace("{goal}", quest_goal);
+    if let Some(handoff) = &phase.handoff {
+        out.push_str("\n\nHandoff from phase `");
+        out.push_str(&handoff.from_phase);
+        out.push_str("` (status `");
+        out.push_str(&handoff.prior_status);
+        out.push_str("`):\n- ");
+        out.push_str(&handoff.reason);
+        for fact in &handoff.carried_context {
+            out.push_str("\n- ");
+            out.push_str(fact);
+        }
+    }
+    out
+}
+
+/// Mark the current phase complete and advance the quest. The next pending
+/// phase receives a structured [`QuestHandoff`] and its `sub_prompt` is
+/// recomposed deterministically. Phases the user has explicitly edited
+/// (see [`set_phase_sub_prompt`]) are preserved — Cast must not silently
+/// clobber a user's choice.
+///
+/// Returns the index of the next pending phase, or `None` when the quest
+/// has no further work.
+pub(crate) fn advance(quest: &mut Quest, summary: QuestPhaseSummary) -> Option<usize> {
+    let current = quest.current_index()?;
+    let from_name = quest.phases[current].name.clone();
+    let prior_status_label = phase_status_label(&summary);
+    let reason = handoff_reason(&from_name, &prior_status_label);
+    let carried = summary.carried_context.clone();
+
+    quest.phases[current].status = QuestPhaseStatus::Complete(summary);
+    quest.cursor = current + 1;
+
+    let next_index = quest.current_index()?;
+    let goal = quest.goal.clone();
+    let next = &mut quest.phases[next_index];
+    next.handoff = Some(QuestHandoff {
+        from_phase: from_name,
+        prior_status: prior_status_label,
+        reason,
+        carried_context: carried,
+    });
+    if !next.edited_by_user {
+        next.sub_prompt = compose_sub_prompt(next, &goal);
+    }
+    Some(next_index)
+}
+
+/// Override the sub-prompt for a pending phase. Marks the phase as
+/// user-edited so a later [`advance`] does not silently regenerate the
+/// text. Errors out if the phase is not pending — Cast does not rewrite
+/// already-running or completed phases.
+pub(crate) fn set_phase_sub_prompt(
+    quest: &mut Quest,
+    index: usize,
+    sub_prompt: String,
+) -> Result<()> {
+    let phase = quest
+        .phases
+        .get_mut(index)
+        .ok_or_else(|| anyhow!("quest phase index {index} out of range"))?;
+    if !matches!(phase.status, QuestPhaseStatus::Pending) {
+        return Err(anyhow!(
+            "phase `{}` is not pending; sub-prompts can only be edited before the phase runs",
+            phase.name
+        ));
+    }
+    phase.sub_prompt = sub_prompt;
+    phase.edited_by_user = true;
+    Ok(())
+}
+
+/// Skip a pending phase with a recorded reason. Useful when the prior
+/// phase already satisfied this phase's goal (e.g. tests passed during
+/// implement, so verify becomes a no-op).
+pub(crate) fn skip_phase(quest: &mut Quest, index: usize, reason: String) -> Result<()> {
+    let phase = quest
+        .phases
+        .get_mut(index)
+        .ok_or_else(|| anyhow!("quest phase index {index} out of range"))?;
+    if !matches!(phase.status, QuestPhaseStatus::Pending) {
+        return Err(anyhow!(
+            "phase `{}` is not pending; only pending phases can be skipped",
+            phase.name
+        ));
+    }
+    phase.status = QuestPhaseStatus::Skipped { reason };
+    if quest.cursor == index {
+        quest.cursor = index + 1;
+    }
+    Ok(())
+}
+
+fn phase_status_label(summary: &QuestPhaseSummary) -> String {
+    if let Some(status) = &summary.exit_status {
+        match summary.exit_code {
+            Some(code) => format!("{status} (exit {code})"),
+            None => status.clone(),
+        }
+    } else if let Some(code) = summary.exit_code {
+        format!("exit {code}")
+    } else {
+        "complete".to_string()
+    }
+}
+
+fn handoff_reason(from_phase: &str, prior_status_label: &str) -> String {
+    let lower = prior_status_label.to_ascii_lowercase();
+    let failed = lower.starts_with("failed")
+        || lower.contains("error")
+        || lower.contains("exit 1")
+        || lower.contains("interrupted");
+    if failed {
+        format!(
+            "Phase `{from_phase}` finished with `{prior_status_label}` — incorporate the failure context before continuing."
+        )
+    } else {
+        format!(
+            "Phase `{from_phase}` finished with `{prior_status_label}` — carry its result into the next sub-prompt."
+        )
+    }
+}
+
+fn derive_quest_title(goal: &str) -> String {
+    let collapsed: String = goal.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.is_empty() {
+        return "Untitled quest".to_string();
+    }
+    let count = collapsed.chars().count();
+    if count <= QUEST_TITLE_CHARS {
+        return collapsed;
+    }
+    let mut out: String = collapsed.chars().take(QUEST_TITLE_CHARS - 1).collect();
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quest(goal: &str) -> Quest {
+        quest_from_goal(goal, Some(CastHarness::Codex))
+    }
+
+    #[test]
+    fn quest_from_goal_uses_default_three_phase_template() {
+        let q = quest("ship phase 5 sub-prompting");
+        assert_eq!(q.goal, "ship phase 5 sub-prompting");
+        assert_eq!(
+            q.phases.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
+            vec!["design", "implement", "verify"]
+        );
+        assert_eq!(q.cursor, 0);
+        assert!(!q.is_complete());
+    }
+
+    #[test]
+    fn every_phase_starts_with_a_concrete_sub_prompt_containing_the_goal() {
+        let q = quest("rename the legacy `cody` module to `cast`");
+        for phase in &q.phases {
+            assert!(
+                !phase.sub_prompt.is_empty(),
+                "phase `{}` must have a sub_prompt",
+                phase.name
+            );
+            assert!(
+                phase.sub_prompt.contains("rename the legacy `cody` module to `cast`"),
+                "phase `{}` sub_prompt should include the user goal verbatim, got:\n{}",
+                phase.name,
+                phase.sub_prompt
+            );
+        }
+    }
+
+    #[test]
+    fn compose_sub_prompt_substitutes_goal_and_appends_handoff() {
+        let mut q = quest("fix the flaky integration test");
+        q.phases[1].handoff = Some(QuestHandoff {
+            from_phase: "design".to_string(),
+            prior_status: "completed (exit 0)".to_string(),
+            reason: "Design pinned the seam to `cast::quest`.".to_string(),
+            carried_context: vec!["touched `cast/quest.rs`".to_string()],
+        });
+        let composed = compose_sub_prompt(&q.phases[1], &q.goal);
+        assert!(composed.contains("fix the flaky integration test"));
+        assert!(composed.contains("Handoff from phase `design`"));
+        assert!(composed.contains("status `completed (exit 0)`"));
+        assert!(composed.contains("Design pinned the seam to `cast::quest`."));
+        assert!(composed.contains("touched `cast/quest.rs`"));
+    }
+
+    #[test]
+    fn advance_marks_prior_complete_and_recomposes_next_sub_prompt() {
+        let mut q = quest("polish the README");
+        let original_implement = q.phases[1].sub_prompt.clone();
+
+        let next = advance(
+            &mut q,
+            QuestPhaseSummary {
+                session_id: Some("session-abc".to_string()),
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                carried_context: vec!["proposed bullet list of edits".to_string()],
+            },
+        );
+
+        assert_eq!(next, Some(1), "cursor should advance to the implement phase");
+        assert_eq!(q.cursor, 1);
+        assert!(matches!(q.phases[0].status, QuestPhaseStatus::Complete(_)));
+        assert!(matches!(q.phases[1].status, QuestPhaseStatus::Pending));
+        // The recomposed sub-prompt carries the handoff text, so it must
+        // differ from the bare template form built at quest construction.
+        assert_ne!(
+            q.phases[1].sub_prompt, original_implement,
+            "implement sub_prompt should be refreshed with handoff context after advance"
+        );
+        assert!(q.phases[1]
+            .sub_prompt
+            .contains("proposed bullet list of edits"));
+        let handoff = q.phases[1].handoff.as_ref().expect("handoff attached");
+        assert_eq!(handoff.from_phase, "design");
+        assert!(handoff.reason.contains("carry its result"));
+    }
+
+    #[test]
+    fn advance_after_failed_phase_uses_failure_oriented_handoff_reason() {
+        let mut q = quest("upgrade the rust toolchain");
+        advance(
+            &mut q,
+            QuestPhaseSummary {
+                session_id: None,
+                exit_status: Some("failed".to_string()),
+                exit_code: Some(1),
+                carried_context: vec!["`cargo build` exited 1 on `coven-cli`".to_string()],
+            },
+        );
+        let handoff = q.phases[1].handoff.as_ref().expect("handoff attached");
+        assert!(
+            handoff.reason.contains("incorporate the failure context"),
+            "failed phase should produce a failure-flavoured reason, got: {}",
+            handoff.reason
+        );
+        assert!(q.phases[1].sub_prompt.contains("`cargo build` exited 1"));
+    }
+
+    #[test]
+    fn set_phase_sub_prompt_overrides_and_survives_subsequent_advance() {
+        let mut q = quest("rotate the daemon socket path");
+        set_phase_sub_prompt(
+            &mut q,
+            1,
+            "Move the socket to `$XDG_RUNTIME_DIR/coven.sock` and update the lockfile.".to_string(),
+        )
+        .unwrap();
+        assert!(q.phases[1].edited_by_user);
+
+        advance(
+            &mut q,
+            QuestPhaseSummary {
+                session_id: None,
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                carried_context: vec!["socket location decided".to_string()],
+            },
+        );
+
+        // The handoff is still attached so the user can read it, but the
+        // sub_prompt text the user authored is preserved verbatim.
+        assert!(q.phases[1].handoff.is_some(), "handoff should still attach");
+        assert_eq!(
+            q.phases[1].sub_prompt,
+            "Move the socket to `$XDG_RUNTIME_DIR/coven.sock` and update the lockfile.",
+            "user-authored sub_prompt must not be clobbered by advance"
+        );
+    }
+
+    #[test]
+    fn set_phase_sub_prompt_rejects_non_pending_phases() {
+        let mut q = quest("anything");
+        q.phases[0].status = QuestPhaseStatus::Running {
+            session_id: "session-1".to_string(),
+        };
+        let err = set_phase_sub_prompt(&mut q, 0, "ignored".to_string()).unwrap_err();
+        assert!(err.to_string().contains("not pending"));
+    }
+
+    #[test]
+    fn skip_phase_advances_cursor_and_marks_status() {
+        let mut q = quest("publish a release");
+        skip_phase(&mut q, 2, "verify happens in CI".to_string()).unwrap();
+        assert!(matches!(
+            q.phases[2].status,
+            QuestPhaseStatus::Skipped { .. }
+        ));
+
+        advance(
+            &mut q,
+            QuestPhaseSummary {
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                ..QuestPhaseSummary::default()
+            },
+        );
+        // After design completes, cursor moves to implement (1).
+        assert_eq!(q.cursor, 1);
+        advance(
+            &mut q,
+            QuestPhaseSummary {
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                ..QuestPhaseSummary::default()
+            },
+        );
+        // Implement completes; cursor lands on the skipped verify (2). The
+        // next `current()` call shows verify as skipped so the shell can
+        // jump past it without re-prompting.
+        assert_eq!(q.cursor, 2);
+        let current = q.current().expect("verify exists");
+        assert!(matches!(current.status, QuestPhaseStatus::Skipped { .. }));
+    }
+
+    #[test]
+    fn advance_returns_none_after_the_last_phase() {
+        let mut q = quest("teach Cast to whistle");
+        let r1 = advance(&mut q, QuestPhaseSummary::default());
+        let r2 = advance(&mut q, QuestPhaseSummary::default());
+        let r3 = advance(&mut q, QuestPhaseSummary::default());
+        let r4 = advance(&mut q, QuestPhaseSummary::default());
+        assert_eq!((r1, r2, r3, r4), (Some(1), Some(2), None, None));
+        assert!(q.is_complete());
+        assert!(q.current().is_none());
+    }
+
+    #[test]
+    fn handoff_status_label_falls_back_when_exit_code_only() {
+        let label = phase_status_label(&QuestPhaseSummary {
+            exit_status: None,
+            exit_code: Some(2),
+            ..QuestPhaseSummary::default()
+        });
+        assert_eq!(label, "exit 2");
+
+        let label = phase_status_label(&QuestPhaseSummary::default());
+        assert_eq!(label, "complete");
+    }
+
+    #[test]
+    fn quest_title_truncates_very_long_goals() {
+        let goal = "do every single conceivable thing across the whole repository in one go please";
+        let q = quest_from_goal(goal, None);
+        assert!(q.title.chars().count() <= QUEST_TITLE_CHARS);
+        assert!(q.title.ends_with('…'));
+    }
+}

--- a/crates/coven-cli/src/tui/cast/render.rs
+++ b/crates/coven-cli/src/tui/cast/render.rs
@@ -11,6 +11,7 @@ use crate::theme::{self, fit_chars, palette_for, Fg, Palette, TerminalMode};
 
 use super::outcome::CastOutcome;
 use super::plan::{CastHarnessSource, CastPlan, CastStepKind};
+use super::quest::{Quest, QuestPhase, QuestPhaseStatus};
 use super::safety::{CastRisk, SafetyDecision};
 
 const CAST_INTRO_INNER_WIDTH: usize = 76;
@@ -228,6 +229,129 @@ fn render_outcome_with_mode(outcome: &CastOutcome, mode: TerminalMode) -> String
     }
 
     frame
+}
+
+/// Cast's quest handoff card: shown between phases of a sequential quest
+/// so the user can read what the prior phase produced and exactly what the
+/// next phase's sub-prompt will be before approving the handoff. The card
+/// is a *visible delegation announcement* — it never executes anything; it
+/// just makes Cast's deterministic composer inspectable.
+#[allow(dead_code)]
+pub(crate) fn render_quest_handoff(quest: &Quest, next_index: usize) -> String {
+    render_quest_handoff_with_mode(quest, next_index, theme::mode())
+}
+
+#[allow(dead_code)]
+pub(crate) fn render_quest_handoff_plain(quest: &Quest, next_index: usize) -> String {
+    render_quest_handoff_with_mode(quest, next_index, TerminalMode::NoColor)
+}
+
+fn render_quest_handoff_with_mode(quest: &Quest, next_index: usize, mode: TerminalMode) -> String {
+    let p = palette_for(mode);
+    let mut frame = String::new();
+
+    push_section_header(&mut frame, &p, "Cast handoff");
+    push_label_row(&mut frame, &p, "quest", &quest.title);
+    push_label_row(
+        &mut frame,
+        &p,
+        "phase",
+        &quest_phase_position_label(quest, next_index),
+    );
+
+    if let Some(next) = quest.phases.get(next_index) {
+        if let Some(handoff) = &next.handoff {
+            push_label_row(&mut frame, &p, "from", &handoff.from_phase);
+            push_label_row(&mut frame, &p, "prior", &handoff.prior_status);
+            push_continuation_row(&mut frame, &p, &handoff.reason);
+            if !handoff.carried_context.is_empty() {
+                frame.push('\n');
+                push_section_header(&mut frame, &p, "Carried context");
+                for fact in handoff.carried_context.iter().take(4) {
+                    push_note_row(&mut frame, &p, fact);
+                }
+            }
+        } else {
+            push_label_row(&mut frame, &p, "from", "(quest start)");
+        }
+
+        let harness_label = next
+            .harness
+            .map(|h| h.label())
+            .unwrap_or("(default harness)");
+        let edited_marker = if next.edited_by_user {
+            " · user-edited"
+        } else {
+            ""
+        };
+        push_label_row(
+            &mut frame,
+            &p,
+            "delegate to",
+            &format!("{harness_label}{edited_marker}"),
+        );
+
+        frame.push('\n');
+        push_section_header(&mut frame, &p, "Sub-prompt");
+        for line in clip_sub_prompt_lines(&next.sub_prompt) {
+            push_sub_prompt_line(&mut frame, &p, &line);
+        }
+
+        frame.push('\n');
+        push_footer_hint(&mut frame, &p, quest_handoff_footer_hint(next));
+    } else {
+        push_label_row(&mut frame, &p, "status", "quest complete");
+        frame.push('\n');
+        push_footer_hint(&mut frame, &p, "no further phases · type a new spell");
+    }
+
+    frame
+}
+
+fn quest_phase_position_label(quest: &Quest, next_index: usize) -> String {
+    let total = quest.phases.len();
+    let phase_name = quest
+        .phases
+        .get(next_index)
+        .map(|p| p.name.as_str())
+        .unwrap_or("(end)");
+    let position = (next_index + 1).min(total.max(1));
+    format!("{position}/{total} · {phase_name}")
+}
+
+fn quest_handoff_footer_hint(next: &QuestPhase) -> &'static str {
+    match &next.status {
+        QuestPhaseStatus::Pending => {
+            "enter approves the sub-prompt · type to edit · esc cancels"
+        }
+        QuestPhaseStatus::Running { .. } => "phase running · attach to follow",
+        QuestPhaseStatus::Complete(_) => "phase already complete · advance again",
+        QuestPhaseStatus::Skipped { .. } => "phase skipped · advance to continue",
+    }
+}
+
+/// Keep the visible sub-prompt block bounded; long composer output (with
+/// many carried-context bullets) would push the footer out of the user's
+/// view. We cap at 8 lines, with an ellipsis line at the end so the user
+/// knows there is more text the harness will receive.
+const SUB_PROMPT_VISIBLE_LINES: usize = 8;
+
+fn clip_sub_prompt_lines(sub_prompt: &str) -> Vec<String> {
+    let lines: Vec<&str> = sub_prompt.lines().collect();
+    if lines.len() <= SUB_PROMPT_VISIBLE_LINES {
+        return lines.iter().map(|l| (*l).to_string()).collect();
+    }
+    let mut out: Vec<String> = lines
+        .iter()
+        .take(SUB_PROMPT_VISIBLE_LINES - 1)
+        .map(|l| (*l).to_string())
+        .collect();
+    out.push(format!("… {} more lines", lines.len() - (SUB_PROMPT_VISIBLE_LINES - 1)));
+    out
+}
+
+fn push_sub_prompt_line(frame: &mut String, p: &Palette, line: &str) {
+    frame.push_str(&format!("  {}{}{}\n", p.text, line, p.reset));
 }
 
 /// What the user typed (or, if Cast built the plan without raw input, the
@@ -642,6 +766,130 @@ mod tests {
             !frame.contains("note 4"),
             "outcome should clip to 3 notes, frame:\n{frame}"
         );
+    }
+
+    #[test]
+    fn quest_handoff_card_shows_source_phase_status_and_next_sub_prompt() {
+        use crate::tui::cast::quest::{
+            advance, quest_from_goal, QuestPhaseSummary,
+        };
+
+        let mut quest = quest_from_goal(
+            "ship phase 5 sub-prompting",
+            Some(CastHarness::Codex),
+        );
+        let next = advance(
+            &mut quest,
+            QuestPhaseSummary {
+                session_id: Some("session-abc123".to_string()),
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                carried_context: vec![
+                    "added `cast::quest` module".to_string(),
+                    "drafted handoff card".to_string(),
+                ],
+            },
+        )
+        .expect("advance should yield the implement phase");
+
+        let frame = render_quest_handoff_plain(&quest, next);
+
+        assert!(frame.contains("Cast handoff"), "missing header, frame:\n{frame}");
+        assert_label_column(&frame, "quest");
+        assert_label_column(&frame, "phase");
+        assert_label_column(&frame, "from");
+        assert_label_column(&frame, "prior");
+        assert_label_column(&frame, "delegate to");
+
+        assert!(frame.contains("ship phase 5 sub-prompting"));
+        assert!(frame.contains("2/3 · implement"));
+        assert!(frame.contains("Codex"));
+        assert!(
+            frame.contains("Phase `design` finished with `completed (exit 0)`"),
+            "handoff reason should describe prior status, frame:\n{frame}"
+        );
+        assert!(
+            frame.contains("Sub-prompt"),
+            "render must surface the next sub-prompt block"
+        );
+        assert!(
+            frame.contains("ship phase 5 sub-prompting"),
+            "sub-prompt should echo the user's goal verbatim"
+        );
+        assert!(frame.contains("added `cast::quest` module"));
+        assert_no_ansi_leakage(&frame);
+    }
+
+    #[test]
+    fn quest_handoff_card_marks_user_edited_sub_prompt_so_users_can_tell() {
+        use crate::tui::cast::quest::{
+            advance, quest_from_goal, set_phase_sub_prompt, QuestPhaseSummary,
+        };
+
+        let mut quest = quest_from_goal("rotate the daemon socket", Some(CastHarness::Codex));
+        set_phase_sub_prompt(
+            &mut quest,
+            1,
+            "Move the socket to `$XDG_RUNTIME_DIR/coven.sock`.".to_string(),
+        )
+        .unwrap();
+        let next = advance(
+            &mut quest,
+            QuestPhaseSummary {
+                exit_status: Some("completed".to_string()),
+                exit_code: Some(0),
+                ..QuestPhaseSummary::default()
+            },
+        )
+        .unwrap();
+
+        let frame = render_quest_handoff_plain(&quest, next);
+        assert!(
+            frame.contains("user-edited"),
+            "user-authored sub_prompts should be flagged, frame:\n{frame}"
+        );
+        assert!(frame.contains("Move the socket to `$XDG_RUNTIME_DIR/coven.sock`."));
+    }
+
+    #[test]
+    fn quest_handoff_card_handles_quest_complete_state_with_no_panic() {
+        use crate::tui::cast::quest::{advance, quest_from_goal, QuestPhaseSummary};
+
+        let mut quest = quest_from_goal("trivial", Some(CastHarness::Codex));
+        // Drain all phases.
+        advance(&mut quest, QuestPhaseSummary::default());
+        advance(&mut quest, QuestPhaseSummary::default());
+        advance(&mut quest, QuestPhaseSummary::default());
+        assert!(quest.is_complete());
+
+        // Asking for the handoff at the past-the-end cursor must not panic.
+        let frame = render_quest_handoff_plain(&quest, quest.phases.len());
+        assert!(frame.contains("quest complete"), "frame:\n{frame}");
+    }
+
+    #[test]
+    fn quest_handoff_card_clips_very_long_sub_prompts() {
+        use crate::tui::cast::quest::{
+            advance, quest_from_goal, set_phase_sub_prompt, QuestPhaseSummary,
+        };
+
+        let mut quest = quest_from_goal("anything", Some(CastHarness::Codex));
+        // Compose a sub-prompt with many lines so the renderer clips.
+        let long: String = (0..30)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        set_phase_sub_prompt(&mut quest, 1, long).unwrap();
+        let next = advance(&mut quest, QuestPhaseSummary::default()).unwrap();
+
+        let frame = render_quest_handoff_plain(&quest, next);
+        assert!(frame.contains("line 0"));
+        assert!(
+            frame.contains("more lines"),
+            "long sub_prompt should be clipped with a `… N more lines` indicator, frame:\n{frame}"
+        );
+        // The last few lines should NOT appear once we clip.
+        assert!(!frame.contains("line 29"));
     }
 
     #[test]

--- a/docs/design/cast-quest-flow.md
+++ b/docs/design/cast-quest-flow.md
@@ -1,0 +1,143 @@
+---
+summary: "Phase 5 design contract for Cast's sequential goal flow: deterministic sub-prompts, visible handoffs, and a structured advance step between phases."
+title: "Cast — Sequential Goal Flow (Phase 5)"
+description: "How Cast turns a high-level user goal into an ordered Quest of phases, each producing a concrete sub-prompt and a visible handoff to the harness."
+---
+
+# Cast — Sequential Goal Flow (Phase 5)
+
+This document is the design target for the Cast quest flow added in Phase 5. The implementation lives in `crates/coven-cli/src/tui/cast/quest.rs` (pure logic) and `crates/coven-cli/src/tui/cast/render.rs` (`render_quest_handoff`). The Cast shell wires the quest into its existing gate / follow / outcome surfaces in a follow-up phase; the module is intentionally callable on its own first so the deterministic core can be exercised by tests without a daemon.
+
+## 1. Why a quest
+
+Phase 4 and earlier treat every spell as a single launch: parse → plan → gate → dispatch → outcome. A real piece of repository work is rarely one launch — it is design → implement → verify, with the next step shaped by what just happened. Phase 5 makes that loop a first-class Cast surface so the user can:
+
+1. State a high-level goal once.
+2. Read the concrete sub-prompt Cast would hand to a harness for the *first* phase.
+3. Approve, edit, or skip that sub-prompt.
+4. Inspect the result.
+5. Read the recomposed sub-prompt for the next phase, with a visible note about *why* it changed.
+
+No LLM planner is introduced inside Cast. Sub-prompts are assembled from structured templates plus the prior phase's recorded outcome, so every handoff is reproducible, inspectable, and overridable.
+
+## 2. Data model (`cast::quest`)
+
+```text
+Quest
+ ├ title         derived from the user's goal (truncated to 60 chars)
+ ├ goal          the original free-text request
+ ├ phases        Vec<QuestPhase>  (default rhythm: design → implement → verify)
+ └ cursor        index of the next non-complete phase
+
+QuestPhase
+ ├ name          short identifier: "design" | "implement" | "verify"
+ ├ goal          noun-phrase role description for this phase
+ ├ harness       Option<CastHarness>  (defaults to the quest's harness)
+ ├ template      base sub-prompt template (with `{goal}` substitution)
+ ├ sub_prompt    currently-resolved text Cast would send right now
+ ├ status        Pending | Running { session_id } | Complete(summary) | Skipped { reason }
+ ├ handoff       Option<QuestHandoff>  (attached by `advance` from the prior phase)
+ └ edited_by_user  true once a user override lands; prevents silent regeneration
+
+QuestPhaseSummary
+ ├ session_id        daemon session that ran this phase (if any)
+ ├ exit_status       e.g. "completed", "failed", "interrupted"
+ ├ exit_code         Option<i32>
+ └ carried_context   bulletable facts to surface in the next sub-prompt
+
+QuestHandoff
+ ├ from_phase        the prior phase's `name`
+ ├ prior_status      human-readable label (e.g. "completed (exit 0)")
+ ├ reason            *why* the next sub-prompt was updated
+ └ carried_context   verbatim from the prior summary
+```
+
+## 3. Composer (`compose_sub_prompt`)
+
+Pure function. Returns:
+
+```text
+<template with {goal} substituted>
+
+Handoff from phase `<from_phase>` (status `<prior_status>`):
+- <reason>
+- <carried_context bullet 1>
+- <carried_context bullet 2>
+…
+```
+
+The handoff block is omitted on the first phase. This is the *exact* text the harness receives.
+
+## 4. Advance step (`advance`)
+
+```text
+advance(quest, summary) →
+  1. Snapshot the current phase's name + status.
+  2. Mark current phase Complete(summary).
+  3. Move cursor forward by one.
+  4. If a next pending phase exists:
+       attach QuestHandoff { from_phase, prior_status, reason, carried_context }
+       if !next.edited_by_user: recompose next.sub_prompt
+  5. Return Some(next_index) or None.
+```
+
+Failure-flavoured reasons (`"failed"`, `"error"`, `"exit 1"`, `"interrupted"`) produce a different handoff sentence (`"incorporate the failure context before continuing"`) than success (`"carry its result into the next sub-prompt"`). Tests pin this distinction so the user always sees the right framing.
+
+User edits via `set_phase_sub_prompt(quest, index, text)` are *sticky*: subsequent advances still attach a handoff (so the user can read why Cast wanted to update the prompt), but the `sub_prompt` text itself is preserved verbatim.
+
+## 5. Visible handoff card (`render_quest_handoff`)
+
+Rendered between phases. Follows the §2.5 hierarchy from `cast-tui-contract.md`:
+
+```text
+Cast handoff
+quest         Ship phase 5 sub-prompting
+phase         2/3 · implement
+from          design
+prior         completed (exit 0)
+              Phase `design` finished with `completed (exit 0)` — carry its result into the next sub-prompt.
+delegate to   Codex
+
+Carried context
+  ·  added `cast::quest` module
+  ·  drafted handoff card
+
+Sub-prompt
+  Implement the change agreed in the prior design phase. …
+  …
+  Handoff from phase `design` (status `completed (exit 0)`):
+  - Phase `design` finished with `completed (exit 0)` — …
+  - added `cast::quest` module
+  - drafted handoff card
+
+enter approves the sub-prompt · type to edit · esc cancels
+```
+
+- Sub-prompts longer than 8 lines are clipped with a `… N more lines` indicator; the full text still goes to the harness, but the card stays under one screen.
+- User-edited sub-prompts get a `· user-edited` tag on the `delegate to` row so the user can tell Cast did not author the current text.
+- The card never executes anything — it is a visible *announcement* of the delegation Cast is about to make.
+
+## 6. Shell wiring (next phase)
+
+Two seams will need to land in `crates/coven-cli/src/tui/shell.rs`:
+
+1. A new `CastIntent::Quest { goal }` variant (parsed from `/quest <goal>` or natural-language patterns like `start a quest to …`). The planner builds a `Quest` via `quest_from_goal` and surfaces it through the existing plan/outcome pipeline.
+2. Between phases, the shell:
+   - prints `render_quest_handoff(&quest, next_index)`,
+   - reuses `evaluate_gate` against the next phase's sub-prompt (so the safety classifier still vets per-phase content),
+   - dispatches the underlying launch through `dispatch_cast_launch` with the phase's sub-prompt as the harness task,
+   - on exit, builds a `QuestPhaseSummary` from the `CastSessionExit` plus any author-supplied carried context, calls `advance`, and loops.
+
+This module deliberately stops short of the shell wiring so Phase 5's contract — sub-prompts, handoffs, advance — is verifiable on its own.
+
+## 7. Done-when (this phase)
+
+- [x] `cast::quest` module compiles and lives next to the existing Cast surface.
+- [x] `quest_from_goal` produces a concrete sub-prompt for every phase up front.
+- [x] `advance` attaches a structured handoff and recomposes the next sub-prompt deterministically.
+- [x] `set_phase_sub_prompt` lets the user override the next sub-prompt and survives the next advance.
+- [x] `skip_phase` rolls the cursor past a phase the user judged unnecessary.
+- [x] `render_quest_handoff` shows the source phase, prior status, carried context, target harness, and the sub-prompt text the harness will see.
+- [x] 15 new unit tests cover the composer, advancer, edits, skip, failure framing, and the render card (incl. long sub-prompts and quest exhaustion).
+- [ ] Shell wiring for `/quest <goal>` — Phase 6.
+- [ ] Quest event ledger entries (`cast.quest.*`) so re-attach can reconstruct state — Phase 6.

--- a/docs/design/cast-quest-flow.md
+++ b/docs/design/cast-quest-flow.md
@@ -27,7 +27,7 @@ Quest
  ├ title         derived from the user's goal (truncated to 60 chars)
  ├ goal          the original free-text request
  ├ phases        Vec<QuestPhase>  (default rhythm: design → implement → verify)
- └ cursor        index of the next non-complete phase
+ └ cursor        index of the next pending phase (skipped/complete are bypassed)
 
 QuestPhase
  ├ name          short identifier: "design" | "implement" | "verify"
@@ -74,14 +74,14 @@ The handoff block is omitted on the first phase. This is the *exact* text the ha
 advance(quest, summary) →
   1. Snapshot the current phase's name + status.
   2. Mark current phase Complete(summary).
-  3. Move cursor forward by one.
+  3. Move cursor to the next pending phase (skipping complete/skipped phases).
   4. If a next pending phase exists:
-       attach QuestHandoff { from_phase, prior_status, reason, carried_context }
-       if !next.edited_by_user: recompose next.sub_prompt
+        attach QuestHandoff { from_phase, prior_status, reason, carried_context }
+        if !next.edited_by_user: recompose next.sub_prompt
   5. Return Some(next_index) or None.
 ```
 
-Failure-flavoured reasons (`"failed"`, `"error"`, `"exit 1"`, `"interrupted"`) produce a different handoff sentence (`"incorporate the failure context before continuing"`) than success (`"carry its result into the next sub-prompt"`). Tests pin this distinction so the user always sees the right framing.
+Failure-flavoured reasons are based on structured phase outcomes (`exit_code != 0` or `exit_status` of `failed`/`error`/`interrupted`) and produce a different handoff sentence (`"incorporate the failure context before continuing"`) than success (`"carry its result into the next sub-prompt"`). Tests pin this distinction so the user always sees the right framing.
 
 User edits via `set_phase_sub_prompt(quest, index, text)` are *sticky*: subsequent advances still attach a handoff (so the user can read why Cast wanted to update the prompt), but the `sub_prompt` text itself is preserved verbatim.
 


### PR DESCRIPTION
## Summary

- Adds `cast::quest`: a pure module that decomposes a high-level user goal into an ordered `Quest` (default rhythm: design → implement → verify) where each phase carries a concrete `sub_prompt` ready to hand to a harness.
- `advance(quest, summary)` marks the current phase complete, attaches a structured `QuestHandoff` to the next phase, and recomposes that phase's `sub_prompt` deterministically — preserving any user-authored override via `set_phase_sub_prompt`.
- `render_quest_handoff` produces a visible card showing source phase, prior status, carried context, target harness, and the verbatim sub-prompt the harness will see. Sub-prompts longer than 8 lines clip with a `… N more lines` indicator; user-authored sub-prompts render a `· user-edited` tag.

Deliberately keeps Cast deterministic and local-first: no LLM planner runs inside Cast. Sub-prompts are assembled from structured templates plus the recorded prior outcome, so every handoff is reproducible, inspectable, and overridable before the harness sees it.

The shell wiring for a `/quest <goal>` intent is intentionally deferred to the next phase; the Phase 5 seam is documented in `docs/design/cast-quest-flow.md` (§6).

## Done-when (from the phase goal)

- [x] Each phase can produce a concrete sub-prompt (`quest_from_goal` composes them up front).
- [x] The next phase can be updated from the previous result (`advance` + `QuestHandoff` + recompose; failure status produces a failure-framed reason).
- [x] The user can see what was delegated and why (`render_quest_handoff` card).

## Test plan

- [x] `cargo test -p coven-cli --bin coven cast::quest` — 11/11 green
- [x] `cargo test -p coven-cli --bin coven cast::render::tests::quest_handoff` — 4/4 green
- [x] `cargo test -p coven-cli --bin coven cast::` — 105/105 green (no regressions in the rest of the Cast suite)
- [x] `cargo build -p coven-cli` — clean (only the 4 pre-existing `theme.rs` `BORDER_*` dead-code warnings; nothing from this change)

## Files

- `crates/coven-cli/src/tui/cast/quest.rs` *(new, 534 lines incl. 11 unit tests)* — `Quest`, `QuestPhase`, `QuestPhaseStatus`, `QuestPhaseSummary`, `QuestHandoff`; `quest_from_goal`, `compose_sub_prompt`, `advance`, `set_phase_sub_prompt`, `skip_phase`.
- `crates/coven-cli/src/tui/cast/render.rs` — adds `render_quest_handoff` + 4 plain-mode render tests.
- `crates/coven-cli/src/tui/cast/mod.rs` — re-exports the new public surface so Phase 6 shell wiring has a stable seam.
- `docs/design/cast-quest-flow.md` *(new)* — Phase 5 design contract: data model, composer, advance step, visible handoff card layout, and the Phase 6 shell-wiring seam.