### PR TITLE
feat: remember OpenClaw patch repo location

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -30,6 +30,7 @@ const DEFAULT_SESSION_STATUS: &str = "created";
 const RUNNING_SESSION_STATUS: &str = "running";
 const FAILED_SESSION_STATUS: &str = "failed";
 const DEFAULT_TITLE_CHARS: usize = 48;
+const OPENCLAW_REPOSITORY_ID: &str = "openclaw";
 
 #[derive(Parser, Debug)]
 #[command(name = "coven")]
@@ -280,7 +281,12 @@ fn run_patch_openclaw(
     _keep_session: bool,
 ) -> Result<()> {
     let start_dir = std::env::current_dir().context("failed to read current directory")?;
-    let detected_repo = openclaw_repo::detect_openclaw_repo(repo.as_deref(), &start_dir)?;
+    let stored_repo = stored_repository_path(OPENCLAW_REPOSITORY_ID)?;
+    let detected_repo = openclaw_repo::detect_openclaw_repo_with_stored(
+        repo.as_deref(),
+        &start_dir,
+        stored_repo.as_deref(),
+    )?;
     let git_state = openclaw_repo::inspect_git_state(&detected_repo.root)?;
     let issue = match joined_optional_issue(issue)? {
         Some(issue) => issue,
@@ -323,6 +329,7 @@ fn run_patch_openclaw(
     }
 
     let session_id = launch_patch_session(&request)?;
+    remember_openclaw_repo_location(&request.repo)?;
     let verification_results =
         verification::run_verification(&request.repo.root, &request.verification_profile)?;
     let verification_lines = verification_results
@@ -356,6 +363,38 @@ fn run_patch_openclaw(
         })
     );
     Ok(())
