### PR TITLE
fix(cli): fail closed when packaged binary is missing

### DIFF
--- a/packages/cli/bin/coven.js
+++ b/packages/cli/bin/coven.js
@@ -13,20 +13,17 @@ const packagedBinary = path.resolve(
   process.arch,
   process.platform === 'win32' ? 'coven.exe' : 'coven'
 );
-const repoDebugBinary = path.resolve(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'target',
-  'debug',
-  process.platform === 'win32' ? 'coven.exe' : 'coven'
-);
-const binary = existsSync(packagedBinary) ? packagedBinary : repoDebugBinary;
+if (!existsSync(packagedBinary)) {
+  console.error(
+    `Coven packaged binary not found at ${packagedBinary}. ` +
+      'Reinstall @opencoven/cli for your platform.'
+  );
+  process.exit(1);
+}
 
-const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' });
+const result = spawnSync(packagedBinary, process.argv.slice(2), { stdio: 'inherit' });
 if (result.error) {
-  console.error(`Failed to launch Coven binary at ${binary}: ${result.error.message}`);
+  console.error(`Failed to launch Coven binary at ${packagedBinary}: ${result.error.message}`);
   process.exit(1);
 }
 process.exit(result.status ?? 1);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
     "coven": "bin/coven.js"
   },
   "files": [
+    "native",
     "assets",
     "bin",
     "README.md"


### PR DESCRIPTION
### Motivation
- Prevent the npm CLI shim from resolving and executing a binary outside the package tree (e.g., `node_modules/target/debug/coven`) which allows attacker-controlled code execution.
- Ensure the wrapper only launches the shipped native binary and fails closed when that binary is absent.
- Make packed installs include the expected native binary path so the shim has a valid packaged target.

### Description
- Updated `packages/cli/bin/coven.js` to remove the `../../../target/debug/coven` fallback and to `exit(1)` with a clear error when `native/<platform>/<arch>/coven` is not present, and to always spawn the packaged binary path.
- Removed computation and use of the repo debug fallback variable and replaced uses of the fallback with the packaged path check and error.
- Added `native` to the `files` array in `packages/cli/package.json` so packed/published tarballs include the `native` directory.

### Testing
- Ran `npm pack --quiet` in `packages/cli` and confirmed the pack command succeeded and produced `opencoven-cli-0.0.0.tgz` (success).
- Verified the modified `bin/coven.js` file contains the new existence check and that the shim no longer selects an external fallback (file diff inspected, success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5f08cab883279326394d6c0557d9)