### PR TITLE
docs: roll out v0.0.49 release notes

### DIFF
--- a/docs/es/reference/release-notes.md
+++ b/docs/es/reference/release-notes.md
@@ -6,6 +6,17 @@ read_when:
 title: "Changelog y notas de release de Coven"
 ---
 
+## Semana del 24 de junio de 2026
+
+### Nuevas funcionalidades
+
+- **Wrapper de npm `@opencoven/coven` copublicado (v0.0.49).** El pipeline de release ahora publica un segundo nombre de wrapper, `@opencoven/coven`, junto con `@opencoven/cli`. Ambos wrappers dependen de los mismos paquetes nativos `@opencoven/cli-*`, así que instalar cualquiera de los dos termina en el mismo binario `coven`. Esto permite que docs y onboarding anuncien el nombre canónico *coven* sin romper instalaciones existentes de `@opencoven/cli`. Consulta [PR #257](https://github.com/OpenCoven/coven/pull/257) y el [runbook de releasing](/reference/releasing) para la configuración única de Trusted Publisher que necesita el paquete nuevo antes de su primer release OIDC.
+- **Spec de Coven Group Chat (v0.0.49).** Se añadió el diseño v1 para una primitiva de chat grupal del lado del servidor en `specs/coven-group-chat/` (PRODUCT + TECH). Hoy el chat grupal sólo existe como una ilusión de fan-out en el cliente iOS; el spec define un objeto de servidor durable y sincronizado, con ordenación monótona de eventos para que iOS, web y CLI lean el mismo grupo. La implementación se rastrea por separado. Consulta [PR #258](https://github.com/OpenCoven/coven/pull/258).
+
+### Actualizaciones
+
+- **Referencias a OpenMeow eliminadas en docs y código (v0.0.49).** OpenMeow no es una aplicación de OpenCoven — CastCodes es el cliente canónico. Ejemplos y etiquetas sueltas de OpenMeow en docs en inglés/español/ruso, `DESIGN.md`, `ARCHITECTURE.md`, `AUTH.md`, `API-CONTRACT.md` y referencias relacionadas se reescribieron en lenguaje neutro al producto. `crates/coven-cli/src/api.rs` renombra el origen de prueba `openmeow` a `external-client`, y `skills/coven-task-manager` elimina `openmeow` de la lista de etiquetas de repo reconocidas. No hay cambios de comportamiento en runtime. Consulta [PR #256](https://github.com/OpenCoven/coven/pull/256).
+
 ## Semana del 18 de junio de 2026
 
 ### Nuevas funcionalidades

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -6,6 +6,17 @@ read_when:
 title: "Coven changelog and release notes"
 ---
 
+## Week of June 24, 2026
+
+### New features
+
+- **Co-published `@opencoven/coven` npm wrapper (v0.0.49).** The release pipeline now publishes a second wrapper package name, `@opencoven/coven`, alongside the existing `@opencoven/cli`. Both wrappers depend on the same `@opencoven/cli-*` native platform packages, so installing either one ends up with the same `coven` binary. This lets docs and onboarding advertise the canonical *coven* name without breaking existing `@opencoven/cli` installs. See [PR #257](https://github.com/OpenCoven/coven/pull/257) and the [releasing runbook](/reference/releasing) for the trusted-publisher one-time setup the new package needs before its first OIDC release.
+- **Coven Group Chat spec (v0.0.49).** Added the v1 design for a server-side group-chat primitive under `specs/coven-group-chat/` (PRODUCT + TECH). Today, group chat exists only as an iOS client-side fan-out illusion; the spec defines a durable, synced server object with monotonic event ordering so iOS, web, and CLI all read the same group. Implementation tracked separately. See [PR #258](https://github.com/OpenCoven/coven/pull/258).
+
+### Updates
+
+- **OpenMeow references removed from docs and code (v0.0.49).** OpenMeow is not an OpenCoven application — CastCodes is the canonical client. Stray OpenMeow examples and labels in English/Spanish/Russian docs, `DESIGN.md`, `ARCHITECTURE.md`, `AUTH.md`, `API-CONTRACT.md`, and related references were rewritten in product-neutral language. `crates/coven-cli/src/api.rs` renames the `openmeow` test origin to `external-client`, and `skills/coven-task-manager` drops `openmeow` from the recognized repo-label list. No runtime behavior changes. See [PR #256](https://github.com/OpenCoven/coven/pull/256).
+
 ## Week of June 18, 2026
 
 ### New features

--- a/docs/ru/reference/release-notes.md
+++ b/docs/ru/reference/release-notes.md
@@ -6,6 +6,17 @@ read_when:
 title: "Changelog и release notes Coven"
 ---
 
+## Неделя от 24 июня 2026
+
+### Новые возможности
+
+- **Сопубликованный npm-обёртка `@opencoven/coven` (v0.0.49).** Release-pipeline теперь публикует второе имя обёртки, `@opencoven/coven`, рядом с существующим `@opencoven/cli`. Обе обёртки зависят от одних и тех же native-пакетов `@opencoven/cli-*`, поэтому установка любой из них даёт тот же бинарь `coven`. Это позволяет docs и онбордингу рекламировать каноническое имя *coven*, не ломая существующие установки `@opencoven/cli`. См. [PR #257](https://github.com/OpenCoven/coven/pull/257) и [руководство по релизам](/reference/releasing) для одноразовой настройки Trusted Publisher, которая нужна для первого OIDC-релиза нового пакета.
+- **Spec Coven Group Chat (v0.0.49).** Добавлен v1-дизайн серверной примитивы группового чата в `specs/coven-group-chat/` (PRODUCT + TECH). Сегодня групповой чат существует только как клиентская fan-out-иллюзия в iOS; spec определяет долговременный серверный объект с монотонной нумерацией событий, чтобы iOS, web и CLI видели одну и ту же группу. Реализация отслеживается отдельно. См. [PR #258](https://github.com/OpenCoven/coven/pull/258).
+
+### Обновления
+
+- **Убраны упоминания OpenMeow в docs и коде (v0.0.49).** OpenMeow не является приложением OpenCoven — канонический клиент это CastCodes. Оставшиеся примеры и метки OpenMeow в английских/испанских/русских docs, в `DESIGN.md`, `ARCHITECTURE.md`, `AUTH.md`, `API-CONTRACT.md` и смежных файлах переписаны нейтрально по отношению к продукту. `crates/coven-cli/src/api.rs` переименовывает тестовое origin `openmeow` в `external-client`, а `skills/coven-task-manager` убирает `openmeow` из списка распознаваемых меток репозиториев. Изменений в runtime-поведении нет. См. [PR #256](https://github.com/OpenCoven/coven/pull/256).
+
 ## Неделя от 18 июня 2026
 
 ### Новые возможности


### PR DESCRIPTION
Document v0.0.49 changes across English, Spanish, and Russian release notes.

## Items in v0.0.49

- **Co-published `@opencoven/coven` wrapper alongside `@opencoven/cli`** ([PR #257](https://github.com/OpenCoven/coven/pull/257)). Both wrappers depend on the same native `@opencoven/cli-*` platform packages and resolve to the same binary, so installing either works identically.
- **Coven Group Chat product + tech spec** ([PR #258](https://github.com/OpenCoven/coven/pull/258)) under `specs/coven-group-chat/`. Defines a server-side group primitive replacing the iOS client-side fan-out illusion. Implementation tracked separately.
- **OpenMeow references scrubbed** from docs, API test fixture, and task-manager skill ([PR #256](https://github.com/OpenCoven/coven/pull/256)). Product-neutral language.

## Verification

- Preflight `node scripts/test-cli-prepublish.mjs` (with `COVEN_NPM_VERSION=0.0.49`): all 5 checks passed.
- `python3 scripts/check-secrets.py`: passed.

No runtime behavior changes for end users in this release.

## Next

After this merges, cut a signed annotated tag `v0.0.49` on `main` to trigger the release workflow.