### PR TITLE
cast(phase 8): approve / edit / skip / cancel per quest phase

### DIFF
--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -33,17 +33,14 @@ pub(crate) use intent::{parse_spell, CastHarness, CastIntent};
 pub(crate) use outcome::CastOutcome;
 pub(crate) use plan::{build_plan, CastPlan};
 pub(crate) use quest::{
-    advance as advance_quest, quest_from_goal, Quest, QuestPhase, QuestPhaseSummary,
+    advance as advance_quest, parse_phase_action, quest_from_goal, set_phase_sub_prompt,
+    skip_phase, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus, QuestPhaseSummary,
 };
-// `compose_sub_prompt`, `set_phase_sub_prompt`, `skip_phase`, `QuestHandoff`,
-// and `QuestPhaseStatus` are exercised by the in-module test suite and the
-// edit / skip UX deferred per the Phase 7 scope decision; keep them in the
-// public crate surface so the future UX can pick them up without further
-// plumbing.
+// `compose_sub_prompt` and `QuestHandoff` are exercised by the in-module
+// test suite; they remain in the public crate surface so a future async /
+// detached-quest UX can read them without further plumbing.
 #[allow(unused_imports)]
-pub(crate) use quest::{
-    compose_sub_prompt, set_phase_sub_prompt, skip_phase, QuestHandoff, QuestPhaseStatus,
-};
+pub(crate) use quest::{compose_sub_prompt, QuestHandoff};
 pub(crate) use render::{
     render_cast_frame_for_terminal, render_outcome, render_plan_intro, render_quest_handoff,
 };

--- a/crates/coven-cli/src/tui/cast/quest.rs
+++ b/crates/coven-cli/src/tui/cast/quest.rs
@@ -301,6 +301,89 @@ pub(crate) fn skip_phase(quest: &mut Quest, index: usize, reason: String) -> Res
     Ok(())
 }
 
