### PR TITLE
Secure private session logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +199,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,6 +234,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -282,6 +327,7 @@ name = "coven-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "chacha20poly1305",
  "chrono",
  "clap",
  "crossterm",
@@ -289,6 +335,7 @@ dependencies = [
  "libc",
  "portable-pty",
  "ratatui",
+ "regex",
  "rusqlite",
  "serde",
  "serde_json",
@@ -343,6 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
 ]
 
@@ -740,6 +788,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,6 +1138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1277,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1374,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "ratatui"
@@ -1686,6 +1763,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2044,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "utf8parse"
@@ -2425,6 +2518,12 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 <h1 align="center">OpenCoven / Coven</h1>
 
-<h3 align="center">The local runtime that powers CastCodes</h3>
+<h3 align="center">Project-scoped harness sessions for the OpenCoven ecosystem</h3>
 
 <p align="center">
-  Coven powers CastCodes with project-scoped harness sessions, local logs, artifacts, handoffs, policy, and orchestration.<br/>
-  CastCodes is where users inspect the work. Coven is the runtime authority underneath.
+  Run Codex, Claude Code, and future harnesses inside explicit local project boundaries.<br/>
+  Launch, observe, attach, and coordinate agent work through one neutral runtime substrate.
 </p>
 
 <p align="center">
@@ -76,20 +76,29 @@ coven sessions --json
 
 `coven doctor` checks whether supported local harness CLIs are available. `coven run` creates a project-scoped session record, validates the working directory, and launches the selected harness through Coven-managed PTY execution. In a terminal, `coven sessions` opens a human session browser where you can select work and choose visible actions like **Rejoin**, **View Log**, **Summon**, **Archive**, and **Sacrifice** without copying IDs; use `--plain` for scripts or `--json` for client discovery.
 
+Coven also provides a rescue loop for OpenClaw contributors and users:
+
+```sh
+coven patch openclaw
+```
+
+If OpenClaw breaks, Coven gives you a predictable repair room: choose a repo, choose a harness, get a verified patch.
+
 ## What it does
 
-Coven is the local harness substrate for CastCodes. It does not replace the workspace UI; it gives CastCodes a trusted room where project work can happen visibly and safely.
+Coven is the local harness substrate for OpenCoven. It does not replace your coding agent, your UI, or OpenClaw. It gives them a shared room where project work can happen visibly and safely.
 
-OpenCoven is the umbrella behind that product direction. CastCodes is the public workspace; Coven is the local runtime layer: project-scoped sessions, harness-neutral execution, inspectable history, and explicit authority boundaries.
+OpenCoven is an open ecosystem for persistent AI familiars: named agents with memory, tools, identity, roles, and continuity. Coven provides the local runtime layer for that vision: project-scoped sessions, harness-neutral execution, inspectable history, and explicit authority boundaries.
 
 - **Project-root boundaries** — every launch is tied to an explicit repository/project root.
 - **Harness-neutral runtime** — v0 focuses on Codex and Claude Code, with a clean adapter path for future harnesses.
 - **Human session browser** — live and completed work can be selected, rejoined, viewed, archived, restored, or sacrificed without memorizing ids.
 - **Attachable PTY sessions** — live work can still be replayed/followed from explicit CLI verbs.
-- **CastCodes runtime API** — CastCodes and advanced local integrations coordinate through the same socket contract.
+- **Local daemon API** — comux, OpenMeow, and the external OpenClaw plugin can coordinate through the same socket contract.
 - **SQLite-backed history** — session metadata and event logs survive daemon restarts.
+- **Redacted logs by default** — event payloads are redacted before normal storage and API display; raw artifacts are opt-in, encrypted locally, and short-lived.
 - **Rust authority layer** — launch, cwd, input, kill, and path-sensitive requests are revalidated in Rust.
-- **Advanced compatibility** — legacy and external clients stay outside the trust root and talk to Coven as socket clients.
+- **External OpenClaw bridge** — `@opencoven/coven` is an opt-in plugin; OpenClaw core does not include Coven code.
 - **OpenCoven package shape** — CLI wrapper packages live under the `@opencoven/*` namespace while the command stays `coven`.
 
 ## Commands
@@ -110,11 +119,12 @@ OpenCoven is the umbrella behind that product direction. CastCodes is the public
 | `coven sessions --all` | Browse active and archived sessions in a terminal; print all when piped |
 | `coven sessions --manage` | Force the interactive session browser |
 | `coven sessions --plain` | Force plain table output for scripts/copying |
-| `coven sessions --json` | Print a JSON `sessions` array for CastCodes and other local clients |
+| `coven sessions --json` | Print a JSON `sessions` array for clients such as comux |
 | `coven attach <session-id>` | Replay/follow session output and forward input |
 | `coven summon <session-id>` | Restore an archived session, then replay/follow it |
 | `coven archive <session-id>` | Hide a non-running session from the active list while preserving events |
 | `coven sacrifice <session-id> --yes` | Permanently delete a non-running session and its events |
+| `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs |
 
 Session rituals are intentionally explicit. **Archive** is reversible and keeps the ledger. **Summon** brings an archived session back into the active list. **Sacrifice** is destructive, refuses live sessions, and requires `--yes` so beginners do not delete work by accident.
 
@@ -132,10 +142,14 @@ Coven's current auth posture is same-user local access over `<covenHome>/coven.s
 | `POST /api/v1/sessions` | Launch a session |
 | `GET /api/v1/sessions/:id` | Fetch one session |
 | `GET /api/v1/events?sessionId=...` | Read session events |
+| `GET /api/v1/sessions/:id/events` | Read redacted session events |
+| `GET /api/v1/sessions/:id/log` | Read bounded redacted log previews |
 | `POST /api/v1/sessions/:id/input` | Forward input to a live session |
 | `POST /api/v1/sessions/:id/kill` | Kill a live session |
 
 Treat the socket API as the product contract. Clients may validate for UX, but the Rust daemon remains the authority boundary. See [`docs/API.md`](docs/API.md) for compatibility rules.
+
+Default API log and event responses are redacted. Raw sensitive artifacts are not returned by broad endpoints and remain unavailable unless explicit local debug persistence is enabled.
 
 Current stable contract: [`docs/API-CONTRACT.md`](docs/API-CONTRACT.md). `GET /api/v1/health` exposes the named contract `apiVersion: "coven.daemon.v1"` and machine-readable capabilities for client handshakes.
 
@@ -160,13 +174,13 @@ npm install -g @anthropic-ai/claude-code
 claude doctor
 ```
 
-## CastCodes integration
+## OpenCoven integrations
 
-CastCodes is the primary public workspace and proof surface for Coven. It should present visible project-scoped lanes, terminal/output status, local workspace context, changed files, diffs, verification results, and explicit review/merge/cleanup actions while Coven remains the daemon/runtime/API/session authority.
+- **comux** is the visual cockpit for agent panes and can consume Coven-managed sessions through the local API.
+- **OpenClaw** integrates only through the external `@opencoven/coven` plugin package.
+- **OpenMeow** can consume Coven session status, intake, or notifications as the desktop companion surface matures.
 
-comux proved useful terminal-cockpit primitives: panes, worktree isolation, agent launchers, rituals, file/diff inspection, review, merge, PR, cleanup, lifecycle hooks, and Coven session visibility. Those primitives are being folded into CastCodes-native concepts so Coven has one primary product surface.
-
-Advanced compatibility paths such as comux, OpenMeow, and the external `@opencoven/coven` OpenClaw plugin may remain documented where technically necessary, but beginner/product docs should not lead with them.
+Coven is the room where harnesses run. The clients decide how to present and route that work.
 
 ## Documentation
 
@@ -180,8 +194,7 @@ Advanced compatibility paths such as comux, OpenMeow, and the external `@opencov
 - [Glossary](docs/GLOSSARY.md) — future orchestration terms without current CLI/API promises.
 
 ### Architecture & Reference
-- [CastCodes integration](docs/CASTCODES-INTEGRATION.md)
-- [comux migration reference](docs/COMUX-DEMO-LOOP.md)
+- [comux + Coven demo loop](docs/COMUX-DEMO-LOOP.md)
 - [Architecture diagrams](docs/ARCHITECTURE.md)
 - [Session lifecycle](docs/SESSION-LIFECYCLE.md)
 - [Operational model](docs/OPERATIONAL-MODEL.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,19 @@ Coven should not require repository-stored secrets. Runtime state belongs outsid
 - private keys and certificates
 
 The CI secret guard scans both the current tree and git history for common token/key patterns without printing matched values.
+
+## Session logs and sensitive artifacts
+
+Coven treats session logs, prompts, harness output, tool payloads, and event history as sensitive local data. Do not place secrets in prompts or session context.
+
+Default session event payloads are redacted before they are stored in SQLite or returned from `/events`, `/sessions/:id/events`, or `/sessions/:id/log`. Redaction covers common authorization headers, cookies, provider token shapes, private key blocks, secret-like `.env` assignments, private gateway URLs, and configured extra patterns.
+
+Raw sensitive artifact persistence is disabled by default. If `privacy.toml` sets `persist_raw_artifacts = true` or `COVEN_PERSIST_RAW_ARTIFACTS=1`, Coven stores raw payload artifacts separately from normal logs using authenticated local encryption. The encryption key is generated under `<COVEN_HOME>/keys/session-artifacts.key` with private file permissions and is not stored in the repository or SQLite database.
+
+The local key-file provider is an MVP for local-first encryption. It protects raw artifact rows from casual database inspection, but it is not a replacement for OS keychain-backed key management on shared or higher-risk machines.
+
+Default retention is short for raw encrypted artifacts and bounded for operational logs:
+
+- Raw encrypted artifacts: 7 days.
+- Redacted event logs: 30 days.
+- Manual pruning: `coven logs prune`.

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -23,6 +23,8 @@ toml = "1.1"
 uuid = { version = "1", features = ["v4"] }
 sysinfo = "0.39"
 dirs-next = "2"
+regex = "1"
+chacha20poly1305 = { version = "0.10", features = ["std", "rand_core"] }
 # Chat TUI
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "underline-color"] }
 unicode-width = "0.2"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -9,8 +9,9 @@ use uuid::Uuid;
 use crate::{
     control_plane,
     daemon::DaemonStatus,
+    encrypted_artifacts::SensitiveArtifactStore,
     harness::{ConversationHint, HarnessLaunchMode},
-    project, store,
+    privacy, project, store,
 };
 
 const MAX_EVENTS_LIMIT: i64 = 1_000;
