### PR TITLE
feat(eval-loop): resolve familiar workspace from familiars.toml

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -206,7 +206,9 @@ pub fn handle_request_with_runtime(
         ("GET", p) if p.starts_with("/skills/eval-loop/") && !p.ends_with("/run") => {
             let familiar_id = p.trim_start_matches("/skills/eval-loop/");
             match crate::eval_loop::get_eval_loop_state(coven_home, familiar_id)? {
-                Some(state) => json_response(200, &serde_json::json!({ "ok": true, "state": state })),
+                Some(state) => {
+                    json_response(200, &serde_json::json!({ "ok": true, "state": state }))
+                }
                 None => api_error(
                     404,
                     "skill_not_active",
@@ -224,11 +226,19 @@ pub fn handle_request_with_runtime(
                 .and_then(|v| v.get("track").and_then(|t| t.as_str()).map(str::to_string))
                 .unwrap_or_else(|| "synthesis".to_string());
             match crate::eval_loop::enqueue_run(coven_home, familiar_id, &track) {
-                Ok(spec) => json_response(202, &serde_json::json!({ "ok": true, "runId": spec.run_id, "track": spec.track })),
+                Ok(spec) => json_response(
+                    202,
+                    &serde_json::json!({ "ok": true, "runId": spec.run_id, "track": spec.track }),
+                ),
                 Err(err) => {
                     let msg = err.to_string();
                     if msg.contains("already in progress") {
-                        api_error(409, "run_in_progress", &msg, Some(serde_json::json!({ "familiarId": familiar_id })))
+                        api_error(
+                            409,
+                            "run_in_progress",
+                            &msg,
+                            Some(serde_json::json!({ "familiarId": familiar_id })),
+                        )
                     } else if msg.contains("track must be") {
                         api_error(400, "invalid_request", &msg, None)
                     } else {

--- a/crates/coven-cli/src/cockpit_sources.rs
+++ b/crates/coven-cli/src/cockpit_sources.rs
@@ -33,6 +33,10 @@ pub struct FamiliarDto {
     pub last_seen: String,
     pub active_sessions: u32,
     pub memory_freshness: String,
+    /// Explicit workspace path declared in familiars.toml. `None` means
+    /// the daemon uses the conventional `~/.coven/familiars/<id>/` path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<std::path::PathBuf>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -55,6 +59,10 @@ struct FamiliarEntry {
     description: String,
     pronouns: Option<String>,
     active_channel: Option<String>,
+    /// Explicit workspace path for this familiar. When set, the daemon uses this
+    /// instead of the conventional `~/.coven/familiars/<id>/` path.
+    /// Accepts `~` expansion. Optional — most familiars do not need to set this.
+    workspace: Option<String>,
 }
 
 pub fn read_familiars(coven_home: &Path) -> Result<Vec<FamiliarDto>> {
@@ -93,6 +101,18 @@ pub fn read_familiars(coven_home: &Path) -> Result<Vec<FamiliarDto>> {
             last_seen: "—".to_string(),
             active_sessions: 0,
             memory_freshness,
+            workspace: entry.workspace.map(|p| {
+                // Expand leading ~ to home directory
+                if let Some(rest) = p.strip_prefix("~/") {
+                    dirs_next::home_dir()
+                        .map(|home| home.join(rest))
+                        .unwrap_or_else(|| std::path::PathBuf::from(&p))
+                } else if p == "~" {
+                    dirs_next::home_dir().unwrap_or_else(|| std::path::PathBuf::from(&p))
+                } else {
+                    std::path::PathBuf::from(p)
+                }
+            }),
             id: entry.id,
         });
     }
@@ -585,6 +605,7 @@ description = "..."
             last_seen: "—".to_string(),
             active_sessions: 0,
             memory_freshness: "—".to_string(),
+            workspace: None,
         };
         let json = serde_json::to_string(&dto_without)?;
         assert!(

--- a/crates/coven-cli/src/eval_loop.rs
+++ b/crates/coven-cli/src/eval_loop.rs
@@ -110,8 +110,7 @@ pub fn get_eval_loop_state(
         Ok(raw) => raw,
         Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
         Err(err) => {
-            return Err(err)
-                .with_context(|| format!("failed to read {}", tsv_path.display()))
+            return Err(err).with_context(|| format!("failed to read {}", tsv_path.display()))
         }
     };
 
@@ -154,11 +153,7 @@ pub fn get_eval_loop_state(
 /// the iteration. The daemon does not run the loop directly.
 ///
 /// Returns `Err` if a run is already in progress (lock file exists).
-pub fn enqueue_run(
-    coven_home: &Path,
-    familiar_id: &str,
-    track: &str,
-) -> Result<RunSpec> {
+pub fn enqueue_run(coven_home: &Path, familiar_id: &str, track: &str) -> Result<RunSpec> {
     let track = validate_track(track)?;
     let workspace = familiar_workspace(coven_home, familiar_id);
     let eval_dir = workspace.join(EVAL_LOOP_DIR);
@@ -181,8 +176,7 @@ pub fn enqueue_run(
     // Write spec first, then lock — the familiar watches for lock disappearance
     // to know a run completed. Atomic enough: both are small local writes.
     let spec_path = eval_dir.join(RUN_SPEC_FILE);
-    let spec_json =
-        serde_json::to_string_pretty(&spec).context("failed to serialize run spec")?;
+    let spec_json = serde_json::to_string_pretty(&spec).context("failed to serialize run spec")?;
     fs::write(&spec_path, &spec_json)
         .with_context(|| format!("failed to write run spec at {}", spec_path.display()))?;
 
@@ -209,18 +203,13 @@ fn familiar_workspace(coven_home: &Path, familiar_id: &str) -> PathBuf {
 }
 
 fn is_running(workspace: &Path) -> bool {
-    workspace
-        .join(EVAL_LOOP_DIR)
-        .join(RUN_LOCK_FILE)
-        .exists()
+    workspace.join(EVAL_LOOP_DIR).join(RUN_LOCK_FILE).exists()
 }
 
 fn validate_track(track: &str) -> Result<&str> {
     match track {
         "synthesis" | "prompt" | "memory" => Ok(track),
-        other => anyhow::bail!(
-            "track must be `synthesis`, `prompt`, or `memory`, got `{other}`"
-        ),
+        other => anyhow::bail!("track must be `synthesis`, `prompt`, or `memory`, got `{other}`"),
     }
 }
 
@@ -357,9 +346,36 @@ mod tests {
         fs::create_dir_all(&workspace).unwrap();
         let tsv = format!(
             "{}{}{}",
-            tsv_line("2026-06-05T10:00:00Z", "synthesis", 1, "S1", 0.60, 0.68, 0.08, "ACCEPT"),
-            tsv_line("2026-06-05T11:00:00Z", "prompt",    2, "P1", 0.55, 0.50, -0.05, "REVERT"),
-            tsv_line("2026-06-05T12:00:00Z", "memory",    3, "M1", 0.70, 0.74, 0.04, "ACCEPT"),
+            tsv_line(
+                "2026-06-05T10:00:00Z",
+                "synthesis",
+                1,
+                "S1",
+                0.60,
+                0.68,
+                0.08,
+                "ACCEPT"
+            ),
+            tsv_line(
+                "2026-06-05T11:00:00Z",
+                "prompt",
+                2,
+                "P1",
+                0.55,
+                0.50,
+                -0.05,
+                "REVERT"
+            ),
+            tsv_line(
+                "2026-06-05T12:00:00Z",
+                "memory",
+                3,
+                "M1",
+                0.70,
+                0.74,
+                0.04,
+                "ACCEPT"
+            ),
         );
         fs::write(workspace.join(RESULTS_TSV), tsv).unwrap();
 
@@ -442,7 +458,6 @@ mod tests {
         assert!(validate_track("harness").is_err());
         assert!(validate_track("SYNTHESIS").is_err()); // case-sensitive
     }
-
 }
 
 #[cfg(test)]

--- a/crates/coven-cli/src/eval_loop.rs
+++ b/crates/coven-cli/src/eval_loop.rs
@@ -267,6 +267,7 @@ fn parse_results_tsv(raw: &str) -> Vec<LoopIterationDto> {
 mod tests {
     use super::*;
 
+    #[allow(clippy::too_many_arguments)]
     fn tsv_line(
         ts: &str,
         track: &str,

--- a/crates/coven-cli/src/eval_loop.rs
+++ b/crates/coven-cli/src/eval_loop.rs
@@ -195,10 +195,17 @@ pub fn enqueue_run(
 // ── Private helpers ───────────────────────────────────────────────────────────
 
 fn familiar_workspace(coven_home: &Path, familiar_id: &str) -> PathBuf {
-    // Convention: ~/.coven/familiars/<id>/
-    // This matches where familiars store their workspace data.
-    // If a TOML `workspace` field is added later, resolve it here.
-    coven_home.join("familiars").join(familiar_id)
+    // Prefer the explicit `workspace` path declared in familiars.toml when present.
+    // Falls back to the conventional `~/.coven/familiars/<id>/` path.
+    crate::cockpit_sources::read_familiars(coven_home)
+        .ok()
+        .and_then(|familiars| {
+            familiars
+                .into_iter()
+                .find(|f| f.id == familiar_id)
+                .and_then(|f| f.workspace)
+        })
+        .unwrap_or_else(|| coven_home.join("familiars").join(familiar_id))
 }
 
 fn is_running(workspace: &Path) -> bool {
@@ -434,5 +441,60 @@ mod tests {
         assert!(validate_track("").is_err());
         assert!(validate_track("harness").is_err());
         assert!(validate_track("SYNTHESIS").is_err()); // case-sensitive
+    }
+
+}
+
+#[cfg(test)]
+mod workspace_resolution_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn uses_toml_workspace_field_when_set() {
+        let temp = tempfile::tempdir().unwrap();
+        let custom_ws = temp.path().join("custom-ws");
+        fs::create_dir_all(&custom_ws).unwrap();
+
+        let toml = format!(
+            "[[familiar]]\nid = \"sage\"\ndisplay_name = \"Sage\"\nrole = \"Research\"\ndescription = \"Reads.\"\nworkspace = \"{}\"\n",
+            custom_ws.display()
+        );
+        fs::write(temp.path().join("familiars.toml"), toml).unwrap();
+
+        let resolved = familiar_workspace(temp.path(), "sage");
+        assert_eq!(resolved, custom_ws, "should use TOML workspace path");
+    }
+
+    #[test]
+    fn falls_back_to_convention_when_no_workspace_field() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("familiars.toml"),
+            "[[familiar]]\nid = \"sage\"\ndisplay_name = \"Sage\"\nrole = \"R\"\ndescription = \"D\"\n",
+        ).unwrap();
+
+        let resolved = familiar_workspace(temp.path(), "sage");
+        assert_eq!(resolved, temp.path().join("familiars").join("sage"));
+    }
+
+    #[test]
+    fn falls_back_to_convention_when_toml_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let resolved = familiar_workspace(temp.path(), "sage");
+        assert_eq!(resolved, temp.path().join("familiars").join("sage"));
+    }
+
+    #[test]
+    fn unknown_familiar_uses_convention_path() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(
+            temp.path().join("familiars.toml"),
+            "[[familiar]]\nid = \"nova\"\ndisplay_name = \"Nova\"\nrole = \"Queen\"\ndescription = \"Orchestrates.\"\n",
+        ).unwrap();
+
+        // sage is not in the TOML — should still get a sensible conventional path
+        let resolved = familiar_workspace(temp.path(), "sage");
+        assert_eq!(resolved, temp.path().join("familiars").join("sage"));
     }
 }


### PR DESCRIPTION
## The remaining thing, resolved.

The eval-loop skill previously hardcoded `~/.coven/familiars/<id>/` as every familiar's workspace path. This adds a first-class `workspace` field to `familiars.toml` so the daemon uses whatever path the familiar actually lives at.

---

### What changed

**`cockpit_sources.rs`**
- `FamiliarEntry` (private TOML struct): new `workspace: Option<String>` field
- `FamiliarDto` (public API struct): new `workspace: Option<PathBuf>` — `~` expanded on read, omitted from wire when `None`
- `read_familiars()`: maps `entry.workspace` through `~` expansion via `dirs_next`

**`eval_loop.rs`**
- `familiar_workspace()`: reads `familiars.toml`, uses declared `workspace` when present, falls back to `~/.coven/familiars/<id>/` otherwise
- Graceful fallback in every case: missing TOML, missing familiar, missing field — all resolve cleanly to the conventional path
- 4 new workspace resolution tests

---

### Usage

```toml
[[familiar]]
id = "sage"
display_name = "Sage"
workspace = "~/Documents/GitHub/openclaw/workspace/sage"
```

No field = conventional path. Fully backwards compatible.

---

### Tests
751 passing · 0 failing · 0 regressions