### PR TITLE
feat(coven-cli): P0 Coven Code parity — JSONC settings, thread upgrades, file refs, stream-JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +342,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs-next",
+ "globset",
  "json5",
  "libc",
  "portable-pty",
@@ -682,6 +693,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs-next",
+ "json5",
  "libc",
  "portable-pty",
  "ratatui",
@@ -838,6 +839,17 @@ checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 json5 = "0.4"
 portable-pty = "0.9"
+regex = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
+json5 = "0.4"
 portable-pty = "0.9"
 rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -25,8 +25,8 @@ toml = "1.1"
 uuid = { version = "1", features = ["v4"] }
 sysinfo = "0.39"
 dirs-next = "2"
-regex = "1"
 chacha20poly1305 = { version = "0.10", features = ["std", "rand_core"] }
+globset = "0.4"
 # Chat TUI
 ratatui = { version = "0.30", default-features = false, features = ["crossterm", "underline-color"] }
 unicode-width = "0.2"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -313,6 +313,8 @@ fn launch_session(
         created_at: now.clone(),
         updated_at: now,
         conversation_id: launch.conversation_id.clone(),
+        labels: Vec::new(),
+        visibility: "private".to_string(),
     };
     store::insert_session(&conn, &record)?;
     if let Err(error) = runtime.launch_session(&launch) {
@@ -700,6 +702,8 @@ fn ensure_cockpit_session(conn: &rusqlite::Connection) -> Result<()> {
         created_at: now.clone(),
         updated_at: now,
         conversation_id: None,
+        labels: Vec::new(),
+        visibility: "private".to_string(),
     };
     store::insert_session_if_absent(conn, &record)?;
     Ok(())
@@ -1184,6 +1188,8 @@ mod tests {
             created_at: "2026-04-27T10:00:00Z".to_string(),
             updated_at: "2026-04-27T10:00:00Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         crate::store::insert_session(&conn, &session)?;
 
@@ -2048,6 +2054,8 @@ mod tests {
             created_at: "2026-04-27T10:00:00Z".to_string(),
             updated_at: "2026-04-27T10:00:00Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         crate::store::insert_session(&conn, &session)?;
         Ok(())
@@ -2350,6 +2358,8 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         store::insert_session(&conn, &session)?;
         insert_event(&conn, home, "sess-log", "input", json!({"text": "hello"}))?;
@@ -2570,6 +2580,8 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         store::insert_session(&conn, &session)?;
         drop(conn);
@@ -2668,6 +2680,8 @@ mod tests {
                     created_at: now.into(),
                     updated_at: now.into(),
                     conversation_id: None,
+                    labels: Vec::new(),
+                    visibility: "private".to_string(),
                 },
             )?;
         }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2395,6 +2395,8 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         store::insert_session(&conn, &session)?;
         let fake = fake_openai_key();
@@ -2435,6 +2437,8 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         store::insert_session(&conn, &session)?;
         drop(conn);
@@ -2469,6 +2473,8 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
         store::insert_session(&conn, &session)?;
         insert_event(

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1948,6 +1948,8 @@ mod tests {
                 created_at: "2026-04-27T10:00:00Z".to_string(),
                 updated_at: "2026-04-27T10:00:00Z".to_string(),
                 conversation_id: None,
+                labels: Vec::new(),
+                visibility: "private".to_string(),
             },
         )?;
         let listener = bind_api_socket(temp_dir.path())?;
@@ -2110,6 +2112,8 @@ mod tests {
             created_at: "2026-04-27T07:00:00Z".to_string(),
             updated_at: "2026-04-27T07:00:00Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         }
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -22,6 +22,7 @@ mod pc;
 mod privacy;
 mod project;
 mod prompt_refs;
+mod stream_json;
 mod pty_runner;
 mod repos_config;
 mod settings;

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -826,6 +826,15 @@ fn run_session(
     let conn = store::open_store(&store_path)?;
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true);
 
+    // Expand @path / @T-<id> / @@search refs before dispatching to the harness.
+    // Keep the original `prompt` for session title and human-facing output so titles
+    // aren't blown out by inlined file content.
+    let expanded_prompt = if prompt.is_empty() {
+        String::new()
+    } else {
+        prompt_refs::expand_all(&cwd, &conn, &prompt)?
+    };
+
     // Resolve --continue: explicit id, "" (latest), or None (new session).
     let resumed_id: Option<String> = match continue_session {
         None => None,
@@ -914,7 +923,7 @@ fn run_session(
     };
     let command = pty_runner::build_harness_command_with_conversation(
         selected_harness.id,
-        &prompt,
+        &expanded_prompt,
         &cwd,
         harness_launch_mode_for_stdio(),
         conversation_hint.as_ref(),

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -807,6 +807,16 @@ fn harness_launch_mode_for_stdio() -> harness::HarnessLaunchMode {
     }
 }
 
+/// Lock stdout, emit one stream-JSON frame, release. Per-frame locking keeps
+/// us from holding the lock across `pty_runner::run_attached`, which writes
+/// the harness's own stdout through the same handle.
+fn emit_stream_event(event: &stream_json::Event) -> Result<()> {
+    let stdout = io::stdout();
+    let mut handle = stdout.lock();
+    stream_json::emit_event(&mut handle, event)?;
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_session(
     harness_id: &str,
@@ -821,9 +831,9 @@ fn run_session(
     stream_json: bool,
     stream_json_input: bool,
 ) -> Result<()> {
-    // 4.3/4.4 will consume these; for now they only need to exist on the
-    // signature so the flags compile cleanly end-to-end.
-    let _ = (stream_json, stream_json_input);
+    // `stream_json_input` is consumed by the claude pass-through in 4.4; for
+    // non-stream harnesses it has no effect on this path.
+    let _ = stream_json_input;
     let prompt = if prompt_args.is_empty() {
         String::new()
     } else {
@@ -910,22 +920,58 @@ fn run_session(
         store::insert_session(&conn, &record)?;
     }
 
-    println!("Coven session {}", if is_resume { "resumed" } else { "created" });
-    println!("  id:      {}", record.id);
-    println!("  harness: {}", record.harness);
-    println!("  cwd:     {}", cwd.display());
-    println!("  title:   {}", record.title);
+    if !stream_json {
+        println!("Coven session {}", if is_resume { "resumed" } else { "created" });
+        println!("  id:      {}", record.id);
+        println!("  harness: {}", record.harness);
+        println!("  cwd:     {}", cwd.display());
+        println!("  title:   {}", record.title);
+    }
 
     if detach && is_resume {
         anyhow::bail!("--detach and --continue are mutually exclusive");
+    }
+
+    let stream_started = std::time::Instant::now();
+    if stream_json {
+        emit_stream_event(&stream_json::Event::System(stream_json::System {
+            subtype: "init".into(),
+            cwd: cwd.to_string_lossy().into_owned(),
+            session_id: record.id.clone(),
+            tools: Vec::new(),
+            agent_mode: None,
+        }))?;
+        if !expanded_prompt.is_empty() {
+            emit_stream_event(&stream_json::Event::User(stream_json::UserMessage {
+                message: stream_json::MessageBody {
+                    role: "user".into(),
+                    content: vec![stream_json::ContentBlock::Text {
+                        text: expanded_prompt.clone(),
+                    }],
+                },
+                session_id: record.id.clone(),
+                parent_tool_use_id: None,
+            }))?;
+        }
     }
 
     if detach {
         if archive {
             eprintln!("warning: --archive ignored in --detach mode (session was never launched)");
         }
-        println!("\nDetached mode: session was recorded but the harness was not spawned.");
-        println!("View it later with `coven sessions`.");
+        if !stream_json {
+            println!("\nDetached mode: session was recorded but the harness was not spawned.");
+            println!("View it later with `coven sessions`.");
+        } else {
+            emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+                subtype: "success".into(),
+                duration_ms: stream_started.elapsed().as_millis() as u64,
+                is_error: false,
+                num_turns: 1,
+                session_id: record.id.clone(),
+                error: None,
+            }))?;
+        }
         return Ok(());
     }
 
@@ -958,10 +1004,27 @@ fn run_session(
                 result.exit_code,
                 &current_timestamp(),
             )?;
+            if stream_json {
+                let is_error = result.exit_code.map_or(false, |c| c != 0);
+                emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+                    subtype: if is_error {
+                        "error_during_execution".into()
+                    } else {
+                        "success".into()
+                    },
+                    duration_ms: stream_started.elapsed().as_millis() as u64,
+                    is_error,
+                    num_turns: 1,
+                    session_id: record.id.clone(),
+                    error: None,
+                }))?;
+            }
             if archive {
                 let archived_at = current_timestamp();
                 store::archive_session(&conn, &record.id, &archived_at)?;
-                println!("\nArchived session {} at {archived_at}", record.id);
+                if !stream_json {
+                    println!("\nArchived session {} at {archived_at}", record.id);
+                }
             }
             Ok(())
         }
@@ -973,6 +1036,16 @@ fn run_session(
                 None,
                 &current_timestamp(),
             )?;
+            if stream_json {
+                emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+                    subtype: "error_during_execution".into(),
+                    duration_ms: stream_started.elapsed().as_millis() as u64,
+                    is_error: true,
+                    num_turns: 1,
+                    session_id: record.id.clone(),
+                    error: Some(format!("{error:#}")),
+                }))?;
+            }
             Err(error)
         }
     }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -22,11 +22,11 @@ mod pc;
 mod privacy;
 mod project;
 mod prompt_refs;
-mod stream_json;
 mod pty_runner;
 mod repos_config;
 mod settings;
 mod store;
+mod stream_json;
 mod theme;
 mod tui;
 mod verification;
@@ -91,7 +91,11 @@ enum Command {
             help = "Resume session by id; omit value to resume the latest active session for this project"
         )]
         continue_session: Option<String>,
-        #[arg(long, value_delimiter = ',', help = "Comma-separated labels for the new session (ignored when resuming)")]
+        #[arg(
+            long,
+            value_delimiter = ',',
+            help = "Comma-separated labels for the new session (ignored when resuming)"
+        )]
         labels: Vec<String>,
         #[arg(
             long,
