### PR TITLE
fix(coven-cli): confine prompt path expansion to workspace

### DIFF
--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -69,6 +69,9 @@ pub fn expand_path(cwd: &Path, raw: &str) -> Result<String> {
     if !full.exists() {
         return Ok(format!("[missing @{raw}]"));
     }
+    let Some(full) = resolve_path_inside(cwd, &full) else {
+        return Ok(format!("[missing @{raw}]"));
+    };
     let mime = guess_mime(&full);
     if mime.starts_with("image/") {
         let bytes = std::fs::metadata(&full)?.len();
@@ -170,17 +173,29 @@ fn walkdir(root: &Path) -> Vec<PathBuf> {
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() {
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if meta.file_type().is_symlink() {
+                continue;
+            }
+            if meta.is_dir() {
                 if path.file_name().and_then(|s| s.to_str()) == Some(".git") {
                     continue;
                 }
                 stack.push(path);
-            } else {
+            } else if meta.is_file() {
                 out.push(path);
             }
         }
     }
     out
+}
+
+fn resolve_path_inside(root: &Path, candidate: &Path) -> Option<PathBuf> {
+    let root = std::fs::canonicalize(root).ok()?;
+    let candidate = std::fs::canonicalize(candidate).ok()?;
+    candidate.starts_with(&root).then_some(candidate)
 }
 
 /// Expand every `@path`, `@T-<id>`, and `@@search` ref found in `prompt`.
@@ -297,6 +312,28 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let expanded = expand_path(temp.path(), "nope.md").unwrap();
         assert_eq!(expanded, "[missing @nope.md]");
+    }
+
+    #[test]
+    fn expand_path_rejects_parent_traversal_outside_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let outside = temp.path().join("outside.txt");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&outside, "SECRET").unwrap();
+        let expanded = expand_path(&root, "../outside.txt").unwrap();
+        assert_eq!(expanded, "[missing @../outside.txt]");
+    }
+
+    #[test]
+    fn expand_path_rejects_absolute_path_outside_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let outside = temp.path().join("outside.txt");
+        let root = temp.path().join("root");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&outside, "SECRET").unwrap();
+        let expanded = expand_path(&root, outside.to_str().unwrap()).unwrap();
+        assert!(expanded.starts_with("[missing @"));
     }
 
     #[test]

--- a/crates/coven-cli/src/prompt_refs.rs
+++ b/crates/coven-cli/src/prompt_refs.rs
@@ -336,6 +336,23 @@ mod tests {
         assert!(expanded.starts_with("[missing @"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn expand_path_rejects_symlink_escape_outside_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let outside = temp.path().join("outside.txt");
+        let root = temp.path().join("root");
+        let link = root.join("linked-secret.txt");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&outside, "SECRET").unwrap();
+        symlink(&outside, &link).unwrap();
+
+        let expanded = expand_path(&root, "linked-secret.txt").unwrap();
+        assert_eq!(expanded, "[missing @linked-secret.txt]");
+    }
+
     #[test]
     fn expand_path_truncates_at_max_lines() {
         let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
### Motivation
- The prompt `@path` and `@glob` expansion could read absolute paths, traverse `..`, and follow symlinks, allowing attacker-controlled prompts to inline files outside the selected project/cwd. 
- A minimal containment check is required so expansions cannot exfiltrate files from outside the workspace while preserving existing missing-file semantics. 
- Glob walking also followed symlinks and could induce symlink-escape or cycle behavior that needs hardening.

### Description
- Add `resolve_path_inside` which canonicalizes both the workspace root and candidate target and returns `Some(path)` only when the canonical candidate starts with the canonical root. 
- Make `expand_path` call `resolve_path_inside` and treat out-of-root or un-canonicalizable paths as missing placeholders (preserving prior `"[missing @...]"` behavior). 
- Harden `walkdir` to use `std::fs::symlink_metadata`, skip symlinks entirely, and only push real directories/files so glob expansion cannot follow symlinked directories outside the workspace. 
- Add regression tests exercising parent-traversal (`@../outside.txt`) and absolute-path escapes to assert they now yield the missing-placeholder behavior, and keep existing unit tests for other behaviors.

### Testing
- Added unit tests under `crates/coven-cli/src/prompt_refs.rs` for traversal and absolute-path rejection which should pass in CI and local environments. 
- Attempted to run `cargo test -p coven-cli prompt_refs`, but the run failed in this environment due to a crates.io download error (`CONNECT tunnel failed, response 403`) preventing dependency fetch; the failure is environmental and not a test regression. 
- The change is deliberately minimal and preserves prior behavior for in-root files, images, truncation, and glob caps while preventing out-of-root reads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1671b104508327bb6842b7ccbd470d)