### PR TITLE
feat(chat): persistent + grouped + warm conversations (claude stream-mode + codex resume)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs-next",
+ "libc",
  "portable-pty",
  "ratatui",
  "rusqlite",

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -27,5 +27,8 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm",
 unicode-width = "0.2"
 textwrap = "0.16"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -69,6 +69,12 @@ pub struct SessionLaunch {
     pub prompt: String,
     pub title: String,
     pub conversation: Option<ConversationHint>,
+    /// Caller-supplied id used to group this session with other turns of the
+    /// same chat conversation in `/sessions`. Independent of the harness
+    /// CLI's own session-resume mechanism (see `ConversationHint`); the
+    /// chat layer typically passes a chat-generated UUID stable for the
+    /// lifetime of the conversation. `None` = ungrouped (one-off run).
+    pub conversation_id: Option<String>,
 }
 
 pub trait SessionRuntime {
@@ -265,6 +271,7 @@ fn launch_session(
         archived_at: None,
         created_at: now.clone(),
         updated_at: now,
+        conversation_id: launch.conversation_id.clone(),
     };
     store::insert_session(&conn, &record)?;
     if let Err(error) = runtime.launch_session(&launch) {
@@ -291,6 +298,12 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         .to_string();
 
     let conversation = conversation_from_payload(&payload)?;
+    let conversation_id = payload
+        .get("conversationId")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned);
 
     Ok(SessionLaunch {
         id: Uuid::new_v4().to_string(),
@@ -301,6 +314,7 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         prompt,
         title,
         conversation,
+        conversation_id,
     })
 }
 
@@ -774,6 +788,7 @@ mod tests {
             archived_at: None,
             created_at: "2026-04-27T10:00:00Z".to_string(),
             updated_at: "2026-04-27T10:00:00Z".to_string(),
+            conversation_id: None,
         };
         crate::store::insert_session(&conn, &session)?;
 
@@ -939,6 +954,73 @@ mod tests {
                 id: "abc-123".to_string()
             })
         );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_persists_conversation_id_on_the_session_row() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi",
+            "conversation": {"mode": "init", "id": "abc-123"},
+            "conversationId": "abc-123"
+        })
+        .to_string();
+
+        handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(
+            runtime.launches.borrow()[0].conversation_id.as_deref(),
+            Some("abc-123")
+        );
+
+        // And it round-trips through the session list payload too.
+        let list = handle_request("GET", "/sessions", temp_dir.path(), None)?;
+        assert!(
+            list.body.contains(r#""conversation_id":"abc-123""#),
+            "list response should expose conversation_id, got: {}",
+            list.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_treats_missing_conversation_id_as_null() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi"
+        })
+        .to_string();
+
+        handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert!(runtime.launches.borrow()[0].conversation_id.is_none());
         Ok(())
     }
 
@@ -1312,6 +1394,7 @@ mod tests {
             archived_at: None,
             created_at: "2026-04-27T10:00:00Z".to_string(),
             updated_at: "2026-04-27T10:00:00Z".to_string(),
+            conversation_id: None,
         };
         crate::store::insert_session(&conn, &session)?;
         Ok(())

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -313,6 +313,19 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         .context("failed to resolve projectRoot")?;
     let canonical_cwd = project::resolve_inside_root(&canonical_project_root, cwd.map(Path::new))?;
     let harness = required_string(&payload, "harness")?;
+    // Validate against the supported harness set up-front (client error)
+    // instead of letting the runtime's arg builder surface it later as a
+    // 500. Bonus: rejecting here means we never insert a session row for
+    // a launch that can't possibly succeed.
+    let supported: Vec<&'static str> = crate::harness::built_in_harness_specs()
+        .into_iter()
+        .map(|spec| spec.id)
+        .collect();
+    if !supported.iter().any(|id| *id == harness) {
+        anyhow::bail!(
+            "harness `{harness}` is not a supported harness; expected one of {supported:?}"
+        );
+    }
     let launch_mode = launch_mode_from_payload(&payload)?;
     let prompt = required_string(&payload, "prompt")?;
     let title = payload
@@ -426,6 +439,16 @@ fn record_input(
             );
         }
     };
+    // Validate `data` shape here (client error) instead of letting the
+    // runtime surface it as a 500. Required field, must be a string.
+    if !payload.get("data").map(|v| v.is_string()).unwrap_or(false) {
+        return api_error(
+            400,
+            "invalid_request",
+            "input payload requires string field `data`",
+            Some(json!({ "sessionId": session_id })),
+        );
+    }
     if let Err(error) = runtime.send_input(session_id, &payload) {
         if error.to_string().contains("not live") {
             return session_not_live_response(session_id);
@@ -1256,6 +1279,99 @@ mod tests {
         assert_eq!(
             runtime.inputs.borrow().as_slice(),
             &["session-1:hello coven"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_with_unknown_harness_returns_400_upfront_no_session_row() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "hermes",
+            "launchMode": "nonInteractive",
+            "prompt": "hello"
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(
+            response.body.contains("not a supported harness"),
+            "expected supported-harness validation message, got: {}",
+            response.body
+        );
+        assert!(
+            runtime.launches.borrow().is_empty(),
+            "runtime must not be invoked for an unsupported harness"
+        );
+        // And no session row should have been inserted.
+        let sessions = handle_request("GET", "/sessions", temp_dir.path(), None)?;
+        assert!(
+            sessions.body.contains("[]"),
+            "no session row should exist after a 400-rejected launch, got: {}",
+            sessions.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn input_request_with_missing_data_field_returns_400_not_500() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        let response = handle_request_with_body(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{"foo":"bar"}"#),
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(
+            response.body.contains("invalid_request"),
+            "missing `data` is a client error, expected 400 invalid_request, got: {}",
+            response.body
+        );
+        assert!(
+            response.body.contains("`data`"),
+            "expected the message to name the missing field, got: {}",
+            response.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn input_request_with_non_string_data_field_returns_400_not_500() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        let response = handle_request_with_body(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{"data": 42}"#),
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(
+            response.body.contains("invalid_request"),
+            "non-string `data` is a client error, expected 400 invalid_request, got: {}",
+            response.body
         );
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6,7 +6,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use uuid::Uuid;
 
-use crate::{control_plane, daemon::DaemonStatus, harness::HarnessLaunchMode, project, store};
+use crate::{
+    control_plane,
+    daemon::DaemonStatus,
+    harness::{ConversationHint, HarnessLaunchMode},
+    project, store,
+};
 
 const MAX_EVENTS_LIMIT: i64 = 1_000;
 pub const COVEN_API_VERSION: &str = "v1";
@@ -63,6 +68,7 @@ pub struct SessionLaunch {
     pub launch_mode: HarnessLaunchMode,
     pub prompt: String,
     pub title: String,
+    pub conversation: Option<ConversationHint>,
 }
 
 pub trait SessionRuntime {
@@ -284,6 +290,8 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         .unwrap_or(&prompt)
         .to_string();
 
+    let conversation = conversation_from_payload(&payload)?;
+
     Ok(SessionLaunch {
         id: Uuid::new_v4().to_string(),
         project_root: canonical_project_root.to_string_lossy().into_owned(),
@@ -292,6 +300,7 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         launch_mode,
         prompt,
         title,
+        conversation,
     })
 }
 
@@ -302,6 +311,34 @@ fn launch_mode_from_payload(payload: &Value) -> Result<HarnessLaunchMode> {
         Some(other) => {
             anyhow::bail!("launchMode must be `interactive` or `nonInteractive`, got `{other}`")
         }
+    }
+}
+
+fn conversation_from_payload(payload: &Value) -> Result<Option<ConversationHint>> {
+    let Some(value) = payload.get("conversation") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let object = value
+        .as_object()
+        .context("conversation must be an object with `mode` and `id` fields")?;
+    let mode = object
+        .get("mode")
+        .and_then(Value::as_str)
+        .context("conversation.mode is required and must be `init` or `resume`")?;
+    let id = object
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .context("conversation.id is required and must be a non-empty string")?
+        .to_string();
+    match mode {
+        "init" => Ok(Some(ConversationHint::Init { id })),
+        "resume" => Ok(Some(ConversationHint::Resume { id })),
+        other => anyhow::bail!("conversation.mode must be `init` or `resume`, got `{other}`"),
     }
 }
 
@@ -835,6 +872,106 @@ mod tests {
             runtime.launches.borrow()[0].launch_mode,
             HarnessLaunchMode::NonInteractive
         );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_threads_conversation_hint_through_to_runtime() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hello",
+            "conversation": {"mode": "init", "id": "abc-123"}
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 201);
+        assert_eq!(
+            runtime.launches.borrow()[0].conversation,
+            Some(ConversationHint::Init {
+                id: "abc-123".to_string()
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_accepts_resume_conversation_hint() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "follow up",
+            "conversation": {"mode": "resume", "id": "abc-123"}
+        })
+        .to_string();
+
+        handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(
+            runtime.launches.borrow()[0].conversation,
+            Some(ConversationHint::Resume {
+                id: "abc-123".to_string()
+            })
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_rejects_malformed_conversation_mode() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi",
+            "conversation": {"mode": "forge", "id": "abc"}
+        })
+        .to_string();
+
+        let result = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        );
+
+        let error = result.unwrap_err();
+        assert!(
+            error.to_string().contains("conversation.mode"),
+            "expected error to mention conversation.mode, got: {error}"
+        );
+        assert!(runtime.launches.borrow().is_empty());
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -322,9 +322,10 @@ fn launch_mode_from_payload(payload: &Value) -> Result<HarnessLaunchMode> {
     match payload.get("launchMode").and_then(Value::as_str) {
         Some("interactive") | None => Ok(HarnessLaunchMode::Interactive),
         Some("nonInteractive") => Ok(HarnessLaunchMode::NonInteractive),
-        Some(other) => {
-            anyhow::bail!("launchMode must be `interactive` or `nonInteractive`, got `{other}`")
-        }
+        Some("stream") => Ok(HarnessLaunchMode::Stream),
+        Some(other) => anyhow::bail!(
+            "launchMode must be `interactive`, `nonInteractive`, or `stream`, got `{other}`"
+        ),
     }
 }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -411,12 +411,31 @@ fn record_input(
         return session_not_live_response(session_id);
     }
 
-    let payload = parse_body(body)?;
+    // Same structured-error pattern as `launch_session`: malformed JSON
+    // or runtime send failures must NOT propagate to the accept loop
+    // (that crashes the daemon process). Parse errors → 400; runtime
+    // errors → 500 except for "not live" which is the dedicated 409.
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return api_error(
+                400,
+                "invalid_request",
+                &error.to_string(),
+                Some(json!({ "sessionId": session_id })),
+            );
+        }
+    };
     if let Err(error) = runtime.send_input(session_id, &payload) {
         if error.to_string().contains("not live") {
             return session_not_live_response(session_id);
         }
-        return Err(error);
+        return api_error(
+            500,
+            "send_input_failed",
+            &error.to_string(),
+            Some(json!({ "sessionId": session_id })),
+        );
     }
     insert_event(&conn, session_id, "input", payload)?;
     json_response(202, &json!({ "ok": true, "accepted": true }))
@@ -440,11 +459,19 @@ fn kill_session(
         return session_not_live_response(session_id);
     }
 
+    // Same structured-error pattern as the launch + input handlers: a
+    // runtime kill failure (libc::kill returning EPERM, etc.) must
+    // become a 500 response, not an Err that brings down the daemon.
     if let Err(error) = runtime.kill_session(session_id) {
         if error.to_string().contains("not live") {
             return session_not_live_response(session_id);
         }
-        return Err(error);
+        return api_error(
+            500,
+            "kill_failed",
+            &error.to_string(),
+            Some(json!({ "sessionId": session_id })),
+        );
     }
     let now = current_timestamp();
     store::update_session_status(&conn, session_id, "killed", None, &now)?;
@@ -1229,6 +1256,105 @@ mod tests {
         assert_eq!(
             runtime.inputs.borrow().as_slice(),
             &["session-1:hello coven"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn input_request_with_malformed_body_returns_400_not_daemon_crash() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        let response = handle_request_with_body(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some("{ not json"),
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(
+            response.body.contains("invalid_request"),
+            "expected structured `invalid_request` code, got: {}",
+            response.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn input_request_runtime_failure_returns_500_not_daemon_crash() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        // Runtime that fails send_input with a non-"not live" message
+        // — we want the daemon to surface it as a structured 500
+        // instead of bubbling it to serve_next_connection's `?`.
+        struct FailingInput;
+        impl SessionRuntime for FailingInput {
+            fn launch_session(&self, _: &SessionLaunch) -> Result<()> {
+                Ok(())
+            }
+            fn send_input(&self, _: &str, _: &Value) -> Result<()> {
+                Err(anyhow::anyhow!("simulated send_input failure"))
+            }
+            fn kill_session(&self, _: &str) -> Result<()> {
+                Ok(())
+            }
+        }
+        let runtime = FailingInput;
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{"data":"hello"}"#),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 500);
+        assert!(
+            response.body.contains("send_input_failed"),
+            "expected structured `send_input_failed` code, got: {}",
+            response.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn kill_request_runtime_failure_returns_500_not_daemon_crash() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        struct FailingKill;
+        impl SessionRuntime for FailingKill {
+            fn launch_session(&self, _: &SessionLaunch) -> Result<()> {
+                Ok(())
+            }
+            fn send_input(&self, _: &str, _: &Value) -> Result<()> {
+                Ok(())
+            }
+            fn kill_session(&self, _: &str) -> Result<()> {
+                Err(anyhow::anyhow!("simulated kill_session failure"))
+            }
+        }
+        let runtime = FailingKill;
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions/session-1/kill",
+            temp_dir.path(),
+            None,
+            Some("{}"),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 500);
+        assert!(
+            response.body.contains("kill_failed"),
+            "expected structured `kill_failed` code, got: {}",
+            response.body
         );
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -257,8 +257,23 @@ fn launch_session(
     body: Option<&str>,
     runtime: &dyn SessionRuntime,
 ) -> Result<ApiResponse> {
-    let payload = parse_body(body)?;
-    let launch = session_launch_from_payload(payload)?;
+    // Client-side validation errors (malformed JSON, bad fields,
+    // unsupported launchMode, malformed `conversation` object, …) must
+    // become structured 400 responses. Bubbling them up as Err crashes
+    // the daemon, since the api-server loop `?`-propagates errors out
+    // of the accept loop and terminates the process.
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return api_error(400, "invalid_request", &error.to_string(), None);
+        }
+    };
+    let launch = match session_launch_from_payload(payload) {
+        Ok(launch) => launch,
+        Err(error) => {
+            return api_error(400, "invalid_request", &error.to_string(), None);
+        }
+    };
     let conn = store::open_store(&store_path(coven_home))?;
     let now = current_timestamp();
     let record = store::SessionRecord {
@@ -1026,7 +1041,8 @@ mod tests {
     }
 
     #[test]
-    fn launch_request_rejects_malformed_conversation_mode() -> anyhow::Result<()> {
+    fn launch_request_with_malformed_conversation_mode_returns_400_not_daemon_crash(
+    ) -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let project_root = temp_dir.path().join("repo");
         std::fs::create_dir_all(&project_root)?;
@@ -1040,19 +1056,27 @@ mod tests {
         })
         .to_string();
 
-        let result = handle_request_with_runtime(
+        let response = handle_request_with_runtime(
             "POST",
             "/sessions",
             temp_dir.path(),
             None,
             Some(&body),
             &runtime,
-        );
+        )?;
 
-        let error = result.unwrap_err();
+        // Must be a structured 400 — bubbling the error up to the
+        // daemon's accept loop would take the daemon down.
+        assert_eq!(response.status, 400);
         assert!(
-            error.to_string().contains("conversation.mode"),
-            "expected error to mention conversation.mode, got: {error}"
+            response.body.contains("conversation.mode"),
+            "expected body to mention conversation.mode, got: {}",
+            response.body
+        );
+        assert!(
+            response.body.contains("invalid_request"),
+            "expected structured `invalid_request` code, got: {}",
+            response.body
         );
         assert!(runtime.launches.borrow().is_empty());
         Ok(())
@@ -1103,19 +1127,20 @@ mod tests {
         })
         .to_string();
 
-        let error = handle_request_with_runtime(
+        let response = handle_request_with_runtime(
             "POST",
             "/sessions",
             temp_dir.path(),
             None,
             Some(&body),
             &runtime,
-        )
-        .unwrap_err();
+        )?;
 
+        assert_eq!(response.status, 400);
         assert!(
-            error.to_string().contains("outside the Coven project root"),
-            "unexpected error: {error:?}"
+            response.body.contains("outside the Coven project root"),
+            "unexpected body: {}",
+            response.body
         );
         assert!(runtime.launches.borrow().is_empty());
         Ok(())
@@ -1126,17 +1151,18 @@ mod tests {
         let temp_dir = tempfile::tempdir()?;
         let runtime = RecordingRuntime::default();
 
-        let error = handle_request_with_runtime(
+        let response = handle_request_with_runtime(
             "POST",
             "/sessions",
             temp_dir.path(),
             None,
             Some(r#"{"harness":"codex"}"#),
             &runtime,
-        )
-        .unwrap_err();
+        )?;
 
-        assert!(error.to_string().contains("projectRoot"));
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains("projectRoot"));
+        assert!(response.body.contains("invalid_request"));
         assert!(runtime.launches.borrow().is_empty());
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -290,8 +290,18 @@ fn launch_session(
     };
     store::insert_session(&conn, &record)?;
     if let Err(error) = runtime.launch_session(&launch) {
+        // Don't propagate to the accept loop — that crashes the daemon.
+        // Runtime launch failures are user-facing (missing harness CLI,
+        // missing auth, child closed stdin during stream-mode init):
+        // mark the session row failed and return a structured response
+        // so the client surfaces the cause and the daemon stays up.
         store::update_session_status(&conn, &record.id, "failed", None, &current_timestamp())?;
-        return Err(error);
+        return api_error(
+            500,
+            "launch_failed",
+            &error.to_string(),
+            Some(json!({ "sessionId": record.id })),
+        );
     }
     json_response(201, &record)
 }
@@ -1083,7 +1093,7 @@ mod tests {
     }
 
     #[test]
-    fn launch_request_persists_failed_status_when_runtime_launch_fails() -> anyhow::Result<()> {
+    fn launch_request_runtime_failure_returns_500_and_marks_session_failed() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let project_root = temp_dir.path().join("repo");
         std::fs::create_dir_all(&project_root)?;
@@ -1095,18 +1105,29 @@ mod tests {
         })
         .to_string();
 
-        let error = handle_request_with_runtime(
+        let response = handle_request_with_runtime(
             "POST",
             "/sessions",
             temp_dir.path(),
             None,
             Some(&body),
             &runtime,
-        )
-        .unwrap_err();
+        )?;
         let sessions = handle_request("GET", "/sessions", temp_dir.path(), None)?;
 
-        assert!(error.to_string().contains("launch failed"));
+        // Must be a structured response — propagating Err would crash
+        // the daemon's accept loop.
+        assert_eq!(response.status, 500);
+        assert!(
+            response.body.contains("launch_failed"),
+            "expected structured `launch_failed` code, got: {}",
+            response.body
+        );
+        assert!(
+            response.body.contains("launch failed"),
+            "expected runtime error message in the body, got: {}",
+            response.body
+        );
         assert!(sessions.body.contains(r#""status":"failed""#));
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -450,7 +450,14 @@ fn record_input(
         );
     }
     if let Err(error) = runtime.send_input(session_id, &payload) {
-        if error.to_string().contains("not live") {
+        // Match the typed sentinel from the daemon runtime instead of
+        // substring-matching the error message — refactoring the prose
+        // later can't accidentally route the not-live case to the
+        // generic 500 path.
+        if error
+            .downcast_ref::<crate::daemon::NotLiveError>()
+            .is_some()
+        {
             return session_not_live_response(session_id);
         }
         return api_error(
@@ -486,7 +493,10 @@ fn kill_session(
     // runtime kill failure (libc::kill returning EPERM, etc.) must
     // become a 500 response, not an Err that brings down the daemon.
     if let Err(error) = runtime.kill_session(session_id) {
-        if error.to_string().contains("not live") {
+        if error
+            .downcast_ref::<crate::daemon::NotLiveError>()
+            .is_some()
+        {
             return session_not_live_response(session_id);
         }
         return api_error(
@@ -1399,6 +1409,46 @@ mod tests {
     }
 
     #[test]
+    fn input_request_not_live_runtime_error_routes_to_409_via_typed_downcast() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+
+        struct NotLiveRuntime;
+        impl SessionRuntime for NotLiveRuntime {
+            fn launch_session(&self, _: &SessionLaunch) -> Result<()> {
+                Ok(())
+            }
+            fn send_input(&self, _: &str, _: &Value) -> Result<()> {
+                Err(anyhow::Error::new(crate::daemon::NotLiveError {
+                    session_id: "session-1".to_string(),
+                }))
+            }
+            fn kill_session(&self, _: &str) -> Result<()> {
+                Ok(())
+            }
+        }
+        let runtime = NotLiveRuntime;
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{"data":"hi"}"#),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 409);
+        assert!(
+            response.body.contains("session_not_live"),
+            "typed NotLiveError must route to 409 session_not_live, got: {}",
+            response.body
+        );
+        Ok(())
+    }
+
+    #[test]
     fn input_request_runtime_failure_returns_500_not_daemon_crash() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         insert_test_session(temp_dir.path(), "session-1")?;
@@ -1656,11 +1706,15 @@ mod tests {
         }
 
         fn send_input(&self, session_id: &str, _payload: &Value) -> Result<()> {
-            anyhow::bail!("session `{session_id}` is not live in this daemon")
+            Err(anyhow::Error::new(crate::daemon::NotLiveError {
+                session_id: session_id.to_string(),
+            }))
         }
 
         fn kill_session(&self, session_id: &str) -> Result<()> {
-            anyhow::bail!("session `{session_id}` is not live in this daemon")
+            Err(anyhow::Error::new(crate::daemon::NotLiveError {
+                session_id: session_id.to_string(),
+            }))
         }
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1350,6 +1350,7 @@ mod tests {
                 archived_at: None,
                 created_at: "2026-04-27T10:00:00Z".to_string(),
                 updated_at: "2026-04-27T10:00:00Z".to_string(),
+                conversation_id: None,
             },
         )?;
         let listener = bind_api_socket(temp_dir.path())?;
@@ -1454,6 +1455,7 @@ mod tests {
             archived_at: None,
             created_at: "2026-04-27T07:00:00Z".to_string(),
             updated_at: "2026-04-27T07:00:00Z".to_string(),
+            conversation_id: None,
         }
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -59,7 +59,19 @@ pub struct LiveSessionRuntime {
     sessions: Mutex<HashMap<String, LiveSessionHandle>>,
 }
 
+/// What kind of underlying process is bound to a registered live session.
+/// PTY sessions take raw text on stdin (we forward `payload.data` as bytes).
+/// Stream sessions take newline-delimited JSON; `payload.data` gets wrapped
+/// in a `{"type":"user","message":{"role":"user","content":[{...}]}}` envelope
+/// before being written to the child. See `docs/chat-persistence.md`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LiveSessionKind {
+    Pty,
+    Stream,
+}
+
 struct LiveSessionHandle {
+    kind: LiveSessionKind,
     input: Box<dyn Write + Send>,
     killer: Box<dyn RuntimeKiller>,
 }
@@ -79,10 +91,27 @@ impl LiveSessionRuntime {
         input: Box<dyn Write + Send>,
         killer: Box<dyn RuntimeKiller>,
     ) -> Result<()> {
+        self.register_kind(session_id, LiveSessionKind::Pty, input, killer)
+    }
+
+    fn register_kind(
+        &self,
+        session_id: String,
+        kind: LiveSessionKind,
+        input: Box<dyn Write + Send>,
+        killer: Box<dyn RuntimeKiller>,
+    ) -> Result<()> {
         self.sessions
             .lock()
             .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?
-            .insert(session_id, LiveSessionHandle { input, killer });
+            .insert(
+                session_id,
+                LiveSessionHandle {
+                    kind,
+                    input,
+                    killer,
+                },
+            );
         Ok(())
     }
 }
@@ -100,8 +129,37 @@ impl SessionRuntime for LiveSessionRuntime {
             .coven_home
             .as_ref()
             .map(|coven_home| output_observer(coven_home.to_path_buf(), launch.id.clone()));
+
+        if launch.launch_mode == crate::harness::HarnessLaunchMode::Stream {
+            let piped = pty_runner::spawn_piped_with_observer(&command, observer)?;
+            let killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller {
+                child: piped.child,
+            });
+            let mut input = piped.input;
+            // Send the launch's prompt as the first stream-json user
+            // message so the chat doesn't need a separate send call right
+            // after launch. Best-effort: if the write fails the session is
+            // still registered and the caller can retry via send_input.
+            if !launch.prompt.is_empty() {
+                if let Err(error) = write_stream_message(input.as_mut(), &launch.prompt) {
+                    eprintln!("[stream-launch] initial message write failed: {error}");
+                }
+            }
+            return self.register_kind(
+                launch.id.clone(),
+                LiveSessionKind::Stream,
+                input,
+                killer,
+            );
+        }
+
         let detached = pty_runner::spawn_detached_with_observer(&command, observer)?;
-        self.register(launch.id.clone(), detached.input, Box::new(detached.killer))
+        self.register_kind(
+            launch.id.clone(),
+            LiveSessionKind::Pty,
+            detached.input,
+            Box::new(detached.killer),
+        )
     }
 
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()> {
@@ -116,14 +174,21 @@ impl SessionRuntime for LiveSessionRuntime {
         let session = sessions
             .get_mut(session_id)
             .with_context(|| format!("session `{session_id}` is not live in this daemon"))?;
-        session
-            .input
-            .write_all(data.as_bytes())
-            .context("failed to write input to live session")?;
-        session
-            .input
-            .flush()
-            .context("failed to flush live session input")?;
+        match session.kind {
+            LiveSessionKind::Pty => {
+                session
+                    .input
+                    .write_all(data.as_bytes())
+                    .context("failed to write input to live session")?;
+                session
+                    .input
+                    .flush()
+                    .context("failed to flush live session input")?;
+            }
+            LiveSessionKind::Stream => {
+                write_stream_message(session.input.as_mut(), data)?;
+            }
+        }
         Ok(())
     }
 
@@ -136,6 +201,53 @@ impl SessionRuntime for LiveSessionRuntime {
             .remove(session_id)
             .with_context(|| format!("session `{session_id}` is not live in this daemon"))?;
         session.killer.kill()
+    }
+}
+
+/// Wrap raw user text in claude's stream-json user-message envelope and
+/// write it to `input`, followed by a newline so the child reads it
+/// immediately. Used by both the launch-time initial message and by the
+/// per-turn `send_input` path.
+fn write_stream_message(input: &mut dyn Write, text: &str) -> Result<()> {
+    let envelope = json!({
+        "type": "user",
+        "message": {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": text}
+            ]
+        }
+    });
+    let mut line = serde_json::to_string(&envelope)
+        .context("failed to encode stream-json user envelope")?;
+    line.push('\n');
+    input
+        .write_all(line.as_bytes())
+        .context("failed to write stream-json message to live session")?;
+    input
+        .flush()
+        .context("failed to flush stream-json message to live session")?;
+    Ok(())
+}
+
+/// Killer for a non-PTY piped child (stream-mode harness sessions).
+/// `pty_runner::spawn_piped_with_observer` returns an `Arc<Mutex<Option<Child>>>`
+/// shared with the drain thread; killing tells the kernel to terminate the
+/// child while the drain thread also has access for its eventual `wait`.
+struct PipedKiller {
+    child: std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>,
+}
+
+impl RuntimeKiller for PipedKiller {
+    fn kill(&mut self) -> Result<()> {
+        let mut guard = self
+            .child
+            .lock()
+            .map_err(|_| anyhow::anyhow!("piped child mutex poisoned"))?;
+        if let Some(child) = guard.as_mut() {
+            let _ = child.kill();
+        }
+        Ok(())
     }
 }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -70,10 +70,16 @@ enum LiveSessionKind {
     Stream,
 }
 
+/// Registered live session. `input` and `killer` each sit behind their own
+/// `Arc<Mutex<…>>` so `send_input` and `kill_session` can drop the global
+/// `sessions` map lock before doing any potentially-blocking I/O (a
+/// stream-mode harness whose child has stopped reading stdin will block
+/// the write; we don't want that to wedge every other session op,
+/// including a concurrent `/kill` to recover).
 struct LiveSessionHandle {
     kind: LiveSessionKind,
-    input: Box<dyn Write + Send>,
-    killer: Box<dyn RuntimeKiller>,
+    input: std::sync::Arc<Mutex<Box<dyn Write + Send>>>,
+    killer: std::sync::Arc<Mutex<Box<dyn RuntimeKiller>>>,
 }
 
 impl LiveSessionRuntime {
@@ -101,6 +107,7 @@ impl LiveSessionRuntime {
         input: Box<dyn Write + Send>,
         killer: Box<dyn RuntimeKiller>,
     ) -> Result<()> {
+        use std::sync::Arc;
         self.sessions
             .lock()
             .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?
@@ -108,8 +115,8 @@ impl LiveSessionRuntime {
                 session_id,
                 LiveSessionHandle {
                     kind,
-                    input,
-                    killer,
+                    input: Arc::new(Mutex::new(input)),
+                    killer: Arc::new(Mutex::new(killer)),
                 },
             );
         Ok(())
@@ -144,7 +151,7 @@ impl SessionRuntime for LiveSessionRuntime {
                 );
             }
             let piped = pty_runner::spawn_piped_with_observer(&command, observer)?;
-            let mut killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller { pid: piped.pid });
+            let mut killer_box: Box<dyn RuntimeKiller> = Box::new(PipedKiller { pid: piped.pid });
             let mut input = piped.input;
             // Send the launch's prompt as the first stream-json user
             // message so the chat doesn't need a separate send call right
@@ -155,7 +162,7 @@ impl SessionRuntime for LiveSessionRuntime {
             // pretending we delivered the prompt.
             if !launch.prompt.is_empty() {
                 if let Err(error) = write_stream_message(input.as_mut(), &launch.prompt) {
-                    let _ = killer.kill();
+                    let _ = killer_box.kill();
                     return Err(error).with_context(|| {
                         format!(
                             "stream-mode launch of `{}` failed: child closed stdin before the initial message landed (auth/setup error?)",
@@ -164,7 +171,12 @@ impl SessionRuntime for LiveSessionRuntime {
                     });
                 }
             }
-            return self.register_kind(launch.id.clone(), LiveSessionKind::Stream, input, killer);
+            return self.register_kind(
+                launch.id.clone(),
+                LiveSessionKind::Stream,
+                input,
+                killer_box,
+            );
         }
 
         let detached = pty_runner::spawn_detached_with_observer(&command, observer)?;
@@ -181,40 +193,60 @@ impl SessionRuntime for LiveSessionRuntime {
             .get("data")
             .and_then(Value::as_str)
             .context("input payload requires string field `data`")?;
-        let mut sessions = self
-            .sessions
+        // Look up the per-session input writer under the map lock, then
+        // drop the map lock BEFORE blocking on the actual write. A
+        // stream-mode child that's stopped reading stdin can stall the
+        // write indefinitely; holding the global map lock during that
+        // would wedge every other session op (including a concurrent
+        // /kill that wants to recover from exactly this state).
+        let (kind, input) = {
+            let sessions = self
+                .sessions
+                .lock()
+                .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
+            let session = sessions
+                .get(session_id)
+                .with_context(|| format!("session `{session_id}` is not live in this daemon"))?;
+            (session.kind, std::sync::Arc::clone(&session.input))
+        };
+        let mut input = input
             .lock()
-            .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
-        let session = sessions
-            .get_mut(session_id)
-            .with_context(|| format!("session `{session_id}` is not live in this daemon"))?;
-        match session.kind {
+            .map_err(|_| anyhow::anyhow!("live session input lock poisoned"))?;
+        match kind {
             LiveSessionKind::Pty => {
-                session
-                    .input
+                input
                     .write_all(data.as_bytes())
                     .context("failed to write input to live session")?;
-                session
-                    .input
+                input
                     .flush()
                     .context("failed to flush live session input")?;
             }
             LiveSessionKind::Stream => {
-                write_stream_message(session.input.as_mut(), data)?;
+                write_stream_message(input.as_mut(), data)?;
             }
         }
         Ok(())
     }
 
     fn kill_session(&self, session_id: &str) -> Result<()> {
-        let mut sessions = self
-            .sessions
+        // Remove the handle under the map lock, then drop the map lock
+        // before doing the actual kill. The killer is in its own
+        // `Arc<Mutex>` so a concurrent `send_input` that's blocked on a
+        // hung write can't prevent us from issuing the kill.
+        let handle = {
+            let mut sessions = self
+                .sessions
+                .lock()
+                .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
+            sessions
+                .remove(session_id)
+                .with_context(|| format!("session `{session_id}` is not live in this daemon"))?
+        };
+        let mut killer = handle
+            .killer
             .lock()
-            .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
-        let mut session = sessions
-            .remove(session_id)
-            .with_context(|| format!("session `{session_id}` is not live in this daemon"))?;
-        session.killer.kill()
+            .map_err(|_| anyhow::anyhow!("live session killer lock poisoned"))?;
+        killer.kill()
     }
 }
 
@@ -1052,6 +1084,79 @@ mod tests {
             *self.killed.lock().unwrap() = true;
             Ok(())
         }
+    }
+
+    /// `Write` impl whose `write` blocks until a kill signal is set.
+    /// Used to simulate a stream-mode child that has stopped reading
+    /// stdin — we want `kill_session` to succeed even while
+    /// `send_input` is mid-write to that exact session.
+    #[derive(Clone)]
+    struct BlockingWriter {
+        unblock: std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+    }
+
+    impl Write for BlockingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let (lock, cvar) = &*self.unblock;
+            let mut guard = lock.lock().unwrap();
+            while !*guard {
+                guard = cvar.wait(guard).unwrap();
+            }
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn kill_session_succeeds_even_while_send_input_is_blocked_on_a_hung_child() {
+        use std::sync::{Arc, Condvar, Mutex as StdMutex};
+        use std::thread;
+
+        let runtime = Arc::new(LiveSessionRuntime::default());
+        let unblock = Arc::new((StdMutex::new(false), Condvar::new()));
+        let writer = BlockingWriter {
+            unblock: Arc::clone(&unblock),
+        };
+        let killed = Arc::new(StdMutex::new(false));
+        runtime
+            .register(
+                "wedged-session".to_string(),
+                Box::new(writer),
+                Box::new(RecordingKiller {
+                    killed: killed.clone(),
+                }),
+            )
+            .unwrap();
+
+        // Kick off a send that will block on the writer.
+        let sender_runtime = Arc::clone(&runtime);
+        let sender = thread::spawn(move || {
+            SessionRuntime::send_input(
+                &*sender_runtime,
+                "wedged-session",
+                &serde_json::json!({ "data": "wedge" }),
+            )
+        });
+
+        // Give the sender a moment to take the input lock + block.
+        thread::sleep(std::time::Duration::from_millis(50));
+
+        // Kill must succeed regardless of the wedged send.
+        SessionRuntime::kill_session(&*runtime, "wedged-session")
+            .expect("kill_session must not be blocked by a hung send_input on the same session");
+        assert!(*killed.lock().unwrap());
+
+        // Let the writer unblock so the sender thread can finish (its
+        // post-kill state isn't what we're testing).
+        {
+            let (lock, cvar) = &*unblock;
+            *lock.lock().unwrap() = true;
+            cvar.notify_all();
+        }
+        let _ = sender.join();
     }
 
     #[test]

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -89,11 +89,12 @@ impl LiveSessionRuntime {
 
 impl SessionRuntime for LiveSessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()> {
-        let command = pty_runner::build_harness_command(
+        let command = pty_runner::build_harness_command_with_conversation(
             &launch.harness,
             &launch.prompt,
             Path::new(&launch.cwd),
             launch.launch_mode,
+            launch.conversation.as_ref(),
         )?;
         let observer = self
             .coven_home

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -334,19 +334,59 @@ fn output_observer(coven_home: PathBuf, session_id: String) -> pty_runner::Detac
     let output_session_id = session_id.clone();
     let exit_home = coven_home;
     let exit_session_id = session_id;
+    // Per-session byte buffer. `spawn_detached_with_observer` (and the
+    // piped variant) feed us arbitrary 8KiB reads, so a multi-byte
+    // UTF-8 codepoint can straddle two callbacks. Decoding each chunk
+    // independently with `from_utf8_lossy` would insert U+FFFD at the
+    // split, permanently corrupting JSON in stream-mode (and garbling
+    // emoji/non-ASCII text in PTY mode). We append raw bytes, decode
+    // only the longest valid-UTF-8 prefix, and keep the trailing
+    // partial codepoint for the next chunk.
+    let mut buffer: Vec<u8> = Vec::with_capacity(8192);
 
     pty_runner::DetachedPtyObserver {
         on_output: Box::new(move |chunk| {
             if chunk.is_empty() {
                 return;
             }
-            let text = String::from_utf8_lossy(&chunk).into_owned();
-            let _ = record_session_event(
-                &output_home,
-                &output_session_id,
-                "output",
-                json!({ "data": text }),
-            );
+            buffer.extend_from_slice(&chunk);
+            // Take the longest valid-UTF-8 prefix; bytes after that are
+            // either a partial codepoint at a chunk boundary (wait for
+            // more) or genuinely invalid bytes (handled below).
+            let valid_up_to = match std::str::from_utf8(&buffer) {
+                Ok(_) => buffer.len(),
+                Err(error) => error.valid_up_to(),
+            };
+            if valid_up_to > 0 {
+                let safe = std::str::from_utf8(&buffer[..valid_up_to])
+                    .expect("valid_up_to is by definition valid utf-8")
+                    .to_string();
+                buffer.drain(..valid_up_to);
+                let _ = record_session_event(
+                    &output_home,
+                    &output_session_id,
+                    "output",
+                    json!({ "data": safe }),
+                );
+            }
+            // Pathological tail: if the remaining bytes can't be a
+            // partial codepoint (>4 bytes — max UTF-8 codepoint length),
+            // the stream is genuinely malformed. Drop one byte via
+            // lossy decode so we make progress instead of buffering
+            // forever. Re-runs of from_utf8 on subsequent chunks will
+            // either find new valid prefixes or repeat this drain.
+            while buffer.len() > 4
+                && std::str::from_utf8(&buffer).err().map(|e| e.valid_up_to()) == Some(0)
+            {
+                let dropped: Vec<u8> = buffer.drain(..1).collect();
+                let lossy = String::from_utf8_lossy(&dropped).into_owned();
+                let _ = record_session_event(
+                    &output_home,
+                    &output_session_id,
+                    "output",
+                    json!({ "data": lossy }),
+                );
+            }
         }),
         on_exit: Box::new(move |result| {
             let _ = record_session_exit(&exit_home, &exit_session_id, result);
@@ -987,6 +1027,42 @@ fn parse_request_line(line: &str) -> Result<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn output_observer_buffers_multibyte_codepoints_split_across_chunks() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        // Seed a session row so record_session_event has a valid FK.
+        let session = session_record("buffered");
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        crate::store::insert_session(&conn, &session)?;
+
+        let observer = output_observer(temp_dir.path().to_path_buf(), session.id.clone());
+        let pty_runner::DetachedPtyObserver { mut on_output, .. } = observer;
+
+        // 🎉 = 0xF0 0x9F 0x8E 0x89. Split it across two chunks so the
+        // old (non-buffered) implementation would lossy-decode each
+        // half into U+FFFD and corrupt the text.
+        let emoji_bytes = "🎉".as_bytes(); // 4 bytes
+        on_output(emoji_bytes[..2].to_vec());
+        on_output(emoji_bytes[2..].to_vec());
+
+        // Read back the recorded events and concatenate their decoded
+        // text. The original emoji must round-trip intact.
+        let events = crate::store::list_events(&conn, &session.id)?;
+        let mut decoded = String::new();
+        for event in events.iter().filter(|e| e.kind == "output") {
+            let payload: serde_json::Value = serde_json::from_str(&event.payload_json)?;
+            if let Some(text) = payload.get("data").and_then(|v| v.as_str()) {
+                decoded.push_str(text);
+            }
+        }
+        assert_eq!(
+            decoded, "🎉",
+            "split-codepoint output must reassemble to the original character, not U+FFFD"
+        );
+        Ok(())
+    }
 
     #[test]
     fn live_runtime_rejects_stream_launch_for_non_stream_capable_harness() {

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -132,9 +132,7 @@ impl SessionRuntime for LiveSessionRuntime {
 
         if launch.launch_mode == crate::harness::HarnessLaunchMode::Stream {
             let piped = pty_runner::spawn_piped_with_observer(&command, observer)?;
-            let killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller {
-                child: piped.child,
-            });
+            let killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller { child: piped.child });
             let mut input = piped.input;
             // Send the launch's prompt as the first stream-json user
             // message so the chat doesn't need a separate send call right
@@ -145,12 +143,7 @@ impl SessionRuntime for LiveSessionRuntime {
                     eprintln!("[stream-launch] initial message write failed: {error}");
                 }
             }
-            return self.register_kind(
-                launch.id.clone(),
-                LiveSessionKind::Stream,
-                input,
-                killer,
-            );
+            return self.register_kind(launch.id.clone(), LiveSessionKind::Stream, input, killer);
         }
 
         let detached = pty_runner::spawn_detached_with_observer(&command, observer)?;
@@ -218,8 +211,8 @@ fn write_stream_message(input: &mut dyn Write, text: &str) -> Result<()> {
             ]
         }
     });
-    let mut line = serde_json::to_string(&envelope)
-        .context("failed to encode stream-json user envelope")?;
+    let mut line =
+        serde_json::to_string(&envelope).context("failed to encode stream-json user envelope")?;
     line.push('\n');
     input
         .write_all(line.as_bytes())

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -334,59 +334,24 @@ fn output_observer(coven_home: PathBuf, session_id: String) -> pty_runner::Detac
     let output_session_id = session_id.clone();
     let exit_home = coven_home;
     let exit_session_id = session_id;
-    // Per-session byte buffer. `spawn_detached_with_observer` (and the
-    // piped variant) feed us arbitrary 8KiB reads, so a multi-byte
-    // UTF-8 codepoint can straddle two callbacks. Decoding each chunk
-    // independently with `from_utf8_lossy` would insert U+FFFD at the
-    // split, permanently corrupting JSON in stream-mode (and garbling
-    // emoji/non-ASCII text in PTY mode). We append raw bytes, decode
-    // only the longest valid-UTF-8 prefix, and keep the trailing
-    // partial codepoint for the next chunk.
-    let mut buffer: Vec<u8> = Vec::with_capacity(8192);
-
+    // UTF-8 boundary safety is enforced by `drain_detached_output` in
+    // pty_runner per-source (separate buffers for stdout and stderr in
+    // stream mode), so each chunk we receive here is already valid
+    // UTF-8. We just decode and record. Lossy decode is a defensive
+    // fallback that should never trigger.
     pty_runner::DetachedPtyObserver {
         on_output: Box::new(move |chunk| {
             if chunk.is_empty() {
                 return;
             }
-            buffer.extend_from_slice(&chunk);
-            // Take the longest valid-UTF-8 prefix; bytes after that are
-            // either a partial codepoint at a chunk boundary (wait for
-            // more) or genuinely invalid bytes (handled below).
-            let valid_up_to = match std::str::from_utf8(&buffer) {
-                Ok(_) => buffer.len(),
-                Err(error) => error.valid_up_to(),
-            };
-            if valid_up_to > 0 {
-                let safe = std::str::from_utf8(&buffer[..valid_up_to])
-                    .expect("valid_up_to is by definition valid utf-8")
-                    .to_string();
-                buffer.drain(..valid_up_to);
-                let _ = record_session_event(
-                    &output_home,
-                    &output_session_id,
-                    "output",
-                    json!({ "data": safe }),
-                );
-            }
-            // Pathological tail: if the remaining bytes can't be a
-            // partial codepoint (>4 bytes — max UTF-8 codepoint length),
-            // the stream is genuinely malformed. Drop one byte via
-            // lossy decode so we make progress instead of buffering
-            // forever. Re-runs of from_utf8 on subsequent chunks will
-            // either find new valid prefixes or repeat this drain.
-            while buffer.len() > 4
-                && std::str::from_utf8(&buffer).err().map(|e| e.valid_up_to()) == Some(0)
-            {
-                let dropped: Vec<u8> = buffer.drain(..1).collect();
-                let lossy = String::from_utf8_lossy(&dropped).into_owned();
-                let _ = record_session_event(
-                    &output_home,
-                    &output_session_id,
-                    "output",
-                    json!({ "data": lossy }),
-                );
-            }
+            let text = String::from_utf8(chunk)
+                .unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned());
+            let _ = record_session_event(
+                &output_home,
+                &output_session_id,
+                "output",
+                json!({ "data": text }),
+            );
         }),
         on_exit: Box::new(move |result| {
             let _ = record_session_exit(&exit_home, &exit_session_id, result);
@@ -1029,26 +994,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn output_observer_buffers_multibyte_codepoints_split_across_chunks() -> Result<()> {
+    fn output_observer_records_each_callback_as_an_event() -> Result<()> {
+        // UTF-8 boundary safety lives in pty_runner::drain_detached_output
+        // now (see its tests). The observer's only job is to take each
+        // chunk it receives and persist it as an `output` event. This
+        // test pins that minimal contract by feeding the observer two
+        // pre-decoded chunks and checking they show up verbatim in the
+        // events table.
         let temp_dir = tempfile::tempdir()?;
-        crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
-        // Seed a session row so record_session_event has a valid FK.
-        let session = session_record("buffered");
         let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        let session = session_record("buffered");
         crate::store::insert_session(&conn, &session)?;
 
         let observer = output_observer(temp_dir.path().to_path_buf(), session.id.clone());
         let pty_runner::DetachedPtyObserver { mut on_output, .. } = observer;
 
-        // 🎉 = 0xF0 0x9F 0x8E 0x89. Split it across two chunks so the
-        // old (non-buffered) implementation would lossy-decode each
-        // half into U+FFFD and corrupt the text.
-        let emoji_bytes = "🎉".as_bytes(); // 4 bytes
-        on_output(emoji_bytes[..2].to_vec());
-        on_output(emoji_bytes[2..].to_vec());
+        // The drain layer would only ever hand us valid-UTF-8 slices,
+        // so simulate that: a complete emoji and then a plain ASCII
+        // chunk, each fully decodable on its own.
+        on_output("🎉".as_bytes().to_vec());
+        on_output(b" done".to_vec());
 
-        // Read back the recorded events and concatenate their decoded
-        // text. The original emoji must round-trip intact.
         let events = crate::store::list_events(&conn, &session.id)?;
         let mut decoded = String::new();
         for event in events.iter().filter(|e| e.kind == "output") {
@@ -1057,10 +1023,7 @@ mod tests {
                 decoded.push_str(text);
             }
         }
-        assert_eq!(
-            decoded, "🎉",
-            "split-codepoint output must reassemble to the original character, not U+FFFD"
-        );
+        assert_eq!(decoded, "🎉 done");
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -132,7 +132,7 @@ impl SessionRuntime for LiveSessionRuntime {
 
         if launch.launch_mode == crate::harness::HarnessLaunchMode::Stream {
             let piped = pty_runner::spawn_piped_with_observer(&command, observer)?;
-            let killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller { child: piped.child });
+            let killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller { pid: piped.pid });
             let mut input = piped.input;
             // Send the launch's prompt as the first stream-json user
             // message so the chat doesn't need a separate send call right
@@ -224,23 +224,42 @@ fn write_stream_message(input: &mut dyn Write, text: &str) -> Result<()> {
 }
 
 /// Killer for a non-PTY piped child (stream-mode harness sessions).
-/// `pty_runner::spawn_piped_with_observer` returns an `Arc<Mutex<Option<Child>>>`
-/// shared with the drain thread; killing tells the kernel to terminate the
-/// child while the drain thread also has access for its eventual `wait`.
+/// `pty_runner::spawn_piped_with_observer` returns just the child's PID
+/// because the `Child` handle itself lives inside the wait/drain thread —
+/// sharing it through a `Mutex` would deadlock when `wait()` blocks while
+/// `kill()` waits for the same lock. Sending SIGTERM via the PID
+/// short-circuits that: the kernel signals the child, `wait()` returns,
+/// and the cleanup observer fires.
 struct PipedKiller {
-    child: std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>,
+    pid: u32,
 }
 
 impl RuntimeKiller for PipedKiller {
+    #[cfg(unix)]
     fn kill(&mut self) -> Result<()> {
-        let mut guard = self
-            .child
-            .lock()
-            .map_err(|_| anyhow::anyhow!("piped child mutex poisoned"))?;
-        if let Some(child) = guard.as_mut() {
-            let _ = child.kill();
+        let pid = self.pid as libc::pid_t;
+        // SIGTERM gives the child a chance to clean up; if it doesn't
+        // respond the OS will reap it when its parent (the daemon) exits.
+        let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+        if rc != 0 {
+            let error = std::io::Error::last_os_error();
+            // ESRCH means the process is already gone — fine, that's the
+            // post-condition we want.
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error).with_context(|| {
+                    format!("failed to send SIGTERM to stream harness pid {pid}")
+                });
+            }
         }
         Ok(())
+    }
+
+    #[cfg(not(unix))]
+    fn kill(&mut self) -> Result<()> {
+        anyhow::bail!(
+            "stream-mode harness kill not implemented on this platform (pid {})",
+            self.pid
+        )
     }
 }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -248,9 +248,16 @@ fn write_stream_message(input: &mut dyn Write, text: &str) -> Result<()> {
 /// `pty_runner::spawn_piped_with_observer` returns just the child's PID
 /// because the `Child` handle itself lives inside the wait/drain thread —
 /// sharing it through a `Mutex` would deadlock when `wait()` blocks while
-/// `kill()` waits for the same lock. Sending SIGTERM via the PID
-/// short-circuits that: the kernel signals the child, `wait()` returns,
-/// and the cleanup observer fires.
+/// `kill()` waits for the same lock.
+///
+/// The spawn path puts the child in its own session/process group via
+/// `setsid()` (pre_exec), so we can signal the entire group with one
+/// syscall — that picks up subprocesses the harness may have spawned
+/// (skills, MCP servers, shells, …) which would otherwise survive as
+/// orphans. We send SIGKILL (not SIGTERM) because the daemon kill path
+/// is reached from explicit user intent (`/kill`, `/clear`, chat exit)
+/// where the right behavior is "stop immediately"; SIGTERM would let a
+/// harness that ignores it linger past the user's request.
 struct PipedKiller {
     pid: u32,
 }
@@ -259,16 +266,16 @@ impl RuntimeKiller for PipedKiller {
     #[cfg(unix)]
     fn kill(&mut self) -> Result<()> {
         let pid = self.pid as libc::pid_t;
-        // SIGTERM gives the child a chance to clean up; if it doesn't
-        // respond the OS will reap it when its parent (the daemon) exits.
-        let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+        // Negative argument signals the process group (pgid == pid
+        // since the child called setsid). SIGKILL can't be ignored.
+        let rc = unsafe { libc::kill(-pid, libc::SIGKILL) };
         if rc != 0 {
             let error = std::io::Error::last_os_error();
-            // ESRCH means the process is already gone — fine, that's the
-            // post-condition we want.
+            // ESRCH means the group is already gone — fine, that's
+            // the post-condition we want.
             if error.raw_os_error() != Some(libc::ESRCH) {
                 return Err(error).with_context(|| {
-                    format!("failed to send SIGTERM to stream harness pid {pid}")
+                    format!("failed to SIGKILL stream harness process group {pid}")
                 });
             }
         }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -53,6 +53,28 @@ pub trait RuntimeKiller: Send {
     fn kill(&mut self) -> Result<()>;
 }
 
+/// Sentinel error returned by `LiveSessionRuntime::send_input` and
+/// `kill_session` when the session id isn't in the live registry. The
+/// API layer downcasts to this type instead of substring-matching the
+/// error message — refactoring the prose now can't accidentally route
+/// "not live" cases to the generic 500 path.
+#[derive(Debug)]
+pub struct NotLiveError {
+    pub session_id: String,
+}
+
+impl std::fmt::Display for NotLiveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "session `{}` is not live in this daemon",
+            self.session_id
+        )
+    }
+}
+
+impl std::error::Error for NotLiveError {}
+
 #[derive(Default)]
 pub struct LiveSessionRuntime {
     coven_home: Option<PathBuf>,
@@ -204,9 +226,11 @@ impl SessionRuntime for LiveSessionRuntime {
                 .sessions
                 .lock()
                 .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
-            let session = sessions
-                .get(session_id)
-                .with_context(|| format!("session `{session_id}` is not live in this daemon"))?;
+            let session = sessions.get(session_id).ok_or_else(|| {
+                anyhow::Error::new(NotLiveError {
+                    session_id: session_id.to_string(),
+                })
+            })?;
             (session.kind, std::sync::Arc::clone(&session.input))
         };
         let mut input = input
@@ -238,9 +262,11 @@ impl SessionRuntime for LiveSessionRuntime {
                 .sessions
                 .lock()
                 .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
-            sessions
-                .remove(session_id)
-                .with_context(|| format!("session `{session_id}` is not live in this daemon"))?
+            sessions.remove(session_id).ok_or_else(|| {
+                anyhow::Error::new(NotLiveError {
+                    session_id: session_id.to_string(),
+                })
+            })?
         };
         let mut killer = handle
             .killer

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -131,16 +131,37 @@ impl SessionRuntime for LiveSessionRuntime {
             .map(|coven_home| output_observer(coven_home.to_path_buf(), launch.id.clone()));
 
         if launch.launch_mode == crate::harness::HarnessLaunchMode::Stream {
+            // Defense in depth: only allow Stream mode for harnesses that
+            // actually have a stream-json entrypoint. Without this check
+            // the chat's local gating could be bypassed by another client
+            // requesting Stream for, say, codex — the daemon would then
+            // JSON-wrap stdin into a one-shot `codex exec` process that
+            // doesn't understand it.
+            if !crate::harness::harness_supports_stream_mode(&launch.harness) {
+                anyhow::bail!(
+                    "harness `{}` does not support stream-mode launches; use launchMode `nonInteractive` instead",
+                    launch.harness
+                );
+            }
             let piped = pty_runner::spawn_piped_with_observer(&command, observer)?;
-            let killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller { pid: piped.pid });
+            let mut killer: Box<dyn RuntimeKiller> = Box::new(PipedKiller { pid: piped.pid });
             let mut input = piped.input;
             // Send the launch's prompt as the first stream-json user
             // message so the chat doesn't need a separate send call right
-            // after launch. Best-effort: if the write fails the session is
-            // still registered and the caller can retry via send_input.
+            // after launch. A write failure here means the child already
+            // exited (e.g. auth missing) — treat that as a hard launch
+            // error: kill what's left of the child and surface it to the
+            // caller so the session row is marked failed instead of
+            // pretending we delivered the prompt.
             if !launch.prompt.is_empty() {
                 if let Err(error) = write_stream_message(input.as_mut(), &launch.prompt) {
-                    eprintln!("[stream-launch] initial message write failed: {error}");
+                    let _ = killer.kill();
+                    return Err(error).with_context(|| {
+                        format!(
+                            "stream-mode launch of `{}` failed: child closed stdin before the initial message landed (auth/setup error?)",
+                            launch.harness
+                        )
+                    });
                 }
             }
             return self.register_kind(launch.id.clone(), LiveSessionKind::Stream, input, killer);
@@ -927,6 +948,28 @@ fn parse_request_line(line: &str) -> Result<(&str, &str)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn live_runtime_rejects_stream_launch_for_non_stream_capable_harness() {
+        let runtime = LiveSessionRuntime::default();
+        let launch = crate::api::SessionLaunch {
+            id: "session-x".to_string(),
+            project_root: "/tmp/x".to_string(),
+            cwd: "/tmp/x".to_string(),
+            harness: "codex".to_string(),
+            launch_mode: crate::harness::HarnessLaunchMode::Stream,
+            prompt: "hello".to_string(),
+            title: "stream codex (should be rejected)".to_string(),
+            conversation: None,
+            conversation_id: None,
+        };
+
+        let error = SessionRuntime::launch_session(&runtime, &launch).unwrap_err();
+        assert!(
+            error.to_string().contains("does not support stream-mode"),
+            "rejection message should name the constraint, got: {error}"
+        );
+    }
 
     #[test]
     fn live_runtime_writes_input_to_registered_session() -> Result<()> {

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -26,9 +26,18 @@ pub enum HarnessLaunchMode {
 
 /// Whether the harness CLI has a long-lived JSON-streaming mode the daemon
 /// can keep alive across chat turns. Claude does (`stream-json`); codex
-/// doesn't (only one-shot `codex exec`). See `docs/chat-persistence.md`.
+/// doesn't (only one-shot `codex exec`). Gated to Unix today because the
+/// daemon's stream-mode kill path uses `libc::kill(pid, SIGTERM)` — a
+/// Windows process-termination path would let this widen. See
+/// `docs/chat-persistence.md`.
+#[cfg(unix)]
 pub fn harness_supports_stream_mode(harness_id: &str) -> bool {
     harness_id == "claude"
+}
+
+#[cfg(not(unix))]
+pub fn harness_supports_stream_mode(_harness_id: &str) -> bool {
+    false
 }
 
 /// Hint passed when a chat turn wants to participate in a multi-turn

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -16,6 +16,19 @@ pub struct HarnessSummary {
 pub enum HarnessLaunchMode {
     Interactive,
     NonInteractive,
+    /// Long-lived stream-json process: stdin reads newline-delimited JSON
+    /// messages, stdout writes newline-delimited JSON events. Only
+    /// `claude` supports this today (`-p --input-format stream-json
+    /// --output-format stream-json --verbose`). Codex falls back to
+    /// `NonInteractive` if asked for `Stream`.
+    Stream,
+}
+
+/// Whether the harness CLI has a long-lived JSON-streaming mode the daemon
+/// can keep alive across chat turns. Claude does (`stream-json`); codex
+/// doesn't (only one-shot `codex exec`). See `docs/chat-persistence.md`.
+pub fn harness_supports_stream_mode(harness_id: &str) -> bool {
+    harness_id == "claude"
 }
 
 /// Hint passed when a chat turn wants to participate in a multi-turn
@@ -62,6 +75,10 @@ impl HarnessCommandSpec {
         let prefix_args = match mode {
             HarnessLaunchMode::Interactive => self.interactive_prompt_prefix_args,
             HarnessLaunchMode::NonInteractive => self.non_interactive_prompt_prefix_args,
+            // Stream mode bypasses `prompt_args` entirely (no trailing
+            // prompt; messages arrive on stdin). Fall back to
+            // non-interactive args if a caller somehow lands here.
+            HarnessLaunchMode::Stream => self.non_interactive_prompt_prefix_args,
         };
 
         prefix_args
@@ -135,6 +152,20 @@ pub fn command_parts_for_harness_with_conversation(
         .find(|spec| spec.id == harness_id)
         .ok_or_else(|| anyhow!("unsupported harness `{harness_id}`"))?;
 
+    // Stream mode reads prompts from stdin as JSON messages, so the prompt
+    // argument is not appended. The continuity hint (claude resume / init)
+    // still maps to a CLI flag; codex falls back to one-shot.
+    if mode == HarnessLaunchMode::Stream {
+        if let Some(args) = stream_args(&spec, hint) {
+            return Ok((spec.executable, args));
+        }
+        // Harness doesn't support stream: fall through to non-interactive.
+        return Ok((
+            spec.executable,
+            spec.prompt_args(prompt, HarnessLaunchMode::NonInteractive),
+        ));
+    }
+
     if let Some(hint) = hint {
         if let Some(args) = continuity_args(&spec, mode, hint) {
             return Ok((spec.executable, args.into_iter().chain(std::iter::once(prompt.to_string())).collect()));
@@ -142,6 +173,36 @@ pub fn command_parts_for_harness_with_conversation(
     }
 
     Ok((spec.executable, spec.prompt_args(prompt, mode)))
+}
+
+/// Per-harness translation of stream-mode launch into CLI args. Stream-mode
+/// processes are long-lived: stdin is a stream of newline-delimited JSON
+/// messages and stdout is a stream of newline-delimited JSON events.
+/// Returns `None` for harnesses that don't support stream mode so the
+/// caller can fall back to a one-shot launch.
+fn stream_args(spec: &HarnessCommandSpec, hint: Option<&ConversationHint>) -> Option<Vec<String>> {
+    match spec.id {
+        "claude" => {
+            let mut args: Vec<String> = vec![
+                "--print".to_string(),
+                "--input-format".to_string(),
+                "stream-json".to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+                "--verbose".to_string(),
+            ];
+            if let Some(hint) = hint {
+                let flag = match hint {
+                    ConversationHint::Init { .. } => "--session-id",
+                    ConversationHint::Resume { .. } => "--resume",
+                };
+                args.push(flag.to_string());
+                args.push(hint.id().to_string());
+            }
+            Some(args)
+        }
+        _ => None,
+    }
 }
 
 /// Per-harness translation of a `ConversationHint` into CLI args that precede

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -168,7 +168,12 @@ pub fn command_parts_for_harness_with_conversation(
 
     if let Some(hint) = hint {
         if let Some(args) = continuity_args(&spec, mode, hint) {
-            return Ok((spec.executable, args.into_iter().chain(std::iter::once(prompt.to_string())).collect()));
+            return Ok((
+                spec.executable,
+                args.into_iter()
+                    .chain(std::iter::once(prompt.to_string()))
+                    .collect(),
+            ));
         }
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -142,7 +142,7 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
     ]
 }
 
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn command_parts_for_harness(
     harness_id: &str,
     prompt: &str,

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -18,6 +18,27 @@ pub enum HarnessLaunchMode {
     NonInteractive,
 }
 
+/// Hint passed when a chat turn wants to participate in a multi-turn
+/// conversation by reusing the underlying harness CLI's session-resume
+/// mechanism. Only consulted in `NonInteractive` mode today.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConversationHint {
+    /// First turn of a conversation. The harness should create a session
+    /// claimed under this id so later turns can resume it.
+    Init { id: String },
+    /// Subsequent turn. The harness should resume the session at this id and
+    /// append the new prompt to its history.
+    Resume { id: String },
+}
+
+impl ConversationHint {
+    pub fn id(&self) -> &str {
+        match self {
+            ConversationHint::Init { id } | ConversationHint::Resume { id } => id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HarnessCommandSpec {
     pub id: &'static str,
@@ -82,17 +103,69 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
     ]
 }
 
+#[allow(dead_code)]
 pub fn command_parts_for_harness(
     harness_id: &str,
     prompt: &str,
     mode: HarnessLaunchMode,
+) -> Result<(&'static str, Vec<String>)> {
+    command_parts_for_harness_with_conversation(harness_id, prompt, mode, None)
+}
+
+/// Build a harness command line, optionally injecting session-continuity flags
+/// so the harness CLI resumes a prior conversation. Only Claude is wired up
+/// today; other harnesses ignore the hint and fall back to one-shot args.
+/// See `docs/chat-persistence.md` for how to extend this for Codex.
+pub fn command_parts_for_harness_with_conversation(
+    harness_id: &str,
+    prompt: &str,
+    mode: HarnessLaunchMode,
+    hint: Option<&ConversationHint>,
 ) -> Result<(&'static str, Vec<String>)> {
     let spec = built_in_harness_specs()
         .into_iter()
         .find(|spec| spec.id == harness_id)
         .ok_or_else(|| anyhow!("unsupported harness `{harness_id}`"))?;
 
+    if let Some(hint) = hint {
+        if let Some(args) = continuity_args(&spec, mode, hint) {
+            return Ok((spec.executable, args.into_iter().chain(std::iter::once(prompt.to_string())).collect()));
+        }
+    }
+
     Ok((spec.executable, spec.prompt_args(prompt, mode)))
+}
+
+/// Per-harness translation of a `ConversationHint` into CLI args that precede
+/// the prompt. Returns `None` when the harness has no resume support (or when
+/// the launch mode doesn't support it) so the caller falls back to defaults.
+fn continuity_args(
+    spec: &HarnessCommandSpec,
+    mode: HarnessLaunchMode,
+    hint: &ConversationHint,
+) -> Option<Vec<String>> {
+    // Continuity only makes sense in non-interactive mode today. Interactive
+    // mode launches the harness TUI, which has its own resume picker.
+    if mode != HarnessLaunchMode::NonInteractive {
+        return None;
+    }
+    match spec.id {
+        "claude" => {
+            let flag = match hint {
+                ConversationHint::Init { .. } => "--session-id",
+                ConversationHint::Resume { .. } => "--resume",
+            };
+            Some(vec![
+                "--print".to_string(),
+                flag.to_string(),
+                hint.id().to_string(),
+            ])
+        }
+        // Codex resume support lives in `codex exec resume <id>` and would
+        // need to capture the id from the first run's output. Tracked in
+        // `docs/chat-persistence.md`.
+        _ => None,
+    }
 }
 
 fn executable_exists(executable: &str) -> bool {
@@ -326,6 +399,114 @@ mod tests {
                 .to_string()
                 .contains("unsupported harness")
         );
+    }
+
+    #[test]
+    fn claude_init_hint_attaches_session_id_flag_in_print_mode() -> anyhow::Result<()> {
+        let hint = ConversationHint::Init {
+            id: "abc-123".to_string(),
+        };
+        let parts = command_parts_for_harness_with_conversation(
+            "claude",
+            "hello",
+            HarnessLaunchMode::NonInteractive,
+            Some(&hint),
+        )?;
+        assert_eq!(
+            parts,
+            (
+                "claude",
+                vec![
+                    "--print".to_string(),
+                    "--session-id".to_string(),
+                    "abc-123".to_string(),
+                    "hello".to_string(),
+                ]
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn claude_resume_hint_attaches_resume_flag_in_print_mode() -> anyhow::Result<()> {
+        let hint = ConversationHint::Resume {
+            id: "abc-123".to_string(),
+        };
+        let parts = command_parts_for_harness_with_conversation(
+            "claude",
+            "follow up",
+            HarnessLaunchMode::NonInteractive,
+            Some(&hint),
+        )?;
+        assert_eq!(
+            parts,
+            (
+                "claude",
+                vec![
+                    "--print".to_string(),
+                    "--resume".to_string(),
+                    "abc-123".to_string(),
+                    "follow up".to_string(),
+                ]
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn interactive_mode_ignores_conversation_hint() -> anyhow::Result<()> {
+        let hint = ConversationHint::Init {
+            id: "abc-123".to_string(),
+        };
+        let parts = command_parts_for_harness_with_conversation(
+            "claude",
+            "hello",
+            HarnessLaunchMode::Interactive,
+            Some(&hint),
+        )?;
+        assert_eq!(parts, ("claude", vec!["hello".to_string()]));
+        Ok(())
+    }
+
+    #[test]
+    fn codex_ignores_conversation_hint_today() -> anyhow::Result<()> {
+        let hint = ConversationHint::Init {
+            id: "abc-123".to_string(),
+        };
+        let parts = command_parts_for_harness_with_conversation(
+            "codex",
+            "fix tests",
+            HarnessLaunchMode::NonInteractive,
+            Some(&hint),
+        )?;
+        assert_eq!(
+            parts,
+            (
+                "codex",
+                vec![
+                    "exec".to_string(),
+                    "--skip-git-repo-check".to_string(),
+                    "--color".to_string(),
+                    "never".to_string(),
+                    "fix tests".to_string(),
+                ]
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn none_hint_matches_legacy_command_parts() -> anyhow::Result<()> {
+        let with_none = command_parts_for_harness_with_conversation(
+            "claude",
+            "hello",
+            HarnessLaunchMode::NonInteractive,
+            None,
+        )?;
+        let legacy =
+            command_parts_for_harness("claude", "hello", HarnessLaunchMode::NonInteractive)?;
+        assert_eq!(with_none, legacy);
+        Ok(())
     }
 
     #[cfg(unix)]

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -19,8 +19,20 @@ pub enum HarnessLaunchMode {
     /// Long-lived stream-json process: stdin reads newline-delimited JSON
     /// messages, stdout writes newline-delimited JSON events. Only
     /// `claude` supports this today (`-p --input-format stream-json
-    /// --output-format stream-json --verbose`). Codex falls back to
-    /// `NonInteractive` if asked for `Stream`.
+    /// --output-format stream-json --verbose`).
+    ///
+    /// Capability is enforced at two layers:
+    /// - `command_parts_for_harness_with_conversation` (the offline arg
+    ///   builder): codex's `stream_args` returns `None`, so the builder
+    ///   falls back to non-interactive args. This makes the function
+    ///   safe to call standalone.
+    /// - `daemon::LiveSessionRuntime::launch_session` (the live runtime):
+    ///   explicitly rejects stream-mode launches when
+    ///   `harness_supports_stream_mode(harness)` is false, returning a
+    ///   structured `500 launch_failed` so the client sees the actual
+    ///   constraint instead of a silently-downgraded behavior. The
+    ///   chat layer is the only caller that requests Stream today and
+    ///   already gates on `harness_supports_stream_mode` before doing so.
     Stream,
 }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -33,7 +33,10 @@ pub fn harness_supports_stream_mode(harness_id: &str) -> bool {
 
 /// Hint passed when a chat turn wants to participate in a multi-turn
 /// conversation by reusing the underlying harness CLI's session-resume
-/// mechanism. Only consulted in `NonInteractive` mode today.
+/// mechanism. Consulted in `NonInteractive` mode (each turn cold-starts
+/// claude/codex with `--resume`/`exec resume`) and in `Stream` mode (the
+/// long-lived claude process is launched with `--session-id`/`--resume`
+/// up front).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConversationHint {
     /// First turn of a conversation. The harness should create a session
@@ -137,10 +140,15 @@ pub fn command_parts_for_harness(
     command_parts_for_harness_with_conversation(harness_id, prompt, mode, None)
 }
 
-/// Build a harness command line, optionally injecting session-continuity flags
-/// so the harness CLI resumes a prior conversation. Only Claude is wired up
-/// today; other harnesses ignore the hint and fall back to one-shot args.
-/// See `docs/chat-persistence.md` for how to extend this for Codex.
+/// Build a harness command line, optionally injecting session-continuity
+/// flags so the harness CLI resumes a prior conversation. Claude uses
+/// `--session-id`/`--resume` (works in both NonInteractive and Stream
+/// modes); codex uses `codex exec … resume <id>` for resume turns and
+/// falls through to a fresh launch for the Init turn (since codex
+/// auto-assigns its own session id, which the chat captures from
+/// output later). Harnesses with no resume support ignore the hint and
+/// fall back to one-shot args. See `docs/chat-persistence.md` for how
+/// to extend this for new harnesses.
 pub fn command_parts_for_harness_with_conversation(
     harness_id: &str,
     prompt: &str,

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -27,8 +27,10 @@ pub enum HarnessLaunchMode {
 /// Whether the harness CLI has a long-lived JSON-streaming mode the daemon
 /// can keep alive across chat turns. Claude does (`stream-json`); codex
 /// doesn't (only one-shot `codex exec`). Gated to Unix today because the
-/// daemon's stream-mode kill path uses `libc::kill(pid, SIGTERM)` — a
-/// Windows process-termination path would let this widen. See
+/// daemon's stream-mode kill path relies on Unix process-group semantics
+/// (`setsid()` at spawn, then `kill(-pid, SIGKILL)` to tear down the
+/// harness plus any subprocesses it spawned in one syscall). A Windows
+/// process-tree termination path would let this widen. See
 /// `docs/chat-persistence.md`.
 #[cfg(unix)]
 pub fn harness_supports_stream_mode(harness_id: &str) -> bool {

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -39,6 +39,14 @@ impl ConversationHint {
     }
 }
 
+/// Whether the harness CLI lets the caller pre-assign a session id at launch
+/// time (e.g. `claude --session-id <uuid>`). Harnesses that auto-generate
+/// session ids (e.g. codex) return `false`; the chat app captures the id from
+/// the first turn's output instead. See `docs/chat-persistence.md`.
+pub fn harness_supports_preassigned_session_id(harness_id: &str) -> bool {
+    harness_id == "claude"
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HarnessCommandSpec {
     pub id: &'static str,
@@ -161,9 +169,21 @@ fn continuity_args(
                 hint.id().to_string(),
             ])
         }
-        // Codex resume support lives in `codex exec resume <id>` and would
-        // need to capture the id from the first run's output. Tracked in
-        // `docs/chat-persistence.md`.
+        "codex" => match hint {
+            // Codex auto-assigns the session id on the first turn; we capture
+            // it from output and feed it back on subsequent turns.
+            ConversationHint::Init { .. } => None,
+            ConversationHint::Resume { id } => {
+                let mut args: Vec<String> = spec
+                    .non_interactive_prompt_prefix_args
+                    .iter()
+                    .map(|arg| (*arg).to_string())
+                    .collect();
+                args.push("resume".to_string());
+                args.push(id.clone());
+                Some(args)
+            }
+        },
         _ => None,
     }
 }
@@ -469,7 +489,8 @@ mod tests {
     }
 
     #[test]
-    fn codex_ignores_conversation_hint_today() -> anyhow::Result<()> {
+    fn codex_init_hint_falls_through_to_default_args_so_codex_can_assign_its_own_id(
+    ) -> anyhow::Result<()> {
         let hint = ConversationHint::Init {
             id: "abc-123".to_string(),
         };
@@ -493,6 +514,42 @@ mod tests {
             )
         );
         Ok(())
+    }
+
+    #[test]
+    fn codex_resume_hint_uses_exec_resume_subcommand_with_id() -> anyhow::Result<()> {
+        let hint = ConversationHint::Resume {
+            id: "019e5998-7130-7872-8d96-a6b67c5b6406".to_string(),
+        };
+        let parts = command_parts_for_harness_with_conversation(
+            "codex",
+            "follow up",
+            HarnessLaunchMode::NonInteractive,
+            Some(&hint),
+        )?;
+        assert_eq!(
+            parts,
+            (
+                "codex",
+                vec![
+                    "exec".to_string(),
+                    "--skip-git-repo-check".to_string(),
+                    "--color".to_string(),
+                    "never".to_string(),
+                    "resume".to_string(),
+                    "019e5998-7130-7872-8d96-a6b67c5b6406".to_string(),
+                    "follow up".to_string(),
+                ]
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn preassigned_session_id_support_is_per_harness() {
+        assert!(harness_supports_preassigned_session_id("claude"));
+        assert!(!harness_supports_preassigned_session_id("codex"));
+        assert!(!harness_supports_preassigned_session_id("unknown"));
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -479,6 +479,7 @@ fn launch_patch_session(request: &patch::PatchOpenClawRequest) -> Result<String>
         archived_at: None,
         created_at: now.clone(),
         updated_at: now.clone(),
+        conversation_id: None,
     };
     store::insert_session(&conn, &record)?;
     store::insert_json_event(
@@ -624,6 +625,7 @@ fn run_session(
         archived_at: None,
         created_at: now.clone(),
         updated_at: now,
+        conversation_id: None,
     };
 
     store::insert_session(&conn, &record)?;
@@ -1766,6 +1768,7 @@ mod tests {
             archived_at: None,
             created_at: "2026-04-27T06:00:00Z".to_string(),
             updated_at: "2026-04-27T06:00:00Z".to_string(),
+            conversation_id: None,
         };
 
         assert_eq!(
@@ -1786,6 +1789,7 @@ mod tests {
             archived_at: None,
             created_at: "2026-05-14T07:00:00Z".to_string(),
             updated_at: "2026-05-14T07:00:01Z".to_string(),
+            conversation_id: None,
         };
 
         let rendered = render_sessions_json(&[session])?;
@@ -1897,6 +1901,7 @@ mod tests {
             archived_at: archived_at.map(ToOwned::to_owned),
             created_at: "2026-05-08T07:00:00Z".to_string(),
             updated_at: "2026-05-08T07:05:00Z".to_string(),
+            conversation_id: None,
         }
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1,5 +1,6 @@
-use std::io::{self, IsTerminal, Read, Write};
+use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::thread;
 
 use anyhow::{Context, Result};
@@ -90,6 +91,116 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
 #[allow(dead_code)]
 pub fn spawn_detached(command: &HarnessCommand) -> Result<DetachedPtySession> {
     spawn_detached_with_observer(command, None)
+}
+
+/// Handle returned by `spawn_piped_with_observer`. The child is wrapped in
+/// an `Arc<Mutex<Option<...>>>` so the drain thread can take it for `wait`
+/// while the daemon's killer holds a separate clone for `kill`.
+pub struct PipedSession {
+    pub input: Box<dyn Write + Send>,
+    pub child: std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>,
+}
+
+/// Spawn `command` as a plain piped child process (no PTY) and stream its
+/// stdout to `observer`. Used by stream-mode harness launches where the
+/// child reads newline-delimited JSON from stdin and writes
+/// newline-delimited JSON to stdout — wrapping in a PTY would add ANSI
+/// escapes the child wouldn't otherwise emit. Lifecycle mirrors
+/// `spawn_detached_with_observer`: a background thread drains stdout and
+/// fires `on_exit` when the child finishes.
+pub fn spawn_piped_with_observer(
+    command: &HarnessCommand,
+    observer: Option<DetachedPtyObserver>,
+) -> Result<PipedSession> {
+    use std::process::Command as StdCommand;
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    let mut std_command = StdCommand::new(&command.program);
+    std_command.args(&command.args);
+    std_command.current_dir(&command.cwd);
+    std_command.stdin(Stdio::piped());
+    std_command.stdout(Stdio::piped());
+    std_command.stderr(Stdio::piped());
+
+    let mut child = std_command
+        .spawn()
+        .with_context(|| format!("failed to spawn harness `{}` in piped mode", command.program))?;
+
+    let stdin = child
+        .stdin
+        .take()
+        .context("failed to take child stdin in piped mode")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("failed to take child stdout in piped mode")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("failed to take child stderr in piped mode")?;
+
+    // Drain stderr to keep the buffer from filling and the child from
+    // blocking. Stream-json harnesses surface auth/setup errors there.
+    thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines().flatten() {
+            eprintln!("[stream-stderr] {line}");
+        }
+    });
+
+    let shared_child = Arc::new(StdMutex::new(Some(child)));
+    let shared_for_wait = Arc::clone(&shared_child);
+    thread::spawn(move || {
+        let mut reader = stdout;
+        let mut observer = observer;
+        drain_detached_output(
+            &mut reader,
+            observer.as_mut().map(|observer| &mut observer.on_output),
+        );
+        let result = wait_for_piped_child(&shared_for_wait);
+        if let Some(observer) = observer {
+            (observer.on_exit)(result);
+        }
+    });
+
+    Ok(PipedSession {
+        input: Box::new(stdin),
+        child: shared_child,
+    })
+}
+
+fn wait_for_piped_child(
+    child: &std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>,
+) -> PtyRunResult {
+    let mut guard = match child.lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            return PtyRunResult {
+                status: "failed",
+                exit_code: None,
+            };
+        }
+    };
+    let Some(child) = guard.as_mut() else {
+        return PtyRunResult {
+            status: "completed",
+            exit_code: None,
+        };
+    };
+    match child.wait() {
+        Ok(status) => {
+            let exit_code = status.code();
+            let status_label = if status.success() { "completed" } else { "failed" };
+            PtyRunResult {
+                status: status_label,
+                exit_code,
+            }
+        }
+        Err(_) => PtyRunResult {
+            status: "failed",
+            exit_code: None,
+        },
+    }
 }
 
 pub fn spawn_detached_with_observer(

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -122,9 +122,12 @@ pub fn spawn_piped_with_observer(
     std_command.stdout(Stdio::piped());
     std_command.stderr(Stdio::piped());
 
-    let mut child = std_command
-        .spawn()
-        .with_context(|| format!("failed to spawn harness `{}` in piped mode", command.program))?;
+    let mut child = std_command.spawn().with_context(|| {
+        format!(
+            "failed to spawn harness `{}` in piped mode",
+            command.program
+        )
+    })?;
 
     let stdin = child
         .stdin
@@ -141,9 +144,11 @@ pub fn spawn_piped_with_observer(
 
     // Drain stderr to keep the buffer from filling and the child from
     // blocking. Stream-json harnesses surface auth/setup errors there.
+    // `map_while(Result::ok)` stops at the first read error instead of
+    // looping forever on EBADF (clippy::lines_filter_map_ok).
     thread::spawn(move || {
         let reader = BufReader::new(stderr);
-        for line in reader.lines().flatten() {
+        for line in reader.lines().map_while(Result::ok) {
             eprintln!("[stream-stderr] {line}");
         }
     });
@@ -190,7 +195,11 @@ fn wait_for_piped_child(
     match child.wait() {
         Ok(status) => {
             let exit_code = status.code();
-            let status_label = if status.success() { "completed" } else { "failed" };
+            let status_label = if status.success() {
+                "completed"
+            } else {
+                "failed"
+            };
             PtyRunResult {
                 status: status_label,
                 exit_code,

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -58,7 +58,22 @@ pub fn build_harness_command(
     cwd: &Path,
     mode: crate::harness::HarnessLaunchMode,
 ) -> Result<HarnessCommand> {
-    let (program, args) = crate::harness::command_parts_for_harness(harness_id, prompt, mode)?;
+    build_harness_command_with_conversation(harness_id, prompt, cwd, mode, None)
+}
+
+pub fn build_harness_command_with_conversation(
+    harness_id: &str,
+    prompt: &str,
+    cwd: &Path,
+    mode: crate::harness::HarnessLaunchMode,
+    conversation: Option<&crate::harness::ConversationHint>,
+) -> Result<HarnessCommand> {
+    let (program, args) = crate::harness::command_parts_for_harness_with_conversation(
+        harness_id,
+        prompt,
+        mode,
+        conversation,
+    )?;
 
     Ok(HarnessCommand {
         program: program.to_string(),

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -297,12 +297,56 @@ fn drain_detached_output(
     mut on_output: Option<&mut Box<dyn FnMut(Vec<u8>) + Send + 'static>>,
 ) {
     let mut buffer = [0_u8; 8192];
+    // Per-drain UTF-8 reassembly buffer. Each call to this function
+    // owns its own buffer, so concurrent stdout+stderr drains in
+    // `spawn_piped_with_observer` (which share an `on_output` via
+    // Arc<Mutex>) can't corrupt each other's codepoint state. Each
+    // chunk we hand to the callback is guaranteed valid UTF-8.
+    let mut utf8_buf: Vec<u8> = Vec::with_capacity(8192);
     loop {
         match reader.read(&mut buffer) {
-            Ok(0) => break,
+            Ok(0) => {
+                // EOF: flush any trailing bytes (lossy if the stream
+                // ended mid-codepoint — better to surface garbled
+                // glyphs than drop the final message entirely).
+                if !utf8_buf.is_empty() {
+                    if let Some(callback) = on_output.as_deref_mut() {
+                        let text = String::from_utf8_lossy(&utf8_buf).into_owned();
+                        callback(text.into_bytes());
+                    }
+                }
+                break;
+            }
             Ok(bytes_read) => {
-                if let Some(callback) = on_output.as_deref_mut() {
-                    callback(buffer[..bytes_read].to_vec());
+                utf8_buf.extend_from_slice(&buffer[..bytes_read]);
+                // Emit the longest valid-UTF-8 prefix; keep the trailing
+                // partial codepoint in the buffer for the next read.
+                let valid_up_to = match std::str::from_utf8(&utf8_buf) {
+                    Ok(_) => utf8_buf.len(),
+                    Err(error) => error.valid_up_to(),
+                };
+                if valid_up_to > 0 {
+                    let prefix: Vec<u8> = utf8_buf.drain(..valid_up_to).collect();
+                    if let Some(callback) = on_output.as_deref_mut() {
+                        callback(prefix);
+                    }
+                }
+                // Pathological tail: if the remaining bytes can't be a
+                // partial codepoint (>4 bytes — max UTF-8 codepoint
+                // length), the stream is genuinely malformed. Drop one
+                // byte at a time via lossy decode so we make progress
+                // instead of buffering forever.
+                while utf8_buf.len() > 4
+                    && std::str::from_utf8(&utf8_buf)
+                        .err()
+                        .map(|e| e.valid_up_to())
+                        == Some(0)
+                {
+                    let dropped: Vec<u8> = utf8_buf.drain(..1).collect();
+                    if let Some(callback) = on_output.as_deref_mut() {
+                        let lossy = String::from_utf8_lossy(&dropped).into_owned();
+                        callback(lossy.into_bytes());
+                    }
                 }
             }
             Err(_) => break,
@@ -472,6 +516,94 @@ mod tests {
         drain_detached_output(&mut reader, Some(&mut callback));
 
         assert_eq!(captured.lock().unwrap().as_slice(), b"hello coven");
+    }
+
+    /// `Read` adapter that yields a fixed sequence of byte slices, one per
+    /// `read` call, then EOF. Lets us drive `drain_detached_output` with
+    /// the same chunk boundaries the kernel would produce when a
+    /// multi-byte UTF-8 codepoint straddles two reads.
+    struct ChunkedReader<'a> {
+        chunks: std::collections::VecDeque<&'a [u8]>,
+    }
+
+    impl<'a> Read for ChunkedReader<'a> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            match self.chunks.pop_front() {
+                Some(chunk) => {
+                    let n = chunk.len().min(buf.len());
+                    buf[..n].copy_from_slice(&chunk[..n]);
+                    if n < chunk.len() {
+                        self.chunks.push_front(&chunk[n..]);
+                    }
+                    Ok(n)
+                }
+                None => Ok(0),
+            }
+        }
+    }
+
+    #[test]
+    fn drain_detached_output_reassembles_codepoint_split_across_reads() {
+        // 🎉 = F0 9F 8E 89. Split across two reads so the first ends
+        // mid-codepoint. The drainer must hold the trailing bytes back
+        // until the continuation arrives instead of lossy-decoding to
+        // U+FFFD.
+        let emoji = "🎉".as_bytes();
+        let (head, tail) = emoji.split_at(2);
+        let mut reader = ChunkedReader {
+            chunks: vec![head, tail].into(),
+        };
+
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let captured_for_cb = captured.clone();
+        let mut callback: Box<dyn FnMut(Vec<u8>) + Send + 'static> = Box::new(move |chunk| {
+            captured_for_cb
+                .lock()
+                .unwrap()
+                .push_str(std::str::from_utf8(&chunk).expect(
+                    "drain_detached_output must only emit chunks that are themselves valid UTF-8",
+                ));
+        });
+
+        drain_detached_output(&mut reader, Some(&mut callback));
+
+        assert_eq!(
+            captured.lock().unwrap().as_str(),
+            "🎉",
+            "split codepoint must round-trip; the drain owns per-call buffer state"
+        );
+    }
+
+    #[test]
+    fn drain_detached_output_flushes_trailing_partial_codepoint_on_eof() {
+        // A read that delivers only the first 2 bytes of a 4-byte
+        // codepoint and then closes. The buffered tail can never
+        // complete, but it shouldn't silently disappear either — flush
+        // it through `from_utf8_lossy` so the user sees something.
+        let half = &"🎉".as_bytes()[..2];
+        let mut reader = ChunkedReader {
+            chunks: vec![half].into(),
+        };
+        let captured = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let captured_for_cb = captured.clone();
+        let mut callback: Box<dyn FnMut(Vec<u8>) + Send + 'static> = Box::new(move |chunk| {
+            captured_for_cb
+                .lock()
+                .unwrap()
+                .push_str(&String::from_utf8_lossy(&chunk));
+        });
+
+        drain_detached_output(&mut reader, Some(&mut callback));
+
+        let final_text = captured.lock().unwrap().clone();
+        assert!(
+            !final_text.is_empty(),
+            "EOF with a partial codepoint must flush, not drop the bytes"
+        );
+        assert!(
+            final_text.contains('\u{FFFD}'),
+            "the flushed bytes are unrecoverable; expected U+FFFD replacement, got: {final_text:?}"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -126,6 +126,27 @@ pub fn spawn_piped_with_observer(
     std_command.stdin(Stdio::piped());
     std_command.stdout(Stdio::piped());
     std_command.stderr(Stdio::piped());
+    // Put the child in its own session/process group so the daemon can
+    // signal it (and any subprocesses it spawns — skills, MCP servers,
+    // shells) as a single unit via `kill(-pid, …)` from `PipedKiller`.
+    // Without this, signals to the pid only reach the immediate child
+    // and leave grandchildren as orphans.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            std_command.pre_exec(|| {
+                // setsid() makes the calling process the session leader
+                // of a new session AND the leader of a new process
+                // group with no controlling terminal. Returns -1 on
+                // failure (we propagate as io::Error to abort the spawn).
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
 
     let mut child = std_command.spawn().with_context(|| {
         format!(

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -93,12 +93,14 @@ pub fn spawn_detached(command: &HarnessCommand) -> Result<DetachedPtySession> {
     spawn_detached_with_observer(command, None)
 }
 
-/// Handle returned by `spawn_piped_with_observer`. The child is wrapped in
-/// an `Arc<Mutex<Option<...>>>` so the drain thread can take it for `wait`
-/// while the daemon's killer holds a separate clone for `kill`.
+/// Handle returned by `spawn_piped_with_observer`. The child handle itself
+/// is owned by the internal wait thread (so `wait()` can block without
+/// blocking the killer); the caller gets a writable stdin and the PID so
+/// it can signal termination via `libc::kill` instead of needing exclusive
+/// access to the `Child`.
 pub struct PipedSession {
     pub input: Box<dyn Write + Send>,
-    pub child: std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>,
+    pub pid: u32,
 }
 
 /// Spawn `command` as a plain piped child process (no PTY) and stream its
@@ -107,7 +109,10 @@ pub struct PipedSession {
 /// newline-delimited JSON to stdout — wrapping in a PTY would add ANSI
 /// escapes the child wouldn't otherwise emit. Lifecycle mirrors
 /// `spawn_detached_with_observer`: a background thread drains stdout and
-/// fires `on_exit` when the child finishes.
+/// fires `on_exit` when the child finishes. Stderr is line-buffered and
+/// forwarded to `observer.on_output` wrapped in a stream-json
+/// `{"type":"system","subtype":"stderr","text":"…"}` envelope so chat
+/// surfaces auth/setup errors instead of swallowing them.
 pub fn spawn_piped_with_observer(
     command: &HarnessCommand,
     observer: Option<DetachedPtyObserver>,
@@ -129,6 +134,7 @@ pub fn spawn_piped_with_observer(
         )
     })?;
 
+    let pid = child.id();
     let stdin = child
         .stdin
         .take()
@@ -142,74 +148,69 @@ pub fn spawn_piped_with_observer(
         .take()
         .context("failed to take child stderr in piped mode")?;
 
-    // Drain stderr to keep the buffer from filling and the child from
-    // blocking. Stream-json harnesses surface auth/setup errors there.
-    // `map_while(Result::ok)` stops at the first read error instead of
-    // looping forever on EBADF (clippy::lines_filter_map_ok).
+    // Share the on_output callback between the stdout and stderr drain
+    // threads — both want to feed the same observer pipeline. `on_exit` is
+    // moved into the stdout thread (it fires exactly once when the child
+    // exits). If no observer was supplied, both callbacks are no-ops.
+    let DetachedPtyObserver { on_output, on_exit } = observer.unwrap_or(DetachedPtyObserver {
+        on_output: Box::new(|_| {}),
+        on_exit: Box::new(|_| {}),
+    });
+    let on_output_shared = Arc::new(StdMutex::new(on_output));
+
+    // Stderr drain: line-buffered, wrapped in a stream-json system
+    // envelope so chat can render auth/setup messages as system lines
+    // rather than dropping them silently.
+    let stderr_callback = Arc::clone(&on_output_shared);
     thread::spawn(move || {
         let reader = BufReader::new(stderr);
         for line in reader.lines().map_while(Result::ok) {
-            eprintln!("[stream-stderr] {line}");
+            let envelope = serde_json::json!({
+                "type": "system",
+                "subtype": "stderr",
+                "text": line,
+            });
+            let mut payload = envelope.to_string();
+            payload.push('\n');
+            if let Ok(mut cb) = stderr_callback.lock() {
+                cb(payload.into_bytes());
+            }
         }
     });
 
-    let shared_child = Arc::new(StdMutex::new(Some(child)));
-    let shared_for_wait = Arc::clone(&shared_child);
+    // Stdout drain + wait. The wait thread OWNS `child`; the killer never
+    // touches the `Child` handle, only the PID. That removes the previous
+    // deadlock risk where `wait()` and `kill()` raced on a shared mutex.
+    let stdout_callback = Arc::clone(&on_output_shared);
     thread::spawn(move || {
         let mut reader = stdout;
-        let mut observer = observer;
-        drain_detached_output(
-            &mut reader,
-            observer.as_mut().map(|observer| &mut observer.on_output),
-        );
-        let result = wait_for_piped_child(&shared_for_wait);
-        if let Some(observer) = observer {
-            (observer.on_exit)(result);
-        }
+        let mut bridge: Box<dyn FnMut(Vec<u8>) + Send + 'static> = Box::new(move |chunk| {
+            if let Ok(mut cb) = stdout_callback.lock() {
+                cb(chunk);
+            }
+        });
+        drain_detached_output(&mut reader, Some(&mut bridge));
+        let result = match child.wait() {
+            Ok(status) => PtyRunResult {
+                status: if status.success() {
+                    "completed"
+                } else {
+                    "failed"
+                },
+                exit_code: status.code(),
+            },
+            Err(_) => PtyRunResult {
+                status: "failed",
+                exit_code: None,
+            },
+        };
+        on_exit(result);
     });
 
     Ok(PipedSession {
         input: Box::new(stdin),
-        child: shared_child,
+        pid,
     })
-}
-
-fn wait_for_piped_child(
-    child: &std::sync::Arc<std::sync::Mutex<Option<std::process::Child>>>,
-) -> PtyRunResult {
-    let mut guard = match child.lock() {
-        Ok(guard) => guard,
-        Err(_) => {
-            return PtyRunResult {
-                status: "failed",
-                exit_code: None,
-            };
-        }
-    };
-    let Some(child) = guard.as_mut() else {
-        return PtyRunResult {
-            status: "completed",
-            exit_code: None,
-        };
-    };
-    match child.wait() {
-        Ok(status) => {
-            let exit_code = status.code();
-            let status_label = if status.success() {
-                "completed"
-            } else {
-                "failed"
-            };
-            PtyRunResult {
-                status: status_label,
-                exit_code,
-            }
-        }
-        Err(_) => PtyRunResult {
-            status: "failed",
-            exit_code: None,
-        },
-    }
 }
 
 pub fn spawn_detached_with_observer(

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -160,20 +160,39 @@ pub fn spawn_piped_with_observer(
 
     // Stderr drain: line-buffered, wrapped in a stream-json system
     // envelope so chat can render auth/setup messages as system lines
-    // rather than dropping them silently.
+    // rather than dropping them silently. Reads raw bytes with
+    // `read_until(b'\n')` + `from_utf8_lossy` so non-UTF-8 stderr
+    // (rare but seen in some sandboxed environments) doesn't truncate
+    // the stream at the first decode error — which `BufRead::lines()`
+    // would do.
     let stderr_callback = Arc::clone(&on_output_shared);
     thread::spawn(move || {
-        let reader = BufReader::new(stderr);
-        for line in reader.lines().map_while(Result::ok) {
-            let envelope = serde_json::json!({
-                "type": "system",
-                "subtype": "stderr",
-                "text": line,
-            });
-            let mut payload = envelope.to_string();
-            payload.push('\n');
-            if let Ok(mut cb) = stderr_callback.lock() {
-                cb(payload.into_bytes());
+        let mut reader = BufReader::new(stderr);
+        let mut buf: Vec<u8> = Vec::with_capacity(256);
+        loop {
+            buf.clear();
+            match reader.read_until(b'\n', &mut buf) {
+                Ok(0) => break, // EOF
+                Ok(_) => {
+                    // Strip the trailing newline (if any) for cleaner
+                    // display; the JSON envelope adds its own.
+                    let trimmed = match buf.last() {
+                        Some(b'\n') => &buf[..buf.len() - 1],
+                        _ => &buf[..],
+                    };
+                    let line = String::from_utf8_lossy(trimmed);
+                    let envelope = serde_json::json!({
+                        "type": "system",
+                        "subtype": "stderr",
+                        "text": line,
+                    });
+                    let mut payload = envelope.to_string();
+                    payload.push('\n');
+                    if let Ok(mut cb) = stderr_callback.lock() {
+                        cb(payload.into_bytes());
+                    }
+                }
+                Err(_) => break,
             }
         }
     });

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -15,6 +15,13 @@ pub struct SessionRecord {
     pub archived_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    /// Optional grouping id so chat-style multi-turn conversations show as a
+    /// single thread in `/sessions` instead of one row per turn. Distinct
+    /// from `id` (which is per-session) and from the harness CLI's own
+    /// session-resume id (which is the same for claude, different for
+    /// codex). See `docs/chat-persistence.md`.
+    #[serde(default)]
+    pub conversation_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -66,7 +73,8 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             exit_code INTEGER,
             archived_at TEXT,
             created_at TEXT NOT NULL,
-            updated_at TEXT NOT NULL
+            updated_at TEXT NOT NULL,
+            conversation_id TEXT
         );
 
         CREATE TABLE IF NOT EXISTS events (
@@ -96,6 +104,7 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     .context("failed to initialize Coven store schema")?;
     ensure_exit_code_column(&conn)?;
     ensure_archived_at_column(&conn)?;
+    ensure_conversation_id_column(&conn)?;
 
     Ok(conn)
 }
@@ -146,6 +155,39 @@ fn ensure_archived_at_column(conn: &Connection) -> Result<()> {
         conn.execute("ALTER TABLE sessions ADD COLUMN archived_at TEXT", [])
             .context("failed to add sessions.archived_at column")?;
     }
+
+    Ok(())
+}
+
+fn ensure_conversation_id_column(conn: &Connection) -> Result<()> {
+    let mut statement = conn
+        .prepare("PRAGMA table_info(sessions)")
+        .context("failed to inspect sessions schema")?;
+    let has_conversation_id = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .context("failed to query sessions schema")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to read sessions schema")?
+        .into_iter()
+        .any(|column| column == "conversation_id");
+
+    if !has_conversation_id {
+        conn.execute(
+            "ALTER TABLE sessions ADD COLUMN conversation_id TEXT",
+            [],
+        )
+        .context("failed to add sessions.conversation_id column")?;
+    }
+    // Idempotent — covers both the fresh-create path (column came from
+    // the initial CREATE TABLE) and the migration path (column added just
+    // above). Lives outside the if-block so existing stores opened by a
+    // newer binary still get the index.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_conversation_id
+            ON sessions(conversation_id)",
+        [],
+    )
+    .context("failed to create sessions.conversation_id index")?;
 
     Ok(())
 }
@@ -226,8 +268,9 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
             exit_code,
             archived_at,
             created_at,
-            updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            updated_at,
+            conversation_id
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
         params![
             &record.id,
             &record.project_root,
@@ -238,6 +281,7 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
             &record.archived_at,
             &record.created_at,
             &record.updated_at,
+            &record.conversation_id,
         ],
     )
     .with_context(|| format!("failed to insert session {}", record.id))?;
@@ -312,7 +356,8 @@ fn list_sessions_with_archive_filter(
                 exit_code,
                 archived_at,
                 created_at,
-                updated_at
+                updated_at,
+                conversation_id
             FROM sessions
             {archive_filter}
             ORDER BY created_at DESC, id DESC",
@@ -331,6 +376,7 @@ fn list_sessions_with_archive_filter(
                 archived_at: row.get(6)?,
                 created_at: row.get(7)?,
                 updated_at: row.get(8)?,
+                conversation_id: row.get(9)?,
             })
         })
         .context("failed to query sessions")?
@@ -1007,6 +1053,7 @@ mod tests {
             archived_at: None,
             created_at: created_at.to_string(),
             updated_at: created_at.to_string(),
+            conversation_id: None,
         }
     }
 }

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -172,11 +172,8 @@ fn ensure_conversation_id_column(conn: &Connection) -> Result<()> {
         .any(|column| column == "conversation_id");
 
     if !has_conversation_id {
-        conn.execute(
-            "ALTER TABLE sessions ADD COLUMN conversation_id TEXT",
-            [],
-        )
-        .context("failed to add sessions.conversation_id column")?;
+        conn.execute("ALTER TABLE sessions ADD COLUMN conversation_id TEXT", [])
+            .context("failed to add sessions.conversation_id column")?;
     }
     // Idempotent — covers both the fresh-create path (column came from
     // the initial CREATE TABLE) and the migration path (column added just

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -17,9 +17,11 @@ pub struct SessionRecord {
     pub updated_at: String,
     /// Optional grouping id so chat-style multi-turn conversations show as a
     /// single thread in `/sessions` instead of one row per turn. Distinct
-    /// from `id` (which is per-session) and from the harness CLI's own
-    /// session-resume id (which is the same for claude, different for
-    /// codex). See `docs/chat-persistence.md`.
+    /// from `id` (which is per-session). In practice today this id is the
+    /// same value the chat passes to the harness CLI for resume — claude
+    /// uses a chat-generated UUID for both `--session-id` and grouping;
+    /// codex uses its own captured `session id: <uuid>` for both `exec
+    /// resume` and grouping. See `docs/chat-persistence.md`.
     #[serde(default)]
     pub conversation_id: Option<String>,
 }

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -136,6 +136,13 @@ pub(super) struct App {
     /// event don't clutter the chat after we've already kicked off a
     /// retry. Entries are cleared once their exit (or kill) event arrives.
     suppressed_session_ids: HashSet<String>,
+    /// Per-harness daemon session ids for long-lived stream-mode processes.
+    /// On the first chat turn for a stream-capable harness we launch with
+    /// `HarnessLaunchMode::Stream` and store the daemon session id here;
+    /// subsequent turns reuse it via `send_input` (no fresh launch, no
+    /// cold-start). Cleared on session exit/kill/`/clear`/`/new`. Today
+    /// only claude is stream-capable. See `docs/chat-persistence.md`.
+    harness_stream_session_ids: HashMap<String, String>,
     client: Box<dyn ChatClient>,
 }
 
@@ -296,6 +303,7 @@ impl App {
             last_chat_prompt: None,
             auto_retry_consumed: false,
             suppressed_session_ids: HashSet::new(),
+            harness_stream_session_ids: HashMap::new(),
             client,
         };
 
@@ -504,11 +512,14 @@ impl App {
     /// does. Used by Ctrl+L so the keybind doesn't have to fake a slash
     /// command through the parser. Also drops the harness conversation ids
     /// (both in-memory and on disk) so the next turn starts a fresh thread
-    /// rather than silently resuming after a restart.
+    /// rather than silently resuming after a restart, and tears down any
+    /// long-lived stream sessions so the next claude turn cold-starts a
+    /// fresh process.
     pub(super) fn clear_transcript(&mut self) {
         self.messages.clear();
         self.scroll_offset = 0;
         self.harness_conversation_ids.clear();
+        self.kill_all_stream_sessions();
         self.clear_persisted_conversations();
         self.push_system_message("Chat cleared.");
     }
@@ -516,13 +527,31 @@ impl App {
     /// Drop the in-memory + persisted harness conversation ids without
     /// touching the visible transcript. Useful when a user wants to start
     /// a fresh thread (next message will create a new harness session) but
-    /// keep the prior exchange visible for their own reference.
+    /// keep the prior exchange visible for their own reference. Tears down
+    /// any long-lived stream sessions for the same reason as `/clear`.
     pub(super) fn start_new_conversation(&mut self) {
         self.harness_conversation_ids.clear();
+        self.kill_all_stream_sessions();
         self.clear_persisted_conversations();
         self.push_system_message(
             "Started a new conversation. Your next message creates a fresh thread; the transcript above stays for reference.",
         );
+    }
+
+    /// Kill every tracked stream-mode daemon session and clear our local
+    /// map. Best-effort: kill failures are logged but don't block the
+    /// caller. Used by `/clear` and `/new` to ensure the next message
+    /// cold-starts a fresh stream process.
+    fn kill_all_stream_sessions(&mut self) {
+        let ids: Vec<String> = self.harness_stream_session_ids.values().cloned().collect();
+        for id in ids {
+            if let Err(error) = self.client.kill_session(&id) {
+                self.push_system_message(&format!(
+                    "Stream session {id} kill failed: {error}. Daemon may still hold it."
+                ));
+            }
+        }
+        self.harness_stream_session_ids.clear();
     }
 
     pub(super) fn handle_slash_command(&mut self, input: &str) -> SlashCommandResult {
@@ -851,6 +880,24 @@ impl App {
         // Stash the prompt so stale-id recovery can auto-resend it without
         // making the user retype.
         self.last_chat_prompt = Some(prompt.to_string());
+
+        // Fast path for stream-mode harnesses (today: claude). If we
+        // already have a long-lived stream session for this harness, send
+        // the next user message into it instead of cold-starting a new
+        // daemon session.
+        if harness::harness_supports_stream_mode(harness) {
+            if let Some(stream_id) = self.harness_stream_session_ids.get(harness).cloned() {
+                self.active_session_id = Some(stream_id.clone());
+                self.active_session_harness = Some(harness.to_string());
+                self.chat_owns_active_session = true;
+                self.reset_event_poll_failures();
+                self.forward_input_to_session(&stream_id, prompt);
+                // No SessionRecord to return — the caller's "Started
+                // daemon session" outcome is suppressed for warm sends.
+                return None;
+            }
+        }
+
         let hint = self.conversation_hint_for_harness(harness);
         // Same map that holds the harness-CLI session id also serves as the
         // ledger conversation id, so /sessions can collapse multi-turn
@@ -858,7 +905,13 @@ impl App {
         // from output), so it lands as an ungrouped row — see
         // `docs/chat-persistence.md`.
         let conversation_id = self.harness_conversation_ids.get(harness).cloned();
-        let result = LaunchRequest::for_current_dir(harness, prompt).map(|request| {
+        let launch_mode = if harness::harness_supports_stream_mode(harness) {
+            crate::harness::HarnessLaunchMode::Stream
+        } else {
+            crate::harness::HarnessLaunchMode::NonInteractive
+        };
+        let result = LaunchRequest::for_current_dir(harness, prompt).map(|mut request| {
+            request.launch_mode = launch_mode;
             let request = match hint {
                 Some(hint) => request.with_conversation(hint),
                 None => request,
@@ -876,6 +929,10 @@ impl App {
                 self.chat_owns_active_session = true;
                 self.last_event_seq = None;
                 self.reset_event_poll_failures();
+                if launch_mode == crate::harness::HarnessLaunchMode::Stream {
+                    self.harness_stream_session_ids
+                        .insert(harness.to_string(), session.id.clone());
+                }
                 self.push_system_message("Connected. Waiting for the reply.");
                 self.poll_session_events();
                 Some(session)
@@ -1132,6 +1189,12 @@ impl App {
             return;
         }
         self.harness_conversation_ids.remove(&harness);
+        // The dying stream session (if any) can't be reused: claude rejected
+        // its --resume id and is about to exit. Drop it so the auto-retry
+        // cold-starts a fresh stream process instead of forwarding to a
+        // half-dead pipe. The eventual exit event will be ignored thanks
+        // to the suppression entry below.
+        self.harness_stream_session_ids.remove(&harness);
         self.persist_conversations();
         // Hide any further output and the eventual exit event for the
         // failed session so the user only sees the system message + the
@@ -1164,6 +1227,61 @@ impl App {
         }
     }
 
+    /// Parse a chunk of stream-mode harness output (newline-delimited JSON)
+    /// and turn it into chat-visible messages. Each line is one JSON event:
+    /// `assistant.message.content[].text` becomes an agent message; the
+    /// `result` event marks the turn complete and clears `is_responding`;
+    /// other event types (system init, rate_limit_event, …) are ignored
+    /// for now. Malformed lines are silently dropped — stream-mode is too
+    /// noisy to surface every parse error.
+    fn dispatch_stream_json_output(&mut self, _session_id: &str, data: &str) {
+        let sender = self.active_agent_label().to_string();
+        for line in data.split('\n') {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let Ok(value): Result<serde_json::Value, _> = serde_json::from_str(trimmed) else {
+                continue;
+            };
+            let Some(kind) = value.get("type").and_then(serde_json::Value::as_str) else {
+                continue;
+            };
+            match kind {
+                "assistant" => {
+                    let Some(content) = value
+                        .get("message")
+                        .and_then(|m| m.get("content"))
+                        .and_then(serde_json::Value::as_array)
+                    else {
+                        continue;
+                    };
+                    let mut buffer = String::new();
+                    for block in content {
+                        if block.get("type").and_then(serde_json::Value::as_str) == Some("text") {
+                            if let Some(text) = block.get("text").and_then(serde_json::Value::as_str)
+                            {
+                                buffer.push_str(text);
+                            }
+                        }
+                    }
+                    if !buffer.is_empty() {
+                        if self.streaming_mode.is_live() {
+                            self.push_or_append_agent_message(&sender, &buffer);
+                        } else {
+                            self.buffer_pending_agent_output(&sender, &buffer);
+                        }
+                    }
+                }
+                "result" => {
+                    self.flush_pending_agent_buffer();
+                    self.is_responding = false;
+                }
+                _ => {}
+            }
+        }
+    }
+
     fn push_event_message(&mut self, event: &store::EventRecord) {
         // Drop events from sessions we've decided to hide (today: failed
         // sessions whose stale-id we already auto-recovered from). Clear
@@ -1183,6 +1301,18 @@ impl App {
                     // The stale handler may have just suppressed this very
                     // session; if so, skip displaying this chunk too.
                     if self.suppressed_session_ids.contains(&event.session_id) {
+                        return;
+                    }
+                    // Stream-mode output is newline-delimited JSON. Parse
+                    // assistant text directly out of it instead of feeding
+                    // it through the text/ANSI cleaner meant for PTY
+                    // sessions.
+                    let is_stream = self
+                        .harness_stream_session_ids
+                        .values()
+                        .any(|id| id == &event.session_id);
+                    if is_stream {
+                        self.dispatch_stream_json_output(&event.session_id, &data);
                         return;
                     }
                     let sender = self.active_agent_label().to_string();
@@ -1207,6 +1337,11 @@ impl App {
                     self.active_session_harness = None;
                     self.chat_owns_active_session = false;
                 }
+                // If a stream session for any harness died, drop its id so
+                // the next turn cold-starts a fresh one instead of
+                // forwarding to a dead pipe.
+                self.harness_stream_session_ids
+                    .retain(|_, id| id != &event.session_id);
                 self.agent_output_mode = AgentOutputMode::Unknown;
                 self.push_system_message(&format!("Session {status}."));
             }
@@ -1218,6 +1353,8 @@ impl App {
                     self.chat_owns_active_session = false;
                     self.is_responding = false;
                 }
+                self.harness_stream_session_ids
+                    .retain(|_, id| id != &event.session_id);
                 self.agent_output_mode = AgentOutputMode::Unknown;
                 self.push_system_message("Session kill recorded.");
             }
@@ -2405,6 +2542,156 @@ mod tests {
     }
 
     #[test]
+    fn first_claude_chat_turn_launches_in_stream_mode_and_tracks_the_daemon_session_id() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 1, "first claude turn must launch once");
+        assert_eq!(
+            launched[0].launch_mode,
+            crate::harness::HarnessLaunchMode::Stream,
+            "claude chat turns must take the stream path",
+        );
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets active session id")
+            .to_string();
+        assert_eq!(
+            app.harness_stream_session_ids.get("claude").cloned(),
+            Some(session_id),
+            "first stream launch must register its daemon session id under claude"
+        );
+    }
+
+    #[test]
+    fn second_claude_chat_turn_reuses_the_stream_session_via_send_input_not_launch() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let stream_session_id = app
+            .active_session_id()
+            .expect("first launch")
+            .to_string();
+        assert_eq!(mirror.launched.borrow().len(), 1);
+
+        // Stream-mode sessions don't fire an exit between turns; instead
+        // each turn ends with a `result` event that clears is_responding.
+        // Simulate that so the next user message isn't gated.
+        let result_chunk = r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
+        app.push_event_message(&output_event(1, &stream_session_id, &result_chunk));
+        assert!(!app.is_responding);
+
+        app.input = "second".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        assert_eq!(
+            mirror.launched.borrow().len(),
+            1,
+            "second turn must NOT cold-start a new launch when a stream session exists"
+        );
+        assert!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .any(|call| call == &format!("input:{stream_session_id}:second\n")),
+            "second turn must forward via send_input to the existing stream session"
+        );
+    }
+
+    #[test]
+    fn codex_chat_turn_does_not_take_the_stream_path() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(0); // codex
+        app.input = "do a thing".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 1);
+        assert_eq!(
+            launched[0].launch_mode,
+            crate::harness::HarnessLaunchMode::NonInteractive,
+            "codex doesn't support stream mode; must fall back to non-interactive"
+        );
+        assert!(
+            app.harness_stream_session_ids.is_empty(),
+            "codex turns must not register a stream session id"
+        );
+    }
+
+    #[test]
+    fn stream_json_assistant_output_renders_as_chat_message() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch").to_string();
+
+        let chunk = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello, Val."}]}}"#.to_string() + "\n";
+        app.push_event_message(&output_event(1, &session_id, &chunk));
+
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("Hello, Val.")
+                    && matches!(m.role, MessageRole::Agent)),
+            "stream-json assistant text must be rendered as an agent message"
+        );
+        // is_responding stays true until the result event arrives.
+        assert!(app.is_responding);
+
+        let result_chunk = r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
+        app.push_event_message(&output_event(2, &session_id, &result_chunk));
+        assert!(!app.is_responding, "result event must clear is_responding");
+    }
+
+    #[test]
+    fn stream_session_exit_event_drops_the_tracked_id_so_next_turn_cold_starts() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch").to_string();
+
+        // Simulate the stream process dying (crash, kill, etc.).
+        app.push_event_message(&EventRecord {
+            seq: 1,
+            id: "event-exit".to_string(),
+            session_id: session_id.clone(),
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "failed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+        assert!(
+            app.harness_stream_session_ids.is_empty(),
+            "exit must drop the dead stream session from the per-harness map"
+        );
+
+        // Next turn cold-starts a fresh stream session instead of forwarding.
+        app.input = "second".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        assert_eq!(mirror.launched.borrow().len(), 2);
+    }
+
+    #[test]
     fn slash_new_drops_conversation_ids_but_preserves_visible_transcript() {
         let coven_home = tempfile::tempdir().unwrap();
         let project_root = tempfile::tempdir().unwrap();
@@ -2722,12 +3009,11 @@ mod tests {
         let retry_session = app.active_session_id().expect("retry session").to_string();
         assert_ne!(retry_session, failed_session);
 
-        // Output from the retry session must still be rendered.
-        app.push_event_message(&output_event(
-            2,
-            &retry_session,
-            "Hi from the new conversation.\n",
-        ));
+        // Output from the retry session must still be rendered. The retry
+        // is a stream-mode claude session, so the chunk is a stream-json
+        // assistant event rather than plain text.
+        let assistant_chunk = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hi from the new conversation."}]}}"#.to_string() + "\n";
+        app.push_event_message(&output_event(2, &retry_session, &assistant_chunk));
 
         assert!(
             app.messages

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -121,6 +121,15 @@ pub(super) struct App {
     /// Harness id of `active_session_id`. Used to decide whether output from
     /// the active session is worth scanning for a codex session-id banner.
     active_session_harness: Option<String>,
+    /// Most recent user prompt the chat sent through `run_harness_prompt`,
+    /// stashed so stale-id recovery can auto-resend it with no hint instead
+    /// of asking the user to retype.
+    last_chat_prompt: Option<String>,
+    /// True if we've already auto-retried once during the current user turn.
+    /// Reset by `handle_input` so a fresh user message gets a fresh retry
+    /// budget; prevents an infinite loop if the retry itself somehow hits
+    /// stale-detection too.
+    auto_retry_consumed: bool,
     client: Box<dyn ChatClient>,
 }
 
@@ -274,6 +283,8 @@ impl App {
             project_root,
             chat_owns_active_session: false,
             active_session_harness: None,
+            last_chat_prompt: None,
+            auto_retry_consumed: false,
             client,
         };
 
@@ -431,6 +442,8 @@ impl App {
         }
 
         self.event_poll_paused_for_api_mismatch = false;
+        // Each user message gets a fresh auto-retry budget.
+        self.auto_retry_consumed = false;
 
         if self.pending_cast_confirmation.is_some() {
             let result = self.resolve_pending_cast_confirmation(&raw);
@@ -808,6 +821,9 @@ impl App {
     fn run_harness_prompt(&mut self, harness: &str, prompt: &str) -> Option<store::SessionRecord> {
         self.is_responding = true;
         self.agent_output_mode = AgentOutputMode::Unknown;
+        // Stash the prompt so stale-id recovery can auto-resend it without
+        // making the user retype.
+        self.last_chat_prompt = Some(prompt.to_string());
         let hint = self.conversation_hint_for_harness(harness);
         let result = LaunchRequest::for_current_dir(harness, prompt).map(|request| match hint {
             Some(hint) => request.with_conversation(hint),
@@ -1059,9 +1075,10 @@ impl App {
 
     /// If the harness rejected our `Resume` because the prior session no
     /// longer exists (claude or codex local store wiped, server-side
-    /// expiry, etc.), drop the stale id from memory and disk and tell the
-    /// user so they can retry with a fresh thread. Only fires for chat-owned
-    /// sessions where we actually had a stored id to send.
+    /// expiry, etc.), drop the stale id from memory and disk and either
+    /// auto-resend the original prompt (preferred) or tell the user to
+    /// retype if we've already auto-retried this turn. Only fires for
+    /// chat-owned sessions where we actually had a stored id to send.
     fn maybe_clear_stale_conversation_id(&mut self, data: &str) {
         if !self.chat_owns_active_session {
             return;
@@ -1077,9 +1094,29 @@ impl App {
         }
         self.harness_conversation_ids.remove(&harness);
         self.persist_conversations();
-        self.push_system_message(&format!(
-            "Prior {harness} conversation no longer exists. Send your message again to start a fresh one."
-        ));
+
+        // Try to auto-resend so the user doesn't have to retype. Skip if
+        // we've already retried this turn (defense against a retry that
+        // itself trips the stale phrase — natural flow won't, since a
+        // post-drop turn sends no Resume, but be defensive anyway).
+        let prompt = self
+            .last_chat_prompt
+            .clone()
+            .filter(|_| !self.auto_retry_consumed);
+        match prompt {
+            Some(prompt) => {
+                self.push_system_message(&format!(
+                    "Prior {harness} conversation no longer exists. Starting a new one and re-sending your message."
+                ));
+                self.auto_retry_consumed = true;
+                self.run_harness_prompt(&harness, &prompt);
+            }
+            None => {
+                self.push_system_message(&format!(
+                    "Prior {harness} conversation no longer exists. Send your message again to start a fresh one."
+                ));
+            }
+        }
     }
 
     fn push_event_message(&mut self, event: &store::EventRecord) {
@@ -2309,7 +2346,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_claude_resume_drops_id_from_memory_and_disk_and_warns_user() {
+    fn stale_claude_resume_replaces_id_and_auto_resends_original_prompt() {
         let coven_home = tempfile::tempdir().unwrap();
         let project_root = tempfile::tempdir().unwrap();
         let stored_id = "fab1efac-1234-5678-9abc-def012345678";
@@ -2319,7 +2356,8 @@ mod tests {
             .expect("seed persisted state");
 
         let client = RecordingChatClient::default();
-        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        let (mut app, mirror) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
         app.active_agent = Some(1); // claude
         app.input = "hello again".to_string();
         app.cursor_pos = app.input.len();
@@ -2330,23 +2368,92 @@ mod tests {
         app.push_event_message(&output_event(
             1,
             &session_id,
-            &format!(
-                "No conversation found with session ID: {stored_id}\n",
-            ),
+            &format!("No conversation found with session ID: {stored_id}\n"),
         ));
 
-        assert!(
-            !app.harness_conversation_ids.contains_key("claude"),
-            "stale id must be dropped from memory"
-        );
+        // Stale id must be gone — but auto-retry should have created a
+        // fresh one in its place (claude pre-assigns via --session-id).
+        let new_id = app
+            .harness_conversation_ids
+            .get("claude")
+            .cloned()
+            .expect("auto-retry should have stored a fresh claude id");
+        assert_ne!(new_id, stored_id, "fresh id must not equal the stale one");
         let stored = persistence::load_for_project(coven_home.path(), project_root.path());
+        assert_eq!(
+            stored.get("claude").cloned(),
+            Some(new_id.clone()),
+            "fresh id must be persisted to disk"
+        );
+
+        // Two launches: the original (Resume with stale id) and the auto-
+        // retry (Init with the fresh id, carrying the same prompt).
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 2);
+        assert_eq!(launched[0].prompt, "hello again");
+        assert_eq!(launched[1].prompt, "hello again");
+        match &launched[1].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => {
+                assert_eq!(id, &new_id);
+            }
+            other => panic!("auto-retry should carry Init with the new id, got {other:?}"),
+        }
         assert!(
-            !stored.contains_key("claude"),
-            "stale id must also be removed from disk"
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("re-sending your message")),
+            "user must see a system message about the auto-retry"
+        );
+    }
+
+    #[test]
+    fn stale_recovery_only_auto_retries_once_per_user_turn() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let stored_id = "fab1efac-1234-5678-9abc-def012345678";
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), stored_id.to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let first_session = app.active_session_id().expect("first launch").to_string();
+
+        // First stale event → consumes the auto-retry budget.
+        app.push_event_message(&output_event(
+            1,
+            &first_session,
+            &format!("No conversation found with session ID: {stored_id}\n"),
+        ));
+        let after_first_retry = mirror.launched.borrow().len();
+        assert_eq!(after_first_retry, 2, "first stale event triggers a retry");
+        let retry_session = app.active_session_id().expect("retry sets id").to_string();
+        let retry_id = app.harness_conversation_ids.get("claude").cloned().unwrap();
+
+        // Simulate the retry itself also somehow hitting stale (pathological
+        // — claude wouldn't really say this for an Init session — but we
+        // guard against it to bound the loop).
+        app.push_event_message(&output_event(
+            2,
+            &retry_session,
+            &format!("No conversation found with session ID: {retry_id}\n"),
+        ));
+        assert_eq!(
+            mirror.launched.borrow().len(),
+            after_first_retry,
+            "second stale event in the same turn must not auto-retry again"
         );
         assert!(
-            app.messages.iter().any(|m| m.content.contains("no longer exists")),
-            "user must see a system message explaining the reset"
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("Send your message again")),
+            "second stale event falls back to asking the user to retype"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1087,6 +1087,23 @@ impl App {
             Err(error) => {
                 self.is_responding = false;
                 self.push_system_message(&format!("Input rejected: {error}"));
+                // For stream-mode failures, the long-lived child is
+                // almost certainly dead (daemon returns NotLiveError
+                // when the registry entry is gone, which only happens
+                // after the wait thread reaped the process). Drop the
+                // tracking entry and its buffer so the next user
+                // message cold-starts a fresh stream session instead
+                // of looping into the same dead pipe.
+                if is_stream {
+                    self.harness_stream_session_ids
+                        .retain(|_, id| id != session_id);
+                    self.stream_json_buffers.remove(session_id);
+                    if self.active_session_id.as_deref() == Some(session_id) {
+                        self.active_session_id = None;
+                        self.active_session_harness = None;
+                        self.chat_owns_active_session = false;
+                    }
+                }
             }
         }
     }
@@ -2180,6 +2197,7 @@ mod tests {
         events: Rc<RefCell<Vec<EventRecord>>>,
         event_error: Rc<RefCell<Option<String>>>,
         launch_error: Rc<RefCell<Option<String>>>,
+        send_input_error: Rc<RefCell<Option<String>>>,
     }
 
     impl RecordingChatClient {
@@ -2240,6 +2258,9 @@ mod tests {
             self.calls
                 .borrow_mut()
                 .push(format!("input:{session_id}:{data}"));
+            if let Some(error) = self.send_input_error.borrow().clone() {
+                return Err(anyhow::anyhow!(error));
+            }
             Ok(())
         }
 
@@ -2794,6 +2815,55 @@ mod tests {
             app.harness_stream_session_ids.get("claude").cloned(),
             Some(session_id),
             "first stream launch must register its daemon session id under claude"
+        );
+    }
+
+    #[test]
+    fn stream_send_failure_drops_tracking_so_next_turn_cold_starts() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let stream_session = app.active_session_id().expect("first launch").to_string();
+        assert!(app.harness_stream_session_ids.contains_key("claude"));
+
+        // Complete the first turn so the next message isn't gated by
+        // is_responding, then arm the mock so the next send_input fails
+        // (e.g. daemon NotLiveError).
+        let result_chunk =
+            r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
+        app.push_event_message(&output_event(1, &stream_session, &result_chunk));
+        *mirror.send_input_error.borrow_mut() = Some("simulated NotLive".to_string());
+
+        app.input = "second".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        // The send to the dead stream session failed — chat must drop
+        // the tracking entry so it doesn't loop back to the same dead
+        // pipe on the third message. Both the per-harness id and the
+        // per-session JSON buffer should be gone, and active state
+        // cleared so the user isn't gated by stale is_responding.
+        assert!(
+            !app.harness_stream_session_ids.contains_key("claude"),
+            "send failure on stream session must drop the per-harness id so the next turn cold-starts"
+        );
+        assert!(!app.stream_json_buffers.contains_key(&stream_session));
+        assert!(app.active_session_id().is_none());
+        assert!(!app.is_responding);
+
+        // Now disarm the mock and prove the next message launches fresh.
+        *mirror.send_input_error.borrow_mut() = None;
+        let launches_before_retype = mirror.launched.borrow().len();
+        app.input = "third".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        assert_eq!(
+            mirror.launched.borrow().len(),
+            launches_before_retype + 1,
+            "after the dead-stream cleanup, next message must cold-start a fresh launch"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -171,7 +171,11 @@ pub(super) const SLASH_COMMANDS: &[SlashCommand] = &[
     },
     SlashCommand {
         name: "/clear",
-        summary: "Clear the chat transcript",
+        summary: "Clear the transcript and start a fresh thread",
+    },
+    SlashCommand {
+        name: "/new",
+        summary: "Start a fresh thread; keep the transcript visible",
     },
     SlashCommand {
         name: "/agent",
@@ -509,6 +513,18 @@ impl App {
         self.push_system_message("Chat cleared.");
     }
 
+    /// Drop the in-memory + persisted harness conversation ids without
+    /// touching the visible transcript. Useful when a user wants to start
+    /// a fresh thread (next message will create a new harness session) but
+    /// keep the prior exchange visible for their own reference.
+    pub(super) fn start_new_conversation(&mut self) {
+        self.harness_conversation_ids.clear();
+        self.clear_persisted_conversations();
+        self.push_system_message(
+            "Started a new conversation. Your next message creates a fresh thread; the transcript above stays for reference.",
+        );
+    }
+
     pub(super) fn handle_slash_command(&mut self, input: &str) -> SlashCommandResult {
         let parts: Vec<&str> = input.splitn(2, char::is_whitespace).collect();
         let cmd = parts[0].to_lowercase();
@@ -521,6 +537,10 @@ impl App {
             }
             "/clear" | "/cls" => {
                 self.clear_transcript();
+                SlashCommandResult::Handled
+            }
+            "/new" => {
+                self.start_new_conversation();
                 SlashCommandResult::Handled
             }
             "/agent" | "/a" => {
@@ -1550,6 +1570,7 @@ fn is_chat_local_slash(input: &str) -> bool {
             | "/palette"
             | "/clear"
             | "/cls"
+            | "/new"
             | "/agent"
             | "/a"
             | "/export"
@@ -2307,6 +2328,105 @@ mod tests {
             Some(captured_id),
             "codex session id must be persisted as soon as it's captured"
         );
+    }
+
+    #[test]
+    fn slash_new_drops_conversation_ids_but_preserves_visible_transcript() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let messages_after_first_turn = app.messages.len();
+        assert!(
+            app.harness_conversation_ids.contains_key("claude"),
+            "first claude turn must seed an id"
+        );
+        assert!(
+            persistence::conversations_file(coven_home.path(), project_root.path()).exists(),
+            "first turn must have persisted the id"
+        );
+
+        app.input = "/new".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        // Conversation ids gone from both memory and disk.
+        assert!(app.harness_conversation_ids.is_empty());
+        assert!(
+            !persistence::conversations_file(coven_home.path(), project_root.path()).exists(),
+            "/new must delete the persistence file too"
+        );
+
+        // Visible transcript preserved (plus the /new system message).
+        assert!(
+            app.messages.len() >= messages_after_first_turn + 1,
+            "/new must keep prior messages and add at least its own system message"
+        );
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.content == "first" && matches!(m.role, MessageRole::User)),
+            "the user message from the prior turn must still be visible after /new"
+        );
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("Started a new conversation"))
+        );
+    }
+
+    #[test]
+    fn first_chat_turn_after_slash_new_sends_init_not_resume() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let first_id = match &mirror.launched.borrow()[0].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => id.clone(),
+            other => panic!("turn 1 should be Init, got {other:?}"),
+        };
+        // Mark the first turn as completed so the next launch isn't gated.
+        let session_id = app.active_session_id().expect("first launch").to_string();
+        app.push_event_message(&EventRecord {
+            seq: 1,
+            id: "event-1".to_string(),
+            session_id,
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        app.input = "/new".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        app.input = "fresh topic".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 2);
+        match &launched[1].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => {
+                assert_ne!(id, &first_id, "/new must yield a fresh conversation id");
+            }
+            other => panic!("first turn after /new should be Init, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn slash_new_is_a_chat_local_command_not_routed_through_cast() {
+        assert!(is_chat_local_slash("/new"));
+        assert!(is_chat_local_slash("/NEW"));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -568,15 +568,35 @@ impl App {
     /// logged but don't block the caller. Used by `/clear`, `/new`, and
     /// `shutdown` to ensure the next message cold-starts a fresh stream
     /// process (or no process at all, on exit).
+    ///
+    /// Also clears `active_session_id` if it points at one of the killed
+    /// sessions and adds each killed id to `suppressed_session_ids`, so
+    /// the user's "Chat cleared."/"Started a new conversation." line
+    /// isn't followed by an orphan "Session kill recorded." once the
+    /// daemon's kill event eventually polls in.
     fn kill_all_stream_sessions(&mut self) {
         let ids: Vec<String> = self.harness_stream_session_ids.values().cloned().collect();
-        for id in ids {
-            if let Err(error) = self.client.kill_session(&id) {
+        for id in &ids {
+            if let Err(error) = self.client.kill_session(id) {
                 self.push_system_message(&format!(
                     "Stream session {id} kill failed: {error}. Daemon may still hold it."
                 ));
             }
-            self.stream_json_buffers.remove(&id);
+            self.stream_json_buffers.remove(id);
+            // Suppress the impending kill/exit events for this session so
+            // they don't leak back into the transcript after the user
+            // reset state.
+            self.suppressed_session_ids.insert(id.clone());
+            // If the active session is one we're tearing down, clear the
+            // active-session fields now so the event poller stops
+            // chasing it and the next user input is treated as a fresh
+            // turn rather than a "reply still streaming" rejection.
+            if self.active_session_id.as_deref() == Some(id.as_str()) {
+                self.active_session_id = None;
+                self.active_session_harness = None;
+                self.chat_owns_active_session = false;
+                self.is_responding = false;
+            }
         }
         self.harness_stream_session_ids.clear();
     }
@@ -2901,6 +2921,49 @@ mod tests {
         assert!(
             !app.stream_json_buffers.contains_key(&session_id),
             "exit must drop the per-session JSON buffer so it doesn't leak across the chat"
+        );
+    }
+
+    #[test]
+    fn clear_transcript_suppresses_the_orphan_kill_event_so_it_doesnt_echo_after_chat_cleared() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let stream_id = app.active_session_id().expect("first launch").to_string();
+
+        app.clear_transcript();
+
+        // The kill request fires synchronously; the daemon's resulting
+        // `kill` event arrives later via polling. /clear must
+        // pre-suppress the failed session so that event doesn't push
+        // "Session kill recorded." back into the just-cleared transcript.
+        assert!(
+            app.suppressed_session_ids.contains(&stream_id),
+            "killed stream session must be suppressed so its kill event doesn't echo after /clear"
+        );
+        // And the active-session state must be cleared so the next
+        // user input isn't gated by stale is_responding.
+        assert!(app.active_session_id().is_none());
+        assert!(!app.is_responding);
+
+        // Simulate the delayed kill event arriving — it must NOT push
+        // "Session kill recorded." into the transcript now.
+        app.push_event_message(&EventRecord {
+            seq: 1,
+            id: "event-kill".to_string(),
+            session_id: stream_id.clone(),
+            kind: "kill".to_string(),
+            payload_json: "{}".to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+        assert!(
+            !app.messages
+                .iter()
+                .any(|m| m.content.contains("Session kill recorded")),
+            "kill event for a suppressed stream session must not surface"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1194,6 +1194,17 @@ impl App {
             Ok(events) => {
                 self.reset_event_poll_failures();
                 for event in events {
+                    // If `push_event_message` swapped the active session
+                    // mid-batch (e.g. stale-id recovery auto-relaunched
+                    // into a new session and reset `last_event_seq` to
+                    // None), stop processing this batch. Continuing
+                    // would advance `last_event_seq` to one of the OLD
+                    // session's seqs, causing the next poll for the NEW
+                    // session to query with a cursor that filters out
+                    // the new session's own events.
+                    if self.active_session_id.as_deref() != Some(session_id.as_str()) {
+                        break;
+                    }
                     self.last_event_seq = Some(event.seq);
                     self.push_event_message(&event);
                 }
@@ -1883,6 +1894,21 @@ fn harness_supports_chat_resume(harness: &str) -> bool {
 /// claude and codex unhelpfully exit with code 0 in this case, so we have to
 /// pattern-match on their distinctive error wording. See
 /// `docs/chat-persistence.md` under "stale-id auto-recovery".
+///
+/// The match is intentionally a broad `contains` rather than a strict
+/// per-line / per-envelope check because the same phrase appears in both
+/// the PTY mode (NonInteractive) plain-text output and the Stream mode
+/// stderr envelope (`{"type":"system","subtype":"stderr","text":"…"}`),
+/// and a single regex needs to handle both. The phrases ("No conversation
+/// found with session ID", "no rollout found for thread id",
+/// "thread/resume failed") are distinctive enough that the realistic
+/// false-positive surface is narrow: a model reply that literally quotes
+/// the phrase — e.g. "The error you saw was 'No conversation found…'" —
+/// would auto-drop the conversation id and trigger an auto-retry. If
+/// that becomes a real annoyance, the right fix is splitting detection
+/// into a per-stream-mode JSON path (look at `system/stderr` text only)
+/// and a per-PTY-mode line path, instead of one regex that's also asked
+/// to match assistant prose.
 fn detect_stale_session(harness: &str, data: &str) -> bool {
     match harness {
         "claude" => data.contains("No conversation found with session ID"),
@@ -3362,6 +3388,84 @@ mod tests {
                 .iter()
                 .any(|m| m.content.contains("Hi from the new conversation")),
             "retry-session output must not be suppressed"
+        );
+    }
+
+    #[test]
+    fn poll_session_events_stops_advancing_cursor_when_active_session_changes_mid_batch() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let stored_id = "fab1efac-1234-5678-9abc-def012345678";
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), stored_id.to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let old_session = app.active_session_id().expect("first launch").to_string();
+
+        // Pre-load three events for the OLD session: a harmless first
+        // one, a stale-error in the middle, and a "trailing noise"
+        // event afterward. Without the active-session-id guard in
+        // poll_session_events, processing the trailing event would
+        // overwrite `last_event_seq` after the stale handler had
+        // reset it to None for the new session, leaving a poisoned
+        // cursor.
+        let stored_id_for_error = stored_id.to_string();
+        let old_session_for_events = old_session.clone();
+        mirror.events.borrow_mut().extend(vec![
+            EventRecord {
+                seq: 10,
+                id: "ev-10".to_string(),
+                session_id: old_session_for_events.clone(),
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({ "data": "" }).to_string(),
+                created_at: "2026-05-19T00:00:00Z".to_string(),
+            },
+            EventRecord {
+                seq: 11,
+                id: "ev-11".to_string(),
+                session_id: old_session_for_events.clone(),
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({
+                    "data": format!("No conversation found with session ID: {stored_id_for_error}\n")
+                })
+                .to_string(),
+                created_at: "2026-05-19T00:00:00Z".to_string(),
+            },
+            EventRecord {
+                seq: 12,
+                id: "ev-12".to_string(),
+                session_id: old_session_for_events,
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({ "data": "trailing noise after stale\n" })
+                    .to_string(),
+                created_at: "2026-05-19T00:00:00Z".to_string(),
+            },
+        ]);
+
+        app.poll_session_events();
+
+        // Active session should have swapped to the retry session.
+        let new_session = app
+            .active_session_id()
+            .expect("auto-retry must have set a new active session");
+        assert_ne!(new_session, old_session);
+
+        // Cursor must be at None (the value the auto-retry reset to),
+        // NOT Some(12) from the trailing OLD-session event. If it were
+        // Some(12), the next poll for the new session would query with
+        // after_seq=12 and skip any new-session events that arrived
+        // with smaller seqs.
+        assert_eq!(
+            app.last_event_seq, None,
+            "active-session swap during a batch must stop the loop from advancing the cursor past the swap"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -953,7 +953,10 @@ impl App {
     /// `Init` with a freshly generated UUID. For harnesses that auto-assign
     /// (codex) the first turn sends no hint and the id is captured from
     /// output afterwards via `maybe_capture_codex_session_id`.
-    fn conversation_hint_for_harness(&mut self, harness: &str) -> Option<harness::ConversationHint> {
+    fn conversation_hint_for_harness(
+        &mut self,
+        harness: &str,
+    ) -> Option<harness::ConversationHint> {
         if !harness_supports_chat_resume(harness) {
             return None;
         }
@@ -1164,7 +1167,8 @@ impl App {
             return;
         }
         if let Some(id) = extract_codex_session_id(data) {
-            self.harness_conversation_ids.insert("codex".to_string(), id);
+            self.harness_conversation_ids
+                .insert("codex".to_string(), id);
             self.persist_conversations();
         }
     }
@@ -1259,7 +1263,8 @@ impl App {
                     let mut buffer = String::new();
                     for block in content {
                         if block.get("type").and_then(serde_json::Value::as_str) == Some("text") {
-                            if let Some(text) = block.get("text").and_then(serde_json::Value::as_str)
+                            if let Some(text) =
+                                block.get("text").and_then(serde_json::Value::as_str)
                             {
                                 buffer.push_str(text);
                             }
@@ -1756,8 +1761,7 @@ fn detect_stale_session(harness: &str, data: &str) -> bool {
     match harness {
         "claude" => data.contains("No conversation found with session ID"),
         "codex" => {
-            data.contains("no rollout found for thread id")
-                || data.contains("thread/resume failed")
+            data.contains("no rollout found for thread id") || data.contains("thread/resume failed")
         }
         _ => false,
     }
@@ -2233,7 +2237,10 @@ mod tests {
         app.input = "first".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let first_session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let first_session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
         let init_id = match &mirror.launched.borrow()[0].conversation {
             Some(crate::harness::ConversationHint::Init { id }) => id.clone(),
             other => panic!("first turn should be Init, got {other:?}"),
@@ -2271,7 +2278,10 @@ mod tests {
         app.input = "first".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
         app.push_event_message(&EventRecord {
             seq: 1,
             id: "event-1".to_string(),
@@ -2295,7 +2305,10 @@ mod tests {
         };
         match &launched[1].conversation {
             Some(crate::harness::ConversationHint::Init { id }) => {
-                assert_ne!(id, &init_id_1, "/clear should yield a fresh conversation id");
+                assert_ne!(
+                    id, &init_id_1,
+                    "/clear should yield a fresh conversation id"
+                );
             }
             other => panic!("expected Init after /clear, got {other:?}"),
         }
@@ -2389,7 +2402,10 @@ mod tests {
         app.input = "first".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
 
         // Simulate codex emitting its session-id banner mid-stream.
         let captured_id = "019e5998-7130-7872-8d96-a6b67c5b6406";
@@ -2430,7 +2446,10 @@ mod tests {
         app.input = "first".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
 
         let first_id = "019e5998-7130-7872-8d96-a6b67c5b6406";
         let later_id = "ffffffff-ffff-ffff-ffff-ffffffffffff";
@@ -2447,7 +2466,9 @@ mod tests {
         ));
 
         assert_eq!(
-            app.harness_conversation_ids.get("codex").map(String::as_str),
+            app.harness_conversation_ids
+                .get("codex")
+                .map(String::as_str),
             Some(first_id),
             "first captured id must stick"
         );
@@ -2492,7 +2513,9 @@ mod tests {
         let (mut app, mirror) =
             app_with_persistence(client, coven_home.path(), project_root.path());
         assert_eq!(
-            app.harness_conversation_ids.get("claude").map(String::as_str),
+            app.harness_conversation_ids
+                .get("claude")
+                .map(String::as_str),
             Some(stored_id),
             "App must load persisted conversation ids on startup"
         );
@@ -2524,7 +2547,10 @@ mod tests {
         app.input = "first".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
 
         let captured_id = "019eaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
         app.push_event_message(&output_event(
@@ -2577,16 +2603,14 @@ mod tests {
         app.input = "first".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let stream_session_id = app
-            .active_session_id()
-            .expect("first launch")
-            .to_string();
+        let stream_session_id = app.active_session_id().expect("first launch").to_string();
         assert_eq!(mirror.launched.borrow().len(), 1);
 
         // Stream-mode sessions don't fire an exit between turns; instead
         // each turn ends with a `result` event that clears is_responding.
         // Simulate that so the next user message isn't gated.
-        let result_chunk = r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
+        let result_chunk =
+            r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
         app.push_event_message(&output_event(1, &stream_session_id, &result_chunk));
         assert!(!app.is_responding);
 
@@ -2642,20 +2666,23 @@ mod tests {
         app.handle_input();
         let session_id = app.active_session_id().expect("first launch").to_string();
 
-        let chunk = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello, Val."}]}}"#.to_string() + "\n";
+        let chunk =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello, Val."}]}}"#
+                .to_string()
+                + "\n";
         app.push_event_message(&output_event(1, &session_id, &chunk));
 
         assert!(
             app.messages
                 .iter()
-                .any(|m| m.content.contains("Hello, Val.")
-                    && matches!(m.role, MessageRole::Agent)),
+                .any(|m| m.content.contains("Hello, Val.") && matches!(m.role, MessageRole::Agent)),
             "stream-json assistant text must be rendered as an agent message"
         );
         // is_responding stays true until the result event arrives.
         assert!(app.is_responding);
 
-        let result_chunk = r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
+        let result_chunk =
+            r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
         app.push_event_message(&output_event(2, &session_id, &result_chunk));
         assert!(!app.is_responding, "result event must clear is_responding");
     }
@@ -2733,11 +2760,10 @@ mod tests {
                 .any(|m| m.content == "first" && matches!(m.role, MessageRole::User)),
             "the user message from the prior turn must still be visible after /new"
         );
-        assert!(
-            app.messages
-                .iter()
-                .any(|m| m.content.contains("Started a new conversation"))
-        );
+        assert!(app
+            .messages
+            .iter()
+            .any(|m| m.content.contains("Started a new conversation")));
     }
 
     #[test]
@@ -2871,7 +2897,10 @@ mod tests {
         app.input = "hello again".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
 
         // Simulate claude rejecting our stale --resume.
         app.push_event_message(&output_event(
@@ -2957,11 +2986,7 @@ mod tests {
 
         // None of the failed session's content (raw error, trailing noise,
         // "Session completed.") should appear in the transcript.
-        let transcript: Vec<&str> = app
-            .messages
-            .iter()
-            .map(|m| m.content.as_str())
-            .collect();
+        let transcript: Vec<&str> = app.messages.iter().map(|m| m.content.as_str()).collect();
         for content in &transcript {
             assert!(
                 !content.contains("No conversation found with session ID"),
@@ -2977,7 +3002,9 @@ mod tests {
             );
         }
         // The system message and the retry's "Connected" line should be visible.
-        assert!(transcript.iter().any(|c| c.contains("re-sending your message")));
+        assert!(transcript
+            .iter()
+            .any(|c| c.contains("re-sending your message")));
         assert!(transcript.iter().any(|c| c.contains("Connected")));
         // Suppression entry must be cleared once the exit is consumed.
         assert!(!app.suppressed_session_ids.contains(&failed_session));
@@ -3091,7 +3118,10 @@ mod tests {
         app.input = "hello again".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
 
         app.push_event_message(&output_event(
             1,
@@ -3106,7 +3136,10 @@ mod tests {
         );
         let stored = persistence::load_for_project(coven_home.path(), project_root.path());
         assert!(!stored.contains_key("codex"));
-        assert_eq!(stored.get("claude").map(String::as_str), Some("claude-uuid"));
+        assert_eq!(
+            stored.get("claude").map(String::as_str),
+            Some("claude-uuid")
+        );
     }
 
     #[test]
@@ -3118,11 +3151,9 @@ mod tests {
         persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
             .expect("seed persisted state");
 
-        let attached =
-            test_session("attached-session", "claude", "external", "running");
+        let attached = test_session("attached-session", "claude", "external", "running");
         let client = RecordingChatClient::with_session(attached);
-        let (mut app, _) =
-            app_with_persistence(client, coven_home.path(), project_root.path());
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
         app.attach_session("attached-session");
         assert!(!app.chat_owns_active_session);
 
@@ -3146,13 +3177,15 @@ mod tests {
         let coven_home = tempfile::tempdir().unwrap();
         let project_root = tempfile::tempdir().unwrap();
         let client = RecordingChatClient::default();
-        let (mut app, _) =
-            app_with_persistence(client, coven_home.path(), project_root.path());
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
         app.active_agent = Some(0); // codex
         app.input = "hi".to_string();
         app.cursor_pos = app.input.len();
         app.handle_input();
-        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let session_id = app
+            .active_session_id()
+            .expect("first launch sets id")
+            .to_string();
         assert!(!app.harness_conversation_ids.contains_key("codex"));
 
         // Stale phrase arrives during a turn that had no stored codex id —

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -507,9 +507,15 @@ impl App {
                 "Previous reply is still streaming. Wait for it to finish or press Ctrl+C to interrupt.",
             );
         } else {
-            // Always launch a fresh daemon session per chat turn; the harness
-            // CLI (today only Claude) carries conversation state through
-            // `--session-id` / `--resume`. See docs/chat-persistence.md.
+            // Route into the chat-launch path. Non-stream harnesses (codex
+            // today) cold-start a fresh daemon session per turn, carrying
+            // conversation state through the harness CLI's own resume
+            // mechanism (--session-id/--resume for claude when not in
+            // stream mode, `exec resume <id>` for codex). Stream-mode
+            // harnesses (claude on unix) take a fast-path inside
+            // `run_harness_prompt` that reuses the existing long-lived
+            // daemon session via `forward_input_to_session` instead.
+            // See docs/chat-persistence.md.
             self.launch_chat_session(&raw);
         }
         self.scroll_to_bottom();
@@ -547,9 +553,10 @@ impl App {
     }
 
     /// Kill every tracked stream-mode daemon session and clear our local
-    /// map. Best-effort: kill failures are logged but don't block the
-    /// caller. Used by `/clear` and `/new` to ensure the next message
-    /// cold-starts a fresh stream process.
+    /// map (including the per-session JSON buffers — leaving those behind
+    /// would leak across a long chat). Best-effort: kill failures are
+    /// logged but don't block the caller. Used by `/clear` and `/new` to
+    /// ensure the next message cold-starts a fresh stream process.
     fn kill_all_stream_sessions(&mut self) {
         let ids: Vec<String> = self.harness_stream_session_ids.values().cloned().collect();
         for id in ids {
@@ -558,6 +565,7 @@ impl App {
                     "Stream session {id} kill failed: {error}. Daemon may still hold it."
                 ));
             }
+            self.stream_json_buffers.remove(&id);
         }
         self.harness_stream_session_ids.clear();
     }
@@ -1214,11 +1222,14 @@ impl App {
         }
         self.harness_conversation_ids.remove(&harness);
         // The dying stream session (if any) can't be reused: claude rejected
-        // its --resume id and is about to exit. Drop it so the auto-retry
-        // cold-starts a fresh stream process instead of forwarding to a
-        // half-dead pipe. The eventual exit event will be ignored thanks
-        // to the suppression entry below.
-        self.harness_stream_session_ids.remove(&harness);
+        // its --resume id and is about to exit. Drop it (and its JSON
+        // line buffer) so the auto-retry cold-starts a fresh stream
+        // process instead of forwarding to a half-dead pipe. The
+        // eventual exit event will be ignored thanks to the suppression
+        // entry below.
+        if let Some(stale_stream_id) = self.harness_stream_session_ids.remove(&harness) {
+            self.stream_json_buffers.remove(&stale_stream_id);
+        }
         self.persist_conversations();
         // Hide any further output and the eventual exit event for the
         // failed session so the user only sees the system message + the
@@ -1396,9 +1407,11 @@ impl App {
                 }
                 // If a stream session for any harness died, drop its id so
                 // the next turn cold-starts a fresh one instead of
-                // forwarding to a dead pipe.
+                // forwarding to a dead pipe. Also drop its JSON buffer
+                // (partial lines from before the exit are stale now).
                 self.harness_stream_session_ids
                     .retain(|_, id| id != &event.session_id);
+                self.stream_json_buffers.remove(&event.session_id);
                 self.agent_output_mode = AgentOutputMode::Unknown;
                 self.push_system_message(&format!("Session {status}."));
             }
@@ -1412,6 +1425,7 @@ impl App {
                 }
                 self.harness_stream_session_ids
                     .retain(|_, id| id != &event.session_id);
+                self.stream_json_buffers.remove(&event.session_id);
                 self.agent_output_mode = AgentOutputMode::Unknown;
                 self.push_system_message("Session kill recorded.");
             }
@@ -2796,6 +2810,65 @@ mod tests {
                 .iter()
                 .any(|m| m.content.contains("warning: auth token expiring soon")),
             "stream-json stderr envelope must surface as a system message in the transcript"
+        );
+    }
+
+    #[test]
+    fn stream_session_exit_event_also_drops_the_per_session_json_buffer() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch").to_string();
+
+        // Feed a partial JSON line so the buffer has content to leak.
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"par"#,
+        ));
+        assert!(
+            app.stream_json_buffers.contains_key(&session_id),
+            "partial line must be buffered"
+        );
+
+        app.push_event_message(&EventRecord {
+            seq: 2,
+            id: "event-exit".to_string(),
+            session_id: session_id.clone(),
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+        assert!(
+            !app.stream_json_buffers.contains_key(&session_id),
+            "exit must drop the per-session JSON buffer so it doesn't leak across the chat"
+        );
+    }
+
+    #[test]
+    fn clear_transcript_drops_stream_json_buffers_too() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch").to_string();
+
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"par"#,
+        ));
+        assert!(app.stream_json_buffers.contains_key(&session_id));
+
+        app.clear_transcript();
+        assert!(
+            !app.stream_json_buffers.contains_key(&session_id),
+            "/clear must drop per-session JSON buffers along with the stream session ids"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1382,14 +1382,25 @@ impl App {
                     // {"type":"system","subtype":"stderr","text":...} so
                     // chat surfaces auth/setup errors instead of dropping
                     // them. Other system subtypes (init, etc.) stay silent.
+                    //
+                    // The stderr text comes from a subprocess we don't
+                    // control — it can contain ANSI escapes or other
+                    // control codes that would corrupt the TUI render.
+                    // Run it through `clean_terminal_output` to strip
+                    // those before pushing to the transcript.
                     let subtype = value
                         .get("subtype")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("");
                     if subtype == "stderr" {
                         if let Some(text) = value.get("text").and_then(serde_json::Value::as_str) {
-                            if !text.is_empty() {
-                                self.push_system_message(&format!("[{sender} stderr] {text}"));
+                            if let Some(safe) = clean_terminal_output(text) {
+                                let trimmed = safe.trim_end_matches('\n');
+                                if !trimmed.is_empty() {
+                                    self.push_system_message(&format!(
+                                        "[{sender} stderr] {trimmed}"
+                                    ));
+                                }
                             }
                         }
                     }

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -852,9 +852,21 @@ impl App {
         // making the user retype.
         self.last_chat_prompt = Some(prompt.to_string());
         let hint = self.conversation_hint_for_harness(harness);
-        let result = LaunchRequest::for_current_dir(harness, prompt).map(|request| match hint {
-            Some(hint) => request.with_conversation(hint),
-            None => request,
+        // Same map that holds the harness-CLI session id also serves as the
+        // ledger conversation id, so /sessions can collapse multi-turn
+        // threads. Codex's very first turn has no entry yet (we capture
+        // from output), so it lands as an ungrouped row — see
+        // `docs/chat-persistence.md`.
+        let conversation_id = self.harness_conversation_ids.get(harness).cloned();
+        let result = LaunchRequest::for_current_dir(harness, prompt).map(|request| {
+            let request = match hint {
+                Some(hint) => request.with_conversation(hint),
+                None => request,
+            };
+            match conversation_id {
+                Some(id) => request.with_conversation_id(id),
+                None => request,
+            }
         });
         let result = result.and_then(|request| self.client.launch_session(request));
         match result {
@@ -1988,6 +2000,7 @@ mod tests {
             archived_at: None,
             created_at: "2026-05-19T00:00:00Z".to_string(),
             updated_at: "2026-05-19T00:00:00Z".to_string(),
+            conversation_id: None,
         }
     }
 
@@ -2149,6 +2162,67 @@ mod tests {
             }
             other => panic!("expected Init after /clear, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn claude_chat_turn_carries_conversation_id_matching_the_init_uuid() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        let init_id = match &launched[0].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => id.clone(),
+            other => panic!("expected Init, got {other:?}"),
+        };
+        assert_eq!(
+            launched[0].conversation_id.as_deref(),
+            Some(init_id.as_str()),
+            "claude chat turns must carry conversation_id equal to the session uuid"
+        );
+    }
+
+    #[test]
+    fn codex_first_chat_turn_lands_without_conversation_id_then_subsequent_turns_carry_it() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(0); // codex
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        // First codex launch: no captured id yet, no conversation_id either.
+        assert!(mirror.launched.borrow()[0].conversation_id.is_none());
+
+        let session_id = app.active_session_id().expect("first launch").to_string();
+        let captured = "019eaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            &format!("session id: {captured}\n"),
+        ));
+        app.push_event_message(&EventRecord {
+            seq: 2,
+            id: "event-2".to_string(),
+            session_id,
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        app.input = "follow up".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 2);
+        assert_eq!(
+            launched[1].conversation_id.as_deref(),
+            Some(captured),
+            "second codex turn must carry the captured id as conversation_id"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1,8 +1,11 @@
 //! Chat application state, behavior, and helpers. Owns `App` and all of its
 //! methods; provides `discover_agents` and the spinner-frame data.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
+
+use uuid::Uuid;
 
 use crate::{
     harness, store,
@@ -100,6 +103,15 @@ pub(super) struct App {
     /// Timestamp of the most recent Ctrl+C press, used to require a double
     /// tap before exiting so a stray ^C doesn't kill the session.
     last_interrupt_at: Option<Instant>,
+    /// Per-harness conversation ids so chat turns reuse the harness CLI's
+    /// own session-resume mechanism (today only `claude --session-id` /
+    /// `--resume`). Reset on `/clear`. See `docs/chat-persistence.md`.
+    harness_conversation_ids: HashMap<String, String>,
+    /// True when `active_session_id` points at a session this chat launched
+    /// as a turn (so the next message should be a fresh launch + resume).
+    /// False when the user `/attach`ed an externally-spawned session, in
+    /// which case typing is forwarded as stdin to that PTY.
+    chat_owns_active_session: bool,
     client: Box<dyn ChatClient>,
 }
 
@@ -229,6 +241,8 @@ impl App {
             slash_suggestion_index: 0,
             slash_popup_dismissed: false,
             last_interrupt_at: None,
+            harness_conversation_ids: HashMap::new(),
+            chat_owns_active_session: false,
             client,
         };
 
@@ -407,9 +421,24 @@ impl App {
             return Some(result);
         }
 
-        if let Some(session_id) = self.active_session_id.clone() {
+        // If the user is talking to an externally-spawned session they
+        // `/attach`ed to, keep the legacy "type forwards as stdin" flow —
+        // it's how you drive a long-running `coven run` task. Chat-owned
+        // sessions take the resume path instead.
+        if let Some(session_id) = self
+            .active_session_id
+            .clone()
+            .filter(|_| !self.chat_owns_active_session)
+        {
             self.forward_input_to_session(&session_id, &raw);
+        } else if self.is_responding {
+            self.push_system_message(
+                "Previous reply is still streaming. Wait for it to finish or press Ctrl+C to interrupt.",
+            );
         } else {
+            // Always launch a fresh daemon session per chat turn; the harness
+            // CLI (today only Claude) carries conversation state through
+            // `--session-id` / `--resume`. See docs/chat-persistence.md.
             self.launch_chat_session(&raw);
         }
         self.scroll_to_bottom();
@@ -418,10 +447,12 @@ impl App {
 
     /// Clear the visible transcript and reset scroll, matching what `/clear`
     /// does. Used by Ctrl+L so the keybind doesn't have to fake a slash
-    /// command through the parser.
+    /// command through the parser. Also drops the harness conversation ids so
+    /// the next turn starts a fresh `--session-id`-claimed thread.
     pub(super) fn clear_transcript(&mut self) {
         self.messages.clear();
         self.scroll_offset = 0;
+        self.harness_conversation_ids.clear();
         self.push_system_message("Chat cleared.");
     }
 
@@ -744,11 +775,16 @@ impl App {
     fn run_harness_prompt(&mut self, harness: &str, prompt: &str) -> Option<store::SessionRecord> {
         self.is_responding = true;
         self.agent_output_mode = AgentOutputMode::Unknown;
-        let result = LaunchRequest::for_current_dir(harness, prompt)
-            .and_then(|request| self.client.launch_session(request));
+        let hint = self.conversation_hint_for_harness(harness);
+        let result = LaunchRequest::for_current_dir(harness, prompt).map(|request| match hint {
+            Some(hint) => request.with_conversation(hint),
+            None => request,
+        });
+        let result = result.and_then(|request| self.client.launch_session(request));
         match result {
             Ok(session) => {
                 self.active_session_id = Some(session.id.clone());
+                self.chat_owns_active_session = true;
                 self.last_event_seq = None;
                 self.reset_event_poll_failures();
                 self.push_system_message("Connected. Waiting for the reply.");
@@ -765,6 +801,26 @@ impl App {
         }
     }
 
+    /// Decide whether a launch for `harness` should ride a resumable chat
+    /// session, and if so produce the right hint (Init for the first turn,
+    /// Resume for subsequent turns). Records the id on first use so later
+    /// turns route through `--resume`.
+    fn conversation_hint_for_harness(&mut self, harness: &str) -> Option<harness::ConversationHint> {
+        if !harness_supports_chat_resume(harness) {
+            return None;
+        }
+        if let Some(id) = self.harness_conversation_ids.get(harness) {
+            return Some(harness::ConversationHint::Resume { id: id.clone() });
+        }
+        let id = Uuid::new_v4().to_string();
+        self.harness_conversation_ids
+            .insert(harness.to_string(), id.clone());
+        Some(harness::ConversationHint::Init { id })
+    }
+
+    /// Send raw text as stdin to a session the user `/attach`ed to (i.e. one
+    /// chat did not launch). Chat-owned sessions never take this path; they
+    /// resume via a fresh `--resume` launch instead.
     fn forward_input_to_session(&mut self, session_id: &str, raw: &str) {
         self.is_responding = true;
         let result = self.client.send_input(session_id, &format!("{raw}\n"));
@@ -781,6 +837,7 @@ impl App {
         match self.client.get_session(session_id) {
             Ok(session) => {
                 self.active_session_id = Some(session.id.clone());
+                self.chat_owns_active_session = false;
                 self.last_event_seq = None;
                 self.agent_output_mode = AgentOutputMode::Unknown;
                 self.reset_event_poll_failures();
@@ -833,6 +890,7 @@ impl App {
             Ok(()) => {
                 if self.active_session_id.as_deref() == Some(session_id) {
                     self.active_session_id = None;
+                    self.chat_owns_active_session = false;
                 }
                 self.push_system_message(&format!("Sacrificed session {session_id}."));
             }
@@ -927,6 +985,7 @@ impl App {
                 self.is_responding = false;
                 if self.active_session_id.as_deref() == Some(event.session_id.as_str()) {
                     self.active_session_id = None;
+                    self.chat_owns_active_session = false;
                 }
                 self.agent_output_mode = AgentOutputMode::Unknown;
                 self.push_system_message(&format!("Session {status}."));
@@ -935,6 +994,7 @@ impl App {
                 self.flush_pending_agent_buffer();
                 if self.active_session_id.as_deref() == Some(event.session_id.as_str()) {
                     self.active_session_id = None;
+                    self.chat_owns_active_session = false;
                     self.is_responding = false;
                 }
                 self.agent_output_mode = AgentOutputMode::Unknown;
@@ -1319,6 +1379,15 @@ fn is_chat_local_slash(input: &str) -> bool {
 fn should_keep_launch_inline(plan: &CastPlan) -> bool {
     !matches!(plan.intent, CastIntent::NaturalSpell { .. })
         || !matches!(plan.risk(), CastRisk::Safe)
+}
+
+/// Whether a chat turn launched against this harness should reuse the prior
+/// turn's conversation via the harness CLI's session-resume mechanism. Today
+/// only Claude supports this through `--session-id` / `--resume`; Codex
+/// support would land in `harness::continuity_args`. See
+/// `docs/chat-persistence.md`.
+fn harness_supports_chat_resume(harness: &str) -> bool {
+    harness == "claude"
 }
 
 fn format_cast_plan_for_chat(plan: &CastPlan) -> String {
@@ -1719,7 +1788,149 @@ mod tests {
     }
 
     #[test]
-    fn plain_chat_input_launches_interactive_daemon_session_without_mock_response() {
+    fn first_claude_chat_turn_attaches_init_conversation_hint() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 1);
+        assert_eq!(launched[0].harness, "claude");
+        match &launched[0].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => {
+                assert!(!id.is_empty(), "Init id must be a non-empty uuid");
+            }
+            other => panic!("first turn should carry Init hint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn second_claude_chat_turn_reuses_init_id_as_resume() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let first_session_id = app.active_session_id().expect("first launch sets id").to_string();
+        let init_id = match &mirror.launched.borrow()[0].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => id.clone(),
+            other => panic!("first turn should be Init, got {other:?}"),
+        };
+
+        // Simulate harness exit so the next turn isn't gated by is_responding.
+        app.push_event_message(&EventRecord {
+            seq: 1,
+            id: "event-1".to_string(),
+            session_id: first_session_id,
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        app.input = "second".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 2);
+        match &launched[1].conversation {
+            Some(crate::harness::ConversationHint::Resume { id }) => {
+                assert_eq!(id, &init_id, "second turn must resume the first turn's id");
+            }
+            other => panic!("second turn should carry Resume hint, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clear_transcript_drops_conversation_ids_so_next_turn_is_init() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        app.push_event_message(&EventRecord {
+            seq: 1,
+            id: "event-1".to_string(),
+            session_id,
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        app.clear_transcript();
+
+        app.input = "fresh".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 2);
+        let init_id_1 = match &launched[0].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => id.clone(),
+            other => panic!("expected first Init, got {other:?}"),
+        };
+        match &launched[1].conversation {
+            Some(crate::harness::ConversationHint::Init { id }) => {
+                assert_ne!(id, &init_id_1, "/clear should yield a fresh conversation id");
+            }
+            other => panic!("expected Init after /clear, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_chat_turn_carries_no_conversation_hint_today() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(0); // codex
+        app.input = "do a thing".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 1);
+        assert_eq!(launched[0].harness, "codex");
+        assert!(
+            launched[0].conversation.is_none(),
+            "codex has no resume support yet — see docs/chat-persistence.md"
+        );
+    }
+
+    #[test]
+    fn chat_input_while_responding_does_not_launch_a_second_session() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        assert!(app.is_responding, "first turn should set is_responding");
+
+        // Second send while previous reply is still streaming.
+        app.input = "too soon".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        assert_eq!(
+            mirror.launched.borrow().len(),
+            1,
+            "second send while is_responding must not launch a fresh session"
+        );
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("still streaming")));
+    }
+
+    #[test]
+    fn plain_chat_input_launches_non_interactive_daemon_session_without_mock_response() {
         let client = RecordingChatClient::default();
         let (mut app, mirror) = app_with_client(client);
         app.input = "summarize the repo".to_string();
@@ -1734,7 +1945,7 @@ mod tests {
         assert_eq!(launched[0].prompt, "summarize the repo");
         assert_eq!(
             launched[0].launch_mode,
-            crate::harness::HarnessLaunchMode::Interactive
+            crate::harness::HarnessLaunchMode::NonInteractive
         );
         assert!(app.active_session_id().is_some());
         assert!(app.messages.iter().any(|message| message

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -552,11 +552,22 @@ impl App {
         );
     }
 
+    /// Best-effort shutdown for the chat App: tears down any long-lived
+    /// stream-mode daemon sessions so they don't outlive `coven chat`.
+    /// Called by `run_chat` on every exit path (slash `/exit`, double
+    /// Ctrl+C, Ctrl+D, panic-free unwind of the event loop). Safe to
+    /// call multiple times — `kill_all_stream_sessions` is idempotent on
+    /// an empty map.
+    pub(super) fn shutdown(&mut self) {
+        self.kill_all_stream_sessions();
+    }
+
     /// Kill every tracked stream-mode daemon session and clear our local
     /// map (including the per-session JSON buffers — leaving those behind
     /// would leak across a long chat). Best-effort: kill failures are
-    /// logged but don't block the caller. Used by `/clear` and `/new` to
-    /// ensure the next message cold-starts a fresh stream process.
+    /// logged but don't block the caller. Used by `/clear`, `/new`, and
+    /// `shutdown` to ensure the next message cold-starts a fresh stream
+    /// process (or no process at all, on exit).
     fn kill_all_stream_sessions(&mut self) {
         let ids: Vec<String> = self.harness_stream_session_ids.values().cloned().collect();
         for id in ids {
@@ -1101,7 +1112,14 @@ impl App {
             Ok(session) => {
                 self.push_system_message(&format!("Summoned session {session_id}."));
                 self.active_session_id = Some(session.id.clone());
+                self.active_session_harness = Some(session.harness.clone());
+                // Summon attaches to an externally-spawned (or
+                // previously-archived) session; treat it like /attach so
+                // typing forwards to its PTY stdin instead of cold-
+                // starting a chat turn over it.
+                self.chat_owns_active_session = false;
                 self.last_event_seq = None;
+                self.agent_output_mode = AgentOutputMode::Unknown;
                 self.reset_event_poll_failures();
                 self.push_system_message(&format!(
                     "Attached to daemon session {} ({}, {})",
@@ -2821,6 +2839,33 @@ mod tests {
                 .iter()
                 .any(|m| m.content.contains("warning: auth token expiring soon")),
             "stream-json stderr envelope must surface as a system message in the transcript"
+        );
+    }
+
+    #[test]
+    fn shutdown_kills_tracked_stream_sessions_and_clears_state() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let stream_id = app.active_session_id().expect("first launch").to_string();
+        assert!(!app.harness_stream_session_ids.is_empty());
+
+        app.shutdown();
+
+        assert!(
+            app.harness_stream_session_ids.is_empty(),
+            "shutdown must clear tracked stream session ids"
+        );
+        assert!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .any(|c| c == &format!("kill:{stream_id}")),
+            "shutdown must issue a kill for each tracked stream session so chat exit doesn't leak a claude process"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -143,6 +143,13 @@ pub(super) struct App {
     /// cold-start). Cleared on session exit/kill/`/clear`/`/new`. Today
     /// only claude is stream-capable. See `docs/chat-persistence.md`.
     harness_stream_session_ids: HashMap<String, String>,
+    /// Per-stream-session accumulator for partial JSON lines. Daemon
+    /// output events come from 8KiB reads of the child's stdout; a single
+    /// JSON line can be split across two events. We buffer the trailing
+    /// partial line here and prepend it to the next event so
+    /// `dispatch_stream_json_output` only ever tries to parse complete
+    /// newline-terminated lines.
+    stream_json_buffers: HashMap<String, String>,
     client: Box<dyn ChatClient>,
 }
 
@@ -304,6 +311,7 @@ impl App {
             auto_retry_consumed: false,
             suppressed_session_ids: HashSet::new(),
             harness_stream_session_ids: HashMap::new(),
+            stream_json_buffers: HashMap::new(),
             client,
         };
 
@@ -1006,12 +1014,24 @@ impl App {
         }
     }
 
-    /// Send raw text as stdin to a session the user `/attach`ed to (i.e. one
-    /// chat did not launch). Chat-owned sessions never take this path; they
-    /// resume via a fresh `--resume` launch instead.
+    /// Send raw text as stdin to a session — either one the user
+    /// `/attach`ed to (PTY-backed) or one of our own long-lived stream
+    /// sessions. PTY sessions need a trailing newline so Enter submits;
+    /// stream sessions don't, because the daemon wraps the payload in a
+    /// JSON envelope verbatim and the inner `\n` would otherwise leak
+    /// into the user message text on every turn after the first.
     fn forward_input_to_session(&mut self, session_id: &str, raw: &str) {
         self.is_responding = true;
-        let result = self.client.send_input(session_id, &format!("{raw}\n"));
+        let is_stream = self
+            .harness_stream_session_ids
+            .values()
+            .any(|id| id == session_id);
+        let payload = if is_stream {
+            raw.to_string()
+        } else {
+            format!("{raw}\n")
+        };
+        let result = self.client.send_input(session_id, &payload);
         match result {
             Ok(()) => self.poll_session_events(),
             Err(error) => {
@@ -1238,9 +1258,24 @@ impl App {
     /// other event types (system init, rate_limit_event, …) are ignored
     /// for now. Malformed lines are silently dropped — stream-mode is too
     /// noisy to surface every parse error.
-    fn dispatch_stream_json_output(&mut self, _session_id: &str, data: &str) {
+    fn dispatch_stream_json_output(&mut self, session_id: &str, data: &str) {
         let sender = self.active_agent_label().to_string();
-        for line in data.split('\n') {
+        // Daemon output events come from raw 8KiB reads, so a JSON line
+        // can be split across two events. Buffer the trailing partial
+        // line and prepend it to the next chunk so we only try to parse
+        // complete newline-terminated lines.
+        let buffer = self
+            .stream_json_buffers
+            .entry(session_id.to_string())
+            .or_default();
+        buffer.push_str(data);
+        let (complete, remainder) = match buffer.rfind('\n') {
+            Some(idx) => (buffer[..=idx].to_string(), buffer[idx + 1..].to_string()),
+            None => (String::new(), std::mem::take(buffer)),
+        };
+        *buffer = remainder;
+
+        for line in complete.split('\n') {
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
@@ -1260,27 +1295,44 @@ impl App {
                     else {
                         continue;
                     };
-                    let mut buffer = String::new();
+                    let mut chunk = String::new();
                     for block in content {
                         if block.get("type").and_then(serde_json::Value::as_str) == Some("text") {
                             if let Some(text) =
                                 block.get("text").and_then(serde_json::Value::as_str)
                             {
-                                buffer.push_str(text);
+                                chunk.push_str(text);
                             }
                         }
                     }
-                    if !buffer.is_empty() {
+                    if !chunk.is_empty() {
                         if self.streaming_mode.is_live() {
-                            self.push_or_append_agent_message(&sender, &buffer);
+                            self.push_or_append_agent_message(&sender, &chunk);
                         } else {
-                            self.buffer_pending_agent_output(&sender, &buffer);
+                            self.buffer_pending_agent_output(&sender, &chunk);
                         }
                     }
                 }
                 "result" => {
                     self.flush_pending_agent_buffer();
                     self.is_responding = false;
+                }
+                "system" => {
+                    // Daemon wraps stream-mode child stderr in
+                    // {"type":"system","subtype":"stderr","text":...} so
+                    // chat surfaces auth/setup errors instead of dropping
+                    // them. Other system subtypes (init, etc.) stay silent.
+                    let subtype = value
+                        .get("subtype")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
+                    if subtype == "stderr" {
+                        if let Some(text) = value.get("text").and_then(serde_json::Value::as_str) {
+                            if !text.is_empty() {
+                                self.push_system_message(&format!("[{sender} stderr] {text}"));
+                            }
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -2628,8 +2680,8 @@ mod tests {
                 .calls
                 .borrow()
                 .iter()
-                .any(|call| call == &format!("input:{stream_session_id}:second\n")),
-            "second turn must forward via send_input to the existing stream session"
+                .any(|call| call == &format!("input:{stream_session_id}:second")),
+            "second turn must forward via send_input to the existing stream session WITHOUT a trailing newline (the daemon wraps payload verbatim in a JSON envelope; a literal \\n would leak into the user message text)"
         );
     }
 
@@ -2685,6 +2737,66 @@ mod tests {
             r#"{"type":"result","subtype":"success","is_error":false}"#.to_string() + "\n";
         app.push_event_message(&output_event(2, &session_id, &result_chunk));
         assert!(!app.is_responding, "result event must clear is_responding");
+    }
+
+    #[test]
+    fn stream_json_assistant_split_across_two_output_chunks_still_renders_correctly() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch").to_string();
+
+        // Realistic case: the daemon's 8KiB read split a single JSON line
+        // exactly in the middle. Without buffering, both halves are
+        // unparseable and the assistant text would be dropped silently.
+        let full_line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello from split."}]}}"#;
+        let split_at = full_line.len() / 2;
+        let (head, tail) = full_line.split_at(split_at);
+
+        app.push_event_message(&output_event(1, &session_id, head));
+        // After the first chunk there's no newline yet, so nothing renders.
+        assert!(
+            !app.messages
+                .iter()
+                .any(|m| m.content.contains("Hello from split.")),
+            "first chunk alone must not render — line isn't complete"
+        );
+
+        // The second chunk completes the line; render now.
+        app.push_event_message(&output_event(2, &session_id, &format!("{tail}\n")));
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("Hello from split.")),
+            "rejoined line must parse and render after the trailing newline arrives"
+        );
+    }
+
+    #[test]
+    fn stream_json_stderr_envelope_renders_as_system_message() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch").to_string();
+
+        let stderr_chunk =
+            r#"{"type":"system","subtype":"stderr","text":"warning: auth token expiring soon"}"#
+                .to_string()
+                + "\n";
+        app.push_event_message(&output_event(1, &session_id, &stderr_chunk));
+
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("warning: auth token expiring soon")),
+            "stream-json stderr envelope must surface as a system message in the transcript"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1315,6 +1315,17 @@ impl App {
                 self.run_harness_prompt(&harness, &prompt);
             }
             None => {
+                // No auto-retry: clear the active-session state now so
+                // the user's next message isn't gated as "still
+                // streaming". Without this, the failed session's
+                // events stay suppressed (so exit/kill won't reach
+                // the normal state-reset arms in push_event_message),
+                // and the chat wedges with `is_responding == true`
+                // forever.
+                self.is_responding = false;
+                self.active_session_id = None;
+                self.active_session_harness = None;
+                self.chat_owns_active_session = false;
                 self.push_system_message(&format!(
                     "Prior {harness} conversation no longer exists. Send your message again to start a fresh one."
                 ));
@@ -3568,6 +3579,31 @@ mod tests {
                 .iter()
                 .any(|m| m.content.contains("Send your message again")),
             "second stale event falls back to asking the user to retype"
+        );
+        // The fallback path must also clear the wedged state so the
+        // user's NEXT message can actually be sent — otherwise
+        // is_responding stays true forever (failed session's exit
+        // event is suppressed, normal state-reset arms in
+        // push_event_message never run).
+        assert!(
+            !app.is_responding,
+            "after the retry-exhausted fallback, is_responding must be cleared so the next message isn't gated"
+        );
+        assert!(
+            app.active_session_id().is_none(),
+            "after the retry-exhausted fallback, active_session_id must be cleared so the next message launches fresh"
+        );
+
+        // And prove the chat is actually usable: send a new message, it
+        // should produce a fresh launch instead of being rejected.
+        let launches_before_retype = mirror.launched.borrow().len();
+        app.input = "second attempt".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        assert_eq!(
+            mirror.launched.borrow().len(),
+            launches_before_retype + 1,
+            "user's manual retype after retry-exhausted fallback must produce a fresh launch, not a still-streaming rejection"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -112,6 +112,9 @@ pub(super) struct App {
     /// False when the user `/attach`ed an externally-spawned session, in
     /// which case typing is forwarded as stdin to that PTY.
     chat_owns_active_session: bool,
+    /// Harness id of `active_session_id`. Used to decide whether output from
+    /// the active session is worth scanning for a codex session-id banner.
+    active_session_harness: Option<String>,
     client: Box<dyn ChatClient>,
 }
 
@@ -243,6 +246,7 @@ impl App {
             last_interrupt_at: None,
             harness_conversation_ids: HashMap::new(),
             chat_owns_active_session: false,
+            active_session_harness: None,
             client,
         };
 
@@ -784,6 +788,7 @@ impl App {
         match result {
             Ok(session) => {
                 self.active_session_id = Some(session.id.clone());
+                self.active_session_harness = Some(session.harness.clone());
                 self.chat_owns_active_session = true;
                 self.last_event_seq = None;
                 self.reset_event_poll_failures();
@@ -802,9 +807,11 @@ impl App {
     }
 
     /// Decide whether a launch for `harness` should ride a resumable chat
-    /// session, and if so produce the right hint (Init for the first turn,
-    /// Resume for subsequent turns). Records the id on first use so later
-    /// turns route through `--resume`.
+    /// session, and if so produce the right hint. For harnesses where we can
+    /// pre-assign the session id (claude `--session-id`) the first turn sends
+    /// `Init` with a freshly generated UUID. For harnesses that auto-assign
+    /// (codex) the first turn sends no hint and the id is captured from
+    /// output afterwards via `capture_session_id_from_output`.
     fn conversation_hint_for_harness(&mut self, harness: &str) -> Option<harness::ConversationHint> {
         if !harness_supports_chat_resume(harness) {
             return None;
@@ -812,10 +819,14 @@ impl App {
         if let Some(id) = self.harness_conversation_ids.get(harness) {
             return Some(harness::ConversationHint::Resume { id: id.clone() });
         }
-        let id = Uuid::new_v4().to_string();
-        self.harness_conversation_ids
-            .insert(harness.to_string(), id.clone());
-        Some(harness::ConversationHint::Init { id })
+        if harness::harness_supports_preassigned_session_id(harness) {
+            let id = Uuid::new_v4().to_string();
+            self.harness_conversation_ids
+                .insert(harness.to_string(), id.clone());
+            Some(harness::ConversationHint::Init { id })
+        } else {
+            None
+        }
     }
 
     /// Send raw text as stdin to a session the user `/attach`ed to (i.e. one
@@ -837,6 +848,7 @@ impl App {
         match self.client.get_session(session_id) {
             Ok(session) => {
                 self.active_session_id = Some(session.id.clone());
+                self.active_session_harness = Some(session.harness.clone());
                 self.chat_owns_active_session = false;
                 self.last_event_seq = None;
                 self.agent_output_mode = AgentOutputMode::Unknown;
@@ -890,6 +902,7 @@ impl App {
             Ok(()) => {
                 if self.active_session_id.as_deref() == Some(session_id) {
                     self.active_session_id = None;
+                    self.active_session_harness = None;
                     self.chat_owns_active_session = false;
                 }
                 self.push_system_message(&format!("Sacrificed session {session_id}."));
@@ -962,10 +975,30 @@ impl App {
         }
     }
 
+    /// Codex auto-assigns a session id on its first turn and prints it in
+    /// the run header (`session id: <uuid>`). When this chat owns a running
+    /// codex session and we haven't captured its id yet, scan the chunk for
+    /// the banner so the *next* turn can `codex exec resume <id> <prompt>`.
+    fn maybe_capture_codex_session_id(&mut self, data: &str) {
+        if !self.chat_owns_active_session {
+            return;
+        }
+        if self.active_session_harness.as_deref() != Some("codex") {
+            return;
+        }
+        if self.harness_conversation_ids.contains_key("codex") {
+            return;
+        }
+        if let Some(id) = extract_codex_session_id(data) {
+            self.harness_conversation_ids.insert("codex".to_string(), id);
+        }
+    }
+
     fn push_event_message(&mut self, event: &store::EventRecord) {
         match event.kind.as_str() {
             "output" => {
                 if let Some(data) = event_payload_text(event, "data") {
+                    self.maybe_capture_codex_session_id(&data);
                     let sender = self.active_agent_label().to_string();
                     if let Some(text) =
                         human_facing_agent_output(&data, &mut self.agent_output_mode)
@@ -985,6 +1018,7 @@ impl App {
                 self.is_responding = false;
                 if self.active_session_id.as_deref() == Some(event.session_id.as_str()) {
                     self.active_session_id = None;
+                    self.active_session_harness = None;
                     self.chat_owns_active_session = false;
                 }
                 self.agent_output_mode = AgentOutputMode::Unknown;
@@ -994,6 +1028,7 @@ impl App {
                 self.flush_pending_agent_buffer();
                 if self.active_session_id.as_deref() == Some(event.session_id.as_str()) {
                     self.active_session_id = None;
+                    self.active_session_harness = None;
                     self.chat_owns_active_session = false;
                     self.is_responding = false;
                 }
@@ -1382,12 +1417,29 @@ fn should_keep_launch_inline(plan: &CastPlan) -> bool {
 }
 
 /// Whether a chat turn launched against this harness should reuse the prior
-/// turn's conversation via the harness CLI's session-resume mechanism. Today
-/// only Claude supports this through `--session-id` / `--resume`; Codex
-/// support would land in `harness::continuity_args`. See
-/// `docs/chat-persistence.md`.
+/// turn's conversation via the harness CLI's session-resume mechanism. See
+/// `docs/chat-persistence.md` for the per-harness mechanics.
 fn harness_supports_chat_resume(harness: &str) -> bool {
-    harness == "claude"
+    matches!(harness, "claude" | "codex")
+}
+
+/// Scan `data` (a chunk of cleaned-but-not-line-filtered harness output) for a
+/// codex session-id banner line and return the uuid if present. Codex prints
+/// `session id: <uuid>` in the header of every `codex exec` run; we capture
+/// it so the next chat turn can `codex exec resume <id> <prompt>`.
+fn extract_codex_session_id(data: &str) -> Option<String> {
+    const PREFIX: &str = "session id:";
+    for line in data.lines() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix(PREFIX) else {
+            continue;
+        };
+        let id = rest.trim();
+        if !id.is_empty() {
+            return Some(id.to_string());
+        }
+    }
+    None
 }
 
 fn format_cast_plan_for_chat(plan: &CastPlan) -> String {
@@ -1885,7 +1937,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_chat_turn_carries_no_conversation_hint_today() {
+    fn codex_first_chat_turn_carries_no_hint_so_codex_can_assign_its_own_session_id() {
         let client = RecordingChatClient::default();
         let (mut app, mirror) = app_with_client(client);
         app.active_agent = Some(0); // codex
@@ -1899,8 +1951,94 @@ mod tests {
         assert_eq!(launched[0].harness, "codex");
         assert!(
             launched[0].conversation.is_none(),
-            "codex has no resume support yet — see docs/chat-persistence.md"
+            "codex auto-assigns ids; first turn must not carry a hint"
         );
+    }
+
+    #[test]
+    fn second_codex_chat_turn_resumes_using_id_captured_from_first_turn_output() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_agent = Some(0); // codex
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+
+        // Simulate codex emitting its session-id banner mid-stream.
+        let captured_id = "019e5998-7130-7872-8d96-a6b67c5b6406";
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            &format!("OpenAI Codex v0.132.0\n--------\nsession id: {captured_id}\n--------\n"),
+        ));
+        // And then exit so we can fire the next turn without is_responding gating.
+        app.push_event_message(&EventRecord {
+            seq: 2,
+            id: "event-2".to_string(),
+            session_id,
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        app.input = "follow up".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        assert_eq!(launched.len(), 2);
+        match &launched[1].conversation {
+            Some(crate::harness::ConversationHint::Resume { id }) => {
+                assert_eq!(id, captured_id);
+            }
+            other => panic!("second codex turn must Resume with captured id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_session_id_capture_is_not_overridden_by_later_output() {
+        let client = RecordingChatClient::default();
+        let (mut app, _mirror) = app_with_client(client);
+        app.active_agent = Some(0); // codex
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+
+        let first_id = "019e5998-7130-7872-8d96-a6b67c5b6406";
+        let later_id = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            &format!("session id: {first_id}\n"),
+        ));
+        // Another id later in the same turn must not clobber the captured one.
+        app.push_event_message(&output_event(
+            2,
+            &session_id,
+            &format!("session id: {later_id}\n"),
+        ));
+
+        assert_eq!(
+            app.harness_conversation_ids.get("codex").map(String::as_str),
+            Some(first_id),
+            "first captured id must stick"
+        );
+    }
+
+    #[test]
+    fn extract_codex_session_id_parses_banner_lines_only() {
+        assert_eq!(
+            extract_codex_session_id("session id: 019e5998-7130-7872-8d96-a6b67c5b6406"),
+            Some("019e5998-7130-7872-8d96-a6b67c5b6406".to_string())
+        );
+        assert_eq!(
+            extract_codex_session_id("workdir: /tmp\n--------\nsession id: abc-123\n"),
+            Some("abc-123".to_string())
+        );
+        assert_eq!(extract_codex_session_id("session id:\n"), None);
+        assert_eq!(extract_codex_session_id("hello world"), None);
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1,7 +1,7 @@
 //! Chat application state, behavior, and helpers. Owns `App` and all of its
 //! methods; provides `discover_agents` and the spinner-frame data.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -130,6 +130,12 @@ pub(super) struct App {
     /// budget; prevents an infinite loop if the retry itself somehow hits
     /// stale-detection too.
     auto_retry_consumed: bool,
+    /// Session ids whose events should be hidden from the visible
+    /// transcript. Populated when stale-recovery fires so the raw harness
+    /// error chunk, any trailing teardown output, and the orphaned exit
+    /// event don't clutter the chat after we've already kicked off a
+    /// retry. Entries are cleared once their exit (or kill) event arrives.
+    suppressed_session_ids: HashSet<String>,
     client: Box<dyn ChatClient>,
 }
 
@@ -285,6 +291,7 @@ impl App {
             active_session_harness: None,
             last_chat_prompt: None,
             auto_retry_consumed: false,
+            suppressed_session_ids: HashSet::new(),
             client,
         };
 
@@ -1094,6 +1101,12 @@ impl App {
         }
         self.harness_conversation_ids.remove(&harness);
         self.persist_conversations();
+        // Hide any further output and the eventual exit event for the
+        // failed session so the user only sees the system message + the
+        // retry's reply.
+        if let Some(failed_session_id) = self.active_session_id.clone() {
+            self.suppressed_session_ids.insert(failed_session_id);
+        }
 
         // Try to auto-resend so the user doesn't have to retype. Skip if
         // we've already retried this turn (defense against a retry that
@@ -1120,11 +1133,26 @@ impl App {
     }
 
     fn push_event_message(&mut self, event: &store::EventRecord) {
+        // Drop events from sessions we've decided to hide (today: failed
+        // sessions whose stale-id we already auto-recovered from). Clear
+        // the entry once the session has reached a terminal event so the
+        // set doesn't grow over the chat lifetime.
+        if self.suppressed_session_ids.contains(&event.session_id) {
+            if matches!(event.kind.as_str(), "exit" | "kill") {
+                self.suppressed_session_ids.remove(&event.session_id);
+            }
+            return;
+        }
         match event.kind.as_str() {
             "output" => {
                 if let Some(data) = event_payload_text(event, "data") {
                     self.maybe_capture_codex_session_id(&data);
                     self.maybe_clear_stale_conversation_id(&data);
+                    // The stale handler may have just suppressed this very
+                    // session; if so, skip displaying this chunk too.
+                    if self.suppressed_session_ids.contains(&event.session_id) {
+                        return;
+                    }
                     let sender = self.active_agent_label().to_string();
                     if let Some(text) =
                         human_facing_agent_output(&data, &mut self.agent_output_mode)
@@ -2403,6 +2431,115 @@ mod tests {
                 .iter()
                 .any(|m| m.content.contains("re-sending your message")),
             "user must see a system message about the auto-retry"
+        );
+    }
+
+    #[test]
+    fn stale_recovery_hides_raw_error_chunk_and_failed_session_exit_from_transcript() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let stored_id = "fab1efac-1234-5678-9abc-def012345678";
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), stored_id.to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hello again".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let failed_session = app.active_session_id().expect("first launch").to_string();
+
+        // The chunk that contains the stale phrase.
+        app.push_event_message(&output_event(
+            1,
+            &failed_session,
+            &format!("No conversation found with session ID: {stored_id}\n"),
+        ));
+        // A trailing chunk from the same failed session (ANSI cleanup, etc.).
+        app.push_event_message(&output_event(
+            2,
+            &failed_session,
+            "trailing teardown noise\n",
+        ));
+        // And finally the failed session's exit event.
+        app.push_event_message(&EventRecord {
+            seq: 3,
+            id: "event-exit".to_string(),
+            session_id: failed_session.clone(),
+            kind: "exit".to_string(),
+            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        });
+
+        // None of the failed session's content (raw error, trailing noise,
+        // "Session completed.") should appear in the transcript.
+        let transcript: Vec<&str> = app
+            .messages
+            .iter()
+            .map(|m| m.content.as_str())
+            .collect();
+        for content in &transcript {
+            assert!(
+                !content.contains("No conversation found with session ID"),
+                "raw stale error must be hidden, found: {content}"
+            );
+            assert!(
+                !content.contains("trailing teardown noise"),
+                "trailing output from the failed session must be hidden, found: {content}"
+            );
+            assert!(
+                !content.contains("Session completed"),
+                "orphaned exit message from the failed session must be hidden, found: {content}"
+            );
+        }
+        // The system message and the retry's "Connected" line should be visible.
+        assert!(transcript.iter().any(|c| c.contains("re-sending your message")));
+        assert!(transcript.iter().any(|c| c.contains("Connected")));
+        // Suppression entry must be cleared once the exit is consumed.
+        assert!(!app.suppressed_session_ids.contains(&failed_session));
+    }
+
+    #[test]
+    fn suppression_only_applies_to_the_failed_session_not_other_sessions() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let stored_id = "fab1efac-1234-5678-9abc-def012345678";
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), stored_id.to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let failed_session = app.active_session_id().expect("first launch").to_string();
+
+        app.push_event_message(&output_event(
+            1,
+            &failed_session,
+            &format!("No conversation found with session ID: {stored_id}\n"),
+        ));
+        let retry_session = app.active_session_id().expect("retry session").to_string();
+        assert_ne!(retry_session, failed_session);
+
+        // Output from the retry session must still be rendered.
+        app.push_event_message(&output_event(
+            2,
+            &retry_session,
+            "Hi from the new conversation.\n",
+        ));
+
+        assert!(
+            app.messages
+                .iter()
+                .any(|m| m.content.contains("Hi from the new conversation")),
+            "retry-session output must not be suppressed"
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1398,13 +1398,30 @@ impl App {
                     // control — it can contain ANSI escapes or other
                     // control codes that would corrupt the TUI render.
                     // Run it through `clean_terminal_output` to strip
-                    // those before pushing to the transcript.
+                    // those before pushing to the transcript. We also
+                    // pipe stderr text through `maybe_clear_stale_conversation_id`
+                    // here (instead of the broad chunk-level check in
+                    // `push_event_message`) so stale-id auto-retry
+                    // never fires off assistant prose that happens to
+                    // quote the error phrase.
                     let subtype = value
                         .get("subtype")
                         .and_then(serde_json::Value::as_str)
                         .unwrap_or("");
                     if subtype == "stderr" {
                         if let Some(text) = value.get("text").and_then(serde_json::Value::as_str) {
+                            self.maybe_clear_stale_conversation_id(text);
+                            // If the stale handler just suppressed this
+                            // session, skip rendering the raw stderr
+                            // line — the auto-retry's "Prior X
+                            // conversation no longer exists. Starting a
+                            // new one and re-sending your message."
+                            // system message tells the user what they
+                            // need to know, and the raw harness error
+                            // would just be noise after it.
+                            if self.suppressed_session_ids.contains(session_id) {
+                                continue;
+                            }
                             if let Some(safe) = clean_terminal_output(text) {
                                 let trimmed = safe.trim_end_matches('\n');
                                 if !trimmed.is_empty() {
@@ -1436,21 +1453,33 @@ impl App {
             "output" => {
                 if let Some(data) = event_payload_text(event, "data") {
                     self.maybe_capture_codex_session_id(&data);
-                    self.maybe_clear_stale_conversation_id(&data);
+                    // Stale-id detection is scoped per-mode to avoid
+                    // false-positive auto-retries on assistant text
+                    // that happens to quote the error phrase. Stream
+                    // mode runs stale checks ONLY against the stderr
+                    // text inside `{"type":"system","subtype":"stderr"}`
+                    // envelopes (see `dispatch_stream_json_output`); we
+                    // skip the broad text match here. PTY mode (NonInteractive
+                    // codex / fallback claude) doesn't have a JSON
+                    // structure to lean on, so we still run the broad
+                    // match on the raw chunk.
+                    let is_stream = self
+                        .harness_stream_session_ids
+                        .values()
+                        .any(|id| id == &event.session_id);
+                    if !is_stream {
+                        self.maybe_clear_stale_conversation_id(&data);
+                    }
                     // The stale handler may have just suppressed this very
                     // session; if so, skip displaying this chunk too.
                     if self.suppressed_session_ids.contains(&event.session_id) {
                         return;
                     }
-                    // Stream-mode output is newline-delimited JSON. Parse
-                    // assistant text directly out of it instead of feeding
-                    // it through the text/ANSI cleaner meant for PTY
-                    // sessions.
-                    let is_stream = self
-                        .harness_stream_session_ids
-                        .values()
-                        .any(|id| id == &event.session_id);
                     if is_stream {
+                        // Stream-mode output is newline-delimited JSON.
+                        // dispatch_stream_json_output extracts assistant
+                        // text from envelopes AND scopes stale detection
+                        // to system/stderr text only.
                         self.dispatch_stream_json_output(&event.session_id, &data);
                         return;
                     }
@@ -1895,20 +1924,15 @@ fn harness_supports_chat_resume(harness: &str) -> bool {
 /// pattern-match on their distinctive error wording. See
 /// `docs/chat-persistence.md` under "stale-id auto-recovery".
 ///
-/// The match is intentionally a broad `contains` rather than a strict
-/// per-line / per-envelope check because the same phrase appears in both
-/// the PTY mode (NonInteractive) plain-text output and the Stream mode
-/// stderr envelope (`{"type":"system","subtype":"stderr","text":"…"}`),
-/// and a single regex needs to handle both. The phrases ("No conversation
-/// found with session ID", "no rollout found for thread id",
-/// "thread/resume failed") are distinctive enough that the realistic
-/// false-positive surface is narrow: a model reply that literally quotes
-/// the phrase — e.g. "The error you saw was 'No conversation found…'" —
-/// would auto-drop the conversation id and trigger an auto-retry. If
-/// that becomes a real annoyance, the right fix is splitting detection
-/// into a per-stream-mode JSON path (look at `system/stderr` text only)
-/// and a per-PTY-mode line path, instead of one regex that's also asked
-/// to match assistant prose.
+/// The match is a broad `contains` because callers scope the input
+/// before passing it in. For Stream mode `push_event_message` skips the
+/// broad check and `dispatch_stream_json_output` calls this only with
+/// the unwrapped `text` of `system/stderr` envelopes, so assistant
+/// prose can never trip it. For PTY mode (NonInteractive codex / fallback
+/// claude) we still match the whole stdout chunk because there's no
+/// JSON structure to lean on; the realistic risk there is a turn-1
+/// codex error message that quotes the phrase, which is acceptable
+/// given codex's stale error is also turn-1-only.
 fn detect_stale_session(harness: &str, data: &str) -> bool {
     match harness {
         "claude" => data.contains("No conversation found with session ID"),
@@ -2306,6 +2330,21 @@ mod tests {
             payload_json: serde_json::json!({ "data": data }).to_string(),
             created_at: "2026-05-19T00:00:00Z".to_string(),
         }
+    }
+
+    /// Build a stream-json `{"type":"system","subtype":"stderr","text":...}\n`
+    /// envelope, the wire format the daemon emits for piped-child stderr
+    /// lines. Stale-id detection in stream-mode runs ONLY against the
+    /// unwrapped `text` of these envelopes (not against assistant
+    /// content), so stale tests must use this helper when simulating a
+    /// stream session.
+    fn stale_stderr_chunk(text: &str) -> String {
+        let envelope = serde_json::json!({
+            "type": "system",
+            "subtype": "stderr",
+            "text": text,
+        });
+        format!("{envelope}\n")
     }
 
     #[test]
@@ -3247,7 +3286,9 @@ mod tests {
         app.push_event_message(&output_event(
             1,
             &session_id,
-            &format!("No conversation found with session ID: {stored_id}\n"),
+            &stale_stderr_chunk(&format!(
+                "No conversation found with session ID: {stored_id}"
+            )),
         ));
 
         // Stale id must be gone — but auto-retry should have created a
@@ -3307,7 +3348,9 @@ mod tests {
         app.push_event_message(&output_event(
             1,
             &failed_session,
-            &format!("No conversation found with session ID: {stored_id}\n"),
+            &stale_stderr_chunk(&format!(
+                "No conversation found with session ID: {stored_id}"
+            )),
         ));
         // A trailing chunk from the same failed session (ANSI cleanup, etc.).
         app.push_event_message(&output_event(
@@ -3372,7 +3415,9 @@ mod tests {
         app.push_event_message(&output_event(
             1,
             &failed_session,
-            &format!("No conversation found with session ID: {stored_id}\n"),
+            &stale_stderr_chunk(&format!(
+                "No conversation found with session ID: {stored_id}"
+            )),
         ));
         let retry_session = app.active_session_id().expect("retry session").to_string();
         assert_ne!(retry_session, failed_session);
@@ -3434,7 +3479,9 @@ mod tests {
                 session_id: old_session_for_events.clone(),
                 kind: "output".to_string(),
                 payload_json: serde_json::json!({
-                    "data": format!("No conversation found with session ID: {stored_id_for_error}\n")
+                    "data": stale_stderr_chunk(&format!(
+                        "No conversation found with session ID: {stored_id_for_error}"
+                    ))
                 })
                 .to_string(),
                 created_at: "2026-05-19T00:00:00Z".to_string(),
@@ -3492,7 +3539,9 @@ mod tests {
         app.push_event_message(&output_event(
             1,
             &first_session,
-            &format!("No conversation found with session ID: {stored_id}\n"),
+            &stale_stderr_chunk(&format!(
+                "No conversation found with session ID: {stored_id}"
+            )),
         ));
         let after_first_retry = mirror.launched.borrow().len();
         assert_eq!(after_first_retry, 2, "first stale event triggers a retry");
@@ -3505,7 +3554,9 @@ mod tests {
         app.push_event_message(&output_event(
             2,
             &retry_session,
-            &format!("No conversation found with session ID: {retry_id}\n"),
+            &stale_stderr_chunk(&format!(
+                "No conversation found with session ID: {retry_id}"
+            )),
         ));
         assert_eq!(
             mirror.launched.borrow().len(),

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1057,11 +1057,37 @@ impl App {
         }
     }
 
+    /// If the harness rejected our `Resume` because the prior session no
+    /// longer exists (claude or codex local store wiped, server-side
+    /// expiry, etc.), drop the stale id from memory and disk and tell the
+    /// user so they can retry with a fresh thread. Only fires for chat-owned
+    /// sessions where we actually had a stored id to send.
+    fn maybe_clear_stale_conversation_id(&mut self, data: &str) {
+        if !self.chat_owns_active_session {
+            return;
+        }
+        let Some(harness) = self.active_session_harness.clone() else {
+            return;
+        };
+        if !self.harness_conversation_ids.contains_key(&harness) {
+            return;
+        }
+        if !detect_stale_session(&harness, data) {
+            return;
+        }
+        self.harness_conversation_ids.remove(&harness);
+        self.persist_conversations();
+        self.push_system_message(&format!(
+            "Prior {harness} conversation no longer exists. Send your message again to start a fresh one."
+        ));
+    }
+
     fn push_event_message(&mut self, event: &store::EventRecord) {
         match event.kind.as_str() {
             "output" => {
                 if let Some(data) = event_payload_text(event, "data") {
                     self.maybe_capture_codex_session_id(&data);
+                    self.maybe_clear_stale_conversation_id(&data);
                     let sender = self.active_agent_label().to_string();
                     if let Some(text) =
                         human_facing_agent_output(&data, &mut self.agent_output_mode)
@@ -1484,6 +1510,22 @@ fn should_keep_launch_inline(plan: &CastPlan) -> bool {
 /// `docs/chat-persistence.md` for the per-harness mechanics.
 fn harness_supports_chat_resume(harness: &str) -> bool {
     matches!(harness, "claude" | "codex")
+}
+
+/// Whether `data` (a chunk of harness output) indicates the harness rejected
+/// our `Resume` because the session id it carried no longer exists. Both
+/// claude and codex unhelpfully exit with code 0 in this case, so we have to
+/// pattern-match on their distinctive error wording. See
+/// `docs/chat-persistence.md` under "stale-id auto-recovery".
+fn detect_stale_session(harness: &str, data: &str) -> bool {
+    match harness {
+        "claude" => data.contains("No conversation found with session ID"),
+        "codex" => {
+            data.contains("no rollout found for thread id")
+                || data.contains("thread/resume failed")
+        }
+        _ => false,
+    }
 }
 
 /// Scan `data` (a chunk of cleaned-but-not-line-filtered harness output) for a
@@ -2240,6 +2282,169 @@ mod tests {
 
         assert!(app.harness_conversation_ids.contains_key("claude"));
         assert!(app.coven_home.is_none());
+    }
+
+    #[test]
+    fn detect_stale_session_matches_known_per_harness_phrases() {
+        assert!(detect_stale_session(
+            "claude",
+            "No conversation found with session ID: 00000000-0000-0000-0000-000000000000"
+        ));
+        assert!(detect_stale_session(
+            "codex",
+            "Error: thread/resume: thread/resume failed: no rollout found for thread id 00000000-..."
+        ));
+        assert!(detect_stale_session(
+            "codex",
+            "thread/resume failed: something else"
+        ));
+        // Different harness id doesn't match either phrase.
+        assert!(!detect_stale_session(
+            "hermes",
+            "No conversation found with session ID: x"
+        ));
+        // Plain content with neither phrase.
+        assert!(!detect_stale_session("claude", "Hi Persist."));
+        assert!(!detect_stale_session("codex", "session id: 019e..."));
+    }
+
+    #[test]
+    fn stale_claude_resume_drops_id_from_memory_and_disk_and_warns_user() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let stored_id = "fab1efac-1234-5678-9abc-def012345678";
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), stored_id.to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hello again".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+
+        // Simulate claude rejecting our stale --resume.
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            &format!(
+                "No conversation found with session ID: {stored_id}\n",
+            ),
+        ));
+
+        assert!(
+            !app.harness_conversation_ids.contains_key("claude"),
+            "stale id must be dropped from memory"
+        );
+        let stored = persistence::load_for_project(coven_home.path(), project_root.path());
+        assert!(
+            !stored.contains_key("claude"),
+            "stale id must also be removed from disk"
+        );
+        assert!(
+            app.messages.iter().any(|m| m.content.contains("no longer exists")),
+            "user must see a system message explaining the reset"
+        );
+    }
+
+    #[test]
+    fn stale_codex_resume_drops_codex_id_only() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        // Seed both claude and codex; only codex should get dropped.
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), "claude-uuid".to_string());
+        seed.insert("codex".to_string(), "codex-uuid".to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(0); // codex
+        app.input = "hello again".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            "Error: thread/resume: thread/resume failed: no rollout found for thread id codex-uuid\n",
+        ));
+
+        assert!(!app.harness_conversation_ids.contains_key("codex"));
+        assert!(
+            app.harness_conversation_ids.contains_key("claude"),
+            "claude id must not be touched by a codex stale event"
+        );
+        let stored = persistence::load_for_project(coven_home.path(), project_root.path());
+        assert!(!stored.contains_key("codex"));
+        assert_eq!(stored.get("claude").map(String::as_str), Some("claude-uuid"));
+    }
+
+    #[test]
+    fn stale_pattern_in_attached_session_output_does_not_drop_chat_ids() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), "claude-uuid".to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let attached =
+            test_session("attached-session", "claude", "external", "running");
+        let client = RecordingChatClient::with_session(attached);
+        let (mut app, _) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
+        app.attach_session("attached-session");
+        assert!(!app.chat_owns_active_session);
+
+        // Output from the attached session contains the stale phrase, but
+        // since chat doesn't own this session we must not touch our own
+        // persisted ids.
+        app.push_event_message(&output_event(
+            1,
+            "attached-session",
+            "No conversation found with session ID: irrelevant\n",
+        ));
+
+        assert!(
+            app.harness_conversation_ids.contains_key("claude"),
+            "attached-session output must not clobber chat-owned ids"
+        );
+    }
+
+    #[test]
+    fn stale_pattern_with_no_stored_id_is_a_noop() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let client = RecordingChatClient::default();
+        let (mut app, _) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(0); // codex
+        app.input = "hi".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+        assert!(!app.harness_conversation_ids.contains_key("codex"));
+
+        // Stale phrase arrives during a turn that had no stored codex id —
+        // nothing to drop, nothing to warn about.
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            "thread/resume failed: bogus\n",
+        ));
+
+        assert!(
+            !app.messages
+                .iter()
+                .any(|m| m.content.contains("no longer exists")),
+            "must not emit a misleading warning when there was no stored id"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -2751,7 +2751,7 @@ mod tests {
 
         // Visible transcript preserved (plus the /new system message).
         assert!(
-            app.messages.len() >= messages_after_first_turn + 1,
+            app.messages.len() > messages_after_first_turn,
             "/new must keep prior messages and add at least its own system message"
         );
         assert!(

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 use super::client::{coven_home_dir, ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
+use super::persistence;
 use super::settings::{self, ChatSettings, StreamingMode};
 
 // ── Data types ─────────────────────────────────────────────────────────────
@@ -104,9 +105,14 @@ pub(super) struct App {
     /// tap before exiting so a stray ^C doesn't kill the session.
     last_interrupt_at: Option<Instant>,
     /// Per-harness conversation ids so chat turns reuse the harness CLI's
-    /// own session-resume mechanism (today only `claude --session-id` /
-    /// `--resume`). Reset on `/clear`. See `docs/chat-persistence.md`.
+    /// own session-resume mechanism. Persisted per-project so a fresh
+    /// `coven chat` invocation resumes the prior conversation. Reset on
+    /// `/clear`. See `docs/chat-persistence.md`.
     harness_conversation_ids: HashMap<String, String>,
+    /// Canonical project root used to scope persisted conversation ids. If
+    /// missing (e.g. tests, broken cwd), the chat runs without cross-restart
+    /// persistence.
+    project_root: Option<PathBuf>,
     /// True when `active_session_id` points at a session this chat launched
     /// as a turn (so the next message should be a fresh launch + resume).
     /// False when the user `/attach`ed an externally-spawned session, in
@@ -208,10 +214,30 @@ impl App {
         client: Box<dyn ChatClient>,
         coven_home: Option<PathBuf>,
     ) -> Self {
+        Self::new_with_state_and_project_root(
+            agents,
+            active_agent,
+            client,
+            coven_home,
+            std::env::current_dir().ok(),
+        )
+    }
+
+    pub(super) fn new_with_state_and_project_root(
+        agents: Vec<AgentInfo>,
+        active_agent: Option<usize>,
+        client: Box<dyn ChatClient>,
+        coven_home: Option<PathBuf>,
+        project_root: Option<PathBuf>,
+    ) -> Self {
         let streaming_mode = coven_home
             .as_deref()
             .map(|home| settings::load_from(home).streaming)
             .unwrap_or_default();
+        let harness_conversation_ids = match (coven_home.as_deref(), project_root.as_deref()) {
+            (Some(home), Some(root)) => persistence::load_for_project(home, root),
+            _ => HashMap::new(),
+        };
         let mut app = App {
             messages: Vec::new(),
             input: String::new(),
@@ -244,7 +270,8 @@ impl App {
             slash_suggestion_index: 0,
             slash_popup_dismissed: false,
             last_interrupt_at: None,
-            harness_conversation_ids: HashMap::new(),
+            harness_conversation_ids,
+            project_root,
             chat_owns_active_session: false,
             active_session_harness: None,
             client,
@@ -451,12 +478,14 @@ impl App {
 
     /// Clear the visible transcript and reset scroll, matching what `/clear`
     /// does. Used by Ctrl+L so the keybind doesn't have to fake a slash
-    /// command through the parser. Also drops the harness conversation ids so
-    /// the next turn starts a fresh `--session-id`-claimed thread.
+    /// command through the parser. Also drops the harness conversation ids
+    /// (both in-memory and on disk) so the next turn starts a fresh thread
+    /// rather than silently resuming after a restart.
     pub(super) fn clear_transcript(&mut self) {
         self.messages.clear();
         self.scroll_offset = 0;
         self.harness_conversation_ids.clear();
+        self.clear_persisted_conversations();
         self.push_system_message("Chat cleared.");
     }
 
@@ -811,7 +840,7 @@ impl App {
     /// pre-assign the session id (claude `--session-id`) the first turn sends
     /// `Init` with a freshly generated UUID. For harnesses that auto-assign
     /// (codex) the first turn sends no hint and the id is captured from
-    /// output afterwards via `capture_session_id_from_output`.
+    /// output afterwards via `maybe_capture_codex_session_id`.
     fn conversation_hint_for_harness(&mut self, harness: &str) -> Option<harness::ConversationHint> {
         if !harness_supports_chat_resume(harness) {
             return None;
@@ -823,9 +852,42 @@ impl App {
             let id = Uuid::new_v4().to_string();
             self.harness_conversation_ids
                 .insert(harness.to_string(), id.clone());
+            self.persist_conversations();
             Some(harness::ConversationHint::Init { id })
         } else {
             None
+        }
+    }
+
+    /// Best-effort write of `harness_conversation_ids` to the per-project
+    /// persistence file. Logged on failure (as a system message) but never
+    /// fatal — the in-memory map is authoritative for the current session.
+    fn persist_conversations(&mut self) {
+        let (Some(home), Some(root)) = (self.coven_home.as_deref(), self.project_root.as_deref())
+        else {
+            return;
+        };
+        if let Err(error) =
+            persistence::save_for_project(home, root, &self.harness_conversation_ids)
+        {
+            self.push_system_message(&format!(
+                "Could not persist chat conversation ids: {error}. Resume across restarts may not work."
+            ));
+        }
+    }
+
+    /// Best-effort delete of the per-project persistence file. Called from
+    /// `/clear` so a deliberate reset doesn't silently resume on the next
+    /// `coven chat` invocation. Logged on failure but never fatal.
+    fn clear_persisted_conversations(&mut self) {
+        let (Some(home), Some(root)) = (self.coven_home.as_deref(), self.project_root.as_deref())
+        else {
+            return;
+        };
+        if let Err(error) = persistence::clear_for_project(home, root) {
+            self.push_system_message(&format!(
+                "Could not clear persisted chat conversation ids: {error}."
+            ));
         }
     }
 
@@ -991,6 +1053,7 @@ impl App {
         }
         if let Some(id) = extract_codex_session_id(data) {
             self.harness_conversation_ids.insert("codex".to_string(), id);
+            self.persist_conversations();
         }
     }
 
@@ -1617,7 +1680,9 @@ mod tests {
     use super::*;
     use crate::store::{EventRecord, SessionRecord};
     use crate::tui::chat::client::{ChatClient, ChatEventQuery, LaunchRequest};
+    use crate::tui::chat::persistence;
     use std::cell::RefCell;
+    use std::path::Path;
     use std::rc::Rc;
 
     fn app_with_agents(agents: Vec<AgentInfo>) -> App {
@@ -1758,6 +1823,28 @@ mod tests {
         let mut app = App::new_with_client(Box::new(client));
         app.agents = vec![agent("codex", true), agent("claude", true)];
         app.active_agent = Some(0);
+        app.messages.clear();
+        (app, mirror)
+    }
+
+    /// Like `app_with_client` but with `coven_home` + `project_root` wired
+    /// so cross-restart persistence is exercised. Returns the mirror plus the
+    /// two paths so tests can simulate a restart by constructing a second
+    /// App that points at the same persisted store.
+    fn app_with_persistence(
+        client: RecordingChatClient,
+        coven_home: &Path,
+        project_root: &Path,
+    ) -> (App, RecordingChatClient) {
+        let mirror = client.clone();
+        let agents = vec![agent("codex", true), agent("claude", true)];
+        let mut app = App::new_with_state_and_project_root(
+            agents,
+            Some(0),
+            Box::new(client),
+            Some(coven_home.to_path_buf()),
+            Some(project_root.to_path_buf()),
+        );
         app.messages.clear();
         (app, mirror)
     }
@@ -2025,6 +2112,134 @@ mod tests {
             Some(first_id),
             "first captured id must stick"
         );
+    }
+
+    #[test]
+    fn first_claude_turn_persists_conversation_id_to_disk() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        let stored = persistence::load_for_project(coven_home.path(), project_root.path());
+        let in_memory = app
+            .harness_conversation_ids
+            .get("claude")
+            .cloned()
+            .expect("first claude turn must record an id");
+        assert_eq!(
+            stored.get("claude").cloned(),
+            Some(in_memory),
+            "claude conversation id must be persisted to disk after Init"
+        );
+    }
+
+    #[test]
+    fn fresh_app_resumes_persisted_claude_conversation_on_first_send() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let stored_id = "fab1efac-1234-5678-9abc-def012345678";
+        let mut seed = std::collections::HashMap::new();
+        seed.insert("claude".to_string(), stored_id.to_string());
+        persistence::save_for_project(coven_home.path(), project_root.path(), &seed)
+            .expect("seed persisted state");
+
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) =
+            app_with_persistence(client, coven_home.path(), project_root.path());
+        assert_eq!(
+            app.harness_conversation_ids.get("claude").map(String::as_str),
+            Some(stored_id),
+            "App must load persisted conversation ids on startup"
+        );
+
+        app.active_agent = Some(1); // claude
+        app.input = "hello again".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+
+        let launched = mirror.launched.borrow();
+        match &launched[0].conversation {
+            Some(crate::harness::ConversationHint::Resume { id }) => {
+                assert_eq!(
+                    id, stored_id,
+                    "first turn after restart must Resume with persisted id"
+                );
+            }
+            other => panic!("expected Resume on first turn after restart, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_session_id_capture_is_persisted_to_disk() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(0); // codex
+        app.input = "first".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        let session_id = app.active_session_id().expect("first launch sets id").to_string();
+
+        let captured_id = "019eaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        app.push_event_message(&output_event(
+            1,
+            &session_id,
+            &format!("session id: {captured_id}\n"),
+        ));
+
+        let stored = persistence::load_for_project(coven_home.path(), project_root.path());
+        assert_eq!(
+            stored.get("codex").map(String::as_str),
+            Some(captured_id),
+            "codex session id must be persisted as soon as it's captured"
+        );
+    }
+
+    #[test]
+    fn clear_transcript_wipes_persisted_conversations_file() {
+        let coven_home = tempfile::tempdir().unwrap();
+        let project_root = tempfile::tempdir().unwrap();
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_persistence(client, coven_home.path(), project_root.path());
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+        app.handle_input();
+        assert!(
+            persistence::conversations_file(coven_home.path(), project_root.path()).exists(),
+            "first turn should have created the persistence file"
+        );
+
+        app.clear_transcript();
+
+        assert!(
+            !persistence::conversations_file(coven_home.path(), project_root.path()).exists(),
+            "/clear must delete the persistence file so restart starts fresh"
+        );
+        assert!(app.harness_conversation_ids.is_empty());
+    }
+
+    #[test]
+    fn app_without_coven_home_does_not_attempt_persistence() {
+        // Sanity check: tests that don't pass a coven_home (the default
+        // `app_with_client` path) must keep working without touching disk.
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_agent = Some(1); // claude
+        app.input = "hello".to_string();
+        app.cursor_pos = app.input.len();
+
+        app.handle_input();
+
+        assert!(app.harness_conversation_ids.contains_key("claude"));
+        assert!(app.coven_home.is_none());
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1028,6 +1028,17 @@ impl App {
     /// stream sessions don't, because the daemon wraps the payload in a
     /// JSON envelope verbatim and the inner `\n` would otherwise leak
     /// into the user message text on every turn after the first.
+    ///
+    /// **Limitation**: this distinguishes stream-vs-PTY by checking our
+    /// own `harness_stream_session_ids` map, which only knows about
+    /// stream sessions this chat instance launched. If a future
+    /// `/attach` connects to a stream session launched by another
+    /// process (or a stream session that survived a restart), the check
+    /// would mis-treat it as PTY and append the spurious `\n`. Today no
+    /// flow produces this state — only chat launches stream sessions
+    /// and `/attach` is documented for `coven run`-spawned PTY tasks —
+    /// but the proper fix is exposing the session kind on
+    /// `SessionRecord` so the daemon is the source of truth.
     fn forward_input_to_session(&mut self, session_id: &str, raw: &str) {
         self.is_responding = true;
         let is_stream = self

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -28,6 +28,13 @@ pub(crate) struct LaunchRequest {
     pub(crate) prompt: String,
     pub(crate) title: String,
     pub(crate) conversation: Option<harness::ConversationHint>,
+    /// Stable per-conversation id used to group multiple chat turns under
+    /// one row in `/sessions`. Distinct from `conversation` (which drives
+    /// the harness CLI's own resume args). Today chat uses the same uuid
+    /// for both fields on claude turns and a chat-generated uuid on codex
+    /// turns (since codex auto-assigns its own session id). See
+    /// `docs/chat-persistence.md`.
+    pub(crate) conversation_id: Option<String>,
 }
 
 impl LaunchRequest {
@@ -43,11 +50,17 @@ impl LaunchRequest {
             prompt: prompt.to_string(),
             title: session_title(prompt),
             conversation: None,
+            conversation_id: None,
         })
     }
 
     pub(crate) fn with_conversation(mut self, hint: harness::ConversationHint) -> Self {
         self.conversation = Some(hint);
+        self
+    }
+
+    pub(crate) fn with_conversation_id(mut self, id: String) -> Self {
+        self.conversation_id = Some(id);
         self
     }
 }
@@ -185,6 +198,11 @@ impl ChatClient for DaemonChatClient {
                 "conversation".to_string(),
                 json!({"mode": mode, "id": id}),
             );
+        }
+        if let Some(conversation_id) = request.conversation_id.as_ref() {
+            body.as_object_mut()
+                .expect("json! literal is an object")
+                .insert("conversationId".to_string(), json!(conversation_id));
         }
         self.request_json("POST", "/api/v1/sessions", Some(body))
     }

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -195,10 +195,9 @@ impl ChatClient for DaemonChatClient {
                 harness::ConversationHint::Init { id } => ("init", id),
                 harness::ConversationHint::Resume { id } => ("resume", id),
             };
-            body.as_object_mut().expect("json! literal is an object").insert(
-                "conversation".to_string(),
-                json!({"mode": mode, "id": id}),
-            );
+            body.as_object_mut()
+                .expect("json! literal is an object")
+                .insert("conversation".to_string(), json!({"mode": mode, "id": id}));
         }
         if let Some(conversation_id) = request.conversation_id.as_ref() {
             body.as_object_mut()

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -185,6 +185,7 @@ impl ChatClient for DaemonChatClient {
             "launchMode": match request.launch_mode {
                 harness::HarnessLaunchMode::Interactive => "interactive",
                 harness::HarnessLaunchMode::NonInteractive => "nonInteractive",
+                harness::HarnessLaunchMode::Stream => "stream",
             },
             "prompt": request.prompt,
             "title": request.title,

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -27,6 +27,7 @@ pub(crate) struct LaunchRequest {
     pub(crate) launch_mode: harness::HarnessLaunchMode,
     pub(crate) prompt: String,
     pub(crate) title: String,
+    pub(crate) conversation: Option<harness::ConversationHint>,
 }
 
 impl LaunchRequest {
@@ -38,10 +39,16 @@ impl LaunchRequest {
             project_root: cwd.clone(),
             cwd,
             harness: harness.to_string(),
-            launch_mode: harness::HarnessLaunchMode::Interactive,
+            launch_mode: harness::HarnessLaunchMode::NonInteractive,
             prompt: prompt.to_string(),
             title: session_title(prompt),
+            conversation: None,
         })
+    }
+
+    pub(crate) fn with_conversation(mut self, hint: harness::ConversationHint) -> Self {
+        self.conversation = Some(hint);
+        self
     }
 }
 
@@ -158,21 +165,28 @@ impl DaemonChatClient {
 
 impl ChatClient for DaemonChatClient {
     fn launch_session(&mut self, request: LaunchRequest) -> Result<store::SessionRecord> {
-        self.request_json(
-            "POST",
-            "/api/v1/sessions",
-            Some(json!({
-                "projectRoot": request.project_root,
-                "cwd": request.cwd,
-                "harness": request.harness,
-                "launchMode": match request.launch_mode {
-                    harness::HarnessLaunchMode::Interactive => "interactive",
-                    harness::HarnessLaunchMode::NonInteractive => "nonInteractive",
-                },
-                "prompt": request.prompt,
-                "title": request.title,
-            })),
-        )
+        let mut body = json!({
+            "projectRoot": request.project_root,
+            "cwd": request.cwd,
+            "harness": request.harness,
+            "launchMode": match request.launch_mode {
+                harness::HarnessLaunchMode::Interactive => "interactive",
+                harness::HarnessLaunchMode::NonInteractive => "nonInteractive",
+            },
+            "prompt": request.prompt,
+            "title": request.title,
+        });
+        if let Some(hint) = request.conversation.as_ref() {
+            let (mode, id) = match hint {
+                harness::ConversationHint::Init { id } => ("init", id),
+                harness::ConversationHint::Resume { id } => ("resume", id),
+            };
+            body.as_object_mut().expect("json! literal is an object").insert(
+                "conversation".to_string(),
+                json!({"mode": mode, "id": id}),
+            );
+        }
+        self.request_json("POST", "/api/v1/sessions", Some(body))
     }
 
     fn get_session(&mut self, session_id: &str) -> Result<store::SessionRecord> {
@@ -378,17 +392,35 @@ mod tests {
     }
 
     #[test]
-    fn launch_request_uses_current_dir_and_interactive_mode_for_chat() -> Result<()> {
+    fn launch_request_uses_current_dir_and_non_interactive_mode_for_chat() -> Result<()> {
         let request = LaunchRequest::for_current_dir("codex", "summarize")?;
 
         assert_eq!(request.harness, "codex");
         assert_eq!(request.prompt, "summarize");
         assert_eq!(
             request.launch_mode,
-            crate::harness::HarnessLaunchMode::Interactive
+            crate::harness::HarnessLaunchMode::NonInteractive
         );
+        assert!(request.conversation.is_none());
         assert!(!request.project_root.is_empty());
         assert_eq!(request.project_root, request.cwd);
+        Ok(())
+    }
+
+    #[test]
+    fn with_conversation_attaches_resume_hint() -> Result<()> {
+        let request = LaunchRequest::for_current_dir("claude", "next turn")?.with_conversation(
+            crate::harness::ConversationHint::Resume {
+                id: "abc-123".to_string(),
+            },
+        );
+
+        assert_eq!(
+            request.conversation,
+            Some(crate::harness::ConversationHint::Resume {
+                id: "abc-123".to_string()
+            })
+        );
         Ok(())
     }
 }

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -29,10 +29,12 @@ pub(crate) struct LaunchRequest {
     pub(crate) title: String,
     pub(crate) conversation: Option<harness::ConversationHint>,
     /// Stable per-conversation id used to group multiple chat turns under
-    /// one row in `/sessions`. Distinct from `conversation` (which drives
-    /// the harness CLI's own resume args). Today chat uses the same uuid
-    /// for both fields on claude turns and a chat-generated uuid on codex
-    /// turns (since codex auto-assigns its own session id). See
+    /// one row in `/sessions`. Conceptually distinct from `conversation`
+    /// (which drives the harness CLI's own resume args), though in
+    /// practice both fields carry the same value for both harnesses:
+    /// claude's chat-generated UUID is also the `conversation_id`, and
+    /// codex's captured `session id: <uuid>` is reused as the
+    /// `conversation_id` once we learn it. See
     /// `docs/chat-persistence.md`.
     pub(crate) conversation_id: Option<String>,
 }

--- a/crates/coven-cli/src/tui/chat/mod.rs
+++ b/crates/coven-cli/src/tui/chat/mod.rs
@@ -5,6 +5,7 @@ mod app;
 pub(crate) mod client;
 mod events;
 mod highlight;
+mod persistence;
 mod render;
 mod settings;
 

--- a/crates/coven-cli/src/tui/chat/mod.rs
+++ b/crates/coven-cli/src/tui/chat/mod.rs
@@ -34,6 +34,11 @@ pub fn run_chat() -> Result<()> {
     let mut terminal = TerminalSession::enter()?;
     let mut app = App::new();
     let result = run_event_loop(&mut terminal, &mut app);
+    // Tear down long-lived stream sessions (claude --stream-json) before
+    // we release the terminal. Covers every normal exit path — /exit,
+    // double Ctrl+C, Ctrl+D, plus errors from the event loop — so a
+    // closed chat doesn't leave a claude process running in the daemon.
+    app.shutdown();
     terminal.restore()?;
     result
 }

--- a/crates/coven-cli/src/tui/chat/persistence.rs
+++ b/crates/coven-cli/src/tui/chat/persistence.rs
@@ -52,10 +52,7 @@ fn temporary_conversations_file(coven_home: &Path, project_root: &Path) -> PathB
 /// set on any error (missing file, corrupt JSON, permissions). Conversation
 /// state is best-effort — a failure to read must not block the chat from
 /// coming up.
-pub(super) fn load_for_project(
-    coven_home: &Path,
-    project_root: &Path,
-) -> HashMap<String, String> {
+pub(super) fn load_for_project(coven_home: &Path, project_root: &Path) -> HashMap<String, String> {
     let path = conversations_file(coven_home, project_root);
     let Ok(data) = std::fs::read(&path) else {
         return HashMap::new();
@@ -195,7 +192,11 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let dir = conversations_dir(temp.path());
         std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(conversations_file(temp.path(), project.path()), b"{ not json").unwrap();
+        std::fs::write(
+            conversations_file(temp.path(), project.path()),
+            b"{ not json",
+        )
+        .unwrap();
 
         let loaded = load_for_project(temp.path(), project.path());
         assert!(loaded.is_empty());
@@ -272,7 +273,10 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let project = tempfile::tempdir().unwrap();
         let temp_path = temporary_conversations_file(temp.path(), project.path());
-        assert_eq!(temp_path.parent(), Some(conversations_dir(temp.path()).as_path()));
+        assert_eq!(
+            temp_path.parent(),
+            Some(conversations_dir(temp.path()).as_path())
+        );
         assert_ne!(temp_path, conversations_file(temp.path(), project.path()));
     }
 }

--- a/crates/coven-cli/src/tui/chat/persistence.rs
+++ b/crates/coven-cli/src/tui/chat/persistence.rs
@@ -1,0 +1,278 @@
+//! Per-project store of chat conversation ids so a fresh `coven chat`
+//! invocation can resume the prior conversation with each harness.
+//!
+//! On-disk form is a small JSON document at
+//! `<coven_home>/chat-conversations/<project-key>.json`. The project key is a
+//! deterministic FNV-1a hash of the canonicalized project root, hex-encoded;
+//! changing the project root means a new file (which is the right behavior —
+//! different projects shouldn't share a thread). See
+//! `docs/chat-persistence.md` for the broader design.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+const DIR_NAME: &str = "chat-conversations";
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct StoredConversations {
+    /// Display copy of the project root that produced this file's key.
+    /// Stored for human inspection / collision debugging — not used to look
+    /// the file back up.
+    #[serde(default)]
+    pub(super) project_root: String,
+    /// Harness id → conversation id (e.g. `"claude" → "<uuid>"`).
+    #[serde(default)]
+    pub(super) conversations: HashMap<String, String>,
+}
+
+pub(super) fn conversations_dir(coven_home: &Path) -> PathBuf {
+    coven_home.join(DIR_NAME)
+}
+
+pub(super) fn conversations_file(coven_home: &Path, project_root: &Path) -> PathBuf {
+    conversations_dir(coven_home).join(format!("{}.json", project_key(project_root)))
+}
+
+fn temporary_conversations_file(coven_home: &Path, project_root: &Path) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    conversations_dir(coven_home).join(format!(
+        ".{}.json.{}.{}.tmp",
+        project_key(project_root),
+        std::process::id(),
+        nanos
+    ))
+}
+
+/// Load stored conversation ids for `project_root`, falling back to an empty
+/// set on any error (missing file, corrupt JSON, permissions). Conversation
+/// state is best-effort — a failure to read must not block the chat from
+/// coming up.
+pub(super) fn load_for_project(
+    coven_home: &Path,
+    project_root: &Path,
+) -> HashMap<String, String> {
+    let path = conversations_file(coven_home, project_root);
+    let Ok(data) = std::fs::read(&path) else {
+        return HashMap::new();
+    };
+    serde_json::from_slice::<StoredConversations>(&data)
+        .map(|stored| stored.conversations)
+        .unwrap_or_default()
+}
+
+/// Persist `conversations` for `project_root` atomically. Returns the
+/// underlying io error so callers can log it; chat should *not* abort the
+/// turn on a persistence failure (the in-memory state is still authoritative).
+pub(super) fn save_for_project(
+    coven_home: &Path,
+    project_root: &Path,
+    conversations: &HashMap<String, String>,
+) -> std::io::Result<()> {
+    let dir = conversations_dir(coven_home);
+    std::fs::create_dir_all(&dir)?;
+    let stored = StoredConversations {
+        project_root: project_root.to_string_lossy().into_owned(),
+        conversations: conversations.clone(),
+    };
+    let body = serde_json::to_vec_pretty(&stored)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    let path = conversations_file(coven_home, project_root);
+    let temp_path = temporary_conversations_file(coven_home, project_root);
+    std::fs::write(&temp_path, body)?;
+    replace_conversations_file(&temp_path, &path)?;
+    if let Ok(handle) = std::fs::File::open(&dir) {
+        let _ = handle.sync_all();
+    }
+    Ok(())
+}
+
+/// Remove the stored conversations file for `project_root`. Missing-file is
+/// treated as success (the post-condition is "no file"). Other io errors are
+/// returned for logging — callers should not abort.
+pub(super) fn clear_for_project(coven_home: &Path, project_root: &Path) -> std::io::Result<()> {
+    let path = conversations_file(coven_home, project_root);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// FNV-1a 64-bit hash of the canonical project root, hex-encoded. Stable
+/// across Rust versions and machines (unlike `std::collections::hash_map`'s
+/// SipHash, which Rust may reseed). 16 hex chars is plenty of namespace for
+/// per-user storage and short enough to type if you ever need to inspect a
+/// file by hand.
+fn project_key(project_root: &Path) -> String {
+    let canonical = project_root
+        .canonicalize()
+        .unwrap_or_else(|_| project_root.to_path_buf());
+    let bytes = canonical.as_os_str().as_encoded_bytes();
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+#[cfg(not(windows))]
+fn replace_conversations_file(temp_path: &Path, path: &Path) -> std::io::Result<()> {
+    std::fs::rename(temp_path, path)
+}
+
+#[cfg(windows)]
+fn replace_conversations_file(temp_path: &Path, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+    #[link(name = "Kernel32")]
+    extern "system" {
+        #[link_name = "MoveFileExW"]
+        fn move_file_ex_w(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+
+    let existing: Vec<u16> = temp_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let new: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let ok = unsafe {
+        move_file_ex_w(
+            existing.as_ptr(),
+            new.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_returns_empty_when_file_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let loaded = load_for_project(temp.path(), project.path());
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips_conversation_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let mut conversations = HashMap::new();
+        conversations.insert("claude".to_string(), "claude-uuid".to_string());
+        conversations.insert("codex".to_string(), "codex-uuid".to_string());
+
+        save_for_project(temp.path(), project.path(), &conversations).expect("save");
+        let loaded = load_for_project(temp.path(), project.path());
+
+        assert_eq!(loaded, conversations);
+    }
+
+    #[test]
+    fn corrupt_conversations_file_falls_back_to_empty() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let dir = conversations_dir(temp.path());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(conversations_file(temp.path(), project.path()), b"{ not json").unwrap();
+
+        let loaded = load_for_project(temp.path(), project.path());
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn save_overwrites_existing_conversations_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let mut first = HashMap::new();
+        first.insert("claude".to_string(), "old-uuid".to_string());
+        save_for_project(temp.path(), project.path(), &first).expect("first save");
+
+        let mut second = HashMap::new();
+        second.insert("claude".to_string(), "new-uuid".to_string());
+        save_for_project(temp.path(), project.path(), &second).expect("second save");
+
+        assert_eq!(load_for_project(temp.path(), project.path()), second);
+    }
+
+    #[test]
+    fn clear_removes_existing_conversations_file_and_treats_missing_as_success() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let mut conversations = HashMap::new();
+        conversations.insert("claude".to_string(), "claude-uuid".to_string());
+        save_for_project(temp.path(), project.path(), &conversations).expect("save");
+
+        clear_for_project(temp.path(), project.path()).expect("clear existing");
+        assert!(!conversations_file(temp.path(), project.path()).exists());
+
+        // Second clear on an already-empty store must not error.
+        clear_for_project(temp.path(), project.path()).expect("clear missing");
+    }
+
+    #[test]
+    fn different_projects_get_different_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let project_a = tempfile::tempdir().unwrap();
+        let project_b = tempfile::tempdir().unwrap();
+        let mut conversations_a = HashMap::new();
+        conversations_a.insert("claude".to_string(), "a-uuid".to_string());
+        let mut conversations_b = HashMap::new();
+        conversations_b.insert("claude".to_string(), "b-uuid".to_string());
+
+        save_for_project(temp.path(), project_a.path(), &conversations_a).expect("save a");
+        save_for_project(temp.path(), project_b.path(), &conversations_b).expect("save b");
+
+        assert_eq!(
+            load_for_project(temp.path(), project_a.path()),
+            conversations_a
+        );
+        assert_eq!(
+            load_for_project(temp.path(), project_b.path()),
+            conversations_b
+        );
+    }
+
+    #[test]
+    fn project_key_is_deterministic() {
+        let project = tempfile::tempdir().unwrap();
+        assert_eq!(project_key(project.path()), project_key(project.path()));
+    }
+
+    #[test]
+    fn project_key_changes_with_path() {
+        let project_a = tempfile::tempdir().unwrap();
+        let project_b = tempfile::tempdir().unwrap();
+        assert_ne!(project_key(project_a.path()), project_key(project_b.path()));
+    }
+
+    #[test]
+    fn temporary_conversations_file_stays_in_chat_conversations_dir() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = tempfile::tempdir().unwrap();
+        let temp_path = temporary_conversations_file(temp.path(), project.path());
+        assert_eq!(temp_path.parent(), Some(conversations_dir(temp.path()).as_path()));
+        assert_ne!(temp_path, conversations_file(temp.path(), project.path()));
+    }
+}

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -867,22 +867,37 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
         )));
     } else {
         let entries = collapse_sessions_by_conversation(&app.sessions);
-        let active_conv = app.active_session_id().and_then(|active| {
+        // Compute the composite key of the chat's active session (same
+        // shape as `collapse_sessions_by_conversation` uses) so the
+        // active-marker matches the same grouping a colliding
+        // conversation_id across projects/harnesses can't trip.
+        let active_key: Option<(&str, &str, &str)> = app.active_session_id().and_then(|active| {
             app.sessions
                 .iter()
                 .find(|session| session.id == active)
-                .and_then(|session| session.conversation_id.as_deref())
+                .and_then(|session| {
+                    session.conversation_id.as_deref().map(|conv| {
+                        (
+                            session.project_root.as_str(),
+                            session.harness.as_str(),
+                            conv,
+                        )
+                    })
+                })
         });
         for entry in entries.iter().take(10) {
             let (rep, turn_count) = match entry {
                 SessionOverlayEntry::Group { rep, turn_count } => (*rep, *turn_count),
                 SessionOverlayEntry::Singleton { session } => (*session, 1),
             };
-            // A row is "active" if the chat's active_session_id belongs to
-            // it: either via shared conversation_id (group) or matching the
+            // A row is "active" if the chat's active_session_id belongs
+            // to it: either via shared composite `(project_root,
+            // harness, conversation_id)` key (group) or matching the
             // singleton's own id.
             let is_active = match rep.conversation_id.as_deref() {
-                Some(conv) => active_conv == Some(conv),
+                Some(conv) => {
+                    active_key == Some((rep.project_root.as_str(), rep.harness.as_str(), conv))
+                }
                 None => app.active_session_id() == Some(rep.id.as_str()),
             };
             let marker = if is_active { ">" } else { " " };
@@ -945,11 +960,20 @@ enum SessionOverlayEntry<'a> {
     },
 }
 
-/// Collapse sessions that share a `conversation_id` into a single entry per
+/// Collapse sessions that share a conversation into a single entry per
 /// conversation, keyed on the FIRST session encountered (callers pass
 /// daemon-listed sessions in `created_at DESC` order, so the first per
 /// conversation is the most recent turn). Sessions without a
 /// `conversation_id` pass through as singletons.
+///
+/// The grouping key is the composite `(project_root, harness,
+/// conversation_id)` rather than `conversation_id` alone. The chat
+/// generates UUIDs which won't realistically collide across projects
+/// or harnesses, but `conversation_id` is a caller-supplied opaque
+/// string — a buggy or malicious client could send the same value
+/// from two different projects (or two different harnesses in the
+/// same chat) and otherwise watch the overlay merge unrelated rows
+/// into a single entry. Composite key makes that misuse harmless.
 ///
 /// Runs in O(N) over `sessions` with two passes (counts + entries). Called
 /// from `render_session_overlay` per frame while the overlay is open, so
@@ -962,21 +986,31 @@ fn collapse_sessions_by_conversation(
     sessions: &[crate::store::SessionRecord],
 ) -> Vec<SessionOverlayEntry<'_>> {
     use std::collections::{HashMap, HashSet};
-    let mut counts: HashMap<&str, usize> = HashMap::new();
+    type GroupKey<'a> = (&'a str, &'a str, &'a str);
+    fn key_of(session: &crate::store::SessionRecord) -> Option<GroupKey<'_>> {
+        session.conversation_id.as_deref().map(|conv| {
+            (
+                session.project_root.as_str(),
+                session.harness.as_str(),
+                conv,
+            )
+        })
+    }
+    let mut counts: HashMap<GroupKey<'_>, usize> = HashMap::new();
     for session in sessions {
-        if let Some(conv) = session.conversation_id.as_deref() {
-            *counts.entry(conv).or_insert(0) += 1;
+        if let Some(key) = key_of(session) {
+            *counts.entry(key).or_insert(0) += 1;
         }
     }
-    let mut seen: HashSet<&str> = HashSet::new();
+    let mut seen: HashSet<GroupKey<'_>> = HashSet::new();
     let mut entries: Vec<SessionOverlayEntry<'_>> = Vec::new();
     for session in sessions {
-        match session.conversation_id.as_deref() {
-            Some(conv) => {
-                if seen.insert(conv) {
+        match key_of(session) {
+            Some(key) => {
+                if seen.insert(key) {
                     entries.push(SessionOverlayEntry::Group {
                         rep: session,
-                        turn_count: counts.get(conv).copied().unwrap_or(1),
+                        turn_count: counts.get(&key).copied().unwrap_or(1),
                     });
                 }
             }
@@ -1451,10 +1485,20 @@ mod tests {
         conversation: Option<&str>,
         title: &str,
     ) -> crate::store::SessionRecord {
+        make_session_in("/tmp/project", "claude", id, conversation, title)
+    }
+
+    fn make_session_in(
+        project_root: &str,
+        harness: &str,
+        id: &str,
+        conversation: Option<&str>,
+        title: &str,
+    ) -> crate::store::SessionRecord {
         crate::store::SessionRecord {
             id: id.to_string(),
-            project_root: "/tmp/project".to_string(),
-            harness: "claude".to_string(),
+            project_root: project_root.to_string(),
+            harness: harness.to_string(),
             title: title.to_string(),
             status: "completed".to_string(),
             exit_code: Some(0),
@@ -1524,6 +1568,75 @@ mod tests {
         }
         assert_eq!(badge(100), "99+t");
         assert_eq!(badge(7), " 7t ");
+    }
+
+    #[test]
+    fn collapse_sessions_keys_on_composite_project_and_harness_not_just_conversation_id() {
+        // Same conversation_id used by sessions in two different projects
+        // (a pathological / buggy-client scenario). The collapse must
+        // NOT merge them — otherwise a malicious or sloppy client could
+        // make an unrelated project's chat history appear inside the
+        // current project's overlay.
+        let sessions = vec![
+            make_session_in(
+                "/proj/A",
+                "claude",
+                "a-1",
+                Some("shared-id"),
+                "A chat reply",
+            ),
+            make_session_in(
+                "/proj/B",
+                "claude",
+                "b-1",
+                Some("shared-id"),
+                "B chat reply",
+            ),
+        ];
+        let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(
+            entries.len(),
+            2,
+            "same conversation_id under different project_root must NOT merge: got {entries:?}",
+            entries = entries
+                .iter()
+                .map(|e| match e {
+                    SessionOverlayEntry::Group { rep, turn_count } =>
+                        format!("Group({}, {})", rep.id, turn_count),
+                    SessionOverlayEntry::Singleton { session } =>
+                        format!("Singleton({})", session.id),
+                })
+                .collect::<Vec<_>>()
+        );
+        for entry in &entries {
+            match entry {
+                SessionOverlayEntry::Group { turn_count, .. } => assert_eq!(*turn_count, 1),
+                SessionOverlayEntry::Singleton { .. } => {}
+            }
+        }
+    }
+
+    #[test]
+    fn collapse_sessions_keys_on_harness_not_just_conversation_id() {
+        // Same project, same conversation_id, different harness — should
+        // also stay separate (defends against a client that reuses
+        // ledger ids across harnesses).
+        let sessions = vec![
+            make_session_in(
+                "/proj/X",
+                "claude",
+                "c-1",
+                Some("shared-id"),
+                "claude reply",
+            ),
+            make_session_in("/proj/X", "codex", "k-1", Some("shared-id"), "codex reply"),
+        ];
+        let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(
+            entries.len(),
+            2,
+            "same conversation_id under different harness must NOT merge"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -866,31 +866,51 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
             theme::ratatui_style(DIM),
         )));
     } else {
-        for session in app.sessions.iter().take(10) {
-            let marker = if app.active_session_id() == Some(session.id.as_str()) {
-                ">"
+        let entries = collapse_sessions_by_conversation(&app.sessions);
+        let active_conv = app.active_session_id().and_then(|active| {
+            app.sessions
+                .iter()
+                .find(|session| session.id == active)
+                .and_then(|session| session.conversation_id.as_deref())
+        });
+        for entry in entries.iter().take(10) {
+            let (rep, turn_count) = match entry {
+                SessionOverlayEntry::Group { rep, turn_count } => (*rep, *turn_count),
+                SessionOverlayEntry::Singleton { session } => (*session, 1),
+            };
+            // A row is "active" if the chat's active_session_id belongs to
+            // it: either via shared conversation_id (group) or matching the
+            // singleton's own id.
+            let is_active = match rep.conversation_id.as_deref() {
+                Some(conv) => active_conv == Some(conv),
+                None => app.active_session_id() == Some(rep.id.as_str()),
+            };
+            let marker = if is_active { ">" } else { " " };
+            let turn_badge = if turn_count > 1 {
+                format!("{turn_count:>2}t ")
             } else {
-                " "
+                "    ".to_string()
             };
             lines.push(Line::from(vec![
                 Span::styled(format!(" {marker} "), theme::ratatui_style(PRIMARY)),
                 Span::styled(
-                    format!("{:<8}", session.status),
+                    format!("{:<8}", rep.status),
                     theme::status_style(Status::Ready),
                 ),
                 Span::styled(
-                    format!(" {:<7} ", session.harness),
+                    format!(" {:<7} ", rep.harness),
                     theme::ratatui_style(DIM),
                 ),
+                Span::styled(turn_badge, theme::ratatui_style(DIM)),
                 Span::styled(
-                    truncate_for_width(&session.id, 12),
+                    truncate_for_width(&rep.id, 12),
                     theme::ratatui_style(PRIMARY),
                 ),
                 Span::styled("  ", theme::ratatui_style(DIM)),
                 Span::styled(
                     truncate_for_width(
-                        &session.title,
-                        popup_area.width.saturating_sub(36) as usize,
+                        &rep.title,
+                        popup_area.width.saturating_sub(40) as usize,
                     ),
                     theme::ratatui_style(TEXT),
                 ),
@@ -912,6 +932,53 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
         .block(block)
         .wrap(Wrap { trim: false });
     f.render_widget(overlay, popup_area);
+}
+
+/// One row in the `/sessions` overlay. Either a singleton session (legacy
+/// one-off `coven run`-style launches) or a group of N chat turns that all
+/// share the same conversation_id — collapsed into a single representative
+/// row so the overlay isn't flooded after a long chat.
+enum SessionOverlayEntry<'a> {
+    Group {
+        rep: &'a crate::store::SessionRecord,
+        turn_count: usize,
+    },
+    Singleton {
+        session: &'a crate::store::SessionRecord,
+    },
+}
+
+/// Collapse sessions that share a `conversation_id` into a single entry per
+/// conversation, keyed on the FIRST session encountered (callers pass
+/// daemon-listed sessions in `created_at DESC` order, so the first per
+/// conversation is the most recent turn). Sessions without a
+/// `conversation_id` pass through as singletons.
+fn collapse_sessions_by_conversation(
+    sessions: &[crate::store::SessionRecord],
+) -> Vec<SessionOverlayEntry<'_>> {
+    use std::collections::{HashMap, HashSet};
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for session in sessions {
+        if let Some(conv) = session.conversation_id.as_deref() {
+            *counts.entry(conv).or_insert(0) += 1;
+        }
+    }
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut entries: Vec<SessionOverlayEntry<'_>> = Vec::new();
+    for session in sessions {
+        match session.conversation_id.as_deref() {
+            Some(conv) => {
+                if seen.insert(conv) {
+                    entries.push(SessionOverlayEntry::Group {
+                        rep: session,
+                        turn_count: counts.get(conv).copied().unwrap_or(1),
+                    });
+                }
+            }
+            None => entries.push(SessionOverlayEntry::Singleton { session }),
+        }
+    }
+    entries
 }
 
 /// Floating slash-command autocomplete. Anchored just above the input area so
@@ -1372,6 +1439,92 @@ mod tests {
             "left edge preserved: {only:?}"
         );
         assert!(only.ends_with('\u{2026}'), "ellipsis applied: {only:?}");
+    }
+
+    fn make_session(id: &str, conversation: Option<&str>, title: &str) -> crate::store::SessionRecord {
+        crate::store::SessionRecord {
+            id: id.to_string(),
+            project_root: "/tmp/project".to_string(),
+            harness: "claude".to_string(),
+            title: title.to_string(),
+            status: "completed".to_string(),
+            exit_code: Some(0),
+            archived_at: None,
+            created_at: "2026-05-24T00:00:00Z".to_string(),
+            updated_at: "2026-05-24T00:00:00Z".to_string(),
+            conversation_id: conversation.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn collapse_sessions_returns_empty_for_empty_input() {
+        let entries = collapse_sessions_by_conversation(&[]);
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn collapse_sessions_groups_consecutive_same_conversation_into_one_entry() {
+        let sessions = vec![
+            make_session("turn-3", Some("conv-a"), "third"),
+            make_session("turn-2", Some("conv-a"), "second"),
+            make_session("turn-1", Some("conv-a"), "first"),
+        ];
+        let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(entries.len(), 1);
+        match &entries[0] {
+            SessionOverlayEntry::Group { rep, turn_count } => {
+                assert_eq!(rep.id, "turn-3", "rep must be the first (most recent) turn");
+                assert_eq!(*turn_count, 3);
+            }
+            SessionOverlayEntry::Singleton { .. } => panic!("expected a Group"),
+        }
+    }
+
+    #[test]
+    fn collapse_sessions_passes_through_sessions_with_no_conversation_id_as_singletons() {
+        let sessions = vec![
+            make_session("solo-2", None, "free-running task 2"),
+            make_session("solo-1", None, "free-running task 1"),
+        ];
+        let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(entries.len(), 2);
+        for entry in &entries {
+            assert!(matches!(entry, SessionOverlayEntry::Singleton { .. }));
+        }
+    }
+
+    #[test]
+    fn collapse_sessions_handles_interleaved_groups_and_singletons() {
+        // Imagine: a fresh codex run between two chat turns of the same
+        // conversation. Daemon returns DESC by created_at so chat turn 2
+        // is first, codex run second, chat turn 1 third.
+        let sessions = vec![
+            make_session("turn-2", Some("conv-a"), "chat reply 2"),
+            make_session("solo", None, "ad-hoc codex run"),
+            make_session("turn-1", Some("conv-a"), "chat reply 1"),
+        ];
+        let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(entries.len(), 2);
+        match &entries[0] {
+            SessionOverlayEntry::Group { rep, turn_count } => {
+                assert_eq!(rep.id, "turn-2");
+                assert_eq!(*turn_count, 2);
+            }
+            other => panic!("expected first entry to be Group, got {:?}", overlay_kind(other)),
+        }
+        match &entries[1] {
+            SessionOverlayEntry::Singleton { session } => {
+                assert_eq!(session.id, "solo");
+            }
+            other => panic!("expected second entry to be Singleton, got {:?}", overlay_kind(other)),
+        }
+    }
+
+    fn overlay_kind(entry: &SessionOverlayEntry<'_>) -> &'static str {
+        match entry {
+            SessionOverlayEntry::Group { .. } => "Group",
+            SessionOverlayEntry::Singleton { .. } => "Singleton",
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -897,10 +897,7 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
                     format!("{:<8}", rep.status),
                     theme::status_style(Status::Ready),
                 ),
-                Span::styled(
-                    format!(" {:<7} ", rep.harness),
-                    theme::ratatui_style(DIM),
-                ),
+                Span::styled(format!(" {:<7} ", rep.harness), theme::ratatui_style(DIM)),
                 Span::styled(turn_badge, theme::ratatui_style(DIM)),
                 Span::styled(
                     truncate_for_width(&rep.id, 12),
@@ -908,10 +905,7 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
                 ),
                 Span::styled("  ", theme::ratatui_style(DIM)),
                 Span::styled(
-                    truncate_for_width(
-                        &rep.title,
-                        popup_area.width.saturating_sub(40) as usize,
-                    ),
+                    truncate_for_width(&rep.title, popup_area.width.saturating_sub(40) as usize),
                     theme::ratatui_style(TEXT),
                 ),
             ]));
@@ -1441,7 +1435,11 @@ mod tests {
         assert!(only.ends_with('\u{2026}'), "ellipsis applied: {only:?}");
     }
 
-    fn make_session(id: &str, conversation: Option<&str>, title: &str) -> crate::store::SessionRecord {
+    fn make_session(
+        id: &str,
+        conversation: Option<&str>,
+        title: &str,
+    ) -> crate::store::SessionRecord {
         crate::store::SessionRecord {
             id: id.to_string(),
             project_root: "/tmp/project".to_string(),
@@ -1510,13 +1508,19 @@ mod tests {
                 assert_eq!(rep.id, "turn-2");
                 assert_eq!(*turn_count, 2);
             }
-            other => panic!("expected first entry to be Group, got {:?}", overlay_kind(other)),
+            other => panic!(
+                "expected first entry to be Group, got {:?}",
+                overlay_kind(other)
+            ),
         }
         match &entries[1] {
             SessionOverlayEntry::Singleton { session } => {
                 assert_eq!(session.id, "solo");
             }
-            other => panic!("expected second entry to be Singleton, got {:?}", overlay_kind(other)),
+            other => panic!(
+                "expected second entry to be Singleton, got {:?}",
+                overlay_kind(other)
+            ),
         }
     }
 

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -886,10 +886,13 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
                 None => app.active_session_id() == Some(rep.id.as_str()),
             };
             let marker = if is_active { ">" } else { " " };
-            let turn_badge = if turn_count > 1 {
-                format!("{turn_count:>2}t ")
-            } else {
-                "    ".to_string()
+            // Badge is a fixed 4-char field (" 2t ", "12t ", "99+t",
+            // "    ") so the columns to the right stay aligned even
+            // when a single conversation accumulates a lot of turns.
+            let turn_badge = match turn_count {
+                0 | 1 => "    ".to_string(),
+                2..=99 => format!("{turn_count:>2}t "),
+                _ => "99+t".to_string(),
             };
             lines.push(Line::from(vec![
                 Span::styled(format!(" {marker} "), theme::ratatui_style(PRIMARY)),
@@ -1489,6 +1492,30 @@ mod tests {
         for entry in &entries {
             assert!(matches!(entry, SessionOverlayEntry::Singleton { .. }));
         }
+    }
+
+    #[test]
+    fn turn_badge_format_keeps_a_fixed_four_char_width_at_every_count() {
+        // Reproduce render_session_overlay's badge logic in isolation so
+        // we can assert the column doesn't grow once a conversation
+        // exceeds 99 turns.
+        let badge = |turn_count: usize| -> String {
+            match turn_count {
+                0 | 1 => "    ".to_string(),
+                2..=99 => format!("{turn_count:>2}t "),
+                _ => "99+t".to_string(),
+            }
+        };
+        for n in [0_usize, 1, 2, 9, 10, 42, 99, 100, 250, 9999] {
+            let rendered = badge(n);
+            assert_eq!(
+                rendered.chars().count(),
+                4,
+                "badge for turn_count={n} must be 4 chars wide, got {rendered:?}"
+            );
+        }
+        assert_eq!(badge(100), "99+t");
+        assert_eq!(badge(7), " 7t ");
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -950,6 +950,14 @@ enum SessionOverlayEntry<'a> {
 /// daemon-listed sessions in `created_at DESC` order, so the first per
 /// conversation is the most recent turn). Sessions without a
 /// `conversation_id` pass through as singletons.
+///
+/// Runs in O(N) over `sessions` with two passes (counts + entries). Called
+/// from `render_session_overlay` per frame while the overlay is open, so
+/// the realistic cost ceiling is N×<200 (a few hundred sessions on a
+/// busy user's machine) × ~10 frames/sec — sub-millisecond per render.
+/// If `app.sessions` ever grows past O(thousands), move this behind a
+/// cache that invalidates on `refresh_sessions` instead of recomputing
+/// per frame.
 fn collapse_sessions_by_conversation(
     sessions: &[crate::store::SessionRecord],
 ) -> Vec<SessionOverlayEntry<'_>> {

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -575,6 +575,7 @@ fn create_local_quest_anchor(
         archived_at: None,
         created_at: timestamp.clone(),
         updated_at: timestamp.clone(),
+        conversation_id: None,
     };
     store::insert_session(&conn, &record)?;
     let harness_label = default_harness
@@ -1132,6 +1133,7 @@ fn dispatch_via_daemon(
         prompt: prompt.to_string(),
         title,
         conversation: None,
+        conversation_id: None,
     };
 
     let mut client = DaemonChatClient::default();

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1131,6 +1131,7 @@ fn dispatch_via_daemon(
         launch_mode: crate::harness::HarnessLaunchMode::Interactive,
         prompt: prompt.to_string(),
         title,
+        conversation: None,
     };
 
     let mut client = DaemonChatClient::default();

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -64,20 +64,19 @@ flowchart TD
   Parse -- ok --> Route{Route exists?}
   Route -- no --> ErrNotFound["404 not_found"]
   Route -- yes --> Validate{Field validation}
-  Validate -- cwd outside root --> ErrCwd["400 project_root_violation"]
+  Validate -- cwd outside root --> ErrInvalid
   Validate -- unknown harness/action --> ErrInvalid
   Validate -- ok --> Action{Resource lookup}
   Action -- session missing --> ErrSession["404 session_not_found"]
   Action -- session not live --> ErrLive["409 session_not_live"]
-  Action -- PTY spawn fails --> ErrPty["500 pty_spawn_failed"]
-  Action -- launch (init write / spawn) fails --> ErrLaunch["500 launch_failed"]
+  Action -- launch (PTY/pipe spawn, init write, harness startup) fails --> ErrLaunch["500 launch_failed"]
   Action -- send_input fails --> ErrSend["500 send_input_failed"]
   Action -- kill_session fails --> ErrKill["500 kill_failed"]
   Action -- runtime down --> ErrRuntime["503 runtime_unavailable"]
   Action -- internal panic --> ErrInternal["500 internal_error"]
   Action -- ok --> Success[Documented success shape]
 
-  ErrInvalid & ErrNotFound & ErrCwd & ErrSession & ErrLive & ErrPty & ErrLaunch & ErrSend & ErrKill & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
+  ErrInvalid & ErrNotFound & ErrSession & ErrLive & ErrLaunch & ErrSend & ErrKill & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
 ```
 
 All API errors use the following stable envelope. Clients must branch on `error.code`, not `error.message`:

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -70,11 +70,14 @@ flowchart TD
   Action -- session missing --> ErrSession["404 session_not_found"]
   Action -- session not live --> ErrLive["409 session_not_live"]
   Action -- PTY spawn fails --> ErrPty["500 pty_spawn_failed"]
+  Action -- launch (init write / spawn) fails --> ErrLaunch["500 launch_failed"]
+  Action -- send_input fails --> ErrSend["500 send_input_failed"]
+  Action -- kill_session fails --> ErrKill["500 kill_failed"]
   Action -- runtime down --> ErrRuntime["503 runtime_unavailable"]
   Action -- internal panic --> ErrInternal["500 internal_error"]
   Action -- ok --> Success[Documented success shape]
 
-  ErrInvalid & ErrNotFound & ErrCwd & ErrSession & ErrLive & ErrPty & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
+  ErrInvalid & ErrNotFound & ErrCwd & ErrSession & ErrLive & ErrPty & ErrLaunch & ErrSend & ErrKill & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
 ```
 
 All API errors use the following stable envelope. Clients must branch on `error.code`, not `error.message`:
@@ -98,11 +101,14 @@ All API errors use the following stable envelope. Clients must branch on `error.
 | Code                   | HTTP status | Description                                      |
 |------------------------|-------------|--------------------------------------------------|
 | `not_found`            | 404         | Generic route not found.                         |
-| `invalid_request`      | 400 or 404  | Malformed request or unsupported API version.    |
+| `invalid_request`      | 400 or 404  | Malformed request, unknown harness id, missing required field, or unsupported API version. |
 | `session_not_found`    | 404         | Session id does not exist.                       |
 | `session_not_live`     | 409         | Session exists but is not running.               |
 | `project_root_violation`| 400        | cwd is outside the declared project root.        |
 | `pty_spawn_failed`     | 500         | PTY harness could not be launched.               |
+| `launch_failed`        | 500         | Daemon accepted the launch payload but the runtime (PTY/pipe spawn, initial-message write, harness CLI startup) failed. `details.sessionId` is the row that was inserted and marked `failed`. |
+| `send_input_failed`    | 500         | Daemon accepted the input payload but the runtime write failed (closed pipe, killed process, IO error). `details.sessionId` is the affected session. |
+| `kill_failed`          | 500         | Daemon accepted the kill request but the runtime signal/kill call failed (permission, missing process, IO error). `details.sessionId` is the affected session. |
 | `runtime_unavailable`  | 503         | The session runtime is unavailable.              |
 | `internal_error`       | 500         | Unexpected internal error.                       |
 

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -104,8 +104,8 @@ All API errors use the following stable envelope. Clients must branch on `error.
 | `invalid_request`      | 400 or 404  | Malformed request, unknown harness id, missing required field, or unsupported API version. |
 | `session_not_found`    | 404         | Session id does not exist.                       |
 | `session_not_live`     | 409         | Session exists but is not running.               |
-| `project_root_violation`| 400        | cwd is outside the declared project root.        |
-| `pty_spawn_failed`     | 500         | PTY harness could not be launched.               |
+| `project_root_violation`| 400        | Reserved. Cwd-outside-root currently emits `invalid_request` with the violation message in the body; promoting to its own code would let clients branch without parsing prose. |
+| `pty_spawn_failed`     | 500         | Reserved. PTY spawn failures currently emit `launch_failed`; promoting to its own code would let clients distinguish "the PTY couldn't open" (likely a host issue) from "the harness CLI errored at startup" (likely an auth/config issue). |
 | `launch_failed`        | 500         | Daemon accepted the launch payload but the runtime (PTY/pipe spawn, initial-message write, harness CLI startup) failed. `details.sessionId` is the row that was inserted and marked `failed`. |
 | `send_input_failed`    | 500         | Daemon accepted the input payload but the runtime write failed (closed pipe, killed process, IO error). `details.sessionId` is the affected session. |
 | `kill_failed`          | 500         | Daemon accepted the kill request but the runtime signal/kill call failed (permission, missing process, IO error). `details.sessionId` is the affected session. |

--- a/docs/SESSION-LIFECYCLE.md
+++ b/docs/SESSION-LIFECYCLE.md
@@ -78,7 +78,7 @@ sequenceDiagram
   end
   Daemon->>Daemon: canonicalize cwd inside projectRoot
   alt cwd outside root
-    Daemon-->>Client: 400 project_root_violation
+    Daemon-->>Client: 400 invalid_request (cwd outside project root)
   end
   Daemon->>Daemon: lookup harness in adapter table
   alt harness unknown
@@ -86,9 +86,9 @@ sequenceDiagram
   end
   Daemon->>Store: insert session (status=created)
   Daemon->>PTY: spawn argv (prefix args + prompt)
-  alt PTY spawn fails
+  alt spawn / initial-write fails
     Daemon->>Store: update status=failed
-    Daemon-->>Client: 500 pty_spawn_failed
+    Daemon-->>Client: 500 launch_failed (details.sessionId set)
   else PTY spawn ok
     Daemon->>Store: update status=running
     Daemon-->>Client: 200 SessionRecord

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -98,16 +98,18 @@ CLI's own session API avoids both problems.
   separate entries of `harness_conversation_ids`. There's no cross-harness
   context transfer; switching agents effectively starts (or resumes) a
   parallel thread with the new agent.
-- **Stale ids** — auto-recovered. If the harness CLI rejects our `Resume`
-  because the prior session no longer exists (claude: `No conversation found
-  with session ID:`; codex: `no rollout found for thread id` /
-  `thread/resume failed`), the chat detects the message in the output
-  stream, drops the id from both memory and disk, and surfaces "Prior
-  <harness> conversation no longer exists. Send your message again to start
-  a fresh one." The next turn launches with no hint (claude) or no
-  `resume` arg (codex), creating a new conversation. Detection uses
-  output-text matching because both harnesses exit 0 on the stale-id
-  error.
+- **Stale ids** — auto-recovered with auto-retry. If the harness CLI rejects
+  our `Resume` because the prior session no longer exists (claude: `No
+  conversation found with session ID:`; codex: `no rollout found for thread
+  id` / `thread/resume failed`), the chat detects the message in the output
+  stream, drops the id from both memory and disk, and immediately re-sends
+  the user's original prompt with no resume hint. The user sees "Prior
+  <harness> conversation no longer exists. Starting a new one and
+  re-sending your message." then the reply from the fresh conversation.
+  Bounded to one auto-retry per user turn — a second stale event in the
+  same turn falls back to "Send your message again to start a fresh one."
+  so a degenerate loop can't pile up launches. Detection uses output-text
+  matching because both harnesses exit 0 on the stale-id error.
 - **`/attach`ed sessions.** Typing while attached to a session launched by
   `coven run` (not by chat) still forwards to that session's stdin — the
   resume path only applies to sessions chat itself launched.
@@ -162,22 +164,23 @@ CLI's own session API avoids both problems.
 
 ## Future work
 
-### Auto-retry after stale-id recovery
+### Hiding the raw stale-error chunk from the transcript
 
-Today stale-id detection drops the id and asks the user to send their
-message again. A nicer flow would auto-resend the original prompt with no
-hint so the chat appears seamless. Implementation sketch:
+When stale-recovery fires, the user briefly sees the raw harness error
+(e.g. `No conversation found with session ID: …`) rendered as an agent
+message right before the system message and auto-retry kick in. A polish
+would suppress that one chunk from the transcript so the flow reads:
+system message → new reply, with no scary error in between. Two
+approaches:
 
-1. Stash the last-sent prompt in `App` at launch time (e.g.
-   `last_sent_prompt: Option<String>`).
-2. On stale detection, after clearing the id, immediately re-invoke
-   `run_harness_prompt(harness, prompt)`.
-3. Guard against an infinite loop with a "retry-once" flag that resets
-   per user-typed message.
+- Return early from `push_event_message`'s output branch when stale is
+  detected, skipping the human-facing render for *that* chunk only.
+- Track `suppressed_session_ids: HashSet<String>` and skip all output +
+  exit events from the failed session id (handles the case where the
+  harness emits additional output before exiting).
 
-This wasn't worth the complexity for the first cut — the user-facing
-"Send your message again" line plus Up-arrow to recall the prior input
-is one keystroke + Enter.
+The second is more robust but adds a sweep of the event handler; the
+first is one-line.
 
 ### `/new` as a separate verb
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -13,9 +13,17 @@ extend the mechanism to additional harnesses.
 Conversations persist across `coven chat` invocations on a per-project basis:
 on startup the chat seeds its in-memory map from
 `$COVEN_HOME/chat-conversations/<project-key>.json`, so the next message
-sends `Resume` immediately. `/clear` deletes that file. Different projects
-get different files (the key is a deterministic FNV-1a hash of the canonical
-project root path); changing project directory yields a fresh thread.
+sends `Resume` immediately. Different projects get different files (the key
+is a deterministic FNV-1a hash of the canonical project root path);
+changing project directory yields a fresh thread.
+
+Two slash verbs reset state:
+
+- **`/clear`** clears the visible transcript *and* drops the conversation
+  ids (memory + disk). Use it when you want a complete reset.
+- **`/new`** drops the conversation ids (memory + disk) but **keeps** the
+  visible transcript. Use it when you want to start a fresh thread but
+  still scroll up to reference the prior exchange.
 
 The two harnesses differ in *who assigns the session id*:
 
@@ -43,11 +51,13 @@ with each launch:
 - **`Resume { id }`** — subsequent turn. The harness CLI is told to resume
   that session and append the new prompt.
 
-The chat app keeps a `HashMap<harness_id, conversation_id>` for the lifetime
-of the `App`. On the first turn for a harness, it generates a UUID, stores it,
-and sends `Init`. On every later turn it sends `Resume` with the same id.
-`/clear` (and Ctrl+L) drop the map so the next turn starts a brand-new
-conversation.
+The chat app keeps a `HashMap<harness_id, conversation_id>` seeded from the
+persistence file on startup. On the first turn for a harness that doesn't
+have a stored id yet, it generates a UUID (claude) or waits to capture one
+from output (codex), stores it, and sends `Init` (claude) or no hint
+(codex). On every later turn it sends `Resume` with the stored id. `/clear`
+(and Ctrl+L) drop the map *and* the visible transcript; `/new` drops just
+the map.
 
 ### Data flow
 
@@ -166,13 +176,6 @@ CLI's own session API avoids both problems.
    the right id.
 
 ## Future work
-
-### `/new` as a separate verb
-
-`/clear` today does double duty: it clears the visible transcript *and*
-the persisted conversation. A `/new` verb that only resets the conversation
-(keeping the transcript visible for context) would split the two so users
-can scroll back through history while starting a fresh thread.
 
 ### One ledger row per conversation
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -25,15 +25,26 @@ Two slash verbs reset state:
   visible transcript. Use it when you want to start a fresh thread but
   still scroll up to reference the prior exchange.
 
-Each chat turn still launches a fresh daemon session under the hood, but
-the daemon's session store now carries a `conversation_id` column that
-groups the turns. The chat passes the harness conversation id (claude's
-session uuid, or codex's captured id) as `conversationId` in every launch
-payload, and the `/sessions` overlay collapses sessions that share an id
-into a single row with an `Nt` turn-count badge. Codex's *first* turn
-lands ungrouped because chat doesn't learn codex's id until it appears in
-output; subsequent codex turns and every claude turn group cleanly. The
-column also flows through to `coven sessions` for non-TUI clients.
+The daemon's session store carries a `conversation_id` column so the
+`/sessions` overlay can collapse multi-turn chat threads into a single
+visible row. The chat passes the harness conversation id as
+`conversationId` in every launch payload. Behavior differs between
+harnesses because they have different process models:
+
+- **Codex (per-turn)**: every chat turn cold-starts a new daemon session
+  carrying the same `conversation_id`. The `/sessions` overlay collapses
+  the N rows into one entry with an `Nt` turn-count badge that
+  increments with each turn. Codex's *first* turn lands ungrouped
+  because chat doesn't learn codex's id until it appears in output;
+  subsequent codex turns and the rest group cleanly.
+- **Claude (stream-mode)**: only the *first* turn creates a daemon
+  session row; subsequent turns are piped into the same long-lived
+  process via stdin, with no fresh ledger row per turn. So the overlay
+  shows one row per claude chat (no badge — singleton). To see the
+  per-turn breakdown, drill into the session's events.
+
+The `conversation_id` column also flows through to `coven sessions` for
+non-TUI clients.
 
 The two harnesses differ in *who assigns the session id*:
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -25,6 +25,16 @@ Two slash verbs reset state:
   visible transcript. Use it when you want to start a fresh thread but
   still scroll up to reference the prior exchange.
 
+Each chat turn still launches a fresh daemon session under the hood, but
+the daemon's session store now carries a `conversation_id` column that
+groups the turns. The chat passes the harness conversation id (claude's
+session uuid, or codex's captured id) as `conversationId` in every launch
+payload, and the `/sessions` overlay collapses sessions that share an id
+into a single row with an `Nt` turn-count badge. Codex's *first* turn
+lands ungrouped because chat doesn't learn codex's id until it appears in
+output; subsequent codex turns and every claude turn group cleanly. The
+column also flows through to `coven sessions` for non-TUI clients.
+
 The two harnesses differ in *who assigns the session id*:
 
 - **Claude** lets us pre-assign one via `--session-id <uuid>`. The chat app
@@ -176,16 +186,6 @@ CLI's own session API avoids both problems.
    the right id.
 
 ## Future work
-
-### One ledger row per conversation
-
-Today each chat turn shows up as a separate session in `/sessions`. That's
-ledger noise. Options:
-
-- Daemon API change: add a `conversation_id` column to the session store and
-  group by it in the `/sessions` overlay.
-- Chat-side aggregation: keep displaying one row per launch, but tag each
-  with its conversation id and let the overlay collapse them.
 
 ### True streaming follow-ups
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -7,8 +7,8 @@ extend the mechanism to additional harnesses.
 
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
-| `claude` | ✅ | `claude --print --session-id <uuid>` on turn 1; `claude --print --resume <uuid>` on subsequent turns |
-| `codex` | ✅ | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns |
+| `claude` | ✅ stream-mode | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). |
+| `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:
 on startup the chat seeds its in-memory map from
@@ -51,10 +51,15 @@ modes.
 
 ## How it works
 
-Every chat turn launches a fresh daemon session in `NonInteractive` launch
-mode (`claude --print …`, `codex exec …`). To preserve conversational state
-across those one-shot launches, the chat app passes a `ConversationHint` along
-with each launch:
+Codex chat turns launch a fresh daemon session in `NonInteractive` mode
+(`codex exec …`) per turn. Claude chat turns launch a single long-lived
+daemon session in `Stream` mode (`claude --print --input-format stream-json
+--output-format stream-json --verbose …`) on the first turn; every
+subsequent turn pipes a JSON user message into the same process's stdin
+and reads JSON events back from its stdout — no cold-start. To preserve
+conversational state across daemon-session boundaries (codex per-turn,
+claude across `coven chat` restarts), the chat app passes a
+`ConversationHint` along with each launch:
 
 - **`Init { id }`** — first turn for this harness. The harness CLI is told to
   claim a session under this UUID.
@@ -187,15 +192,20 @@ CLI's own session API avoids both problems.
 
 ## Future work
 
-### True streaming follow-ups
+### Stream-mode for codex
 
-Each follow-up turn is a fresh process; latency includes the harness CLI's
-cold start (~1-3 s for claude). For lower-latency chat, options are:
+Codex doesn't have a long-lived stream-json mode (only `--json` for a
+single result), so codex chat turns still cold-start. If Codex ships
+something equivalent, the wiring is mostly already there: add `"codex"`
+to `harness_supports_stream_mode`, fill in `stream_args` for codex, and
+update `daemon::write_stream_message` if codex's user-message envelope
+differs from claude's.
 
-- Use `claude --input-format stream-json --output-format stream-json` to keep
-  one harness process alive across turns, feeding new prompts as JSON
-  messages on stdin. Avoids cold-start per turn but requires a
-  daemon-side change to keep a long-lived process per chat and route
-  per-turn JSON messages to it.
-- A first-party Coven gateway that holds the model connection directly, with
-  the harness CLI being just one of several backends.
+### First-party Coven gateway
+
+The longer-term plan: a first-party Coven gateway that holds the model
+connection directly. Harness CLIs become one of several backends rather
+than the only option. Would let Coven offer chat that doesn't depend on
+having claude or codex installed locally, and would unlock features
+neither CLI exposes (cross-harness conversation handoff, server-side
+multi-user state, …).

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -7,7 +7,7 @@ extend the mechanism to additional harnesses.
 
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
-| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id\|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path uses `setsid()` at spawn + `kill(-pid, SIGKILL)` (Unix process-group semantics) to tear down the harness and any subprocesses it spawned (skills, MCP servers, shells) in one syscall. |
+| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose` daemon process per chat, plus `--session-id <uuid>` on the first turn and `--resume <uuid>` for cross-restart continuation. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path uses `setsid()` at spawn + `kill(-pid, SIGKILL)` (Unix process-group semantics) to tear down the harness and any subprocesses it spawned (skills, MCP servers, shells) in one syscall. |
 | `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -7,7 +7,7 @@ extend the mechanism to additional harnesses.
 
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
-| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path uses `setsid()` at spawn + `kill(-pid, SIGKILL)` (Unix process-group semantics) to tear down the harness and any subprocesses it spawned (skills, MCP servers, shells) in one syscall. |
+| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id\|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path uses `setsid()` at spawn + `kill(-pid, SIGKILL)` (Unix process-group semantics) to tear down the harness and any subprocesses it spawned (skills, MCP servers, shells) in one syscall. |
 | `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -31,12 +31,17 @@ visible row. The chat passes the harness conversation id as
 `conversationId` in every launch payload. Behavior differs between
 harnesses because they have different process models:
 
-- **Codex (per-turn)**: every chat turn cold-starts a new daemon session
-  carrying the same `conversation_id`. The `/sessions` overlay collapses
-  the N rows into one entry with an `Nt` turn-count badge that
-  increments with each turn. Codex's *first* turn lands ungrouped
-  because chat doesn't learn codex's id until it appears in output;
-  subsequent codex turns and the rest group cleanly.
+- **Codex (per-turn)**: every chat turn cold-starts a new daemon session.
+  Turn 1 lands as its own singleton row in `/sessions` because chat
+  doesn't learn codex's session id until it appears in the run banner
+  *after* launch — so the launch payload has no `conversationId` to
+  group by. Turn 2 onward carries the captured id and groups together
+  into one entry with an `Nt` turn-count badge that increments per
+  turn. Net display: 1 singleton row for the cold start + 1 collapsed
+  entry covering turns 2..N. Fixing the singleton would mean
+  decoupling the chat's ledger id from the harness's resume id (chat
+  generates its own UUID up front for grouping, separate from
+  whatever codex assigns for `exec resume`).
 - **Claude (stream-mode)**: only the *first* turn creates a daemon
   session row; subsequent turns are piped into the same long-lived
   process via stdin, with no fresh ledger row per turn. So the overlay

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -1,0 +1,161 @@
+# Chat Conversation Persistence
+
+How `coven chat` keeps follow-up messages in the same conversation, and how to
+extend the mechanism to additional harnesses.
+
+## Status
+
+| Harness | Resume support | Mechanism |
+| --- | --- | --- |
+| `claude` | ✅ | `claude --print --session-id <uuid>` on turn 1; `claude --print --resume <uuid>` on subsequent turns |
+| `codex` | ❌ (not yet) | One-shot per turn; no conversation memory across turns |
+
+Resume support is scoped to a single `coven chat` invocation. Exiting the chat
+ends the conversation; the next invocation starts fresh. See **Future work**
+below for cross-restart persistence.
+
+## How it works
+
+Every chat turn launches a fresh daemon session in `NonInteractive` launch
+mode (`claude --print …`, `codex exec …`). To preserve conversational state
+across those one-shot launches, the chat app passes a `ConversationHint` along
+with each launch:
+
+- **`Init { id }`** — first turn for this harness. The harness CLI is told to
+  claim a session under this UUID.
+- **`Resume { id }`** — subsequent turn. The harness CLI is told to resume
+  that session and append the new prompt.
+
+The chat app keeps a `HashMap<harness_id, conversation_id>` for the lifetime
+of the `App`. On the first turn for a harness, it generates a UUID, stores it,
+and sends `Init`. On every later turn it sends `Resume` with the same id.
+`/clear` (and Ctrl+L) drop the map so the next turn starts a brand-new
+conversation.
+
+### Data flow
+
+```
+chat App
+  └─ run_harness_prompt(harness, prompt)
+       └─ conversation_hint_for_harness(harness)  → Option<ConversationHint>
+            └─ LaunchRequest::with_conversation(hint)
+                 └─ POST /api/v1/sessions  { ..., "conversation": {"mode": "init"|"resume", "id": "<uuid>"} }
+                      └─ daemon: pty_runner::build_harness_command_with_conversation
+                           └─ harness::command_parts_for_harness_with_conversation
+                                └─ continuity_args(spec, mode, hint)  → ["--print","--resume","<uuid>"]
+```
+
+`continuity_args` is the per-harness translation point — it's where you wire
+up a new harness's resume flags. It lives in `crates/coven-cli/src/harness.rs`.
+
+### Why not drive the harness TUI through a PTY?
+
+An earlier approach launched the harness in `Interactive` mode (full TUI) and
+piped subsequent messages as raw stdin bytes. That works for turn 1 but turn 2
+silently fails: once the harness negotiates the Kitty keyboard protocol
+(`CSI > 1 u`), Enter is encoded as `\x1b[13u`, not raw `\n`, so a piped
+`"<text>\n"` types the characters into the harness's input box but never
+submits. The output stream is also flooded with TUI rendering (spinner frames,
+status bars, ANSI repaints) that has to be filtered. Resume via the harness
+CLI's own session API avoids both problems.
+
+### What does *not* resume
+
+- **Switching agents mid-conversation** (`/agent codex` then `/agent claude`)
+  preserves each harness's own conversation independently. Switching to codex
+  doesn't carry over claude's context — codex has no resume support yet (see
+  below).
+- **Restarts** of `coven chat`. The conversation id is in-memory only.
+- **`/attach`ed sessions.** Typing while attached to a session launched by
+  `coven run` (not by chat) still forwards to that session's stdin — the
+  resume path only applies to sessions chat itself launched.
+
+## Adding support for a new harness
+
+1. **Map the harness CLI's resume flags.** Read the CLI's docs to find:
+   - How to create a session with a chosen id (or accept it auto-generating
+     one and capture from output).
+   - How to resume a session by id in non-interactive mode.
+
+   For claude these are `--session-id <uuid>` and `--resume <uuid>` — both
+   work with `--print`. For codex they're `codex exec resume <id>` and
+   `codex exec resume --last`. Other harnesses will differ.
+
+2. **Extend `continuity_args` in `crates/coven-cli/src/harness.rs`.** Add a
+   new arm to the `match spec.id` block that translates `Init` and `Resume`
+   hints into the harness's actual CLI args:
+
+   ```rust
+   "codex" => {
+       let cmd = match hint {
+           ConversationHint::Init { .. } => return None, // codex auto-creates
+           ConversationHint::Resume { id } => vec![
+               "exec".to_string(), "resume".to_string(), id.clone(),
+               // ...any other flags...
+           ],
+       };
+       Some(cmd)
+   }
+   ```
+
+   Note codex's wrinkle: the `Init` turn doesn't take an id — codex generates
+   one. You'd need to either:
+   - Capture codex's session id from the first turn's output (it prints
+     `session id: <uuid>` in its header), parse it, and stash it as the
+     `Resume` id for follow-up turns. This is fragile to upstream format
+     changes.
+   - Or use `codex exec resume --last`, which avoids parsing but breaks if
+     the user runs another codex session in between (the wrong session
+     becomes "last").
+
+3. **Flip `harness_supports_chat_resume` in `crates/coven-cli/src/tui/chat/app.rs`.**
+   It's a simple `harness == "claude"` check today; add your new id.
+
+4. **Add tests** in `harness::tests` covering Init + Resume → expected args,
+   matching the existing `claude_init_hint_attaches_session_id_flag_in_print_mode`
+   and `claude_resume_hint_attaches_resume_flag_in_print_mode`.
+
+5. **Add an end-to-end app test** in `tui::chat::app::tests` similar to
+   `second_claude_chat_turn_reuses_init_id_as_resume`, asserting your harness
+   threads the hint through `LaunchRequest`.
+
+## Future work
+
+### Cross-restart persistence
+
+Right now a closing `coven chat` loses the conversation. To persist:
+
+1. On `Init`, write the conversation id to a per-project file under
+   `$COVEN_HOME/chat-conversations/<project-hash>.json` (or extend
+   `chat-settings.json`).
+2. On `coven chat` startup, read it back and seed
+   `harness_conversation_ids` with the stored id. Next message will send
+   `Resume`.
+3. Add a `/new` slash command to clear stored ids and start fresh (mirroring
+   what `/clear` does in-memory today).
+4. Decide what to do when the stored id no longer exists on the harness side
+   (claude's `--resume` will error). Either surface the error and fall back to
+   `Init`, or detect the missing-session error pattern and silently regenerate.
+
+### One ledger row per conversation
+
+Today each chat turn shows up as a separate session in `/sessions`. That's
+ledger noise. Options:
+
+- Daemon API change: add a `conversation_id` column to the session store and
+  group by it in the `/sessions` overlay.
+- Chat-side aggregation: keep displaying one row per launch, but tag each
+  with its conversation id and let the overlay collapse them.
+
+### True streaming follow-ups
+
+Each follow-up turn is a fresh process; latency includes the harness CLI's
+cold start (~1-3 s for claude). For lower-latency chat, options are:
+
+- Use `claude --input-format stream-json --output-format stream-json` to keep
+  one harness process alive across turns, feeding new prompts as JSON
+  messages on stdin. Avoids cold-start per turn but requires a
+  daemon-side change to keep a long-lived process per chat and route
+  per-turn JSON messages to it.
+- A first-party Coven gateway that holds the model connection directly, with
+  the harness CLI being just one of several backends.

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -8,11 +8,25 @@ extend the mechanism to additional harnesses.
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
 | `claude` | ✅ | `claude --print --session-id <uuid>` on turn 1; `claude --print --resume <uuid>` on subsequent turns |
-| `codex` | ❌ (not yet) | One-shot per turn; no conversation memory across turns |
+| `codex` | ✅ | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns |
 
 Resume support is scoped to a single `coven chat` invocation. Exiting the chat
 ends the conversation; the next invocation starts fresh. See **Future work**
 below for cross-restart persistence.
+
+The two harnesses differ in *who assigns the session id*:
+
+- **Claude** lets us pre-assign one via `--session-id <uuid>`. The chat app
+  generates a UUID upfront, sends `ConversationHint::Init { id }` on turn 1,
+  and `Resume { id }` thereafter. The id is known before any output arrives.
+- **Codex** assigns its own id and prints it in the run banner. The chat app
+  sends *no* hint on turn 1 (so codex assigns), scans the output for
+  `session id: <uuid>`, stores it, and sends `Resume { captured_id }` on
+  subsequent turns. The first captured id sticks for the rest of the chat —
+  later banners (e.g. from `codex exec resume`) don't override it.
+
+`harness::harness_supports_preassigned_session_id` distinguishes the two
+modes.
 
 ## How it works
 
@@ -62,10 +76,11 @@ CLI's own session API avoids both problems.
 ### What does *not* resume
 
 - **Switching agents mid-conversation** (`/agent codex` then `/agent claude`)
-  preserves each harness's own conversation independently. Switching to codex
-  doesn't carry over claude's context — codex has no resume support yet (see
-  below).
-- **Restarts** of `coven chat`. The conversation id is in-memory only.
+  preserves each harness's own conversation independently — they live in
+  separate entries of `harness_conversation_ids`. There's no cross-harness
+  context transfer; switching agents effectively starts (or resumes) a
+  parallel thread with the new agent.
+- **Restarts** of `coven chat`. The conversation ids are in-memory only.
 - **`/attach`ed sessions.** Typing while attached to a session launched by
   `coven run` (not by chat) still forwards to that session's stdin — the
   resume path only applies to sessions chat itself launched.
@@ -73,69 +88,66 @@ CLI's own session API avoids both problems.
 ## Adding support for a new harness
 
 1. **Map the harness CLI's resume flags.** Read the CLI's docs to find:
-   - How to create a session with a chosen id (or accept it auto-generating
-     one and capture from output).
+   - Whether the CLI lets you pre-assign a session id at launch, or whether
+     it auto-generates one (and prints it somewhere parseable).
    - How to resume a session by id in non-interactive mode.
 
-   For claude these are `--session-id <uuid>` and `--resume <uuid>` — both
-   work with `--print`. For codex they're `codex exec resume <id>` and
-   `codex exec resume --last`. Other harnesses will differ.
+   Claude: pre-assign via `--session-id <uuid>`, resume via `--resume <uuid>`
+   — both work with `--print`. Codex: auto-assigns and prints
+   `session id: <uuid>` in the run header; resume via `codex exec … resume
+   <uuid> <prompt>`.
 
 2. **Extend `continuity_args` in `crates/coven-cli/src/harness.rs`.** Add a
-   new arm to the `match spec.id` block that translates `Init` and `Resume`
-   hints into the harness's actual CLI args:
+   new arm to the `match spec.id` block translating `Init` and `Resume` into
+   the harness's actual CLI args. Both existing arms are good templates:
+   `"claude"` for pre-assigned ids, `"codex"` for the auto-assign +
+   capture-from-output flow (`Init` returns `None` so the default args run,
+   `Resume` injects `resume <id>` after the prefix args).
 
-   ```rust
-   "codex" => {
-       let cmd = match hint {
-           ConversationHint::Init { .. } => return None, // codex auto-creates
-           ConversationHint::Resume { id } => vec![
-               "exec".to_string(), "resume".to_string(), id.clone(),
-               // ...any other flags...
-           ],
-       };
-       Some(cmd)
-   }
-   ```
+3. **Tell the chat app the new harness supports resume.** Add the id to
+   `harness_supports_chat_resume` in
+   `crates/coven-cli/src/tui/chat/app.rs`. If the harness pre-assigns ids
+   (claude-style), also add it to
+   `harness::harness_supports_preassigned_session_id` so the chat generates a
+   UUID upfront. Auto-assigning harnesses (codex-style) need *no* entry
+   there.
 
-   Note codex's wrinkle: the `Init` turn doesn't take an id — codex generates
-   one. You'd need to either:
-   - Capture codex's session id from the first turn's output (it prints
-     `session id: <uuid>` in its header), parse it, and stash it as the
-     `Resume` id for follow-up turns. This is fragile to upstream format
-     changes.
-   - Or use `codex exec resume --last`, which avoids parsing but breaks if
-     the user runs another codex session in between (the wrong session
-     becomes "last").
+4. **For auto-assigning harnesses, wire output capture.** Codex uses
+   `extract_codex_session_id` (scans for `session id: <uuid>` lines) called
+   from `maybe_capture_codex_session_id` in the chat app's output event
+   handler. For a new harness with a different banner format, add a sibling
+   extractor and call it from `maybe_capture_codex_session_id` (or refactor
+   into a dispatcher keyed on `active_session_harness`).
 
-3. **Flip `harness_supports_chat_resume` in `crates/coven-cli/src/tui/chat/app.rs`.**
-   It's a simple `harness == "claude"` check today; add your new id.
+5. **Add tests** in `harness::tests` covering Init + Resume → expected args,
+   matching `claude_init_hint_attaches_session_id_flag_in_print_mode` /
+   `codex_resume_hint_uses_exec_resume_subcommand_with_id`.
 
-4. **Add tests** in `harness::tests` covering Init + Resume → expected args,
-   matching the existing `claude_init_hint_attaches_session_id_flag_in_print_mode`
-   and `claude_resume_hint_attaches_resume_flag_in_print_mode`.
-
-5. **Add an end-to-end app test** in `tui::chat::app::tests` similar to
-   `second_claude_chat_turn_reuses_init_id_as_resume`, asserting your harness
-   threads the hint through `LaunchRequest`.
+6. **Add app-level tests** in `tui::chat::app::tests` similar to
+   `second_claude_chat_turn_reuses_init_id_as_resume` (pre-assigned) or
+   `second_codex_chat_turn_resumes_using_id_captured_from_first_turn_output`
+   (capture-from-output), asserting the second turn carries `Resume` with
+   the right id.
 
 ## Future work
 
 ### Cross-restart persistence
 
-Right now a closing `coven chat` loses the conversation. To persist:
+Right now closing `coven chat` loses the conversation. To persist:
 
-1. On `Init`, write the conversation id to a per-project file under
-   `$COVEN_HOME/chat-conversations/<project-hash>.json` (or extend
-   `chat-settings.json`).
-2. On `coven chat` startup, read it back and seed
-   `harness_conversation_ids` with the stored id. Next message will send
-   `Resume`.
+1. Whenever an id is added to `harness_conversation_ids` (claude's `Init` or
+   codex's capture from output), write the `(harness, id)` pair to a
+   per-project file under `$COVEN_HOME/chat-conversations/<project-hash>.json`
+   (or extend `chat-settings.json`).
+2. On `coven chat` startup, read it back and seed `harness_conversation_ids`
+   with the stored ids. The next message will send `Resume` directly without
+   needing turn 1 to capture anything.
 3. Add a `/new` slash command to clear stored ids and start fresh (mirroring
    what `/clear` does in-memory today).
 4. Decide what to do when the stored id no longer exists on the harness side
-   (claude's `--resume` will error). Either surface the error and fall back to
-   `Init`, or detect the missing-session error pattern and silently regenerate.
+   (claude's `--resume` will error; codex's `exec resume <id>` will error).
+   Either surface the error and fall back to no-hint, or detect the
+   missing-session error pattern and silently regenerate.
 
 ### One ledger row per conversation
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -98,14 +98,17 @@ CLI's own session API avoids both problems.
   separate entries of `harness_conversation_ids`. There's no cross-harness
   context transfer; switching agents effectively starts (or resumes) a
   parallel thread with the new agent.
-- **Stale ids** — auto-recovered with auto-retry. If the harness CLI rejects
-  our `Resume` because the prior session no longer exists (claude: `No
-  conversation found with session ID:`; codex: `no rollout found for thread
-  id` / `thread/resume failed`), the chat detects the message in the output
-  stream, drops the id from both memory and disk, and immediately re-sends
-  the user's original prompt with no resume hint. The user sees "Prior
-  <harness> conversation no longer exists. Starting a new one and
-  re-sending your message." then the reply from the fresh conversation.
+- **Stale ids** — auto-recovered with auto-retry, raw error hidden. If the
+  harness CLI rejects our `Resume` because the prior session no longer
+  exists (claude: `No conversation found with session ID:`; codex: `no
+  rollout found for thread id` / `thread/resume failed`), the chat detects
+  the message in the output stream, drops the id from both memory and disk,
+  re-sends the user's original prompt with no resume hint, **and**
+  suppresses every remaining event from the failed daemon session (the
+  stale-error chunk itself, any trailing teardown output, and the orphaned
+  exit event). The transcript reads: "Prior <harness> conversation no
+  longer exists. Starting a new one and re-sending your message." → reply
+  from the fresh conversation, with no scary raw error in between.
   Bounded to one auto-retry per user turn — a second stale event in the
   same turn falls back to "Send your message again to start a fresh one."
   so a degenerate loop can't pile up launches. Detection uses output-text
@@ -163,24 +166,6 @@ CLI's own session API avoids both problems.
    the right id.
 
 ## Future work
-
-### Hiding the raw stale-error chunk from the transcript
-
-When stale-recovery fires, the user briefly sees the raw harness error
-(e.g. `No conversation found with session ID: …`) rendered as an agent
-message right before the system message and auto-retry kick in. A polish
-would suppress that one chunk from the transcript so the flow reads:
-system message → new reply, with no scary error in between. Two
-approaches:
-
-- Return early from `push_event_message`'s output branch when stale is
-  detected, skipping the human-facing render for *that* chunk only.
-- Track `suppressed_session_ids: HashSet<String>` and skip all output +
-  exit events from the failed session id (handles the case where the
-  harness emits additional output before exiting).
-
-The second is more robust but adds a sweep of the event handler; the
-first is one-line.
 
 ### `/new` as a separate verb
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -7,7 +7,7 @@ extend the mechanism to additional harnesses.
 
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
-| `claude` | ✅ stream-mode | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). |
+| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path is `libc::kill(pid, SIGTERM)`. |
 | `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -7,7 +7,7 @@ extend the mechanism to additional harnesses.
 
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
-| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path is `libc::kill(pid, SIGTERM)`. |
+| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose [--session-id|--resume <uuid>]` daemon process per chat. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path uses `setsid()` at spawn + `kill(-pid, SIGKILL)` (Unix process-group semantics) to tear down the harness and any subprocesses it spawned (skills, MCP servers, shells) in one syscall. |
 | `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -98,11 +98,16 @@ CLI's own session API avoids both problems.
   separate entries of `harness_conversation_ids`. There's no cross-harness
   context transfer; switching agents effectively starts (or resumes) a
   parallel thread with the new agent.
-- **Stale ids** — if the harness CLI no longer recognizes the persisted id
-  (e.g. you deleted claude's local session store, or codex's), the next turn
-  surfaces the harness's error as a normal exit and stops mid-conversation.
-  Recovery today is manual: `/clear` then retry. Auto-recovery is in the
-  Future work list.
+- **Stale ids** — auto-recovered. If the harness CLI rejects our `Resume`
+  because the prior session no longer exists (claude: `No conversation found
+  with session ID:`; codex: `no rollout found for thread id` /
+  `thread/resume failed`), the chat detects the message in the output
+  stream, drops the id from both memory and disk, and surfaces "Prior
+  <harness> conversation no longer exists. Send your message again to start
+  a fresh one." The next turn launches with no hint (claude) or no
+  `resume` arg (codex), creating a new conversation. Detection uses
+  output-text matching because both harnesses exit 0 on the stale-id
+  error.
 - **`/attach`ed sessions.** Typing while attached to a session launched by
   `coven run` (not by chat) still forwards to that session's stdin — the
   resume path only applies to sessions chat itself launched.
@@ -157,19 +162,22 @@ CLI's own session API avoids both problems.
 
 ## Future work
 
-### Stale-id auto-recovery
+### Auto-retry after stale-id recovery
 
-Today a stale persisted id (the harness CLI no longer knows it) surfaces as
-a normal error exit and the user has to `/clear` and retry. A nicer flow:
+Today stale-id detection drops the id and asks the user to send their
+message again. A nicer flow would auto-resend the original prompt with no
+hint so the chat appears seamless. Implementation sketch:
 
-1. Detect "session not found" in the exit event payload or stderr (each
-   harness has its own wording — claude says e.g. `No conversation found
-   with session ID …`; codex says `session <id> not found`).
-2. On detection: drop the stale id from `harness_conversation_ids`, call
-   `persist_conversations`, and surface a short system message ("Prior
-   conversation expired; starting fresh.").
-3. Optional: auto-relaunch the turn with no hint so the user doesn't have
-   to retype.
+1. Stash the last-sent prompt in `App` at launch time (e.g.
+   `last_sent_prompt: Option<String>`).
+2. On stale detection, after clearing the id, immediately re-invoke
+   `run_harness_prompt(harness, prompt)`.
+3. Guard against an infinite loop with a "retry-once" flag that resets
+   per user-typed message.
+
+This wasn't worth the complexity for the first cut — the user-facing
+"Send your message again" line plus Up-arrow to recall the prior input
+is one keystroke + Enter.
 
 ### `/new` as a separate verb
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -10,9 +10,12 @@ extend the mechanism to additional harnesses.
 | `claude` | ✅ | `claude --print --session-id <uuid>` on turn 1; `claude --print --resume <uuid>` on subsequent turns |
 | `codex` | ✅ | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns |
 
-Resume support is scoped to a single `coven chat` invocation. Exiting the chat
-ends the conversation; the next invocation starts fresh. See **Future work**
-below for cross-restart persistence.
+Conversations persist across `coven chat` invocations on a per-project basis:
+on startup the chat seeds its in-memory map from
+`$COVEN_HOME/chat-conversations/<project-key>.json`, so the next message
+sends `Resume` immediately. `/clear` deletes that file. Different projects
+get different files (the key is a deterministic FNV-1a hash of the canonical
+project root path); changing project directory yields a fresh thread.
 
 The two harnesses differ in *who assigns the session id*:
 
@@ -49,18 +52,33 @@ conversation.
 ### Data flow
 
 ```
-chat App
+chat App startup
+  └─ persistence::load_for_project(coven_home, project_root)  → HashMap<harness, id>
+       └─ seeds harness_conversation_ids
+
+chat App on user message
   └─ run_harness_prompt(harness, prompt)
        └─ conversation_hint_for_harness(harness)  → Option<ConversationHint>
+            └─ (claude pre-assign path) persistence::save_for_project(...)
             └─ LaunchRequest::with_conversation(hint)
                  └─ POST /api/v1/sessions  { ..., "conversation": {"mode": "init"|"resume", "id": "<uuid>"} }
                       └─ daemon: pty_runner::build_harness_command_with_conversation
                            └─ harness::command_parts_for_harness_with_conversation
                                 └─ continuity_args(spec, mode, hint)  → ["--print","--resume","<uuid>"]
+
+chat App on output (codex path)
+  └─ maybe_capture_codex_session_id(data)
+       └─ on hit: insert into map + persistence::save_for_project(...)
+
+chat App on /clear
+  └─ harness_conversation_ids.clear()
+       └─ persistence::clear_for_project(...)  // deletes the file
 ```
 
 `continuity_args` is the per-harness translation point — it's where you wire
 up a new harness's resume flags. It lives in `crates/coven-cli/src/harness.rs`.
+The persistence layer lives in
+`crates/coven-cli/src/tui/chat/persistence.rs`.
 
 ### Why not drive the harness TUI through a PTY?
 
@@ -80,10 +98,18 @@ CLI's own session API avoids both problems.
   separate entries of `harness_conversation_ids`. There's no cross-harness
   context transfer; switching agents effectively starts (or resumes) a
   parallel thread with the new agent.
-- **Restarts** of `coven chat`. The conversation ids are in-memory only.
+- **Stale ids** — if the harness CLI no longer recognizes the persisted id
+  (e.g. you deleted claude's local session store, or codex's), the next turn
+  surfaces the harness's error as a normal exit and stops mid-conversation.
+  Recovery today is manual: `/clear` then retry. Auto-recovery is in the
+  Future work list.
 - **`/attach`ed sessions.** Typing while attached to a session launched by
   `coven run` (not by chat) still forwards to that session's stdin — the
   resume path only applies to sessions chat itself launched.
+- **Concurrent `coven chat` invocations in the same project** race on the
+  persistence file (last write wins). For single-user terminal use this is
+  fine; multi-terminal workflows should expect the second invocation to
+  silently overwrite the first when its turn completes.
 
 ## Adding support for a new harness
 
@@ -131,23 +157,26 @@ CLI's own session API avoids both problems.
 
 ## Future work
 
-### Cross-restart persistence
+### Stale-id auto-recovery
 
-Right now closing `coven chat` loses the conversation. To persist:
+Today a stale persisted id (the harness CLI no longer knows it) surfaces as
+a normal error exit and the user has to `/clear` and retry. A nicer flow:
 
-1. Whenever an id is added to `harness_conversation_ids` (claude's `Init` or
-   codex's capture from output), write the `(harness, id)` pair to a
-   per-project file under `$COVEN_HOME/chat-conversations/<project-hash>.json`
-   (or extend `chat-settings.json`).
-2. On `coven chat` startup, read it back and seed `harness_conversation_ids`
-   with the stored ids. The next message will send `Resume` directly without
-   needing turn 1 to capture anything.
-3. Add a `/new` slash command to clear stored ids and start fresh (mirroring
-   what `/clear` does in-memory today).
-4. Decide what to do when the stored id no longer exists on the harness side
-   (claude's `--resume` will error; codex's `exec resume <id>` will error).
-   Either surface the error and fall back to no-hint, or detect the
-   missing-session error pattern and silently regenerate.
+1. Detect "session not found" in the exit event payload or stderr (each
+   harness has its own wording — claude says e.g. `No conversation found
+   with session ID …`; codex says `session <id> not found`).
+2. On detection: drop the stale id from `harness_conversation_ids`, call
+   `persist_conversations`, and surface a short system message ("Prior
+   conversation expired; starting fresh.").
+3. Optional: auto-relaunch the turn with no hint so the user doesn't have
+   to retype.
+
+### `/new` as a separate verb
+
+`/clear` today does double duty: it clears the visible transcript *and*
+the persisted conversation. A `/new` verb that only resets the conversation
+(keeping the transcript visible for context) would split the two so users
+can scroll back through history while starting a fresh thread.
 
 ### One ledger row per conversation
 

--- a/docs/es/API-CONTRACT.md
+++ b/docs/es/API-CONTRACT.md
@@ -60,17 +60,19 @@ flowchart TD
   Parse -- ok --> Route{Route exists?}
   Route -- no --> ErrNotFound["404 not_found"]
   Route -- yes --> Validate{Field validation}
-  Validate -- cwd outside root --> ErrCwd["400 project_root_violation"]
+  Validate -- cwd outside root --> ErrInvalid
   Validate -- unknown harness/action --> ErrInvalid
   Validate -- ok --> Action{Resource lookup}
   Action -- session missing --> ErrSession["404 session_not_found"]
   Action -- session not live --> ErrLive["409 session_not_live"]
-  Action -- PTY spawn fails --> ErrPty["500 pty_spawn_failed"]
+  Action -- launch (PTY/pipe spawn, init write, harness startup) fails --> ErrLaunch["500 launch_failed"]
+  Action -- send_input fails --> ErrSend["500 send_input_failed"]
+  Action -- kill_session fails --> ErrKill["500 kill_failed"]
   Action -- runtime down --> ErrRuntime["503 runtime_unavailable"]
   Action -- internal panic --> ErrInternal["500 internal_error"]
   Action -- ok --> Success[Documented success shape]
 
-  ErrInvalid & ErrNotFound & ErrCwd & ErrSession & ErrLive & ErrPty & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
+  ErrInvalid & ErrNotFound & ErrSession & ErrLive & ErrLaunch & ErrSend & ErrKill & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
 ```
 
 Todos los errores de la API usan el siguiente sobre estable. Los clientes deben ramificar en `error.code`, no en `error.message`:
@@ -94,11 +96,14 @@ Todos los errores de la API usan el siguiente sobre estable. Los clientes deben 
 | Código                 | Estado HTTP | Descripción                                      |
 |------------------------|-------------|--------------------------------------------------|
 | `not_found`            | 404         | Ruta genérica no encontrada.                     |
-| `invalid_request`      | 400 o 404   | Petición mal formada o versión de API no compatible. |
+| `invalid_request`      | 400 o 404   | Petición mal formada, id de harness desconocido, campo obligatorio ausente, o versión de API no compatible. |
 | `session_not_found`    | 404         | El id de sesión no existe.                       |
 | `session_not_live`     | 409         | La sesión existe pero no está en ejecución.      |
-| `project_root_violation`| 400        | El cwd está fuera de la raíz de proyecto declarada. |
-| `pty_spawn_failed`     | 500         | El harness PTY no pudo lanzarse.                 |
+| `project_root_violation`| 400        | Reservado. Las violaciones de cwd actualmente emiten `invalid_request`; promover a un código propio permitiría a los clientes ramificar sin parsear el mensaje. |
+| `pty_spawn_failed`     | 500         | Reservado. Los fallos de spawn de PTY actualmente emiten `launch_failed`; promover a un código propio distinguiría "no se pudo abrir el PTY" de "el CLI del harness falló al iniciar". |
+| `launch_failed`        | 500         | El daemon aceptó la petición pero el runtime (PTY/pipe spawn, escritura inicial, arranque del CLI) falló. `details.sessionId` es la fila insertada y marcada como `failed`. |
+| `send_input_failed`    | 500         | El daemon aceptó el payload de input pero la escritura del runtime falló (pipe cerrado, proceso muerto, error de IO). `details.sessionId` es la sesión afectada. |
+| `kill_failed`          | 500         | El daemon aceptó la petición de kill pero la señal/llamada del runtime falló (permisos, proceso ausente, error de IO). `details.sessionId` es la sesión afectada. |
 | `runtime_unavailable`  | 503         | El runtime de la sesión no está disponible.      |
 | `internal_error`       | 500         | Error interno inesperado.                        |
 

--- a/docs/es/SESSION-LIFECYCLE.md
+++ b/docs/es/SESSION-LIFECYCLE.md
@@ -74,7 +74,7 @@ sequenceDiagram
   end
   Daemon->>Daemon: canonicalize cwd inside projectRoot
   alt cwd outside root
-    Daemon-->>Client: 400 project_root_violation
+    Daemon-->>Client: 400 invalid_request (cwd fuera de la raíz del proyecto)
   end
   Daemon->>Daemon: lookup harness in adapter table
   alt harness unknown
@@ -82,9 +82,9 @@ sequenceDiagram
   end
   Daemon->>Store: insert session (status=created)
   Daemon->>PTY: spawn argv (prefix args + prompt)
-  alt PTY spawn fails
+  alt spawn / initial-write fails
     Daemon->>Store: update status=failed
-    Daemon-->>Client: 500 pty_spawn_failed
+    Daemon-->>Client: 500 launch_failed (details.sessionId)
   else PTY spawn ok
     Daemon->>Store: update status=running
     Daemon-->>Client: 200 SessionRecord

--- a/docs/es/reference/api.md
+++ b/docs/es/reference/api.md
@@ -36,10 +36,10 @@ flowchart LR
 | GET | `/api/v1/capabilities` | Catálogo de capabilities con pistas de política. | — | `{ capabilities: [...] }` | — |
 | POST | `/api/v1/actions` | Enrutar un id de acción conocido del plano de control. | `{ action, origin, intentId, args }` | `{ ok, accepted, status, event }` | `400 invalid_request` (acción desconocida) |
 | GET | `/api/v1/sessions` | Listar sesiones activas. | — | `SessionRecord[]` | — |
-| POST | `/api/v1/sessions` | Lanzar una sesión de harness limitada al proyecto. | `{ projectRoot, cwd?, harness, prompt, title? }` | `SessionRecord` | `400 project_root_violation`, `400 invalid_request`, `500 pty_spawn_failed` |
+| POST | `/api/v1/sessions` | Lanzar una sesión de harness limitada al proyecto. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request` (incluye cwd fuera de proyecto, id de harness desconocido, body mal formado), `500 launch_failed` (runtime spawn / escritura inicial / arranque del CLI falló; fila marcada como `failed`) |
 | GET | `/api/v1/sessions/:id` | Obtener una sesión. | — | `SessionRecord` | `404 session_not_found` |
-| POST | `/api/v1/sessions/:id/input` | Reenviar input a una sesión viva. | `{ data }` | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live` |
-| POST | `/api/v1/sessions/:id/kill` | Matar una sesión viva. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live` |
+| POST | `/api/v1/sessions/:id/input` | Reenviar input a una sesión viva. | `{ data }` | `{ ok, accepted }` | `400 invalid_request` (body mal formado / `data` ausente o no-string), `404 session_not_found`, `409 session_not_live`, `500 send_input_failed` |
+| POST | `/api/v1/sessions/:id/kill` | Matar una sesión viva. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live`, `500 kill_failed` |
 | GET | `/api/v1/events` | Leer eventos de sesión paginados. | — (`?sessionId`, `?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `400 invalid_request` |
 
 Todas las respuestas de error usan el sobre estructurado documentado en [Contrato de la API](/API-CONTRACT#structured-error-envelope).

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -36,10 +36,10 @@ flowchart LR
 | GET | `/api/v1/capabilities` | Capability catalog with policy hints. | — | `{ capabilities: [...] }` | — |
 | POST | `/api/v1/actions` | Route a known control-plane action id. | `{ action, origin, intentId, args }` | `{ ok, accepted, status, event }` | `400 invalid_request` (unknown action) |
 | GET | `/api/v1/sessions` | List active sessions. | — | `SessionRecord[]` | — |
-| POST | `/api/v1/sessions` | Launch a project-scoped harness session. | `{ projectRoot, cwd?, harness, prompt, title? }` | `SessionRecord` | `400 project_root_violation`, `400 invalid_request`, `500 pty_spawn_failed` |
+| POST | `/api/v1/sessions` | Launch a project-scoped harness session. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request` (includes cwd-outside-project-root, unknown harness id, malformed body, etc.), `500 launch_failed` (runtime spawn / initial-message-write / harness startup failed; row marked `failed`) |
 | GET | `/api/v1/sessions/:id` | Fetch one session. | — | `SessionRecord` | `404 session_not_found` |
-| POST | `/api/v1/sessions/:id/input` | Forward input to a live session. | `{ data }` | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live` |
-| POST | `/api/v1/sessions/:id/kill` | Kill a live session. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live` |
+| POST | `/api/v1/sessions/:id/input` | Forward input to a live session. | `{ data }` | `{ ok, accepted }` | `400 invalid_request` (malformed body / missing or non-string `data`), `404 session_not_found`, `409 session_not_live`, `500 send_input_failed` |
+| POST | `/api/v1/sessions/:id/kill` | Kill a live session. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live`, `500 kill_failed` |
 | GET | `/api/v1/events` | Read paginated session events. | — (`?sessionId`, `?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `400 invalid_request` |
 
 All error responses use the structured envelope documented in [API contract](/API-CONTRACT#structured-error-envelope).

--- a/docs/ru/API-CONTRACT.md
+++ b/docs/ru/API-CONTRACT.md
@@ -60,17 +60,19 @@ flowchart TD
   Parse -- ok --> Route{Route exists?}
   Route -- no --> ErrNotFound["404 not_found"]
   Route -- yes --> Validate{Field validation}
-  Validate -- cwd outside root --> ErrCwd["400 project_root_violation"]
+  Validate -- cwd outside root --> ErrInvalid
   Validate -- unknown harness/action --> ErrInvalid
   Validate -- ok --> Action{Resource lookup}
   Action -- session missing --> ErrSession["404 session_not_found"]
   Action -- session not live --> ErrLive["409 session_not_live"]
-  Action -- PTY spawn fails --> ErrPty["500 pty_spawn_failed"]
+  Action -- launch (PTY/pipe spawn, init write, harness startup) fails --> ErrLaunch["500 launch_failed"]
+  Action -- send_input fails --> ErrSend["500 send_input_failed"]
+  Action -- kill_session fails --> ErrKill["500 kill_failed"]
   Action -- runtime down --> ErrRuntime["503 runtime_unavailable"]
   Action -- internal panic --> ErrInternal["500 internal_error"]
   Action -- ok --> Success[Documented success shape]
 
-  ErrInvalid & ErrNotFound & ErrCwd & ErrSession & ErrLive & ErrPty & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
+  ErrInvalid & ErrNotFound & ErrSession & ErrLive & ErrLaunch & ErrSend & ErrKill & ErrRuntime & ErrInternal -->|"{ error: { code, message, details } }"| Client[Client branches on code]
 ```
 
 Все ошибки API используют следующий стабильный конверт. Клиенты должны ветвиться по `error.code`, а не по `error.message`:
@@ -94,11 +96,14 @@ flowchart TD
 | Код                    | HTTP-статус | Описание                                         |
 |------------------------|-------------|--------------------------------------------------|
 | `not_found`            | 404         | Общий маршрут не найден.                         |
-| `invalid_request`      | 400 или 404 | Некорректный запрос или неподдерживаемая версия API. |
+| `invalid_request`      | 400 или 404 | Некорректный запрос, неизвестный id harness, отсутствует обязательное поле, или неподдерживаемая версия API. |
 | `session_not_found`    | 404         | Id сессии не существует.                         |
 | `session_not_live`     | 409         | Сессия существует, но не выполняется.            |
-| `project_root_violation`| 400        | cwd находится вне объявленного корня проекта.    |
-| `pty_spawn_failed`     | 500         | PTY harness не удалось запустить.                |
+| `project_root_violation`| 400        | Зарезервировано. Нарушения cwd сейчас возвращают `invalid_request`; продвижение в отдельный код позволит клиентам ветвиться без парсинга текста. |
+| `pty_spawn_failed`     | 500         | Зарезервировано. Сбои spawn PTY сейчас возвращают `launch_failed`; продвижение в отдельный код позволит различать "не удалось открыть PTY" и "CLI harness упал при старте". |
+| `launch_failed`        | 500         | Демон принял payload запуска, но runtime (PTY/pipe spawn, начальная запись, старт CLI harness) дал сбой. `details.sessionId` — строка, помеченная как `failed`. |
+| `send_input_failed`    | 500         | Демон принял payload ввода, но запись в runtime дала сбой (закрытый pipe, мёртвый процесс, ошибка IO). `details.sessionId` — затронутая сессия. |
+| `kill_failed`          | 500         | Демон принял запрос kill, но сигнал/вызов runtime дал сбой (нет прав, отсутствует процесс, ошибка IO). `details.sessionId` — затронутая сессия. |
 | `runtime_unavailable`  | 503         | Runtime сессии недоступен.                       |
 | `internal_error`       | 500         | Неожиданная внутренняя ошибка.                   |
 

--- a/docs/ru/SESSION-LIFECYCLE.md
+++ b/docs/ru/SESSION-LIFECYCLE.md
@@ -74,7 +74,7 @@ sequenceDiagram
   end
   Daemon->>Daemon: canonicalize cwd inside projectRoot
   alt cwd outside root
-    Daemon-->>Client: 400 project_root_violation
+    Daemon-->>Client: 400 invalid_request (cwd вне корня проекта)
   end
   Daemon->>Daemon: lookup harness in adapter table
   alt harness unknown
@@ -82,9 +82,9 @@ sequenceDiagram
   end
   Daemon->>Store: insert session (status=created)
   Daemon->>PTY: spawn argv (prefix args + prompt)
-  alt PTY spawn fails
+  alt spawn / initial-write fails
     Daemon->>Store: update status=failed
-    Daemon-->>Client: 500 pty_spawn_failed
+    Daemon-->>Client: 500 launch_failed (details.sessionId)
   else PTY spawn ok
     Daemon->>Store: update status=running
     Daemon-->>Client: 200 SessionRecord

--- a/docs/ru/reference/api.md
+++ b/docs/ru/reference/api.md
@@ -36,10 +36,10 @@ flowchart LR
 | GET | `/api/v1/capabilities` | Каталог capabilities с подсказками политики. | — | `{ capabilities: [...] }` | — |
 | POST | `/api/v1/actions` | Маршрутизировать известный id действия плоскости управления. | `{ action, origin, intentId, args }` | `{ ok, accepted, status, event }` | `400 invalid_request` (неизвестное действие) |
 | GET | `/api/v1/sessions` | Перечислить активные сессии. | — | `SessionRecord[]` | — |
-| POST | `/api/v1/sessions` | Запустить сессию harness'а, ограниченную проектом. | `{ projectRoot, cwd?, harness, prompt, title? }` | `SessionRecord` | `400 project_root_violation`, `400 invalid_request`, `500 pty_spawn_failed` |
+| POST | `/api/v1/sessions` | Запустить сессию harness'а, ограниченную проектом. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request` (включая cwd вне проекта, неизвестный id harness, некорректный body), `500 launch_failed` (runtime spawn / начальная запись / старт CLI дали сбой; строка помечена как `failed`) |
 | GET | `/api/v1/sessions/:id` | Получить одну сессию. | — | `SessionRecord` | `404 session_not_found` |
-| POST | `/api/v1/sessions/:id/input` | Переслать input в живую сессию. | `{ data }` | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live` |
-| POST | `/api/v1/sessions/:id/kill` | Убить живую сессию. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live` |
+| POST | `/api/v1/sessions/:id/input` | Переслать input в живую сессию. | `{ data }` | `{ ok, accepted }` | `400 invalid_request` (некорректный body / `data` отсутствует или не-string), `404 session_not_found`, `409 session_not_live`, `500 send_input_failed` |
+| POST | `/api/v1/sessions/:id/kill` | Убить живую сессию. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live`, `500 kill_failed` |
 | GET | `/api/v1/events` | Прочитать пагинированные события сессии. | — (`?sessionId`, `?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `400 invalid_request` |
 
 Все ответы об ошибках используют структурированный конверт, задокументированный в [Контракт API](/API-CONTRACT#structured-error-envelope).


### PR DESCRIPTION
## Summary

The whole arc of `coven chat`:

- **Per-turn conversations**: claude turns ride `claude --print --session-id <uuid>` then `--resume <uuid>`; codex turns capture `session id: <uuid>` from output and feed it back as `codex exec … resume <uuid> <prompt>`.
- **Cross-restart persistence**: per-project `$COVEN_HOME/chat-conversations/<key>.json` seeds the resume ids so closing and reopening `coven chat` continues the same thread.
- **Reset verbs**: `/clear` (transcript + ids), `/new` (ids only, transcript preserved).
- **Stale-id auto-recovery**: detected from output, drops stale id, auto-retries the user's prompt, suppresses the failed session's events from the transcript so the user just sees system message → fresh reply.
- **One ledger row per conversation**: new `conversation_id` column on the sessions table (additive migration) groups chat turns; `/sessions` overlay collapses them with an `Nt` turn-count badge.
- **Warm claude via stream-json**: claude turns now ride a long-lived daemon process (`claude --print --input-format stream-json --output-format stream-json --verbose`). First turn spawns + writes the initial user envelope; subsequent turns pipe new JSON messages into the same stdin and read JSON events back. Output handler parses `assistant.message.content[].text` and clears `is_responding` on `result`. Codex keeps the per-turn path (no stream-json equivalent in the codex CLI).
- Replaces the prior Interactive-PTY-driving approach that silently dropped follow-up messages once the harness negotiated the Kitty keyboard protocol.
- Preserves the `/attach + type → stdin` flow for sessions launched outside chat via a `chat_owns_active_session` flag.
- `harness::harness_supports_preassigned_session_id` (claude pre-assigns; codex auto-assigns) and `harness::harness_supports_stream_mode` (claude only) gate the two harness-specific paths.
- `docs/chat-persistence.md` documents the whole design: per-harness mechanics, why we avoided driving the harness TUI, recipe for adding new harnesses, failure modes, and remaining future-work (codex stream-mode if their CLI gets one; first-party Coven gateway).

## Test plan

- [x] `cargo build -p coven-cli --bin coven` — clean
- [x] `cargo test -p coven-cli --bin coven` — 570 passed, 0 failed (55+ new tests across `harness::`, `api::`, `tui::chat::client::`, `tui::chat::persistence::`, `tui::chat::render::`, `tui::chat::app::`)
- [x] End-to-end against the live daemon — claude per-turn turn 1 "Hi Persist." / turn 2 via `--resume` "Persist." Codex turn 1 captured `session id: 019e599b-…` / turn 2 with that id "You told me your name is `CodexPersist2`." Stale resumes printed verbatim error messages that the detection patterns match for both harnesses. Two claude chat turns with the same `conversationId` payload field stored as two session rows sharing one conversation_id. Stream-mode: one daemon stream session handled multiple JSON messages, both replies came back with their result events.
- [ ] Reviewer: launch `coven chat`, send 2+ messages with `claude`; confirm the second message references the first AND `/sessions` shows the conversation as one singleton row (no badge — claude stream-mode reuses one daemon row across turns) AND turn 2's cold-start is gone (you should see "Connected" only once, on the first turn)
- [ ] Reviewer: same with `codex` (note codex's first turn appears as its own row until you send the second message; codex still cold-starts each turn)
- [ ] Reviewer: close and reopen `coven chat` in the same directory, send a message that references the prior conversation, confirm it's remembered
- [ ] Reviewer: edit `$COVEN_HOME/chat-conversations/<...>.json` to set the stored claude id to `00000000-0000-0000-0000-000000000000`, reopen `coven chat`, send a message — confirm the transcript shows ONLY "Prior claude conversation no longer exists. Starting a new one and re-sending your message." + the fresh reply
- [ ] Reviewer: `/clear` mid-conversation; confirm transcript clears AND a subsequent restart starts fresh AND any long-lived claude process is killed (check `ps aux | grep claude`)
- [ ] Reviewer: `/new` mid-conversation; confirm transcript is preserved but the next message starts a fresh thread
- [ ] Reviewer: `/attach` to a `coven run` session; confirm typing still forwards to that session

🤖 Generated with [Claude Code](https://claude.com/claude-code)