### PR TITLE
docs: add Coven Group Chat product & tech specs

### DIFF
--- a/specs/coven-group-chat/PRODUCT.md
+++ b/specs/coven-group-chat/PRODUCT.md
@@ -1,0 +1,119 @@
+# Coven Group Chat — PRODUCT
+
+**Status:** Draft v1 · 2026-06-23
+**Owner:** Nova 🜂 (orchestration draft) → implementation routed to Cody
+**Acceptance target:** A group conversation is a first-class server object. iOS, web, and CLI all create, read, and continue the same group, with one synced transcript.
+
+## Problem
+
+Group chat exists on exactly one surface — the iOS Cave — and only as a client-side illusion.
+
+The server has **no multi-familiar concept**. A session is one conversation with one familiar (`/api/chat/send`, `GET/DELETE /api/chat/conversation/:id`). iOS fakes a group by holding a `sessionIds` map (familiarId → sessionId) and fanning a prompt out to N independent sessions concurrently, then streaming each reply into its own attributed bubble (`ChatThread.swift`, lines 36–40).
+
+That illusion has three hard costs:
+
+1. **No cross-device groups.** Group membership and the merged timeline live only in the iOS app's local persistence. Open the same account on web or another device and the group does not exist.
+2. **No re-sync.** Direct chats pull-to-refresh from the server; groups cannot (`reSync` no-ops for `isGroup`) because there is no shared turn ordering across the N sessions to merge.
+3. **No web / CLI parity.** Web Cave has no group UI at all — its only "group" is *projects grouping single sessions by codebase*. There is nothing on the server for web or CLI to render.
+
+This spec defines a server-side group primitive so a group becomes one durable, synced object that every surface reads the same way.
+
+## Goals
+
+- A group is a real server object: stable `id`, `title`, ordered `memberFamiliarIds`, and a child session per member.
+- One inbound user message fans out to every member and returns a **single multiplexed event stream**, each event attributed to the familiar that produced it.
+- The server assigns a **monotonic sequence** across all group events (the user turn + each familiar's reply turn) so any client reconstructs one canonical timeline — enabling re-sync and cross-device.
+- iOS, web, and CLI use the same group endpoints. No surface owns group state privately.
+- Migration path: iOS's existing local `sessionIds` map adopts cleanly into a server group; no data loss.
+
+## Non-goals (v1)
+
+- Familiar-to-familiar turns (a familiar reacting to another familiar's reply in the same turn). v1 fan-out is **parallel and independent** — every member answers the user, not each other.
+- Shared/merged context across members (each member's session keeps its own context window). Cross-member context sharing is v2.
+- Human↔human group chat. Members are familiars; the user is the single human participant.
+- Group-level slash commands beyond what direct chat already supports.
+- Real-time presence / typing indicators across devices (the event stream already implies activity; rich presence is later).
+
+## Why server-side, not "just port the iOS fan-out to web"
+
+Porting the client illusion to web would duplicate the bug on a second surface: two clients, two private merged timelines, still no re-sync, still no cross-device. The fan-out logic is cheap; the **canonical ordering and durable membership** are the actual product. Those can only live in one place — the server.
+
+## Architecture
+
+```mermaid
+graph TD
+    iOS["iOS Cave"] --> API["Coven group API"]
+    Web["Web Cave"] --> API
+    CLI["coven-cli TUI"] --> API
+
+    API --> GRP["GroupConversation\n(id, title, members[])"]
+    GRP --> S1["session: Nova"]
+    GRP --> S2["session: Sage"]
+    GRP --> S3["session: Cody"]
+
+    API --> SEQ["sequence assigner\n(canonical timeline)"]
+    SEQ --> Stream["multiplexed event stream\n(attributed by familiarId)"]
+```
+
+A group owns one child session per member. A user message is appended to the group timeline once (with a sequence number), then dispatched to every member session. Each member's reply turn is folded back into the same timeline under its own sequence + `familiarId`. Every client renders the one ordered transcript.
+
+## Interface contract
+
+```typescript
+interface GroupConversation {
+  id: string;
+  title: string;
+  memberFamiliarIds: string[];      // ordered; drives avatar cluster + attribution
+  memberSessionIds: Record<string, string>; // familiarId → child sessionId
+  createdAt: string;                // ISO 8601
+  updatedAt: string;
+}
+
+interface GroupEvent {
+  seq: number;                      // monotonic, group-scoped — the canonical order
+  role: "user" | "familiar";
+  familiarId?: string;              // set when role === "familiar"
+  text: string;
+  streaming: boolean;
+  ts: string;                       // ISO 8601
+}
+```
+
+- `POST /api/groups` → create a group from `{ title?, memberFamiliarIds[] }`; server provisions a child session per member.
+- `POST /api/groups/:id/send` → append the user turn, fan out to members, return an SSE stream of `GroupEvent`s (one logical sub-stream per member, interleaved, each carrying `seq` + `familiarId`).
+- `GET /api/groups/:id` → the group + its full ordered timeline (backs re-sync and first load on any device).
+- `PATCH /api/groups/:id` → rename, add/remove member (add provisions a session; remove archives it).
+- `DELETE /api/groups/:id` → delete group + child sessions.
+- `GET /api/groups` → list groups for the account.
+
+## Acceptance for v1
+
+1. `GroupConversation` and `GroupEvent` are defined server-side and documented in `coven/docs/API-CONTRACT.md`.
+2. Creating a group provisions one child session per member familiar.
+3. `send` fans out to all members concurrently and streams attributed `GroupEvent`s with correct, monotonic `seq` values.
+4. `GET /api/groups/:id` returns one canonically-ordered transcript that two devices reconstruct identically.
+5. iOS group re-sync (pull-to-refresh) works against `GET /api/groups/:id` — the `isGroup` no-op in `ChatThread.reSync` is removed.
+6. A group created on iOS is visible and continuable on web, and vice-versa.
+7. Migration: an existing iOS local group (its `sessionIds` map) can be adopted into a server group without losing message history.
+8. Contract tests cover create / send / fan-out ordering / re-sync / membership change.
+
+## Future
+
+```mermaid
+gantt
+    title Coven Group Chat Roadmap
+    dateFormat YYYY-MM-DD
+    section v1 - Server primitive
+    GroupConversation + endpoints   :t1, 2026-06-23, 5d
+    Fan-out send + sequenced stream :t2, after t1, 4d
+    iOS adopts server groups        :t3, after t2, 4d
+    Web Cave group UI               :t4, after t2, 6d
+    Migration + contract tests      :t5, after t3, 3d
+    section v2 - Richer groups
+    Cross-member shared context     :t6, 2026-09-01, 10d
+    Familiar-to-familiar turns      :t7, after t6, 10d
+    CLI TUI group view              :t8, after t6, 7d
+```
+
+- **v2:** Members can see and build on each other's replies (shared context); familiar-to-familiar turn-taking; CLI group view.
+- **Later:** Group-level orchestration (a "facilitator" familiar that routes the user's ask to the right member), and group templates ("Research crew", "Ship review").

--- a/specs/coven-group-chat/TECH.md
+++ b/specs/coven-group-chat/TECH.md
@@ -1,0 +1,157 @@
+# Coven Group Chat — TECH
+
+**Status:** Draft v1 · 2026-06-23
+**Companion to:** [PRODUCT.md](./PRODUCT.md)
+
+## Where this lives
+
+Group chat is a **server primitive**, so the source of truth is the Coven session/daemon layer, surfaced through the Cave's API routes. The existing single-session chat plumbing is the foundation — a group is an orchestration layer *over* sessions, not a parallel system.
+
+```mermaid
+graph TD
+    routes["coven-cave/src/app/api/groups/*"] --> svc["group service\n(coven-cave/src/lib/groups/*)"]
+    svc --> sess["existing session layer\n(/api/chat/send, conversation store)"]
+    svc --> store["group store\n(membership + sequenced timeline)"]
+```
+
+```
+coven-cave/
+  src/
+    app/api/groups/
+      route.ts                 # GET (list) , POST (create)
+      [id]/route.ts            # GET (group + timeline), PATCH (rename/members), DELETE
+      [id]/send/route.ts       # POST → fan-out, SSE stream of GroupEvent
+    lib/groups/
+      types.ts                 # GroupConversation, GroupEvent
+      group-store.ts           # persistence: membership + sequenced timeline
+      fan-out.ts               # dispatch a turn to N member sessions
+      sequence.ts              # monotonic, group-scoped seq assignment
+```
+
+The single-session endpoints (`/api/chat/send`, `/api/chat/conversation/:id`) are unchanged. A group's child sessions are ordinary sessions — they remain individually addressable, which is what makes migration and "leave the group, keep the chat" cheap.
+
+## Today's reality (what we build on)
+
+- A session is one conversation with one familiar. `POST /api/chat/send` streams a reply; `GET /api/chat/conversation/:id` returns history; `DELETE` removes it.
+- iOS fakes a group: `ChatThread` holds `sessionIds: [String: String]` (familiarId → sessionId) and `send` loops members, calling the single-session stream per member (`ChatThread.swift`). There is no server group, so `reSync` no-ops when `isGroup`.
+- Web Cave has no group concept at all.
+
+The migration target is exactly this `sessionIds` map → `GroupConversation.memberSessionIds`.
+
+## Types
+
+```typescript
+// src/lib/groups/types.ts
+
+export interface GroupConversation {
+  id: string;
+  title: string;
+  memberFamiliarIds: string[];                 // ordered
+  memberSessionIds: Record<string, string>;    // familiarId → child sessionId
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GroupEvent {
+  seq: number;                  // monotonic within the group — the canonical order
+  role: "user" | "familiar";
+  familiarId?: string;          // present iff role === "familiar"
+  text: string;
+  streaming: boolean;
+  ts: string;
+}
+```
+
+## Sequence assignment — the core invariant
+
+The whole point is **one canonical order** every client agrees on. The server, not the client, owns `seq`.
+
+```mermaid
+flowchart TD
+    A[user sends in group] --> B[append user GroupEvent\nseq = next]
+    B --> C[fan out to each member session]
+    C --> D1[Nova reply turn\nseq = next on first token]
+    C --> D2[Sage reply turn\nseq = next on first token]
+    C --> D3[Cody reply turn\nseq = next on first token]
+    D1 --> E[stream tokens under that seq + familiarId]
+    D2 --> E
+    D3 --> E
+```
+
+- `seq` is assigned **once per turn**, at the moment a turn begins (user message appended, or a member emits its first token). Tokens for a turn stream under that fixed `seq`.
+- Members answer **in parallel**; `seq` order reflects first-token arrival, which is deterministic to replay because it is persisted with the event. Two devices loading `GET /api/groups/:id` get byte-identical ordering.
+- This is the single fact iOS lacks today, and it is exactly why iOS groups can't re-sync.
+
+## Fan-out
+
+```typescript
+// src/lib/groups/fan-out.ts (sketch)
+export async function* fanOut(group, userText) {
+  const userEvent = await store.appendUser(group.id, userText); // assigns seq
+  yield userEvent;
+
+  // dispatch concurrently to each member's existing session
+  const streams = group.memberFamiliarIds.map((fid) =>
+    sendToSession(group.memberSessionIds[fid], userText, fid)
+  );
+
+  // merge member streams; each member's first token claims a seq
+  for await (const ev of mergeAttributed(streams, store, group.id)) {
+    yield ev; // GroupEvent with seq + familiarId, streaming flag
+  }
+}
+```
+
+`sendToSession` is the **existing** single-session send path. The group layer adds only: append-once user event, seq assignment, and attributed stream merge. No new model/harness wiring.
+
+## Endpoints
+
+| Method | Path | Body / returns |
+| --- | --- | --- |
+| `GET` | `/api/groups` | list account's `GroupConversation`s |
+| `POST` | `/api/groups` | `{ title?, memberFamiliarIds[] }` → provisions a child session per member; returns `GroupConversation` |
+| `GET` | `/api/groups/:id` | `{ group, events: GroupEvent[] }` — full ordered timeline (re-sync + first load) |
+| `POST` | `/api/groups/:id/send` | `{ text }` → **SSE stream** of `GroupEvent` |
+| `PATCH` | `/api/groups/:id` | rename, or add/remove member (add provisions a session; remove archives it) |
+| `DELETE` | `/api/groups/:id` | delete group + child sessions |
+
+SSE framing matches the existing chat stream conventions (`/api/chat/send`, `/api/sessions/[id]/events`) so clients reuse their stream parser — they just additionally read `seq` + `familiarId` off each event.
+
+## Client changes
+
+### iOS (smallest — it already has the shape)
+- `ChatThread.memberSessionIds` already exists as `sessionIds`. Bind it to a server `GroupConversation.id`.
+- `send` for groups calls `POST /api/groups/:id/send` instead of looping per-member client-side. The attributed bubbles already key on `familiarId` — unchanged.
+- Remove the `isGroup` guard in `reSync`; point group re-sync at `GET /api/groups/:id`.
+
+### Web Cave (new UI, existing patterns)
+- Add a group thread view that renders one timeline with per-familiar attribution + avatar cluster (mirror iOS `ThreadRow` / `AvatarClusterView`).
+- New-group compose reuses the familiar multiselect already present (`familiar-multiselect`).
+
+### CLI (v2)
+- TUI group view is deferred to v2; the endpoints are ready for it.
+
+## Migration
+
+```mermaid
+flowchart TD
+    A[iOS local group\nsessionIds map] --> B[POST /api/groups/adopt]
+    B --> C[server creates GroupConversation\nmemberSessionIds = existing sessionIds]
+    C --> D[rebuild timeline by interleaving\neach member session history by ts → assign seq]
+    D --> E[iOS rebinds thread to group id]
+```
+
+- An `adopt` path takes an iOS group's `sessionIds` map, wraps the **already-existing** sessions in a `GroupConversation`, and backfills the timeline by interleaving each child session's history by timestamp to assign `seq`. No history is lost; sessions are reused, not recreated.
+- Groups created after v1 ships are server-native from birth and skip adoption.
+
+## Failure / edge handling
+
+- A member session erroring mid-fan-out emits a `GroupEvent` with `streaming:false` + an error marker for that `familiarId` only; other members are unaffected (matches today's per-bubble error isolation).
+- Removing a member archives its child session rather than deleting it, so its prior turns stay in the timeline (history must not gain holes).
+- Re-sync while a turn is streaming is rejected (same rule as direct chat) so an in-flight reply is never clobbered.
+
+## Dependencies
+
+- No new harness/model wiring — reuses the existing session send + conversation store.
+- Group store persistence sits alongside the existing conversation store; schema adds a group table (membership + events with `seq`) or equivalent in whatever the session store already uses.
+- No Rust FFI required for v1; the daemon may later audit/throttle group fan-out (same future note as Channels).


### PR DESCRIPTION
Adds the v1 design for **server-side group chat** under `specs/coven-group-chat/`. Companion to the existing `coven-channels`, `coven-handoff-packet`, and `coven-workflow-standard` specs.

## What this is

Today, group chat exists only on iOS as a client-side illusion: `ChatThread.swift` holds a `sessionIds` map (familiarId → sessionId) and fans a single user prompt out to N independent server sessions. The server has no multi-familiar concept, so groups can't re-sync, can't cross devices, and can't render on web/CLI.

This spec defines a **first-class server group primitive** so a group becomes one durable, synced object that every surface reads the same way.

## Files

- `specs/coven-group-chat/PRODUCT.md` — problem, goals, non-goals, acceptance target, migration path from iOS's local `sessionIds`.
- `specs/coven-group-chat/TECH.md` — `GroupConversation` + `GroupEvent` types, server-owned monotonic sequence, fan-out + SSE multiplex, API surface (`/api/groups`, `/api/groups/[id]`, `/api/groups/[id]/send`), edge cases.

## Status

**Draft v1.** Opening as a draft PR so the spec can be reviewed/iterated before merging — implementation is not blocked by merge timing.