### PR TITLE
feat(release): publish @opencoven/coven wrapper alongside @opencoven/cli

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -3,8 +3,9 @@ name: Release npm packages
 # Tag-driven, OIDC-authenticated release pipeline.
 #
 # Trigger: any `v*` tag push starts the workflow.
-# Auth: npm trusted publishing via GitHub Actions OIDC — no long-lived NPM_TOKEN required. Configure each
-#       @opencoven/cli* package on npmjs.com -> Settings -> Trusted Publishers before the first OIDC release.
+# Auth: npm trusted publishing via GitHub Actions OIDC — no long-lived NPM_TOKEN required. Configure
+#       @opencoven/cli, @opencoven/coven, and each @opencoven/cli-* native package on npmjs.com
+#       -> Settings -> Trusted Publishers before the first OIDC release.
 # Gate: the `verify-tag` job requires an SSH-signed annotated tag, confirms GitHub has cryptographically
 #       verified it, and checks that local git verification trusts the release signing key
 #       (e.g. `git config gpg.format ssh && git tag -s v0.0.17 -m "..." && git push origin v0.0.17`).

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { defaultTargetName, isOidcContext, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion } from './publish-npm.mjs';
+import { defaultTargetName, isOidcContext, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
@@ -56,6 +56,20 @@ test('wrapper declares linux x64 native package as an optional dependency', () =
   const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
   const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
   assert.equal(packageJson.optionalDependencies['@opencoven/cli-linux-x64'], '0.0.0');
+});
+
+test('release publishes the current and coven-named wrapper packages', () => {
+  assert.deepEqual(wrapperPackageNameList(), ['@opencoven/cli', '@opencoven/coven']);
+  assert.equal(wrapperPackageDirName('@opencoven/cli'), 'coven');
+  assert.equal(wrapperPackageDirName('@opencoven/coven'), 'coven-alias');
+});
+
+test('coven-named wrapper keeps cli-prefixed native package names', () => {
+  const source = '@opencoven/cli uses @opencoven/cli-macos and @opencoven/cli-linux-x64';
+  assert.equal(
+    wrapperTextForPackage(source, '@opencoven/coven'),
+    '@opencoven/coven uses @opencoven/cli-macos and @opencoven/cli-linux-x64'
+  );
 });
 
 test('wrapper declares windows native package as an optional dependency', () => {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const distRoot = path.join(repoRoot, 'npm', 'dist');
+const primaryWrapperPackageName = '@opencoven/cli';
+const wrapperPackageNames = [primaryWrapperPackageName, '@opencoven/coven'];
 
 const targets = {
   macos: {
@@ -78,15 +80,17 @@ function main() {
   });
 
   if (!skipWrapper) {
-    const wrapperDir = writeWrapperPackage(version);
-    run('npm', publishArgs(dryRun), {
-      cwd: wrapperDir,
-      env: publishEnv(dryRun)
-    });
+    for (const packageName of wrapperPackageNames) {
+      const wrapperDir = writeWrapperPackage(version, packageName);
+      run('npm', publishArgs(dryRun), {
+        cwd: wrapperDir,
+        env: publishEnv(dryRun)
+      });
+    }
   }
 
   console.log(`Prepared npm packages in ${distRoot}`);
-  console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${target.packageName}${skipWrapper ? '' : ' and @opencoven/cli'} at version ${version}.`);
+  console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${target.packageName}${skipWrapper ? '' : ` and ${wrapperPackageNames.join(', ')}`} at version ${version}.`);
 }
 
 function writePlatformPackage(targetName, target, binaryPath, version) {
@@ -108,18 +112,30 @@ function writePlatformPackage(targetName, target, binaryPath, version) {
   return outDir;
 }
 
-function writeWrapperPackage(version) {
-  const outDir = path.join(distRoot, 'coven');
+function writeWrapperPackage(version, packageName = primaryWrapperPackageName) {
+  const outDir = path.join(distRoot, wrapperPackageDirName(packageName));
   cpSync(path.join(repoRoot, 'npm', 'coven'), outDir, { recursive: true });
   const packagePath = path.join(outDir, 'package.json');
   const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  packageJson.name = packageName;
   packageJson.version = version;
-  for (const packageName of Object.keys(packageJson.optionalDependencies)) {
-    packageJson.optionalDependencies[packageName] = version;
+  for (const optionalName of Object.keys(packageJson.optionalDependencies)) {
+    packageJson.optionalDependencies[optionalName] = version;
   }
   writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+  rewriteWrapperText(path.join(outDir, 'README.md'), packageName);
+  rewriteWrapperText(path.join(outDir, 'bin', 'coven.js'), packageName);
   chmodSync(path.join(outDir, 'bin', 'coven.js'), 0o755);
   return outDir;
+}
+
+function rewriteWrapperText(filePath, packageName) {
+  const text = readFileSync(filePath, 'utf8');
+  writeFileSync(filePath, wrapperTextForPackage(text, packageName));
+}
+
+export function wrapperTextForPackage(text, packageName) {
+  return text.replace(/@opencoven\/cli(?!-)/g, packageName);
 }
 
 export function releaseVersion(env = process.env, packageVersion = wrapperPackageVersion()) {
@@ -138,6 +154,14 @@ export function releaseVersion(env = process.env, packageVersion = wrapperPackag
 
 export function targetPackageName(targetName) {
   return targets[targetName]?.packageName;
+}
+
+export function wrapperPackageNameList() {
+  return [...wrapperPackageNames];
+}
+
+export function wrapperPackageDirName(packageName) {
+  return packageName === primaryWrapperPackageName ? 'coven' : 'coven-alias';
 }
 
 export function defaultTargetName(platform, arch) {


### PR DESCRIPTION
The npm release pipeline now publishes **both** wrapper names from one signed tag:

- `@opencoven/cli` — existing primary; fully backward-compatible.
- `@opencoven/coven` — new co-published alias.

Both wrappers depend on the same native `@opencoven/cli-*` platform packages as optional dependencies, so installing either ends up with the same binary. Co-publishing lets the canonical *coven* name be advertised in docs without breaking existing installs of `@opencoven/cli`.

## Implementation

- **`scripts/publish-npm.mjs`** — `writeWrapperPackage` now takes a `packageName`, rewrites `README.md` and `bin/coven.js` text via `wrapperTextForPackage`, and emits into `npm/dist/<wrapperPackageDirName>` (`coven` for the primary, `coven-alias` for the new name). The main loop publishes both.
- **`.github/workflows/release-npm.yml`** — comment updated to call out both wrapper packages so trusted-publisher setup is documented.
- **`scripts/publish-npm-test.mjs`** — two new tests pin `wrapperPackageNameList()`, `wrapperPackageDirName`, and `wrapperTextForPackage` so the regex only rewrites the bare `@opencoven/cli` reference (not `@opencoven/cli-macos` or similar).

## Verification

```
$ node --test scripts/publish-npm-test.mjs
ℹ tests 37
ℹ pass 37
ℹ fail 0
```

Before the first OIDC release of `@opencoven/coven`, configure it as a Trusted Publisher on npmjs.com — same procedure as the existing packages.