### PR TITLE
ci: add cargo-deny supply-chain gate for Rust dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,14 @@ jobs:
         with:
           python-version: '3.x'
       - run: python scripts/check-secrets.py
+
+  cargo-deny:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Commit-pinned (v2.0.20): a supply-chain gate must not itself depend on a
+      # mutable action tag. Config lives in deny.toml at the repo root.
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check advisories bans sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,31 @@
+# cargo-deny configuration — supply-chain gate for the Rust dependency tree.
+# Enforced in CI (.github/workflows/ci.yml). Docs: https://embarkstudios.github.io/cargo-deny/
+#
+# Scope is intentionally the security-relevant checks:
+#   * advisories — known vulnerabilities / RUSTSEC advisories, yanked crates
+#   * bans       — wildcard version requirements (and duplicate-version noise)
+#   * sources    — dependencies must come from the official crates.io registry
+#
+# License compliance is deliberately left out for now so this gate stays focused
+# on security and does not fail on license classification; it can be enabled as
+# a follow-up by adding a `[licenses]` allow-list and `check licenses` in CI.
+
+[advisories]
+# RUSTSEC advisory database. cargo-deny errors on vulnerabilities by default.
+# Refuse yanked crates — a yanked dependency is a supply-chain smell.
+yanked = "deny"
+# Only add advisory IDs here with a written justification, never silently.
+ignore = []
+
+[bans]
+# Duplicate transitive versions are common and noisy — surface but don't fail.
+multiple-versions = "warn"
+# Our own crates must pin real version requirements, never "*".
+wildcards = "deny"
+
+[sources]
+# Only the official crates.io registry is trusted. Reject unknown registries
+# and any git sources (there are none today).
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Adds a dependency-vulnerability gate to CI — the one supply-chain hole in the current setup. CI runs `fmt`/`clippy`/`test` + `check-secrets.py`, but nothing audits the dependency tree (261 crates, recently grown).

## What
A new `cargo-deny` job in `.github/workflows/ci.yml` runs `cargo deny check advisories bans sources` on every PR/push:

- **advisories** — fail on known vulnerabilities (RUSTSEC) and yanked crates.
- **bans** — fail on wildcard (`*`) version requirements; surface duplicate transitive versions as warnings (non-fatal).
- **sources** — dependencies must come from the official crates.io registry (reject unknown registries / git sources).

Config lives in `deny.toml` at the repo root.

## Scope
Intentionally **security-only**. License compliance is left for a follow-up so this gate stays focused and does not fail on license classification; enabling it later is a one-line change (`[licenses]` allow-list + `check licenses`).

## Notes
- `cargo-deny-action` is **commit-pinned** (`bb137d7…` = v2.0.20) — a supply-chain gate should not itself depend on a mutable action tag.
- Verified locally with cargo-deny 0.19.8 against the current `Cargo.lock`: **`advisories ok, bans ok, sources ok`**. Two duplicate-version warnings (`thiserror`, `wit-bindgen`) are surfaced but non-fatal.

_Opened against the contribution freeze as a focused hardening change, in the same vein as #144 / #145 / #148._
