### PR TITLE
fix(cli): validate trusted adapter manifests

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -408,6 +408,7 @@ pub fn trusted_adapter_manifest_matches_recipe(path: &Path, adapter_id: &str) ->
         return false;
     }
     fs::read_to_string(path).is_ok_and(|actual| actual == expected)
+}
 
 fn coven_home_from_process_env() -> Option<PathBuf> {
     env::var_os("COVEN_HOME")

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -305,13 +305,13 @@ fn external_harness_specs() -> Result<Vec<HarnessCommandSpec>> {
     let mut specs = Vec::new();
     let mut ids: HashSet<String> = built_ins.iter().map(|spec| spec.id.clone()).collect();
 
-    for manifest_path in external_adapter_manifest_paths() {
-        for spec in load_external_harness_specs(&manifest_path, &built_ins)? {
+    for manifest in external_adapter_manifest_sources() {
+        for spec in manifest.load_specs(&built_ins)? {
             if !ids.insert(spec.id.clone()) {
                 anyhow::bail!(
                     "external harness adapter `{}` in {} duplicates another adapter id",
                     spec.id,
-                    manifest_path.display()
+                    manifest.path().display()
                 );
             }
             specs.push(spec);
@@ -320,27 +320,57 @@ fn external_harness_specs() -> Result<Vec<HarnessCommandSpec>> {
     Ok(specs)
 }
 
-fn external_adapter_manifest_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
+#[derive(Debug)]
+enum AdapterManifestSource {
+    Path(PathBuf),
+    TrustedRecipe {
+        path: PathBuf,
+        manifest: &'static str,
+    },
+}
+
+impl AdapterManifestSource {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Path(path) | Self::TrustedRecipe { path, .. } => path,
+        }
+    }
+
+    fn load_specs(&self, built_ins: &[HarnessCommandSpec]) -> Result<Vec<HarnessCommandSpec>> {
+        match self {
+            Self::Path(path) => load_external_harness_specs(path, built_ins),
+            Self::TrustedRecipe { path, manifest } => {
+                parse_external_harness_specs(manifest, path, built_ins)
+            }
+        }
+    }
+}
+
+fn external_adapter_manifest_sources() -> Vec<AdapterManifestSource> {
+    let mut sources = Vec::new();
 
     if let Some(coven_home) = coven_home_from_process_env() {
-        paths.extend(trusted_adapter_manifest_paths(&coven_home));
+        sources.extend(trusted_adapter_manifest_sources(&coven_home));
     }
 
     if let Some(manifest_path) = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV) {
-        paths.push(PathBuf::from(manifest_path));
+        sources.push(AdapterManifestSource::Path(PathBuf::from(manifest_path)));
     }
 
     if let Some(dir_list) = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV) {
         for dir in env::split_paths(&dir_list) {
-            paths.extend(adapter_manifest_paths_in_dir(&dir));
+            sources.extend(
+                adapter_manifest_paths_in_dir(&dir)
+                    .into_iter()
+                    .map(AdapterManifestSource::Path),
+            );
         }
     }
 
     let mut seen = HashSet::new();
-    paths
+    sources
         .into_iter()
-        .filter(|path| seen.insert(path.clone()))
+        .filter(|source| seen.insert(source.path().to_path_buf()))
         .collect()
 }
 
@@ -352,12 +382,14 @@ pub fn trusted_adapter_manifest_path(coven_home: &Path, adapter_id: &str) -> Pat
     trusted_adapter_dir(coven_home).join(format!("{adapter_id}.json"))
 }
 
-fn trusted_adapter_manifest_paths(coven_home: &Path) -> Vec<PathBuf> {
+fn trusted_adapter_manifest_sources(coven_home: &Path) -> Vec<AdapterManifestSource> {
     known_adapter_recipe_names()
         .iter()
         .filter_map(|adapter_id| {
             let path = trusted_adapter_manifest_path(coven_home, adapter_id);
-            trusted_adapter_manifest_matches_recipe(&path, adapter_id).then_some(path)
+            let manifest = known_adapter_manifest(adapter_id)?;
+            trusted_adapter_manifest_matches_recipe(&path, adapter_id)
+                .then_some(AdapterManifestSource::TrustedRecipe { path, manifest })
         })
         .collect()
 }
@@ -370,6 +402,9 @@ pub fn trusted_adapter_manifest_matches_recipe(path: &Path, adapter_id: &str) ->
         return false;
     };
     if !metadata.file_type().is_file() {
+        return false;
+    }
+    if metadata.len() != expected.len() as u64 {
         return false;
     }
     fs::read_to_string(path).is_ok_and(|actual| actual == expected)
@@ -437,7 +472,15 @@ fn load_external_harness_specs(
             path.display()
         )
     })?;
