### PR TITLE
fix(cli): add run reasoning flags and resilient FTS backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven run <harness> <prompt> --cwd <path>`    | Launch from a cwd inside the project root                        |
 | `coven run <harness> <prompt> --title <title>` | Set a readable session title                                     |
 | `coven run <harness> <prompt> --model <id>`    | Forward a model override to the harness                          |
+| `coven run <harness> <prompt> --think`         | Request deeper reasoning when the harness supports it            |
+| `coven run <harness> <prompt> --speed <level>` | Set a latency/reasoning hint: `fast`, `balanced`, or `thorough`  |
 | `coven run <harness> --continue`               | Resume the latest active session for this project                |
 | `coven run <harness> --continue <id>`          | Resume a specific session by id                                  |
 | `coven run <harness> <prompt> --detach`        | Create the session record without launching the harness          |

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -259,9 +259,9 @@ impl SessionRuntime for LiveSessionRuntime {
             launch.launch_mode,
             launch.conversation.as_ref(),
             familiar_ctx.as_ref(),
-            // The daemon launch path does not carry a model selection yet;
-            // `coven run --model` drives the foreground path. Default to None.
-            None,
+            // The daemon launch path does not carry model/think/speed selection
+            // yet; `coven run` drives those foreground flags.
+            crate::harness::HarnessLaunchOptions::default(),
         )?;
         let observer = self
             .coven_home

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -47,6 +47,53 @@ pub enum HarnessLaunchMode {
     Stream,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HarnessSpeed {
+    Fast,
+    Balanced,
+    Thorough,
+}
+
+impl HarnessSpeed {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "fast" => Ok(Self::Fast),
+            "balanced" => Ok(Self::Balanced),
+            "thorough" => Ok(Self::Thorough),
+            other => {
+                anyhow::bail!("invalid speed `{other}`; expected one of: fast, balanced, thorough")
+            }
+        }
+    }
+
+    fn claude_effort(self) -> &'static str {
+        match self {
+            Self::Fast => "low",
+            Self::Balanced => "medium",
+            Self::Thorough => "high",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HarnessLaunchOptions<'a> {
+    pub model: Option<&'a str>,
+    pub think: bool,
+    pub speed: Option<HarnessSpeed>,
+}
+
+impl<'a> HarnessLaunchOptions<'a> {
+    fn normalized_model(self) -> Option<&'a str> {
+        self.model.map(str::trim).filter(|m| !m.is_empty())
+    }
+
+    pub(crate) fn claude_effort(self) -> Option<&'static str> {
+        self.speed
+            .map(HarnessSpeed::claude_effort)
+            .or_else(|| self.think.then_some("high"))
+    }
+}
+
 /// Whether the harness CLI has a long-lived JSON-streaming mode the daemon
 /// can keep alive across chat turns. Claude does (`stream-json`); codex
 /// doesn't (only one-shot `codex exec`). Unix kills the stream process tree
@@ -84,6 +131,14 @@ impl ConversationHint {
 /// session ids (e.g. codex) return `false`; the chat app captures the id from
 /// the first turn's output instead. See `docs/chat-persistence.md`.
 pub fn harness_supports_preassigned_session_id(harness_id: &str) -> bool {
+    harness_id == "claude"
+}
+
+pub fn harness_supports_think(harness_id: &str) -> bool {
+    harness_id == "claude"
+}
+
+pub fn harness_supports_speed(harness_id: &str) -> bool {
     harness_id == "claude"
 }
 
@@ -540,7 +595,14 @@ pub fn command_parts_for_harness(
     prompt: &str,
     mode: HarnessLaunchMode,
 ) -> Result<(String, Vec<String>)> {
-    command_parts_for_harness_with_conversation(harness_id, prompt, mode, None, None, None)
+    command_parts_for_harness_with_conversation(
+        harness_id,
+        prompt,
+        mode,
+        None,
+        None,
+        HarnessLaunchOptions::default(),
+    )
 }
 
 /// Claude Code prompts before running tool calls that aren't pre-allowlisted.
@@ -597,7 +659,7 @@ pub fn command_parts_for_harness_with_conversation(
     mode: HarnessLaunchMode,
     hint: Option<&ConversationHint>,
     familiar: Option<&FamiliarContext>,
-    model: Option<&str>,
+    options: HarnessLaunchOptions<'_>,
 ) -> Result<(String, Vec<String>)> {
     let specs = configured_harness_specs()?;
     let configured_ids = specs
@@ -614,10 +676,11 @@ pub fn command_parts_for_harness_with_conversation(
     // Model selection forwards to the harness's native flag as a normal option
     // ahead of the prompt positional. Adapters that declare no model mechanism
     // yield no args (the run layer warns); a blank/missing model is a no-op.
-    let model_args: Vec<String> = match model.map(str::trim) {
+    let model_args: Vec<String> = match options.normalized_model() {
         Some(m) if !m.is_empty() => spec.model_args(m),
         _ => Vec::new(),
     };
+    let launch_option_args = launch_option_args(harness_id, options);
 
     // Resolve effective prompt: inject familiar identity preamble when present.
     // Harnesses with a dedicated --system-prompt flag get identity there instead,
@@ -644,7 +707,11 @@ pub fn command_parts_for_harness_with_conversation(
                 program,
                 with_claude_permission_flags(
                     harness_id,
-                    sanitize_argv_for_platform(prepend_model_args(&model_args, args)),
+                    sanitize_argv_for_platform(prepend_launch_args(
+                        &model_args,
+                        &launch_option_args,
+                        args,
+                    )),
                 ),
             ));
         }
@@ -653,8 +720,9 @@ pub fn command_parts_for_harness_with_conversation(
             program,
             with_claude_permission_flags(
                 harness_id,
-                sanitize_argv_for_platform(prepend_model_args(
+                sanitize_argv_for_platform(prepend_launch_args(
                     &model_args,
+                    &launch_option_args,
                     spec.prompt_args(&effective_prompt, HarnessLaunchMode::NonInteractive),
                 )),
             ),
@@ -668,8 +736,9 @@ pub fn command_parts_for_harness_with_conversation(
                 args.insert(0, f.identity_preamble());
                 args.insert(0, flag.to_string());
             }
-            let args = prepend_model_args(
+            let args = prepend_launch_args(
                 &model_args,
+                &launch_option_args,
                 args.into_iter()
                     .chain(std::iter::once(effective_prompt))
                     .collect(),
@@ -689,20 +758,35 @@ pub fn command_parts_for_harness_with_conversation(
         program,
         with_claude_permission_flags(
             harness_id,
-            sanitize_argv_for_platform(prepend_model_args(&model_args, args)),
+            sanitize_argv_for_platform(prepend_launch_args(&model_args, &launch_option_args, args)),
         ),
     ))
 }
 
-/// Prepend resolved model argv tokens ahead of `args` (which ends with the
-/// prompt positional). Keeps `--model` parsing before the prompt, matching how
-/// Cave emits the flag.
-fn prepend_model_args(model_args: &[String], args: Vec<String>) -> Vec<String> {
-    if model_args.is_empty() {
+fn launch_option_args(harness_id: &str, options: HarnessLaunchOptions<'_>) -> Vec<String> {
+    if harness_id != "claude" {
+        return Vec::new();
+    }
+    options
+        .claude_effort()
+        .map(|effort| vec!["--effort".to_string(), effort.to_string()])
+        .unwrap_or_default()
+}
+
+/// Prepend resolved launch argv tokens ahead of `args` (which ends with the
+/// prompt positional). Keeps Coven-managed options before the prompt, matching
+/// how Cave emits run flags.
+fn prepend_launch_args(
+    model_args: &[String],
+    option_args: &[String],
+    args: Vec<String>,
+) -> Vec<String> {
+    if model_args.is_empty() && option_args.is_empty() {
         return args;
     }
-    let mut out = Vec::with_capacity(model_args.len() + args.len());
+    let mut out = Vec::with_capacity(model_args.len() + option_args.len() + args.len());
     out.extend_from_slice(model_args);
+    out.extend_from_slice(option_args);
     out.extend(args);
     out
 }
@@ -1458,7 +1542,7 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             Some(&hint),
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         assert_eq!(
             parts,
@@ -1486,7 +1570,7 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             Some(&hint),
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         assert_eq!(
             parts,
@@ -1514,7 +1598,7 @@ mod tests {
             HarnessLaunchMode::Interactive,
             Some(&hint),
             None,
-            None,
+            HarnessLaunchOptions::default(),
         );
         assert_eq!(
             parts.unwrap(),
@@ -1535,7 +1619,7 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             Some(&hint),
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         assert_eq!(
             parts,
@@ -1564,7 +1648,7 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             Some(&hint),
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         assert_eq!(
             parts,
@@ -1592,7 +1676,7 @@ mod tests {
             HarnessLaunchMode::Stream,
             None,
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         assert_eq!(program, "claude");
         assert!(!args
@@ -1683,7 +1767,10 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            Some("openai/gpt-5.5"),
+            HarnessLaunchOptions {
+                model: Some("openai/gpt-5.5"),
+                ..Default::default()
+            },
         )?;
         assert_eq!(program, "codex");
         assert_eq!(
@@ -1713,7 +1800,10 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            Some("anthropic/claude-sonnet-4"),
+            HarnessLaunchOptions {
+                model: Some("anthropic/claude-sonnet-4"),
+                ..Default::default()
+            },
         )?;
         assert_eq!(
             args,
@@ -1728,6 +1818,82 @@ mod tests {
     }
 
     #[test]
+    fn claude_think_maps_to_effort_high() -> anyhow::Result<()> {
+        let (_, args) = command_parts_for_harness_with_conversation(
+            "claude",
+            "hi",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                think: true,
+                ..Default::default()
+            },
+        )?;
+        assert_eq!(
+            args,
+            vec![
+                "--effort".to_string(),
+                "high".to_string(),
+                "--print".to_string(),
+                "hi".to_string(),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn claude_speed_maps_to_effort_levels() -> anyhow::Result<()> {
+        let (_, fast_args) = command_parts_for_harness_with_conversation(
+            "claude",
+            "hi",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                speed: Some(HarnessSpeed::Fast),
+                ..Default::default()
+            },
+        )?;
+        let (_, thorough_args) = command_parts_for_harness_with_conversation(
+            "claude",
+            "hi",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                speed: Some(HarnessSpeed::Thorough),
+                ..Default::default()
+            },
+        )?;
+
+        assert_eq!(fast_args[0..2], ["--effort", "low"]);
+        assert_eq!(thorough_args[0..2], ["--effort", "high"]);
+        Ok(())
+    }
+
+    #[test]
+    fn codex_ignores_think_and_speed_launch_hints() -> anyhow::Result<()> {
+        let with_hints = command_parts_for_harness_with_conversation(
+            "codex",
+            "fix tests",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                think: true,
+                speed: Some(HarnessSpeed::Thorough),
+                ..Default::default()
+            },
+        )?;
+        let legacy =
+            command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?;
+
+        assert_eq!(with_hints, legacy);
+        Ok(())
+    }
+
+    #[test]
     fn no_model_leaves_args_unchanged() -> anyhow::Result<()> {
         let with_model = command_parts_for_harness_with_conversation(
             "codex",
@@ -1735,7 +1901,7 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         let blank_model = command_parts_for_harness_with_conversation(
             "codex",
@@ -1743,7 +1909,10 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            Some("   "),
+            HarnessLaunchOptions {
+                model: Some("   "),
+                ..Default::default()
+            },
         )?;
         let legacy =
             command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?;
@@ -1782,7 +1951,10 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            Some("openai/gpt-5.5"),
+            HarnessLaunchOptions {
+                model: Some("openai/gpt-5.5"),
+                ..Default::default()
+            },
         );
         restore_adapter_manifest_env(previous);
 
@@ -1835,7 +2007,10 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            Some("openai/gpt-5.5"),
+            HarnessLaunchOptions {
+                model: Some("openai/gpt-5.5"),
+                ..Default::default()
+            },
         );
         restore_adapter_manifest_env(previous);
 
@@ -1859,7 +2034,7 @@ mod tests {
             HarnessLaunchMode::NonInteractive,
             None,
             None,
-            None,
+            HarnessLaunchOptions::default(),
         )?;
         let legacy =
             command_parts_for_harness("claude", "hello", HarnessLaunchMode::NonInteractive)?;

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -135,6 +135,18 @@ enum Command {
         model: Option<String>,
         #[arg(
             long,
+            help = "Request deeper reasoning when the harness supports it. Unsupported harnesses warn and continue."
+        )]
+        think: bool,
+        #[arg(
+            long,
+            value_name = "LEVEL",
+            value_parser = ["fast", "balanced", "thorough"],
+            help = "Latency/reasoning hint: fast, balanced, or thorough. Unsupported harnesses warn and continue."
+        )]
+        speed: Option<String>,
+        #[arg(
+            long,
             help = "Emit JSONL events on stdout (system.init / user / assistant / tool_result / result)"
         )]
         stream_json: bool,
@@ -379,6 +391,8 @@ fn run_cli(cli: Cli) -> Result<()> {
             archive,
             familiar,
             model,
+            think,
+            speed,
             stream_json,
             stream_json_input,
         }) => run_session(
@@ -393,6 +407,8 @@ fn run_cli(cli: Cli) -> Result<()> {
             archive,
             familiar.as_deref(),
             model.as_deref(),
+            think,
+            speed.as_deref(),
             stream_json,
             stream_json_input,
         ),
@@ -1349,6 +1365,8 @@ fn run_session(
     archive: bool,
     familiar_id: Option<&str>,
     model: Option<&str>,
+    think: bool,
+    speed: Option<&str>,
     stream_json: bool,
     stream_json_input: bool,
 ) -> Result<()> {
@@ -1404,6 +1422,7 @@ fn run_session(
     // mechanism warn (don't error) so a selection degrades gracefully. A blank
     // value is ignored.
     let requested_model: Option<&str> = model.map(str::trim).filter(|m| !m.is_empty());
+    let requested_speed = speed.map(harness::HarnessSpeed::parse).transpose()?;
     if let (Some(requested), Some(s)) = (requested_model, spec.as_ref()) {
         if !s.supports_model() {
             eprintln!(
@@ -1413,6 +1432,30 @@ fn run_session(
             );
         }
     }
+    if think && !harness::harness_supports_think(&selected_harness.id) {
+        eprintln!(
+            "warning: harness `{}` does not support --think; ignoring the request",
+            selected_harness.id
+        );
+    }
+    if let Some(speed) = requested_speed {
+        if !harness::harness_supports_speed(&selected_harness.id) {
+            eprintln!(
+                "warning: harness `{}` does not support --speed {}; ignoring the request",
+                selected_harness.id,
+                match speed {
+                    harness::HarnessSpeed::Fast => "fast",
+                    harness::HarnessSpeed::Balanced => "balanced",
+                    harness::HarnessSpeed::Thorough => "thorough",
+                }
+            );
+        }
+    }
+    let launch_options = harness::HarnessLaunchOptions {
+        model: requested_model,
+        think,
+        speed: requested_speed,
+    };
 
     let effective_prompt = match (&familiar_ctx, spec.as_ref()) {
         (Some(f), Some(s)) if s.system_prompt_flag.is_none() && !expanded_prompt.is_empty() => {
@@ -1572,7 +1615,7 @@ fn run_session(
             &effective_prompt,
             stream_json_input,
             claude_system_prompt.as_deref(),
-            requested_model,
+            launch_options,
             &mut handle,
         );
         drop(handle);
@@ -1660,7 +1703,7 @@ fn run_session(
         harness_launch_mode_for_stdio(),
         conversation_hint.as_ref(),
         familiar_for_args,
-        requested_model,
+        launch_options,
     )?;
     match pty_runner::run_attached(&command) {
         Ok(result) => {

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -59,7 +59,15 @@ pub fn build_harness_command(
     cwd: &Path,
     mode: crate::harness::HarnessLaunchMode,
 ) -> Result<HarnessCommand> {
-    build_harness_command_with_conversation(harness_id, prompt, cwd, mode, None, None, None)
+    build_harness_command_with_conversation(
+        harness_id,
+        prompt,
+        cwd,
+        mode,
+        None,
+        None,
+        crate::harness::HarnessLaunchOptions::default(),
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -70,7 +78,7 @@ pub fn build_harness_command_with_conversation(
     mode: crate::harness::HarnessLaunchMode,
     conversation: Option<&crate::harness::ConversationHint>,
     familiar: Option<&crate::harness::FamiliarContext>,
-    model: Option<&str>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
 ) -> Result<HarnessCommand> {
     let (program, args) = crate::harness::command_parts_for_harness_with_conversation(
         harness_id,
@@ -78,7 +86,7 @@ pub fn build_harness_command_with_conversation(
         mode,
         conversation,
         familiar,
-        model,
+        options,
     )?;
 
     Ok(HarnessCommand {
@@ -118,7 +126,7 @@ pub fn stream_claude<W: Write>(
     prompt: &str,
     forward_stdin: bool,
     system_prompt: Option<&str>,
-    model: Option<&str>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
     out: &mut W,
 ) -> Result<i32> {
     stream_claude_with_program(
@@ -129,7 +137,7 @@ pub fn stream_claude<W: Write>(
         prompt,
         forward_stdin,
         system_prompt,
-        model,
+        options,
         out,
     )
 }
@@ -143,7 +151,7 @@ fn stream_claude_with_program<W: Write>(
     prompt: &str,
     forward_stdin: bool,
     system_prompt: Option<&str>,
-    model: Option<&str>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
     out: &mut W,
 ) -> Result<i32> {
     stream_claude_with_program_and_permission_bypass(
@@ -154,7 +162,7 @@ fn stream_claude_with_program<W: Write>(
         prompt,
         forward_stdin,
         system_prompt,
-        model,
+        options,
         crate::harness::claude_permission_bypass_enabled(),
         out,
     )
@@ -169,7 +177,7 @@ fn stream_claude_with_program_and_permission_bypass<W: Write>(
     prompt: &str,
     forward_stdin: bool,
     system_prompt: Option<&str>,
-    model: Option<&str>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
     permission_bypass_enabled: bool,
     out: &mut W,
 ) -> Result<i32> {
@@ -182,7 +190,8 @@ fn stream_claude_with_program_and_permission_bypass<W: Write>(
     // `_The "claude" harness completed but produced no output._`
     // Strip the `provider/` namespace so claude's `--model` gets a bare id,
     // matching the non-stream path (`harness::normalize_model_id`).
-    let normalized_model: Option<&str> = model
+    let normalized_model: Option<&str> = options
+        .model
         .map(str::trim)
         .filter(|m| !m.is_empty())
         .map(crate::harness::normalize_model_id);
@@ -199,6 +208,9 @@ fn stream_claude_with_program_and_permission_bypass<W: Write>(
     }
     if let Some(m) = normalized_model {
         args.extend_from_slice(&["--model", m]);
+    }
+    if let Some(effort) = options.claude_effort() {
+        args.extend_from_slice(&["--effort", effort]);
     }
     args.extend_from_slice(&["--output-format", "stream-json", "--verbose"]);
     if is_resume {
@@ -718,7 +730,7 @@ exit 7
             "hello prompt",
             false,
             None,
-            None,
+            crate::harness::HarnessLaunchOptions::default(),
             &mut out,
         )?;
 
@@ -769,7 +781,7 @@ exit 0
             // MUST be present.
             true,
             None,
-            None,
+            crate::harness::HarnessLaunchOptions::default(),
             &mut out,
         )?;
 
@@ -808,7 +820,7 @@ exit 0
             "hello prompt",
             false,
             None,
-            None,
+            crate::harness::HarnessLaunchOptions::default(),
             true,
             &mut out,
         )?;
@@ -852,7 +864,7 @@ exit 0
             "hello again",
             false,
             None,
-            None,
+            crate::harness::HarnessLaunchOptions::default(),
             &mut out,
         )?;
 
@@ -892,13 +904,58 @@ exit 0
             false,
             None,
             // Namespaced id is normalized to the bare model before forwarding.
-            Some("anthropic/claude-sonnet-4"),
+            crate::harness::HarnessLaunchOptions {
+                model: Some("anthropic/claude-sonnet-4"),
+                ..Default::default()
+            },
             &mut out,
         )?;
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
             "-p\n--model\nclaude-sonnet-4\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_claude_forwards_think_as_effort_high() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_claude = temp_dir.path().join("fake-claude");
+        std::fs::write(
+            &fake_claude,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_claude)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_claude, permissions)?;
+
+        let mut out = Vec::new();
+        let _code = stream_claude_with_program(
+            fake_claude.to_str().unwrap(),
+            temp_dir.path(),
+            "session-123",
+            false,
+            "hello prompt",
+            false,
+            None,
+            crate::harness::HarnessLaunchOptions {
+                think: true,
+                ..Default::default()
+            },
+            &mut out,
+        )?;
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "-p\n--effort\nhigh\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -10,6 +10,9 @@ use crate::{
     privacy::{self, PrivacyConfig},
 };
 
+const FTS_BACKFILL_BATCH_SIZE: i64 = 1_000;
+const FTS_BACKFILL_COMPLETE_KEY: &str = "events_fts_backfill_complete";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionRecord {
     pub id: String,
@@ -106,15 +109,9 @@ pub fn open_store(path: &Path) -> Result<Connection> {
 
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
-    // WAL mode allows concurrent readers alongside a single writer and avoids
-    // "database is locked" errors under typical daemon + API concurrency.
-    // busy_timeout gives writers up to 5 s to retry before returning SQLITE_BUSY.
+    configure_writable_connection(&conn)?;
     conn.execute_batch(
-        "PRAGMA journal_mode = WAL;
-        PRAGMA busy_timeout = 5000;
-        PRAGMA foreign_keys = ON;
-
-        CREATE TABLE IF NOT EXISTS sessions (
+        "CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY NOT NULL,
             project_root TEXT NOT NULL,
             harness TEXT NOT NULL,
@@ -174,6 +171,11 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             updated_at TEXT NOT NULL
         );
 
+        CREATE TABLE IF NOT EXISTS store_meta (
+            key TEXT PRIMARY KEY NOT NULL,
+            value TEXT NOT NULL
+        );
+
         CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
             payload_json,
             content='events',
@@ -204,52 +206,81 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_visibility_column(&conn)?;
     ensure_familiar_id_column(&conn)?;
 
-    // Backfill: index any events that predate the FTS table (a one-time
-    // migration of a pre-FTS store). After the table+triggers exist, every new
-    // event is indexed by the `events_fts_insert` trigger, so this only matters
-    // on the first open after upgrade.
-    //
-    // Two things are deliberate here:
-    //
-    // 1. Probe with a READ before writing. `open_store` runs on EVERY
-    //    connection, and the daemon opens a fresh connection per API request
-    //    (see api.rs). An unconditional write means every request grabs the WAL
-    //    write lock just to open the store. Under concurrency (the chat bridge
-    //    firing several requests while the harness streams events) those opens
-    //    pile up on the single WAL writer; once the wait exceeds `busy_timeout`
-    //    the open fails with SQLITE_BUSY ("database is locked") and the whole
-    //    request dies. The probe takes only a SHARED lock and never contends
-    //    with the writer, so the steady-state open path does zero writes.
-    //
-    // 2. Rebuild via the FTS5 'rebuild' command, not an `INSERT ... SELECT`
-    //    dedup join. `events_fts` is an external-content table, so its `rowid`
-    //    resolves through the content (`events`) table — `LEFT JOIN events_fts
-    //    f ON f.rowid = e.rowid WHERE f.rowid IS NULL` is therefore ALWAYS
-    //    empty and the old backfill silently indexed nothing. 'rebuild'
-    //    repopulates the index from the content table the way FTS5 intends.
-    //
-    // The emptiness probe reads `events_fts_docsize` — FTS5's shadow table with
-    // one row per *indexed* document — not `events_fts` itself. A plain
-    // `SELECT ... FROM events_fts` walks the external content rowids and so
-    // looks non-empty even when nothing is indexed; `_docsize` reflects the
-    // real index, so it correctly reports "freshly created, never populated".
-    let index_is_empty: bool = conn
-        .query_row(
-            "SELECT NOT EXISTS(SELECT 1 FROM events_fts_docsize)",
-            [],
-            |row| row.get(0),
-        )
-        .context("failed to probe events_fts index state")?;
-    let has_events: bool = conn
-        .query_row("SELECT EXISTS(SELECT 1 FROM events)", [], |row| row.get(0))
-        .context("failed to probe events for backfill")?;
-
-    if index_is_empty && has_events {
-        conn.execute("INSERT INTO events_fts(events_fts) VALUES('rebuild')", [])
-            .context("failed to backfill events_fts")?;
-    }
+    backfill_events_fts_if_needed(&conn)?;
 
     Ok(conn)
