### PR TITLE
fix(chat): keep status bar tail visible at narrow widths

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -2106,6 +2106,38 @@ mod tests {
     }
 
     #[test]
+    fn status_bar_keeps_composing_indicator_at_eighty_columns() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.handle_slash_command("/stream off");
+        // A realistic long cwd previously pushed the rightmost segment off the
+        // status bar; the project label must yield first so the spinner +
+        // (composing) tail always survives.
+        app.project_label = "/Users/buns/Documents/GitHub/OpenCoven/coven".to_string();
+        app.active_session_id = Some("demo-session".to_string());
+        app.is_responding = true;
+        app.push_event_message(&output_event(1, "demo-session", "partial reply"));
+        assert!(app.has_pending_batched_output());
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 10)).unwrap();
+        terminal
+            .draw(|frame| crate::tui::chat::render::render_ui(frame, &mut app))
+            .unwrap();
+        let frame = crate::tui::chat::render::buffer_to_plain_text(terminal.backend().buffer());
+
+        assert!(
+            frame.contains("stream: off"),
+            "stream chip missing at 80 cols:\n{frame}"
+        );
+        assert!(
+            frame.contains("(composing)"),
+            "composing suffix clipped at 80 cols:\n{frame}"
+        );
+    }
+
+    #[test]
     fn batched_streaming_holds_output_until_session_exits() {
         let client = RecordingChatClient::default();
         let (mut app, _) = app_with_client(client);

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -74,40 +74,53 @@ fn render_status_bar(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let stream_label = app.streaming_mode().status_label();
-    let status_spans = vec![
-        Span::styled(
-            format!(" coven {harness} "),
-            theme::ratatui_style(PRIMARY).bold(),
-        ),
-        Span::styled("\u{00b7} ", theme::ratatui_style(DIM)),
-        Span::styled(
-            truncate_for_width(project, area.width.saturating_sub(60) as usize),
-            theme::ratatui_style(DIM),
-        ),
-        Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
-        Span::styled(
-            format!("daemon: {daemon_status}"),
-            theme::ratatui_style(DIM),
-        ),
-        Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
-        Span::styled(format!("stream: {stream_label}"), theme::ratatui_style(DIM)),
-        Span::styled(" \u{00b7} ", theme::ratatui_style(DIM)),
-        if app.is_responding {
-            let composing = if app.has_pending_batched_output() {
-                " (composing)"
-            } else {
-                ""
-            };
-            Span::styled(
-                format!(
-                    "{} responding...{composing}",
-                    SPINNER_FRAMES[app.spinner_frame]
-                ),
-                theme::ratatui_style(DIM),
-            )
+    let head_text = format!(" coven {harness} ");
+    let separator = "\u{00b7} ";
+    let separator_padded = " \u{00b7} ";
+    let daemon_text = format!("daemon: {daemon_status}");
+    let stream_text = format!("stream: {stream_label}");
+    let state_text = if app.is_responding {
+        let composing = if app.has_pending_batched_output() {
+            " (composing)"
         } else {
-            Span::styled("\u{2713} ready", theme::status_style(Status::Ready))
-        },
+            ""
+        };
+        format!(
+            "{} responding...{composing}",
+            SPINNER_FRAMES[app.spinner_frame]
+        )
+    } else {
+        "\u{2713} ready".to_string()
+    };
+
+    // Compute the project-label budget from what the rest of the row actually
+    // needs, so the rightmost segment never clips when daemon: running and the
+    // batched "(composing)" suffix push the tail wider than usual.
+    let fixed_width = UnicodeWidthStr::width(head_text.as_str())
+        + UnicodeWidthStr::width(separator)
+        + UnicodeWidthStr::width(separator_padded) * 3
+        + UnicodeWidthStr::width(daemon_text.as_str())
+        + UnicodeWidthStr::width(stream_text.as_str())
+        + UnicodeWidthStr::width(state_text.as_str());
+    let project_budget = (area.width as usize).saturating_sub(fixed_width);
+    let project_text = truncate_for_width(project, project_budget);
+
+    let state_style = if app.is_responding {
+        theme::ratatui_style(DIM)
+    } else {
+        theme::status_style(Status::Ready)
+    };
+
+    let status_spans = vec![
+        Span::styled(head_text, theme::ratatui_style(PRIMARY).bold()),
+        Span::styled(separator, theme::ratatui_style(DIM)),
+        Span::styled(project_text, theme::ratatui_style(DIM)),
+        Span::styled(separator_padded, theme::ratatui_style(DIM)),
+        Span::styled(daemon_text, theme::ratatui_style(DIM)),
+        Span::styled(separator_padded, theme::ratatui_style(DIM)),
+        Span::styled(stream_text, theme::ratatui_style(DIM)),
+        Span::styled(separator_padded, theme::ratatui_style(DIM)),
+        Span::styled(state_text, state_style),
     ];
 
     let status_line = Line::from(status_spans);
@@ -686,7 +699,7 @@ pub(crate) fn render_chat_frame_plain_for_test(width: u16, height: u16) -> Strin
 }
 
 #[cfg(test)]
-fn buffer_to_plain_text(buffer: &ratatui::buffer::Buffer) -> String {
+pub(super) fn buffer_to_plain_text(buffer: &ratatui::buffer::Buffer) -> String {
     let width = buffer.area.width as usize;
     buffer
         .content()


### PR DESCRIPTION
## Summary

Follow-up to #108. The status bar in the chat TUI was sizing the project label with a fixed `saturating_sub(60)` budget tuned for `daemon: ready` and no composing suffix. As soon as a session was running and batched output was buffered, the rightmost segment — including `responding... (composing)` — could clip off the right edge on narrow terminals.

This commit recomputes the project-label budget from the actual rendered width of the head, separators, daemon chip, stream chip, and spinner/composing suffix, so the project label is always the segment that yields first.

## Test plan

- [x] New regression test `status_bar_keeps_composing_indicator_at_eighty_columns` renders the chat frame at 80×10 with a long project path, batched mode, an active session, and a pending buffer; asserts both `stream: off` and `(composing)` survive in the rendered output.
- [x] `cargo fmt -p coven-cli`, `cargo clippy -p coven-cli --all-targets -- -D warnings`, `cargo test -p coven-cli` all green (396 unit + 4 smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)