### PR TITLE
docs(familiars): add familiar identity model spec, plan, and public docs

### DIFF
--- a/docs/familiars/identity.md
+++ b/docs/familiars/identity.md
@@ -1,9 +1,84 @@
 ---
-summary: "How identity is persisted across sessions, devices, and harness swaps."
+summary: "How familiar identity is declared, resolved, and carried across sessions."
 read_when:
-  - Understanding familiar identity
+  - Understanding why a familiar is more than a harness prompt
+  - Designing a familiar that survives model or provider changes
+  - Explaining how relationship affects familiar behavior
 title: "Identity"
-description: "Identity for OpenCoven familiars: how each persistent agent keeps a stable name, role, voice, and memory across harness sessions and host restarts."
+description: "Identity for OpenCoven familiars: declared familiar manifests, effective familiar resolution, relationships, memory profile, and governance."
 ---
 
-Stub — fill in. See [Familiars overview](/familiars).
+Familiar identity is the layer that lets a named agent remain itself while its harness, model, tools, or client changes.
+
+```text
+familiar.yaml
+  -> identity resolver
+  -> effective familiar
+  -> session
+```
+
+## Identity is not configuration
+
+Configuration chooses commands, models, paths, and tools. Identity declares purpose, roles, principles, relationships, memory profile, and governance.
+
+Coven resolves identity before launching a session so clients and harnesses receive an explicit effective familiar instead of a loose prompt string.
+
+## What identity carries
+
+A familiar identity should include:
+
+- **Purpose** — why the familiar exists.
+- **Roles** — the work it is suited to perform.
+- **Principles** — behavioral constraints such as truth before confidence.
+- **Relationships** — how it relates to its owner and other familiars.
+- **Memory profile** — what continuity follows it.
+- **Capability intent** — what kinds of hands it expects to use.
+- **Governance** — autonomy, approval, and provenance rules.
+
+## Soul, mind, hands
+
+OpenCoven separates a familiar into three layers:
+
+```text
+Familiar
+  Soul  -> purpose, roles, principles, relationships
+  Mind  -> skills, workflows, memory profile
+  Hands -> tools, harnesses, MCP, browser, desktop, GitHub
+```
+
+Hands can change without changing the familiar. Nova using GitHub and Nova using another work system should still resolve as Nova.
+
+## Relationships matter
+
+Relationship is architectural, not decorative.
+
+An engineer familiar acting as a maintainer should not resolve the same governance posture as the same engineer familiar acting as an apprentice. The skills may be identical, but autonomy, explanation style, memory behavior, and approval gates can differ.
+
+## Effective familiar
+
+The identity resolver turns a declared familiar into an effective familiar:
+
+```json
+{
+  "schemaVersion": "coven.effective_familiar.v1",
+  "id": "nova",
+  "displayName": "Nova",
+  "roles": ["orchestrator", "maintainer-companion"],
+  "principles": ["Truth before confidence."],
+  "memoryProfile": {
+    "profile": "continuity-curated"
+  },
+  "governance": {
+    "autonomy": "supervised",
+    "externalActions": "require_approval"
+  }
+}
+```
+
+The effective familiar is what a session consumes. The manifest is the declaration; the resolver is the authority that normalizes it.
+
+## Governance
+
+Capability intent is not a permission grant. It is resolved into policy metadata that the daemon, clients, approval gates, and repository rules can enforce.
+
+This keeps identity expressive without turning it into a bypass around trust.

