### PR TITLE
fix(chat): render tables unwrapped and preserve streamed blank lines

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1137,7 +1137,12 @@ fn clean_terminal_output(data: &str) -> Option<String> {
         }
     }
 
-    (!output.trim().is_empty()).then_some(output)
+    // Newlines carry paragraph-break structure even when nothing visible
+    // surrounds them, so keep any chunk that has a newline OR any
+    // non-whitespace char. Drop only space/tab-only or fully empty chunks —
+    // those are pure control noise after escape sequences are stripped.
+    let has_structure = output.chars().any(|ch| ch == '\n' || !ch.is_whitespace());
+    has_structure.then_some(output)
 }
 
 fn skip_escape_sequence<I>(chars: &mut std::iter::Peekable<I>)
@@ -2004,6 +2009,25 @@ mod tests {
         assert_eq!(clean_terminal_output("\x1b[?25l\x1b[?25h"), None);
         assert_eq!(clean_terminal_output("\x1b]0;just a title\x07"), None);
         assert_eq!(clean_terminal_output("\r\r\r"), None);
+        // Pure space/tab without any newline is still invisible noise.
+        assert_eq!(clean_terminal_output("   "), None);
+        assert_eq!(clean_terminal_output("\t\t"), None);
+    }
+
+    #[test]
+    fn clean_terminal_output_preserves_newline_only_chunks_for_paragraph_breaks() {
+        // When the daemon streams a markdown reply line-by-line, blank source
+        // lines arrive as `\n`-only payloads. Dropping them collapses the
+        // paragraph structure on the way to the message body, so headings
+        // and tables end up stuck to the next block. Keep any chunk that
+        // carries a newline.
+        assert_eq!(clean_terminal_output("\n"), Some("\n".to_string()));
+        assert_eq!(clean_terminal_output("\n\n"), Some("\n\n".to_string()));
+        // Even mixed with control noise the newline must survive.
+        assert_eq!(
+            clean_terminal_output("\x1b[?25l\n\x1b[?25h"),
+            Some("\n".to_string())
+        );
     }
 
     #[test]
