### PR TITLE
fix(run): resume claude sessions with --resume instead of --session-id

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1383,6 +1383,7 @@ fn run_session(
         let exit_code = pty_runner::stream_claude(
             &cwd,
             &record.id,
+            is_resume,
             &effective_prompt,
             stream_json_input,
             claude_system_prompt.as_deref(),

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -627,11 +627,26 @@ mod tests {
         Ok(())
     }
 
+    /// Serializes the fake-claude tests: each writes an executable script and
+    /// immediately spawns it. Run in parallel, one test's `fork` can inherit
+    /// another's still-open write fd and the exec fails with ETXTBSY
+    /// ("Text file busy") — a real CI flake, not a theoretical one.
+    #[cfg(unix)]
+    static FAKE_CLAUDE_SPAWN_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[cfg(unix)]
+    fn fake_claude_spawn_guard() -> std::sync::MutexGuard<'static, ()> {
+        FAKE_CLAUDE_SPAWN_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[cfg(unix)]
     #[test]
     fn stream_claude_forwards_jsonl_and_returns_exit_code() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
+        let _guard = fake_claude_spawn_guard();
         let temp_dir = tempfile::tempdir()?;
         let fake_claude = temp_dir.path().join("fake-claude");
         std::fs::write(
@@ -680,6 +695,7 @@ exit 7
     fn stream_claude_includes_input_format_when_forwarding_stdin() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
+        let _guard = fake_claude_spawn_guard();
         let temp_dir = tempfile::tempdir()?;
         let fake_claude = temp_dir.path().join("fake-claude");
         std::fs::write(
@@ -720,6 +736,7 @@ exit 0
     fn stream_claude_resumes_with_resume_flag_not_session_id() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
+        let _guard = fake_claude_spawn_guard();
         let temp_dir = tempfile::tempdir()?;
         let fake_claude = temp_dir.path().join("fake-claude");
         std::fs::write(

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -97,12 +97,20 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
 /// --session-id <id> <prompt>` already emits the Coven-compatible JSONL
 /// schema; we just forward each line untouched to `out`.
 ///
+/// `is_resume` picks the session flag: `--session-id <id>` only CREATES
+/// sessions — passing an id that already exists fails with "Session ID
+/// <id> is already in use", which made every `coven run --continue` turn
+/// error and lose the conversation. Resumed turns use `--resume <id>`,
+/// which continues the session in place (in `-p` mode the id is kept, so
+/// the Coven session record id stays valid for the next turn).
+///
 /// When `forward_stdin` is true, lines on our stdin are piped to claude's
 /// stdin so callers can feed additional user messages mid-run. Stderr is
 /// inherited so claude's own diagnostics land on the terminal.
 pub fn stream_claude<W: Write>(
     cwd: &Path,
     session_id: &str,
+    is_resume: bool,
     prompt: &str,
     forward_stdin: bool,
     system_prompt: Option<&str>,
@@ -112,6 +120,7 @@ pub fn stream_claude<W: Write>(
         "claude",
         cwd,
         session_id,
+        is_resume,
         prompt,
         forward_stdin,
         system_prompt,
@@ -119,10 +128,12 @@ pub fn stream_claude<W: Write>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn stream_claude_with_program<W: Write>(
     program: &str,
     cwd: &Path,
     session_id: &str,
+    is_resume: bool,
     prompt: &str,
     forward_stdin: bool,
     system_prompt: Option<&str>,
@@ -142,13 +153,12 @@ fn stream_claude_with_program<W: Write>(
     if let Some(sp) = system_prompt {
         args.extend_from_slice(&["--system-prompt", sp]);
     }
-    args.extend_from_slice(&[
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--session-id",
-        session_id,
-    ]);
+    args.extend_from_slice(&["--output-format", "stream-json", "--verbose"]);
+    if is_resume {
+        args.extend_from_slice(&["--resume", session_id]);
+    } else {
+        args.extend_from_slice(&["--session-id", session_id]);
+    }
 
     let mut child = std::process::Command::new(program)
         .args(&args)
@@ -642,6 +652,7 @@ exit 7
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-123",
+            false,
             "hello prompt",
             false,
             None,
@@ -687,6 +698,7 @@ exit 0
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-456",
+            false,
             "hello prompt",
             // forward_stdin=true → long-lived chat mode where claude reads
             // user messages as JSONL on stdin, so --input-format stream-json
@@ -699,6 +711,47 @@ exit 0
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
             "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_claude_resumes_with_resume_flag_not_session_id() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_claude = temp_dir.path().join("fake-claude");
+        std::fs::write(
+            &fake_claude,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_claude)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_claude, permissions)?;
+
+        let mut out = Vec::new();
+        let _code = stream_claude_with_program(
+            fake_claude.to_str().unwrap(),
+            temp_dir.path(),
+            "session-789",
+            // is_resume=true → the session already exists. `--session-id`
+            // only creates sessions and fails with "Session ID <id> is
+            // already in use" on reuse, so resumed turns MUST go through
+            // `--resume` or every `coven run --continue` loses the chat.
+            true,
+            "hello again",
+            false,
+            None,
+            &mut out,
+        )?;
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "-p\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\nhello again\n"
         );
         Ok(())
     }


### PR DESCRIPTION
## Problem

`coven run claude --stream-json --continue <id>` failed on **every** resumed turn. The claude stream-json fast path (`main.rs` → `pty_runner::stream_claude`) always launched `claude -p --session-id <record.id>`, but `--session-id` only *creates* sessions — reusing an existing id fails with:

```
Error: Session ID <id> is already in use.
```

`is_resume` was never even threaded into `stream_claude`.

Downstream, Coven Cave's chat bridge pattern-matches that error and transparently retries without `--continue` — so every resumed chat turn silently started a **fresh session with no conversation history**. This is the root cause of "resuming chats in cave fails every time" (cave-side symptom previously mitigated in coven-cave `b547dc1`, which fixed conversation forking but could not fix the lost context).

## Fix

Thread `is_resume` into `stream_claude` and pass `--resume <id>` on resumed turns. In `-p` mode `--resume` keeps the same session id (verified on claude 2.1.173), so the Coven session record id stays valid for every subsequent turn — matching the contract `docs/chat-persistence.md` already specifies ("pre-assign via `--session-id`, resume via `--resume`"). First turns are unchanged.

## Verification

- New unit test `stream_claude_resumes_with_resume_flag_not_session_id` pins the resumed argv; the two existing argv tests pin first-turn behavior unchanged.
- Full `coven-cli` suite: 799 passed, 0 failed. Clippy clean.
- End-to-end with the built binary: codeword stored on turn 1 is recalled on turn 2 **and** turn 3 via `--continue`, same session id throughout, `is_error: false`. Before the fix the identical turn-2 invocation reproduced `Session ID ... is already in use` 100% of the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)