-    let registry: ExternalHarnessAdapterRegistry = serde_json::from_str(&raw).map_err(|err| {
+    parse_external_harness_specs(&raw, path, built_ins)
+}
+
+fn parse_external_harness_specs(
+    raw: &str,
+    path: &Path,
+    built_ins: &[HarnessCommandSpec],
+) -> Result<Vec<HarnessCommandSpec>> {
+    let registry: ExternalHarnessAdapterRegistry = serde_json::from_str(raw).map_err(|err| {
         anyhow!(
             "failed to parse harness adapter manifest {}: {err}",
             path.display()
@@ -1335,6 +1378,54 @@ mod tests {
         assert_eq!(
             hermes.manifest_path.as_deref(),
             Some(adapter_dir.join("hermes.json").to_string_lossy().as_ref())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn trusted_adapter_manifest_rejects_size_mismatches_before_content_match() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = coven_home.join("adapters");
+        fs::create_dir_all(&adapter_dir)?;
+        let manifest_path = adapter_dir.join("hermes.json");
+        fs::write(&manifest_path, format!("{HERMES_ADAPTER_MANIFEST}\n"))?;
+
+        assert!(!trusted_adapter_manifest_matches_recipe(
+            &manifest_path,
+            "hermes"
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn trusted_adapter_manifest_source_parses_bundled_recipe_after_validation() -> anyhow::Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = coven_home.join("adapters");
+        fs::create_dir_all(&adapter_dir)?;
+        let manifest_path = adapter_dir.join("hermes.json");
+        fs::write(&manifest_path, HERMES_ADAPTER_MANIFEST)?;
+
+        let mut sources = trusted_adapter_manifest_sources(&coven_home);
+        assert_eq!(sources.len(), 1);
+        fs::write(
+            &manifest_path,
+            r#"{"adapters":[{"id":"hermes","label":"Planted","executable":"sh","interactive_prompt_prefix_args":["-c"],"non_interactive_prompt_prefix_args":["-c"],"install_hint":"planted"}]}"#,
+        )?;
+
+        let specs = sources.remove(0).load_specs(&built_in_harness_specs())?;
+        let hermes = specs
+            .iter()
+            .find(|spec| spec.id == "hermes")
+            .expect("trusted source should parse bundled hermes recipe");
+
+        assert_eq!(hermes.executable, "hermes");
+        assert_eq!(
+            hermes.manifest_path.as_deref(),
+            Some(manifest_path.to_string_lossy().as_ref())
         );
         Ok(())
     }

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -408,7 +408,6 @@ pub fn trusted_adapter_manifest_matches_recipe(path: &Path, adapter_id: &str) ->
         return false;
     }
     fs::read_to_string(path).is_ok_and(|actual| actual == expected)
-}
 
 fn coven_home_from_process_env() -> Option<PathBuf> {
     env::var_os("COVEN_HOME")

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -324,9 +324,7 @@ fn external_adapter_manifest_paths() -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
     if let Some(coven_home) = coven_home_from_process_env() {
-        paths.extend(adapter_manifest_paths_in_dir(&trusted_adapter_dir(
-            &coven_home,
-        )));
+        paths.extend(trusted_adapter_manifest_paths(&coven_home));
     }
 
     if let Some(manifest_path) = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV) {
@@ -352,6 +350,29 @@ pub fn trusted_adapter_dir(coven_home: &Path) -> PathBuf {
 
 pub fn trusted_adapter_manifest_path(coven_home: &Path, adapter_id: &str) -> PathBuf {
     trusted_adapter_dir(coven_home).join(format!("{adapter_id}.json"))
+}
+
+fn trusted_adapter_manifest_paths(coven_home: &Path) -> Vec<PathBuf> {
+    known_adapter_recipe_names()
+        .iter()
+        .filter_map(|adapter_id| {
+            let path = trusted_adapter_manifest_path(coven_home, adapter_id);
+            trusted_adapter_manifest_matches_recipe(&path, adapter_id).then_some(path)
+        })
+        .collect()
+}
+
+pub fn trusted_adapter_manifest_matches_recipe(path: &Path, adapter_id: &str) -> bool {
+    let Some(expected) = known_adapter_manifest(adapter_id) else {
+        return false;
+    };
+    let Ok(metadata) = fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !metadata.file_type().is_file() {
+        return false;
+    }
+    fs::read_to_string(path).is_ok_and(|actual| actual == expected)
 }
 
 fn coven_home_from_process_env() -> Option<PathBuf> {
@@ -1297,22 +1318,7 @@ mod tests {
         let coven_home = temp_dir.path().join("coven-home");
         let adapter_dir = coven_home.join("adapters");
         fs::create_dir_all(&adapter_dir)?;
-        fs::write(
-            adapter_dir.join("hermes.json"),
-            r#"{
-              "adapters": [
-                {
-                  "id": "hermes",
-                  "label": "Hermes Agent",
-                  "executable": "hermes",
-                  "interactive_prompt_prefix_args": ["chat", "--source", "coven", "-q"],
-                  "non_interactive_prompt_prefix_args": ["chat", "--source", "coven", "-Q", "-q"],
-                  "install_hint": "Install Hermes Agent and put it on PATH.",
-                  "system_prompt_flag": null
-                }
-              ]
-            }"#,
-        )?;
+        fs::write(adapter_dir.join("hermes.json"), HERMES_ADAPTER_MANIFEST)?;
 
         let _guard = env_lock().lock().unwrap();
         let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
@@ -1330,6 +1336,40 @@ mod tests {
             hermes.manifest_path.as_deref(),
             Some(adapter_dir.join("hermes.json").to_string_lossy().as_ref())
         );
+        Ok(())
+    }
+
+    #[test]
+    fn configured_harness_specs_ignore_coven_home_adapter_manifest_that_differs_from_recipe(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = coven_home.join("adapters");
+        fs::create_dir_all(&adapter_dir)?;
+        fs::write(
+            adapter_dir.join("hermes.json"),
+            r#"{
+              "adapters": [
+                {
+                  "id": "hermes",
+                  "label": "Planted Hermes",
+                  "executable": "sh",
+                  "interactive_prompt_prefix_args": ["-c", "echo planted"],
+                  "non_interactive_prompt_prefix_args": ["-c", "echo planted"],
+                  "install_hint": "planted"
+                }
+              ]
+            }"#,
+        )?;
+
+        let _guard = env_lock().lock().unwrap();
+        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
+        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+
+        let specs = configured_harness_specs()?;
+
+        assert!(specs.iter().all(|spec| spec.id != "hermes"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -845,8 +845,14 @@ fn run_adapter_install(adapter: &str) -> Result<()> {
             manifest_path.display()
         );
     } else {
-        if manifest_path.symlink_metadata().is_ok() {
-            std::fs::remove_file(&manifest_path).with_context(|| {
+        if let Ok(metadata) = manifest_path.symlink_metadata() {
+            let remove_result =
+                if metadata.file_type().is_dir() && !metadata.file_type().is_symlink() {
+                    std::fs::remove_dir_all(&manifest_path)
+                } else {
+                    std::fs::remove_file(&manifest_path)
+                };
+            remove_result.with_context(|| {
                 format!(
                     "failed to replace trusted adapter manifest {}",
                     manifest_path.display()

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -838,12 +838,21 @@ fn run_adapter_install(adapter: &str) -> Result<()> {
             adapter_dir.display()
         )
     })?;
-    if manifest_path.exists() {
+    let installed = harness::trusted_adapter_manifest_matches_recipe(&manifest_path, adapter);
+    if installed {
         println!(
             "Adapter `{adapter}` is already installed at {}",
             manifest_path.display()
         );
     } else {
+        if manifest_path.symlink_metadata().is_ok() {
+            std::fs::remove_file(&manifest_path).with_context(|| {
+                format!(
+                    "failed to replace trusted adapter manifest {}",
+                    manifest_path.display()
+                )
+            })?;
+        }
         std::fs::write(&manifest_path, manifest).with_context(|| {
             format!(
                 "failed to write trusted adapter manifest {}",

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -364,9 +364,58 @@ fn adapter_install_hermes_replaces_existing_manifest() -> anyhow::Result<()> {
         &install,
         "Installed adapter `hermes`",
     );
-    let manifest = fs::read_to_string(manifest_path)?;
-    assert!(manifest.contains("\"executable\": \"hermes\""));
-    assert!(!manifest.contains("\"executable\":\"sh\""));
+    let manifest = serde_json::from_str::<Value>(&fs::read_to_string(manifest_path)?)?;
+    let adapter = manifest
+        .get("adapters")
+        .and_then(Value::as_array)
+        .and_then(|adapters| adapters.first())
+        .expect("installed manifest should include one adapter");
+    assert_eq!(adapter.get("id").and_then(Value::as_str), Some("hermes"));
+    assert_eq!(
+        adapter.get("executable").and_then(Value::as_str),
+        Some("hermes")
+    );
+    Ok(())
+}
+
+#[test]
+fn adapter_install_hermes_replaces_existing_manifest_directory() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let adapter_dir = coven_home.join("adapters");
+    let manifest_path = adapter_dir.join("hermes.json");
+    fs::create_dir_all(&manifest_path)?;
+    fs::write(manifest_path.join("planted.txt"), "keep install broken")?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    let install = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["adapter", "install", "hermes"],
+    )?;
+
+    assert_success(
+        "adapter install hermes replaces manifest directory",
+        &install,
+    );
+    assert_stdout_contains(
+        "adapter install hermes replaces manifest directory",
+        &install,
+        "Installed adapter `hermes`",
+    );
+    let manifest = serde_json::from_str::<Value>(&fs::read_to_string(manifest_path)?)?;
+    let adapter = manifest
+        .get("adapters")
+        .and_then(Value::as_array)
+        .and_then(|adapters| adapters.first())
+        .expect("installed manifest should include one adapter");
+    assert_eq!(adapter.get("id").and_then(Value::as_str), Some("hermes"));
+    assert_eq!(
+        adapter.get("executable").and_then(Value::as_str),
+        Some("hermes")
+    );
     Ok(())
 }
 

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -338,6 +338,39 @@ fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
 }
 
 #[test]
+fn adapter_install_hermes_replaces_existing_manifest() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let adapter_dir = coven_home.join("adapters");
+    fs::create_dir_all(&adapter_dir)?;
+    let manifest_path = adapter_dir.join("hermes.json");
+    fs::write(
+        &manifest_path,
+        r#"{"adapters":[{"id":"hermes","label":"Planted","executable":"sh","interactive_prompt_prefix_args":["-c"],"non_interactive_prompt_prefix_args":["-c"],"install_hint":"planted"}]}"#,
+    )?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    let install = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["adapter", "install", "hermes"],
+    )?;
+
+    assert_success("adapter install hermes replaces manifest", &install);
+    assert_stdout_contains(
+        "adapter install hermes replaces manifest",
+        &install,
+        "Installed adapter `hermes`",
+    );
+    let manifest = fs::read_to_string(manifest_path)?;
+    assert!(manifest.contains("\"executable\": \"hermes\""));
+    assert!(!manifest.contains("\"executable\":\"sh\""));
+    Ok(())
+}
+
+#[test]
 fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");


### PR DESCRIPTION
### Motivation
- The code previously auto-loaded any `.json` under `COVEN_HOME/adapters`, creating an implicit trust path that allowed planted manifests to register harnesses which could execute attacker-controlled commands.
- This change protects the adapter trust store by ensuring only known, bundled adapter recipes are implicitly trusted when their manifest files exactly match the packaged recipe and are regular (non-symlink) files.
- The install flow is hardened so existing untrusted or stale manifests are replaced rather than silently accepted as already installed.

### Description
- Replace the unconstrained `adapter_manifest_paths_in_dir` scan of `COVEN_HOME/adapters` with `trusted_adapter_manifest_paths`, which only yields manifests for known recipe names that pass exact content matching via `trusted_adapter_manifest_matches_recipe`.
- Add `trusted_adapter_manifest_matches_recipe` to check that a manifest is a non-symlink regular file and that its text matches the bundled recipe returned by `known_adapter_manifest` before treating it as installed.
- Update the installer (`run_adapter_install`) to treat a manifest as installed only if it matches the recipe, and to remove symlinked or stale manifests before writing the trusted manifest.
- Add tests and regressions: unit test to ensure a planted/modified `COVEN_HOME/adapters/hermes.json` is ignored, a unit test that a correct bundled Hermes manifest is loaded from `COVEN_HOME`, and a smoke test verifying `coven adapter install hermes` replaces an existing planted manifest.

### Testing
- Ran `cargo fmt` to apply formatting without errors.
- Ran `cargo test -p coven-cli adapter` which executed the adapter unit and smoke tests.
- All adapter-related tests passed (including the new regressions) with no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34be73d2388327bda28d679e2d67f5)