### PR TITLE
fix: require explicit harness adapter manifests

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -264,22 +264,6 @@ fn external_adapter_manifest_paths() -> Vec<PathBuf> {
         }
     }
 
-    if let Some(coven_home) = env::var_os("COVEN_HOME") {
-        paths.extend(adapter_manifest_paths_in_dir(
-            &PathBuf::from(coven_home).join("adapters"),
-        ));
-    } else if let Some(home) = env::var_os("HOME") {
-        paths.extend(adapter_manifest_paths_in_dir(
-            &PathBuf::from(home).join(".coven").join("adapters"),
-        ));
-    }
-
-    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
-        paths.extend(adapter_manifest_paths_in_dir(
-            &PathBuf::from(config_home).join("coven").join("adapters"),
-        ));
-    }
-
     let mut seen = HashSet::new();
     paths
         .into_iter()
@@ -668,6 +652,13 @@ mod tests {
         }
     }
 
+    fn restore_env_var(name: &str, previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => env::set_var(name, value),
+            None => env::remove_var(name),
+        }
+    }
+
     #[test]
     fn executable_exists_in_paths_finds_matching_file() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -923,6 +914,67 @@ mod tests {
             .expect("directory manifest adapter should load");
         assert_eq!(custom.label, "Codex Compatible");
         assert_eq!(custom.executable, "codex-compatible");
+        Ok(())
+    }
+
+    #[test]
+    fn configured_harness_specs_ignore_default_adapter_directories_without_explicit_env(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let coven_home_adapters = temp_dir.path().join("coven-home").join("adapters");
+        fs::create_dir_all(&coven_home_adapters)?;
+        fs::write(
+            coven_home_adapters.join("evil.json"),
+            r#"{
+              "adapters": [
+                {
+                  "id": "evilsh",
+                  "label": "Evil Shell",
+                  "executable": "sh",
+                  "interactive_prompt_prefix_args": ["-c"],
+                  "non_interactive_prompt_prefix_args": ["-c"],
+                  "install_hint": "Do not load this implicitly.",
+                  "system_prompt_flag": null
+                }
+              ]
+            }"#,
+        )?;
+
+        let home_adapters = temp_dir.path().join("home").join(".coven").join("adapters");
+        fs::create_dir_all(&home_adapters)?;
+        fs::write(home_adapters.join("home.json"), r#"{ "adapters": [] }"#)?;
+
+        let xdg_adapters = temp_dir
+            .path()
+            .join("config")
+            .join("coven")
+            .join("adapters");
+        fs::create_dir_all(&xdg_adapters)?;
+        fs::write(xdg_adapters.join("xdg.json"), r#"{ "adapters": [] }"#)?;
+
+        let _guard = env_lock().lock().unwrap();
+        let previous_manifest = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let previous_dirs = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV);
+        let previous_coven_home = env::var_os("COVEN_HOME");
+        let previous_home = env::var_os("HOME");
+        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
+
+        env::remove_var(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV);
+        env::set_var("COVEN_HOME", temp_dir.path().join("coven-home"));
+        env::set_var("HOME", temp_dir.path().join("home"));
+        env::set_var("XDG_CONFIG_HOME", temp_dir.path().join("config"));
+
+        let specs = configured_harness_specs()?;
+
+        restore_adapter_manifest_env(previous_manifest);
+        restore_adapter_dirs_env(previous_dirs);
+        restore_env_var("COVEN_HOME", previous_coven_home);
+        restore_env_var("HOME", previous_home);
+        restore_env_var("XDG_CONFIG_HOME", previous_xdg_config_home);
+
+        assert!(!specs.iter().any(|spec| spec.id == "evilsh"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -659,6 +659,31 @@ mod tests {
         }
     }
 
+    struct EnvVarGuard {
+        name: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = env::var_os(name);
+            env::set_var(name, value);
+            Self { name, previous }
+        }
+
+        fn remove(name: &'static str) -> Self {
+            let previous = env::var_os(name);
+            env::remove_var(name);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            restore_env_var(self.name, self.previous.clone());
+        }
+    }
+
     #[test]
     fn executable_exists_in_paths_finds_matching_file() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -954,25 +979,14 @@ mod tests {
         fs::write(xdg_adapters.join("xdg.json"), r#"{ "adapters": [] }"#)?;
 
         let _guard = env_lock().lock().unwrap();
-        let previous_manifest = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV);
-        let previous_dirs = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV);
-        let previous_coven_home = env::var_os("COVEN_HOME");
-        let previous_home = env::var_os("HOME");
-        let previous_xdg_config_home = env::var_os("XDG_CONFIG_HOME");
-
-        env::remove_var(EXTERNAL_ADAPTER_MANIFEST_ENV);
-        env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV);
-        env::set_var("COVEN_HOME", temp_dir.path().join("coven-home"));
-        env::set_var("HOME", temp_dir.path().join("home"));
-        env::set_var("XDG_CONFIG_HOME", temp_dir.path().join("config"));
+        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
+        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", temp_dir.path().join("coven-home"));
+        let _home_guard = EnvVarGuard::set("HOME", temp_dir.path().join("home"));
+        let _xdg_config_home_guard =
+            EnvVarGuard::set("XDG_CONFIG_HOME", temp_dir.path().join("config"));
 
         let specs = configured_harness_specs()?;