@@ -2103,6 +2127,34 @@ mod tests {
             .collect();
         assert_eq!(agent_messages.len(), 1);
         assert_eq!(agent_messages[0].content, "Hello world!\n");
+    }
+
+    #[test]
+    fn streamed_blank_line_chunks_keep_paragraph_breaks_in_message_body() {
+        // Regression: prior to keeping newline-only chunks, splitting a reply
+        // by lines and streaming each one separately erased the paragraph
+        // boundaries because the blank-line events were silently dropped.
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+
+        for (idx, chunk) in ["First paragraph.\n", "\n", "Second paragraph.\n"]
+            .iter()
+            .enumerate()
+        {
+            app.push_event_message(&output_event((idx as i64) + 1, "session-1", chunk));
+        }
+
+        let agent: Vec<_> = app
+            .messages
+            .iter()
+            .filter(|message| matches!(message.role, MessageRole::Agent))
+            .collect();
+        assert_eq!(agent.len(), 1);
+        assert_eq!(
+            agent[0].content, "First paragraph.\n\nSecond paragraph.\n",
+            "the blank-line chunk between paragraphs must survive"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -314,6 +314,18 @@ fn append_agent_content_lines<'a>(lines: &mut Vec<Line<'a>>, content: &str, wrap
             continue;
         }
 
+        if is_table_row(line) {
+            // Tables only survive when cell alignment is preserved; wrapping
+            // a row fragments the pipes and trashes the columns. Truncate
+            // with `\u{2026}` so the row stays on one visual line — losing
+            // the right edge is far easier to read than losing the columns.
+            let body = line.trim_end();
+            let visible_budget = wrap_width.saturating_sub(2).max(1);
+            let visible = truncate_for_width(body, visible_budget);
+            lines.push(Line::from(Span::styled(format!("  {visible}"), text_style)));
+            continue;
+        }
+
         let wrap_target = wrap_width.saturating_sub(2).max(1);
         for wl in textwrap::wrap(line, wrap_target) {
             lines.push(Line::from(Span::styled(format!("  {wl}"), text_style)));
@@ -346,6 +358,13 @@ fn strip_bullet_prefix(line: &str) -> Option<(usize, &'static str, &str)> {
         return Some((indent, "\u{2022} ", rest));
     }
     None
+}
+
+/// Lines beginning with `|` (after any leading indent) look like markdown
+/// table rows. They have to render unwrapped so column boundaries survive;
+/// wrapping at width turns the table into pipe-and-dash spaghetti.
+fn is_table_row(line: &str) -> bool {
+    line.trim_start().starts_with('|')
 }
 
 fn render_input(f: &mut Frame, app: &App, area: Rect) {
@@ -854,6 +873,71 @@ mod tests {
                 "raw `* ` marker leaked: {line:?}"
             );
         }
+    }
+
+    #[test]
+    fn agent_lines_preserve_table_row_alignment_at_wide_widths() {
+        // When the table fits inside the wrap budget, every row should land
+        // on its own line unwrapped so column boundaries stay intact.
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let content = "\
+| Mode    | Status chip   | Best for                    |
+|---------|---------------|-----------------------------|
+| live    | stream: live  | watching long-running plans |
+| batched | stream: off   | short queries and demos     |";
+        append_agent_content_lines(&mut lines, content, 80);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+
+        assert_eq!(rendered.len(), 4, "every table row should render unwrapped");
+        for row in &rendered {
+            assert!(
+                row.matches('|').count() == 4,
+                "row lost a pipe (should have 4): {row:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_lines_truncate_table_rows_with_ellipsis_at_narrow_widths() {
+        // When the source row is wider than the wrap budget, truncate with
+        // an ellipsis so the row stays on one line and the column header
+        // remains readable. Losing the right edge beats losing the columns.
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let row = "| A | B | C | D | E | F | G | H |";
+        append_agent_content_lines(&mut lines, row, 16);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+
+        assert_eq!(rendered.len(), 1, "table row must not wrap");
+        let only = &rendered[0];
+        assert!(
+            only.starts_with("  | A | B"),
+            "left edge preserved: {only:?}"
+        );
+        assert!(only.ends_with('\u{2026}'), "ellipsis applied: {only:?}");
+    }
+
+    #[test]
+    fn agent_lines_render_table_separator_row_without_wrapping() {
+        // The `|---|---|...` separator row is what makes a markdown table
+        // visually a table; if it wraps the table reads as garbage.
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        let content = "| Col A | Col B |\n|-------|-------|\n| value | other |";
+        append_agent_content_lines(&mut lines, content, 80);
+
+        let rendered: Vec<String> = lines
+            .iter()
+            .map(|line| line.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+        assert_eq!(rendered.len(), 3);
+        assert!(rendered[1].contains("|-------|-------|"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #108 / #109 / #110. Stress-testing with a wide markdown table exposed two related rendering issues:

### 1. Markdown tables fragment when narrower than the wrap budget

Table rows fell through to the prose-wrapping branch, so every row word-wrapped at the chat width. The closing `|` flopped onto the next row, the `---` separator split mid-dash, and cell alignment was destroyed.

**Fix:** add an `is_table_row` check (line starts with `|` after any leading indent) and route those rows through truncate-with-`…` instead of wrap. The row stays on one visual line and the columns read cleanly. Losing the right edge on narrow terminals is far easier to read than losing the table structure.

#### Before (96 cols, ~110-wide table):
```
   | Mode    | Status chip   | When output appears        | Buffered state    | Best for
   |
   |---------|---------------|----------------------------|-------------------|--------------
   ------------------|
   | live    | stream: live  | as each chunk arrives      | none              | watching
   long-running plans    |
```

#### After (same width):
```
   | Mode    | Status chip   | When output appears        | Buffered state    | Bes…
   |---------|---------------|----------------------------|-------------------|----…
   | live    | stream: live  | as each chunk arrives      | none              | wat…
```

### 2. Streamed blank lines disappear from message bodies

When the daemon streams a reply line-by-line, blank source lines arrive as `\n`-only output events. `clean_terminal_output`'s `(!output.trim().is_empty()).then_some` filter treated them as pure control noise and dropped them, collapsing every paragraph boundary in the rendered message.

**Fix:** tighten the filter to keep any chunk that has a newline OR any non-whitespace char. Control sequences, pure-space, and pure-tab chunks still drop — but `\n` survives because newlines carry structural information even when nothing visible surrounds them.

## Test plan

- [x] `agent_lines_preserve_table_row_alignment_at_wide_widths` — 4-row table at 80 cols, every row keeps its 4 pipes.
- [x] `agent_lines_truncate_table_rows_with_ellipsis_at_narrow_widths` — 8-column row at 16 cols renders unwrapped with `…` on the right.
- [x] `agent_lines_render_table_separator_row_without_wrapping` — `|---|---|` row preserved verbatim.
- [x] `clean_terminal_output_preserves_newline_only_chunks_for_paragraph_breaks` — `\n`-only chunks survive, even when sandwiched between control sequences.
- [x] `clean_terminal_output_drops_messages_that_are_pure_control_noise` expanded to assert pure-space and pure-tab chunks still drop.
- [x] `streamed_blank_line_chunks_keep_paragraph_breaks_in_message_body` — end-to-end through `push_event_message`: three chunks (`"P1.\n"`, `"\n"`, `"P2.\n"`) land as `"P1.\n\nP2.\n"` in the agent message.
- [x] `cargo fmt -p coven-cli`, `cargo clippy -p coven-cli --all-targets -- -D warnings`, `cargo test -p coven-cli` all green (403 unit + 4 smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)