+}
+
+fn stored_repository_path(repository_id: &str) -> Result<Option<PathBuf>> {
+    let Some(store_path) = coven_store_path_if_exists()? else {
+        return Ok(None);
+    };
+    let Some(conn) = store::open_existing_store_read_only(&store_path)? else {
+        return Ok(None);
+    };
+    if !store::repositories_table_exists(&conn)? {
+        return Ok(None);
+    }
+    Ok(store::get_repository(&conn, repository_id)?.map(|repo| PathBuf::from(repo.path)))
+}
+
+fn remember_openclaw_repo_location(repo: &openclaw_repo::OpenClawRepo) -> Result<()> {
+    let store_path = coven_store_path()?;
+    let conn = store::open_store(&store_path)?;
+    let now = current_timestamp();
+    let existing = store::get_repository(&conn, OPENCLAW_REPOSITORY_ID)?;
+    store::upsert_repository(
+        &conn,
+        &store::RepositoryRecord {
+            id: OPENCLAW_REPOSITORY_ID.to_string(),
+            path: repo.root.to_string_lossy().into_owned(),
+            package_name: repo.package_name.clone(),
+            created_at: existing
+                .map(|repo| repo.created_at)
+                .unwrap_or_else(|| now.clone()),
+            updated_at: now,
+        },
+    )
 }
 
 fn joined_optional_issue(issue: Vec<String>) -> Result<Option<String>> {
@@ -897,6 +936,11 @@ fn coven_store_path() -> Result<PathBuf> {
     std::fs::create_dir_all(&home)
         .with_context(|| format!("failed to create Coven home directory {}", home.display()))?;
     Ok(home.join(STORE_FILE_NAME))
+}
+
+fn coven_store_path_if_exists() -> Result<Option<PathBuf>> {
+    let store_path = coven_home_dir()?.join(STORE_FILE_NAME);
+    Ok(store_path.exists().then_some(store_path))
 }
 
 fn coven_home_dir() -> Result<PathBuf> {

--- a/crates/coven-cli/src/openclaw_repo.rs
+++ b/crates/coven-cli/src/openclaw_repo.rs
@@ -23,27 +23,45 @@ impl GitState {
     }
 }
 
-pub fn detect_openclaw_repo(
+pub fn detect_openclaw_repo_with_stored(
     explicit_repo: Option<&Path>,
     start_dir: &Path,
+    stored_repo: Option<&Path>,
 ) -> Result<OpenClawRepo> {
     if let Some(repo) = explicit_repo {
         return validate_openclaw_repo(repo);
     }
 
+    if let Some(repo) = detect_openclaw_repo_from_ancestor(start_dir)? {
+        return Ok(repo);
+    }
+
+    if let Some(repo) = stored_repo {
+        return validate_openclaw_repo(repo).with_context(|| {
+            format!(
+                "stored OpenClaw repo path {} is no longer valid; pass --repo <path>",
+                repo.display()
+            )
+        });
+    }
+
+    anyhow::bail!(
+        "could not find an OpenClaw source checkout from {}; pass --repo <path>",
+        start_dir.display()
+    );
+}
+
+fn detect_openclaw_repo_from_ancestor(start_dir: &Path) -> Result<Option<OpenClawRepo>> {
     let mut candidate = start_dir
         .canonicalize()
         .with_context(|| format!("failed to resolve start directory {}", start_dir.display()))?;
 
     loop {
         if looks_like_openclaw_repo(&candidate)? {
-            return validate_openclaw_repo(&candidate);
+            return validate_openclaw_repo(&candidate).map(Some);
         }
         if !candidate.pop() {
-            anyhow::bail!(
-                "could not find an OpenClaw source checkout from {}; pass --repo <path>",
-                start_dir.display()
-            );
+            return Ok(None);
         }
     }
 }
@@ -189,7 +207,7 @@ mod tests {
         let repo = temp.path().join("openclaw");
         write_openclaw_fixture(&repo)?;
 
-        let detected = detect_openclaw_repo(Some(&repo), temp.path())?;
+        let detected = detect_openclaw_repo_with_stored(Some(&repo), temp.path(), None)?;
 
         assert_eq!(detected.root, repo.canonicalize()?);
         assert_eq!(detected.package_name.as_deref(), Some("openclaw"));
@@ -203,7 +221,7 @@ mod tests {
         fs::create_dir_all(repo.join(".git"))?;
         fs::write(repo.join("package.json"), r#"{"name":"other"}"#)?;
 
-        let error = detect_openclaw_repo(Some(&repo), temp.path()).unwrap_err();
+        let error = detect_openclaw_repo_with_stored(Some(&repo), temp.path(), None).unwrap_err();
 
         assert!(
             error
@@ -223,9 +241,54 @@ mod tests {
         // Also create the child dir so ancestry search works
         fs::create_dir_all(&child)?;
 
-        let detected = detect_openclaw_repo(None, &child)?;
+        let detected = detect_openclaw_repo_with_stored(None, &child, None)?;
 
         assert_eq!(detected.root, repo.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn detects_stored_openclaw_repo_when_current_directory_is_elsewhere() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let repo = temp.path().join("openclaw");
+        let unrelated = temp.path().join("notes");
+        write_openclaw_fixture(&repo)?;
+        fs::create_dir(&unrelated)?;
+
+        let detected = detect_openclaw_repo_with_stored(None, &unrelated, Some(&repo))?;
+
+        assert_eq!(detected.root, repo.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_openclaw_repo_beats_stored_repo() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let explicit = temp.path().join("explicit");
+        let stored = temp.path().join("stored");
+        write_openclaw_fixture(&explicit)?;
+        write_openclaw_fixture(&stored)?;
+
+        let detected =
+            detect_openclaw_repo_with_stored(Some(&explicit), temp.path(), Some(&stored))?;
+
+        assert_eq!(detected.root, explicit.canonicalize()?);
+        Ok(())
+    }
+
+    #[test]
+    fn ancestry_openclaw_repo_beats_stored_repo() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let ancestor = temp.path().join("ancestor");
+        let child = ancestor.join("src/gateway");
+        let stored = temp.path().join("stored");
+        write_openclaw_fixture(&ancestor)?;
+        write_openclaw_fixture(&stored)?;
+        fs::create_dir_all(&child)?;
+
+        let detected = detect_openclaw_repo_with_stored(None, &child, Some(&stored))?;
+
+        assert_eq!(detected.root, ancestor.canonicalize()?);
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -25,6 +25,15 @@ pub struct EventRecord {
     pub kind: String,
     pub payload_json: String,
     pub created_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepositoryRecord {
+    pub id: String,
+    pub path: String,
+    pub package_name: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 #[derive(Debug, Default)]
@@ -74,6 +83,14 @@ pub fn open_store(path: &Path) -> Result<Connection> {
 
         CREATE INDEX IF NOT EXISTS idx_events_session_created_at
             ON events(session_id, created_at);
+
+        CREATE TABLE IF NOT EXISTS repositories (
+            id TEXT PRIMARY KEY NOT NULL,
+            path TEXT NOT NULL,
+            package_name TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
         ",
     )
     .context("failed to initialize Coven store schema")?;
@@ -81,6 +98,16 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_archived_at_column(&conn)?;
 
     Ok(conn)
+}
+
+pub fn open_existing_store_read_only(path: &Path) -> Result<Option<Connection>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+        .with_context(|| format!("failed to open Coven store read-only at {}", path.display()))?;
+    Ok(Some(conn))
 }
 
 fn ensure_exit_code_column(conn: &Connection) -> Result<()> {
@@ -121,6 +148,71 @@ fn ensure_archived_at_column(conn: &Connection) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn upsert_repository(conn: &Connection, record: &RepositoryRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO repositories (
+            id,
+            path,
+            package_name,
+            created_at,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5)
+        ON CONFLICT(id) DO UPDATE SET
+            path = excluded.path,
+            package_name = excluded.package_name,
+            updated_at = excluded.updated_at",
+        params![
+            &record.id,
+            &record.path,
+            &record.package_name,
+            &record.created_at,
+            &record.updated_at,
+        ],
+    )
+    .with_context(|| format!("failed to upsert repository {}", record.id))?;
+
+    Ok(())
+}
+
+pub fn get_repository(conn: &Connection, id: &str) -> Result<Option<RepositoryRecord>> {
+    use rusqlite::OptionalExtension;
+
+    conn.query_row(
+        "SELECT id, path, package_name, created_at, updated_at
+         FROM repositories
+         WHERE id = ?1
+         LIMIT 1",
+        params![id],
+        |row| {
+            Ok(RepositoryRecord {
+                id: row.get(0)?,
+                path: row.get(1)?,
+                package_name: row.get(2)?,
+                created_at: row.get(3)?,
+                updated_at: row.get(4)?,
+            })
+        },
+    )
+    .optional()
+    .with_context(|| format!("failed to get repository {id}"))
+}
+
+pub fn repositories_table_exists(conn: &Connection) -> Result<bool> {
+    let exists = conn
+        .query_row(
+            "SELECT EXISTS(
+                SELECT 1
+                FROM sqlite_master
+                WHERE type = 'table' AND name = 'repositories'
+            )",
+            [],
+            |row| row.get::<_, bool>(0),
+        )
+        .context("failed to inspect repositories schema")?;
+
+    Ok(exists)
 }
 
 pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
@@ -448,6 +540,94 @@ mod tests {
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "session-1");
+        Ok(())
+    }
+
+    #[test]
+    fn stores_and_retrieves_repository_locations() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        let repo = RepositoryRecord {
+            id: "openclaw".to_string(),
+            path: "/repo/openclaw".to_string(),
+            package_name: Some("openclaw".to_string()),
+            created_at: "2026-05-24T05:00:00Z".to_string(),
+            updated_at: "2026-05-24T05:00:00Z".to_string(),
+        };
+
+        upsert_repository(&conn, &repo)?;
+
+        assert_eq!(get_repository(&conn, "openclaw")?, Some(repo));
+        Ok(())
+    }
+
+    #[test]
+    fn repository_locations_are_updated_without_changing_created_at() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        upsert_repository(
+            &conn,
+            &RepositoryRecord {
+                id: "openclaw".to_string(),
+                path: "/old/openclaw".to_string(),
+                package_name: Some("openclaw".to_string()),
+                created_at: "2026-05-24T05:00:00Z".to_string(),
+                updated_at: "2026-05-24T05:00:00Z".to_string(),
+            },
+        )?;
+
+        upsert_repository(
+            &conn,
+            &RepositoryRecord {
+                id: "openclaw".to_string(),
+                path: "/new/openclaw".to_string(),
+                package_name: Some("@openclaw/openclaw".to_string()),
+                created_at: "2026-05-24T06:00:00Z".to_string(),
+                updated_at: "2026-05-24T06:00:00Z".to_string(),
+            },
+        )?;
+
+        assert_eq!(
+            get_repository(&conn, "openclaw")?,
+            Some(RepositoryRecord {
+                id: "openclaw".to_string(),
+                path: "/new/openclaw".to_string(),
+                package_name: Some("@openclaw/openclaw".to_string()),
+                created_at: "2026-05-24T05:00:00Z".to_string(),
+                updated_at: "2026-05-24T06:00:00Z".to_string(),
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn missing_store_does_not_open_read_only() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let store_path = temp_dir.path().join("missing.db");
+
+        let conn = open_existing_store_read_only(&store_path)?;
+
+        assert!(conn.is_none());
+        assert!(!store_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn repositories_table_exists_detects_missing_table() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let store_path = temp_dir.path().join("legacy.db");
+        let conn = Connection::open(&store_path)?;
+        conn.execute(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY NOT NULL
+            )",
+            [],
+        )?;
+        drop(conn);
+
+        let conn = open_existing_store_read_only(&store_path)?.expect("store should exist");
+
+        assert!(!repositories_table_exists(&conn)?);
         Ok(())
     }
 

--- a/docs/reference/cli-patch.md
+++ b/docs/reference/cli-patch.md
@@ -6,4 +6,30 @@ title: "coven patch"
 description: "Reference for coven patch: targeted rescue and repair flows, including the openclaw subcommand that drives the OpenClaw harness rescue loop."
 ---
 
-Stub — fill in.
+`coven patch` runs guided repair flows for known project targets. The first target is OpenClaw.
+
+## OpenClaw
+
+Use `coven patch openclaw` when an OpenClaw source checkout needs a local repair pass through a supported harness.
+
+```sh
+coven patch openclaw
+coven patch openclaw "fix Codex auth profile order after invalidated OAuth token"
+coven patch openclaw "fix failing gateway auth test" --repo ~/Documents/GitHub/openclaw/openclaw --harness codex
+```
+
+The command selects an OpenClaw repository in this order:
+
+1. `--repo <path>`, when provided.
+2. The nearest OpenClaw source checkout above the current directory.
+3. The stored OpenClaw repository location in the local Coven store.
+
+When a non-dry-run patch session launches, Coven records the canonical OpenClaw repo path in `<COVEN_HOME>/coven.sqlite3`. Future `coven patch openclaw ...` runs can then be started from outside the OpenClaw checkout without repeating `--repo`.
+
+If the stored path becomes invalid, pass a fresh `--repo <path>` to replace it.
+
+## Safety
+
+The OpenClaw patch flow does not commit or push. It records a Coven session, launches the selected harness in the chosen repo, runs verification after the harness exits, and reports changed files plus verification status.
+
+Use `--dry-run` to inspect the selected repo, prompt brief, and verification profile without launching a harness or updating the stored repo location.

--- a/docs/superpowers/specs/2026-05-04-coven-patch-openclaw-design.md
+++ b/docs/superpowers/specs/2026-05-04-coven-patch-openclaw-design.md
@@ -412,3 +412,25 @@ New local API endpoints, scoped narrowly:
 - No multi-tenant Supreme. One Supreme per local user, bound to `COVEN_HOME`.
 - No automatic Lead restart or self-healing.
 - No new Supreme-only persistence schema in v0; Leads reuse session/event tables with a `patch_metadata` event marker.
+
+## Amendment: stored OpenClaw repository location (2026-05-24)
+
+Status: accepted for the current CLI rescue loop.
+
+### Motivation
+
+`coven patch openclaw` should not require users to run the command from inside an OpenClaw checkout every time. Once Coven has validated an OpenClaw repo, it can safely remember the canonical path in its local store and reuse it later.
+
+### Behavior
+
+Repository resolution now follows this precedence:
+
+1. Explicit `--repo <path>`.
+2. OpenClaw source checkout found by walking upward from the current directory.
+3. Stored OpenClaw repository path from the local Coven store.
+
+When a real patch session launches, Coven stores the selected canonical repo path under the `openclaw` repository id in `<COVEN_HOME>/coven.sqlite3`. `--dry-run` remains side-effect free and does not update the stored path.
+
+### Scope
+
+This is intentionally a small registry, not a general repo manager. The initial stored target is OpenClaw only; future patch targets can add their own repository ids when they get dedicated patch flows.


### PR DESCRIPTION
## Summary
- add local SQLite repository storage for Coven repo locations
- resolve `coven patch openclaw` via `--repo`, cwd ancestry, then stored OpenClaw path
- document the stored repo behavior and keep dry-runs side-effect free

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p coven-cli`
- explicit `--repo` dry-run smoke
- stored fallback dry-run smoke from `/tmp`

Co-authored-by: Nova <nova@openclaw.local>