### PR TITLE
Wrap Windows cmd-shim arguments to prevent .cmd reparse injection

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -800,7 +800,8 @@ fn prepend_launch_args(
 /// invoked through `cmd.exe`. cmd.exe interprets metacharacters like
 /// `& | < > ^ % ! "` in arguments even inside double-quoted strings in some
 /// invocation paths. Neutralize them by caret-escaping the dangerous
-/// characters and leave argument-boundary quoting to `std::process::Command`.
+/// characters and wrapping affected arguments in quotes so `.cmd` shims that
+/// re-expand `%*` keep the value as data during a second `cmd.exe` parse.
 ///
 /// On non-Windows platforms this is a no-op: the OS exec model passes
 /// argv entries as null-terminated byte arrays without shell parsing.
@@ -826,13 +827,15 @@ fn escape_cmd_shim_metacharacters(arg: &str) -> String {
         return arg.to_string();
     }
 
-    let mut escaped = String::with_capacity(arg.len() * 2);
+    let mut escaped = String::with_capacity((arg.len() * 2) + 2);
+    escaped.push('"');
     for ch in arg.chars() {
         if CMD_METACHARACTERS.contains(&ch) {
             escaped.push('^');
         }
         escaped.push(ch);
     }
+    escaped.push('"');
     escaped
 }
 
@@ -1157,14 +1160,14 @@ mod tests {
     }
 
     #[test]
-    fn cmd_shim_metacharacters_are_caret_escaped_without_wrapping() {
+    fn cmd_shim_metacharacters_are_caret_escaped_and_wrapped() {
         assert_eq!(escape_cmd_shim_metacharacters("safe prompt"), "safe prompt");
 
         let escaped = escape_cmd_shim_metacharacters(r#"a&b|c<d>e^f%g!h"i"#);
 
-        assert_eq!(escaped, r#"a^&b^|c^<d^>e^^f^%g^!h^"i"#);
-        assert!(!escaped.starts_with('"'));
-        assert!(!escaped.ends_with('"'));
+        assert_eq!(escaped, r#""a^&b^|c^<d^>e^^f^%g^!h^"i""#);
+        assert!(escaped.starts_with('"'));
+        assert!(escaped.ends_with('"'));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- The Windows sanitizer previously only caret-escaped cmd metacharacters which can be consumed by a first `cmd.exe` parse and re-exposed by npm-style `.cmd` shims that expand `%*`, allowing attacker-controlled arguments to become shell syntax on a second parse.
- The intent is to ensure arguments containing cmd metacharacters remain data across a potential second `cmd.exe` invocation used by batch shims.

### Description
- Change `escape_cmd_shim_metacharacters` to wrap the escaped argument in double quotes in addition to caret-escaping metacharacters so `.cmd` shims that re-expand `%*` retain the argument as a single data token.
- Update the earlier explanatory comment for Windows sanitization to document quoting as well as caret-escaping and keep `sanitize_argv_for_platform` using the updated sanitizer.
- Update the unit test to assert the wrapped-and-caret-escaped output (`cmd_shim_metacharacters_are_caret_escaped_and_wrapped`) instead of the previous no-wrap behavior.

### Testing
- Ran `cargo test -p coven-cli cmd_shim_metacharacters_are_caret_escaped_and_wrapped -- --nocapture`, which passed.
- Ran `cargo test -p coven-cli builds_claude_command_without_shell_interpolation -- --nocapture`, which passed.
- Ran the full `cargo test -p coven-cli`, where the unit and protocol tests passed but the smoke test `smoke_daemon_session_replay_and_safe_session_rituals` failed due to a daemon PID not exiting after `SIGTERM` during restart (test failure unrelated to the sanitizer change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4495c0f9488327b18b126f7f5801f8)