@@ -212,6 +213,15 @@ pub fn handle_request_with_runtime(
         ("GET", path) if path.starts_with("/sessions/") && path.ends_with("/log") => {
             let session_id = session_action_id(path, "/log");
             list_session_log(coven_home, session_id)
+        }
+        ("GET", path) if path.starts_with("/sessions/") && path.ends_with("/events") => {
+            let session_id = session_action_id(path, "/events");
+            let q = query.unwrap_or_default();
+            list_session_events(coven_home, session_id, q)
+        }
+        ("GET", path) if path.starts_with("/sessions/") && path.contains("/artifacts/") => {
+            let q = query.unwrap_or_default();
+            get_session_artifact(coven_home, path, q)
         }
         ("GET", path) if path.starts_with("/sessions/") => {
             let session_id = path.trim_start_matches("/sessions/");
@@ -483,7 +493,7 @@ fn record_input(
             Some(json!({ "sessionId": session_id })),
         );
     }
-    insert_event(&conn, session_id, "input", payload)?;
+    insert_event(&conn, coven_home, session_id, "input", payload)?;
     json_response(202, &json!({ "ok": true, "accepted": true }))
 }
 
@@ -524,7 +534,13 @@ fn kill_session(
     }
     let now = current_timestamp();
     store::update_session_status(&conn, session_id, "killed", None, &now)?;
-    insert_event(&conn, session_id, "kill", json!({ "status": "killed" }))?;
+    insert_event(
+        &conn,
+        coven_home,
+        session_id,
+        "kill",
+        json!({ "status": "killed" }),
+    )?;
     json_response(202, &json!({ "ok": true, "accepted": true }))
 }
 
@@ -654,6 +670,7 @@ fn submit_cast(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
     }
     insert_event(
         &conn,
+        coven_home,
         session_id,
         "cast",
         json!({ "cast_id": cast_id, "code": code, "target": target }),
@@ -785,6 +802,76 @@ fn list_session_log(coven_home: &Path, session_id: &str) -> Result<ApiResponse> 
     json_response(200, &lines)
 }
 
