### PR TITLE
fix(openclaw-coven): validate cwd before unavailable-daemon fallback

### DIFF
--- a/packages/openclaw-coven/src/runtime.test.ts
+++ b/packages/openclaw-coven/src/runtime.test.ts
@@ -178,16 +178,23 @@ describe("CovenAcpRuntime", () => {
         }),
       }),
     });
+    const outsideWorkspaceDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "openclaw-coven-outside-workspace-"),
+    );
 
-    await expect(
-      runtime.ensureSession({
-        sessionKey: "agent:codex:test",
-        agent: "codex",
-        mode: "oneshot",
-        cwd: "/tmp/attacker",
-      }),
-    ).rejects.toThrow(/outside workspace/);
-    expect(fallback.ensureSession).not.toHaveBeenCalled();
+    try {
+      await expect(
+        runtime.ensureSession({
+          sessionKey: "agent:codex:test",
+          agent: "codex",
+          mode: "oneshot",
+          cwd: outsideWorkspaceDir,
+        }),
+      ).rejects.toThrow(/outside workspace/);
+      expect(fallback.ensureSession).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(outsideWorkspaceDir, { recursive: true, force: true });
+    }
   });
   it("falls back when Coven health checks do not settle before the deadline", async () => {
     vi.useFakeTimers();

--- a/packages/openclaw-coven/src/runtime.test.ts
+++ b/packages/openclaw-coven/src/runtime.test.ts
@@ -166,6 +166,29 @@ describe("CovenAcpRuntime", () => {
     expect(fallback.ensureSession).toHaveBeenCalledOnce();
   });
 
+
+  it("rejects unavailable-Coven fallback sessions whose cwd is outside the workspace", async () => {
+    const fallback = fallbackRuntime();
+    registerAcpRuntimeBackend({ id: "acpx", runtime: fallback });
+    const runtime = new CovenAcpRuntime({
+      config: { ...config, allowFallback: true },
+      client: fakeClient({
+        health: vi.fn(async () => {
+          throw new Error("offline");
+        }),
+      }),
+    });
+
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:codex:test",
+        agent: "codex",
+        mode: "oneshot",
+        cwd: "/tmp/attacker",
+      }),
+    ).rejects.toThrow(/outside workspace/);
+    expect(fallback.ensureSession).not.toHaveBeenCalled();
+  });
   it("falls back when Coven health checks do not settle before the deadline", async () => {
     vi.useFakeTimers();
     const fallback = fallbackRuntime();

--- a/packages/openclaw-coven/src/runtime.ts
+++ b/packages/openclaw-coven/src/runtime.ts
@@ -615,7 +615,10 @@ export class CovenAcpRuntime implements AcpRuntime {
   private async ensureFallbackSession(
     input: Parameters<AcpRuntime["ensureSession"]>[0],
   ): Promise<AcpRuntimeHandle> {
-    return await this.requireFallbackRuntime().ensureSession(input);
+    return await this.requireFallbackRuntime().ensureSession({
+      ...input,
+      cwd: this.resolveWorkspaceCwd(input.cwd),
+    });
   }
 
   private async *runFallbackTurn(


### PR DESCRIPTION
### Motivation
- Prevent a workspace-confinement bypass where the unavailable-daemon fallback forwarded an attacker-controlled absolute `cwd` to the fallback runtime without validation.
- Ensure the same `resolveWorkspaceCwd()` check used for other fallback paths is applied to the direct unavailable-Coven fallback path.

### Description
- In `packages/openclaw-coven/src/runtime.ts` updated `ensureFallbackSession()` to call `this.resolveWorkspaceCwd(input.cwd)` and pass the sanitized `cwd` to the fallback runtime instead of forwarding the raw `input` unchanged.
- Added a regression test `rejects unavailable-Coven fallback sessions whose cwd is outside the workspace` in `packages/openclaw-coven/src/runtime.test.ts` that asserts an out-of-workspace `cwd` is rejected and the fallback `ensureSession` is not invoked.

### Testing
- Added the unit test in `packages/openclaw-coven/src/runtime.test.ts` but running the test suite in this environment failed to install `vitest` due to registry access (`npm ERR! 403 Forbidden`), so automated test execution could not be completed here.
- The change is intentionally minimal and uses the existing `resolveWorkspaceCwd()` helper to preserve current runtime behavior while closing the bypass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5eca05dc8327bd398e8ccadbfdc6)