### PR TITLE
docs: define external harness adapter boundary

### DIFF
--- a/docs/FUTURE-HARNESSES.md
+++ b/docs/FUTURE-HARNESSES.md
@@ -9,9 +9,9 @@ description: "Notes on what the Coven adapter seam must preserve before adding H
 
 # Future harness notes
 
-Coven v0 intentionally supports only the Codex and Claude Code adapters. This note records what the current adapter seam must preserve before adding additional harnesses such as Hermes.
+Coven v0 intentionally supports only the Codex and Claude Code default adapters. This note records what the adapter seam must preserve before adding additional external harness adapters such as Hermes.
 
-OpenClaw is not a Coven harness target in v0. OpenClaw integration is externalized through the `@opencoven/coven` plugin, which acts as a socket client for the Rust daemon.
+OpenClaw is the first external integration boundary, not a daemon-launched harness target. OpenClaw integration is externalized through the `@opencoven/coven` plugin, which acts as a socket client for the Rust daemon. See [OpenClaw bridge](/harnesses/openclaw).
 
 ## Current adapter contract
 
@@ -63,7 +63,7 @@ A Hermes adapter probably should not be a direct copy of the Codex/Claude shape.
 
 Do not add Hermes to `coven doctor` or `coven run` yet.
 
-For now, keep the adapter seam able to express prefix-arg CLIs (`chat -q <prompt>`) and revisit the actual Hermes adapter after:
+For now, keep the adapter seam able to express prefix-arg CLIs (`chat -q <prompt>`) and revisit the actual Hermes adapter as an external adapter after:
 
 - direct Coven Codex/Claude sessions have been used more;
 - CastCodes-facing attach/open or lane replay has had real usage;
@@ -91,8 +91,13 @@ flowchart LR
     Custom["user-defined custom adapter"]
   end
 
+  subgraph Clients["External clients"]
+    OpenClaw["OpenClaw\n@opencoven/coven bridge"]
+  end
+
   V0 --> Research
   Research --> Later
+  OpenClaw --> V0
 
   style Codex fill:#9A8ECD,stroke:#D4B5FF,color:#1A1825
   style Claude fill:#9A8ECD,stroke:#D4B5FF,color:#1A1825

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -1,19 +1,26 @@
 ---
 title: "Harness adapter guide"
-summary: "The harness adapter shape Coven uses today, the bar for adding new harnesses, and how Codex and Claude Code map onto the v0 adapter surface."
+summary: "How Coven harness adapters work, how external adapters graduate, and why OpenClaw/Hermes should not be hardcoded into the daemon."
 read_when:
   - Reviewing supported harness behavior
   - Evaluating a future harness adapter
-description: "The harness adapter shape Coven uses today, the bar for adding new harnesses, and how Codex and Claude Code map onto the v0 adapter surface."
+description: "How Coven harness adapters work, how external adapters graduate, and why OpenClaw/Hermes should not be hardcoded into the daemon."
 ---
 
 # Harness adapter guide
 
-Coven v0 supports Codex and Claude Code. This guide describes the current adapter shape and the bar for adding more harnesses.
+Coven should treat every harness as an adapter. The daemon can ship a small default adapter set for compatibility, but no harness should become privileged runtime logic. OpenClaw, Hermes, Aider, Gemini, and future agents should enter through the same adapter contract and maturity checklist.
+
+The goal is a harness-neutral runtime:
+
+- Coven owns project-root validation, PTY supervision, session ids, event replay, and local socket policy.
+- The adapter owns how to detect and invoke one external CLI.
+- Provider auth, model/provider config, tools, skills, and memory stay inside that external harness.
+- Clients can discover supported adapters instead of hard-coding "Codex vs Claude" assumptions.
 
 ## Current adapter shape
 
-A built-in harness adapter defines:
+A Coven harness adapter defines:
 
 - stable Coven harness id;
 - user-facing label;
@@ -22,9 +29,27 @@ A built-in harness adapter defines:
 - prompt argument shape for non-interactive mode; and
 - install/authentication hint for `coven doctor`.
 
-The current implementation expects the prompt to be the final command argument after any fixed prefix args.
+The current implementation expects the prompt to be the final command argument after any fixed prefix args. Keep that invariant unless the adapter explicitly documents a safer stdin or protocol mode.
 
