### PR TITLE
fix: close review thread cleanup

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -13,7 +13,7 @@ A system where agents, tools, and workflows converge under intentional orchestra
 
 OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity. It moves AI beyond disposable chat sessions and toward durable, personal, intelligible systems that people can own, customize, and collaborate with over time.
 
-The value should be instantly clear: OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to the user.
+The value should be instantly clear: OpenCoven turns AI from a blank chatbox into a living workspace of agents that remember, coordinate, and belong to you.
 
 ### Vision
 Most AI today feels temporary: a user opens a chat, explains context, gets a response, and starts over. OpenCoven is built around a different future: AI that can stay.

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -82,11 +82,11 @@ enum Command {
     Sessions {
         #[arg(long, help = "Include archived sessions")]
         all: bool,
-        #[arg(long, help = "Open the interactive session action browser")]
+        #[arg(long, conflicts_with_all = ["plain", "json"], help = "Open the interactive session action browser")]
         manage: bool,
-        #[arg(long, help = "Print a plain table instead of the session browser")]
+        #[arg(long, conflicts_with_all = ["manage", "json"], help = "Print a plain table instead of the session browser")]
         plain: bool,
-        #[arg(long, help = "Print sessions as JSON for clients such as comux")]
+        #[arg(long, conflicts_with_all = ["manage", "plain"], help = "Print sessions as JSON for clients such as comux")]
         json: bool,
     },
     #[command(about = "Replay/follow a session and forward input to live daemon sessions")]
@@ -1542,11 +1542,11 @@ mod tests {
             other => panic!("expected sessions command, got {other:?}"),
         }
 
-        let managed = Cli::parse_from(["coven", "sessions", "--manage", "--plain"]);
+        let managed = Cli::parse_from(["coven", "sessions", "--manage"]);
         match managed.command {
             Some(Command::Sessions { manage, plain, .. }) => {
                 assert!(manage);
-                assert!(plain);
+                assert!(!plain);
             }
             other => panic!("expected sessions command, got {other:?}"),
         }
@@ -1722,6 +1722,20 @@ mod tests {
                 assert!(keep_session);
             }
             other => panic!("expected patch openclaw command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_rejects_conflicting_sessions_output_modes() {
+        for args in [
+            ["coven", "sessions", "--json", "--plain"],
+            ["coven", "sessions", "--json", "--manage"],
+            ["coven", "sessions", "--plain", "--manage"],
+        ] {
+            assert!(
+                Cli::try_parse_from(args).is_err(),
+                "sessions output modes should be mutually exclusive: {args:?}"
+            );
         }
     }
 

--- a/crates/coven-cli/src/pc/display.rs
+++ b/crates/coven-cli/src/pc/display.rs
@@ -1,4 +1,5 @@
 use crate::pc::diagnostics::{DiskInfo, ProcessInfo, SystemSnapshot};
+use serde_json::json;
 
 pub enum OutputFormat {
     Compact,
@@ -8,15 +9,23 @@ pub enum OutputFormat {
 
 fn health_indicator(pct: f32, warn: f32, crit: f32) -> &'static str {
     if pct >= crit {
-        "🔴"
+        "[crit]"
     } else if pct >= warn {
-        "🟡"
+        "[warn]"
     } else {
-        "🟢"
+        "[ok]"
     }
 }
 
-pub fn print_status(snap: &SystemSnapshot, _format: &OutputFormat) {
+pub fn print_status(snap: &SystemSnapshot, format: &OutputFormat) {
+    print!("{}", format_status(snap, format));
+}
+
+fn format_status(snap: &SystemSnapshot, format: &OutputFormat) -> String {
+    if matches!(format, OutputFormat::Json) {
+        return format_json(snap);
+    }
+
     let cpu_ind = health_indicator(snap.cpu_usage_pct, 70.0, 90.0);
     let mem_pct = if snap.memory_total_mb > 0 {
         snap.memory_used_mb as f32 / snap.memory_total_mb as f32 * 100.0
@@ -24,18 +33,18 @@ pub fn print_status(snap: &SystemSnapshot, _format: &OutputFormat) {
         0.0
     };
     let mem_ind = health_indicator(mem_pct, 70.0, 90.0);
-    println!(
+    format!(
         "{cpu_ind} CPU {:.1}%  {mem_ind} RAM {}/{} MB  uptime {}",
         snap.cpu_usage_pct,
         snap.memory_used_mb,
         snap.memory_total_mb,
         format_uptime(snap.uptime_secs),
-    );
+    )
 }
 
 pub fn print_full(snap: &SystemSnapshot, format: &OutputFormat) {
     match format {
-        OutputFormat::Json => print_json(snap),
+        OutputFormat::Json => println!("{}", format_json(snap)),
         OutputFormat::Compact | OutputFormat::Verbose => print_human(snap, format),
     }
 }
@@ -114,36 +123,34 @@ pub fn print_disk_usage(snap: &SystemSnapshot) {
     }
 }
 
-fn print_json(snap: &SystemSnapshot) {
-    // Minimal JSON output — no external serde dependency needed for this simple shape
-    println!("{{");
-    println!("  \"cpu_usage_pct\": {:.2},", snap.cpu_usage_pct);
-    println!("  \"memory_used_mb\": {},", snap.memory_used_mb);
-    println!("  \"memory_total_mb\": {},", snap.memory_total_mb);
-    println!("  \"swap_used_mb\": {},", snap.swap_used_mb);
-    println!("  \"swap_total_mb\": {},", snap.swap_total_mb);
-    println!("  \"uptime_secs\": {},", snap.uptime_secs);
-    println!("  \"processes\": [");
+fn format_json(snap: &SystemSnapshot) -> String {
     let procs: Vec<_> = snap.processes.iter().take(20).collect();
-    for (i, p) in procs.iter().enumerate() {
-        let comma = if i + 1 < procs.len() { "," } else { "" };
-        // Redact argv in JSON output too (verbose-only)
-        println!(
-            "    {{\"pid\": {}, \"name\": {:?}, \"cpu_pct\": {:.2}, \"memory_mb\": {}}}{}",
-            p.pid, p.name, p.cpu_pct, p.memory_mb, comma
-        );
-    }
-    println!("  ],");
-    println!("  \"disks\": [");
-    for (i, d) in snap.disks.iter().enumerate() {
-        let comma = if i + 1 < snap.disks.len() { "," } else { "" };
-        println!(
-            "    {{\"mount\": {:?}, \"total_gb\": {:.2}, \"available_gb\": {:.2}, \"used_pct\": {:.1}}}{}",
-            d.mount, d.total_gb, d.available_gb, d.used_pct, comma
-        );
-    }
-    println!("  ]");
-    println!("}}");
+    let value = json!({
+        "cpu_usage_pct": snap.cpu_usage_pct,
+        "memory_used_mb": snap.memory_used_mb,
+        "memory_total_mb": snap.memory_total_mb,
+        "swap_used_mb": snap.swap_used_mb,
+        "swap_total_mb": snap.swap_total_mb,
+        "uptime_secs": snap.uptime_secs,
+        "processes": procs.iter().map(|p| {
+            json!({
+                "pid": p.pid,
+                "name": p.name,
+                "cpu_pct": p.cpu_pct,
+                "memory_mb": p.memory_mb,
+            })
+        }).collect::<Vec<_>>(),
+        "disks": snap.disks.iter().map(|d| {
+            json!({
+                "mount": d.mount,
+                "total_gb": d.total_gb,
+                "available_gb": d.available_gb,
+                "used_pct": d.used_pct,
+            })
+        }).collect::<Vec<_>>(),
+    });
+
+    serde_json::to_string_pretty(&value).expect("system snapshot JSON serialization cannot fail")
 }
 
 fn format_uptime(secs: u64) -> String {
@@ -156,5 +163,54 @@ fn format_uptime(secs: u64) -> String {
         format!("{hours}h {mins}m")
     } else {
         format!("{mins}m")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_snapshot() -> SystemSnapshot {
+        SystemSnapshot {
+            cpu_usage_pct: 12.5,
+            memory_used_mb: 1024,
+            memory_total_mb: 4096,
+            swap_used_mb: 0,
+            swap_total_mb: 0,
+            uptime_secs: 3661,
+            processes: vec![ProcessInfo {
+                pid: 42,
+                name: "proc \"quoted\"\u{7}".to_string(),
+                cpu_pct: 3.5,
+                memory_mb: 64,
+                argv: None,
+            }],
+            disks: vec![DiskInfo {
+                mount: "/Volumes/name \"quoted\"\u{7}".to_string(),
+                total_gb: 100.0,
+                available_gb: 40.0,
+                used_pct: 60.0,
+            }],
+        }
+    }
+
+    #[test]
+    fn status_json_serializes_valid_json_with_expected_keys() {
+        let body = format_status(&sample_snapshot(), &OutputFormat::Json);
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["cpu_usage_pct"], 12.5);
+        assert_eq!(value["processes"][0]["name"], "proc \"quoted\"\u{7}");
+        assert_eq!(value["disks"][0]["mount"], "/Volumes/name \"quoted\"\u{7}");
+    }
+
+    #[test]
+    fn human_status_uses_non_emoji_indicators() {
+        let body = format_status(&sample_snapshot(), &OutputFormat::Compact);
+
+        assert!(body.contains("[ok] CPU"));
+        assert!(!body.contains('🟢'));
+        assert!(!body.contains('🟡'));
+        assert!(!body.contains('🔴'));
     }
 }

--- a/crates/coven-cli/src/pc/relief.rs
+++ b/crates/coven-cli/src/pc/relief.rs
@@ -1,10 +1,33 @@
 use anyhow::{bail, Result};
 use std::path::PathBuf;
-use sysinfo::{Pid, Signal, System};
+use sysinfo::{Pid, Process, Signal, System};
 
 /// Hardcoded cache directories eligible for clearing. Never uses glob expansion.
 const USER_CACHE_DIRS: &[&str] = &["Library/Caches"];
 const SYSTEM_CACHE_DIR: &str = "/Library/Caches";
+
+#[derive(Debug, PartialEq, Eq)]
+struct ProcessIdentity {
+    name: String,
+    start_time: u64,
+    exe: Option<PathBuf>,
+    cmd: Vec<String>,
+}
+
+impl ProcessIdentity {
+    fn from_process(process: &Process) -> Self {
+        Self {
+            name: process.name().to_string(),
+            start_time: process.start_time(),
+            exe: process.exe().map(PathBuf::from),
+            cmd: process.cmd().to_vec(),
+        }
+    }
+
+    fn matches(&self, other: &Self) -> bool {
+        self == other
+    }
+}
 
 /// Kill a process by PID. Requires --confirm flag at the CLI layer.
 /// Uses SIGTERM only (no SIGKILL in v1). Re-checks PID identity before signaling.
@@ -17,12 +40,12 @@ pub fn kill_by_pid(pid: u32, confirm: bool) -> Result<()> {
     sys.refresh_all();
 
     let pid_key = Pid::from_u32(pid);
-    let name = sys
+    let identity = sys
         .process(pid_key)
-        .map(|p| p.name().to_string())
+        .map(ProcessIdentity::from_process)
         .ok_or_else(|| anyhow::anyhow!("No process found with PID {pid}"))?;
 
-    eprintln!("Sending SIGTERM to PID {pid} ({name})...");
+    eprintln!("Sending SIGTERM to PID {pid} ({})...", identity.name);
 
     // Re-check identity immediately before signaling to avoid PID reuse mistakes
     sys.refresh_process(pid_key);
@@ -30,22 +53,26 @@ pub fn kill_by_pid(pid: u32, confirm: bool) -> Result<()> {
         .process(pid_key)
         .ok_or_else(|| anyhow::anyhow!("Process {pid} disappeared before signal could be sent"))?;
 
-    // Verify name still matches
-    let current_name = proc.name().to_string();
-    if current_name != name {
+    let current_identity = ProcessIdentity::from_process(proc);
+    if !identity.matches(&current_identity) {
         bail!(
-            "PID {pid} identity changed ({name} → {current_name}). Refusing to signal to avoid PID reuse mistake."
+            "PID {pid} identity changed ({} → {}). Refusing to signal to avoid PID reuse mistake.",
+            identity.name,
+            current_identity.name,
         );
     }
 
     let sent = proc.kill_with(Signal::Term);
     match sent {
         Some(true) => {
-            println!("SIGTERM sent to PID {pid} ({name}).");
+            println!("SIGTERM sent to PID {pid} ({}).", identity.name);
             Ok(())
         }
         Some(false) | None => {
-            bail!("Failed to send SIGTERM to PID {pid} ({name}). Check permissions.");
+            bail!(
+                "Failed to send SIGTERM to PID {pid} ({}). Check permissions.",
+                identity.name
+            );
         }
     }
 }
@@ -96,7 +123,14 @@ fn clear_directory_contents(path: &PathBuf, cleared: &mut usize, errors: &mut us
     };
     for entry in entries.flatten() {
         let entry_path = entry.path();
-        let result = if entry_path.is_dir() {
+        let metadata = match std::fs::symlink_metadata(&entry_path) {
+            Ok(metadata) => metadata,
+            Err(_) => {
+                *errors += 1;
+                continue;
+            }
+        };
+        let result = if metadata.file_type().is_dir() {
             std::fs::remove_dir_all(&entry_path)
         } else {
             std::fs::remove_file(&entry_path)
@@ -105,5 +139,51 @@ fn clear_directory_contents(path: &PathBuf, cleared: &mut usize, errors: &mut us
             Ok(()) => *cleared += 1,
             Err(_) => *errors += 1,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_identity_requires_more_than_name_to_match() {
+        let first = ProcessIdentity {
+            name: "worker".to_string(),
+            start_time: 100,
+            exe: Some(PathBuf::from("/bin/worker")),
+            cmd: vec!["worker".to_string()],
+        };
+        let reused_pid = ProcessIdentity {
+            name: "worker".to_string(),
+            start_time: 200,
+            exe: Some(PathBuf::from("/bin/worker")),
+            cmd: vec!["worker".to_string()],
+        };
+
+        assert!(!first.matches(&reused_pid));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clear_directory_contents_removes_symlink_without_traversing_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let cache = temp.path().join("cache");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("keep.txt"), "do not delete").unwrap();
+        symlink(&outside, cache.join("outside-link")).unwrap();
+
+        let mut cleared = 0;
+        let mut errors = 0;
+        clear_directory_contents(&cache, &mut cleared, &mut errors);
+
+        assert_eq!(errors, 0);
+        assert_eq!(cleared, 1);
+        assert!(outside.join("keep.txt").exists());
+        assert!(!cache.join("outside-link").exists());
     }
 }

--- a/crates/coven-cli/src/tui/cast/attach.rs
+++ b/crates/coven-cli/src/tui/cast/attach.rs
@@ -137,6 +137,18 @@ pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<Reconst
         .and_then(CastHarness::from_token);
 
     let mut quest = quest_from_goal(&goal, default_harness);
+    if let Some(title) = payload.get("title").and_then(Value::as_str) {
+        quest.title = title.to_string();
+    }
+    if let Some(phase_names) = payload.get("phases").and_then(Value::as_array) {
+        if phase_names.len() == quest.phases.len() {
+            for (phase, name) in quest.phases.iter_mut().zip(phase_names) {
+                if let Some(name) = name.as_str().filter(|name| !name.trim().is_empty()) {
+                    phase.name = name.to_string();
+                }
+            }
+        }
+    }
     let mut is_complete = false;
 
     for event in events {
@@ -171,8 +183,19 @@ pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<Reconst
                 }
             }
             kind if kind == CAST_QUEST_PHASE_COMPLETED_KIND => {
-                let payload =
-                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+                let Ok(payload) = serde_json::from_str::<Value>(&event.payload_json) else {
+                    continue;
+                };
+                let Some(idx) = payload
+                    .get("index")
+                    .and_then(Value::as_u64)
+                    .map(|v| v as usize)
+                else {
+                    continue;
+                };
+                if quest.current_index() != Some(idx) {
+                    continue;
+                }
                 let summary = QuestPhaseSummary {
                     session_id: payload
                         .get("session_id")
@@ -220,6 +243,7 @@ pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<Reconst
 pub(crate) fn format_quest_attach_note(info: &CastQuestAttachInfo) -> Option<String> {
     let title = info.title.as_deref().unwrap_or("(untitled quest)");
     let progress = match info.total_phases {
+        Some(total) if total > 0 && info.completed_phases == 0 => format!("0/{total} complete"),
         Some(total) if total > 0 => format!("phase {}/{total}", info.completed_phases.min(total)),
         _ => format!("{} phases run", info.completed_phases),
     };
@@ -546,6 +570,19 @@ mod tests {
     }
 
     #[test]
+    fn format_quest_attach_note_avoids_phase_zero() {
+        let info = CastQuestAttachInfo {
+            title: Some("Ship phase 7".to_string()),
+            total_phases: Some(3),
+            completed_phases: 0,
+            ..Default::default()
+        };
+        let note = format_quest_attach_note(&info).expect("note should be produced");
+        assert!(note.contains("0/3 complete"));
+        assert!(!note.contains("phase 0/3"));
+    }
+
+    #[test]
     fn format_quest_attach_note_describes_complete_quest() {
         let info = CastQuestAttachInfo {
             title: Some("Ship phase 7".to_string()),
@@ -644,6 +681,7 @@ mod tests {
         assert_eq!(recon.anchor_session_id, "anchor-id");
         assert!(!recon.is_complete);
         assert_eq!(recon.quest.cursor, 0);
+        assert_eq!(recon.quest.title, "Test quest");
         assert_eq!(recon.quest.goal, "ship phase 9");
     }
 
@@ -771,10 +809,22 @@ mod tests {
             phase_completed_event(3, 0, "completed", 0),
         ];
         let recon = reconstruct_quest(&events).expect("should reconstruct");
-        // The first (malformed) event still triggers an advance because
-        // `unwrap_or(Value::Null)` yields a default summary; both advances
-        // run, so cursor lands at 2.
-        assert_eq!(recon.quest.cursor, 2);
+        assert_eq!(recon.quest.cursor, 1);
+    }
+
+    #[test]
+    fn reconstruct_quest_ignores_phase_completed_events_with_wrong_index() {
+        let events = vec![
+            started_event_with("anchor-id", "ship phase 9", "codex"),
+            phase_completed_event(2, 2, "completed", 0),
+            phase_completed_event(3, 0, "completed", 0),
+        ];
+        let recon = reconstruct_quest(&events).expect("should reconstruct");
+        assert_eq!(recon.quest.cursor, 1);
+        assert!(matches!(
+            recon.quest.phases[2].status,
+            super::super::quest::QuestPhaseStatus::Pending
+        ));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use quest::{
     set_phase_sub_prompt, skip_phase, PhaseInteraction, Quest, QuestPhase, QuestPhaseStatus,
     QuestPhaseSummary, CAST_QUEST_ADVANCED_KIND, CAST_QUEST_COMPLETED_KIND,
     CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_PHASE_EDITED_KIND, CAST_QUEST_PHASE_SKIPPED_KIND,
-    CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
+    CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND, PHASE_PROMPT_HINT,
 };
 // `compose_sub_prompt` and `QuestHandoff` are exercised by the in-module
 // test suite; they remain in the public crate surface so a future async /

--- a/crates/coven-cli/src/tui/cast/quest.rs
+++ b/crates/coven-cli/src/tui/cast/quest.rs
@@ -16,11 +16,9 @@
 //!
 //! Integration boundary: this module is pure. The Cast shell wires the
 //! quest into its existing gate / follow / outcome surfaces; `quest.rs`
-//! does no IO and never reaches the daemon directly. Phase 7 lands the
-//! shell wiring, so the module is no longer dead — but `skip_phase`,
-//! `set_phase_sub_prompt`, and `compose_sub_prompt` remain reachable only
-//! through future UX (edit / skip prompts deferred per the Phase 7 scope
-//! decision). Their `#[allow(dead_code)]` annotations document that.
+//! does no IO and never reaches the daemon directly. The approve / edit /
+//! skip / cancel UX lives in the shell; this module owns the deterministic
+//! state transitions and parser that keep the event ledger replayable.
 
 use anyhow::{anyhow, Result};
 
@@ -37,6 +35,11 @@ pub(crate) const CAST_QUEST_PHASE_SKIPPED_KIND: &str = "cast.quest.phase_skipped
 pub(crate) const CAST_QUEST_PHASE_EDITED_KIND: &str = "cast.quest.phase_edited";
 pub(crate) const CAST_QUEST_ADVANCED_KIND: &str = "cast.quest.advanced";
 pub(crate) const CAST_QUEST_COMPLETED_KIND: &str = "cast.quest.completed";
+
+/// One line of phase-prompt help, shared by the handoff card and shell
+/// prompt so the rendered contract and accepted commands cannot drift.
+pub(crate) const PHASE_PROMPT_HINT: &str =
+    "enter approve · type to replace · /skip [reason] · /cancel [reason]";
 
 /// A sequential goal Cast is guiding the user through. Owns the original
 /// user request and an ordered list of [`QuestPhase`]s. `cursor` points at
@@ -68,16 +71,13 @@ pub(crate) struct QuestPhase {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum QuestPhaseStatus {
     Pending,
-    /// Reserved for a future "live attach to a running quest phase" UX —
-    /// the shell loop in Phase 7 transitions Pending → Complete directly.
-    #[allow(dead_code)]
+    /// The phase launched and has not recorded a completion event yet.
+    /// Replay uses this to pause instead of re-prompting or re-launching.
     Running {
         session_id: String,
     },
     Complete(QuestPhaseSummary),
-    /// Set by `skip_phase` (currently only exercised by tests; the
-    /// auto-advance loop never skips on its own).
-    #[allow(dead_code)]
+    /// Set by `skip_phase` when the user explicitly skips a phase.
     Skipped {
         reason: String,
     },
@@ -271,9 +271,6 @@ pub(crate) fn advance(quest: &mut Quest, summary: QuestPhaseSummary) -> Option<u
 /// text. Errors out if the phase is not pending — Cast does not rewrite
 /// already-running or completed phases.
 ///
-/// Reserved for the edit-sub-prompt UX deferred per Phase 7's scope
-/// decision; currently only the in-module test suite calls it.
-#[allow(dead_code)]
 pub(crate) fn set_phase_sub_prompt(
     quest: &mut Quest,
     index: usize,
@@ -326,9 +323,6 @@ pub(crate) fn mark_phase_running(
 /// phase already satisfied this phase's goal (e.g. tests passed during
 /// implement, so verify becomes a no-op).
 ///
-/// Reserved for the skip-phase UX deferred per Phase 7's scope decision;
-/// currently only the in-module test suite calls it.
-#[allow(dead_code)]
 pub(crate) fn skip_phase(quest: &mut Quest, index: usize, reason: String) -> Result<()> {
     let phase = quest
         .phases

--- a/crates/coven-cli/src/tui/cast/render.rs
+++ b/crates/coven-cli/src/tui/cast/render.rs
@@ -11,7 +11,7 @@ use crate::theme::{self, fit_chars, palette_for, Fg, Palette, TerminalMode};
 
 use super::outcome::CastOutcome;
 use super::plan::{CastHarnessSource, CastPlan, CastStepKind};
-use super::quest::{Quest, QuestPhase, QuestPhaseStatus};
+use super::quest::{Quest, QuestPhase, QuestPhaseStatus, PHASE_PROMPT_HINT};
 use super::safety::{CastRisk, SafetyDecision};
 
 const CAST_INTRO_INNER_WIDTH: usize = 76;
@@ -314,9 +314,7 @@ fn quest_phase_position_label(quest: &Quest, next_index: usize) -> String {
 
 fn quest_handoff_footer_hint(next: &QuestPhase) -> &'static str {
     match &next.status {
-        QuestPhaseStatus::Pending => {
-            "enter approve · type to replace · /skip [reason] · /cancel [reason]"
-        }
+        QuestPhaseStatus::Pending => PHASE_PROMPT_HINT,
         QuestPhaseStatus::Running { .. } => "phase running · attach to follow",
         QuestPhaseStatus::Complete(_) => "phase already complete · advance again",
         QuestPhaseStatus::Skipped { .. } => "phase skipped · advance to continue",
@@ -388,6 +386,8 @@ fn push_section_header(frame: &mut String, p: &Palette, title: &str) {
 /// whole frame.
 fn push_label_row(frame: &mut String, p: &Palette, label: &str, value: &str) {
     let label_block = format!("{:<width$}", label, width = LABEL_COLUMN_WIDTH);
+    let value_width = CAST_INTRO_INNER_WIDTH.saturating_sub(LABEL_COLUMN_WIDTH + 2);
+    let value = fit_chars(value, value_width);
     frame.push_str(&format!(
         "{}{}{}  {}{}{}\n",
         p.field_label, label_block, p.reset, p.text, value, p.reset
@@ -499,6 +499,31 @@ mod tests {
         let frame = render_cast_frame_plain(None, None);
         assert!(frame.contains("not inside a project root"));
         assert!(frame.contains("coven doctor"));
+    }
+
+    #[test]
+    fn label_rows_truncate_long_values_to_card_width() {
+        let long_project = PathBuf::from(format!("/tmp/{}", "very-long-segment/".repeat(16)));
+        let frame = render_cast_frame_plain(Some(&long_project), Some("codex"));
+        let full_project = long_project.display().to_string();
+        let value_width = CAST_INTRO_INNER_WIDTH - LABEL_COLUMN_WIDTH - 2;
+        let truncated_project = fit_chars(&full_project, value_width);
+
+        assert!(
+            frame.contains(&truncated_project),
+            "long project path should be truncated into the value column, frame:\n{frame}"
+        );
+        assert!(
+            !frame.contains(&full_project),
+            "long project path overflowed the card instead of being truncated, frame:\n{frame}"
+        );
+        for line in frame.lines() {
+            assert!(
+                line.chars().count() <= CAST_INTRO_INNER_WIDTH,
+                "line exceeded Cast card width ({} > {CAST_INTRO_INNER_WIDTH}): {line}",
+                line.chars().count()
+            );
+        }
     }
 
     fn natural_plan(prompt: &str) -> CastPlan {

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -12,7 +12,7 @@ use ratatui::{
     },
     Frame,
 };
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::theme::{
     self, Status, AGENT_LABEL, BACKDROP, BORDER_DIM, DIM, HINT_KEY, HINT_LABEL, PRIMARY,
@@ -281,11 +281,7 @@ fn append_agent_content_lines<'a>(lines: &mut Vec<Line<'a>>, content: &str, wrap
         }
 
         if in_code_block {
-            let visible = if wrap_width > 4 && line.chars().count() > wrap_width - 4 {
-                line.chars().take(wrap_width - 4).collect::<String>()
-            } else {
-                line.to_string()
-            };
+            let visible = truncate_for_width(line, wrap_width.saturating_sub(4));
             // Code blocks are verbatim — no inline-markdown parsing inside.
             // With a known language tag, hand the visible line to the syntax
             // tokenizer so keywords/strings/numbers/comments pick up brand
@@ -404,7 +400,7 @@ fn strip_heading_prefix(line: &str) -> Option<(u8, &str)> {
 
 fn strip_bullet_prefix(line: &str) -> Option<(usize, &'static str, &str)> {
     let trimmed = line.trim_start();
-    let indent = line.len() - trimmed.len();
+    let indent = leading_whitespace_columns(line, line.len() - trimmed.len());
     if let Some(rest) = trimmed.strip_prefix("- ") {
         return Some((indent, "\u{2022} ", rest));
     }
@@ -412,6 +408,17 @@ fn strip_bullet_prefix(line: &str) -> Option<(usize, &'static str, &str)> {
         return Some((indent, "\u{2022} ", rest));
     }
     None
+}
+
+fn leading_whitespace_columns(line: &str, byte_len: usize) -> usize {
+    line[..byte_len]
+        .chars()
+        .map(|ch| match ch {
+            '\t' => 4,
+            ' ' => 1,
+            _ => ch.width().unwrap_or(1),
+        })
+        .sum()
 }
 
 /// Lines beginning with `|` (after any leading indent) look like markdown
@@ -459,7 +466,7 @@ fn parse_inline_markdown<'a>(text: &str, default_style: Style) -> Vec<Span<'a>> 
                     if let Some(end) = after.find("**") {
                         let body = &after[..end];
                         let closes_on_word =
-                            body.chars().last().is_some_and(|c| !c.is_whitespace());
+                            body.chars().next_back().is_some_and(|c| !c.is_whitespace());
                         if closes_on_word {
                             flush_inline_buf(&mut spans, &mut buf, default_style);
                             let bold = default_style.add_modifier(Modifier::BOLD);
@@ -486,7 +493,7 @@ fn parse_inline_markdown<'a>(text: &str, default_style: Style) -> Vec<Span<'a>> 
                     while let Some(p) = after[search_at..].find('*') {
                         let abs = search_at + p;
                         let body = &after[..abs];
-                        let last_ok = body.chars().last().is_some_and(|c| !c.is_whitespace());
+                        let last_ok = body.chars().next_back().is_some_and(|c| !c.is_whitespace());
                         let not_double = after.as_bytes().get(abs + 1) != Some(&b'*');
                         if last_ok && not_double {
                             found = Some(abs);
@@ -1008,16 +1015,24 @@ fn input_line_count(input: &str) -> usize {
 }
 
 fn truncate_for_width(value: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
     if UnicodeWidthStr::width(value) <= max_width {
         return value.to_string();
     }
+    if max_width == 1 {
+        return "\u{2026}".to_string();
+    }
     let mut output = String::new();
+    let mut output_width = 0usize;
+    let content_budget = max_width - 1;
     for ch in value.chars() {
-        let next_width = UnicodeWidthStr::width(output.as_str())
-            + UnicodeWidthStr::width(ch.to_string().as_str());
-        if next_width >= max_width.saturating_sub(1) {
+        let ch_width = ch.width().unwrap_or(0);
+        if output_width + ch_width > content_budget {
             break;
         }
+        output_width += ch_width;
         output.push(ch);
     }
     output.push('…');
@@ -1360,6 +1375,52 @@ mod tests {
     }
 
     #[test]
+    fn truncate_for_width_never_exceeds_requested_budget() {
+        assert_eq!(truncate_for_width("abcdef", 0), "");
+        assert_eq!(truncate_for_width("abcdef", 1), "\u{2026}");
+        assert_eq!(truncate_for_width("abcdef", 2), "a\u{2026}");
+        assert_eq!(truncate_for_width("abcdef", 4), "abc\u{2026}");
+
+        let wide = truncate_for_width("表表abc", 4);
+        assert!(UnicodeWidthStr::width(wide.as_str()) <= 4);
+        assert!(wide.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn agent_lines_truncate_code_blocks_by_display_width() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        append_agent_content_lines(&mut lines, "```\n表表abc\n```", 6);
+
+        let code_line = find_code_line(&lines, "").expect("code line emitted");
+        let visible: String = code_line
+            .spans
+            .iter()
+            .skip(1)
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            UnicodeWidthStr::width(visible.as_str()) <= 2,
+            "visible code text should fit the post-prefix budget: {visible:?}"
+        );
+    }
+
+    #[test]
+    fn agent_lines_treat_tab_bullet_indent_as_columns() {
+        let mut lines: Vec<Line<'_>> = Vec::new();
+        append_agent_content_lines(&mut lines, "\t- nested", 40);
+
+        let rendered: String = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect();
+        assert!(
+            rendered.starts_with("      \u{2022} nested"),
+            "tab indent should expand to four columns after the message margin: {rendered:?}"
+        );
+    }
+
+    #[test]
     fn agent_lines_render_table_separator_row_without_wrapping() {
         // The `|---|---|...` separator row is what makes a markdown table
         // visually a table; if it wraps the table reads as garbage.
@@ -1482,9 +1543,9 @@ mod tests {
     }
 
     #[test]
-    fn inline_markdown_preserves_backticks_inside_inline_code() {
-        // The first backtick opens, the next closes — nested backticks would
-        // need fence-style triple-tick handling we don't support today.
+    fn inline_markdown_preserves_stars_inside_inline_code() {
+        // Stars inside an inline-code span should stay literal rather than
+        // becoming italic markers.
         let default_style = theme::ratatui_style(TEXT);
         let spans = parse_inline_markdown("see `*foo*` for the literal stars", default_style);
         let texts: Vec<String> = spans.iter().map(|s| s.content.to_string()).collect();

--- a/crates/coven-cli/src/tui/chat/settings.rs
+++ b/crates/coven-cli/src/tui/chat/settings.rs
@@ -48,6 +48,18 @@ pub(super) fn settings_path(coven_home: &Path) -> PathBuf {
     coven_home.join("chat-settings.json")
 }
 
+fn temporary_settings_path(coven_home: &Path) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    coven_home.join(format!(
+        ".chat-settings.json.{}.{}.tmp",
+        std::process::id(),
+        nanos
+    ))
+}
+
 /// Load settings from disk, falling back to defaults on any error. The TUI
 /// uses this on startup, so an unreadable or partially-written file must not
 /// stop the chat from coming up — it just resets to defaults silently.
@@ -66,7 +78,14 @@ pub(super) fn save_to(coven_home: &Path, settings: &ChatSettings) -> std::io::Re
     std::fs::create_dir_all(coven_home)?;
     let body = serde_json::to_vec_pretty(settings)
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    std::fs::write(settings_path(coven_home), body)
+    let path = settings_path(coven_home);
+    let temp_path = temporary_settings_path(coven_home);
+    std::fs::write(&temp_path, body)?;
+    std::fs::rename(&temp_path, &path)?;
+    if let Ok(dir) = std::fs::File::open(coven_home) {
+        let _ = dir.sync_all();
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -110,5 +129,14 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(settings_path(temp.path()), b"not json").unwrap();
         assert_eq!(load_from(temp.path()), ChatSettings::default());
+    }
+
+    #[test]
+    fn temporary_settings_path_stays_in_coven_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let temp_path = temporary_settings_path(temp.path());
+
+        assert_eq!(temp_path.parent(), Some(temp.path()));
+        assert_ne!(temp_path, settings_path(temp.path()));
     }
 }

--- a/crates/coven-cli/src/tui/sessions.rs
+++ b/crates/coven-cli/src/tui/sessions.rs
@@ -7,6 +7,7 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType},
 };
+use serde::Serialize;
 
 use super::is_key_press;
 use crate::theme::fit_chars;
@@ -626,7 +627,12 @@ pub(crate) fn format_session_line(session: &store::SessionRecord) -> String {
 }
 
 pub(crate) fn render_sessions_json(sessions: &[store::SessionRecord]) -> Result<String> {
-    serde_json::to_string_pretty(&serde_json::json!({ "sessions": sessions }))
+    #[derive(Serialize)]
+    struct SessionsJson<'a> {
+        sessions: &'a [store::SessionRecord],
+    }
+
+    serde_json::to_string_pretty(&SessionsJson { sessions })
         .context("failed to serialize sessions as JSON")
 }
 

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -21,6 +21,7 @@ use super::cast::{
     QuestPhase, QuestPhaseStatus, QuestPhaseSummary, SafetyDecision, CAST_QUEST_ADVANCED_KIND,
     CAST_QUEST_COMPLETED_KIND, CAST_QUEST_PHASE_COMPLETED_KIND, CAST_QUEST_PHASE_EDITED_KIND,
     CAST_QUEST_PHASE_SKIPPED_KIND, CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
+    PHASE_PROMPT_HINT,
 };
 use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
 use super::{is_key_press, sessions};
@@ -584,8 +585,8 @@ fn create_local_quest_anchor(
         &id,
         CAST_QUEST_STARTED_KIND,
         &serde_json::json!({
-            "title": quest.title,
-            "goal": quest.goal,
+            "title": quest.title.clone(),
+            "goal": quest.goal.clone(),
             "harness": harness_label,
             "phases": quest.phases.iter().map(|p| p.name.clone()).collect::<Vec<_>>(),
             "synthetic": true,
@@ -648,6 +649,17 @@ fn run_quest_loop(
         print!("{}", render_quest_handoff(&quest, idx));
         println!();
 
+        if let QuestPhaseStatus::Running { session_id } = &quest.phases[idx].status {
+            return Ok(running_phase_outcome(
+                &request_text,
+                &quest,
+                anchor_session_id.clone(),
+                completed_notes,
+                idx,
+                session_id,
+            ));
+        }
+
         let mut reader = stdin_line_reader;
         match run_phase_interaction(&mut quest, idx, anchor_session_id.as_deref(), &mut reader)? {
             PhaseInteraction::Cancel { reason } => {
@@ -668,6 +680,7 @@ fn run_quest_loop(
                 let phase_name = quest.phases[idx].name.clone();
                 skip_phase(&mut quest, idx, reason.clone())?;
                 completed_notes.push(format!("Phase `{phase_name}`: skipped — {reason}"));
+                let next = quest.current_index();
                 if let Some(anchor) = anchor_session_id.as_deref() {
                     write_quest_event(
                         anchor,
@@ -676,6 +689,14 @@ fn run_quest_loop(
                             "phase": phase_name,
                             "index": idx,
                             "reason": reason,
+                        }),
+                    );
+                    write_quest_event(
+                        anchor,
+                        CAST_QUEST_ADVANCED_KIND,
+                        serde_json::json!({
+                            "from_index": idx,
+                            "next_index": next,
                         }),
                     );
                 }
@@ -727,6 +748,23 @@ fn run_quest_loop(
             GateOutcome::Proceed => {}
         }
 
+        let pre_dispatch_phase_started_written = if let Some(anchor) = anchor_session_id.as_deref()
+        {
+            write_quest_event(
+                anchor,
+                CAST_QUEST_PHASE_STARTED_KIND,
+                serde_json::json!({
+                    "phase": quest.phases[idx].name,
+                    "index": idx,
+                    "session_id": serde_json::Value::Null,
+                    "harness": phase_harness.id(),
+                }),
+            );
+            true
+        } else {
+            false
+        };
+
         let phase_outcome = dispatch_cast_launch(
             &phase_plan,
             phase_harness.id(),
@@ -746,8 +784,8 @@ fn run_quest_loop(
                     sid,
                     CAST_QUEST_STARTED_KIND,
                     serde_json::json!({
-                        "title": quest.title,
-                        "goal": quest.goal,
+                        "title": quest.title.clone(),
+                        "goal": quest.goal.clone(),
                         "harness": phase_harness.id(),
                         "phases": quest
                             .phases
@@ -760,16 +798,18 @@ fn run_quest_loop(
         }
 
         if let Some(anchor) = anchor_session_id.as_deref() {
-            write_quest_event(
-                anchor,
-                CAST_QUEST_PHASE_STARTED_KIND,
-                serde_json::json!({
-                    "phase": quest.phases[idx].name,
-                    "index": idx,
-                    "session_id": phase_session_id,
-                    "harness": phase_harness.id(),
-                }),
-            );
+            if !pre_dispatch_phase_started_written {
+                write_quest_event(
+                    anchor,
+                    CAST_QUEST_PHASE_STARTED_KIND,
+                    serde_json::json!({
+                        "phase": quest.phases[idx].name,
+                        "index": idx,
+                        "session_id": phase_session_id.clone(),
+                        "harness": phase_harness.id(),
+                    }),
+                );
+            }
         }
 
         // Phase 10: explicit Pending → Running transition. The shell loop
@@ -820,7 +860,7 @@ fn run_quest_loop(
             anchor,
             CAST_QUEST_COMPLETED_KIND,
             serde_json::json!({
-                "title": quest.title,
+                "title": quest.title.clone(),
                 "phase_count": quest.phases.len(),
             }),
         );
@@ -849,11 +889,34 @@ fn resolve_phase_harness(
     phase.harness.or(default_harness)
 }
 
-/// One line of phase-prompt help, matching the handoff card's footer hint.
-/// The wording is duplicated here (the card is rendered separately) but
-/// kept short and contract-aligned per §2.6 of `cast-tui-contract.md`.
-const PHASE_PROMPT_HINT: &str =
-    "enter approve · type to replace · /skip [reason] · /cancel [reason]";
+fn running_phase_outcome(
+    request_text: &str,
+    quest: &Quest,
+    anchor_session_id: Option<String>,
+    mut completed_notes: Vec<String>,
+    idx: usize,
+    phase_session_id: &str,
+) -> CastOutcome {
+    let phase_name = &quest.phases[idx].name;
+    completed_notes.push(format!(
+        "Phase `{phase_name}` is already running in session `{phase_session_id}`."
+    ));
+    let next_step = if phase_session_id.is_empty() {
+        "Re-attach the quest anchor after checking the running phase's harness output.".to_string()
+    } else {
+        format!(
+            "Run `coven attach {phase_session_id}` to follow the running phase, then re-attach the quest anchor."
+        )
+    };
+    quest_outcome(
+        request_text,
+        quest,
+        anchor_session_id,
+        completed_notes,
+        Some(next_step),
+        Some(format!("Quest paused at running phase `{phase_name}`.")),
+    )
+}
 
 /// Drive the per-phase interaction described in
 /// `docs/design/cast-quest-flow.md` §5: render → prompt → loop on edits →
@@ -1327,6 +1390,16 @@ fn attach_via_daemon(
         maybe_spawn_cast_input_forwarder(coven_home_dir()?, session.id.clone());
     }
 
+    let replay_history = if is_live {
+        Vec::new()
+    } else {
+        client.list_events(ChatEventQuery {
+            session_id: &session.id,
+            after_seq: None,
+            limit: None,
+        })?
+    };
+
     let mut observer = TranscriptObserver::new(io::stdout());
     let exit = if is_live {
         let mut pacer = SleepPacer::new(Duration::from_millis(250));
@@ -1340,7 +1413,7 @@ fn attach_via_daemon(
         // For completed sessions, drain the historical event log once. The
         // follower observer renders the transcript exactly as it did on the
         // original run and reports the exit when it lands in the replay.
-        replay_completed_session(&mut client, &session.id, &mut observer)?
+        replay_completed_session(&replay_history, &mut observer)
     };
 
     if is_live {
@@ -1361,18 +1434,12 @@ fn attach_via_daemon(
     // a quest anchor and (Phase 9) to *resume* the quest loop at the next
     // pending phase when the user attaches mid-quest.
     if !is_live {
-        let history = client.list_events(ChatEventQuery {
-            session_id: &session.id,
-            after_seq: None,
-            limit: None,
-        })?;
-
         // Phase 9: if this session is a quest anchor with work left, hand
         // off to the resume loop. The returned outcome replaces the
         // standard attach outcome — the quest is the user's foreground
         // activity now. Completed quests fall through to the
         // detect-and-inform note that Phase 7 introduced.
-        if let Some(reconstructed) = cast::reconstruct_quest(&history) {
+        if let Some(reconstructed) = cast::reconstruct_quest(&replay_history) {
             if !reconstructed.is_complete && reconstructed.quest.current_index().is_some() {
                 println!();
                 println!(
@@ -1389,11 +1456,12 @@ fn attach_via_daemon(
             }
         }
 
-        if let Some(note) = cast::find_cast_summary(&history).and_then(|s| format_summary_note(&s))
+        if let Some(note) =
+            cast::find_cast_summary(&replay_history).and_then(|s| format_summary_note(&s))
         {
             notes.push(note);
         }
-        if let Some(note) = cast::find_cast_quest_info(&history)
+        if let Some(note) = cast::find_cast_quest_info(&replay_history)
             .and_then(|info| cast::format_quest_attach_note(&info))
         {
             notes.push(note);
@@ -1439,19 +1507,12 @@ fn attach_via_daemon(
 /// observer the live follower uses. Returns the decoded exit if the replay
 /// contains an `exit` event so the outcome card can show the original status.
 fn replay_completed_session(
-    client: &mut dyn ChatClient,
-    session_id: &str,
+    records: &[store::EventRecord],
     observer: &mut dyn FollowerObserver,
-) -> Result<Option<CastSessionExit>> {
-    let records = client.list_events(ChatEventQuery {
-        session_id,
-        after_seq: None,
-        limit: None,
-    })?;
-
+) -> Option<CastSessionExit> {
     let mut exit = None;
     for record in records {
-        let decoded = cast::follow::decode_event(&record);
+        let decoded = cast::follow::decode_event(record);
         match &decoded {
             cast::follow::CastFollowEvent::Output(chunk) => observer.on_output(chunk),
             cast::follow::CastFollowEvent::Exit { status, exit_code } => {
@@ -1464,7 +1525,7 @@ fn replay_completed_session(
             cast::follow::CastFollowEvent::Other { kind } => observer.on_other(kind),
         }
     }
-    Ok(exit)
+    exit
 }
 
 fn format_exit_summary(exit: &CastSessionExit) -> String {
@@ -1679,6 +1740,38 @@ mod quest_interaction_tests {
             }
             other => panic!("expected Cancel, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn running_phase_outcome_points_to_existing_session_instead_of_reprompting() {
+        let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
+        mark_phase_running(&mut quest, 0, "session-design-id".to_string()).unwrap();
+
+        let outcome = running_phase_outcome(
+            "/quest polish the README",
+            &quest,
+            Some("anchor-session-id".to_string()),
+            Vec::new(),
+            0,
+            "session-design-id",
+        );
+
+        assert_eq!(outcome.session_id.as_deref(), Some("anchor-session-id"));
+        assert!(
+            outcome
+                .next_step
+                .as_deref()
+                .unwrap_or_default()
+                .contains("coven attach session-design-id"),
+            "running phase should direct the user to the already-started session, outcome: {outcome:?}"
+        );
+        assert!(
+            outcome
+                .notes
+                .iter()
+                .any(|note| note.contains("already running in session `session-design-id`")),
+            "running phase note should explain why Cast did not prompt again, outcome: {outcome:?}"
+        );
     }
 }
 
@@ -2112,68 +2205,9 @@ pub(crate) fn render_frame_plain_for_test(selection: usize) -> String {
 
 #[cfg(test)]
 mod attach_tests {
-    use std::cell::RefCell;
     use std::io::Cursor;
 
     use super::*;
-    use crate::tui::chat::client::LaunchRequest;
-
-    /// Stub client that returns a canned event log on every `list_events` call
-    /// and records which session id was queried. Mirrors the stub in
-    /// `cast::follow` tests but kept local to shell.rs so the wiring (not the
-    /// already-tested decode pipeline) is what's under test here.
-    struct ReplayClient {
-        events: Vec<store::EventRecord>,
-        queries: RefCell<Vec<String>>,
-    }
-
-    impl ReplayClient {
-        fn new(events: Vec<store::EventRecord>) -> Self {
-            Self {
-                events,
-                queries: RefCell::new(Vec::new()),
-            }
-        }
-    }
-
-    impl ChatClient for ReplayClient {
-        fn launch_session(&mut self, _request: LaunchRequest) -> Result<store::SessionRecord> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn get_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {
-            self.queries.borrow_mut().push(query.session_id.to_string());
-            Ok(self.events.clone())
-        }
-
-        fn send_input(&mut self, _session_id: &str, _data: &str) -> Result<()> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn kill_session(&mut self, _session_id: &str) -> Result<()> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn archive_session(&mut self, _session_id: &str) -> Result<()> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn summon_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
-            unimplemented!("not exercised by replay tests")
-        }
-
-        fn sacrifice_session(&mut self, _session_id: &str) -> Result<()> {
-            unimplemented!("not exercised by replay tests")
-        }
-    }
 
     fn output_event(seq: i64, data: &str) -> store::EventRecord {
         store::EventRecord {
@@ -2209,16 +2243,15 @@ mod attach_tests {
 
     #[test]
     fn replay_completed_session_streams_full_transcript_into_observer() {
-        let mut client = ReplayClient::new(vec![
+        let records = vec![
             output_event(1, "hello\n"),
             output_event(2, "world\n"),
             exit_event(3, "completed", Some(0)),
-        ]);
+        ];
         let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut observer = TranscriptObserver::new(&mut buffer);
 
-        let exit =
-            replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
+        let exit = replay_completed_session(&records, &mut observer);
 
         let rendered = String::from_utf8(buffer.into_inner()).unwrap();
         assert!(
@@ -2237,23 +2270,18 @@ mod attach_tests {
         let exit = exit.expect("replay should surface the recorded exit");
         assert_eq!(exit.status, "completed");
         assert_eq!(exit.exit_code, Some(0));
-
-        let queries = client.queries.borrow();
-        assert_eq!(queries.len(), 1, "one full-history fetch is enough");
-        assert_eq!(queries[0], "session-1");
     }
 
     #[test]
     fn replay_completed_session_returns_none_when_no_exit_event_in_log() {
-        let mut client = ReplayClient::new(vec![
+        let records = vec![
             output_event(1, "still going\n"),
             output_event(2, "no exit yet\n"),
-        ]);
+        ];
         let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut observer = TranscriptObserver::new(&mut buffer);
 
-        let exit =
-            replay_completed_session(&mut client, "session-1", &mut observer).expect("replay");
+        let exit = replay_completed_session(&records, &mut observer);
 
         assert!(
             exit.is_none(),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,7 +69,7 @@ Shipped:
 
 Now:
 
-- **Cast launcher redesign** (Phases 1–6 on `cast/*` branches): collapses the Coven launcher chrome into a single-prompt surface with a two-lane Commands + Snapshot body, plan/outcome cards for every spell, and a sequential quest flow that hands off between phases with deterministic sub-prompts. The visual contract lives in [`docs/design/cast-tui-contract.md`](/design/cast-tui-contract) and the quest flow in [`docs/design/cast-quest-flow.md`](/design/cast-quest-flow). PR #99 is the current review slice (Phase 6 verification + readiness).
+- **Cast launcher redesign** (Phases 1–6 on `cast/*` branches): collapses the Coven launcher chrome into a single-prompt surface with a two-lane Commands + Snapshot body, plan/outcome cards for every spell, and a sequential quest flow that hands off between phases with deterministic sub-prompts. The repo-local design notes live under `docs/design/`. PR #99 is the current review slice (Phase 6 verification + readiness).
 - Keep the versioned daemon API contract and external-client compatibility work aligned. See [`docs/API-CONTRACT.md`](/API-CONTRACT).
 - Keep the public docs aligned with the actual CLI/API surface.
 

--- a/docs/design/cast-phase6-inspection.md
+++ b/docs/design/cast-phase6-inspection.md
@@ -124,7 +124,7 @@ Cast — your Coven familiar
 Cast, your Coven familiar, is ready. Type a spell, or use a slash command.
 
 Context
-Project        /Users/buns/Documents/GitHub/OpenCoven/coven
+Project        /path/to/opencoven/coven
 Default harness codex
 
 Example spells

--- a/docs/design/cast-quest-flow.md
+++ b/docs/design/cast-quest-flow.md
@@ -2,6 +2,9 @@
 summary: "Phase 5 design contract for Cast's sequential goal flow: deterministic sub-prompts, visible handoffs, and a structured advance step between phases."
 title: "Cast — Sequential Goal Flow (Phase 5)"
 description: "How Cast turns a high-level user goal into an ordered Quest of phases, each producing a concrete sub-prompt and a visible handoff to the harness."
+read_when:
+  - Understanding Cast quest handoffs
+  - Reviewing `/quest <goal>` behavior
 ---
 
 # Cast — Sequential Goal Flow (Phase 5)
@@ -110,7 +113,7 @@ Sub-prompt
   - added `cast::quest` module
   - drafted handoff card
 
-enter approves the sub-prompt · type to edit · esc cancels
+enter approve · type to replace · /skip [reason] · /cancel [reason]
 ```
 
 - Sub-prompts longer than 8 lines are clipped with a `… N more lines` indicator; the full text still goes to the harness, but the card stays under one screen.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -177,6 +177,7 @@
                 "pages": [
                   "BRAND",
                   "PRODUCT-SPEC",
+                  "design/cast-quest-flow",
                   "reference/releasing",
                   "reference/release-notes"
                 ]

--- a/npm/coven-platform-template/README.md
+++ b/npm/coven-platform-template/README.md
@@ -1,5 +1,5 @@
 # Native Coven CLI package
 
-This package contains one platform-specific Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select this optional dependency on supported systems.
+This package contains one platform-specific Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select the matching optional dependency on supported systems.
 
-Linux x64 builds target glibc-based distributions. Alpine Linux is not supported. Windows builds target x64 Windows.
+Current platform packages cover macOS Apple Silicon, glibc-based Linux x64, and Windows x64. Alpine Linux is not supported.

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -127,10 +127,11 @@ def is_programming_identifier_token(token: str) -> bool:
     token to be composed only of `[A-Za-z0-9_./-]`, to be split into at least
     three segments by `_`/`.`/`/`/`-`, for at least one segment to contain
     letters (so a token of pure-digit segments still trips the entropy rule),
-    and for every letter-bearing segment to be uniformly single-case. Real API
-    tokens lack separators, mix case within a segment, or contain base64-only
-    characters such as `+`/`=`, so they continue to fail at least one of these
-    checks and trip the entropy rule as before.
+    and for every letter-bearing segment to be uniformly single-case while
+    allowing digits inside those identifier/path/triple segments. Real API tokens
+    lack separators, mix case within a segment, or contain base64-only characters
+    such as `+`/`=`, so they continue to fail at least one of these checks and
+    trip the entropy rule as before.
     """
     if not re.fullmatch(r"[A-Za-z0-9_./-]+", token):
         return False

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -272,3 +272,11 @@ test('release workflow concurrency keeps overlapping releases from interleaving'
   assert.match(workflow, /^concurrency:\s*\n\s*group:\s*release-npm/m);
   assert.match(workflow, /cancel-in-progress:\s*false/);
 });
+
+test('prepublish smoke has explicit dry-run version override and registry failure message', () => {
+  const scriptPath = new URL('test-cli-prepublish.mjs', import.meta.url);
+  const script = readFileSync(scriptPath, 'utf8');
+
+  assert.match(script, /COVEN_NPM_DRY_RUN_VERSION/);
+  assert.match(script, /Could not read current \$\{packageName\} version/);
+});

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -25,6 +25,9 @@
 //                         the repo has known pre-existing high-entropy hits
 //                         in committed test fixtures; CI still runs it.
 //   --keep-tempdir        Leave the temp install dir on disk for inspection.
+//   COVEN_NPM_DRY_RUN_VERSION=vX.Y.Z
+//                         Override the synthesized dry-run version when the
+//                         public npm registry cannot be reached.
 //
 // Exit code is non-zero on the first failing step.
 
@@ -211,25 +214,40 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
 })();
 
 function synthesizeDryRunVersion(packageName) {
+  const override = process.env.COVEN_NPM_DRY_RUN_VERSION?.trim();
+  if (override) {
+    const normalized = override.replace(/^v/, '');
+    if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(normalized)) {
+      fail(`COVEN_NPM_DRY_RUN_VERSION must be a semver version, got ${override}`);
+    }
+    return normalized;
+  }
+
   const view = spawnSync('npm', ['view', packageName, 'version', '--silent'], {
     stdio: ['ignore', 'pipe', 'pipe'],
     encoding: 'utf8'
   });
-  let baseMajor = 0;
-  let baseMinor = 0;
-  let basePatch = 0;
-  if (view.status === 0) {
-    const reported = view.stdout.trim();
-    const match = reported.match(/^(\d+)\.(\d+)\.(\d+)/);
-    if (match) {
-      baseMajor = Number(match[1]);
-      baseMinor = Number(match[2]);
-      basePatch = Number(match[3]);
-    }
+  if (view.status !== 0) {
+    const stderr = view.stderr.trim();
+    fail(
+      `Could not read current ${packageName} version from npm. ` +
+        'Set COVEN_NPM_DRY_RUN_VERSION to an unpublished higher semver and rerun.' +
+        (stderr ? `\nnpm stderr:\n${stderr}` : '')
+    );
+  }
+  const reported = view.stdout.trim();
+  const match = reported.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    fail(
+      `Could not read current ${packageName} version from npm output: ${reported || '(empty)'}`
+    );
   }
   // Bump patch (no prerelease suffix) so `npm publish --dry-run` accepts it
   // under the implicit "latest" tag. The version is never published, but it
   // must compare higher than what's already on the registry.
+  const baseMajor = Number(match[1]);
+  const baseMinor = Number(match[2]);
+  const basePatch = Number(match[3]);
   return `${baseMajor}.${baseMinor}.${basePatch + 1}`;
 }
 


### PR DESCRIPTION
## Summary
- fixes remaining actionable Coven review-thread buckets across `coven pc`, Cast quest replay/ledger/rendering, chat rendering/settings persistence, sessions output modes, npm prepublish, docs, and package copy
- adds targeted regression coverage for the review findings
- updates public docs links and release-readiness checks so the next npm release has a clean gate

## Verification
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `node --test scripts/publish-npm-test.mjs`
- `python3 scripts/check-secrets.py`
- `node scripts/test-cli-prepublish.mjs`
- `(cd docs && npm run docs:check)`
- `git diff --check`