### PR TITLE
fix: euid/ownership fail-closed on client-side socket connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
+      # Windows test failures are pre-existing and tracked in:
+      #   #178 (workspace/PTY/stream-mode tests)
+      # They will be fixed by issues #190-#193 (Windows-specific impl work).
+      # continue-on-error keeps the leg visible (red = known failures) without
+      # blocking main; remove this once #178 is fully resolved.
       - run: cargo test --workspace --locked
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
   secret-guard:
     name: Secret guard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
-      # Windows test failures are pre-existing and tracked in:
-      #   #178 (workspace/PTY/stream-mode tests)
-      # They will be fixed by issues #190-#193 (Windows-specific impl work).
-      # continue-on-error keeps the leg visible (red = known failures) without
-      # blocking main; remove this once #178 is fully resolved.
       - run: cargo test --workspace --locked
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
   secret-guard:
     name: Secret guard

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -906,6 +906,16 @@ fn daemon_health_reports_pid(socket: &str, expected_pid: u32) -> Result<bool> {
 
 #[cfg(unix)]
 fn daemon_status_from_health_socket(socket: &str) -> Result<Option<DaemonStatus>> {
+    let socket_path = std::path::Path::new(socket);
+    // Fail-closed: refuse to connect to a socket that is not owned by the
+    // current effective uid. A foreign-owned socket could be an attacker's
+    // listener planted at the expected path.
+    if let Ok(metadata) = std::fs::symlink_metadata(socket_path) {
+        use std::os::unix::fs::MetadataExt;
+        // SAFETY: geteuid() only reads the effective uid and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        check_owned_by_current_user(socket_path, metadata.uid(), euid)?;
+    }
     let mut stream = UnixStream::connect(socket)
         .with_context(|| format!("failed to connect to Coven daemon socket {socket}"))?;
     stream


### PR DESCRIPTION
The bind-side (`bind_api_socket`) and home-directory (`ensure_private_coven_home`) ownership checks were already in place. This closes the remaining client-side gap:

**`daemon_status_from_health_socket`** now calls `check_owned_by_current_user` on the socket path (via `symlink_metadata`) before `UnixStream::connect`. A foreign-owned socket at the expected path causes a hard error instead of a silent connection.

Closes #189