### PR TITLE
cast(phase 9): re-attach reconstructs a Quest and resumes the loop

### DIFF
--- a/crates/coven-cli/src/tui/cast/attach.rs
+++ b/crates/coven-cli/src/tui/cast/attach.rs
@@ -9,21 +9,19 @@ use serde_json::Value;
 
 use crate::store;
 
+use super::intent::CastHarness;
+use super::quest::{
+    advance, quest_from_goal, set_phase_sub_prompt, skip_phase, Quest, QuestPhaseSummary,
+    CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
+};
+
 /// Event kind Cast writes when a launched session finishes. See
 /// `shell::write_cast_summary_event` for the producer side.
 pub(crate) const CAST_SUMMARY_KIND: &str = "cast.summary";
 
-/// Event kind Cast writes on the anchor session when a quest begins. See
-/// `shell::dispatch_cast_quest` for the producer side.
-pub(crate) const CAST_QUEST_STARTED_KIND: &str = "cast.quest.started";
-
-/// Event kind Cast writes on the anchor session when a quest's last phase
-/// has finished.
-pub(crate) const CAST_QUEST_COMPLETED_KIND: &str = "cast.quest.completed";
-
-/// Event kind Cast writes on the anchor session right after each phase
-/// finishes. Used by the re-attach detector to compute the phase index.
-pub(crate) const CAST_QUEST_PHASE_COMPLETED_KIND: &str = "cast.quest.phase_completed";
+use super::quest::{
+    CAST_QUEST_COMPLETED_KIND, CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_STARTED_KIND,
+};
 
 /// Decoded `cast.summary` event. All fields are optional because Cast may
 /// have written a partial payload (e.g. an older Cast that didn't record
@@ -105,6 +103,92 @@ pub(crate) fn find_cast_quest_info(events: &[store::EventRecord]) -> Option<Cast
         total_phases,
         completed_phases,
         is_complete,
+    })
+}
+
+/// Replayed quest state plus the anchor session id we attached to. The
+/// re-attach path in `tui::shell::attach_via_daemon` uses this to either
+/// resume the quest loop at the next pending phase or, when the quest is
+/// already complete, surface a summary note.
+#[derive(Clone, Debug)]
+pub(crate) struct ReconstructedQuest {
+    pub(crate) quest: Quest,
+    pub(crate) is_complete: bool,
+    pub(crate) anchor_session_id: String,
+}
+
+/// Replay `cast.quest.*` events from an anchor session to rebuild a
+/// `Quest` in the state it was in when the user last interacted with it.
+///
+/// Returns `None` when `events` does not contain a `cast.quest.started`
+/// payload (the session is not a quest anchor). The reconstructor is
+/// best-effort: malformed event payloads and out-of-range indices are
+/// skipped silently so a corrupt event log never blocks the resume path.
+pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<ReconstructedQuest> {
+    let started = events
+        .iter()
+        .find(|event| event.kind == CAST_QUEST_STARTED_KIND)?;
+    let payload = serde_json::from_str::<Value>(&started.payload_json).ok()?;
+    let goal = payload.get("goal").and_then(Value::as_str)?.to_string();
+    let default_harness = payload
+        .get("harness")
+        .and_then(Value::as_str)
+        .and_then(CastHarness::from_token);
+
+    let mut quest = quest_from_goal(&goal, default_harness);
+    let mut is_complete = false;
+
+    for event in events {
+        match event.kind.as_str() {
+            kind if kind == CAST_QUEST_PHASE_EDITED_KIND => {
+                let payload =
+                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+                let idx = payload.get("index").and_then(Value::as_u64);
+                let sub_prompt = payload.get("sub_prompt").and_then(Value::as_str);
+                if let (Some(idx), Some(text)) = (idx, sub_prompt) {
+                    let _ = set_phase_sub_prompt(&mut quest, idx as usize, text.to_string());
+                }
+            }
+            kind if kind == CAST_QUEST_PHASE_COMPLETED_KIND => {
+                let payload =
+                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+                let summary = QuestPhaseSummary {
+                    session_id: payload
+                        .get("session_id")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    exit_status: payload
+                        .get("exit_status")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    exit_code: payload
+                        .get("exit_code")
+                        .and_then(Value::as_i64)
+                        .map(|v| v as i32),
+                    carried_context: Vec::new(),
+                };
+                advance(&mut quest, summary);
+            }
+            kind if kind == CAST_QUEST_PHASE_SKIPPED_KIND => {
+                let payload =
+                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+                let idx = payload.get("index").and_then(Value::as_u64);
+                let reason = payload.get("reason").and_then(Value::as_str);
+                if let (Some(idx), Some(reason)) = (idx, reason) {
+                    let _ = skip_phase(&mut quest, idx as usize, reason.to_string());
+                }
+            }
+            kind if kind == CAST_QUEST_COMPLETED_KIND => {
+                is_complete = true;
+            }
+            _ => {}
+        }
+    }
+
+    Some(ReconstructedQuest {
+        quest,
+        is_complete,
+        anchor_session_id: started.session_id.clone(),
     })
 }
 
