### PR TITLE
fix(harness): keep Claude permissions enabled by default

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 pub const EXTERNAL_ADAPTER_MANIFEST_ENV: &str = "COVEN_HARNESS_ADAPTER_MANIFEST";
 pub const EXTERNAL_ADAPTER_DIRS_ENV: &str = "COVEN_HARNESS_ADAPTER_DIRS";
+pub const CLAUDE_BYPASS_PERMISSIONS_ENV: &str = "COVEN_CLAUDE_BYPASS_PERMISSIONS";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HarnessSummary {
@@ -418,14 +419,21 @@ pub fn command_parts_for_harness(
 }
 
 /// Claude Code prompts before running tool calls that aren't pre-allowlisted.
-/// Cave launches claude sessions in a PTY with no human attached, so such a
-/// prompt stalls the session until a watchdog fails it (observed: an SSO
-/// review task hung ~5 min on a `gh pr view` permission prompt, then exited
-/// 1). Force `bypassPermissions` on every claude launch — interactive,
-/// non-interactive, and stream — so unattended sessions never block. The flag
-/// is order-independent among claude's other flags, so we prepend it.
+/// Preserve those prompts by default so untrusted prompt text cannot silently
+/// drive tool execution. Operators that run Claude in an explicitly trusted,
+/// unattended environment may opt in to bypassing prompts with
+/// `COVEN_CLAUDE_BYPASS_PERMISSIONS=1`.
+pub fn claude_permission_bypass_enabled() -> bool {
+    env::var(CLAUDE_BYPASS_PERMISSIONS_ENV)
+        .map(|value| {
+            let value = value.trim();
+            value == "1" || value.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
 fn with_claude_permission_flags(harness_id: &str, args: Vec<String>) -> Vec<String> {
-    if harness_id != "claude" {
+    if harness_id != "claude" || !claude_permission_bypass_enabled() {
         return args;
     }
     let mut flagged = Vec::with_capacity(args.len() + 2);
@@ -730,6 +738,13 @@ mod tests {
         }
     }
 
+    fn restore_claude_bypass_env(previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => env::set_var(CLAUDE_BYPASS_PERMISSIONS_ENV, value),
+            None => env::remove_var(CLAUDE_BYPASS_PERMISSIONS_ENV),
+        }
+    }
+
     #[test]
     fn executable_exists_in_paths_finds_matching_file() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -828,14 +843,7 @@ mod tests {
         );
         assert_eq!(
             command_parts_for_harness("claude", "polish ui", HarnessLaunchMode::Interactive)?,
-            (
-                "claude".to_string(),
-                vec![
-                    "--permission-mode".to_string(),
-                    "bypassPermissions".to_string(),
-                    "polish ui".to_string(),
-                ]
-            )
+            ("claude".to_string(), vec!["polish ui".to_string()])
         );
         Ok(())
     }
@@ -859,12 +867,7 @@ mod tests {
             command_parts_for_harness("claude", "polish ui", HarnessLaunchMode::NonInteractive)?,
             (
                 "claude".to_string(),
-                vec![
-                    "--permission-mode".to_string(),
-                    "bypassPermissions".to_string(),
-                    "--print".to_string(),
-                    "polish ui".to_string(),
-                ]
+                vec!["--print".to_string(), "polish ui".to_string()]
             )
         );
         Ok(())
@@ -1068,8 +1071,6 @@ mod tests {
             (
                 "claude".to_string(),
                 vec![
-                    "--permission-mode".to_string(),
-                    "bypassPermissions".to_string(),
                     "--print".to_string(),
                     "--session-id".to_string(),
                     "abc-123".to_string(),
@@ -1097,8 +1098,6 @@ mod tests {
             (
                 "claude".to_string(),
                 vec![
-                    "--permission-mode".to_string(),
-                    "bypassPermissions".to_string(),
                     "--print".to_string(),
                     "--resume".to_string(),
                     "abc-123".to_string(),
@@ -1123,14 +1122,7 @@ mod tests {
         );
         assert_eq!(
             parts.unwrap(),
-            (
-                "claude".to_string(),
-                vec![
-                    "--permission-mode".to_string(),
-                    "bypassPermissions".to_string(),
-                    "hello".to_string(),
-                ]
-            )
+            ("claude".to_string(), vec!["hello".to_string()])
         );
         Ok(())
     }
@@ -1195,7 +1187,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_stream_mode_bypasses_permission_prompts() -> anyhow::Result<()> {
+    fn claude_stream_mode_preserves_permission_prompts_by_default() -> anyhow::Result<()> {
         let (program, args) = command_parts_for_harness_with_conversation(
             "claude",
             "hello",
@@ -1204,9 +1196,24 @@ mod tests {
             None,
         )?;
         assert_eq!(program, "claude");
-        // The bypass flag is prepended ahead of stream-mode's own flags.
-        assert_eq!(&args[..2], &["--permission-mode", "bypassPermissions"]);
+        assert!(!args
+            .iter()
+            .any(|a| a == "--permission-mode" || a == "bypassPermissions"));
         assert!(args.iter().any(|a| a == "--output-format"));
+        Ok(())
+    }
+
+    #[test]
+    fn claude_permission_bypass_requires_explicit_env_opt_in() -> anyhow::Result<()> {
+        let _guard = env_lock().lock().unwrap();
+        let previous = env::var_os(CLAUDE_BYPASS_PERMISSIONS_ENV);
+        env::set_var(CLAUDE_BYPASS_PERMISSIONS_ENV, "1");
+
+        let (_, args) =
+            command_parts_for_harness("claude", "hello", HarnessLaunchMode::Interactive)?;
+
+        restore_claude_bypass_env(previous);
+        assert_eq!(&args[..2], &["--permission-mode", "bypassPermissions"]);
         Ok(())
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -424,7 +424,17 @@ pub fn command_parts_for_harness(
 /// unattended environment may opt in to bypassing prompts with
 /// `COVEN_CLAUDE_BYPASS_PERMISSIONS=1`.
 pub fn claude_permission_bypass_enabled() -> bool {
-    env::var(CLAUDE_BYPASS_PERMISSIONS_ENV)
+    claude_permission_bypass_enabled_from_value(
+        env::var(CLAUDE_BYPASS_PERMISSIONS_ENV).ok().as_deref(),
+    )
+}
+
+fn with_claude_permission_flags(harness_id: &str, args: Vec<String>) -> Vec<String> {
+    with_claude_permission_flags_enabled(harness_id, args, claude_permission_bypass_enabled())
+}
+
+fn claude_permission_bypass_enabled_from_value(value: Option<&str>) -> bool {
+    value
         .map(|value| {
             let value = value.trim();
             value == "1" || value.eq_ignore_ascii_case("true")
@@ -432,8 +442,12 @@ pub fn claude_permission_bypass_enabled() -> bool {
         .unwrap_or(false)
 }
 
-fn with_claude_permission_flags(harness_id: &str, args: Vec<String>) -> Vec<String> {
-    if harness_id != "claude" || !claude_permission_bypass_enabled() {
+fn with_claude_permission_flags_enabled(
+    harness_id: &str,
+    args: Vec<String>,
+    bypass_enabled: bool,
+) -> Vec<String> {
+    if harness_id != "claude" || !bypass_enabled {
         return args;
     }
     let mut flagged = Vec::with_capacity(args.len() + 2);
@@ -735,13 +749,6 @@ mod tests {
         match previous {
             Some(value) => env::set_var(EXTERNAL_ADAPTER_DIRS_ENV, value),
             None => env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV),
-        }
-    }
-
-    fn restore_claude_bypass_env(previous: Option<std::ffi::OsString>) {
-        match previous {
-            Some(value) => env::set_var(CLAUDE_BYPASS_PERMISSIONS_ENV, value),
-            None => env::remove_var(CLAUDE_BYPASS_PERMISSIONS_ENV),
         }
     }
 
@@ -1204,17 +1211,26 @@ mod tests {
     }
 
     #[test]
-    fn claude_permission_bypass_requires_explicit_env_opt_in() -> anyhow::Result<()> {
-        let _guard = env_lock().lock().unwrap();
-        let previous = env::var_os(CLAUDE_BYPASS_PERMISSIONS_ENV);
-        env::set_var(CLAUDE_BYPASS_PERMISSIONS_ENV, "1");
+    fn claude_permission_bypass_requires_explicit_opt_in_values() {
+        assert!(claude_permission_bypass_enabled_from_value(Some("1")));
+        assert!(claude_permission_bypass_enabled_from_value(Some("true")));
+        assert!(claude_permission_bypass_enabled_from_value(Some(" TRUE ")));
+        assert!(!claude_permission_bypass_enabled_from_value(None));
+        assert!(!claude_permission_bypass_enabled_from_value(Some("0")));
+        assert!(!claude_permission_bypass_enabled_from_value(Some("false")));
+    }
 
-        let (_, args) =
-            command_parts_for_harness("claude", "hello", HarnessLaunchMode::Interactive)?;
-
-        restore_claude_bypass_env(previous);
-        assert_eq!(&args[..2], &["--permission-mode", "bypassPermissions"]);
-        Ok(())
+    #[test]
+    fn claude_permission_bypass_opt_in_adds_flags() {
+        let args = with_claude_permission_flags_enabled("claude", vec!["hello".to_string()], true);
+        assert_eq!(
+            args,
+            vec![
+                "--permission-mode".to_string(),
+                "bypassPermissions".to_string(),
+                "hello".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -146,11 +146,10 @@ fn stream_claude_with_program<W: Write>(
     // Without this branch, one-shot turns hang on stdin then exit with no
     // assistant text — the symptom that surfaces in Cave as
     // `_The "claude" harness completed but produced no output._`
-    // Bypass permission prompts: this stream runs unattended (no TTY for a
-    // human to answer a tool-permission prompt), so a prompt would hang the
-    // turn. Mirrors the `with_claude_permission_flags` injection on the
-    // PTY/interactive launch path in `harness.rs`.
-    let mut args: Vec<&str> = vec!["-p", "--permission-mode", "bypassPermissions"];
+    let mut args: Vec<&str> = vec!["-p"];
+    if crate::harness::claude_permission_bypass_enabled() {
+        args.extend_from_slice(&["--permission-mode", "bypassPermissions"]);
+    }
     if forward_stdin {
         args.extend_from_slice(&["--input-format", "stream-json"]);
     }
@@ -685,7 +684,7 @@ exit 7
         // which is the bug this commit fixes.
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
         );
         assert_eq!(
             String::from_utf8(out)?,
@@ -730,7 +729,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--permission-mode\nbypassPermissions\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
+            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
         );
         Ok(())
     }
@@ -772,7 +771,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\nhello again\n"
+            "-p\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\nhello again\n"
         );
         Ok(())
     }
@@ -894,22 +893,10 @@ exit 0
         .unwrap();
 
         assert_eq!(command.program(), "claude");
-        // claude always launches with permission prompts bypassed (the flag is
-        // prepended after platform sanitization, so it stays unquoted).
         #[cfg(windows)]
-        assert_eq!(
-            command.args(),
-            &[
-                "--permission-mode",
-                "bypassPermissions",
-                "\"explain && exit\""
-            ]
-        );
+        assert_eq!(command.args(), &["\"explain && exit\""]);
         #[cfg(not(windows))]
-        assert_eq!(
-            command.args(),
-            &["--permission-mode", "bypassPermissions", "explain && exit"]
-        );
+        assert_eq!(command.args(), &["explain && exit"]);
         assert_eq!(command.cwd(), cwd);
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -139,6 +139,31 @@ fn stream_claude_with_program<W: Write>(
     system_prompt: Option<&str>,
     out: &mut W,
 ) -> Result<i32> {
+    stream_claude_with_program_and_permission_bypass(
+        program,
+        cwd,
+        session_id,
+        is_resume,
+        prompt,
+        forward_stdin,
+        system_prompt,
+        crate::harness::claude_permission_bypass_enabled(),
+        out,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn stream_claude_with_program_and_permission_bypass<W: Write>(
+    program: &str,
+    cwd: &Path,
+    session_id: &str,
+    is_resume: bool,
+    prompt: &str,
+    forward_stdin: bool,
+    system_prompt: Option<&str>,
+    permission_bypass_enabled: bool,
+    out: &mut W,
+) -> Result<i32> {
     // `--input-format stream-json` makes claude read user messages as JSONL
     // on stdin and IGNORE the positional <prompt>. We only want that mode
     // when the caller is feeding stdin (long-lived chat); for one-shot turns
@@ -147,7 +172,7 @@ fn stream_claude_with_program<W: Write>(
     // assistant text — the symptom that surfaces in Cave as
     // `_The "claude" harness completed but produced no output._`
     let mut args: Vec<&str> = vec!["-p"];
-    if crate::harness::claude_permission_bypass_enabled() {
+    if permission_bypass_enabled {
         args.extend_from_slice(&["--permission-mode", "bypassPermissions"]);
     }
     if forward_stdin {
@@ -730,6 +755,45 @@ exit 0
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
             "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_claude_honors_permission_bypass_opt_in() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_claude = temp_dir.path().join("fake-claude");
+        std::fs::write(
+            &fake_claude,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_claude)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_claude, permissions)?;
+
+        let mut out = Vec::new();
+        let _code = stream_claude_with_program_and_permission_bypass(
+            fake_claude.to_str().unwrap(),
+            temp_dir.path(),
+            "session-456",
+            false,
+            "hello prompt",
+            false,
+            None,
+            true,
+            &mut out,
+        )?;
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
         );
         Ok(())
     }


### PR DESCRIPTION
### Motivation
- A prior change unconditionally injected `--permission-mode bypassPermissions` for `claude` launches, which removed Claude Code’s interactive permission prompts and introduced a security boundary regression. 
- Restore the safer default of preserving Claude permission prompts while still providing an explicit opt-in for trusted unattended deployments.

### Description
- Add a new environment toggle `CLAUDE_BYPASS_PERMISSIONS_ENV` (`COVEN_CLAUDE_BYPASS_PERMISSIONS`) and helper `claude_permission_bypass_enabled()` to control whether bypass is applied. 
- Gate `with_claude_permission_flags` behind `claude_permission_bypass_enabled()` so `--permission-mode bypassPermissions` is only prepended when the env opt-in is enabled. 
- Update the dedicated stream launcher in `stream_claude_with_program` to start with `-p` and only append the bypass flags when the opt-in is set. 
- Adjust and add unit tests to assert the default-safe behavior and to validate the env opt-in; add `restore_claude_bypass_env` test helper and update expectations in `harness.rs` and `pty_runner.rs` tests.

### Testing
- Ran formatting check with `cargo fmt --check`, which succeeded. 
- Ran targeted unit tests `cargo test -p coven-cli pty_runner::tests::stream_claude` and `cargo test -p coven-cli pty_runner::tests::builds_claude_command_without_shell_interpolation`, both succeeded. 
- Ran the `coven-cli` harness tests with `cargo test -p coven-cli -- --nocapture`, and the full suite completed successfully (all harness and pty_runner tests passing); the repository-wide test run completed with the crate tests passing (805 passed; 1 ignored).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cd55266ec8327ba6100b6860d93f6)