### PR TITLE
feat(familiars): icon field on /api/v1/familiars (read + write)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "toml",
+ "toml_edit",
  "unicode-width",
  "uuid",
 ]
@@ -1653,6 +1654,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -1997,11 +2007,20 @@ checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2014,13 +2033,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -2444,6 +2483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -22,6 +22,7 @@ rusqlite = { version = "0.39", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"
+toml_edit = { version = "0.22", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 sysinfo = "0.39"
 dirs-next = "2"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -191,6 +191,12 @@ pub fn handle_request_with_runtime(
         ("GET", "/familiars") => {
             json_response(200, &crate::cockpit_sources::read_familiars(coven_home)?)
         }
+        ("PUT", path) if path.starts_with("/familiars/") && path.ends_with("/icon") => {
+            let id = path
+                .trim_start_matches("/familiars/")
+                .trim_end_matches("/icon");
+            update_familiar_icon(coven_home, id, body)
+        }
         ("GET", "/skills") => json_response(200, &crate::cockpit_sources::scan_skills(coven_home)?),
         ("GET", "/memory") => json_response(200, &crate::cockpit_sources::scan_memory(coven_home)?),
         ("GET", "/research") => {
@@ -919,6 +925,61 @@ fn insert_event(
             created_at: current_timestamp(),
         },
     )
+}
+
+fn update_familiar_icon(
+    coven_home: &Path,
+    familiar_id: &str,
+    body: Option<&str>,
+) -> Result<ApiResponse> {
+    if familiar_id.is_empty() || familiar_id.contains('/') {
+        return api_error(
+            400,
+            "invalid_request",
+            "Familiar id is required and must not contain '/'.",
+            None,
+        );
+    }
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return api_error(400, "invalid_request", &error.to_string(), None);
+        }
+    };
+    // Accept `{ "icon": "ph:cat-fill" }`, `{ "icon": "🐈" }`, `{ "icon": null }`,
+    // or an empty body `{}` (treated as null → clear). Reject any non-string,
+    // non-null `icon` value so a typo doesn't silently write `[1,2,3]`.
+    let icon: Option<String> = match payload.get("icon") {
+        None | Some(Value::Null) => None,
+        Some(Value::String(s)) => Some(s.clone()),
+        Some(_) => {
+            return api_error(
+                400,
+                "invalid_request",
+                "Field `icon` must be a string or null.",
+                None,
+            );
+        }
+    };
+    let outcome =
+        crate::cockpit_sources::write_familiar_icon(coven_home, familiar_id, icon.as_deref())?;
+    use crate::cockpit_sources::WriteFamiliarIconOutcome;
+    match outcome {
+        WriteFamiliarIconOutcome::Updated => json_response(
+            200,
+            &json!({ "ok": true, "action": "updated", "id": familiar_id }),
+        ),
+        WriteFamiliarIconOutcome::Cleared => json_response(
+            200,
+            &json!({ "ok": true, "action": "cleared", "id": familiar_id }),
+        ),
+        WriteFamiliarIconOutcome::NotFound => api_error(
+            404,
+            "familiar_not_found",
+            "No familiar with that id is declared in familiars.toml.",
+            Some(json!({ "id": familiar_id })),
+        ),
+    }
 }
 
 fn parse_body(body: Option<&str>) -> Result<Value> {
@@ -2751,5 +2812,143 @@ mod tests {
 
     fn fake_openai_key() -> String {
         format!("sk-{}", "c".repeat(40))
+    }
+
+    // ---- PUT /api/v1/familiars/{id}/icon ---------------------------------
+
+    fn seed_familiars_toml(home: &Path) -> Result<()> {
+        std::fs::write(
+            home.join("familiars.toml"),
+            r#"[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "Builds and debugs."
+
+[[familiar]]
+id = "sage"
+display_name = "Sage"
+role = "Research"
+description = "Reads and synthesizes."
+icon = "ph:leaf-fill"
+"#,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn put_familiar_icon_updates_existing_value() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let response = handle_request_with_body(
+            "PUT",
+            "/api/v1/familiars/sage/icon",
+            home,
+            None,
+            Some(r#"{"icon":"🌿"}"#),
+        )?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["action"], "updated");
+        assert_eq!(body["id"], "sage");
+        let raw = std::fs::read_to_string(home.join("familiars.toml"))?;
+        assert!(raw.contains("icon = \"🌿\""), "got {raw}");
+        Ok(())
+    }
+
+    #[test]
+    fn put_familiar_icon_inserts_when_absent() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let response = handle_request_with_body(
+            "PUT",
+            "/api/v1/familiars/cody/icon",
+            home,
+            None,
+            Some(r#"{"icon":"ph:lightning-fill"}"#),
+        )?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["action"], "updated");
+        let raw = std::fs::read_to_string(home.join("familiars.toml"))?;
+        assert!(raw.contains("icon = \"ph:lightning-fill\""), "got {raw}");
+        // Other familiar's icon must be untouched.
+        assert!(raw.contains("icon = \"ph:leaf-fill\""));
+        Ok(())
+    }
+
+    #[test]
+    fn put_familiar_icon_clears_when_null() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let response = handle_request_with_body(
+            "PUT",
+            "/api/v1/familiars/sage/icon",
+            home,
+            None,
+            Some(r#"{"icon":null}"#),
+        )?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["action"], "cleared");
+        let raw = std::fs::read_to_string(home.join("familiars.toml"))?;
+        assert!(!raw.contains("ph:leaf-fill"));
+        Ok(())
+    }
+
+    #[test]
+    fn put_familiar_icon_returns_404_for_unknown_id() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let response = handle_request_with_body(
+            "PUT",
+            "/api/v1/familiars/ghost/icon",
+            home,
+            None,
+            Some(r#"{"icon":"ph:ghost-fill"}"#),
+        )?;
+        assert_eq!(response.status, 404);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "familiar_not_found");
+        Ok(())
+    }
+
+    #[test]
+    fn put_familiar_icon_rejects_non_string_icon() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let response = handle_request_with_body(
+            "PUT",
+            "/api/v1/familiars/sage/icon",
+            home,
+            None,
+            Some(r#"{"icon":[1,2,3]}"#),
+        )?;
+        assert_eq!(response.status, 400);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "invalid_request");
+        // File must be untouched.
+        let raw = std::fs::read_to_string(home.join("familiars.toml"))?;
+        assert!(raw.contains("ph:leaf-fill"));
+        Ok(())
+    }
+
+    #[test]
+    fn put_familiar_icon_with_empty_body_clears() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let response =
+            handle_request_with_body("PUT", "/api/v1/familiars/sage/icon", home, None, None)?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["action"], "cleared");
+        Ok(())
     }
 }

