### PR TITLE
docs(release): add v0.0.32 release notes

### DIFF
--- a/docs/es/reference/release-notes.md
+++ b/docs/es/reference/release-notes.md
@@ -6,6 +6,23 @@ read_when:
 title: "Changelog y notas de release de Coven"
 ---
 
+## Semana del 3 de junio de 2026
+
+### Nuevas funcionalidades
+
+- **Protocolo de trabajo paralelo de Coven.** Coven ahora incluye comandos `coven wt`, `coven claim` y `coven hooks` para coordinar varios agentes de programación de IA en un mismo repositorio. El protocolo crea worktrees de git aislados, registra claims de rama con TTL, instala hooks encadenables de seguridad, bloquea commits accidentales en ramas protegidas y exige una frase explícita de intención de merge antes de pushes a ramas protegidas. Consulta [issue #167](https://github.com/OpenCoven/coven/issues/167) y [PR #169](https://github.com/OpenCoven/coven/pull/169).
+- **Persistencia de identidad familiar en sesiones.** Las sesiones ahora pueden llevar un `familiar_id` resuelto, dando a dashboards, APIs y superficies de agentes una forma durable de mostrar qué familiar inició o posee una sesión. Consulta [PR #168](https://github.com/OpenCoven/coven/pull/168).
+
+### Actualizaciones
+
+- **Resolución compartida de familiares.** La CLI, el daemon y la API local ahora resuelven identidades familiares por una única ruta compartida antes del lanzamiento, de modo que los metadatos guardados de sesión reflejan la identidad familiar canónica y no una cadena de entrada sin validar.
+- **Guardrails para carriles paralelos.** El protocolo de worktrees incluye superficies de status, doctor, prune, claim acquire/release/heartbeat/canary e instalación de hooks para que la coordinación entre agentes pueda escalar sin depender de scripts shell ad hoc.
+
+### Correcciones de errores
+
+- **Los IDs de familiar desconocidos ya no crean sesiones.** `POST /sessions` ahora rechaza un `familiarId` desconocido con `400 unknown_familiar` antes de insertar una fila de sesión o lanzar un runtime. Una configuración de familiares mal formada devuelve `500 familiar_lookup_failed` sin lanzar nada.
+- **`coven run --familiar <id>` falla temprano con familiares desconocidos.** Los lanzamientos locales por CLI ahora coinciden con el comportamiento del daemon/API y evitan guardar IDs de familiar no resueltos.
+
 ## Semana del 17 de mayo de 2026
 
 ### Correcciones de errores

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -6,6 +6,23 @@ read_when:
 title: "Coven changelog and release notes"
 ---
 
+## Week of June 3, 2026
+
+### New features
+
+- **Coven Parallel Work Protocol.** Coven now ships first-class `coven wt`, `coven claim`, and `coven hooks` commands for coordinating multiple AI coding agents in one repository. The protocol creates isolated git worktrees, records TTL-bound agent branch claims, installs chainable safety hooks, blocks accidental commits on protected branches, and requires an explicit merge-intent phrase before protected-branch pushes. See [issue #167](https://github.com/OpenCoven/coven/issues/167) and [PR #169](https://github.com/OpenCoven/coven/pull/169).
+- **Session familiar identity persistence.** Sessions can now carry a resolved `familiar_id`, giving dashboards, APIs, and downstream agent surfaces a durable way to show which familiar launched or owns a session. See [PR #168](https://github.com/OpenCoven/coven/pull/168).
+
+### Updates
+
+- **Shared familiar resolution.** The CLI, daemon, and local API now resolve familiar identities through one shared path before launch, so stored session metadata reflects the canonical familiar identity rather than an unchecked input string.
+- **Parallel-lane guardrails.** The worktree protocol includes status, doctor, prune, claim acquire/release/heartbeat/canary, and hook-install surfaces so agent coordination can scale from a single local checkout to multi-agent work without relying on ad hoc shell scripts.
+
+### Bug fixes
+
+- **Unknown familiar IDs no longer create sessions.** `POST /sessions` now rejects an unknown `familiarId` with `400 unknown_familiar` before inserting a session row or launching a runtime. Malformed familiar configuration returns `500 familiar_lookup_failed` without launching.
+- **`coven run --familiar <id>` fails early for unknown familiars.** Local CLI launches now match daemon/API behavior and avoid silently recording unresolved familiar IDs.
+
 ## Week of May 20, 2026
 
 ### New features

--- a/docs/ru/reference/release-notes.md
+++ b/docs/ru/reference/release-notes.md
@@ -6,6 +6,23 @@ read_when:
 title: "Changelog и release notes Coven"
 ---
 
+## Неделя от 3 июня 2026
+
+### Новые возможности
+
+- **Протокол параллельной работы Coven.** В Coven появились команды `coven wt`, `coven claim` и `coven hooks` для координации нескольких AI-агентов разработки в одном репозитории. Протокол создаёт изолированные git worktree, записывает claims на ветки с TTL, устанавливает цепочечные safety hooks, блокирует случайные коммиты в защищённые ветки и требует явную фразу намерения merge перед push в защищённые ветки. См. [issue #167](https://github.com/OpenCoven/coven/issues/167) и [PR #169](https://github.com/OpenCoven/coven/pull/169).
+- **Сохранение идентичности familiar в сессиях.** Сессии теперь могут хранить разрешённый `familiar_id`, чтобы dashboards, API и агентские поверхности могли стабильно показывать, какой familiar запустил сессию или владеет ей. См. [PR #168](https://github.com/OpenCoven/coven/pull/168).
+
+### Обновления
+
+- **Общая резолюция familiars.** CLI, daemon и локальный API теперь разрешают familiar identities через один общий путь перед запуском, поэтому сохранённые метаданные сессии отражают каноническую familiar identity, а не непроверенную входную строку.
+- **Guardrails для параллельных lane.** Протокол worktree включает поверхности status, doctor, prune, claim acquire/release/heartbeat/canary и установку hooks, чтобы координация агентов масштабировалась без ad hoc shell-скриптов.
+
+### Исправления ошибок
+
+- **Неизвестные familiar IDs больше не создают сессии.** `POST /sessions` теперь отклоняет неизвестный `familiarId` с `400 unknown_familiar` до вставки строки сессии или запуска runtime. Некорректная конфигурация familiars возвращает `500 familiar_lookup_failed` без запуска.
+- **`coven run --familiar <id>` рано завершается для неизвестных familiars.** Локальные CLI-запуски теперь соответствуют поведению daemon/API и не сохраняют неразрешённые familiar IDs.
+
 ## Неделя от 17 мая 2026
 
 ### Исправления ошибок


### PR DESCRIPTION
## Summary\n- Add v0.0.32 release notes for the Coven Parallel Work Protocol (#167/#169).\n- Document familiar_id session persistence and validation (#168).\n- Mirror the release note entry across English, Spanish, and Russian docs.\n\n## Verification\n- git diff --check\n\nRelease tracking: #170