### PR TITLE
feat: make Coven terminal chat-first

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -25,7 +25,7 @@ mod tui;
 mod verification;
 
 const DEFAULT_COVEN_HOME_DIR: &str = ".coven";
-const STORE_FILE_NAME: &str = "coven.sqlite3";
+pub(crate) const STORE_FILE_NAME: &str = "coven.sqlite3";
 const DEFAULT_SESSION_STATUS: &str = "created";
 const RUNNING_SESSION_STATUS: &str = "running";
 const FAILED_SESSION_STATUS: &str = "failed";
@@ -876,7 +876,7 @@ fn joined_prompt(prompt_args: &[String]) -> Result<String> {
     Ok(prompt.to_string())
 }
 
-fn current_timestamp() -> String {
+pub(crate) fn current_timestamp() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -41,6 +41,14 @@ const DEFAULT_TITLE_CHARS: usize = 48;
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
+    #[arg(
+        value_name = "PROMPT",
+        num_args = 0..,
+        trailing_var_arg = true,
+        allow_hyphen_values = true,
+        help = "Task to run through Cast when no subcommand is provided"
+    )]
+    prompt: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -135,12 +143,24 @@ enum DaemonCommand {
     Serve,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InteractiveShellRoute {
+    Chat,
+    PlainCast,
+}
+
 fn main() -> Result<()> {
     let cli = Cli::parse();
+    run_cli(cli)
+}
+
+fn run_cli(cli: Cli) -> Result<()> {
+    if cli.command.is_none() && !cli.prompt.is_empty() {
+        return run_bare_prompt(&cli.prompt);
+    }
+
     match cli.command {
-        None => tui::shell::run(),
-        Some(Command::Chat) => tui::chat::run_chat(),
-        Some(Command::Tui) => tui::shell::run(),
+        None | Some(Command::Chat) | Some(Command::Tui) => run_shared_interactive_shell(),
         Some(Command::Doctor) => run_doctor(),
         Some(Command::Daemon { command }) => run_daemon_command(command),
         Some(Command::Run {
@@ -162,6 +182,30 @@ fn main() -> Result<()> {
         Some(Command::Sacrifice { session_id, yes }) => sacrifice_session_command(&session_id, yes),
         Some(Command::Patch { command }) => run_patch_command(command),
         Some(Command::Pc { command }) => pc::run_pc_command(command),
+    }
+}
+
+fn run_bare_prompt(prompt: &[String]) -> Result<()> {
+    let prompt = joined_prompt(prompt)?;
+    tui::shell::run_cast_spell(&prompt)
+}
+
+fn run_shared_interactive_shell() -> Result<()> {
+    match interactive_shell_route(None, io::stdin().is_terminal(), io::stdout().is_terminal()) {
+        InteractiveShellRoute::Chat => tui::chat::run_chat(),
+        InteractiveShellRoute::PlainCast => tui::shell::run(),
+    }
+}
+
+fn interactive_shell_route(
+    _command: Option<&Command>,
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> InteractiveShellRoute {
+    if stdin_is_terminal && stdout_is_terminal {
+        InteractiveShellRoute::Chat
+    } else {
+        InteractiveShellRoute::PlainCast
     }
 }
 
@@ -971,6 +1015,15 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_bare_prompt_as_cast_spell() {
+        let parsed = Cli::try_parse_from(["coven", "fix tests"])
+            .expect("bare prompt should be accepted for script-friendly Cast input");
+
+        assert!(parsed.command.is_none());
+        assert_eq!(parsed.prompt, vec!["fix tests"]);
+    }
+
+    #[test]
     fn cli_accepts_explicit_tui_command() {
         let cli = Cli::parse_from(["coven", "tui"]);
 
@@ -988,6 +1041,38 @@ mod tests {
             Some(Command::Chat) => {}
             other => panic!("expected chat command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn default_tui_and_chat_use_shared_chat_shell_for_interactive_terminals() {
+        assert_eq!(
+            interactive_shell_route(None, true, true),
+            InteractiveShellRoute::Chat
+        );
+        assert_eq!(
+            interactive_shell_route(Some(&Command::Tui), true, true),
+            InteractiveShellRoute::Chat
+        );
+        assert_eq!(
+            interactive_shell_route(Some(&Command::Chat), true, true),
+            InteractiveShellRoute::Chat
+        );
+    }
+
+    #[test]
+    fn default_tui_and_chat_keep_plain_cast_output_for_pipes() {
+        assert_eq!(
+            interactive_shell_route(None, true, false),
+            InteractiveShellRoute::PlainCast
+        );
+        assert_eq!(
+            interactive_shell_route(Some(&Command::Tui), false, true),
+            InteractiveShellRoute::PlainCast
+        );
+        assert_eq!(
+            interactive_shell_route(Some(&Command::Chat), false, false),
+            InteractiveShellRoute::PlainCast
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/follow.rs
+++ b/crates/coven-cli/src/tui/cast/follow.rs
@@ -275,6 +275,18 @@ mod tests {
         fn kill_session(&mut self, _session_id: &str) -> Result<()> {
             unimplemented!("not exercised in follower tests")
         }
+
+        fn archive_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised in follower tests")
+        }
+
+        fn summon_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised in follower tests")
+        }
+
+        fn sacrifice_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised in follower tests")
+        }
     }
 
     fn output_event(seq: i64, data: &str) -> store::EventRecord {

--- a/crates/coven-cli/src/tui/cast/intent.rs
+++ b/crates/coven-cli/src/tui/cast/intent.rs
@@ -64,6 +64,9 @@ pub(crate) enum CastIntent {
     ArchiveSession {
         session_id: String,
     },
+    KillSession {
+        session_id: String,
+    },
     SacrificeSession {
         session_id: String,
     },
@@ -137,6 +140,9 @@ fn parse_slash_command(input: &str) -> Result<Option<CastIntent>> {
         })?,
         "/archive" => session_id_intent(rest, "/archive", |session_id| {
             CastIntent::ArchiveSession { session_id }
+        })?,
+        "/kill" => session_id_intent(rest, "/kill", |session_id| CastIntent::KillSession {
+            session_id,
         })?,
         "/sacrifice" => session_id_intent(rest, "/sacrifice", |session_id| {
             CastIntent::SacrificeSession { session_id }
@@ -478,6 +484,12 @@ mod tests {
         assert_eq!(
             intent("/archive abc"),
             CastIntent::ArchiveSession {
+                session_id: "abc".to_string()
+            }
+        );
+        assert_eq!(
+            intent("/kill abc"),
+            CastIntent::KillSession {
                 session_id: "abc".to_string()
             }
         );

--- a/crates/coven-cli/src/tui/cast/plan.rs
+++ b/crates/coven-cli/src/tui/cast/plan.rs
@@ -64,6 +64,7 @@ pub(crate) enum CastStepKind {
     Attach,
     Summon,
     Archive,
+    Kill,
     Sacrifice,
     Diagnose,
     Inform,
@@ -126,6 +127,14 @@ where
             CastStep::new(
                 CastStepKind::Archive,
                 "Hide the session from the active list; keep events",
+            ),
+        ),
+        CastIntent::KillSession { ref session_id } => simple_plan(
+            intent.clone(),
+            &format!("Kill live session {}", short_id(session_id)),
+            CastStep::new(
+                CastStepKind::Kill,
+                "Ask the daemon to stop the live session",
             ),
         ),
         CastIntent::SacrificeSession { ref session_id } => {
@@ -357,7 +366,8 @@ fn simple_plan(intent: CastIntent, headline: &str, step: CastStep) -> CastPlan {
     let session_id = match &intent {
         CastIntent::AttachSession { session_id }
         | CastIntent::SummonSession { session_id }
-        | CastIntent::ArchiveSession { session_id } => Some(session_id.clone()),
+        | CastIntent::ArchiveSession { session_id }
+        | CastIntent::KillSession { session_id } => Some(session_id.clone()),
         _ => None,
     };
     CastPlan {
@@ -556,6 +566,24 @@ mod tests {
             .iter()
             .any(|step| step.kind == CastStepKind::Attach));
         assert!(plan.headline.contains("abcdef123456"));
+    }
+
+    #[test]
+    fn kill_intent_records_session_id_in_plan() {
+        let plan = build_plan(
+            CastIntent::KillSession {
+                session_id: "abcdef123456".to_string(),
+            },
+            codex,
+        )
+        .unwrap();
+
+        assert_eq!(plan.session_id.as_deref(), Some("abcdef123456"));
+        assert!(plan
+            .steps
+            .iter()
+            .any(|step| step.kind == CastStepKind::Kill));
+        assert_eq!(plan.risk(), CastRisk::Safe);
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/render.rs
+++ b/crates/coven-cli/src/tui/cast/render.rs
@@ -461,6 +461,7 @@ fn step_kind_label(kind: CastStepKind) -> &'static str {
         CastStepKind::Attach => "attach",
         CastStepKind::Summon => "summon",
         CastStepKind::Archive => "archive",
+        CastStepKind::Kill => "kill",
         CastStepKind::Sacrifice => "sacrifice",
         CastStepKind::Diagnose => "diagnose",
         CastStepKind::Inform => "inform",

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -63,6 +63,7 @@ pub(super) struct App {
     pub(super) scroll_offset: usize,
     pub(super) agents: Vec<AgentInfo>,
     pub(super) active_agent: Option<usize>,
+    project_label: String,
     pub(super) input_mode: InputMode,
     pub(super) agent_select_index: usize,
     pub(super) show_help: bool,
@@ -104,6 +105,7 @@ impl App {
             scroll_offset: 0,
             agents,
             active_agent,
+            project_label: current_project_label(),
             input_mode: InputMode::Normal,
             agent_select_index: 0,
             show_help: false,
@@ -191,6 +193,10 @@ impl App {
             .unwrap_or("—")
     }
 
+    pub(super) fn project_label(&self) -> &str {
+        &self.project_label
+    }
+
     pub(super) fn active_session_id(&self) -> Option<&str> {
         self.active_session_id.as_deref()
     }
@@ -210,12 +216,6 @@ impl App {
             let result = self.resolve_pending_cast_confirmation(&raw);
             self.scroll_to_bottom();
             return Some(result);
-        }
-
-        if is_confirmation_response(&raw) {
-            self.push_system_message("No Cast confirmation is pending.");
-            self.scroll_to_bottom();
-            return Some(SlashCommandResult::Handled);
         }
 
         let raw = self.cast_slash_with_context(&raw);
@@ -913,6 +913,12 @@ fn timestamp_now() -> String {
     chrono::Local::now().format("%H:%M").to_string()
 }
 
+fn current_project_label() -> String {
+    std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "unknown project".to_string())
+}
+
 fn split_first_arg(input: &str) -> Option<(&str, &str)> {
     let trimmed = input.trim();
     let split_idx = trimmed.find(char::is_whitespace)?;
@@ -945,13 +951,6 @@ fn is_chat_local_slash(input: &str) -> bool {
             | "/trace"
             | "/mem"
             | "/debug"
-    )
-}
-
-fn is_confirmation_response(input: &str) -> bool {
-    matches!(
-        input.trim().to_ascii_lowercase().as_str(),
-        "accept" | "approve" | "yes" | "y" | "reject" | "cancel" | "no" | "n"
     )
 }
 
@@ -1691,7 +1690,11 @@ mod tests {
         app.handle_input();
 
         assert!(app.pending_cast_confirmation.is_none());
-        assert!(mirror.launched.borrow().is_empty());
+        assert!(!mirror
+            .launched
+            .borrow()
+            .iter()
+            .any(|request| request.prompt == "publish the package"));
         assert!(app
             .messages
             .iter()
@@ -1757,6 +1760,32 @@ mod tests {
             .calls
             .borrow()
             .contains(&"input:session-1:next step\n".to_string()));
+    }
+
+    #[test]
+    fn confirmation_words_forward_to_active_session_without_pending_cast_confirmation() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Existing",
+            "running",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.attach_session("session-1");
+        app.input = "yes".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        assert!(mirror
+            .calls
+            .borrow()
+            .contains(&"input:session-1:yes\n".to_string()));
+        assert!(!app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("No Cast confirmation is pending")));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -3,7 +3,15 @@
 
 use std::time::{Duration, Instant};
 
-use crate::{harness, store};
+use crate::{
+    harness, store,
+    tui::cast::{
+        self, build_plan, parse_spell,
+        plan::{CastHarnessSource, CastPlan},
+        safety::{CastRisk, SafetyDecision},
+        CastHarness, CastIntent,
+    },
+};
 
 use super::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
 
@@ -66,10 +74,12 @@ pub(super) struct App {
     event_poll_backoff_until: Option<Instant>,
     event_poll_failure_streak: u32,
     last_event_poll_error: Option<String>,
+    event_poll_paused_for_api_mismatch: bool,
     pub(super) sessions: Vec<store::SessionRecord>,
     pub(super) show_session_overlay: bool,
     pub(super) input_history: Vec<String>,
     pub(super) history_index: Option<usize>,
+    pending_cast_confirmation: Option<CastPlan>,
     client: Box<dyn ChatClient>,
 }
 
@@ -82,7 +92,7 @@ impl App {
         Self::new_with_state(agents, active_agent, Box::<DaemonChatClient>::default())
     }
 
-    fn new_with_state(
+    pub(super) fn new_with_state(
         agents: Vec<AgentInfo>,
         active_agent: Option<usize>,
         client: Box<dyn ChatClient>,
@@ -105,24 +115,18 @@ impl App {
             event_poll_backoff_until: None,
             event_poll_failure_streak: 0,
             last_event_poll_error: None,
+            event_poll_paused_for_api_mismatch: false,
             sessions: Vec::new(),
             show_session_overlay: false,
             input_history: Vec::new(),
             history_index: None,
+            pending_cast_confirmation: None,
             client,
         };
 
-        app.push_system_message(
-            "Welcome to the Coven. Type a message to chat, or /help for commands.",
-        );
+        app.push_system_message("Ready. Type a task or /help.");
 
-        if let Some(idx) = app.active_agent {
-            let agent = &app.agents[idx];
-            app.push_system_message(&format!(
-                "Active agent: {} ({})",
-                agent.label, agent.harness
-            ));
-        } else {
+        if app.active_agent.is_none() {
             app.push_system_message("No agents available. Run `coven doctor` to check your setup.");
         }
 
@@ -200,12 +204,34 @@ impl App {
             return Some(SlashCommandResult::Handled);
         }
 
-        if raw.starts_with('/') {
+        self.event_poll_paused_for_api_mismatch = false;
+
+        if self.pending_cast_confirmation.is_some() {
+            let result = self.resolve_pending_cast_confirmation(&raw);
+            self.scroll_to_bottom();
+            return Some(result);
+        }
+
+        if is_confirmation_response(&raw) {
+            self.push_system_message("No Cast confirmation is pending.");
+            self.scroll_to_bottom();
+            return Some(SlashCommandResult::Handled);
+        }
+
+        let raw = self.cast_slash_with_context(&raw);
+
+        if raw.starts_with('/') && is_chat_local_slash(&raw) {
             return Some(self.handle_slash_command(&raw));
         }
 
         self.record_history(&raw);
         self.push_user_message(&raw);
+        if raw.starts_with('/') {
+            let result = self.launch_chat_session(&raw);
+            self.scroll_to_bottom();
+            return Some(result);
+        }
+
         if let Some(session_id) = self.active_session_id.clone() {
             self.forward_input_to_session(&session_id, &raw);
         } else {
@@ -263,7 +289,7 @@ impl App {
                     self.push_system_message("Usage: /run <harness> <prompt>");
                     return SlashCommandResult::Handled;
                 };
-                self.run_harness_prompt(harness, prompt);
+                let _ = self.run_harness_prompt(harness, prompt);
                 SlashCommandResult::Handled
             }
             "/kill" => {
@@ -314,28 +340,140 @@ impl App {
         }
     }
 
-    fn launch_chat_session(&mut self, prompt: &str) {
-        let Some(agent) = self
-            .active_agent
-            .and_then(|idx| self.agents.get(idx))
-            .cloned()
-        else {
-            self.push_system_message(
-                "No active agent. Use /agent to select one, or run `coven doctor`.",
-            );
-            return;
+    fn launch_chat_session(&mut self, prompt: &str) -> SlashCommandResult {
+        let plan = match parse_spell(prompt)
+            .and_then(|intent| build_plan(intent, || self.default_cast_harness()))
+            .map(|plan| plan.with_raw_spell(prompt))
+        {
+            Ok(plan) => plan,
+            Err(error) => {
+                self.push_system_message(&format!("{error}"));
+                return SlashCommandResult::Handled;
+            }
         };
-        if !agent.available {
-            self.push_system_message(&format!(
-                "{} is not available. Run `coven doctor` to troubleshoot.",
-                agent.label
-            ));
-            return;
-        }
-        self.run_harness_prompt(&agent.harness, prompt);
+        self.dispatch_cast_plan(plan)
     }
 
-    fn run_harness_prompt(&mut self, harness: &str, prompt: &str) {
+    fn dispatch_cast_plan(&mut self, plan: CastPlan) -> SlashCommandResult {
+        self.push_system_message(&format_cast_plan_for_chat(&plan));
+
+        match &plan.decision {
+            SafetyDecision::Proceed => self.execute_cast_plan(plan),
+            SafetyDecision::Confirm { suggestion, .. } => {
+                self.push_system_message(&format!(
+                    "Confirmation required before launch. Type accept to proceed or reject to cancel. {suggestion}"
+                ));
+                self.pending_cast_confirmation = Some(plan);
+                SlashCommandResult::Handled
+            }
+            SafetyDecision::Reject { alternative, .. } => {
+                self.push_system_message(&format!("Cast rejected this spell. {alternative}"));
+                SlashCommandResult::Handled
+            }
+        }
+    }
+
+    fn execute_cast_plan(&mut self, plan: CastPlan) -> SlashCommandResult {
+        match plan.intent {
+            CastIntent::NaturalSpell { prompt } | CastIntent::HarnessSpell { prompt, .. } => {
+                let Some(plan_harness) = plan.harness else {
+                    self.push_system_message(
+                        "No harness available. Run `coven doctor` to install Codex or Claude Code.",
+                    );
+                    return SlashCommandResult::Handled;
+                };
+                if let Some(session) = self.run_harness_prompt(plan_harness.harness.id(), &prompt) {
+                    self.push_system_message(&format_cast_outcome_for_chat(
+                        plan_harness.harness.label(),
+                        &session.id,
+                    ));
+                }
+            }
+            CastIntent::OpenSessions | CastIntent::OpenAllSessions => {
+                self.refresh_sessions();
+                self.show_session_overlay = true;
+            }
+            CastIntent::AttachSession { session_id } => self.attach_session(&session_id),
+            CastIntent::SummonSession { session_id } => self.summon_session(&session_id),
+            CastIntent::ArchiveSession { session_id } => self.archive_session(&session_id),
+            CastIntent::KillSession { session_id } => self.kill_session(&session_id),
+            CastIntent::SacrificeSession { session_id } => self.sacrifice_session(&session_id),
+            CastIntent::Doctor => self.push_system_message("Run `coven doctor` for setup checks."),
+            CastIntent::DaemonStatus => {
+                self.push_system_message("Run `coven daemon status` to inspect the local daemon.")
+            }
+            CastIntent::Help => self.show_help = true,
+            CastIntent::StartHere | CastIntent::OpenTui => {
+                self.show_help = true;
+                self.push_system_message(
+                    "Command discovery is open. Type a task, /run <harness> <task>, /sessions, or /help.",
+                );
+            }
+            CastIntent::PatchOpenClaw => {
+                self.push_system_message(
+                    "Patch flow: type `patch openclaw <issue>` as a task, or run `coven patch openclaw` for the guided repair flow.",
+                );
+            }
+            CastIntent::Quest { goal } => {
+                self.push_system_message(&format!(
+                    "Quest planned for: {goal}. Cast will run each phase through this composer; start with the design phase prompt when ready."
+                ));
+            }
+            CastIntent::Quit => return SlashCommandResult::Quit,
+        }
+        SlashCommandResult::Handled
+    }
+
+    fn resolve_pending_cast_confirmation(&mut self, raw: &str) -> SlashCommandResult {
+        let normalized = raw.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "accept" | "approve" | "yes" | "y" => {
+                if let Some(mut plan) = self.pending_cast_confirmation.take() {
+                    plan.decision = SafetyDecision::Proceed;
+                    self.push_system_message("Accepted Cast confirmation.");
+                    return self.execute_cast_plan(plan);
+                }
+            }
+            "reject" | "cancel" | "no" | "n" => {
+                self.pending_cast_confirmation = None;
+                self.push_system_message("Rejected Cast confirmation.");
+            }
+            _ => {
+                self.push_system_message(
+                    "A Cast confirmation is pending. Type accept to proceed or reject to cancel.",
+                );
+            }
+        }
+        SlashCommandResult::Handled
+    }
+
+    pub(super) fn cancel_pending_cast_confirmation(&mut self) -> bool {
+        if self.pending_cast_confirmation.take().is_some() {
+            self.push_system_message("Cancelled Cast confirmation.");
+            true
+        } else {
+            false
+        }
+    }
+
+    fn default_cast_harness(&self) -> Option<CastHarness> {
+        self.active_agent
+            .and_then(|idx| self.agents.get(idx))
+            .filter(|agent| agent.available)
+            .and_then(|agent| CastHarness::from_token(&agent.harness))
+            .or_else(cast::default_harness)
+    }
+
+    fn cast_slash_with_context(&mut self, raw: &str) -> String {
+        if raw.trim().eq_ignore_ascii_case("/kill") {
+            if let Some(session_id) = self.active_session_id.clone() {
+                return format!("/kill {session_id}");
+            }
+        }
+        raw.to_string()
+    }
+
+    fn run_harness_prompt(&mut self, harness: &str, prompt: &str) -> Option<store::SessionRecord> {
         self.is_responding = true;
         let result = LaunchRequest::for_current_dir(harness, prompt)
             .and_then(|request| self.client.launch_session(request));
@@ -349,10 +487,14 @@ impl App {
                     session.id, session.harness
                 ));
                 self.poll_session_events();
+                Some(session)
             }
             Err(error) => {
                 self.is_responding = false;
-                self.push_system_message(&format!("Daemon launch failed: {error}"));
+                self.push_system_message(&format!(
+                    "Daemon launch failed: {error}. Start it with `coven daemon start`, then retry."
+                ));
+                None
             }
         }
     }
@@ -395,6 +537,42 @@ impl App {
         }
     }
 
+    fn archive_session(&mut self, session_id: &str) {
+        match self.client.archive_session(session_id) {
+            Ok(()) => self.push_system_message(&format!("Archived session {session_id}.")),
+            Err(error) => self.push_system_message(&format!("Archive failed: {error}")),
+        }
+    }
+
+    fn summon_session(&mut self, session_id: &str) {
+        match self.client.summon_session(session_id) {
+            Ok(session) => {
+                self.push_system_message(&format!("Summoned session {session_id}."));
+                self.active_session_id = Some(session.id.clone());
+                self.last_event_seq = None;
+                self.reset_event_poll_failures();
+                self.push_system_message(&format!(
+                    "Attached to daemon session {} ({}, {})",
+                    session.id, session.harness, session.status
+                ));
+                self.poll_session_events();
+            }
+            Err(error) => self.push_system_message(&format!("Summon failed: {error}")),
+        }
+    }
+
+    fn sacrifice_session(&mut self, session_id: &str) {
+        match self.client.sacrifice_session(session_id) {
+            Ok(()) => {
+                if self.active_session_id.as_deref() == Some(session_id) {
+                    self.active_session_id = None;
+                }
+                self.push_system_message(&format!("Sacrificed session {session_id}."));
+            }
+            Err(error) => self.push_system_message(&format!("Sacrifice failed: {error}")),
+        }
+    }
+
     pub(super) fn refresh_sessions(&mut self) {
         match self.client.list_sessions() {
             Ok(sessions) => self.sessions = sessions,
@@ -411,6 +589,9 @@ impl App {
             .event_poll_backoff_until
             .is_some_and(|until| until > now)
         {
+            return;
+        }
+        if self.event_poll_paused_for_api_mismatch {
             return;
         }
         match self.client.list_events(ChatEventQuery {
@@ -433,17 +614,26 @@ impl App {
         self.event_poll_backoff_until = None;
         self.event_poll_failure_streak = 0;
         self.last_event_poll_error = None;
+        self.event_poll_paused_for_api_mismatch = false;
     }
 
     fn record_event_poll_failure(&mut self, error: anyhow::Error) {
         let message = error.to_string();
+        if is_api_mismatch_error(&message) {
+            self.event_poll_paused_for_api_mismatch = true;
+        }
         let repeated_error = self.last_event_poll_error.as_deref() == Some(message.as_str());
         self.event_poll_failure_streak = self.event_poll_failure_streak.saturating_add(1);
         self.event_poll_backoff_until =
             Some(Instant::now() + event_poll_backoff(self.event_poll_failure_streak));
         self.last_event_poll_error = Some(message.clone());
         if !repeated_error {
-            self.push_system_message(&format!("Event follow failed: {message}"));
+            let message = if self.event_poll_paused_for_api_mismatch {
+                format!("Event follow failed: {message}. polling paused until next input.")
+            } else {
+                format!("Event follow failed: {message}")
+            };
+            self.push_system_message(&message);
         }
     }
 
@@ -699,6 +889,10 @@ fn event_poll_backoff(streak: u32) -> Duration {
     Duration::from_millis(millis)
 }
 
+fn is_api_mismatch_error(message: &str) -> bool {
+    message.contains("Coven daemon API mismatch")
+}
+
 // ── Discover agents from built-in harnesses ────────────────────────────────
 
 pub(super) fn discover_agents() -> Vec<AgentInfo> {
@@ -725,6 +919,82 @@ fn split_first_arg(input: &str) -> Option<(&str, &str)> {
     let first = &trimmed[..split_idx];
     let rest = trimmed[split_idx..].trim();
     (!first.is_empty() && !rest.is_empty()).then_some((first, rest))
+}
+
+fn is_chat_local_slash(input: &str) -> bool {
+    let command = input
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(
+        command.as_str(),
+        "/help"
+            | "/h"
+            | "/commands"
+            | "/palette"
+            | "/clear"
+            | "/cls"
+            | "/agent"
+            | "/a"
+            | "/export"
+            | "/exit"
+            | "/quit"
+            | "/q"
+            | "/delegate"
+            | "/trace"
+            | "/mem"
+            | "/debug"
+    )
+}
+
+fn is_confirmation_response(input: &str) -> bool {
+    matches!(
+        input.trim().to_ascii_lowercase().as_str(),
+        "accept" | "approve" | "yes" | "y" | "reject" | "cancel" | "no" | "n"
+    )
+}
+
+fn format_cast_plan_for_chat(plan: &CastPlan) -> String {
+    let harness = plan
+        .harness
+        .map(|plan_harness| {
+            let source = match plan_harness.source {
+                CastHarnessSource::UserChose => "user-chosen",
+                CastHarnessSource::SafeDefault => "Cast default",
+            };
+            format!("harness {} · {source}", plan_harness.harness.label())
+        })
+        .unwrap_or_else(|| "harness none".to_string());
+    let risk = match plan.risk() {
+        CastRisk::Safe => "[ SAFE ]",
+        CastRisk::Confirm => "[ CONFIRM ]",
+        CastRisk::Reject => "[ REJECT ]",
+    };
+    let steps = if plan
+        .steps
+        .iter()
+        .any(|step| step.kind == crate::tui::cast::plan::CastStepKind::LaunchSession)
+    {
+        "launch project-scoped session".to_string()
+    } else {
+        plan.steps
+            .first()
+            .map(|step| step.note.clone())
+            .unwrap_or_else(|| "no side effects".to_string())
+    };
+
+    let session = plan
+        .session_id
+        .as_deref()
+        .map(|session_id| format!("\n  session  {session_id}"))
+        .unwrap_or_default();
+
+    format!("Cast plan\n  {harness}  risk {risk}{session}\n  steps  {steps}")
+}
+
+fn format_cast_outcome_for_chat(harness_label: &str, session_id: &str) -> String {
+    format!("Cast outcome\n  launched  {harness_label} daemon session\n  session  {session_id}")
 }
 
 fn event_payload_text(event: &store::EventRecord, field: &str) -> Option<String> {
@@ -828,6 +1098,7 @@ mod tests {
         sessions: Rc<RefCell<Vec<SessionRecord>>>,
         events: Rc<RefCell<Vec<EventRecord>>>,
         event_error: Rc<RefCell<Option<String>>>,
+        launch_error: Rc<RefCell<Option<String>>>,
     }
 
     impl RecordingChatClient {
@@ -842,6 +1113,9 @@ mod tests {
         fn launch_session(&mut self, request: LaunchRequest) -> anyhow::Result<SessionRecord> {
             self.calls.borrow_mut().push("launch".to_string());
             self.launched.borrow_mut().push(request.clone());
+            if let Some(error) = self.launch_error.borrow().clone() {
+                return Err(anyhow::anyhow!(error));
+            }
             let session = test_session(&request.id, &request.harness, &request.prompt, "running");
             self.sessions.borrow_mut().push(session.clone());
             Ok(session)
@@ -890,6 +1164,43 @@ mod tests {
 
         fn kill_session(&mut self, session_id: &str) -> anyhow::Result<()> {
             self.calls.borrow_mut().push(format!("kill:{session_id}"));
+            Ok(())
+        }
+
+        fn archive_session(&mut self, session_id: &str) -> anyhow::Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(format!("archive:{session_id}"));
+            let mut sessions = self.sessions.borrow_mut();
+            let session = sessions
+                .iter_mut()
+                .find(|session| session.id == session_id)
+                .ok_or_else(|| anyhow::anyhow!("session not found"))?;
+            session.archived_at = Some("2026-05-19T01:00:00Z".to_string());
+            Ok(())
+        }
+
+        fn summon_session(&mut self, session_id: &str) -> anyhow::Result<SessionRecord> {
+            self.calls.borrow_mut().push(format!("summon:{session_id}"));
+            let mut sessions = self.sessions.borrow_mut();
+            let session = sessions
+                .iter_mut()
+                .find(|session| session.id == session_id)
+                .ok_or_else(|| anyhow::anyhow!("session not found"))?;
+            session.archived_at = None;
+            Ok(session.clone())
+        }
+
+        fn sacrifice_session(&mut self, session_id: &str) -> anyhow::Result<()> {
+            self.calls
+                .borrow_mut()
+                .push(format!("sacrifice:{session_id}"));
+            let mut sessions = self.sessions.borrow_mut();
+            let index = sessions
+                .iter()
+                .position(|session| session.id == session_id)
+                .ok_or_else(|| anyhow::anyhow!("session not found"))?;
+            sessions.remove(index);
             Ok(())
         }
     }
@@ -946,12 +1257,13 @@ mod tests {
 
         let result = app.handle_input();
 
-        match result {
-            Some(SlashCommandResult::Unknown(command)) => assert_eq!(command, "/missing"),
-            other => panic!("expected unknown command result, got {other:?}"),
-        }
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
         assert!(app.input.is_empty());
         assert_eq!(app.cursor_pos, 0);
+        assert!(app.messages.iter().any(|message| message
+            .content
+            .contains("unknown Cast slash command `/missing`")
+            && message.content.contains("/help")));
     }
 
     #[test]
@@ -1023,7 +1335,7 @@ mod tests {
         app.push_event_message(&EventRecord {
             seq: 1,
             id: "event-1".to_string(),
-            session_id,
+            session_id: session_id.to_string(),
             kind: "exit".to_string(),
             payload_json: serde_json::json!({ "status": "completed" }).to_string(),
             created_at: "2026-05-19T00:00:00Z".to_string(),
@@ -1031,6 +1343,359 @@ mod tests {
 
         assert_eq!(app.active_session_id(), None);
         assert!(!app.is_responding);
+    }
+
+    #[test]
+    fn daemon_launch_failure_surfaces_start_guidance_inline() {
+        let client = RecordingChatClient::default();
+        *client.launch_error.borrow_mut() = Some("connection refused".to_string());
+        let (mut app, _) = app_with_client(client);
+        app.input = "fix the failing tests".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        assert!(app.messages.iter().any(|message| message
+            .content
+            .contains("Daemon launch failed: connection refused")
+            && message.content.contains("coven daemon start")));
+    }
+
+    #[test]
+    fn plain_chat_input_appends_cast_plan_before_daemon_launch() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.input = "fix the failing tests".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let plan_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Cast plan"))
+            .expect("chat transcript should include Cast plan");
+        let launch_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Started daemon session"))
+            .expect("safe plan should launch");
+        assert!(plan_index < launch_index);
+        assert!(app.messages[plan_index].content.contains("risk [ SAFE ]"));
+        assert!(app.messages[plan_index]
+            .content
+            .contains("steps  launch project-scoped session"));
+    }
+
+    #[test]
+    fn safe_chat_launch_appends_cast_outcome_after_daemon_launch() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.input = "fix the failing tests".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let launch_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Started daemon session"))
+            .expect("safe plan should launch");
+        let outcome_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Cast outcome"))
+            .expect("chat transcript should include Cast outcome");
+        assert!(launch_index < outcome_index);
+        assert!(app.messages[outcome_index]
+            .content
+            .contains("launched  Codex daemon session"));
+    }
+
+    #[test]
+    fn slash_run_input_appends_cast_plan_before_daemon_launch() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "/run claude review the diff".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 1);
+        assert_eq!(launched[0].harness, "claude");
+        assert_eq!(launched[0].prompt, "review the diff");
+        let plan_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Cast plan"))
+            .expect("chat transcript should include Cast plan");
+        let launch_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Started daemon session"))
+            .expect("safe slash plan should launch");
+        assert!(plan_index < launch_index);
+        assert!(app.messages[plan_index]
+            .content
+            .contains("harness Claude Code · user-chosen"));
+    }
+
+    #[test]
+    fn slash_attach_input_appends_cast_plan_before_attaching() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Existing",
+            "running",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "/attach session-1".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        assert_eq!(app.active_session_id(), Some("session-1"));
+        assert!(mirror.calls.borrow().contains(&"get:session-1".to_string()));
+        let plan_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Cast plan"))
+            .expect("chat transcript should include Cast plan");
+        let attach_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Attached to daemon session"))
+            .expect("attach should still work");
+        assert!(plan_index < attach_index);
+    }
+
+    #[test]
+    fn slash_kill_input_appends_cast_plan_before_killing_session() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Existing",
+            "running",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "/kill session-1".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        assert!(mirror
+            .calls
+            .borrow()
+            .contains(&"kill:session-1".to_string()));
+        let plan_index = app
+            .messages
+            .iter()
+            .position(|message| message.content.contains("Cast plan"))
+            .expect("chat transcript should include Cast plan");
+        let kill_index = app
+            .messages
+            .iter()
+            .position(|message| {
+                message
+                    .content
+                    .contains("Kill accepted for session session-1")
+            })
+            .expect("kill should still work");
+        assert!(plan_index < kill_index);
+    }
+
+    #[test]
+    fn slash_kill_without_id_uses_active_session_through_cast_plan() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Existing",
+            "running",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.input = "/kill".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        assert!(mirror
+            .calls
+            .borrow()
+            .contains(&"kill:session-1".to_string()));
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Cast plan")
+                && message.content.contains("session-1")));
+    }
+
+    #[test]
+    fn slash_archive_input_appends_cast_plan_before_archiving_session() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Existing",
+            "completed",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "/archive session-1".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        assert!(mirror
+            .calls
+            .borrow()
+            .contains(&"archive:session-1".to_string()));
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Cast plan")
+                && message.content.contains("session-1")));
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Archived session session-1")));
+    }
+
+    #[test]
+    fn slash_summon_input_appends_cast_plan_before_summoning_and_attaching() {
+        let mut session = test_session("session-1", "codex", "Existing", "completed");
+        session.archived_at = Some("2026-05-18T00:00:00Z".to_string());
+        let client = RecordingChatClient::with_session(session);
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "/summon session-1".to_string();
+        app.cursor_pos = app.input.len();
+
+        let result = app.handle_input();
+
+        assert!(matches!(result, Some(SlashCommandResult::Handled)));
+        assert!(mirror
+            .calls
+            .borrow()
+            .contains(&"summon:session-1".to_string()));
+        assert_eq!(app.active_session_id(), Some("session-1"));
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Cast plan")
+                && message.content.contains("session-1")));
+    }
+
+    #[test]
+    fn slash_sacrifice_waits_for_confirmation_then_deletes_session() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Existing",
+            "completed",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "/sacrifice session-1".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        assert!(app.pending_cast_confirmation.is_some());
+        assert!(!mirror
+            .calls
+            .borrow()
+            .contains(&"sacrifice:session-1".to_string()));
+
+        app.input = "accept".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        assert!(app.pending_cast_confirmation.is_none());
+        assert!(mirror
+            .calls
+            .borrow()
+            .contains(&"sacrifice:session-1".to_string()));
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Sacrificed session session-1")));
+    }
+
+    #[test]
+    fn informational_cast_slashes_do_not_fall_through_to_unwired_message() {
+        for input in ["/start", "/tui", "/patch", "/quest ship chat mode"] {
+            let client = RecordingChatClient::default();
+            let (mut app, _) = app_with_client(client);
+            app.input = input.to_string();
+            app.cursor_pos = app.input.len();
+
+            let result = app.handle_input();
+
+            assert!(matches!(result, Some(SlashCommandResult::Handled)));
+            assert!(app
+                .messages
+                .iter()
+                .any(|message| message.content.contains("Cast plan")));
+            assert!(!app
+                .messages
+                .iter()
+                .any(|message| message.content.contains("not wired yet")));
+        }
+    }
+
+    #[test]
+    fn risky_chat_input_waits_for_confirmation_and_accept_launches_without_duplicate_plan() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "publish the package".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        assert!(app.pending_cast_confirmation.is_some());
+        assert!(mirror.launched.borrow().is_empty());
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Confirmation required")));
+
+        app.input = "accept".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        assert!(app.pending_cast_confirmation.is_none());
+        assert_eq!(mirror.launched.borrow().len(), 1);
+        assert_eq!(
+            app.messages
+                .iter()
+                .filter(|message| message.content.contains("Cast plan"))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn escape_cancels_pending_confirmation_before_accept_can_launch() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.input = "publish the package".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+        app.cancel_pending_cast_confirmation();
+        app.input = "accept".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        assert!(app.pending_cast_confirmation.is_none());
+        assert!(mirror.launched.borrow().is_empty());
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Cancelled Cast confirmation")));
     }
 
     #[test]
@@ -1228,6 +1893,48 @@ mod tests {
                 .filter(|message| message.content == "Event follow failed: daemon unavailable")
                 .count(),
             1
+        );
+    }
+
+    #[test]
+    fn api_mismatch_stops_event_polling_until_next_user_input() {
+        let client = RecordingChatClient::default();
+        *client.event_error.borrow_mut() = Some(
+            "Coven daemon API mismatch: expected coven.daemon.v1, got coven.daemon.v0".to_string(),
+        );
+        let (mut app, mirror) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+
+        app.poll_session_events();
+        app.event_poll_backoff_until = Some(Instant::now() - Duration::from_millis(1));
+        app.poll_session_events();
+
+        assert_eq!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .filter(|call| *call == "events:session-1:0")
+                .count(),
+            1
+        );
+        assert!(app.messages.iter().any(|message| {
+            message.content.contains("Coven daemon API mismatch")
+                && message.content.contains("polling paused")
+        }));
+
+        app.input = "continue".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        assert_eq!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .filter(|call| *call == "events:session-1:0")
+                .count(),
+            2
         );
     }
 }

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -1,7 +1,9 @@
 //! Daemon-backed chat client for the rich TUI.
 //!
-//! This module intentionally stays thin: the daemon owns session launch,
-//! cwd validation, input delivery, kill, persistence, and structured errors.
+//! This module intentionally stays thin: the daemon owns live session launch,
+//! cwd validation, input delivery, kill, and structured errors. Local session
+//! ritual verbs use the shared store path/timestamp helpers because they are
+//! ledger-only mutations.
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
@@ -13,7 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     api::{EventsResponse, HealthResponse, COVEN_API_NAMED_VERSION},
-    daemon, harness, store,
+    current_timestamp, daemon, harness, store, STORE_FILE_NAME,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -90,7 +92,7 @@ impl DaemonChatClient {
 
 impl DaemonChatClient {
     fn store_path(&self) -> PathBuf {
-        self.coven_home.join("coven.sqlite3")
+        self.coven_home.join(STORE_FILE_NAME)
     }
 
     fn open_store(&self) -> Result<rusqlite::Connection> {
@@ -213,7 +215,7 @@ impl ChatClient for DaemonChatClient {
         if session.status == "running" {
             anyhow::bail!("session `{session_id}` is still running; stop it before archiving");
         }
-        store::archive_session(&conn, session_id, &timestamp_now())
+        store::archive_session(&conn, session_id, &current_timestamp())
     }
 
     fn summon_session(&mut self, session_id: &str) -> Result<store::SessionRecord> {
@@ -222,7 +224,7 @@ impl ChatClient for DaemonChatClient {
             anyhow::bail!("session `{session_id}` not found");
         };
         if session.archived_at.is_some() {
-            store::summon_session(&conn, session_id, &timestamp_now())?;
+            store::summon_session(&conn, session_id, &current_timestamp())?;
             let Some(session) = store::get_session(&conn, session_id)? else {
                 anyhow::bail!("session `{session_id}` not found");
             };
@@ -325,10 +327,6 @@ fn daemon_error(status: u16, body: &str) -> anyhow::Error {
         }
     }
     anyhow!("Coven daemon rejected request with HTTP {status}")
-}
-
-fn timestamp_now() -> String {
-    chrono::Utc::now().to_rfc3339()
 }
 
 fn coven_home_dir() -> PathBuf {

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -57,6 +57,9 @@ pub(crate) trait ChatClient {
     fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>>;
     fn send_input(&mut self, session_id: &str, data: &str) -> Result<()>;
     fn kill_session(&mut self, session_id: &str) -> Result<()>;
+    fn archive_session(&mut self, session_id: &str) -> Result<()>;
+    fn summon_session(&mut self, session_id: &str) -> Result<store::SessionRecord>;
+    fn sacrifice_session(&mut self, session_id: &str) -> Result<()>;
 }
 
 pub(crate) struct DaemonChatClient {
@@ -86,6 +89,14 @@ impl DaemonChatClient {
 }
 
 impl DaemonChatClient {
+    fn store_path(&self) -> PathBuf {
+        self.coven_home.join("coven.sqlite3")
+    }
+
+    fn open_store(&self) -> Result<rusqlite::Connection> {
+        store::open_store(&self.store_path())
+    }
+
     fn request_json<T: for<'de> Deserialize<'de>>(
         &mut self,
         method: &str,
@@ -193,6 +204,43 @@ impl ChatClient for DaemonChatClient {
             Some(json!({})),
         )
     }
+
+    fn archive_session(&mut self, session_id: &str) -> Result<()> {
+        let conn = self.open_store()?;
+        let Some(session) = store::get_session(&conn, session_id)? else {
+            anyhow::bail!("session `{session_id}` not found");
+        };
+        if session.status == "running" {
+            anyhow::bail!("session `{session_id}` is still running; stop it before archiving");
+        }
+        store::archive_session(&conn, session_id, &timestamp_now())
+    }
+
+    fn summon_session(&mut self, session_id: &str) -> Result<store::SessionRecord> {
+        let conn = self.open_store()?;
+        let Some(session) = store::get_session(&conn, session_id)? else {
+            anyhow::bail!("session `{session_id}` not found");
+        };
+        if session.archived_at.is_some() {
+            store::summon_session(&conn, session_id, &timestamp_now())?;
+            let Some(session) = store::get_session(&conn, session_id)? else {
+                anyhow::bail!("session `{session_id}` not found");
+            };
+            return Ok(session);
+        }
+        Ok(session)
+    }
+
+    fn sacrifice_session(&mut self, session_id: &str) -> Result<()> {
+        let conn = self.open_store()?;
+        let Some(session) = store::get_session(&conn, session_id)? else {
+            anyhow::bail!("session `{session_id}` not found");
+        };
+        if session.status == "running" {
+            anyhow::bail!("session `{session_id}` is still running; do not sacrifice live work");
+        }
+        store::sacrifice_session(&conn, session_id)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -277,6 +325,10 @@ fn daemon_error(status: u16, body: &str) -> anyhow::Error {
         }
     }
     anyhow!("Coven daemon rejected request with HTTP {status}")
+}
+
+fn timestamp_now() -> String {
+    chrono::Utc::now().to_rfc3339()
 }
 
 fn coven_home_dir() -> PathBuf {

--- a/crates/coven-cli/src/tui/chat/events.rs
+++ b/crates/coven-cli/src/tui/chat/events.rs
@@ -136,6 +136,7 @@ pub(super) fn run_event_loop(
                             app.scroll_offset = app.scroll_offset.saturating_add(page);
                             // Will be clamped during render
                         }
+                        KeyCode::Esc if app.cancel_pending_cast_confirmation() => {}
                         KeyCode::Esc if !app.input.is_empty() => {
                             app.input.clear();
                             app.cursor_pos = 0;

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -66,9 +66,7 @@ pub(super) fn render_ui(f: &mut Frame, app: &mut App) {
 
 fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     let harness = app.active_agent_harness();
-    let project = std::env::current_dir()
-        .map(|path| path.display().to_string())
-        .unwrap_or_else(|_| "unknown project".to_string());
+    let project = app.project_label();
     let daemon_status = if app.active_session_id().is_some() {
         "running"
     } else {
@@ -82,7 +80,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled("\u{00b7} ", theme::ratatui_style(DIM)),
         Span::styled(
-            truncate_for_width(&project, area.width.saturating_sub(28) as usize),
+            truncate_for_width(project, area.width.saturating_sub(28) as usize),
             theme::ratatui_style(DIM),
         ),
         Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -65,24 +65,32 @@ pub(super) fn render_ui(f: &mut Frame, app: &mut App) {
 }
 
 fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
-    let agent_name = app.active_agent_label();
     let harness = app.active_agent_harness();
-    let session = app.active_session_id().unwrap_or("no-session");
+    let project = std::env::current_dir()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "unknown project".to_string());
+    let daemon_status = if app.active_session_id().is_some() {
+        "running"
+    } else {
+        "ready"
+    };
 
     let status_spans = vec![
         Span::styled(
-            " \u{2666} coven chat ",
+            format!(" coven {harness} "),
             theme::ratatui_style(PRIMARY).bold(),
         ),
-        Span::styled(" \u{2502} ", theme::ratatui_style(DIM)),
+        Span::styled("\u{00b7} ", theme::ratatui_style(DIM)),
         Span::styled(
-            format!("\u{25C9} {agent_name}"),
-            theme::ratatui_style(AGENT_LABEL).bold(),
+            truncate_for_width(&project, area.width.saturating_sub(28) as usize),
+            theme::ratatui_style(DIM),
         ),
-        Span::styled(format!(" ({harness})"), theme::ratatui_style(DIM)),
-        Span::styled(" \u{2502} ", theme::ratatui_style(DIM)),
-        Span::styled(session.to_string(), theme::ratatui_style(DIM)),
-        Span::styled(" \u{2502} ", theme::ratatui_style(DIM)),
+        Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
+        Span::styled(
+            format!("daemon: {daemon_status}"),
+            theme::ratatui_style(DIM),
+        ),
+        Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
         if app.is_responding {
             Span::styled(
                 format!("{} responding...", SPINNER_FRAMES[app.spinner_frame]),
@@ -129,8 +137,13 @@ fn render_messages(f: &mut Frame, app: &mut App, area: Rect) {
         };
 
         if matches!(msg.role, MessageRole::System) {
-            // System messages are single-line
-            lines.push(Line::from(Span::styled(sender_text, sender_style)));
+            for (idx, content_line) in msg.content.lines().enumerate() {
+                let prefix = if idx == 0 { "\u{2731} " } else { "  " };
+                lines.push(Line::from(Span::styled(
+                    format!("{prefix}{content_line}"),
+                    sender_style,
+                )));
+            }
             continue;
         }
 
@@ -249,18 +262,11 @@ fn render_hint_bar(f: &mut Frame, app: &App, area: Rect) {
         ]
     } else {
         vec![
-            Span::styled(" /help", theme::ratatui_style(HINT_KEY).bold()),
-            Span::styled(" commands  ", theme::ratatui_style(HINT_LABEL)),
-            Span::styled("/agent", theme::ratatui_style(HINT_KEY).bold()),
-            Span::styled(" switch  ", theme::ratatui_style(HINT_LABEL)),
-            Span::styled("PgUp/PgDn", theme::ratatui_style(HINT_KEY).bold()),
-            Span::styled(" scroll  ", theme::ratatui_style(HINT_LABEL)),
-            Span::styled("Shift+Enter", theme::ratatui_style(HINT_KEY).bold()),
-            Span::styled(" newline  ", theme::ratatui_style(HINT_LABEL)),
-            Span::styled("Ctrl+K", theme::ratatui_style(HINT_KEY).bold()),
-            Span::styled(" palette  ", theme::ratatui_style(HINT_LABEL)),
-            Span::styled("Ctrl+C", theme::ratatui_style(HINT_KEY).bold()),
-            Span::styled(" quit  ", theme::ratatui_style(HINT_LABEL)),
+            Span::styled(" > ", theme::ratatui_style(HINT_KEY).bold()),
+            Span::styled(
+                "Try \"review this branch\" or /help",
+                theme::ratatui_style(HINT_LABEL),
+            ),
         ]
     };
 
@@ -525,8 +531,59 @@ fn truncate_for_width(value: &str, max_width: usize) -> String {
 }
 
 #[cfg(test)]
+pub(crate) fn render_chat_frame_plain_for_test(width: u16, height: u16) -> String {
+    use ratatui::{backend::TestBackend, Terminal};
+
+    use super::{app::AgentInfo, client::DaemonChatClient};
+
+    let agents = vec![AgentInfo {
+        id: "codex".to_string(),
+        label: "codex".to_string(),
+        harness: "codex".to_string(),
+        available: true,
+    }];
+    let mut app = App::new_with_state(agents, Some(0), Box::<DaemonChatClient>::default());
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal
+        .draw(|frame| render_ui(frame, &mut app))
+        .expect("render chat frame");
+
+    buffer_to_plain_text(terminal.backend().buffer())
+}
+
+#[cfg(test)]
+fn buffer_to_plain_text(buffer: &ratatui::buffer::Buffer) -> String {
+    let width = buffer.area.width as usize;
+    buffer
+        .content()
+        .chunks(width)
+        .map(|row| {
+            row.iter()
+                .map(|cell| cell.symbol())
+                .collect::<String>()
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chat_first_frame_opens_on_transcript_composer_and_status() {
+        let frame = render_chat_frame_plain_for_test(80, 20);
+
+        assert!(frame.contains("coven codex"));
+        assert!(frame.contains("Ready. Type a task or /help."));
+        assert!(frame.contains("> Try \"review this branch\" or /help"));
+        assert!(!frame.contains("Commands"));
+        assert!(!frame.contains("/start"));
+        assert!(!frame.contains("Session browser"));
+    }
 
     #[test]
     fn cursor_position_counts_trailing_newline_as_next_line() {

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -306,7 +306,7 @@ enum LauncherChoice {
 /// `CastIntent`, builds a plan, renders the intro card the user sees before
 /// any side effect, runs the safety gate, dispatches the matching handler,
 /// then renders the outcome card.
-fn run_cast_spell(raw: &str) -> Result<()> {
+pub(crate) fn run_cast_spell(raw: &str) -> Result<()> {
     let plan = cast::plan_spell(raw)?;
     print_plan_intro(&plan);
     dispatch_cast_plan(plan)
@@ -377,6 +377,17 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
                 next_step: Some(
                     "Use `/summon <id>` later to restore it; events are preserved.".to_string(),
                 ),
+                notes: vec![],
+            }
+        }
+        CastIntent::KillSession { session_id } => {
+            let mut client = DaemonChatClient::default();
+            client.kill_session(&session_id)?;
+            CastOutcome {
+                request: request_text,
+                launched: Some(format!("Kill accepted for session {session_id}")),
+                session_id: Some(session_id),
+                next_step: Some("Use `/attach <id>` to inspect the final transcript.".to_string()),
                 notes: vec![],
             }
         }
@@ -2153,6 +2164,18 @@ mod attach_tests {
         }
 
         fn kill_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn archive_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn summon_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised by replay tests")
+        }
+
+        fn sacrifice_session(&mut self, _session_id: &str) -> Result<()> {
             unimplemented!("not exercised by replay tests")
         }
     }

--- a/docs/design/chat-first-tui-goal.md
+++ b/docs/design/chat-first-tui-goal.md
@@ -1,0 +1,81 @@
+# Long-Running Goal: Coven Chat-First TUI
+
+**Repo:** OpenCoven/coven | **Branch:** feat/chat-first-tui | **Full design:** docs/design/chat-first-tui.md
+
+## Goal
+
+Redesign the default Coven terminal experience so that `coven`, `coven tui`, and `coven chat` all open the same chat-first full-screen TUI — similar in feel to Claude Code or Claurst — while preserving Cast planning, safety gates, and daemon-backed sessions.
+
+## What to build
+
+**One shared chat shell.** Make `Command::Tui`, `Command::Chat`, and bare `coven` (interactive TTY) all call a single shared shell backed by the existing `tui::chat` ratatui lifecycle. The old launcher (`tui::shell`) stops being the default first screen; keep it as a non-interactive Cast output path only.
+
+**Cast-aware composer.** Route all composer input through Cast planning before side effects. Safe plans proceed immediately. Risky plans show an inline confirmation card. Accept/reject/Esc resolves pending confirmations. Outcomes append to the transcript. Support both natural language and slash commands from the same composer.
+
+**Command palette overlay.** Move the launcher-style command menu behind `Ctrl+K` and `/commands`. `/help` should also surface command discovery. Remove them from the first-paint frame.
+
+**Default visual layout:**
+
+```
+Coven codex · /path/to/project · daemon: running
+
+✦ coven
+  Ready. Type a task or /help.
+
+> fix the failing tests
+
+✦ Cast plan
+  harness Codex · Cast default  risk [ SAFE ]
+  steps  launch project-scoped session
+✦ Codex
+  ...streamed output...
+
+───────────────────────────────────
+> Try "review this branch" or /help
+```
+
+Rules: transcript is primary surface, composer always at the bottom, compact persistent status row, no launch menu on first paint.
+
+**Session state.** Track one active session by default. Forward follow-up input to a running session. Clear completed sessions cleanly before the next message. Keep `/attach <id>`, `/sessions`, and `/kill [id]` working.
+
+**Non-interactive output.** When stdout is not a TTY, keep the existing plain Cast frame. `coven "fix tests"` and `coven tui | head` must remain script-friendly.
+
+**Error handling.** Daemon unavailable → inline `coven daemon start` guidance. Harness unavailable → `coven doctor` guidance. API mismatch → stop polling. Small terminal → minimal fallback. Unknown command → inline error + suggest `/help`.
+
+## Do NOT
+
+- Do not clone Claude Code branding, exact wording, or private behavior.
+- Do not change harness auth, daemon APIs, or store schema unless a narrow need is proven.
+- Do not remove existing commands (`/sessions`, `/attach`, `/doctor`, `/daemon`, `/patch`, `/quest`, ritual verbs).
+- Do not require live Codex, Claude, or provider credentials in tests.
+
+## Migration stages
+
+1. Add chat frame snapshot helpers and tests for the target first screen.
+2. Route `Command::Tui` and default `None` to the shared chat shell for interactive terminals.
+3. Route cast input through Cast planning before daemon launch.
+4. Move command-palette into `/help`, `/commands`, `Ctrl+K` overlays.
+5. Preserve and re-test non-interactive Cast plain output.
+6. Run full verification, open a PR.
+
+## Automated gates (must pass before PR)
+
+```bash
+cargo test -p coven-cli
+cargo clippy -p coven-cli --no-deps
+cargo fmt --check
+git diff --check
+cargo build -p coven-cli
+```
+
+## Acceptance criteria
+
+- `coven`, `coven tui`, `coven chat` all open the same chat-first TUI.
+- First frame is transcript/composer/status — not a launcher menu.
+- Plain language and slash commands work from one composer.
+- Cast plan/safety/outcome behavior preserved inside transcript flow.
+- Existing daemon session launch, attach, follow, kill, and export still work.
+- Non-interactive Cast output still works.
+- Focused snapshot/state tests cover new visual and interaction contracts.
+- Full repo gates pass.
+- Raw/duplicated Codex output does not appear in chat.

--- a/docs/design/chat-first-tui.md
+++ b/docs/design/chat-first-tui.md
@@ -1,0 +1,195 @@
+---
+title: "Coven Chat-First Terminal UI"
+description: "Redesign Coven's default terminal experience as a chat-first coding-agent TUI while preserving Cast planning, safety gates, and daemon-backed sessions."
+---
+
+# Coven Chat-First Terminal UI — Design Plan
+
+Status: Approved direction, ready for implementation
+Date: 2026-05-20
+Scope: Replace the default `coven` / `coven tui` launcher-first experience with a chat-first terminal UI. Make `coven chat` use the same interaction model.
+
+## Summary
+
+Coven should open like a working coding-agent terminal, not like a command launcher. The default interactive experience should be a full-screen chat UI with a compact status row, transcript, composer, active session state, and inline Cast planning.
+
+## Problem
+
+The current default Coven terminal flow opens a raw-terminal Cast launcher with example spells and action rows. It makes Coven feel like a command menu instead of a coding-agent terminal. A chat-first terminal should let the user land directly in a working loop: see project/runtime/session context, type a natural task immediately, stream agent output into a transcript, approve risky actions inline, and discover commands progressively.
+
+Coven already has most of the required backend pieces:
+
+- `tui::shell` — current default launcher and Cast dispatch
+- `tui::chat` — ratatui chat surface, transcript, composer, daemon session launch, attach, input forwarding, polling, history, help, session overlay
+- `tui::cast` — spell parsing, planning, safety decisions, plan cards, quest flow, outcomes, daemon-backed follow behavior
+
+## Goals
+
+1. Make `coven` and `coven tui` open a chat-first full-screen TUI in interactive terminals.
+2. Make `coven chat` use the same experience.
+3. Preserve Cast as the planning, safety, and dispatch layer.
+4. Preserve daemon-backed launch, attach, replay, follow, kill, export, and event polling.
+5. Move command discovery into `/help`, `/commands`, and `Ctrl+K`.
+6. Keep non-interactive output script-friendly by retaining the existing plain Cast frame.
+7. Keep implementation testable with snapshots, focused state tests, and daemon/client fakes.
+
+## Non-Goals
+
+- Do not clone Claude Code branding, exact text, or private implementation behavior.
+- Do not change harness auth, provider/model ownership, daemon APIs, or store schema unless a narrow need appears.
+- Do not remove existing commands like `/sessions`, `/attach`, `/doctor`, `/daemon`, `/patch`, `/quest`, or session ritual verbs.
+- Do not build a graphical or web UI.
+- Do not require live Codex, Claude, or provider credentials in tests.
+
+## Architecture
+
+### 1. One Shared Chat Shell
+
+Introduce one shared chat-first shell used by `Command::Chat`, `Command::Tui`, and bare `coven` in an interactive terminal. Reuse the existing `tui::chat` ratatui lifecycle. Do not create a second full-screen stack. The existing launcher stops being the first screen; keep its plumbing for non-interactive Cast output and compatibility paths only.
+
+### 2. Cast-Aware Composer
+
+All composer submissions pass through Cast before side effects:
+
+1. User types into the composer.
+2. Chat app builds a Cast plan from the raw spell.
+3. Safe plans proceed directly.
+4. Risky/ambiguous plans render inline confirmation cards.
+5. Accept/reject resolves the pending confirmation.
+6. Launch, attach, quest, patch, and session actions reuse existing Cast and daemon paths.
+7. Outcomes append to the transcript.
+
+The composer supports both natural language and slash commands:
+`fix the failing tests` / `/sessions` / `/claude review the diff` / `/quest continue`
+
+### 3. Command Palette Overlay
+
+The current menu becomes an overlay, not the default first screen.
+
+- `/help` — readable command help in the transcript or overlay
+- `Ctrl+K` — compact command palette overlay
+- `/commands` — alias for the same overlay
+
+### 4. Visual Layout
+
+```
+Coven codex · /path/to/project · daemon: running
+
+✦ coven
+  Ready. Type a task or /help.
+
+> fix the failing tests
+
+✦ Cast plan
+  harness Codex · Cast default
+  risk [ SAFE ]
+  steps launch project-scoped session
+
+✦ Codex
+  ...streamed output...
+
+────────────────────────────────────────────────────────
+> Try "review this branch" or /help
+```
+
+Visual rules:
+- transcript is the primary surface
+- composer is always at the bottom
+- status is compact and persistent
+- no decorative launch menu on first paint
+- hints are short and contextual
+- layout must work without heavy color dependence
+
+### 5. Session Model
+
+Shell tracks one active session by default. When an active session exits, the next plain prompt launches a new session cleanly.
+
+Required interactions: start from natural language, stream output to transcript, forward follow-up input, clear on exit/kill, `/attach <id>` replays/follows, `/sessions` opens overlay, `/kill [id]` stops active/named session.
+
+### 6. Non-Interactive Behavior
+
+If stdin or stdout is not a TTY, `coven` and `coven tui` keep printing the existing plain Cast frame. These paths must remain readable, deterministic, and CI-friendly.
+
+## Components
+
+**`tui::chat::app`** — transcript messages, composer content/cursor, active harness/agent, active session id/event cursor, overlays, pending Cast confirmation. New Cast state should stay narrow.
+
+**`tui::chat::render`** — compact status row, transcript, bottom composer, overlays, small-terminal fallback. Add plain snapshot helpers for tests.
+
+**`tui::chat::events`** — text entry, Enter submit, Shift+Enter newline, Ctrl+C/D exit, Ctrl+K palette, Esc clears overlay/confirmation/composer, Up/Down history, overlay navigation.
+
+**`tui::chat::client`** — daemon-backed transport boundary only. No socket code in render or events.
+
+**`tui::cast`** — spell parsing, plan rendering, safety decisions, quests, outcomes, attach summaries. May add adapter helpers so chat can render Cast content as transcript messages.
+
+## Data Flow
+
+**Safe prompt:** compose → Cast plan → plan transcript message → daemon launch → output events → completion message → clear session.
+
+**Confirmation prompt:** compose → Cast returns Confirm → inline plan card → pending-confirmation state → yes/no/Esc → proceed or cancelled outcome.
+
+**Slash command:** compose → Cast intent or chat-local command → overlay or transcript result → no daemon launch unless required.
+
+**Daemon events:** poll/stream → normalize into transcript entries → update status row → completion/error/kill clears running state. Terminal output is transcript content, never raw nested TUI output.
+
+## Error Handling
+
+- Daemon unavailable: inline `coven daemon start` / restart guidance
+- Harness unavailable: `coven doctor` guidance, keep composer usable
+- API mismatch: show mismatch, stop polling until next user action
+- Event polling failure: keep existing backoff and coalescing behavior
+- Small terminal: minimal "Terminal too small" frame
+- Unknown command: concise inline error, suggest `/help`
+
+## Testing Contracts
+
+1. `coven`, `coven tui`, and `coven chat` route to same interactive shell entry point when attached to a TTY.
+2. Non-interactive `coven tui` still prints the plain Cast frame.
+3. Default chat frame has compact status row, welcome transcript, and bottom composer.
+4. Default chat frame does not contain the old launcher-first command list.
+5. `/help`, `/commands`, or `Ctrl+K` exposes the command surface that was previously first-screen.
+6. Plain input appends a Cast plan transcript entry before launching.
+7. Safe prompts launch without confirmation.
+8. Confirmation prompts pause for explicit approval.
+9. Session exit and kill clear active session.
+10. Existing daemon-backed attach/replay/follow/input-forwarding/kill/export behavior still works.
+11. Raw nested Codex TUI output does not appear inside Coven chat.
+
+Minimum automated gates:
+
+```bash
+cargo test -p coven-cli
+cargo clippy -p coven-cli --no-deps
+cargo fmt --check
+git diff --check
+```
+
+Manual verification:
+
+```bash
+cargo build -p coven-cli
+./target/debug/coven          # confirm chat-first first frame
+./target/debug/coven tui | head  # confirm plain Cast output
+```
+
+## Migration Plan
+
+1. Add chat frame snapshot helpers and tests for the target first screen.
+2. Make `Command::Tui` and default `None` call the shared chat shell for interactive terminals.
+3. Adapt chat input to route through Cast planning before daemon launch.
+4. Move command-palette behavior into `/help`, `/commands`, and `Ctrl+K` overlays.
+5. Preserve and re-test non-interactive Cast plain output.
+6. Run full verification and open a PR separate from prior chat-state fixes.
+
+## Acceptance Criteria
+
+Complete when evidence proves:
+
+- `coven`, `coven tui`, and `coven chat` open the same chat-first interactive TUI.
+- First interactive frame is transcript/composer/status oriented, not launcher/menu oriented.
+- Plain language and slash commands work from one composer.
+- Cast plan/safety/outcome behavior is preserved inside the transcript flow.
+- Existing daemon-backed session launch, attach, event follow, input forwarding, kill, and export behavior still works.
+- Non-interactive output remains script-friendly.
+- Focused snapshot/state tests cover the new visual and interaction contract.
+- Full repo gates pass.

--- a/docs/superpowers/specs/2026-05-20-claude-like-tui-design.md
+++ b/docs/superpowers/specs/2026-05-20-claude-like-tui-design.md
@@ -1,0 +1,254 @@
+---
+title: "Claude Code-like Coven TUI design"
+description: "Recreate the default Coven TUI as a chat-first terminal experience while preserving Cast planning, safety gates, and daemon-backed sessions."
+---
+
+# Claude Code-like Coven TUI — Design
+
+**Status:** Approved direction — ready for implementation planning after review  
+**Date:** 2026-05-20  
+**Scope:** Replace the default `coven` / `coven tui` launcher-first experience with a chat-first terminal UI, and bring `coven chat` into the same interaction model.
+
+## Problem
+
+The current default Coven terminal flow opens a raw-terminal Cast launcher: a command palette with example spells, slash spells, and direct action rows. That makes sense as an onboarding menu, but it does not feel like Claude Code. Claude Code's terminal experience is conversation-first: the user lands in a working chat loop, sees project/runtime context, types natural language immediately, and discovers commands through slash help rather than starting from a menu.
+
+Coven already has most of the required backend behavior:
+
+- `tui::shell` owns the default `coven` / `coven tui` raw-terminal launcher and Cast dispatch.
+- `tui::chat` owns a ratatui transcript/composer surface with daemon session launch, attach, input forwarding, event polling, history, agent selection, help, and session overlay.
+- `tui::cast` owns spell parsing, safety decisions, plan cards, outcomes, quest flow, and daemon-backed follow behavior.
+
+The redesign should change the product shape without discarding these proven pieces.
+
+## Goals
+
+1. Make `coven` and `coven tui` open a chat-first full-screen TUI.
+2. Make `coven chat` use the same experience so users do not learn two terminal products.
+3. Preserve Cast as the planner, safety gate, and dispatcher for typed spells.
+4. Preserve daemon-backed session launch, event polling, attach/replay, kill, and export behavior.
+5. Make slash commands discoverable through `/help` and `Ctrl+K`, not through a launch menu as the first screen.
+6. Keep non-interactive output friendly for pipes and CI by retaining the existing plain Cast frame.
+7. Keep the implementation testable through text snapshots and focused state tests.
+
+## Non-goals
+
+- Do not clone Claude Code branding, exact copy, or private behavior. The target is familiar interaction grammar: chat-first, compact status, natural prompt, slash-command discovery.
+- Do not change harness auth, model/provider ownership, daemon APIs, or store schema unless implementation proves a narrow need.
+- Do not remove existing commands such as `/sessions`, `/attach`, `/doctor`, `/daemon`, `/patch`, `/quest`, or session ritual verbs.
+- Do not implement a graphical or web UI.
+- Do not make the first implementation depend on live Codex or Claude credentials for tests.
+
+## Recommended Architecture
+
+### 1. A single chat-first shell
+
+Introduce a shared chat shell entry point used by both:
+
+- `Command::Chat`
+- `Command::Tui`
+- `None` (plain `coven` in an interactive terminal)
+
+The shell should reuse the ratatui lifecycle from `tui::chat` rather than adding a second full-screen stack. The existing raw-terminal launcher in `tui::shell` becomes legacy plumbing for non-interactive Cast output and for command dispatch helpers that still make sense.
+
+### 2. Cast-aware chat input
+
+Plain input in the new shell should route through Cast's parser/planner path before side effects:
+
+1. User enters text in the composer.
+2. The app builds a Cast plan from the raw spell.
+3. Safe plans proceed directly.
+4. Confirm/reject plans surface inline in the transcript with an explicit response path.
+5. Launch/attach/session actions reuse existing Cast and daemon machinery.
+6. Outcome summaries append to the transcript.
+
+The user should be able to type either natural language (`fix the failing tests`) or slash commands (`/sessions`, `/claude review the diff`) in the same composer.
+
+### 3. Command palette as overlay
+
+The current menu should not be the first screen. It should become:
+
+- `/help`: readable command help in the transcript or overlay.
+- `Ctrl+K`: compact command palette overlay.
+- `/commands`: alias for the same overlay.
+
+The palette lists the existing command surface, but it is secondary to the composer.
+
+### 4. Visual layout
+
+The default frame should be quiet and dense:
+
+```text
+Coven                  codex · /path/to/project                 daemon: running
+
+✦ coven
+  Ready. Type a task or /help.
+
+> fix the failing tests
+
+✦ Cast plan
+  harness      Codex · Cast default
+  risk         [ SAFE ]
+  steps        launch project-scoped session
+
+✦ Codex
+  ...streamed output...
+
+────────────────────────────────────────────────────────────────────────────
+> Try "review this branch" or /help
+```
+
+Important visual rules:
+
+- The transcript is the primary surface.
+- The composer is always at the bottom.
+- Status is compact and persistent.
+- There is no decorative launch menu on first paint.
+- Hints are short and contextual.
+- Existing brand color tokens remain available, but the layout should not depend on heavy color to be understandable.
+
+### 5. Session model
+
+The shell should track one active session at a time by default, matching the current chat TUI. When an active session exits, the next plain prompt launches a new session. Attach/replay uses the session overlay and existing daemon APIs.
+
+Required session interactions:
+
+- Start a session from natural language.
+- Stream output into transcript.
+- Forward follow-up input to a running session.
+- Clear active session on exit or kill.
+- `/attach <id>` replays or follows.
+- `/sessions` opens session overlay.
+- `/kill [id]` stops active or named live session.
+
+### 6. Non-interactive behavior
+
+If stdin or stdout is not a TTY, `coven` and `coven tui` should keep printing the existing plain Cast frame. This preserves scripts, docs snapshots, and current CI-friendly behavior.
+
+## Components
+
+### `tui::chat::app`
+
+Owns durable app state:
+
+- transcript messages
+- composer content and cursor
+- active harness/agent
+- active session id and event cursor
+- command palette/help/session overlays
+- pending Cast confirmation, if any
+
+New state should be narrowly added for Cast plans and confirmation prompts rather than widening daemon or store types.
+
+### `tui::chat::render`
+
+Owns the full-screen frame:
+
+- compact status row
+- transcript
+- bottom composer
+- help/command palette overlay
+- session overlay
+- small-terminal fallback
+
+Add plain snapshot helpers so tests can assert the new frame without a real terminal.
+
+### `tui::chat::events`
+
+Owns key handling:
+
+- text entry
+- Enter submit
+- Shift+Enter newline
+- Ctrl+C / Ctrl+D exit
+- Ctrl+K palette
+- Esc clears overlay or composer
+- Up/Down history when composer is focused
+- overlay navigation where relevant
+
+### `tui::chat::client`
+
+Remains the daemon-backed transport boundary. The redesign should not move direct socket code into render or event code.
+
+### `tui::cast`
+
+Remains the semantic layer for spell parsing, plan rendering, safety, quests, outcomes, and attach summaries. Implementation may add adapter helpers so chat can render Cast plan/outcome content as transcript messages instead of printing to stdout.
+
+## Data Flow
+
+### Safe natural prompt
+
+1. Composer receives `fix the failing tests`.
+2. Chat app calls Cast planning with the raw spell.
+3. Plan is appended as a system/Cast transcript message.
+4. Daemon session launches with the resolved harness and prompt.
+5. Output events append as assistant/agent transcript messages.
+6. Exit event appends a completion message and clears active session.
+
+### Confirmation prompt
+
+1. Composer receives a risky spell such as `publish the crate`.
+2. Cast returns `Confirm`.
+3. Transcript shows the plan and confirmation reason.
+4. App enters pending-confirmation state.
+5. `yes` proceeds; empty input, `no`, or Esc cancels and appends a cancelled outcome.
+
+### Slash command
+
+1. Composer receives `/sessions`.
+2. Cast intent or chat-local command maps to the session overlay.
+3. Overlay uses existing session list APIs.
+4. Selecting or typing `/attach <id>` enters attach/replay/follow flow.
+
+## Error Handling
+
+- Daemon unavailable: show an inline message with `coven daemon start` / `restart` guidance.
+- Harness unavailable: show `coven doctor` guidance and keep the composer usable.
+- API mismatch: show the daemon API mismatch and stop polling until the next user action.
+- Event polling failure: keep existing backoff and coalescing behavior.
+- Small terminal: show a minimal "Terminal too small" frame.
+- Unknown command: show a concise inline error and suggest `/help`.
+
+## Testing
+
+Implementation should use test-first changes around these contracts:
+
+1. `coven` / `coven tui` / `coven chat` route to the same interactive shell entry point when attached to a TTY.
+2. Non-interactive `coven tui` still prints the Cast plain frame.
+3. The default chat frame contains a compact status row, welcome transcript, and bottom composer, and does not contain the old launcher-first command list.
+4. `/help` or `Ctrl+K` exposes the command surface that used to be first-screen.
+5. Plain input appends a Cast plan transcript entry before launching.
+6. Safe prompts launch without confirmation; confirm prompts pause for explicit approval.
+7. Session exit and kill clear active session.
+8. Existing `cargo test -p coven-cli`, `cargo clippy -p coven-cli --no-deps`, and secret guard pass.
+
+Manual verification should include:
+
+- Launch `target/debug/coven` in a real TTY and confirm the first frame is chat-first.
+- Type a harmless prompt with a fake or available harness and confirm transcript flow.
+- Run `/help`, `/sessions`, and `/quit`.
+- Pipe `target/debug/coven tui | head` and confirm plain Cast output still works.
+
+## Migration Plan
+
+The implementation plan should be split into small reviewable stages:
+
+1. Add chat frame snapshot helpers and tests for the target first screen.
+2. Make `Command::Tui` and default `None` call the shared chat shell for interactive terminals.
+3. Adapt chat input to route through Cast planning before daemon launch.
+4. Move command-palette behavior into `/help` and `Ctrl+K` overlays.
+5. Preserve and re-test non-interactive Cast plain output.
+6. Run full verification and open a PR separate from prior chat-state fixes.
+
+## Acceptance Criteria
+
+The goal is complete when current evidence proves:
+
+- `coven`, `coven tui`, and `coven chat` open the same chat-first interactive TUI.
+- The first interactive frame is transcript/composer/status oriented, not launcher/menu oriented.
+- Plain language and slash commands work from one composer.
+- Cast plan/safety/outcome behavior is preserved inside the transcript flow.
+- Existing daemon-backed session launch, attach, event follow, input forwarding, kill, and export behavior still work.
+- Non-interactive output remains script-friendly.
+- Focused snapshot/state tests cover the new visual and interaction contract.
+- Full repo gates pass.


### PR DESCRIPTION
## Summary
- Route interactive `coven`, `coven tui`, and `coven chat` into the shared chat-first ratatui shell while preserving plain Cast output for pipes.
- Send chat composer input through Cast planning, confirmation, outcome, and daemon/session actions before side effects.
- Keep command discovery behind `/help`, `/commands`, and Ctrl+K; add API mismatch polling pause and bare prompt Cast routing.

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p coven-cli`
- `cargo clippy -p coven-cli --no-deps`
- `cargo build -p coven-cli`
- `printf "" | target/debug/coven`
- `printf "" | target/debug/coven tui`
- `printf "" | target/debug/coven chat`
- `target/debug/coven "/help" </dev/null`
- PTY smoke: `target/debug/coven` renders the chat-first first frame