+/// What the user chose to do at a phase-interaction prompt. The shell
+/// loop in `tui::shell::dispatch_cast_quest` reads one line of input per
+/// phase and turns it into one of these via [`parse_phase_action`].
+///
+/// Phase 8 keeps the parser pure (string in, enum out) so the side-effect
+/// boundary lives entirely in the shell. The parser owns the UX rules;
+/// the shell owns the side effects.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum PhaseInteraction {
+    /// Enter on an empty line — run the phase as Cast composed it.
+    Approve,
+    /// User typed `/skip` (with or without a reason). The phase is marked
+    /// `Skipped` and the cursor rolls forward.
+    Skip { reason: String },
+    /// User typed `/cancel` — the quest aborts cleanly with the supplied
+    /// reason on the outcome card.
+    Cancel { reason: String },
+    /// User typed free-text — Cast replaces the current phase's
+    /// `sub_prompt` verbatim and re-renders the handoff card so the user
+    /// can re-approve, edit again, skip, or cancel.
+    Edit { sub_prompt: String },
+}
+
+const PHASE_SKIP_DEFAULT_REASON: &str = "skipped by the user";
+const PHASE_CANCEL_DEFAULT_REASON: &str = "cancelled by the user";
+
+/// Parse one line of user input at the phase-interaction prompt. The
+/// rules are intentionally narrow:
+///
+/// - Empty (after trimming) → `Approve`.
+/// - `/skip` or `/skip <reason>` → `Skip` with the trimmed reason, or a
+///   default reason when the user omitted one.
+/// - `/cancel` or `/cancel <reason>` → `Cancel` with the trimmed reason
+///   or a default reason.
+/// - Anything else → `Edit` with the typed text as the new sub-prompt
+///   (single-line replacement; the shell loop re-renders the handoff and
+///   re-prompts so the user can refine before approving).
+pub(crate) fn parse_phase_action(line: &str) -> PhaseInteraction {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return PhaseInteraction::Approve;
+    }
+    if let Some(rest) = strip_command_prefix(trimmed, "/skip") {
+        return PhaseInteraction::Skip {
+            reason: non_empty_reason(rest, PHASE_SKIP_DEFAULT_REASON),
+        };
+    }
+    if let Some(rest) = strip_command_prefix(trimmed, "/cancel") {
+        return PhaseInteraction::Cancel {
+            reason: non_empty_reason(rest, PHASE_CANCEL_DEFAULT_REASON),
+        };
+    }
+    PhaseInteraction::Edit {
+        sub_prompt: trimmed.to_string(),
+    }
+}
+
+/// Strip a `/command` (or `/command <rest>`) prefix and return the
+/// remainder. Returns `None` when the input doesn't start with that
+/// command. Matches the exact command followed by either end-of-input or
+/// whitespace so `/cancel` doesn't swallow `/cancellation-policy` typed
+/// as an edit.
+fn strip_command_prefix<'a>(input: &'a str, command: &str) -> Option<&'a str> {
+    if input == command {
+        return Some("");
+    }
+    let with_space = input.strip_prefix(command)?;
+    if with_space.starts_with(char::is_whitespace) {
+        Some(with_space.trim_start())
+    } else {
+        None
+    }
+}
+
+fn non_empty_reason(reason: &str, default: &str) -> String {
+    let trimmed = reason.trim();
+    if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
 fn phase_status_label(summary: &QuestPhaseSummary) -> String {
     if let Some(status) = &summary.exit_status {
         match summary.exit_code {
@@ -559,6 +642,89 @@ mod tests {
 
         let label = phase_status_label(&QuestPhaseSummary::default());
         assert_eq!(label, "complete");
+    }
+
+    #[test]
+    fn parse_phase_action_treats_empty_input_as_approve() {
+        assert_eq!(parse_phase_action(""), PhaseInteraction::Approve);
+        assert_eq!(parse_phase_action("   "), PhaseInteraction::Approve);
+        assert_eq!(parse_phase_action("\n"), PhaseInteraction::Approve);
+    }
+
+    #[test]
+    fn parse_phase_action_recognises_skip_with_and_without_reason() {
+        assert_eq!(
+            parse_phase_action("/skip"),
+            PhaseInteraction::Skip {
+                reason: PHASE_SKIP_DEFAULT_REASON.to_string(),
+            }
+        );
+        assert_eq!(
+            parse_phase_action("/skip verify happens in CI"),
+            PhaseInteraction::Skip {
+                reason: "verify happens in CI".to_string(),
+            }
+        );
+        // Trailing whitespace on the reason is trimmed.
+        assert_eq!(
+            parse_phase_action("/skip   already covered   "),
+            PhaseInteraction::Skip {
+                reason: "already covered".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_phase_action_recognises_cancel_with_and_without_reason() {
+        assert_eq!(
+            parse_phase_action("/cancel"),
+            PhaseInteraction::Cancel {
+                reason: PHASE_CANCEL_DEFAULT_REASON.to_string(),
+            }
+        );
+        assert_eq!(
+            parse_phase_action("/cancel changed my mind"),
+            PhaseInteraction::Cancel {
+                reason: "changed my mind".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_phase_action_treats_other_text_as_edit() {
+        assert_eq!(
+            parse_phase_action("Implement only the SQL helpers"),
+            PhaseInteraction::Edit {
+                sub_prompt: "Implement only the SQL helpers".to_string(),
+            }
+        );
+        // Leading/trailing whitespace is trimmed.
+        assert_eq!(
+            parse_phase_action("   add unit tests too   "),
+            PhaseInteraction::Edit {
+                sub_prompt: "add unit tests too".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_phase_action_does_not_swallow_lookalike_commands_in_edit_text() {
+        // `/cancellation-policy` is a plausible edit (a noun phrase the
+        // user types as the new sub-prompt). The strict prefix matcher
+        // must not treat it as `/cancel`.
+        assert_eq!(
+            parse_phase_action("/cancellation-policy"),
+            PhaseInteraction::Edit {
+                sub_prompt: "/cancellation-policy".to_string(),
+            }
+        );
+        // `/skipper` likewise stays an edit.
+        assert_eq!(
+            parse_phase_action("/skipper"),
+            PhaseInteraction::Edit {
+                sub_prompt: "/skipper".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/render.rs
+++ b/crates/coven-cli/src/tui/cast/render.rs
@@ -314,7 +314,9 @@ fn quest_phase_position_label(quest: &Quest, next_index: usize) -> String {
 
 fn quest_handoff_footer_hint(next: &QuestPhase) -> &'static str {
     match &next.status {
-        QuestPhaseStatus::Pending => "enter approves the sub-prompt · type to edit · esc cancels",
+        QuestPhaseStatus::Pending => {
+            "enter approve · type to replace · /skip [reason] · /cancel [reason]"
+        }
         QuestPhaseStatus::Running { .. } => "phase running · attach to follow",
         QuestPhaseStatus::Complete(_) => "phase already complete · advance again",
         QuestPhaseStatus::Skipped { .. } => "phase skipped · advance to continue",

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -14,9 +14,10 @@ use uuid::Uuid;
 
 use super::cast::{
     self, advance_quest, build_plan, evaluate_gate, find_cast_summary, follow_until_exit,
-    format_summary_note, quest_from_goal, render_cast_frame_for_terminal, render_outcome,
-    render_plan_intro, render_quest_handoff, CastHarness, CastIntent, CastOutcome, CastPlan,
-    CastSessionExit, FollowerObserver, FollowerPacer, GateOutcome, Quest, QuestPhase,
+    format_summary_note, parse_phase_action, quest_from_goal, render_cast_frame_for_terminal,
+    render_outcome, render_plan_intro, render_quest_handoff, set_phase_sub_prompt, skip_phase,
+    CastHarness, CastIntent, CastOutcome, CastPlan, CastSessionExit, FollowerObserver,
+    FollowerPacer, GateOutcome, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus,
     QuestPhaseSummary, SafetyDecision,
 };
 use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
@@ -510,6 +511,7 @@ fn dispatch_harness_spell(plan: &CastPlan, harness_id: &str, prompt: &str) -> Re
 const CAST_QUEST_STARTED: &str = "cast.quest.started";
 const CAST_QUEST_PHASE_STARTED: &str = "cast.quest.phase_started";
 const CAST_QUEST_PHASE_COMPLETED: &str = "cast.quest.phase_completed";
+const CAST_QUEST_PHASE_SKIPPED: &str = "cast.quest.phase_skipped";
 const CAST_QUEST_ADVANCED: &str = "cast.quest.advanced";
 const CAST_QUEST_COMPLETED: &str = "cast.quest.completed";
 
@@ -528,9 +530,58 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
     let request_text = outcome_request_text(plan);
 
     while let Some(idx) = quest.current_index() {
+        // Phases the user (or a prior skip_phase call) already marked as
+        // Skipped are walked past without re-prompting. The cursor was
+        // already nudged forward by `skip_phase`, but defensively handle
+        // the case here so a future async UX that bumps `cursor` without
+        // calling `skip_phase` still behaves.
+        if matches!(quest.phases[idx].status, QuestPhaseStatus::Skipped { .. }) {
+            quest.cursor = idx + 1;
+            continue;
+        }
+
         println!();
         print!("{}", render_quest_handoff(&quest, idx));
         println!();
+
+        let mut reader = stdin_line_reader;
+        match run_phase_interaction(&mut quest, idx, &mut reader)? {
+            PhaseInteraction::Cancel { reason } => {
+                let phase_name = quest.phases[idx].name.clone();
+                completed_notes.push(format!("Phase `{phase_name}` cancelled: {reason}"));
+                return Ok(quest_outcome(
+                    &request_text,
+                    &quest,
+                    anchor_session_id.clone(),
+                    completed_notes,
+                    Some("Re-run `/quest <goal>` to start over.".to_string()),
+                    Some(format!(
+                        "Quest cancelled at phase `{phase_name}` — {reason}."
+                    )),
+                ));
+            }
+            PhaseInteraction::Skip { reason } => {
+                let phase_name = quest.phases[idx].name.clone();
+                skip_phase(&mut quest, idx, reason.clone())?;
+                completed_notes.push(format!("Phase `{phase_name}`: skipped — {reason}"));
+                if let Some(anchor) = anchor_session_id.as_deref() {
+                    write_quest_event(
+                        anchor,
+                        CAST_QUEST_PHASE_SKIPPED,
+                        serde_json::json!({
+                            "phase": phase_name,
+                            "index": idx,
+                            "reason": reason,
+                        }),
+                    );
+                }
+                continue;
+            }
+            PhaseInteraction::Edit { .. } => {
+                unreachable!("Edit is consumed inside run_phase_interaction's inner loop")
+            }
+            PhaseInteraction::Approve => {}
+        }
 
         let phase_harness = match resolve_phase_harness(&quest.phases[idx], default_harness) {
             Some(harness) => harness,
@@ -551,7 +602,6 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
 
         let phase_plan = quest_phase_plan(&quest, idx, phase_harness, goal)?;
 
-        let mut reader = stdin_line_reader;
         match evaluate_gate(&phase_plan, &mut reader)? {
             GateOutcome::Cancelled { reason, next_step } => {
                 completed_notes.push(format!(
@@ -680,6 +730,43 @@ fn resolve_phase_harness(
     default_harness: Option<CastHarness>,
 ) -> Option<CastHarness> {
     phase.harness.or(default_harness)
+}
+
+/// One line of phase-prompt help, matching the handoff card's footer hint.
+/// The wording is duplicated here (the card is rendered separately) but
+/// kept short and contract-aligned per §2.6 of `cast-tui-contract.md`.
+const PHASE_PROMPT_HINT: &str =
+    "enter approve · type to replace · /skip [reason] · /cancel [reason]";
+
+/// Drive the per-phase interaction described in
+/// `docs/design/cast-quest-flow.md` §5: render → prompt → loop on edits →
+/// resolve to Approve / Skip / Cancel.
+///
+/// `Edit` is consumed inside this function (the handoff card re-renders
+/// with the new sub-prompt and the user is prompted again) so callers
+/// only see one of the three terminal actions.
+fn run_phase_interaction<R>(
+    quest: &mut Quest,
+    idx: usize,
+    reader: &mut R,
+) -> Result<PhaseInteraction>
+where
+    R: FnMut(&str) -> Result<String>,
+{
+    loop {
+        let phase_name = quest.phases[idx].name.clone();
+        let prompt = format!("Phase `{phase_name}` — {PHASE_PROMPT_HINT}: ");
+        let line = reader(&prompt)?;
+        match parse_phase_action(&line) {
+            PhaseInteraction::Edit { sub_prompt } => {
+                set_phase_sub_prompt(quest, idx, sub_prompt)?;
+                println!();
+                print!("{}", render_quest_handoff(quest, idx));
+                println!();
+            }
+            terminal => return Ok(terminal),
+        }
+    }
 }
 
 /// Synthesize a per-phase `CastPlan` so the existing safety gate can vet
@@ -1380,6 +1467,63 @@ fn parse_harness_slash_command(harness: &str, rest: &str) -> Result<MagicalTuiRe
         harness: harness.to_string(),
         prompt: prompt.to_string(),
     })
+}
+
+#[cfg(test)]
+mod quest_interaction_tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    fn scripted_reader(script: Vec<&'static str>) -> impl FnMut(&str) -> Result<String> {
+        let lines = RefCell::new(script.into_iter());
+        move |_prompt: &str| {
+            Ok(lines
+                .borrow_mut()
+                .next()
+                .map(str::to_string)
+                .unwrap_or_default())
+        }
+    }
+
+    #[test]
+    fn run_phase_interaction_returns_approve_on_empty_input() {
+        let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
+        let mut reader = scripted_reader(vec![""]);
+        let action = run_phase_interaction(&mut quest, 0, &mut reader).unwrap();
+        assert_eq!(action, PhaseInteraction::Approve);
+    }
+
+    #[test]
+    fn run_phase_interaction_loops_on_edit_until_terminal_action() {
+        let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
+        let original = quest.phases[0].sub_prompt.clone();
+        // First line is an edit → second line skips. The function must
+        // apply the edit, mark the phase as user-edited, then return Skip.
+        let mut reader = scripted_reader(vec!["draft just the headlines", "/skip already covered"]);
+        let action = run_phase_interaction(&mut quest, 0, &mut reader).unwrap();
+        assert_eq!(
+            action,
+            PhaseInteraction::Skip {
+                reason: "already covered".to_string(),
+            }
+        );
+        assert!(quest.phases[0].edited_by_user);
+        assert_eq!(quest.phases[0].sub_prompt, "draft just the headlines");
+        assert_ne!(quest.phases[0].sub_prompt, original);
+    }
+
+    #[test]
+    fn run_phase_interaction_returns_cancel_with_default_reason() {
+        let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
+        let mut reader = scripted_reader(vec!["/cancel"]);
+        let action = run_phase_interaction(&mut quest, 0, &mut reader).unwrap();
+        match action {
+            PhaseInteraction::Cancel { reason } => {
+                assert!(!reason.is_empty(), "default reason should be non-empty");
+            }
+            other => panic!("expected Cancel, got {other:?}"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/docs/design/cast-quest-flow.md
+++ b/docs/design/cast-quest-flow.md
@@ -142,11 +142,25 @@ This module deliberately stops short of the shell wiring so Phase 5's contract �
 - [x] Shell wiring for `/quest <goal>` — landed in Phase 7. `dispatch_cast_quest` in `tui/shell.rs` loops phases, gates each sub-prompt, dispatches via `dispatch_cast_launch`, and advances on each `cast.summary`-derived `QuestPhaseSummary`.
 - [x] Quest event ledger entries (`cast.quest.*`) — landed in Phase 7. `cast.quest.{started, phase_started, phase_completed, advanced, completed}` are written to the first phase's session (the "anchor"). `cast::find_cast_quest_info` decodes them so `/attach <anchor>` surfaces a one-line quest-anchor note alongside the cast.summary.
 
-## 8. Deferred to a later phase
+## 8. Edit / skip UX per phase (Phase 8)
 
-Per the Phase 7 scope decision, four things did **not** land and are tracked for the next slice:
+After Phase 7 auto-advance landed, Phase 8 wired the §5 approve / edit / skip / cancel loop into `dispatch_cast_quest`:
 
-- **Edit / skip UX per phase.** Phase 7 auto-advances every phase. `set_phase_sub_prompt`, `skip_phase`, `compose_sub_prompt`, `QuestHandoff`, and `QuestPhaseStatus::Skipped` are still in the crate surface but reachable only through tests; their `#[allow(dead_code)]` notes call this out.
+- **`PhaseInteraction` + `parse_phase_action`** (in `tui/cast/quest.rs`) — pure parser, four variants:
+  - Empty input → `Approve` (run the phase as Cast composed it).
+  - `/skip [reason]` → `Skip { reason }` with a default reason when omitted.
+  - `/cancel [reason]` → `Cancel { reason }` with a default reason when omitted.
+  - Anything else → `Edit { sub_prompt }` (single-line replacement; the shell loop applies it via `set_phase_sub_prompt`, re-renders the handoff card, and re-prompts so the user can refine, approve, skip, or cancel).
+- **`run_phase_interaction`** (in `tui/shell.rs`) — drives the prompt loop with an injectable reader so it is testable without stdin. `Edit` is consumed inside the loop; callers only see one of the three terminal actions.
+- **`cast.quest.phase_skipped`** event is written to the anchor when the user skips, alongside the other `cast.quest.*` reconstruction aids.
+- **Footer hint** on the Pending handoff card now reads `enter approve · type to replace · /skip [reason] · /cancel [reason]`, matching the parser exactly.
+
+The Edit flow is intentionally a **single-line full replacement** because the per-phase prompt is one line of cooked stdin. Pasting a multi-line block typically arrives as one line on the prompt; for richer multi-line editing the user can use `$EDITOR` outside Cast and paste back. A future phase could swap in a multi-line editor surface.
+
+## 9. Deferred to a later phase
+
+Three §7 deferrals from Phase 7 are still open:
+
 - **Full re-attach state rebuild.** `/attach <anchor>` currently prints a one-line note ("phase N/M, in progress / complete"). Replaying `cast.quest.*` events to reconstruct a `Quest` and re-render the next handoff card is the long pole and a separate phase.
 - **Local-PTY fallback ledger.** Quest event writes are best-effort and skipped silently when `dispatch_cast_launch` falls back to the synchronous local PTY path (no daemon, no session id, no anchor). Re-attach will not find a quest there.
 - **`QuestPhaseStatus::Running` transition.** The shell loop transitions Pending → Complete directly (synchronous dispatch). A future async / detached-quest UX would set Running between the two.


### PR DESCRIPTION
## Summary

- Closes the largest §8 deferral from Phase 7: the per-phase approve / edit / skip / cancel UX described in `cast-quest-flow.md` §5.
- New `PhaseInteraction` + `parse_phase_action` (pure parser) live in `tui/cast/quest.rs`; new `run_phase_interaction` loop helper in `tui/shell.rs` drives the prompt with an injectable reader so it's testable without stdin.
- `dispatch_cast_quest` branches on the terminal action: Approve falls through to the existing gate + dispatch + advance flow; Skip calls `skip_phase` and writes a new `cast.quest.phase_skipped` event; Cancel returns a cancellation outcome with the user's reason.
- Handoff card footer hint on the Pending row now reads exactly what the parser accepts: \`enter approve · type to replace · /skip [reason] · /cancel [reason]\`.

## Parser rules (see `cast-quest-flow.md` §8)

| Input | Action |
| --- | --- |
| empty / whitespace | `Approve` — run the phase as composed |
| `/skip` or `/skip <reason>` | `Skip { reason }` (default reason when omitted) |
| `/cancel` or `/cancel <reason>` | `Cancel { reason }` (default reason when omitted) |
| anything else | `Edit { sub_prompt }` — single-line full replacement; the loop re-renders and re-prompts |

Strict prefix matching: \`/cancellation-policy\` stays an Edit, not a Cancel. \`/skipper\` stays an Edit, not a Skip.

## Gate results

- \`cargo fmt --all -- --check\` — clean
- \`cargo clippy -p coven-cli --tests --no-deps -- -D warnings\` — clean
- \`cargo test -p coven-cli\` — 333 unit + 4 smoke, 0 failures (8 new tests this phase: 5 parser, 3 interaction loop)

## Still deferred (cast-quest-flow.md §9)

- Full quest re-attach state rebuild.
- Local-PTY fallback ledger.
- \`QuestPhaseStatus::Running\` transition for a future async / detached-quest UX.

## Test plan

- [ ] Start the daemon, run \`/quest fix the failing tests\` in the launcher. At the first handoff prompt, press Enter — phase dispatches with the composed sub-prompt unchanged.
- [ ] Run another quest. At the second handoff, type a one-line replacement sub-prompt and Enter. Confirm the handoff card re-renders with the new text and a fresh prompt. Press Enter — the phase runs with the edited sub-prompt.
- [ ] Run a third quest. At the implement phase, type \`/skip already done\`. Confirm the phase is recorded as skipped, the loop advances to verify, and the outcome card lists \"Phase \\\`implement\\\`: skipped — already done\".
- [ ] Run a fourth quest. At any prompt, type \`/cancel changed my mind\`. Confirm the loop returns immediately, the outcome card shows \"Quest cancelled at phase \\\`<name>\\\` — changed my mind.\".
- [ ] \`coven attach <anchor-id>\` after a quest that included a skip. Confirm the existing one-line quest-anchor note still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)