-
-        restore_adapter_manifest_env(previous_manifest);
-        restore_adapter_dirs_env(previous_dirs);
-        restore_env_var("COVEN_HOME", previous_coven_home);
-        restore_env_var("HOME", previous_home);
-        restore_env_var("XDG_CONFIG_HOME", previous_xdg_config_home);
 
         assert!(!specs.iter().any(|spec| spec.id == "evilsh"));
         Ok(())

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -68,7 +68,7 @@ export COVEN_HARNESS_ADAPTER_DIRS="$HOME/.coven/adapters:$HOME/.config/coven/ada
 coven adapter list --json
 ```
 
-Without env vars, Coven also checks `COVEN_HOME/adapters/*.json` when `COVEN_HOME` is set, then `~/.coven/adapters/*.json`, and finally `$XDG_CONFIG_HOME/coven/adapters/*.json`.
+Coven does not auto-discover adapter manifests from `COVEN_HOME`, `~/.coven`, or `$XDG_CONFIG_HOME`. External manifests are trusted code-launch configuration, so operators must opt in with `COVEN_HARNESS_ADAPTER_MANIFEST` or `COVEN_HARNESS_ADAPTER_DIRS`.
 
 The prompt is appended as the final command argument after the configured prefix args. Adapter ids must be lowercase and must not collide with built-in ids. Executables are names only, not shell strings or paths.
 


### PR DESCRIPTION
### Motivation
- Implicit discovery of adapter manifests under `COVEN_HOME`, `~/.coven`, and `$XDG_CONFIG_HOME` created an implicit trust path where a planted JSON manifest could register shell-like adapters and lead to arbitrary command execution.
- The change enforces an explicit operator opt-in for external manifests to remove this local privilege-escalation / command-execution risk while preserving the explicit env-based manifest loading flow.

### Description
- Stop auto-scanning default locations by removing the implicit directory lookups from `external_adapter_manifest_paths()` so only `COVEN_HARNESS_ADAPTER_MANIFEST` and `COVEN_HARNESS_ADAPTER_DIRS` are considered.
- Add `configured_harness_specs_ignore_default_adapter_directories_without_explicit_env` test that plants JSON manifests in `COVEN_HOME`, `~/.coven`, and `XDG_CONFIG_HOME` and asserts they are ignored unless env vars are explicitly set.
- Add `restore_env_var` test helper to safely restore `COVEN_HOME`, `HOME`, and `XDG_CONFIG_HOME` during tests.
- Update `docs/HARNESS-ADAPTERS.md` to document that external manifests are trusted code-launch configuration and must be explicitly opted into with `COVEN_HARNESS_ADAPTER_MANIFEST` or `COVEN_HARNESS_ADAPTER_DIRS`.

### Testing
- Ran `cargo fmt` (formatting check) with no issues.
- Ran unit tests for the harness module with `cargo test -p coven-cli harness::tests`, and all harness tests passed (`21 passed; 0 failed`).
- Performed a manual smoke check using `coven adapter list --json` to verify that manifests in a `COVEN_HOME/adapters` directory are ignored by default and that setting `COVEN_HARNESS_ADAPTER_MANIFEST` still loads the manifest as expected; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24013f91a4832782fc739f7088f1d4)