### PR TITLE
fix(release): skip already-published npm packages so reruns are safe

### DIFF
--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
-import { defaultTargetName, isOidcContext, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
+import { defaultTargetName, isOidcContext, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
@@ -328,4 +328,24 @@ test('prepublish smoke has explicit dry-run version override and registry failur
 
   assert.match(script, /COVEN_NPM_DRY_RUN_VERSION/);
   assert.match(script, /Could not read current \$\{packageName\} version/);
+});
+
+test('packageVersionPublished returns true when npm view exits 0 (version exists on registry)', () => {
+  const result = packageVersionPublished('@opencoven/cli', '0.0.49', () => ({ status: 0 }));
+  assert.equal(result, true);
+});
+
+test('packageVersionPublished returns false when npm view exits non-zero (E404, not yet published)', () => {
+  const result = packageVersionPublished('@opencoven/coven', '0.0.49', () => ({ status: 1 }));
+  assert.equal(result, false);
+});
+
+test('publish-npm.mjs gates real publishes behind packageVersionPublished for rerun safety', () => {
+  const scriptPath = new URL('publish-npm.mjs', import.meta.url);
+  const script = readFileSync(scriptPath, 'utf8');
+
+  assert.match(script, /function publishOrSkip\(/);
+  assert.match(script, /Skipping \$\{packageName\}@\$\{version\}: already published/);
+  assert.match(script, /publishOrSkip\(target\.packageName/);
+  assert.match(script, /publishOrSkip\(packageName/);
 });

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -74,23 +74,47 @@ function main() {
 
   const platformDir = writePlatformPackage(targetName, target, binaryPath, version);
 
-  run('npm', publishArgs(dryRun), {
-    cwd: platformDir,
-    env: publishEnv(dryRun)
-  });
+  publishOrSkip(target.packageName, version, dryRun, platformDir);
 
   if (!skipWrapper) {
     for (const packageName of wrapperPackageNames) {
       const wrapperDir = writeWrapperPackage(version, packageName);
-      run('npm', publishArgs(dryRun), {
-        cwd: wrapperDir,
-        env: publishEnv(dryRun)
-      });
+      publishOrSkip(packageName, version, dryRun, wrapperDir);
     }
   }
 
   console.log(`Prepared npm packages in ${distRoot}`);
   console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${target.packageName}${skipWrapper ? '' : ` and ${wrapperPackageNames.join(', ')}`} at version ${version}.`);
+}
+
+function publishOrSkip(packageName, version, dryRun, cwd) {
+  if (!dryRun && packageVersionPublished(packageName, version)) {
+    console.log(`Skipping ${packageName}@${version}: already published to npm.`);
+    return;
+  }
+  run('npm', publishArgs(dryRun), {
+    cwd,
+    env: publishEnv(dryRun)
+  });
+}
+
+export function packageVersionPublished(packageName, version, runner = npmViewRunner) {
+  const result = runner(packageName, version);
+  if (result.status === 0) {
+    return true;
+  }
+  // npm view exits non-zero (commonly 1) with E404 when the version doesn't exist.
+  // Any other surface (network error, auth error) returns false so the caller still
+  // attempts the publish and surfaces the real error.
+  return false;
+}
+
+function npmViewRunner(packageName, version) {
+  return spawnSync('npm', ['view', `${packageName}@${version}`, 'version'], {
+    cwd: repoRoot,
+    env: process.env,
+    stdio: ['ignore', 'ignore', 'ignore']
+  });
 }
 
 function writePlatformPackage(targetName, target, binaryPath, version) {


### PR DESCRIPTION
## Why

When a release workflow partially succeeds, rerunning the failed job replays the publish step for every platform — including the platforms that already published. npm rejects re-publish of the same version with `EPUBLISHCONFLICT`, so the retry can never finish even after the underlying blocker is removed.

This bit us on **v0.0.49**, where `@opencoven/coven@0.0.49` failed E404 (new package, Trusted Publisher not yet configured on npmjs.org). After Val added the Trusted Publisher and we tried to rerun, the matrix replayed from `linux-x64` and aborted on "You cannot publish over the previously published versions: 0.0.49" before ever reaching the `@opencoven/coven` step that we actually needed to retry.

## What

- New `publishOrSkip(packageName, version, dryRun, cwd)` wrapper used in both the platform-publish step and the wrapper-publish loop.
- New `packageVersionPublished(packageName, version)` helper that shells out to `npm view <pkg>@<version> version` and treats:
  - exit 0 → already on registry, skip with a clear log line
  - any other exit → run the publish so npm surfaces its own error (E404, auth, etc.)
- 3 new tests covering the helper + the script wiring.

## Why this design

- Cheapest possible check (a single `npm view`) before each publish — no extra deps.
- Test-injectable runner via the 3rd arg so tests don't need network.
- Dry-run paths bypass the check entirely (we still want to verify the package builds locally even if a real publish already happened).
- The skip-on-success / fall-through-on-error pattern means a transient registry hiccup doesn't silently no-op a real publish — we only skip when we have a positive confirmation the version exists.

## Test plan

- `node --test scripts/publish-npm-test.mjs` → 40/40 pass (3 new + 37 existing).
- The next release with a fresh package addition can now be retried cleanly after one-time Trusted Publisher setup, without manually cutting a fresh version tag.

## Follow-up

After this merges, the v0.0.49 retry path is:
1. Confirm Trusted Publisher for `@opencoven/coven` is in place on npmjs.org.
2. `gh workflow run release-npm.yml -R OpenCoven/coven -f ref=v0.0.49` (or rerun #28131345563 in the Actions UI once this fix is on `main`).
3. Already-published platforms skip cleanly; the missing `@opencoven/coven@0.0.49` publishes; GitHub Release page finalizes.

This fix is on `main` so it lands ahead of any future v0.0.50 cuts too.