### PR TITLE
docs: clarify SSH release tag signing

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -2,7 +2,8 @@ name: Release npm packages
 
 # Tag-driven, OIDC-authenticated release pipeline.
 #
-# Trigger: pushing a signed annotated tag matching `v*` (e.g. `git tag -s v0.0.17 -m "..." && git push origin v0.0.17`).
+# Trigger: pushing an SSH-signed annotated tag matching `v*`
+#          (e.g. `git config gpg.format ssh && git tag -s v0.0.17 -m "..." && git push origin v0.0.17`).
 # Auth: npm trusted publishing via GitHub Actions OIDC — no long-lived NPM_TOKEN required. Configure each
 #       @opencoven/cli* package on npmjs.com -> Settings -> Trusted Publishers before the first OIDC release.
 # Gate: the `verify-tag` job confirms the tag is annotated, that GitHub has cryptographically verified

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -219,6 +219,11 @@ test('release workflow verifies the signed release tag before building or publis
   );
   assert.match(
     workflow,
+    /gpg\.format ssh[\s\S]*git tag -s/,
+    'release instructions must show SSH signing configuration before the signed tag command'
+  );
+  assert.match(
+    workflow,
     /empty line/,
     'verify-tag must reject empty allowed signer entries before authorization checks'
   );


### PR DESCRIPTION
## Summary
- clarify the release workflow header to show SSH signing config before creating a signed tag
- add workflow coverage so the release instructions stay aligned with SSH allowed-signers verification

## Verification
- red test first: `node --test scripts/publish-npm-test.mjs` failed before the comment update
- `node --test scripts/publish-npm-test.mjs`
- `git diff --check`
- `python3 scripts/check-secrets.py`