### PR TITLE
fix: quiet windows settings ffi lint

### DIFF
--- a/crates/coven-cli/src/tui/chat/settings.rs
+++ b/crates/coven-cli/src/tui/chat/settings.rs
@@ -102,7 +102,8 @@ fn replace_settings_file(temp_path: &Path, path: &Path) -> std::io::Result<()> {
 
     #[link(name = "Kernel32")]
     extern "system" {
-        fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
+        #[link_name = "MoveFileExW"]
+        fn move_file_ex_w(existing: *const u16, new: *const u16, flags: u32) -> i32;
     }
 
     let existing: Vec<u16> = temp_path
@@ -116,7 +117,7 @@ fn replace_settings_file(temp_path: &Path, path: &Path) -> std::io::Result<()> {
         .chain(std::iter::once(0))
         .collect();
     let ok = unsafe {
-        MoveFileExW(
+        move_file_ex_w(
             existing.as_ptr(),
             new.as_ptr(),
             MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,


### PR DESCRIPTION
## Summary
- renames the Windows `MoveFileExW` FFI binding to a snake_case Rust symbol while preserving the linked Windows API name

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p coven-cli tui::chat::settings --locked`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`