--- a/crates/coven-cli/src/cockpit_sources.rs
+++ b/crates/coven-cli/src/cockpit_sources.rs
@@ -17,6 +17,12 @@ pub struct FamiliarDto {
     pub name: String,
     pub display_name: String,
     pub emoji: String,
+    /// Optional glyph hint. Either a literal emoji char (`"🐈"`) or a
+    /// Phosphor icon name (`"ph:cat-fill"`). Clients use this in preference
+    /// to `emoji` when they have a richer icon system — see CovenCave's
+    /// glyph picker. Omitted from the wire when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
     pub role: String,
     pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -41,6 +47,10 @@ struct FamiliarEntry {
     name: Option<String>,
     display_name: String,
     emoji: Option<String>,
+    /// See [`FamiliarDto::icon`]. Free-form string at this layer — the
+    /// renderer decides whether to treat a `ph:` prefix as an icon vs.
+    /// treat anything else as an emoji literal.
+    icon: Option<String>,
     role: String,
     description: String,
     pronouns: Option<String>,
@@ -67,6 +77,14 @@ pub fn read_familiars(coven_home: &Path) -> Result<Vec<FamiliarDto>> {
             name: entry.name.unwrap_or_else(|| entry.id.clone()),
             display_name: entry.display_name,
             emoji: entry.emoji.unwrap_or_default(),
+            icon: entry.icon.and_then(|s| {
+                let trimmed = s.trim().to_string();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            }),
             role: entry.role,
             description: entry.description,
             pronouns: entry.pronouns,
@@ -79,6 +97,104 @@ pub fn read_familiars(coven_home: &Path) -> Result<Vec<FamiliarDto>> {
         });
     }
     Ok(out)
+}
+
+/// Outcome of a [`write_familiar_icon`] call.
+#[derive(Debug, PartialEq, Eq)]
+pub enum WriteFamiliarIconOutcome {
+    /// The named familiar's `icon` field was updated (or inserted) in-place.
+    Updated,
+    /// The named familiar's `icon` field was removed because the new value
+    /// was `None` or whitespace-only.
+    Cleared,
+    /// No `[[familiar]]` block in `familiars.toml` has a matching `id`.
+    NotFound,
+}
+
+/// Update (or clear) a familiar's `icon` field in `~/.coven/familiars.toml`,
+/// preserving the rest of the file's formatting + comments.
+///
+/// `icon = None` (or a whitespace-only `Some`) removes the field entirely.
+/// `icon = Some("ph:cat-fill")` or `Some("🐈‍⬛")` either inserts or replaces
+/// the value. Returns the [`WriteFamiliarIconOutcome`] so callers can map
+/// `NotFound` → 404 without re-reading the file.
+///
+/// Writes are atomic via `tempfile + rename` inside the same directory so a
+/// crash mid-write can never leave a half-written `familiars.toml`.
+pub fn write_familiar_icon(
+    coven_home: &Path,
+    familiar_id: &str,
+    icon: Option<&str>,
+) -> Result<WriteFamiliarIconOutcome> {
+    use toml_edit::{value, DocumentMut};
+
+    let path = coven_home.join(FAMILIARS_CONFIG_FILE);
+    let raw =
+        fs::read_to_string(&path).with_context(|| format!("failed to read {}", path.display()))?;
+    let mut doc: DocumentMut = raw
+        .parse()
+        .with_context(|| format!("failed to parse {}", path.display()))?;
+
+    // Normalize whitespace-only icons to None at the boundary so the file
+    // never carries an empty glyph.
+    let normalized: Option<&str> = icon.and_then(|s| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t)
+        }
+    });
+
+    // `[[familiar]]` arrays of tables live under the top-level `familiar`
+    // key as an `ArrayOfTables`. Scan for the table whose `id` matches.
+    let array = match doc
+        .get_mut("familiar")
+        .and_then(|item| item.as_array_of_tables_mut())
+    {
+        Some(arr) => arr,
+        None => return Ok(WriteFamiliarIconOutcome::NotFound),
+    };
+
+    let target = array.iter_mut().find(|tbl| {
+        tbl.get("id")
+            .and_then(|item| item.as_str())
+            .map(|s| s == familiar_id)
+            .unwrap_or(false)
+    });
+
+    let table = match target {
+        Some(t) => t,
+        None => return Ok(WriteFamiliarIconOutcome::NotFound),
+    };
+
+    let outcome = match normalized {
+        Some(s) => {
+            table["icon"] = value(s);
+            WriteFamiliarIconOutcome::Updated
+        }
+        None => {
+            if table.remove("icon").is_some() {
+                WriteFamiliarIconOutcome::Cleared
+            } else {
+                // Nothing to clear, but still a successful no-op write.
+                WriteFamiliarIconOutcome::Cleared
+            }
+        }
+    };
+
+    // Atomic write: write to a sibling tempfile in the same directory so the
+    // subsequent `rename` is on the same filesystem and POSIX-atomic. A crash
+    // mid-write can leave `.familiars.toml.tmp` behind but never a half-
+    // written `familiars.toml`.
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp_path = dir.join(".familiars.toml.tmp");
+    fs::write(&tmp_path, doc.to_string())
+        .with_context(|| format!("failed to write {}", tmp_path.display()))?;
+    fs::rename(&tmp_path, &path)
+        .with_context(|| format!("failed to rename tempfile over {}", path.display()))?;
+
+    Ok(outcome)
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -400,6 +516,219 @@ description = "Builds and debugs."
         assert_eq!(out[1].id, "cody");
         assert!(out[1].pronouns.is_none());
         assert!(out[1].active_channel.is_none());
