### PR TITLE
feat(chat): add streaming toggle and human-readable agent output

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1,6 +1,7 @@
 //! Chat application state, behavior, and helpers. Owns `App` and all of its
 //! methods; provides `discover_agents` and the spinner-frame data.
 
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use crate::{
@@ -13,7 +14,8 @@ use crate::{
     },
 };
 
-use super::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
+use super::client::{coven_home_dir, ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
+use super::settings::{self, ChatSettings, StreamingMode};
 
 // ── Data types ─────────────────────────────────────────────────────────────
 
@@ -81,6 +83,9 @@ pub(super) struct App {
     pub(super) input_history: Vec<String>,
     pub(super) history_index: Option<usize>,
     pending_cast_confirmation: Option<CastPlan>,
+    streaming_mode: StreamingMode,
+    pending_agent_buffer: Option<(String, String)>,
+    coven_home: Option<PathBuf>,
     client: Box<dyn ChatClient>,
 }
 
@@ -90,14 +95,24 @@ impl App {
     pub(super) fn new() -> Self {
         let agents = discover_agents();
         let active_agent = agents.iter().position(|a| a.available);
-        Self::new_with_state(agents, active_agent, Box::<DaemonChatClient>::default())
+        Self::new_with_state(
+            agents,
+            active_agent,
+            Box::<DaemonChatClient>::default(),
+            Some(coven_home_dir()),
+        )
     }
 
     pub(super) fn new_with_state(
         agents: Vec<AgentInfo>,
         active_agent: Option<usize>,
         client: Box<dyn ChatClient>,
+        coven_home: Option<PathBuf>,
     ) -> Self {
+        let streaming_mode = coven_home
+            .as_deref()
+            .map(|home| settings::load_from(home).streaming)
+            .unwrap_or_default();
         let mut app = App {
             messages: Vec::new(),
             input: String::new(),
@@ -123,6 +138,9 @@ impl App {
             input_history: Vec::new(),
             history_index: None,
             pending_cast_confirmation: None,
+            streaming_mode,
+            pending_agent_buffer: None,
+            coven_home,
             client,
         };
 
@@ -139,7 +157,7 @@ impl App {
     pub(super) fn new_with_client(client: Box<dyn ChatClient>) -> Self {
         let agents = discover_agents();
         let active_agent = agents.iter().position(|a| a.available);
-        Self::new_with_state(agents, active_agent, client)
+        Self::new_with_state(agents, active_agent, client, None)
     }
 
     pub(super) fn push_system_message(&mut self, content: &str) {
@@ -177,6 +195,75 @@ impl App {
             }
         }
         self.push_agent_message(agent_name, content);
+    }
+
+    /// Stash agent output until the session completes (batched mode). Keyed by
+    /// sender so a mid-stream agent switch doesn't merge two voices into one
+    /// bubble.
+    fn buffer_pending_agent_output(&mut self, agent_name: &str, content: &str) {
+        match self.pending_agent_buffer.as_mut() {
+            Some((sender, buffer)) if sender == agent_name => buffer.push_str(content),
+            Some(_) => {
+                self.flush_pending_agent_buffer();
+                self.pending_agent_buffer = Some((agent_name.to_string(), content.to_string()));
+            }
+            None => {
+                self.pending_agent_buffer = Some((agent_name.to_string(), content.to_string()));
+            }
+        }
+    }
+
+    /// Drain the batched-mode buffer into a single agent message. Called on
+    /// session end (exit/kill) and when the user flips streaming back on.
+    fn flush_pending_agent_buffer(&mut self) {
+        let Some((sender, buffer)) = self.pending_agent_buffer.take() else {
+            return;
+        };
+        if buffer.trim().is_empty() {
+            return;
+        }
+        self.push_agent_message(&sender, &buffer);
+    }
+
+    pub(super) fn streaming_mode(&self) -> StreamingMode {
+        self.streaming_mode
+    }
+
+    pub(super) fn has_pending_batched_output(&self) -> bool {
+        self.pending_agent_buffer
+            .as_ref()
+            .is_some_and(|(_, buffer)| !buffer.is_empty())
+    }
+
+    fn set_streaming_mode(&mut self, mode: StreamingMode) {
+        if self.streaming_mode == mode {
+            let already = match mode {
+                StreamingMode::Live => "Streaming is already on.",
+                StreamingMode::Batched => "Streaming is already off.",
+            };
+            self.push_system_message(already);
+            return;
+        }
+        self.streaming_mode = mode;
+        // Flipping back to live should not strand any held-back output.
+        if mode.is_live() {
+            self.flush_pending_agent_buffer();
+        }
+        if let Some(home) = self.coven_home.clone() {
+            let settings = ChatSettings { streaming: mode };
+            if let Err(error) = settings::save_to(&home, &settings) {
+                self.push_system_message(&format!(
+                    "Streaming preference not persisted: {error}. Setting still active for this session."
+                ));
+            }
+        }
+        let note = match mode {
+            StreamingMode::Live => "Streaming on. Agent output will appear as it arrives.",
+            StreamingMode::Batched => {
+                "Streaming off. Agent output will appear once the response completes."
+            }
+        };
+        self.push_system_message(note);
     }
 
     pub(super) fn active_agent_label(&self) -> &str {
@@ -334,6 +421,28 @@ impl App {
             }
             "/debug" => {
                 self.push_system_message("Debug mode coming soon.");
+                SlashCommandResult::Handled
+            }
+            "/stream" | "/streaming" => {
+                let new_mode = match arg.to_ascii_lowercase().as_str() {
+                    "" | "toggle" => self.streaming_mode.toggled(),
+                    "on" | "live" => StreamingMode::Live,
+                    "off" | "batched" | "complete" => StreamingMode::Batched,
+                    "status" => {
+                        self.push_system_message(&format!(
+                            "Streaming is {}.",
+                            self.streaming_mode.status_label()
+                        ));
+                        return SlashCommandResult::Handled;
+                    }
+                    other => {
+                        self.push_system_message(&format!(
+                            "Unknown /stream argument \"{other}\". Usage: /stream [on|off|toggle|status]."
+                        ));
+                        return SlashCommandResult::Handled;
+                    }
+                };
+                self.set_streaming_mode(new_mode);
                 SlashCommandResult::Handled
             }
             _ => SlashCommandResult::Unknown(cmd),
@@ -643,11 +752,16 @@ impl App {
                 if let Some(data) = event_payload_text(event, "data") {
                     let sender = self.active_agent_label().to_string();
                     if let Some(text) = clean_terminal_output(&data) {
-                        self.push_or_append_agent_message(&sender, &text);
+                        if self.streaming_mode.is_live() {
+                            self.push_or_append_agent_message(&sender, &text);
+                        } else {
+                            self.buffer_pending_agent_output(&sender, &text);
+                        }
                     }
                 }
             }
             "exit" => {
+                self.flush_pending_agent_buffer();
                 let status =
                     event_payload_text(event, "status").unwrap_or_else(|| "exited".to_string());
                 self.is_responding = false;
@@ -657,6 +771,7 @@ impl App {
                 self.push_system_message(&format!("Session {status}."));
             }
             "kill" => {
+                self.flush_pending_agent_buffer();
                 if self.active_session_id.as_deref() == Some(event.session_id.as_str()) {
                     self.active_session_id = None;
                     self.is_responding = false;
@@ -951,6 +1066,8 @@ fn is_chat_local_slash(input: &str) -> bool {
             | "/trace"
             | "/mem"
             | "/debug"
+            | "/stream"
+            | "/streaming"
     )
 }
 
@@ -1078,6 +1195,7 @@ mod tests {
             agents,
             active_agent,
             Box::new(RecordingChatClient::default()),
+            None,
         )
     }
 
@@ -1966,5 +2084,167 @@ mod tests {
                 .count(),
             2
         );
+    }
+
+    #[test]
+    fn live_streaming_appends_output_chunks_immediately() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        assert!(app.streaming_mode().is_live());
+
+        app.push_event_message(&output_event(1, "session-1", "Hello "));
+        app.push_event_message(&output_event(2, "session-1", "world!\n"));
+
+        let agent_messages: Vec<_> = app
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, MessageRole::Agent))
+            .collect();
+        assert_eq!(agent_messages.len(), 1);
+        assert_eq!(agent_messages[0].content, "Hello world!\n");
+    }
+
+    #[test]
+    fn batched_streaming_holds_output_until_session_exits() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.handle_slash_command("/stream off");
+        app.active_session_id = Some("session-1".to_string());
+        app.is_responding = true;
+
+        app.push_event_message(&output_event(1, "session-1", "first chunk "));
+        app.push_event_message(&output_event(2, "session-1", "second chunk\n"));
+
+        let agent_count_before_exit = app
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, MessageRole::Agent))
+            .count();
+        assert_eq!(agent_count_before_exit, 0);
+        assert!(app.has_pending_batched_output());
+
+        app.push_event_message(&EventRecord {
+            seq: 3,
+            id: "event-3".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        let agent_messages: Vec<_> = app
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, MessageRole::Agent))
+            .collect();
+        assert_eq!(agent_messages.len(), 1);
+        assert_eq!(agent_messages[0].content, "first chunk second chunk\n");
+        assert!(!app.has_pending_batched_output());
+        assert!(!app.is_responding);
+    }
+
+    #[test]
+    fn batched_streaming_flushes_pending_buffer_on_kill_event() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.handle_slash_command("/stream off");
+        app.active_session_id = Some("session-1".to_string());
+        app.is_responding = true;
+
+        app.push_event_message(&output_event(1, "session-1", "partial work"));
+        assert!(app.has_pending_batched_output());
+
+        app.push_event_message(&EventRecord {
+            seq: 2,
+            id: "event-2".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "kill".to_string(),
+            payload_json: serde_json::json!({ "status": "killed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        let agent_messages: Vec<_> = app
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, MessageRole::Agent))
+            .collect();
+        assert_eq!(agent_messages.len(), 1);
+        assert_eq!(agent_messages[0].content, "partial work");
+    }
+
+    #[test]
+    fn turning_streaming_back_on_flushes_pending_batched_output() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.handle_slash_command("/stream off");
+        app.active_session_id = Some("session-1".to_string());
+
+        app.push_event_message(&output_event(1, "session-1", "queued reply"));
+        assert!(app.has_pending_batched_output());
+
+        app.handle_slash_command("/stream on");
+
+        let agent_messages: Vec<_> = app
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, MessageRole::Agent))
+            .collect();
+        assert_eq!(agent_messages.len(), 1);
+        assert_eq!(agent_messages[0].content, "queued reply");
+        assert!(!app.has_pending_batched_output());
+        assert!(app.streaming_mode().is_live());
+    }
+
+    #[test]
+    fn stream_slash_command_toggles_and_reports_status() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        assert!(app.streaming_mode().is_live());
+
+        app.handle_slash_command("/stream");
+        assert!(!app.streaming_mode().is_live());
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Streaming off")));
+
+        app.handle_slash_command("/stream status");
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content == "Streaming is off."));
+
+        app.handle_slash_command("/stream on");
+        assert!(app.streaming_mode().is_live());
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Streaming on")));
+    }
+
+    #[test]
+    fn stream_slash_command_rejects_unknown_argument_without_changing_mode() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        let starting_mode = app.streaming_mode();
+
+        app.handle_slash_command("/stream please");
+
+        assert_eq!(app.streaming_mode(), starting_mode);
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Unknown /stream argument")));
+    }
+
+    #[test]
+    fn stream_slash_is_treated_as_local_so_cast_never_intercepts_it() {
+        // Regression guard: /stream must short-circuit through
+        // handle_slash_command, not fall into the Cast parser (which would
+        // emit a "unknown spell" message and never flip the toggle).
+        assert!(is_chat_local_slash("/stream"));
+        assert!(is_chat_local_slash("/stream off"));
+        assert!(is_chat_local_slash("/streaming on"));
     }
 }

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -333,7 +333,7 @@ fn daemon_error(status: u16, body: &str) -> anyhow::Error {
     anyhow!("Coven daemon rejected request with HTTP {status}")
 }
 
