### PR TITLE
fix(cli): make Hermes adapter setup discoverable

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -480,7 +480,8 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         .collect();
     if !supported.contains(&harness.as_str()) {
         anyhow::bail!(
-            "harness `{harness}` is not a supported harness; expected one of {supported:?}"
+            "{}",
+            crate::harness::unsupported_harness_message(&harness, &supported)
         );
     }
     let launch_mode = launch_mode_from_payload(&payload)?;
@@ -2004,8 +2005,15 @@ mod tests {
 
         assert_eq!(response.status, 400);
         assert!(
-            response.body.contains("not a supported harness"),
-            "expected supported-harness validation message, got: {}",
+            response.body.contains("unsupported harness `hermes`"),
+            "expected unsupported-harness validation message, got: {}",
+            response.body
+        );
+        assert!(
+            response
+                .body
+                .contains(crate::harness::EXTERNAL_ADAPTER_MANIFEST_ENV),
+            "expected external adapter manifest guidance, got: {}",
             response.body
         );
         assert!(

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 pub const EXTERNAL_ADAPTER_MANIFEST_ENV: &str = "COVEN_HARNESS_ADAPTER_MANIFEST";
 pub const EXTERNAL_ADAPTER_DIRS_ENV: &str = "COVEN_HARNESS_ADAPTER_DIRS";
 pub const CLAUDE_BYPASS_PERMISSIONS_ENV: &str = "COVEN_CLAUDE_BYPASS_PERMISSIONS";
+pub const TRUSTED_ADAPTERS_DIR_NAME: &str = "adapters";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HarnessSummary {
@@ -285,6 +286,20 @@ pub fn configured_harnesses() -> Result<Vec<HarnessSummary>> {
         .collect())
 }
 
+pub fn unsupported_harness_message(harness_id: &str, configured_ids: &[&str]) -> String {
+    let configured = if configured_ids.is_empty() {
+        "(none)".to_string()
+    } else {
+        configured_ids.join(", ")
+    };
+    format!(
+        "unsupported harness `{harness_id}`. Configured harnesses: {configured}. \
+To use Hermes, run `coven adapter install hermes`, then `coven adapter doctor hermes`. \
+For other external harnesses, create a trusted adapter manifest under COVEN_HOME/{TRUSTED_ADAPTERS_DIR_NAME} \
+or set {EXTERNAL_ADAPTER_MANIFEST_ENV} / {EXTERNAL_ADAPTER_DIRS_ENV} before starting Coven."
+    )
+}
+
 fn external_harness_specs() -> Result<Vec<HarnessCommandSpec>> {
     let built_ins = built_in_harness_specs();
     let mut specs = Vec::new();
@@ -308,6 +323,12 @@ fn external_harness_specs() -> Result<Vec<HarnessCommandSpec>> {
 fn external_adapter_manifest_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
+    if let Some(coven_home) = coven_home_from_process_env() {
+        paths.extend(adapter_manifest_paths_in_dir(&trusted_adapter_dir(
+            &coven_home,
+        )));
+    }
+
     if let Some(manifest_path) = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV) {
         paths.push(PathBuf::from(manifest_path));
     }
@@ -323,6 +344,21 @@ fn external_adapter_manifest_paths() -> Vec<PathBuf> {
         .into_iter()
         .filter(|path| seen.insert(path.clone()))
         .collect()
+}
+
+pub fn trusted_adapter_dir(coven_home: &Path) -> PathBuf {
+    coven_home.join(TRUSTED_ADAPTERS_DIR_NAME)
+}
+
+pub fn trusted_adapter_manifest_path(coven_home: &Path, adapter_id: &str) -> PathBuf {
+    trusted_adapter_dir(coven_home).join(format!("{adapter_id}.json"))
+}
+
+fn coven_home_from_process_env() -> Option<PathBuf> {
+    env::var_os("COVEN_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs_next::home_dir().map(|home| home.join(crate::DEFAULT_COVEN_HOME_DIR)))
 }
 
 fn adapter_manifest_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
@@ -342,6 +378,32 @@ fn adapter_manifest_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
         .collect();
     paths.sort();
     paths
+}
+
+pub fn known_adapter_manifest(adapter_id: &str) -> Option<&'static str> {
+    match adapter_id {
+        "hermes" => Some(HERMES_ADAPTER_MANIFEST),
+        _ => None,
+    }
+}
+
+const HERMES_ADAPTER_MANIFEST: &str = r#"{
+  "adapters": [
+    {
+      "id": "hermes",
+      "label": "Hermes Agent",
+      "executable": "hermes",
+      "interactive_prompt_prefix_args": ["chat", "--source", "coven", "-q"],
+      "non_interactive_prompt_prefix_args": ["chat", "--source", "coven", "-Q", "-q"],
+      "install_hint": "Install Hermes Agent, add it to PATH, and complete Hermes setup before using this adapter.",
+      "system_prompt_flag": null
+    }
+  ]
+}
+"#;
+
+pub fn known_adapter_recipe_names() -> &'static [&'static str] {
+    &["hermes"]
 }
 
 fn load_external_harness_specs(
@@ -537,10 +599,16 @@ pub fn command_parts_for_harness_with_conversation(
     familiar: Option<&FamiliarContext>,
     model: Option<&str>,
 ) -> Result<(String, Vec<String>)> {
-    let spec = configured_harness_specs()?
-        .into_iter()
+    let specs = configured_harness_specs()?;
+    let configured_ids = specs
+        .iter()
+        .map(|spec| spec.id.as_str())
+        .collect::<Vec<_>>();
+    let spec = specs
+        .iter()
         .find(|spec| spec.id == harness_id)
-        .ok_or_else(|| anyhow!("unsupported harness `{harness_id}`"))?;
+        .cloned()
+        .ok_or_else(|| anyhow!(unsupported_harness_message(harness_id, &configured_ids)))?;
     let program = spawn_executable_for_platform(&spec.executable);
 
     // Model selection forwards to the harness's native flag as a normal option
@@ -1123,6 +1191,17 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_harness_message_points_to_external_adapter_manifest() {
+        let message = unsupported_harness_message("hermes", &["codex", "claude"]);
+
+        assert!(message.contains("unsupported harness `hermes`"));
+        assert!(message.contains("Configured harnesses: codex, claude"));
+        assert!(message.contains(EXTERNAL_ADAPTER_MANIFEST_ENV));
+        assert!(message.contains(EXTERNAL_ADAPTER_DIRS_ENV));
+        assert!(message.contains("coven adapter doctor hermes"));
+    }
+
+    #[test]
     fn external_manifest_can_register_hermes_without_making_it_built_in() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let manifest = temp_dir.path().join("adapters.json");
@@ -1213,22 +1292,64 @@ mod tests {
     }
 
     #[test]
-    fn configured_harness_specs_ignore_default_adapter_directories_without_explicit_env(
-    ) -> anyhow::Result<()> {
+    fn configured_harness_specs_load_trusted_coven_home_adapter_directory() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-
-        let coven_home_adapters = temp_dir.path().join("coven-home").join("adapters");
-        fs::create_dir_all(&coven_home_adapters)?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = coven_home.join("adapters");
+        fs::create_dir_all(&adapter_dir)?;
         fs::write(
-            coven_home_adapters.join("evil.json"),
+            adapter_dir.join("hermes.json"),
             r#"{
               "adapters": [
                 {
-                  "id": "evilsh",
-                  "label": "Evil Shell",
-                  "executable": "sh",
-                  "interactive_prompt_prefix_args": ["-c"],
-                  "non_interactive_prompt_prefix_args": ["-c"],
+                  "id": "hermes",
+                  "label": "Hermes Agent",
+                  "executable": "hermes",
+                  "interactive_prompt_prefix_args": ["chat", "--source", "coven", "-q"],
+                  "non_interactive_prompt_prefix_args": ["chat", "--source", "coven", "-Q", "-q"],
+                  "install_hint": "Install Hermes Agent and put it on PATH.",
+                  "system_prompt_flag": null
+                }
+              ]
+            }"#,
+        )?;
+
+        let _guard = env_lock().lock().unwrap();
+        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
+        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+
+        let specs = configured_harness_specs()?;
+
+        let hermes = specs
+            .iter()
+            .find(|spec| spec.id == "hermes")
+            .expect("trusted COVEN_HOME adapter should load");
+        assert_eq!(hermes.label, "Hermes Agent");
+        assert_eq!(
+            hermes.manifest_path.as_deref(),
+            Some(adapter_dir.join("hermes.json").to_string_lossy().as_ref())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn configured_harness_specs_ignore_home_and_xdg_adapter_dirs_without_explicit_env(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let home_adapters = temp_dir.path().join("home").join(".coven").join("adapters");
+        fs::create_dir_all(&home_adapters)?;
+        fs::write(
+            home_adapters.join("home.json"),
+            r#"{
+              "adapters": [
+                {
+                  "id": "home-implicit",
+                  "label": "Home Implicit",
+                  "executable": "home-implicit",
+                  "interactive_prompt_prefix_args": [],
+                  "non_interactive_prompt_prefix_args": [],
                   "install_hint": "Do not load this implicitly.",
                   "system_prompt_flag": null
                 }
@@ -1236,29 +1357,42 @@ mod tests {
             }"#,
         )?;
 
-        let home_adapters = temp_dir.path().join("home").join(".coven").join("adapters");
-        fs::create_dir_all(&home_adapters)?;
-        fs::write(home_adapters.join("home.json"), r#"{ "adapters": [] }"#)?;
-
         let xdg_adapters = temp_dir
             .path()
             .join("config")
             .join("coven")
             .join("adapters");
         fs::create_dir_all(&xdg_adapters)?;
-        fs::write(xdg_adapters.join("xdg.json"), r#"{ "adapters": [] }"#)?;
+        fs::write(
+            xdg_adapters.join("xdg.json"),
+            r#"{
+              "adapters": [
+                {
+                  "id": "xdg-implicit",
+                  "label": "XDG Implicit",
+                  "executable": "xdg-implicit",
+                  "interactive_prompt_prefix_args": [],
+                  "non_interactive_prompt_prefix_args": [],
+                  "install_hint": "Do not load this implicitly.",
+                  "system_prompt_flag": null
+                }
+              ]
+            }"#,
+        )?;
 
         let _guard = env_lock().lock().unwrap();
         let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
         let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
-        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", temp_dir.path().join("coven-home"));
+        let _coven_home_guard =
+            EnvVarGuard::set("COVEN_HOME", temp_dir.path().join("empty-coven-home"));
         let _home_guard = EnvVarGuard::set("HOME", temp_dir.path().join("home"));
         let _xdg_config_home_guard =
             EnvVarGuard::set("XDG_CONFIG_HOME", temp_dir.path().join("config"));
 
         let specs = configured_harness_specs()?;
 
-        assert!(!specs.iter().any(|spec| spec.id == "evilsh"));
+        assert!(!specs.iter().any(|spec| spec.id == "home-implicit"));
+        assert!(!specs.iter().any(|spec| spec.id == "xdg-implicit"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -38,7 +38,7 @@ mod theme;
 mod tui;
 mod verification;
 
-const DEFAULT_COVEN_HOME_DIR: &str = ".coven";
+pub(crate) const DEFAULT_COVEN_HOME_DIR: &str = ".coven";
 pub(crate) const STORE_FILE_NAME: &str = "coven.sqlite3";
 const DEFAULT_SESSION_STATUS: &str = "created";
 const RUNNING_SESSION_STATUS: &str = "running";
@@ -253,6 +253,11 @@ enum AdapterCommand {
     Doctor {
         #[arg(help = "Adapter id to diagnose")]
         adapter: Option<String>,
+    },
+    #[command(about = "Install a trusted local adapter recipe")]
+    Install {
+        #[arg(help = "Adapter recipe to install, e.g. hermes")]
+        adapter: String,
     },
 }
 
@@ -745,6 +750,7 @@ fn run_adapter_command(command: AdapterCommand) -> Result<()> {
     match command {
         AdapterCommand::List { json } => run_adapter_list(json),
         AdapterCommand::Doctor { adapter } => run_adapter_doctor(adapter.as_deref()),
+        AdapterCommand::Install { adapter } => run_adapter_install(&adapter),
     }
 }
 
@@ -812,6 +818,47 @@ fn run_adapter_doctor(adapter: Option<&str>) -> Result<()> {
             println!("       {}", harness.install_hint);
         }
     }
+    Ok(())
+}
+
+fn run_adapter_install(adapter: &str) -> Result<()> {
+    let manifest = harness::known_adapter_manifest(adapter).ok_or_else(|| {
+        anyhow!(
+            "unknown adapter recipe `{adapter}`. Known recipes: {}",
+            harness::known_adapter_recipe_names().join(", ")
+        )
+    })?;
+    let coven_home = coven_home_dir()?;
+    let adapter_dir = harness::trusted_adapter_dir(&coven_home);
+    let manifest_path = harness::trusted_adapter_manifest_path(&coven_home, adapter);
+
+    std::fs::create_dir_all(&adapter_dir).with_context(|| {
+        format!(
+            "failed to create trusted adapter directory {}",
+            adapter_dir.display()
+        )
+    })?;
+    if manifest_path.exists() {
+        println!(
+            "Adapter `{adapter}` is already installed at {}",
+            manifest_path.display()
+        );
+    } else {
+        std::fs::write(&manifest_path, manifest).with_context(|| {
+            format!(
+                "failed to write trusted adapter manifest {}",
+                manifest_path.display()
+            )
+        })?;
+        println!(
+            "Installed adapter `{adapter}` at {}",
+            manifest_path.display()
+        );
+    }
+
+    println!("Next steps:");
+    println!("  coven adapter doctor {adapter}");
+    println!("  coven run {adapter} \"what is in this project?\"");
     Ok(())
 }
 
@@ -1815,14 +1862,14 @@ fn ensure_successful_http_response(response: &str) -> Result<()> {
 
 fn selected_available_harness(harness_id: &str) -> Result<harness::HarnessSummary> {
     let harnesses = harness::configured_harnesses()?;
-    let known_harnesses = harnesses
+    let configured_ids = harnesses
         .iter()
         .map(|harness| harness.id.as_str())
-        .collect::<Vec<_>>()
-        .join(", ");
+        .collect::<Vec<_>>();
     let selected = harnesses
-        .into_iter()
-        .find(|harness| harness.id == harness_id);
+        .iter()
+        .find(|harness| harness.id == harness_id)
+        .cloned();
 
     match selected {
         Some(harness) if harness.available => Ok(harness),
@@ -1832,7 +1879,8 @@ fn selected_available_harness(harness_id: &str) -> Result<harness::HarnessSummar
             harness.install_hint
         )),
         None => Err(anyhow!(
-            "unknown harness `{harness_id}`. Configured harnesses: {known_harnesses}"
+            "{}",
+            harness::unsupported_harness_message(harness_id, &configured_ids)
         )),
     }
 }
@@ -1875,17 +1923,53 @@ fn coven_store_path_if_exists() -> Result<Option<PathBuf>> {
 }
 
 fn coven_home_dir() -> Result<PathBuf> {
-    coven_home_from_env(std::env::var_os("COVEN_HOME"), std::env::var_os("HOME"))
+    coven_home_from_env(
+        std::env::var_os("COVEN_HOME"),
+        std::env::var_os("HOME"),
+        std::env::var_os("USERPROFILE"),
+        std::env::var_os("HOMEDRIVE"),
+        std::env::var_os("HOMEPATH"),
+        dirs_next::home_dir().map(OsString::from),
+    )
 }
 
-fn coven_home_from_env(coven_home: Option<OsString>, home: Option<OsString>) -> Result<PathBuf> {
+fn coven_home_from_env(
+    coven_home: Option<OsString>,
+    home: Option<OsString>,
+    user_profile: Option<OsString>,
+    home_drive: Option<OsString>,
+    home_path: Option<OsString>,
+    platform_home: Option<OsString>,
+) -> Result<PathBuf> {
     if let Some(coven_home) = coven_home.filter(|value| !value.is_empty()) {
         return Ok(PathBuf::from(coven_home));
     }
 
-    let home =
-        home.ok_or_else(|| anyhow!("HOME is not set; set COVEN_HOME to choose a store path"))?;
+    let home = home
+        .filter(|value| !value.is_empty())
+        .or_else(|| user_profile.filter(|value| !value.is_empty()))
+        .or_else(|| windows_home_from_drive_and_path(home_drive, home_path))
+        .or_else(|| platform_home.filter(|value| !value.is_empty()))
+        .ok_or_else(|| {
+            anyhow!(
+                "could not find a home directory for Coven. Set COVEN_HOME to choose a store path, \
+for example `COVEN_HOME=$HOME/.coven` on macOS/Linux or \
+`$env:COVEN_HOME=\"$env:USERPROFILE\\.coven\"` in PowerShell."
+            )
+        })?;
     Ok(PathBuf::from(home).join(DEFAULT_COVEN_HOME_DIR))
+}
+
+fn windows_home_from_drive_and_path(
+    home_drive: Option<OsString>,
+    home_path: Option<OsString>,
+) -> Option<OsString> {
+    let drive = home_drive?.into_string().ok()?;
+    let path = home_path?.into_string().ok()?;
+    if drive.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some(OsString::from(format!("{drive}{path}")))
 }
 
 #[cfg(test)]
@@ -1909,6 +1993,44 @@ mod tests {
         MagicalTuiMove, MagicalTuiRequest, MAGICAL_TUI_MAX_INNER_WIDTH,
     };
     use crossterm::event::KeyEventKind;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn restore_env_var(name: &str, previous: Option<OsString>) {
+        match previous {
+            Some(value) => std::env::set_var(name, value),
+            None => std::env::remove_var(name),
+        }
+    }
+
+    struct EnvVarGuard {
+        name: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: impl AsRef<OsStr>) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::set_var(name, value);
+            Self { name, previous }
+        }
+
+        fn remove(name: &'static str) -> Self {
+            let previous = std::env::var_os(name);
+            std::env::remove_var(name);
+            Self { name, previous }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            restore_env_var(self.name, self.previous.clone());
+        }
+    }
 
     #[test]
     fn tui_launcher_and_session_browser_are_owned_by_tui_modules() {
@@ -1987,6 +2109,10 @@ mod tests {
         let path = coven_home_from_env(
             Some(OsString::from("/tmp/custom-coven-home")),
             Some(OsString::from("/tmp/ignored-home")),
+            None,
+            None,
+            None,
+            None,
         )?;
 
         assert_eq!(path, PathBuf::from("/tmp/custom-coven-home"));
@@ -1995,9 +2121,34 @@ mod tests {
 
     #[test]
     fn coven_home_from_env_defaults_under_home() -> Result<()> {
-        let path = coven_home_from_env(None, Some(OsString::from("/tmp/user-home")))?;
+        let path = coven_home_from_env(
+            None,
+            Some(OsString::from("/tmp/user-home")),
+            None,
+            None,
+            None,
+            None,
+        )?;
 
         assert_eq!(path, PathBuf::from("/tmp/user-home").join(".coven"));
+        Ok(())
+    }
+
+    #[test]
+    fn coven_home_from_env_uses_windows_drive_and_path_when_needed() -> Result<()> {
+        let path = coven_home_from_env(
+            None,
+            None,
+            None,
+            Some(OsString::from("C:")),
+            Some(OsString::from("\\Users\\hostname")),
+            None,
+        )?;
+
+        assert_eq!(
+            path,
+            PathBuf::from("C:\\Users\\hostname").join(DEFAULT_COVEN_HOME_DIR)
+        );
         Ok(())
     }
 
@@ -2577,6 +2728,27 @@ mod tests {
             }) => assert_eq!(adapter.as_deref(), Some("claude")),
             other => panic!("expected adapter doctor command, got {other:?}"),
         }
+
+        let install = Cli::parse_from(["coven", "adapter", "install", "hermes"]);
+        match install.command {
+            Some(Command::Adapter {
+                command: AdapterCommand::Install { adapter },
+            }) => assert_eq!(adapter, "hermes"),
+            other => panic!("expected adapter install command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn coven_home_uses_userprofile_when_home_is_missing() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let user_profile = temp_dir.path().join("windows-user");
+        let _guard = env_lock().lock().unwrap();
+        let _coven_home = EnvVarGuard::remove("COVEN_HOME");
+        let _home = EnvVarGuard::remove("HOME");
+        let _user_profile = EnvVarGuard::set("USERPROFILE", &user_profile);
+
+        assert_eq!(coven_home_dir()?, user_profile.join(DEFAULT_COVEN_HOME_DIR));
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -308,6 +308,36 @@ fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
 }
 
 #[test]
+fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    let install = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["adapter", "install", "hermes"],
+    )?;
+
+    assert_success("adapter install hermes", &install);
+    assert_stdout_contains(
+        "adapter install hermes",
+        &install,
+        "Installed adapter `hermes`",
+    );
+    assert!(coven_home.join("adapters").join("hermes.json").exists());
+
+    let doctor = run_coven(&coven, &coven_home, &path, &["adapter", "doctor", "hermes"])?;
+
+    assert_success("adapter doctor hermes", &doctor);
+    assert_stdout_contains("adapter doctor hermes", &doctor, "Hermes Agent");
+    assert_stdout_contains("adapter doctor hermes", &doctor, "manifest:");
+    Ok(())
+}
+
+#[test]
 fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");

--- a/docs/harnesses/hermes.md
+++ b/docs/harnesses/hermes.md
@@ -3,34 +3,37 @@ summary: "Experimental Hermes adapter notes for the external manifest path."
 read_when:
   - Tracking the Hermes adapter roadmap
 title: "Hermes (experimental)"
-description: "Experimental Hermes adapter notes for Coven's external harness manifest path. Hermes is not a built-in Coven harness."
+description: "Experimental Hermes adapter notes for Coven's trusted local adapter recipe. Hermes is not a built-in Coven harness."
 ---
 
-Hermes is **not** a built-in Coven harness today. Do not describe it as supported by `coven doctor`, default fallback selection, CastCodes slash commands, or OpenClaw's default agent mapping.
+Hermes is **not** a built-in Coven harness today. Do not describe it as supported by default fallback selection, CastCodes slash commands, or OpenClaw's default agent mapping.
 
-Hermes can be used as a research target for the generic external adapter manifest once a maintainer has a real Hermes install to smoke test.
+Hermes can be used as a research target for the generic external adapter system once a maintainer has a real Hermes install to smoke test.
 
-## Experimental manifest
+## Install the local adapter recipe
 
-Set `COVEN_HARNESS_ADAPTER_MANIFEST` to a JSON file like this while testing:
+Use the bundled recipe instead of hand-writing a manifest:
 
-```json
-{
-  "adapters": [
-    {
-      "id": "hermes",
-      "label": "Hermes Agent",
-      "executable": "hermes",
-      "interactive_prompt_prefix_args": ["chat", "--source", "coven", "-q"],
-      "non_interactive_prompt_prefix_args": ["chat", "--source", "coven", "-Q", "-q"],
-      "install_hint": "Install Hermes Agent and complete Hermes setup before using this adapter.",
-      "system_prompt_flag": null
-    }
-  ]
-}
+```sh
+coven adapter install hermes
+coven adapter doctor hermes
+coven run hermes "what is in this project?"
 ```
 
-The manifest only proves command construction and explicit opt-in loading. It does not make Hermes a default adapter.
+`coven adapter install hermes` writes a trusted manifest to `COVEN_HOME/adapters/hermes.json`. Coven loads manifests from that Coven-owned trust store automatically, plus any manifests explicitly named with `COVEN_HARNESS_ADAPTER_MANIFEST` or `COVEN_HARNESS_ADAPTER_DIRS`.
+
+If Hermes is installed outside the daemon's `PATH`, add its directory to
+`PATH` before starting Coven. For example, a Raspberry Pi install at
+`/home/o/.local/bin/hermes` should expose `/home/o/.local/bin` to the Coven
+daemon; adapter manifests intentionally take executable names, not absolute
+paths.
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+coven adapter install hermes
+coven adapter doctor hermes
+coven run hermes "what is in this project?"
+```
 
 ## Promotion checklist
 

--- a/docs/install/coven-home.md
+++ b/docs/install/coven-home.md
@@ -6,4 +6,30 @@ title: "COVEN_HOME layout"
 description: "How to lay out COVEN_HOME on a fresh install: the SQLite ledger, append-only event log, sockets, and per-session directories the daemon expects."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+`COVEN_HOME` is Coven's local state directory. If you do not set it, Coven uses `<home>/.coven`.
+
+Coven resolves `<home>` from the normal platform home directory. On Windows this includes `USERPROFILE` and `HOMEDRIVE` + `HOMEPATH`, so `coven doctor` should not require a Unix-style `HOME` variable.
+
+The directory contains:
+
+- `coven.sqlite3` — the local session ledger;
+- `daemon.json` and daemon sockets/pipes — local daemon metadata;
+- `sessions/` and event logs — per-session artifacts;
+- `familiars.toml` — optional local familiar declarations;
+- `adapters/` — trusted local harness adapter manifests, including recipes created by `coven adapter install <id>`.
+
+Override it only when you want Coven state somewhere else:
+
+```sh
+export COVEN_HOME="$HOME/.coven"
+coven doctor
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven"
+coven doctor
+```
+
+See [Install overview](/install/index) for the broader install flow.

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -38,7 +38,15 @@ Install and authenticate at least one harness CLI before expecting `coven run` t
 
 ## Windows notes
 
+- `coven doctor` should work in PowerShell even when the `HOME` environment variable is absent. Coven resolves its default store from `COVEN_HOME`, `HOME`, `USERPROFILE`, `HOMEDRIVE` + `HOMEPATH`, or the platform home directory.
 - Keep `COVEN_HOME` on a local path owned by your Windows user when you override it.
+- To override the store path in PowerShell, use:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven"
+coven doctor
+```
+
 - Run Coven and your harness CLI from the same environment. A harness installed only inside WSL2 is not available to native Windows PowerShell unless you expose it separately.
 - If terminal input behaves oddly, update to the latest wrapper and run `coven tui` again. The Windows TUI filters key-press events so typed characters, arrows, and Enter should be handled once.
 


### PR DESCRIPTION
## Summary
- add `coven adapter install hermes` to write a trusted local Hermes adapter manifest
- load trusted adapter manifests from `COVEN_HOME/adapters/*.json` automatically
- improve unsupported-harness and Windows home-directory guidance for new users

## Verification
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p coven-cli`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`

Co-authored-by: Nova <nova@opencoven.ai>