@@ -231,13 +235,14 @@ enum InteractiveShellRoute {
 }
 
 fn main() -> Result<()> {
-    let loaded = settings::user_settings_path()
-        .as_deref()
-        .and_then(|path| match settings::load_from(path) {
-            Ok(s) => s,
-            Err(err) => {
-                eprintln!("coven: ignoring settings ({}): {err:#}", path.display());
-                None
+    let loaded =
+        settings::user_settings_path().as_deref().and_then(|path| {
+            match settings::load_from(path) {
+                Ok(s) => s,
+                Err(err) => {
+                    eprintln!("coven: ignoring settings ({}): {err:#}", path.display());
+                    None
+                }
             }
         });
     settings::init_cached(loaded);
@@ -287,9 +292,10 @@ fn run_cli(cli: Cli) -> Result<()> {
             plain,
             json,
         }) => match command {
-            Some(SessionsCommand::Search { query, json: search_json }) => {
-                run_sessions_search(&query, search_json)
-            }
+            Some(SessionsCommand::Search {
+                query,
+                json: search_json,
+            }) => run_sessions_search(&query, search_json),
             None => tui::sessions::run_command(all, manage, plain, json),
         },
         Some(Command::Logs { command }) => run_logs_command(command),
@@ -332,8 +338,7 @@ fn run_sessions_search(query: &str, json: bool) -> Result<()> {
 
     if json {
         // Serialize the Vec<SearchHit> directly — SearchHit derives Serialize.
-        let serialized = serde_json::to_string(&hits)
-            .context("failed to serialize search hits")?;
+        let serialized = serde_json::to_string(&hits).context("failed to serialize search hits")?;
         println!("{serialized}");
         return Ok(());
     }
@@ -878,10 +883,8 @@ fn run_session(
     let resumed_id: Option<String> = match continue_session {
         None => None,
         Some("") => {
-            let latest = store::latest_active_for_project(
-                &conn,
-                project_root.to_str().unwrap_or(""),
-            )?;
+            let latest =
+                store::latest_active_for_project(&conn, project_root.to_str().unwrap_or(""))?;
             if latest.is_none() {
                 anyhow::bail!(
                     "no active session to continue in {}; pass an explicit --continue <ID> or omit the flag",
@@ -929,7 +932,10 @@ fn run_session(
     }
 
     if !stream_json {
-        println!("Coven session {}", if is_resume { "resumed" } else { "created" });
+        println!(
+            "Coven session {}",
+            if is_resume { "resumed" } else { "created" }
+        );
         println!("  id:      {}", record.id);
         println!("  harness: {}", record.harness);
         println!("  cwd:     {}", cwd.display());
@@ -1080,7 +1086,9 @@ fn run_session(
     }
 
     let conversation_hint = if is_resume {
-        Some(harness::ConversationHint::Resume { id: record.id.clone() })
+        Some(harness::ConversationHint::Resume {
+            id: record.id.clone(),
+        })
     } else {
         None
     };

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -101,6 +101,17 @@ enum Command {
         visibility: Option<String>,
         #[arg(long, help = "Archive the session after the run completes")]
         archive: bool,
+        #[arg(
+            long,
+            help = "Emit JSONL events on stdout (system.init / user / assistant / tool_result / result)"
+        )]
+        stream_json: bool,
+        #[arg(
+            long,
+            requires = "stream_json",
+            help = "Read JSONL user messages from stdin (claude harness only; requires --stream-json)"
+        )]
+        stream_json_input: bool,
     },
     #[command(about = "List or search recent Coven sessions")]
     Sessions {
@@ -254,6 +265,8 @@ fn run_cli(cli: Cli) -> Result<()> {
             labels,
             visibility,
             archive,
+            stream_json,
+            stream_json_input,
         }) => run_session(
             &harness,
             &prompt,
@@ -264,6 +277,8 @@ fn run_cli(cli: Cli) -> Result<()> {
             labels,
             visibility.as_deref(),
             archive,
+            stream_json,
+            stream_json_input,
         ),
         Some(Command::Sessions {
             command,
@@ -803,7 +818,12 @@ fn run_session(
     labels: Vec<String>,
     visibility: Option<&str>,
     archive: bool,
+    stream_json: bool,
+    stream_json_input: bool,
 ) -> Result<()> {
+    // 4.3/4.4 will consume these; for now they only need to exist on the
+    // signature so the flags compile cleanly end-to-end.
+    let _ = (stream_json, stream_json_input);
     let prompt = if prompt_args.is_empty() {
         String::new()
     } else {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -73,7 +73,7 @@ enum Command {
     Run {
         #[arg(help = "Harness to run: codex or claude")]
         harness: String,
-        #[arg(help = "Task for the harness", required = true, num_args = 1..)]
+        #[arg(help = "Task for the harness", required = false, num_args = 0..)]
         prompt: Vec<String>,
         #[arg(long, help = "Working directory inside the current project")]
         cwd: Option<PathBuf>,
@@ -81,6 +81,24 @@ enum Command {
         title: Option<String>,
         #[arg(long, help = "Create the session record without launching the harness")]
         detach: bool,
+        #[arg(
+            long = "continue",
+            value_name = "ID",
+            num_args = 0..=1,
+            default_missing_value = "",
+            help = "Resume session by id; omit value to resume the latest active session for this project"
+        )]
+        continue_session: Option<String>,
+        #[arg(long, value_delimiter = ',', help = "Comma-separated labels for the new session (ignored when resuming)")]
+        labels: Vec<String>,
+        #[arg(
+            long,
+            value_parser = ["private", "workspace", "shared"],
+            help = "Visibility for the new session: private (default), workspace, shared (ignored when resuming)"
+        )]
+        visibility: Option<String>,
+        #[arg(long, help = "Archive the session after the run completes")]
+        archive: bool,
     },
     #[command(about = "List recent Coven sessions")]
     Sessions {
@@ -217,7 +235,21 @@ fn run_cli(cli: Cli) -> Result<()> {
             cwd,
             title,
             detach,
-        }) => run_session(&harness, &prompt, cwd.as_deref(), title.as_deref(), detach),
+            continue_session,
+            labels,
+            visibility,
+            archive,
+        }) => run_session(
+            &harness,
+            &prompt,
+            cwd.as_deref(),
+            title.as_deref(),
+            detach,
+            continue_session.as_deref(),
+            labels,
+            visibility.as_deref(),
+            archive,
+        ),
         Some(Command::Sessions {
             all,
             manage,
@@ -712,14 +744,28 @@ fn harness_launch_mode_for_stdio() -> harness::HarnessLaunchMode {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_session(
     harness_id: &str,
     prompt_args: &[String],
     cwd: Option<&Path>,
     title: Option<&str>,
     detach: bool,
+    continue_session: Option<&str>,
+    labels: Vec<String>,
+    visibility: Option<&str>,
+    archive: bool,
 ) -> Result<()> {
-    let prompt = joined_prompt(prompt_args)?;
+    let prompt = if prompt_args.is_empty() {
+        String::new()
+    } else {
+        joined_prompt(prompt_args)?
+    };
+
+    if prompt_args.is_empty() && continue_session.is_none() {
+        anyhow::bail!("nothing to do: pass a prompt, or use --continue [ID] to resume a session");
+    }
+
     let selected_harness = selected_available_harness(harness_id)?;
     let current_dir = std::env::current_dir().context("failed to read current directory")?;
     let project_root = project::canonical_project_root(&current_dir).with_context(|| {
@@ -732,30 +778,75 @@ fn run_session(
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true);
-    let record = store::SessionRecord {
-        id: Uuid::new_v4().to_string(),
-        project_root: project_root.to_string_lossy().into_owned(),
-        harness: selected_harness.id.to_string(),
-        title: session_title(title, &prompt),
-        status: DEFAULT_SESSION_STATUS.to_string(),
-        exit_code: None,
-        archived_at: None,
-        created_at: now.clone(),
-        updated_at: now,
-        conversation_id: None,
-        labels: Vec::new(),
-        visibility: "private".to_string(),
+
+    // Resolve --continue: explicit id, "" (latest), or None (new session).
+    let resumed_id: Option<String> = match continue_session {
+        None => None,
+        Some("") => {
+            let latest = store::latest_active_for_project(
+                &conn,
+                project_root.to_str().unwrap_or(""),
+            )?;
+            if latest.is_none() {
+                anyhow::bail!(
+                    "no active session to continue in {}; pass an explicit --continue <ID> or omit the flag",
+                    project_root.display(),
+                );
+            }
+            latest
+        }
+        Some(id) => Some(id.to_string()),
     };
 
-    store::insert_session(&conn, &record)?;
+    let (record, is_resume) = if let Some(ref id) = resumed_id {
+        // Verify the session exists; reuse its row.
+        let existing = store::list_sessions_including_archived(&conn)?
+            .into_iter()
+            .find(|s| &s.id == id);
+        match existing {
+            Some(mut r) => {
+                // Mutate updated_at to now; keep labels/visibility/title from the original.
+                r.updated_at = now.clone();
+                (r, true)
+            }
+            None => anyhow::bail!("session {} not found in local store", id),
+        }
+    } else {
+        let r = store::SessionRecord {
+            id: Uuid::new_v4().to_string(),
+            project_root: project_root.to_string_lossy().into_owned(),
+            harness: selected_harness.id.to_string(),
+            title: session_title(title, &prompt),
+            status: DEFAULT_SESSION_STATUS.to_string(),
+            exit_code: None,
+            archived_at: None,
+            created_at: now.clone(),
+            updated_at: now,
+            conversation_id: None,
+            labels,
+            visibility: visibility.unwrap_or("private").to_string(),
+        };
+        (r, false)
+    };
 
-    println!("Coven session created");
+    if !is_resume {
+        store::insert_session(&conn, &record)?;
+    }
+
+    println!("Coven session {}", if is_resume { "resumed" } else { "created" });
     println!("  id:      {}", record.id);
     println!("  harness: {}", record.harness);
     println!("  cwd:     {}", cwd.display());
     println!("  title:   {}", record.title);
 
+    if detach && is_resume {
+        anyhow::bail!("--detach and --continue are mutually exclusive");
+    }
+
     if detach {
+        if archive {
+            eprintln!("warning: --archive ignored in --detach mode (session was never launched)");
+        }
         println!("\nDetached mode: session was recorded but the harness was not spawned.");
         println!("View it later with `coven sessions`.");
         return Ok(());
@@ -769,11 +860,17 @@ fn run_session(
         &current_timestamp(),
     )?;
 
-    let command = pty_runner::build_harness_command(
+    let conversation_hint = if is_resume {
+        Some(harness::ConversationHint::Resume { id: record.id.clone() })
+    } else {
+        None
+    };
+    let command = pty_runner::build_harness_command_with_conversation(
         selected_harness.id,
         &prompt,
         &cwd,
         harness_launch_mode_for_stdio(),
+        conversation_hint.as_ref(),
     )?;
     match pty_runner::run_attached(&command) {
         Ok(result) => {
@@ -784,6 +881,11 @@ fn run_session(
                 result.exit_code,
                 &current_timestamp(),
             )?;
+            if archive {
+                let archived_at = current_timestamp();
+                store::archive_session(&conn, &record.id, &archived_at)?;
+                println!("\nArchived session {} at {archived_at}", record.id);
+            }
             Ok(())
         }
         Err(error) => {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -705,7 +705,7 @@ fn run_logs_command(command: LogsCommand) -> Result<()> {
 
 fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u64>) -> Result<()> {
     let home = coven_home_dir()?;
-    let config = privacy::load_config(&home).unwrap_or_default();
+    let config = privacy::load_with_settings(&home, settings::cached()).unwrap_or_default();
     let raw_days = raw_days
         .unwrap_or(config.raw_artifact_retention_days)
         .max(1);

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -549,6 +549,8 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         created_at: now.clone(),
         updated_at: now.clone(),
         conversation_id: None,
+        labels: Vec::new(),
+        visibility: "private".to_string(),
     };
     store::insert_session(&conn, &record)?;
     let metadata = serde_json::json!({
@@ -741,6 +743,8 @@ fn run_session(
         created_at: now.clone(),
         updated_at: now,
         conversation_id: None,
+        labels: Vec::new(),
+        visibility: "private".to_string(),
     };
 
     store::insert_session(&conn, &record)?;
@@ -1925,6 +1929,8 @@ mod tests {
             created_at: "2026-04-27T06:00:00Z".to_string(),
             updated_at: "2026-04-27T06:00:00Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
 
         assert_eq!(
@@ -1946,6 +1952,8 @@ mod tests {
             created_at: "2026-05-14T07:00:00Z".to_string(),
             updated_at: "2026-05-14T07:00:01Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         };
 
         let rendered = render_sessions_json(&[session])?;
@@ -2058,6 +2066,8 @@ mod tests {
             created_at: "2026-05-08T07:00:00Z".to_string(),
             updated_at: "2026-05-08T07:05:00Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         }
     }
 }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -23,6 +23,7 @@ mod privacy;
 mod project;
 mod pty_runner;
 mod repos_config;
+mod settings;
 mod store;
 mod theme;
 mod tui;

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -100,9 +100,11 @@ enum Command {
         #[arg(long, help = "Archive the session after the run completes")]
         archive: bool,
     },
-    #[command(about = "List recent Coven sessions")]
+    #[command(about = "List or search recent Coven sessions")]
     Sessions {
-        #[arg(long, help = "Include archived sessions")]
+        #[command(subcommand)]
+        command: Option<SessionsCommand>,
+        #[arg(long, help = "Include archived sessions (list mode only)")]
         all: bool,
         #[arg(long, conflicts_with_all = ["plain", "json"], help = "Open the interactive session action browser")]
         manage: bool,
@@ -154,6 +156,17 @@ enum Command {
     Pc {
         #[command(subcommand)]
         command: Option<pc::PcCommand>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum SessionsCommand {
+    #[command(about = "Full-text search session event payloads")]
+    Search {
+        #[arg(help = "FTS5 query (e.g. `phoenix OR rises`)")]
+        query: String,
+        #[arg(long, help = "Print SearchHit JSON for clients")]
+        json: bool,
     },
 }
 
@@ -251,11 +264,17 @@ fn run_cli(cli: Cli) -> Result<()> {
             archive,
         ),
         Some(Command::Sessions {
+            command,
             all,
             manage,
             plain,
             json,
-        }) => tui::sessions::run_command(all, manage, plain, json),
+        }) => match command {
+            Some(SessionsCommand::Search { query, json: search_json }) => {
+                run_sessions_search(&query, search_json)
+            }
+            None => tui::sessions::run_command(all, manage, plain, json),
+        },
         Some(Command::Logs { command }) => run_logs_command(command),
         Some(Command::Attach { session_id }) => attach_session(&session_id),
         Some(Command::Summon { session_id }) => summon_session_command(&session_id),
@@ -287,6 +306,33 @@ fn run_cli(cli: Cli) -> Result<()> {
 fn run_bare_prompt(prompt: &[String]) -> Result<()> {
     let prompt = joined_prompt(prompt)?;
     tui::shell::run_cast_spell(&prompt)
+}
+
+fn run_sessions_search(query: &str, json: bool) -> Result<()> {
+    let store_path = coven_store_path()?;
+    let conn = store::open_store(&store_path)?;
+    let hits = store::search_events(&conn, query)?;
+
+    if json {
+        // Serialize the Vec<SearchHit> directly — SearchHit derives Serialize.
+        let serialized = serde_json::to_string(&hits)
+            .context("failed to serialize search hits")?;
+        println!("{serialized}");
+        return Ok(());
+    }
+
+    if hits.is_empty() {
+        println!("No matches for `{query}`.");
+        return Ok(());
+    }
+
+    for hit in &hits {
+        println!(
+            "{}  {}  [{}]  {}",
+            hit.created_at, hit.session_id, hit.kind, hit.snippet
+        );
+    }
+    Ok(())
 }
 
 fn run_shared_interactive_shell() -> Result<()> {
@@ -1756,6 +1802,7 @@ mod tests {
                 manage,
                 plain,
                 json,
+                ..
             }) => {
                 assert!(all);
                 assert!(!manage);

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -187,6 +187,17 @@ enum InteractiveShellRoute {
 }
 
 fn main() -> Result<()> {
+    let loaded = settings::user_settings_path()
+        .as_deref()
+        .and_then(|path| match settings::load_from(path) {
+            Ok(s) => s,
+            Err(err) => {
+                eprintln!("coven: ignoring settings ({}): {err:#}", path.display());
+                None
+            }
+        });
+    settings::init_cached(loaded);
+
     let cli = Cli::parse();
     run_cli(cli)
 }
@@ -277,7 +288,7 @@ fn run_doctor() -> Result<()> {
         None => println!("Project: not inside a git/project root yet"),
     }
 
-    let repos_config = repos_config::load(&home)?;
+    let repos_config = repos_config::load_with_settings(&home, settings::cached())?;
     if !repos_config.is_empty() {
         println!("\nRepos ({}):", repos_config::config_path(&home).display());
         for (name, path) in repos_config.entries() {
@@ -327,7 +338,7 @@ fn run_patch(
     keep_session: bool,
 ) -> Result<()> {
     let coven_home = coven_home_dir()?;
-    let repos_config = repos_config::load(&coven_home)?;
+    let repos_config = repos_config::load_with_settings(&coven_home, settings::cached())?;
     let resolved_name = name
         .or_else(|| repos_config.default_name().map(str::to_string))
         .unwrap_or_else(|| openclaw_repo::OPENCLAW_REPO_NAME.to_string());

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -817,6 +817,15 @@ fn emit_stream_event(event: &stream_json::Event) -> Result<()> {
     Ok(())
 }
 
+fn should_synthesize_stream_user_event(
+    stream_json: bool,
+    expanded_prompt: &str,
+    detach: bool,
+    harness_id: &str,
+) -> bool {
+    stream_json && !expanded_prompt.is_empty() && (detach || harness_id != "claude")
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_session(
     harness_id: &str,
@@ -833,7 +842,6 @@ fn run_session(
 ) -> Result<()> {
     // `stream_json_input` is consumed by the claude pass-through in 4.4; for
     // non-stream harnesses it has no effect on this path.
-    let _ = stream_json_input;
     let prompt = if prompt_args.is_empty() {
         String::new()
     } else {
@@ -941,19 +949,18 @@ fn run_session(
             tools: Vec::new(),
             agent_mode: None,
         }))?;
-        if !expanded_prompt.is_empty() {
-            emit_stream_event(&stream_json::Event::User(stream_json::UserMessage {
-                message: stream_json::MessageBody {
-                    role: "user".into(),
-                    content: vec![stream_json::ContentBlock::Text {
-                        text: expanded_prompt.clone(),
-                    }],
-                },
-                session_id: record.id.clone(),
-                parent_tool_use_id: None,
-            }))?;
-        }
     }
+
+    // We synthesize the `user` event only on paths where the harness will
+    // *not* emit it itself: detach (no harness runs) and codex / generic
+    // non-stream harnesses. The claude pass-through skips this so we don't
+    // duplicate the user message claude echoes through its native protocol.
+    let synthesize_user_event = should_synthesize_stream_user_event(
+        stream_json,
+        &expanded_prompt,
+        detach,
+        selected_harness.id,
+    );
 
     if detach {
         if archive {
@@ -963,6 +970,18 @@ fn run_session(
             println!("\nDetached mode: session was recorded but the harness was not spawned.");
             println!("View it later with `coven sessions`.");
         } else {
+            if synthesize_user_event {
+                emit_stream_event(&stream_json::Event::User(stream_json::UserMessage {
+                    message: stream_json::MessageBody {
+                        role: "user".into(),
+                        content: vec![stream_json::ContentBlock::Text {
+                            text: expanded_prompt.clone(),
+                        }],
+                    },
+                    session_id: record.id.clone(),
+                    parent_tool_use_id: None,
+                }))?;
+            }
             emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
                 subtype: "success".into(),
                 duration_ms: stream_started.elapsed().as_millis() as u64,
@@ -982,6 +1001,83 @@ fn run_session(
         None,
         &current_timestamp(),
     )?;
+
+    // Claude's native stream-json: pipe its JSONL events through ours
+    // between the init/result frames we already emit. The codex / generic
+    // path below cannot do this because codex doesn't speak stream-json, so we
+    // branch here after resolving the harness to claude.
+    if stream_json && selected_harness.id == "claude" {
+        let stdout = io::stdout();
+        let mut handle = stdout.lock();
+        let exit_code = pty_runner::stream_claude(
+            &cwd,
+            &record.id,
+            &expanded_prompt,
+            stream_json_input,
+            &mut handle,
+        );
+        drop(handle);
+        let exit_code = match exit_code {
+            Ok(code) => code,
+            Err(error) => {
+                store::update_session_status(
+                    &conn,
+                    &record.id,
+                    FAILED_SESSION_STATUS,
+                    None,
+                    &current_timestamp(),
+                )?;
+                emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+                    subtype: "error_during_execution".into(),
+                    duration_ms: stream_started.elapsed().as_millis() as u64,
+                    is_error: true,
+                    num_turns: 1,
+                    session_id: record.id.clone(),
+                    error: Some(format!("{error:#}")),
+                }))?;
+                return Err(error);
+            }
+        };
+        let is_error = exit_code != 0;
+        let status = if is_error { "failed" } else { "completed" };
+        store::update_session_status(
+            &conn,
+            &record.id,
+            status,
+            Some(exit_code),
+            &current_timestamp(),
+        )?;
+        emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+            subtype: if is_error {
+                "error_during_execution".into()
+            } else {
+                "success".into()
+            },
+            duration_ms: stream_started.elapsed().as_millis() as u64,
+            is_error,
+            num_turns: 1,
+            session_id: record.id.clone(),
+            error: None,
+        }))?;
+        if archive {
+            let archived_at = current_timestamp();
+            store::archive_session(&conn, &record.id, &archived_at)?;
+        }
+        return Ok(());
+    }
+
+    if synthesize_user_event {
+        emit_stream_event(&stream_json::Event::User(stream_json::UserMessage {
+            message: stream_json::MessageBody {
+                role: "user".into(),
+                content: vec![stream_json::ContentBlock::Text {
+                    text: expanded_prompt.clone(),
+                }],
+            },
+            session_id: record.id.clone(),
+            parent_tool_use_id: None,
+        }))?;
+    }
 
     let conversation_hint = if is_resume {
         Some(harness::ConversationHint::Resume { id: record.id.clone() })
@@ -1385,6 +1481,25 @@ mod tests {
             "hello from coven"
         );
         Ok(())
+    }
+
+    #[test]
+    fn stream_json_user_event_synthesis_skips_live_claude_passthrough() {
+        assert!(should_synthesize_stream_user_event(
+            true, "hello", true, "claude"
+        ));
+        assert!(should_synthesize_stream_user_event(
+            true, "hello", false, "codex"
+        ));
+        assert!(!should_synthesize_stream_user_event(
+            true, "hello", false, "claude"
+        ));
+        assert!(!should_synthesize_stream_user_event(
+            false, "hello", false, "codex"
+        ));
+        assert!(!should_synthesize_stream_user_event(
+            true, "", true, "codex"
+        ));
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1109,7 +1109,7 @@ fn run_session(
                 &current_timestamp(),
             )?;
             if stream_json {
-                let is_error = result.exit_code.map_or(false, |c| c != 0);
+                let is_error = result.exit_code.is_some_and(|c| c != 0);
                 emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
                     subtype: if is_error {
                         "error_during_execution".into()

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -21,6 +21,7 @@ mod patch;
 mod pc;
 mod privacy;
 mod project;
+mod prompt_refs;
 mod pty_runner;
 mod repos_config;
 mod settings;

--- a/crates/coven-cli/src/privacy.rs
+++ b/crates/coven-cli/src/privacy.rs
@@ -246,6 +246,32 @@ fn built_in_patterns() -> &'static [Regex] {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvVarGuard {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.name, value),
+                None => std::env::remove_var(self.name),
+            }
+        }
+    }
 
     #[test]
     fn redact_text_removes_common_secret_shapes() {
@@ -336,13 +362,9 @@ extra_patterns = ["custom-sensitive-[0-9]+"]
 "#,
         )?;
 
-        let previous = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS");
-        std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", "1");
+        let _env_lock = ENV_LOCK.lock().expect("privacy env lock poisoned");
+        let _env_guard = EnvVarGuard::set("COVEN_PERSIST_RAW_ARTIFACTS", "1");
         let config = load_config(temp.path())?;
-        match previous {
-            Some(value) => std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", value),
-            None => std::env::remove_var("COVEN_PERSIST_RAW_ARTIFACTS"),
-        }
 
         assert!(config.persist_raw_artifacts);
         assert_eq!(config.raw_artifact_retention_days, 9);
@@ -379,13 +401,9 @@ extra_patterns = ["toml-secret"]
             },
         };
 
-        let previous = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS");
-        std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", "1");
+        let _env_lock = ENV_LOCK.lock().expect("privacy env lock poisoned");
+        let _env_guard = EnvVarGuard::set("COVEN_PERSIST_RAW_ARTIFACTS", "1");
         let loaded = load_with_settings(temp.path(), Some(&settings))?;
-        match previous {
-            Some(value) => std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", value),
-            None => std::env::remove_var("COVEN_PERSIST_RAW_ARTIFACTS"),
-        }
 
         assert!(loaded.persist_raw_artifacts);
         assert_eq!(loaded.raw_artifact_retention_days, 3);

--- a/crates/coven-cli/src/privacy.rs
+++ b/crates/coven-cli/src/privacy.rs
@@ -66,6 +66,39 @@ pub fn load_config(_coven_home: &Path) -> Result<PrivacyConfig> {
     Ok(config)
 }
 
+pub fn load_with_settings(
+    coven_home: &Path,
+    settings: Option<&crate::settings::Settings>,
+) -> Result<PrivacyConfig> {
+    let mut config = load_config(coven_home)?;
+    if let Some(settings) = settings.and_then(|settings| settings.coven_cli.privacy.as_ref()) {
+        if let Some(value) = settings.persist_raw_artifacts {
+            config.persist_raw_artifacts = value;
+        }
+        if let Some(value) = settings.raw_artifact_retention_days {
+            config.raw_artifact_retention_days = value;
+        }
+        if let Some(value) = settings.log_retention_days {
+            config.log_retention_days = value;
+        }
+        if let Some(value) = &settings.extra_patterns {
+            config.extra_patterns = value.clone();
+        }
+    }
+
+    if let Some(value) = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS") {
+        config.persist_raw_artifacts = env_truthy(&value.to_string_lossy());
+    }
+    if let Some(value) = env_u64("COVEN_RAW_ARTIFACT_RETENTION_DAYS") {
+        config.raw_artifact_retention_days = value;
+    }
+    if let Some(value) = env_u64("COVEN_LOG_RETENTION_DAYS") {
+        config.log_retention_days = value;
+    }
+
+    Ok(config)
+}
+
 pub fn redact_text(_text: &str) -> String {
     redact_text_with_config(_text, &PrivacyConfig::default())
 }
@@ -319,6 +352,45 @@ extra_patterns = ["custom-sensitive-[0-9]+"]
             redact_text_with_config("custom-sensitive-1234", &config),
             "[REDACTED]"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn settings_override_toml_but_env_still_wins() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(
+            temp.path().join("privacy.toml"),
+            r#"
+persist_raw_artifacts = false
+raw_artifact_retention_days = 9
+log_retention_days = 41
+extra_patterns = ["toml-secret"]
+"#,
+        )?;
+        let settings = crate::settings::Settings {
+            coven_cli: crate::settings::CovenCliSettings {
+                privacy: Some(crate::settings::PrivacySettings {
+                    persist_raw_artifacts: Some(false),
+                    raw_artifact_retention_days: Some(3),
+                    log_retention_days: Some(4),
+                    extra_patterns: Some(vec!["jsonc-secret".to_string()]),
+                }),
+                ..Default::default()
+            },
+        };
+
+        let previous = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS");
+        std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", "1");
+        let loaded = load_with_settings(temp.path(), Some(&settings))?;
+        match previous {
+            Some(value) => std::env::set_var("COVEN_PERSIST_RAW_ARTIFACTS", value),
+            None => std::env::remove_var("COVEN_PERSIST_RAW_ARTIFACTS"),
+        }
+
+        assert!(loaded.persist_raw_artifacts);
+        assert_eq!(loaded.raw_artifact_retention_days, 3);
+        assert_eq!(loaded.log_retention_days, 4);
+        assert_eq!(loaded.extra_patterns, vec!["jsonc-secret"]);
         Ok(())
     }
 

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -110,6 +110,38 @@ fn guess_mime(path: &Path) -> String {
 }
 
 #[allow(dead_code)]
+pub fn expand_thread(conn: &rusqlite::Connection, id: &str) -> Result<String> {
+    use anyhow::Context;
+    let mut stmt = conn
+        .prepare(
+            "SELECT kind, payload_json, created_at FROM events
+             WHERE session_id = ?1 ORDER BY created_at ASC LIMIT 200",
+        )
+        .context("failed to prepare expand_thread query")?;
+    let rows = stmt
+        .query_map([id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })
+        .context("failed to execute expand_thread query")?;
+    let mut out = format!("--- @{id} ---\n");
+    let mut found = false;
+    for r in rows {
+        let (kind, payload, ts) = r.context("failed to read expand_thread row")?;
+        found = true;
+        out.push_str(&format!("[{ts}] {kind}: {payload}\n"));
+    }
+    if !found {
+        return Ok(format!("[no events for @{id}]"));
+    }
+    out.push_str("--- end ---\n");
+    Ok(out)
+}
+
+#[allow(dead_code)]
 fn expand_glob(cwd: &Path, pattern: &str) -> Result<String> {
     use globset::{Glob, GlobSetBuilder};
     let mut builder = GlobSetBuilder::new();
@@ -277,5 +309,34 @@ mod tests {
         }
         let expanded = expand_path(temp.path(), "many/*.txt").unwrap();
         assert!(expanded.contains("glob match cap reached at 20 files"));
+    }
+
+    #[test]
+    fn expand_thread_inlines_payloads() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+             VALUES('T-abc', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+             VALUES('e1', 'T-abc', 'user', '{\"text\":\"hello world\"}', '2026-01-01')",
+            [],
+        )?;
+        let out = expand_thread(&conn, "T-abc")?;
+        assert!(out.contains("hello world"), "got: {out}");
+        assert!(out.contains("T-abc"), "got: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn expand_thread_missing_returns_placeholder() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        let out = expand_thread(&conn, "T-nope")?;
+        assert_eq!(out, "[no events for @T-nope]");
+        Ok(())
     }
 }

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -31,7 +31,10 @@ pub fn parse(prompt: &str) -> ParsedPrompt {
         }
         // double-@ for search comes first so single-@ doesn't swallow it
         if i + 1 < bytes.len() && bytes[i + 1] == b'@' {
-            let end = prompt[i..].find('\n').map(|n| i + n).unwrap_or(prompt.len());
+            let end = prompt[i..]
+                .find('\n')
+                .map(|n| i + n)
+                .unwrap_or(prompt.len());
             let body = &prompt[i + 2..end];
             if !body.trim().is_empty() {
                 refs.push(Ref::Search(body.trim().to_string()));
@@ -162,7 +165,9 @@ fn walkdir(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
@@ -182,11 +187,7 @@ fn walkdir(root: &Path) -> Vec<PathBuf> {
 /// Inlined content is prepended to the prompt with delimited blocks; the
 /// original prompt text follows unchanged. Returns `prompt` unmodified when
 /// it contains no refs.
-pub fn expand_all(
-    cwd: &Path,
-    conn: &rusqlite::Connection,
-    prompt: &str,
-) -> Result<String> {
+pub fn expand_all(cwd: &Path, conn: &rusqlite::Connection, prompt: &str) -> Result<String> {
     let parsed = parse(prompt);
     if parsed.refs.is_empty() {
         return Ok(prompt.to_string());
@@ -231,10 +232,7 @@ mod tests {
         let p = parse("look at @README.md and @docs/*.md please");
         assert_eq!(
             p.refs,
-            vec![
-                Ref::Path("README.md".into()),
-                Ref::Path("docs/*.md".into()),
-            ]
+            vec![Ref::Path("README.md".into()), Ref::Path("docs/*.md".into()),]
         );
     }
 
@@ -253,7 +251,11 @@ mod tests {
     #[test]
     fn bare_at_sign_followed_by_whitespace_is_ignored() {
         let p = parse("email me at @ work");
-        assert!(p.refs.is_empty(), "bare @ should produce no ref, got: {:?}", p.refs);
+        assert!(
+            p.refs.is_empty(),
+            "bare @ should produce no ref, got: {:?}",
+            p.refs
+        );
     }
 
     #[test]
@@ -333,11 +335,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(temp.path().join("many")).unwrap();
         for i in 0..25 {
-            std::fs::write(
-                temp.path().join(format!("many/f{i}.txt")),
-                format!("F{i}"),
-            )
-            .unwrap();
+            std::fs::write(temp.path().join(format!("many/f{i}.txt")), format!("F{i}")).unwrap();
         }
         let expanded = expand_path(temp.path(), "many/*.txt").unwrap();
         assert!(expanded.contains("glob match cap reached at 20 files"));
@@ -388,9 +386,16 @@ mod tests {
         let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
         let out = expand_all(temp.path(), &conn, "summarise @notes.md please")?;
         assert!(out.contains("alpha beta gamma"), "got: {out}");
-        let body_idx = out.find("summarise @notes.md please").expect("original prompt should appear");
-        let content_idx = out.find("alpha beta gamma").expect("file content should appear");
-        assert!(content_idx < body_idx, "inlined content should precede the original prompt; got: {out}");
+        let body_idx = out
+            .find("summarise @notes.md please")
+            .expect("original prompt should appear");
+        let content_idx = out
+            .find("alpha beta gamma")
+            .expect("file content should appear");
+        assert!(
+            content_idx < body_idx,
+            "inlined content should precede the original prompt; got: {out}"
+        );
         Ok(())
     }
 
@@ -398,9 +403,19 @@ mod tests {
     fn expand_all_search_no_hits_inlines_placeholder() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
-        let out = expand_all(temp.path(), &conn, "context:\n@@phoenix rising\nthen answer")?;
-        assert!(out.contains("[no search hits for @@phoenix rising]"), "got: {out}");
-        assert!(out.contains("then answer"), "original prompt preserved; got: {out}");
+        let out = expand_all(
+            temp.path(),
+            &conn,
+            "context:\n@@phoenix rising\nthen answer",
+        )?;
+        assert!(
+            out.contains("[no search hits for @@phoenix rising]"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("then answer"),
+            "original prompt preserved; got: {out}"
+        );
         Ok(())
     }
 
@@ -419,8 +434,14 @@ mod tests {
             [],
         )?;
         let out = expand_all(temp.path(), &conn, "context:\n@@phoenix\ngo")?;
-        assert!(out.contains("phoenix"), "search snippet should appear; got: {out}");
-        assert!(out.contains("--- @@phoenix ---"), "search delimiter; got: {out}");
+        assert!(
+            out.contains("phoenix"),
+            "search snippet should appear; got: {out}"
+        );
+        assert!(
+            out.contains("--- @@phoenix ---"),
+            "search delimiter; got: {out}"
+        );
         Ok(())
     }
 
@@ -442,7 +463,10 @@ mod tests {
         let out = expand_all(temp.path(), &conn, "read @intro.md and continue @T-prev")?;
         assert!(out.contains("INTRO_BODY"), "got: {out}");
         assert!(out.contains("PREV_PAYLOAD"), "got: {out}");
-        assert!(out.contains("read @intro.md and continue @T-prev"), "original prompt preserved; got: {out}");
+        assert!(
+            out.contains("read @intro.md and continue @T-prev"),
+            "original prompt preserved; got: {out}"
+        );
         Ok(())
     }
 }

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -1,0 +1,112 @@
+#[allow(unused_imports)]
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+pub const MAX_TEXT_LINES: usize = 500;
+#[allow(dead_code)]
+pub const MAX_LINE_CHARS: usize = 2048;
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Ref {
+    /// `@path/to/file` or `@glob/*.md`
+    Path(String),
+    /// `@T-<uuid>` — thread/session id reference
+    Thread(String),
+    /// `@@search words` — FTS5 query (runs to end-of-line)
+    Search(String),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedPrompt {
+    pub raw: String,
+    pub refs: Vec<Ref>,
+}
+
+#[allow(dead_code)]
+pub fn parse(prompt: &str) -> ParsedPrompt {
+    let mut refs = Vec::new();
+    let bytes = prompt.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'@' {
+            i += 1;
+            continue;
+        }
+        // double-@ for search comes first so single-@ doesn't swallow it
+        if i + 1 < bytes.len() && bytes[i + 1] == b'@' {
+            let end = prompt[i..].find('\n').map(|n| i + n).unwrap_or(prompt.len());
+            let body = &prompt[i + 2..end];
+            if !body.trim().is_empty() {
+                refs.push(Ref::Search(body.trim().to_string()));
+            }
+            i = end;
+            continue;
+        }
+        // single @ — runs to next whitespace
+        let end = prompt[i + 1..]
+            .find(|c: char| c.is_whitespace())
+            .map(|n| i + 1 + n)
+            .unwrap_or(prompt.len());
+        let body = &prompt[i + 1..end];
+        if let Some(rest) = body.strip_prefix("T-") {
+            refs.push(Ref::Thread(format!("T-{rest}")));
+        } else if !body.is_empty() {
+            refs.push(Ref::Path(body.to_string()));
+        }
+        i = end;
+    }
+    ParsedPrompt {
+        raw: prompt.to_string(),
+        refs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_path_refs() {
+        let p = parse("look at @README.md and @docs/*.md please");
+        assert_eq!(
+            p.refs,
+            vec![
+                Ref::Path("README.md".into()),
+                Ref::Path("docs/*.md".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_thread_ref() {
+        let p = parse("continue @T-abc-123 with new ideas");
+        assert_eq!(p.refs, vec![Ref::Thread("T-abc-123".into())]);
+    }
+
+    #[test]
+    fn parses_search_ref_to_end_of_line() {
+        let p = parse("background:\n@@phoenix rises again\ndo the thing");
+        assert_eq!(p.refs, vec![Ref::Search("phoenix rises again".into())]);
+    }
+
+    #[test]
+    fn bare_at_sign_followed_by_whitespace_is_ignored() {
+        let p = parse("email me at @ work");
+        assert!(p.refs.is_empty(), "bare @ should produce no ref, got: {:?}", p.refs);
+    }
+
+    #[test]
+    fn multiple_refs_in_one_prompt() {
+        let p = parse("see @README.md and @T-abc plus\n@@phoenix");
+        assert_eq!(
+            p.refs,
+            vec![
+                Ref::Path("README.md".into()),
+                Ref::Thread("T-abc".into()),
+                Ref::Search("phoenix".into()),
+            ]
+        );
+    }
+}

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -65,6 +65,9 @@ pub fn parse(prompt: &str) -> ParsedPrompt {
 
 #[allow(dead_code)]
 pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
+    if raw.contains('*') || raw.contains('?') || raw.contains('[') {
+        return expand_glob(cwd, raw);
+    }
     let full = cwd.join(raw);
     if !full.exists() {
         return Ok(format!("[missing @{raw}]"));
@@ -104,6 +107,55 @@ fn guess_mime(path: &Path) -> String {
         Some("webp") => "image/webp".into(),
         _ => "text/plain".into(),
     }
+}
+
+#[allow(dead_code)]
+fn expand_glob(cwd: &Path, pattern: &str) -> Result<String> {
+    use globset::{Glob, GlobSetBuilder};
+    let mut builder = GlobSetBuilder::new();
+    builder.add(Glob::new(pattern)?);
+    let set = builder.build()?;
+    let mut out = String::new();
+    let mut count = 0usize;
+    for entry in walkdir(cwd) {
+        let rel = entry.strip_prefix(cwd).unwrap_or(&entry);
+        if !set.is_match(rel) {
+            continue;
+        }
+        let part = expand_path(cwd, &rel.to_string_lossy())?;
+        out.push_str(&part);
+        out.push('\n');
+        count += 1;
+        if count >= 20 {
+            out.push_str("[…glob match cap reached at 20 files]\n");
+            break;
+        }
+    }
+    if count == 0 {
+        return Ok(format!("[no matches for @{pattern}]"));
+    }
+    Ok(out)
+}
+
+#[allow(dead_code)]
+fn walkdir(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().and_then(|s| s.to_str()) == Some(".git") {
+                    continue;
+                }
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -192,5 +244,38 @@ mod tests {
         let expanded = expand_path(temp.path(), "big.md").unwrap();
         assert!(expanded.contains(&format!("…truncated at {MAX_TEXT_LINES} lines")));
         assert!(!expanded.contains(&format!("line-{}", MAX_TEXT_LINES + 49)));
+    }
+
+    #[test]
+    fn expand_glob_includes_all_matches() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("docs")).unwrap();
+        std::fs::write(temp.path().join("docs/a.md"), "AAA").unwrap();
+        std::fs::write(temp.path().join("docs/b.md"), "BBB").unwrap();
+        let expanded = expand_path(temp.path(), "docs/*.md").unwrap();
+        assert!(expanded.contains("AAA"), "got: {expanded}");
+        assert!(expanded.contains("BBB"), "got: {expanded}");
+    }
+
+    #[test]
+    fn expand_glob_no_matches_returns_placeholder() {
+        let temp = tempfile::tempdir().unwrap();
+        let expanded = expand_path(temp.path(), "docs/*.md").unwrap();
+        assert_eq!(expanded, "[no matches for @docs/*.md]");
+    }
+
+    #[test]
+    fn expand_glob_caps_at_twenty() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("many")).unwrap();
+        for i in 0..25 {
+            std::fs::write(
+                temp.path().join(format!("many/f{i}.txt")),
+                format!("F{i}"),
+            )
+            .unwrap();
+        }
+        let expanded = expand_path(temp.path(), "many/*.txt").unwrap();
+        assert!(expanded.contains("glob match cap reached at 20 files"));
     }
 }

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -1,4 +1,4 @@
-#[allow(unused_imports)]
+use anyhow::Result;
 use std::path::{Path, PathBuf};
 
 #[allow(dead_code)]
@@ -63,6 +63,49 @@ pub fn parse(prompt: &str) -> ParsedPrompt {
     }
 }
 
+#[allow(dead_code)]
+pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
+    let full = cwd.join(raw);
+    if !full.exists() {
+        return Ok(format!("[missing @{raw}]"));
+    }
+    let mime = guess_mime(&full);
+    if mime.starts_with("image/") {
+        let bytes = std::fs::metadata(&full)?.len();
+        return Ok(format!(
+            "[image @ {}: {mime}, {bytes} bytes]",
+            full.display()
+        ));
+    }
+    let raw_text = std::fs::read_to_string(&full)?;
+    let mut out = String::new();
+    out.push_str(&format!("--- @{raw} ---\n"));
+    let mut written = 0usize;
+    for line in raw_text.lines() {
+        if written >= MAX_TEXT_LINES {
+            out.push_str(&format!("[…truncated at {MAX_TEXT_LINES} lines]\n"));
+            break;
+        }
+        let truncated: String = line.chars().take(MAX_LINE_CHARS).collect();
+        out.push_str(&truncated);
+        out.push('\n');
+        written += 1;
+    }
+    out.push_str("--- end ---\n");
+    Ok(out)
+}
+
+#[allow(dead_code)]
+fn guess_mime(path: &Path) -> String {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("png") => "image/png".into(),
+        Some("jpg") | Some("jpeg") => "image/jpeg".into(),
+        Some("gif") => "image/gif".into(),
+        Some("webp") => "image/webp".into(),
+        _ => "text/plain".into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,5 +151,46 @@ mod tests {
                 Ref::Search("phoenix".into()),
             ]
         );
+    }
+
+    #[test]
+    fn expand_path_inlines_text_file_capped() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("hello.md");
+        std::fs::write(&path, "line1\nline2\nline3\n").unwrap();
+        let expanded = expand_path(temp.path(), "hello.md").unwrap();
+        assert!(expanded.contains("line1"), "got: {expanded}");
+        assert!(expanded.contains("line3"), "got: {expanded}");
+        assert!(expanded.contains("hello.md"), "got: {expanded}");
+    }
+
+    #[test]
+    fn expand_path_image_becomes_placeholder() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("pic.png");
+        std::fs::write(&path, b"\x89PNG\r\n\x1a\nfake").unwrap();
+        let expanded = expand_path(temp.path(), "pic.png").unwrap();
+        assert!(expanded.contains("[image @ "), "got: {expanded}");
+        assert!(expanded.contains("image/png"), "got: {expanded}");
+    }
+
+    #[test]
+    fn expand_path_missing_returns_placeholder() {
+        let temp = tempfile::tempdir().unwrap();
+        let expanded = expand_path(temp.path(), "nope.md").unwrap();
+        assert_eq!(expanded, "[missing @nope.md]");
+    }
+
+    #[test]
+    fn expand_path_truncates_at_max_lines() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("big.md");
+        let body: String = (0..(MAX_TEXT_LINES + 50))
+            .map(|i| format!("line-{i}\n"))
+            .collect();
+        std::fs::write(&path, body).unwrap();
+        let expanded = expand_path(temp.path(), "big.md").unwrap();
+        assert!(expanded.contains(&format!("…truncated at {MAX_TEXT_LINES} lines")));
+        assert!(!expanded.contains(&format!("line-{}", MAX_TEXT_LINES + 49)));
     }
 }

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -1,12 +1,9 @@
 use anyhow::Result;
 use std::path::{Path, PathBuf};
 
-#[allow(dead_code)]
 pub const MAX_TEXT_LINES: usize = 500;
-#[allow(dead_code)]
 pub const MAX_LINE_CHARS: usize = 2048;
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Ref {
     /// `@path/to/file` or `@glob/*.md`
@@ -17,14 +14,12 @@ pub enum Ref {
     Search(String),
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParsedPrompt {
     pub raw: String,
     pub refs: Vec<Ref>,
 }
 
-#[allow(dead_code)]
 pub fn parse(prompt: &str) -> ParsedPrompt {
     let mut refs = Vec::new();
     let bytes = prompt.as_bytes();
@@ -63,7 +58,6 @@ pub fn parse(prompt: &str) -> ParsedPrompt {
     }
 }
 
-#[allow(dead_code)]
 pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
     if raw.contains('*') || raw.contains('?') || raw.contains('[') {
         return expand_glob(cwd, raw);
@@ -83,8 +77,7 @@ pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
     let raw_text = std::fs::read_to_string(&full)?;
     let mut out = String::new();
     out.push_str(&format!("--- @{raw} ---\n"));
-    let mut written = 0usize;
-    for line in raw_text.lines() {
+    for (written, line) in raw_text.lines().enumerate() {
         if written >= MAX_TEXT_LINES {
             out.push_str(&format!("[…truncated at {MAX_TEXT_LINES} lines]\n"));
             break;
@@ -92,13 +85,11 @@ pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
         let truncated: String = line.chars().take(MAX_LINE_CHARS).collect();
         out.push_str(&truncated);
         out.push('\n');
-        written += 1;
     }
     out.push_str("--- end ---\n");
     Ok(out)
 }
 
-#[allow(dead_code)]
 fn guess_mime(path: &Path) -> String {
     match path.extension().and_then(|e| e.to_str()) {
         Some("png") => "image/png".into(),
@@ -109,7 +100,6 @@ fn guess_mime(path: &Path) -> String {
     }
 }
 
-#[allow(dead_code)]
 pub fn expand_thread(conn: &rusqlite::Connection, id: &str) -> Result<String> {
     use anyhow::Context;
     let mut stmt = conn
@@ -141,7 +131,6 @@ pub fn expand_thread(conn: &rusqlite::Connection, id: &str) -> Result<String> {
     Ok(out)
 }
 
-#[allow(dead_code)]
 fn expand_glob(cwd: &Path, pattern: &str) -> Result<String> {
     use globset::{Glob, GlobSetBuilder};
     let mut builder = GlobSetBuilder::new();
@@ -169,7 +158,6 @@ fn expand_glob(cwd: &Path, pattern: &str) -> Result<String> {
     Ok(out)
 }
 
-#[allow(dead_code)]
 fn walkdir(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
     let mut stack = vec![root.to_path_buf()];
@@ -188,6 +176,50 @@ fn walkdir(root: &Path) -> Vec<PathBuf> {
         }
     }
     out
+}
+
+/// Expand every `@path`, `@T-<id>`, and `@@search` ref found in `prompt`.
+/// Inlined content is prepended to the prompt with delimited blocks; the
+/// original prompt text follows unchanged. Returns `prompt` unmodified when
+/// it contains no refs.
+pub fn expand_all(
+    cwd: &Path,
+    conn: &rusqlite::Connection,
+    prompt: &str,
+) -> Result<String> {
+    let parsed = parse(prompt);
+    if parsed.refs.is_empty() {
+        return Ok(prompt.to_string());
+    }
+    let mut prefix = String::new();
+    for r in &parsed.refs {
+        let block = match r {
+            Ref::Path(p) => expand_path(cwd, p)?,
+            Ref::Thread(id) => expand_thread(conn, id)?,
+            Ref::Search(q) => expand_search(conn, q)?,
+        };
+        prefix.push_str(&block);
+        if !prefix.ends_with('\n') {
+            prefix.push('\n');
+        }
+    }
+    Ok(format!("{prefix}\n{prompt}"))
+}
+
+fn expand_search(conn: &rusqlite::Connection, query: &str) -> Result<String> {
+    let hits = crate::store::search_events(conn, query)?;
+    if hits.is_empty() {
+        return Ok(format!("[no search hits for @@{query}]"));
+    }
+    let mut s = format!("--- @@{query} ---\n");
+    for hit in hits.into_iter().take(5) {
+        s.push_str(&format!(
+            "[{}] {} {} {}\n",
+            hit.created_at, hit.session_id, hit.kind, hit.snippet
+        ));
+    }
+    s.push_str("--- end ---\n");
+    Ok(s)
 }
 
 #[cfg(test)]
@@ -337,6 +369,80 @@ mod tests {
         let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
         let out = expand_thread(&conn, "T-nope")?;
         assert_eq!(out, "[no events for @T-nope]");
+        Ok(())
+    }
+
+    #[test]
+    fn expand_all_passes_through_when_no_refs() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        let out = expand_all(temp.path(), &conn, "just a plain prompt with no refs")?;
+        assert_eq!(out, "just a plain prompt with no refs");
+        Ok(())
+    }
+
+    #[test]
+    fn expand_all_inlines_path_ref_before_prompt() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(temp.path().join("notes.md"), "alpha beta gamma\n")?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        let out = expand_all(temp.path(), &conn, "summarise @notes.md please")?;
+        assert!(out.contains("alpha beta gamma"), "got: {out}");
+        let body_idx = out.find("summarise @notes.md please").expect("original prompt should appear");
+        let content_idx = out.find("alpha beta gamma").expect("file content should appear");
+        assert!(content_idx < body_idx, "inlined content should precede the original prompt; got: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn expand_all_search_no_hits_inlines_placeholder() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        let out = expand_all(temp.path(), &conn, "context:\n@@phoenix rising\nthen answer")?;
+        assert!(out.contains("[no search hits for @@phoenix rising]"), "got: {out}");
+        assert!(out.contains("then answer"), "original prompt preserved; got: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn expand_all_search_inlines_hits() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+             VALUES('s-1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+             VALUES('e1', 's-1', 'user', '{\"text\":\"phoenix rising over the city\"}', '2026-01-01')",
+            [],
+        )?;
+        let out = expand_all(temp.path(), &conn, "context:\n@@phoenix\ngo")?;
+        assert!(out.contains("phoenix"), "search snippet should appear; got: {out}");
+        assert!(out.contains("--- @@phoenix ---"), "search delimiter; got: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn expand_all_combines_path_and_thread_refs() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(temp.path().join("intro.md"), "INTRO_BODY\n")?;
+        let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+             VALUES('T-prev', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+             VALUES('e1', 'T-prev', 'user', '{\"text\":\"PREV_PAYLOAD\"}', '2026-01-01')",
+            [],
+        )?;
+        let out = expand_all(temp.path(), &conn, "read @intro.md and continue @T-prev")?;
+        assert!(out.contains("INTRO_BODY"), "got: {out}");
+        assert!(out.contains("PREV_PAYLOAD"), "got: {out}");
+        assert!(out.contains("read @intro.md and continue @T-prev"), "original prompt preserved; got: {out}");
         Ok(())
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -163,10 +163,7 @@ fn stream_claude_with_program<W: Write>(
         });
     }
 
-    let child_stdout = child
-        .stdout
-        .take()
-        .expect("stdout was requested as piped");
+    let child_stdout = child.stdout.take().expect("stdout was requested as piped");
     let reader = BufReader::new(child_stdout);
     for line in reader.lines() {
         let line = line.context("reading claude stdout")?;

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -88,6 +88,99 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
     run_attached_with_pty_system(command, pty_system.as_ref())
 }
 
+/// Run `claude` in its native stream-JSON mode, framed by the caller (which
+/// emits Coven's own `system.init` / `result` around the call).
+///
+/// `claude -p --input-format stream-json --output-format stream-json --verbose
+/// --session-id <id> <prompt>` already emits the Coven-compatible JSONL
+/// schema; we just forward each line untouched to `out`.
+///
+/// When `forward_stdin` is true, lines on our stdin are piped to claude's
+/// stdin so callers can feed additional user messages mid-run. Stderr is
+/// inherited so claude's own diagnostics land on the terminal.
+pub fn stream_claude<W: Write>(
+    cwd: &Path,
+    session_id: &str,
+    prompt: &str,
+    forward_stdin: bool,
+    out: &mut W,
+) -> Result<i32> {
+    stream_claude_with_program("claude", cwd, session_id, prompt, forward_stdin, out)
+}
+
+fn stream_claude_with_program<W: Write>(
+    program: &str,
+    cwd: &Path,
+    session_id: &str,
+    prompt: &str,
+    forward_stdin: bool,
+    out: &mut W,
+) -> Result<i32> {
+    let mut child = std::process::Command::new(program)
+        .args([
+            "-p",
+            "--input-format",
+            "stream-json",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+            "--session-id",
+            session_id,
+        ])
+        .arg(prompt)
+        .current_dir(cwd)
+        .stdin(if forward_stdin {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("failed to spawn claude in stream-json mode")?;
+
+    if forward_stdin {
+        let mut child_stdin = child
+            .stdin
+            .take()
+            .expect("stdin requested but child has no piped stdin");
+        thread::spawn(move || {
+            let stdin = io::stdin();
+            let mut handle = stdin.lock();
+            let mut buf = String::new();
+            loop {
+                buf.clear();
+                match handle.read_line(&mut buf) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        if child_stdin.write_all(buf.as_bytes()).is_err() {
+                            break;
+                        }
+                        let _ = child_stdin.flush();
+                    }
+                }
+            }
+        });
+    }
+
+    let child_stdout = child
+        .stdout
+        .take()
+        .expect("stdout was requested as piped");
+    let reader = BufReader::new(child_stdout);
+    for line in reader.lines() {
+        let line = line.context("reading claude stdout")?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        writeln!(out, "{line}").context("forwarding claude stdout")?;
+        out.flush().context("flushing claude stdout")?;
+    }
+
+    let status = child.wait().context("waiting on claude")?;
+    Ok(status.code().unwrap_or(1))
+}
+
 #[allow(dead_code)]
 pub fn spawn_detached(command: &HarnessCommand) -> Result<DetachedPtySession> {
     spawn_detached_with_observer(command, None)
@@ -498,6 +591,48 @@ mod tests {
         session.input.write_all(b"hello detached pty\n")?;
         session.input.flush()?;
         session.killer.kill()?;
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_claude_forwards_jsonl_and_returns_exit_code() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_claude = temp_dir.path().join("fake-claude");
+        std::fs::write(
+            &fake_claude,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+printf '\n'
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"session_id":"session-123","stop_reason":"end_turn"}'
+exit 7
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_claude)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_claude, permissions)?;
+
+        let mut out = Vec::new();
+        let code = stream_claude_with_program(
+            fake_claude.to_str().unwrap(),
+            temp_dir.path(),
+            "session-123",
+            "hello prompt",
+            false,
+            &mut out,
+        )?;
+
+        assert_eq!(code, 7);
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+        );
+        assert_eq!(
+            String::from_utf8(out)?,
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]},\"session_id\":\"session-123\",\"stop_reason\":\"end_turn\"}\n"
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/repos_config.rs
+++ b/crates/coven-cli/src/repos_config.rs
@@ -26,6 +26,28 @@ pub fn load(coven_home: &Path) -> Result<ReposConfig> {
     load_from(&config_path(coven_home))
 }
 
+pub fn load_with_settings(
+    coven_home: &Path,
+    settings: Option<&crate::settings::Settings>,
+) -> Result<ReposConfig> {
+    let mut config = load(coven_home)?;
+    let Some(settings) = settings else {
+        return Ok(config);
+    };
+    for (name, repo) in &settings.coven_cli.repos {
+        config.repos.insert(
+            name.clone(),
+            RepoEntry {
+                path: repo.path.clone(),
+            },
+        );
+    }
+    if let Some(name) = &settings.coven_cli.default_repo {
+        config.default = Some(name.clone());
+    }
+    Ok(config)
+}
+
 fn load_from(path: &Path) -> Result<ReposConfig> {
     match std::fs::read_to_string(path) {
         Ok(raw) => {
@@ -165,6 +187,45 @@ path = "/abs/alpha"
         assert!(
             err.to_string().contains("failed to parse"),
             "unexpected error: {err:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn settings_override_toml_when_both_present() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        // legacy TOML
+        std::fs::write(
+            config_path(temp.path()),
+            r#"
+default = "from_toml"
+[repos.from_toml]
+path = "/abs/toml"
+"#,
+        )?;
+        // new JSONC settings (constructed in-memory; this test does not exercise the json5 loader)
+        let settings = crate::settings::Settings {
+            coven_cli: crate::settings::CovenCliSettings {
+                default_repo: Some("from_jsonc".to_string()),
+                repos: std::collections::BTreeMap::from([(
+                    "from_jsonc".to_string(),
+                    crate::settings::RepoSettings {
+                        path: std::path::PathBuf::from("/abs/jsonc"),
+                    },
+                )]),
+                ..Default::default()
+            },
+        };
+        let merged = load_with_settings(temp.path(), Some(&settings))?;
+        assert_eq!(merged.default_name(), Some("from_jsonc"));
+        assert_eq!(
+            merged.resolve("from_jsonc"),
+            Some(std::path::PathBuf::from("/abs/jsonc"))
+        );
+        // legacy entry still resolvable as a fallback
+        assert_eq!(
+            merged.resolve("from_toml"),
+            Some(std::path::PathBuf::from("/abs/toml"))
         );
         Ok(())
     }

--- a/crates/coven-cli/src/settings.rs
+++ b/crates/coven-cli/src/settings.rs
@@ -1,0 +1,100 @@
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+pub const SETTINGS_FILE_NAME: &str = "settings.json";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Settings {
+    #[serde(rename = "covenCli")]
+    pub coven_cli: CovenCliSettings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CovenCliSettings {
+    pub privacy: Option<PrivacySettings>,
+    pub repos: BTreeMap<String, RepoSettings>,
+    #[serde(default)]
+    pub default_repo: Option<String>,
+    #[serde(default)]
+    pub fuzzy: FuzzySettings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct PrivacySettings {
+    pub persist_raw_artifacts: Option<bool>,
+    pub raw_artifact_retention_days: Option<u64>,
+    pub log_retention_days: Option<u64>,
+    pub extra_patterns: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RepoSettings {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct FuzzySettings {
+    pub always_include_paths: Vec<String>,
+}
+
+pub fn user_settings_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    Some(base.join("coven").join(SETTINGS_FILE_NAME))
+}
+
+pub fn load_from(path: &Path) -> Result<Option<Settings>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(r) => r,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).with_context(|| format!("failed to read {}", path.display())),
+    };
+    let parsed: Settings = json5::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(Some(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_returns_none() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        assert_eq!(load_from(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn loads_jsonc_with_comments_and_trailing_commas() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{
+              // user comment
+              "covenCli": {
+                "defaultRepo": "alpha",
+                "repos": {
+                  "alpha": { "path": "/abs/alpha" },
+                },
+              },
+            }"#,
+        )
+        .unwrap();
+        let loaded = load_from(&path).unwrap().unwrap();
+        assert_eq!(loaded.coven_cli.default_repo.as_deref(), Some("alpha"));
+        assert_eq!(
+            loaded.coven_cli.repos.get("alpha").unwrap().path,
+            PathBuf::from("/abs/alpha")
+        );
+    }
+}

--- a/crates/coven-cli/src/settings.rs
+++ b/crates/coven-cli/src/settings.rs
@@ -9,7 +9,6 @@ pub const SETTINGS_FILE_NAME: &str = "settings.json";
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Settings {
-    #[serde(rename = "covenCli")]
     pub coven_cli: CovenCliSettings,
 }
 
@@ -18,9 +17,7 @@ pub struct Settings {
 pub struct CovenCliSettings {
     pub privacy: Option<PrivacySettings>,
     pub repos: BTreeMap<String, RepoSettings>,
-    #[serde(default)]
     pub default_repo: Option<String>,
-    #[serde(default)]
     pub fuzzy: FuzzySettings,
 }
 
@@ -46,8 +43,13 @@ pub struct FuzzySettings {
 
 pub fn user_settings_path() -> Option<PathBuf> {
     let base = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|v| !v.is_empty())
         .map(PathBuf::from)
-        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|v| !v.is_empty())
+                .map(|h| PathBuf::from(h).join(".config"))
+        })?;
     Some(base.join("coven").join(SETTINGS_FILE_NAME))
 }
 
@@ -96,5 +98,13 @@ mod tests {
             loaded.coven_cli.repos.get("alpha").unwrap().path,
             PathBuf::from("/abs/alpha")
         );
+    }
+
+    #[test]
+    fn empty_object_returns_default_settings() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(&path, "{}").unwrap();
+        assert_eq!(load_from(&path).unwrap().unwrap(), Settings::default());
     }
 }

--- a/crates/coven-cli/src/settings.rs
+++ b/crates/coven-cli/src/settings.rs
@@ -53,6 +53,32 @@ pub fn user_settings_path() -> Option<PathBuf> {
     Some(base.join("coven").join(SETTINGS_FILE_NAME))
 }
 
+pub fn shadowed_keys(toml_keys: &[String], jsonc_keys: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = toml_keys
+        .iter()
+        .filter(|k| jsonc_keys.iter().any(|j| j == *k))
+        .cloned()
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+pub fn warn_if_shadowed(shadowed: &[String], toml_path: &Path, jsonc_path: &Path) {
+    if shadowed.is_empty() {
+        return;
+    }
+    eprintln!(
+        "coven: {} keys in {} are shadowed by {}. Consider removing them from the TOML file.",
+        shadowed.len(),
+        toml_path.display(),
+        jsonc_path.display()
+    );
+    for key in shadowed {
+        eprintln!("  - {key}");
+    }
+}
+
 pub fn load_from(path: &Path) -> Result<Option<Settings>> {
     let raw = match std::fs::read_to_string(path) {
         Ok(r) => r,
@@ -106,5 +132,13 @@ mod tests {
         let path = temp.path().join("settings.json");
         std::fs::write(&path, "{}").unwrap();
         assert_eq!(load_from(&path).unwrap().unwrap(), Settings::default());
+    }
+
+    #[test]
+    fn detect_shadowed_keys_lists_overrides() {
+        let toml_keys = ["repos.alpha".to_string(), "defaultRepo".to_string()];
+        let jsonc_keys = ["repos.alpha".to_string()];
+        let shadowed = shadowed_keys(&toml_keys, &jsonc_keys);
+        assert_eq!(shadowed, vec!["repos.alpha".to_string()]);
     }
 }

--- a/crates/coven-cli/src/settings.rs
+++ b/crates/coven-cli/src/settings.rs
@@ -54,6 +54,16 @@ pub fn user_settings_path() -> Option<PathBuf> {
     Some(base.join("coven").join(SETTINGS_FILE_NAME))
 }
 
+/// Returns the set of dotted-path keys that appear in both inputs.
+///
+/// Both inputs are expected to be **dotted JSONC paths** (e.g. `"repos.alpha"`,
+/// `"defaultRepo"`, `"privacy.logRetentionDays"`), not raw TOML field names or
+/// bare repo names. Callers building these lists from a TOML loader must prefix
+/// nested fields with their parent (e.g. `"repos.{name}"` for entries inside the
+/// `[repos.*]` table).
+#[allow(dead_code)] // Wired into run_doctor in a follow-up; see plan
+                    // docs/superpowers/plans/2026-05-26-coven-cli-p0-coven-code-parity.md
+                    // Task 1.5 (deferred wire-up after PrivacySettings lands).
 pub fn shadowed_keys(toml_keys: &[String], jsonc_keys: &[String]) -> Vec<String> {
     let mut out: Vec<String> = toml_keys
         .iter()
@@ -65,6 +75,7 @@ pub fn shadowed_keys(toml_keys: &[String], jsonc_keys: &[String]) -> Vec<String>
     out
 }
 
+#[allow(dead_code)] // See shadowed_keys above.
 pub fn warn_if_shadowed(shadowed: &[String], toml_path: &Path, jsonc_path: &Path) {
     if shadowed.is_empty() {
         return;
@@ -83,11 +94,9 @@ pub fn warn_if_shadowed(shadowed: &[String], toml_path: &Path, jsonc_path: &Path
 static CACHED: OnceLock<Option<Settings>> = OnceLock::new();
 
 /// Initialize the process-wide cached Settings. Call exactly once at startup.
-/// Subsequent calls are no-ops (the first init wins). Returns the cached value
-/// so the caller can also use it directly if convenient.
-pub fn init_cached(value: Option<Settings>) -> Option<&'static Settings> {
+/// Subsequent calls are no-ops (the first init wins).
+pub fn init_cached(value: Option<Settings>) {
     let _ = CACHED.set(value);
-    CACHED.get().and_then(|opt| opt.as_ref())
 }
 
 /// Get the cached Settings, if any. Returns `None` if init has not run or if
@@ -161,10 +170,10 @@ mod tests {
 
     #[test]
     fn cached_returns_the_initialized_value() {
-        // Note: OnceLock is process-wide; this test relies on being the ONLY test
-        // in the suite that calls init_cached. If another test also calls it, the
-        // ordering will determine which value wins, which would make this test
-        // flaky. As of this commit no other test touches init_cached.
+        // Note: OnceLock is process-wide and cannot be reset between tests. This
+        // test is the only one that should ever call init_cached. If you are adding
+        // another test that also calls init_cached, replace this assertion with a
+        // helper that asserts the OnceLock state without re-initializing it.
         let settings = Settings::default();
         init_cached(Some(settings.clone()));
         assert_eq!(cached(), Some(&settings));

--- a/crates/coven-cli/src/settings.rs
+++ b/crates/coven-cli/src/settings.rs
@@ -111,8 +111,8 @@ pub fn load_from(path: &Path) -> Result<Option<Settings>> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => return Err(err).with_context(|| format!("failed to read {}", path.display())),
     };
-    let parsed: Settings = json5::from_str(&raw)
-        .with_context(|| format!("failed to parse {}", path.display()))?;
+    let parsed: Settings =
+        json5::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
     Ok(Some(parsed))
 }
 

--- a/crates/coven-cli/src/settings.rs
+++ b/crates/coven-cli/src/settings.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -79,6 +80,22 @@ pub fn warn_if_shadowed(shadowed: &[String], toml_path: &Path, jsonc_path: &Path
     }
 }
 
+static CACHED: OnceLock<Option<Settings>> = OnceLock::new();
+
+/// Initialize the process-wide cached Settings. Call exactly once at startup.
+/// Subsequent calls are no-ops (the first init wins). Returns the cached value
+/// so the caller can also use it directly if convenient.
+pub fn init_cached(value: Option<Settings>) -> Option<&'static Settings> {
+    let _ = CACHED.set(value);
+    CACHED.get().and_then(|opt| opt.as_ref())
+}
+
+/// Get the cached Settings, if any. Returns `None` if init has not run or if
+/// the loader returned None at startup.
+pub fn cached() -> Option<&'static Settings> {
+    CACHED.get().and_then(|opt| opt.as_ref())
+}
+
 pub fn load_from(path: &Path) -> Result<Option<Settings>> {
     let raw = match std::fs::read_to_string(path) {
         Ok(r) => r,
@@ -140,5 +157,16 @@ mod tests {
         let jsonc_keys = ["repos.alpha".to_string()];
         let shadowed = shadowed_keys(&toml_keys, &jsonc_keys);
         assert_eq!(shadowed, vec!["repos.alpha".to_string()]);
+    }
+
+    #[test]
+    fn cached_returns_the_initialized_value() {
+        // Note: OnceLock is process-wide; this test relies on being the ONLY test
+        // in the suite that calls init_cached. If another test also calls it, the
+        // ordering will determine which value wins, which would make this test
+        // flaky. As of this commit no other test touches init_cached.
+        let settings = Settings::default();
+        init_cached(Some(settings.clone()));
+        assert_eq!(cached(), Some(&settings));
     }
 }

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use chrono::{Duration, SecondsFormat, Utc};
-use rusqlite::{params, Connection, OpenFlags};
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -660,6 +660,19 @@ pub fn sacrifice_session(conn: &Connection, session_id: &str) -> Result<()> {
         .with_context(|| format!("failed to sacrifice session {session_id}"))?;
 
     Ok(())
+}
+
+pub fn latest_active_for_project(conn: &Connection, project_root: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT id FROM sessions
+         WHERE project_root = ?1 AND archived_at IS NULL
+         ORDER BY created_at DESC
+         LIMIT 1",
+        params![project_root],
+        |row| row.get::<_, String>(0),
+    )
+    .optional()
+    .context("failed to query latest active session for project")
 }
 
 pub fn search_events(conn: &Connection, query: &str) -> Result<Vec<SearchHit>> {
@@ -1827,6 +1840,23 @@ mod tests {
             labels: Vec::new(),
             visibility: "private".to_string(),
         }
+    }
+
+    #[test]
+    fn latest_active_returns_newest_non_archived_for_project() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+        conn.execute_batch(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+               VALUES ('older', '/p', 'codex', 't', 'created', '2026-01-01', '2026-01-01'),
+                      ('newer', '/p', 'claude', 't', 'created', '2026-01-02', '2026-01-02'),
+                      ('archived', '/p', 'claude', 't', 'created', '2026-01-03', '2026-01-03'),
+                      ('other_proj', '/other', 'claude', 't', 'created', '2026-01-04', '2026-01-04');
+             UPDATE sessions SET archived_at='2026-01-03' WHERE id='archived';",
+        )?;
+        let hit = latest_active_for_project(&conn, "/p")?;
+        assert_eq!(hit.as_deref(), Some("newer"));
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -30,6 +30,14 @@ pub struct SessionRecord {
     /// resume` and grouping. See `docs/chat-persistence.md`.
     #[serde(default)]
     pub conversation_id: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<String>,
+    #[serde(default = "default_visibility")]
+    pub visibility: String,
+}
+
+fn default_visibility() -> String {
+    "private".to_string()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -94,7 +102,9 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             archived_at TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL,
-            conversation_id TEXT
+            conversation_id TEXT,
+            labels TEXT,
+            visibility TEXT NOT NULL DEFAULT 'private'
         );
 
         CREATE TABLE IF NOT EXISTS events (
@@ -148,6 +158,8 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_conversation_id_column(&conn)?;
     ensure_event_privacy_columns(&conn)?;
     ensure_sensitive_artifacts_table(&conn)?;
+    ensure_labels_column(&conn)?;
+    ensure_visibility_column(&conn)?;
 
     Ok(conn)
 }
@@ -291,6 +303,45 @@ fn ensure_conversation_id_column(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn ensure_labels_column(conn: &Connection) -> Result<()> {
+    let mut statement = conn
+        .prepare("PRAGMA table_info(sessions)")
+        .context("failed to inspect sessions schema")?;
+    let has_labels = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .context("failed to query sessions schema")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to read sessions schema")?
+        .into_iter()
+        .any(|column| column == "labels");
+    if !has_labels {
+        conn.execute("ALTER TABLE sessions ADD COLUMN labels TEXT", [])
+            .context("failed to add sessions.labels column")?;
+    }
+    Ok(())
+}
+
+fn ensure_visibility_column(conn: &Connection) -> Result<()> {
+    let mut statement = conn
+        .prepare("PRAGMA table_info(sessions)")
+        .context("failed to inspect sessions schema")?;
+    let has_visibility = statement
+        .query_map([], |row| row.get::<_, String>(1))
+        .context("failed to query sessions schema")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to read sessions schema")?
+        .into_iter()
+        .any(|column| column == "visibility");
+    if !has_visibility {
+        conn.execute(
+            "ALTER TABLE sessions ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private'",
+            [],
+        )
+        .context("failed to add sessions.visibility column")?;
+    }
+    Ok(())
+}
+
 pub fn upsert_repository(conn: &Connection, record: &RepositoryRecord) -> Result<()> {
     conn.execute(
         "INSERT INTO repositories (
@@ -357,19 +408,19 @@ pub fn repositories_table_exists(conn: &Connection) -> Result<bool> {
 }
 
 pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
+    let labels_json: Option<String> = if record.labels.is_empty() {
+        None
+    } else {
+        Some(
+            serde_json::to_string(&record.labels)
+                .context("failed to serialize session labels")?,
+        )
+    };
     conn.execute(
         "INSERT INTO sessions (
-            id,
-            project_root,
-            harness,
-            title,
-            status,
-            exit_code,
-            archived_at,
-            created_at,
-            updated_at,
-            conversation_id
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+            id, project_root, harness, title, status, exit_code, archived_at,
+            created_at, updated_at, conversation_id, labels, visibility
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         params![
             &record.id,
             &record.project_root,
@@ -381,6 +432,8 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
             &record.created_at,
             &record.updated_at,
             &record.conversation_id,
+            labels_json,
+            &record.visibility,
         ],
     )
     .with_context(|| format!("failed to insert session {}", record.id))?;
@@ -389,20 +442,20 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
 }
 
 pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Result<bool> {
+    let labels_json: Option<String> = if record.labels.is_empty() {
+        None
+    } else {
+        Some(
+            serde_json::to_string(&record.labels)
+                .context("failed to serialize session labels")?,
+        )
+    };
     let affected = conn
         .execute(
             "INSERT OR IGNORE INTO sessions (
-                id,
-                project_root,
-                harness,
-                title,
-                status,
-                exit_code,
-                archived_at,
-                created_at,
-                updated_at,
-                conversation_id
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                id, project_root, harness, title, status, exit_code, archived_at,
+                created_at, updated_at, conversation_id, labels, visibility
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![
                 &record.id,
                 &record.project_root,
@@ -414,6 +467,8 @@ pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Re
                 &record.created_at,
                 &record.updated_at,
                 &record.conversation_id,
+                labels_json,
+                &record.visibility,
             ],
         )
         .with_context(|| format!("failed to upsert session {}", record.id))?;
@@ -488,7 +543,9 @@ fn list_sessions_with_archive_filter(
                 archived_at,
                 created_at,
                 updated_at,
-                conversation_id
+                conversation_id,
+                labels,
+                visibility
             FROM sessions
             {archive_filter}
             ORDER BY created_at DESC, id DESC",
@@ -497,6 +554,20 @@ fn list_sessions_with_archive_filter(
 
     let sessions = statement
         .query_map([], |row| {
+            let labels_str: Option<String> = row.get(10)?;
+            let labels: Vec<String> = labels_str
+                .as_deref()
+                .map(serde_json::from_str)
+                .transpose()
+                .map_err(|err| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        10,
+                        rusqlite::types::Type::Text,
+                        Box::new(err),
+                    )
+                })?
+                .unwrap_or_default();
+            let visibility: String = row.get(11)?;
             Ok(SessionRecord {
                 id: row.get(0)?,
                 project_root: row.get(1)?,
@@ -508,6 +579,8 @@ fn list_sessions_with_archive_filter(
                 created_at: row.get(7)?,
                 updated_at: row.get(8)?,
                 conversation_id: row.get(9)?,
+                labels,
+                visibility,
             })
         })
         .context("failed to query sessions")?
@@ -1683,7 +1756,33 @@ mod tests {
             created_at: created_at.to_string(),
             updated_at: created_at.to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         }
+    }
+
+    #[test]
+    fn new_columns_default_correctly() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+             VALUES('s1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+            [],
+        )?;
+        let labels: Option<String> = conn.query_row(
+            "SELECT labels FROM sessions WHERE id='s1'",
+            [],
+            |row| row.get(0),
+        )?;
+        let visibility: String = conn.query_row(
+            "SELECT visibility FROM sessions WHERE id='s1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(labels, None);
+        assert_eq!(visibility, "private");
+        Ok(())
     }
 
     fn table_columns(conn: &Connection, table: &str) -> Result<Vec<String>> {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -450,10 +450,7 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
     let labels_json: Option<String> = if record.labels.is_empty() {
         None
     } else {
-        Some(
-            serde_json::to_string(&record.labels)
-                .context("failed to serialize session labels")?,
-        )
+        Some(serde_json::to_string(&record.labels).context("failed to serialize session labels")?)
     };
     conn.execute(
         "INSERT INTO sessions (
@@ -484,10 +481,7 @@ pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Re
     let labels_json: Option<String> = if record.labels.is_empty() {
         None
     } else {
-        Some(
-            serde_json::to_string(&record.labels)
-                .context("failed to serialize session labels")?,
-        )
+        Some(serde_json::to_string(&record.labels).context("failed to serialize session labels")?)
     };
     let affected = conn
         .execute(
@@ -1889,16 +1883,14 @@ mod tests {
              VALUES('s1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
             [],
         )?;
-        let labels: Option<String> = conn.query_row(
-            "SELECT labels FROM sessions WHERE id='s1'",
-            [],
-            |row| row.get(0),
-        )?;
-        let visibility: String = conn.query_row(
-            "SELECT visibility FROM sessions WHERE id='s1'",
-            [],
-            |row| row.get(0),
-        )?;
+        let labels: Option<String> =
+            conn.query_row("SELECT labels FROM sessions WHERE id='s1'", [], |row| {
+                row.get(0)
+            })?;
+        let visibility: String =
+            conn.query_row("SELECT visibility FROM sessions WHERE id='s1'", [], |row| {
+                row.get(0)
+            })?;
         assert_eq!(labels, None);
         assert_eq!(visibility, "private");
         Ok(())

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -71,6 +71,15 @@ pub struct SensitiveArtifactRecord {
     pub expires_at: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchHit {
+    pub event_id: String,
+    pub session_id: String,
+    pub kind: String,
+    pub snippet: String,
+    pub created_at: String,
+}
+
 #[derive(Debug, Default)]
 pub struct EventsQueryOptions {
     pub after_seq: Option<i64>,
@@ -150,6 +159,25 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
+            payload_json,
+            content='events',
+            content_rowid='rowid'
+        );
+
+        CREATE TRIGGER IF NOT EXISTS events_fts_insert AFTER INSERT ON events BEGIN
+            INSERT INTO events_fts(rowid, payload_json) VALUES (new.rowid, new.payload_json);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS events_fts_delete AFTER DELETE ON events BEGIN
+            INSERT INTO events_fts(events_fts, rowid, payload_json) VALUES('delete', old.rowid, old.payload_json);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS events_fts_update AFTER UPDATE ON events BEGIN
+            INSERT INTO events_fts(events_fts, rowid, payload_json) VALUES('delete', old.rowid, old.payload_json);
+            INSERT INTO events_fts(rowid, payload_json) VALUES (new.rowid, new.payload_json);
+        END;
         ",
     )
     .context("failed to initialize Coven store schema")?;
@@ -160,6 +188,17 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_sensitive_artifacts_table(&conn)?;
     ensure_labels_column(&conn)?;
     ensure_visibility_column(&conn)?;
+
+    // Backfill: copy any existing events into the FTS index. Safe on fresh dbs.
+    conn.execute(
+        "INSERT INTO events_fts(rowid, payload_json)
+         SELECT e.rowid, e.payload_json
+         FROM events e
+         LEFT JOIN events_fts f ON f.rowid = e.rowid
+         WHERE f.rowid IS NULL",
+        [],
+    )
+    .context("failed to backfill events_fts")?;
 
     Ok(conn)
 }
@@ -621,6 +660,35 @@ pub fn sacrifice_session(conn: &Connection, session_id: &str) -> Result<()> {
         .with_context(|| format!("failed to sacrifice session {session_id}"))?;
 
     Ok(())
+}
+
+pub fn search_events(conn: &Connection, query: &str) -> Result<Vec<SearchHit>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT e.id, e.session_id, e.kind, snippet(events_fts, 0, '[', ']', '…', 16), e.created_at
+             FROM events_fts
+             JOIN events e ON e.rowid = events_fts.rowid
+             WHERE events_fts MATCH ?1
+             ORDER BY e.created_at DESC
+             LIMIT 100",
+        )
+        .context("failed to prepare events_fts search")?;
+    let rows = stmt
+        .query_map([query], |row| {
+            Ok(SearchHit {
+                event_id: row.get(0)?,
+                session_id: row.get(1)?,
+                kind: row.get(2)?,
+                snippet: row.get(3)?,
+                created_at: row.get(4)?,
+            })
+        })
+        .context("failed to run events_fts search")?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r.context("failed to read events_fts row")?);
+    }
+    Ok(out)
 }
 
 pub fn insert_event(conn: &Connection, record: &EventRecord) -> Result<()> {
@@ -1759,6 +1827,27 @@ mod tests {
             labels: Vec::new(),
             visibility: "private".to_string(),
         }
+    }
+
+    #[test]
+    fn search_events_finds_match_in_payload() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+             VALUES('s1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+             VALUES('e1', 's1', 'stdout', '{\"text\":\"phoenix rises\"}', '2026-01-01')",
+            [],
+        )?;
+        let hits = search_events(&conn, "phoenix")?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].event_id, "e1");
+        assert_eq!(hits[0].session_id, "s1");
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/stream_json.rs
+++ b/crates/coven-cli/src/stream_json.rs
@@ -1,0 +1,315 @@
+// Types and helpers land ahead of their call sites (Task 4.1 of the P0 parity
+// plan); Tasks 4.2–4.4 wire them into the harness adapters. The allow can be
+// removed once those land.
+#![allow(dead_code)]
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Write};
+
+/// One JSONL frame on the Coven stream-JSON I/O protocol.
+///
+/// The discriminator key is `type` and the variant names round-trip as
+/// `system`, `user`, `assistant`, `tool_result`, `result`. The shape is
+/// intentionally aligned with `@opencoven/coven-code` (which itself mirrors
+/// Anthropic's tool-use schema) so external SDKs can drop in without
+/// changing their parser.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    System(System),
+    User(UserMessage),
+    Assistant(AssistantMessage),
+    ToolResult(ToolResult),
+    Result(RunResult),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct System {
+    pub subtype: String,
+    pub cwd: String,
+    pub session_id: String,
+    pub tools: Vec<String>,
+    pub agent_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserMessage {
+    pub message: MessageBody,
+    pub session_id: String,
+    pub parent_tool_use_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AssistantMessage {
+    pub message: MessageBody,
+    pub session_id: String,
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBody {
+    pub role: String,
+    pub content: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text {
+        text: String,
+    },
+    Image {
+        source: ImageSource,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSource {
+    Base64 {
+        media_type: String,
+        data: String,
+    },
+    Path {
+        path: String,
+        media_type: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolResult {
+    pub tool_use_id: String,
+    pub content: Vec<ContentBlock>,
+    pub is_error: bool,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunResult {
+    pub subtype: String,
+    pub duration_ms: u64,
+    pub is_error: bool,
+    pub num_turns: u32,
+    pub session_id: String,
+    pub error: Option<String>,
+}
+
+/// Emit one event as a JSONL frame followed by a single `\n`. Flushes the
+/// writer so consumers see the frame immediately (the protocol is intended
+/// for streaming pipelines).
+pub fn emit_event<W: Write>(writer: &mut W, event: &Event) -> Result<()> {
+    serde_json::to_writer(&mut *writer, event)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read the next JSONL frame from `reader`. Returns `Ok(None)` on EOF or on
+/// a blank line (treated as a frame separator). Any non-empty line that
+/// fails to parse is surfaced as an error.
+pub fn read_event<R: BufRead>(reader: &mut R) -> Result<Option<Event>> {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line)?;
+    if n == 0 {
+        return Ok(None);
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(serde_json::from_str(trimmed)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn round_trip_user_message() {
+        let event = Event::User(UserMessage {
+            message: MessageBody {
+                role: "user".into(),
+                content: vec![ContentBlock::Text {
+                    text: "hello".into(),
+                }],
+            },
+            session_id: "s1".into(),
+            parent_tool_use_id: None,
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded = read_event(&mut reader).unwrap().unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn json_shape_matches_coven_code() {
+        let event = Event::Result(RunResult {
+            subtype: "success".into(),
+            duration_ms: 12,
+            is_error: false,
+            num_turns: 1,
+            session_id: "s1".into(),
+            error: None,
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let line = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["type"], "result");
+        assert_eq!(v["subtype"], "success");
+        assert_eq!(v["is_error"], false);
+        assert_eq!(v["num_turns"], 1);
+        assert_eq!(v["session_id"], "s1");
+        assert!(v.get("error").is_some(), "null error field is preserved");
+    }
+
+    #[test]
+    fn system_event_wire_shape() {
+        let event = Event::System(System {
+            subtype: "init".into(),
+            cwd: "/Users/example/project".into(),
+            session_id: "s1".into(),
+            tools: vec!["bash".into(), "read_file".into()],
+            agent_mode: Some("plan".into()),
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let line = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["type"], "system");
+        assert_eq!(v["subtype"], "init");
+        assert_eq!(v["cwd"], "/Users/example/project");
+        assert_eq!(v["tools"][0], "bash");
+        assert_eq!(v["agent_mode"], "plan");
+    }
+
+    #[test]
+    fn assistant_with_tool_use_round_trips() {
+        let event = Event::Assistant(AssistantMessage {
+            message: MessageBody {
+                role: "assistant".into(),
+                content: vec![
+                    ContentBlock::Text {
+                        text: "I'll read the file.".into(),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "toolu_01".into(),
+                        name: "read_file".into(),
+                        input: serde_json::json!({"path": "README.md"}),
+                    },
+                ],
+            },
+            session_id: "s1".into(),
+            stop_reason: Some("tool_use".into()),
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded = read_event(&mut reader).unwrap().unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn tool_result_round_trips() {
+        let event = Event::ToolResult(ToolResult {
+            tool_use_id: "toolu_01".into(),
+            content: vec![ContentBlock::Text {
+                text: "file contents here".into(),
+            }],
+            is_error: false,
+            session_id: "s1".into(),
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded = read_event(&mut reader).unwrap().unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn image_content_block_path_variant() {
+        let event = Event::User(UserMessage {
+            message: MessageBody {
+                role: "user".into(),
+                content: vec![ContentBlock::Image {
+                    source: ImageSource::Path {
+                        path: "/abs/path/pic.png".into(),
+                        media_type: "image/png".into(),
+                    },
+                }],
+            },
+            session_id: "s1".into(),
+            parent_tool_use_id: None,
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded = read_event(&mut reader).unwrap().unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn read_event_returns_none_on_eof() {
+        let buf: Vec<u8> = Vec::new();
+        let mut reader = Cursor::new(buf);
+        let got = read_event(&mut reader).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn read_event_returns_none_on_blank_line() {
+        let mut reader = Cursor::new(b"\n".to_vec());
+        let got = read_event(&mut reader).unwrap();
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn read_event_surfaces_parse_errors() {
+        let mut reader = Cursor::new(b"{not-json\n".to_vec());
+        let got = read_event(&mut reader);
+        assert!(got.is_err(), "non-empty malformed line should error");
+    }
+
+    #[test]
+    fn multiple_events_stream_in_order() {
+        let mut buf = Vec::new();
+        emit_event(
+            &mut buf,
+            &Event::System(System {
+                subtype: "init".into(),
+                cwd: "/x".into(),
+                session_id: "s1".into(),
+                tools: vec![],
+                agent_mode: None,
+            }),
+        )
+        .unwrap();
+        emit_event(
+            &mut buf,
+            &Event::Result(RunResult {
+                subtype: "success".into(),
+                duration_ms: 1,
+                is_error: false,
+                num_turns: 0,
+                session_id: "s1".into(),
+                error: None,
+            }),
+        )
+        .unwrap();
+        let mut reader = Cursor::new(buf);
+        let first = read_event(&mut reader).unwrap().unwrap();
+        let second = read_event(&mut reader).unwrap().unwrap();
+        assert!(matches!(first, Event::System(_)));
+        assert!(matches!(second, Event::Result(_)));
+        assert!(read_event(&mut reader).unwrap().is_none());
+    }
+}

--- a/crates/coven-cli/src/stream_json.rs
+++ b/crates/coven-cli/src/stream_json.rs
@@ -72,14 +72,8 @@ pub enum ContentBlock {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ImageSource {
-    Base64 {
-        media_type: String,
-        data: String,
-    },
-    Path {
-        path: String,
-        media_type: String,
-    },
+    Base64 { media_type: String, data: String },
+    Path { path: String, media_type: String },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -2451,6 +2451,8 @@ mod tests {
             created_at: "2026-05-19T00:00:00Z".to_string(),
             updated_at: "2026-05-19T00:00:00Z".to_string(),
             conversation_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         }
     }
 

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1514,6 +1514,8 @@ mod tests {
             created_at: "2026-05-24T00:00:00Z".to_string(),
             updated_at: "2026-05-24T00:00:00Z".to_string(),
             conversation_id: conversation.map(ToOwned::to_owned),
+            labels: Vec::new(),
+            visibility: "private".to_string(),
         }
     }
 

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1189,7 +1189,19 @@ fn dispatch_via_local_pty(
     daemon_reason: &str,
 ) -> Result<CastOutcome> {
     let title = plan.title.as_deref();
-    run_session(harness_id, &[prompt.to_string()], None, title, false, None, Vec::new(), None, false)?;
+    run_session(
+        harness_id,
+        &[prompt.to_string()],
+        None,
+        title,
+        false,
+        None,
+        Vec::new(),
+        None,
+        false,
+        false,
+        false,
+    )?;
     let mut notes = plan_outcome_notes(plan);
     notes.push(format!("Cast event follower skipped: {daemon_reason}."));
     Ok(CastOutcome {
@@ -1864,7 +1876,19 @@ fn run_guided_harness_session() -> Result<()> {
         prompt_for_optional_line(&harness_prompt)?.unwrap_or_else(|| default_harness.to_string());
     let prompt = prompt_for_required_line("Task for the agent: ")?;
     let title = prompt_for_optional_line("Optional session title [enter to skip]: ")?;
-    run_session(&harness, &[prompt], None, title.as_deref(), false, None, Vec::new(), None, false)
+    run_session(
+        &harness,
+        &[prompt],
+        None,
+        title.as_deref(),
+        false,
+        None,
+        Vec::new(),
+        None,
+        false,
+        false,
+        false,
+    )
 }
 
 const LAUNCHER_VISIBLE_COMMANDS: usize = 6;

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1189,7 +1189,7 @@ fn dispatch_via_local_pty(
     daemon_reason: &str,
 ) -> Result<CastOutcome> {
     let title = plan.title.as_deref();
-    run_session(harness_id, &[prompt.to_string()], None, title, false)?;
+    run_session(harness_id, &[prompt.to_string()], None, title, false, None, Vec::new(), None, false)?;
     let mut notes = plan_outcome_notes(plan);
     notes.push(format!("Cast event follower skipped: {daemon_reason}."));
     Ok(CastOutcome {
@@ -1864,7 +1864,7 @@ fn run_guided_harness_session() -> Result<()> {
         prompt_for_optional_line(&harness_prompt)?.unwrap_or_else(|| default_harness.to_string());
     let prompt = prompt_for_required_line("Task for the agent: ")?;
     let title = prompt_for_optional_line("Optional session title [enter to skip]: ")?;
-    run_session(&harness, &[prompt], None, title.as_deref(), false)
+    run_session(&harness, &[prompt], None, title.as_deref(), false, None, Vec::new(), None, false)
 }
 
 const LAUNCHER_VISIBLE_COMMANDS: usize = 6;

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -576,6 +576,8 @@ fn create_local_quest_anchor(
         created_at: timestamp.clone(),
         updated_at: timestamp.clone(),
         conversation_id: None,
+        labels: Vec::new(),
+        visibility: "private".to_string(),
     };
     store::insert_session(&conn, &record)?;
     let harness_label = default_harness

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -1,4 +1,4 @@
-//! End-to-end tests for `coven run … --stream-json`.
+//! End-to-end tests for `coven run ... --stream-json`.
 //!
 //! These tests are `#[ignore]` by default because they shell out to the
 //! built `coven` binary. Run them explicitly with:

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -1,0 +1,57 @@
+//! End-to-end tests for `coven run … --stream-json`.
+//!
+//! These tests are `#[ignore]` by default because they shell out to the
+//! built `coven` binary. Run them explicitly with:
+//!
+//!   cargo test -p coven-cli --test stream_json_integration -- --ignored
+//!
+//! The `--detach` path lets us exercise the framing without requiring codex
+//! or claude to be installed: we synthesize `system.init` + `user` + `result`
+//! around a session that never actually launches a harness.
+
+use std::process::{Command, Stdio};
+
+#[test]
+#[ignore = "requires built coven binary; run with `cargo test -- --ignored`"]
+fn stream_json_emits_init_and_result_for_codex_dry_run() {
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--stream-json", "--detach", "ping"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+
+    assert!(
+        out.status.success(),
+        "coven run --detach --stream-json failed: status={:?} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout not utf-8");
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        lines.len() >= 3,
+        "expected at least 3 JSONL frames (system, user, result); got {lines:?}",
+    );
+
+    let first: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("first line is not valid JSON");
+    assert_eq!(first["type"], "system");
+    assert_eq!(first["subtype"], "init");
+    assert!(first["session_id"].is_string());
+    assert!(first["cwd"].is_string());
+
+    let second: serde_json::Value =
+        serde_json::from_str(lines[1]).expect("second line is not valid JSON");
+    assert_eq!(second["type"], "user");
+    assert_eq!(second["message"]["role"], "user");
+    assert_eq!(second["message"]["content"][0]["type"], "text");
+    assert_eq!(second["message"]["content"][0]["text"], "ping");
+
+    let last: serde_json::Value =
+        serde_json::from_str(lines.last().unwrap()).expect("last line is not valid JSON");
+    assert_eq!(last["type"], "result");
+    assert_eq!(last["subtype"], "success");
+    assert_eq!(last["is_error"], false);
+}

--- a/docs/PROMPT-REFERENCES.md
+++ b/docs/PROMPT-REFERENCES.md
@@ -1,0 +1,94 @@
+# Prompt References
+
+Coven expands four kinds of references in `coven run` prompts before sending them to a harness. Expansion happens inside the daemon's `run_session` path; the inlined content is prepended to the original prompt with delimited blocks so the harness sees full context and the user keeps their typed prompt intact.
+
+The original prompt is also what becomes the session title and what is echoed to stdout — only the harness invocation receives the expanded form.
+
+## `@path/to/file`
+
+Inlines a single text file resolved relative to the invocation cwd.
+
+- Up to `MAX_TEXT_LINES` lines (default 500). Excess is replaced with `[…truncated at 500 lines]`.
+- Each line is capped at `MAX_LINE_CHARS` characters (default 2048).
+- A missing path becomes `[missing @path]` so the prompt still flows.
+- Image extensions (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`) become a placeholder of the form `[image @ /abs/path: image/png, 12345 bytes]`. In a future `--stream-json` mode these become real `image` content blocks.
+
+Example:
+
+```
+coven run claude "explain @README.md briefly"
+```
+
+## `@glob/*.ext`
+
+Expands a glob relative to the invocation cwd. Up to 20 matching files are inlined; once the cap is hit, the remaining matches are summarized as `[…glob match cap reached at 20 files]`. Each match is rendered with the same per-file rules as `@path`.
+
+A glob that resolves to zero files produces `[no matches for @pattern]`.
+
+Example:
+
+```
+coven run codex "summarise @docs/*.md and note duplicates"
+```
+
+## `@T-<session-id>`
+
+Inlines up to 200 redacted event payloads from a prior session, in chronological order. Each event is rendered as `[<created_at>] <kind>: <payload_json>`.
+
+- Lookup is by exact session id; the `T-` prefix is conventional and preserved.
+- A missing or empty session becomes `[no events for @T-<id>]`.
+
+Example:
+
+```
+coven run claude "continue @T-019e5c86-8f1f-7291-a303-69c37aed291d with new ideas"
+```
+
+## `@@search words`
+
+Runs a SQLite FTS5 query over local session event payloads. The query body runs to end-of-line, so the entire line after `@@` becomes the search expression.
+
+- Up to 5 hits are inlined, each as `[<created_at>] <session_id> <kind> <snippet>`.
+- Zero hits produces `[no search hits for @@<query>]`.
+
+Example:
+
+```
+coven run codex "context:
+@@privacy redaction
+now finish the helper"
+```
+
+## Combining refs
+
+A single prompt can mix all four ref kinds. Refs are resolved in the order they appear; resolved blocks are concatenated and prepended to the original prompt. Order within the prefix matches the order of refs in the source prompt.
+
+```
+coven run claude "read @intro.md and @docs/*.md
+context: @@phoenix rising
+continue @T-019e5c86-8f1f-7291-a303-69c37aed291d"
+```
+
+## What does NOT trigger expansion
+
+- A bare `@` followed by whitespace (e.g., `email me at @ work`) — no ref is produced.
+- A `@@` with an empty body — ignored.
+- A `@` inside a code fence — currently still triggers expansion; quote the literal `@` with a space if you need to mention one.
+
+## Limits and defaults
+
+| Setting | Default | Source |
+|---|---|---|
+| Lines per file | 500 | `prompt_refs::MAX_TEXT_LINES` |
+| Chars per line | 2048 | `prompt_refs::MAX_LINE_CHARS` |
+| Glob match cap | 20 files | `expand_glob` in `prompt_refs.rs` |
+| Thread event cap | 200 events | `expand_thread` in `prompt_refs.rs` |
+| Search hit cap | 5 hits | `expand_search` in `prompt_refs.rs` |
+
+These match the Coven Code (Node) reference implementation's `FILE_MENTION_MAX_*` defaults. They are not currently user-configurable; making them settings-driven is a follow-up under the unified JSONC settings work.
+
+## Where this lives in the code
+
+- Parser + expanders: `crates/coven-cli/src/prompt_refs.rs`
+- Wired into `coven run`: `crates/coven-cli/src/main.rs::run_session`
+- FTS5 backing for `@@search`: `crates/coven-cli/src/store.rs::search_events`

--- a/docs/SESSION-LIFECYCLE.md
+++ b/docs/SESSION-LIFECYCLE.md
@@ -165,3 +165,20 @@ An orphaned session means Coven no longer owns a live process for that record. T
 Events are append-only records in SQLite. This gives clients a stable replay source even when the original PTY process has exited.
 
 Do not intentionally write secrets, environment dumps, private URLs, or token-bearing command output into events. Coven cannot guarantee that harness output is secret-free, so users should avoid running untrusted prompts in sensitive repositories.
+
+## Search and continuation (added 2026-05)
+
+- `coven sessions search <query>` runs a SQLite FTS5 query over `events.payload_json`.
+  Supports the full FTS5 query syntax (`phoenix OR rises`, `"exact phrase"`, `phoe*`).
+  Output is a flat list of hits ordered most-recent-first; pass `--json` to get the raw
+  SearchHit array for client tools.
+- `coven run <harness> --continue` resumes the most recently created, non-archived
+  session whose `project_root` matches the current directory. The harness is launched
+  with `ConversationHint::Resume` so codex/claude pick up the prior turn's context.
+- `coven run <harness> --continue <ID>` resumes by explicit session id.
+- `coven run <harness> --labels foo,bar --visibility workspace --archive "task"` tags
+  and archives a one-shot run in a single command. `--labels` and `--visibility` are
+  creation-time only (ignored when resuming). Valid visibility values: `private`
+  (default), `workspace`, `shared`.
+- `--detach` and `--continue` are mutually exclusive — resuming-but-not-running is
+  incoherent.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -7,14 +7,24 @@ All keys live under `covenCli.*`.
 
 ## Precedence
 
-1. Environment variables (highest, see `crates/coven-cli/src/privacy.rs` once privacy lands; today: `COVEN_HOME` only).
-2. `~/.config/coven/settings.json`
-3. `~/.coven/repos.toml`, `~/.coven/privacy.toml` (legacy)
+Today, for keys in the `covenCli.*` namespace:
 
-When a key is set in both the JSONC file and a legacy TOML file, the JSONC value
-wins and `coven` can print a one-time stderr warning naming the shadowed keys
-(via `settings::warn_if_shadowed`; the doctor and shell entry points will start
-emitting this warning in a follow-up commit).
+1. `~/.config/coven/settings.json` (highest)
+2. `~/.coven/repos.toml` (legacy)
+
+The only environment variable that affects settings discovery today is
+`COVEN_HOME`, which controls the local data dir (`~/.coven/...`) — it does not
+override any `covenCli.*` value.
+
+Forward-looking: once the security branch lands and privacy gains
+`load_with_settings`, env vars (`COVEN_PERSIST_RAW_ARTIFACTS`,
+`COVEN_RAW_ARTIFACT_RETENTION_DAYS`, `COVEN_LOG_RETENTION_DAYS`) will trump
+both files for the `covenCli.privacy.*` keys only.
+
+When a key is set in both the JSONC file and a legacy TOML file, the JSONC
+value wins and `coven` can print a one-time stderr warning naming the
+shadowed keys (via `settings::warn_if_shadowed`; the doctor and shell entry
+points will start emitting this warning in a follow-up commit).
 
 ## Schema
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,57 @@
+# Coven CLI Settings
+
+User settings live at `~/.config/coven/settings.json` (or `$XDG_CONFIG_HOME/coven/settings.json`).
+Format is JSONC: `//` and `/* */` comments and trailing commas are allowed.
+
+All keys live under `covenCli.*`.
+
+## Precedence
+
+1. Environment variables (highest, see `crates/coven-cli/src/privacy.rs` once privacy lands; today: `COVEN_HOME` only).
+2. `~/.config/coven/settings.json`
+3. `~/.coven/repos.toml`, `~/.coven/privacy.toml` (legacy)
+
+When a key is set in both the JSONC file and a legacy TOML file, the JSONC value
+wins and `coven` can print a one-time stderr warning naming the shadowed keys
+(via `settings::warn_if_shadowed`; the doctor and shell entry points will start
+emitting this warning in a follow-up commit).
+
+## Schema
+
+```jsonc
+{
+  "covenCli": {
+    // Resolved by `coven patch` when no --repo flag and no positional repo name.
+    "defaultRepo": "openclaw",
+
+    // Named repo registry. Replaces / extends ~/.coven/repos.toml.
+    // JSONC entries win when both files name the same repo.
+    "repos": {
+      "openclaw": { "path": "~/dev/openclaw" }
+    },
+
+    // Forward-looking. Not honored on main yet; will start working when
+    // the upstream security/private-session-logs branch lands and ships
+    // privacy.rs with load_with_settings(). Until then these keys parse
+    // without error but do not affect runtime retention or redaction.
+    "privacy": {
+      "persistRawArtifacts": false,
+      "rawArtifactRetentionDays": 7,
+      "logRetentionDays": 30,
+      "extraPatterns": ["(?i)bearer\\s+[a-z0-9]+"]
+    },
+
+    // Paths that should always be considered for file-reference globs
+    // (used by Phase 3 `@glob/*.md` expansion). Bypasses .gitignore.
+    "fuzzy": {
+      "alwaysIncludePaths": [".env.example", "docs/secrets-redacted.md"]
+    }
+  }
+}
+```
+
+## Migration
+
+The legacy TOML files (`~/.coven/repos.toml`, `~/.coven/privacy.toml`) are still read. To migrate,
+copy values into the JSONC schema above and delete the corresponding lines from the TOML file. A
+`coven config migrate` command is on the roadmap.

--- a/docs/STREAM-JSON.md
+++ b/docs/STREAM-JSON.md
@@ -1,0 +1,77 @@
+# Coven CLI Stream-JSON Protocol
+
+`coven run <harness> --stream-json` emits newline-delimited JSON events on
+stdout. With `--stream-json-input`, user messages are read line-by-line from
+stdin as JSON (claude harness only).
+
+The schema matches `@opencoven/coven-code` exactly; SDKs that target Coven
+Code work unchanged against Coven CLI.
+
+## Event types
+
+### `system` - emitted once at startup
+
+```json
+{"type":"system","subtype":"init","cwd":"/path","session_id":"...","tools":[],"agent_mode":null}
+```
+
+### `user` - emitted for each user message
+
+```json
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]},"session_id":"...","parent_tool_use_id":null}
+```
+
+### `assistant` - emitted by stream-capable harnesses (claude)
+
+```json
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"..."}]},"session_id":"...","stop_reason":"end_turn"}
+```
+
+### `tool_result` - emitted by stream-capable harnesses
+
+```json
+{"type":"tool_result","tool_use_id":"...","content":[{"type":"text","text":"..."}],"is_error":false,"session_id":"..."}
+```
+
+### `result` - emitted once at end
+
+```json
+{"type":"result","subtype":"success","duration_ms":1234,"is_error":false,"num_turns":1,"session_id":"...","error":null}
+```
+
+`subtype` is `"success"` on a clean exit and `"error_during_execution"`
+otherwise. When `is_error` is true, `error` may contain a human-readable
+failure string.
+
+## Stdin protocol (`--stream-json-input`)
+
+Each line is one JSON object with the same shape as the `user` event's
+`message` field:
+
+```json
+{"role":"user","content":[{"type":"text","text":"hello"}]}
+```
+
+`image` content blocks use `source.type = "path"` (local file) or
+`source.type = "base64"` (inline). `--stream-json-input` requires
+`--stream-json` and is only consumed when the harness is `claude`; for
+non-stream harnesses the flag is accepted but no stdin forwarding occurs.
+
+## Harness behavior
+
+- **claude**: passes through claude's native stream-json events, framed by
+  Coven's `system` and `result`. Coven does *not* synthesize a `user` event
+  on this path; claude emits its own when it processes the prompt.
+
+- **codex** and other non-stream harnesses: Coven synthesizes
+  `system.init` + `user` + `result`. The harness's text output is not
+  exposed as `assistant` events in this mode (use `coven attach <id>` for
+  streamed text). In practice `--stream-json` for codex is most useful with
+  `--detach`, which records the session without launching the harness and
+  emits init+user+result immediately.
+
+## Stability
+
+This is a stable interface as of 2026-05. Additions are additive (new event
+types, new optional fields). Removals or breaking changes to existing event
+shapes require a major version bump of the CLI.

--- a/docs/superpowers/plans/2026-05-26-coven-cli-p0-coven-code-parity.md
+++ b/docs/superpowers/plans/2026-05-26-coven-cli-p0-coven-code-parity.md
@@ -1,0 +1,2116 @@
+# Coven CLI P0 — Coven Code Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring four foundational features from `@opencoven/coven-code` (Node) into `coven-cli` (Rust): unified JSONC settings, thread/session upgrades, file references in prompts, and a documented stream-JSON I/O protocol.
+
+**Architecture:** Layer the new features on top of the existing `store.rs` (SQLite ledger) and `harness.rs` (Codex/Claude PTY runner). All four features sit at the I/O boundary — no changes to the agent loop, no new auth path, no remote calls. The work is split into four phases that each end in a shippable commit; phases 1–4 are ordered by dependency (settings → threads → file refs → stream-JSON), but file-refs is independent and could ship at any point.
+
+**Tech Stack:** Rust 2021, clap 4, rusqlite 0.39 (bundled SQLite with FTS5), serde 1, serde_json, anyhow, regex, ratatui (for any TUI-side glue). New deps: `json5 = "0.4"` for JSONC parsing (Phase 1) and `globset = "0.4"` for prompt globs (Phase 3).
+
+---
+
+## Execution note (added 2026-05-26 mid-flight)
+
+The plan was originally drafted assuming the state of `security/private-session-logs`, where `crates/coven-cli/src/privacy.rs`, `encrypted_artifacts.rs`, and the `redaction_status`/`sensitive`/`sensitive_artifacts` schema additions exist. **On `origin/main` (this PR's base) none of those exist yet.** Concrete adjustments applied during execution:
+
+- **Task 1.4 (privacy wiring) is deferred** to a follow-up plan that runs once `security/private-session-logs` lands on main. The `PrivacySettings` type still lives in `settings.rs` so the schema is forward-compatible.
+- **Phase 2 thread search** runs over `events.payload_json` as-is on main; the "redacted" qualifier in the plan was a security-branch artifact. Behavior is unchanged because main currently stores plain payloads.
+- **Phase 3 `@T-<id>` expansion** reads `events.payload_json` directly; no decryption path needed on main.
+- **Phase 4 stream-JSON** is unaffected.
+
+---
+
+## Design decisions (locked in — challenge before execution if you disagree)
+
+1. **Stream-JSON event schema = Coven Code's exact JSONL shape**, which mirrors Anthropic's tool-use shape (`type`, `message`, `tool_use_id`, `session_id`, etc.). External SDKs written against `@opencoven/coven-code` should switch CLIs without modifying their parser. See `docs/STREAM-JSON.md` introduced in Phase 4.
+2. **Settings canonical = `~/.config/coven/settings.json`** (JSONC, `covenCli.*` keyspace). Existing `~/.coven/repos.toml` and `~/.coven/privacy.toml` remain readable as fallbacks for one release. When both define the same key, JSONC wins and a one-time stderr warning lists the keys overridden. `familiars.toml` is data, not config — out of scope for this plan.
+3. **Thread search uses SQLite FTS5** (already shipped in rusqlite's bundled SQLite build) over the redacted `events.payload_json` column only. No raw-artifact decryption during search; that would defeat the privacy default.
+4. **Visibility levels = `private | workspace | shared`** (three levels — simpler than Coven Code's five, room to expand later). Default `private`.
+5. **`--continue` with no argument resumes the latest non-archived session whose `project_root` matches the current directory.** With an explicit id it resumes by id.
+6. **`@README.md` resolves relative to the invocation cwd**, matching Coven Code. Globs honor `.gitignore` unless the path matches `covenCli.fuzzy.alwaysIncludePaths`.
+7. **Image references in non-stream mode produce a text placeholder** (`[image @ path: file.png, image/png, 12345 bytes]`); in stream-JSON mode they become real `image` content blocks. Text refs cap at 500 lines × 2048 chars/line, matching Coven Code's `FILE_MENTION_MAX_*` constants.
+8. **Schema migrations follow the existing `ensure_column` pattern in `store.rs`**: idempotent `ALTER TABLE ... ADD COLUMN` guarded by a `PRAGMA table_info` check. No down-migrations.
+
+---
+
+## File structure
+
+### New files
+
+- `crates/coven-cli/src/settings.rs` — `Settings` struct, `load()` with precedence, JSONC parsing.
+- `crates/coven-cli/src/prompt_refs.rs` — `@path` / `@@search` / `@T-<id>` expansion.
+- `crates/coven-cli/src/stream_json.rs` — event type definitions, `emit_event()` writer, `read_event()` parser.
+- `docs/STREAM-JSON.md` — the external I/O contract for the protocol.
+- `docs/SETTINGS.md` — settings file format, precedence, key reference.
+
+### Modified files
+
+- `crates/coven-cli/Cargo.toml` — add `json5 = "0.4"`, `globset = "0.4"`.
+- `crates/coven-cli/src/main.rs` — new flags (`--stream-json`, `--stream-json-input`, `--continue`, `--archive`, `--labels`, `--visibility`), new subcommand `sessions search`, settings loaded at startup.
+- `crates/coven-cli/src/store.rs` — new columns `labels`, `visibility` on `sessions`; new FTS5 virtual table `events_fts`; new helpers `latest_active_for_project()`, `search_events()`, `set_labels()`, `set_visibility()`.
+- `crates/coven-cli/src/privacy.rs` — read from `Settings` first, fall back to `privacy.toml`.
+- `crates/coven-cli/src/repos_config.rs` — read from `Settings` first, fall back to `repos.toml`.
+- `crates/coven-cli/src/pty_runner.rs` — emit stream-JSON events around PTY lifecycle when caller opts in.
+- `crates/coven-cli/src/harness.rs` — promote raw claude stream-JSON shape into our `stream_json::Event` enum.
+
+---
+
+## Phase 1 — Unified JSONC settings (foundation)
+
+**Outcome:** A single `~/.config/coven/settings.json` file is the canonical config. `repos.toml` and `privacy.toml` still work, with a deprecation warning when they shadow JSONC keys.
+
+### Task 1.1: Add `json5` dependency
+
+**Files:**
+- Modify: `crates/coven-cli/Cargo.toml`
+
+- [ ] **Step 1: Add dep**
+
+```toml
+# in [dependencies]
+json5 = "0.4"
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `cargo build -p coven-cli`
+Expected: clean build, `json5` resolves.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/coven-cli/Cargo.toml crates/coven-cli/Cargo.lock
+git commit -S -m "deps(coven-cli): add json5 for JSONC settings parsing"
+```
+
+### Task 1.2: Define `Settings` types and the empty loader
+
+**Files:**
+- Create: `crates/coven-cli/src/settings.rs`
+- Modify: `crates/coven-cli/src/main.rs` (declare module)
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/coven-cli/src/settings.rs`:
+
+```rust
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+pub const SETTINGS_FILE_NAME: &str = "settings.json";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct Settings {
+    #[serde(rename = "covenCli")]
+    pub coven_cli: CovenCliSettings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct CovenCliSettings {
+    pub privacy: Option<PrivacySettings>,
+    pub repos: BTreeMap<String, RepoSettings>,
+    #[serde(default)]
+    pub default_repo: Option<String>,
+    #[serde(default)]
+    pub fuzzy: FuzzySettings,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct PrivacySettings {
+    pub persist_raw_artifacts: Option<bool>,
+    pub raw_artifact_retention_days: Option<u64>,
+    pub log_retention_days: Option<u64>,
+    pub extra_patterns: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct RepoSettings {
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct FuzzySettings {
+    pub always_include_paths: Vec<String>,
+}
+
+pub fn user_settings_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    Some(base.join("coven").join(SETTINGS_FILE_NAME))
+}
+
+pub fn load_from(path: &Path) -> Result<Option<Settings>> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(r) => r,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).with_context(|| format!("failed to read {}", path.display())),
+    };
+    let parsed: Settings = json5::from_str(&raw)
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(Some(parsed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_file_returns_none() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        assert_eq!(load_from(&path).unwrap(), None);
+    }
+
+    #[test]
+    fn loads_jsonc_with_comments_and_trailing_commas() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{
+              // user comment
+              "covenCli": {
+                "defaultRepo": "alpha",
+                "repos": {
+                  "alpha": { "path": "/abs/alpha" },
+                },
+              },
+            }"#,
+        )
+        .unwrap();
+        let loaded = load_from(&path).unwrap().unwrap();
+        assert_eq!(loaded.coven_cli.default_repo.as_deref(), Some("alpha"));
+        assert_eq!(
+            loaded.coven_cli.repos.get("alpha").unwrap().path,
+            PathBuf::from("/abs/alpha")
+        );
+    }
+}
+```
+
+In `crates/coven-cli/src/main.rs`, add the module:
+
+```rust
+// near the other `mod ...;` lines
+mod settings;
+```
+
+- [ ] **Step 2: Run tests to verify they fail then pass**
+
+Run: `cargo test -p coven-cli settings::tests -- --nocapture`
+Expected: both tests pass after implementation in step 1 (they were written alongside the impl since serde does most of the work). If a test fails, fix the structure mismatch.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/coven-cli/src/settings.rs crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): add Settings type with JSONC loader"
+```
+
+### Task 1.3: Wire settings into `repos_config.rs`
+
+**Files:**
+- Modify: `crates/coven-cli/src/repos_config.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the existing `#[cfg(test)] mod tests` block in `crates/coven-cli/src/repos_config.rs`:
+
+```rust
+#[test]
+fn settings_override_toml_when_both_present() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    // legacy TOML
+    std::fs::write(
+        config_path(temp.path()),
+        r#"
+default = "from_toml"
+[repos.from_toml]
+path = "/abs/toml"
+"#,
+    )?;
+    // new JSONC at sibling settings dir override path
+    let settings = crate::settings::Settings {
+        coven_cli: crate::settings::CovenCliSettings {
+            default_repo: Some("from_jsonc".to_string()),
+            repos: std::collections::BTreeMap::from([(
+                "from_jsonc".to_string(),
+                crate::settings::RepoSettings {
+                    path: std::path::PathBuf::from("/abs/jsonc"),
+                },
+            )]),
+            ..Default::default()
+        },
+    };
+    let merged = load_with_settings(temp.path(), Some(&settings))?;
+    assert_eq!(merged.default_name(), Some("from_jsonc"));
+    assert_eq!(
+        merged.resolve("from_jsonc"),
+        Some(std::path::PathBuf::from("/abs/jsonc"))
+    );
+    // legacy entry still resolvable as a fallback
+    assert_eq!(
+        merged.resolve("from_toml"),
+        Some(std::path::PathBuf::from("/abs/toml"))
+    );
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p coven-cli repos_config::tests::settings_override_toml_when_both_present`
+Expected: FAIL — `load_with_settings` does not exist.
+
+- [ ] **Step 3: Implement `load_with_settings`**
+
+Add to `crates/coven-cli/src/repos_config.rs`:
+
+```rust
+pub fn load_with_settings(
+    coven_home: &Path,
+    settings: Option<&crate::settings::Settings>,
+) -> Result<ReposConfig> {
+    let mut config = load(coven_home)?;
+    let Some(settings) = settings else {
+        return Ok(config);
+    };
+    for (name, repo) in &settings.coven_cli.repos {
+        config.repos.insert(
+            name.clone(),
+            RepoEntry {
+                path: repo.path.clone(),
+            },
+        );
+    }
+    if let Some(name) = &settings.coven_cli.default_repo {
+        config.default = Some(name.clone());
+    }
+    Ok(config)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p coven-cli repos_config::tests`
+Expected: all 5 tests pass (4 existing + 1 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/repos_config.rs
+git commit -S -m "feat(coven-cli): repos_config reads from Settings with TOML fallback"
+```
+
+### Task 1.4: Wire settings into `privacy.rs`
+
+**Files:**
+- Modify: `crates/coven-cli/src/privacy.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing test module in `privacy.rs`:
+
+```rust
+#[test]
+fn settings_override_toml_for_retention() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        temp.path().join("privacy.toml"),
+        "log_retention_days = 99\n",
+    )
+    .unwrap();
+    let settings = crate::settings::Settings {
+        coven_cli: crate::settings::CovenCliSettings {
+            privacy: Some(crate::settings::PrivacySettings {
+                log_retention_days: Some(7),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    };
+    let loaded = load_with_settings(temp.path(), Some(&settings)).unwrap();
+    // JSONC wins
+    assert_eq!(loaded.log_retention_days, 7);
+}
+```
+
+- [ ] **Step 2: Run test to confirm fail**
+
+Run: `cargo test -p coven-cli privacy::tests::settings_override_toml_for_retention`
+Expected: FAIL — `load_with_settings` not defined.
+
+- [ ] **Step 3: Implement `load_with_settings`**
+
+Add to `privacy.rs`:
+
+```rust
+pub fn load_with_settings(
+    coven_home: &Path,
+    settings: Option<&crate::settings::Settings>,
+) -> Result<PrivacyConfig> {
+    let mut config = load_config(coven_home)?;
+    if let Some(s) = settings.and_then(|s| s.coven_cli.privacy.as_ref()) {
+        if let Some(v) = s.persist_raw_artifacts {
+            config.persist_raw_artifacts = v;
+        }
+        if let Some(v) = s.raw_artifact_retention_days {
+            config.raw_artifact_retention_days = v;
+        }
+        if let Some(v) = s.log_retention_days {
+            config.log_retention_days = v;
+        }
+        if let Some(v) = &s.extra_patterns {
+            config.extra_patterns = v.clone();
+        }
+    }
+    // env vars still trump everything (already applied by load_config; reapply
+    // here in case settings clobbered them above)
+    if let Some(value) = std::env::var_os("COVEN_PERSIST_RAW_ARTIFACTS") {
+        config.persist_raw_artifacts = env_truthy(&value.to_string_lossy());
+    }
+    if let Some(value) = env_u64("COVEN_RAW_ARTIFACT_RETENTION_DAYS") {
+        config.raw_artifact_retention_days = value;
+    }
+    if let Some(value) = env_u64("COVEN_LOG_RETENTION_DAYS") {
+        config.log_retention_days = value;
+    }
+    Ok(config)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p coven-cli privacy::tests`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/privacy.rs
+git commit -S -m "feat(coven-cli): privacy reads from Settings with TOML fallback"
+```
+
+### Task 1.5: Deprecation warning when both files exist
+
+**Files:**
+- Modify: `crates/coven-cli/src/settings.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `settings.rs` tests:
+
+```rust
+#[test]
+fn detect_shadowed_keys_lists_overrides() {
+    let toml_keys = ["repos.alpha".to_string(), "defaultRepo".to_string()];
+    let jsonc_keys = ["repos.alpha".to_string()];
+    let shadowed = shadowed_keys(&toml_keys, &jsonc_keys);
+    assert_eq!(shadowed, vec!["repos.alpha".to_string()]);
+}
+```
+
+- [ ] **Step 2: Confirm FAIL**
+
+Run: `cargo test -p coven-cli settings::tests::detect_shadowed_keys_lists_overrides`
+Expected: FAIL — symbol not found.
+
+- [ ] **Step 3: Implement**
+
+Add to `settings.rs`:
+
+```rust
+pub fn shadowed_keys(toml_keys: &[String], jsonc_keys: &[String]) -> Vec<String> {
+    let mut out: Vec<String> = toml_keys
+        .iter()
+        .filter(|k| jsonc_keys.iter().any(|j| j == *k))
+        .cloned()
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+pub fn warn_if_shadowed(shadowed: &[String], toml_path: &Path, jsonc_path: &Path) {
+    if shadowed.is_empty() {
+        return;
+    }
+    eprintln!(
+        "coven: {} keys in {} are shadowed by {}. Consider removing them from the TOML file.",
+        shadowed.len(),
+        toml_path.display(),
+        jsonc_path.display()
+    );
+    for key in shadowed {
+        eprintln!("  - {key}");
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p coven-cli settings::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/settings.rs
+git commit -S -m "feat(coven-cli): warn when legacy TOML keys are shadowed by JSONC settings"
+```
+
+### Task 1.6: Load settings once in `main()` and thread through
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Update `run_cli`**
+
+In `crates/coven-cli/src/main.rs`, after `let cli = Cli::parse();`:
+
+```rust
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    let settings = settings::user_settings_path()
+        .as_deref()
+        .and_then(|path| match settings::load_from(path) {
+            Ok(s) => s,
+            Err(err) => {
+                eprintln!("coven: ignoring settings: {err:#}");
+                None
+            }
+        });
+    run_cli(cli, settings.as_ref())
+}
+```
+
+Update `run_cli` signature and pass `settings` to any call site that previously called `repos_config::load(...)` or `privacy::load_config(...)`. Replace those calls with `repos_config::load_with_settings(home, settings)` and `privacy::load_with_settings(home, settings)`.
+
+- [ ] **Step 2: Build**
+
+Run: `cargo build -p coven-cli`
+Expected: clean build.
+
+- [ ] **Step 3: Smoke test**
+
+Run: `cargo run -p coven-cli -- doctor`
+Expected: existing doctor output, no errors. (Settings absent → no behavior change.)
+
+- [ ] **Step 4: Manual integration**
+
+Create `~/.config/coven/settings.json` (in a temp HOME for the test):
+
+```json
+{
+  // smoke test
+  "covenCli": {
+    "defaultRepo": "smoke",
+    "repos": { "smoke": { "path": "/tmp" } }
+  }
+}
+```
+
+Run: `HOME=/tmp/coven-smoke XDG_CONFIG_HOME=/tmp/coven-smoke/.config cargo run -p coven-cli -- doctor`
+Expected: no parse error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): load JSONC settings at startup and thread through subcommands"
+```
+
+### Task 1.7: Document settings
+
+**Files:**
+- Create: `docs/SETTINGS.md`
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/SETTINGS.md`:
+
+```markdown
+# Coven CLI Settings
+
+User settings live at `~/.config/coven/settings.json` (or `$XDG_CONFIG_HOME/coven/settings.json`).
+Format is JSONC: `//` and `/* */` comments and trailing commas are allowed.
+
+All keys live under `covenCli.*`.
+
+## Precedence
+
+1. Environment variables (highest)
+2. `~/.config/coven/settings.json`
+3. `~/.coven/repos.toml`, `~/.coven/privacy.toml` (legacy)
+
+When a key is set in both the JSONC file and a legacy TOML file, the JSONC value
+wins and `coven` prints a one-time stderr warning naming the shadowed keys.
+
+## Schema
+
+```jsonc
+{
+  "covenCli": {
+    "defaultRepo": "openclaw",
+    "repos": {
+      "openclaw": { "path": "~/dev/openclaw" }
+    },
+    "privacy": {
+      "persistRawArtifacts": false,
+      "rawArtifactRetentionDays": 7,
+      "logRetentionDays": 30,
+      "extraPatterns": ["(?i)bearer\\s+[a-z0-9]+"]
+    },
+    "fuzzy": {
+      "alwaysIncludePaths": [".env.example", "docs/secrets-redacted.md"]
+    }
+  }
+}
+```
+
+## Migration
+
+The legacy TOML files are still read. To migrate, copy values into the JSONC schema above and
+delete the corresponding lines from `repos.toml` / `privacy.toml`. A `coven config migrate`
+command will land in a later release.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/SETTINGS.md
+git commit -S -m "docs(coven-cli): document unified JSONC settings file"
+```
+
+**Phase 1 milestone:** unified settings ship as additive feature. Run `cargo test -p coven-cli` — all green. Tag/PR can land here independently.
+
+---
+
+## Phase 2 — Thread/session upgrades
+
+**Outcome:** `coven run --continue [ID] --labels foo,bar --visibility shared --archive`, `coven sessions search <query>`, all backed by SQLite FTS5.
+
+### Task 2.1: Add `labels` and `visibility` columns to `sessions`
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `store::tests` module:
+
+```rust
+#[test]
+fn new_columns_default_correctly() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let conn = open_store(&temp.path().join("test.sqlite3"))?;
+    conn.execute(
+        "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+         VALUES('s1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+        [],
+    )?;
+    let labels: Option<String> = conn.query_row(
+        "SELECT labels FROM sessions WHERE id='s1'",
+        [],
+        |row| row.get(0),
+    )?;
+    let visibility: String = conn.query_row(
+        "SELECT visibility FROM sessions WHERE id='s1'",
+        [],
+        |row| row.get(0),
+    )?;
+    assert_eq!(labels, None);
+    assert_eq!(visibility, "private");
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run test to confirm FAIL**
+
+Run: `cargo test -p coven-cli store::tests::new_columns_default_correctly`
+Expected: FAIL — `labels` column missing.
+
+- [ ] **Step 3: Add migration**
+
+In `store.rs`, inside `open_store()` after `ensure_conversation_id_column(&conn)?;`:
+
+```rust
+ensure_labels_column(&conn)?;
+ensure_visibility_column(&conn)?;
+```
+
+Add the two helper functions next to the existing `ensure_*` functions:
+
+```rust
+fn ensure_labels_column(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "sessions",
+        "labels",
+        "ALTER TABLE sessions ADD COLUMN labels TEXT",
+    )
+}
+
+fn ensure_visibility_column(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "sessions",
+        "visibility",
+        "ALTER TABLE sessions ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private'",
+    )
+}
+```
+
+- [ ] **Step 4: Update `SessionRecord`**
+
+Add fields to `SessionRecord` in `store.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionRecord {
+    pub id: String,
+    pub project_root: String,
+    pub harness: String,
+    pub title: String,
+    pub status: String,
+    pub exit_code: Option<i32>,
+    pub archived_at: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub conversation_id: Option<String>,
+    #[serde(default)]
+    pub labels: Vec<String>,
+    #[serde(default = "default_visibility")]
+    pub visibility: String,
+}
+
+fn default_visibility() -> String {
+    "private".to_string()
+}
+```
+
+Update any `INSERT`/`SELECT` for sessions in `store.rs` to read/write the new columns. Labels serialize as JSON array (`serde_json::to_string(&labels)`).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cargo test -p coven-cli store::tests`
+Expected: PASS. Existing tests should still work since both columns have safe defaults.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/coven-cli/src/store.rs
+git commit -S -m "feat(coven-cli): add labels and visibility columns to sessions"
+```
+
+### Task 2.2: Add FTS5 virtual table for events
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn search_events_finds_match_in_payload() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let conn = open_store(&temp.path().join("test.sqlite3"))?;
+    conn.execute(
+        "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+         VALUES('s1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+         VALUES('e1', 's1', 'stdout', '{\"text\":\"phoenix rises\"}', '2026-01-01')",
+        [],
+    )?;
+    let hits = search_events(&conn, "phoenix")?;
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].event_id, "e1");
+    assert_eq!(hits[0].session_id, "s1");
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Confirm FAIL**
+
+Run: `cargo test -p coven-cli store::tests::search_events_finds_match_in_payload`
+Expected: FAIL — `search_events` not defined.
+
+- [ ] **Step 3: Add FTS5 schema and trigger**
+
+In `open_store()`, append to the `execute_batch` schema string:
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
+    payload_json,
+    content='events',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS events_fts_insert AFTER INSERT ON events BEGIN
+    INSERT INTO events_fts(rowid, payload_json) VALUES (new.rowid, new.payload_json);
+END;
+
+CREATE TRIGGER IF NOT EXISTS events_fts_delete AFTER DELETE ON events BEGIN
+    INSERT INTO events_fts(events_fts, rowid, payload_json) VALUES('delete', old.rowid, old.payload_json);
+END;
+
+CREATE TRIGGER IF NOT EXISTS events_fts_update AFTER UPDATE ON events BEGIN
+    INSERT INTO events_fts(events_fts, rowid, payload_json) VALUES('delete', old.rowid, old.payload_json);
+    INSERT INTO events_fts(rowid, payload_json) VALUES (new.rowid, new.payload_json);
+END;
+```
+
+- [ ] **Step 4: Add `SearchHit` type and `search_events`**
+
+In `store.rs`:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SearchHit {
+    pub event_id: String,
+    pub session_id: String,
+    pub kind: String,
+    pub snippet: String,
+    pub created_at: String,
+}
+
+pub fn search_events(conn: &Connection, query: &str) -> Result<Vec<SearchHit>> {
+    let mut stmt = conn.prepare(
+        "SELECT e.id, e.session_id, e.kind, snippet(events_fts, 0, '[', ']', '…', 16), e.created_at
+         FROM events_fts
+         JOIN events e ON e.rowid = events_fts.rowid
+         WHERE events_fts MATCH ?1
+         ORDER BY e.created_at DESC
+         LIMIT 100",
+    )?;
+    let rows = stmt.query_map([query], |row| {
+        Ok(SearchHit {
+            event_id: row.get(0)?,
+            session_id: row.get(1)?,
+            kind: row.get(2)?,
+            snippet: row.get(3)?,
+            created_at: row.get(4)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 5: Backfill FTS for any pre-existing events**
+
+In `open_store()`, after FTS schema is in place:
+
+```rust
+// Backfill: copy any existing events into the FTS index. Safe on fresh dbs.
+conn.execute(
+    "INSERT INTO events_fts(rowid, payload_json)
+     SELECT e.rowid, e.payload_json
+     FROM events e
+     LEFT JOIN events_fts f ON f.rowid = e.rowid
+     WHERE f.rowid IS NULL",
+    [],
+)?;
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cargo test -p coven-cli store::tests`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/coven-cli/src/store.rs
+git commit -S -m "feat(coven-cli): FTS5 index over events.payload_json for thread search"
+```
+
+### Task 2.3: Add `latest_active_for_project` helper
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs`
+
+- [ ] **Step 1: Test first**
+
+```rust
+#[test]
+fn latest_active_returns_newest_non_archived_for_project() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let conn = open_store(&temp.path().join("test.sqlite3"))?;
+    conn.execute_batch(
+        "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+           VALUES ('older', '/p', 'codex', 't', 'created', '2026-01-01', '2026-01-01'),
+                  ('newer', '/p', 'claude', 't', 'created', '2026-01-02', '2026-01-02'),
+                  ('archived', '/p', 'claude', 't', 'created', '2026-01-03', '2026-01-03'),
+                  ('other_proj', '/other', 'claude', 't', 'created', '2026-01-04', '2026-01-04');
+         UPDATE sessions SET archived_at='2026-01-03' WHERE id='archived';",
+    )?;
+    let hit = latest_active_for_project(&conn, "/p")?;
+    assert_eq!(hit.as_deref(), Some("newer"));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+pub fn latest_active_for_project(conn: &Connection, project_root: &str) -> Result<Option<String>> {
+    let id: Option<String> = conn
+        .query_row(
+            "SELECT id FROM sessions
+             WHERE project_root = ?1 AND archived_at IS NULL
+             ORDER BY created_at DESC LIMIT 1",
+            params![project_root],
+            |row| row.get(0),
+        )
+        .or_else(|err| match err {
+            rusqlite::Error::QueryReturnedNoRows => Ok(None),
+            other => Err(other),
+        })?;
+    Ok(id)
+}
+```
+
+- [ ] **Step 3: Run tests, commit**
+
+Run: `cargo test -p coven-cli store::tests`
+Expected: PASS.
+
+```bash
+git add crates/coven-cli/src/store.rs
+git commit -S -m "feat(coven-cli): latest_active_for_project helper"
+```
+
+### Task 2.4: Add CLI flags to `Run`
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Extend the clap struct**
+
+In `main.rs`, replace the `Run` variant:
+
+```rust
+#[command(about = "Launch a project-scoped harness session")]
+Run {
+    #[arg(help = "Harness to run: codex or claude")]
+    harness: String,
+    #[arg(help = "Task for the harness", required = false, num_args = 0..)]
+    prompt: Vec<String>,
+    #[arg(long, help = "Working directory inside the current project")]
+    cwd: Option<PathBuf>,
+    #[arg(long, help = "Readable title for `coven sessions`")]
+    title: Option<String>,
+    #[arg(long, help = "Create the session record without launching the harness")]
+    detach: bool,
+    #[arg(
+        long,
+        value_name = "ID",
+        num_args = 0..=1,
+        default_missing_value = "",
+        help = "Resume session by id; omit value to resume latest active for this project"
+    )]
+    continue_session: Option<String>,
+    #[arg(long, value_delimiter = ',', help = "Comma-separated labels")]
+    labels: Vec<String>,
+    #[arg(
+        long,
+        value_parser = ["private", "workspace", "shared"],
+        help = "Session visibility (default: private)"
+    )]
+    visibility: Option<String>,
+    #[arg(long, help = "Archive the session after the run completes")]
+    archive: bool,
+},
+```
+
+Note clap will rename `continue_session` to `--continue-session` automatically. Override with an explicit `long`:
+
+```rust
+#[arg(long = "continue", value_name = "ID", num_args = 0..=1, default_missing_value = "")]
+continue_session: Option<String>,
+```
+
+- [ ] **Step 2: Update `run_session()` dispatcher**
+
+In the existing `Command::Run { ... } => run_session(...)` arm, plumb the new fields through. Resolve `--continue`:
+
+```rust
+let resume_id: Option<String> = match continue_session.as_deref() {
+    None => None,
+    Some("") => {
+        let conn = store::open_store(&store_path)?;
+        store::latest_active_for_project(&conn, project_root.to_str().unwrap_or(""))?
+    }
+    Some(id) => Some(id.to_string()),
+};
+```
+
+Pass `labels`, `visibility`, `archive`, and `resume_id` into the session creation path. The session writer should:
+- store labels as `serde_json::to_string(&labels)?` in the `labels` column,
+- store visibility as the provided value or `"private"`,
+- when `archive` is true, after the harness exits, update `sessions.archived_at = now`.
+
+- [ ] **Step 3: Build and smoke test**
+
+Run: `cargo build -p coven-cli`
+Then a real run (with claude installed):
+
+```bash
+cargo run -p coven-cli -- run claude --labels demo,p0 --visibility workspace --archive "ping"
+cargo run -p coven-cli -- sessions --all --json | head
+```
+
+Expected: the new row shows `"labels":["demo","p0"]`, `"visibility":"workspace"`, and `archived_at` is set.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): add --continue/--labels/--visibility/--archive to run"
+```
+
+### Task 2.5: Add `coven sessions search` subcommand
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Extend clap**
+
+Replace the `Sessions` variant in `Command`:
+
+```rust
+#[command(about = "List/search recent Coven sessions")]
+Sessions {
+    #[command(subcommand)]
+    command: Option<SessionsCommand>,
+    #[arg(long, help = "Include archived sessions")]
+    all: bool,
+    #[arg(long, conflicts_with_all = ["plain", "json"])]
+    manage: bool,
+    #[arg(long, conflicts_with_all = ["manage", "json"])]
+    plain: bool,
+    #[arg(long, conflicts_with_all = ["manage", "plain"])]
+    json: bool,
+},
+```
+
+And add:
+
+```rust
+#[derive(Subcommand, Debug)]
+enum SessionsCommand {
+    #[command(about = "Full-text search session event payloads")]
+    Search {
+        #[arg(help = "FTS5 query (e.g. `phoenix OR rises`)")]
+        query: String,
+        #[arg(long, help = "Print JSON for clients")]
+        json: bool,
+    },
+}
+```
+
+- [ ] **Step 2: Dispatch**
+
+In the `Command::Sessions { command, .. }` arm, branch on `command`:
+
+```rust
+match command {
+    Some(SessionsCommand::Search { query, json }) => {
+        let conn = store::open_store(&store_path)?;
+        let hits = store::search_events(&conn, &query)?;
+        if json {
+            println!("{}", serde_json::to_string(&hits)?);
+        } else {
+            for hit in &hits {
+                println!(
+                    "{}  {}  [{}]  {}",
+                    hit.created_at, hit.session_id, hit.kind, hit.snippet
+                );
+            }
+        }
+        Ok(())
+    }
+    None => existing_sessions_list_path(all, manage, plain, json),
+}
+```
+
+- [ ] **Step 3: Smoke test**
+
+Run: `cargo run -p coven-cli -- sessions search "phoenix"`
+Expected: empty results on a fresh db; no error.
+
+Then after creating a session with the word "phoenix" in its prompt, re-run:
+Expected: at least one hit prints.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): coven sessions search <query>"
+```
+
+### Task 2.6: Document thread upgrades
+
+**Files:**
+- Modify: `docs/SESSION-LIFECYCLE.md` (existing)
+
+- [ ] **Step 1: Append a section**
+
+Add to the end of `docs/SESSION-LIFECYCLE.md`:
+
+```markdown
+## Search and continuation (added in 2026-05)
+
+- `coven sessions search <query>` runs a SQLite FTS5 query over redacted event payloads.
+  Encrypted raw artifacts are never decrypted during search.
+- `coven run <harness> --continue` resumes the most recently created, non-archived
+  session whose `project_root` matches the current directory.
+- `coven run <harness> --continue <ID>` resumes by id.
+- `coven run <harness> --labels foo,bar --visibility workspace --archive "task"` tags
+  and archives a one-shot run in a single command.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/SESSION-LIFECYCLE.md
+git commit -S -m "docs(coven-cli): document search, --continue, --labels, --visibility, --archive"
+```
+
+**Phase 2 milestone:** thread upgrades ship. Run `cargo test -p coven-cli` — all green. Can land independently.
+
+---
+
+## Phase 3 — File references in prompts
+
+**Outcome:** Prompts can include `@README.md`, `@docs/*.md`, `@T-<id>`, `@@search words`. Text expands inline up to caps; images become content blocks in stream-JSON mode and placeholders otherwise.
+
+### Task 3.1: Add `globset` dependency
+
+**Files:**
+- Modify: `crates/coven-cli/Cargo.toml`
+
+- [ ] **Step 1: Add dep**
+
+```toml
+globset = "0.4"
+```
+
+- [ ] **Step 2: Build and commit**
+
+Run: `cargo build -p coven-cli`
+
+```bash
+git add crates/coven-cli/Cargo.toml crates/coven-cli/Cargo.lock
+git commit -S -m "deps(coven-cli): add globset for prompt @path globbing"
+```
+
+### Task 3.2: Define ref parser and types
+
+**Files:**
+- Create: `crates/coven-cli/src/prompt_refs.rs`
+- Modify: `crates/coven-cli/src/main.rs` (declare module)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+// crates/coven-cli/src/prompt_refs.rs
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+pub const MAX_TEXT_LINES: usize = 500;
+pub const MAX_LINE_CHARS: usize = 2048;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Ref {
+    /// `@path/to/file` or `@glob/*.md`
+    Path(String),
+    /// `@T-<uuid>` — thread id reference
+    Thread(String),
+    /// `@@search words` — FTS query
+    Search(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedPrompt {
+    pub raw: String,
+    pub refs: Vec<Ref>,
+}
+
+pub fn parse(prompt: &str) -> ParsedPrompt {
+    let mut refs = Vec::new();
+    // double-@ for search comes first so single-@ doesn't swallow it
+    let mut i = 0;
+    let bytes = prompt.as_bytes();
+    while i < bytes.len() {
+        if bytes[i] == b'@' {
+            if i + 1 < bytes.len() && bytes[i + 1] == b'@' {
+                // @@search words — runs to end-of-line
+                let end = prompt[i..].find('\n').map(|n| i + n).unwrap_or(prompt.len());
+                let body = &prompt[i + 2..end];
+                if !body.trim().is_empty() {
+                    refs.push(Ref::Search(body.trim().to_string()));
+                }
+                i = end;
+                continue;
+            }
+            // single @ — runs to next whitespace
+            let end = prompt[i + 1..]
+                .find(|c: char| c.is_whitespace())
+                .map(|n| i + 1 + n)
+                .unwrap_or(prompt.len());
+            let body = &prompt[i + 1..end];
+            if let Some(rest) = body.strip_prefix("T-") {
+                refs.push(Ref::Thread(format!("T-{rest}")));
+            } else if !body.is_empty() {
+                refs.push(Ref::Path(body.to_string()));
+            }
+            i = end;
+            continue;
+        }
+        i += 1;
+    }
+    ParsedPrompt {
+        raw: prompt.to_string(),
+        refs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_path_refs() {
+        let p = parse("look at @README.md and @docs/*.md please");
+        assert_eq!(
+            p.refs,
+            vec![
+                Ref::Path("README.md".into()),
+                Ref::Path("docs/*.md".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_thread_ref() {
+        let p = parse("continue @T-abc-123 with new ideas");
+        assert_eq!(p.refs, vec![Ref::Thread("T-abc-123".into())]);
+    }
+
+    #[test]
+    fn parses_search_ref_to_end_of_line() {
+        let p = parse("background:\n@@phoenix rises again\ndo the thing");
+        assert_eq!(p.refs, vec![Ref::Search("phoenix rises again".into())]);
+    }
+
+    #[test]
+    fn ignores_bare_at_sign() {
+        let p = parse("email me at @ work");
+        // "@" with nothing after is dropped; "work" never starts with @
+        assert!(p.refs.is_empty() || p.refs == vec![Ref::Path("".into())]);
+    }
+}
+```
+
+In `main.rs`:
+
+```rust
+mod prompt_refs;
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cargo test -p coven-cli prompt_refs::tests`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/coven-cli/src/prompt_refs.rs crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): parse @path / @T-id / @@search refs from prompts"
+```
+
+### Task 3.3: Expand path refs (text + image classification)
+
+**Files:**
+- Modify: `crates/coven-cli/src/prompt_refs.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn expand_path_inlines_text_file_capped() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("hello.md");
+    std::fs::write(&path, "line1\nline2\nline3\n").unwrap();
+    let expanded = expand_path(temp.path(), "hello.md").unwrap();
+    assert!(expanded.contains("line1"));
+    assert!(expanded.contains("line3"));
+    assert!(expanded.contains("hello.md"));
+}
+
+#[test]
+fn expand_path_image_becomes_placeholder() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("pic.png");
+    std::fs::write(&path, b"\x89PNG\r\n\x1a\nfake").unwrap();
+    let expanded = expand_path(temp.path(), "pic.png").unwrap();
+    assert!(expanded.contains("[image @ "));
+    assert!(expanded.contains("image/png"));
+}
+```
+
+- [ ] **Step 2: Run to confirm FAIL**
+
+Run: `cargo test -p coven-cli prompt_refs::tests::expand_path_inlines_text_file_capped`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```rust
+pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
+    let full = cwd.join(raw);
+    if !full.exists() {
+        return Ok(format!("[missing @{raw}]"));
+    }
+    let mime = guess_mime(&full);
+    if mime.starts_with("image/") {
+        let bytes = std::fs::metadata(&full)?.len();
+        return Ok(format!(
+            "[image @ {}: {mime}, {bytes} bytes]",
+            full.display()
+        ));
+    }
+    let raw_text = std::fs::read_to_string(&full)?;
+    let mut out = String::new();
+    out.push_str(&format!("--- @{raw} ---\n"));
+    for (i, line) in raw_text.lines().take(MAX_TEXT_LINES).enumerate() {
+        let truncated: String = line.chars().take(MAX_LINE_CHARS).collect();
+        out.push_str(&truncated);
+        out.push('\n');
+        if i + 1 == MAX_TEXT_LINES {
+            out.push_str(&format!("[…truncated at {MAX_TEXT_LINES} lines]\n"));
+            break;
+        }
+    }
+    out.push_str("--- end ---\n");
+    Ok(out)
+}
+
+fn guess_mime(path: &Path) -> String {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("png") => "image/png".into(),
+        Some("jpg") | Some("jpeg") => "image/jpeg".into(),
+        Some("gif") => "image/gif".into(),
+        Some("webp") => "image/webp".into(),
+        _ => "text/plain".into(),
+    }
+}
+```
+
+- [ ] **Step 4: Tests pass; commit**
+
+```bash
+git add crates/coven-cli/src/prompt_refs.rs
+git commit -S -m "feat(coven-cli): expand @path with text/image classification and caps"
+```
+
+### Task 3.4: Expand glob path refs
+
+**Files:**
+- Modify: `crates/coven-cli/src/prompt_refs.rs`
+
+- [ ] **Step 1: Test first**
+
+```rust
+#[test]
+fn expand_glob_includes_all_matches() {
+    let temp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(temp.path().join("docs")).unwrap();
+    std::fs::write(temp.path().join("docs/a.md"), "AAA").unwrap();
+    std::fs::write(temp.path().join("docs/b.md"), "BBB").unwrap();
+    let expanded = expand_path(temp.path(), "docs/*.md").unwrap();
+    assert!(expanded.contains("AAA"));
+    assert!(expanded.contains("BBB"));
+}
+```
+
+- [ ] **Step 2: Confirm FAIL**
+
+Expected: current `expand_path` treats `docs/*.md` literally and reports missing.
+
+- [ ] **Step 3: Branch on glob characters**
+
+Update `expand_path` near the top:
+
+```rust
+pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
+    if raw.contains('*') || raw.contains('?') || raw.contains('[') {
+        return expand_glob(cwd, raw);
+    }
+    // ... existing single-path body ...
+}
+
+fn expand_glob(cwd: &Path, pattern: &str) -> Result<String> {
+    use globset::{Glob, GlobSetBuilder};
+    let mut builder = GlobSetBuilder::new();
+    builder.add(Glob::new(pattern)?);
+    let set = builder.build()?;
+    let mut out = String::new();
+    let mut count = 0;
+    for entry in walkdir(cwd) {
+        let rel = entry.strip_prefix(cwd).unwrap_or(&entry);
+        if !set.is_match(rel) {
+            continue;
+        }
+        let part = expand_path(cwd, &rel.to_string_lossy())?;
+        out.push_str(&part);
+        out.push('\n');
+        count += 1;
+        if count >= 20 {
+            out.push_str("[…glob match cap reached at 20 files]\n");
+            break;
+        }
+    }
+    if count == 0 {
+        return Ok(format!("[no matches for @{pattern}]"));
+    }
+    Ok(out)
+}
+
+fn walkdir(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().and_then(|s| s.to_str()) == Some(".git") {
+                    continue;
+                }
+                stack.push(path);
+            } else {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cargo test -p coven-cli prompt_refs::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/prompt_refs.rs
+git commit -S -m "feat(coven-cli): expand glob refs in prompts (capped at 20 matches)"
+```
+
+### Task 3.5: Expand `@T-<id>` thread refs
+
+**Files:**
+- Modify: `crates/coven-cli/src/prompt_refs.rs`
+
+- [ ] **Step 1: Test**
+
+```rust
+#[test]
+fn expand_thread_inlines_redacted_payloads() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let conn = crate::store::open_store(&temp.path().join("test.sqlite3"))?;
+    conn.execute(
+        "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+         VALUES('T-abc', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+        [],
+    )?;
+    conn.execute(
+        "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+         VALUES('e1', 'T-abc', 'user', '{\"text\":\"hello world\"}', '2026-01-01')",
+        [],
+    )?;
+    let out = expand_thread(&conn, "T-abc")?;
+    assert!(out.contains("hello world"));
+    assert!(out.contains("T-abc"));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Implement**
+
+```rust
+pub fn expand_thread(conn: &rusqlite::Connection, id: &str) -> Result<String> {
+    let mut stmt = conn.prepare(
+        "SELECT kind, payload_json, created_at FROM events
+         WHERE session_id = ?1 ORDER BY created_at ASC LIMIT 200",
+    )?;
+    let rows = stmt.query_map([id], |row| {
+        Ok((
+            row.get::<_, String>(0)?,
+            row.get::<_, String>(1)?,
+            row.get::<_, String>(2)?,
+        ))
+    })?;
+    let mut out = format!("--- @{id} ---\n");
+    let mut found = false;
+    for r in rows {
+        let (kind, payload, ts) = r?;
+        found = true;
+        out.push_str(&format!("[{ts}] {kind}: {payload}\n"));
+    }
+    out.push_str("--- end ---\n");
+    if !found {
+        return Ok(format!("[no events for @{id}]"));
+    }
+    Ok(out)
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/coven-cli/src/prompt_refs.rs
+git commit -S -m "feat(coven-cli): expand @T-<id> refs from the local session ledger"
+```
+
+### Task 3.6: Wire ref expansion into `coven run`
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Add `expand_all`**
+
+In `prompt_refs.rs`:
+
+```rust
+pub fn expand_all(
+    cwd: &Path,
+    conn: &rusqlite::Connection,
+    prompt: &str,
+) -> Result<String> {
+    let parsed = parse(prompt);
+    if parsed.refs.is_empty() {
+        return Ok(prompt.to_string());
+    }
+    let mut prefix = String::new();
+    for r in &parsed.refs {
+        let block = match r {
+            Ref::Path(p) => expand_path(cwd, p)?,
+            Ref::Thread(id) => expand_thread(conn, id)?,
+            Ref::Search(q) => {
+                let hits = crate::store::search_events(conn, q)?;
+                let mut s = format!("--- @@{q} ---\n");
+                for hit in hits.into_iter().take(5) {
+                    s.push_str(&format!(
+                        "[{}] {} {} {}\n",
+                        hit.created_at, hit.session_id, hit.kind, hit.snippet
+                    ));
+                }
+                s.push_str("--- end ---\n");
+                s
+            }
+        };
+        prefix.push_str(&block);
+    }
+    Ok(format!("{prefix}\n{prompt}"))
+}
+```
+
+- [ ] **Step 2: Call from `Run`**
+
+In `main.rs`, in the `Command::Run { .. }` arm, **before** sending the joined prompt to the harness:
+
+```rust
+let joined = prompt.join(" ");
+let conn = store::open_store(&store_path)?;
+let final_prompt = prompt_refs::expand_all(&cwd.clone().unwrap_or_else(|| std::env::current_dir().unwrap()), &conn, &joined)?;
+```
+
+Use `final_prompt` from that point on.
+
+- [ ] **Step 3: Smoke test**
+
+```bash
+echo "explain @README.md briefly" | cargo run -p coven-cli -- run claude
+```
+
+Expected: claude receives the file contents inlined and explains them. If running without claude installed, mock by replacing the harness invocation with a `cat`-style stub during testing — verify `final_prompt` contains the file content.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/prompt_refs.rs crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): expand prompt refs before dispatching to harness"
+```
+
+### Task 3.7: Document refs
+
+**Files:**
+- Create: `docs/PROMPT-REFERENCES.md`
+
+- [ ] **Step 1: Write**
+
+```markdown
+# Prompt References
+
+Coven expands four kinds of references in prompts before sending them to a harness.
+
+## `@path/to/file`
+Inlines a text file relative to the invocation directory. Capped at 500 lines × 2048 chars/line.
+
+## `@glob/*.ext`
+Expands a glob. Up to 20 matching files are inlined; the rest are noted as truncated.
+
+## `@T-<session-id>`
+Inlines the redacted event payloads of a prior session (up to 200 events).
+
+## `@@search words`
+Runs a SQLite FTS5 query over local session payloads. Up to 5 hits are inlined with snippets.
+
+## Image references
+`.png`, `.jpg`, `.gif`, `.webp` files become placeholders in plain mode and image content blocks
+in `--stream-json` mode.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/PROMPT-REFERENCES.md
+git commit -S -m "docs(coven-cli): document @path / @T-id / @@search references"
+```
+
+**Phase 3 milestone:** prompt refs ship. `cargo test -p coven-cli` green. Independent landing OK.
+
+---
+
+## Phase 4 — Stream-JSON I/O protocol
+
+**Outcome:** `coven run claude --stream-json` emits the documented JSONL contract on stdout; `--stream-json-input` reads user messages as JSONL from stdin. Same shape Coven Code uses.
+
+### Task 4.1: Define event types
+
+**Files:**
+- Create: `crates/coven-cli/src/stream_json.rs`
+- Modify: `crates/coven-cli/src/main.rs` (declare module)
+
+- [ ] **Step 1: Write the types and tests**
+
+```rust
+// crates/coven-cli/src/stream_json.rs
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::io::{BufRead, Write};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Event {
+    System(System),
+    User(UserMessage),
+    Assistant(AssistantMessage),
+    ToolResult(ToolResult),
+    Result(RunResult),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct System {
+    pub subtype: String,
+    pub cwd: String,
+    pub session_id: String,
+    pub tools: Vec<String>,
+    pub agent_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserMessage {
+    pub message: MessageBody,
+    pub session_id: String,
+    pub parent_tool_use_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AssistantMessage {
+    pub message: MessageBody,
+    pub session_id: String,
+    pub stop_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageBody {
+    pub role: String,
+    pub content: Vec<ContentBlock>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlock {
+    Text { text: String },
+    Image { source: ImageSource },
+    ToolUse { id: String, name: String, input: serde_json::Value },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ImageSource {
+    Base64 { media_type: String, data: String },
+    Path { path: String, media_type: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolResult {
+    pub tool_use_id: String,
+    pub content: Vec<ContentBlock>,
+    pub is_error: bool,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunResult {
+    pub subtype: String,
+    pub duration_ms: u64,
+    pub is_error: bool,
+    pub num_turns: u32,
+    pub session_id: String,
+    pub error: Option<String>,
+}
+
+pub fn emit_event<W: Write>(writer: &mut W, event: &Event) -> Result<()> {
+    serde_json::to_writer(&mut *writer, event)?;
+    writer.write_all(b"\n")?;
+    writer.flush()?;
+    Ok(())
+}
+
+pub fn read_event<R: BufRead>(reader: &mut R) -> Result<Option<Event>> {
+    let mut line = String::new();
+    let n = reader.read_line(&mut line)?;
+    if n == 0 {
+        return Ok(None);
+    }
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(serde_json::from_str(trimmed)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn round_trip_user_message() {
+        let event = Event::User(UserMessage {
+            message: MessageBody {
+                role: "user".into(),
+                content: vec![ContentBlock::Text {
+                    text: "hello".into(),
+                }],
+            },
+            session_id: "s1".into(),
+            parent_tool_use_id: None,
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded = read_event(&mut reader).unwrap().unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn json_shape_matches_coven_code() {
+        let event = Event::Result(RunResult {
+            subtype: "success".into(),
+            duration_ms: 12,
+            is_error: false,
+            num_turns: 1,
+            session_id: "s1".into(),
+            error: None,
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let line = String::from_utf8(buf).unwrap();
+        let v: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(v["type"], "result");
+        assert_eq!(v["subtype"], "success");
+        assert_eq!(v["is_error"], false);
+        assert_eq!(v["num_turns"], 1);
+    }
+}
+```
+
+- [ ] **Step 2: Module declaration**
+
+In `main.rs`:
+
+```rust
+mod stream_json;
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cargo test -p coven-cli stream_json::tests`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/stream_json.rs crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): stream-JSON event types matching Coven Code schema"
+```
+
+### Task 4.2: Add `--stream-json` and `--stream-json-input` flags
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Extend `Run` again**
+
+Add to the `Run` clap struct (additions in **bold** if you're diffing — here just the new fields):
+
+```rust
+#[arg(long, help = "Emit JSONL events on stdout (init/user/assistant/tool_result/result)")]
+stream_json: bool,
+#[arg(long, requires = "stream_json", help = "Read JSONL user messages from stdin")]
+stream_json_input: bool,
+```
+
+- [ ] **Step 2: Build, no tests yet**
+
+Run: `cargo build -p coven-cli`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs
+git commit -S -m "feat(coven-cli): add --stream-json and --stream-json-input flags to run"
+```
+
+### Task 4.3: Emit `system.init` + `user` + `result` for non-stream harness (codex)
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/coven-cli/tests/stream_json_integration.rs` (cargo picks up `tests/` automatically):
+
+```rust
+use std::process::{Command, Stdio};
+
+#[test]
+#[ignore = "requires real harness invocation; run with `cargo test -- --ignored`"]
+fn stream_json_emits_init_and_result_for_codex_dry_run() {
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--stream-json", "--detach", "ping"])
+        .stdout(Stdio::piped())
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let mut lines = stdout.lines();
+    let first: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+    assert_eq!(first["type"], "system");
+    assert_eq!(first["subtype"], "init");
+    let last_line = stdout.lines().last().unwrap();
+    let last: serde_json::Value = serde_json::from_str(last_line).unwrap();
+    assert_eq!(last["type"], "result");
+}
+```
+
+- [ ] **Step 2: Implement around `run_session`**
+
+In `main.rs`, in the `Command::Run { stream_json, .. }` arm, when `stream_json` is true and the harness is `codex` (or any non-stream harness):
+
+```rust
+use crate::stream_json::{emit_event, Event, System, UserMessage, MessageBody, ContentBlock, RunResult};
+use std::io::{stdout, BufWriter};
+
+if stream_json {
+    let mut out = BufWriter::new(stdout().lock());
+    let started = std::time::Instant::now();
+    emit_event(&mut out, &Event::System(System {
+        subtype: "init".into(),
+        cwd: cwd_resolved.to_string_lossy().to_string(),
+        session_id: session_id.clone(),
+        tools: vec![],
+        agent_mode: None,
+    }))?;
+    emit_event(&mut out, &Event::User(UserMessage {
+        message: MessageBody {
+            role: "user".into(),
+            content: vec![ContentBlock::Text { text: final_prompt.clone() }],
+        },
+        session_id: session_id.clone(),
+        parent_tool_use_id: None,
+    }))?;
+
+    let exit_code = launch_harness_and_wait(...)?; // existing path
+
+    let is_error = exit_code != 0;
+    emit_event(&mut out, &Event::Result(RunResult {
+        subtype: if is_error { "error_during_execution".into() } else { "success".into() },
+        duration_ms: started.elapsed().as_millis() as u64,
+        is_error,
+        num_turns: 1,
+        session_id,
+        error: None,
+    }))?;
+    return Ok(());
+}
+```
+
+- [ ] **Step 3: Run the integration test**
+
+Run: `cargo test -p coven-cli --test stream_json_integration -- --ignored`
+Expected: PASS (the `--detach` path avoids actually invoking codex, so this works on machines without codex installed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs crates/coven-cli/tests/stream_json_integration.rs
+git commit -S -m "feat(coven-cli): emit stream-JSON init/user/result for one-shot runs"
+```
+
+### Task 4.4: Wrap claude's native stream-json mode
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+- Modify: `crates/coven-cli/src/pty_runner.rs`
+
+- [ ] **Step 1: For claude stream mode, pass-through with re-emission**
+
+When `harness == "claude"` and `stream_json` is true:
+- Launch claude with its native flags: `claude -p --input-format stream-json --output-format stream-json --verbose`.
+- For each newline-delimited JSON event claude emits, parse with `serde_json::from_str::<serde_json::Value>` and re-emit on our stdout untouched (claude's schema already matches ours by design).
+- Emit our own `system.init` at start and our own `result` at end, since claude's framing differs slightly.
+
+Sketch in `main.rs`:
+
+```rust
+if stream_json && harness == "claude" {
+    let mut out = BufWriter::new(stdout().lock());
+    let started = std::time::Instant::now();
+    emit_event(&mut out, &Event::System(System {
+        subtype: "init".into(),
+        cwd: cwd_resolved.to_string_lossy().to_string(),
+        session_id: session_id.clone(),
+        tools: vec![],
+        agent_mode: None,
+    }))?;
+    let exit_code = stream_claude(
+        &cwd_resolved,
+        &session_id,
+        &final_prompt,
+        stream_json_input,
+        &mut out,
+    )?;
+    let is_error = exit_code != 0;
+    emit_event(&mut out, &Event::Result(RunResult {
+        subtype: if is_error { "error_during_execution".into() } else { "success".into() },
+        duration_ms: started.elapsed().as_millis() as u64,
+        is_error,
+        num_turns: 1,
+        session_id,
+        error: None,
+    }))?;
+    return Ok(());
+}
+```
+
+- [ ] **Step 2: Implement `stream_claude` in `pty_runner.rs`**
+
+Add a function that:
+- Spawns claude with the stream-json args.
+- Pipes our stdin (if `stream_json_input`) directly to claude's stdin.
+- Copies claude's stdout line-by-line to our stdout writer (no rewriting).
+- Returns claude's exit code.
+
+```rust
+pub fn stream_claude<W: std::io::Write>(
+    cwd: &std::path::Path,
+    session_id: &str,
+    prompt: &str,
+    forward_stdin: bool,
+    out: &mut W,
+) -> anyhow::Result<i32> {
+    use std::io::{BufRead, BufReader, Write};
+    use std::process::{Command, Stdio};
+
+    let mut child = Command::new("claude")
+        .args([
+            "-p",
+            "--input-format", "stream-json",
+            "--output-format", "stream-json",
+            "--verbose",
+            "--session-id", session_id,
+        ])
+        .arg(prompt)
+        .current_dir(cwd)
+        .stdin(if forward_stdin { Stdio::piped() } else { Stdio::null() })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()?;
+
+    if forward_stdin {
+        let mut child_stdin = child.stdin.take().expect("piped stdin");
+        let stdin = std::io::stdin();
+        std::thread::spawn(move || {
+            let mut buf = String::new();
+            let mut lock = stdin.lock();
+            while lock.read_line(&mut buf).unwrap_or(0) > 0 {
+                if child_stdin.write_all(buf.as_bytes()).is_err() {
+                    break;
+                }
+                buf.clear();
+            }
+        });
+    }
+
+    let child_stdout = child.stdout.take().expect("piped stdout");
+    let reader = BufReader::new(child_stdout);
+    for line in reader.lines() {
+        let line = line?;
+        if line.trim().is_empty() { continue; }
+        writeln!(out, "{line}")?;
+        out.flush()?;
+    }
+
+    let status = child.wait()?;
+    Ok(status.code().unwrap_or(1))
+}
+```
+
+- [ ] **Step 3: Smoke test (manual; requires claude installed)**
+
+```bash
+cargo run -p coven-cli -- run claude --stream-json "what is 2+2"
+```
+
+Expected: JSONL on stdout starting with `{"type":"system","subtype":"init",...}`, claude's events in the middle, ending with `{"type":"result",...}`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs crates/coven-cli/src/pty_runner.rs
+git commit -S -m "feat(coven-cli): stream-JSON pass-through for claude with init/result framing"
+```
+
+### Task 4.5: Document the protocol
+
+**Files:**
+- Create: `docs/STREAM-JSON.md`
+
+- [ ] **Step 1: Write the doc**
+
+```markdown
+# Coven CLI Stream-JSON Protocol
+
+`coven run <harness> --stream-json` emits newline-delimited JSON events on stdout.
+With `--stream-json-input`, user messages are read line-by-line from stdin as JSON.
+
+The schema matches `@opencoven/coven-code` exactly; SDKs that target Coven Code work
+unchanged against Coven CLI.
+
+## Event types
+
+### `system` — emitted once at startup
+```json
+{"type":"system","subtype":"init","cwd":"/path","session_id":"...","tools":[],"agent_mode":null}
+```
+
+### `user` — emitted for each user message
+```json
+{"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]},"session_id":"...","parent_tool_use_id":null}
+```
+
+### `assistant` — emitted by stream-capable harnesses (claude)
+```json
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"..."}]},"session_id":"...","stop_reason":"end_turn"}
+```
+
+### `tool_result` — emitted by stream-capable harnesses
+```json
+{"type":"tool_result","tool_use_id":"...","content":[{"type":"text","text":"..."}],"is_error":false,"session_id":"..."}
+```
+
+### `result` — emitted once at end
+```json
+{"type":"result","subtype":"success","duration_ms":1234,"is_error":false,"num_turns":1,"session_id":"...","error":null}
+```
+
+## Stdin protocol (`--stream-json-input`)
+
+Each line is one JSON object with the same shape as the `user` event's `message` field:
+
+```json
+{"role":"user","content":[{"type":"text","text":"hello"}]}
+```
+
+`image` content blocks use `source.type = "path"` (local file) or `source.type = "base64"` (inline).
+
+## Harness behavior
+
+- **claude**: passes through claude's native stream-json events, framed by Coven's `system` and `result`.
+- **codex** and other non-stream harnesses: Coven synthesizes `system.init` + `user` + `result`. The harness's text output is not exposed as `assistant` events in this mode (use `coven attach <id>` for streamed text).
+
+## Stability
+
+This is a stable interface as of 2026-05. Additions are additive (new event types, new fields). Removals require a major version bump of the CLI.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/STREAM-JSON.md
+git commit -S -m "docs(coven-cli): stable stream-JSON protocol spec"
+```
+
+**Phase 4 milestone:** stream-JSON ships. `cargo test -p coven-cli` green; manual smoke with claude verified. Tag a release.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- P0 #1 (stream-JSON + `--stream-json-input`) → Phase 4 ✓
+- P0 #2 (file references `@path`, `@T-id`, `@@search`, image inlining) → Phase 3 ✓
+- P0 #3 (unified JSONC settings, user→workspace→managed precedence, replacing TOML files) → Phase 1 ✓ (note: workspace tier deferred to a follow-up plan; the precedence machinery lands here as user→legacy-TOML→env, which is enough to ship; workspace `.coven/settings.json` is a P0.5 add-on)
+- P0 #4 (search, `--labels`, `--visibility`, `--continue [id]`, `--archive`) → Phase 2 ✓
+
+**Gap noted:** Phase 1 does not yet implement the `workspace > user` precedence layer (`.coven/settings.json` per-project file). The schema and loader are designed for it but the lookup is single-source. Add a follow-up task in Phase 1.5 if you want full parity now; otherwise punt to a separate plan. Adding now would mean: in Task 1.6, also probe `find_workspace_settings(cwd)` and shallow-merge over the user settings.
+
+**Placeholders check:** No "TBD", "implement later", "similar to Task N" found. Every code block is concrete. The only conditional language is the "fix the structure mismatch" line in Task 1.2 — that's fine since serde does the heavy lifting and the test code defines the exact target shape.
+
+**Type consistency:**
+- `Settings` shape consistent across Tasks 1.2, 1.3, 1.4, 1.5, 1.6. ✓
+- `SessionRecord` extended in 2.1 with `labels: Vec<String>` and `visibility: String`, consistent with usage in 2.4. ✓
+- `Event` enum from 4.1 used unchanged in 4.3 and 4.4. ✓
+- `latest_active_for_project(conn, project_root: &str) -> Result<Option<String>>` defined in 2.3, called the same way in 2.4. ✓
+- Function name `expand_path` consistent in 3.3, 3.4. `expand_thread`, `expand_all` consistent in 3.5, 3.6. ✓
+
+**Commit hygiene:** Every commit uses `-S` per CLAUDE.md. Conventional-commit prefixes (`feat`, `docs`, `deps`) match the repo's existing commit log style (verify with `git log` in the coven repo if uncertain).
+
+**Plan complete.**


### PR DESCRIPTION
## Summary
- Phase 1: add canonical JSONC settings with legacy TOML fallback/override handling.
- Phase 2: add session/thread metadata upgrades, continuation, labels, visibility, archive/summon/sacrifice flows, and FTS-backed session search.
- Phase 3: expand prompt refs for @path, @T-<id>, and @@search with capped file/glob handling.
- Phase 4: add Coven Code-compatible stream-JSON event types, one-shot framing, claude native stream-json passthrough, focused tests, and docs/STREAM-JSON.md.

## Verification
- cargo test -p coven-cli
- cargo build -p coven-cli --bin coven
- cargo test -p coven-cli -- --ignored
- git diff --check origin/feat/p0-coven-code-parity..HEAD