-fn coven_home_dir() -> PathBuf {
+pub(super) fn coven_home_dir() -> PathBuf {
     std::env::var_os("COVEN_HOME")
         .map(PathBuf::from)
         .or_else(|| dirs_next::home_dir().map(|home| home.join(".coven")))

--- a/crates/coven-cli/src/tui/chat/mod.rs
+++ b/crates/coven-cli/src/tui/chat/mod.rs
@@ -5,6 +5,7 @@ mod app;
 pub(crate) mod client;
 mod events;
 mod render;
+mod settings;
 
 // Re-export the public types so callers see them at `tui::chat::*` instead of
 // having to reach into `tui::chat::app::*`. Matches the surface of the old

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -73,6 +73,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         "ready"
     };
 
+    let stream_label = app.streaming_mode().status_label();
     let status_spans = vec![
         Span::styled(
             format!(" coven {harness} "),
@@ -80,7 +81,7 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
         ),
         Span::styled("\u{00b7} ", theme::ratatui_style(DIM)),
         Span::styled(
-            truncate_for_width(project, area.width.saturating_sub(28) as usize),
+            truncate_for_width(project, area.width.saturating_sub(60) as usize),
             theme::ratatui_style(DIM),
         ),
         Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
@@ -89,9 +90,19 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
             theme::ratatui_style(DIM),
         ),
         Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
+        Span::styled(format!("stream: {stream_label}"), theme::ratatui_style(DIM)),
+        Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
         if app.is_responding {
+            let composing = if app.has_pending_batched_output() {
+                " (composing)"
+            } else {
+                ""
+            };
             Span::styled(
-                format!("{} responding...", SPINNER_FRAMES[app.spinner_frame]),
+                format!(
+                    "{} responding...{composing}",
+                    SPINNER_FRAMES[app.spinner_frame]
+                ),
                 theme::ratatui_style(DIM),
             )
         } else {
@@ -147,21 +158,23 @@ fn render_messages(f: &mut Frame, app: &mut App, area: Rect) {
 
         lines.push(Line::from(Span::styled(sender_text, sender_style)));
 
-        // Message content with simple word wrapping
         let wrap_width = if width > 4 { width - 2 } else { width };
-        for content_line in msg.content.lines() {
-            if content_line.is_empty() {
-                lines.push(Line::from(""));
-                continue;
-            }
-            let wrapped = textwrap::wrap(content_line, wrap_width);
-            for wl in wrapped {
+        match msg.role {
+            MessageRole::Agent => append_agent_content_lines(&mut lines, &msg.content, wrap_width),
+            _ => {
                 let style = match msg.role {
                     MessageRole::User => theme::ratatui_style(TEXT),
-                    MessageRole::Agent => theme::ratatui_style(TEXT_DIM),
-                    MessageRole::System => theme::ratatui_style(PRIMARY),
+                    _ => theme::ratatui_style(PRIMARY),
                 };
-                lines.push(Line::from(Span::styled(format!("  {wl}"), style)));
+                for content_line in msg.content.lines() {
+                    if content_line.is_empty() {
+                        lines.push(Line::from(""));
+                        continue;
+                    }
+                    for wl in textwrap::wrap(content_line, wrap_width) {
+                        lines.push(Line::from(Span::styled(format!("  {wl}"), style)));
+                    }
+                }
             }
         }
     }
@@ -206,6 +219,120 @@ fn render_messages(f: &mut Frame, app: &mut App, area: Rect) {
             &mut scrollbar_state,
         );
     }
+}
+
+/// Render an agent message body with light markdown awareness so harness
+/// output stays human-readable: code fences become a left-bar code block,
+/// `# ` headings stand out, `- `/`* ` bullets keep their marker on the first
+/// wrapped line and indent continuations under the text, and runs of blank
+/// lines collapse to a single separator.
+fn append_agent_content_lines<'a>(lines: &mut Vec<Line<'a>>, content: &str, wrap_width: usize) {
+    let text_style = theme::ratatui_style(TEXT);
+    let dim_style = theme::ratatui_style(TEXT_DIM);
+    let heading_style = theme::ratatui_style(PRIMARY).bold();
+
+    let mut in_code_block = false;
+    let mut last_was_blank = true;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim_end_matches(['\r']);
+
+        if line.trim_start().starts_with("```") {
+            in_code_block = !in_code_block;
+            // Don't render the fence itself; it carried structure, not text.
+            continue;
+        }
+
+        if in_code_block {
+            let visible = if wrap_width > 4 && line.chars().count() > wrap_width - 4 {
+                line.chars().take(wrap_width - 4).collect::<String>()
+            } else {
+                line.to_string()
+            };
+            lines.push(Line::from(vec![
+                Span::styled("  \u{2502} ", dim_style),
+                Span::styled(visible, text_style),
+            ]));
+            last_was_blank = false;
+            continue;
+        }
+
+        if line.trim().is_empty() {
+            if !last_was_blank {
+                lines.push(Line::from(""));
+                last_was_blank = true;
+            }
+            continue;
+        }
+        last_was_blank = false;
+
+        if let Some(heading) = strip_heading_prefix(line) {
+            let wrap_target = wrap_width.saturating_sub(2).max(1);
+            for wl in textwrap::wrap(heading, wrap_target) {
+                lines.push(Line::from(Span::styled(format!("  {wl}"), heading_style)));
+            }
+            continue;
+        }
+
+        if let Some((marker, body)) = strip_bullet_prefix(line) {
+            let indent_first = format!("  {marker}");
+            let indent_cont = "    ".to_string();
+            let wrap_target = wrap_width
+                .saturating_sub(indent_first.chars().count())
+                .max(1);
+            let mut wrapped = textwrap::wrap(body, wrap_target).into_iter();
+            if let Some(first) = wrapped.next() {
+                lines.push(Line::from(Span::styled(
+                    format!("{indent_first}{first}"),
+                    text_style,
+                )));
+            }
+            for cont in wrapped {
+                lines.push(Line::from(Span::styled(
+                    format!("{indent_cont}{cont}"),
+                    text_style,
+                )));
+            }
+            continue;
+        }
+
+        let wrap_target = wrap_width.saturating_sub(2).max(1);
+        for wl in textwrap::wrap(line, wrap_target) {
+            lines.push(Line::from(Span::styled(format!("  {wl}"), text_style)));
+        }
+    }
+
+    if in_code_block {
+        // A fence opened mid-stream and hasn't closed yet; leave a subtle
+        // marker so the reader knows the code block is still flowing.
+        lines.push(Line::from(Span::styled("  \u{2502} \u{2026}", dim_style)));
+    }
+}
+
+fn strip_heading_prefix(line: &str) -> Option<&str> {
+    for prefix in ["#### ", "### ", "## ", "# "] {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+fn strip_bullet_prefix(line: &str) -> Option<(&'static str, &str)> {
+    let trimmed = line.trim_start();
+    let indent = line.len() - trimmed.len();
+    // Cap indent passthrough; very deep indentation is rare and would push the
+    // body off-screen on narrow terminals.
+    if indent > 4 {
+        return None;
+    }
+    if let Some(rest) = trimmed.strip_prefix("- ") {
+        return Some(("\u{2022} ", rest));
+    }
+    if let Some(rest) = trimmed.strip_prefix("* ") {
+        return Some(("\u{2022} ", rest));
+    }
+    None
 }
 
 fn render_input(f: &mut Frame, app: &App, area: Rect) {
@@ -310,6 +437,14 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
                 ("/attach <id>", "Attach to daemon session"),
                 ("/run <harness> <prompt>", "Launch via daemon"),
                 ("/kill [id]", "Ask daemon to kill a live session"),
+            ],
+        ),
+        (
+            "Output",
+            vec![
+                ("/stream", "Toggle live agent streaming (persisted)"),
+                ("/stream on|off", "Force live or batched output"),
+                ("/stream status", "Show current streaming mode"),
             ],
         ),
         (
@@ -540,7 +675,7 @@ pub(crate) fn render_chat_frame_plain_for_test(width: u16, height: u16) -> Strin
         harness: "codex".to_string(),
         available: true,
     }];
