### PR TITLE
ci: add windows-latest matrix leg to Rust checks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
       - name: Clippy
         if: runner.os == 'Linux'
         run: cargo clippy --workspace --all-targets -- -D warnings
+      # Windows test failures are pre-existing, tracked in #178 (workspace/PTY/stream-mode).
+      # Will be fixed by #190-#193. continue-on-error keeps the leg visible without blocking main.
       - run: cargo test --workspace --locked
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
   secret-guard:
     name: Secret guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,26 @@ env:
 jobs:
   rust:
     name: Rust checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - name: Install native link dependencies
+      - name: Install native link dependencies (Linux only)
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
-      - run: cargo fmt --check
-      - run: cargo clippy --workspace --all-targets -- -D warnings
+      # fmt/clippy only on Linux to keep Windows leg focused on build+test
+      - name: Check formatting
+        if: runner.os == 'Linux'
+        run: cargo fmt --check
+      - name: Clippy
+        if: runner.os == 'Linux'
+        run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --locked
 
   secret-guard:


### PR DESCRIPTION
Adds `windows-latest` alongside `ubuntu-latest` in the `rust` job matrix so `#[cfg(windows)]` daemon code is compiled and tested on every PR.

- fmt + clippy: Linux-only (avoids openblas dep issues on Windows runner)
- `cargo test --workspace --locked`: both legs
- `fail-fast: false` so Windows failures are independently visible

First regression target: #178 (Windows test failures)

Closes #188