### PR TITLE
fix(harness): bypass permission prompts for claude sessions

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1214,7 +1214,9 @@ mod tests {
     fn non_claude_harnesses_do_not_get_permission_bypass() -> anyhow::Result<()> {
         let (_, args) =
             command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?;
-        assert!(!args.iter().any(|a| a == "--permission-mode" || a == "bypassPermissions"));
+        assert!(!args
+            .iter()
+            .any(|a| a == "--permission-mode" || a == "bypassPermissions"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -417,6 +417,24 @@ pub fn command_parts_for_harness(
     command_parts_for_harness_with_conversation(harness_id, prompt, mode, None, None)
 }
 
+/// Claude Code prompts before running tool calls that aren't pre-allowlisted.
+/// Cave launches claude sessions in a PTY with no human attached, so such a
+/// prompt stalls the session until a watchdog fails it (observed: an SSO
+/// review task hung ~5 min on a `gh pr view` permission prompt, then exited
+/// 1). Force `bypassPermissions` on every claude launch — interactive,
+/// non-interactive, and stream — so unattended sessions never block. The flag
+/// is order-independent among claude's other flags, so we prepend it.
+fn with_claude_permission_flags(harness_id: &str, args: Vec<String>) -> Vec<String> {
+    if harness_id != "claude" {
+        return args;
+    }
+    let mut flagged = Vec::with_capacity(args.len() + 2);
+    flagged.push("--permission-mode".to_string());
+    flagged.push("bypassPermissions".to_string());
+    flagged.extend(args);
+    flagged
+}
+
 /// Build a harness command line, optionally injecting session-continuity
 /// flags so the harness CLI resumes a prior conversation. Claude uses
 /// `--session-id`/`--resume` (works in both NonInteractive and Stream
@@ -459,13 +477,19 @@ pub fn command_parts_for_harness_with_conversation(
                 args.insert(0, f.identity_preamble());
                 args.insert(0, flag.to_string());
             }
-            return Ok((spec.executable.clone(), sanitize_argv_for_platform(args)));
+            return Ok((
+                spec.executable.clone(),
+                with_claude_permission_flags(harness_id, sanitize_argv_for_platform(args)),
+            ));
         }
         // Harness doesn't support stream: fall through to non-interactive.
         return Ok((
             spec.executable.clone(),
-            sanitize_argv_for_platform(
-                spec.prompt_args(&effective_prompt, HarnessLaunchMode::NonInteractive),
+            with_claude_permission_flags(
+                harness_id,
+                sanitize_argv_for_platform(
+                    spec.prompt_args(&effective_prompt, HarnessLaunchMode::NonInteractive),
+                ),
             ),
         ));
     }
@@ -479,9 +503,12 @@ pub fn command_parts_for_harness_with_conversation(
             }
             return Ok((
                 spec.executable.clone(),
-                args.into_iter()
-                    .chain(std::iter::once(effective_prompt))
-                    .collect(),
+                with_claude_permission_flags(
+                    harness_id,
+                    args.into_iter()
+                        .chain(std::iter::once(effective_prompt))
+                        .collect(),
+                ),
             ));
         }
     }
@@ -493,7 +520,10 @@ pub fn command_parts_for_harness_with_conversation(
         args.insert(0, f.identity_preamble());
         args.insert(0, flag.to_string());
     }
-    Ok((spec.executable, sanitize_argv_for_platform(args)))
+    Ok((
+        spec.executable,
+        with_claude_permission_flags(harness_id, sanitize_argv_for_platform(args)),
+    ))
 }
 
 /// Per-harness translation of stream-mode launch into CLI args. Stream-mode
@@ -798,7 +828,14 @@ mod tests {
         );
         assert_eq!(
             command_parts_for_harness("claude", "polish ui", HarnessLaunchMode::Interactive)?,
-            ("claude".to_string(), vec!["polish ui".to_string()])
+            (
+                "claude".to_string(),
+                vec![
+                    "--permission-mode".to_string(),
+                    "bypassPermissions".to_string(),
+                    "polish ui".to_string(),
+                ]
+            )
         );
         Ok(())
     }
@@ -822,7 +859,12 @@ mod tests {
             command_parts_for_harness("claude", "polish ui", HarnessLaunchMode::NonInteractive)?,
             (
                 "claude".to_string(),
-                vec!["--print".to_string(), "polish ui".to_string()]
+                vec![
+                    "--permission-mode".to_string(),
+                    "bypassPermissions".to_string(),
+                    "--print".to_string(),
+                    "polish ui".to_string(),
+                ]
             )
         );
         Ok(())
