### PR TITLE
fix(ci): cover memory hash and Windows executable lookup

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -936,7 +936,8 @@ mod tests {
     #[test]
     fn executable_exists_in_paths_finds_matching_file() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let executable = temp_dir.path().join("codex");
+        let executable_name = if cfg!(windows) { "codex.exe" } else { "codex" };
+        let executable = temp_dir.path().join(executable_name);
         fs::write(&executable, "")?;
         make_executable(&executable)?;
 

--- a/crates/coven-memory/src/ingest.rs
+++ b/crates/coven-memory/src/ingest.rs
@@ -129,3 +129,17 @@ fn hex_hash(s: &str) -> String {
     // lowercase hex, so existing chunk hashes stay stable.
     h.finalize().iter().map(|b| format!("{b:02x}")).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::hex_hash;
+
+    #[test]
+    fn hex_hash_matches_known_sha256() {
+        assert_eq!(
+            hex_hash("hello"),
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        );
+        assert_eq!(hex_hash("hello").len(), 64);
+    }
+}


### PR DESCRIPTION
## Summary
- add a regression test against the known SHA-256 of `hello` for coven-memory ingestion hashes
- make the executable lookup test use a `.exe` fixture on Windows so PATHEXT-based resolution can find it

## Root cause
Current `main` already hex-encodes finalized SHA-256 bytes explicitly after the `sha2` 0.11 `LowerHex` break. This PR keeps that behavior covered with a regression test. The refreshed Windows CI leg also exposed a cross-platform test fixture issue: the lookup test created extensionless `codex`, while Windows executable lookup expands through PATHEXT and expects `codex.exe`/`.cmd` style candidates.

## Verification
- `cargo test -p coven-memory hex_hash_matches_known_sha256 -- --nocapture`
- `cargo test -p coven-memory`
- `cargo test -p coven-cli harness::tests::executable_exists_in_paths_finds_matching_file -- --nocapture`
- `cargo test -p coven-cli`
- `git diff --check origin/main...HEAD`