### PR TITLE
docs: add Coven workflow standard

### DIFF
--- a/docs/superpowers/plans/2026-06-11-coven-workflow-standard.md
+++ b/docs/superpowers/plans/2026-06-11-coven-workflow-standard.md
@@ -1,0 +1,457 @@
+# Coven Workflow Standard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement CWF-01 so users can create, validate, preview, share, and run the same workflow manifest from Coven Code and Cave.
+
+**Architecture:** Start with the shared schema and validator in `OpenCoven/coven`, then expose daemon/CLI APIs, then integrate Coven Code and Cave as clients. The canonical workflow file remains the source of truth; Cave-only display state stays in sidecars.
+
+**Tech Stack:** Rust Coven daemon/CLI, JSON Schema, YAML, Coven Code Rust TUI, Cave Next.js/TypeScript UI, tar.gz bundle import/export.
+
+**Spec:** `specs/coven-workflow-standard/PRODUCT.md` and `specs/coven-workflow-standard/TECH.md`
+
+---
+
+## File Structure
+
+`OpenCoven/coven`:
+
+- Create `schemas/workflow/coven.workflow.v1.schema.json`: JSON Schema source of truth.
+- Create `schemas/workflow/examples/cody-review-pr.workflow.yaml`: simple workflow fixture.
+- Create `schemas/workflow/examples/sage-research-synthesis/WORKFLOW.md`: directory workflow fixture.
+- Create `crates/coven-cli/src/workflows/manifest.rs`: typed manifest structs and normalization.
+- Create `crates/coven-cli/src/workflows/validation.rs`: schema, semantic, and preflight validation entry points.
+- Create `crates/coven-cli/src/workflows/discovery.rs`: workflow root discovery and duplicate handling.
+- Create `crates/coven-cli/src/workflows/dry_run.rs`: dry-run plan builder.
+- Create `crates/coven-cli/src/workflows/bundles.rs`: import/export bundle checks.
+- Modify `crates/coven-cli/src/api.rs`: workflow API routes.
+- Modify `crates/coven-cli/src/main.rs`: module declaration and `coven workflows ...` CLI group.
+
+`OpenCoven/coven-code`:
+
+- Modify `src-rust/crates/commands`: `/workflow` slash command group.
+- Modify `src-rust/crates/tui`: workflow picker/editor and validation preview.
+- Modify `docs/commands.md` and `docs/index.md`: user docs.
+
+`OpenCoven/coven-cave`:
+
+- Create `src/lib/workflows.ts`: client-side types and API helpers.
+- Create `src/lib/workflow-sidecar.ts`: `WORKFLOW.cave.json` read/write helpers.
+- Create `src/app/api/workflows/*`: Cave server proxy routes.
+- Create `src/components/workflows-*`: list, builder, validator, dry-run, run-history components.
+- Modify shell/navigation files to expose Workflows.
+
+---
+
+### Task 1: Add shared schema and examples
+
+**Files:**
+- Create: `schemas/workflow/coven.workflow.v1.schema.json`
+- Create: `schemas/workflow/examples/cody-review-pr.workflow.yaml`
+- Create: `schemas/workflow/examples/sage-research-synthesis/WORKFLOW.md`
+
+- [ ] **Step 1: Create the schema**
+
+Add `schemas/workflow/coven.workflow.v1.schema.json` with the required fields from the TECH spec. Include `if`/`then` clauses for:
+
+```json
+{
+  "if": { "properties": { "pattern": { "const": "loop-until-done" } } },
+  "then": { "required": ["exit_criteria"] }
+}
+```
+
+and:
+
+```json
+{
+  "if": { "properties": { "ward_gate": { "const": false } } },
+  "then": { "required": ["ward_gate_reason"] }
+}
+```
+
+Use `additionalProperties: false` at the top level and allow extension only through `custom_fields`.
+
+- [ ] **Step 2: Add the simple YAML fixture**
+
+Create `schemas/workflow/examples/cody-review-pr.workflow.yaml` using the example manifest from `specs/coven-workflow-standard/PRODUCT.md`.
+
+- [ ] **Step 3: Add the WORKFLOW.md fixture**
+
+Create `schemas/workflow/examples/sage-research-synthesis/WORKFLOW.md` with YAML front matter for a `fan-out-and-synthesize` research workflow and a short Markdown body describing when to use it.
+
+- [ ] **Step 4: Sanity-check the schema and YAML fixtures**
+
+Run:
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven
+jq empty schemas/workflow/coven.workflow.v1.schema.json
+ruby -e 'require "yaml"; YAML.load_file(ARGV[0])' schemas/workflow/examples/cody-review-pr.workflow.yaml
+ruby -e 'text = File.read(ARGV[0]); abort("missing front matter") unless text.start_with?("---\n"); YAML.safe_load(text.split(/^---\s*$/, 3)[1], permitted_classes: [], aliases: false)' schemas/workflow/examples/sage-research-synthesis/WORKFLOW.md
+```
+
+Expected: schema JSON parses, YAML fixture parses, and `WORKFLOW.md` has valid YAML front matter. Full JSON Schema validation is added as Rust tests in Task 2 so the repo does not depend on a global YAML-aware schema CLI.
+
+---
+
+### Task 2: Add manifest parsing and schema validation in Coven
+
+**Files:**
+- Create: `crates/coven-cli/src/workflows/mod.rs`
+- Create: `crates/coven-cli/src/workflows/manifest.rs`
+- Create: `crates/coven-cli/src/workflows/validation.rs`
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Write parser tests**
+
+Add tests for:
+
+```rust
+#[test]
+fn parses_yaml_workflow_file() {
+    let source = include_str!("../../../../schemas/workflow/examples/cody-review-pr.workflow.yaml");
+    let manifest = WorkflowManifest::from_yaml(source).unwrap();
+    assert_eq!(manifest.schema_version, "coven.workflow.v1");
+    assert_eq!(manifest.id, "cody-review-pr");
+}
+
+#[test]
+fn parses_workflow_md_front_matter() {
+    let source = include_str!("../../../../schemas/workflow/examples/sage-research-synthesis/WORKFLOW.md");
+    let manifest = WorkflowManifest::from_workflow_md(source).unwrap();
+    assert_eq!(manifest.schema_version, "coven.workflow.v1");
+    assert_eq!(manifest.pattern, WorkflowPattern::FanOutAndSynthesize);
+}
+```
+
+- [ ] **Step 2: Implement manifest structs**
+
+Define `WorkflowManifest`, `WorkflowStep`, `WorkflowLimits`, `WorkflowPermissions`, `WorkflowInput`, `WorkflowOutput`, and `WorkflowPattern` with `serde` derives. Use strongly typed enums for `pattern` and `steps[].kind`.
+
+- [ ] **Step 3: Implement front-matter parsing**
+
+Parse `WORKFLOW.md` by requiring the file to start with `---`, reading until the next `---`, and feeding only that YAML block to `serde_yaml`.
+
+- [ ] **Step 4: Write schema-validation tests**
+
+Add tests for missing `schema_version`, missing `limits.max_agents`, `ward_gate: false` without `ward_gate_reason`, and `loop-until-done` without `exit_criteria`.
+
+- [ ] **Step 5: Implement schema validation**
+
+Use the existing Rust JSON Schema crate if present; otherwise add a small dependency such as `jsonschema` in `crates/coven-cli/Cargo.toml`. Return `WorkflowValidationResult` with issue objects matching the TECH spec.
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven
+cargo test -p coven-cli workflows::manifest workflows::validation
+```
+
+If Cargo rejects multiple test filters, run them separately:
+
+```bash
+cargo test -p coven-cli workflows::manifest
+cargo test -p coven-cli workflows::validation
+```
+
+Expected: all new parser and schema-validation tests pass.
+
+---
+
+### Task 3: Add discovery, semantic lint, and dry-run
+
+**Files:**
+- Create: `crates/coven-cli/src/workflows/discovery.rs`
+- Create: `crates/coven-cli/src/workflows/dry_run.rs`
+- Modify: `crates/coven-cli/src/workflows/validation.rs`
+
+- [ ] **Step 1: Write discovery tests**
+
+Cover all three roots:
+
+```rust
+#[test]
+fn discovers_project_coven_before_project_coven_code_before_user_coven() {
+    let roots = WorkflowRoots::new(project.join(".coven/workflows"), project.join(".coven-code/workflows"), home.join(".coven/workflows"));
+    let discovered = discover_workflows(&roots).unwrap();
+    assert_eq!(discovered[0].source, WorkflowSource::ProjectCoven);
+}
+```
+
+- [ ] **Step 2: Implement discovery**
+
+Discover `*/WORKFLOW.md`, `*.workflow.yaml`, and `*.workflow.yml`. Store canonical path, source tier, ID, version, name, familiar, and validation state.
+
+- [ ] **Step 3: Write semantic lint tests**
+
+Test unknown familiar, unknown skill, bad `needs` reference, workflow cycle, and nesting depth over five. Use fake registries so tests do not depend on the user's machine.
+
+- [ ] **Step 4: Implement semantic lint**
+
+Add a `WorkflowReferenceRegistry` trait with methods for familiar, skill, tool, command, and workflow lookup. Production uses real registries; tests use fakes.
+
+- [ ] **Step 5: Write dry-run tests**
+
+Assert that dry-run returns estimates and never calls any executor. Use a fake executor with a counter and assert the counter stays zero.
+
+- [ ] **Step 6: Implement dry-run**
+
+Dry-run calls schema validation, semantic lint, and runtime preflight, then builds `WorkflowDryRunPlan` from limits, permissions, external accounts, capabilities, and human-gate steps.
+
+- [ ] **Step 7: Run targeted tests**
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven
+cargo test -p coven-cli workflows::discovery workflows::validation workflows::dry_run
+```
+
+If Cargo rejects multiple test filters, run them separately:
+
+```bash
+cargo test -p coven-cli workflows::discovery
+cargo test -p coven-cli workflows::validation
+cargo test -p coven-cli workflows::dry_run
+```
+
+Expected: all discovery, semantic lint, and dry-run tests pass.
+
+---
+
+### Task 4: Add Coven API and CLI workflow commands
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs`
+- Modify: `crates/coven-cli/src/main.rs` or existing CLI command module
+- Modify: `docs/reference/cli.md`
+- Modify: `docs/API.md`
+
+- [ ] **Step 1: Add API tests**
+
+Add tests for:
+
+```rust
+get_workflows_lists_discovered_workflows
+post_workflows_validate_returns_grouped_issues
+post_workflows_dry_run_does_not_execute_steps
+post_workflows_run_rejects_invalid_workflow
+post_workflows_import_rejects_path_traversal_bundle
+```
+
+- [ ] **Step 2: Implement API routes**
+
+Add routes from `TECH.md`:
+
+```text
+GET /api/v1/workflows
+GET /api/v1/workflows/:id
+POST /api/v1/workflows/validate
+POST /api/v1/workflows/dry-run
+POST /api/v1/workflows/run
+GET /api/v1/workflow-runs/:id
+POST /api/v1/workflows/import
+POST /api/v1/workflows/export
+```
+
+- [ ] **Step 3: Add CLI tests**
+
+Test `coven workflows list`, `show`, `validate`, and `dry-run` against fixture roots.
+
+- [ ] **Step 4: Implement CLI commands**
+
+Wire commands to the same workflow service used by the API. Print validation issues grouped by tier and use JSON output when the existing CLI supports machine-readable output.
+
+- [ ] **Step 5: Update Coven docs**
+
+Document the API routes in `docs/API.md` and CLI commands in `docs/reference/cli.md`.
+
+- [ ] **Step 6: Verify Coven**
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven
+cargo test -p coven-cli workflows
+cargo fmt --check
+cargo clippy -p coven-cli -- -D warnings
+```
+
+Expected: tests pass, formatting is clean, clippy has no warnings.
+
+---
+
+### Task 5: Add Coven Code `/workflow` and TUI surfaces
+
+**Files:**
+- Modify: `~/Documents/GitHub/OpenCoven/coven-code/src-rust/crates/commands/src/lib.rs`
+- Modify: `~/Documents/GitHub/OpenCoven/coven-code/src-rust/crates/tui/src/app.rs`
+- Modify: `~/Documents/GitHub/OpenCoven/coven-code/docs/commands.md`
+- Modify: `~/Documents/GitHub/OpenCoven/coven-code/docs/index.md`
+
+- [ ] **Step 1: Write command tests**
+
+In `claurst-commands`, test:
+
+```rust
+workflow_list_shows_discovered_workflows
+workflow_validate_prints_schema_and_semantic_issues
+workflow_dry_run_refuses_invalid_workflow
+workflow_run_requires_clean_dry_run
+workflow_export_writes_bundle
+```
+
+- [ ] **Step 2: Implement `/workflow` command group**
+
+Add subcommands:
+
+```text
+list
+show <id>
+new
+validate <path-or-id>
+dry-run <id>
+run <id>
+explain <id>
+doctor
+export <id>
+```
+
+When the Coven daemon is online, call its workflow API. When offline, support local list, show, new, validate, dry-run, explain, doctor, and export using the shared schema files vendored or generated from `OpenCoven/coven`.
+
+- [ ] **Step 3: Add TUI picker/editor**
+
+Add a workflow picker reachable from the command palette and `/coven` surfaces. Each row shows ID, familiar, pattern, validation state, and canonical path. The editor exposes required fields first and an advanced raw YAML pane second.
+
+- [ ] **Step 4: Add dry-run preview**
+
+Before run, render dry-run estimates: max agents, timeout, cost ceiling, external accounts, permissions, and human gates. Disable run when dry-run is not clean.
+
+- [ ] **Step 5: Update Coven Code docs**
+
+Document `/workflow` in `docs/commands.md` and link it from `docs/index.md`.
+
+- [ ] **Step 6: Verify Coven Code**
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven-code/src-rust
+cargo test -p claurst-commands workflow
+cargo check --workspace
+cargo fmt --all --check
+```
+
+Expected: command tests pass, workspace checks, formatting is clean.
+
+---
+
+### Task 6: Add Cave Workflows interface
+
+**Files:**
+- Create: `coven-cave/src/lib/workflows.ts`
+- Create: `coven-cave/src/lib/workflow-sidecar.ts`
+- Create: `coven-cave/src/app/api/workflows/route.ts`
+- Create: `coven-cave/src/app/api/workflows/validate/route.ts`
+- Create: `coven-cave/src/app/api/workflows/dry-run/route.ts`
+- Create: `coven-cave/src/components/workflows-view.tsx`
+- Create: `coven-cave/src/components/workflow-builder.tsx`
+- Create: `coven-cave/src/components/workflow-validator-panel.tsx`
+- Create: `coven-cave/src/components/workflow-dry-run-preview.tsx`
+
+- [ ] **Step 1: Write API helper tests**
+
+Test that Cave forwards validation and dry-run requests to the daemon and preserves `WorkflowValidationIssue` shape exactly.
+
+- [ ] **Step 2: Implement API helpers**
+
+`src/lib/workflows.ts` defines shared TypeScript interfaces matching the TECH spec and functions for list, validate, dry-run, run, import, and export.
+
+- [ ] **Step 3: Write sidecar tests**
+
+Test that `WORKFLOW.cave.json` stores layout state without modifying `WORKFLOW.md`.
+
+- [ ] **Step 4: Implement sidecar helpers**
+
+`src/lib/workflow-sidecar.ts` reads and writes only Cave display fields: node positions, colors, collapsed groups, sidebar pins, and selected tab.
+
+- [ ] **Step 5: Build Workflows view**
+
+Create a dense operational view: list on the left, details/validator/preview on the right, builder accessible through a create button. Avoid marketing copy. The first screen is the usable workflow browser.
+
+- [ ] **Step 6: Build builder form**
+
+The form includes required fields, inputs, outputs, permissions, limits, Ward gate, steps, and `on_error`. Advanced YAML remains editable for power users.
+
+- [ ] **Step 7: Build validator and dry-run panels**
+
+Group issues by tier. Render dry-run estimates and blockers. Human gates appear as pending approval rows.
+
+- [ ] **Step 8: Add navigation**
+
+Expose Workflows in Cave's main navigation where roles, skills, plugins, board, and library surfaces already live.
+
+- [ ] **Step 9: Verify Cave**
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven-cave
+pnpm test:app
+pnpm test:api
+pnpm tsc --noEmit
+```
+
+Expected: app tests, API tests, and TypeScript checks pass.
+
+---
+
+### Task 7: Cross-client round-trip verification
+
+**Files:**
+- Modify docs only if verification exposes mismatched user-facing behavior.
+
+- [ ] **Step 1: Create from Coven Code**
+
+Run `/workflow new`, create a workflow in `.coven/workflows/cody-review-pr/WORKFLOW.md`, validate it, and dry-run it.
+
+- [ ] **Step 2: Open in Cave**
+
+Open Cave Workflows and confirm the same workflow appears with the same ID, version, familiar, pattern, validation result, and dry-run estimates.
+
+- [ ] **Step 3: Edit Cave sidecar**
+
+Move graph nodes or change layout, save, and confirm only `WORKFLOW.cave.json` changes.
+
+- [ ] **Step 4: Create from Cave**
+
+Create a second workflow in Cave, save it, and validate it from Coven Code with `/workflow validate`.
+
+- [ ] **Step 5: Export and import**
+
+Export both workflows, import them into a clean temp `$COVEN_HOME`, and confirm validation passes or reports only missing local capabilities.
+
+- [ ] **Step 6: Verify all repos**
+
+Run:
+
+```bash
+cd ~/Documents/GitHub/OpenCoven/coven && cargo test -p coven-cli workflows
+cd ~/Documents/GitHub/OpenCoven/coven-code/src-rust && cargo test -p claurst-commands workflow
+cd ~/Documents/GitHub/OpenCoven/coven-cave && pnpm test:app && pnpm test:api && pnpm tsc --noEmit
+```
+
+Expected: all workflow-related tests and checks pass.
+
+---
+
+## Execution Notes
+
+- Do not embed script bodies in workflow manifests.
+- Do not store secrets in manifests, sidecars, examples, or bundles.
+- Do not put Cave layout state in `WORKFLOW.md`.
+- Do not commit until Val explicitly asks.
+- Commit boundaries, once approved, should be one task per commit.
+
+## Open Questions Deferred Past v1
+
+- Scheduling grammar.
+- Rollback/idempotency markers.
+- Marketplace publication policy.
+- Full graph-editor interactions.
+- Signed external script artifacts.

--- a/specs/coven-workflow-standard/PRODUCT.md
+++ b/specs/coven-workflow-standard/PRODUCT.md
@@ -1,0 +1,464 @@
+# Coven Workflow Standard - PRODUCT
+
+**Status:** Draft v1 - 2026-06-11
+**Owner:** Coven runtime, Coven Code, Cave
+**Acceptance target:** "A Coven user can create, validate, preview, share, and run a workflow from either Coven Code or Cave, with the same manifest and the same safety result."
+
+---
+
+## Problem
+
+Coven has several useful building blocks already: familiars, skills, tools,
+hooks, sessions, standing orders, Coven Code slash commands, and Cave surfaces
+for roles, boards, chat, and library context. What it lacks is a shared
+workflow contract.
+
+Without that contract:
+
+- A repeated task is trapped inside one harness, one Cave affordance, or one
+  agent's prose instructions.
+- Cave and Coven Code can drift into different workflow shapes.
+- Users cannot inspect the required inputs, optional knobs, limits,
+  permissions, and approval gates before a workflow runs.
+- Import/export is risky because executable behavior can be hidden inside an
+  opaque script body.
+- There is no shared dry-run or preview surface for estimating agents, cost,
+  permissions, and human review points before execution.
+
+The workflow standard gives Coven a portable recipe format, not an arbitrary
+automation runtime.
+
+---
+
+## Philosophy alignment
+
+Coven workflows must stay local-first, readable, inspectable, and user-owned.
+A workflow is a recipe for orchestration across existing Coven capabilities. It
+can call a familiar, skill, tool, command, prompt, or another workflow, but the
+manifest itself is declarative in v1.
+
+The important guarantee is that Cave and Coven Code do not have secret
+parallel semantics. They read and write the same canonical file on disk, run
+the same validator, show the same dry-run plan, and enforce the same safety
+rules.
+
+---
+
+## Scope of v1
+
+v1 establishes:
+
+1. A portable `coven.workflow.v1` manifest format.
+2. Two canonical file forms:
+   - `workflows/<id>/WORKFLOW.md` with YAML front matter plus narrative docs.
+   - `<id>.workflow.yaml` for simple workflows with five or fewer steps.
+3. JSON Schema validation that runs in editors, Coven Code, Cave, and the
+   daemon.
+4. Semantic lint for references, pattern rules, cycle checks, and registry
+   availability.
+5. Runtime preflight for limits, installed dependencies, Ward gates, and
+   permission posture.
+6. Mandatory dry-run/plan mode before execution.
+7. Import/export bundles for sharing without secrets.
+8. A Coven Code TUI and slash-command surface for fast terminal use.
+9. A Cave workflow browser, builder, validator, preview, and run-history
+   surface for friendly authoring.
+
+Out of scope for v1:
+
+- Embedded arbitrary script bodies.
+- General scheduling grammar beyond `trigger: null` or `trigger.kind: manual`.
+- Cloud sync.
+- Automatic rollback of external side effects.
+- A visual graph editor as the only authoring surface.
+- Model-specific routing. Workflows declare capabilities, not model names.
+
+---
+
+## User outcomes
+
+### Create
+
+A user can scaffold a workflow from either client:
+
+- Coven Code: `/workflow new` or command-palette/TUI picker.
+- Cave: Workflows view, template gallery, or builder form.
+
+The scaffold must include every required field and validation-safe defaults
+where defaults are allowed.
+
+### Inspect
+
+A user can see:
+
+- Required inputs and optional configuration.
+- Step list and step kinds.
+- Permissions and external touch points.
+- Limits for agents, time, and cost.
+- Human-gate points.
+- Outputs and artifacts.
+- Error handling behavior.
+- Which familiar owns or recommends the workflow.
+
+### Validate
+
+A user gets deterministic errors with:
+
+- `code`
+- `path` as JSON Pointer
+- `message`
+- `suggestion`
+- `tier`: `schema`, `semantic`, or `preflight`
+
+### Preview
+
+Dry-run produces a non-executing plan that estimates:
+
+- Agent count.
+- Tool and skill dependencies.
+- Required human gates.
+- Permission prompts.
+- Token/cost budget range.
+- Runtime limit posture.
+- Output artifacts.
+- Reasons the run would be blocked.
+
+### Run
+
+Running a workflow creates observable run state:
+
+- Status.
+- Started and ended timestamps.
+- Step statuses.
+- Logs or linked session events.
+- Artifacts.
+- Final result.
+- Validation and dry-run result used for the run.
+
+---
+
+## Canonical manifest
+
+The manifest is YAML. `WORKFLOW.md` stores the manifest in front matter and
+allows human narrative below it. `<id>.workflow.yaml` stores only the manifest.
+
+Required fields:
+
+```yaml
+schema_version: coven.workflow.v1
+id: cody-review-pr
+version: 1.0.0
+name: Review PR
+summary: Review a GitHub pull request with a verification pass.
+description: >
+  Runs a structured code review, collects findings, and gates any suggested
+  changes behind human approval.
+pattern: sequential
+familiar: cody
+requires:
+  - reasoning
+inputs:
+  pr_url:
+    type: string
+    required: true
+    description: GitHub pull request URL.
+outputs:
+  review:
+    type: markdown
+    description: Ordered review findings and residual risk.
+permissions:
+  filesystem: read
+  network: true
+  external_accounts:
+    - github
+  approval: before_external_write
+limits:
+  max_agents: 2
+  timeout_s: 1800
+  cost_ceiling_usd: 3.00
+ward_gate: true
+steps:
+  - id: inspect-pr
+    kind: tool
+    uses: github.pr.inspect
+    with:
+      pr_url: ${inputs.pr_url}
+  - id: review
+    kind: agent
+    uses: familiar:cody
+    needs:
+      - inspect-pr
+  - id: approval
+    kind: human-gate
+    prompt: Approve posting or implementing review feedback?
+on_error:
+  strategy: stop
+  notify: true
+```
+
+---
+
+## Required field semantics
+
+| Field | Requirement |
+|---|---|
+| `schema_version` | Must be `coven.workflow.v1` for v1 workflows. Missing schema is a hard error. |
+| `id` | Kebab-case stable slug. Recommended namespace is `<familiar>-<name>`. |
+| `version` | Semver. |
+| `name` | Short display name. |
+| `summary` | One-sentence summary for lists and previews. |
+| `description` | Human-readable explanation. May be front matter or narrative body in `WORKFLOW.md`. |
+| `pattern` | Closed enum: `fan-out-and-synthesize`, `classify-and-act`, `adversarial-verification`, `generate-and-filter`, `tournament`, `loop-until-done`, `sequential`, `custom`. |
+| `custom_pattern_name` | Required only when `pattern: custom`. |
+| `custom_pattern_description` | Required only when `pattern: custom`. |
+| `familiar` | Familiar ID, not instance path or running session ID. |
+| `requires` | Capability requirements such as `reasoning`, `code-edit`, `web`, `vision`, or `long-context`; no model names. |
+| `inputs` | Map of user-provided inputs, each with type and required/default rules. |
+| `outputs` | Map of expected outputs or artifacts. |
+| `permissions` | Filesystem, network, external account, tool, and approval posture. |
+| `limits.max_agents` | Required integer. No default. |
+| `limits.timeout_s` | Required integer. No default. |
+| `limits.cost_ceiling_usd` | Required number. No default. |
+| `ward_gate` | Defaults to `true`. If `false`, `ward_gate_reason` is required. |
+| `steps` | Non-empty ordered list. |
+| `on_error` | Explicit failure strategy. |
+
+`exit_criteria` is required when `pattern: loop-until-done`.
+
+---
+
+## Optional configuration
+
+Optional fields may be omitted without changing safety posture:
+
+| Field | Default | Notes |
+|---|---|---|
+| `trigger` | `null` | v1 is manual-first. `trigger.kind: manual` is equivalent to null. |
+| `visibility.coven_code` | `true` | Whether Coven Code lists the workflow. |
+| `visibility.coven_cave` | `true` | Whether Cave lists the workflow. |
+| `tags` | `[]` | Search and gallery labels. |
+| `roles` | `[]` | Role affinities by ID. |
+| `display_name` | `name` | Alternate UI label. |
+| `examples` | `[]` | Example inputs and expected outputs. |
+| `custom_fields` | `{}` | Extension map ignored by validators except for reserved-key checks. |
+
+Cave-only display state never goes in the manifest. Step graph layout, panel
+widths, color overrides, collapsed groups, pins, and draft cursor state live in
+`WORKFLOW.cave.json`.
+
+---
+
+## Step kinds
+
+| Kind | Purpose |
+|---|---|
+| `agent` | Run a familiar/subagent by stable familiar ID. |
+| `skill` | Invoke a named skill by `skill-id@semver-range`, never by local path. |
+| `tool` | Invoke a registered tool by stable ID. |
+| `command` | Invoke a Coven or Coven Code command by stable command ID. |
+| `prompt` | Run a prompt-only step against the selected familiar/runtime. |
+| `human-gate` | Pause for user approval. Cave shows a pending gate; Coven Code shows an interactive prompt. |
+| `workflow` | Invoke another workflow by ID and semver range. |
+
+Nested workflows must pass cycle detection. v1 maximum nesting depth is five.
+
+External scripts are not embedded. If an existing script must be called, wrap it
+as a `tool` or `command` capability and preflight that capability before run.
+
+---
+
+## Validation tiers
+
+Validation fails early at the cheapest tier.
+
+### Tier 1: Schema
+
+JSON Schema checks:
+
+- Required fields.
+- Types.
+- Closed enums.
+- Semver shape.
+- Kebab-case ID.
+- Conditional requirements such as `exit_criteria` and `custom_pattern_name`.
+- Required limits.
+
+### Tier 2: Semantic lint
+
+Semantic lint checks:
+
+- Familiar ID exists.
+- Skill, tool, command, and workflow references resolve.
+- Nested workflows do not cycle and stay within depth five.
+- `needs` references point to earlier step IDs.
+- Pattern-specific rules are satisfied.
+- No model names or internal executor fields are used.
+- `custom_fields` does not shadow reserved fields.
+
+### Tier 3: Runtime preflight
+
+Preflight checks:
+
+- Required skills, plugins, tools, and external accounts are available.
+- Filesystem and network permissions can be requested under the current safety
+  posture.
+- Ward gates are present for protected tiers.
+- `limits` are within local policy.
+- Dry-run plan can be produced without execution.
+
+---
+
+## Ward and approval policy
+
+Ward compliance is part of v1, not a later retrofit.
+
+Protected workflows must include `val_review_required: true` when they touch:
+
+- SOUL or identity files.
+- MEMORY or daily memory files.
+- Ward policy files.
+- Plugin or skill approval state.
+- Secrets, tokens, or account credentials.
+- Public posting or external writes.
+
+If `ward_gate: false`, the manifest must include `ward_gate_reason`. The
+validator emits a Tier-1 Cave event and a Coven Code warning so the bypass is
+auditable.
+
+---
+
+## Storage and discovery
+
+Clients discover workflows from these roots, in order:
+
+1. Project `.coven/workflows/`.
+2. Project `.coven-code/workflows/` for Coven Code compatibility.
+3. User `~/.coven/workflows/`.
+
+The canonical file on disk is the source of truth. Cave may keep sidecars and
+run history, but it does not fork the manifest.
+
+Recommended complex layout:
+
+```text
+workflows/
+  cody-review-pr/
+    WORKFLOW.md
+    WORKFLOW.cave.json
+    examples/
+      happy-path.yaml
+```
+
+Recommended simple layout:
+
+```text
+workflows/
+  cody-review-pr.workflow.yaml
+```
+
+---
+
+## Import and export
+
+Shared bundles use:
+
+```text
+<id>-v<version>.coven-workflow.tar.gz
+```
+
+The bundle includes:
+
+- `MANIFEST.json` with bundle metadata and file checksums.
+- The canonical `WORKFLOW.md` or `.workflow.yaml`.
+- Optional examples and docs.
+- No secrets.
+- No runtime-local paths unless explicitly marked as examples.
+
+Import validates before install and shows a dry-run preview before enabling.
+
+---
+
+## Cave surface
+
+Cave gets the friendly authoring path:
+
+- Workflows top-level section or Library subsection.
+- Template gallery.
+- Builder form for required fields.
+- Text editor for advanced users.
+- Validator panel with grouped schema, semantic, and preflight errors.
+- Preview button backed by dry-run.
+- Run history with step status, logs, artifacts, and gates.
+- Sidecar-backed graph/layout view.
+- Dirty-state protection when the file changes on disk.
+
+Cave writes only canonical manifest fields to `WORKFLOW.md` or
+`.workflow.yaml`. UI display state goes to `WORKFLOW.cave.json`.
+
+---
+
+## Coven Code surface
+
+Coven Code gets the fast terminal path:
+
+```text
+/workflow list
+/workflow show <id>
+/workflow new
+/workflow validate <path-or-id>
+/workflow dry-run <id>
+/workflow run <id>
+/workflow explain <id>
+/workflow doctor
+/workflow export <id>
+```
+
+The TUI also gets a workflow picker/editor reachable from the command palette
+and relevant `/coven` surfaces. The picker uses the same validator and dry-run
+planner as Cave.
+
+---
+
+## Migration
+
+Existing skill prose does not need forced migration. Keep `## Steps` in skills
+until the behavior needs parallelism, gates, data binding, or cross-familiar
+coordination. Then extract a workflow and reference the skill from a workflow
+step.
+
+Existing dynamic workflow scripts should be wrapped as external tools or
+commands. The workflow manifest references the capability; it does not embed
+script source.
+
+---
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Cave and Coven Code diverge | Canonical file is source of truth; shared schema and validator. |
+| Lock-in to current harness internals | Use familiar IDs, capability requirements, and stable tool/skill IDs. |
+| Missing schema from early workflows | Hard fail in validator; scaffold always stamps `schema_version`. |
+| Unbounded execution | Require `max_agents`, `timeout_s`, and `cost_ceiling_usd`. |
+| Hidden Ward bypass | `ward_gate: false` requires `ward_gate_reason` and emits audit events. |
+| Graph editor pollutes portable manifest | Cave layout sidecar only. |
+
+---
+
+## Acceptance for v1
+
+1. A workflow scaffold created in Cave validates and runs from Coven Code.
+2. A workflow scaffold created in Coven Code validates and opens in Cave.
+3. The shared validator returns the same error list for the same invalid file
+   in both clients.
+4. Dry-run produces a plan without executing steps.
+5. A workflow with missing limits fails schema validation.
+6. A workflow with `pattern: loop-until-done` and no `exit_criteria` fails
+   schema validation.
+7. A workflow with `ward_gate: false` and no `ward_gate_reason` fails schema
+   validation.
+8. Cave sidecar edits do not modify the canonical workflow manifest.
+9. Import rejects bundles containing secrets or embedded executable script
+   bodies.
+10. Exported bundles re-import on a clean machine with only missing-capability
+    warnings, not parse errors.