--- a/docs/superpowers/plans/2026-06-15-familiar-identity-model.md
+++ b/docs/superpowers/plans/2026-06-15-familiar-identity-model.md
@@ -49,7 +49,7 @@ Create `schemas/familiar/coven.familiar.v1.schema.json`:
     "schema_version": { "const": "coven.familiar.v1" },
     "id": {
       "type": "string",
-      "pattern": "^[a-z][a-z0-9-]{1,63}$"
+      "pattern": "^[a-z][a-z0-9-]{0,63}$"
     },
     "display_name": {
       "type": "string",
@@ -198,6 +198,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct FamiliarManifest {
     pub schema_version: String,
     pub id: String,
@@ -208,6 +209,7 @@ pub struct FamiliarManifest {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct FamiliarIdentity {
     pub purpose: String,
     pub roles: Vec<String>,
@@ -216,6 +218,7 @@ pub struct FamiliarIdentity {
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct FamiliarSkills {
     #[serde(default)]
     pub required: Vec<String>,
@@ -226,9 +229,13 @@ pub struct FamiliarSkills {
 impl FamiliarManifest {
     pub fn from_yaml(source: &str) -> Result<Self> {
         let manifest: Self = serde_yaml::from_str(source).context("failed to parse familiar manifest YAML")?;
-        anyhow::ensure!(manifest.schema_version == "coven.familiar.v1", "unsupported familiar schema version");
+        anyhow::ensure!(
+            manifest.schema_version == "coven.familiar.v1",
+            "unsupported familiar schema version: expected \"coven.familiar.v1\", found \"{}\"",
+            manifest.schema_version
+        );
         anyhow::ensure!(!manifest.id.trim().is_empty(), "familiar id is required");
-        anyhow::ensure!(!manifest.identity.roles.is_empty(), "familiar roles are required");
+        anyhow::ensure!(!manifest.identity.roles.is_empty(), "familiar roles are required: at least one role must be declared");
         Ok(manifest)
     }
 }
@@ -311,6 +318,7 @@ Create `crates/coven-cli/src/familiar_identity/effective.rs`:
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct EffectiveFamiliar {
     pub schema_version: String,
     pub id: String,
@@ -322,6 +330,7 @@ pub struct EffectiveFamiliar {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct EffectiveFamiliarProvenance {
     pub manifest_path: Option<String>,
     pub resolved_from: Vec<String>,
@@ -462,7 +471,7 @@ fn effective_familiar_converts_to_launch_context() {
 - [ ] **Step 3: Run targeted tests**
 
 ```bash
-cargo test -p coven-cli harness:: effective_familiar_converts_to_launch_context
+cargo test -p coven-cli harness::effective_familiar_converts_to_launch_context
 ```
 
 If Cargo rejects multiple filters, run:
@@ -499,9 +508,9 @@ Expected JSON contains:
 
 ```json
 {
-  "schema_version": "coven.effective_familiar.v1",
+  "schemaVersion": "coven.effective_familiar.v1",
   "id": "nova",
-  "display_name": "Nova"
+  "displayName": "Nova"
 }
 ```
 

--- a/docs/superpowers/plans/2026-06-15-familiar-identity-model.md
+++ b/docs/superpowers/plans/2026-06-15-familiar-identity-model.md
@@ -1,0 +1,625 @@
+# Familiar Identity Model Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first-class familiar identity resolver so Coven turns `familiar.yaml` declarations into typed effective familiar identity for sessions.
+
+**Architecture:** Introduce a schema-backed manifest and Rust resolver beside the existing familiar context path, then swap harness launch identity injection to use resolved `EffectiveFamiliar`. Keep governance and capability intent as policy metadata, not raw permission grants.
+
+**Tech Stack:** Rust Coven CLI/daemon, Serde, JSON Schema, YAML/TOML compatibility, existing harness launch path, Markdown docs.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-familiar-identity-model.md`
+
+---
+
+## File Structure
+
+- Create `schemas/familiar/coven.familiar.v1.schema.json`: manifest schema for declared familiar identity.
+- Create `schemas/familiar/examples/nova.familiar.yaml`: representative fixture for a full identity declaration.
+- Create `crates/coven-cli/src/familiar_identity/mod.rs`: module exports and public resolver entrypoint.
+- Create `crates/coven-cli/src/familiar_identity/manifest.rs`: Serde structs and YAML loading.
+- Create `crates/coven-cli/src/familiar_identity/effective.rs`: normalized `EffectiveFamiliar` structs and preamble rendering.
+- Create `crates/coven-cli/src/familiar_identity/resolver.rs`: precedence, validation, and provenance assembly.
+- Modify `crates/coven-cli/src/harness.rs`: replace shallow `FamiliarContext` construction with resolver output.
+- Modify `crates/coven-cli/src/api.rs`: expose resolved identity fields in familiar/session launch responses where appropriate.
+- Modify `crates/coven-cli/src/main.rs`: add `coven familiars resolve <id> --json`.
+- Modify `docs/familiars/identity.md`: replace stub with public explanation.
+
+---
+
+### Task 1: Add schema and example manifest
+
+**Files:**
+- Create: `schemas/familiar/coven.familiar.v1.schema.json`
+- Create: `schemas/familiar/examples/nova.familiar.yaml`
+
+- [ ] **Step 1: Write the schema file**
+
+Create `schemas/familiar/coven.familiar.v1.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.opencoven.ai/familiar/coven.familiar.v1.schema.json",
+  "title": "Coven Familiar Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "id", "display_name", "identity"],
+  "properties": {
+    "schema_version": { "const": "coven.familiar.v1" },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{1,63}$"
+    },
+    "display_name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 80
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["purpose", "roles"],
+      "properties": {
+        "purpose": { "type": "string", "minLength": 1, "maxLength": 500 },
+        "roles": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1, "maxLength": 80 }
+        },
+        "principles": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1, "maxLength": 180 }
+        },
+        "relationships": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "memory": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "skills": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "required": { "type": "array", "items": { "type": "string" } },
+        "preferred": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "workflows": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "capability_intent": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "governance": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Add the fixture**
+
+Create `schemas/familiar/examples/nova.familiar.yaml`:
+
+```yaml
+schema_version: coven.familiar.v1
+id: nova
+display_name: Nova
+identity:
+  purpose: Trusted companion for building, organizing, remembering, and moving OpenCoven forward.
+  roles:
+    - orchestrator
+    - maintainer-companion
+  principles:
+    - Truth before confidence.
+    - Prefer local execution when it protects privacy and agency.
+  relationships:
+    owner:
+      kind: sovereign-source
+      display_name: Valentina
+memory:
+  profile: continuity-curated
+  scopes:
+    - long_term
+    - daily_notes
+    - project_context
+skills:
+  required:
+    - verification-before-completion
+  preferred:
+    - writing-plans
+capability_intent:
+  filesystem: local_workspace
+  github: maintainer_assist
+governance:
+  autonomy: supervised
+  external_actions: require_approval
+```
+
+- [ ] **Step 3: Validate basic file syntax**
+
+Run:
+
+```bash
+jq empty schemas/familiar/coven.familiar.v1.schema.json
+ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], aliases: false)' schemas/familiar/examples/nova.familiar.yaml
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add schemas/familiar/coven.familiar.v1.schema.json schemas/familiar/examples/nova.familiar.yaml
+git commit -m "feat(familiars): add familiar manifest schema"
+```
+
+---
+
+### Task 2: Parse declared familiar manifests
+
+**Files:**
+- Create: `crates/coven-cli/src/familiar_identity/mod.rs`
+- Create: `crates/coven-cli/src/familiar_identity/manifest.rs`
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Add module declaration**
+
+In `crates/coven-cli/src/main.rs`, add:
+
+```rust
+mod familiar_identity;
+```
+
+- [ ] **Step 2: Create module exports**
+
+Create `crates/coven-cli/src/familiar_identity/mod.rs`:
+
+```rust
+pub mod manifest;
+
+pub use manifest::{FamiliarIdentity, FamiliarManifest, FamiliarSkills};
+```
+
+- [ ] **Step 3: Write parser tests first**
+
+Create `crates/coven-cli/src/familiar_identity/manifest.rs` with tests first:
+
+```rust
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FamiliarManifest {
+    pub schema_version: String,
+    pub id: String,
+    pub display_name: String,
+    pub identity: FamiliarIdentity,
+    #[serde(default)]
+    pub skills: FamiliarSkills,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FamiliarIdentity {
+    pub purpose: String,
+    pub roles: Vec<String>,
+    #[serde(default)]
+    pub principles: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct FamiliarSkills {
+    #[serde(default)]
+    pub required: Vec<String>,
+    #[serde(default)]
+    pub preferred: Vec<String>,
+}
+
+impl FamiliarManifest {
+    pub fn from_yaml(source: &str) -> Result<Self> {
+        let manifest: Self = serde_yaml::from_str(source).context("failed to parse familiar manifest YAML")?;
+        anyhow::ensure!(manifest.schema_version == "coven.familiar.v1", "unsupported familiar schema version");
+        anyhow::ensure!(!manifest.id.trim().is_empty(), "familiar id is required");
+        anyhow::ensure!(!manifest.identity.roles.is_empty(), "familiar roles are required");
+        Ok(manifest)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nova_fixture() {
+        let source = include_str!("../../../../schemas/familiar/examples/nova.familiar.yaml");
+        let manifest = FamiliarManifest::from_yaml(source).unwrap();
+        assert_eq!(manifest.schema_version, "coven.familiar.v1");
+        assert_eq!(manifest.id, "nova");
+        assert!(manifest.identity.roles.contains(&"orchestrator".to_string()));
+        assert!(manifest.skills.required.contains(&"verification-before-completion".to_string()));
+    }
+
+    #[test]
+    fn rejects_missing_roles() {
+        let err = FamiliarManifest::from_yaml(
+            r#"
+schema_version: coven.familiar.v1
+id: nova
+display_name: Nova
+identity:
+  purpose: Test
+  roles: []
+"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("roles"));
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p coven-cli familiar_identity::manifest
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs crates/coven-cli/src/familiar_identity
+git commit -m "feat(familiars): parse familiar identity manifests"
+```
+
+---
+
+### Task 3: Resolve effective familiar identity
+
+**Files:**
+- Create: `crates/coven-cli/src/familiar_identity/effective.rs`
+- Create: `crates/coven-cli/src/familiar_identity/resolver.rs`
+- Modify: `crates/coven-cli/src/familiar_identity/mod.rs`
+
+- [ ] **Step 1: Export effective and resolver modules**
+
+Update `crates/coven-cli/src/familiar_identity/mod.rs`:
+
+```rust
+pub mod effective;
+pub mod manifest;
+pub mod resolver;
+
+pub use effective::{EffectiveFamiliar, EffectiveFamiliarProvenance};
+pub use manifest::{FamiliarIdentity, FamiliarManifest, FamiliarSkills};
+pub use resolver::{resolve_familiar_from_manifest, FamiliarResolveRequest};
+```
+
+- [ ] **Step 2: Add effective familiar structs**
+
+Create `crates/coven-cli/src/familiar_identity/effective.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct EffectiveFamiliar {
+    pub schema_version: String,
+    pub id: String,
+    pub display_name: String,
+    pub roles: Vec<String>,
+    pub principles: Vec<String>,
+    pub identity_preamble: String,
+    pub provenance: EffectiveFamiliarProvenance,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct EffectiveFamiliarProvenance {
+    pub manifest_path: Option<String>,
+    pub resolved_from: Vec<String>,
+}
+```
+
+- [ ] **Step 3: Add resolver tests and implementation**
+
+Create `crates/coven-cli/src/familiar_identity/resolver.rs`:
+
+```rust
+use super::effective::{EffectiveFamiliar, EffectiveFamiliarProvenance};
+use super::manifest::FamiliarManifest;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FamiliarResolveRequest {
+    pub manifest_path: Option<String>,
+}
+
+pub fn resolve_familiar_from_manifest(
+    manifest: FamiliarManifest,
+    request: FamiliarResolveRequest,
+) -> EffectiveFamiliar {
+    let role_summary = manifest.identity.roles.join(", ");
+    let identity_preamble = format!(
+        "[Identity: You are {name}, a familiar with roles: {roles}. Purpose: {purpose}. Respond as {name}, not as the underlying tool.]",
+        name = manifest.display_name,
+        roles = role_summary,
+        purpose = manifest.identity.purpose,
+    );
+
+    EffectiveFamiliar {
+        schema_version: "coven.effective_familiar.v1".to_string(),
+        id: manifest.id,
+        display_name: manifest.display_name,
+        roles: manifest.identity.roles,
+        principles: manifest.identity.principles,
+        identity_preamble,
+        provenance: EffectiveFamiliarProvenance {
+            manifest_path: request.manifest_path,
+            resolved_from: vec!["manifest".to_string()],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::familiar_identity::manifest::FamiliarManifest;
+
+    #[test]
+    fn resolves_effective_identity_with_preamble_and_provenance() {
+        let manifest = FamiliarManifest::from_yaml(include_str!(
+            "../../../../schemas/familiar/examples/nova.familiar.yaml"
+        ))
+        .unwrap();
+
+        let effective = resolve_familiar_from_manifest(
+            manifest,
+            FamiliarResolveRequest {
+                manifest_path: Some("schemas/familiar/examples/nova.familiar.yaml".to_string()),
+            },
+        );
+
+        assert_eq!(effective.schema_version, "coven.effective_familiar.v1");
+        assert_eq!(effective.id, "nova");
+        assert!(effective.identity_preamble.contains("You are Nova"));
+        assert!(effective.identity_preamble.contains("orchestrator"));
+        assert_eq!(
+            effective.provenance.manifest_path.as_deref(),
+            Some("schemas/familiar/examples/nova.familiar.yaml")
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p coven-cli familiar_identity
+```
+
+Expected: manifest and resolver tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/familiar_identity
+git commit -m "feat(familiars): resolve effective familiar identity"
+```
+
+---
+
+### Task 4: Wire resolved identity into harness launch
+
+**Files:**
+- Modify: `crates/coven-cli/src/harness.rs`
+
+- [ ] **Step 1: Add an adapter from `EffectiveFamiliar` to existing launch context**
+
+In `crates/coven-cli/src/harness.rs`, keep the public launch API stable by adding:
+
+```rust
+impl From<crate::familiar_identity::EffectiveFamiliar> for FamiliarContext {
+    fn from(effective: crate::familiar_identity::EffectiveFamiliar) -> Self {
+        Self {
+            id: effective.id,
+            name: effective.display_name,
+            role: Some(effective.roles.join(", ")),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add a regression test**
+
+Near the existing `FamiliarContext` tests in `harness.rs`, add:
+
+```rust
+#[test]
+fn effective_familiar_converts_to_launch_context() {
+    let manifest = crate::familiar_identity::FamiliarManifest::from_yaml(include_str!(
+        "../../../../schemas/familiar/examples/nova.familiar.yaml"
+    ))
+    .unwrap();
+    let effective = crate::familiar_identity::resolve_familiar_from_manifest(
+        manifest,
+        crate::familiar_identity::FamiliarResolveRequest::default(),
+    );
+    let context: FamiliarContext = effective.into();
+    assert_eq!(context.id, "nova");
+    assert_eq!(context.name, "Nova");
+    assert!(context.identity_preamble().contains("Nova"));
+    assert!(context.identity_preamble().contains("orchestrator"));
+}
+```
+
+- [ ] **Step 3: Run targeted tests**
+
+```bash
+cargo test -p coven-cli harness:: effective_familiar_converts_to_launch_context
+```
+
+If Cargo rejects multiple filters, run:
+
+```bash
+cargo test -p coven-cli effective_familiar_converts_to_launch_context
+```
+
+Expected: new test passes and existing harness identity tests continue to pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/harness.rs
+git commit -m "feat(familiars): use resolved identity for harness context"
+```
+
+---
+
+### Task 5: Add CLI inspection command
+
+**Files:**
+- Modify: `crates/coven-cli/src/main.rs`
+
+- [ ] **Step 1: Add CLI test or snapshot**
+
+If the repo has CLI command tests, add a test that invokes:
+
+```bash
+coven familiars resolve nova --manifest schemas/familiar/examples/nova.familiar.yaml --json
+```
+
+Expected JSON contains:
+
+```json
+{
+  "schema_version": "coven.effective_familiar.v1",
+  "id": "nova",
+  "display_name": "Nova"
+}
+```
+
+If no CLI command test harness exists, add a unit test for the handler function before wiring the Clap command.
+
+- [ ] **Step 2: Implement command handler**
+
+Add a `familiars resolve` command that:
+
+1. accepts `<id>`;
+2. accepts optional `--manifest <path>`;
+3. loads the manifest;
+4. verifies the loaded manifest ID matches `<id>`;
+5. prints `EffectiveFamiliar` as pretty JSON when `--json` is present.
+
+- [ ] **Step 3: Run verification**
+
+```bash
+cargo test -p coven-cli familiar_identity
+cargo run -p coven-cli -- familiars resolve nova --manifest schemas/familiar/examples/nova.familiar.yaml --json
+```
+
+Expected: tests pass and command prints `coven.effective_familiar.v1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs
+git commit -m "feat(familiars): inspect resolved identity from the CLI"
+```
+
+---
+
+### Task 6: Update public docs
+
+**Files:**
+- Modify: `docs/familiars/identity.md`
+- Modify if needed: `docs/familiars/index.md`
+
+- [ ] **Step 1: Replace identity stub**
+
+Write `docs/familiars/identity.md` with:
+
+```md
+---
+summary: "How familiar identity is declared, resolved, and carried across sessions."
+read_when:
+  - Understanding why a familiar is more than a harness prompt
+  - Designing a familiar that survives model or provider changes
+title: "Identity"
+description: "Identity for OpenCoven familiars: declared familiar manifests, effective familiar resolution, relationships, memory profile, and governance."
+---
+
+Familiar identity is the layer that lets a named agent remain itself while its harness, model, tools, or client changes.
+
+```text
+familiar.yaml
+  -> identity resolver
+  -> effective familiar
+  -> session
+```
+
+## Identity is not configuration
+
+Configuration chooses commands, models, paths, and tools. Identity declares purpose, roles, principles, relationships, memory profile, and governance. Coven resolves identity before launching a session so clients and harnesses receive an explicit effective familiar instead of a loose prompt string.
+
+## Soul, mind, hands
+
+- Soul: purpose, roles, principles, relationships.
+- Mind: skills, workflows, and memory profile.
+- Hands: tools, harnesses, MCP servers, browser, desktop, and GitHub.
+
+Hands can change without changing the familiar.
+
+## Relationships matter
+
+Relationship affects permissions, memory behavior, autonomy, communication style, and delegation. An engineer familiar acting as a maintainer should not resolve the same governance posture as the same engineer familiar acting as an apprentice.
+
+## Governance
+
+Capability intent is not a permission grant. It is resolved into policy metadata that the daemon, clients, approval gates, and repository rules can enforce.
+```
+
+- [ ] **Step 2: Run docs sanity checks**
+
+```bash
+node -e 'const fs=require("fs"); const text=fs.readFileSync("docs/familiars/identity.md","utf8"); const banned=["Stub " + "— fill in"]; for (const marker of banned) if (text.includes(marker)) { console.error(marker); process.exit(1); }'
+git diff --check docs/familiars/identity.md
+```
+
+Expected: the placeholder scan exits 0 and `git diff --check` exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/familiars/identity.md docs/familiars/index.md
+git commit -m "docs(familiars): document identity resolution"
+```
+
+---
+
+## Final Verification
+
+Run:
+
+```bash
+cargo test -p coven-cli familiar_identity
+cargo test -p coven-cli harness
+jq empty schemas/familiar/coven.familiar.v1.schema.json
+ruby -e 'require "yaml"; YAML.safe_load(File.read(ARGV[0]), permitted_classes: [], aliases: false)' schemas/familiar/examples/nova.familiar.yaml
+node -e 'const fs=require("fs"); const files=["docs/superpowers/plans/2026-06-15-familiar-identity-model.md","docs/superpowers/specs/2026-06-15-familiar-identity-model.md","docs/familiars/identity.md"]; const banned=["Stub " + "— fill in","TB" + "D","implement " + "later"]; for (const file of files) { const text=fs.readFileSync(file,"utf8"); for (const marker of banned) if (text.includes(marker)) { console.error(`${file}: ${marker}`); process.exit(1); } }'
+git diff --check
+```
+
+Expected:
+
+- Rust tests pass.
+- Schema parses.
+- YAML fixture parses.
+- Placeholder scan returns no matches in the new docs.
+- Diff whitespace check exits 0.

--- a/docs/superpowers/specs/2026-06-15-familiar-identity-model.md
+++ b/docs/superpowers/specs/2026-06-15-familiar-identity-model.md
@@ -1,0 +1,318 @@
+# Familiar Identity Model Design
+
+Date: 2026-06-15
+Status: Draft architecture canon
+Owner: OpenCoven / Coven daemon
+Source: Valentina's "OpenCoven Should Not Treat Identity As Configuration" research report
+
+## Executive Summary
+
+OpenCoven should treat familiar identity as a first-class runtime object, not as prompt text or client configuration. Capabilities, skills, tools, MCP servers, plugins, harness adapters, and models are increasingly converging across the agent ecosystem; durable identity is the layer OpenCoven can own.
+
+The core architectural move is:
+
+```text
+Familiar manifest
+  -> identity resolver
+  -> effective familiar
+  -> session
+```
+
+This is deeper than the common framework pattern:
+
+```text
+Agent definition
+  -> session
+```
+
+The resolver becomes the authority that turns a declared familiar into the concrete identity, memory profile, relationship posture, capability intent, governance constraints, and harness-specific prompt material used by a running session.
+
+## Current State
+
+Coven already has the beginning of this idea:
+
+- `crates/coven-cli/src/harness.rs` defines `FamiliarContext`.
+- `coven run --familiar` can inject a concise identity preamble into harness prompts.
+- `crates/coven-cli/src/api.rs` accepts `familiar_id` and `caller_familiar_id` for daemon launch requests.
+- `crates/coven-cli/src/eval_loop.rs` resolves familiar workspace paths from `~/.coven/familiars.toml`.
+- `docs/familiars/index.md` states that a familiar outlives a single harness session.
+- `docs/familiars/identity.md` is still a stub and should become the public explanation once the model lands.
+
+That current model is useful, but too shallow. It mostly resolves name and role into a text preamble. The next model should resolve a durable familiar declaration into a typed effective familiar.
+
+## Design Principle
+
+Identity is not configuration.
+
+Configuration answers:
+
+- which command to run;
+- which model to request;
+- which tools are available;
+- which working directory to use.
+
+Identity answers:
+
+- who this familiar is;
+- what relationship it has to the owner and other familiars;
+- what principles constrain its behavior;
+- what memory profile follows it;
+- what autonomy and governance posture applies;
+- how it should remain itself across model, provider, harness, runtime, plugin, and client changes.
+
+## Manifest Shape
+
+Add a first-class `familiar.yaml` manifest format. The manifest declares stable identity intent. It does not directly grant permissions.
+
+```yaml
+schema_version: coven.familiar.v1
+id: nova
+display_name: Nova
+
+identity:
+  purpose: Trusted companion for building, organizing, remembering, and moving OpenCoven forward.
+  roles:
+    - orchestrator
+    - maintainer-companion
+  principles:
+    - Truth before confidence.
+    - Prefer local execution when it protects privacy and agency.
+    - Explain tradeoffs without pretending uncertainty away.
+  relationships:
+    owner:
+      kind: sovereign-source
+      display_name: Valentina
+    team:
+      - familiar_id: sage
+        kind: peer-researcher
+      - familiar_id: cody
+        kind: implementation-partner
+
+memory:
+  profile: continuity-curated
+  scopes:
+    - long_term
+    - daily_notes
+    - project_context
+  retention:
+    default: curated
+    secrets: never_persist_without_explicit_request
+
+skills:
+  required:
+    - systematic-debugging
+    - verification-before-completion
+  preferred:
+    - writing-plans
+    - requesting-code-review
+
+workflows:
+  defaults:
+    - code-review
+    - research-synthesis
+    - release-triage
+
+capability_intent:
+  filesystem: local_workspace
+  github: maintainer_assist
+  browser: verify_when_needed
+  desktop: explicit_consent_only
+
+governance:
+  autonomy: supervised
+  external_actions: require_approval
+  merge_rules:
+    protected_branches:
+      - main
+    require_verification: true
+  provenance:
+    coauthor_when_relevant: true
+```
+
+## Effective Familiar Shape
+
+The resolver emits a normalized `EffectiveFamiliar`. This is the object sessions consume.
+
+```json
+{
+  "schemaVersion": "coven.effective_familiar.v1",
+  "id": "nova",
+  "displayName": "Nova",
+  "identityPreamble": "[Identity: You are Nova...]",
+  "roles": ["orchestrator", "maintainer-companion"],
+  "principles": ["Truth before confidence."],
+  "relationships": {
+    "owner": {
+      "kind": "sovereign-source",
+      "displayName": "Valentina"
+    }
+  },
+  "memoryProfile": {
+    "profile": "continuity-curated",
+    "scopes": ["long_term", "daily_notes", "project_context"]
+  },
+  "skills": {
+    "required": ["systematic-debugging", "verification-before-completion"],
+    "preferred": ["writing-plans", "requesting-code-review"]
+  },
+  "capabilityPolicy": {
+    "filesystem": "local_workspace",
+    "github": "maintainer_assist",
+    "browser": "verify_when_needed",
+    "desktop": "explicit_consent_only"
+  },
+  "governance": {
+    "autonomy": "supervised",
+    "externalActions": "require_approval"
+  },
+  "provenance": {
+    "manifestPath": "~/.coven/familiars/nova/familiar.yaml",
+    "resolvedAt": "2026-06-15T00:00:00Z"
+  }
+}
+```
+
+## Resolver Responsibilities
+
+The identity resolver is responsible for deterministic normalization, not model behavior.
+
+It should:
+
+1. Load the declared familiar manifest.
+2. Validate schema version and required identity fields.
+3. Merge user-level defaults, project-level overrides, and session request overrides using explicit precedence.
+4. Resolve relationships to known familiar IDs where possible.
+5. Resolve memory profile into allowed memory scopes and storage roots.
+6. Resolve skill references into known local or installed skills.
+7. Resolve capability intent into policy, not raw tool grants.
+8. Attach governance gates that downstream launch paths must respect.
+9. Render harness-specific identity material without losing the typed source object.
+
+It should not:
+
+- directly run tools;
+- silently widen permissions;
+- mutate memory;
+- claim relationship state that is not declared or inferred by an explicit rule;
+- hide unsupported fields from clients.
+
+## Precedence Model
+
+Use a simple, inspectable precedence chain:
+
+```text
+built-in schema defaults
+  < user familiar manifest
+  < project familiar overlay
+  < workflow invocation intent
+  < one-shot session override
+```
+
+Every override must be reflected in `provenance` so clients can explain why a familiar behaved a certain way.
+
+## Relationship Is Architectural
+
+Relationship changes behavior without changing skills.
+
+Example:
+
+```yaml
+id: forge
+identity:
+  roles: [engineer]
+  relationships:
+    owner:
+      kind: maintainer
+```
+
+and:
+
+```yaml
+id: forge
+identity:
+  roles: [engineer]
+  relationships:
+    owner:
+      kind: apprentice
+```
+
+can use the same harness and skills, but should resolve different defaults for autonomy, explanation style, memory write behavior, and approval gates.
+
+This makes relationship part of runtime policy, not decorative copy.
+
+## Soul, Mind, Hands
+
+Use this mental model in docs and architecture reviews:
+
+```text
+Familiar
+  Soul  -> purpose, role, principles, relationship
+  Mind  -> skills, workflows, memory profile
+  Hands -> tools, harnesses, MCP, browser, desktop, GitHub
+```
+
+Hands are swappable. Soul is not.
+
+Nova with GitHub and Nova with Jira should still resolve as Nova.
+
+## Governance Boundary
+
+Manifest `capability_intent` is intentionally not a permission grant. It tells the resolver what the familiar expects. The daemon, client, user approvals, worktree protocol, and repository rules remain the enforcement layers.
+
+That distinction keeps familiar identity expressive without making it a bypass around trust gates.
+
+## Relationship To Ward And Familiar Contract
+
+The Familiar Contract defines what a familiar is and what it owes.
+
+Ward is the runtime enforcement layer for where identity can extend and under what conditions.
+
+The identity resolver sits between them:
+
+```text
+Familiar Contract
+  -> familiar.yaml
+  -> identity resolver
+  -> EffectiveFamiliar
+  -> Ward / daemon / harness launch
+  -> session
+```
+
+The resolver should not replace Contract or Ward. It makes their inputs concrete at session time.
+
+## Product Implications
+
+If this lands, OpenCoven can credibly claim:
+
+- familiars survive model and harness swaps;
+- identity can be versioned, diffed, reviewed, and rolled back;
+- relationships can influence permissions and autonomy;
+- memory scope is part of identity, not a random tool setting;
+- multi-familiar orchestration can route to named entities instead of anonymous workers;
+- clients can render why a familiar has a capability or governance gate.
+
+## Initial Milestones
+
+1. Add `schemas/familiar/coven.familiar.v1.schema.json`.
+2. Add typed Rust structs for declared and effective familiars.
+3. Implement `resolve_familiar(coven_home, project_root, request)` in the Coven CLI/daemon crate.
+4. Replace the current shallow `FamiliarContext` construction with resolver output.
+5. Add `coven familiars resolve <id> --json` for inspection.
+6. Update `docs/familiars/identity.md` from stub to public docs.
+7. Teach Cave and CastCodes to display effective familiar identity provenance when launching sessions.
+
+## Non-Goals
+
+- Do not build a broad plugin marketplace in this work.
+- Do not grant tools directly from `familiar.yaml`.
+- Do not make relationship fields anthropomorphic claims of consciousness.
+- Do not require every harness to support system prompts.
+- Do not migrate every existing familiar at once.
+
+## Open Questions
+
+1. Should `familiar.yaml` live at `~/.coven/familiars/<id>/familiar.yaml`, inside project `.coven/familiars/`, or both?
+2. Should relationship kinds be an enum in v1, or freeform strings with known recommendations?
+3. Should skill references be resolved by name only, or include source/package provenance?
+4. How much of `EffectiveFamiliar` belongs in daemon API responses by default?
+5. Should `Familiar Contract` be imported as a schema dependency or remain a linked conceptual authority?

--- a/docs/superpowers/specs/2026-06-15-familiar-identity-model.md
+++ b/docs/superpowers/specs/2026-06-15-familiar-identity-model.md
@@ -1,7 +1,8 @@
 # Familiar Identity Model Design
 
 Date: 2026-06-15
-Status: Draft architecture canon
+Status: Draft
+Canonicality: Proposed
 Owner: OpenCoven / Coven daemon
 Source: Valentina's "OpenCoven Should Not Treat Identity As Configuration" research report
 


### PR DESCRIPTION
> **⚠️ PRs are not being accepted until July 2026.**
> Please close this PR and open an Issue instead. PRs opened before July 2026 will be closed without review.
> See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

## Description

Promotes an internal research report into a cohesive, Coven-facing architecture packet proposing a first-class "familiar identity" resolver and manifest.

- Adds a detailed design spec for a Familiar Identity Model (manifest → resolver → effective familiar → session).
- Adds a step-by-step implementation plan (schema, Rust structs/resolver, harness wiring, CLI inspection).
- Replaces the familiars identity stub page with public-facing documentation explaining identity, relationships, effective familiars, and governance.

**Review feedback addressed:**

- **Regex** — Updated `id` pattern from `{1,63}` to `{0,63}` so single-character IDs are valid per the schema.
- **`deny_unknown_fields`** — Added `#[serde(deny_unknown_fields)]` to `FamiliarManifest`, `FamiliarIdentity`, and `FamiliarSkills` structs so YAML typos are surfaced as errors rather than silently ignored, matching the schema's `additionalProperties: false` intent.
- **Actionable validation errors** — Schema version mismatch now includes both the expected and observed value; roles error describes what is required.
- **camelCase wire format** — Added `#[serde(rename_all = "camelCase")]` to `EffectiveFamiliar` and `EffectiveFamiliarProvenance` so serialized JSON matches the camelCase shape documented in the spec.
- **CLI snapshot alignment** — Updated expected JSON keys in the plan from `schema_version`/`display_name` to `schemaVersion`/`displayName` to match the camelCase wire format.
- **Test command** — Removed spurious space in `harness:: effective_familiar_converts_to_launch_context` → `harness::effective_familiar_converts_to_launch_context`.
- **Spec status** — Replaced contradictory `Status: Draft architecture canon` with two unambiguous fields: `Status: Draft` and `Canonicality: Proposed`.

## Linked Issue

## Testing

Changes are confined to documentation and plan files. Verified with `git diff --check` (no whitespace issues). The plan's bash and Rust code snippets were reviewed for correctness against the documented schema and spec.