### PR TITLE
release: fail on pre-existing npm package versions

### DIFF
--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -340,12 +340,13 @@ test('packageVersionPublished returns false when npm view exits non-zero (E404, 
   assert.equal(result, false);
 });
 
-test('publish-npm.mjs gates real publishes behind packageVersionPublished for rerun safety', () => {
+test('publish-npm.mjs fails closed when a package version already exists', () => {
   const scriptPath = new URL('publish-npm.mjs', import.meta.url);
   const script = readFileSync(scriptPath, 'utf8');
 
-  assert.match(script, /function publishOrSkip\(/);
-  assert.match(script, /Skipping \$\{packageName\}@\$\{version\}: already published/);
-  assert.match(script, /publishOrSkip\(target\.packageName/);
-  assert.match(script, /publishOrSkip\(packageName/);
+  assert.match(script, /function publishPackage\(/);
+  assert.match(script, /Refusing to publish wrappers that could trust an unverified pre-existing artifact/);
+  assert.match(script, /publishPackage\(target\.packageName/);
+  assert.match(script, /publishPackage\(packageName/);
+  assert.doesNotMatch(script, /Skipping \$\{packageName\}@\$\{version\}: already published/);
 });

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -345,7 +345,8 @@ test('publish-npm.mjs fails closed when a package version already exists', () =>
   const script = readFileSync(scriptPath, 'utf8');
 
   assert.match(script, /function publishPackage\(/);
-  assert.match(script, /Refusing to publish wrappers that could trust an unverified pre-existing artifact/);
+  assert.match(script, /Refusing to publish because this package version already exists on npm/);
+  assert.doesNotMatch(script, /Refusing to publish wrappers/);
   assert.match(script, /publishPackage\(target\.packageName/);
   assert.match(script, /publishPackage\(packageName/);
   assert.doesNotMatch(script, /Skipping \$\{packageName\}@\$\{version\}: already published/);

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -74,12 +74,12 @@ function main() {
 
   const platformDir = writePlatformPackage(targetName, target, binaryPath, version);
 
-  publishOrSkip(target.packageName, version, dryRun, platformDir);
+  publishPackage(target.packageName, version, dryRun, platformDir);
 
   if (!skipWrapper) {
     for (const packageName of wrapperPackageNames) {
       const wrapperDir = writeWrapperPackage(version, packageName);
-      publishOrSkip(packageName, version, dryRun, wrapperDir);
+      publishPackage(packageName, version, dryRun, wrapperDir);
     }
   }
 
@@ -87,10 +87,9 @@ function main() {
   console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${target.packageName}${skipWrapper ? '' : ` and ${wrapperPackageNames.join(', ')}`} at version ${version}.`);
 }
 
-function publishOrSkip(packageName, version, dryRun, cwd) {
+function publishPackage(packageName, version, dryRun, cwd) {
   if (!dryRun && packageVersionPublished(packageName, version)) {
-    console.log(`Skipping ${packageName}@${version}: already published to npm.`);
-    return;
+    fail(`${packageName}@${version} is already published to npm. Refusing to publish wrappers that could trust an unverified pre-existing artifact.`);
   }
   run('npm', publishArgs(dryRun), {
     cwd,

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -89,7 +89,7 @@ function main() {
 
 function publishPackage(packageName, version, dryRun, cwd) {
   if (!dryRun && packageVersionPublished(packageName, version)) {
-    fail(`${packageName}@${version} is already published to npm. Refusing to publish wrappers that could trust an unverified pre-existing artifact.`);
+    fail(`${packageName}@${version} is already published to npm. Refusing to publish because this package version already exists on npm and could trust an unverified pre-existing artifact.`);
   }
   run('npm', publishArgs(dryRun), {
     cwd,


### PR DESCRIPTION
### Motivation
- The release script previously skipped publishing when `npm view <pkg>@<version>` indicated a version existed, which silently trusts any pre-published artifact and can allow a malicious or stale package to be accepted into a release.
- The intent is to make publishes fail closed for real (non-dry-run) publishes so an unexpected existing registry version blocks the release and forces human review.

### Description
- Replace the skip-on-existing flow by renaming `publishOrSkip` to `publishPackage` and make the main publish path call `publishPackage` for both platform and wrapper packages in `scripts/publish-npm.mjs`.
- Change `publishPackage` to call `packageVersionPublished(...)` and call `fail(...)` when a package version is already present instead of logging and returning, preventing the release from trusting unverified existing artifacts.
- Update `scripts/publish-npm-test.mjs` to assert the new fail-closed behavior (look for `function publishPackage(` and the refusal message) and to remove expectations about the previous "Skipping ... already published" behavior.

### Testing
- Ran `node --test scripts/publish-npm-test.mjs` and all tests passed (40 tests, 0 failures).
- Ran `git diff --check` and it reported no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c7a72e90883278205aa8c2be71d3f)