### PR TITLE
Harden daemon: fail closed on symlinked COVEN_HOME and non-socket socket path

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use std::io::{BufRead, BufReader, Read};
 #[cfg(unix)]
 use std::os::unix::{
-    fs::PermissionsExt,
+    fs::{FileTypeExt, PermissionsExt},
     net::{UnixListener, UnixStream},
 };
 
@@ -467,6 +467,18 @@ pub fn daemon_socket_path(coven_home: &Path) -> PathBuf {
 
 #[cfg(unix)]
 fn ensure_private_coven_home(coven_home: &Path) -> Result<()> {
+    // Fail closed if the home already exists as a symlink: following it would
+    // let anyone able to plant the link redirect daemon state (socket, status,
+    // SQLite ledger) outside the trusted directory. See docs/AUTH.md
+    // "Current hardening gap".
+    if let Ok(metadata) = std::fs::symlink_metadata(coven_home) {
+        if metadata.file_type().is_symlink() {
+            anyhow::bail!(
+                "refusing to use Coven home {}: path is a symlink",
+                coven_home.display()
+            );
+        }
+    }
     std::fs::create_dir_all(coven_home)
         .with_context(|| format!("failed to create Coven home {}", coven_home.display()))?;
     std::fs::set_permissions(coven_home, std::fs::Permissions::from_mode(0o700)).with_context(
@@ -957,9 +969,34 @@ pub fn serve_next_tcp_connection(
 pub fn bind_api_socket(coven_home: &Path) -> Result<UnixListener> {
     ensure_private_coven_home(coven_home)?;
     let socket_path = daemon_socket_path(coven_home);
-    if socket_path.exists() {
-        std::fs::remove_file(&socket_path)
-            .with_context(|| format!("failed to remove stale socket {}", socket_path.display()))?;
+    // Only ever replace a genuine, non-symlink socket. Blindly removing
+    // whatever sits at the path would follow an attacker-planted symlink or
+    // delete an unrelated file. See docs/AUTH.md "Current hardening gap".
+    match std::fs::symlink_metadata(&socket_path) {
+        Ok(metadata) => {
+            let file_type = metadata.file_type();
+            if file_type.is_symlink() {
+                anyhow::bail!(
+                    "refusing to bind Coven API socket {}: path is a symlink",
+                    socket_path.display()
+                );
+            }
+            if !file_type.is_socket() {
+                anyhow::bail!(
+                    "refusing to bind Coven API socket {}: path exists and is not a socket",
+                    socket_path.display()
+                );
+            }
+            std::fs::remove_file(&socket_path).with_context(|| {
+                format!("failed to remove stale socket {}", socket_path.display())
+            })?;
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("failed to inspect socket path {}", socket_path.display())
+            });
+        }
     }
     let listener = UnixListener::bind(&socket_path)
         .with_context(|| format!("failed to bind Coven API socket {}", socket_path.display()))?;
@@ -1571,6 +1608,65 @@ mod tests {
 
         let home_mode = std::fs::metadata(temp_dir.path())?.permissions().mode() & 0o777;
         assert_eq!(home_mode, 0o700);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_private_coven_home_rejects_symlinked_home() -> Result<()> {
+        use std::os::unix::fs::symlink;
+        let temp_dir = tempfile::tempdir()?;
+        let target = temp_dir.path().join("real-home");
+        std::fs::create_dir(&target)?;
+        let link = temp_dir.path().join("link-home");
+        symlink(&target, &link)?;
+
+        let error = ensure_private_coven_home(&link)
+            .expect_err("a symlinked Coven home must be refused (AUTH.md fail-closed)");
+        assert!(
+            error.to_string().contains("symlink"),
+            "error should name the symlink cause, got: {error}"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_api_socket_refuses_symlinked_socket_path() -> Result<()> {
+        use std::os::unix::fs::symlink;
+        let temp_dir = tempfile::tempdir()?;
+        // Plant a symlink (to a real file) where the socket should be created.
+        let decoy = temp_dir.path().join("decoy");
+        std::fs::write(&decoy, b"x")?;
+        symlink(&decoy, daemon_socket_path(temp_dir.path()))?;
+
+        let error = bind_api_socket(temp_dir.path())
+            .expect_err("a symlinked socket path must be refused (AUTH.md fail-closed)");
+        assert!(
+            error.to_string().contains("symlink"),
+            "error should name the symlink cause, got: {error}"
+        );
+        // The guard must refuse before touching the link, so its target survives.
+        assert!(
+            decoy.exists(),
+            "the symlink target must not be removed by the bind guard"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_api_socket_refuses_non_socket_at_socket_path() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(daemon_socket_path(temp_dir.path()), b"not a socket")?;
+
+        let error = bind_api_socket(temp_dir.path()).expect_err(
+            "a non-socket file at the socket path must be refused (AUTH.md fail-closed)",
+        );
+        assert!(
+            error.to_string().contains("not a socket"),
+            "error should name the non-socket cause, got: {error}"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes the two still-open `docs/AUTH.md` "Current hardening gap" fail-closed checks in `crates/coven-cli/src/daemon.rs`:

- `ensure_private_coven_home` now refuses a `COVEN_HOME` that is a symlink, so following it cannot redirect daemon state (socket, status, SQLite ledger) outside the trusted directory.
- `bind_api_socket` now inspects the socket path with `symlink_metadata` and refuses a symlink or any non-socket file, instead of calling `remove_file` on whatever happens to be there. Only a genuine stale socket is replaced.

## Why

`docs/AUTH.md` lists these exact conditions under "Before broad distribution, Rust should fail closed when ... `COVEN_HOME` resolves through a symlink ... an existing socket path is a symlink or non-socket file." The TypeScript plugin already validates the socket trust anchor; this brings the Rust daemon in line. The euid-ownership check from the same list is intentionally left out of this PR because it needs a `libc::geteuid` dependency.

## Changes

- `ensure_private_coven_home`: `symlink_metadata` guard; bail when the home is a symlink.
- `bind_api_socket`: `symlink_metadata` + `FileTypeExt::is_socket`; bail on a symlink or non-socket; only `remove_file` a genuine stale socket; treat `NotFound` as fresh.
- 3 new `#[cfg(unix)]` tests (symlinked home, symlinked socket path with target-not-deleted assertion, non-socket file at the socket path).

std-only — no new dependencies, no `unsafe`, Unix-gated.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --locked` all green on Linux: 696 unit + 4 smoke tests pass, including the 3 new ones, no regressions.

Tracked by #142.

---

Note: I see PRs are frozen until July per CONTRIBUTING — opening this for visibility since it is a small, isolated security hardening that closes a documented gap. Completely fine to close or hold it until the window reopens; the branch will keep.