### PR TITLE
docs: roll out v0.0.48 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The Rust daemon is the authority boundary. All clients — including the CLI its
 | ---------------------------- | --------------------------------------------------------------------------- |
 | **Rust stable toolchain**    | Required only when building from source                                     |
 | **Git**                      | Required                                                                    |
-| **macOS or Linux**           | Daemon socket and PTY behavior; Windows x64 support staged for next release |
+| **macOS, Linux, or Windows x64** | Native npm packages are published for all three platforms                  |
 | **Node.js 18+**              | Required only for npm wrapper or package/plugin development                 |
 | **At least one harness CLI** | Codex and/or Claude Code (see below)                                        |
 
@@ -151,7 +151,7 @@ coven doctor
 | `@opencoven/cli`           | Universal wrapper — auto-selects your platform |
 | `@opencoven/cli-macos`     | macOS (arm64 + x64)                            |
 | `@opencoven/cli-linux-x64` | Linux x64                                      |
-| `@opencoven/cli-windows`   | Windows x64 (staging for next release)         |
+| `@opencoven/cli-windows`   | Windows x64                                    |
 
 ### Build from source (recommended for contributors)
 
@@ -611,7 +611,7 @@ No. Coven itself is fully local. Your harness CLIs (Codex, Claude Code) require 
 
 **Q: Is Windows supported?**
 
-The `@opencoven/cli-windows` package is staged for the next release. The daemon socket and PTY behavior currently target macOS and Linux. Adventurous Windows users may build from source.
+Yes. `@opencoven/cli-windows` ships a native Windows x64 binary, and the universal `@opencoven/cli` wrapper selects it automatically. Run `coven doctor` from the same PowerShell, Windows Terminal, or WSL2 environment where your harness CLI is installed.
 
 **Q: What is `coven pc`?**
 

--- a/docs/es/reference/release-notes.md
+++ b/docs/es/reference/release-notes.md
@@ -6,6 +6,23 @@ read_when:
 title: "Changelog y notas de release de Coven"
 ---
 