+        // No `icon` field set in this fixture — must round-trip as None.
+        assert!(out[0].icon.is_none());
+        assert!(out[1].icon.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn read_familiars_carries_icon_field_for_both_shapes() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"
+[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "..."
+icon = "ph:lightning-fill"
+
+[[familiar]]
+id = "kitten"
+display_name = "Kitten"
+role = "General"
+description = "..."
+icon = "🐈‍⬛"
+
+[[familiar]]
+id = "whitespace"
+display_name = "Whitespace"
+role = "Edge case"
+description = "..."
+icon = "   "
+
+[[familiar]]
+id = "no-icon"
+display_name = "No icon"
+role = "Edge case"
+description = "..."
+"#,
+        )?;
+        let out = read_familiars(temp.path())?;
+        assert_eq!(out[0].icon.as_deref(), Some("ph:lightning-fill"));
+        assert_eq!(out[1].icon.as_deref(), Some("🐈‍⬛"));
+        // Whitespace-only icon must normalize to None so clients don't try to
+        // render an empty glyph.
+        assert!(
+            out[2].icon.is_none(),
+            "whitespace icon should normalize to None"
+        );
+        assert!(out[3].icon.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_dto_skips_serializing_absent_icon() -> Result<()> {
+        let dto_without = FamiliarDto {
+            id: "sage".to_string(),
+            name: "sage".to_string(),
+            display_name: "Sage".to_string(),
+            emoji: "🌿".to_string(),
+            icon: None,
+            role: "Research".to_string(),
+            description: "...".to_string(),
+            pronouns: None,
+            status: "offline".to_string(),
+            active_channel: None,
+            last_seen: "—".to_string(),
+            active_sessions: 0,
+            memory_freshness: "—".to_string(),
+        };
+        let json = serde_json::to_string(&dto_without)?;
+        assert!(
+            !json.contains("\"icon\""),
+            "absent icon must not appear on the wire: {json}"
+        );
+        let dto_with = FamiliarDto {
+            icon: Some("ph:cat-fill".to_string()),
+            ..dto_without
+        };
+        let json = serde_json::to_string(&dto_with)?;
+        assert!(json.contains("\"icon\":\"ph:cat-fill\""), "got {json}");
+        Ok(())
+    }
+
+    #[test]
+    fn write_familiar_icon_inserts_when_absent_and_preserves_other_fields() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"# top of file
+[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "Builds and debugs."
+# trailing comment
+"#,
+        )?;
+        let outcome = write_familiar_icon(temp.path(), "cody", Some("ph:lightning-fill"))?;
+        assert_eq!(outcome, WriteFamiliarIconOutcome::Updated);
+        let raw = fs::read_to_string(temp.path().join(FAMILIARS_CONFIG_FILE))?;
+        assert!(raw.contains("icon = \"ph:lightning-fill\""), "got {raw}");
+        // Existing fields + comments must be preserved.
+        assert!(raw.contains("display_name = \"Cody\""));
+        assert!(raw.contains("# top of file"));
+        assert!(raw.contains("# trailing comment"));
+        // Round-trip through the reader.
+        let read = read_familiars(temp.path())?;
+        assert_eq!(read[0].icon.as_deref(), Some("ph:lightning-fill"));
+        Ok(())
+    }
+
+    #[test]
+    fn write_familiar_icon_replaces_existing_value() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "..."
+icon = "ph:lightning-fill"
+"#,
+        )?;
+        let outcome = write_familiar_icon(temp.path(), "cody", Some("🐈"))?;
+        assert_eq!(outcome, WriteFamiliarIconOutcome::Updated);
+        let raw = fs::read_to_string(temp.path().join(FAMILIARS_CONFIG_FILE))?;
+        assert!(raw.contains("icon = \"🐈\""), "got {raw}");
+        assert!(
+            !raw.contains("ph:lightning-fill"),
+            "old icon should be gone"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn write_familiar_icon_clears_field_when_value_is_none() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "..."
+icon = "ph:lightning-fill"
+"#,
+        )?;
+        let outcome = write_familiar_icon(temp.path(), "cody", None)?;
+        assert_eq!(outcome, WriteFamiliarIconOutcome::Cleared);
+        let raw = fs::read_to_string(temp.path().join(FAMILIARS_CONFIG_FILE))?;
+        assert!(!raw.contains("icon ="), "icon line must be removed: {raw}");
+        let read = read_familiars(temp.path())?;
+        assert!(read[0].icon.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn write_familiar_icon_treats_whitespace_as_clear() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "..."
+icon = "ph:lightning-fill"
+"#,
+        )?;
+        let outcome = write_familiar_icon(temp.path(), "cody", Some("   "))?;
+        assert_eq!(outcome, WriteFamiliarIconOutcome::Cleared);
+        let raw = fs::read_to_string(temp.path().join(FAMILIARS_CONFIG_FILE))?;
+        assert!(!raw.contains("icon ="), "icon line must be removed: {raw}");
+        Ok(())
+    }
+
+    #[test]
+    fn write_familiar_icon_returns_not_found_for_unknown_id() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "..."
+"#,
+        )?;
+        let outcome = write_familiar_icon(temp.path(), "ghost", Some("ph:ghost-fill"))?;
+        assert_eq!(outcome, WriteFamiliarIconOutcome::NotFound);
+        // File must be unchanged when not found.
+        let raw = fs::read_to_string(temp.path().join(FAMILIARS_CONFIG_FILE))?;
+        assert!(!raw.contains("ph:ghost-fill"));
+        Ok(())
+    }
+
+    #[test]
+    fn write_familiar_icon_leaves_no_tempfile_on_success() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "..."
+"#,
+        )?;
+        write_familiar_icon(temp.path(), "cody", Some("ph:cat-fill"))?;
+        let tmp_path = temp.path().join(".familiars.toml.tmp");
+        assert!(!tmp_path.exists(), "atomic write left a tempfile behind");
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The daemon now owns the full read+write story for a familiar's glyph.