+fn get_session_artifact(coven_home: &Path, path: &str, query: &str) -> Result<ApiResponse> {
+    let Some(rest) = path.strip_prefix("/sessions/") else {
+        return api_error(404, "not_found", "Route not found.", None);
+    };
+    let Some((session_id, artifact_id)) = rest.split_once("/artifacts/") else {
+        return api_error(404, "not_found", "Route not found.", None);
+    };
+    if query_param(query, "raw") != Some("1") {
+        return api_error(
+            400,
+            "raw_artifact_requires_raw_flag",
+            "Raw artifact retrieval requires raw=1.",
+            Some(json!({ "sessionId": session_id, "artifactId": artifact_id })),
+        );
+    }
+    let config = privacy::load_config(coven_home).unwrap_or_default();
+    if !config.persist_raw_artifacts {
+        return api_error(
+            403,
+            "raw_artifacts_disabled",
+            "Raw artifact persistence is not enabled.",
+            Some(json!({ "sessionId": session_id, "artifactId": artifact_id })),
+        );
+    }
+
+    let conn = store::open_store(&store_path(coven_home))?;
+    if store::get_session(&conn, session_id)?.is_none() {
+        return api_error(
+            404,
+            "session_not_found",
+            "Session was not found.",
+            Some(json!({ "sessionId": session_id })),
+        );
+    }
+    let Some(artifact) = store::get_sensitive_artifact(&conn, session_id, artifact_id)? else {
+        return api_error(
+            404,
+            "artifact_not_found",
+            "Sensitive artifact was not found.",
+            Some(json!({ "sessionId": session_id, "artifactId": artifact_id })),
+        );
+    };
+    if artifact.expires_at <= current_timestamp() {
+        return api_error(
+            404,
+            "artifact_expired",
+            "Sensitive artifact has expired.",
+            Some(json!({ "sessionId": session_id, "artifactId": artifact_id })),
+        );
+    }
+    let plaintext = SensitiveArtifactStore::load(coven_home)?.decrypt(
+        session_id,
+        &artifact.event_id,
+        &artifact.kind,
+        &store::artifact_payload(&artifact),
+    )?;
+    let payload = serde_json::from_slice::<Value>(&plaintext)
+        .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&plaintext).into_owned()));
+    json_response(
+        200,
+        &json!({
+            "sessionId": session_id,
+            "artifactId": artifact.id,
+            "eventId": artifact.event_id,
+            "kind": artifact.kind,
+            "payload": payload,
+        }),
+    )
+}
+
 fn event_to_log_line(event: store::EventRecord) -> LogLineDto {
     let payload: Value = serde_json::from_str(&event.payload_json).unwrap_or(Value::Null);
     let preview = payload_preview(&payload);
@@ -803,34 +890,19 @@ fn event_to_log_line(event: store::EventRecord) -> LogLineDto {
 }
 
 fn payload_preview(payload: &Value) -> String {
-    const MAX: usize = 240;
-    // `data` is what the daemon's input/output events actually carry (see
-    // `LiveSessionRuntime::send_input` and the output observer); `text` and
-    // `message` cover hand-rolled event shapes we may emit later.
-    let text = payload
-        .get("text")
-        .or_else(|| payload.get("message"))
-        .or_else(|| payload.get("data"))
-        .and_then(Value::as_str)
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| payload.to_string());
-    if text.chars().count() > MAX {
-        let mut truncated: String = text.chars().take(MAX).collect();
-        truncated.push('…');
-        truncated
-    } else {
-        text
-    }
+    privacy::payload_preview(payload, 240)
 }
 
 fn insert_event(
     conn: &rusqlite::Connection,
+    coven_home: &Path,
     session_id: &str,
     kind: &str,
     payload: Value,
 ) -> Result<()> {
-    store::insert_event(
+    store::insert_event_with_privacy(
         conn,
+        coven_home,
         &store::EventRecord {
             // seq is populated by SQLite's rowid on insertion; the 0 here is a
             // placeholder that the INSERT statement ignores.
@@ -2280,9 +2352,9 @@ mod tests {
             conversation_id: None,
         };
         store::insert_session(&conn, &session)?;
-        insert_event(&conn, "sess-log", "input", json!({"text": "hello"}))?;
-        insert_event(&conn, "sess-log", "output", json!({"text": "world"}))?;
-        insert_event(&conn, "sess-log", "error", json!({"message": "boom"}))?;
+        insert_event(&conn, home, "sess-log", "input", json!({"text": "hello"}))?;
+        insert_event(&conn, home, "sess-log", "output", json!({"text": "world"}))?;
+        insert_event(&conn, home, "sess-log", "error", json!({"message": "boom"}))?;
         drop(conn);
 
         let response = handle_request("GET", "/api/v1/sessions/sess-log/log", home, None)?;
@@ -2294,6 +2366,137 @@ mod tests {
         assert!(lines[0]["message"].as_str().unwrap().contains("hello"));
         assert_eq!(lines[2]["level"], "error");
         assert!(lines[2]["message"].as_str().unwrap().contains("boom"));
+        Ok(())
+    }
+
+    #[test]
+    fn logs_and_events_return_redacted_payloads_by_default() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let conn = store::open_store(&store_path(home))?;
+        let session = store::SessionRecord {
+            id: "sess-secret".into(),
+            project_root: "/tmp/proj".into(),
+            harness: "codex".into(),
+            title: "demo".into(),
+            status: "running".into(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            conversation_id: None,
+        };
+        store::insert_session(&conn, &session)?;
+        let fake = fake_openai_key();
+        insert_event(
+            &conn,
+            home,
+            "sess-secret",
+            "input",
+            json!({"data": format!("Authorization: Bearer {fake}")}),
+        )?;
+        drop(conn);
+
+        let log = handle_request("GET", "/api/v1/sessions/sess-secret/log", home, None)?;
+        let events = handle_request("GET", "/api/v1/events?sessionId=sess-secret", home, None)?;
+        let alias = handle_request("GET", "/api/v1/sessions/sess-secret/events", home, None)?;
+
+        for response in [log, events, alias] {
+            assert_eq!(response.status, 200);
+            assert!(!response.body.contains(&fake));
+            assert!(response.body.contains("[REDACTED]"));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn raw_artifact_endpoint_is_disabled_by_default() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let conn = store::open_store(&store_path(home))?;
+        let session = store::SessionRecord {
+            id: "sess-secret".into(),
+            project_root: "/tmp/proj".into(),
+            harness: "codex".into(),
+            title: "demo".into(),
+            status: "running".into(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            conversation_id: None,
+        };
+        store::insert_session(&conn, &session)?;
+        drop(conn);
+
+        let response = handle_request(
+            "GET",
+            "/api/v1/sessions/sess-secret/artifacts/event-1?raw=1",
+            home,
+            None,
+        )?;
+
+        assert_eq!(response.status, 403);
+        assert!(response.body.contains(r#""code":"raw_artifacts_disabled""#));
+        assert!(!response.body.contains("payload"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_artifact_endpoint_returns_404_for_expired_artifact() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        std::fs::write(home.join("privacy.toml"), "persist_raw_artifacts = true\n")?;
+        let conn = store::open_store(&store_path(home))?;
+        let session = store::SessionRecord {
+            id: "sess-secret".into(),
+            project_root: "/tmp/proj".into(),
+            harness: "codex".into(),
+            title: "demo".into(),
+            status: "running".into(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:00Z".into(),
+            conversation_id: None,
+        };
+        store::insert_session(&conn, &session)?;
+        insert_event(
+            &conn,
+            home,
+            "sess-secret",
+            "input",
+            json!({"data": "secret"}),
+        )?;
+        let event_id = store::list_events(&conn, "sess-secret")?
+            .pop()
+            .expect("event")
+            .id;
+        store::insert_sensitive_artifact(
+            &conn,
+            &store::SensitiveArtifactRecord {
+                id: "artifact-1".into(),
+                session_id: "sess-secret".into(),
+                event_id,
+                kind: "input".into(),
+                nonce: vec![0; 24],
+                ciphertext: vec![1, 2, 3],
+                created_at: "2026-01-01T00:00:00Z".into(),
+                expires_at: "2026-01-02T00:00:00Z".into(),
+            },
+        )?;
+        drop(conn);
+
+        let response = handle_request(
+            "GET",
+            "/api/v1/sessions/sess-secret/artifacts/artifact-1?raw=1",
+            home,
+            None,
+        )?;
+
+        assert_eq!(response.status, 404);
+        assert!(response.body.contains(r#""code":"artifact_expired""#));
+        assert!(!response.body.contains("payload"));
         Ok(())
     }
 
@@ -2524,5 +2727,9 @@ mod tests {
         let first = &codes[0];
         assert_eq!(first["type"], "status");
         Ok(())
+    }
+
+    fn fake_openai_key() -> String {
+        format!("sk-{}", "c".repeat(40))
     }
 }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -417,8 +417,9 @@ fn record_session_exit(
             )?;
         }
     }
-    crate::store::insert_event(
+    crate::store::insert_event_with_privacy(
         &conn,
+        coven_home,
         &crate::store::EventRecord {
             seq: 0,
             id: uuid::Uuid::new_v4().to_string(),
@@ -441,8 +442,9 @@ fn record_session_event(
     payload: Value,
 ) -> Result<()> {
     let conn = crate::store::open_store(&coven_home.join("coven.sqlite3"))?;
-    crate::store::insert_event(
+    crate::store::insert_event_with_privacy(
         &conn,
+        coven_home,
         &crate::store::EventRecord {
             seq: 0,
             id: uuid::Uuid::new_v4().to_string(),

--- a/crates/coven-cli/src/encrypted_artifacts.rs
+++ b/crates/coven-cli/src/encrypted_artifacts.rs
@@ -1,0 +1,189 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+use chacha20poly1305::{
+    aead::{Aead, AeadCore, KeyInit, OsRng, Payload},
+    XChaCha20Poly1305, XNonce,
+};
+
+const KEY_DIR_NAME: &str = "keys";
+const KEY_FILE_NAME: &str = "session-artifacts.key";
+const KEY_LEN: usize = 32;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedPayload {
+    pub nonce: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct SensitiveArtifactStore {
+    key: [u8; KEY_LEN],
+}
+
+impl SensitiveArtifactStore {
+    pub fn load(coven_home: &Path) -> Result<Self> {
+        let key_path = coven_home.join(KEY_DIR_NAME).join(KEY_FILE_NAME);
+        let key = match std::fs::read_to_string(&key_path) {
+            Ok(raw) => decode_key(raw.trim())
+                .with_context(|| "failed to load artifact encryption key".to_string())?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let key = XChaCha20Poly1305::generate_key(&mut OsRng);
+                let bytes: [u8; KEY_LEN] = key
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow!("failed to generate artifact encryption key material"))?;
+                write_key_file(&key_path, &bytes)?;
+                bytes
+            }
+            Err(error) => {
+                return Err(error).with_context(|| "failed to load artifact encryption key");
+            }
+        };
+        Ok(Self { key })
+    }
+
+    pub fn encrypt(
+        &self,
+        session_id: &str,
+        event_id: &str,
+        kind: &str,
+        plaintext: &[u8],
+    ) -> Result<EncryptedPayload> {
+        let cipher = XChaCha20Poly1305::new_from_slice(&self.key)
+            .map_err(|_| anyhow!("failed to initialize artifact encryption"))?;
+        let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let aad = artifact_aad(session_id, event_id, kind);
+        let ciphertext = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext,
+                    aad: aad.as_bytes(),
+                },
+            )
+            .map_err(|_| anyhow!("failed to encrypt sensitive artifact"))?;
+        Ok(EncryptedPayload {
+            nonce: nonce.to_vec(),
+            ciphertext,
+        })
+    }
+
+    pub fn decrypt(
+        &self,
+        session_id: &str,
+        event_id: &str,
+        kind: &str,
+        payload: &EncryptedPayload,
+    ) -> Result<Vec<u8>> {
+        let cipher = XChaCha20Poly1305::new_from_slice(&self.key)
+            .map_err(|_| anyhow!("failed to initialize artifact encryption"))?;
+        if payload.nonce.len() != 24 {
+            anyhow::bail!("sensitive artifact nonce is invalid");
+        }
+        let aad = artifact_aad(session_id, event_id, kind);
+        cipher
+            .decrypt(
+                XNonce::from_slice(&payload.nonce),
+                Payload {
+                    msg: payload.ciphertext.as_slice(),
+                    aad: aad.as_bytes(),
+                },
+            )
+            .map_err(|_| anyhow!("failed to decrypt sensitive artifact"))
+    }
+}
+
+fn artifact_aad(session_id: &str, event_id: &str, kind: &str) -> String {
+    format!("coven.session-artifact.v1:{session_id}:{event_id}:{kind}")
+}
+
+fn write_key_file(path: &Path, key: &[u8; KEY_LEN]) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("artifact encryption key path has no parent")?;
+    std::fs::create_dir_all(parent)
+        .context("failed to create artifact encryption key directory")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+            .context("failed to protect artifact encryption key directory")?;
+    }
+    std::fs::write(path, encode_key(key)).context("failed to write artifact encryption key")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .context("failed to protect artifact encryption key")?;
+    }
+    Ok(())
+}
+
+fn encode_key(key: &[u8; KEY_LEN]) -> String {
+    let mut out = String::with_capacity(KEY_LEN * 2 + 1);
+    for byte in key {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out.push('\n');
+    out
+}
+
+fn decode_key(raw: &str) -> Result<[u8; KEY_LEN]> {
+    if raw.len() != KEY_LEN * 2 || !raw.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        anyhow::bail!("artifact encryption key is invalid");
+    }
+    let mut key = [0_u8; KEY_LEN];
+    for (idx, chunk) in raw.as_bytes().chunks(2).enumerate() {
+        let pair = std::str::from_utf8(chunk).context("artifact encryption key is invalid")?;
+        key[idx] = u8::from_str_radix(pair, 16).context("artifact encryption key is invalid")?;
+    }
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_payload() -> Vec<u8> {
+        [
+            b"{\"data\":\"".as_slice(),
+            b"fake-private-session-payload".as_slice(),
+            b"\"}".as_slice(),
+        ]
+        .concat()
+    }
+
+    #[test]
+    fn encrypt_decrypt_round_trip_uses_nonce_and_aad() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store = SensitiveArtifactStore::load(temp.path())?;
+        let plaintext = fake_payload();
+
+        let encrypted = store.encrypt("session-1", "event-1", "output", &plaintext)?;
+        assert_ne!(encrypted.ciphertext, plaintext);
+        assert_eq!(encrypted.nonce.len(), 24);
+
+        let decrypted = store.decrypt("session-1", "event-1", "output", &encrypted)?;
+        assert_eq!(decrypted, plaintext);
+
+        let wrong_aad = store.decrypt("session-1", "event-2", "output", &encrypted);
+        assert!(wrong_aad.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_key_file_fails_closed_without_plaintext() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let keys = temp.path().join("keys");
+        std::fs::create_dir_all(&keys)?;
+        std::fs::write(keys.join("session-artifacts.key"), "not-a-valid-key")?;
+
+        let error = SensitiveArtifactStore::load(temp.path()).unwrap_err();
+        let message = error.to_string();
+
+        assert!(message.contains("artifact encryption key"));
+        assert!(!message.contains("not-a-valid-key"));
+        Ok(())
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -14,10 +14,12 @@ mod api;
 mod cockpit_sources;
 mod control_plane;
 mod daemon;
+mod encrypted_artifacts;
 mod harness;
 mod openclaw_repo;
 mod patch;
 mod pc;
+mod privacy;
 mod project;
 mod pty_runner;
 mod repos_config;
@@ -90,6 +92,11 @@ enum Command {
         #[arg(long, conflicts_with_all = ["manage", "plain"], help = "Print sessions as JSON for clients such as comux")]
         json: bool,
     },
+    #[command(about = "Manage local log retention")]
+    Logs {
+        #[command(subcommand)]
+        command: LogsCommand,
+    },
     #[command(about = "Replay/follow a session and forward input to live daemon sessions")]
     Attach { session_id: String },
     #[command(about = "Summon an archived session back, then replay/follow it")]
@@ -151,6 +158,27 @@ enum DaemonCommand {
     },
 }
 
+#[derive(Subcommand, Debug)]
+enum LogsCommand {
+    #[command(about = "Prune expired raw artifacts and old redacted event logs")]
+    Prune {
+        #[arg(long, help = "Report what would be pruned without deleting rows")]
+        dry_run: bool,
+        #[arg(
+            long,
+            value_name = "DAYS",
+            help = "Override raw artifact retention days"
+        )]
+        raw_days: Option<u64>,
+        #[arg(
+            long,
+            value_name = "DAYS",
+            help = "Override redacted event retention days"
+        )]
+        event_days: Option<u64>,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InteractiveShellRoute {
     Chat,
@@ -184,6 +212,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             plain,
             json,
         }) => tui::sessions::run_command(all, manage, plain, json),
+        Some(Command::Logs { command }) => run_logs_command(command),
         Some(Command::Attach { session_id }) => attach_session(&session_id),
         Some(Command::Summon { session_id }) => summon_session_command(&session_id),
         Some(Command::Archive { session_id }) => archive_session_command(&session_id),
@@ -492,7 +521,8 @@ fn default_harness_id() -> Option<&'static str> {
 
 fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
     let selected_harness = selected_available_harness(request.harness_id.as_str())?;
-    let store_path = coven_store_path()?;
+    let coven_home = coven_home_dir()?;
+    let store_path = coven_home.join(STORE_FILE_NAME);
     let conn = store::open_store(&store_path)?;
     let now = current_timestamp();
     let brief = patch::build_repair_brief(request);
@@ -509,19 +539,25 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         conversation_id: None,
     };
     store::insert_session(&conn, &record)?;
-    store::insert_json_event(
+    let metadata = serde_json::json!({
+        "patchTarget": request.repo.repo_name,
+        "repoRoot": request.repo.root,
+        "issue": request.issue,
+        "harnessId": request.harness_id.as_str(),
+        "verificationProfile": request.verification_profile.as_str(),
+        "status": "running"
+    });
+    store::insert_event_with_privacy(
         &conn,
-        &record.id,
-        "patch_metadata",
-        &serde_json::json!({
-            "patchTarget": request.repo.repo_name,
-            "repoRoot": request.repo.root,
-            "issue": request.issue,
-            "harnessId": request.harness_id.as_str(),
-            "verificationProfile": request.verification_profile.as_str(),
-            "status": "running"
-        }),
-        &now,
+        &coven_home,
+        &store::EventRecord {
+            seq: 0,
+            id: Uuid::new_v4().to_string(),
+            session_id: record.id.clone(),
+            kind: "patch_metadata".to_string(),
+            payload_json: metadata.to_string(),
+            created_at: now,
+        },
     )?;
 
     store::update_session_status(
@@ -546,6 +582,45 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         &current_timestamp(),
     )?;
     Ok(record.id)
+}
+
+fn run_logs_command(command: LogsCommand) -> Result<()> {
+    match command {
+        LogsCommand::Prune {
+            dry_run,
+            raw_days,
+            event_days,
+        } => prune_logs_command(dry_run, raw_days, event_days),
+    }
+}
+
+fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u64>) -> Result<()> {
+    let home = coven_home_dir()?;
+    let config = privacy::load_config(&home).unwrap_or_default();
+    let raw_days = raw_days
+        .unwrap_or(config.raw_artifact_retention_days)
+        .max(1);
+    let event_days = event_days.unwrap_or(config.log_retention_days).max(1);
+    let conn = store::open_store(&home.join(STORE_FILE_NAME))?;
+    let now = current_timestamp();
+    let raw_cutoff = store::retention_cutoff(&now, raw_days);
+    let event_cutoff = store::retention_cutoff(&now, event_days);
+    let raw_count = store::count_prunable_sensitive_artifacts(&conn, &now, &raw_cutoff)?;
+    let event_count = store::count_events_older_than(&conn, &event_cutoff)?;
+
+    if dry_run {
+        println!(
+            "logs prune dryRun=true rawArtifacts={raw_count} events={event_count} rawDays={raw_days} eventDays={event_days}"
+        );
+        return Ok(());
+    }
+
+    let raw_pruned = store::prune_sensitive_artifacts(&conn, &now, &raw_cutoff)?;
+    let events_pruned = store::prune_events_older_than(&conn, &event_cutoff)?;
+    println!(
+        "logs pruned rawArtifacts={raw_pruned} events={events_pruned} rawCutoff={raw_cutoff} eventCutoff={event_cutoff}"
+    );
+    Ok(())
 }
 
 fn run_daemon_command(command: DaemonCommand) -> Result<()> {
@@ -1606,6 +1681,36 @@ mod tests {
                 assert!(yes);
             }
             other => panic!("expected sacrifice command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_logs_prune_options() {
+        let cli = Cli::parse_from([
+            "coven",
+            "logs",
+            "prune",
+            "--dry-run",
+            "--raw-days",
+            "3",
+            "--event-days",
+            "14",
+        ]);
+
+        match cli.command {
+            Some(Command::Logs {
+                command:
+                    LogsCommand::Prune {
+                        dry_run,
+                        raw_days,
+                        event_days,
+                    },
+            }) => {
+                assert!(dry_run);
+                assert_eq!(raw_days, Some(3));
+                assert_eq!(event_days, Some(14));
+            }
+            other => panic!("expected logs prune command, got {other:?}"),
         }
     }
 

--- a/crates/coven-cli/src/pc/diagnostics.rs
+++ b/crates/coven-cli/src/pc/diagnostics.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use sysinfo::{Disks, Pid, System};
+use sysinfo::{Disks, Pid, ProcessesToUpdate, System};
 
 #[derive(Debug)]
 pub struct SystemSnapshot {
@@ -37,7 +37,7 @@ pub fn snapshot(verbose: bool) -> Result<SystemSnapshot> {
     std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
     sys.refresh_all();
 
-    let cpu_usage_pct = sys.global_cpu_info().cpu_usage();
+    let cpu_usage_pct = sys.global_cpu_usage();
     let memory_used_mb = sys.used_memory() / 1024 / 1024;
     let memory_total_mb = sys.total_memory() / 1024 / 1024;
     let swap_used_mb = sys.used_swap() / 1024 / 1024;
@@ -49,11 +49,16 @@ pub fn snapshot(verbose: bool) -> Result<SystemSnapshot> {
         .iter()
         .map(|(pid, p)| ProcessInfo {
             pid: pid.as_u32(),
-            name: p.name().to_string(),
+            name: p.name().to_string_lossy().into_owned(),
             cpu_pct: p.cpu_usage(),
             memory_mb: p.memory() / 1024 / 1024,
             argv: if verbose {
-                Some(p.cmd().to_vec())
+                Some(
+                    p.cmd()
+                        .iter()
+                        .map(|arg| arg.to_string_lossy().into_owned())
+                        .collect(),
+                )
             } else {
                 None
             },
@@ -104,6 +109,7 @@ pub fn snapshot(verbose: bool) -> Result<SystemSnapshot> {
 pub fn process_name_for_pid(pid: u32) -> Option<String> {
     let mut sys = System::new();
     let pid_key = Pid::from_u32(pid);
-    sys.refresh_process(pid_key);
-    sys.process(pid_key).map(|p| p.name().to_string())
+    sys.refresh_processes(ProcessesToUpdate::Some(&[pid_key]), true);
+    sys.process(pid_key)
+        .map(|p| p.name().to_string_lossy().into_owned())
 }

--- a/crates/coven-cli/src/pc/relief.rs
+++ b/crates/coven-cli/src/pc/relief.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use std::path::PathBuf;
-use sysinfo::{Pid, Process, Signal, System};
+use sysinfo::{Pid, Process, ProcessesToUpdate, Signal, System};
 
 /// Hardcoded cache directories eligible for clearing. Never uses glob expansion.
 const USER_CACHE_DIRS: &[&str] = &["Library/Caches"];
@@ -17,10 +17,14 @@ struct ProcessIdentity {
 impl ProcessIdentity {
     fn from_process(process: &Process) -> Self {
         Self {
-            name: process.name().to_string(),
+            name: process.name().to_string_lossy().into_owned(),
             start_time: process.start_time(),
             exe: process.exe().map(PathBuf::from),
-            cmd: process.cmd().to_vec(),
+            cmd: process
+                .cmd()
+                .iter()
+                .map(|arg| arg.to_string_lossy().into_owned())
+                .collect(),
         }
     }
 
@@ -48,7 +52,7 @@ pub fn kill_by_pid(pid: u32, confirm: bool) -> Result<()> {
     eprintln!("Sending SIGTERM to PID {pid} ({})...", identity.name);
 
     // Re-check identity immediately before signaling to avoid PID reuse mistakes
-    sys.refresh_process(pid_key);
+    sys.refresh_processes(ProcessesToUpdate::Some(&[pid_key]), true);
     let proc = sys
         .process(pid_key)
         .ok_or_else(|| anyhow::anyhow!("Process {pid} disappeared before signal could be sent"))?;

--- a/crates/coven-cli/src/privacy.rs
+++ b/crates/coven-cli/src/privacy.rs
@@ -1,0 +1,344 @@
+use std::path::Path;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+const REDACTED: &str = "[REDACTED]";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivacyConfig {
+    pub persist_raw_artifacts: bool,
+    pub raw_artifact_retention_days: u64,
+    pub log_retention_days: u64,
+    pub extra_patterns: Vec<String>,
+}
+
+impl Default for PrivacyConfig {
+    fn default() -> Self {
+        Self {
+            persist_raw_artifacts: false,
+            raw_artifact_retention_days: 7,
+            log_retention_days: 30,
+            extra_patterns: Vec::new(),
+        }
+    }
+}
+
+pub fn load_config(_coven_home: &Path) -> Result<PrivacyConfig> {
+    let mut config = PrivacyConfig::default();
+    let path = _coven_home.join("privacy.toml");
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => {
+            let file_config: PrivacyConfigFile = toml::from_str(&raw)
+                .with_context(|| format!("failed to parse {}", path.display()))?;
+            if let Some(value) = file_config.persist_raw_artifacts {
+                config.persist_raw_artifacts = value;
+            }
+            if let Some(value) = file_config.raw_artifact_retention_days {
+                config.raw_artifact_retention_days = value;
+            }
+            if let Some(value) = file_config.log_retention_days {
+                config.log_retention_days = value;
+            }
+            if let Some(value) = file_config.extra_patterns {
+                config.extra_patterns = value;
+            }
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to read {}", path.display()))
+        }
+    }
+
+    if let Some(value) = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS") {
+        config.persist_raw_artifacts = env_truthy(&value.to_string_lossy());
+    }
+    if let Some(value) = env_u64("COVEN_RAW_ARTIFACT_RETENTION_DAYS") {
+        config.raw_artifact_retention_days = value;
+    }
+    if let Some(value) = env_u64("COVEN_LOG_RETENTION_DAYS") {
+        config.log_retention_days = value;
+    }
+
+    Ok(config)
+}
+
+pub fn redact_text(_text: &str) -> String {
+    redact_text_with_config(_text, &PrivacyConfig::default())
+}
+
+pub fn redact_text_with_config(_text: &str, _config: &PrivacyConfig) -> String {
+    let mut out = _text.to_string();
+    for regex in built_in_patterns() {
+        out = regex.replace_all(&out, REDACTED).into_owned();
+    }
+    for pattern in &_config.extra_patterns {
+        if let Ok(regex) = Regex::new(pattern) {
+            out = regex.replace_all(&out, REDACTED).into_owned();
+        }
+    }
+    out
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn redact_value(_value: &Value) -> Value {
+    redact_value_with_config(_value, &PrivacyConfig::default())
+}
+
+pub fn redact_payload_json(_payload_json: &str) -> String {
+    redact_payload_json_with_config(_payload_json, &PrivacyConfig::default())
+}
+
+pub fn redact_payload_json_with_config(_payload_json: &str, config: &PrivacyConfig) -> String {
+    match serde_json::from_str::<Value>(_payload_json) {
+        Ok(value) => redact_value_with_config(&value, config).to_string(),
+        Err(_) => redact_text_with_config(_payload_json, config),
+    }
+}
+
+pub fn payload_preview(_payload: &Value, _max_chars: usize) -> String {
+    let text = _payload
+        .get("text")
+        .or_else(|| _payload.get("message"))
+        .or_else(|| _payload.get("data"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| _payload.to_string());
+    truncate_chars(&redact_text(&text), _max_chars)
+}
+
+#[derive(Debug, Deserialize)]
+struct PrivacyConfigFile {
+    persist_raw_artifacts: Option<bool>,
+    raw_artifact_retention_days: Option<u64>,
+    log_retention_days: Option<u64>,
+    extra_patterns: Option<Vec<String>>,
+}
+
+fn env_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn env_u64(name: &str) -> Option<u64> {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|value| *value > 0)
+}
+
+fn redact_value_with_config(value: &Value, config: &PrivacyConfig) -> Value {
+    match value {
+        Value::String(text) => Value::String(redact_text_with_config(text, config)),
+        Value::Array(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| redact_value_with_config(value, config))
+                .collect(),
+        ),
+        Value::Object(map) => {
+            let mut redacted = Map::new();
+            for (key, value) in map {
+                let value = if secretish_name(key) {
+                    Value::String(REDACTED.to_string())
+                } else {
+                    redact_value_with_config(value, config)
+                };
+                redacted.insert(key.clone(), value);
+            }
+            Value::Object(redacted)
+        }
+        other => other.clone(),
+    }
+}
+
+pub fn secretish_name(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase().replace('-', "_");
+    normalized == "authorization"
+        || normalized == "cookie"
+        || normalized == "set_cookie"
+        || normalized.contains("api_key")
+        || normalized.contains("apikey")
+        || normalized.contains("access_token")
+        || normalized.contains("refresh_token")
+        || normalized.contains("auth_token")
+        || normalized.contains("github_token")
+        || normalized.contains("openai_api_key")
+        || normalized.contains("anthropic_api_key")
+        || normalized.contains("private_key")
+        || normalized.contains("password")
+        || normalized.contains("secret")
+        || normalized.ends_with("_token")
+        || normalized == "token"
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let mut truncated: String = text.chars().take(max_chars).collect();
+    truncated.push_str("...");
+    truncated
+}
+
+fn built_in_patterns() -> &'static [Regex] {
+    static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+    PATTERNS
+        .get_or_init(|| {
+            [
+                r"(?is)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+                r"(?im)\bAuthorization\s*:\s*(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+",
+                r"(?im)\b(?:Cookie|Set-Cookie)\s*:\s*[^\r\n]+",
+                r#"(?i)\b(?:OPENAI_API_KEY|ANTHROPIC_API_KEY|GITHUB_TOKEN|GH_TOKEN|API[_-]?KEY|ACCESS[_-]?TOKEN|REFRESH[_-]?TOKEN|AUTH[_-]?TOKEN|SECRET|PASSWORD|PRIVATE[_-]?KEY)\s*=\s*["']?[^"'\s]+"#,
+                r#"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|secret|password|private[_-]?key)\s*[:=]\s*["']?[^"',\s}]+"#,
+                r"\bsk-ant-[A-Za-z0-9_-]{20,}\b",
+                r"\bsk-[A-Za-z0-9]{20,}\b",
+                r"\bgh[pousr]_[A-Za-z0-9_]{20,}\b",
+                r"\bgithub_pat_[A-Za-z0-9_]{20,}\b",
+                r#"(?i)(?:https?://)[^\s"']*(?:gateway|private|internal)[^\s"']*"#,
+                r#"(?i)([?&](?:token|key|secret|api_key|access_token)=)[^&\s"']+"#,
+            ]
+            .into_iter()
+            .map(|pattern| Regex::new(pattern).expect("valid privacy redaction regex"))
+            .collect()
+        })
+        .as_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_text_removes_common_secret_shapes() {
+        let fake_openai = fake_openai_key();
+        let fake_github = fake_github_token();
+        let fake_anthropic = fake_anthropic_key();
+        let fake_gateway = fake_gateway_url();
+        let fake_env = format!("OPENAI_API_KEY={fake_openai}");
+        let fake_private_key_body = "fake".repeat(7);
+        let fake_private_key = format!(
+            "{}\n{}\n{}",
+            private_key_marker("BEGIN"),
+            fake_private_key_body,
+            private_key_marker("END")
+        );
+        let input = format!(
+            "Authorization: Bearer {fake_openai}\nAuthorization: Basic dXNlcjpwYXNz\nCookie: session={fake_github}\n{fake_env}\nANTHROPIC_API_KEY={fake_anthropic}\nkey={fake_github}\nurl={fake_gateway}\n{fake_private_key}"
+        );
+
+        let redacted = redact_text(&input);
+
+        for secret in [
+            &fake_openai,
+            &fake_github,
+            &fake_anthropic,
+            "dXNlcjpwYXNz",
+            "fakegatewaytoken123",
+            &fake_private_key_body,
+        ] {
+            assert!(
+                !redacted.contains(secret),
+                "fake secret survived redaction: {secret}"
+            );
+        }
+        assert!(redacted.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_value_removes_secretish_object_fields_and_string_contents() {
+        let fake_openai = fake_openai_key();
+        let fake_github = fake_github_token();
+        let fake_anthropic = fake_anthropic_key();
+        let value = serde_json::json!({
+            "message": format!("call me with bearer {fake_openai}"),
+            "headers": {
+                "authorization": format!("Bearer {fake_github}"),
+                "cookie": format!("session={fake_anthropic}")
+            },
+            "nested": [{ "OPENAI_API_KEY": fake_openai }]
+        });
+
+        let redacted = redact_value(&value);
+        let body = redacted.to_string();
+
+        for secret in [&fake_openai, &fake_github, &fake_anthropic] {
+            assert!(
+                !body.contains(secret),
+                "fake secret survived JSON redaction"
+            );
+        }
+        assert!(body.contains("[REDACTED]"));
+    }
+
+    #[test]
+    fn payload_preview_redacts_and_bounds_text_fields() {
+        let fake_openai = fake_openai_key();
+        let payload = serde_json::json!({
+            "data": format!("{} {}", "x".repeat(300), fake_openai),
+        });
+
+        let preview = payload_preview(&payload, 80);
+
+        assert!(!preview.contains(&fake_openai));
+        assert!(preview.chars().count() <= 83);
+        assert!(preview.ends_with("..."));
+    }
+
+    #[test]
+    fn load_config_reads_file_and_env_overrides() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(
+            temp.path().join("privacy.toml"),
+            r#"
+persist_raw_artifacts = false
+raw_artifact_retention_days = 9
+log_retention_days = 41
+extra_patterns = ["custom-sensitive-[0-9]+"]
+"#,
+        )?;
+
+        let previous = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS");
+        std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", "1");
+        let config = load_config(temp.path())?;
+        match previous {
+            Some(value) => std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", value),
+            None => std::env::remove_var("COVEN_PERSIST_RAW_ARTIFACTS"),
+        }
+
+        assert!(config.persist_raw_artifacts);
+        assert_eq!(config.raw_artifact_retention_days, 9);
+        assert_eq!(config.log_retention_days, 41);
+        assert_eq!(config.extra_patterns, vec!["custom-sensitive-[0-9]+"]);
+        assert_eq!(
+            redact_text_with_config("custom-sensitive-1234", &config),
+            "[REDACTED]"
+        );
+        Ok(())
+    }
+
+    fn fake_openai_key() -> String {
+        format!("sk-{}", "a".repeat(40))
+    }
+
+    fn fake_github_token() -> String {
+        format!("ghp_{}", "b".repeat(40))
+    }
+
+    fn fake_anthropic_key() -> String {
+        format!("sk-ant-{}", "c".repeat(40))
+    }
+
+    fn fake_gateway_url() -> String {
+        "https://private-gateway.example.test/session?token=fakegatewaytoken123".to_string()
+    }
+
+    fn private_key_marker(boundary: &str) -> String {
+        format!("-----{boundary} {}-----", "PRIVATE KEY")
+    }
+}

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1,8 +1,14 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use chrono::{Duration, SecondsFormat, Utc};
 use rusqlite::{params, Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
+
+use crate::{
+    encrypted_artifacts::{EncryptedPayload, SensitiveArtifactStore},
+    privacy::{self, PrivacyConfig},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionRecord {
@@ -45,6 +51,18 @@ pub struct RepositoryRecord {
     pub updated_at: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SensitiveArtifactRecord {
+    pub id: String,
+    pub session_id: String,
+    pub event_id: String,
+    pub kind: String,
+    pub nonce: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+    pub created_at: String,
+    pub expires_at: String,
+}
+
 #[derive(Debug, Default)]
 pub struct EventsQueryOptions {
     pub after_seq: Option<i64>,
@@ -85,6 +103,8 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             kind TEXT NOT NULL,
             payload_json TEXT NOT NULL,
             created_at TEXT NOT NULL,
+            redaction_status TEXT NOT NULL DEFAULT 'redacted',
+            sensitive INTEGER NOT NULL DEFAULT 0,
             FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
         );
 
@@ -93,6 +113,25 @@ pub fn open_store(path: &Path) -> Result<Connection> {
 
         CREATE INDEX IF NOT EXISTS idx_events_session_created_at
             ON events(session_id, created_at);
+
+        CREATE TABLE IF NOT EXISTS sensitive_artifacts (
+            id TEXT PRIMARY KEY NOT NULL,
+            session_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            nonce BLOB NOT NULL,
+            ciphertext BLOB NOT NULL,
+            created_at TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+            FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_session
+            ON sensitive_artifacts(session_id, created_at);
+
+        CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_expires_at
+            ON sensitive_artifacts(expires_at);
 
         CREATE TABLE IF NOT EXISTS repositories (
             id TEXT PRIMARY KEY NOT NULL,
@@ -107,8 +146,69 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_exit_code_column(&conn)?;
     ensure_archived_at_column(&conn)?;
     ensure_conversation_id_column(&conn)?;
+    ensure_event_privacy_columns(&conn)?;
+    ensure_sensitive_artifacts_table(&conn)?;
 
     Ok(conn)
+}
+
+fn ensure_event_privacy_columns(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "events",
+        "redaction_status",
+        "ALTER TABLE events ADD COLUMN redaction_status TEXT NOT NULL DEFAULT 'legacy'",
+    )?;
+    ensure_column(
+        conn,
+        "events",
+        "sensitive",
+        "ALTER TABLE events ADD COLUMN sensitive INTEGER NOT NULL DEFAULT 0",
+    )?;
+    Ok(())
+}
+
+fn ensure_column(conn: &Connection, table: &str, column: &str, sql: &str) -> Result<()> {
+    let mut statement = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .with_context(|| format!("failed to inspect {table} schema"))?;
+    let has_column = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .with_context(|| format!("failed to query {table} schema"))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("failed to read {table} schema"))?
+        .into_iter()
+        .any(|candidate| candidate == column);
+
+    if !has_column {
+        conn.execute(sql, [])
+            .with_context(|| format!("failed to add {table}.{column} column"))?;
+    }
+    Ok(())
+}
+
+fn ensure_sensitive_artifacts_table(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS sensitive_artifacts (
+            id TEXT PRIMARY KEY NOT NULL,
+            session_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            nonce BLOB NOT NULL,
+            ciphertext BLOB NOT NULL,
+            created_at TEXT NOT NULL,
+            expires_at TEXT NOT NULL,
+            FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE,
+            FOREIGN KEY (event_id) REFERENCES events(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_session
+            ON sensitive_artifacts(session_id, created_at);
+
+        CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_expires_at
+            ON sensitive_artifacts(expires_at);",
+    )
+    .context("failed to initialize sensitive artifact schema")
 }
 
 pub fn open_existing_store_read_only(path: &Path) -> Result<Option<Connection>> {
@@ -451,24 +551,101 @@ pub fn sacrifice_session(conn: &Connection, session_id: &str) -> Result<()> {
 }
 
 pub fn insert_event(conn: &Connection, record: &EventRecord) -> Result<()> {
+    let config = PrivacyConfig::default();
+    let redacted_payload = privacy::redact_payload_json_with_config(&record.payload_json, &config);
+    let sensitive = redacted_payload != record.payload_json;
+    let redaction_status = if sensitive { "redacted" } else { "clean" };
+    insert_event_raw(conn, record, &redacted_payload, redaction_status, sensitive)
+}
+
+pub fn insert_event_with_privacy(
+    conn: &Connection,
+    coven_home: &Path,
+    record: &EventRecord,
+) -> Result<()> {
+    let config = privacy::load_config(coven_home).unwrap_or_default();
+    let redacted_payload = privacy::redact_payload_json_with_config(&record.payload_json, &config);
+    let sensitive = redacted_payload != record.payload_json;
+    let mut redaction_status = if sensitive { "redacted" } else { "clean" };
+    insert_event_raw(conn, record, &redacted_payload, redaction_status, sensitive)?;
+
+    if config.persist_raw_artifacts && sensitive {
+        let artifact_result = SensitiveArtifactStore::load(coven_home)
+            .and_then(|store| {
+                store.encrypt(
+                    &record.session_id,
+                    &record.id,
+                    &record.kind,
+                    record.payload_json.as_bytes(),
+                )
+            })
+            .and_then(|encrypted| {
+                insert_sensitive_artifact(
+                    conn,
+                    &SensitiveArtifactRecord {
+                        id: record.id.clone(),
+                        session_id: record.session_id.clone(),
+                        event_id: record.id.clone(),
+                        kind: record.kind.clone(),
+                        nonce: encrypted.nonce,
+                        ciphertext: encrypted.ciphertext,
+                        created_at: record.created_at.clone(),
+                        expires_at: retention_expires_at(
+                            &record.created_at,
+                            config.raw_artifact_retention_days,
+                        ),
+                    },
+                )
+            });
+        redaction_status = if artifact_result.is_ok() {
+            "redacted_raw_encrypted"
+        } else {
+            "redacted_raw_unavailable"
+        };
+        set_event_redaction_status(conn, &record.id, redaction_status)?;
+    }
+
+    Ok(())
+}
+
+fn insert_event_raw(
+    conn: &Connection,
+    record: &EventRecord,
+    payload_json: &str,
+    redaction_status: &str,
+    sensitive: bool,
+) -> Result<()> {
     conn.execute(
         "INSERT INTO events (
             id,
             session_id,
             kind,
             payload_json,
-            created_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5)",
+            created_at,
+            redaction_status,
+            sensitive
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         params![
             &record.id,
             &record.session_id,
             &record.kind,
-            &record.payload_json,
+            payload_json,
             &record.created_at,
+            redaction_status,
+            if sensitive { 1 } else { 0 },
         ],
     )
     .with_context(|| format!("failed to insert event {}", record.id))?;
 
+    Ok(())
+}
+
+fn set_event_redaction_status(conn: &Connection, event_id: &str, status: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE events SET redaction_status = ?2 WHERE id = ?1",
+        params![event_id, status],
+    )
+    .with_context(|| format!("failed to update redaction status for event {event_id}"))?;
     Ok(())
 }
 
@@ -537,7 +714,7 @@ pub fn list_events_with_options(
     // present.  All user-provided values are bound via parameterized placeholders
     // (?1, ?2, ?3), so there is no SQL injection risk.
     let mut sql = String::from(
-        "SELECT rowid AS seq, id, session_id, kind, payload_json, created_at
+        "SELECT rowid AS seq, id, session_id, kind, payload_json, created_at, redaction_status
          FROM events WHERE session_id = ?1",
     );
     let has_cursor = after_rowid.is_some();
@@ -555,14 +732,19 @@ pub fn list_events_with_options(
         .context("failed to prepare event list query")?;
 
     let map_row = |row: &rusqlite::Row<'_>| {
-        Ok(EventRecord {
+        let mut record = EventRecord {
             seq: row.get(0)?,
             id: row.get(1)?,
             session_id: row.get(2)?,
             kind: row.get(3)?,
             payload_json: row.get(4)?,
             created_at: row.get(5)?,
-        })
+        };
+        let redaction_status: String = row.get(6)?;
+        if redaction_status == "legacy" {
+            record.payload_json = privacy::redact_payload_json(&record.payload_json);
+        }
+        Ok(record)
     };
 
     let events = match (after_rowid, opts.limit) {
@@ -583,6 +765,127 @@ pub fn list_events_with_options(
     .context("failed to read events")?;
 
     Ok(events)
+}
+
+pub fn insert_sensitive_artifact(
+    conn: &Connection,
+    record: &SensitiveArtifactRecord,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO sensitive_artifacts (
+            id, session_id, event_id, kind, nonce, ciphertext, created_at, expires_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        params![
+            &record.id,
+            &record.session_id,
+            &record.event_id,
+            &record.kind,
+            &record.nonce,
+            &record.ciphertext,
+            &record.created_at,
+            &record.expires_at,
+        ],
+    )
+    .with_context(|| format!("failed to insert sensitive artifact {}", record.id))?;
+    Ok(())
+}
+
+pub fn get_sensitive_artifact(
+    conn: &Connection,
+    session_id: &str,
+    artifact_id: &str,
+) -> Result<Option<SensitiveArtifactRecord>> {
+    use rusqlite::OptionalExtension;
+
+    conn.query_row(
+        "SELECT id, session_id, event_id, kind, nonce, ciphertext, created_at, expires_at
+         FROM sensitive_artifacts
+         WHERE id = ?1 AND session_id = ?2
+         LIMIT 1",
+        params![artifact_id, session_id],
+        |row| {
+            Ok(SensitiveArtifactRecord {
+                id: row.get(0)?,
+                session_id: row.get(1)?,
+                event_id: row.get(2)?,
+                kind: row.get(3)?,
+                nonce: row.get(4)?,
+                ciphertext: row.get(5)?,
+                created_at: row.get(6)?,
+                expires_at: row.get(7)?,
+            })
+        },
+    )
+    .optional()
+    .with_context(|| format!("failed to get sensitive artifact {artifact_id}"))
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn count_sensitive_artifacts(conn: &Connection) -> Result<i64> {
+    conn.query_row("SELECT COUNT(*) FROM sensitive_artifacts", [], |row| {
+        row.get(0)
+    })
+    .context("failed to count sensitive artifacts")
+}
+
+pub fn count_prunable_sensitive_artifacts(
+    conn: &Connection,
+    now: &str,
+    retention_cutoff: &str,
+) -> Result<i64> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM sensitive_artifacts WHERE expires_at < ?1 OR created_at < ?2",
+        params![now, retention_cutoff],
+        |row| row.get(0),
+    )
+    .context("failed to count prunable sensitive artifacts")
+}
+
+pub fn count_events_older_than(conn: &Connection, cutoff: &str) -> Result<i64> {
+    conn.query_row(
+        "SELECT COUNT(*) FROM events WHERE created_at < ?1",
+        params![cutoff],
+        |row| row.get(0),
+    )
+    .context("failed to count old events")
+}
+
+pub fn prune_sensitive_artifacts(
+    conn: &Connection,
+    now: &str,
+    retention_cutoff: &str,
+) -> Result<usize> {
+    conn.execute(
+        "DELETE FROM sensitive_artifacts WHERE expires_at < ?1 OR created_at < ?2",
+        params![now, retention_cutoff],
+    )
+    .context("failed to prune sensitive artifacts")
+}
+
+pub fn prune_events_older_than(conn: &Connection, cutoff: &str) -> Result<usize> {
+    conn.execute("DELETE FROM events WHERE created_at < ?1", params![cutoff])
+        .context("failed to prune events")
+}
+
+pub fn retention_cutoff(now: &str, days: u64) -> String {
+    let parsed = chrono::DateTime::parse_from_rfc3339(now)
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc::now());
+    (parsed - Duration::days(days as i64)).to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+fn retention_expires_at(created_at: &str, days: u64) -> String {
+    let parsed = chrono::DateTime::parse_from_rfc3339(created_at)
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_else(|_| Utc::now());
+    (parsed + Duration::days(days as i64)).to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+pub fn artifact_payload(record: &SensitiveArtifactRecord) -> EncryptedPayload {
+    EncryptedPayload {
+        nonce: record.nonce.clone(),
+        ciphertext: record.ciphertext.clone(),
+    }
 }
 
 #[cfg(test)]
@@ -909,6 +1212,301 @@ mod tests {
     }
 
     #[test]
+    fn event_schema_adds_privacy_columns_to_existing_store() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("legacy.db");
+        {
+            let conn = Connection::open(&path)?;
+            conn.execute_batch(
+                "CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    project_root TEXT NOT NULL,
+                    harness TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE TABLE events (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    session_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );",
+            )?;
+        }
+
+        let conn = open_store(&path)?;
+        let event_columns = table_columns(&conn, "events")?;
+        let artifact_columns = table_columns(&conn, "sensitive_artifacts")?;
+
+        assert!(event_columns.contains(&"redaction_status".to_string()));
+        assert!(event_columns.contains(&"sensitive".to_string()));
+        assert!(artifact_columns.contains(&"ciphertext".to_string()));
+        assert!(artifact_columns.contains(&"nonce".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn event_insert_stores_redacted_payload_by_default() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        let fake = fake_openai_key();
+
+        insert_json_event(
+            &conn,
+            "session-1",
+            "input",
+            &serde_json::json!({ "data": format!("token={fake}") }),
+            "2026-04-27T06:01:00Z",
+        )?;
+
+        let (payload, status, sensitive): (String, String, i64) = conn.query_row(
+            "SELECT payload_json, redaction_status, sensitive FROM events WHERE id IS NOT NULL",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )?;
+        assert!(!payload.contains(&fake));
+        assert!(payload.contains("[REDACTED]"));
+        assert_eq!(status, "redacted");
+        assert_eq!(sensitive, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_plaintext_rows_are_redacted_when_listed() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("legacy.db");
+        let fake = fake_github_token();
+        {
+            let conn = Connection::open(&path)?;
+            conn.execute_batch(
+                "CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    project_root TEXT NOT NULL,
+                    harness TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                CREATE TABLE events (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    session_id TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );",
+            )?;
+            conn.execute(
+                "INSERT INTO sessions (id, project_root, harness, title, status, created_at, updated_at)
+                 VALUES ('session-1', '/repo', 'codex', 'Legacy', 'completed', '2026-04-27T06:00:00Z', '2026-04-27T06:00:00Z')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO events (id, session_id, kind, payload_json, created_at)
+                 VALUES ('event-1', 'session-1', 'output', ?1, '2026-04-27T06:01:00Z')",
+                params![
+                    serde_json::json!({ "data": format!("Authorization: Bearer {fake}") })
+                        .to_string()
+                ],
+            )?;
+        }
+        let conn = open_store(&path)?;
+
+        let events = list_events(&conn, "session-1")?;
+
+        assert_eq!(events.len(), 1);
+        assert!(!events[0].payload_json.contains(&fake));
+        assert!(events[0].payload_json.contains("[REDACTED]"));
+        Ok(())
+    }
+
+    #[test]
+    fn raw_artifacts_are_encrypted_when_explicitly_enabled() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("privacy.toml"),
+            "persist_raw_artifacts = true\nraw_artifact_retention_days = 7\n",
+        )?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        let fake = fake_openai_key();
+        let raw_payload = serde_json::json!({ "data": format!("secret {fake}") }).to_string();
+        let record = EventRecord {
+            seq: 0,
+            id: "event-raw".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "output".to_string(),
+            payload_json: raw_payload.clone(),
+            created_at: "2026-04-27T06:01:00Z".to_string(),
+        };
+
+        insert_event_with_privacy(&conn, temp_dir.path(), &record)?;
+
+        let stored_payload: String = conn.query_row(
+            "SELECT payload_json FROM events WHERE id = 'event-raw'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert!(!stored_payload.contains(&fake));
+        let artifact = get_sensitive_artifact(&conn, "session-1", "event-raw")?
+            .expect("artifact should exist");
+        assert_ne!(artifact.ciphertext, raw_payload.as_bytes());
+        let decrypted = crate::encrypted_artifacts::SensitiveArtifactStore::load(temp_dir.path())?
+            .decrypt(
+                "session-1",
+                "event-raw",
+                "output",
+                &artifact_payload(&artifact),
+            )?;
+        assert_eq!(String::from_utf8(decrypted)?, raw_payload);
+        Ok(())
+    }
+
+    #[test]
+    fn raw_artifact_key_failure_keeps_redacted_event_only() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("privacy.toml"),
+            "persist_raw_artifacts = true\n",
+        )?;
+        let keys = temp_dir.path().join("keys");
+        std::fs::create_dir_all(&keys)?;
+        std::fs::write(keys.join("session-artifacts.key"), "invalid-key-material")?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        let fake = fake_openai_key();
+        let record = EventRecord {
+            seq: 0,
+            id: "event-fail".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "input".to_string(),
+            payload_json: serde_json::json!({ "data": format!("secret {fake}") }).to_string(),
+            created_at: "2026-04-27T06:01:00Z".to_string(),
+        };
+
+        insert_event_with_privacy(&conn, temp_dir.path(), &record)?;
+
+        let (payload, status): (String, String) = conn.query_row(
+            "SELECT payload_json, redaction_status FROM events WHERE id = 'event-fail'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert!(!payload.contains(&fake));
+        assert_eq!(status, "redacted_raw_unavailable");
+        assert_eq!(count_sensitive_artifacts(&conn)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn pruning_removes_expired_artifacts_and_old_events() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        for (id, created_at) in [
+            ("old-event", "2026-04-01T00:00:00Z"),
+            ("fresh-event", "2026-04-26T00:00:00Z"),
+        ] {
+            insert_event(
+                &conn,
+                &EventRecord {
+                    seq: 0,
+                    id: id.to_string(),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json: serde_json::json!({ "data": id }).to_string(),
+                    created_at: created_at.to_string(),
+                },
+            )?;
+        }
+        insert_sensitive_artifact(
+            &conn,
+            &SensitiveArtifactRecord {
+                id: "expired".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "old-event".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![1, 2, 3],
+                created_at: "2026-04-01T00:00:00Z".to_string(),
+                expires_at: "2026-04-08T00:00:00Z".to_string(),
+            },
+        )?;
+
+        let pruned_artifacts =
+            prune_sensitive_artifacts(&conn, "2026-05-01T00:00:00Z", "2026-04-24T00:00:00Z")?;
+        let cutoff = retention_cutoff("2026-05-01T00:00:00Z", 7);
+        let pruned_events = prune_events_older_than(&conn, &cutoff)?;
+
+        assert_eq!(pruned_artifacts, 1);
+        assert_eq!(pruned_events, 1);
+        let events = list_events(&conn, "session-1")?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].payload_json, r#"{"data":"fresh-event"}"#);
+        Ok(())
+    }
+
+    #[test]
+    fn pruning_sensitive_artifacts_honors_expires_at_and_created_at_cutoff() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "event-1".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({ "data": "old raw payload" }).to_string(),
+                created_at: "2026-04-20T00:00:00Z".to_string(),
+            },
+        )?;
+        insert_sensitive_artifact(
+            &conn,
+            &SensitiveArtifactRecord {
+                id: "older-than-override".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![1, 2, 3],
+                created_at: "2026-04-20T00:00:00Z".to_string(),
+                expires_at: "2026-05-04T00:00:00Z".to_string(),
+            },
+        )?;
+        insert_sensitive_artifact(
+            &conn,
+            &SensitiveArtifactRecord {
+                id: "expired-by-record".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![4, 5, 6],
+                created_at: "2026-04-26T00:00:00Z".to_string(),
+                expires_at: "2026-04-26T12:00:00Z".to_string(),
+            },
+        )?;
+
+        let cutoff = retention_cutoff("2026-04-27T00:00:00Z", 1);
+
+        assert_eq!(
+            count_prunable_sensitive_artifacts(&conn, "2026-04-27T00:00:00Z", &cutoff)?,
+            2
+        );
+        assert_eq!(
+            prune_sensitive_artifacts(&conn, "2026-04-27T00:00:00Z", &cutoff)?,
+            2
+        );
+        assert_eq!(count_sensitive_artifacts(&conn)?, 0);
+        Ok(())
+    }
+
+    #[test]
     fn events_have_monotonic_seq_fields() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let conn = open_store(&temp_dir.path().join("coven.db"))?;
@@ -1086,5 +1684,22 @@ mod tests {
             updated_at: created_at.to_string(),
             conversation_id: None,
         }
+    }
+
+    fn table_columns(conn: &Connection, table: &str) -> Result<Vec<String>> {
+        let mut statement = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+        let columns = statement
+            .query_map([], |row| row.get::<_, String>(1))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(anyhow::Error::from)?;
+        Ok(columns)
+    }
+
+    fn fake_openai_key() -> String {
+        format!("sk-{}", "a".repeat(40))
+    }
+
+    fn fake_github_token() -> String {
+        format!("ghp_{}", "b".repeat(40))
     }
 }

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -9,7 +9,7 @@ description: "The versioned coven.daemon.v1 contract under /api/v1: health negot
 
 # Coven local API contract
 
-The Coven daemon socket API is the compatibility boundary for CastCodes and advanced local clients such as comux or `@opencoven/coven`.
+The Coven daemon socket API is a public compatibility boundary for comux and external clients such as `@opencoven/coven`.
 
 ## Current stable version
 
@@ -19,6 +19,7 @@ The Coven daemon socket API is the compatibility boundary for CastCodes and adva
 - Control-plane clients should discover capabilities before sending action ids.
 - All API failures are returned as structured `{ "error": { "code", "message", "details" } }` envelopes.
 - Events include a monotonic `seq` cursor for incremental reads.
+- Event payloads are redacted by default before API display.
 
 ## `GET /api/v1/health`
 
@@ -110,10 +111,13 @@ All API errors use the following stable envelope. Clients must branch on `error.
 | `kill_failed`          | 500         | Daemon accepted the kill request but the runtime signal/kill call failed (permission, missing process, IO error). `details.sessionId` is the affected session. |
 | `runtime_unavailable`  | 503         | The session runtime is unavailable.              |
 | `internal_error`       | 500         | Unexpected internal error.                       |
+| `raw_artifacts_disabled` | 403       | Raw artifact retrieval was requested without explicit raw artifact persistence enabled. |
+| `raw_artifact_requires_raw_flag` | 400 | Raw artifact retrieval omitted the required `raw=1` query flag. |
+| `artifact_not_found`   | 404         | Sensitive artifact id does not exist for the session. |
 
 ## Capability catalog shape (`v1`)
 
-`GET /api/v1/capabilities` returns the daemon/control-plane capability catalog. This is the intended handshake for CastCodes and advanced clients deciding which actions to show or route through Coven.
+`GET /api/v1/capabilities` returns the daemon/control-plane capability catalog. This is the intended OpenMeow handshake for deciding which actions to show or route through Coven.
 
 ```json
 {
@@ -214,7 +218,7 @@ Endpoints that return this shape:
 
 ## Event record shape and cursor pagination (`v1`)
 
-`GET /api/v1/events` returns a paginated envelope with monotonic `seq` cursors.
+`GET /api/v1/events` returns a paginated envelope with monotonic `seq` cursors. `GET /api/v1/sessions/:id/events` is the session-scoped alias with the same response shape and cursor query parameters except that `sessionId` comes from the path.
 
 ### Query parameters
 
@@ -247,6 +251,39 @@ Endpoints that return this shape:
 ```
 
 `nextCursor` is `null` when there are no events. `hasMore` is `true` when a `limit` was applied and more events may exist.
+
+`payload_json` is the redacted preview payload used by clients. Raw sensitive artifacts are never included in this envelope.
+
+## Log preview shape (`v1`)
+
+`GET /api/v1/sessions/:id/log` currently returns the full redacted log preview for the session as an unbounded array:
+
+```json
+[
+  {
+    "ts": "2026-05-09T06:43:10Z",
+    "level": "info",
+    "message": "> hello"
+  }
+]
+```
+
+## Raw artifact access (`v1`)
+
+`GET /api/v1/sessions/:id/artifacts/:artifactId?raw=1` is intentionally narrow. It is unavailable unless raw artifact persistence is explicitly enabled in local privacy settings. Disabled installs return:
+
+```json
+{
+  "error": {
+    "code": "raw_artifacts_disabled",
+    "message": "Raw artifact persistence is not enabled.",
+    "details": {
+      "sessionId": "session-1",
+      "artifactId": "event-1"
+    }
+  }
+}
+```
 
 ### Incremental read pattern
 
@@ -315,10 +352,9 @@ Shared non-success responses use the structured error envelope:
 }
 ```
 
-## CastCodes and advanced client compatibility
+## comux and OpenClaw bridge compatibility
 
-- CastCodes should read the `capabilities` object from `/health` to decide which Coven-backed workspace features to show.
-- comux may continue to read the same capability shape as a legacy/reference client.
+- comux reads the `capabilities` object from `/health` to decide which features to use.
 - The `@opencoven/coven` OpenClaw bridge (`packages/openclaw-coven`) is updated in this repo alongside the daemon and uses `apiVersion === "coven.daemon.v1"` as its contract guard.
 - Client updates to use `afterSeq` cursors and paginated event envelopes may happen independently of the daemon update; the daemon-enforced shape is the source of truth.
 - The `supportedApiVersions` field has been removed from the health response in `coven.daemon.v1`; clients should check `apiVersion` directly.

--- a/docs/API.md
+++ b/docs/API.md
@@ -21,7 +21,7 @@ flowchart LR
   Router --> Capabilities["/capabilities"]
   Router --> Actions["/actions"]
   Router --> Sessions["/sessions[/:id[/input|/kill]]"]
-  Router --> Events["/events"]
+  Router --> Events["/events + /sessions/:id/events"]
   Router --> Version["/api-version"]
 
   Health & Capabilities & Actions & Sessions & Events & Version -->|"{ ... } or { error: { code, message, details } }"| Client
@@ -46,13 +46,19 @@ Versioned clients should use the `/api/v1` prefix:
 | `GET /api/v1/sessions` | List active sessions |
 | `POST /api/v1/sessions` | Launch a session |
 | `GET /api/v1/sessions/:id` | Fetch one session |
-| `GET /api/v1/events?sessionId=...` | Read session events |
+| `GET /api/v1/events?sessionId=...` | Read redacted session events |
+| `GET /api/v1/sessions/:id/events` | Read redacted session events |
+| `GET /api/v1/sessions/:id/log` | Read bounded redacted log previews |
 | `POST /api/v1/sessions/:id/input` | Forward input to a live session |
 | `POST /api/v1/sessions/:id/kill` | Kill a live session |
 
 Unversioned routes currently remain as legacy aliases during the early MVP window, but new clients should not rely on them.
 
 Unknown `/api/<version>/...` prefixes fail closed with an `unsupported API version` JSON response.
+
+## Log privacy
+
+Event payloads returned by `/events`, `/sessions/:id/events`, and `/sessions/:id/log` are redacted by default. Raw sensitive artifacts are not included in broad responses. The narrow raw artifact route requires explicit local raw artifact persistence and `raw=1`; otherwise it returns a structured `raw_artifacts_disabled` error.
 
 ## Health response
 
@@ -81,7 +87,7 @@ When no daemon metadata is available, `daemon` is `null`.
 
 ## Control-plane capabilities
 
-`GET /api/v1/capabilities` is the discovery point for CastCodes and advanced local clients. It returns capability ids, adapter ownership, availability, policy hints, and action ids. This keeps clients from hard-coding what the daemon can do.
+`GET /api/v1/capabilities` is the discovery point for first-party clients such as OpenMeow. It returns capability ids, adapter ownership, availability, policy hints, and action ids. This keeps clients from hard-coding what the daemon can do.
 
 ```json
 {
@@ -108,12 +114,12 @@ When no daemon metadata is available, `daemon` is `null`.
 
 ## Control-plane actions
 
-`POST /api/v1/actions` accepts a client intent envelope. The daemon routes only known actions; unknown actions fail closed before any adapter can run.
+`POST /api/v1/actions` accepts an OpenMeow-style intent envelope. The daemon routes only known actions; unknown actions fail closed before any adapter can run.
 
 ```json
 {
   "action": "coven.capabilities.refresh",
-  "origin": "castcodes",
+  "origin": "open-meow",
   "intentId": "intent-1",
   "args": {}
 }
@@ -130,7 +136,7 @@ Immediately completed safe actions return `200` with an event-shaped payload tha
   "event": {
     "kind": "capabilities.refreshed",
     "action": "coven.capabilities.refresh",
-    "origin": "castcodes",
+    "origin": "open-meow",
     "intentId": "intent-1",
     "payload": { "capabilities": 3 }
   }
@@ -143,4 +149,4 @@ Immediately completed safe actions return `200` with an event-shaped payload tha
 - Existing required fields should not be removed or renamed inside `v1`.
 - Breaking response-shape or behavior changes require a new API version prefix.
 - External clients should call `/api/v1/health` before assuming compatibility.
-- Daemon changes that affect `/api/v1/health`, `/api/v1/sessions`, `/api/v1/events`, input, or kill behavior should update client compatibility tests in the same repo.
+- Daemon changes that affect `/api/v1/health`, `/api/v1/sessions`, `/api/v1/events`, `/api/v1/sessions/:id/events`, input, or kill behavior should update client compatibility tests in the same repo.

--- a/docs/daemon/configuration.md
+++ b/docs/daemon/configuration.md
@@ -23,6 +23,29 @@ When `COVEN_HOME` is set, the daemon uses:
 - `<COVEN_HOME>/coven.sock` for the Unix socket.
 - `<COVEN_HOME>/coven.sqlite3` for the session ledger and event log.
 - `<COVEN_HOME>/daemon.json` for background daemon metadata.
+- `<COVEN_HOME>/privacy.toml` for local log privacy settings when present.
+- `<COVEN_HOME>/keys/session-artifacts.key` for the local encrypted artifact key when raw artifact persistence is enabled.
+
+## Log privacy
+
+Session logs are redacted by default before they are stored in SQLite or returned through the API.
+
+Optional `privacy.toml`:
+
+```toml
+persist_raw_artifacts = false
+raw_artifact_retention_days = 7
+log_retention_days = 30
+extra_patterns = ["custom-sensitive-[0-9]+"]
+```
+
+Environment overrides:
+
+- `COVEN_PERSIST_RAW_ARTIFACTS=1`
+- `COVEN_RAW_ARTIFACT_RETENTION_DAYS=<days>`
+- `COVEN_LOG_RETENTION_DAYS=<days>`
+
+Raw artifacts are unavailable unless explicitly enabled. When enabled, raw artifacts are encrypted at rest with a local key outside SQLite. If the key cannot be loaded or created, Coven keeps redacted logging working and skips raw artifact persistence.
 
 ## Unsupported knobs
 
@@ -37,6 +60,13 @@ coven daemon restart
 ```
 
 `restart` rebinds the socket under the selected state directory.
+
+Prune retained log data:
+
+```bash
+coven logs prune --dry-run
+coven logs prune
+```
 
 ## Related
 

--- a/docs/reference/api-events.md
+++ b/docs/reference/api-events.md
@@ -6,4 +6,20 @@ title: "Events endpoint"
 description: "Reference for the events endpoint: how clients stream and replay append-only Coven session events from the daemon's local socket API."
 ---
 
-Stub — fill in.
+`GET /api/v1/events?sessionId=<id>` and `GET /api/v1/sessions/:id/events` return the same paginated envelope:
+
+```json
+{
+  "events": [],
+  "nextCursor": null,
+  "hasMore": false
+}
+```
+
+Supported cursors:
+
+- `afterSeq`
+- `afterEventId`
+- `limit`
+
+Payloads are redacted before storage and before API display. Raw sensitive artifacts are not included in event responses.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -23,6 +23,8 @@ flowchart LR
   Sessions --> SCreate["POST /"]
   Sessions --> SById["/:id"]
   SById --> SGet["GET /"]
+  SById --> SEvents["GET /events"]
+  SById --> SLog["GET /log"]
   SById --> SInput["POST /input"]
   SById --> SKill["POST /kill"]
 ```
@@ -38,9 +40,11 @@ flowchart LR
 | GET | `/api/v1/sessions` | List active sessions. | — | `SessionRecord[]` | — |
 | POST | `/api/v1/sessions` | Launch a project-scoped harness session. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request` (includes cwd-outside-project-root, unknown harness id, malformed body, etc.), `500 launch_failed` (runtime spawn / initial-message-write / harness startup failed; row marked `failed`) |
 | GET | `/api/v1/sessions/:id` | Fetch one session. | — | `SessionRecord` | `404 session_not_found` |
+| GET | `/api/v1/sessions/:id/events` | Read redacted session events. | — (`?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `404 session_not_found` |
+| GET | `/api/v1/sessions/:id/log` | Read bounded redacted log previews. | — | `[{ ts, level, message }]` | `404 session_not_found` |
 | POST | `/api/v1/sessions/:id/input` | Forward input to a live session. | `{ data }` | `{ ok, accepted }` | `400 invalid_request` (malformed body / missing or non-string `data`), `404 session_not_found`, `409 session_not_live`, `500 send_input_failed` |
 | POST | `/api/v1/sessions/:id/kill` | Kill a live session. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live`, `500 kill_failed` |
-| GET | `/api/v1/events` | Read paginated session events. | — (`?sessionId`, `?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `400 invalid_request` |
+| GET | `/api/v1/events` | Read paginated redacted session events. | — (`?sessionId`, `?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `400 invalid_request` |
 
 All error responses use the structured envelope documented in [API contract](/API-CONTRACT#structured-error-envelope).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -22,6 +22,7 @@ flowchart TB
   Root --> Archive["archive"]
   Root --> Sacrifice["sacrifice"]
   Root --> Patch["patch"]
+  Root --> Logs["logs"]
   Root --> Pc["pc (macOS-first)"]
 
   Daemon --> DStart["start"]
@@ -38,6 +39,8 @@ flowchart TB
   Sessions --> SManage["--manage"]
 
   Patch --> POpenclaw["openclaw &lt;prompt&gt;"]
+
+  Logs --> LPrune["prune [--dry-run]"]
 
   Pc --> PcStatus["status [--json]"]
   Pc --> PcTop["top --n N"]
@@ -61,6 +64,7 @@ flowchart TB
 | `coven archive <session-id>` | Hide a non-running session while preserving events. |
 | `coven sacrifice <session-id> --yes` | Permanently delete a non-running session. |
 | `coven patch openclaw <prompt>` | Local OpenClaw rescue loop. Does not commit or push. |
+| `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs. |
 | `coven pc` | macOS-first diagnostics and explicit `--confirm` relief operations. |
 
 ## Common flags by command
@@ -70,6 +74,7 @@ flowchart TB
 | `coven run` | `--cwd <path>`, `--title <text>`, `--detach` |
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sacrifice` | `--yes` (required) |
+| `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
 | `coven pc kill` | `--confirm` (required) |
 | `coven pc cache clear` | `--confirm` (required) |
 | `coven pc top` | `--n <N>`, `--verbose` |
@@ -81,6 +86,15 @@ flowchart TB
 - **Pipe-friendly commands** accept `--plain` for tables and `--json` for machine output.
 - **Destructive commands** require `--yes` (or `--confirm` for `coven pc` relief).
 - **Daemon-touching commands** print install/repair hints when the socket is missing.
+
+## Log retention
+
+`coven logs prune` applies the local privacy retention policy:
+
+- Raw encrypted artifacts default to 7 days.
+- Redacted operational event logs default to 30 days.
+- `--dry-run` prints counts only.
+- `--raw-days <N>` and `--event-days <N>` override the configured retention for one run.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary
- centralize redaction and privacy configuration for session event payloads
- persist redacted previews in normal event logs and protect legacy rows at read time
- add opt-in encrypted raw session artifacts with local key-file storage and retention pruning
- document the privacy model, retention defaults, API behavior, and key-file limitations

## Architecture
- `privacy` owns redaction, bounded previews, config loading, and env overrides.
- `events.payload_json` remains the default API/UI surface and stores redacted payloads.
- `sensitive_artifacts` stores opt-in raw payload artifacts separately with XChaCha20-Poly1305 nonces/ciphertext and AAD bound to session/event/kind.
- `coven logs prune` deletes expired encrypted artifacts first, then old redacted operational events.
- Local MVP key storage uses `<COVEN_HOME>/keys/session-artifacts.key` outside the repo and SQLite DB; OS keychain remains follow-up work.

## Verification
- `cargo fmt --check`
- `cargo test -p coven-cli privacy --locked`
- `cargo test -p coven-cli encrypted_artifacts --locked`
- `cargo test -p coven-cli store --locked`
- `cargo test -p coven-cli api --locked`
- `cargo test -p coven-cli cli_accepts_logs_prune_options --locked`
- `cargo test --workspace --locked`
- `python3 scripts/check-secrets.py`
- `git diff --check`