+}
+
+fn configure_writable_connection(conn: &Connection) -> Result<()> {
+    // WAL mode allows concurrent readers alongside a single writer and avoids
+    // "database is locked" errors under typical daemon + API concurrency.
+    // busy_timeout gives writers up to 5 s to retry before returning SQLITE_BUSY.
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA busy_timeout = 5000;
+         PRAGMA foreign_keys = ON;",
+    )
+    .context("failed to configure writable Coven store connection")?;
+    Ok(())
+}
+
+fn configure_read_only_connection(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "PRAGMA busy_timeout = 5000;
+         PRAGMA foreign_keys = ON;",
+    )
+    .context("failed to configure read-only Coven store connection")?;
+    Ok(())
+}
+
+fn backfill_events_fts_if_needed(conn: &Connection) -> Result<()> {
+    let already_complete: Option<String> = conn
+        .query_row(
+            "SELECT value FROM store_meta WHERE key = ?1",
+            [FTS_BACKFILL_COMPLETE_KEY],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("failed to read events_fts backfill state")?;
+    if already_complete.as_deref() == Some("1") {
+        return Ok(());
+    }
+
+    loop {
+        let inserted = match conn.execute(
+            "INSERT INTO events_fts(rowid, payload_json)
+             SELECT e.rowid, e.payload_json
+             FROM events e
+             LEFT JOIN events_fts_docsize d ON d.id = e.rowid
+             WHERE d.id IS NULL
+             ORDER BY e.rowid
+             LIMIT ?1",
+            [FTS_BACKFILL_BATCH_SIZE],
+        ) {
+            Ok(inserted) => inserted,
+            Err(error) => {
+                eprintln!(
+                    "warning: events_fts backfill skipped for now; session dispatch will continue ({error})"
+                );
+                return Ok(());
+            }
+        };
+        if inserted == 0 {
+            break;
+        }
+    }
+
+    if let Err(error) = conn.execute(
+        "INSERT INTO store_meta(key, value)
+         VALUES(?1, '1')
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        [FTS_BACKFILL_COMPLETE_KEY],
+    ) {
+        eprintln!(
+            "warning: events_fts backfill completed but could not record completion ({error})"
+        );
+    }
+    Ok(())
 }
 
 fn ensure_event_privacy_columns(conn: &Connection) -> Result<()> {
@@ -318,6 +349,7 @@ pub fn open_existing_store_read_only(path: &Path) -> Result<Option<Connection>> 
 
     let conn = Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
         .with_context(|| format!("failed to open Coven store read-only at {}", path.display()))?;
+    configure_read_only_connection(&conn)?;
     Ok(Some(conn))
 }
 
@@ -2023,6 +2055,49 @@ mod tests {
         drop(upgraded);
         let reopened = open_store(&path)?;
         assert_eq!(search_events(&reopened, "phoenix")?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn events_fts_backfill_busy_is_non_fatal() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("test.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "event-1".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"data":"phoenix rises"}"#.to_string(),
+                created_at: "2026-04-27T06:01:00Z".to_string(),
+            },
+        )?;
+        conn.execute(
+            "INSERT INTO events_fts(events_fts) VALUES('delete-all')",
+            [],
+        )?;
+        conn.execute(
+            "DELETE FROM store_meta WHERE key = 'events_fts_backfill_complete'",
+            [],
+        )?;
+        conn.execute_batch("PRAGMA busy_timeout = 1")?;
+
+        let locker = Connection::open(&path)?;
+        locker.execute_batch("PRAGMA busy_timeout = 1; BEGIN IMMEDIATE")?;
+
+        backfill_events_fts_if_needed(&conn)?;
+
+        let complete: Option<String> = conn
+            .query_row(
+                "SELECT value FROM store_meta WHERE key = 'events_fts_backfill_complete'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()?;
+        assert_eq!(complete, None);
         Ok(())
     }
 

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1206,6 +1206,8 @@ fn dispatch_via_local_pty(
         // model: the cast/shell path does not select a model.
         None,
         false,
+        None,
+        false,
         false,
     )?;
     let mut notes = plan_outcome_notes(plan);
@@ -1895,6 +1897,8 @@ fn run_guided_harness_session() -> Result<()> {
         false,
         None,
         // model: the cast/shell path does not select a model.
+        None,
+        false,
         None,
         false,
         false,

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -31,6 +31,7 @@ The default command opens the prompt-first TUI. You can also use the explicit CL
 coven doctor
 coven daemon start
 coven run codex "fix the failing tests"
+coven run claude "audit this branch" --think
 coven sessions
 ```
 

--- a/docs/reference/cli-run.md
+++ b/docs/reference/cli-run.md
@@ -6,4 +6,36 @@ title: "coven run"
 description: "Reference for coven run: one-shot harness execution that spawns a session, streams events, and records the result in the Coven ledger."
 ---
 
-Stub — fill in.
+## Usage
+
+```bash
+coven run <harness> <prompt> [flags]
+```
+
+`<harness>` is a configured harness id such as `codex` or `claude`.
+
+## Common Flags
+
+| Flag | Behavior |
+|---|---|
+| `--cwd <path>` | Launch from a directory inside the resolved project root. |
+| `--title <text>` | Store a readable session title. |
+| `--model <id>` | Forward a model override to harnesses that declare model support. Namespaced ids such as `anthropic/claude-sonnet-4` are forwarded to the harness as the bare model id. |
+| `--think` | Request deeper reasoning. Claude maps this to `--effort high`; unsupported harnesses warn and continue. |
+| `--speed <level>` | Set a latency/reasoning hint: `fast`, `balanced`, or `thorough`. Claude maps these to `--effort low`, `medium`, or `high`; unsupported harnesses warn and continue. |
+| `--detach` | Create the session record without launching the harness. |
+| `--continue [id]` | Resume a specific session, or the latest active session for this project when `id` is omitted. |
+| `--labels <a,b>` | Attach comma-separated labels to a new session. |
+| `--visibility <private\|workspace\|shared>` | Set session visibility metadata. |
+| `--archive` | Archive the session after the run completes. |
+| `--familiar <id>` | Inject familiar identity context. |
+| `--stream-json` | Emit Coven JSONL events on stdout. |
+| `--stream-json-input` | With `--stream-json`, read JSONL user messages from stdin for Claude stream mode. |
+
+Examples:
+
+```bash
+coven run claude "audit this branch" --think
+coven run claude "make the smallest fix" --speed fast
+coven run codex "fix the failing tests" --speed thorough
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,7 +92,7 @@ flowchart TB
 
 | Command | Flags |
 |---|---|
-| `coven run` | `--cwd <path>`, `--title <text>`, `--detach` |
+| `coven run` | `--cwd <path>`, `--title <text>`, `--detach`, `--model <id>`, `--think`, `--speed fast\|balanced\|thorough` |
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sacrifice` | `--yes` (required) |
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |


### PR DESCRIPTION
## Summary
- add `coven run --think` and `--speed fast|balanced|thorough`, mapping Claude to `--effort` and warning/no-oping unsupported harnesses
- carry launch options through foreground and Claude stream-json paths while preserving existing model passthrough behavior
- make `events_fts` backfill batched, best-effort, and non-fatal under SQLITE_BUSY, with completion tracking and read-only busy timeout setup
- update run command docs and README command reference

Closes #246
Fixes #249

## Test Plan
- [x] `cargo test -p coven-cli`
- [x] `cargo clippy -p coven-cli -- -D warnings`
- [x] `git diff --check HEAD^..HEAD`
- [x] repeated the same verification in a clean detached worktree for commit `44f8f37`