### PR TITLE
fix(daemon): stop the socket-takeover orphan storm + EINVAL connection drops

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1491,6 +1491,24 @@ pub fn bind_api_socket(coven_home: &Path) -> Result<UnixListener> {
             }
             // SAFETY: geteuid() only reads the effective uid and cannot fail.
             check_owned_by_current_user(&socket_path, metadata.uid(), unsafe { libc::geteuid() })?;
+            // Break the socket-takeover orphan cycle: before unlinking and
+            // rebinding, probe the existing socket's /health endpoint. If a live
+            // daemon is already serving here, refuse to take over. Removing its
+            // socket inode would not stop it — the incumbent keeps running on the
+            // now-unlinked inode (no longer reachable by new clients, but never
+            // exiting), leaking a zombie that competes for the path. Repeated
+            // takeovers are how a single daemon turns into dozens. Only a dead or
+            // stale socket — connection refused, or a non-ok health body — may be
+            // reclaimed. See OpenCoven/coven#197 and docs/AUTH.md.
+            if let Ok(Some(incumbent)) =
+                daemon_status_from_health_socket(&socket_path.to_string_lossy())
+            {
+                anyhow::bail!(
+                    "a healthy Coven daemon (pid {}) is already serving {}; refusing to take over",
+                    incumbent.pid,
+                    socket_path.display()
+                );
+            }
             std::fs::remove_file(&socket_path).with_context(|| {
                 format!("failed to remove stale socket {}", socket_path.display())
             })?;