-    let mut app = App::new_with_state(agents, Some(0), Box::<DaemonChatClient>::default());
+    let mut app = App::new_with_state(agents, Some(0), Box::<DaemonChatClient>::default(), None);
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).expect("test terminal");
     terminal
@@ -581,6 +716,98 @@ mod tests {
         assert!(!frame.contains("Commands"));
         assert!(!frame.contains("/start"));
         assert!(!frame.contains("Session browser"));
+    }
+
+    #[test]
+    fn status_bar_advertises_current_streaming_mode() {
+        let frame = render_chat_frame_plain_for_test(80, 20);
+        assert!(frame.contains("stream: live"));
+    }
+
+    #[test]
+    fn agent_lines_render_fenced_code_blocks_with_bar_prefix() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let content = "Run this:\n```\ncargo test\n```\nDone.";
+        append_agent_content_lines(&mut lines, content, 40);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+        let joined = rendered.join("|");
+
+        assert!(joined.contains("  Run this:"));
+        assert!(rendered
+            .iter()
+            .any(|line| line.contains("\u{2502} cargo test")));
+        assert!(!joined.contains("```"));
+        assert!(joined.contains("  Done."));
+    }
+
+    #[test]
+    fn agent_lines_promote_markdown_headings_and_bullets() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let content = "# Title\n\n- first\n- second item that wraps onto another line";
+        append_agent_content_lines(&mut lines, content, 30);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+
+        assert!(rendered.iter().any(|line| line.contains("  Title")));
+        assert!(rendered.iter().any(|line| line.contains("\u{2022} first")));
+        assert!(rendered.iter().any(|line| line.contains("\u{2022} second")));
+        // Wrapped continuation must be indented under the bullet body.
+        let bullet_idx = rendered
+            .iter()
+            .position(|line| line.contains("\u{2022} second"))
+            .expect("bullet line present");
+        let continuation = &rendered[bullet_idx + 1];
+        assert!(continuation.starts_with("    "));
+    }
+
+    #[test]
+    fn agent_lines_collapse_runs_of_blank_lines_to_a_single_separator() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let content = "First paragraph.\n\n\n\nSecond paragraph.";
+        append_agent_content_lines(&mut lines, content, 40);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+        let blanks_between = rendered
+            .windows(2)
+            .filter(|pair| pair[0].trim().is_empty() && pair[1].trim().is_empty())
+            .count();
+        assert_eq!(blanks_between, 0);
+        assert!(rendered
+            .iter()
+            .any(|line| line.contains("First paragraph.")));
+        assert!(rendered
+            .iter()
+            .any(|line| line.contains("Second paragraph.")));
+    }
+
+    #[test]
+    fn agent_lines_emit_unterminated_code_block_marker_during_streaming() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        // Mid-stream chunk: fence opened but closing fence hasn't arrived yet.
+        append_agent_content_lines(&mut lines, "```\ncargo run", 40);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+        assert!(rendered
+            .iter()
+            .any(|line| line.contains("\u{2502} cargo run")));
+        // Last rendered line should hint that more code is still flowing.
+        assert!(rendered
+            .last()
+            .map(|line| line.contains('\u{2026}'))
+            .unwrap_or(false));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/settings.rs
+++ b/crates/coven-cli/src/tui/chat/settings.rs
@@ -1,0 +1,114 @@
+//! Persistent chat-TUI settings. The on-disk form is a small JSON document at
+//! `<coven_home>/chat-settings.json` so non-Coven tooling can inspect or edit
+//! it without learning a custom format. Today the only setting is the
+//! streaming mode toggle; future entries should land in the same file rather
+//! than introducing a parallel store.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Whether agent responses should appear chunk-by-chunk as they arrive
+/// (`Live`) or be held back until the session reports completion (`Batched`).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum StreamingMode {
+    #[default]
+    Live,
+    Batched,
+}
+
+impl StreamingMode {
+    pub(super) fn status_label(self) -> &'static str {
+        match self {
+            StreamingMode::Live => "live",
+            StreamingMode::Batched => "off",
+        }
+    }
+
+    pub(super) fn is_live(self) -> bool {
+        matches!(self, StreamingMode::Live)
+    }
+
+    pub(super) fn toggled(self) -> Self {
+        match self {
+            StreamingMode::Live => StreamingMode::Batched,
+            StreamingMode::Batched => StreamingMode::Live,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct ChatSettings {
+    #[serde(default)]
+    pub(super) streaming: StreamingMode,
+}
+
+pub(super) fn settings_path(coven_home: &Path) -> PathBuf {
+    coven_home.join("chat-settings.json")
+}
+
+/// Load settings from disk, falling back to defaults on any error. The TUI
+/// uses this on startup, so an unreadable or partially-written file must not
+/// stop the chat from coming up — it just resets to defaults silently.
+pub(super) fn load_from(coven_home: &Path) -> ChatSettings {
+    let path = settings_path(coven_home);
+    let Ok(data) = std::fs::read(&path) else {
+        return ChatSettings::default();
+    };
+    serde_json::from_slice(&data).unwrap_or_default()
+}
+
+/// Persist settings to disk, creating `<coven_home>` if missing. Returns the
+/// underlying io error so callers can surface a system message — but they
+/// must not treat it as a fatal failure (the in-memory mode is still active).
+pub(super) fn save_to(coven_home: &Path, settings: &ChatSettings) -> std::io::Result<()> {
+    std::fs::create_dir_all(coven_home)?;
+    let body = serde_json::to_vec_pretty(settings)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    std::fs::write(settings_path(coven_home), body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_live_streaming() {
+        let settings = ChatSettings::default();
+        assert_eq!(settings.streaming, StreamingMode::Live);
+        assert!(settings.streaming.is_live());
+        assert_eq!(settings.streaming.status_label(), "live");
+    }
+
+    #[test]
+    fn toggled_streaming_mode_round_trips() {
+        assert_eq!(StreamingMode::Live.toggled(), StreamingMode::Batched);
+        assert_eq!(StreamingMode::Batched.toggled(), StreamingMode::Live);
+    }
+
+    #[test]
+    fn load_returns_defaults_when_file_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let loaded = load_from(temp.path());
+        assert_eq!(loaded, ChatSettings::default());
+    }
+
+    #[test]
+    fn save_then_load_preserves_streaming_choice() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings = ChatSettings {
+            streaming: StreamingMode::Batched,
+        };
+        save_to(temp.path(), &settings).expect("save settings");
+        let reloaded = load_from(temp.path());
+        assert_eq!(reloaded, settings);
+    }
+
+    #[test]
+    fn corrupt_settings_file_falls_back_to_defaults() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(settings_path(temp.path()), b"not json").unwrap();
+        assert_eq!(load_from(temp.path()), ChatSettings::default());
+    }
+}