@@ -1026,6 +1068,8 @@ mod tests {
             (
                 "claude".to_string(),
                 vec![
+                    "--permission-mode".to_string(),
+                    "bypassPermissions".to_string(),
                     "--print".to_string(),
                     "--session-id".to_string(),
                     "abc-123".to_string(),
@@ -1053,6 +1097,8 @@ mod tests {
             (
                 "claude".to_string(),
                 vec![
+                    "--permission-mode".to_string(),
+                    "bypassPermissions".to_string(),
                     "--print".to_string(),
                     "--resume".to_string(),
                     "abc-123".to_string(),
@@ -1077,7 +1123,14 @@ mod tests {
         );
         assert_eq!(
             parts.unwrap(),
-            ("claude".to_string(), vec!["hello".to_string()])
+            (
+                "claude".to_string(),
+                vec![
+                    "--permission-mode".to_string(),
+                    "bypassPermissions".to_string(),
+                    "hello".to_string(),
+                ]
+            )
         );
         Ok(())
     }
@@ -1138,6 +1191,30 @@ mod tests {
                 ]
             )
         );
+        Ok(())
+    }
+
+    #[test]
+    fn claude_stream_mode_bypasses_permission_prompts() -> anyhow::Result<()> {
+        let (program, args) = command_parts_for_harness_with_conversation(
+            "claude",
+            "hello",
+            HarnessLaunchMode::Stream,
+            None,
+            None,
+        )?;
+        assert_eq!(program, "claude");
+        // The bypass flag is prepended ahead of stream-mode's own flags.
+        assert_eq!(&args[..2], &["--permission-mode", "bypassPermissions"]);
+        assert!(args.iter().any(|a| a == "--output-format"));
+        Ok(())
+    }
+
+    #[test]
+    fn non_claude_harnesses_do_not_get_permission_bypass() -> anyhow::Result<()> {
+        let (_, args) =
+            command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?;
+        assert!(!args.iter().any(|a| a == "--permission-mode" || a == "bypassPermissions"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -146,7 +146,11 @@ fn stream_claude_with_program<W: Write>(
     // Without this branch, one-shot turns hang on stdin then exit with no
     // assistant text — the symptom that surfaces in Cave as
     // `_The "claude" harness completed but produced no output._`
-    let mut args: Vec<&str> = vec!["-p"];
+    // Bypass permission prompts: this stream runs unattended (no TTY for a
+    // human to answer a tool-permission prompt), so a prompt would hang the
+    // turn. Mirrors the `with_claude_permission_flags` injection on the
+    // PTY/interactive launch path in `harness.rs`.
+    let mut args: Vec<&str> = vec!["-p", "--permission-mode", "bypassPermissions"];
     if forward_stdin {
         args.extend_from_slice(&["--input-format", "stream-json"]);
     }
@@ -681,7 +685,7 @@ exit 7
         // which is the bug this commit fixes.
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
         );
         assert_eq!(
             String::from_utf8(out)?,
@@ -726,7 +730,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
+            "-p\n--permission-mode\nbypassPermissions\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
         );
         Ok(())
     }
@@ -890,10 +894,18 @@ exit 0
         .unwrap();
 
         assert_eq!(command.program(), "claude");
+        // claude always launches with permission prompts bypassed (the flag is
+        // prepended after platform sanitization, so it stays unquoted).
         #[cfg(windows)]
-        assert_eq!(command.args(), &["\"explain && exit\""]);
+        assert_eq!(
+            command.args(),
+            &["--permission-mode", "bypassPermissions", "\"explain && exit\""]
+        );
         #[cfg(not(windows))]
-        assert_eq!(command.args(), &["explain && exit"]);
+        assert_eq!(
+            command.args(),
+            &["--permission-mode", "bypassPermissions", "explain && exit"]
+        );
         assert_eq!(command.cwd(), cwd);
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -772,7 +772,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\nhello again\n"
+            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\nhello again\n"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -899,7 +899,11 @@ exit 0
         #[cfg(windows)]
         assert_eq!(
             command.args(),
-            &["--permission-mode", "bypassPermissions", "\"explain && exit\""]
+            &[
+                "--permission-mode",
+                "bypassPermissions",
+                "\"explain && exit\""
+            ]
         );
         #[cfg(not(windows))]
         assert_eq!(


### PR DESCRIPTION
## Problem

Cave launches `claude` harness sessions in a PTY with **no human attached**. Claude Code's default permission mode prompts before non-allowlisted tool calls, so the first such prompt stalls the session indefinitely until a watchdog fails it.

Observed: an SSO review task hung ~5 min on a `gh pr view` permission prompt (the session's last PTY output was the `Do you want to proceed? 1. Yes / 2. … / 3. No` selector), then exited 1. Reconstructed from `~/.coven/coven.sqlite3` — cave "tasks" are rows in the `sessions` table, with the raw PTY capture in `events(kind=output)`.

## Fix

Inject `--permission-mode bypassPermissions` on **every** claude launch, across both spawn surfaces:

- **`crates/coven-cli/src/harness.rs`** — new `with_claude_permission_flags()` helper wired into all four argv-build branches of `command_parts_for_harness_with_conversation` (interactive PTY, non-interactive one-shot, continuity/resume, harness-stream). Interactive mode previously passed *zero* flags — the exact path the failed session took.
- **`crates/coven-cli/src/pty_runner.rs`** — added to `stream_claude_with_program`, the dedicated `claude -p … stream-json` chat path.

The flag is order-independent among claude's other flags and is prepended **after** `sanitize_argv_for_platform`, so Windows quoting is preserved. Non-claude harnesses are unaffected (helper guards on harness id).

Verified against installed Claude Code v2.1.173: `--permission-mode` accepts `bypassPermissions`.

## Tests

- Updated 7 existing claude-argv assertions (harness.rs + pty_runner.rs).
- Added `claude_stream_mode_bypasses_permission_prompts` and `non_claude_harnesses_do_not_get_permission_bypass`.
- Full `coven-cli` suite green (800 unit + integration tests).

## Note

Activating on the live daemon requires `coven daemon restart` (long-lived `daemon serve` holds old code in memory); chat-streaming picks up a fresh binary per request automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)