### PR TITLE
feat(cli): add Coven Parallel Work Protocol

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -147,7 +147,11 @@ enum Command {
     },
     #[command(about = "Create, list, diagnose, and prune Coven worktrees")]
     Wt {
-        #[arg(help = "Branch to create or enter in the sibling <repo>.wt directory")]
+        #[arg(
+            help = "Branch to create or enter in the sibling <repo>.wt directory",
+            conflicts_with_all = ["list", "doctor", "prune_merged", "prune_stale"],
+            required_unless_present_any = ["list", "doctor", "prune_merged", "prune_stale"]
+        )]
         branch: Option<String>,
         #[arg(long, conflicts_with_all = ["doctor", "prune_merged", "prune_stale"], help = "List worktrees with claim and dirty state")]
         list: bool,

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -20,6 +20,7 @@ mod daemon;
 mod encrypted_artifacts;
 mod harness;
 mod openclaw_repo;
+mod parallel_protocol;
 mod patch;
 mod pc;
 mod privacy;
@@ -144,6 +145,29 @@ enum Command {
         #[command(subcommand)]
         command: LogsCommand,
     },
+    #[command(about = "Create, list, diagnose, and prune Coven worktrees")]
+    Wt {
+        #[arg(help = "Branch to create or enter in the sibling <repo>.wt directory")]
+        branch: Option<String>,
+        #[arg(long, conflicts_with_all = ["doctor", "prune_merged", "prune_stale"], help = "List worktrees with claim and dirty state")]
+        list: bool,
+        #[arg(long, conflicts_with_all = ["list", "prune_merged", "prune_stale"], help = "Report protocol layout and hook issues")]
+        doctor: bool,
+        #[arg(long, conflicts_with_all = ["list", "doctor", "prune_stale"], help = "Remove clean worktrees whose branches are merged into the primary branch")]
+        prune_merged: bool,
+        #[arg(long, value_name = "DAYS", conflicts_with_all = ["list", "doctor", "prune_merged"], help = "Remove clean worktrees not modified for DAYS")]
+        prune_stale: Option<u64>,
+    },
+    #[command(about = "Manage TTL-bounded agent branch claims")]
+    Claim {
+        #[command(subcommand)]
+        command: ClaimCommand,
+    },
+    #[command(about = "Install Coven Parallel Work Protocol git hooks")]
+    Hooks {
+        #[command(subcommand)]
+        command: HooksCommand,
+    },
     #[command(about = "Replay/follow a session and forward input to live daemon sessions")]
     Attach { session_id: String },
     #[command(about = "Summon an archived session back, then replay/follow it")]
@@ -237,6 +261,38 @@ enum LogsCommand {
     },
 }
 