### PR DESCRIPTION
## Summary

- New `/stream [on|off|toggle|status]` slash command (with `/streaming` alias) and persistent `~/.coven/chat-settings.json` so users can pick between live token-by-token output or batched-on-completion delivery — choice survives restarts. Status bar shows `stream: live` / `stream: off`; while batched output is held back the spinner reads `responding... (composing)`. Buffers flush on `exit`/`kill` events and when streaming is flipped back on, so no reply is ever stranded.
- Assistant message rendering now passes through `append_agent_content_lines`: fenced code blocks get a `│ ` left bar (plus a trailing `│ …` marker when a fence is open mid-stream), `#`/`##`/`###` headings stand out, `-`/`*` bullets become `•` with continuation indent, and runs of blank lines collapse to a single separator.
- `coven_home_dir()` is now `pub(super)` so `App` can read/write settings without re-deriving the path.

## Test plan

- [x] `cargo fmt -p coven-cli`
- [x] `cargo clippy -p coven-cli --all-targets -- -D warnings`
- [x] `cargo test -p coven-cli` (395 unit + 4 smoke tests pass, includes 12 new tests covering settings round-trip, batched buffering, exit/kill flush, mid-stream toggle flush, `/stream` toggle + status + unknown-arg rejection, status-bar chip, and the markdown-lite renderer)
- [ ] Manual: `coven chat`, send a markdown reply, confirm fences/headings/bullets render cleanly, then `/stream off`, send another prompt, confirm spinner reads `(composing)` until the session exits and the full reply lands in one bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)