### PR TITLE
feat: add adapter registry diagnostics

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1,19 +1,24 @@
+use std::collections::HashSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 pub const EXTERNAL_ADAPTER_MANIFEST_ENV: &str = "COVEN_HARNESS_ADAPTER_MANIFEST";
+pub const EXTERNAL_ADAPTER_DIRS_ENV: &str = "COVEN_HARNESS_ADAPTER_DIRS";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HarnessSummary {
     pub id: String,
     pub label: String,
     pub executable: String,
     pub available: bool,
     pub install_hint: String,
+    pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,6 +103,8 @@ pub struct HarnessCommandSpec {
     pub interactive_prompt_prefix_args: Vec<String>,
     pub non_interactive_prompt_prefix_args: Vec<String>,
     pub install_hint: String,
+    pub source: String,
+    pub manifest_path: Option<String>,
     /// CLI flag name to pass a system-prompt string (e.g. `Some("--system-prompt")`
     /// for Claude). `None` means the harness has no such flag and identity
     /// should be injected by prepending a preamble to the prompt instead.
@@ -138,6 +145,8 @@ impl HarnessSummary {
             label: spec.label,
             executable: spec.executable,
             install_hint: spec.install_hint,
+            source: spec.source,
+            manifest_path: spec.manifest_path,
         }
     }
 }
@@ -189,6 +198,8 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 "never".to_string(),
             ],
             install_hint: "Install Codex with `npm install -g @openai/codex` or `brew install --cask codex`; if it is already installed, make sure `codex` is on PATH and run `codex login` or `codex` once to authenticate, then retry `coven doctor`.".to_string(),
+            source: "bundled".to_string(),
+            manifest_path: None,
             // Codex has no --system-prompt flag; identity is injected as a
             // bracketed preamble prepended to the prompt.
             system_prompt_flag: None,
@@ -200,6 +211,8 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
             interactive_prompt_prefix_args: Vec::new(),
             non_interactive_prompt_prefix_args: vec!["--print".to_string()],
             install_hint: "Install Claude Code with `npm install -g @anthropic-ai/claude-code`; if it is already installed, make sure `claude` is on PATH and run `claude doctor` to finish local auth/setup, then retry `coven doctor`.".to_string(),
+            source: "bundled".to_string(),
+            manifest_path: None,
             system_prompt_flag: Some("--system-prompt".to_string()),
         },
     ]
@@ -219,13 +232,84 @@ pub fn configured_harnesses() -> Result<Vec<HarnessSummary>> {
 }
 
 fn external_harness_specs() -> Result<Vec<HarnessCommandSpec>> {
-    let Some(manifest_path) = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV) else {
-        return Ok(Vec::new());
-    };
-    load_external_harness_specs(Path::new(&manifest_path))
+    let built_ins = built_in_harness_specs();
+    let mut specs = Vec::new();
+    let mut ids: HashSet<String> = built_ins.iter().map(|spec| spec.id.clone()).collect();
+
+    for manifest_path in external_adapter_manifest_paths() {
+        for spec in load_external_harness_specs(&manifest_path, &built_ins)? {
+            if !ids.insert(spec.id.clone()) {
+                anyhow::bail!(
+                    "external harness adapter `{}` in {} duplicates another adapter id",
+                    spec.id,
+                    manifest_path.display()
+                );
+            }
+            specs.push(spec);
+        }
+    }
+    Ok(specs)
 }
 
