### PR TITLE
Harden daemon: enforce the API socket resolves inside COVEN_HOME (AUTH.md L134)

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -970,6 +970,18 @@ pub fn serve_next_tcp_connection(
 pub fn bind_api_socket(coven_home: &Path) -> Result<UnixListener> {
     ensure_private_coven_home(coven_home)?;
     let socket_path = daemon_socket_path(coven_home);
+    // Fail closed if the socket path would resolve outside the trusted state
+    // directory: socket creation and cleanup must never cross the COVEN_HOME
+    // boundary. daemon_socket_path() builds `<coven_home>/coven.sock`, so this is
+    // an explicit guard so a future change can't let it escape. See docs/AUTH.md
+    // "Current hardening gap".
+    if socket_path.parent() != Some(coven_home) {
+        anyhow::bail!(
+            "refusing to bind Coven API socket {}: resolves outside Coven home {}",
+            socket_path.display(),
+            coven_home.display()
+        );
+    }
     // Only ever replace a genuine, non-symlink socket. Blindly removing
     // whatever sits at the path would follow an attacker-planted symlink or
     // delete an unrelated file. See docs/AUTH.md "Current hardening gap".
@@ -1808,6 +1820,15 @@ mod tests {
         let home_mode = std::fs::metadata(temp_dir.path())?.permissions().mode() & 0o777;
         assert_eq!(home_mode, 0o700);
         Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_socket_path_stays_inside_coven_home() {
+        // AUTH.md L134: the socket must resolve directly inside COVEN_HOME, so
+        // bind_api_socket's containment guard always holds for the derived path.
+        let home = std::path::Path::new("/some/coven/home");
+        assert_eq!(daemon_socket_path(home).parent(), Some(home));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Closes the **socket-path-containment** item from `docs/AUTH.md`'s "Current hardening gap" (L134/L136): the daemon should fail closed when the socket path resolves outside `COVEN_HOME`, or when socket creation/cleanup would cross the trusted state-directory boundary.

## What
`bind_api_socket` now verifies the socket path is a direct child of `COVEN_HOME` before touching it:

```rust
if socket_path.parent() != Some(coven_home) {
    anyhow::bail!("refusing to bind Coven API socket {}: resolves outside Coven home {}", ...);
}
```

`daemon_socket_path()` builds `<coven_home>/coven.sock`, so this held only *by construction*. The guard makes the invariant explicit, so a future refactor (e.g. a configurable socket path) can't silently let socket creation or cleanup escape the trusted directory.

Together with #144 (symlink/non-socket) and #148 (ownership), this completes the AUTH.md daemon-hardening list.

## Tests
- New `daemon_socket_path_stays_inside_coven_home` invariant test.
- Existing socket/permission tests unchanged and green.
- `cargo test --workspace` green, `clippy -D warnings` clean, `fmt` clean.

_Focused hardening change, in the same vein as #144 / #145 / #148._
