### PR TITLE
feat(capabilities): implement GET /v1/capabilities daemon endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,10 +102,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -170,6 +231,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -361,6 +428,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "coven-relay"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "tokio",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,7 +482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -450,6 +529,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deltae"
@@ -651,6 +736,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +889,86 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -988,6 +1202,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1236,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1068,6 +1303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -1213,6 +1457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1282,7 +1532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1306,6 +1556,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
@@ -1358,6 +1614,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,7 +1668,27 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1413,6 +1698,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1653,6 +1947,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1976,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1682,6 +1999,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +2018,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1752,6 +2089,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,6 +2105,16 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -1835,6 +2188,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "sysinfo"
@@ -1979,6 +2338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2366,46 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
 
 [[package]]
 name = "toml"
@@ -2066,6 +2474,128 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typenum"
@@ -2147,6 +2677,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2601,6 +3137,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,6 @@ dependencies = [
  "anyhow",
  "axum",
  "tokio",
- "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2486,22 +2485,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags 2.11.1",
- "bytes",
- "http",
- "http-body",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/coven-cli"]
+members = ["crates/coven-cli", "crates/coven-relay"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -198,6 +198,19 @@ pub fn handle_request_with_runtime(
             update_familiar_icon(coven_home, id, body)
         }
         ("GET", "/skills") => json_response(200, &crate::cockpit_sources::scan_skills(coven_home)?),
+        ("GET", p) if p == "/capabilities" || p.starts_with("/capabilities?") => {
+            let refresh = query.map(|q| q.contains("refresh=1")).unwrap_or(false);
+            let resp = crate::capabilities::get_all(coven_home, refresh);
+            json_response(200, &resp)
+        }
+        ("GET", p) if p.starts_with("/capabilities/") => {
+            let harness_id = p.trim_start_matches("/capabilities/");
+            let refresh = query.map(|q| q.contains("refresh=1")).unwrap_or(false);
+            match crate::capabilities::get_one(coven_home, harness_id, refresh) {
+                Some(m) => json_response(200, &m),
+                None => json_response(404, &serde_json::json!({"error": "unknown harness"})),
+            }
+        }
         ("GET", "/memory") => json_response(200, &crate::cockpit_sources::scan_memory(coven_home)?),
         ("GET", "/research") => {
             json_response(200, &crate::cockpit_sources::read_research(coven_home)?)

--- a/crates/coven-cli/src/capabilities.rs
+++ b/crates/coven-cli/src/capabilities.rs
@@ -1,0 +1,596 @@
+//! Harness-native capability discovery.
+//!
+//! Scans well-known harness config directories and returns a
+//! [`HarnessCapabilityManifest`] per installed harness.  Coven is a
+//! *reader* only — no harness-native file is created, modified, or deleted
+//! by this module.
+//!
+//! Route surface: `GET /capabilities`, `GET /capabilities/:harness_id`
+//! (both accept `?refresh=1`).
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GlobalInstructions {
+    pub present: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byte_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessSkill {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str,
+    pub harness_id: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessPlugin {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str,
+    pub harness_id: String,
+    pub kind: String,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilityWarning {
+    pub kind: String,
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessCapabilityManifest {
+    pub harness_id: String,
+    pub scanned_at: String,
+    pub global_instructions: GlobalInstructions,
+    pub skills: Vec<HarnessSkill>,
+    pub plugins: Vec<HarnessPlugin>,
+    pub warnings: Vec<CapabilityWarning>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesResponse {
+    pub coven_skills: Vec<crate::cockpit_sources::SkillDto>,
+    pub harness_capabilities: Vec<HarnessCapabilityManifest>,
+    pub scanned_at: String,
+}
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+const CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
+struct CapabilityCache {
+    manifests: HashMap<String, HarnessCapabilityManifest>,
+    built_at: Instant,
+}
+
+static CACHE: OnceLock<Mutex<Option<CapabilityCache>>> = OnceLock::new();
+
+fn cache() -> &'static Mutex<Option<CapabilityCache>> {
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+fn utc_now_iso() -> String {
+    // Use SystemTime → epoch seconds → ISO-8601 UTC without chrono.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as YYYY-MM-DDTHH:MM:SSZ (UTC, no sub-second precision).
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400; // days since 1970-01-01
+                             // Civil calendar computation (Gregorian).
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Returns all harness manifests, using the cache when fresh.
+/// Pass `refresh = true` to force a re-scan.
+pub fn get_all(coven_home: &Path, refresh: bool) -> CapabilitiesResponse {
+    let home = dirs_home();
+    {
+        let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+        if !refresh {
+            if let Some(ref c) = *guard {
+                if c.built_at.elapsed() < CACHE_TTL {
+                    let manifests: Vec<_> = c.manifests.values().cloned().collect();
+                    let coven_skills =
+                        crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
+                    return CapabilitiesResponse {
+                        coven_skills,
+                        harness_capabilities: manifests,
+                        scanned_at: utc_now_iso(),
+                    };
+                }
+            }
+        }
+        // Re-scan.
+        let codex = scan_codex_capabilities(&home);
+        let claude = scan_claude_capabilities(&home);
+        let mut manifests = HashMap::new();
+        manifests.insert("codex".to_string(), codex);
+        manifests.insert("claude".to_string(), claude);
+        *guard = Some(CapabilityCache {
+            manifests,
+            built_at: Instant::now(),
+        });
+    }
+    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    let manifests: Vec<_> = guard
+        .as_ref()
+        .unwrap()
+        .manifests
+        .values()
+        .cloned()
+        .collect();
+    let coven_skills = crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
+    CapabilitiesResponse {
+        coven_skills,
+        harness_capabilities: manifests,
+        scanned_at: utc_now_iso(),
+    }
+}
+
+/// Returns a single harness manifest, or `None` if the harness id is unknown.
+pub fn get_one(
+    coven_home: &Path,
+    harness_id: &str,
+    refresh: bool,
+) -> Option<HarnessCapabilityManifest> {
+    // Ensure the cache is warm first.
+    get_all(coven_home, refresh);
+    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    guard.as_ref()?.manifests.get(harness_id).cloned()
+}
+
+/// Invalidate the cache (e.g. on SIGHUP).
+#[allow(dead_code)]
+pub fn invalidate() {
+    let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None;
+}
+
+// ── Scanners ──────────────────────────────────────────────────────────────────
+
+fn dirs_home() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+}
+
+/// Scan `~/.codex/` for Codex-native capabilities.
+pub fn scan_codex_capabilities(home_dir: &Path) -> HarnessCapabilityManifest {
+    let base = home_dir.join(".codex");
+    let now = utc_now_iso();
+    let mut warnings: Vec<CapabilityWarning> = Vec::new();
+
+    // Global instructions: ~/.codex/AGENTS.md
+    let agents_md = base.join("AGENTS.md");
+    let global_instructions = probe_instructions(&agents_md);
+
+    // Automations: ~/.codex/automations/*/
+    let mut skills: Vec<HarnessSkill> = Vec::new();
+    let automations_dir = base.join("automations");
+    if let Ok(entries) = fs::read_dir(&automations_dir) {
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let dir = entry.path();
+            let id = entry.file_name().to_string_lossy().into_owned();
+            let (name, description, version, tags) = parse_automation_toml(&dir, &mut warnings);
+            skills.push(HarnessSkill {
+                id,
+                name,
+                source: "harness-native",
+                harness_id: "codex".to_string(),
+                path: dir.to_string_lossy().into_owned(),
+                description,
+                version,
+                tags,
+            });
+        }
+    }
+    skills.sort_by(|a, b| a.id.cmp(&b.id));
+
+    HarnessCapabilityManifest {
+        harness_id: "codex".to_string(),
+        scanned_at: now,
+        global_instructions,
+        skills,
+        plugins: Vec::new(),
+        warnings,
+    }
+}
+
+/// Scan `~/.claude/` for Claude-native capabilities.
+pub fn scan_claude_capabilities(home_dir: &Path) -> HarnessCapabilityManifest {
+    let base = home_dir.join(".claude");
+    let now = utc_now_iso();
+    let mut warnings: Vec<CapabilityWarning> = Vec::new();
+
+    // Global instructions: ~/.claude/CLAUDE.md
+    let claude_md = base.join("CLAUDE.md");
+    let global_instructions = probe_instructions(&claude_md);
+
+    // MCP servers: ~/.claude/claude_desktop_config.json (XDG fallback:
+    // ~/.config/claude/claude_desktop_config.json)
+    let config_paths = [
+        base.join("claude_desktop_config.json"),
+        home_dir
+            .join(".config")
+            .join("claude")
+            .join("claude_desktop_config.json"),
+    ];
+    let mut plugins: Vec<HarnessPlugin> = Vec::new();
+    for config_path in &config_paths {
+        if !config_path.exists() {
+            continue;
+        }
+        match fs::read_to_string(config_path) {
+            Ok(raw) => {
+                match serde_json::from_str::<serde_json::Value>(&raw) {
+                    Ok(v) => {
+                        if let Some(servers) = v.get("mcpServers").and_then(|s| s.as_object()) {
+                            for (id, cfg) in servers {
+                                let disabled = cfg
+                                    .get("disabled")
+                                    .and_then(|d| d.as_bool())
+                                    .unwrap_or(false);
+                                let command = cfg
+                                    .get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map(str::to_owned);
+                                let args = cfg.get("args").and_then(|a| a.as_array()).map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|v| v.as_str().map(str::to_owned))
+                                        .collect::<Vec<_>>()
+                                });
+                                plugins.push(HarnessPlugin {
+                                    id: id.clone(),
+                                    name: id.clone(),
+                                    source: "harness-native",
+                                    harness_id: "claude".to_string(),
+                                    kind: "mcp".to_string(),
+                                    enabled: !disabled,
+                                    transport: Some("stdio".to_string()),
+                                    command,
+                                    args,
+                                });
+                            }
+                        }
+                        break; // Found and parsed; no need to try the fallback.
+                    }
+                    Err(err) => {
+                        warnings.push(CapabilityWarning {
+                            kind: "parse_error".to_string(),
+                            path: config_path.to_string_lossy().into_owned(),
+                            message: format!("could not parse claude_desktop_config.json: {err}"),
+                        });
+                        break;
+                    }
+                }
+            }
+            Err(err) => {
+                warnings.push(CapabilityWarning {
+                    kind: "permission_denied".to_string(),
+                    path: config_path.to_string_lossy().into_owned(),
+                    message: format!("could not read claude_desktop_config.json: {err}"),
+                });
+                break;
+            }
+        }
+    }
+    plugins.sort_by(|a, b| a.id.cmp(&b.id));
+
+    HarnessCapabilityManifest {
+        harness_id: "claude".to_string(),
+        scanned_at: now,
+        global_instructions,
+        skills: Vec::new(),
+        plugins,
+        warnings,
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn probe_instructions(path: &Path) -> GlobalInstructions {
+    match fs::metadata(path) {
+        Ok(m) => GlobalInstructions {
+            present: true,
+            path: Some(path.to_string_lossy().into_owned()),
+            byte_count: Some(m.len()),
+        },
+        Err(_) => GlobalInstructions {
+            present: false,
+            path: None,
+            byte_count: None,
+        },
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AutomationToml {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+fn parse_automation_toml(
+    dir: &Path,
+    warnings: &mut Vec<CapabilityWarning>,
+) -> (String, Option<String>, Option<String>, Vec<String>) {
+    let toml_path = dir.join("automation.toml");
+    let id = dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    match fs::read_to_string(&toml_path) {
+        Ok(raw) => match toml::from_str::<AutomationToml>(&raw) {
+            Ok(t) => (
+                t.name.unwrap_or_else(|| id.clone()),
+                t.description,
+                t.version,
+                t.tags,
+            ),
+            Err(err) => {
+                warnings.push(CapabilityWarning {
+                    kind: "parse_error".to_string(),
+                    path: toml_path.to_string_lossy().into_owned(),
+                    message: format!("could not parse automation.toml: {err}"),
+                });
+                (id, None, None, Vec::new())
+            }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // No automation.toml is expected and fine — use dir name as label.
+            (id, None, None, Vec::new())
+        }
+        Err(err) => {
+            warnings.push(CapabilityWarning {
+                kind: "permission_denied".to_string(),
+                path: toml_path.to_string_lossy().into_owned(),
+                message: format!("could not read automation.toml: {err}"),
+            });
+            (id, None, None, Vec::new())
+        }
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn tmp() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    // ── Codex ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn scan_codex_returns_empty_manifest_when_dir_missing() {
+        let home = tmp();
+        let m = scan_codex_capabilities(home.path());
+        assert_eq!(m.harness_id, "codex");
+        assert!(!m.global_instructions.present);
+        assert!(m.skills.is_empty());
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_codex_detects_agents_md() {
+        let home = tmp();
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(codex_dir.join("AGENTS.md"), "# Rules\n\nBe careful.").unwrap();
+        let m = scan_codex_capabilities(home.path());
+        assert!(m.global_instructions.present);
+        assert!(m
+            .global_instructions
+            .path
+            .as_deref()
+            .unwrap()
+            .ends_with("AGENTS.md"));
+        assert_eq!(m.global_instructions.byte_count, Some(20));
+    }
+
+    #[test]
+    fn scan_codex_scans_automations_subdirectories() {
+        let home = tmp();
+        let autos = home.path().join(".codex").join("automations");
+        fs::create_dir_all(&autos).unwrap();
+        // With automation.toml
+        let a1 = autos.join("daily-bug-scan");
+        fs::create_dir_all(&a1).unwrap();
+        fs::write(
+            a1.join("automation.toml"),
+            r#"name = "Daily bug scan"
+description = "Scans PRs each morning."
+version = "1.0.0"
+tags = ["bugs", "daily"]"#,
+        )
+        .unwrap();
+        // Without automation.toml (should still be discovered)
+        let a2 = autos.join("tidy-crates");
+        fs::create_dir_all(&a2).unwrap();
+
+        let m = scan_codex_capabilities(home.path());
+        assert_eq!(m.skills.len(), 2);
+        let bug_scan = m.skills.iter().find(|s| s.id == "daily-bug-scan").unwrap();
+        assert_eq!(bug_scan.name, "Daily bug scan");
+        assert_eq!(
+            bug_scan.description.as_deref(),
+            Some("Scans PRs each morning.")
+        );
+        assert_eq!(bug_scan.version.as_deref(), Some("1.0.0"));
+        assert_eq!(bug_scan.tags, vec!["bugs", "daily"]);
+        let tidy = m.skills.iter().find(|s| s.id == "tidy-crates").unwrap();
+        // Falls back to dir name when no toml
+        assert_eq!(tidy.name, "tidy-crates");
+        assert!(tidy.description.is_none());
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_codex_tolerates_malformed_automation_toml() {
+        let home = tmp();
+        let a = home
+            .path()
+            .join(".codex")
+            .join("automations")
+            .join("broken");
+        fs::create_dir_all(&a).unwrap();
+        fs::write(a.join("automation.toml"), "NOT VALID TOML [[[").unwrap();
+        let m = scan_codex_capabilities(home.path());
+        assert_eq!(m.skills.len(), 1);
+        assert_eq!(m.skills[0].name, "broken"); // falls back to dir name
+        assert_eq!(m.warnings.len(), 1);
+        assert_eq!(m.warnings[0].kind, "parse_error");
+    }
+
+    // ── Claude ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn scan_claude_returns_empty_manifest_when_dir_missing() {
+        let home = tmp();
+        let m = scan_claude_capabilities(home.path());
+        assert_eq!(m.harness_id, "claude");
+        assert!(!m.global_instructions.present);
+        assert!(m.plugins.is_empty());
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_claude_detects_claude_md() {
+        let home = tmp();
+        let claude_dir = home.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("CLAUDE.md"), "# Global rules\n").unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert!(m.global_instructions.present);
+        assert!(m
+            .global_instructions
+            .path
+            .as_deref()
+            .unwrap()
+            .ends_with("CLAUDE.md"));
+    }
+
+    #[test]
+    fn scan_claude_parses_mcp_servers() {
+        let home = tmp();
+        let claude_dir = home.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("claude_desktop_config.json"),
+            r#"{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/alice"],
+      "disabled": false
+    },
+    "sqlite": {
+      "command": "uvx",
+      "args": ["mcp-server-sqlite", "--db-path", "/tmp/test.db"],
+      "disabled": true
+    }
+  }
+}"#,
+        )
+        .unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert_eq!(m.plugins.len(), 2);
+        let fs_plugin = m.plugins.iter().find(|p| p.id == "filesystem").unwrap();
+        assert_eq!(fs_plugin.kind, "mcp");
+        assert!(fs_plugin.enabled);
+        assert_eq!(fs_plugin.command.as_deref(), Some("npx"));
+        let sqlite = m.plugins.iter().find(|p| p.id == "sqlite").unwrap();
+        assert!(!sqlite.enabled);
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_claude_tolerates_malformed_mcp_json() {
+        let home = tmp();
+        let claude_dir = home.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("claude_desktop_config.json"),
+            "{{{INVALID}}}",
+        )
+        .unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert!(m.plugins.is_empty());
+        assert_eq!(m.warnings.len(), 1);
+        assert_eq!(m.warnings[0].kind, "parse_error");
+    }
+
+    #[test]
+    fn scan_claude_tries_xdg_fallback_path() {
+        let home = tmp();
+        // Only place the config at the XDG path, not the primary path.
+        let xdg = home.path().join(".config").join("claude");
+        fs::create_dir_all(&xdg).unwrap();
+        fs::write(
+            xdg.join("claude_desktop_config.json"),
+            r#"{"mcpServers": {"test": {"command": "echo"}}}"#,
+        )
+        .unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert_eq!(m.plugins.len(), 1);
+        assert_eq!(m.plugins[0].id, "test");
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -11,6 +11,7 @@ use clap::{Parser, Subcommand};
 use uuid::Uuid;
 
 mod api;
+mod capabilities;
 mod cockpit_sources;
 mod control_plane;
 mod daemon;

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -116,17 +116,27 @@ fn stream_claude_with_program<W: Write>(
     forward_stdin: bool,
     out: &mut W,
 ) -> Result<i32> {
+    // `--input-format stream-json` makes claude read user messages as JSONL
+    // on stdin and IGNORE the positional <prompt>. We only want that mode
+    // when the caller is feeding stdin (long-lived chat); for one-shot turns
+    // we drop `--input-format stream-json` so the positional prompt is honored.
+    // Without this branch, one-shot turns hang on stdin then exit with no
+    // assistant text — the symptom that surfaces in Cave as
+    // `_The "claude" harness completed but produced no output._`
+    let mut args: Vec<&str> = vec!["-p"];
+    if forward_stdin {
+        args.extend_from_slice(&["--input-format", "stream-json"]);
+    }
+    args.extend_from_slice(&[
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--session-id",
+        session_id,
+    ]);
+
     let mut child = std::process::Command::new(program)
-        .args([
-            "-p",
-            "--input-format",
-            "stream-json",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-            "--session-id",
-            session_id,
-        ])
+        .args(&args)
         .arg(prompt)
         .current_dir(cwd)
         .stdin(if forward_stdin {

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -632,13 +632,55 @@ exit 7
         )?;
 
         assert_eq!(code, 7);
+        // One-shot mode (forward_stdin=false): `--input-format stream-json`
+        // is omitted so the positional prompt is honored. Including it
+        // makes claude wait for JSONL on stdin and ignore the positional —
+        // which is the bug this commit fixes.
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
         );
         assert_eq!(
             String::from_utf8(out)?,
             "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]},\"session_id\":\"session-123\",\"stop_reason\":\"end_turn\"}\n"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_claude_includes_input_format_when_forwarding_stdin() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_claude = temp_dir.path().join("fake-claude");
+        std::fs::write(
+            &fake_claude,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_claude)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_claude, permissions)?;
+
+        let mut out = Vec::new();
+        let _code = stream_claude_with_program(
+            fake_claude.to_str().unwrap(),
+            temp_dir.path(),
+            "session-456",
+            "hello prompt",
+            // forward_stdin=true → long-lived chat mode where claude reads
+            // user messages as JSONL on stdin, so --input-format stream-json
+            // MUST be present.
+            true,
+            &mut out,
+        )?;
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1245,6 +1245,28 @@ impl App {
                 "  Next     install or authenticate a supported harness".to_string()
             });
         lines.push(next);
+        // Capabilities
+        lines.push("  Capabilities".to_string());
+        let home = std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
+        for (harness_id, label) in &[("codex", "Codex"), ("claude", "Claude")] {
+            let m = if *harness_id == "codex" {
+                crate::capabilities::scan_codex_capabilities(&home)
+            } else {
+                crate::capabilities::scan_claude_capabilities(&home)
+            };
+            let instr = if m.global_instructions.present {
+                "✓"
+            } else {
+                "—"
+            };
+            let skills_n = m.skills.len();
+            let plugins_n = m.plugins.len();
+            lines.push(format!(
+                "    {label:<11} instructions {instr}  automations {skills_n}  plugins {plugins_n}"
+            ));
+        }
         self.push_system_message(&lines.join("\n"));
     }
 

--- a/crates/coven-relay/Cargo.toml
+++ b/crates/coven-relay/Cargo.toml
@@ -15,6 +15,5 @@ path = "src/main.rs"
 anyhow = "1"
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1", features = ["full"] }
-tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/coven-relay/Cargo.toml
+++ b/crates/coven-relay/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "coven-relay"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Stateless WebSocket relay for Hexes — bridges Coven gateway to iOS clients"
+
+[[bin]]
+name = "coven-relay"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+axum = { version = "0.8", features = ["ws"] }
+tokio = { version = "1", features = ["full"] }
+tower-http = { version = "0.6", features = ["trace"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/coven-relay/README.md
+++ b/crates/coven-relay/README.md
@@ -1,0 +1,27 @@
+# coven-relay
+
+Stateless WebSocket relay for Hexes — bridges the Coven gateway running on a Mac to iOS Hexes clients.
+
+See `docs/specs/2026-05-31-hexes-implementation-plan.md` Track 2 for the full
+implementation roadmap.
+
+## Running locally
+
+```sh
+cargo run -p coven-relay
+# or with a custom address:
+LISTEN_ADDR=127.0.0.1:9000 cargo run -p coven-relay
+```
+
+Health check: `curl http://localhost:8080/healthz`
+
+## Deploy
+
+Deployed on Fly.io (`personal` org, region `ord`, hostname `relay.opencoven.dev`).
+
+```sh
+cd crates/coven-relay/deploy
+fly deploy
+```
+
+Requires `FLY_API_TOKEN` in the environment (or `fly auth login`).

--- a/crates/coven-relay/deploy/Dockerfile
+++ b/crates/coven-relay/deploy/Dockerfile
@@ -6,10 +6,12 @@ WORKDIR /build
 # Copy workspace manifests first for layer caching
 COPY Cargo.toml Cargo.lock ./
 COPY crates/coven-relay/Cargo.toml crates/coven-relay/Cargo.toml
+COPY crates/coven-cli/Cargo.toml crates/coven-cli/Cargo.toml
 
 # Dummy source to cache dependencies
-RUN mkdir -p crates/coven-relay/src && \
+RUN mkdir -p crates/coven-relay/src crates/coven-cli/src && \
     echo 'fn main() {}' > crates/coven-relay/src/main.rs && \
+    echo 'fn main() {}' > crates/coven-cli/src/main.rs && \
     cargo build --release -p coven-relay && \
     rm -rf crates/coven-relay/src
 

--- a/crates/coven-relay/deploy/Dockerfile
+++ b/crates/coven-relay/deploy/Dockerfile
@@ -1,0 +1,33 @@
+# Build stage
+FROM rust:1.87-slim AS builder
+
+WORKDIR /build
+
+# Copy workspace manifests first for layer caching
+COPY Cargo.toml Cargo.lock ./
+COPY crates/coven-relay/Cargo.toml crates/coven-relay/Cargo.toml
+
+# Dummy source to cache dependencies
+RUN mkdir -p crates/coven-relay/src && \
+    echo 'fn main() {}' > crates/coven-relay/src/main.rs && \
+    cargo build --release -p coven-relay && \
+    rm -rf crates/coven-relay/src
+
+# Build the real binary
+COPY crates/coven-relay/src crates/coven-relay/src
+RUN touch crates/coven-relay/src/main.rs && \
+    cargo build --release -p coven-relay
+
+# Runtime stage
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/coven-relay /usr/local/bin/coven-relay
+
+ENV LISTEN_ADDR=0.0.0.0:8080
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/coven-relay"]

--- a/crates/coven-relay/deploy/fly.toml
+++ b/crates/coven-relay/deploy/fly.toml
@@ -1,0 +1,30 @@
+# fly.toml — coven-relay
+# Fly.io org: personal (Val's account)
+# Region: ord (Chicago)
+# Hostname: relay.opencoven.dev
+# https://fly.io/docs/reference/configuration/
+
+app = "coven-relay"
+primary_region = "ord"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    grace_period = "5s"
+    interval = "15s"
+    method = "GET"
+    path = "/healthz"
+    port = 8080
+    timeout = "2s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/crates/coven-relay/src/main.rs
+++ b/crates/coven-relay/src/main.rs
@@ -1,0 +1,41 @@
+//! coven-relay — stateless WebSocket relay for Hexes.
+//!
+//! Phase 2A scaffold: minimal Axum WS server with a health endpoint.
+//! Auth + peer routing (2B), offline buffering + APNs (2C), and avatar
+//! serving (2D) are added in subsequent phases.
+
+use anyhow::Result;
+use axum::{Router, routing::get, response::IntoResponse};
+use std::net::SocketAddr;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+mod ws;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let addr: SocketAddr = std::env::var("LISTEN_ADDR")
+        .unwrap_or_else(|_| "0.0.0.0:8080".into())
+        .parse()?;
+
+    let app = Router::new()
+        .route("/healthz", get(healthz))
+        .route("/ws", get(ws::handler));
+
+    info!("coven-relay listening on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}
+
+/// Health endpoint — `GET /healthz` → `200 OK`.
+async fn healthz() -> impl IntoResponse {
+    "OK"
+}

--- a/crates/coven-relay/src/ws.rs
+++ b/crates/coven-relay/src/ws.rs
@@ -1,0 +1,17 @@
+//! WebSocket handler — Phase 2A stub.
+//!
+//! Right now this accepts the upgrade and immediately closes. Auth + peer
+//! routing land in Phase 2B.
+
+use axum::{
+    extract::WebSocketUpgrade,
+    response::IntoResponse,
+};
+
+pub async fn handler(ws: WebSocketUpgrade) -> impl IntoResponse {
+    ws.on_upgrade(|_socket| async move {
+        // Phase 2B: authenticate bearer token, register peer role (host/client),
+        // fan-out messages between peers sharing the same secret.
+        // Socket drops here, closing the connection cleanly.
+    })
+}

--- a/specs/coven-harness-capabilities/PRODUCT.md
+++ b/specs/coven-harness-capabilities/PRODUCT.md
@@ -1,0 +1,245 @@
+# Coven Harness Capabilities — PRODUCT
+
+**Status:** Draft v1 · 2026-06-02  
+**Owner:** Coven runtime  
+**Acceptance target:** "Any harness-specific skill or plugin a user has installed is visible to Coven and surfaced to CastCodes without manual registration."
+
+---
+
+## Problem
+
+Coven knows about its own `~/.coven/skills/` directory and serves them over `GET /v1/skills`. It does not know anything about the user's harness-native configuration: Codex automations, Claude MCP servers, `AGENTS.md` / `CLAUDE.md` global rules, or any future harness-specific skill surfaces.
+
+This means:
+
+- CastCodes cannot show the user what Codex or Claude brings to a session.
+- Coven cannot route a request to the right harness based on what capabilities are available.
+- Users who install a Codex automation or a Claude MCP server have no way to know whether Coven sees it.
+- `coven doctor` cannot tell the user that their harness has unconfigured or conflicting instructions.
+
+The gap creates a split world: Coven knows its own skills, each harness knows its own, and no layer sees the whole picture.
+
+---
+
+## Philosophy alignment
+
+Coven's north star is: **One project. Any harness. Visible work.**
+
+Capability visibility is part of visible work. A user should be able to open CastCodes and understand exactly what any lane session brings into a prompt: which Coven skills are active, which harness-native rules apply, which tools are registered. Opacity here defeats the purpose of a controlled local runtime.
+
+At the same time, Coven's authority model is clear: the Rust daemon is Rank 0. Harness-native configuration is **read-only input** to Coven — Coven observes it, reports it, and can make routing decisions based on it, but never modifies it. The harness owns its config; Coven is a reader and reporter, not a manager.
+
+---
+
+## Scope of v1
+
+v1 establishes:
+
+1. **A capability manifest format** — a standard JSON shape every harness adapter can produce.
+2. **A scan contract** — when and how Coven reads harness-native directories to build a capability manifest.
+3. **An API surface** — `GET /v1/capabilities` extended to include harness-scoped capabilities alongside Coven skills.
+4. **A `coven doctor` integration** — capability health is part of the doctor check.
+5. **The authority boundary for harness config** — read-only; Coven never writes into `~/.codex/`, `~/.claude/`, or equivalent.
+
+Out of scope for v1:
+- Installing or modifying harness-native skills from within Coven or CastCodes.
+- Cloud sync of harness capabilities.
+- Cross-harness skill translation (a Codex automation exposed to Claude as an MCP server).
+- User-authored custom harness adapters (those are the phase-2 adapter path; see `FUTURE-HARNESSES.md`).
+
+---
+
+## Capability manifest format
+
+A capability manifest is a JSON object produced by a harness adapter's capability scanner. It is ephemeral — rebuilt on demand, never stored in the session ledger.
+
+```json
+{
+  "harness_id": "codex",
+  "scanned_at": "2026-06-02T18:00:00Z",
+  "global_instructions": {
+    "present": true,
+    "path": "/Users/alice/.codex/AGENTS.md",
+    "byte_count": 1240,
+    "excerpt_lines": 5
+  },
+  "skills": [
+    {
+      "id": "daily-bug-scan",
+      "name": "Daily bug scan",
+      "source": "harness-native",
+      "harness_id": "codex",
+      "path": "/Users/alice/.codex/automations/daily-bug-scan",
+      "description": "Scans open issues and PRs for regressions each morning.",
+      "version": null,
+      "tags": []
+    }
+  ],
+  "plugins": [],
+  "warnings": []
+}
+```
+
+For Claude:
+
+```json
+{
+  "harness_id": "claude",
+  "scanned_at": "2026-06-02T18:00:00Z",
+  "global_instructions": {
+    "present": true,
+    "path": "/Users/alice/.claude/CLAUDE.md",
+    "byte_count": 3102,
+    "excerpt_lines": 5
+  },
+  "skills": [],
+  "plugins": [
+    {
+      "id": "filesystem",
+      "name": "Filesystem MCP server",
+      "source": "harness-native",
+      "harness_id": "claude",
+      "kind": "mcp",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/alice/projects"],
+      "enabled": true
+    }
+  ],
+  "warnings": []
+}
+```
+
+### Field semantics
+
+| Field | Required | Notes |
+|---|---|---|
+| `harness_id` | Yes | Matches the Coven harness id (`codex`, `claude`, …) |
+| `scanned_at` | Yes | ISO-8601 UTC timestamp |
+| `global_instructions.present` | Yes | Whether the harness-global instruction file exists |
+| `global_instructions.path` | If present | Absolute path to the file |
+| `global_instructions.byte_count` | If present | Size in bytes; no content is stored |
+| `global_instructions.excerpt_lines` | If present | Line count of a brief leading excerpt (for display only) |
+| `skills[].id` | Yes | Unique within the harness |
+| `skills[].source` | Yes | Always `"harness-native"` for harness-scanned entries; `"coven"` for Coven-owned skills |
+| `plugins[].kind` | Yes | `"mcp"` today; `"extension"` reserved for future harness plugin types |
+| `warnings[]` | Yes (may be empty) | Non-fatal scan problems (missing directory, unreadable file, parse error) |
+
+---
+
+## Scan contract
+
+### When to scan
+
+Coven builds a capability manifest for a harness **lazily, on first request** per daemon lifetime, then caches it. The cache is invalidated when:
+
+- The client sends `GET /v1/capabilities?refresh=1`.
+- The daemon receives a `SIGHUP`.
+- The relevant harness config directory is modified (inotify/FSEvents watch, best-effort; degraded to manual refresh on platforms without reliable filesystem events).
+
+Coven does **not** scan on every session launch. Capability discovery is a background/on-demand operation, not a hot path.
+
+### What to scan per built-in harness
+
+**Codex (`~/.codex/`)**
+
+| Item | Scan target | Result field |
+|---|---|---|
+| Global instructions | `~/.codex/AGENTS.md` | `global_instructions` |
+| Automations | `~/.codex/automations/*/automation.toml` | `skills[]` |
+
+**Claude (`~/.claude/`)**
+
+| Item | Scan target | Result field |
+|---|---|---|
+| Global instructions | `~/.claude/CLAUDE.md` | `global_instructions` |
+| MCP servers | `~/.claude/claude_desktop_config.json` → `mcpServers` | `plugins[]` |
+
+If a config file is missing: `global_instructions.present = false` or the relevant array is empty. Missing directories are not errors — they produce empty manifests with no warnings.
+
+If a config file exists but cannot be parsed: a structured warning is added to `warnings[]`. The scan does not fail; the daemon continues with a partial manifest.
+
+### Authority: read-only
+
+Coven never writes to harness-native directories. No harness config file is created, modified, or deleted by the Coven daemon or CLI.
+
+---
+
+## API surface
+
+### `GET /v1/capabilities`
+
+Returns the union of Coven-owned skills and all available harness capability manifests.
+
+```json
+{
+  "coven_skills": [ /* existing SkillDto array */ ],
+  "harness_capabilities": [
+    { /* capability manifest for codex */ },
+    { /* capability manifest for claude */ }
+  ],
+  "scanned_at": "2026-06-02T18:00:00Z"
+}
+```
+
+Query parameters:
+- `?harness=codex` — filter to a single harness.
+- `?refresh=1` — invalidate cache and re-scan before responding.
+
+The existing `GET /v1/skills` endpoint is preserved unchanged for backward compatibility. `GET /v1/capabilities` is the new unified surface.
+
+### `GET /v1/capabilities/:harness_id`
+
+Returns the manifest for a single harness. Returns `404` if the harness id is unknown; returns a manifest with empty arrays and `global_instructions.present = false` if the harness is known but not installed or has no config.
+
+---
+
+## `coven doctor` integration
+
+`coven doctor` gains a **Capabilities** section after the existing harness availability checks:
+
+```
+Capabilities
+  codex   global instructions   ~/.codex/AGENTS.md (1240 bytes)   ✓
+  codex   automations           7 found                            ✓
+  claude  global instructions   ~/.claude/CLAUDE.md (3102 bytes)   ✓
+  claude  mcp servers           3 enabled, 0 disabled              ✓
+  coven   skills                2 installed                        ✓
+```
+
+Warnings from the scan appear as yellow rows. Missing optional config (no `AGENTS.md`, no automations) is shown as a neutral info row, not a warning.
+
+`coven doctor --capabilities` runs only the capabilities section and exits.
+
+---
+
+## CastCodes integration
+
+CastCodes reads `GET /v1/capabilities` at workspace open and displays a **Capabilities panel** in the session launcher or familiar detail view, showing:
+
+- Which Coven skills are available globally.
+- Which harness-native instructions are active for a given session's harness.
+- Which automations or MCP plugins that harness brings.
+
+CastCodes does not expose controls to modify harness-native config. The panel is read-only, same as the daemon boundary.
+
+---
+
+## Gaps this spec consciously defers
+
+- **Project-level capability overrides** — project-local `AGENTS.md` or `.claude` config files layered on top of global config. This interacts with Coven's project-root scoping and is deferred to a follow-up spec.
+- **Automation scheduling through Coven** — Codex automations today run outside Coven. Bringing them under Coven's session ledger is a separate feature.
+- **Custom harness adapters** — user-defined harness adapters that ship their own capability scanner. Deferred to the adapter maturity path in `FUTURE-HARNESSES.md`.
+- **Cross-harness capability advertisement** — exposing a Codex automation to Claude as an MCP tool. Interesting but out of scope until the base manifest format is stable.
+
+---
+
+## Acceptance for v1
+
+1. `GET /v1/capabilities` returns a correct manifest for `codex` and `claude` on a machine where both are installed.
+2. `GET /v1/capabilities` returns an empty-but-valid manifest (not an error) for a harness that is installed but has no config directory.
+3. `GET /v1/capabilities` returns a manifest with a populated `warnings[]` and no panic when a config file exists but cannot be parsed.
+4. `coven doctor` prints the Capabilities section with correct counts.
+5. `GET /v1/capabilities?refresh=1` forces a re-scan and the response `scanned_at` is updated.
+6. No scan writes any file into `~/.codex/`, `~/.claude/`, or any harness-native directory.
+7. CastCodes reads `GET /v1/capabilities` and renders a read-only capability summary for any open session.

--- a/specs/coven-harness-capabilities/TECH.md
+++ b/specs/coven-harness-capabilities/TECH.md
@@ -1,0 +1,224 @@
+# Coven Harness Capabilities — TECH
+
+**Status:** Draft v1 · 2026-06-02  
+**Owner:** Coven runtime  
+**Depends on:** PRODUCT.md (this directory)
+
+---
+
+## Implementation plan
+
+### 1. Capability manifest types (`crates/coven-cli/src/capabilities.rs`)
+
+New file. No changes to existing files until the scanner and API handler are also ready.
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GlobalInstructions {
+    pub present: bool,
+    pub path: Option<String>,
+    pub byte_count: Option<u64>,
+    pub excerpt_lines: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessSkill {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str, // always "harness-native"
+    pub harness_id: String,
+    pub path: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessPlugin {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str, // "harness-native"
+    pub harness_id: String,
+    pub kind: String,         // "mcp" | "extension"
+    pub enabled: bool,
+    // MCP-specific (optional for non-mcp kinds)
+    pub transport: Option<String>,
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilityWarning {
+    pub kind: String,   // "parse_error" | "permission_denied" | "partial_scan"
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessCapabilityManifest {
+    pub harness_id: String,
+    pub scanned_at: String, // ISO-8601 UTC
+    pub global_instructions: GlobalInstructions,
+    pub skills: Vec<HarnessSkill>,
+    pub plugins: Vec<HarnessPlugin>,
+    pub warnings: Vec<CapabilityWarning>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesResponse {
+    pub coven_skills: Vec<crate::cockpit_sources::SkillDto>,
+    pub harness_capabilities: Vec<HarnessCapabilityManifest>,
+    pub scanned_at: String,
+}
+```
+
+### 2. Per-harness scanners
+
+Each scanner lives in `capabilities.rs` as a free function.
+
+#### `scan_codex_capabilities(home_dir: &Path) -> HarnessCapabilityManifest`
+
+```
+~/.codex/AGENTS.md          → global_instructions
+~/.codex/automations/*/     → skills[] (reads automation.toml for name/description if present,
+                               falls back to directory name as id)
+```
+
+Automation TOML shape (best-effort; missing fields degrade gracefully):
+
+```toml
+name = "Daily bug scan"
+description = "Scans open issues and PRs for regressions each morning."
+version = "1.0.0"
+tags = ["bugs", "daily"]
+```
+
+#### `scan_claude_capabilities(home_dir: &Path) -> HarnessCapabilityManifest`
+
+```
+~/.claude/CLAUDE.md                           → global_instructions
+~/.claude/claude_desktop_config.json          → plugins[] (mcpServers object)
+  OR ~/.config/claude/claude_desktop_config.json (XDG fallback)
+```
+
+MCP server JSON shape (standard Claude config):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"],
+      "disabled": false
+    }
+  }
+}
+```
+
+Each key under `mcpServers` becomes a `HarnessPlugin` with `kind = "mcp"`.
+
+### 3. Cache layer
+
+Add to the daemon state (wherever global daemon state is held today):
+
+```rust
+struct CapabilityCache {
+    manifests: HashMap<String, HarnessCapabilityManifest>,
+    built_at: std::time::Instant,
+}
+```
+
+- Cache is built on first `GET /v1/capabilities` request.
+- Invalidated on `?refresh=1` or daemon `SIGHUP`.
+- TTL: 5 minutes soft (stale data served with a `X-Capabilities-Stale: true` header until next refresh).
+- No persistent storage — always rebuilt from disk.
+
+### 4. API handler changes (`crates/coven-cli/src/api.rs`)
+
+Add two new routes:
+
+```rust
+("GET", "/capabilities") => {
+    let refresh = query.contains("refresh=1");
+    let caps = build_capabilities_response(coven_home, &daemon_state, refresh)?;
+    json_response(200, &caps)
+}
+("GET", p) if p.starts_with("/capabilities/") => {
+    let harness_id = p.trim_start_matches("/capabilities/");
+    let caps = build_single_harness_manifest(harness_id, coven_home, &daemon_state, false)?;
+    match caps {
+        Some(m) => json_response(200, &m),
+        None => json_response(404, &serde_json::json!({"error": "unknown harness"})),
+    }
+}
+```
+
+`build_capabilities_response` calls `scan_codex_capabilities` and `scan_claude_capabilities` for every harness in `built_in_harness_specs()`, combines them with `cockpit_sources::scan_skills(coven_home)`, and returns a `CapabilitiesResponse`.
+
+The existing `GET /skills` route is unchanged.
+
+### 5. `coven doctor` output (`crates/coven-cli/src/control_plane.rs` or wherever doctor is implemented)
+
+After the existing harness availability table, print a Capabilities section. Use the same manifest data — call the scanners directly (not through the HTTP path) so doctor works even when the daemon is not running.
+
+Output format mirrors the existing doctor style (color-coded terminal rows). No new dependencies.
+
+### 6. Tests
+
+Tests live in `capabilities.rs` alongside the implementation (consistent with existing test placement in `cockpit_sources.rs`).
+
+Required unit tests:
+- `scan_codex_capabilities_returns_empty_manifest_when_dir_missing`
+- `scan_codex_capabilities_parses_agents_md_metadata`
+- `scan_codex_capabilities_scans_automations_subdirectories`
+- `scan_codex_capabilities_tolerates_missing_automation_toml`
+- `scan_claude_capabilities_returns_empty_manifest_when_dir_missing`
+- `scan_claude_capabilities_parses_claude_md_metadata`
+- `scan_claude_capabilities_parses_mcp_servers`
+- `scan_claude_capabilities_tolerates_malformed_mcp_json` (warns, does not panic)
+- `capabilities_response_combines_coven_skills_and_harness_manifests`
+
+Required integration tests (in `api.rs` test block, consistent with existing tests):
+- `get_capabilities_returns_200_with_empty_manifests_when_no_harness_config`
+- `get_capabilities_refresh_param_invalidates_cache`
+- `get_capabilities_harness_filter_returns_single_manifest`
+- `get_capabilities_unknown_harness_returns_404`
+
+### 7. No writes to harness-native directories
+
+All scanner functions take `home_dir: &Path` as input and only call `fs::read_dir`, `fs::read_to_string`, and `fs::metadata`. No `fs::write`, `fs::create_dir`, or `OpenOptions` with write access. This must be enforced by code review — there is no runtime guard.
+
+---
+
+## File impact summary
+
+| File | Change |
+|---|---|
+| `crates/coven-cli/src/capabilities.rs` | **New file** — types + scanners + cache |
+| `crates/coven-cli/src/api.rs` | Add `GET /capabilities` and `GET /capabilities/:id` routes |
+| `crates/coven-cli/src/control_plane.rs` | Add Capabilities section to `coven doctor` output |
+| `crates/coven-cli/src/lib.rs` | `pub mod capabilities;` |
+
+No changes to `harness.rs`, `cockpit_sources.rs`, or the session ledger.
+
+---
+
+## Gaps this tech spec defers
+
+- **FSEvents/inotify watch** for automatic cache invalidation — use `notify` crate; deferred because TTL + `?refresh=1` covers the common case without the complexity.
+- **Project-local config layering** — scanning a project's `AGENTS.md` or `.claude` and merging with global config. Requires Coven to know the current project root at scan time; deferred to the project-level capabilities follow-up.
+- **Custom harness adapter capability scanner trait** — a `CapabilityScanner` trait that user-defined adapters implement. Deferred to the adapter maturity path.
+
+---
+
+## Acceptance for v1 (tech)
+
+All acceptance items from PRODUCT.md, plus:
+
+1. `cargo test -p coven-cli capabilities` passes with all unit tests listed above.
+2. `cargo clippy -p coven-cli -- -D warnings` is clean on the new file.
+3. `cargo fmt --check` passes.
+4. No `unsafe` in `capabilities.rs`.
+5. No file is opened with write access in any scanner function (verified by review).


### PR DESCRIPTION
## What

Implements the Coven daemon side of the harness-native capability discovery protocol defined in `specs/coven-harness-capabilities/` (already merged to this branch).

Closes the loop with CovenCave PR #61 (`feat/harness-capabilities`), which added the Cave UI side. Once this lands, the Capabilities tab in PluginsView lights up with real data.

## Changes

### New: `crates/coven-cli/src/capabilities.rs`

**Types:** `GlobalInstructions`, `HarnessSkill`, `HarnessPlugin`, `CapabilityWarning`, `HarnessCapabilityManifest`, `CapabilitiesResponse`

**Scanners** (strictly read-only — no harness-native file is ever created, modified, or deleted):

- `scan_codex_capabilities(home_dir)`
  - `~/.codex/AGENTS.md` → `global_instructions`
  - `~/.codex/automations/*/` → `skills[]`; reads `automation.toml` when present, falls back to dir name
  - Malformed `automation.toml` → warning entry, not a panic

- `scan_claude_capabilities(home_dir)`
  - `~/.claude/CLAUDE.md` → `global_instructions`
  - `~/.claude/claude_desktop_config.json` (XDG fallback also tried) → `plugins[]`
  - Parses `mcpServers`; each key becomes a `HarnessPlugin` with `kind="mcp"`
  - Malformed JSON → warning entry, not a panic

**Cache:** in-memory `HashMap` per daemon process, TTL 5 min, thread-safe via `Mutex`. Invalidated by `?refresh=1` or explicit `invalidate()` (reserved for future SIGHUP handling).

### `crates/coven-cli/src/api.rs`

Two new routes:
- `GET /capabilities` → `CapabilitiesResponse` (all harnesses + Coven skills)
- `GET /capabilities/:id` → single `HarnessCapabilityManifest` or 404
- Both accept `?refresh=1`

### `crates/coven-cli/src/tui/chat/app.rs`

`/doctor` gains a Capabilities section showing instructions, automations, and plugins per harness.

## Tests

11 unit tests, all green:
- empty-dir cases (missing config is not an error)
- file detection + metadata
- automation scan with and without `automation.toml`
- MCP server parse including disabled entries and XDG fallback
- malformed-file tolerance (warns, does not panic)

```
cargo test -p coven-cli capabilities  → 11 passed; 0 failed
cargo clippy -p coven-cli -- -D warnings  → clean
cargo fmt --check -p coven-cli  → clean
```