Adds an optional `icon` field to `~/.coven/familiars.toml`, served at `GET /api/v1/familiars` and writable via a new `PUT /api/v1/familiars/{id}/icon`. The Cave's glyph picker ([OpenCoven/coven-cave#6](https://github.com/OpenCoven/coven-cave/pull/6), already merged) can stop writing only to Cave-local localStorage and start persisting picks back to the user's TOML — surviving across devices, reinstalls, and other Cave surfaces.

## Schema

```toml
[[familiar]]
id = "cody"
icon = "ph:lightning-fill"   # Phosphor icon

[[familiar]]
id = "kitten"
icon = "🐈‍⬛"                # emoji literal
```

The `ph:` prefix is the wire discriminator. Both shapes round-trip through one field, so the daemon stays neutral about which kind a user wants.

## Endpoints

| Method | Path | Body | Status | Behavior |
|---|---|---|---|---|
| `GET` | `/api/v1/familiars` | — | 200 | `FamiliarDto[]` now includes `icon` when present, omitted when absent |
| `PUT` | `/api/v1/familiars/{id}/icon` | `{ "icon": "ph:cat-fill" }` | 200 | Insert or replace the icon |
| `PUT` | `/api/v1/familiars/{id}/icon` | `{ "icon": null }` or `{}` or empty body | 200 | Clear the field |
| `PUT` | `/api/v1/familiars/{id}/icon` | `{ "icon": [1,2,3] }` | 400 | Reject non-string/non-null |
| `PUT` | `/api/v1/familiars/{id}/icon` | any | 404 | Unknown familiar id — `error.code = "familiar_not_found"` |

