### PR TITLE
fix(chat): keep conversational sessions alive

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1719,7 +1719,7 @@ mod tests {
     }
 
     #[test]
-    fn plain_chat_input_launches_daemon_session_without_mock_response() {
+    fn plain_chat_input_launches_interactive_daemon_session_without_mock_response() {
         let client = RecordingChatClient::default();
         let (mut app, mirror) = app_with_client(client);
         app.input = "summarize the repo".to_string();
@@ -1734,7 +1734,7 @@ mod tests {
         assert_eq!(launched[0].prompt, "summarize the repo");
         assert_eq!(
             launched[0].launch_mode,
-            crate::harness::HarnessLaunchMode::NonInteractive
+            crate::harness::HarnessLaunchMode::Interactive
         );
         assert!(app.active_session_id().is_some());
         assert!(app.messages.iter().any(|message| message

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -38,7 +38,7 @@ impl LaunchRequest {
             project_root: cwd.clone(),
             cwd,
             harness: harness.to_string(),
-            launch_mode: harness::HarnessLaunchMode::NonInteractive,
+            launch_mode: harness::HarnessLaunchMode::Interactive,
             prompt: prompt.to_string(),
             title: session_title(prompt),
         })
@@ -378,11 +378,15 @@ mod tests {
     }
 
     #[test]
-    fn launch_request_uses_current_dir_as_daemon_validated_boundary() -> Result<()> {
+    fn launch_request_uses_current_dir_and_interactive_mode_for_chat() -> Result<()> {
         let request = LaunchRequest::for_current_dir("codex", "summarize")?;
 
         assert_eq!(request.harness, "codex");
         assert_eq!(request.prompt, "summarize");
+        assert_eq!(
+            request.launch_mode,
+            crate::harness::HarnessLaunchMode::Interactive
+        );
         assert!(!request.project_root.is_empty());
         assert_eq!(request.project_root, request.cwd);
         Ok(())


### PR DESCRIPTION
## Summary
- launch default chat prompts as interactive daemon sessions instead of one-shot non-interactive runs
- add regression assertions for the chat launch request and app dispatch path
- confirmed the existing stream default remains live for fresh settings

## Verification
- red: cargo test -p coven-cli plain_chat_input_launches_interactive_daemon_session_without_mock_response failed on NonInteractive vs Interactive before the production change
- cargo test -p coven-cli plain_chat_input_launches_interactive_daemon_session_without_mock_response
- cargo test -p coven-cli launch_request_uses_current_dir_and_interactive_mode_for_chat
- cargo test -p coven-cli defaults_are_live_streaming
- cargo fmt --all --check
- git diff --check
- cargo clippy -p coven-cli --all-targets -- -D warnings
- cargo test -p coven-cli