-## Built-in harnesses
+## External adapter rule
+
+New harnesses should not be added as one-off special cases across the daemon, TUI, docs, OpenClaw plugin, and package READMEs. Add a reusable adapter description first, then wire the daemon and clients against that description.
+
+For now, a code-backed adapter still lands in this repo, but it should be shaped as data plus narrow translation functions. The direction is an external adapter registry/manifest that can describe:
+
+- `id`, `label`, and `executable`;
+- detection and setup hints;
+- interactive, one-shot, and optional stream/resume argv;
+- whether the adapter supports preassigned upstream session ids;
+- whether the adapter has a dedicated system-prompt/identity flag;
+- output expectations and known unsupported modes; and
+- client compatibility notes for OpenClaw, CastCodes, and other consumers.
+
+Do not promote a harness to public support by only adding it to `built_in_harness_specs()`. That makes the UI and docs look supported before the adapter contract is proven.
+
+## Current default adapters
+
+The current default adapters are Codex and Claude Code. They are compatibility defaults, not a model for hardcoding every future harness.
 
 ### Codex
 
@@ -54,6 +79,18 @@ npm install -g @anthropic-ai/claude-code
 claude doctor
 ```
 
+## First external integration: OpenClaw
+
+OpenClaw is the first external integration boundary for Coven, but it is not a daemon-launched harness id. The package `@opencoven/coven` is an external OpenClaw ACP runtime bridge:
+
+- OpenClaw registers ACP backend id `coven`.
+- The bridge talks to the local Coven daemon over the configured Unix socket.
+- OpenClaw chooses an ACP agent id, maps it to a Coven harness id, and launches a project-scoped Coven session.
+- Coven validates the project root, harness id, session id, input, and kill requests.
+- OpenClaw keeps responsibility for its own UI, chat/session routing, plugin lifecycle, and ACP bindings.
+
+This is the integration shape future clients should follow: consume Coven's socket API and adapter discovery, do not import daemon internals or require Coven to know OpenClaw internals.
+
 ## Adapter requirements
 
 Before adding a new harness, confirm:
@@ -65,6 +102,16 @@ Before adding a new harness, confirm:
 - authentication stays in the harness provider's normal local flow;
 - failure modes are understandable in `coven doctor`;
 - tests cover command construction and missing executable behavior.
+
+## Adding a new adapter
+
+1. Start with a research note in `docs/FUTURE-HARNESSES.md` or a dedicated `docs/harnesses/<id>.md` page.
+2. Document the exact CLI contract: install, auth/setup, interactive launch, one-shot prompt launch, quiet/programmatic output mode, resume/session behavior, and unsupported modes.
+3. Add command-construction tests before changing user-facing docs to say the harness is supported.
+4. Add `coven doctor` detection and setup hints.
+5. Add launch behavior behind the generic adapter path, not scattered string checks.
+6. Add client compatibility notes for the OpenClaw bridge and any CastCodes surfaces that expose the harness.
+7. Run a smoke test against a real install or clearly document that support is still research-only.
 
 ## What not to add yet
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -133,6 +133,7 @@
                   "harnesses/index",
                   "harnesses/codex",
                   "harnesses/claude-code",
+                  "harnesses/openclaw",
                   "harnesses/installing",
                   "harnesses/provider-auth",
                   "HARNESS-ADAPTERS",

--- a/docs/harnesses/index.md
+++ b/docs/harnesses/index.md
@@ -17,6 +17,9 @@ A **harness** is an external coding-agent CLI that Coven can launch and supervis
   <Card title="Claude Code" href="/harnesses/claude-code" icon="brain">
     Anthropic Claude Code. Harness id `claude`.
   </Card>
+  <Card title="OpenClaw bridge" href="/harnesses/openclaw" icon="plug">
+    External ACP runtime bridge through `@opencoven/coven`.
+  </Card>
   <Card title="Future harnesses" href="/FUTURE-HARNESSES" icon="compass">
     Hermes, Aider, Gemini CLI, Cline — adapter direction and roadmap signals.
   </Card>
@@ -30,6 +33,8 @@ flowchart LR
   Adapter --> CodexAdapter[Codex adapter]
   Adapter --> ClaudeAdapter[Claude adapter]
   Adapter -. future .-> Future[Hermes / Aider / Gemini]
+  OpenClaw[OpenClaw] --> Bridge["@opencoven/coven plugin"]
+  Bridge --> Coven
   CodexAdapter --> CodexPty[Codex PTY]
   ClaudeAdapter --> ClaudePty[Claude Code PTY]
 ```