Whitespace-only values normalize to `None` so a `"   "` icon can't escape as an empty glyph.

## Write safety

- `cockpit_sources::write_familiar_icon()` does the edit via [`toml_edit`](https://crates.io/crates/toml_edit) so existing field order, comments, and surrounding whitespace are preserved.
- Atomic write: serialize to `.familiars.toml.tmp` in the same directory, then `rename` over the target — POSIX-atomic on the same filesystem and Windows-safe. A crash mid-write can leave the temp file behind but never a half-written `familiars.toml`.

## Tests (12 new)

`cockpit_sources::tests` (6):
- `read_familiars_carries_icon_field_for_both_shapes` — TOML round-trip for `ph:` names, emoji literals, whitespace, absent
- `familiar_dto_skips_serializing_absent_icon` — wire shape contract
- `write_familiar_icon_inserts_when_absent_and_preserves_other_fields` — surrounding fields + comments survive
- `write_familiar_icon_replaces_existing_value`
- `write_familiar_icon_clears_field_when_value_is_none`
- `write_familiar_icon_treats_whitespace_as_clear`
- `write_familiar_icon_returns_not_found_for_unknown_id`
- `write_familiar_icon_leaves_no_tempfile_on_success` — atomic-rename hygiene

`api::tests` (6):
- `put_familiar_icon_updates_existing_value`
- `put_familiar_icon_inserts_when_absent` — also asserts the other familiar's icon stays untouched
- `put_familiar_icon_clears_when_null`
- `put_familiar_icon_returns_404_for_unknown_id`
- `put_familiar_icon_rejects_non_string_icon`
- `put_familiar_icon_with_empty_body_clears`

Pre-existing `read_familiars_parses_toml_entries` extended to also assert `icon = None` on fixtures that don't set it.

## Dependency

Adds `toml_edit = "0.22"` (with `serde` feature) for write-side formatting preservation. `toml = "1.1"` (read-only) stays.

## Test plan

- [x] `cargo fmt --check -p coven-cli` clean (the first CI run failed on this — fixed)
- [x] `cargo test -p coven-cli` all green, all 12 new tests pass
- [x] `cargo check -p coven-cli` clean
- [ ] After merge, set `icon = "ph:cat-fill"` on a familiar in local `~/.coven/familiars.toml`, restart the daemon, hit `GET /api/v1/familiars`, confirm the field appears
- [ ] Same flow but via `PUT` — `curl -X PUT --unix-socket "$COVEN_SOCK" http://x/api/v1/familiars/cody/icon -d '{"icon":"ph:cat-fill"}'` — confirm the TOML is updated and surrounding formatting is preserved

## Follow-up

Cave-side daemon-writer: extend `cave-glyph-overrides.ts` to also `PUT` to this endpoint when the user picks a glyph (with localStorage as a fast-path mirror that stays valid if the daemon is offline). One small PR on `coven-cave`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