@@ -2619,6 +2637,60 @@ mod tests {
         assert!(
             msg.contains("non-loopback"),
             "unexpected error message: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_api_socket_refuses_to_take_over_a_healthy_incumbent() {
+        use crate::api::NoopSessionRuntime;
+        use std::thread;
+        let temp = tempfile::tempdir().expect("tempdir");
+        ensure_private_coven_home(temp.path()).expect("ensure home");
+        let home = temp.path().to_path_buf();
+
+        // Stand up an incumbent daemon: a bound socket plus a thread that answers
+        // a single /health probe, reporting a recognizable pid.
+        let incumbent = bind_api_socket(&home).expect("bind incumbent");
+        let socket = daemon_socket_path(&home).to_string_lossy().into_owned();
+        let server_home = home.clone();
+        let status = DaemonStatus {
+            pid: 4242,
+            started_at: "2026-06-18T00:00:00Z".to_string(),
+            socket,
+        };
+        let server = thread::spawn(move || {
+            serve_next_connection(&incumbent, &server_home, Some(status), &NoopSessionRuntime)
+                .expect("serve health probe");
+        });
+
+        // A second daemon must NOT clobber the live socket. It should bail and
+        // name the incumbent pid rather than unlink the inode out from under it.
+        let error = bind_api_socket(&home).expect_err("must refuse takeover");
+        server.join().expect("incumbent server thread");
+        let msg = format!("{error:#}");
+        assert!(
+            msg.contains("refusing to take over") && msg.contains("4242"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_api_socket_reclaims_a_dead_socket_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        ensure_private_coven_home(temp.path()).expect("ensure home");
+        let home = temp.path().to_path_buf();
+
+        // A crashed daemon (SIGKILL bypasses Drop) leaves the socket file behind
+        // with nothing listening — connecting refuses. Reclaiming it must still
+        // succeed, otherwise the guard would wedge every restart.
+        let dead = bind_api_socket(&home).expect("first bind");
+        drop(dead); // closes the listener; the socket file lingers, unserved
+        let reclaimed = bind_api_socket(&home);
+        assert!(
+            reclaimed.is_ok(),
+            "should reclaim a dead socket: {reclaimed:?}"
         );
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1661,13 +1661,19 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
             .to_string_lossy()
             .into_owned(),
     };
-    write_status(coven_home, &status)?;
     let socket_path = daemon_socket_path(coven_home);
     let status_path = daemon_status_path(coven_home);
     // Install the shutdown hooks before anything else that can fail: a panic
-    // during recovery or bind would otherwise leave daemon.json on disk.
+    // during recovery or bind would otherwise leave a socket file behind.
     install_daemon_panic_hook(coven_home, &socket_path, &status_path);
     install_termination_signal_handlers(&socket_path, &status_path)?;
+    // Acquire the socket BEFORE claiming any on-disk daemon state. bind_api_socket
+    // refuses to take over a socket a healthy daemon already owns; if it bails we
+    // must not yet have written daemon.json or armed the ShutdownGuard, or the
+    // guard would delete the incumbent's status file and unlink its live socket on
+    // our way out — re-orphaning the very daemon we declined to replace.
+    let unix_listener = bind_api_socket(coven_home)?;
+    write_status(coven_home, &status)?;
     let _shutdown_guard = ShutdownGuard {
         socket_path: socket_path.clone(),
         status_path: status_path.clone(),
@@ -1682,7 +1688,6 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         ),
     );
     recover_orphaned_sessions(coven_home, &started_at)?;
-    let unix_listener = bind_api_socket(coven_home)?;
     let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
         coven_home.to_path_buf(),
     ));

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1866,13 +1866,17 @@ pub fn serve_next_connection(
     let (stream, _) = listener
         .accept()
         .context("failed to accept API connection")?;
-    // Apply I/O timeout so a stalled client doesn't hold the handler thread forever.
-    stream
-        .set_read_timeout(Some(SOCKET_IO_TIMEOUT))
-        .context("failed to set read timeout on Unix socket")?;
-    stream
-        .set_write_timeout(Some(SOCKET_IO_TIMEOUT))
-        .context("failed to set write timeout on Unix socket")?;
+    // Best-effort I/O timeouts so a stalled client doesn't pin the handler
+    // thread forever. These are an optimization, not a precondition: on macOS
+    // setsockopt(SO_RCVTIMEO) returns EINVAL (os error 22) for some accepted
+    // fds (e.g. a peer already half-closed by accept time), and a connection
+    // that merely could not have a timeout applied is still serviceable. Making
+    // this fatal aborted those connections and flooded the recovery log with
+    // "failed to set read timeout" — to a polling client like CovenCave it looked
+    // like the daemon constantly dropping. Mirror the named-pipe path, which
+    // already sets these best-effort, and serve the request regardless.
+    let _ = stream.set_read_timeout(Some(SOCKET_IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(SOCKET_IO_TIMEOUT));
     let read = stream.try_clone().context("failed to clone Unix stream")?;
     // Apply a body cap even on local Unix sockets: a buggy or hostile local
     // process should not be able to OOM the daemon with a huge payload.

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -184,7 +184,7 @@ fn concurrent_daemon_start_commands_share_one_daemon() -> anyhow::Result<()> {
 }
 
 #[test]
-fn daemon_start_cleans_up_unreachable_duplicate_daemons() -> anyhow::Result<()> {
+fn daemon_serve_refuses_to_take_over_a_healthy_socket() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
     let path = std::env::var_os("PATH").unwrap_or_default();
@@ -200,6 +200,9 @@ fn daemon_start_cleans_up_unreachable_duplicate_daemons() -> anyhow::Result<()> 
     wait_for_daemon_health(&coven_home)?;
     let first_pid = daemon_status_pid(&coven_home)?;
 
+    // A second `daemon serve` against the live socket must refuse to take over.
+    // Unlinking the incumbent's socket would not stop it — it would keep running
+    // on the orphaned inode — so the duplicate has to exit on its own instead.
     let mut duplicate = Command::new(&coven)
         .args(["daemon", "serve"])
         .env("COVEN_HOME", &coven_home)
@@ -208,30 +211,27 @@ fn daemon_start_cleans_up_unreachable_duplicate_daemons() -> anyhow::Result<()> 
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()?;
-    wait_until("duplicate daemon to take over socket", || {
-        wait_for_daemon_health(&coven_home)?;
-        Ok(daemon_status_pid(&coven_home)? != first_pid)
+    wait_until("duplicate daemon to exit on its own", || {
+        Ok(duplicate.try_wait()?.is_some())
     })?;
-
-    let active_before_cleanup = daemon_status_pid(&coven_home)?;
-    assert_ne!(
-        first_pid, active_before_cleanup,
-        "test setup should leave the first daemon unreachable through the socket"
-    );
-
-    let cleanup = run_coven(&coven, &coven_home, &path, &["daemon", "start"])?;
-    assert_success("daemon start cleanup", &cleanup);
-
-    wait_until("unreachable duplicate daemon cleanup", || {
-        Ok(!pid_is_alive(first_pid as u32))
-    })?;
+    let duplicate_status = duplicate.wait()?;
     assert!(
-        pid_is_alive(active_before_cleanup as u32),
-        "cleanup must preserve the daemon that owns the socket"
+        !duplicate_status.success(),
+        "duplicate serve should fail rather than take over the live socket"
     );
 
-    let _ = duplicate.kill();
-    let _ = duplicate.wait();
+    // The incumbent is untouched: still the recorded owner, still healthy, and the
+    // refused duplicate must not have clobbered daemon.json on its way out.
+    wait_for_daemon_health(&coven_home)?;
+    assert_eq!(
+        first_pid,
+        daemon_status_pid(&coven_home)?,
+        "incumbent must remain the recorded socket owner after a refused takeover"
+    );
+    assert!(
+        pid_is_alive(first_pid as u32),
+        "incumbent daemon must stay alive after a refused takeover"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Symptom

The daemon would not stay connected. On a live machine the cause was a **swarm of ~20 `coven daemon serve` processes** sharing one socket (`~/.coven/coven.sock`), with the active one flooding `~/.coven/daemon-recovery.log` every few seconds with `failed to set read timeout on Unix socket: Invalid argument (os error 22)` and `Broken pipe`. Two distinct bugs combine to produce this; this PR fixes both.

## Bug 1 — socket takeover orphans the incumbent (commit 1)

`bind_api_socket` unconditionally `remove_file`'d and rebound any existing user-owned socket. A second `coven daemon serve` would unlink the incumbent's socket inode and take over the path — **but the incumbent kept running** on the now-unlinked inode, never exiting. Every takeover leaked another zombie, so one daemon multiplied into dozens fighting over the path. `cleanup_unreachable_duplicate_daemons` only runs on `daemon start` and only reaps processes with a matching `COVEN_HOME=` in their environ, so daemons from other spawn paths / older binaries slipped through.

**Fix:** probe the existing socket's `/health` before reclaiming it. If a live daemon answers, bail (`refusing to take over`) instead of orphaning it. Only a dead/stale socket (connection refused, or non-ok health body) is reclaimed — so crash recovery and `daemon restart` are unaffected.

## Bug 2 — set_read_timeout failure aborts the connection (commit 2)

`serve_next_connection` treated `set_read_timeout`/`set_write_timeout` failures as fatal (`.context(...)?`). On macOS `setsockopt(SO_RCVTIMEO)` returns EINVAL for certain accepted fds — notably during the reconnect churn right after a restart, when polling clients (CovenCave) re-dial stale keep-alive connections. So connections were dropped, and the log flooded, at exactly the moment the daemon was recovering — the client saw constant flapping.

**Fix:** set the I/O timeouts best-effort and serve the request regardless, mirroring the named-pipe path which already does `let _ = stream.set_recv_timeout(...)`. The timeout is an optimization against a stalled client, not a precondition for serving.

## Tests

- `bind_api_socket_refuses_to_take_over_a_healthy_incumbent` — a live health-answering listener; a second bind bails and names the incumbent pid.
- `bind_api_socket_reclaims_a_dead_socket_file` — bind, drop the listener (file lingers, unserved); the next bind reclaims it.

`cargo fmt --check`, `cargo clippy -p coven-cli --all-targets`, `cargo test -p coven-cli daemon::` all clean (50 daemon tests pass).

> Note: Bug 2's EINVAL is intermittent (tied to restart/reconnect churn), so a clean live before/after wasn't capturable in the moment; the change only relaxes a fatal error to best-effort and is covered for the normal-serving path by the bind tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)