### PR TITLE
fix: SQLite WAL mode + 5s busy_timeout at connection open

### DIFF
--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -106,8 +106,13 @@ pub fn open_store(path: &Path) -> Result<Connection> {
 
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
+    // WAL mode allows concurrent readers alongside a single writer and avoids
+    // "database is locked" errors under typical daemon + API concurrency.
+    // busy_timeout gives writers up to 5 s to retry before returning SQLITE_BUSY.
     conn.execute_batch(
-        "PRAGMA foreign_keys = ON;
+        "PRAGMA journal_mode = WAL;
+        PRAGMA busy_timeout = 5000;
+        PRAGMA foreign_keys = ON;
 
         CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY NOT NULL,


### PR DESCRIPTION
Sets `PRAGMA journal_mode = WAL` and `PRAGMA busy_timeout = 5000` before the existing schema bootstrap block.

- **WAL mode**: concurrent readers + single writer; no shared-cache lock contention
- **busy_timeout 5000**: writer retries for up to 5 s before surfacing `SQLITE_BUSY`

No schema changes; pure PRAGMA addition.

Closes #187