--- a/specs/coven-workflow-standard/TECH.md
+++ b/specs/coven-workflow-standard/TECH.md
@@ -1,0 +1,372 @@
+# Coven Workflow Standard - TECH
+
+**Status:** Draft v1 - 2026-06-11
+**Owner:** Coven runtime, Coven Code, Cave
+**Depends on:** PRODUCT.md (this directory)
+
+---
+
+## Architecture
+
+The workflow standard is implemented as a shared contract first, then consumed
+by clients.
+
+Core pieces:
+
+1. Schema package in `OpenCoven/coven`.
+2. Validator and dry-run planner in the Coven daemon/runtime layer.
+3. Coven Code command and TUI integration in `OpenCoven/coven-code`.
+4. Cave browser, builder, preview, sidecar, and run-history integration in
+   `OpenCoven/coven-cave`.
+
+The canonical manifest stays a file on disk. Cave and Coven Code are clients of
+that file and the shared validator.
+
+---
+
+## Shared schema files
+
+Create:
+
+```text
+schemas/workflow/coven.workflow.v1.schema.json
+schemas/workflow/examples/cody-review-pr.workflow.yaml
+schemas/workflow/examples/sage-research-synthesis/WORKFLOW.md
+```
+
+The JSON Schema must validate:
+
+- `schema_version: coven.workflow.v1`
+- Required scalar fields.
+- Kebab-case `id`.
+- Semver `version`.
+- Closed `pattern` enum.
+- Required `limits.max_agents`, `limits.timeout_s`,
+  `limits.cost_ceiling_usd`.
+- Required non-empty `steps`.
+- Conditional `exit_criteria` for `loop-until-done`.
+- Conditional `custom_pattern_name` and `custom_pattern_description` for
+  `custom`.
+- Conditional `ward_gate_reason` when `ward_gate` is `false`.
+- Step kind enum.
+- Step `needs` as an array of strings.
+- `custom_fields` as an object.
+
+Do not allow these reserved internal fields anywhere in the manifest:
+
+- `executor`
+- `session_id`
+- `process_id`
+- `workspace_path`
+- `comux_channel`
+- `model`
+- `api_key`
+- `token`
+
+---
+
+## Validator response contract
+
+All validator and preflight errors use:
+
+```json
+{
+  "code": "workflow.required_limits",
+  "path": "/limits/max_agents",
+  "message": "limits.max_agents is required.",
+  "suggestion": "Set limits.max_agents to the maximum number of agents this workflow may spawn.",
+  "tier": "schema"
+}
+```
+
+Types:
+
+```ts
+type WorkflowValidationTier = "schema" | "semantic" | "preflight";
+
+interface WorkflowValidationIssue {
+  code: string;
+  path: string;
+  message: string;
+  suggestion: string;
+  tier: WorkflowValidationTier;
+}
+
+interface WorkflowValidationResult {
+  ok: boolean;
+  schemaVersion: "coven.workflow.v1" | string | null;
+  workflowId: string | null;
+  issues: WorkflowValidationIssue[];
+}
+```
+
+Use the same shape over the daemon API, Coven Code command output, and Cave API
+responses.
+
+---
+
+## Dry-run plan contract
+
+Dry-run never executes steps. It resolves references and estimates posture.
+
+```ts
+interface WorkflowDryRunPlan {
+  ok: boolean;
+  workflowId: string;
+  version: string;
+  steps: Array<{
+    id: string;
+    kind: string;
+    uses?: string;
+    status: "ready" | "blocked";
+    blockers: WorkflowValidationIssue[];
+  }>;
+  estimates: {
+    maxAgents: number;
+    timeoutS: number;
+    costCeilingUsd: number;
+    requiredCapabilities: string[];
+    requiredExternalAccounts: string[];
+    humanGates: string[];
+  };
+  issues: WorkflowValidationIssue[];
+}
+```
+
+If validation fails, dry-run returns `ok: false` and the validation issues. It
+must not continue to runtime preflight after a schema failure.
+
+---
+
+## Daemon and CLI API
+
+Add workflow routes to the local daemon API:
+
+| Route | Purpose |
+|---|---|
+| `GET /api/v1/workflows` | List discovered workflows. |
+| `GET /api/v1/workflows/:id` | Return manifest metadata and canonical path. |
+| `POST /api/v1/workflows/validate` | Validate raw manifest content or a path. |
+| `POST /api/v1/workflows/dry-run` | Return a dry-run plan for a workflow and inputs. |
+| `POST /api/v1/workflows/run` | Start a workflow run after validation and dry-run. |
+| `GET /api/v1/workflow-runs/:id` | Return run state. |
+| `POST /api/v1/workflows/import` | Validate and stage an import bundle. |
+| `POST /api/v1/workflows/export` | Create an export bundle. |
+
+CLI commands:
+
+```text
+coven workflows list
+coven workflows show <id>
+coven workflows validate <path-or-id>
+coven workflows dry-run <id> --input key=value
+coven workflows run <id> --input key=value
+coven workflows import <bundle>
+coven workflows export <id>
+```
+
+Coven Code may call daemon APIs when available and fall back to local shared
+library validation when the daemon is offline.
+
+---
+
+## Discovery order
+
+Workflow roots:
+
+1. `<project>/.coven/workflows/`
+2. `<project>/.coven-code/workflows/`
+3. `$COVEN_HOME/workflows/`, defaulting to `~/.coven/workflows/`
+
+Discovery rules:
+
+- A directory containing `WORKFLOW.md` is one workflow.
+- A file matching `*.workflow.yaml` or `*.workflow.yml` is one workflow.
+- Duplicate IDs resolve by discovery order.
+- Duplicate IDs at the same priority are validation warnings in list views and
+  hard errors when selecting by ID.
+- File watchers may refresh lists, but editors must use dirty-state checks
+  before reloading.
+
+---
+
+## File parsing
+
+`WORKFLOW.md` parsing:
+
+- Read YAML front matter between the first `---` and the next `---`.
+- Treat the Markdown body as human narrative.
+- If `description` is missing in front matter, derive it from the first
+  paragraph after the front matter for display only; validation still requires
+  a description field in the normalized manifest.
+
+`.workflow.yaml` parsing:
+
+- Read the whole file as YAML.
+- No narrative body is available.
+
+Both forms normalize to the same in-memory `WorkflowManifest`.
+
+---
+
+## Runtime execution model
+
+v1 execution is mediated by stable step kinds.
+
+Step execution mapping:
+
+| Step kind | Executor |
+|---|---|
+| `agent` | Spawn or delegate to familiar by ID through Coven harness routing. |
+| `skill` | Resolve skill ID and semver range through Coven skill registry. |
+| `tool` | Resolve registered tool/capability ID. |
+| `command` | Resolve stable Coven or Coven Code command ID. |
+| `prompt` | Send prompt to resolved familiar/runtime. |
+| `human-gate` | Pause run and await explicit user input. |
+| `workflow` | Load nested workflow, validate, preflight, and execute within depth limit. |
+
+The executor writes run events to the session/event ledger so both Cave and
+Coven Code can display the same run state.
+
+---
+
+## Coven Code integration
+
+Repository: `OpenCoven/coven-code`
+
+Expected file impact:
+
+| File area | Change |
+|---|---|
+| `src-rust/crates/core` | Shared workflow manifest types if not consumed from a generated package. |
+| `src-rust/crates/commands` | `/workflow` slash command group and command tests. |
+| `src-rust/crates/tui` | Workflow picker/editor, validation panel, dry-run preview. |
+| `docs/commands.md` | Document `/workflow` commands. |
+| `docs/index.md` | Add workflow feature entry. |
+
+Command behavior:
+
+- `/workflow list` shows ID, version, familiar, pattern, visibility, validation
+  state.
+- `/workflow show <id>` shows normalized manifest summary and canonical path.
+- `/workflow new` scaffolds `WORKFLOW.md` or `.workflow.yaml`.
+- `/workflow validate <path-or-id>` prints grouped issues.
+- `/workflow dry-run <id>` prints the dry-run plan.
+- `/workflow run <id>` refuses to run if validation or dry-run is not clean.
+- `/workflow explain <id>` renders user-facing docs from manifest metadata.
+- `/workflow doctor` checks roots, duplicates, schema availability, and daemon
+  integration.
+- `/workflow export <id>` writes a `.coven-workflow.tar.gz` bundle.
+
+---
+
+## Cave integration
+
+Repository: `OpenCoven/coven-cave`
+
+Expected file impact:
+
+| File area | Change |
+|---|---|
+| `src/lib` | Workflow API client, parser helpers, sidecar helpers. |
+| `src/app/api` | Server routes proxying daemon workflow APIs where needed. |
+| `src/components` | Workflow list, builder, validator panel, dry-run preview, run history. |
+| `docs/superpowers/specs` | Cave UX spec for the Workflows section. |
+| `docs/superpowers/plans` | Cave implementation plan. |
+
+Cave must:
+
+- Read canonical workflow files.
+- Write only manifest fields to canonical files.
+- Write display state to `WORKFLOW.cave.json`.
+- Protect unsaved edits from file watcher reloads.
+- Show schema, semantic, and preflight errors separately.
+- Show human-gate steps as pending approvals.
+- Show run history from daemon run state, not from local UI state alone.
+
+---
+
+## Import/export bundle
+
+Bundle name:
+
+```text
+<id>-v<version>.coven-workflow.tar.gz
+```
+
+`MANIFEST.json`:
+
+```json
+{
+  "schema_version": "coven.workflow.bundle.v1",
+  "workflow_id": "cody-review-pr",
+  "workflow_version": "1.0.0",
+  "created_at": "2026-06-11T00:00:00Z",
+  "files": [
+    {
+      "path": "WORKFLOW.md",
+      "sha256": "hex-encoded-sha256",
+      "kind": "workflow"
+    }
+  ]
+}
+```
+
+Import checks:
+
+- Bundle manifest exists.
+- Checksums match.
+- Exactly one canonical workflow exists.
+- No file path escapes the target directory.
+- Secret-pattern scan passes.
+- No embedded script body fields exist.
+- Workflow validates before install.
+
+---
+
+## Versioning policy
+
+Schema version policy:
+
+- Additive optional fields are minor-compatible.
+- New required fields require a new major schema version.
+- Field removal requires a new major schema version and a migration document.
+- Validators must ignore unknown `custom_fields`.
+- Validators must reject unknown top-level fields unless the schema explicitly
+  allows them.
+
+`schema_version` is always required. There is no v0 or inferred schema.
+
+---
+
+## Acceptance for v1 (tech)
+
+1. `coven.workflow.v1.schema.json` validates both example workflows.
+2. Schema rejects missing `schema_version`.
+3. Schema rejects missing required limit fields.
+4. Schema rejects `ward_gate: false` without `ward_gate_reason`.
+5. Schema rejects `pattern: loop-until-done` without `exit_criteria`.
+6. Semantic lint catches missing familiar, missing skill, bad `needs`
+   references, cycles, and nesting depth over five.
+7. Preflight catches missing installed dependencies and policy-blocked
+   permissions.
+8. Dry-run returns a plan without executing any step.
+9. Coven Code and Cave display identical validation issues for the same bad
+   manifest.
+10. Cave sidecar changes do not alter the canonical manifest file.
+11. Import rejects path traversal, secret-like content, and embedded script
+    bodies.
+12. Exported bundle imports on a clean local Coven install.
+
+---
+
+## Deferred work
+
+v1.1 candidates:
+
+- Scheduling grammar.
+- Rollback/idempotency markers.
+- Visual graph editing as a full authoring surface.
+- Cloud marketplace publication.
+- Remote workflow runs.
+- Embedded script support through signed, separately reviewed artifacts.


### PR DESCRIPTION
## Summary
- add PRODUCT and TECH specs for the Coven workflow manifest standard
- add an implementation plan covering shared schema, CLI/daemon APIs, Coven Code, and Cave clients
- keep the contract focused on portable, inspectable workflow manifests and dry-run safety

## Verification
- git diff --check origin/main...HEAD
- python3 scripts/check-secrets.py