@@ -78,5 +83,6 @@ If `coven doctor` reports a harness as missing, see [Installing harness CLIs](/h
 ## Related
 
 - [Provider auth boundary](/harnesses/provider-auth)
+- [OpenClaw bridge](/harnesses/openclaw)
 - [Harness adapter guide](/HARNESS-ADAPTERS)
 - [Future harness notes](/FUTURE-HARNESSES)

--- a/docs/harnesses/openclaw.md
+++ b/docs/harnesses/openclaw.md
@@ -1,0 +1,84 @@
+---
+summary: "OpenClaw integration through the external @opencoven/coven ACP runtime bridge."
+read_when:
+  - Integrating OpenClaw with Coven
+  - Checking whether OpenClaw is a daemon harness
+title: "OpenClaw bridge"
+description: "OpenClaw integrates with Coven through an external ACP runtime bridge package. It is not hardcoded into the Coven daemon as a built-in harness."
+---
+
+# OpenClaw bridge
+
+OpenClaw is Coven's first external integration boundary. It should not be modeled as a daemon-owned harness like `coven run openclaw`. Instead, OpenClaw connects through the `@opencoven/coven` plugin package and uses Coven as a local session runtime.
+
+## Integration shape
+
+```mermaid
+flowchart LR
+  OpenClaw[OpenClaw ACP runtime] --> Bridge["@opencoven/coven plugin"]
+  Bridge --> Socket["Coven local socket API"]
+  Socket --> Daemon["Coven daemon"]
+  Daemon --> Adapter["Harness adapter router"]
+  Adapter --> Codex["codex"]
+  Adapter --> Claude["claude"]
+  Adapter -. future .-> Hermes["hermes"]
+```
+
+The bridge is a client of the daemon. It does not make OpenClaw a privileged Coven harness and it does not move OpenClaw code into Coven core.
+
+## Responsibilities
+
+OpenClaw owns:
+
+- ACP runtime registration and plugin lifecycle;
+- chat/session routing;
+- user-facing delivery;
+- fallback selection for non-Coven ACP backends; and
+- mapping OpenClaw ACP agent ids to Coven harness ids.
+
+Coven owns:
+
+- the local socket API;
+- project-root validation;
+- harness id validation;
+- PTY supervision;
+- session metadata and event history; and
+- input, attach, kill, archive, summon, and sacrifice policy.
+
+## Configuration
+
+Install the external plugin:
+
+```bash
+openclaw plugins install clawhub:@opencoven/coven
+```
+
+Then opt into the Coven ACP backend in OpenClaw config:
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "coven",
+    defaultAgent: "codex",
+  },
+  plugins: {
+    entries: {
+      "opencoven-coven": {
+        enabled: true,
+        config: {
+          covenHome: "~/.coven",
+        },
+      },
+    },
+  },
+}
+```
+
+The plugin maps OpenClaw ACP agent ids to Coven harness ids. Future harnesses such as Hermes should be enabled through explicit adapter support and plugin mapping, not by hardcoding a special OpenClaw path in the daemon.
+
+## Boundary
+
+Do not add Coven code into OpenClaw core, and do not add OpenClaw internals into the Coven daemon. The compatibility contract is the Coven socket API plus adapter discovery.
+
+Provider credentials stay with the target harness CLI. The OpenClaw bridge does not receive Codex, Claude, Hermes, OpenAI, Anthropic, GitHub, or other provider credentials from Coven.

--- a/packages/openclaw-coven/README.md
+++ b/packages/openclaw-coven/README.md
@@ -58,7 +58,7 @@ Minimal opt-in config:
 
 `allowFallback` defaults to `false`. Enable it only when you intentionally want failed/unavailable Coven launches to fall back to another ACP backend such as `acpx`.
 
-By default, the plugin only maps OpenClaw ACP agent ids for the current Coven v0 scope: Codex and Claude Code. Future harness ids must be explicitly configured in `harnesses` after the Rust daemon supports and validates them.
+By default, the plugin only maps OpenClaw ACP agent ids for the current Coven v0 scope: Codex and Claude Code. Future harness ids, such as Hermes, must be explicitly configured in `harnesses` after the Rust daemon supports and validates them through the generic adapter contract. Do not add special-case OpenClaw or Hermes logic to the daemon.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary\n- clarify that harnesses should follow a generic external adapter boundary instead of becoming hardcoded daemon special cases\n- document OpenClaw as the first external integration through the @opencoven/coven bridge\n- add OpenClaw bridge docs to the harness navigation and tighten plugin README guidance for future harnesses like Hermes\n\n## Verification\n- git diff --check\n- python3 -m json.tool docs/docs.json