-fn load_external_harness_specs(path: &Path) -> Result<Vec<HarnessCommandSpec>> {
+fn external_adapter_manifest_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+
+    if let Some(manifest_path) = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV) {
+        paths.push(PathBuf::from(manifest_path));
+    }
+
+    if let Some(dir_list) = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV) {
+        for dir in env::split_paths(&dir_list) {
+            paths.extend(adapter_manifest_paths_in_dir(&dir));
+        }
+    }
+
+    if let Some(coven_home) = env::var_os("COVEN_HOME") {
+        paths.extend(adapter_manifest_paths_in_dir(
+            &PathBuf::from(coven_home).join("adapters"),
+        ));
+    } else if let Some(home) = env::var_os("HOME") {
+        paths.extend(adapter_manifest_paths_in_dir(
+            &PathBuf::from(home).join(".coven").join("adapters"),
+        ));
+    }
+
+    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
+        paths.extend(adapter_manifest_paths_in_dir(
+            &PathBuf::from(config_home).join("coven").join("adapters"),
+        ));
+    }
+
+    let mut seen = HashSet::new();
+    paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+fn adapter_manifest_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .extension()
+                    .and_then(|extension| extension.to_str())
+                    .is_some_and(|extension| extension.eq_ignore_ascii_case("json"))
+        })
+        .collect();
+    paths.sort();
+    paths
+}
+
+fn load_external_harness_specs(
+    path: &Path,
+    built_ins: &[HarnessCommandSpec],
+) -> Result<Vec<HarnessCommandSpec>> {
     let raw = fs::read_to_string(path).map_err(|err| {
         anyhow!(
             "failed to read harness adapter manifest {}: {err}",
@@ -238,11 +322,10 @@ fn load_external_harness_specs(path: &Path) -> Result<Vec<HarnessCommandSpec>> {
             path.display()
         )
     })?;
-    let built_ins = built_in_harness_specs();
     registry
         .adapters
         .into_iter()
-        .map(|adapter| adapter.into_spec(path, &built_ins))
+        .map(|adapter| adapter.into_spec(path, built_ins))
         .collect()
 }
 
@@ -317,6 +400,8 @@ impl ExternalHarnessAdapterSpec {
             interactive_prompt_prefix_args: self.interactive_prompt_prefix_args,
             non_interactive_prompt_prefix_args: self.non_interactive_prompt_prefix_args,
             install_hint: self.install_hint.trim().to_string(),
+            source: "manifest".to_string(),
+            manifest_path: Some(manifest_path.to_string_lossy().into_owned()),
             system_prompt_flag: self
                 .system_prompt_flag
                 .map(|flag| flag.trim().to_string())
@@ -576,6 +661,13 @@ mod tests {
         }
     }
 
+    fn restore_adapter_dirs_env(previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => env::set_var(EXTERNAL_ADAPTER_DIRS_ENV, value),
+            None => env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV),
+        }
+    }
+
     #[test]
     fn executable_exists_in_paths_finds_matching_file() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -713,6 +805,8 @@ mod tests {
             interactive_prompt_prefix_args: vec!["chat".to_string()],
             non_interactive_prompt_prefix_args: vec!["exec".to_string(), "-q".to_string()],
             install_hint: "Install the future harness.".to_string(),
+            source: "manifest".to_string(),
+            manifest_path: None,
             system_prompt_flag: None,
         };
 
