### PR TITLE
fix: restore capabilities scans and windows ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,7 @@ jobs:
       - name: Clippy
         if: runner.os == 'Linux'
         run: cargo clippy --workspace --all-targets -- -D warnings
-      # Windows test failures are pre-existing, tracked in #178 (workspace/PTY/stream-mode).
-      # Will be fixed by #190-#193. continue-on-error keeps the leg visible without blocking main.
       - run: cargo test --workspace --locked
-        continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
   secret-guard:
     name: Secret guard

--- a/crates/coven-cli/src/capabilities.rs
+++ b/crates/coven-cli/src/capabilities.rs
@@ -224,10 +224,10 @@ pub fn scan_codex_capabilities(home_dir: &Path) -> HarnessCapabilityManifest {
     let automations_dir = base.join("automations");
     if let Ok(entries) = fs::read_dir(&automations_dir) {
         for entry in entries.flatten() {
-            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            let dir = entry.path();
+            if !is_directory_entry(&dir) {
                 continue;
             }
-            let dir = entry.path();
             let id = entry.file_name().to_string_lossy().into_owned();
             let (name, description, version, tags) = parse_automation_toml(&dir, &mut warnings);
             skills.push(HarnessSkill {
@@ -613,17 +613,27 @@ pub fn scan_claude_capabilities(home_dir: &Path) -> HarnessCapabilityManifest {
     }
     plugins.sort_by(|a, b| a.id.cmp(&b.id));
 
+    let mut skills = scan_claude_skills(&base, &mut warnings);
+    skills.sort_by(|a, b| a.id.cmp(&b.id));
+
     HarnessCapabilityManifest {
         harness_id: "claude".to_string(),
         scanned_at: now,
         global_instructions,
-        skills: Vec::new(),
+        skills,
         plugins,
         warnings,
     }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn is_directory_entry(path: &Path) -> bool {
+    match fs::metadata(path) {
+        Ok(metadata) => metadata.is_dir(),
+        Err(_) => false,
+    }
+}
 
 fn probe_instructions(path: &Path) -> GlobalInstructions {
     match fs::metadata(path) {
@@ -650,6 +660,143 @@ struct AutomationToml {
     version: Option<String>,
     #[serde(default)]
     tags: Vec<String>,
+}
+
+#[derive(Debug)]
+struct ClaudeSkillMetadata {
+    name: String,
+    description: Option<String>,
+    version: Option<String>,
+    tags: Vec<String>,
+}
+
+fn scan_claude_skills(
+    claude_dir: &Path,
+    warnings: &mut Vec<CapabilityWarning>,
+) -> Vec<HarnessSkill> {
+    let mut skills = Vec::new();
+    let skills_dir = claude_dir.join("skills");
+    let entries = match fs::read_dir(&skills_dir) {
+        Ok(entries) => entries,
+        Err(_) => return skills,
+    };
+
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !is_directory_entry(&dir) {
+            continue;
+        }
+
+        let skill_path = dir.join("SKILL.md");
+        if !skill_path.exists() {
+            continue;
+        }
+
+        let id = entry.file_name().to_string_lossy().into_owned();
+        let metadata = parse_claude_skill_md(&skill_path, &id, warnings);
+        skills.push(HarnessSkill {
+            id,
+            name: metadata.name,
+            source: "harness-native",
+            harness_id: "claude".to_string(),
+            path: dir.to_string_lossy().into_owned(),
+            description: metadata.description,
+            version: metadata.version,
+            tags: metadata.tags,
+        });
+    }
+
+    skills
+}
+
+fn parse_claude_skill_md(
+    path: &Path,
+    fallback_id: &str,
+    warnings: &mut Vec<CapabilityWarning>,
+) -> ClaudeSkillMetadata {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(err) => {
+            warnings.push(CapabilityWarning {
+                kind: "permission_denied".to_string(),
+                path: path.to_string_lossy().into_owned(),
+                message: format!("could not read SKILL.md: {err}"),
+            });
+            return ClaudeSkillMetadata {
+                name: fallback_id.to_string(),
+                description: None,
+                version: None,
+                tags: Vec::new(),
+            };
+        }
+    };
+
+    let mut metadata = ClaudeSkillMetadata {
+        name: fallback_id.to_string(),
+        description: None,
+        version: None,
+        tags: Vec::new(),
+    };
+
+    let mut lines = raw.lines();
+    if lines.next().map(str::trim) != Some("---") {
+        return metadata;
+    }
+
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed == "---" {
+            break;
+        }
+        let Some((key, value)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        match key.trim() {
+            "name" => {
+                if let Some(name) = parse_frontmatter_string(value) {
+                    metadata.name = name;
+                }
+            }
+            "description" => {
+                metadata.description = parse_frontmatter_string(value);
+            }
+            "version" => {
+                metadata.version = parse_frontmatter_string(value);
+            }
+            "tags" => {
+                metadata.tags = parse_frontmatter_string_list(value);
+            }
+            _ => {}
+        }
+    }
+
+    metadata
+}
+
+fn parse_frontmatter_string(value: &str) -> Option<String> {
+    let unquoted = value
+        .strip_prefix('"')
+        .and_then(|v| v.strip_suffix('"'))
+        .or_else(|| value.strip_prefix('\'').and_then(|v| v.strip_suffix('\'')))
+        .unwrap_or(value)
+        .trim();
+    if unquoted.is_empty() {
+        None
+    } else {
+        Some(unquoted.to_string())
+    }
+}
+
+fn parse_frontmatter_string_list(value: &str) -> Vec<String> {
+    let value = value.trim();
+    let Some(inner) = value.strip_prefix('[').and_then(|v| v.strip_suffix(']')) else {
+        return Vec::new();
+    };
+    inner
+        .split(',')
+        .filter_map(|item| parse_frontmatter_string(item.trim()))
+        .collect()
 }
 
 fn parse_automation_toml(
@@ -789,6 +936,36 @@ tags = ["bugs", "daily"]"#,
         assert_eq!(m.warnings[0].kind, "parse_error");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn scan_codex_follows_symlinked_automation_dirs() {
+        let home = tmp();
+        let real_auto = home.path().join("real-automations").join("nightly-triage");
+        fs::create_dir_all(&real_auto).unwrap();
+        fs::write(
+            real_auto.join("automation.toml"),
+            r#"name = "Nightly triage"
+description = "Reviews stale branches."
+tags = ["triage"]"#,
+        )
+        .unwrap();
+
+        let autos = home.path().join(".codex").join("automations");
+        fs::create_dir_all(&autos).unwrap();
+        std::os::unix::fs::symlink(&real_auto, autos.join("nightly-triage")).unwrap();
+
+        let m = scan_codex_capabilities(home.path());
+
+        assert_eq!(m.skills.len(), 1);
+        assert_eq!(m.skills[0].id, "nightly-triage");
+        assert_eq!(m.skills[0].name, "Nightly triage");
+        assert_eq!(
+            m.skills[0].description.as_deref(),
+            Some("Reviews stale branches.")
+        );
+        assert_eq!(m.skills[0].tags, vec!["triage"]);
+    }
+
     // ── Claude ─────────────────────────────────────────────────────────────
 
     #[test]
@@ -881,6 +1058,68 @@ tags = ["bugs", "daily"]"#,
         let m = scan_claude_capabilities(home.path());
         assert_eq!(m.plugins.len(), 1);
         assert_eq!(m.plugins[0].id, "test");
+    }
+
+    #[test]
+    fn scan_claude_scans_skill_frontmatter() {
+        let home = tmp();
+        let skill = home.path().join(".claude").join("skills").join("reviewer");
+        fs::create_dir_all(&skill).unwrap();
+        fs::write(
+            skill.join("SKILL.md"),
+            r#"---
+name: "Review Helper"
+description: "Reviews code changes."
+version: "1.2.3"
+tags: ["review", "code"]
+---
+
+# Review Helper
+"#,
+        )
+        .unwrap();
+
+        let m = scan_claude_capabilities(home.path());
+
+        assert_eq!(m.skills.len(), 1);
+        let skill = &m.skills[0];
+        assert_eq!(skill.id, "reviewer");
+        assert_eq!(skill.name, "Review Helper");
+        assert_eq!(skill.description.as_deref(), Some("Reviews code changes."));
+        assert_eq!(skill.version.as_deref(), Some("1.2.3"));
+        assert_eq!(skill.tags, vec!["review", "code"]);
+        assert!(m.warnings.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scan_claude_follows_symlinked_skill_dirs() {
+        let home = tmp();
+        let real_skill = home.path().join("real-skills").join("brainstorming");
+        fs::create_dir_all(&real_skill).unwrap();
+        fs::write(
+            real_skill.join("SKILL.md"),
+            r#"---
+name: Brainstorming
+description: Explore before building.
+---
+"#,
+        )
+        .unwrap();
+
+        let skills = home.path().join(".claude").join("skills");
+        fs::create_dir_all(&skills).unwrap();
+        std::os::unix::fs::symlink(&real_skill, skills.join("brainstorming")).unwrap();
+
+        let m = scan_claude_capabilities(home.path());
+
+        assert_eq!(m.skills.len(), 1);
+        assert_eq!(m.skills[0].id, "brainstorming");
+        assert_eq!(m.skills[0].name, "Brainstorming");
+        assert_eq!(
+            m.skills[0].description.as_deref(),
+            Some("Explore before building.")
+        );
     }
 
     // ── Cursor ─────────────────────────────────────────────────────────────────

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -42,7 +42,6 @@ pub enum DaemonStatusState {
     Stale(DaemonStatus),
 }
 
-#[cfg(unix)]
 #[derive(Debug, Deserialize)]
 struct DaemonHealthStatus {
     ok: bool,
@@ -368,6 +367,9 @@ struct PipedKiller {
     #[cfg(windows)]
     job_handle: Option<windows_sys::Win32::Foundation::HANDLE>,
 }
+
+#[cfg(windows)]
+unsafe impl Send for PipedKiller {}
 
 #[cfg(windows)]
 impl Drop for PipedKiller {
@@ -1709,8 +1711,9 @@ unsafe fn restrict_pipe_to_owner(handle: windows_sys::Win32::Foundation::HANDLE)
         Security::{
             Authorization::{
                 ConvertStringSecurityDescriptorToSecurityDescriptorW, SetSecurityInfo,
+                SE_KERNEL_OBJECT,
             },
-            DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
+            DACL_SECURITY_INFORMATION,
         },
     };
 
@@ -1737,10 +1740,10 @@ unsafe fn restrict_pipe_to_owner(handle: windows_sys::Win32::Foundation::HANDLE)
         handle,
         SE_KERNEL_OBJECT,
         DACL_SECURITY_INFORMATION,
-        std::ptr::null(),
-        std::ptr::null(),
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
         acl,
-        std::ptr::null(),
+        std::ptr::null_mut(),
     );
     LocalFree(sd as _);
     if rc != 0 {
@@ -1791,8 +1794,9 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
             Security::{
                 Authorization::{
                     ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW,
+                    SE_KERNEL_OBJECT,
                 },
-                GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION, SE_KERNEL_OBJECT,
+                GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION,
             },
         };
         let pipe_path = format!("\\\\\\.\\\\pipe\\\\",) + &windows_pipe_name(coven_home);
@@ -1816,10 +1820,10 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
                     pipe_path_w.as_ptr() as *mut _,
                     SE_KERNEL_OBJECT,
                     DACL_SECURITY_INFORMATION,
-                    std::ptr::null(),
-                    std::ptr::null(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
                     acl_ptr,
-                    std::ptr::null(),
+                    std::ptr::null_mut(),
                 )
             };
             unsafe { LocalFree(sd as _) };

--- a/crates/coven-cli/src/eval_loop.rs
+++ b/crates/coven-cli/src/eval_loop.rs
@@ -473,7 +473,7 @@ mod workspace_resolution_tests {
         fs::create_dir_all(&custom_ws).unwrap();
 
         let toml = format!(
-            "[[familiar]]\nid = \"sage\"\ndisplay_name = \"Sage\"\nrole = \"Research\"\ndescription = \"Reads.\"\nworkspace = \"{}\"\n",
+            "[[familiar]]\nid = \"sage\"\ndisplay_name = \"Sage\"\nrole = \"Research\"\ndescription = \"Reads.\"\nworkspace = '{}'\n",
             custom_ws.display()
         );
         fs::write(temp.path().join("familiars.toml"), toml).unwrap();

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -47,20 +47,10 @@ pub enum HarnessLaunchMode {
 
 /// Whether the harness CLI has a long-lived JSON-streaming mode the daemon
 /// can keep alive across chat turns. Claude does (`stream-json`); codex
-/// doesn't (only one-shot `codex exec`). Gated to Unix today because the
-/// daemon's stream-mode kill path relies on Unix process-group semantics
-/// (`setsid()` at spawn, then `kill(-pid, SIGKILL)` to tear down the
-/// harness plus any subprocesses it spawned in one syscall). A Windows
-/// process-tree termination path would let this widen. See
-/// `docs/chat-persistence.md`.
-#[cfg(unix)]
+/// doesn't (only one-shot `codex exec`). Unix kills the stream process tree
+/// with process groups; Windows uses a Job Object owned by the daemon.
 pub fn harness_supports_stream_mode(harness_id: &str) -> bool {
     harness_id == "claude"
-}
-
-#[cfg(not(unix))]
-pub fn harness_supports_stream_mode(_harness_id: &str) -> bool {
-    false
 }
 
 /// Hint passed when a chat turn wants to participate in a multi-turn

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::io::Read;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -531,22 +531,24 @@ fn legacy_tui_opted_in() -> bool {
 
 /// Locate the `coven-code` binary on PATH or in `~/.coven-code/bin/`.
 fn coven_code_binary() -> Option<PathBuf> {
-    if let Ok(path_var) = std::env::var("PATH") {
-        let suffix = if cfg!(windows) { ".exe" } else { "" };
-        let name = format!("coven-code{suffix}");
-        for dir in std::env::split_paths(&path_var) {
+    let path_var = std::env::var_os("PATH");
+    let home = dirs_next::home_dir();
+    coven_code_binary_from(path_var.as_deref(), home.as_deref())
+}
+
+fn coven_code_binary_from(path_var: Option<&OsStr>, home: Option<&Path>) -> Option<PathBuf> {
+    let suffix = if cfg!(windows) { ".exe" } else { "" };
+    let name = format!("coven-code{suffix}");
+    if let Some(path_var) = path_var {
+        for dir in std::env::split_paths(path_var) {
             let candidate = dir.join(&name);
             if is_executable_file(&candidate) {
                 return Some(candidate);
             }
         }
     }
-    if let Some(home) = dirs_next::home_dir() {
-        let suffix = if cfg!(windows) { ".exe" } else { "" };
-        let candidate = home
-            .join(".coven-code")
-            .join("bin")
-            .join(format!("coven-code{suffix}"));
+    if let Some(home) = home {
+        let candidate = home.join(".coven-code").join("bin").join(&name);
         if is_executable_file(&candidate) {
             return Some(candidate);
         }
@@ -2875,23 +2877,7 @@ mod tests {
 
     #[test]
     fn coven_code_binary_lookup_returns_none_for_empty_path() {
-        let prev_path = std::env::var("PATH").ok();
-        let prev_home = std::env::var("HOME").ok();
-        // Point PATH and HOME at empty/nonexistent locations so the lookup
-        // cannot resolve a binary anywhere.
-        std::env::set_var("PATH", "");
         let tmp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", tmp.path());
-        assert!(coven_code_binary().is_none());
-        if let Some(p) = prev_path {
-            std::env::set_var("PATH", p);
-        } else {
-            std::env::remove_var("PATH");
-        }
-        if let Some(h) = prev_home {
-            std::env::set_var("HOME", h);
-        } else {
-            std::env::remove_var("HOME");
-        }
+        assert!(coven_code_binary_from(Some(OsStr::new("")), Some(tmp.path())).is_none());
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -600,6 +600,7 @@ mod tests {
         assert_eq!(command.cwd(), cwd);
     }
 
+    #[cfg(unix)]
     #[test]
     fn spawn_detached_starts_pty_and_returns_input_and_kill_handles() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -819,6 +820,9 @@ exit 0
         .unwrap();
 
         assert_eq!(command.program(), "claude");
+        #[cfg(windows)]
+        assert_eq!(command.args(), &["\"explain && exit\""]);
+        #[cfg(not(windows))]
         assert_eq!(command.args(), &["explain && exit"]);
         assert_eq!(command.cwd(), cwd);
     }

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -566,7 +566,7 @@ impl App {
             // conversation state through the harness CLI's own resume
             // mechanism (--session-id/--resume for claude when not in
             // stream mode, `exec resume <id>` for codex). Stream-mode
-            // harnesses (claude on unix) take a fast-path inside
+            // harnesses (claude) take a fast-path inside
             // `run_harness_prompt` that reuses the existing long-lived
             // daemon session via `forward_input_to_session` instead.
             // See docs/chat-persistence.md.

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -7,7 +7,7 @@ extend the mechanism to additional harnesses.
 
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
-| `claude` | ✅ stream-mode (Unix only) | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose` daemon process per chat, plus `--session-id <uuid>` on the first turn and `--resume <uuid>` for cross-restart continuation. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). On non-Unix platforms chat falls back to per-turn `--print` because the daemon's stream-mode kill path uses `setsid()` at spawn + `kill(-pid, SIGKILL)` (Unix process-group semantics) to tear down the harness and any subprocesses it spawned (skills, MCP servers, shells) in one syscall. |
+| `claude` | ✅ stream-mode | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose` daemon process per chat, plus `--session-id <uuid>` on the first turn and `--resume <uuid>` for cross-restart continuation. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). Unix kills the stream process tree with `setsid()` + `kill(-pid, SIGKILL)`; Windows uses a Job Object owned by the daemon. |
 | `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:


### PR DESCRIPTION
## Summary
- follow symlinked Codex automation directories when scanning harness capabilities
- scan Claude Code user skills from ~/.claude/skills/*/SKILL.md, including symlinked skill folders and frontmatter metadata
- fix Windows-only daemon compile blockers and make the Windows CI test leg blocking again

## Verification
- cargo fmt --check
- cargo test -p coven-cli capabilities::tests -- --nocapture
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- git diff --check
- python3 scripts/check-secrets.py

Fixes #210
Fixes #178
Closes #147