+#[derive(Subcommand, Debug)]
+enum ClaimCommand {
+    #[command(about = "Claim a branch for the current agent")]
+    Acquire {
+        #[arg(help = "Branch to claim")]
+        branch: String,
+    },
+    #[command(about = "Release this agent's claim for a branch")]
+    Release {
+        #[arg(help = "Branch to release")]
+        branch: String,
+    },
+    #[command(about = "Extend this agent's claim TTL for a branch")]
+    Heartbeat {
+        #[arg(help = "Branch whose claim should be extended")]
+        branch: String,
+    },
+    #[command(about = "Record the current HEAD for later hook canary checks")]
+    Canary {
+        #[arg(help = "Branch to associate with the current HEAD snapshot")]
+        branch: String,
+    },
+    #[command(about = "Show active and expired claims for this repository")]
+    Status,
+}
+
+#[derive(Subcommand, Debug)]
+enum HooksCommand {
+    #[command(about = "Install pre-commit and pre-push protocol hooks")]
+    Install,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InteractiveShellRoute {
     Chat,
@@ -310,6 +366,29 @@ fn run_cli(cli: Cli) -> Result<()> {
             None => tui::sessions::run_command(all, manage, plain, json),
         },
         Some(Command::Logs { command }) => run_logs_command(command),
+        Some(Command::Wt {
+            branch,
+            list,
+            doctor,
+            prune_merged,
+            prune_stale,
+        }) => parallel_protocol::run_wt_command(
+            branch.as_deref(),
+            list,
+            doctor,
+            prune_merged,
+            prune_stale,
+        ),
+        Some(Command::Claim { command }) => match command {
+            ClaimCommand::Acquire { branch } => parallel_protocol::claim_acquire(&branch),
+            ClaimCommand::Release { branch } => parallel_protocol::claim_release(&branch),
+            ClaimCommand::Heartbeat { branch } => parallel_protocol::claim_heartbeat(&branch),
+            ClaimCommand::Canary { branch } => parallel_protocol::claim_canary(&branch),
+            ClaimCommand::Status => parallel_protocol::claim_status(),
+        },
+        Some(Command::Hooks { command }) => match command {
+            HooksCommand::Install => parallel_protocol::hooks_install(),
+        },
         Some(Command::Attach { session_id }) => attach_session(&session_id),
         Some(Command::Summon { session_id }) => summon_session_command(&session_id),
         Some(Command::Archive { session_id }) => archive_session_command(&session_id),

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -690,11 +690,11 @@ do
   consume_intent=1
 done
 
-if [ "$consume_intent" = "1" ]; then
-  rm -f "$intent_file"
-fi
-
 if [ -x "$common_dir/hooks/pre-push.local" ]; then
   "$common_dir/hooks/pre-push.local" "$@"
+fi
+
+if [ "$consume_intent" = "1" ]; then
+  rm -f "$intent_file"
 fi
 "#;

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -1,0 +1,700 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+const CLAIM_TTL_SECONDS: u64 = 60 * 60;
+const DEFAULT_PRIMARY_BRANCH: &str = "main";
+const MANAGED_HOOK_MARKER: &str = "Coven Parallel Work Protocol managed hook";
+
+#[derive(Debug, Clone)]
+struct Repo {
+    root: PathBuf,
+    common_dir: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+struct Claim {
+    branch: String,
+    agent_id: String,
+    acquired_at: u64,
+    expires_at: u64,
+    head: Option<String>,
+}
+
+#[derive(Debug)]
+struct Worktree {
+    path: PathBuf,
+    branch: Option<String>,
+}
+
+pub(crate) fn run_wt_command(
+    branch: Option<&str>,
+    list: bool,
+    doctor: bool,
+    prune_merged: bool,
+    prune_stale: Option<u64>,
+) -> Result<()> {
+    let repo = Repo::discover()?;
+    match (branch, list, doctor, prune_merged, prune_stale) {
+        (Some(branch), false, false, false, None) => wt_enter_or_create(&repo, branch),
+        (None, true, false, false, None) => wt_list(&repo),
+        (None, false, true, false, None) => wt_doctor(&repo),
+        (None, false, false, true, None) => wt_prune_merged(&repo),
+        (None, false, false, false, Some(days)) => wt_prune_stale(&repo, days),
+        (None, false, false, false, None) => {
+            println!("Usage: coven wt <branch> | --list | --doctor | --prune-merged | --prune-stale DAYS");
+            Ok(())
+        }
+        _ => anyhow::bail!("choose exactly one `coven wt` action"),
+    }
+}
+
+pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
+    let repo = Repo::discover()?;
+    let agent_id = agent_id();
+    let now = unix_now();
+    if let Some(existing) = read_claim(&repo, branch)? {
+        if existing.is_active(now) && existing.agent_id != agent_id {
+            anyhow::bail!(
+                "{} is already claimed by {} until {}",
+                branch,
+                existing.agent_id,
+                existing.expires_at
+            );
+        }
+    }
+
+    let claim = Claim {
+        branch: branch.to_string(),
+        agent_id: agent_id.clone(),
+        acquired_at: now,
+        expires_at: now + claim_ttl_seconds(),
+        head: current_head().ok(),
+    };
+    write_claim(&repo, &claim)?;
+    println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
+    Ok(())
+}
+
+pub(crate) fn claim_release(branch: &str) -> Result<()> {
+    let repo = Repo::discover()?;
+    let agent_id = agent_id();
+    if let Some(existing) = read_claim(&repo, branch)? {
+        if existing.is_active(unix_now()) && existing.agent_id != agent_id {
+            anyhow::bail!(
+                "{} is claimed by {}; {} cannot release it",
+                branch,
+                existing.agent_id,
+                agent_id
+            );
+        }
+        fs::remove_file(claim_path(&repo, branch))
+            .with_context(|| format!("failed to release claim for {branch}"))?;
+        println!("released {branch}");
+    } else {
+        println!("no claim for {branch}");
+    }
+    Ok(())
+}
+
+pub(crate) fn claim_heartbeat(branch: &str) -> Result<()> {
+    let repo = Repo::discover()?;
+    let agent_id = agent_id();
+    let now = unix_now();
+    let mut claim = read_claim(&repo, branch)?.unwrap_or_else(|| Claim {
+        branch: branch.to_string(),
+        agent_id: agent_id.clone(),
+        acquired_at: now,
+        expires_at: now,
+        head: current_head().ok(),
+    });
+    if claim.is_active(now) && claim.agent_id != agent_id {
+        anyhow::bail!(
+            "{} is claimed by {}; {} cannot heartbeat it",
+            branch,
+            claim.agent_id,
+            agent_id
+        );
+    }
+    claim.agent_id = agent_id.clone();
+    claim.expires_at = now + claim_ttl_seconds();
+    write_claim(&repo, &claim)?;
+    println!(
+        "heartbeat {branch} for {agent_id} until {}",
+        claim.expires_at
+    );
+    Ok(())
+}
+
+pub(crate) fn claim_canary(branch: &str) -> Result<()> {
+    let repo = Repo::discover()?;
+    let head = current_head()?;
+    let canary_path = repo.common_dir.join("AGENT_HEAD_AT_START");
+    fs::write(&canary_path, format!("branch={branch}\nhead={head}\n"))
+        .with_context(|| format!("failed to write {}", canary_path.display()))?;
+    println!("recorded canary for {branch} at {head}");
+    Ok(())
+}
+
+pub(crate) fn claim_status() -> Result<()> {
+    let repo = Repo::discover()?;
+    let claims_dir = repo.common_dir.join("agent-claims");
+    if !claims_dir.exists() {
+        println!("No claims.");
+        return Ok(());
+    }
+    let now = unix_now();
+    let mut claims = fs::read_dir(&claims_dir)?
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
+        .collect::<Vec<_>>();
+    claims.sort_by(|a, b| a.branch.cmp(&b.branch));
+    if claims.is_empty() {
+        println!("No claims.");
+        return Ok(());
+    }
+    println!("{:<32} {:<20} {:<10} expires", "branch", "agent", "state");
+    for claim in claims {
+        let state = if claim.is_active(now) {
+            "active"
+        } else {
+            "expired"
+        };
+        println!(
+            "{:<32} {:<20} {:<10} {}",
+            claim.branch, claim.agent_id, state, claim.expires_at
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn hooks_install() -> Result<()> {
+    let repo = Repo::discover()?;
+    let hooks_path = git_config("core.hooksPath")?;
+    if hooks_path
+        .as_deref()
+        .is_some_and(|path| !path.trim().is_empty())
+    {
+        anyhow::bail!(
+            "core.hooksPath is set to {}. Coven will not auto-modify tracked hook directories.\n\
+             Integration options:\n\
+             1. Run the Coven checks from that tracked hook directory.\n\
+             2. Move the tracked hook to .git/hooks/<hook>.local and unset core.hooksPath.",
+            hooks_path.unwrap()
+        );
+    }
+
+    let hooks_dir = repo.common_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir)?;
+    install_hook(&hooks_dir, "pre-commit", PRE_COMMIT_HOOK)?;
+    install_hook(&hooks_dir, "pre-push", PRE_PUSH_HOOK)?;
+    println!(
+        "installed Coven Parallel Work Protocol hooks in {}",
+        hooks_dir.display()
+    );
+    Ok(())
+}
+
+fn wt_enter_or_create(repo: &Repo, branch: &str) -> Result<()> {
+    let path = worktree_path(repo, branch)?;
+    if path.exists() {
+        println!("{}", path.display());
+        return Ok(());
+    }
+    fs::create_dir_all(
+        path.parent()
+            .ok_or_else(|| anyhow!("invalid worktree path {}", path.display()))?,
+    )?;
+    let branch_exists = git_success(["show-ref", "--verify", &format!("refs/heads/{branch}")]);
+    if branch_exists {
+        run_git(["worktree", "add"], [&path, Path::new(branch)])?;
+    } else {
+        run_git(["worktree", "add", "-b", branch], [&path])?;
+    }
+    println!("{}", path.display());
+    Ok(())
+}
+
+fn wt_list(repo: &Repo) -> Result<()> {
+    let worktrees = list_worktrees()?;
+    println!("{:<32} {:<8} {:<20} path", "branch", "dirty", "claim");
+    for worktree in worktrees {
+        let branch = worktree.branch.as_deref().unwrap_or("(detached)");
+        let dirty = if worktree_dirty(&worktree.path)? {
+            "dirty"
+        } else {
+            "clean"
+        };
+        let claim = worktree
+            .branch
+            .as_deref()
+            .and_then(|branch| read_claim(repo, branch).ok().flatten())
+            .filter(|claim| claim.is_active(unix_now()))
+            .map(|claim| claim.agent_id)
+            .unwrap_or_else(|| "-".to_string());
+        println!(
+            "{:<32} {:<8} {:<20} {}",
+            branch,
+            dirty,
+            claim,
+            worktree.path.display()
+        );
+    }
+    Ok(())
+}
+
+fn wt_doctor(repo: &Repo) -> Result<()> {
+    println!("Coven Parallel Work Protocol doctor");
+    println!("repo: {}", repo.root.display());
+    println!("worktree root: {}", worktree_root(repo)?.display());
+    println!("claims: {}", repo.common_dir.join("agent-claims").display());
+    for hook in ["pre-commit", "pre-push"] {
+        let path = repo.common_dir.join("hooks").join(hook);
+        let status = if hook_is_managed(&path)? {
+            "OK"
+        } else {
+            "missing"
+        };
+        println!("hook {hook}: {status}");
+    }
+    for worktree in list_worktrees()? {
+        let expected_root = worktree_root(repo)?;
+        if worktree.path != repo.root && !worktree.path.starts_with(&expected_root) {
+            println!(
+                "layout warning: {} is outside {}",
+                worktree.path.display(),
+                expected_root.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn wt_prune_merged(repo: &Repo) -> Result<()> {
+    let primary = primary_branch();
+    let merged = git_stdout(["branch", "--merged", &primary])?;
+    let merged = merged
+        .lines()
+        .map(|line| line.trim().trim_start_matches('*').trim())
+        .filter(|branch| !branch.is_empty() && *branch != primary)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    prune_worktrees(repo, |worktree| {
+        Ok(worktree
+            .branch
+            .as_deref()
+            .is_some_and(|branch| merged.iter().any(|merged| merged == branch)))
+    })
+}
+
+fn wt_prune_stale(repo: &Repo, days: u64) -> Result<()> {
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(days.saturating_mul(24 * 60 * 60)))
+        .unwrap_or(UNIX_EPOCH);
+    prune_worktrees(repo, |worktree| {
+        Ok(fs::metadata(&worktree.path)
+            .and_then(|metadata| metadata.modified())
+            .map(|modified| modified < cutoff)
+            .unwrap_or(false))
+    })
+}
+
+fn prune_worktrees(repo: &Repo, should_prune: impl Fn(&Worktree) -> Result<bool>) -> Result<()> {
+    let mut pruned = 0usize;
+    for worktree in list_worktrees()? {
+        if worktree.path == repo.root || !should_prune(&worktree)? {
+            continue;
+        }
+        if worktree_dirty(&worktree.path)? {
+            println!("skip dirty {}", worktree.path.display());
+            continue;
+        }
+        run_git(["worktree", "remove"], [&worktree.path])?;
+        println!("removed {}", worktree.path.display());
+        pruned += 1;
+    }
+    println!("pruned {pruned} worktree(s)");
+    Ok(())
+}
+
+fn list_worktrees() -> Result<Vec<Worktree>> {
+    let output = git_stdout(["worktree", "list", "--porcelain"])?;
+    let mut worktrees = Vec::new();
+    let mut path = None;
+    let mut branch = None;
+    for line in output.lines().chain(std::iter::once("")) {
+        if line.is_empty() {
+            if let Some(path) = path.take() {
+                worktrees.push(Worktree {
+                    path,
+                    branch: branch.take(),
+                });
+            }
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("worktree ") {
+            path = Some(PathBuf::from(value));
+        } else if let Some(value) = line.strip_prefix("branch refs/heads/") {
+            branch = Some(value.to_string());
+        }
+    }
+    Ok(worktrees)
+}
+
+fn worktree_dirty(path: &Path) -> Result<bool> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(path)
+        .output()
+        .with_context(|| format!("failed to inspect {}", path.display()))?;
+    if !output.status.success() {
+        anyhow::bail!("git status failed in {}", path.display());
+    }
+    Ok(!output.stdout.is_empty())
+}
+
+fn worktree_root(repo: &Repo) -> Result<PathBuf> {
+    let name = repo
+        .root
+        .file_name()
+        .ok_or_else(|| anyhow!("repo root has no file name: {}", repo.root.display()))?;
+    Ok(repo
+        .root
+        .with_file_name(format!("{}.wt", name.to_string_lossy())))
+}
+
+fn worktree_path(repo: &Repo, branch: &str) -> Result<PathBuf> {
+    Ok(worktree_root(repo)?.join(branch_slug(branch)))
+}
+
+fn write_claim(repo: &Repo, claim: &Claim) -> Result<()> {
+    let claims_dir = repo.common_dir.join("agent-claims");
+    fs::create_dir_all(&claims_dir)?;
+    let path = claim_path(repo, &claim.branch);
+    let mut file = fs::File::create(&path)
+        .with_context(|| format!("failed to create claim {}", path.display()))?;
+    writeln!(file, "branch={}", claim.branch)?;
+    writeln!(file, "agent_id={}", claim.agent_id)?;
+    writeln!(file, "acquired_at={}", claim.acquired_at)?;
+    writeln!(file, "expires_at={}", claim.expires_at)?;
+    if let Some(head) = &claim.head {
+        writeln!(file, "head={head}")?;
+    }
+    Ok(())
+}
+
+fn read_claim(repo: &Repo, branch: &str) -> Result<Option<Claim>> {
+    read_claim_file(&claim_path(repo, branch))
+}
+
+fn read_claim_file(path: &Path) -> Result<Option<Claim>> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read claim {}", path.display()))?;
+    let value = |key: &str| -> Option<String> {
+        contents.lines().find_map(|line| {
+            line.split_once('=')
+                .filter(|(found, _)| *found == key)
+                .map(|(_, value)| value.to_string())
+        })
+    };
+    let branch = value("branch").unwrap_or_else(|| {
+        path.file_name()
+            .map(|name| name.to_string_lossy().to_string())
+            .unwrap_or_else(|| "unknown".to_string())
+    });
+    let Some(agent_id) = value("agent_id") else {
+        return Ok(None);
+    };
+    let acquired_at = value("acquired_at")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let expires_at = value("expires_at")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    Ok(Some(Claim {
+        branch,
+        agent_id,
+        acquired_at,
+        expires_at,
+        head: value("head"),
+    }))
+}
+
+fn claim_path(repo: &Repo, branch: &str) -> PathBuf {
+    repo.common_dir
+        .join("agent-claims")
+        .join(branch_slug(branch))
+}
+
+impl Claim {
+    fn is_active(&self, now: u64) -> bool {
+        self.expires_at > now
+    }
+}
+
+impl Repo {
+    fn discover() -> Result<Self> {
+        let root = PathBuf::from(git_stdout(["rev-parse", "--show-toplevel"])?.trim());
+        let common = PathBuf::from(git_stdout(["rev-parse", "--git-common-dir"])?.trim());
+        let common_dir = if common.is_absolute() {
+            common
+        } else {
+            root.join(common)
+        };
+        Ok(Self { root, common_dir })
+    }
+}
+
+fn install_hook(hooks_dir: &Path, hook: &str, contents: &str) -> Result<()> {
+    let path = hooks_dir.join(hook);
+    let local = hooks_dir.join(format!("{hook}.local"));
+    if path.exists() && !hook_is_managed(&path)? {
+        if local.exists() {
+            anyhow::bail!(
+                "{} already exists and {} is not Coven-managed; refusing to overwrite either hook",
+                path.display(),
+                local.display()
+            );
+        }
+        fs::rename(&path, &local)
+            .with_context(|| format!("failed to move existing hook to {}", local.display()))?;
+    }
+    fs::write(&path, contents).with_context(|| format!("failed to write {}", path.display()))?;
+    set_executable(&path)?;
+    Ok(())
+}
+
+fn hook_is_managed(path: &Path) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    Ok(fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?
+        .contains(MANAGED_HOOK_MARKER))
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)?;
+    Ok(())
+}
+
+fn current_head() -> Result<String> {
+    Ok(git_stdout(["rev-parse", "HEAD"])?.trim().to_string())
+}
+
+fn git_config(key: &str) -> Result<Option<String>> {
+    let output = Command::new("git")
+        .args(["config", "--get", key])
+        .output()
+        .with_context(|| format!("failed to read git config {key}"))?;
+    if output.status.success() {
+        return Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ));
+    }
+    Ok(None)
+}
+
+fn git_stdout<const N: usize>(args: [&str; N]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .context("failed to run git")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git failed: {}\n{}",
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn git_success<const N: usize>(args: [&str; N]) -> bool {
+    Command::new("git")
+        .args(args)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+fn run_git<const N: usize, const M: usize>(args: [&str; N], path_args: [&Path; M]) -> Result<()> {
+    let output = Command::new("git")
+        .args(args)
+        .args(path_args.iter().map(|path| path.as_os_str()))
+        .output()
+        .context("failed to run git")?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git failed: {}\n{}",
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+    Ok(())
+}
+
+fn branch_slug(branch: &str) -> String {
+    let mut slug = String::with_capacity(branch.len());
+    for ch in branch.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+            slug.push(ch);
+        } else {
+            slug.push('-');
+        }
+    }
+    slug.trim_matches('-').to_string()
+}
+
+fn primary_branch() -> String {
+    std::env::var("COVEN_PRIMARY_BRANCH").unwrap_or_else(|_| DEFAULT_PRIMARY_BRANCH.to_string())
+}
+
+fn agent_id() -> String {
+    std::env::var("COVEN_AGENT_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| std::env::var("USER").ok())
+        .unwrap_or_else(|| "unknown-agent".to_string())
+}
+
+fn claim_ttl_seconds() -> u64 {
+    std::env::var("COVEN_CLAIM_TTL_SECONDS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(CLAIM_TTL_SECONDS)
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+const PRE_COMMIT_HOOK: &str = r#"#!/bin/sh
+# Coven Parallel Work Protocol managed hook
+set -eu
+
+slug_branch() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-'
+}
+
+claim_value() {
+  key="$1"
+  file="$2"
+  awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$file"
+}
+
+branch="$(git symbolic-ref --quiet --short HEAD || true)"
+primary="${COVEN_PRIMARY_BRANCH:-main}"
+agent="${COVEN_AGENT_ID:-${USER:-unknown-agent}}"
+common_dir="$(git rev-parse --git-common-dir)"
+
+if [ "$branch" = "$primary" ] && [ "${COVEN_ALLOW_PRIMARY_COMMIT:-}" != "1" ]; then
+  echo "Coven Parallel Work Protocol: refusing commit on protected primary branch '$primary'." >&2
+  echo "Set COVEN_ALLOW_PRIMARY_COMMIT=1 only for explicit human-approved primary commits." >&2
+  exit 1
+fi
+
+if [ -n "$branch" ]; then
+  claim_file="$common_dir/agent-claims/$(slug_branch "$branch")"
+  if [ -f "$claim_file" ]; then
+    claim_agent="$(claim_value agent_id "$claim_file")"
+    expires_at="$(claim_value expires_at "$claim_file")"
+    now="$(date +%s)"
+    if [ -n "$claim_agent" ] && [ "${expires_at:-0}" -gt "$now" ] && [ "$claim_agent" != "$agent" ]; then
+      echo "Coven Parallel Work Protocol: branch '$branch' is claimed by $claim_agent; current agent is $agent." >&2
+      exit 1
+    fi
+  fi
+fi
+
+canary="$common_dir/AGENT_HEAD_AT_START"
+if [ -f "$canary" ] && [ -n "$branch" ]; then
+  canary_branch="$(claim_value branch "$canary")"
+  canary_head="$(claim_value head "$canary")"
+  if [ "$canary_branch" = "$branch" ] && [ -n "$canary_head" ] && git cat-file -e "$canary_head^{commit}" 2>/dev/null; then
+    if ! git merge-base --is-ancestor "$canary_head" HEAD; then
+      echo "Coven Parallel Work Protocol: HEAD canary tripped for '$branch'." >&2
+      echo "Current HEAD is not a descendant of $canary_head." >&2
+      exit 1
+    fi
+  fi
+fi
+
+if [ -x "$common_dir/hooks/pre-commit.local" ]; then
+  "$common_dir/hooks/pre-commit.local" "$@"
+fi
+"#;
+
+const PRE_PUSH_HOOK: &str = r#"#!/bin/sh
+# Coven Parallel Work Protocol managed hook
+set -eu
+
+primary="${COVEN_PRIMARY_BRANCH:-main}"
+protected_regex="${COVEN_PROTECTED_REGEX:-^(release|hotfix)/}"
+merge_phrase="${COVEN_MERGE_PHRASE:-Enchant merge to main.}"
+common_dir="$(git rev-parse --git-common-dir)"
+intent_file="$common_dir/MERGE_INTENT"
+consume_intent=0
+
+is_zero() {
+  case "$1" in
+    0000000000000000000000000000000000000000) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_protected_branch() {
+  branch="$1"
+  if [ "$branch" = "$primary" ]; then
+    return 0
+  fi
+  printf '%s\n' "$branch" | grep -Eq "$protected_regex"
+}
+
+while read -r local_ref local_sha remote_ref remote_sha
+do
+  case "$remote_ref" in
+    refs/heads/*) branch="${remote_ref#refs/heads/}" ;;
+    *) continue ;;
+  esac
+
+  if ! is_protected_branch "$branch"; then
+    continue
+  fi
+
+  if ! is_zero "$remote_sha" && ! is_zero "$local_sha" && ! git merge-base --is-ancestor "$remote_sha" "$local_sha"; then
+    echo "Coven Parallel Work Protocol: refusing force-push to protected branch '$branch'." >&2
+    exit 1
+  fi
+
+  if [ ! -f "$intent_file" ] || [ "$(cat "$intent_file")" != "$merge_phrase" ]; then
+    echo "Coven Parallel Work Protocol: protected branch '$branch' requires $intent_file containing exactly:" >&2
+    echo "$merge_phrase" >&2
+    exit 1
+  fi
+  consume_intent=1
+done
+
+if [ "$consume_intent" = "1" ]; then
+  rm -f "$intent_file"
+fi
+
+if [ -x "$common_dir/hooks/pre-push.local" ]; then
+  "$common_dir/hooks/pre-push.local" "$@"
+fi
+"#;

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -489,6 +489,11 @@ fn set_executable(path: &Path) -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
 fn current_head() -> Result<String> {
     Ok(git_stdout(["rev-parse", "HEAD"])?.trim().to_string())
 }

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -589,7 +589,7 @@ const PRE_COMMIT_HOOK: &str = r#"#!/bin/sh
 set -eu
 
 slug_branch() {
-  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-'
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed -e 's/^-*//' -e 's/-*$//'
 }
 
 claim_value() {

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -1,0 +1,271 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+#[test]
+fn wt_creates_sibling_worktree_and_lists_protocol_state() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let output = repo.coven(["wt", "feature/demo"])?;
+    assert_success("coven wt feature/demo", &output);
+
+    let worktree = repo.path.with_extension("wt").join("feature-demo");
+    assert!(
+        worktree.join(".git").exists(),
+        "expected worktree at {}",
+        worktree.display()
+    );
+    assert_eq!(
+        repo.git_in(&worktree, ["branch", "--show-current"])?,
+        "feature/demo"
+    );
+
+    let list = repo.coven(["wt", "--list"])?;
+    assert_success("coven wt --list", &list);
+    assert_stdout_contains("coven wt --list", &list, "feature/demo");
+    assert_stdout_contains("coven wt --list", &list, "feature-demo");
+    Ok(())
+}
+
+#[test]
+fn claim_acquire_blocks_other_agent_until_release() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+
+    let acquired = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_success("claim acquire by cody", &acquired);
+    assert_stdout_contains("claim acquire by cody", &acquired, "claimed feature/demo");
+
+    let blocked = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_failure("claim acquire by sage", &blocked);
+    assert_stderr_contains("claim acquire by sage", &blocked, "claimed by cody");
+
+    let status = repo.coven(["claim", "status"])?;
+    assert_success("claim status", &status);
+    assert_stdout_contains("claim status", &status, "feature/demo");
+    assert_stdout_contains("claim status", &status, "cody");
+
+    let released = repo.coven_with_env(
+        ["claim", "release", "feature/demo"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_success("claim release by cody", &released);
+
+    let reacquired = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_success("claim acquire by sage after release", &reacquired);
+    Ok(())
+}
+
+#[test]
+fn installed_hooks_block_primary_commits_and_claim_conflicts() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+
+    let install = repo.coven(["hooks", "install"])?;
+    assert_success("hooks install", &install);
+
+    fs::write(repo.path.join("main.txt"), "blocked\n")?;
+    let blocked_main = repo.git_output(["commit", "-am", "blocked on main"], [])?;
+    assert_failure("commit on main", &blocked_main);
+    assert_stderr_contains(
+        "commit on main",
+        &blocked_main,
+        "Coven Parallel Work Protocol",
+    );
+
+    let allowed_main = repo.git_output(
+        ["commit", "-am", "explicit main commit"],
+        [("COVEN_ALLOW_PRIMARY_COMMIT", "1")],
+    )?;
+    assert_success("commit on main with override", &allowed_main);
+
+    repo.git(["checkout", "-b", "feature/demo"])?;
+    let claim = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_success("claim feature/demo", &claim);
+
+    fs::write(repo.path.join("main.txt"), "conflict\n")?;
+    let blocked_claim = repo.git_output(
+        ["commit", "-am", "blocked by claim"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_failure("commit with another agent claim", &blocked_claim);
+    assert_stderr_contains(
+        "commit with another agent claim",
+        &blocked_claim,
+        "claimed by cody",
+    );
+
+    let allowed_claim = repo.git_output(
+        ["commit", "-am", "allowed by owner"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_success("commit with owning claim", &allowed_claim);
+    Ok(())
+}
+
+#[test]
+fn installed_pre_push_requires_merge_intent_for_primary_and_consumes_it() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let remote_dir = tempfile::tempdir()?;
+    let remote = remote_dir.path().join("remote.git");
+    Command::new("git")
+        .args(["init", "--bare"])
+        .arg(&remote)
+        .output()?;
+    repo.git_os(["remote", "add", "origin"], [&remote])?;
+
+    let install = repo.coven(["hooks", "install"])?;
+    assert_success("hooks install", &install);
+
+    let blocked = repo.git_output(["push", "origin", "main"], [])?;
+    assert_failure("push main without intent", &blocked);
+    assert_stderr_contains("push main without intent", &blocked, "MERGE_INTENT");
+
+    fs::write(
+        repo.git_common_dir()?.join("MERGE_INTENT"),
+        "Enchant merge to main.",
+    )?;
+    let allowed = repo.git_output(["push", "origin", "main"], [])?;
+    assert_success("push main with intent", &allowed);
+    assert!(
+        !repo.git_common_dir()?.join("MERGE_INTENT").exists(),
+        "successful protected push should consume MERGE_INTENT"
+    );
+    Ok(())
+}
+
+struct TestRepo {
+    _temp: tempfile::TempDir,
+    path: PathBuf,
+}
+
+impl TestRepo {
+    fn new() -> anyhow::Result<Self> {
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("project");
+        fs::create_dir(&path)?;
+        let repo = Self { _temp: temp, path };
+        repo.git(["init", "--initial-branch=main"])?;
+        repo.git(["config", "user.email", "coven@example.test"])?;
+        repo.git(["config", "user.name", "Coven Test"])?;
+        fs::write(repo.path.join("main.txt"), "initial\n")?;
+        repo.git(["add", "main.txt"])?;
+        repo.git(["commit", "-m", "initial"])?;
+        Ok(repo)
+    }
+
+    fn coven<const N: usize>(&self, args: [&str; N]) -> anyhow::Result<Output> {
+        self.coven_with_env(args, [])
+    }
+
+    fn coven_with_env<const N: usize, const M: usize>(
+        &self,
+        args: [&str; N],
+        env: [(&str, &str); M],
+    ) -> anyhow::Result<Output> {
+        let mut command = Command::new(coven_bin());
+        command
+            .args(args)
+            .current_dir(&self.path)
+            .env("COVEN_HOME", self.path.join(".coven-home"))
+            .env_remove("COVEN_AGENT_ID")
+            .env_remove("COVEN_ALLOW_PRIMARY_COMMIT");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.output().map_err(Into::into)
+    }
+
+    fn git<const N: usize>(&self, args: [&str; N]) -> anyhow::Result<String> {
+        self.git_in(&self.path, args)
+    }
+
+    fn git_in<const N: usize>(&self, cwd: &Path, args: [&str; N]) -> anyhow::Result<String> {
+        let output = Command::new("git").args(args).current_dir(cwd).output()?;
+        assert_success("git", &output);
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+
+    fn git_os<const N: usize, const M: usize>(
+        &self,
+        args: [&str; N],
+        os_args: [&Path; M],
+    ) -> anyhow::Result<Output> {
+        let mut command = Command::new("git");
+        command.args(args).args(os_args).current_dir(&self.path);
+        command.output().map_err(Into::into)
+    }
+
+    fn git_output<const N: usize, const M: usize>(
+        &self,
+        args: [&str; N],
+        env: [(&str, &str); M],
+    ) -> anyhow::Result<Output> {
+        let mut command = Command::new("git");
+        command
+            .args(args)
+            .current_dir(&self.path)
+            .env_remove("COVEN_AGENT_ID")
+            .env_remove("COVEN_ALLOW_PRIMARY_COMMIT");
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        command.output().map_err(Into::into)
+    }
+
+    fn git_common_dir(&self) -> anyhow::Result<PathBuf> {
+        Ok(self.path.join(self.git(["rev-parse", "--git-common-dir"])?))
+    }
+}
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_failure(label: &str, output: &Output) {
+    assert!(
+        !output.status.success(),
+        "{label} unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_stdout_contains(label: &str, output: &Output, needle: &str) {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(needle),
+        "{label} stdout did not contain {needle:?}\nstdout:\n{stdout}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_stderr_contains(label: &str, output: &Output, needle: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(needle),
+        "{label} stderr did not contain {needle:?}\nstdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -135,6 +135,7 @@
                   "harnesses/claude-code",
                   "harnesses/installing",
                   "harnesses/provider-auth",
+                  "familiars/parallel-lanes",
                   "HARNESS-ADAPTERS",
                   "FUTURE-HARNESSES"
                 ]

--- a/docs/familiars/parallel-lanes.md
+++ b/docs/familiars/parallel-lanes.md
@@ -6,4 +6,97 @@ title: "Parallel specialist lanes"
 description: "Parallel specialist lanes in OpenCoven: running multiple familiars side-by-side so each focuses on its own role and harness without blocking the others."
 ---
 
-Stub — fill in. See [Familiars overview](/familiars).
+Parallel lanes let several agents work in the same repository without sharing
+the same mutable checkout. Coven treats this as a harness-agnostic protocol:
+Codex, Claude Code, OpenClaw familiars, CastCodes agents, and future runtimes
+can all participate as long as they use the same git worktree, claim, and hook
+contracts.
+
+## The protocol
+
+The Coven Parallel Work Protocol has three layers:
+
+1. Worktree isolation: feature work happens in a sibling `<repo>.wt/<branch>/`
+   checkout instead of the primary repository checkout.
+2. Agent claims: a branch can be claimed under git's common directory with a
+   TTL so other agents know not to commit into the same branch.
+3. Branch protection hooks: local git hooks block accidental primary-branch
+   commits, cross-agent claim conflicts, protected force-pushes, and protected
+   pushes without explicit merge intent.
+
+Use layer 1 by default. Add layers 2 and 3 whenever more than one agent,
+automation, or background worker can touch the same repository.
+
+## CLI
+
+Create or enter an isolated worktree:
+
+```bash
+coven wt feature/my-branch
+```
+
+List and diagnose worktrees:
+
+```bash
+coven wt --list
+coven wt --doctor
+```
+
+Prune clean worktrees:
+
+```bash
+coven wt --prune-merged
+coven wt --prune-stale 14
+```
+
+Claim a branch for the current agent:
+
+```bash
+COVEN_AGENT_ID=cody coven claim acquire feature/my-branch
+coven claim heartbeat feature/my-branch
+coven claim release feature/my-branch
+coven claim status
+```
+
+Record a HEAD canary for the current branch:
+
+```bash
+coven claim canary feature/my-branch
+```
+
+Install local guard hooks:
+
+```bash
+coven hooks install
+```
+
+The installer writes managed `pre-commit` and `pre-push` hooks into
+`.git/hooks`. If a hook already exists, Coven moves it to `<hook>.local` and
+chains it. If `core.hooksPath` points at a tracked hook directory, Coven refuses
+to modify it automatically and prints integration options.
+
+## Environment
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `COVEN_PRIMARY_BRANCH` | `main` | Primary branch protected by pre-commit and pre-push. |
+| `COVEN_PROTECTED_REGEX` | `^(release\|hotfix)/` | Additional protected branch names for pre-push. |
+| `COVEN_MERGE_PHRASE` | `Enchant merge to main.` | Required exact text in `.git/MERGE_INTENT` before protected pushes. |
+| `COVEN_AGENT_ID` | `$USER` | Stable agent identity for claim ownership. |
+| `COVEN_CLAIM_TTL_SECONDS` | `3600` | Claim lifetime before another agent may acquire it. |
+| `COVEN_ALLOW_PRIMARY_COMMIT` | unset | Set to `1` only for explicit human-approved primary commits. |
+
+## Files
+
+All claim and hook state lives under git's common directory, so linked worktrees
+share the same protocol state:
+
+```text
+<git-common-dir>/agent-claims/<branch-slug>
+<git-common-dir>/AGENT_HEAD_AT_START
+<git-common-dir>/MERGE_INTENT
+<repo>.wt/<branch-slug>/
+```
+
+Claim files use simple `key=value` fields so shell hooks can read them without a
+runtime dependency.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -23,6 +23,9 @@ flowchart TB
   Root --> Sacrifice["sacrifice"]
   Root --> Patch["patch"]
   Root --> Logs["logs"]
+  Root --> Wt["wt"]
+  Root --> Claim["claim"]
+  Root --> Hooks["hooks"]
   Root --> Pc["pc (macOS-first)"]
 
   Daemon --> DStart["start"]
@@ -41,6 +44,19 @@ flowchart TB
   Patch --> POpenclaw["openclaw &lt;prompt&gt;"]
 
   Logs --> LPrune["prune [--dry-run]"]
+
+  Wt --> WtBranch["&lt;branch&gt;"]
+  Wt --> WtList["--list"]
+  Wt --> WtDoctor["--doctor"]
+  Wt --> WtPrune["--prune-merged / --prune-stale DAYS"]
+
+  Claim --> CAcquire["acquire &lt;branch&gt;"]
+  Claim --> CRelease["release &lt;branch&gt;"]
+  Claim --> CHeartbeat["heartbeat &lt;branch&gt;"]
+  Claim --> CCanary["canary &lt;branch&gt;"]
+  Claim --> CStatus["status"]
+
+  Hooks --> HInstall["install"]
 
   Pc --> PcStatus["status [--json]"]
   Pc --> PcTop["top --n N"]
@@ -65,6 +81,11 @@ flowchart TB
 | `coven sacrifice <session-id> --yes` | Permanently delete a non-running session. |
 | `coven patch openclaw <prompt>` | Local OpenClaw rescue loop. Does not commit or push. |
 | `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs. |
+| `coven wt <branch>` | Create or enter a sibling `<repo>.wt/<branch-slug>` git worktree. |
+| `coven wt --list/--doctor/--prune-merged/--prune-stale DAYS` | Inspect and clean Coven protocol worktrees. |
+| `coven claim acquire/release/heartbeat/canary <branch>` | Manage TTL-bounded branch ownership for the current agent. |
+| `coven claim status` | Print branch claims from the current repository. |
+| `coven hooks install` | Install local protocol hooks that block unsafe commits and protected pushes. |
 | `coven pc` | macOS-first diagnostics and explicit `--confirm` relief operations. |
 
 ## Common flags by command
@@ -75,6 +96,7 @@ flowchart TB
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sacrifice` | `--yes` (required) |
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
+| `coven wt` | `--list`, `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |
 | `coven pc kill` | `--confirm` (required) |
 | `coven pc cache clear` | `--confirm` (required) |
 | `coven pc top` | `--n <N>`, `--verbose` |
@@ -95,6 +117,20 @@ flowchart TB
 - Redacted operational event logs default to 30 days.
 - `--dry-run` prints counts only.
 - `--raw-days <N>` and `--event-days <N>` override the configured retention for one run.
+
+## Parallel Work Protocol
+
+`coven wt`, `coven claim`, and `coven hooks install` implement the local
+Coven Parallel Work Protocol for multi-agent repositories.
+
+- `coven wt <branch>` creates or enters `<repo>.wt/<branch-slug>/`.
+- `coven claim acquire <branch>` writes a TTL-bounded branch claim under git's
+  common directory. Set `COVEN_AGENT_ID` to a stable agent name.
+- `coven hooks install` installs `pre-commit` and `pre-push` hooks. Existing
+  hooks are chained through `<hook>.local`; tracked `core.hooksPath`
+  directories are left untouched.
+- Protected pushes require `.git/MERGE_INTENT` to contain
+  `Enchant merge to main.` unless `COVEN_MERGE_PHRASE` changes the phrase.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary

Resolves #167 by making the Coven Parallel Work Protocol a first-class CLI and docs surface.

- add `coven wt` for sibling worktree creation/listing/doctor/pruning
- add `coven claim` for TTL-bounded branch claims, heartbeats, release, status, and HEAD canaries
- add `coven hooks install` for managed pre-commit/pre-push protections with `.local` hook chaining and `core.hooksPath` refusal
- fill the parallel-lanes doc and CLI reference, and publish the page in docs navigation

## Verification

- `cargo test -p coven-cli`
- `cargo check --all-targets`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- `npm run docs:check` in `docs/`
- `coven wt --help`, `coven claim --help`, `coven hooks --help`
