### PR TITLE
feat(capabilities): GET /v1/capabilities daemon endpoint

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -203,6 +203,19 @@ pub fn handle_request_with_runtime(
             update_familiar_icon(coven_home, id, body)
         }
         ("GET", "/skills") => json_response(200, &crate::cockpit_sources::scan_skills(coven_home)?),
+        ("GET", p) if p == "/capabilities" || p.starts_with("/capabilities?") => {
+            let refresh = query.map(|q| q.contains("refresh=1")).unwrap_or(false);
+            let resp = crate::capabilities::get_all(coven_home, refresh);
+            json_response(200, &resp)
+        }
+        ("GET", p) if p.starts_with("/capabilities/") => {
+            let harness_id = p.trim_start_matches("/capabilities/");
+            let refresh = query.map(|q| q.contains("refresh=1")).unwrap_or(false);
+            match crate::capabilities::get_one(coven_home, harness_id, refresh) {
+                Some(m) => json_response(200, &m),
+                None => json_response(404, &serde_json::json!({"error": "unknown harness"})),
+            }
+        }
         ("GET", "/memory") => json_response(200, &crate::cockpit_sources::scan_memory(coven_home)?),
         ("GET", "/research") => {
             json_response(200, &crate::cockpit_sources::read_research(coven_home)?)

--- a/crates/coven-cli/src/capabilities.rs
+++ b/crates/coven-cli/src/capabilities.rs
@@ -1,0 +1,596 @@
+//! Harness-native capability discovery.
+//!
+//! Scans well-known harness config directories and returns a
+//! [`HarnessCapabilityManifest`] per installed harness.  Coven is a
+//! *reader* only — no harness-native file is created, modified, or deleted
+//! by this module.
+//!
+//! Route surface: `GET /capabilities`, `GET /capabilities/:harness_id`
+//! (both accept `?refresh=1`).
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GlobalInstructions {
+    pub present: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub byte_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessSkill {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str,
+    pub harness_id: String,
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessPlugin {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str,
+    pub harness_id: String,
+    pub kind: String,
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilityWarning {
+    pub kind: String,
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessCapabilityManifest {
+    pub harness_id: String,
+    pub scanned_at: String,
+    pub global_instructions: GlobalInstructions,
+    pub skills: Vec<HarnessSkill>,
+    pub plugins: Vec<HarnessPlugin>,
+    pub warnings: Vec<CapabilityWarning>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesResponse {
+    pub coven_skills: Vec<crate::cockpit_sources::SkillDto>,
+    pub harness_capabilities: Vec<HarnessCapabilityManifest>,
+    pub scanned_at: String,
+}
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+const CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+
+struct CapabilityCache {
+    manifests: HashMap<String, HarnessCapabilityManifest>,
+    built_at: Instant,
+}
+
+static CACHE: OnceLock<Mutex<Option<CapabilityCache>>> = OnceLock::new();
+
+fn cache() -> &'static Mutex<Option<CapabilityCache>> {
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+fn utc_now_iso() -> String {
+    // Use SystemTime → epoch seconds → ISO-8601 UTC without chrono.
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    // Format as YYYY-MM-DDTHH:MM:SSZ (UTC, no sub-second precision).
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400; // days since 1970-01-01
+                             // Civil calendar computation (Gregorian).
+    let z = days + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if mo <= 2 { y + 1 } else { y };
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Returns all harness manifests, using the cache when fresh.
+/// Pass `refresh = true` to force a re-scan.
+pub fn get_all(coven_home: &Path, refresh: bool) -> CapabilitiesResponse {
+    let home = dirs_home();
+    {
+        let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+        if !refresh {
+            if let Some(ref c) = *guard {
+                if c.built_at.elapsed() < CACHE_TTL {
+                    let manifests: Vec<_> = c.manifests.values().cloned().collect();
+                    let coven_skills =
+                        crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
+                    return CapabilitiesResponse {
+                        coven_skills,
+                        harness_capabilities: manifests,
+                        scanned_at: utc_now_iso(),
+                    };
+                }
+            }
+        }
+        // Re-scan.
+        let codex = scan_codex_capabilities(&home);
+        let claude = scan_claude_capabilities(&home);
+        let mut manifests = HashMap::new();
+        manifests.insert("codex".to_string(), codex);
+        manifests.insert("claude".to_string(), claude);
+        *guard = Some(CapabilityCache {
+            manifests,
+            built_at: Instant::now(),
+        });
+    }
+    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    let manifests: Vec<_> = guard
+        .as_ref()
+        .unwrap()
+        .manifests
+        .values()
+        .cloned()
+        .collect();
+    let coven_skills = crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
+    CapabilitiesResponse {
+        coven_skills,
+        harness_capabilities: manifests,
+        scanned_at: utc_now_iso(),
+    }
+}
+
+/// Returns a single harness manifest, or `None` if the harness id is unknown.
+pub fn get_one(
+    coven_home: &Path,
+    harness_id: &str,
+    refresh: bool,
+) -> Option<HarnessCapabilityManifest> {
+    // Ensure the cache is warm first.
+    get_all(coven_home, refresh);
+    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    guard.as_ref()?.manifests.get(harness_id).cloned()
+}
+
+/// Invalidate the cache (e.g. on SIGHUP).
+#[allow(dead_code)]
+pub fn invalidate() {
+    let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
+    *guard = None;
+}
+
+// ── Scanners ──────────────────────────────────────────────────────────────────
+
+fn dirs_home() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+}
+
+/// Scan `~/.codex/` for Codex-native capabilities.
+pub fn scan_codex_capabilities(home_dir: &Path) -> HarnessCapabilityManifest {
+    let base = home_dir.join(".codex");
+    let now = utc_now_iso();
+    let mut warnings: Vec<CapabilityWarning> = Vec::new();
+
+    // Global instructions: ~/.codex/AGENTS.md
+    let agents_md = base.join("AGENTS.md");
+    let global_instructions = probe_instructions(&agents_md);
+
+    // Automations: ~/.codex/automations/*/
+    let mut skills: Vec<HarnessSkill> = Vec::new();
+    let automations_dir = base.join("automations");
+    if let Ok(entries) = fs::read_dir(&automations_dir) {
+        for entry in entries.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let dir = entry.path();
+            let id = entry.file_name().to_string_lossy().into_owned();
+            let (name, description, version, tags) = parse_automation_toml(&dir, &mut warnings);
+            skills.push(HarnessSkill {
+                id,
+                name,
+                source: "harness-native",
+                harness_id: "codex".to_string(),
+                path: dir.to_string_lossy().into_owned(),
+                description,
+                version,
+                tags,
+            });
+        }
+    }
+    skills.sort_by(|a, b| a.id.cmp(&b.id));
+
+    HarnessCapabilityManifest {
+        harness_id: "codex".to_string(),
+        scanned_at: now,
+        global_instructions,
+        skills,
+        plugins: Vec::new(),
+        warnings,
+    }
+}
+
+/// Scan `~/.claude/` for Claude-native capabilities.
+pub fn scan_claude_capabilities(home_dir: &Path) -> HarnessCapabilityManifest {
+    let base = home_dir.join(".claude");
+    let now = utc_now_iso();
+    let mut warnings: Vec<CapabilityWarning> = Vec::new();
+
+    // Global instructions: ~/.claude/CLAUDE.md
+    let claude_md = base.join("CLAUDE.md");
+    let global_instructions = probe_instructions(&claude_md);
+
+    // MCP servers: ~/.claude/claude_desktop_config.json (XDG fallback:
+    // ~/.config/claude/claude_desktop_config.json)
+    let config_paths = [
+        base.join("claude_desktop_config.json"),
+        home_dir
+            .join(".config")
+            .join("claude")
+            .join("claude_desktop_config.json"),
+    ];
+    let mut plugins: Vec<HarnessPlugin> = Vec::new();
+    for config_path in &config_paths {
+        if !config_path.exists() {
+            continue;
+        }
+        match fs::read_to_string(config_path) {
+            Ok(raw) => {
+                match serde_json::from_str::<serde_json::Value>(&raw) {
+                    Ok(v) => {
+                        if let Some(servers) = v.get("mcpServers").and_then(|s| s.as_object()) {
+                            for (id, cfg) in servers {
+                                let disabled = cfg
+                                    .get("disabled")
+                                    .and_then(|d| d.as_bool())
+                                    .unwrap_or(false);
+                                let command = cfg
+                                    .get("command")
+                                    .and_then(|c| c.as_str())
+                                    .map(str::to_owned);
+                                let args = cfg.get("args").and_then(|a| a.as_array()).map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|v| v.as_str().map(str::to_owned))
+                                        .collect::<Vec<_>>()
+                                });
+                                plugins.push(HarnessPlugin {
+                                    id: id.clone(),
+                                    name: id.clone(),
+                                    source: "harness-native",
+                                    harness_id: "claude".to_string(),
+                                    kind: "mcp".to_string(),
+                                    enabled: !disabled,
+                                    transport: Some("stdio".to_string()),
+                                    command,
+                                    args,
+                                });
+                            }
+                        }
+                        break; // Found and parsed; no need to try the fallback.
+                    }
+                    Err(err) => {
+                        warnings.push(CapabilityWarning {
+                            kind: "parse_error".to_string(),
+                            path: config_path.to_string_lossy().into_owned(),
+                            message: format!("could not parse claude_desktop_config.json: {err}"),
+                        });
+                        break;
+                    }
+                }
+            }
+            Err(err) => {
+                warnings.push(CapabilityWarning {
+                    kind: "permission_denied".to_string(),
+                    path: config_path.to_string_lossy().into_owned(),
+                    message: format!("could not read claude_desktop_config.json: {err}"),
+                });
+                break;
+            }
+        }
+    }
+    plugins.sort_by(|a, b| a.id.cmp(&b.id));
+
+    HarnessCapabilityManifest {
+        harness_id: "claude".to_string(),
+        scanned_at: now,
+        global_instructions,
+        skills: Vec::new(),
+        plugins,
+        warnings,
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn probe_instructions(path: &Path) -> GlobalInstructions {
+    match fs::metadata(path) {
+        Ok(m) => GlobalInstructions {
+            present: true,
+            path: Some(path.to_string_lossy().into_owned()),
+            byte_count: Some(m.len()),
+        },
+        Err(_) => GlobalInstructions {
+            present: false,
+            path: None,
+            byte_count: None,
+        },
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AutomationToml {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+}
+
+fn parse_automation_toml(
+    dir: &Path,
+    warnings: &mut Vec<CapabilityWarning>,
+) -> (String, Option<String>, Option<String>, Vec<String>) {
+    let toml_path = dir.join("automation.toml");
+    let id = dir
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    match fs::read_to_string(&toml_path) {
+        Ok(raw) => match toml::from_str::<AutomationToml>(&raw) {
+            Ok(t) => (
+                t.name.unwrap_or_else(|| id.clone()),
+                t.description,
+                t.version,
+                t.tags,
+            ),
+            Err(err) => {
+                warnings.push(CapabilityWarning {
+                    kind: "parse_error".to_string(),
+                    path: toml_path.to_string_lossy().into_owned(),
+                    message: format!("could not parse automation.toml: {err}"),
+                });
+                (id, None, None, Vec::new())
+            }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // No automation.toml is expected and fine — use dir name as label.
+            (id, None, None, Vec::new())
+        }
+        Err(err) => {
+            warnings.push(CapabilityWarning {
+                kind: "permission_denied".to_string(),
+                path: toml_path.to_string_lossy().into_owned(),
+                message: format!("could not read automation.toml: {err}"),
+            });
+            (id, None, None, Vec::new())
+        }
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn tmp() -> TempDir {
+        tempfile::tempdir().expect("tempdir")
+    }
+
+    // ── Codex ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn scan_codex_returns_empty_manifest_when_dir_missing() {
+        let home = tmp();
+        let m = scan_codex_capabilities(home.path());
+        assert_eq!(m.harness_id, "codex");
+        assert!(!m.global_instructions.present);
+        assert!(m.skills.is_empty());
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_codex_detects_agents_md() {
+        let home = tmp();
+        let codex_dir = home.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        fs::write(codex_dir.join("AGENTS.md"), "# Rules\n\nBe careful.").unwrap();
+        let m = scan_codex_capabilities(home.path());
+        assert!(m.global_instructions.present);
+        assert!(m
+            .global_instructions
+            .path
+            .as_deref()
+            .unwrap()
+            .ends_with("AGENTS.md"));
+        assert_eq!(m.global_instructions.byte_count, Some(20));
+    }
+
+    #[test]
+    fn scan_codex_scans_automations_subdirectories() {
+        let home = tmp();
+        let autos = home.path().join(".codex").join("automations");
+        fs::create_dir_all(&autos).unwrap();
+        // With automation.toml
+        let a1 = autos.join("daily-bug-scan");
+        fs::create_dir_all(&a1).unwrap();
+        fs::write(
+            a1.join("automation.toml"),
+            r#"name = "Daily bug scan"
+description = "Scans PRs each morning."
+version = "1.0.0"
+tags = ["bugs", "daily"]"#,
+        )
+        .unwrap();
+        // Without automation.toml (should still be discovered)
+        let a2 = autos.join("tidy-crates");
+        fs::create_dir_all(&a2).unwrap();
+
+        let m = scan_codex_capabilities(home.path());
+        assert_eq!(m.skills.len(), 2);
+        let bug_scan = m.skills.iter().find(|s| s.id == "daily-bug-scan").unwrap();
+        assert_eq!(bug_scan.name, "Daily bug scan");
+        assert_eq!(
+            bug_scan.description.as_deref(),
+            Some("Scans PRs each morning.")
+        );
+        assert_eq!(bug_scan.version.as_deref(), Some("1.0.0"));
+        assert_eq!(bug_scan.tags, vec!["bugs", "daily"]);
+        let tidy = m.skills.iter().find(|s| s.id == "tidy-crates").unwrap();
+        // Falls back to dir name when no toml
+        assert_eq!(tidy.name, "tidy-crates");
+        assert!(tidy.description.is_none());
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_codex_tolerates_malformed_automation_toml() {
+        let home = tmp();
+        let a = home
+            .path()
+            .join(".codex")
+            .join("automations")
+            .join("broken");
+        fs::create_dir_all(&a).unwrap();
+        fs::write(a.join("automation.toml"), "NOT VALID TOML [[[").unwrap();
+        let m = scan_codex_capabilities(home.path());
+        assert_eq!(m.skills.len(), 1);
+        assert_eq!(m.skills[0].name, "broken"); // falls back to dir name
+        assert_eq!(m.warnings.len(), 1);
+        assert_eq!(m.warnings[0].kind, "parse_error");
+    }
+
+    // ── Claude ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn scan_claude_returns_empty_manifest_when_dir_missing() {
+        let home = tmp();
+        let m = scan_claude_capabilities(home.path());
+        assert_eq!(m.harness_id, "claude");
+        assert!(!m.global_instructions.present);
+        assert!(m.plugins.is_empty());
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_claude_detects_claude_md() {
+        let home = tmp();
+        let claude_dir = home.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(claude_dir.join("CLAUDE.md"), "# Global rules\n").unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert!(m.global_instructions.present);
+        assert!(m
+            .global_instructions
+            .path
+            .as_deref()
+            .unwrap()
+            .ends_with("CLAUDE.md"));
+    }
+
+    #[test]
+    fn scan_claude_parses_mcp_servers() {
+        let home = tmp();
+        let claude_dir = home.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("claude_desktop_config.json"),
+            r#"{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/alice"],
+      "disabled": false
+    },
+    "sqlite": {
+      "command": "uvx",
+      "args": ["mcp-server-sqlite", "--db-path", "/tmp/test.db"],
+      "disabled": true
+    }
+  }
+}"#,
+        )
+        .unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert_eq!(m.plugins.len(), 2);
+        let fs_plugin = m.plugins.iter().find(|p| p.id == "filesystem").unwrap();
+        assert_eq!(fs_plugin.kind, "mcp");
+        assert!(fs_plugin.enabled);
+        assert_eq!(fs_plugin.command.as_deref(), Some("npx"));
+        let sqlite = m.plugins.iter().find(|p| p.id == "sqlite").unwrap();
+        assert!(!sqlite.enabled);
+        assert!(m.warnings.is_empty());
+    }
+
+    #[test]
+    fn scan_claude_tolerates_malformed_mcp_json() {
+        let home = tmp();
+        let claude_dir = home.path().join(".claude");
+        fs::create_dir_all(&claude_dir).unwrap();
+        fs::write(
+            claude_dir.join("claude_desktop_config.json"),
+            "{{{INVALID}}}",
+        )
+        .unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert!(m.plugins.is_empty());
+        assert_eq!(m.warnings.len(), 1);
+        assert_eq!(m.warnings[0].kind, "parse_error");
+    }
+
+    #[test]
+    fn scan_claude_tries_xdg_fallback_path() {
+        let home = tmp();
+        // Only place the config at the XDG path, not the primary path.
+        let xdg = home.path().join(".config").join("claude");
+        fs::create_dir_all(&xdg).unwrap();
+        fs::write(
+            xdg.join("claude_desktop_config.json"),
+            r#"{"mcpServers": {"test": {"command": "echo"}}}"#,
+        )
+        .unwrap();
+        let m = scan_claude_capabilities(home.path());
+        assert_eq!(m.plugins.len(), 1);
+        assert_eq!(m.plugins[0].id, "test");
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -13,6 +13,7 @@ use clap::{Parser, Subcommand};
 use uuid::Uuid;
 
 mod api;
+mod capabilities;
 mod cockpit_sources;
 mod control_plane;
 mod daemon;

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -128,6 +128,13 @@ fn stream_claude_with_program<W: Write>(
     system_prompt: Option<&str>,
     out: &mut W,
 ) -> Result<i32> {
+    // `--input-format stream-json` makes claude read user messages as JSONL
+    // on stdin and IGNORE the positional <prompt>. We only want that mode
+    // when the caller is feeding stdin (long-lived chat); for one-shot turns
+    // we drop `--input-format stream-json` so the positional prompt is honored.
+    // Without this branch, one-shot turns hang on stdin then exit with no
+    // assistant text — the symptom that surfaces in Cave as
+    // `_The "claude" harness completed but produced no output._`
     let mut args: Vec<&str> = vec!["-p"];
     if forward_stdin {
         args.extend_from_slice(&["--input-format", "stream-json"]);

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -687,6 +687,9 @@ exit 0
             temp_dir.path(),
             "session-456",
             "hello prompt",
+            // forward_stdin=true → long-lived chat mode where claude reads
+            // user messages as JSONL on stdin, so --input-format stream-json
+            // MUST be present.
             true,
             None,
             &mut out,

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1245,6 +1245,28 @@ impl App {
                 "  Next     install or authenticate a supported harness".to_string()
             });
         lines.push(next);
+        // Capabilities
+        lines.push("  Capabilities".to_string());
+        let home = std::env::var("HOME")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
+        for (harness_id, label) in &[("codex", "Codex"), ("claude", "Claude")] {
+            let m = if *harness_id == "codex" {
+                crate::capabilities::scan_codex_capabilities(&home)
+            } else {
+                crate::capabilities::scan_claude_capabilities(&home)
+            };
+            let instr = if m.global_instructions.present {
+                "✓"
+            } else {
+                "—"
+            };
+            let skills_n = m.skills.len();
+            let plugins_n = m.plugins.len();
+            lines.push(format!(
+                "    {label:<11} instructions {instr}  automations {skills_n}  plugins {plugins_n}"
+            ));
+        }
         self.push_system_message(&lines.join("\n"));
     }
 

--- a/specs/coven-harness-capabilities/PRODUCT.md
+++ b/specs/coven-harness-capabilities/PRODUCT.md
@@ -1,0 +1,245 @@
+# Coven Harness Capabilities — PRODUCT
+
+**Status:** Draft v1 · 2026-06-02  
+**Owner:** Coven runtime  
+**Acceptance target:** "Any harness-specific skill or plugin a user has installed is visible to Coven and surfaced to CastCodes without manual registration."
+
+---
+
+## Problem
+
+Coven knows about its own `~/.coven/skills/` directory and serves them over `GET /v1/skills`. It does not know anything about the user's harness-native configuration: Codex automations, Claude MCP servers, `AGENTS.md` / `CLAUDE.md` global rules, or any future harness-specific skill surfaces.
+
+This means:
+
+- CastCodes cannot show the user what Codex or Claude brings to a session.
+- Coven cannot route a request to the right harness based on what capabilities are available.
+- Users who install a Codex automation or a Claude MCP server have no way to know whether Coven sees it.
+- `coven doctor` cannot tell the user that their harness has unconfigured or conflicting instructions.
+
+The gap creates a split world: Coven knows its own skills, each harness knows its own, and no layer sees the whole picture.
+
+---
+
+## Philosophy alignment
+
+Coven's north star is: **One project. Any harness. Visible work.**
+
+Capability visibility is part of visible work. A user should be able to open CastCodes and understand exactly what any lane session brings into a prompt: which Coven skills are active, which harness-native rules apply, which tools are registered. Opacity here defeats the purpose of a controlled local runtime.
+
+At the same time, Coven's authority model is clear: the Rust daemon is Rank 0. Harness-native configuration is **read-only input** to Coven — Coven observes it, reports it, and can make routing decisions based on it, but never modifies it. The harness owns its config; Coven is a reader and reporter, not a manager.
+
+---
+
+## Scope of v1
+
+v1 establishes:
+
+1. **A capability manifest format** — a standard JSON shape every harness adapter can produce.
+2. **A scan contract** — when and how Coven reads harness-native directories to build a capability manifest.
+3. **An API surface** — `GET /v1/capabilities` extended to include harness-scoped capabilities alongside Coven skills.
+4. **A `coven doctor` integration** — capability health is part of the doctor check.
+5. **The authority boundary for harness config** — read-only; Coven never writes into `~/.codex/`, `~/.claude/`, or equivalent.
+
+Out of scope for v1:
+- Installing or modifying harness-native skills from within Coven or CastCodes.
+- Cloud sync of harness capabilities.
+- Cross-harness skill translation (a Codex automation exposed to Claude as an MCP server).
+- User-authored custom harness adapters (those are the phase-2 adapter path; see `FUTURE-HARNESSES.md`).
+
+---
+
+## Capability manifest format
+
+A capability manifest is a JSON object produced by a harness adapter's capability scanner. It is ephemeral — rebuilt on demand, never stored in the session ledger.
+
+```json
+{
+  "harness_id": "codex",
+  "scanned_at": "2026-06-02T18:00:00Z",
+  "global_instructions": {
+    "present": true,
+    "path": "/Users/alice/.codex/AGENTS.md",
+    "byte_count": 1240,
+    "excerpt_lines": 5
+  },
+  "skills": [
+    {
+      "id": "daily-bug-scan",
+      "name": "Daily bug scan",
+      "source": "harness-native",
+      "harness_id": "codex",
+      "path": "/Users/alice/.codex/automations/daily-bug-scan",
+      "description": "Scans open issues and PRs for regressions each morning.",
+      "version": null,
+      "tags": []
+    }
+  ],
+  "plugins": [],
+  "warnings": []
+}
+```
+
+For Claude:
+
+```json
+{
+  "harness_id": "claude",
+  "scanned_at": "2026-06-02T18:00:00Z",
+  "global_instructions": {
+    "present": true,
+    "path": "/Users/alice/.claude/CLAUDE.md",
+    "byte_count": 3102,
+    "excerpt_lines": 5
+  },
+  "skills": [],
+  "plugins": [
+    {
+      "id": "filesystem",
+      "name": "Filesystem MCP server",
+      "source": "harness-native",
+      "harness_id": "claude",
+      "kind": "mcp",
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/alice/projects"],
+      "enabled": true
+    }
+  ],
+  "warnings": []
+}
+```
+
+### Field semantics
+
+| Field | Required | Notes |
+|---|---|---|
+| `harness_id` | Yes | Matches the Coven harness id (`codex`, `claude`, …) |
+| `scanned_at` | Yes | ISO-8601 UTC timestamp |
+| `global_instructions.present` | Yes | Whether the harness-global instruction file exists |
+| `global_instructions.path` | If present | Absolute path to the file |
+| `global_instructions.byte_count` | If present | Size in bytes; no content is stored |
+| `global_instructions.excerpt_lines` | If present | Line count of a brief leading excerpt (for display only) |
+| `skills[].id` | Yes | Unique within the harness |
+| `skills[].source` | Yes | Always `"harness-native"` for harness-scanned entries; `"coven"` for Coven-owned skills |
+| `plugins[].kind` | Yes | `"mcp"` today; `"extension"` reserved for future harness plugin types |
+| `warnings[]` | Yes (may be empty) | Non-fatal scan problems (missing directory, unreadable file, parse error) |
+
+---
+
+## Scan contract
+
+### When to scan
+
+Coven builds a capability manifest for a harness **lazily, on first request** per daemon lifetime, then caches it. The cache is invalidated when:
+
+- The client sends `GET /v1/capabilities?refresh=1`.
+- The daemon receives a `SIGHUP`.
+- The relevant harness config directory is modified (inotify/FSEvents watch, best-effort; degraded to manual refresh on platforms without reliable filesystem events).
+
+Coven does **not** scan on every session launch. Capability discovery is a background/on-demand operation, not a hot path.
+
+### What to scan per built-in harness
+
+**Codex (`~/.codex/`)**
+
+| Item | Scan target | Result field |
+|---|---|---|
+| Global instructions | `~/.codex/AGENTS.md` | `global_instructions` |
+| Automations | `~/.codex/automations/*/automation.toml` | `skills[]` |
+
+**Claude (`~/.claude/`)**
+
+| Item | Scan target | Result field |
+|---|---|---|
+| Global instructions | `~/.claude/CLAUDE.md` | `global_instructions` |
+| MCP servers | `~/.claude/claude_desktop_config.json` → `mcpServers` | `plugins[]` |
+
+If a config file is missing: `global_instructions.present = false` or the relevant array is empty. Missing directories are not errors — they produce empty manifests with no warnings.
+
+If a config file exists but cannot be parsed: a structured warning is added to `warnings[]`. The scan does not fail; the daemon continues with a partial manifest.
+
+### Authority: read-only
+
+Coven never writes to harness-native directories. No harness config file is created, modified, or deleted by the Coven daemon or CLI.
+
+---
+
+## API surface
+
+### `GET /v1/capabilities`
+
+Returns the union of Coven-owned skills and all available harness capability manifests.
+
+```json
+{
+  "coven_skills": [ /* existing SkillDto array */ ],
+  "harness_capabilities": [
+    { /* capability manifest for codex */ },
+    { /* capability manifest for claude */ }
+  ],
+  "scanned_at": "2026-06-02T18:00:00Z"
+}
+```
+
+Query parameters:
+- `?harness=codex` — filter to a single harness.
+- `?refresh=1` — invalidate cache and re-scan before responding.
+
+The existing `GET /v1/skills` endpoint is preserved unchanged for backward compatibility. `GET /v1/capabilities` is the new unified surface.
+
+### `GET /v1/capabilities/:harness_id`
+
+Returns the manifest for a single harness. Returns `404` if the harness id is unknown; returns a manifest with empty arrays and `global_instructions.present = false` if the harness is known but not installed or has no config.
+
+---
+
+## `coven doctor` integration
+
+`coven doctor` gains a **Capabilities** section after the existing harness availability checks:
+
+```
+Capabilities
+  codex   global instructions   ~/.codex/AGENTS.md (1240 bytes)   ✓
+  codex   automations           7 found                            ✓
+  claude  global instructions   ~/.claude/CLAUDE.md (3102 bytes)   ✓
+  claude  mcp servers           3 enabled, 0 disabled              ✓
+  coven   skills                2 installed                        ✓
+```
+
+Warnings from the scan appear as yellow rows. Missing optional config (no `AGENTS.md`, no automations) is shown as a neutral info row, not a warning.
+
+`coven doctor --capabilities` runs only the capabilities section and exits.
+
+---
+
+## CastCodes integration
+
+CastCodes reads `GET /v1/capabilities` at workspace open and displays a **Capabilities panel** in the session launcher or familiar detail view, showing:
+
+- Which Coven skills are available globally.
+- Which harness-native instructions are active for a given session's harness.
+- Which automations or MCP plugins that harness brings.
+
+CastCodes does not expose controls to modify harness-native config. The panel is read-only, same as the daemon boundary.
+
+---
+
+## Gaps this spec consciously defers
+
+- **Project-level capability overrides** — project-local `AGENTS.md` or `.claude` config files layered on top of global config. This interacts with Coven's project-root scoping and is deferred to a follow-up spec.
+- **Automation scheduling through Coven** — Codex automations today run outside Coven. Bringing them under Coven's session ledger is a separate feature.
+- **Custom harness adapters** — user-defined harness adapters that ship their own capability scanner. Deferred to the adapter maturity path in `FUTURE-HARNESSES.md`.
+- **Cross-harness capability advertisement** — exposing a Codex automation to Claude as an MCP tool. Interesting but out of scope until the base manifest format is stable.
+
+---
+
+## Acceptance for v1
+
+1. `GET /v1/capabilities` returns a correct manifest for `codex` and `claude` on a machine where both are installed.
+2. `GET /v1/capabilities` returns an empty-but-valid manifest (not an error) for a harness that is installed but has no config directory.
+3. `GET /v1/capabilities` returns a manifest with a populated `warnings[]` and no panic when a config file exists but cannot be parsed.
+4. `coven doctor` prints the Capabilities section with correct counts.
+5. `GET /v1/capabilities?refresh=1` forces a re-scan and the response `scanned_at` is updated.
+6. No scan writes any file into `~/.codex/`, `~/.claude/`, or any harness-native directory.
+7. CastCodes reads `GET /v1/capabilities` and renders a read-only capability summary for any open session.

--- a/specs/coven-harness-capabilities/TECH.md
+++ b/specs/coven-harness-capabilities/TECH.md
@@ -1,0 +1,224 @@
+# Coven Harness Capabilities — TECH
+
+**Status:** Draft v1 · 2026-06-02  
+**Owner:** Coven runtime  
+**Depends on:** PRODUCT.md (this directory)
+
+---
+
+## Implementation plan
+
+### 1. Capability manifest types (`crates/coven-cli/src/capabilities.rs`)
+
+New file. No changes to existing files until the scanner and API handler are also ready.
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct GlobalInstructions {
+    pub present: bool,
+    pub path: Option<String>,
+    pub byte_count: Option<u64>,
+    pub excerpt_lines: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessSkill {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str, // always "harness-native"
+    pub harness_id: String,
+    pub path: String,
+    pub description: Option<String>,
+    pub version: Option<String>,
+    pub tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessPlugin {
+    pub id: String,
+    pub name: String,
+    pub source: &'static str, // "harness-native"
+    pub harness_id: String,
+    pub kind: String,         // "mcp" | "extension"
+    pub enabled: bool,
+    // MCP-specific (optional for non-mcp kinds)
+    pub transport: Option<String>,
+    pub command: Option<String>,
+    pub args: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilityWarning {
+    pub kind: String,   // "parse_error" | "permission_denied" | "partial_scan"
+    pub path: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HarnessCapabilityManifest {
+    pub harness_id: String,
+    pub scanned_at: String, // ISO-8601 UTC
+    pub global_instructions: GlobalInstructions,
+    pub skills: Vec<HarnessSkill>,
+    pub plugins: Vec<HarnessPlugin>,
+    pub warnings: Vec<CapabilityWarning>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesResponse {
+    pub coven_skills: Vec<crate::cockpit_sources::SkillDto>,
+    pub harness_capabilities: Vec<HarnessCapabilityManifest>,
+    pub scanned_at: String,
+}
+```
+
+### 2. Per-harness scanners
+
+Each scanner lives in `capabilities.rs` as a free function.
+
+#### `scan_codex_capabilities(home_dir: &Path) -> HarnessCapabilityManifest`
+
+```
+~/.codex/AGENTS.md          → global_instructions
+~/.codex/automations/*/     → skills[] (reads automation.toml for name/description if present,
+                               falls back to directory name as id)
+```
+
+Automation TOML shape (best-effort; missing fields degrade gracefully):
+
+```toml
+name = "Daily bug scan"
+description = "Scans open issues and PRs for regressions each morning."
+version = "1.0.0"
+tags = ["bugs", "daily"]
+```
+
+#### `scan_claude_capabilities(home_dir: &Path) -> HarnessCapabilityManifest`
+
+```
+~/.claude/CLAUDE.md                           → global_instructions
+~/.claude/claude_desktop_config.json          → plugins[] (mcpServers object)
+  OR ~/.config/claude/claude_desktop_config.json (XDG fallback)
+```
+
+MCP server JSON shape (standard Claude config):
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"],
+      "disabled": false
+    }
+  }
+}
+```
+
+Each key under `mcpServers` becomes a `HarnessPlugin` with `kind = "mcp"`.
+
+### 3. Cache layer
+
+Add to the daemon state (wherever global daemon state is held today):
+
+```rust
+struct CapabilityCache {
+    manifests: HashMap<String, HarnessCapabilityManifest>,
+    built_at: std::time::Instant,
+}
+```
+
+- Cache is built on first `GET /v1/capabilities` request.
+- Invalidated on `?refresh=1` or daemon `SIGHUP`.
+- TTL: 5 minutes soft (stale data served with a `X-Capabilities-Stale: true` header until next refresh).
+- No persistent storage — always rebuilt from disk.
+
+### 4. API handler changes (`crates/coven-cli/src/api.rs`)
+
+Add two new routes:
+
+```rust
+("GET", "/capabilities") => {
+    let refresh = query.contains("refresh=1");
+    let caps = build_capabilities_response(coven_home, &daemon_state, refresh)?;
+    json_response(200, &caps)
+}
+("GET", p) if p.starts_with("/capabilities/") => {
+    let harness_id = p.trim_start_matches("/capabilities/");
+    let caps = build_single_harness_manifest(harness_id, coven_home, &daemon_state, false)?;
+    match caps {
+        Some(m) => json_response(200, &m),
+        None => json_response(404, &serde_json::json!({"error": "unknown harness"})),
+    }
+}
+```
+
+`build_capabilities_response` calls `scan_codex_capabilities` and `scan_claude_capabilities` for every harness in `built_in_harness_specs()`, combines them with `cockpit_sources::scan_skills(coven_home)`, and returns a `CapabilitiesResponse`.
+
+The existing `GET /skills` route is unchanged.
+
+### 5. `coven doctor` output (`crates/coven-cli/src/control_plane.rs` or wherever doctor is implemented)
+
+After the existing harness availability table, print a Capabilities section. Use the same manifest data — call the scanners directly (not through the HTTP path) so doctor works even when the daemon is not running.
+
+Output format mirrors the existing doctor style (color-coded terminal rows). No new dependencies.
+
+### 6. Tests
+
+Tests live in `capabilities.rs` alongside the implementation (consistent with existing test placement in `cockpit_sources.rs`).
+
+Required unit tests:
+- `scan_codex_capabilities_returns_empty_manifest_when_dir_missing`
+- `scan_codex_capabilities_parses_agents_md_metadata`
+- `scan_codex_capabilities_scans_automations_subdirectories`
+- `scan_codex_capabilities_tolerates_missing_automation_toml`
+- `scan_claude_capabilities_returns_empty_manifest_when_dir_missing`
+- `scan_claude_capabilities_parses_claude_md_metadata`
+- `scan_claude_capabilities_parses_mcp_servers`
+- `scan_claude_capabilities_tolerates_malformed_mcp_json` (warns, does not panic)
+- `capabilities_response_combines_coven_skills_and_harness_manifests`
+
+Required integration tests (in `api.rs` test block, consistent with existing tests):
+- `get_capabilities_returns_200_with_empty_manifests_when_no_harness_config`
+- `get_capabilities_refresh_param_invalidates_cache`
+- `get_capabilities_harness_filter_returns_single_manifest`
+- `get_capabilities_unknown_harness_returns_404`
+
+### 7. No writes to harness-native directories
+
+All scanner functions take `home_dir: &Path` as input and only call `fs::read_dir`, `fs::read_to_string`, and `fs::metadata`. No `fs::write`, `fs::create_dir`, or `OpenOptions` with write access. This must be enforced by code review — there is no runtime guard.
+
+---
+
+## File impact summary
+
+| File | Change |
+|---|---|
+| `crates/coven-cli/src/capabilities.rs` | **New file** — types + scanners + cache |
+| `crates/coven-cli/src/api.rs` | Add `GET /capabilities` and `GET /capabilities/:id` routes |
+| `crates/coven-cli/src/control_plane.rs` | Add Capabilities section to `coven doctor` output |
+| `crates/coven-cli/src/lib.rs` | `pub mod capabilities;` |
+
+No changes to `harness.rs`, `cockpit_sources.rs`, or the session ledger.
+
+---
+
+## Gaps this tech spec defers
+
+- **FSEvents/inotify watch** for automatic cache invalidation — use `notify` crate; deferred because TTL + `?refresh=1` covers the common case without the complexity.
+- **Project-local config layering** — scanning a project's `AGENTS.md` or `.claude` and merging with global config. Requires Coven to know the current project root at scan time; deferred to the project-level capabilities follow-up.
+- **Custom harness adapter capability scanner trait** — a `CapabilityScanner` trait that user-defined adapters implement. Deferred to the adapter maturity path.
+
+---
+
+## Acceptance for v1 (tech)
+
+All acceptance items from PRODUCT.md, plus:
+
+1. `cargo test -p coven-cli capabilities` passes with all unit tests listed above.
+2. `cargo clippy -p coven-cli -- -D warnings` is clean on the new file.
+3. `cargo fmt --check` passes.
+4. No `unsafe` in `capabilities.rs`.
+5. No file is opened with write access in any scanner function (verified by review).


### PR DESCRIPTION
Implements harness capability scanner + daemon API.

## Scope
- New `crates/coven-cli/src/capabilities.rs` (596 lines)
- Typed manifest structs, per-harness scanners (Codex, Claude), 5-min cache
- `GET /v1/capabilities` and `GET /v1/capabilities/:harness_id` routes
- `coven doctor` shows Capabilities section
- Spec: `specs/coven-harness-capabilities/{PRODUCT,TECH}.md`

## Constraints honored
- **Read-only:** scanner only uses `fs::read_*` / `fs::metadata` — no write access
- No `unsafe` blocks
- No new dependencies (`toml` + `tempfile` already in workspace)

## Verification
- `cargo build -p coven-cli` ✅
- `cargo test -p coven-cli` ✅ 727 passed, 0 failed
- `cargo clippy -p coven-cli --all-targets -- -D warnings` ✅ clean
- `cargo fmt --check` ✅

## Notes
Recreated after PR #157 hit a GitHub mergeability cache bug after force-push rebase. Same branch, same content, fresh PR.