@@ -452,6 +536,173 @@ mod tests {
         let note = format_quest_attach_note(&info).expect("note should be produced");
         assert!(note.contains("phase 3/3"));
         assert!(note.contains("complete"));
+    }
+
+    fn phase_completed_event(
+        seq: i64,
+        idx: usize,
+        status: &str,
+        exit_code: i32,
+    ) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "anchor".to_string(),
+            kind: CAST_QUEST_PHASE_COMPLETED_KIND.to_string(),
+            payload_json: serde_json::json!({
+                "phase": format!("p{idx}"),
+                "index": idx,
+                "session_id": format!("session-{idx}"),
+                "exit_status": status,
+                "exit_code": exit_code,
+            })
+            .to_string(),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
+    fn phase_skipped_event(seq: i64, idx: usize, reason: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "anchor".to_string(),
+            kind: CAST_QUEST_PHASE_SKIPPED_KIND.to_string(),
+            payload_json: serde_json::json!({
+                "phase": format!("p{idx}"),
+                "index": idx,
+                "reason": reason,
+            })
+            .to_string(),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
+    fn phase_edited_event(seq: i64, idx: usize, sub_prompt: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "anchor".to_string(),
+            kind: CAST_QUEST_PHASE_EDITED_KIND.to_string(),
+            payload_json: serde_json::json!({
+                "phase": format!("p{idx}"),
+                "index": idx,
+                "sub_prompt": sub_prompt,
+            })
+            .to_string(),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
+    fn started_event_with(session_id: &str, goal: &str, harness: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq: 1,
+            id: "event-1".to_string(),
+            session_id: session_id.to_string(),
+            kind: CAST_QUEST_STARTED_KIND.to_string(),
+            payload_json: serde_json::json!({
+                "title": "Test quest",
+                "goal": goal,
+                "harness": harness,
+                "phases": ["design", "implement", "verify"],
+            })
+            .to_string(),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn reconstruct_quest_returns_none_when_no_started_event() {
+        let events = vec![output_event(1, "noise")];
+        assert!(reconstruct_quest(&events).is_none());
+    }
+
+    #[test]
+    fn reconstruct_quest_rebuilds_initial_state_with_cursor_at_zero() {
+        let events = vec![started_event_with("anchor-id", "ship phase 9", "codex")];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        assert_eq!(recon.anchor_session_id, "anchor-id");
+        assert!(!recon.is_complete);
+        assert_eq!(recon.quest.cursor, 0);
+        assert_eq!(recon.quest.goal, "ship phase 9");
+    }
+
+    #[test]
+    fn reconstruct_quest_replays_phase_completed_events_to_advance_cursor() {
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 9", "codex"),
+            phase_completed_event(2, 0, "completed", 0),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        assert_eq!(recon.quest.cursor, 1);
+        assert!(!recon.is_complete);
+    }
+
+    #[test]
+    fn reconstruct_quest_applies_user_edits_before_completion() {
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 9", "codex"),
+            phase_edited_event(2, 0, "REPLACED design sub-prompt"),
+            phase_completed_event(3, 0, "completed", 0),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        assert!(
+            recon.quest.phases[0].edited_by_user,
+            "phase 0 should be marked edited"
+        );
+        // After completion the phase status is Complete, but the
+        // sub_prompt retains the user's text for re-attach inspection.
+        assert_eq!(
+            recon.quest.phases[0].sub_prompt,
+            "REPLACED design sub-prompt"
+        );
+    }
+
+    #[test]
+    fn reconstruct_quest_replays_skip_and_advances_past_it() {
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 9", "codex"),
+            phase_skipped_event(2, 0, "already covered"),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        // Skipping phase 0 rolls the cursor forward to phase 1.
+        assert_eq!(recon.quest.cursor, 1);
+    }
+
+    #[test]
+    fn reconstruct_quest_marks_is_complete_when_completed_event_present() {
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 9", "codex"),
+            phase_completed_event(2, 0, "completed", 0),
+            phase_completed_event(3, 1, "completed", 0),
+            phase_completed_event(4, 2, "completed", 0),
+            store::EventRecord {
+                seq: 5,
+                id: "event-5".to_string(),
+                session_id: "anchor".to_string(),
+                kind: CAST_QUEST_COMPLETED_KIND.to_string(),
+                payload_json: serde_json::json!({"title": "Test quest"}).to_string(),
+                created_at: "2026-05-20T00:00:00Z".to_string(),
+            },
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        assert!(recon.is_complete);
+        assert_eq!(recon.quest.cursor, 3, "cursor should be past all phases");
+    }
+
+    #[test]
+    fn reconstruct_quest_skips_malformed_event_payloads_without_failing() {
+        let mut bad_completed = phase_completed_event(2, 0, "completed", 0);
+        bad_completed.payload_json = "not json".to_string();
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 9", "codex"),
+            bad_completed,
+            phase_completed_event(3, 0, "completed", 0),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        // The first (malformed) event still triggers an advance because
+        // `unwrap_or(Value::Null)` yields a default summary; both advances
+        // run, so cursor lands at 2.
+        assert_eq!(recon.quest.cursor, 2);
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/intent.rs
+++ b/crates/coven-cli/src/tui/cast/intent.rs
@@ -29,7 +29,7 @@ impl CastHarness {
         }
     }
 
-    fn from_token(token: &str) -> Option<Self> {
+    pub(crate) fn from_token(token: &str) -> Option<Self> {
         match token.to_ascii_lowercase().as_str() {
             "codex" => Some(CastHarness::Codex),
             "claude" | "claude-code" | "claudecode" => Some(CastHarness::Claude),

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -26,6 +26,7 @@ use crate::harness;
 
 pub(crate) use attach::{
     find_cast_quest_info, find_cast_summary, format_quest_attach_note, format_summary_note,
+    reconstruct_quest, ReconstructedQuest,
 };
 pub(crate) use follow::{follow_until_exit, CastSessionExit, FollowerObserver, FollowerPacer};
 pub(crate) use gate::{evaluate_gate, GateOutcome};
@@ -35,6 +36,9 @@ pub(crate) use plan::{build_plan, CastPlan};
 pub(crate) use quest::{
     advance as advance_quest, parse_phase_action, quest_from_goal, set_phase_sub_prompt,
     skip_phase, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus, QuestPhaseSummary,
+    CAST_QUEST_ADVANCED_KIND, CAST_QUEST_COMPLETED_KIND, CAST_QUEST_PHASE_COMPLETED_KIND,
+    CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND, CAST_QUEST_PHASE_STARTED_KIND,
+    CAST_QUEST_STARTED_KIND,
 };
 // `compose_sub_prompt` and `QuestHandoff` are exercised by the in-module
 // test suite; they remain in the public crate surface so a future async /

--- a/crates/coven-cli/src/tui/cast/quest.rs
+++ b/crates/coven-cli/src/tui/cast/quest.rs
@@ -26,6 +26,18 @@ use anyhow::{anyhow, Result};
 
 use super::intent::CastHarness;
 
+/// Canonical event kinds Cast writes to the *anchor* session of a quest.
+/// The reconstructor in `cast::attach` and the writer in `tui::shell`
+/// both reference these so the two stay in sync. See
+/// `docs/design/cast-quest-flow.md` §8 for the writer contract.
+pub(crate) const CAST_QUEST_STARTED_KIND: &str = "cast.quest.started";
+pub(crate) const CAST_QUEST_PHASE_STARTED_KIND: &str = "cast.quest.phase_started";
+pub(crate) const CAST_QUEST_PHASE_COMPLETED_KIND: &str = "cast.quest.phase_completed";
+pub(crate) const CAST_QUEST_PHASE_SKIPPED_KIND: &str = "cast.quest.phase_skipped";
+pub(crate) const CAST_QUEST_PHASE_EDITED_KIND: &str = "cast.quest.phase_edited";
+pub(crate) const CAST_QUEST_ADVANCED_KIND: &str = "cast.quest.advanced";
+pub(crate) const CAST_QUEST_COMPLETED_KIND: &str = "cast.quest.completed";
+
 /// A sequential goal Cast is guiding the user through. Owns the original
 /// user request and an ordered list of [`QuestPhase`]s. `cursor` points at
 /// the next phase that has not yet completed or been skipped.

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -18,7 +18,9 @@ use super::cast::{
     render_outcome, render_plan_intro, render_quest_handoff, set_phase_sub_prompt, skip_phase,
     CastHarness, CastIntent, CastOutcome, CastPlan, CastSessionExit, FollowerObserver,
     FollowerPacer, GateOutcome, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus,
-    QuestPhaseSummary, SafetyDecision,
+    QuestPhaseSummary, SafetyDecision, CAST_QUEST_ADVANCED_KIND, CAST_QUEST_COMPLETED_KIND,
+    CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
+    CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
 };
 use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
 use super::{is_key_press, sessions};
@@ -503,18 +505,6 @@ fn dispatch_harness_spell(plan: &CastPlan, harness_id: &str, prompt: &str) -> Re
     )
 }
 
-/// Event kind prefix Cast writes to the anchor session's event log so a
-/// future `coven attach <anchor>` can detect that the session belongs to a
-/// quest. Per the Phase 7 scope decision (first-session anchor), every
-/// `cast.quest.*` event lives on phase-0's session; later phases still
-/// emit their own `cast.summary` events on their own sessions.
-const CAST_QUEST_STARTED: &str = "cast.quest.started";
-const CAST_QUEST_PHASE_STARTED: &str = "cast.quest.phase_started";
-const CAST_QUEST_PHASE_COMPLETED: &str = "cast.quest.phase_completed";
-const CAST_QUEST_PHASE_SKIPPED: &str = "cast.quest.phase_skipped";
-const CAST_QUEST_ADVANCED: &str = "cast.quest.advanced";
-const CAST_QUEST_COMPLETED: &str = "cast.quest.completed";
-
 /// Loop a deterministic Cast quest through its phases. Each iteration
 /// renders the handoff card, gates the phase's sub-prompt, dispatches via
 /// `dispatch_cast_launch`, then advances the quest with a summary built
@@ -524,10 +514,48 @@ const CAST_QUEST_COMPLETED: &str = "cast.quest.completed";
 /// (no session id means no anchor and no ledger writes).
 fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
     let default_harness = plan.harness.map(|h| h.harness);
-    let mut quest = quest_from_goal(goal, default_harness);
-    let mut anchor_session_id: Option<String> = None;
-    let mut completed_notes: Vec<String> = Vec::new();
+    let quest = quest_from_goal(goal, default_harness);
     let request_text = outcome_request_text(plan);
+    run_quest_loop(quest, None, default_harness, goal, request_text)
+}
+
+/// Resume a quest from a [`ReconstructedQuest`] decoded out of the
+/// anchor session's event log. The quest already has its cursor at the
+/// next pending phase (or past every phase, in which case the caller is
+/// expected to short-circuit). All side effects — handoff card, gate,
+/// dispatch, advance — flow through the same `run_quest_loop` the fresh
+/// `/quest <goal>` path uses, so resumed and fresh quests behave
+/// identically from the first surviving phase onward.
+fn resume_cast_quest(
+    reconstructed: cast::ReconstructedQuest,
+    request_text: String,
+) -> Result<CastOutcome> {
+    let default_harness = reconstructed
+        .quest
+        .phases
+        .iter()
+        .find_map(|phase| phase.harness);
+    let goal = reconstructed.quest.goal.clone();
+    run_quest_loop(
+        reconstructed.quest,
+        Some(reconstructed.anchor_session_id),
+        default_harness,
+        &goal,
+        request_text,
+    )
+}
+
+/// Per-phase loop shared by fresh `/quest <goal>` runs
+/// ([`dispatch_cast_quest`]) and re-attach resumes
+/// ([`resume_cast_quest`]).
+fn run_quest_loop(
+    mut quest: Quest,
+    mut anchor_session_id: Option<String>,
+    default_harness: Option<CastHarness>,
+    goal: &str,
+    request_text: String,
+) -> Result<CastOutcome> {
+    let mut completed_notes: Vec<String> = Vec::new();
 
     while let Some(idx) = quest.current_index() {
         // Phases the user (or a prior skip_phase call) already marked as
@@ -545,7 +573,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
         println!();
 
         let mut reader = stdin_line_reader;
-        match run_phase_interaction(&mut quest, idx, &mut reader)? {
+        match run_phase_interaction(&mut quest, idx, anchor_session_id.as_deref(), &mut reader)? {
             PhaseInteraction::Cancel { reason } => {
                 let phase_name = quest.phases[idx].name.clone();
                 completed_notes.push(format!("Phase `{phase_name}` cancelled: {reason}"));
@@ -567,7 +595,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
                 if let Some(anchor) = anchor_session_id.as_deref() {
                     write_quest_event(
                         anchor,
-                        CAST_QUEST_PHASE_SKIPPED,
+                        CAST_QUEST_PHASE_SKIPPED_KIND,
                         serde_json::json!({
                             "phase": phase_name,
                             "index": idx,
@@ -640,7 +668,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
                 anchor_session_id = Some(sid.clone());
                 write_quest_event(
                     sid,
-                    CAST_QUEST_STARTED,
+                    CAST_QUEST_STARTED_KIND,
                     serde_json::json!({
                         "title": quest.title,
                         "goal": quest.goal,
@@ -658,7 +686,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
         if let Some(anchor) = anchor_session_id.as_deref() {
             write_quest_event(
                 anchor,
-                CAST_QUEST_PHASE_STARTED,
+                CAST_QUEST_PHASE_STARTED_KIND,
                 serde_json::json!({
                     "phase": quest.phases[idx].name,
                     "index": idx,
@@ -674,7 +702,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
         if let Some(anchor) = anchor_session_id.as_deref() {
             write_quest_event(
                 anchor,
-                CAST_QUEST_PHASE_COMPLETED,
+                CAST_QUEST_PHASE_COMPLETED_KIND,
                 serde_json::json!({
                     "phase": quest.phases[idx].name,
                     "index": idx,
@@ -689,7 +717,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
         if let Some(anchor) = anchor_session_id.as_deref() {
             write_quest_event(
                 anchor,
-                CAST_QUEST_ADVANCED,
+                CAST_QUEST_ADVANCED_KIND,
                 serde_json::json!({
                     "from_index": idx,
                     "next_index": next,
@@ -701,7 +729,7 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
     if let Some(anchor) = anchor_session_id.as_deref() {
         write_quest_event(
             anchor,
-            CAST_QUEST_COMPLETED,
+            CAST_QUEST_COMPLETED_KIND,
             serde_json::json!({
                 "title": quest.title,
                 "phase_count": quest.phases.len(),
@@ -745,9 +773,17 @@ const PHASE_PROMPT_HINT: &str =
 /// `Edit` is consumed inside this function (the handoff card re-renders
 /// with the new sub-prompt and the user is prompted again) so callers
 /// only see one of the three terminal actions.
+///
+/// `anchor_session_id` is `Some` once phase 0 has launched and the anchor
+/// session exists; in that case each edit also writes a
+/// `cast.quest.phase_edited` event so a future re-attach can rebuild the
+/// user's sub-prompt verbatim. When `None` (typically before phase 0
+/// dispatches), edits are applied in-memory only — replay will fall back
+/// to the composed sub-prompt for that phase.
 fn run_phase_interaction<R>(
     quest: &mut Quest,
     idx: usize,
+    anchor_session_id: Option<&str>,
     reader: &mut R,
 ) -> Result<PhaseInteraction>
 where
@@ -759,7 +795,18 @@ where
         let line = reader(&prompt)?;
         match parse_phase_action(&line) {
             PhaseInteraction::Edit { sub_prompt } => {
-                set_phase_sub_prompt(quest, idx, sub_prompt)?;
+                set_phase_sub_prompt(quest, idx, sub_prompt.clone())?;
+                if let Some(anchor) = anchor_session_id {
+                    write_quest_event(
+                        anchor,
+                        CAST_QUEST_PHASE_EDITED_KIND,
+                        serde_json::json!({
+                            "phase": phase_name,
+                            "index": idx,
+                            "sub_prompt": sub_prompt,
+                        }),
+                    );
+                }
                 println!();
                 print!("{}", render_quest_handoff(quest, idx));
                 println!();
@@ -1226,13 +1273,37 @@ fn attach_via_daemon(
     // the user can see what the prior run was about. Live attaches just wrote
     // the summary themselves, so showing it again would only echo the exit
     // line we already printed. We also use the same history query to detect
-    // a quest anchor (Phase 7 minimal re-attach aid — detect + inform).
+    // a quest anchor and (Phase 9) to *resume* the quest loop at the next
+    // pending phase when the user attaches mid-quest.
     if !is_live {
         let history = client.list_events(ChatEventQuery {
             session_id: &session.id,
             after_seq: None,
             limit: None,
         })?;
+
+        // Phase 9: if this session is a quest anchor with work left, hand
+        // off to the resume loop. The returned outcome replaces the
+        // standard attach outcome — the quest is the user's foreground
+        // activity now. Completed quests fall through to the
+        // detect-and-inform note that Phase 7 introduced.
+        if let Some(reconstructed) = cast::reconstruct_quest(&history) {
+            if !reconstructed.is_complete && reconstructed.quest.current_index().is_some() {
+                println!();
+                println!(
+                    "Cast resuming quest `{}` from phase {}/{} …",
+                    reconstructed.quest.title,
+                    reconstructed
+                        .quest
+                        .current_index()
+                        .map(|i| i + 1)
+                        .unwrap_or(reconstructed.quest.phases.len()),
+                    reconstructed.quest.phases.len(),
+                );
+                return resume_cast_quest(reconstructed, request_text.to_string());
+            }
+        }
+
         if let Some(note) = cast::find_cast_summary(&history).and_then(|s| format_summary_note(&s))
         {
             notes.push(note);
@@ -1489,7 +1560,7 @@ mod quest_interaction_tests {
     fn run_phase_interaction_returns_approve_on_empty_input() {
         let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
         let mut reader = scripted_reader(vec![""]);
-        let action = run_phase_interaction(&mut quest, 0, &mut reader).unwrap();
+        let action = run_phase_interaction(&mut quest, 0, None, &mut reader).unwrap();
         assert_eq!(action, PhaseInteraction::Approve);
     }
 
@@ -1500,7 +1571,7 @@ mod quest_interaction_tests {
         // First line is an edit → second line skips. The function must
         // apply the edit, mark the phase as user-edited, then return Skip.
         let mut reader = scripted_reader(vec!["draft just the headlines", "/skip already covered"]);
-        let action = run_phase_interaction(&mut quest, 0, &mut reader).unwrap();
+        let action = run_phase_interaction(&mut quest, 0, None, &mut reader).unwrap();
         assert_eq!(
             action,
             PhaseInteraction::Skip {
@@ -1516,7 +1587,7 @@ mod quest_interaction_tests {
     fn run_phase_interaction_returns_cancel_with_default_reason() {
         let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
         let mut reader = scripted_reader(vec!["/cancel"]);
-        let action = run_phase_interaction(&mut quest, 0, &mut reader).unwrap();
+        let action = run_phase_interaction(&mut quest, 0, None, &mut reader).unwrap();
         match action {
             PhaseInteraction::Cancel { reason } => {
                 assert!(!reason.is_empty(), "default reason should be non-empty");

--- a/docs/design/cast-quest-flow.md
+++ b/docs/design/cast-quest-flow.md
@@ -157,10 +157,20 @@ After Phase 7 auto-advance landed, Phase 8 wired the §5 approve / edit / skip /
 
 The Edit flow is intentionally a **single-line full replacement** because the per-phase prompt is one line of cooked stdin. Pasting a multi-line block typically arrives as one line on the prompt; for richer multi-line editing the user can use `$EDITOR` outside Cast and paste back. A future phase could swap in a multi-line editor surface.
 
-## 9. Deferred to a later phase
+## 9. Re-attach quest resume (Phase 9)
 
-Three §7 deferrals from Phase 7 are still open:
+Phase 7's `/attach <anchor>` only printed a one-line note when a session belonged to a quest. Phase 9 replays the anchor's event log into a live `Quest` and resumes the phase loop where the user left off.
 
-- **Full re-attach state rebuild.** `/attach <anchor>` currently prints a one-line note ("phase N/M, in progress / complete"). Replaying `cast.quest.*` events to reconstruct a `Quest` and re-render the next handoff card is the long pole and a separate phase.
+- **`reconstruct_quest`** (in `tui/cast/attach.rs`) — pure function. Reads `cast.quest.started` for the goal + harness + phase names, then walks subsequent `cast.quest.{phase_completed, phase_skipped, phase_edited, completed}` events in order, applying each to a fresh `quest_from_goal` build. Returns a `ReconstructedQuest { quest, is_complete, anchor_session_id }`. Malformed payloads and out-of-range indices are skipped silently so a corrupt event log never blocks the resume path.
+- **`cast.quest.phase_edited`** event was added in Phase 9 so user edits persist across re-attaches. Written from inside `run_phase_interaction` whenever an anchor is already established (phase 1+). Edits made before phase 0 dispatches still apply in-memory but fall back to the composed sub-prompt on replay.
+- **`resume_cast_quest`** (in `tui/shell.rs`) — accepts a `ReconstructedQuest` and a request label, then hands off to the shared `run_quest_loop` extracted from `dispatch_cast_quest`. Resumed quests and fresh quests share every side effect (gate, dispatch, advance, event writes) from the first surviving pending phase onward.
+- **`attach_via_daemon` routing** — when a non-live attach lands on an anchor session and the reconstructed quest has work left, control flow returns the resume outcome directly. Completed quests still render the Phase 7 detect-and-inform note alongside the standard `cast.summary` line.
+
+The event-kind constants live in `tui/cast/quest.rs` (`CAST_QUEST_*_KIND`) and are consumed by both the writer in `tui/shell.rs` and the reconstructor in `tui/cast/attach.rs`, so the two halves stay in sync by construction.
+
+## 10. Deferred to a later phase
+
+Two §7 deferrals are still open:
+
 - **Local-PTY fallback ledger.** Quest event writes are best-effort and skipped silently when `dispatch_cast_launch` falls back to the synchronous local PTY path (no daemon, no session id, no anchor). Re-attach will not find a quest there.
 - **`QuestPhaseStatus::Running` transition.** The shell loop transitions Pending → Complete directly (synchronous dispatch). A future async / detached-quest UX would set Running between the two.


### PR DESCRIPTION
## Summary

- Closes the largest §9 deferral from Phase 8: \`coven attach <anchor>\` now replays the anchor's event log into a live \`Quest\` and resumes the per-phase loop where the user left off.
- New pure \`reconstruct_quest\` in \`tui/cast/attach.rs\` returns a \`ReconstructedQuest { quest, is_complete, anchor_session_id }\` from events, walking \`cast.quest.{phase_edited, phase_completed, phase_skipped, completed}\` in order. Malformed payloads and out-of-range indices are skipped silently so a corrupt event log never blocks resume.
- Adds the missing \`cast.quest.phase_edited\` event (written from \`run_phase_interaction\` whenever the anchor is established) so user edits persist across re-attaches.
- Extracts a shared \`run_quest_loop\` from \`dispatch_cast_quest\`; fresh and resumed quests share every side effect from the first surviving pending phase onward.
- Consolidates the seven \`cast.quest.*_KIND\` constants in \`tui/cast/quest.rs\` as \`pub(crate)\` so writer + reader can't drift.

## Routing decision (in \`attach_via_daemon\`)

| Session shape | Behavior |
| --- | --- |
| Live quest anchor (rare; user attaches mid-phase from another shell) | Keep existing live-attach flow; quest resume is non-live only |
| Non-live anchor, quest has work left | Replace the standard attach outcome with \`resume_cast_quest(reconstructed)\` |
| Non-live anchor, quest already complete | Keep the Phase 7 detect-and-inform note alongside the \`cast.summary\` line |
| Non-quest session | Unchanged \`cast.summary\` rendering |

## Gate results

- \`cargo fmt --all -- --check\` — clean
- \`cargo clippy -p coven-cli --tests --no-deps -- -D warnings\` — clean
- \`cargo test -p coven-cli\` — 340 unit + 4 smoke, 0 failures (7 new reconstructor tests)

## Still deferred (\`cast-quest-flow.md\` §10)

- **Local-PTY fallback ledger.** Quest event writes still require a daemon-backed session; the fallback path runs but writes no events.
- **\`QuestPhaseStatus::Running\` transition.** Loop transitions Pending → Complete directly; \`Running\` is reserved for a future async / detached-quest UX.

## Test plan

- [ ] Start a quest with \`/quest fix the failing tests\`, let phase 0 run to completion, then Ctrl-C before phase 1 dispatches. Run \`coven attach <anchor>\`. Expect Cast to print \"resuming quest \\\`fix the failing tests\\\` from phase 2/3\" and render the implement phase's handoff card.
- [ ] Same setup but after phase 1's handoff card, type a one-line replacement sub-prompt and Ctrl-C. Re-attach: the implement phase's handoff card should display the **edited** sub-prompt verbatim, with the \`edited\` indicator on the delegate row.
- [ ] Run a quest to full completion. \`coven attach <anchor>\` — expect the Phase 7 detect-and-inform note (\"Quest anchor — ... complete\"), no resume.
- [ ] Run a quest, skip the verify phase with \`/skip already in CI\`, let the quest finish. Re-attach: the existing one-line note still renders.
- [ ] Attach to a non-quest session — no behavioral change vs. Phase 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)