### PR TITLE
feat(store): persist familiar_id on sessions

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -1527,6 +1527,45 @@ mod tests {
     }
 
     #[test]
+    fn launch_request_persists_familiar_id_on_the_session_row() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi",
+            "familiarId": "ember"
+        })
+        .to_string();
+
+        handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(
+            runtime.launches.borrow()[0].familiar_id.as_deref(),
+            Some("ember")
+        );
+
+        // And it round-trips through the session list payload too.
+        let list = handle_request("GET", "/sessions", temp_dir.path(), None)?;
+        assert!(
+            list.body.contains(r#""familiar_id":"ember""#),
+            "list response should expose familiar_id, got: {}",
+            list.body
+        );
+        Ok(())
+    }
+
+    #[test]
     fn conversation_id_rejects_shell_metacharacters() {
         // Ids carrying whitespace or shell metacharacters must be rejected so they
         // can never reach the harness CLI's `--session-id`/`--resume`/`resume` argv,

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -318,12 +318,32 @@ fn launch_session(
             return api_error(400, "invalid_request", &error.to_string(), None);
         }
     };
-    let launch = match session_launch_from_payload(payload) {
+    let mut launch = match session_launch_from_payload(payload) {
         Ok(launch) => launch,
         Err(error) => {
             return api_error(400, "invalid_request", &error.to_string(), None);
         }
     };
+    let familiar_ctx = match launch.familiar_id.as_deref() {
+        Some(familiar_id) => match crate::familiar_identity::resolve(coven_home, familiar_id) {
+            Ok(Some(familiar_ctx)) => Some(familiar_ctx),
+            Ok(None) => {
+                let error =
+                    crate::familiar_identity::unknown_familiar_error(coven_home, familiar_id);
+                return api_error(
+                    400,
+                    "unknown_familiar",
+                    &error.to_string(),
+                    Some(json!({ "familiarId": familiar_id })),
+                );
+            }
+            Err(error) => {
+                return api_error(500, "familiar_lookup_failed", &error.to_string(), None);
+            }
+        },
+        None => None,
+    };
+    launch.familiar_id = familiar_ctx.as_ref().map(|familiar| familiar.id.clone());
     let conn = store::open_store(&store_path(coven_home))?;
     let now = current_timestamp();
     let record = store::SessionRecord {
@@ -337,7 +357,7 @@ fn launch_session(
         created_at: now.clone(),
         updated_at: now,
         conversation_id: launch.conversation_id.clone(),
-        familiar_id: launch.familiar_id.clone(),
+        familiar_id: familiar_ctx.as_ref().map(|familiar| familiar.id.clone()),
         labels: Vec::new(),
         visibility: "private".to_string(),
     };
@@ -1529,6 +1549,7 @@ mod tests {
     #[test]
     fn launch_request_persists_familiar_id_on_the_session_row() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
+        seed_familiars_toml(temp_dir.path())?;
         let project_root = temp_dir.path().join("repo");
         std::fs::create_dir_all(&project_root)?;
         let runtime = RecordingRuntime::default();
@@ -1537,7 +1558,7 @@ mod tests {
             "harness": "claude",
             "launchMode": "nonInteractive",
             "prompt": "hi",
-            "familiarId": "ember"
+            "familiarId": "sage"
         })
         .to_string();
 
@@ -1552,15 +1573,98 @@ mod tests {
 
         assert_eq!(
             runtime.launches.borrow()[0].familiar_id.as_deref(),
-            Some("ember")
+            Some("sage")
         );
 
         // And it round-trips through the session list payload too.
         let list = handle_request("GET", "/sessions", temp_dir.path(), None)?;
         assert!(
-            list.body.contains(r#""familiar_id":"ember""#),
+            list.body.contains(r#""familiar_id":"sage""#),
             "list response should expose familiar_id, got: {}",
             list.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_rejects_unknown_familiar_id_without_inserting_session() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        seed_familiars_toml(temp_dir.path())?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi",
+            "familiarId": "missing"
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 400);
+        assert!(
+            response.body.contains("unknown_familiar"),
+            "expected unknown familiar error, got: {}",
+            response.body
+        );
+        assert!(
+            runtime.launches.borrow().is_empty(),
+            "unknown familiar must not launch a runtime"
+        );
+        let list = handle_request("GET", "/sessions", temp_dir.path(), None)?;
+        assert!(
+            list.body == "[]",
+            "unknown familiar must not insert a session row, got: {}",
+            list.body
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_reports_familiar_config_errors_without_launching() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(temp_dir.path().join("familiars.toml"), "[[familiar]\n")?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi",
+            "familiarId": "sage"
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 500);
+        assert!(
+            response.body.contains("familiar_lookup_failed"),
+            "expected familiar config error, got: {}",
+            response.body
+        );
+        assert!(
+            runtime.launches.borrow().is_empty(),
+            "malformed familiar config must not launch a runtime"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -337,6 +337,7 @@ fn launch_session(
         created_at: now.clone(),
         updated_at: now,
         conversation_id: launch.conversation_id.clone(),
+        familiar_id: launch.familiar_id.clone(),
         labels: Vec::new(),
         visibility: "private".to_string(),
     };
@@ -745,6 +746,7 @@ fn ensure_cockpit_session(conn: &rusqlite::Connection) -> Result<()> {
         created_at: now.clone(),
         updated_at: now,
         conversation_id: None,
+        familiar_id: None,
         labels: Vec::new(),
         visibility: "private".to_string(),
     };
@@ -1286,6 +1288,7 @@ mod tests {
             created_at: "2026-04-27T10:00:00Z".to_string(),
             updated_at: "2026-04-27T10:00:00Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2187,6 +2190,7 @@ mod tests {
             created_at: "2026-04-27T10:00:00Z".to_string(),
             updated_at: "2026-04-27T10:00:00Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2491,6 +2495,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2528,6 +2533,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2570,6 +2576,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2606,6 +2613,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2719,6 +2727,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".into(),
             updated_at: "2026-01-01T00:00:00Z".into(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2819,6 +2828,7 @@ mod tests {
                     created_at: now.into(),
                     updated_at: now.into(),
                     conversation_id: None,
+                    familiar_id: None,
                     labels: Vec::new(),
                     visibility: "private".to_string(),
                 },

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -149,21 +149,15 @@ impl LiveSessionRuntime {
 
 impl SessionRuntime for LiveSessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()> {
-        let familiar_ctx = launch.familiar_id.as_deref().and_then(|fid| {
-            self.coven_home.as_ref().and_then(|home| {
-                crate::cockpit_sources::read_familiars(home)
-                    .ok()
-                    .and_then(|familiars| {
-                        familiars.into_iter().find(|f| f.id == fid).map(|f| {
-                            crate::harness::FamiliarContext {
-                                id: f.id,
-                                display_name: f.display_name,
-                                role: Some(f.role).filter(|r| !r.is_empty()),
-                            }
-                        })
-                    })
-            })
-        });
+        let familiar_ctx = match (&self.coven_home, launch.familiar_id.as_deref()) {
+            (Some(home), familiar_id) => {
+                crate::familiar_identity::resolve_optional(home, familiar_id)?
+            }
+            (None, Some(familiar_id)) => {
+                anyhow::bail!("cannot resolve familiar `{familiar_id}` without COVEN_HOME")
+            }
+            (None, None) => None,
+        };
         let command = pty_runner::build_harness_command_with_conversation(
             &launch.harness,
             &launch.prompt,

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2387,6 +2387,7 @@ mod tests {
                 created_at: "2026-04-27T10:00:00Z".to_string(),
                 updated_at: "2026-04-27T10:00:00Z".to_string(),
                 conversation_id: None,
+                familiar_id: None,
                 labels: Vec::new(),
                 visibility: "private".to_string(),
             },
@@ -2551,6 +2552,7 @@ mod tests {
             created_at: "2026-04-27T07:00:00Z".to_string(),
             updated_at: "2026-04-27T07:00:00Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         }

--- a/crates/coven-cli/src/familiar_identity.rs
+++ b/crates/coven-cli/src/familiar_identity.rs
@@ -1,0 +1,101 @@
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+
+use crate::{cockpit_sources, harness};
+
+pub(crate) fn resolve_optional(
+    coven_home: &Path,
+    familiar_id: Option<&str>,
+) -> Result<Option<harness::FamiliarContext>> {
+    let Some(familiar_id) = familiar_id
+        .map(str::trim)
+        .filter(|familiar_id| !familiar_id.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    resolve(coven_home, familiar_id)?
+        .map(Some)
+        .ok_or_else(|| unknown_familiar_error(coven_home, familiar_id))
+}
+
+pub(crate) fn resolve(
+    coven_home: &Path,
+    familiar_id: &str,
+) -> Result<Option<harness::FamiliarContext>> {
+    Ok(cockpit_sources::read_familiars(coven_home)?
+        .into_iter()
+        .find(|familiar| familiar.id == familiar_id)
+        .map(|familiar| harness::FamiliarContext {
+            id: familiar.id,
+            display_name: familiar.display_name,
+            role: Some(familiar.role).filter(|role| !role.is_empty()),
+        }))
+}
+
+pub(crate) fn known_ids(coven_home: &Path) -> Result<Vec<String>> {
+    Ok(cockpit_sources::read_familiars(coven_home)?
+        .into_iter()
+        .map(|familiar| familiar.id)
+        .collect())
+}
+
+pub(crate) fn unknown_familiar_error(coven_home: &Path, familiar_id: &str) -> anyhow::Error {
+    let known = known_ids(coven_home).unwrap_or_default();
+    if known.is_empty() {
+        anyhow!(
+            "unknown familiar `{familiar_id}`; no familiars are configured in {}",
+            coven_home.join("familiars.toml").display()
+        )
+    } else {
+        anyhow!(
+            "unknown familiar `{familiar_id}`; expected one of: {}",
+            known.join(", ")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_optional_returns_context_for_known_familiar() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        seed_familiars(temp.path())?;
+
+        let context = resolve_optional(temp.path(), Some("sage"))?.expect("known familiar");
+
+        assert_eq!(context.id, "sage");
+        assert_eq!(context.display_name, "Sage");
+        assert_eq!(context.role.as_deref(), Some("Research"));
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_optional_rejects_unknown_familiar() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        seed_familiars(temp.path())?;
+
+        let error = resolve_optional(temp.path(), Some("missing")).unwrap_err();
+
+        assert!(error.to_string().contains("unknown familiar `missing`"));
+        assert!(error.to_string().contains("sage"));
+        Ok(())
+    }
+
+    fn seed_familiars(coven_home: &Path) -> Result<()> {
+        std::fs::write(
+            coven_home.join("familiars.toml"),
+            r#"
+[[familiar]]
+id = "sage"
+display_name = "Sage"
+role = "Research"
+description = "Reads and synthesizes."
+"#,
+        )?;
+        Ok(())
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -18,6 +18,7 @@ mod cockpit_sources;
 mod control_plane;
 mod daemon;
 mod encrypted_artifacts;
+mod familiar_identity;
 mod harness;
 mod openclaw_repo;
 mod patch;
@@ -883,6 +884,7 @@ fn run_session(
         )
     })?;
     let cwd = project::resolve_inside_root(&project_root, cwd).context("failed to resolve cwd")?;
+    let coven_home = coven_home_dir()?;
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true);
@@ -901,22 +903,7 @@ fn run_session(
     // via that flag in build_harness_command_with_conversation; the prompt stays
     // clean. For harnesses without one (Codex), we prepend a bracketed identity
     // preamble to the prompt here so the integration layer remains harness-agnostic.
-    let familiar_ctx: Option<harness::FamiliarContext> = familiar_id.and_then(|fid| {
-        coven_home_dir().ok().and_then(|home| {
-            cockpit_sources::read_familiars(&home)
-                .ok()
-                .and_then(|familiars| {
-                    familiars
-                        .into_iter()
-                        .find(|f| f.id == fid)
-                        .map(|f| harness::FamiliarContext {
-                            id: f.id,
-                            display_name: f.display_name,
-                            role: Some(f.role).filter(|r| !r.is_empty()),
-                        })
-                })
-        })
-    });
+    let familiar_ctx = familiar_identity::resolve_optional(&coven_home, familiar_id)?;
     let spec = harness::built_in_harness_specs()
         .into_iter()
         .find(|s| s.id == selected_harness.id);
@@ -973,7 +960,7 @@ fn run_session(
             created_at: now.clone(),
             updated_at: now,
             conversation_id: None,
-            familiar_id: familiar_id.map(|s| s.to_string()),
+            familiar_id: familiar_ctx.as_ref().map(|f| f.id.clone()),
             labels,
             visibility: visibility.unwrap_or("private").to_string(),
         };

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -660,6 +660,7 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         created_at: now.clone(),
         updated_at: now.clone(),
         conversation_id: None,
+        familiar_id: None,
         labels: Vec::new(),
         visibility: "private".to_string(),
     };
@@ -972,6 +973,7 @@ fn run_session(
             created_at: now.clone(),
             updated_at: now,
             conversation_id: None,
+            familiar_id: familiar_id.map(|s| s.to_string()),
             labels,
             visibility: visibility.unwrap_or("private").to_string(),
         };
@@ -2370,6 +2372,7 @@ mod tests {
             created_at: "2026-04-27T06:00:00Z".to_string(),
             updated_at: "2026-04-27T06:00:00Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2393,6 +2396,7 @@ mod tests {
             created_at: "2026-05-14T07:00:00Z".to_string(),
             updated_at: "2026-05-14T07:00:01Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         };
@@ -2507,6 +2511,7 @@ mod tests {
             created_at: "2026-05-08T07:00:00Z".to_string(),
             updated_at: "2026-05-08T07:05:00Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         }

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -30,6 +30,14 @@ pub struct SessionRecord {
     /// resume` and grouping. See `docs/chat-persistence.md`.
     #[serde(default)]
     pub conversation_id: Option<String>,
+    /// Familiar id this session was launched with (`coven run --familiar <id>`).
+    /// Lets clients group sessions by familiar without maintaining a sidecar map.
+    /// `None` for legacy sessions and direct `coven run` invocations without
+    /// the flag. Backfilled by `cwd → ~/.openclaw/workspace/<id>` heuristics
+    /// remains the responsibility of the client (e.g. coven-cave); the daemon
+    /// only persists what the launcher explicitly passed in.
+    #[serde(default)]
+    pub familiar_id: Option<String>,
     #[serde(default)]
     pub labels: Vec<String>,
     #[serde(default = "default_visibility")]
@@ -113,7 +121,8 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             updated_at TEXT NOT NULL,
             conversation_id TEXT,
             labels TEXT,
-            visibility TEXT NOT NULL DEFAULT 'private'
+            visibility TEXT NOT NULL DEFAULT 'private',
+            familiar_id TEXT
         );
 
         CREATE TABLE IF NOT EXISTS events (
@@ -188,6 +197,7 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_sensitive_artifacts_table(&conn)?;
     ensure_labels_column(&conn)?;
     ensure_visibility_column(&conn)?;
+    ensure_familiar_id_column(&conn)?;
 
     // Backfill: copy any existing events into the FTS index. Safe on fresh dbs.
     conn.execute(
@@ -381,6 +391,25 @@ fn ensure_visibility_column(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn ensure_familiar_id_column(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "sessions",
+        "familiar_id",
+        "ALTER TABLE sessions ADD COLUMN familiar_id TEXT",
+    )?;
+    // Index makes "sessions for familiar X" cheap. The column is sparse on
+    // existing stores (legacy sessions are NULL until the client migrates),
+    // so a partial index keeps it small.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_sessions_familiar_id
+            ON sessions(familiar_id) WHERE familiar_id IS NOT NULL",
+        [],
+    )
+    .context("failed to create sessions.familiar_id index")?;
+    Ok(())
+}
+
 pub fn upsert_repository(conn: &Connection, record: &RepositoryRecord) -> Result<()> {
     conn.execute(
         "INSERT INTO repositories (
@@ -455,8 +484,8 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
     conn.execute(
         "INSERT INTO sessions (
             id, project_root, harness, title, status, exit_code, archived_at,
-            created_at, updated_at, conversation_id, labels, visibility
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            created_at, updated_at, conversation_id, labels, visibility, familiar_id
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
         params![
             &record.id,
             &record.project_root,
@@ -470,6 +499,7 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
             &record.conversation_id,
             labels_json,
             &record.visibility,
+            &record.familiar_id,
         ],
     )
     .with_context(|| format!("failed to insert session {}", record.id))?;
@@ -487,8 +517,8 @@ pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Re
         .execute(
             "INSERT OR IGNORE INTO sessions (
                 id, project_root, harness, title, status, exit_code, archived_at,
-                created_at, updated_at, conversation_id, labels, visibility
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                created_at, updated_at, conversation_id, labels, visibility, familiar_id
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
             params![
                 &record.id,
                 &record.project_root,
@@ -502,6 +532,7 @@ pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Re
                 &record.conversation_id,
                 labels_json,
                 &record.visibility,
+                &record.familiar_id,
             ],
         )
         .with_context(|| format!("failed to upsert session {}", record.id))?;
@@ -578,7 +609,8 @@ fn list_sessions_with_archive_filter(
                 updated_at,
                 conversation_id,
                 labels,
-                visibility
+                visibility,
+                familiar_id
             FROM sessions
             {archive_filter}
             ORDER BY created_at DESC, id DESC",
@@ -612,6 +644,7 @@ fn list_sessions_with_archive_filter(
                 created_at: row.get(7)?,
                 updated_at: row.get(8)?,
                 conversation_id: row.get(9)?,
+                familiar_id: row.get(12)?,
                 labels,
                 visibility,
             })
@@ -1831,6 +1864,7 @@ mod tests {
             created_at: created_at.to_string(),
             updated_at: created_at.to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         }
@@ -1891,8 +1925,88 @@ mod tests {
             conn.query_row("SELECT visibility FROM sessions WHERE id='s1'", [], |row| {
                 row.get(0)
             })?;
+        let familiar_id: Option<String> = conn.query_row(
+            "SELECT familiar_id FROM sessions WHERE id='s1'",
+            [],
+            |row| row.get(0),
+        )?;
         assert_eq!(labels, None);
         assert_eq!(visibility, "private");
+        assert_eq!(familiar_id, None);
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_id_round_trips_through_insert_and_list() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+        let mut nova = session_record("with-fam", "2026-06-03T00:00:00Z");
+        nova.familiar_id = Some("nova".to_string());
+        let plain = session_record("no-fam", "2026-06-03T00:00:01Z");
+        insert_session(&conn, &nova)?;
+        insert_session(&conn, &plain)?;
+
+        let listed = list_sessions(&conn)?;
+        let with_fam = listed.iter().find(|s| s.id == "with-fam").unwrap();
+        let no_fam = listed.iter().find(|s| s.id == "no-fam").unwrap();
+        assert_eq!(with_fam.familiar_id.as_deref(), Some("nova"));
+        assert_eq!(no_fam.familiar_id, None);
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_id_index_exists_after_open() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+        // Sanity: column + index were created by open_store / ensure_familiar_id_column.
+        let cols = table_columns(&conn, "sessions")?;
+        assert!(
+            cols.iter().any(|c| c == "familiar_id"),
+            "sessions.familiar_id column missing; cols={cols:?}"
+        );
+        let mut stmt = conn.prepare("SELECT name FROM sqlite_master WHERE type='index'")?;
+        let indexes: Vec<String> = stmt
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        assert!(
+            indexes.iter().any(|i| i == "idx_sessions_familiar_id"),
+            "idx_sessions_familiar_id missing; indexes={indexes:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_db_without_familiar_id_column_migrates_in_place() -> Result<()> {
+        // Simulate a pre-feature store: a session row that pre-dates the
+        // familiar_id column. open_store must add the column without
+        // dropping or rewriting any existing rows.
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("legacy.sqlite3");
+        {
+            let legacy = Connection::open(&path)?;
+            legacy.execute_batch(
+                "CREATE TABLE sessions (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    project_root TEXT NOT NULL,
+                    harness TEXT NOT NULL,
+                    title TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                );
+                INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+                  VALUES ('legacy-1', '/tmp', 'codex', 'old', 'completed', '2026-01-01', '2026-01-01');",
+            )?;
+        }
+        let conn = open_store(&path)?;
+        let cols = table_columns(&conn, "sessions")?;
+        assert!(cols.iter().any(|c| c == "familiar_id"));
+        let familiar_id: Option<String> = conn.query_row(
+            "SELECT familiar_id FROM sessions WHERE id='legacy-1'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(familiar_id, None);
         Ok(())
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -2473,6 +2473,7 @@ mod tests {
             created_at: "2026-05-19T00:00:00Z".to_string(),
             updated_at: "2026-05-19T00:00:00Z".to_string(),
             conversation_id: None,
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         }

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1514,6 +1514,7 @@ mod tests {
             created_at: "2026-05-24T00:00:00Z".to_string(),
             updated_at: "2026-05-24T00:00:00Z".to_string(),
             conversation_id: conversation.map(ToOwned::to_owned),
+            familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
         }

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -576,6 +576,7 @@ fn create_local_quest_anchor(
         created_at: timestamp.clone(),
         updated_at: timestamp.clone(),
         conversation_id: None,
+        familiar_id: None,
         labels: Vec::new(),
         visibility: "private".to_string(),
     };


### PR DESCRIPTION
> **⚠️ PRs are not being accepted until July 2026.**
> Please close this PR and open an Issue instead. PRs opened before July 2026 will be closed without review.
> See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Description

Adds nullable `familiar_id` persistence to daemon session records so familiar identity is stored centrally and returned in session APIs, instead of relying on client-side sidecar mappings.

This includes:
- `familiar_id` schema support and migration for existing stores
- `SessionRecord.familiar_id: Option<String>` serialization support
- Wiring from CLI and daemon session creation paths into stored session rows
- Test coverage for schema migration/index behavior and round-tripping
- **Additional review-feedback test:** API-level regression test confirming request `familiarId` is threaded into runtime launch data and round-trips through `GET /sessions`

## Linked Issue



## Testing

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`