### PR TITLE
docs: separate release trigger and tag gate

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -2,12 +2,12 @@ name: Release npm packages
 
 # Tag-driven, OIDC-authenticated release pipeline.
 #
-# Trigger: pushing an SSH-signed annotated tag matching `v*`
-#          (e.g. `git config gpg.format ssh && git tag -s v0.0.17 -m "..." && git push origin v0.0.17`).
+# Trigger: any `v*` tag push starts the workflow.
 # Auth: npm trusted publishing via GitHub Actions OIDC — no long-lived NPM_TOKEN required. Configure each
 #       @opencoven/cli* package on npmjs.com -> Settings -> Trusted Publishers before the first OIDC release.
-# Gate: the `verify-tag` job confirms the tag is annotated, that GitHub has cryptographically verified
-#       the maintainer's signature, and that local git verification trusts the release signing key.
+# Gate: the `verify-tag` job requires an SSH-signed annotated tag, confirms GitHub has cryptographically
+#       verified it, and checks that local git verification trusts the release signing key
+#       (e.g. `git config gpg.format ssh && git tag -s v0.0.17 -m "..." && git push origin v0.0.17`).
 
 on:
   push:

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -222,6 +222,16 @@ test('release workflow verifies the signed release tag before building or publis
     /gpg\.format ssh[\s\S]*git tag -s/,
     'release instructions must show SSH signing configuration before the signed tag command'
   );
+  assert.doesNotMatch(
+    workflow,
+    /Trigger: pushing an SSH-signed annotated tag/,
+    'release instructions must not imply the GitHub push trigger itself rejects unsigned tags'
+  );
+  assert.match(
+    workflow,
+    /Trigger:[^\n]*any `v\*` tag push[\s\S]*Gate:[^\n]*requires an SSH-signed annotated tag/,
+    'release instructions must separate the broad tag trigger from the signed-tag gate'
+  );
   assert.match(
     workflow,
     /empty line/,


### PR DESCRIPTION
## Summary
- clarify that any `v*` tag push starts the release workflow
- document that the `verify-tag` gate enforces SSH-signed annotated tags and allowed signer verification
- add workflow coverage so trigger wording does not imply GitHub rejects unsigned tags before the job starts

## Verification
- red test first: `node --test scripts/publish-npm-test.mjs` failed before the wording update
- `node --test scripts/publish-npm-test.mjs`
- `git diff --check`
- `python3 scripts/check-secrets.py`