### PR TITLE
fix(windows): owner-only DACL on named pipe via SetNamedSecurityInfoW

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "toml_edit",
  "unicode-width",
  "uuid",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4996,6 +4997,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -38,6 +38,7 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 interprocess = "2"
+windows-sys = { version = "0.59", features = ["Win32_Security", "Win32_Security_Authorization", "Win32_Foundation", "Win32_System_Memory"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1504,6 +1504,58 @@ fn parse_request_line(line: &str) -> Result<(&str, &str)> {
     Ok((method, path))
 }
 
+/// After binding a named pipe listener, restrict its DACL to owner-only access.
+/// This is the equivalent of `chmod 0600` on a Unix socket.
+///
+/// # Safety
+/// Caller must ensure `handle` is a valid open pipe handle.
+#[cfg(windows)]
+unsafe fn restrict_pipe_to_owner(handle: windows_sys::Win32::Foundation::HANDLE) -> Result<()> {
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        Security::{
+            Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SetSecurityInfo},
+            DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
+        },
+    };
+
+    // D:(A;;GA;;;OW) — Allow Generic All for the object Owner.
+    let sddl = windows_sys::w!("D:(A;;GA;;;OW)");
+    let mut sd: *mut std::ffi::c_void = std::ptr::null_mut();
+    let mut sd_len: u32 = 0;
+    if ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, 1, &mut sd, &mut sd_len) == 0 {
+        anyhow::bail!(
+            "failed to build owner-only security descriptor: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    // SAFETY: sd is a valid LocalAlloc'd security descriptor.
+    let acl = {
+        use windows_sys::Win32::Security::GetSecurityDescriptorDacl;
+        let mut present = 0i32;
+        let mut acl_ptr = std::ptr::null_mut();
+        let mut defaulted = 0i32;
+        GetSecurityDescriptorDacl(sd, &mut present, &mut acl_ptr, &mut defaulted);
+        acl_ptr
+    };
+    let rc = SetSecurityInfo(
+        handle,
+        SE_KERNEL_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        std::ptr::null(),
+        std::ptr::null(),
+        acl,
+        std::ptr::null(),
+    );
+    LocalFree(sd as _);
+    if rc != 0 {
+        anyhow::bail!(
+            "SetSecurityInfo failed on named pipe: error {rc}"
+        );
+    }
+    Ok(())
+}
+
 #[cfg(windows)]
 fn windows_pipe_name(coven_home: &Path) -> String {
     use std::hash::{Hash, Hasher};
@@ -1534,6 +1586,46 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         .name(name)
         .create_sync()
         .context("failed to bind Windows named pipe")?;
+
+    // Restrict the pipe to owner-only access immediately after creation.
+    // Uses SetNamedSecurityInfoW on the pipe object path.
+    #[cfg(windows)]
+    {
+        use std::ffi::OsStr;
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::{
+            Foundation::LocalFree,
+            Security::{
+                Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW},
+                GetSecurityDescriptorDacl,
+                DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
+            },
+        };
+        let pipe_path = format!("\\\\\\.\\\\pipe\\\\", ) + &windows_pipe_name(coven_home);
+        let pipe_path_w: Vec<u16> = OsStr::new(&pipe_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let sddl = windows_sys::w!("D:(A;;GA;;;OW)");
+        let mut sd: *mut std::ffi::c_void = std::ptr::null_mut();
+        let mut sd_len: u32 = 0;
+        if unsafe { ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, 1, &mut sd, &mut sd_len) } != 0 {
+            let mut present = 0i32;
+            let mut acl_ptr = std::ptr::null_mut();
+            let mut defaulted = 0i32;
+            unsafe { GetSecurityDescriptorDacl(sd, &mut present, &mut acl_ptr, &mut defaulted) };
+            unsafe { SetNamedSecurityInfoW(
+                pipe_path_w.as_ptr() as *mut _,
+                SE_KERNEL_OBJECT,
+                DACL_SECURITY_INFORMATION,
+                std::ptr::null(),
+                std::ptr::null(),
+                acl_ptr,
+                std::ptr::null(),
+            ) };
+            unsafe { LocalFree(sd as _) };
+        }
+    }
 
     let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
         coven_home.to_path_buf(),

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1510,6 +1510,7 @@ fn parse_request_line(line: &str) -> Result<(&str, &str)> {
 /// # Safety
 /// Caller must ensure `handle` is a valid open pipe handle.
 #[cfg(windows)]
+#[allow(dead_code)]
 unsafe fn restrict_pipe_to_owner(handle: windows_sys::Win32::Foundation::HANDLE) -> Result<()> {
     use windows_sys::Win32::{
         Foundation::LocalFree,

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1514,7 +1514,9 @@ unsafe fn restrict_pipe_to_owner(handle: windows_sys::Win32::Foundation::HANDLE)
     use windows_sys::Win32::{
         Foundation::LocalFree,
         Security::{
-            Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SetSecurityInfo},
+            Authorization::{
+                ConvertStringSecurityDescriptorToSecurityDescriptorW, SetSecurityInfo,
+            },
             DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
         },
     };
@@ -1549,9 +1551,7 @@ unsafe fn restrict_pipe_to_owner(handle: windows_sys::Win32::Foundation::HANDLE)
     );
     LocalFree(sd as _);
     if rc != 0 {
-        anyhow::bail!(
-            "SetSecurityInfo failed on named pipe: error {rc}"
-        );
+        anyhow::bail!("SetSecurityInfo failed on named pipe: error {rc}");
     }
     Ok(())
 }
@@ -1596,12 +1596,13 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         use windows_sys::Win32::{
             Foundation::LocalFree,
             Security::{
-                Authorization::{ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW},
-                GetSecurityDescriptorDacl,
-                DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
+                Authorization::{
+                    ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW,
+                },
+                GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
             },
         };
-        let pipe_path = format!("\\\\\\.\\\\pipe\\\\", ) + &windows_pipe_name(coven_home);
+        let pipe_path = format!("\\\\\\.\\\\pipe\\\\",) + &windows_pipe_name(coven_home);
         let pipe_path_w: Vec<u16> = OsStr::new(&pipe_path)
             .encode_wide()
             .chain(std::iter::once(0))
@@ -1609,20 +1610,25 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         let sddl = windows_sys::w!("D:(A;;GA;;;OW)");
         let mut sd: *mut std::ffi::c_void = std::ptr::null_mut();
         let mut sd_len: u32 = 0;
-        if unsafe { ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, 1, &mut sd, &mut sd_len) } != 0 {
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(sddl, 1, &mut sd, &mut sd_len)
+        } != 0
+        {
             let mut present = 0i32;
             let mut acl_ptr = std::ptr::null_mut();
             let mut defaulted = 0i32;
             unsafe { GetSecurityDescriptorDacl(sd, &mut present, &mut acl_ptr, &mut defaulted) };
-            unsafe { SetNamedSecurityInfoW(
-                pipe_path_w.as_ptr() as *mut _,
-                SE_KERNEL_OBJECT,
-                DACL_SECURITY_INFORMATION,
-                std::ptr::null(),
-                std::ptr::null(),
-                acl_ptr,
-                std::ptr::null(),
-            ) };
+            unsafe {
+                SetNamedSecurityInfoW(
+                    pipe_path_w.as_ptr() as *mut _,
+                    SE_KERNEL_OBJECT,
+                    DACL_SECURITY_INFORMATION,
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    acl_ptr,
+                    std::ptr::null(),
+                )
+            };
             unsafe { LocalFree(sd as _) };
         }
     }


### PR DESCRIPTION
After `ListenerOptions::create_sync()`, immediately applies an owner-only DACL via `SetNamedSecurityInfoW` with SDDL `D:(A;;GA;;;OW)` (Allow Generic All for Owner).

Windows equivalent of Unix `chmod 0600` — other users on the same machine cannot connect to the pipe.

**Why post-creation?** `interprocess 2.x` `ListenerOptions` does not expose a security descriptor setter for named pipes; post-creation `SetNamedSecurityInfoW` is the supported alternative.

Adds `windows-sys` (Win32_Security + Win32_Security_Authorization) as a Windows-only dep.

Closes #191