### PR TITLE
fix(pty_runner): drop --input-format stream-json for one-shot turns

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -116,17 +116,27 @@ fn stream_claude_with_program<W: Write>(
     forward_stdin: bool,
     out: &mut W,
 ) -> Result<i32> {
+    // `--input-format stream-json` makes claude read user messages as JSONL
+    // on stdin and IGNORE the positional <prompt>. We only want that mode
+    // when the caller is feeding stdin (long-lived chat); for one-shot turns
+    // we drop `--input-format stream-json` so the positional prompt is honored.
+    // Without this branch, one-shot turns hang on stdin then exit with no
+    // assistant text — the symptom that surfaces in Cave as
+    // `_The "claude" harness completed but produced no output._`
+    let mut args: Vec<&str> = vec!["-p"];
+    if forward_stdin {
+        args.extend_from_slice(&["--input-format", "stream-json"]);
+    }
+    args.extend_from_slice(&[
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--session-id",
+        session_id,
+    ]);
+
     let mut child = std::process::Command::new(program)
-        .args([
-            "-p",
-            "--input-format",
-            "stream-json",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--session-id",
-            session_id,
-        ])
+        .args(&args)
         .arg(prompt)
         .current_dir(cwd)
         .stdin(if forward_stdin {

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -632,13 +632,55 @@ exit 7
         )?;
 
         assert_eq!(code, 7);
+        // One-shot mode (forward_stdin=false): `--input-format stream-json`
+        // is omitted so the positional prompt is honored. Including it
+        // makes claude wait for JSONL on stdin and ignore the positional —
+        // which is the bug this commit fixes.
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
         );
         assert_eq!(
             String::from_utf8(out)?,
             "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]},\"session_id\":\"session-123\",\"stop_reason\":\"end_turn\"}\n"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_claude_includes_input_format_when_forwarding_stdin() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_claude = temp_dir.path().join("fake-claude");
+        std::fs::write(
+            &fake_claude,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_claude)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_claude, permissions)?;
+
+        let mut out = Vec::new();
+        let _code = stream_claude_with_program(
+            fake_claude.to_str().unwrap(),
+            temp_dir.path(),
+            "session-456",
+            "hello prompt",
+            // forward_stdin=true → long-lived chat mode where claude reads
+            // user messages as JSONL on stdin, so --input-format stream-json
+            // MUST be present.
+            true,
+            &mut out,
+        )?;
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
         );
         Ok(())
     }


### PR DESCRIPTION
## What this fixes

When `stream_claude` runs in **one-shot mode** (`forward_stdin=false`, the path Cave's `/api/chat/send` uses), claude was being spawned with `--input-format stream-json` AND `Stdio::null()` for stdin. With `--input-format stream-json` claude reads user messages as JSONL from stdin and **ignores** the positional `<prompt>` — so it immediately hit EOF, ran zero turns, and exited clean with no assistant text.

Symptom surfaced in Cave as:

> _The "claude" harness completed but produced no output._

…even though the CLI was authenticated and the prompt was non-empty. This is the root cause of "chats don't work" reports.

## Fix

Only include `--input-format stream-json` when we are actually piping stdin (long-lived chat with `coven run claude --stream-json --stream-json-input`). For one-shot turns the positional prompt is honored and we get the real assistant response.

## Verification

Before:
```
{"type":"system","subtype":"init",...,"tools":[],"agent_mode":null}
{"type":"result","subtype":"success","duration_ms":860,"num_turns":1,...}
```

After:
```
{"type":"system","subtype":"init",...,"tools":[...30 entries...]}
{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]...}}
{"type":"result","subtype":"success","duration_ms":2102,"num_turns":1,"result":"ok"}
```

Built locally, installed, and Cave's chat send now returns `is_error: false` with the assistant text.

## Follow-ups (separate)

- Coven currently emits its own `system.init` frame ALSO, so consumers see two `system.init` events when forwarding claude's stream. A small dedup is worth a follow-up.
- Codex 0.135.0 dropped the older `--stream-json` flag (now `codex exec --json`); the codex adapter needs its own update — separate PR.

Co-authored-by: OpenCoven <noreply@opencoven.io>