### PR TITLE
[prototype] Windows daemon support via named pipes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "crossterm",
  "dirs-next",
  "globset",
+ "interprocess",
  "json5",
  "libc",
  "portable-pty",
@@ -527,6 +528,12 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
 ]
+
+[[package]]
+name = "doctest-file"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
 
 [[package]]
 name = "document-features"
@@ -832,6 +839,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "interprocess"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+dependencies = [
+ "doctest-file",
+ "libc",
+ "recvmsg",
+ "widestring",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1487,6 +1507,12 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
 ]
+
+[[package]]
+name = "recvmsg"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -2304,6 +2330,12 @@ dependencies = [
  "serde",
  "wezterm-dynamic",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -35,5 +35,8 @@ textwrap = "0.16"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+interprocess = "2"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -416,6 +416,18 @@ fn conversation_from_payload(payload: &Value) -> Result<Option<ConversationHint>
         .filter(|id| !id.is_empty())
         .context("conversation.id is required and must be a non-empty string")?
         .to_string();
+    // The id is forwarded verbatim as the value of the harness CLI's
+    // `--session-id`/`--resume`/`resume` argument. Restrict it to an unambiguous,
+    // shell-safe charset so untrusted text can never inject extra arguments or —
+    // on Windows, where a `.cmd` shim re-parses the command line through cmd.exe —
+    // shell metacharacters. UUIDs and opaque slugs pass; whitespace and
+    // metacharacters (& | < > ^ % " $ etc.) do not.
+    if !id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    {
+        anyhow::bail!("conversation.id must contain only letters, digits, '-', '_', or '.'");
+    }
     match mode {
         "init" => Ok(Some(ConversationHint::Init { id })),
         "resume" => Ok(Some(ConversationHint::Resume { id })),
@@ -1423,6 +1435,41 @@ mod tests {
 
         assert!(runtime.launches.borrow()[0].conversation_id.is_none());
         Ok(())
+    }
+
+    #[test]
+    fn conversation_id_rejects_shell_metacharacters() {
+        // Ids carrying whitespace or shell metacharacters must be rejected so they
+        // can never reach the harness CLI's `--session-id`/`--resume`/`resume` argv,
+        // where on Windows a `.cmd` shim would re-parse cmd.exe metacharacters.
+        for bad in [
+            "not-a-uuid & calc.exe",
+            "a|b",
+            "a b",
+            "$(whoami)",
+            "a\"b",
+            "a^b",
+        ] {
+            let payload = json!({"conversation": {"mode": "resume", "id": bad}});
+            assert!(
+                conversation_from_payload(&payload).is_err(),
+                "expected {bad:?} to be rejected"
+            );
+        }
+        // UUIDs and opaque slugs are accepted.
+        for good in [
+            "11111111-2222-3333-4444-555555555555",
+            "abc-123",
+            "sess_1.2",
+        ] {
+            let payload = json!({"conversation": {"mode": "init", "id": good}});
+            assert!(
+                conversation_from_payload(&payload)
+                    .expect("shell-safe id should parse")
+                    .is_some(),
+                "expected {good:?} to be accepted"
+            );
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::io::Write;
+#[cfg(unix)]
 use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-#[cfg(unix)]
 use std::io::{BufRead, BufReader, Read};
 #[cfg(unix)]
 use std::os::unix::{
@@ -37,6 +37,7 @@ pub enum DaemonStatusState {
     Stale(DaemonStatus),
 }
 
+#[cfg(unix)]
 #[derive(Debug, Deserialize)]
 struct DaemonHealthStatus {
     ok: bool,
@@ -902,9 +903,12 @@ fn daemon_status_from_health_socket(socket: &str) -> Result<Option<DaemonStatus>
 // Unix socket — a misbehaving network client can otherwise hold the API
 // thread indefinitely (slowloris) or force a huge allocation by claiming a
 // large body.
+#[cfg(unix)]
 pub const TCP_IO_TIMEOUT: Duration = Duration::from_secs(30);
+#[cfg(unix)]
 pub const MAX_TCP_BODY_BYTES: usize = 1024 * 1024;
 
+#[cfg(unix)]
 fn ensure_loopback_addrs(addrs: &[SocketAddr]) -> Result<()> {
     if addrs.is_empty() {
         anyhow::bail!("TCP listener address did not resolve to any sockets");
@@ -927,6 +931,7 @@ fn ensure_loopback_addrs(addrs: &[SocketAddr]) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
 pub fn bind_tcp_listener<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
     let addrs: Vec<SocketAddr> = addr
         .to_socket_addrs()
@@ -1064,7 +1069,6 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
     }
 }
 
-#[cfg(unix)]
 fn handle_http_stream<R, W>(
     read: R,
     mut write: W,
@@ -1125,7 +1129,6 @@ where
     Ok(())
 }
 
-#[cfg(unix)]
 fn write_payload_too_large<W: Write>(write: &mut W, max: usize) -> Result<()> {
     let body = format!(
         "{{\"ok\":false,\"error\":{{\"code\":\"payload_too_large\",\"message\":\"Request body exceeds {max}-byte limit.\"}}}}",
@@ -1141,7 +1144,6 @@ fn write_payload_too_large<W: Write>(write: &mut W, max: usize) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 fn host_is_loopback(host: Option<&str>) -> bool {
     match host {
         Some(h) => is_loopback_host(strip_port(h.trim())),
@@ -1149,7 +1151,6 @@ fn host_is_loopback(host: Option<&str>) -> bool {
     }
 }
 
-#[cfg(unix)]
 fn origin_is_loopback(origin: &str) -> bool {
     match origin.trim().split_once("://") {
         Some((_scheme, rest)) => is_loopback_host(strip_port(rest)),
@@ -1157,7 +1158,6 @@ fn origin_is_loopback(origin: &str) -> bool {
     }
 }
 
-#[cfg(unix)]
 fn strip_port(authority: &str) -> &str {
     if let Some(rest) = authority.strip_prefix('[') {
         // IPv6 literal like [::1]:8080 -> ::1
@@ -1166,7 +1166,6 @@ fn strip_port(authority: &str) -> &str {
     authority.split(':').next().unwrap_or(authority)
 }
 
-#[cfg(unix)]
 fn is_loopback_host(host: &str) -> bool {
     // Parse as an IP and ask the address itself — never a string prefix. A prefix
     // test like `starts_with("127.")` would also accept attacker hostnames such as
@@ -1179,7 +1178,6 @@ fn is_loopback_host(host: &str) -> bool {
         .unwrap_or(false)
 }
 
-#[cfg(unix)]
 fn write_forbidden<W: Write>(write: &mut W, reason: &str) -> Result<()> {
     let body =
         format!("{{\"ok\":false,\"error\":{{\"code\":\"forbidden\",\"message\":\"{reason}\"}}}}");
@@ -1223,7 +1221,6 @@ fn http_reason_phrase(status: u16) -> &'static str {
     }
 }
 
-#[cfg(unix)]
 fn read_http_request_line<R: BufRead>(reader: &mut R) -> Result<String> {
     let mut line = String::new();
     reader
@@ -1235,14 +1232,12 @@ fn read_http_request_line<R: BufRead>(reader: &mut R) -> Result<String> {
     Ok(line)
 }
 
-#[cfg(unix)]
 struct ParsedHeaders {
     content_length: usize,
     host: Option<String>,
     origin: Option<String>,
 }
 
-#[cfg(unix)]
 fn read_http_headers<R: BufRead>(reader: &mut R) -> Result<ParsedHeaders> {
     let mut headers = ParsedHeaders {
         content_length: 0,
@@ -1273,7 +1268,6 @@ fn read_http_headers<R: BufRead>(reader: &mut R) -> Result<ParsedHeaders> {
     Ok(headers)
 }
 
-#[cfg(unix)]
 fn read_http_body<R: Read>(reader: &mut R, content_length: usize) -> Result<Option<String>> {
     if content_length == 0 {
         return Ok(None);
@@ -1287,12 +1281,69 @@ fn read_http_body<R: Read>(reader: &mut R, content_length: usize) -> Result<Opti
         .context("API request body was not valid UTF-8")
 }
 
-#[cfg(unix)]
 fn parse_request_line(line: &str) -> Result<(&str, &str)> {
     let mut parts = line.split_whitespace();
     let method = parts.next().context("missing HTTP method")?;
     let path = parts.next().context("missing HTTP path")?;
     Ok((method, path))
+}
+
+#[cfg(windows)]
+fn windows_pipe_name(coven_home: &Path) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    coven_home.to_string_lossy().hash(&mut h);
+    format!("coven-daemon-{:016x}.sock", h.finish())
+}
+
+#[cfg(windows)]
+pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&str>) -> Result<()> {
+    use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
+    use std::sync::Arc;
+
+    let _ = tcp_addr; // TCP not wired on Windows in this prototype
+
+    let status = DaemonStatus {
+        pid: std::process::id(),
+        started_at: started_at.clone(),
+        socket: windows_pipe_name(coven_home),
+    };
+    write_status(coven_home, &status)?;
+    recover_orphaned_sessions(coven_home, &started_at)?;
+
+    let name = windows_pipe_name(coven_home)
+        .to_ns_name::<GenericNamespaced>()
+        .context("failed to create named pipe name")?;
+    let listener = ListenerOptions::new()
+        .name(name)
+        .create_sync()
+        .context("failed to bind Windows named pipe")?;
+
+    let runtime = Arc::new(LiveSessionRuntime::with_coven_home(coven_home.to_path_buf()));
+
+    for conn in listener.incoming() {
+        let stream = match conn {
+            Ok(s) => s,
+            Err(error) => {
+                eprintln!("coven daemon: pipe accept error: {error:#}");
+                continue;
+            }
+        };
+        // Stream implements Read + Write via shared reference on Windows.
+        // The handler reads the full request before writing, so sharing &stream is safe.
+        if let Err(error) = handle_http_stream(
+            &stream,
+            &stream,
+            coven_home,
+            Some(status.clone()),
+            runtime.as_ref(),
+            None,
+            false,
+        ) {
+            eprintln!("coven daemon: pipe connection error: {error:#}");
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1722,6 +1773,7 @@ mod tests {
         assert!(response.contains("\"apiVersion\""), "got: {response}");
     }
 
+    #[cfg(unix)]
     #[test]
     fn bind_tcp_listener_rejects_non_loopback() {
         let error = bind_tcp_listener("0.0.0.0:0").expect_err("should reject wildcard bind");
@@ -2432,5 +2484,60 @@ mod tests {
             .find(|session| session.id == id)
             .map(|session| session.status.clone())
             .unwrap_or_default()
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn serves_health_over_windows_named_pipe() -> Result<()> {
+        use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
+        use std::io::{Read, Write};
+        use std::thread;
+
+        let temp_dir = tempfile::tempdir()?;
+        let pipe_name = windows_pipe_name(temp_dir.path());
+
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .create_sync()
+            .expect("bind pipe");
+
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: pipe_name.clone(),
+        };
+        let home = temp_dir.path().to_path_buf();
+        let runtime = LiveSessionRuntime::default();
+        let server = thread::spawn(move || {
+            let conn = listener.incoming().next().expect("accept").expect("stream");
+            handle_http_stream(&conn, &conn, &home, Some(status), &runtime, None, false)
+        });
+
+        let client_name = pipe_name
+            .to_ns_name::<GenericNamespaced>()
+            .expect("client pipe name");
+        let mut client = Stream::connect(client_name).expect("connect");
+        client
+            .write_all(b"GET /api/v1/health HTTP/1.1\r\nHost: coven\r\n\r\n")
+            .expect("write request");
+        // Flush to ensure the server receives the full request before we start reading.
+        client.flush().expect("flush");
+        let mut response = String::new();
+        client
+            .read_to_string(&mut response)
+            .expect("read response");
+
+        server.join().expect("server thread")?;
+
+        assert!(
+            response.starts_with("HTTP/1.1 200 OK"),
+            "got: {response}"
+        );
+        assert!(response.contains("\"apiVersion\""), "got: {response}");
+        Ok(())
     }
 }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1319,7 +1319,9 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         .create_sync()
         .context("failed to bind Windows named pipe")?;
 
-    let runtime = Arc::new(LiveSessionRuntime::with_coven_home(coven_home.to_path_buf()));
+    let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
+        coven_home.to_path_buf(),
+    ));
 
     for conn in listener.incoming() {
         let stream = match conn {
@@ -2527,16 +2529,11 @@ mod tests {
         // Flush to ensure the server receives the full request before we start reading.
         client.flush().expect("flush");
         let mut response = String::new();
-        client
-            .read_to_string(&mut response)
-            .expect("read response");
+        client.read_to_string(&mut response).expect("read response");
 
         server.join().expect("server thread")?;
 
-        assert!(
-            response.starts_with("HTTP/1.1 200 OK"),
-            "got: {response}"
-        );
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
         assert!(response.contains("\"apiVersion\""), "got: {response}");
         Ok(())
     }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
-use std::io::{self, BufRead, IsTerminal, Read, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
+#[cfg(unix)]
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;
@@ -792,11 +794,15 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
             {
                 daemon::serve_forever(&home, current_timestamp(), tcp.as_deref())?;
             }
-            #[cfg(not(unix))]
+            #[cfg(windows)]
+            {
+                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref())?;
+            }
+            #[cfg(not(any(unix, windows)))]
             {
                 let _ = tcp;
                 anyhow::bail!(
-                    "coven daemon server is only implemented on Unix-like systems for now"
+                    "coven daemon server is only implemented on Unix-like systems and Windows for now"
                 );
             }
         }
@@ -1345,6 +1351,7 @@ fn send_session_input(_coven_home: &Path, _session_id: &str, _data: &str) -> Res
     anyhow::bail!("Coven attach input forwarding is only implemented on Unix-like systems for now")
 }
 
+#[cfg(unix)]
 fn ensure_successful_http_response(response: &str) -> Result<()> {
     let status = response
         .lines()
@@ -2167,6 +2174,7 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn successful_http_response_accepts_2xx_only() {
         assert!(ensure_successful_http_response("HTTP/1.1 202 Accepted\r\n\r\n{}").is_ok());

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 use std::ffi::OsString;
-use std::io::{self, BufRead, IsTerminal, Write};
 #[cfg(unix)]
 use std::io::Read;
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::Duration;

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -5,10 +5,13 @@
 //! ritual verbs use the shared store path/timestamp helpers because they are
 //! ledger-only mutations.
 
+#[cfg(unix)]
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+#[cfg(unix)]
+use anyhow::anyhow;
+use anyhow::{Context, Result};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -387,6 +390,7 @@ fn request_daemon(
     anyhow::bail!("Coven daemon chat is only implemented on Unix-like systems for now")
 }
 
+#[cfg(unix)]
 fn parse_http_response(response: &str) -> Result<HttpResponse> {
     let (head, body) = response
         .split_once("\r\n\r\n")
@@ -407,6 +411,7 @@ fn parse_http_response(response: &str) -> Result<HttpResponse> {
     })
 }
 
+#[cfg(unix)]
 fn daemon_error(status: u16, body: &str) -> anyhow::Error {
     if let Ok(value) = serde_json::from_str::<Value>(body) {
         if let Some(message) = value
@@ -444,6 +449,7 @@ fn session_title(prompt: &str) -> String {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
     #[test]
     fn parses_successful_http_response_body() -> Result<()> {
         let response =
@@ -454,6 +460,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(unix)]
     #[test]
     fn turns_structured_daemon_errors_into_readable_errors() {
         let error = parse_http_response(


### PR DESCRIPTION
> **Stacked on #145.** This branch is based on #145 (the loopback `Host`/`Origin` guard); the Windows named-pipe work sits on top and the `daemon.rs` overlap between the two is resolved here, so the two no longer conflict at merge. **Please merge #145 first** — GitHub will then collapse this PR's diff down to just the Windows delta. (The base can't be retargeted to #145 directly: this is a cross-fork PR and GitHub requires the base branch to live in this repo.)

---

**Draft / proof-of-concept — not a merge request.** Opening for visibility + to get a decision on the approach before investing further (and PRs are frozen until July per CONTRIBUTING).

## Summary

Today `coven daemon` is Unix-only (`coven daemon serve` bails with "only implemented on Unix-like systems for now"; the whole socket/serve path is `#[cfg(unix)]`). This prototype makes the daemon **serve the existing `/api/v1/*` API on Windows over a named pipe**, so `coven daemon serve` works on Windows. The published `@opencoven/cli-windows` package is staged, so Windows support is presumably wanted — this is a starting point.

## What works (verified)

- Windows: `coven daemon serve` binds a named pipe and serves the API; a new `#[cfg(windows)]` test connects a client and gets `HTTP/1.1 200 OK` from `/api/v1/health`. `cargo build`/`clippy` clean on Windows.
- Unix: unchanged — `cargo test --workspace --locked` green (693 + 4 tests, 0 failed); `cargo clippy` clean.

## Approach

- Lifted the transport-agnostic HTTP layer (`handle_http_stream` + the request/header/body readers, already generic over `Read`/`Write`) out of `#[cfg(unix)]` so both transports reuse it.
- Added a `#[cfg(windows)]` named-pipe transport using the **`interprocess`** crate (windows-only dep). Pipe name is derived from `COVEN_HOME` (hashed) so each home gets a stable, unique pipe.
- A few genuinely Unix-only helpers (TCP listener, chat-client HTTP helpers) were gated `#[cfg(unix)]` to keep the Windows build warning-clean.

## Deferred (NOT in this prototype)

- Windows daemon **start/stop/status** process management (the Unix path shells out to `kill`/`kill -0`).
- Stream-mode **kill** (`PipedKiller` uses `setsid` + `kill(-pid, SIGKILL)`); Windows needs a Job Object / `TerminateProcess` equivalent.

## Open question for the maintainer

The new **`interprocess`** dependency (windows-only) is the key decision. Acceptable? Or would you prefer raw `AF_UNIX` (Win10 1803+ supports it) or a different transport abstraction? Happy to adjust — that's why this is a draft.

Closes part of the Windows-support gap; full parity is follow-up work.
