### PR TITLE
fix: address review cleanup follow-ups

### DIFF
--- a/crates/coven-cli/src/pc/display.rs
+++ b/crates/coven-cli/src/pc/display.rs
@@ -18,7 +18,7 @@ fn health_indicator(pct: f32, warn: f32, crit: f32) -> &'static str {
 }
 
 pub fn print_status(snap: &SystemSnapshot, format: &OutputFormat) {
-    print!("{}", format_status(snap, format));
+    println!("{}", format_status(snap, format));
 }
 
 fn format_status(snap: &SystemSnapshot, format: &OutputFormat) -> String {

--- a/crates/coven-cli/src/tui/chat/settings.rs
+++ b/crates/coven-cli/src/tui/chat/settings.rs
@@ -81,11 +81,52 @@ pub(super) fn save_to(coven_home: &Path, settings: &ChatSettings) -> std::io::Re
     let path = settings_path(coven_home);
     let temp_path = temporary_settings_path(coven_home);
     std::fs::write(&temp_path, body)?;
-    std::fs::rename(&temp_path, &path)?;
+    replace_settings_file(&temp_path, &path)?;
     if let Ok(dir) = std::fs::File::open(coven_home) {
         let _ = dir.sync_all();
     }
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_settings_file(temp_path: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(temp_path, path)
+}
+
+#[cfg(windows)]
+fn replace_settings_file(temp_path: &Path, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+    #[link(name = "Kernel32")]
+    extern "system" {
+        fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+
+    let existing: Vec<u16> = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let new: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let ok = unsafe {
+        MoveFileExW(
+            existing.as_ptr(),
+            new.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -122,6 +163,20 @@ mod tests {
         save_to(temp.path(), &settings).expect("save settings");
         let reloaded = load_from(temp.path());
         assert_eq!(reloaded, settings);
+    }
+
+    #[test]
+    fn save_overwrites_existing_settings_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = settings_path(temp.path());
+        std::fs::write(&path, r#"{"streaming":"live"}"#).unwrap();
+
+        let settings = ChatSettings {
+            streaming: StreamingMode::Batched,
+        };
+        save_to(temp.path(), &settings).expect("overwrite existing settings");
+
+        assert_eq!(load_from(temp.path()), settings);
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -898,12 +898,15 @@ fn running_phase_outcome(
     phase_session_id: &str,
 ) -> CastOutcome {
     let phase_name = &quest.phases[idx].name;
-    completed_notes.push(format!(
-        "Phase `{phase_name}` is already running in session `{phase_session_id}`."
-    ));
     let next_step = if phase_session_id.is_empty() {
+        completed_notes.push(format!(
+            "Phase `{phase_name}` is already running in its recorded harness."
+        ));
         "Re-attach the quest anchor after checking the running phase's harness output.".to_string()
     } else {
+        completed_notes.push(format!(
+            "Phase `{phase_name}` is already running in session `{phase_session_id}`."
+        ));
         format!(
             "Run `coven attach {phase_session_id}` to follow the running phase, then re-attach the quest anchor."
         )
@@ -1771,6 +1774,35 @@ mod quest_interaction_tests {
                 .iter()
                 .any(|note| note.contains("already running in session `session-design-id`")),
             "running phase note should explain why Cast did not prompt again, outcome: {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn running_phase_outcome_without_session_id_avoids_empty_reference() {
+        let mut quest = quest_from_goal("polish the README", Some(CastHarness::Codex));
+        mark_phase_running(&mut quest, 0, String::new()).unwrap();
+
+        let outcome = running_phase_outcome(
+            "/quest polish the README",
+            &quest,
+            Some("anchor-session-id".to_string()),
+            Vec::new(),
+            0,
+            "",
+        );
+
+        assert_eq!(outcome.session_id.as_deref(), Some("anchor-session-id"));
+        assert!(
+            outcome
+                .next_step
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Re-attach the quest anchor"),
+            "running local phase should point back to the quest anchor, outcome: {outcome:?}"
+        );
+        assert!(
+            outcome.notes.iter().all(|note| !note.contains("``")),
+            "running local phase should not render an empty session reference, outcome: {outcome:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- makes chat settings replacement overwrite-safe on Windows while preserving atomic replacement on Unix
- prints `coven pc status` with a trailing newline
- avoids rendering an empty session id for running quest phases in local-PTY fallback paths

## Verification
- `cargo test -p coven-cli --locked`
- `cargo fmt --check`
- `git diff --check`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets -- -D warnings`