### PR TITLE
cast(phase 10): local-PTY ledger + Running state — close the §10 list

### DIFF
--- a/crates/coven-cli/src/tui/cast/attach.rs
+++ b/crates/coven-cli/src/tui/cast/attach.rs
@@ -11,8 +11,9 @@ use crate::store;
 
 use super::intent::CastHarness;
 use super::quest::{
-    advance, quest_from_goal, set_phase_sub_prompt, skip_phase, Quest, QuestPhaseSummary,
-    CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
+    advance, mark_phase_running, quest_from_goal, set_phase_sub_prompt, skip_phase, Quest,
+    QuestPhaseSummary, CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
+    CAST_QUEST_PHASE_STARTED_KIND,
 };
 
 /// Event kind Cast writes when a launched session finishes. See
@@ -140,6 +141,26 @@ pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<Reconst
 
     for event in events {
         match event.kind.as_str() {
+            kind if kind == CAST_QUEST_PHASE_STARTED_KIND => {
+                // Phase 10 defensive: if Cast crashed between dispatch and
+                // advance, the anchor will hold a `phase_started` event
+                // without a matching `phase_completed`. Mark the phase
+                // Running so resume can show "this phase was already
+                // started". When a `phase_completed` later in the log
+                // exists, `advance` below overwrites the status to
+                // Complete and the Running mark becomes invisible.
+                let payload =
+                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+                let idx = payload.get("index").and_then(Value::as_u64);
+                let session_id = payload
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                if let Some(idx) = idx {
+                    let _ = mark_phase_running(&mut quest, idx as usize, session_id);
+                }
+            }
             kind if kind == CAST_QUEST_PHASE_EDITED_KIND => {
                 let payload =
                     serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
@@ -687,6 +708,57 @@ mod tests {
         let recon = reconstruct_quest(&events).expect("should reconstruct");
         assert!(recon.is_complete);
         assert_eq!(recon.quest.cursor, 3, "cursor should be past all phases");
+    }
+
+    fn phase_started_event(seq: i64, idx: usize, session_id: &str) -> store::EventRecord {
+        store::EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: "anchor".to_string(),
+            kind: CAST_QUEST_PHASE_STARTED_KIND.to_string(),
+            payload_json: serde_json::json!({
+                "phase": format!("p{idx}"),
+                "index": idx,
+                "session_id": session_id,
+                "harness": "codex",
+            })
+            .to_string(),
+            created_at: "2026-05-20T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn reconstruct_quest_marks_phase_running_when_started_without_completed() {
+        // Cast crashed between dispatch and advance: phase_started landed
+        // on the anchor but phase_completed never did. Reconstruction
+        // must mark the phase Running so resume can surface that.
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 10", "codex"),
+            phase_started_event(2, 0, "session-design-id"),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        match &recon.quest.phases[0].status {
+            super::super::quest::QuestPhaseStatus::Running { session_id } => {
+                assert_eq!(session_id, "session-design-id");
+            }
+            other => panic!("expected Running, got {other:?}"),
+        }
+        assert_eq!(recon.quest.cursor, 0);
+    }
+
+    #[test]
+    fn reconstruct_quest_overrides_running_with_complete_when_phase_completed_follows() {
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 10", "codex"),
+            phase_started_event(2, 0, "session-design-id"),
+            phase_completed_event(3, 0, "completed", 0),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        assert!(matches!(
+            recon.quest.phases[0].status,
+            super::super::quest::QuestPhaseStatus::Complete(_)
+        ));
+        assert_eq!(recon.quest.cursor, 1);
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -34,11 +34,11 @@ pub(crate) use intent::{parse_spell, CastHarness, CastIntent};
 pub(crate) use outcome::CastOutcome;
 pub(crate) use plan::{build_plan, CastPlan};
 pub(crate) use quest::{
-    advance as advance_quest, parse_phase_action, quest_from_goal, set_phase_sub_prompt,
-    skip_phase, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus, QuestPhaseSummary,
-    CAST_QUEST_ADVANCED_KIND, CAST_QUEST_COMPLETED_KIND, CAST_QUEST_PHASE_COMPLETED_KIND,
-    CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND, CAST_QUEST_PHASE_STARTED_KIND,
-    CAST_QUEST_STARTED_KIND,
+    advance as advance_quest, mark_phase_running, parse_phase_action, quest_from_goal,
+    set_phase_sub_prompt, skip_phase, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus,
+    QuestPhaseSummary, CAST_QUEST_ADVANCED_KIND, CAST_QUEST_COMPLETED_KIND,
+    CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
+    CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
 };
 // `compose_sub_prompt` and `QuestHandoff` are exercised by the in-module
 // test suite; they remain in the public crate surface so a future async /

--- a/crates/coven-cli/src/tui/cast/quest.rs
+++ b/crates/coven-cli/src/tui/cast/quest.rs
@@ -288,6 +288,34 @@ pub(crate) fn set_phase_sub_prompt(
     Ok(())
 }
 
+/// Transition a Pending phase to Running, recording the daemon session
+/// id Cast just launched it as. The shell loop calls this immediately
+/// after `dispatch_cast_launch` returns and before `advance` writes the
+/// final summary, so any reconstructor that sees a `phase_started` event
+/// without a matching `phase_completed` can mark the phase Running
+/// instead of leaving it Pending.
+///
+/// Errors when the phase is not Pending. Cast does not "restart" a phase
+/// that already completed or was skipped.
+pub(crate) fn mark_phase_running(
+    quest: &mut Quest,
+    index: usize,
+    session_id: String,
+) -> Result<()> {
+    let phase = quest
+        .phases
+        .get_mut(index)
+        .ok_or_else(|| anyhow!("quest phase index {index} out of range"))?;
+    if !matches!(phase.status, QuestPhaseStatus::Pending) {
+        return Err(anyhow!(
+            "phase `{}` is not pending; only pending phases can be marked running",
+            phase.name
+        ));
+    }
+    phase.status = QuestPhaseStatus::Running { session_id };
+    Ok(())
+}
+
 /// Skip a pending phase with a recorded reason. Useful when the prior
 /// phase already satisfied this phase's goal (e.g. tests passed during
 /// implement, so verify becomes a no-op).
@@ -654,6 +682,32 @@ mod tests {
 
         let label = phase_status_label(&QuestPhaseSummary::default());
         assert_eq!(label, "complete");
+    }
+
+    #[test]
+    fn mark_phase_running_transitions_pending_to_running_with_session_id() {
+        let mut q = quest("ship phase 10");
+        mark_phase_running(&mut q, 0, "session-design".to_string()).unwrap();
+        match &q.phases[0].status {
+            QuestPhaseStatus::Running { session_id } => {
+                assert_eq!(session_id, "session-design");
+            }
+            other => panic!("expected Running, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mark_phase_running_rejects_non_pending_phases() {
+        let mut q = quest("ship phase 10");
+        // First mark phase 0 Running, then try again — should fail.
+        mark_phase_running(&mut q, 0, "session-design".to_string()).unwrap();
+        let err = mark_phase_running(&mut q, 0, "session-again".to_string()).unwrap_err();
+        assert!(err.to_string().contains("not pending"));
+
+        // Skipped phases also reject.
+        skip_phase(&mut q, 2, "tested in CI".to_string()).unwrap();
+        let err = mark_phase_running(&mut q, 2, "session-verify".to_string()).unwrap_err();
+        assert!(err.to_string().contains("not pending"));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -14,13 +14,13 @@ use uuid::Uuid;
 
 use super::cast::{
     self, advance_quest, build_plan, evaluate_gate, find_cast_summary, follow_until_exit,
-    format_summary_note, parse_phase_action, quest_from_goal, render_cast_frame_for_terminal,
-    render_outcome, render_plan_intro, render_quest_handoff, set_phase_sub_prompt, skip_phase,
-    CastHarness, CastIntent, CastOutcome, CastPlan, CastSessionExit, FollowerObserver,
-    FollowerPacer, GateOutcome, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus,
-    QuestPhaseSummary, SafetyDecision, CAST_QUEST_ADVANCED_KIND, CAST_QUEST_COMPLETED_KIND,
-    CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
-    CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
+    format_summary_note, mark_phase_running, parse_phase_action, quest_from_goal,
+    render_cast_frame_for_terminal, render_outcome, render_plan_intro, render_quest_handoff,
+    set_phase_sub_prompt, skip_phase, CastHarness, CastIntent, CastOutcome, CastPlan,
+    CastSessionExit, FollowerObserver, FollowerPacer, GateOutcome, PhaseInteraction, Quest,
+    QuestPhase, QuestPhaseStatus, QuestPhaseSummary, SafetyDecision, CAST_QUEST_ADVANCED_KIND,
+    CAST_QUEST_COMPLETED_KIND, CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_PHASE_EDITED_KIND,
+    CAST_QUEST_PHASE_SKIPPED_KIND, CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
 };
 use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
 use super::{is_key_press, sessions};
@@ -516,7 +516,72 @@ fn dispatch_cast_quest(plan: &CastPlan, goal: &str) -> Result<CastOutcome> {
     let default_harness = plan.harness.map(|h| h.harness);
     let quest = quest_from_goal(goal, default_harness);
     let request_text = outcome_request_text(plan);
-    run_quest_loop(quest, None, default_harness, goal, request_text)
+
+    // Phase 10: in the daemon-running path, the anchor is established
+    // lazily by phase 0's session (same as Phase 7). In the local-PTY
+    // fallback path there is no daemon session to inherit, so synthesize
+    // a `quest-<uuid>` row up front. Both paths reach `run_quest_loop`
+    // with the same shape; only the anchor's origin differs.
+    let initial_anchor = match daemon_runtime_state()? {
+        DaemonRuntimeState::Running => None,
+        DaemonRuntimeState::NotReady(_) => {
+            Some(create_local_quest_anchor(&quest, default_harness)?)
+        }
+    };
+
+    run_quest_loop(quest, initial_anchor, default_harness, goal, request_text)
+}
+
+/// Insert a synthetic `quest-<uuid>` row into the local sessions table
+/// and write `cast.quest.started` to it. Returns the anchor session id
+/// so `run_quest_loop` can attach later `cast.quest.*` events.
+///
+/// The synthetic session has `harness = "cast-quest"` so a future
+/// session-browser filter can hide it from the main list if we want; for
+/// now it is visible (and labelled "Quest: <title>") so power users can
+/// inspect the event log directly.
+fn create_local_quest_anchor(
+    quest: &Quest,
+    default_harness: Option<CastHarness>,
+) -> Result<String> {
+    let id = format!("quest-{}", Uuid::new_v4());
+    let project_root = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| project::canonical_project_root(&cwd).ok())
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "(unknown)".to_string());
+    let store_path = coven_store_path()?;
+    let conn = store::open_store(&store_path)?;
+    let timestamp = current_timestamp();
+    let record = store::SessionRecord {
+        id: id.clone(),
+        project_root,
+        harness: "cast-quest".to_string(),
+        title: format!("Quest: {}", quest.title),
+        status: "active".to_string(),
+        exit_code: None,
+        archived_at: None,
+        created_at: timestamp.clone(),
+        updated_at: timestamp.clone(),
+    };
+    store::insert_session(&conn, &record)?;
+    let harness_label = default_harness
+        .map(|h| h.id().to_string())
+        .unwrap_or_else(|| "(unset)".to_string());
+    store::insert_json_event(
+        &conn,
+        &id,
+        CAST_QUEST_STARTED_KIND,
+        &serde_json::json!({
+            "title": quest.title,
+            "goal": quest.goal,
+            "harness": harness_label,
+            "phases": quest.phases.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
+            "synthetic": true,
+        }),
+        &timestamp,
+    )?;
+    Ok(id)
 }
 
 /// Resume a quest from a [`ReconstructedQuest`] decoded out of the
@@ -695,6 +760,19 @@ fn run_quest_loop(
                 }),
             );
         }
+
+        // Phase 10: explicit Pending → Running transition. The shell loop
+        // dispatches synchronously so Running is held for a fraction of a
+        // second before `advance` writes Complete, but the transition
+        // matters for the reconstructor: if Cast crashes between dispatch
+        // and advance, replay sees phase_started without phase_completed
+        // and can mark the phase Running. Empty session id (local-PTY
+        // fallback) is preserved as-is — the reconstructor accepts it.
+        let _ = mark_phase_running(
+            &mut quest,
+            idx,
+            phase_session_id.clone().unwrap_or_default(),
+        );
 
         let summary = phase_summary_from_session(phase_session_id.as_deref());
         completed_notes.push(format_phase_note(&quest.phases[idx].name, &summary));

--- a/docs/design/cast-quest-flow.md
+++ b/docs/design/cast-quest-flow.md
@@ -168,9 +168,34 @@ Phase 7's `/attach <anchor>` only printed a one-line note when a session belonge
 
 The event-kind constants live in `tui/cast/quest.rs` (`CAST_QUEST_*_KIND`) and are consumed by both the writer in `tui/shell.rs` and the reconstructor in `tui/cast/attach.rs`, so the two halves stay in sync by construction.
 
-## 10. Deferred to a later phase
+## 10. Loose-end closeouts (Phase 10)
 
-Two §7 deferrals are still open:
+The two §7 deferrals that survived Phase 9 are now closed.
 
-- **Local-PTY fallback ledger.** Quest event writes are best-effort and skipped silently when `dispatch_cast_launch` falls back to the synchronous local PTY path (no daemon, no session id, no anchor). Re-attach will not find a quest there.
-- **`QuestPhaseStatus::Running` transition.** The shell loop transitions Pending → Complete directly (synchronous dispatch). A future async / detached-quest UX would set Running between the two.
+### 10.1 Local-PTY fallback ledger
+
+When `dispatch_cast_quest` detects that the daemon is **not** running, it now synthesizes a `quest-<uuid>` row in the local `sessions` table via `create_local_quest_anchor` and uses it as the anchor for every `cast.quest.*` event in that quest. The synthetic session has:
+
+- `harness = "cast-quest"` (distinguishes it from a real harness session; a future browser filter can hide it).
+- `title = "Quest: <quest.title>"`.
+- `project_root` derived from the user's cwd (falls back to `(unknown)` if no project root resolves).
+- A `cast.quest.started` event with `synthetic: true` in the payload.
+
+Subsequent phases that run via the local PTY fallback still carry `session_id: null` in their `cast.quest.phase_*` payloads (there is no daemon session id to record), but the anchor's event log is complete enough for `reconstruct_quest` to replay state and for `coven attach <quest-id>` to resume.
+
+### 10.2 `QuestPhaseStatus::Running` transition
+
+The shell loop now calls `mark_phase_running(quest, idx, session_id)` between `dispatch_cast_launch` returning and `advance` writing the summary. In synchronous flow the Running state is held for a fraction of a second before advance overwrites it with Complete, but the transition is meaningful for replay:
+
+- The reconstructor in `cast/attach.rs` now applies the same transition on `cast.quest.phase_started` events. If Cast crashed between dispatch and advance, the anchor will hold a `phase_started` without a matching `phase_completed`; replay leaves that phase Running so resume can surface "this phase was already started".
+- If a later `phase_completed` event exists, the reconstructor's `advance` call overwrites Running with Complete — the Running mark is invisible on the happy path.
+
+`mark_phase_running` errors if the phase is not currently Pending, which prevents accidental re-marking on resumed quests.
+
+## 11. Future work
+
+No further open deferrals from §7/§8/§9 remain. Items that could be picked up later but were never on the §7 list:
+
+- **Multi-line edit UX** for `set_phase_sub_prompt`. The Phase 8 single-line replacement still applies; an `$EDITOR`-integrated path would let users author longer sub-prompts without paste-as-one-line tricks.
+- **Browser filter for synthetic quest anchors.** The Phase 10 `cast-quest` harness rows currently show up in `coven sessions` listings. Filtering them by default (with `--all` to reveal) would clean up the browser for users who run many local-PTY quests.
+- **Async / detached quests.** The Running state is now real but only transient. A future async UX could leave a quest in Running while Cast detaches, then advance later from a callback.


### PR DESCRIPTION
## Summary

Closes both remaining §10 deferrals from `cast-quest-flow.md`:

1. **Local-PTY fallback ledger** — `dispatch_cast_quest` now synthesizes a `quest-<uuid>` row in the local sessions table when the daemon is not running, so `cast.quest.*` events land in the local ledger and a future `coven attach <quest-id>` can resume the quest even from a fallback run.
2. **\`QuestPhaseStatus::Running\` transition** — the shell loop now calls `mark_phase_running` between `dispatch_cast_launch` returning and `advance` writing the summary. In synchronous flow the Running state is transient; the value is for replay, where the reconstructor now marks crashed-mid-phase work Running instead of leaving it Pending.

## Synthetic anchor shape

In local-PTY fallback the new `create_local_quest_anchor` writes a sessions row with:

- `id = "quest-<uuid>"`
- `harness = "cast-quest"` (a sentinel a future browser filter can hide)
- `title = "Quest: <quest.title>"`
- `project_root` from the user's cwd (falls back to `(unknown)`)

And a `cast.quest.started` event with `synthetic: true` so reconstructors can distinguish a fallback anchor from a daemon one.

## Reconstructor change

`reconstruct_quest` now handles `cast.quest.phase_started` defensively: when present without a matching `phase_completed`, the phase is marked Running with the recorded session id. A later `phase_completed` overwrites Running with Complete via the existing `advance` call, so the Running mark is invisible on the happy path.

## Gate results

- \`cargo fmt --all -- --check\` — clean
- \`cargo clippy -p coven-cli --tests --no-deps -- -D warnings\` — clean
- \`cargo test -p coven-cli\` — 344 unit + 4 smoke, 0 failures (4 new tests this phase: 2 mark_phase_running, 2 reconstructor Running)

## Future work (no longer "deferred")

`cast-quest-flow.md` §11 lists items that were never on the §7 deferral list:

- Multi-line edit UX (Phase 8 single-line replacement still applies)
- Browser filter for synthetic `cast-quest` anchors
- Async / detached quests using the now-real Running state

## Test plan

- [ ] Stop the daemon (\`coven daemon stop\`). Run \`/quest fix the failing tests\` from the launcher. Expect three phases to dispatch via local PTY. After the quest completes, run \`coven sessions --all\` and confirm a \`cast-quest\` row appears with title \`Quest: fix the failing tests\`.
- [ ] Run \`coven attach <quest-id>\` on that synthetic anchor. Expect the existing Phase 9 detect-and-inform note (since the quest completed).
- [ ] Start the daemon, run another quest. Kill Cast (Ctrl-C) mid-phase, after phase 0 dispatched. Run \`coven attach <phase-0-session-id>\`. Expect Phase 9 resume to render the implement phase's handoff card. The reconstructed quest should show phase 0 as Complete (it finished before the crash) — if the kill landed precisely between dispatch and advance, the new Running state would surface instead.
- [ ] Confirm no regression in fully-daemon happy path: \`/quest fix the failing tests\` with daemon up. All three phases land, sessions in browser look normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)