+## Semana del 18 de junio de 2026
+
+### Nuevas funcionalidades
+
+- **Controles de razonamiento para `coven run` (v0.0.48).** `coven run` ahora acepta `--think` y `--speed fast|balanced|thorough` junto con `--model`. Los lanzamientos de Claude traducen esos hints a `--effort`; los harnesses sin soporte avisan y continúan en vez de fallar. Consulta [issue #246](https://github.com/OpenCoven/coven/issues/246), [PR #254](https://github.com/OpenCoven/coven/pull/254) y [referencia de `coven run`](/reference/cli-run).
+- **Receta confiable del adaptador Hermes (v0.0.41).** `coven adapter install hermes` ahora escribe un manifiesto confiable local bajo `COVEN_HOME/adapters/hermes.json`, y Coven carga automáticamente manifiestos desde ese trust store propio. Los usuarios nuevos ya no necesitan escribir JSON a mano ni configurar `COVEN_HARNESS_ADAPTER_MANIFEST` solo para probar Hermes.
+
+### Actualizaciones
+
+- **Estado del paquete Windows x64.** El README público ahora refleja que `@opencoven/cli-windows` ya está publicado, no en staging. En Windows se puede instalar con el wrapper universal `@opencoven/cli` y verificar los harnesses locales con `coven doctor`.
+
+### Correcciones de errores
+
+- **Backfill resiliente del índice FTS de eventos (v0.0.48).** El backfill de eventos existentes hacia `events_fts` ahora corre en lotes acotados, registra su finalización en `store_meta`, aplica `busy_timeout` a conexiones de lectura y trata `SQLITE_BUSY` como no fatal, de modo que la indexación de búsqueda no bloquea todos los lanzamientos de agentes en historiales grandes. Consulta [issue #249](https://github.com/OpenCoven/coven/issues/249) y [PR #254](https://github.com/OpenCoven/coven/pull/254).
+- **Guía más clara para harnesses no soportados.** Los errores de harness desconocido ahora muestran los IDs configurados y orientan a usuarios de Hermes hacia `coven adapter install hermes` seguido de `coven adapter doctor hermes`.
+- **Fallback de directorio home en Windows.** `coven doctor` y la resolución del store funcionan en PowerShell cuando `HOME` no existe, probando `USERPROFILE`, `HOMEDRIVE` + `HOMEPATH` y el home de la plataforma antes de pedir `COVEN_HOME`.
+
 ## Semana del 3 de junio de 2026
 
 ### Nuevas funcionalidades

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -10,10 +10,16 @@ title: "Coven changelog and release notes"
 
 ### New features
 
+- **Run reasoning controls (v0.0.48).** `coven run` now accepts `--think` and `--speed fast|balanced|thorough` alongside `--model`. Claude launches map the hints to `--effort`; unsupported harnesses warn and continue instead of failing. See [issue #246](https://github.com/OpenCoven/coven/issues/246), [PR #254](https://github.com/OpenCoven/coven/pull/254), and [Run command reference](/reference/cli-run).
 - **Trusted Hermes adapter recipe (v0.0.41).** `coven adapter install hermes` now writes a trusted local adapter manifest under `COVEN_HOME/adapters/hermes.json`, and Coven loads manifests from that Coven-owned trust store automatically. New users no longer need to hand-write JSON or set `COVEN_HARNESS_ADAPTER_MANIFEST` just to try Hermes. See [Hermes harness notes](/harnesses/hermes) and [PR #245](https://github.com/OpenCoven/coven/pull/245).
+
+### Updates
+
+- **Windows x64 package status.** The public README now reflects that `@opencoven/cli-windows` is published, not staged. Windows users can install through the universal `@opencoven/cli` wrapper and verify local harness availability with `coven doctor`.
 
 ### Bug fixes
 
+- **Resilient FTS event-index backfill (v0.0.48).** Existing-event backfill for `events_fts` now runs in bounded batches, records completion in `store_meta`, applies `busy_timeout` to read-only store connections, and treats `SQLITE_BUSY` as non-fatal so search indexing cannot block all agent dispatch on large histories. See [issue #249](https://github.com/OpenCoven/coven/issues/249) and [PR #254](https://github.com/OpenCoven/coven/pull/254).
 - **Clearer unsupported-harness guidance.** Unknown harness errors now show configured harness ids and point Hermes users directly to `coven adapter install hermes` followed by `coven adapter doctor hermes`; other external harnesses still use trusted adapter manifests or the explicit manifest environment variables.
 - **Windows home-directory fallback.** `coven doctor` and store-path resolution now work in PowerShell environments where `HOME` is absent by falling back through `USERPROFILE`, `HOMEDRIVE` + `HOMEPATH`, and the platform home directory before asking users to set `COVEN_HOME`.
 - **PowerShell-native `coven-code` install guidance.** On Windows, `coven` now points missing interactive-UI users to the `install.ps1` installer and PowerShell-compatible `COVEN_LEGACY_TUI` syntax instead of showing Unix `curl | bash` commands.

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -84,6 +84,15 @@ npm view @opencoven/cli-windows version dist-tags
 
 All four should now show the tag's version as `latest`. The package pages on npmjs.com should display a **"Provenance"** badge with a link back to the GitHub Actions run.
 
+Create or update the matching GitHub Release from the successful workflow artifacts. Package the downloaded binaries with the same public asset names as prior releases:
+
+- `coven-vX.Y.Z-macos-aarch64.tar.gz`
+- `coven-vX.Y.Z-linux-x64.tar.gz`
+- `coven-vX.Y.Z-windows-x64.zip`
+- `SHA256SUMS`
+
+The release body should include the npm install command, published package list, action run URL, tagged commit, and compare link. This GitHub Release is the public binary/checksum surface; npm provenance remains the package-integrity surface.
+
 If any package did not publish, do not re-tag with the same version (npm forbids overwrite). Inspect the failed job, fix the underlying cause, then push a new patch-bumped signed tag.
 
 ## Recovering from a refused release

--- a/docs/ru/reference/release-notes.md
+++ b/docs/ru/reference/release-notes.md
@@ -6,6 +6,23 @@ read_when:
 title: "Changelog и release notes Coven"
 ---
 
+## Неделя от 18 июня 2026
+
+### Новые возможности
+
+- **Управление reasoning для `coven run` (v0.0.48).** `coven run` теперь принимает `--think` и `--speed fast|balanced|thorough` вместе с `--model`. Запуски Claude преобразуют эти подсказки в `--effort`; неподдерживаемые harnesses предупреждают и продолжают работу вместо аварийного завершения. См. [issue #246](https://github.com/OpenCoven/coven/issues/246), [PR #254](https://github.com/OpenCoven/coven/pull/254) и [справочник `coven run`](/reference/cli-run).
+- **Доверенный рецепт адаптера Hermes (v0.0.41).** `coven adapter install hermes` теперь записывает доверенный локальный manifest в `COVEN_HOME/adapters/hermes.json`, а Coven автоматически загружает manifests из собственного trust store. Новым пользователям больше не нужно вручную писать JSON или задавать `COVEN_HARNESS_ADAPTER_MANIFEST`, чтобы попробовать Hermes.
+
+### Обновления
+
+- **Статус пакета Windows x64.** Публичный README теперь отражает, что `@opencoven/cli-windows` опубликован, а не находится в staging. Пользователи Windows могут установить универсальный wrapper `@opencoven/cli` и проверить локальные harnesses через `coven doctor`.
+
+### Исправления ошибок
+
+- **Устойчивый backfill FTS-индекса событий (v0.0.48).** Backfill существующих событий в `events_fts` теперь выполняется ограниченными batch-ами, записывает завершение в `store_meta`, применяет `busy_timeout` к read-only соединениям и считает `SQLITE_BUSY` нефатальным, чтобы поисковая индексация не блокировала все запуски агентов на больших историях. См. [issue #249](https://github.com/OpenCoven/coven/issues/249) и [PR #254](https://github.com/OpenCoven/coven/pull/254).
+- **Более понятная подсказка для неподдерживаемых harnesses.** Ошибки неизвестного harness теперь показывают настроенные IDs и направляют пользователей Hermes к `coven adapter install hermes`, затем к `coven adapter doctor hermes`.
+- **Fallback домашнего каталога на Windows.** `coven doctor` и выбор store path работают в PowerShell без `HOME`, последовательно проверяя `USERPROFILE`, `HOMEDRIVE` + `HOMEPATH` и системный home перед тем, как попросить задать `COVEN_HOME`.
+
 ## Неделя от 3 июня 2026
 
 ### Новые возможности


### PR DESCRIPTION
## Summary

- document v0.0.48 run reasoning flags and resilient FTS backfill in release notes
- update README Windows package status now that @opencoven/cli-windows is published
- add GitHub Release asset/checksum postflight to the release runbook

## Verification

- cargo test -p coven-cli
- python3 scripts/check-secrets.py
- git diff --check
- GitHub Release v0.0.48 verified with macOS, Linux, Windows assets and SHA256SUMS
