### PR TITLE
fix(ci): satisfy clippy on harness adapter code

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -477,7 +477,7 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         .into_iter()
         .map(|spec| spec.id)
         .collect();
-    if !supported.iter().any(|id| *id == harness) {
+    if !supported.contains(&harness) {
         anyhow::bail!(
             "harness `{harness}` is not a supported harness; expected one of {supported:?}"
         );

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -479,11 +479,7 @@ fn continuity_args(
             // it from output and feed it back on subsequent turns.
             ConversationHint::Init { .. } => None,
             ConversationHint::Resume { id } => {
-                let mut args: Vec<String> = spec
-                    .non_interactive_prompt_prefix_args
-                    .iter()
-                    .cloned()
-                    .collect();
+                let mut args: Vec<String> = spec.non_interactive_prompt_prefix_args.to_vec();
                 args.push("resume".to_string());
                 args.push(id.clone());
                 Some(args)


### PR DESCRIPTION
## Summary
- Replace the manual supported-harness membership check with Vec::contains.
- Replace iter().cloned().collect() with to_vec() for harness prefix args.

## Verification
- cargo fmt --check
- git diff --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked