### PR TITLE
fix(daemon): enforce loopback-only TCP API binding

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -882,9 +882,19 @@ fn ensure_loopback_addrs(addrs: &[SocketAddr]) -> Result<()> {
     if addrs.is_empty() {
         anyhow::bail!("TCP listener address did not resolve to any sockets");
     }
-    if addrs.iter().any(|addr| !addr.ip().is_loopback()) {
+    let non_loopback_addrs: Vec<SocketAddr> = addrs
+        .iter()
+        .copied()
+        .filter(|addr| !addr.ip().is_loopback())
+        .collect();
+    if !non_loopback_addrs.is_empty() {
+        let non_loopback_addrs = non_loopback_addrs
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ");
         anyhow::bail!(
-            "refusing to bind Coven TCP API to non-loopback address; use 127.0.0.1 or ::1"
+            "refusing to bind Coven TCP API to non-loopback address(es): {non_loopback_addrs}; use 127.0.0.1 or ::1"
         );
     }
     Ok(())

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io::Write;
-use std::net::TcpListener;
+use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
@@ -878,8 +878,26 @@ fn daemon_status_from_health_socket(socket: &str) -> Result<Option<DaemonStatus>
 pub const TCP_IO_TIMEOUT: Duration = Duration::from_secs(30);
 pub const MAX_TCP_BODY_BYTES: usize = 1024 * 1024;
 
-pub fn bind_tcp_listener<A: std::net::ToSocketAddrs>(addr: A) -> Result<TcpListener> {
-    let listener = TcpListener::bind(&addr).with_context(|| "failed to bind Coven TCP listener")?;
+fn ensure_loopback_addrs(addrs: &[SocketAddr]) -> Result<()> {
+    if addrs.is_empty() {
+        anyhow::bail!("TCP listener address did not resolve to any sockets");
+    }
+    if addrs.iter().any(|addr| !addr.ip().is_loopback()) {
+        anyhow::bail!(
+            "refusing to bind Coven TCP API to non-loopback address; use 127.0.0.1 or ::1"
+        );
+    }
+    Ok(())
+}
+
+pub fn bind_tcp_listener<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
+    let addrs: Vec<SocketAddr> = addr
+        .to_socket_addrs()
+        .context("failed to resolve Coven TCP listener address")?
+        .collect();
+    ensure_loopback_addrs(&addrs)?;
+    let listener =
+        TcpListener::bind(&addrs[..]).with_context(|| "failed to bind Coven TCP listener")?;
     Ok(listener)
 }
 
@@ -1427,6 +1445,16 @@ mod tests {
 
         assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
         assert!(response.contains("\"apiVersion\""), "got: {response}");
+    }
+
+    #[test]
+    fn bind_tcp_listener_rejects_non_loopback() {
+        let error = bind_tcp_listener("0.0.0.0:0").expect_err("should reject wildcard bind");
+        let msg = format!("{error:#}");
+        assert!(
+            msg.contains("non-loopback"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the unauthenticated daemon HTTP API by rejecting non-loopback TCP bind targets so the `--tcp` transport cannot be bound to `0.0.0.0`, `[::]`, or other non-loopback interfaces.

### Description
- Validate resolved socket addresses in `bind_tcp_listener` by resolving the provided `ToSocketAddrs` and calling a new `ensure_loopback_addrs` helper that fails if any address is not loopback.
- Update imports to use `SocketAddr` and `ToSocketAddrs` and change `bind_tcp_listener` to resolve and bind the validated address list.
- Add a regression unit test `bind_tcp_listener_rejects_non_loopback` that asserts wildcard/non-loopback binds (e.g. `0.0.0.0:0`) are rejected.
- Keep existing loopback behavior intact; existing TCP health test (`bind_tcp_listener_serves_health_over_tcp`) continues to pass.

### Testing
- Ran `cargo test -p coven-cli bind_tcp_listener -- --nocapture`, and the tests passed: `bind_tcp_listener_rejects_non_loopback` and `bind_tcp_listener_serves_health_over_tcp` both succeeded.
- Existing test suite for the affected crate completed successfully for the exercised tests (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a133d421b048327964938818dff5ae9)