@@ -787,6 +881,99 @@ mod tests {
         assert!(!built_in_harnesses()
             .iter()
             .any(|harness| harness.id == "hermes"));
+        Ok(())
+    }
+
+    #[test]
+    fn configured_harness_specs_load_adapter_manifests_from_directory_env() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let manifest_dir = temp_dir.path().join("adapters");
+        fs::create_dir(&manifest_dir)?;
+        fs::write(
+            manifest_dir.join("codex-compatible.json"),
+            r#"{
+              "adapters": [
+                {
+                  "id": "codex-compatible",
+                  "label": "Codex Compatible",
+                  "executable": "codex-compatible",
+                  "interactive_prompt_prefix_args": [],
+                  "non_interactive_prompt_prefix_args": ["exec", "--color", "never"],
+                  "install_hint": "Install the Codex-compatible CLI and put it on PATH.",
+                  "system_prompt_flag": null
+                }
+              ]
+            }"#,
+        )?;
+
+        let _guard = env_lock().lock().unwrap();
+        let previous_manifest = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let previous_dirs = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV);
+        env::remove_var(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        env::set_var(EXTERNAL_ADAPTER_DIRS_ENV, &manifest_dir);
+
+        let specs = configured_harness_specs()?;
+
+        restore_adapter_manifest_env(previous_manifest);
+        restore_adapter_dirs_env(previous_dirs);
+
+        let custom = specs
+            .iter()
+            .find(|spec| spec.id == "codex-compatible")
+            .expect("directory manifest adapter should load");
+        assert_eq!(custom.label, "Codex Compatible");
+        assert_eq!(custom.executable, "codex-compatible");
+        Ok(())
+    }
+
+    #[test]
+    fn configured_harnesses_include_adapter_source_metadata() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let manifest = temp_dir.path().join("adapters.json");
+        fs::write(
+            &manifest,
+            r#"{
+              "adapters": [
+                {
+                  "id": "solo-codex",
+                  "label": "Solo Codex",
+                  "executable": "codex",
+                  "interactive_prompt_prefix_args": [],
+                  "non_interactive_prompt_prefix_args": ["exec"],
+                  "install_hint": "Install Codex.",
+                  "system_prompt_flag": null
+                }
+              ]
+            }"#,
+        )?;
+
+        let _guard = env_lock().lock().unwrap();
+        let previous_manifest = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let previous_dirs = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV);
+        env::set_var(EXTERNAL_ADAPTER_MANIFEST_ENV, &manifest);
+        env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV);
+
+        let harnesses = configured_harnesses()?;
+
+        restore_adapter_manifest_env(previous_manifest);
+        restore_adapter_dirs_env(previous_dirs);
+
+        let codex = harnesses
+            .iter()
+            .find(|harness| harness.id == "codex")
+            .unwrap();
+        assert_eq!(codex.source, "bundled");
+        assert!(codex.manifest_path.is_none());
+
+        let custom = harnesses
+            .iter()
+            .find(|harness| harness.id == "solo-codex")
+            .unwrap();
+        assert_eq!(custom.source, "manifest");
+        assert_eq!(
+            custom.manifest_path.as_deref(),
+            Some(manifest.to_string_lossy().as_ref())
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -73,6 +73,15 @@ enum Command {
     Tui,
     #[command(about = "Check local setup and print next steps")]
     Doctor,
+    #[command(
+        name = "adapter",
+        alias = "adapters",
+        about = "List and diagnose harness adapters"
+    )]
+    Adapter {
+        #[command(subcommand)]
+        command: AdapterCommand,
+    },
     #[command(about = "Manage the local Coven daemon")]
     Daemon {
         #[command(subcommand)]
@@ -228,6 +237,20 @@ enum SessionsCommand {
 }
 
 #[derive(Subcommand, Debug)]
+enum AdapterCommand {
+    #[command(about = "List configured harness adapters")]
+    List {
+        #[arg(long, help = "Print adapter reports as JSON")]
+        json: bool,
+    },
+    #[command(about = "Diagnose all adapters, or one adapter id")]
+    Doctor {
+        #[arg(help = "Adapter id to diagnose")]
+        adapter: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum DaemonCommand {
     Start,
     Restart,
@@ -331,6 +354,7 @@ fn run_cli(cli: Cli) -> Result<()> {
     match cli.command {
         None | Some(Command::Chat) | Some(Command::Tui) => run_shared_interactive_shell(),
         Some(Command::Doctor) => run_doctor(),
+        Some(Command::Adapter { command }) => run_adapter_command(command),
         Some(Command::Daemon { command }) => run_daemon_command(command),
         Some(Command::Run {
             harness,
@@ -496,7 +520,7 @@ fn run_doctor() -> Result<()> {
     }
 
     println!("\nHarnesses:");
-    let harnesses = harness::built_in_harnesses();
+    let harnesses = harness::configured_harnesses()?;
     for harness in &harnesses {
         let status = if harness.available {
             "ready"
@@ -505,8 +529,8 @@ fn run_doctor() -> Result<()> {
         };
         let marker = if harness.available { "OK" } else { "!!" };
         println!(
-            "  [{marker}] {:<11} `{}` is {status}",
-            harness.label, harness.executable
+            "  [{marker}] {:<18} `{}` is {status} ({})",
+            harness.label, harness.executable, harness.source
         );
         if !harness.available {
             println!("       {}", harness.install_hint);
@@ -519,6 +543,80 @@ fn run_doctor() -> Result<()> {
         println!("  coven sessions");
     } else {
         println!("  Install or authenticate Codex/Claude Code, then run `coven doctor` again.");
+    }
+    Ok(())
+}
+
+fn run_adapter_command(command: AdapterCommand) -> Result<()> {
+    match command {
+        AdapterCommand::List { json } => run_adapter_list(json),
+        AdapterCommand::Doctor { adapter } => run_adapter_doctor(adapter.as_deref()),
+    }
+}
+
+fn run_adapter_list(json: bool) -> Result<()> {
+    let harnesses = harness::configured_harnesses()?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&harnesses)?);
+        return Ok(());
+    }
+
+    println!("Coven adapters");
+    for harness in harnesses {
+        let availability = if harness.available {
+            "ready"
+        } else {
+            "missing"
+        };
+        let manifest = harness
+            .manifest_path
+            .as_deref()
+            .map(|path| format!(" from {path}"))
+            .unwrap_or_default();
+        println!(
+            "  {:<18} {:<10} `{}` {}{}",
+            harness.id, availability, harness.executable, harness.source, manifest
+        );
+    }
+    Ok(())
+}
+
+fn run_adapter_doctor(adapter: Option<&str>) -> Result<()> {
+    let harnesses = harness::configured_harnesses()?;
+    let filtered: Vec<_> = match adapter {
+        Some(id) => harnesses
+            .into_iter()
+            .filter(|harness| harness.id == id)
+            .collect(),
+        None => harnesses,
+    };
+
+    if let Some(id) = adapter {
+        if filtered.is_empty() {
+            anyhow::bail!(
+                "unknown adapter `{id}`; run `coven adapter list` to see configured adapters"
+            );
+        }
+    }
+
+    println!("Coven adapter doctor");
+    for harness in filtered {
+        let marker = if harness.available { "OK" } else { "!!" };
+        let status = if harness.available {
+            "ready"
+        } else {
+            "missing"
+        };
+        println!(
+            "  [{marker}] {:<18} `{}` is {status}",
+            harness.label, harness.executable
+        );
+        if let Some(path) = harness.manifest_path.as_deref() {
+            println!("       manifest: {path}");
+        }
+        if !harness.available {
+            println!("       {}", harness.install_hint);
+        }
     }
     Ok(())
 }
@@ -2241,6 +2339,25 @@ mod tests {
                 assert_eq!(event_days, Some(14));
             }
             other => panic!("expected logs prune command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_adapter_list_and_doctor_commands() {
+        let list = Cli::parse_from(["coven", "adapter", "list", "--json"]);
+        match list.command {
+            Some(Command::Adapter {
+                command: AdapterCommand::List { json },
+            }) => assert!(json),
+            other => panic!("expected adapter list command, got {other:?}"),
+        }
+
+        let doctor_one = Cli::parse_from(["coven", "adapter", "doctor", "claude"]);
+        match doctor_one.command {
+            Some(Command::Adapter {
+                command: AdapterCommand::Doctor { adapter },
+            }) => assert_eq!(adapter.as_deref(), Some("claude")),
+            other => panic!("expected adapter doctor command, got {other:?}"),
         }
     }
 

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -9,14 +9,14 @@ description: "How Coven harness adapters work, how external adapters graduate, a
 
 # Harness adapter guide
 
-Coven should treat every harness as an adapter. The daemon can ship a small default adapter set for compatibility, but no harness should become privileged runtime logic. OpenClaw, Hermes, Aider, Gemini, and future agents should enter through the same adapter contract and maturity checklist.
+Coven should treat every harness as an adapter. The daemon ships a small bundled compatibility adapter set for Codex and Claude Code, but no harness should become privileged runtime logic. OpenClaw, Hermes, Aider, Gemini, and future agents should enter through the same adapter contract and maturity checklist.
 
 The goal is a harness-neutral runtime:
 
 - Coven owns project-root validation, PTY supervision, session ids, event replay, and local socket policy.
 - The adapter owns how to detect and invoke one external CLI.
 - Provider auth, model/provider config, tools, skills, and memory stay inside that external harness.
-- Clients can discover supported adapters instead of hard-coding "Codex vs Claude" assumptions.
+- Clients can discover supported adapters with `coven adapter list` instead of hard-coding "Codex vs Claude" assumptions.
 
 ## Current adapter shape
 
@@ -35,7 +35,9 @@ The current implementation expects the prompt to be the final command argument a
 
 New harnesses should not be added as one-off special cases across the daemon, TUI, docs, OpenClaw plugin, and package READMEs. Add a reusable adapter description first, then wire the daemon and clients against that description.
 
-For now, Codex and Claude Code remain the compatibility defaults. Additional harnesses can be tested through an explicit adapter manifest by setting `COVEN_HARNESS_ADAPTER_MANIFEST` to a JSON file:
+For now, Codex and Claude Code remain the bundled compatibility defaults. Additional harnesses can be tested through explicit adapter manifests.
+
+Load one manifest file:
 
 ```json
 {
@@ -53,6 +55,21 @@ For now, Codex and Claude Code remain the compatibility defaults. Additional har
 }
 ```
 
+```sh
+export COVEN_HARNESS_ADAPTER_MANIFEST=/path/to/adapters.json
+coven adapter list
+coven adapter doctor example
+```
+
+Load every `*.json` manifest in one or more directories:
+
+```sh
+export COVEN_HARNESS_ADAPTER_DIRS="$HOME/.coven/adapters:$HOME/.config/coven/adapters"
+coven adapter list --json
+```
+
+Without env vars, Coven also checks `COVEN_HOME/adapters/*.json` when `COVEN_HOME` is set, then `~/.coven/adapters/*.json`, and finally `$XDG_CONFIG_HOME/coven/adapters/*.json`.
+
 The prompt is appended as the final command argument after the configured prefix args. Adapter ids must be lowercase and must not collide with built-in ids. Executables are names only, not shell strings or paths.
 
 This manifest path is for explicit integration work. It is not a public support claim for every adapter listed in a maintainer's local manifest.
@@ -69,9 +86,9 @@ A code-backed adapter should still be shaped as data plus narrow translation fun
 
 Do not promote a harness to public support by only adding it to `built_in_harness_specs()`. That makes the UI and docs look supported before the adapter contract is proven.
 
-## Current default adapters
+## Bundled compatibility adapters
 
-The current default adapters are Codex and Claude Code. They are compatibility defaults, not a model for hardcoding every future harness.
+The bundled compatibility adapters are Codex and Claude Code. They are first-class supported user paths, not a model for hardcoding every future harness.
 
 ### Codex
 
@@ -125,12 +142,26 @@ Before adding a new harness, confirm:
 - failure modes are understandable in `coven doctor`;
 - tests cover command construction and missing executable behavior.
 
+## Adapter commands
+
+Use these commands to debug a machine that only has Codex, Claude Code, or a local manifest adapter installed:
+
+```sh
+coven adapter list
+coven adapter list --json
+coven adapter doctor
+coven adapter doctor codex
+coven adapter doctor claude
+```
+
+`coven doctor` includes the same configured adapter set in its broader local runtime report.
+
 ## Adding a new adapter
 
 1. Start with a research note in `docs/FUTURE-HARNESSES.md` or a dedicated `docs/harnesses/<id>.md` page.
 2. Document the exact CLI contract: install, auth/setup, interactive launch, one-shot prompt launch, quiet/programmatic output mode, resume/session behavior, and unsupported modes.
 3. Add command-construction tests before changing user-facing docs to say the harness is supported.
-4. Add `coven doctor` detection and setup hints.
+4. Add `coven adapter doctor` / `coven doctor` detection and setup hints.
 5. Add launch behavior behind the generic adapter path, not scattered string checks.
 6. Add client compatibility notes for the OpenClaw bridge and any CastCodes surfaces that expose the harness.
 7. Run a smoke test against a real install or clearly document that support is still research-only.

--- a/docs/PRODUCT-SPEC.md
+++ b/docs/PRODUCT-SPEC.md
@@ -36,7 +36,7 @@ Out of scope for MVP: marketplace plugins, cloud sync, multi-user collaboration,
 
 ## Built-in v0 harness direction
 
-Coven v0 should ship with built-in adapters for Codex and Claude Code. These adapters should detect local CLI availability, construct commands without shell interpolation where possible, run the harness inside a validated project `cwd`, and expose output/input through Coven-managed PTY sessions.
+Coven v0 should ship with bundled compatibility adapters for Codex and Claude Code. These adapters should detect local CLI availability, construct commands without shell interpolation where possible, run the harness inside a validated project `cwd`, and expose output/input through Coven-managed PTY sessions.
 
 Terminal UX should stay centered on the lightweight `coven` command and a human session browser:
 
@@ -53,7 +53,7 @@ In an interactive terminal, `coven sessions` opens a browser with readable actio
 
 ## Future Hermes and adapter path
 
-Hermes and other harnesses should arrive through a small adapter contract after the built-in v0 path is stable. The adapter model should support future targets such as Hermes, Aider, Gemini, OpenCode, and custom command adapters without requiring Coven to become a full plugin marketplace in the MVP.
+Hermes and other harnesses should arrive through the adapter manifest/registry contract after the bundled v0 compatibility path is stable. The adapter model should support future targets such as Hermes, Aider, Gemini, OpenCode, and custom command adapters without requiring Coven to become a full plugin marketplace in the MVP.
 
 ## Current architecture
 

--- a/docs/harnesses/installing.md
+++ b/docs/harnesses/installing.md
@@ -11,7 +11,7 @@ Coven does **not** bundle harness CLIs. Each supported harness is an independent
 
 ## How detection works
 
-`coven doctor` and `POST /api/v1/sessions` both resolve a harness id (`codex`, `claude`, …) to an executable name on `PATH` using the adapter table in [Harness adapters](/HARNESS-ADAPTERS). If the binary is missing, Coven fails closed with an install hint instead of attempting to launch.
+`coven doctor`, `coven adapter doctor`, and `POST /api/v1/sessions` all resolve a harness id (`codex`, `claude`, …) to an executable name on `PATH` using the adapter registry in [Harness adapters](/HARNESS-ADAPTERS). If the binary is missing, Coven fails closed with an install hint instead of attempting to launch.
 
 ```mermaid
 flowchart LR
@@ -23,7 +23,7 @@ flowchart LR
   Resolve -- yes --> Spawn[Spawn validated argv in PTY]
 ```
 
-The daemon revalidates the harness id on every launch request. Clients cannot widen the allowlist by sending a different argv or path; only built-in adapter ids are accepted.
+The daemon revalidates the harness id on every launch request. Clients cannot widen the allowlist by sending a different argv or path; only bundled compatibility adapters and explicit manifest adapters are accepted.
 
 ## Supported v0 harnesses
 
@@ -32,7 +32,7 @@ The daemon revalidates the harness id on every launch request. Clients cannot wi
 | `codex` | `codex` | `npm install -g @openai/codex` | `codex login` | [Codex harness](/harnesses/codex) |
 | `claude` | `claude` | `npm install -g @anthropic-ai/claude-code` | `claude doctor` | [Claude Code harness](/harnesses/claude-code) |
 
-Other CLIs (Hermes, Aider, Gemini CLI, Cline, custom commands) are **not** part of v0. See [Future harness notes](/FUTURE-HARNESSES) for the adapter direction.
+Other CLIs (Hermes, Aider, Gemini CLI, Cline, custom commands) are **not** bundled in v0. Test them through an explicit manifest and `coven adapter doctor`; see [Future harness notes](/FUTURE-HARNESSES) for the adapter direction.
 
 ## Step-by-step install
 
@@ -65,6 +65,7 @@ Other CLIs (Hermes, Aider, Gemini CLI, Cline, custom commands) are **not** part 
   <Step title="Verify Coven sees the harness">
     ```bash
     coven doctor
+    coven adapter list
     ```
 
     Expected output (abridged):
@@ -77,7 +78,7 @@ Other CLIs (Hermes, Aider, Gemini CLI, Cline, custom commands) are **not** part 
     claude:   ok       (/usr/local/bin/claude 0.x.y)
     ```
 
-    If a row shows `missing`, doctor also prints the exact install command shown in the table above.
+    If a row shows `missing`, doctor also prints the exact install command shown in the table above. `coven adapter list --json` is the machine-readable form for clients such as Coven Cave.
   </Step>
 
   <Step title="Launch a session">


### PR DESCRIPTION
## Summary
- add directory-based external adapter manifest discovery via COVEN_HARNESS_ADAPTER_DIRS plus ~/.coven/adapters and XDG config locations
- add adapter source metadata and JSON-friendly adapter summaries
- add coven adapter list/doctor commands and include configured adapters in coven doctor
- update adapter docs to describe bundled Codex/Claude compatibility adapters plus manifest adapters

## Verification
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked (767 passed, 0 failed, 1 ignored; protocol 4 passed; smoke 4 passed)
- git diff --check
- cargo run -p coven-cli -- adapter list --json