### PR TITLE
Improve cross-platform onboarding smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,38 @@ jobs:
       - run: npm test
         working-directory: packages/channels
 
+  npm-onboarding-smoke:
+    name: npm onboarding smoke (${{ matrix.npm-target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-26
+            npm-target: macos
+            rust-target: aarch64-apple-darwin
+          - os: ubuntu-latest
+            npm-target: linux-x64
+            rust-target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            npm-target: windows
+            rust-target: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+      - name: Install native link dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - run: cargo build --release --target ${{ matrix.rust-target }}
+      - run: node scripts/test-cli-prepublish.mjs --target=${{ matrix.npm-target }} --skip-build --skip-secrets-scan
+        env:
+          COVEN_NPM_DRY_RUN_VERSION: 999.0.0
+
   cargo-deny:
     name: Dependency audit
     runs-on: ubuntu-latest

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -123,7 +123,7 @@ jobs:
         include:
           - npm-target: macos
             rust-target: aarch64-apple-darwin
-            runner: macos-latest
+            runner: macos-26
             binary: coven
           - npm-target: linux-x64
             rust-target: x86_64-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ coven doctor
 | Package                    | Platform                                       |
 | -------------------------- | ---------------------------------------------- |
 | `@opencoven/cli`           | Universal wrapper — auto-selects your platform |
-| `@opencoven/cli-macos`     | macOS (arm64 + x64)                            |
+| `@opencoven/cli-macos`     | macOS Apple Silicon                            |
 | `@opencoven/cli-linux-x64` | Linux x64                                      |
 | `@opencoven/cli-windows`   | Windows x64                                    |
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -769,12 +769,7 @@ pub fn start_background_server(
 ) -> Result<DaemonStatus> {
     let spec = background_server_spec(current_exe, coven_home);
     ensure_private_coven_home(coven_home)?;
-    let child = Command::new(&spec.program)
-        .args(&spec.args)
-        .env("COVEN_HOME", &spec.coven_home)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
+    let child = background_server_command(&spec)
         .spawn()
         .with_context(|| format!("failed to start Coven daemon {}", spec.program.display()))?;
     let status = DaemonStatus {
@@ -784,6 +779,35 @@ pub fn start_background_server(
     };
     write_status(coven_home, &status)?;
     Ok(status)
+}
+
+fn background_server_command(spec: &DaemonSpawnSpec) -> Command {
+    let mut command = Command::new(&spec.program);
+    command
+        .args(&spec.args)
+        .env("COVEN_HOME", &spec.coven_home)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    configure_background_server_command(&mut command);
+    command
+}
+
+#[cfg(windows)]
+fn configure_background_server_command(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    command.creation_flags(windows_daemon_creation_flags());
+}
+
+#[cfg(not(windows))]
+fn configure_background_server_command(_command: &mut Command) {}
+
+#[cfg(windows)]
+fn windows_daemon_creation_flags() -> u32 {
+    use windows_sys::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, DETACHED_PROCESS};
+
+    DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP
 }
 
 pub fn ensure_background_server(
@@ -3513,6 +3537,17 @@ mod tests {
         assert_eq!(spec.program, PathBuf::from("/usr/local/bin/coven"));
         assert_eq!(spec.args, vec!["daemon".to_string(), "serve".to_string()]);
         assert_eq!(spec.coven_home, PathBuf::from("/tmp/coven-home"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_background_daemon_spawn_is_detached() {
+        use windows_sys::Win32::System::Threading::{CREATE_NEW_PROCESS_GROUP, DETACHED_PROCESS};
+
+        let flags = windows_daemon_creation_flags();
+
+        assert_ne!(flags & DETACHED_PROCESS, 0);
+        assert_ne!(flags & CREATE_NEW_PROCESS_GROUP, 0);
     }
 
     #[cfg(unix)]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -785,7 +785,12 @@ fn run_doctor() -> Result<()> {
         println!("  coven run {default} \"explain this repo in 5 bullets\"");
         println!("  coven sessions");
     } else {
-        println!("  Install or authenticate Codex/Claude Code, then run `coven doctor` again.");
+        println!("  Install and authenticate at least one harness in this same shell.");
+        println!("  Codex: npm install -g @openai/codex && codex login");
+        println!("  Claude Code: npm install -g @anthropic-ai/claude-code && claude doctor");
+        println!("  If PATH changed, open a new terminal and run `coven doctor` again.");
+        println!("  Then run: coven daemon start");
+        println!("  Install docs: docs/install/index.md");
     }
     Ok(())
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1086,7 +1086,7 @@ exit 0
 
         assert_eq!(command.program(), "claude");
         #[cfg(windows)]
-        assert_eq!(command.args(), &["explain ^&^& exit"]);
+        assert_eq!(command.args(), &["\"explain ^&^& exit\""]);
         #[cfg(not(windows))]
         assert_eq!(command.args(), &["explain && exit"]);
         assert_eq!(command.cwd(), cwd);

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -283,6 +283,39 @@ fn doctor_reports_no_familiars_when_manifest_absent() -> anyhow::Result<()> {
 }
 
 #[test]
+fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let coven = coven_bin();
+    let empty_path = OsString::new();
+
+    let output = run_coven(&coven, &coven_home, &empty_path, &["doctor"])?;
+
+    assert_success("doctor without harnesses", &output);
+    assert_stdout_contains("doctor without harnesses", &output, "Harnesses:");
+    assert_stdout_contains("doctor without harnesses", &output, "`codex` is missing");
+    assert_stdout_contains("doctor without harnesses", &output, "`claude` is missing");
+    assert_stdout_contains(
+        "doctor without harnesses",
+        &output,
+        "Install and authenticate at least one harness in this same shell.",
+    );
+    assert_stdout_contains(
+        "doctor without harnesses",
+        &output,
+        "If PATH changed, open a new terminal and run `coven doctor` again.",
+    );
+    assert_stdout_contains("doctor without harnesses", &output, "coven daemon start");
+    assert_stdout_contains(
+        "doctor without harnesses",
+        &output,
+        "Install docs: docs/install/index.md",
+    );
+    Ok(())
+}
+
+#[test]
 fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");

--- a/docs/daemon/coven-home.md
+++ b/docs/daemon/coven-home.md
@@ -6,4 +6,85 @@ title: "COVEN_HOME"
 description: "Reference for COVEN_HOME: the on-disk root the Coven daemon uses for the SQLite ledger, append-only event log, sockets, and per-session state."
 ---
 
-Stub — fill in. See [Daemon overview](/daemon/index).
+COVEN_HOME is the per-user state root for the Coven CLI and daemon. If unset,
+Coven uses `<home>/.coven`.
+
+Check the active state directory with:
+
+```sh
+coven doctor
+```
+
+The `Store:` line is the effective COVEN_HOME path.
+
+## What lives there
+
+The exact contents can change between releases, but a normal state directory can
+contain:
+
+| Path | Purpose |
+| --- | --- |
+| `coven.sqlite3` | Local session/event store. |
+| `coven.sock` | Local daemon socket on Unix-like hosts. |
+| `daemon.json` | Daemon pid/socket metadata. |
+| `daemon-recovery.log` | Background start/recovery notes. |
+| `familiars.toml` | Optional familiar identity registry. |
+| `repos.toml` | Optional known repository registry. |
+| `logs/` or artifacts directories | Redacted logs and retained session artifacts when enabled. |
+
+Do not edit the SQLite store by hand. Use the CLI when possible:
+
+```sh
+coven sessions
+coven daemon status
+coven logs prune --dry-run
+```
+
+## Defaults by platform
+
+- macOS: `/Users/<you>/.coven`
+- Linux: `/home/<you>/.coven`
+- Windows: `C:\Users\<you>\.coven`
+- WSL2: `/home/<you>/.coven` inside the WSL distribution
+- Containers: whatever path you set with `COVEN_HOME`
+
+## Override for a separate profile
+
+macOS/Linux/WSL2:
+
+```sh
+export COVEN_HOME="$HOME/.coven-work"
+coven doctor
+coven daemon start
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven-work"
+coven doctor
+coven daemon start
+```
+
+Every command that should use that profile must receive the same environment
+variable. If a daemon is already running under another COVEN_HOME, stop or
+restart the daemon for the profile you intend to use.
+
+## Placement rules
+
+Use a local, per-user, persistent directory. Avoid:
+
+- World-writable directories.
+- Synced folders that can rewrite socket or SQLite files.
+- Network filesystems for the daemon socket.
+- Windows-mounted paths from WSL2.
+- Ephemeral container filesystems when you need session history.
+
+If you move COVEN_HOME, restart:
+
+```sh
+coven daemon restart
+coven daemon status
+```
+
+See [Daemon overview](/daemon/index) and [Daemon health](/daemon/health).

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -6,4 +6,86 @@ title: "Health"
 description: "Reference for GET /api/v1/health, the Coven daemon liveness endpoint clients call first to confirm the socket is up and the API contract is negotiated."
 ---
 
-Stub — fill in. See [Daemon overview](/daemon/index).
+Daemon health is the signal that the background process is reachable and using
+the expected socket for the active `COVEN_HOME`.
+
+Use:
+
+```sh
+coven daemon status
+```
+
+Typical healthy output:
+
+```text
+coven daemon status=running ok=true pid=12345 socket=/home/alex/.coven/coven.sock
+```
+
+`running` means Coven found daemon metadata and verified the process/socket.
+`ok=true` means the daemon health response succeeded.
+
+## Status values
+
+| Status | Meaning | Next step |
+| --- | --- | --- |
+| `status=stopped` | No daemon metadata is present. | Run `coven daemon start`. |
+| `status=running ok=true` | The daemon is reachable. | Run `coven doctor` or start a session. |
+| `status=stale ok=false` | Metadata exists, but the daemon no longer looks healthy. | Run `coven daemon stop`, then `coven daemon start`. |
+
+## First-run health check
+
+```sh
+coven doctor
+coven daemon start
+coven daemon status
+cd /path/to/project
+coven run codex "say hello from Coven"
+```
+
+If you use Claude Code:
+
+```sh
+coven run claude "say hello from Coven"
+```
+
+## After upgrade or shell changes
+
+Restart the daemon after replacing the CLI binary, changing `PATH`, or
+authenticating a harness in a new shell:
+
+```sh
+coven --version
+coven daemon restart
+coven daemon status
+```
+
+## Supervisor and remote hosts
+
+For systemd, launchd, SSH, tmux, or container entrypoints, verify health from
+the same user and state directory:
+
+```sh
+echo "${COVEN_HOME:-$HOME/.coven}"
+coven daemon status
+```
+
+PowerShell:
+
+```powershell
+if (-not $env:COVEN_HOME) { $env:COVEN_HOME="$env:USERPROFILE\.coven" }
+coven daemon status
+```
+
+If a supervisor runs `coven daemon serve`, keep `PATH` and `COVEN_HOME` explicit
+in that supervisor configuration.
+
+## When health stays stale
+
+1. Stop the daemon with `coven daemon stop`.
+2. Confirm no old daemon process is still running for the same user.
+3. Confirm the state directory is writable.
+4. Start again with `coven daemon start`.
+5. If it still fails, collect `coven doctor` and `coven daemon status` output for
+   a diagnostics report.
+
+See [Daemon will not start](/help/daemon-wont-start).

--- a/docs/daemon/lifecycle.md
+++ b/docs/daemon/lifecycle.md
@@ -6,4 +6,118 @@ title: "Daemon lifecycle"
 description: "How the Coven daemon starts, supervises sessions, and shuts down cleanly, including socket binding, store recovery, and graceful PTY teardown on exit."
 ---
 
-Stub — fill in. See [Daemon overview](/daemon/index).
+# Daemon lifecycle
+
+The Coven daemon owns live harness sessions, the local socket or pipe, and the SQLite-backed session ledger under `COVEN_HOME`.
+
+Use the daemon commands as the operational surface:
+
+```sh
+coven daemon start
+coven daemon status
+coven daemon restart
+coven daemon stop
+```
+
+## Start
+
+```sh
+coven daemon start
+```
+
+Start creates `COVEN_HOME` when needed, binds the local daemon transport, records daemon metadata, and returns after the daemon is reachable.
+
+Run this after install:
+
+```sh
+coven doctor
+coven daemon start
+coven daemon status
+```
+
+## Status
+
+```sh
+coven daemon status
+```
+
+Status reports whether the daemon is running, stopped, stale, or unreachable. Use it before launching a session and after service-manager changes.
+
+If status reports stale state:
+
+```sh
+coven daemon restart
+```
+
+## Restart
+
+```sh
+coven daemon restart
+```
+
+Restart is the normal repair path after:
+
+- updating the `coven` binary or npm wrapper;
+- changing `COVEN_HOME`;
+- changing shell `PATH`;
+- installing or updating harness CLIs;
+- recovering from a stale socket or stale daemon metadata.
+
+After restart:
+
+```sh
+coven doctor
+coven daemon status
+```
+
+## Stop
+
+```sh
+coven daemon stop
+```
+
+Stop the daemon before uninstalling Coven, moving `COVEN_HOME`, changing service-manager configuration, or replacing a source-built binary.
+
+## First session after daemon start
+
+```sh
+cd /path/to/project
+coven run codex "describe this repo"
+coven sessions
+```
+
+Use Claude Code instead with:
+
+```sh
+coven run claude "describe this repo"
+```
+
+## Service managers
+
+Start manually before adding a service manager. Once `coven doctor` and `coven daemon status` work, use:
+
+- [launchd service](/install/launchd) on macOS;
+- [systemd unit](/install/systemd) on Linux;
+- [Headless server](/install/headless-server) for SSH-oriented operation.
+
+The service manager must inherit or define a `PATH` that exposes `coven` and any harness CLI you expect the daemon to launch.
+
+## State directory
+
+By default, Coven uses `<home>/.coven`. To isolate an environment:
+
+```sh
+export COVEN_HOME="$HOME/.coven-demo"
+coven daemon restart
+coven doctor
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven-demo"
+coven daemon restart
+coven doctor
+```
+
+See [COVEN_HOME](/daemon/coven-home) for the full layout.

--- a/docs/help/community.md
+++ b/docs/help/community.md
@@ -6,4 +6,68 @@ title: "Community"
 description: "Where to get community help with Coven: GitHub discussions, the Discord, and the public channels OpenCoven maintainers monitor for questions and bugs."
 ---
 
-Stub — fill in.
+Use the channel that matches the kind of help you need. Include the output of
+`coven doctor` whenever the question is about setup, daemon state, or harness
+detection.
+
+## Fast setup help
+
+Discord is the fastest path for interactive setup questions:
+
+```text
+https://discord.gg/opencoven
+```
+
+Share:
+
+```sh
+coven --version
+coven doctor
+coven daemon status
+```
+
+Redact project names, prompts, tokens, and private paths before posting.
+
+## Searchable questions
+
+Use GitHub Discussions for questions that should be searchable later:
+
+```text
+https://github.com/OpenCoven/coven/discussions
+```
+
+Good fits:
+
+- Which install path to use for a platform.
+- How to run Coven under systemd, launchd, tmux, SSH, WSL2, or containers.
+- How adapters and harnesses should be modeled.
+- Clarifying docs before filing a bug.
+
+## Bugs
+
+Use GitHub Issues for reproducible bugs:
+
+```text
+https://github.com/OpenCoven/coven/issues
+```
+
+Before filing:
+
+```sh
+coven doctor
+coven daemon status
+```
+
+Then follow [Filing issues](/help/filing-issues).
+
+## Announcements
+
+Follow the public OpenCoven account for release notes and project updates:
+
+```text
+https://x.com/OpenCvn
+```
+
+Do not use social replies for private logs or support bundles. Use Discord,
+Discussions, or Issues depending on whether you need live help, searchable Q&A,
+or bug tracking.

--- a/docs/help/daemon-wont-start.md
+++ b/docs/help/daemon-wont-start.md
@@ -6,4 +6,105 @@ title: "The daemon will not start"
 description: "Fixes when the Coven daemon will not start: socket permissions, stale lock files, conflicting processes, and COVEN_HOME write access on the host."
 ---
 
-Stub — fill in.
+The daemon owns Coven sessions, local socket API state, and the session ledger.
+If it will not start, keep the diagnosis in the same user account and the same
+`COVEN_HOME` that your CLI uses.
+
+Start with:
+
+```sh
+coven doctor
+coven daemon status
+```
+
+`status=stopped` is not an error. Start it:
+
+```sh
+coven daemon start
+coven daemon status
+```
+
+## Restart with the current binary
+
+After updating Coven or changing `PATH`, restart the daemon so the background
+process uses the binary and environment you expect:
+
+```sh
+coven --version
+coven daemon restart
+coven daemon status
+```
+
+If `status=running ok=true` appears, continue with:
+
+```sh
+coven run codex "say hello from Coven"
+```
+
+## Stale socket or pid file
+
+A crashed daemon can leave metadata behind. First ask Coven to clean it up:
+
+```sh
+coven daemon stop
+coven daemon status
+coven daemon start
+```
+
+If the status still reports a stale daemon, inspect the state directory:
+
+```sh
+echo "${COVEN_HOME:-$HOME/.coven}"
+ls -la "${COVEN_HOME:-$HOME/.coven}"
+```
+
+PowerShell:
+
+```powershell
+if (-not $env:COVEN_HOME) { $env:COVEN_HOME="$env:USERPROFILE\.coven" }
+Get-ChildItem $env:COVEN_HOME
+coven daemon status
+```
+
+Remove socket or status files only after confirming no daemon process is using
+them. Then run `coven daemon start` again.
+
+## Permission checks
+
+The daemon needs write access to `COVEN_HOME` and permission to create its local
+socket. Fix ownership or choose a state directory owned by your user:
+
+```sh
+mkdir -p "$HOME/.coven"
+chmod 700 "$HOME/.coven"
+COVEN_HOME="$HOME/.coven" coven doctor
+```
+
+Do not point `COVEN_HOME` at a shared world-writable directory, a synced folder,
+or a Windows filesystem path from WSL2. Use a local per-user directory.
+
+## Supervisor checks
+
+For launchd, systemd, tmux, SSH, or container setups, run the same command the
+supervisor runs from an interactive shell first:
+
+```sh
+coven daemon serve
+```
+
+Stop it with `Ctrl-C` after it binds successfully, then start the supervisor.
+If the interactive command works but the supervisor fails, compare `PATH`,
+`COVEN_HOME`, working directory, and user account.
+
+## What to attach to an issue
+
+Collect:
+
+```sh
+coven --version
+coven doctor
+coven daemon status
+```
+
+Also include your OS, install method, and whether you run Coven directly, under
+systemd/launchd, in WSL2, or in a container. Redact project paths and prompts.

--- a/docs/help/diagnostics-bundle.md
+++ b/docs/help/diagnostics-bundle.md
@@ -6,4 +6,69 @@ title: "Diagnostics bundle"
 description: "How to collect a diagnostics bundle for Coven, including daemon logs, doctor output, and harness versions, ready to attach to a GitHub issue."
 ---
 
-Stub — fill in.
+Coven does not currently ship a single `coven diagnostics bundle` command. Until
+that exists, collect a small redacted bundle manually from the same shell and
+user account that reproduces the issue.
+
+Create a scratch directory:
+
+```sh
+mkdir -p coven-diagnostics
+coven --version > coven-diagnostics/version.txt
+coven doctor > coven-diagnostics/doctor.txt
+coven daemon status > coven-diagnostics/daemon-status.txt
+```
+
+If you are on macOS and using `coven pc`, include a read-only system snapshot:
+
+```sh
+coven pc status --json > coven-diagnostics/pc-status.json
+```
+
+If the problem involves sessions, add a plain session list:
+
+```sh
+coven sessions --plain > coven-diagnostics/sessions.txt
+```
+
+## Include context
+
+Add a short text file with:
+
+- OS and version.
+- Install method: npm wrapper, cargo, source checkout, Docker, Podman, Nix,
+  launchd, systemd, WSL2, or another route.
+- Whether `COVEN_HOME` is default or overridden.
+- Which harness you tried: Codex or Claude Code.
+- The exact command that failed.
+
+## Redaction checklist
+
+Before sharing the bundle, inspect every file:
+
+```sh
+grep -RniE "token|secret|key|password|authorization|bearer" coven-diagnostics || true
+```
+
+Remove provider tokens, private prompts, customer data, home-directory details
+you do not want to share, and any repository paths that identify confidential
+work. Do not attach raw session artifacts unless a maintainer specifically asks
+for them.
+
+## Compress
+
+macOS/Linux/WSL2:
+
+```sh
+tar -czf coven-diagnostics.tgz coven-diagnostics
+```
+
+PowerShell:
+
+```powershell
+Compress-Archive -Path coven-diagnostics -DestinationPath coven-diagnostics.zip
+```
+
+Attach the archive to a GitHub issue or share the individual redacted text files
+in Discord. If you cannot share files, paste only the relevant `coven doctor`
+section and the failing command output.

--- a/docs/help/filing-issues.md
+++ b/docs/help/filing-issues.md
@@ -6,4 +6,69 @@ title: "Filing issues"
 description: "How to file a useful Coven bug report: what to include from coven doctor, the daemon logs, harness versions, and the relevant session record."
 ---
 
-Stub — fill in.
+File issues at the Coven repository when you can reproduce a bug, docs mismatch,
+or install failure. Use GitHub Discussions or Discord for exploratory questions.
+
+Before filing, collect the current local state:
+
+```sh
+coven --version
+coven doctor
+coven daemon status
+```
+
+If the issue involves sessions:
+
+```sh
+coven sessions --plain --all
+```
+
+If it involves a harness:
+
+```sh
+command -v codex
+command -v claude
+```
+
+PowerShell:
+
+```powershell
+Get-Command codex
+Get-Command claude
+```
+
+## Include
+
+- Platform: macOS, Linux, Windows, WSL2, container, Raspberry Pi, or headless
+  server.
+- Install route: npm wrapper, cargo, source checkout, Docker, Podman, Nix,
+  launchd, systemd, or another supervisor.
+- The exact command that failed.
+- Expected behavior and actual behavior.
+- Whether `coven doctor` reports missing harnesses, stopped daemon, running
+  daemon, or stale daemon.
+- A redacted diagnostics bundle from [Diagnostics bundle](/help/diagnostics-bundle)
+  when the issue is not obvious from the command output.
+
+## Redact
+
+Do not include provider tokens, private prompts, customer data, private repo URLs,
+or raw session artifacts unless a maintainer asks for a narrow file. If a path is
+sensitive, replace the prefix with `<project>` or `<home>`.
+
+## Good issue title examples
+
+- `npm install succeeds on Windows but coven doctor cannot find coven.exe`
+- `coven daemon restart leaves stale status under systemd user service`
+- `WSL2 install guide should warn about COVEN_HOME on /mnt/c`
+
+## Where to file
+
+Use GitHub Issues for reproducible bugs:
+
+```text
+https://github.com/OpenCoven/coven/issues
+```
+
+For setup uncertainty, ask in Discord first and include the same `coven doctor`
+summary.

--- a/docs/help/harness-not-found.md
+++ b/docs/help/harness-not-found.md
@@ -6,4 +6,110 @@ title: "Harness not found"
 description: "Fixes when Coven reports a harness CLI is not found: PATH, npm or pip install location, and version checks for Codex and Claude Code."
 ---
 
-Stub — fill in.
+`coven run` does not install or authenticate model-provider CLIs for you. Coven
+looks for supported harness executables on the `PATH` of the same shell that
+launches `coven`, then starts those CLIs inside a project-scoped session.
+
+Start with:
+
+```sh
+coven doctor
+```
+
+In the `Harnesses` section, `ready` means Coven can find the executable. `missing`
+means the binary is not visible from this shell, even if another terminal or app
+can run it.
+
+## Install a supported harness
+
+Codex:
+
+```sh
+npm install -g @openai/codex
+codex login
+coven doctor
+```
+
+Claude Code:
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+coven doctor
+```
+
+Install at least one harness before running:
+
+```sh
+coven run codex "describe this repo"
+```
+
+or:
+
+```sh
+coven run claude "describe this repo"
+```
+
+## Same-shell PATH checks
+
+Run these from the exact shell where `coven doctor` reports the harness missing:
+
+```sh
+command -v codex
+command -v claude
+node --version
+npm --version
+```
+
+PowerShell:
+
+```powershell
+Get-Command codex
+Get-Command claude
+node --version
+npm --version
+```
+
+If install succeeded but `command -v` or `Get-Command` cannot find the binary,
+open a new terminal so the shell refreshes `PATH`. Then run:
+
+```sh
+coven doctor
+```
+
+## Platform notes
+
+- macOS: global npm binaries often live under a Node manager directory such as
+  `~/.nvm/.../bin` or an npm prefix. GUI terminals, launchd jobs, and shells may
+  not share the same `PATH`.
+- Linux and WSL2: install the harness inside the environment where Coven runs.
+  A Windows-side Codex install is not visible from WSL2.
+- Windows: install and authenticate from the same PowerShell, Windows Terminal,
+  or native shell where you will run Coven. If `Get-Command` still fails, inspect
+  the npm global prefix with `npm prefix -g`.
+- Headless hosts: authenticate the provider CLI over SSH before starting Coven
+  under systemd, tmux, or another supervisor.
+
+## Authentication failures
+
+If `coven doctor` says the harness is ready but `coven run` exits immediately,
+the binary is visible but the provider CLI is not authenticated. Run the provider
+setup command directly:
+
+```sh
+codex login
+claude doctor
+```
+
+Then verify again:
+
+```sh
+coven doctor
+coven run codex "say hello"
+```
+
+## Still failing
+
+Capture the exact `Harnesses` section from `coven doctor`, the output of
+`command -v codex` or `Get-Command codex`, and your platform/install method.
+Redact home-directory details if needed before filing an issue.

--- a/docs/help/index.md
+++ b/docs/help/index.md
@@ -43,9 +43,10 @@ description: "Help index for Coven: troubleshooting, environment and paths, perm
   </Step>
   <Step title="Bundle and ask">
     ```bash
-    coven diagnostics bundle
+    coven doctor > coven-doctor.txt
+    coven daemon status > coven-daemon-status.txt
     ```
-    Attach the resulting tarball to a [GitHub issue](/help/filing-issues) or share it in [Discord](https://discord.gg/opencoven).
+    Redact local paths or prompts, then attach the files to a [GitHub issue](/help/filing-issues) or share them in [Discord](https://discord.gg/opencoven). See [Diagnostics bundle](/help/diagnostics-bundle).
   </Step>
 </Steps>
 

--- a/docs/help/paths.md
+++ b/docs/help/paths.md
@@ -6,4 +6,79 @@ title: "Paths and state directories"
 description: "Where Coven stores its state on disk: COVEN_HOME, the SQLite ledger, the append-only event log, sockets, and per-session directories on each host."
 ---
 
-Stub — fill in.
+Coven keeps state in one per-user directory and uses the current project
+directory only for project-root detection and harness execution.
+
+Start with:
+
+```sh
+coven doctor
+```
+
+The `Store:` line shows the active state root.
+
+## Default paths
+
+| Host | Default state directory |
+| --- | --- |
+| macOS | `/Users/<you>/.coven` |
+| Linux | `/home/<you>/.coven` |
+| WSL2 | `/home/<you>/.coven` inside the WSL distribution |
+| Windows | `C:\Users\<you>\.coven` |
+| Containers | The value of `COVEN_HOME`, or the container user's home directory |
+
+Override the state root only when you need a separate profile or an explicit
+persistent mount:
+
+```sh
+export COVEN_HOME="$HOME/.coven-work"
+coven doctor
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven-work"
+coven doctor
+```
+
+## Files you may see
+
+| Path | Purpose |
+| --- | --- |
+| `coven.sqlite3` | Local SQLite ledger for sessions and events. |
+| `daemon.json` | Background daemon metadata. |
+| `coven.sock` | Local daemon socket on Unix-like hosts. |
+| `daemon-recovery.log` | Recovery/startup notes for daemon launches. |
+| `familiars.toml` | Optional familiar identity registry. |
+| `repos.toml` | Optional repository registry. |
+
+Use CLI commands instead of editing state files:
+
+```sh
+coven sessions --plain
+coven daemon status
+coven logs prune --dry-run
+```
+
+## Project paths
+
+Run sessions from inside a project:
+
+```sh
+cd /path/to/project
+coven run codex "describe this repo"
+```
+
+`coven doctor` prints `Project: not inside a git/project root yet` when the
+current directory is not a project. That is fine for install checks, but session
+launches should happen from the project you want the harness to inspect.
+
+## WSL2 and containers
+
+Keep `COVEN_HOME` on the same filesystem where the daemon runs. In WSL2, avoid
+placing it under `/mnt/c/...`; use the Linux home directory. In containers,
+bind-mount a persistent directory if you want sessions and logs to survive
+container replacement.
+
+See [COVEN_HOME layout](/daemon/coven-home) for daemon-specific details.

--- a/docs/help/permissions.md
+++ b/docs/help/permissions.md
@@ -6,4 +6,78 @@ title: "Permissions"
 description: "Permissions Coven needs on each host: filesystem access for COVEN_HOME, socket bind rights, and the same-user model the daemon enforces for clients."
 ---
 
-Stub — fill in.
+Coven runs as your local user. It needs permission to write `COVEN_HOME`, create
+or connect to the local daemon socket, and launch the harness CLI from the
+project directory you choose.
+
+Check the active setup:
+
+```sh
+coven doctor
+coven daemon status
+```
+
+## State directory permissions
+
+The state directory should be owned by the same user that runs Coven:
+
+```sh
+mkdir -p "$HOME/.coven"
+chmod 700 "$HOME/.coven"
+COVEN_HOME="$HOME/.coven" coven doctor
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven"
+coven doctor
+```
+
+Do not use `sudo coven` to work around permission errors. That creates root-owned
+state and can make the normal user unable to start the daemon later.
+
+## Socket access
+
+`coven daemon status` should be run by the same user that started the daemon:
+
+```sh
+coven daemon restart
+coven daemon status
+```
+
+If a supervisor starts the daemon, make the supervisor user, `PATH`, and
+`COVEN_HOME` explicit. A daemon running under another account will not share your
+shell's state or provider authentication.
+
+## Harness permissions
+
+Coven does not own provider credentials. Codex and Claude Code authenticate
+themselves:
+
+```sh
+codex login
+claude doctor
+coven doctor
+```
+
+If `coven doctor` reports the harness is ready but `coven run` fails, run the
+harness command directly in the same shell and project directory. Fix provider
+auth or sandbox prompts there first.
+
+## Platform notes
+
+- macOS may show accessibility, terminal, or developer-tool prompts from the
+  harness CLI. Approve those for the terminal app that launches Coven.
+- Linux systemd user services must define `PATH` and `COVEN_HOME` if they differ
+  from system defaults.
+- Windows shells should run Coven and harness CLIs from the same user profile.
+- WSL2 should keep state and harness installs inside WSL, not split across
+  Windows and Linux environments.
+
+After changing permissions, restart:
+
+```sh
+coven daemon restart
+coven doctor
+```

--- a/docs/help/session-stuck.md
+++ b/docs/help/session-stuck.md
@@ -6,4 +6,95 @@ title: "A session is stuck"
 description: "What to do when a Coven session looks stuck: how to attach, inspect the PTY, read the event log, and decide between archive and sacrifice."
 ---
 
-Stub — fill in.
+A session can look stuck because the harness is still running, the daemon lost
+contact with the process, or the local terminal stopped following output.
+
+Start with read-only checks:
+
+```sh
+coven daemon status
+coven sessions --plain
+```
+
+Find the session id, then attach:
+
+```sh
+coven attach <session-id>
+```
+
+If output resumes, keep using the attached session. If the session already ended,
+`attach` should replay the retained event stream and exit.
+
+## Check daemon health
+
+If no sessions update, verify the daemon:
+
+```sh
+coven doctor
+coven daemon status
+```
+
+When the daemon is stale, restart it:
+
+```sh
+coven daemon restart
+coven daemon status
+```
+
+Then list sessions again:
+
+```sh
+coven sessions --plain --all
+```
+
+## Safe cleanup choices
+
+Archive hides a completed session without deleting events:
+
+```sh
+coven archive <session-id>
+```
+
+Summon restores an archived session:
+
+```sh
+coven summon <session-id>
+```
+
+Sacrifice permanently deletes a non-running session and its events. It requires
+an explicit confirmation flag:
+
+```sh
+coven sacrifice <session-id> --yes
+```
+
+Do not sacrifice live work. The CLI refuses running sessions, but you should
+still check `coven sessions --plain --all` first.
+
+## When the harness is the issue
+
+If only one harness type gets stuck, run its native setup check:
+
+```sh
+codex login
+claude doctor
+coven doctor
+```
+
+Then start a tiny session from a project directory:
+
+```sh
+coven run codex "say hello"
+```
+
+## What to report
+
+When filing an issue, include:
+
+- `coven --version`
+- `coven doctor`
+- `coven daemon status`
+- The session id prefix and whether `coven attach <session-id>` replays output
+- Install method and platform
+
+Redact prompts, paths, and provider account details before sharing.

--- a/docs/install/cargo.md
+++ b/docs/install/cargo.md
@@ -6,4 +6,68 @@ title: "Install via cargo"
 description: "Install Coven from source with cargo: build the Rust daemon and CLI, drop the binary on PATH, and verify the install with coven doctor."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Install via cargo
+
+Use this route when you want to build the Rust CLI yourself. For most users, [Install via npm](/install/npm) is the shorter path.
+
+## From a checkout
+
+```sh
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build -p coven-cli --release
+mkdir -p "$HOME/.local/bin"
+cp target/release/coven "$HOME/.local/bin/coven"
+coven doctor
+```
+
+On Windows, copy `target\release\coven.exe` to a directory on `PATH`, then open a new terminal and run:
+
+```powershell
+coven doctor
+```
+
+## Running without copying
+
+From the repository checkout:
+
+```sh
+cargo run -p coven-cli -- doctor
+cargo run -p coven-cli -- daemon start
+cargo run -p coven-cli -- run codex "describe this repo"
+```
+
+## Harness setup
+
+Coven still needs a harness CLI for real agent work:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Run `coven doctor` after installing or changing harness auth.
+
+## Updating a cargo-built binary
+
+```sh
+cd /path/to/coven
+git pull --ff-only
+cargo build -p coven-cli --release
+cp target/release/coven "$HOME/.local/bin/coven"
+coven daemon restart
+coven doctor
+```
+
+Use the Windows binary name when updating a Windows install.
+
+## Related
+
+- [Install from source](/install/from-source)
+- [COVEN_HOME layout](/daemon/coven-home)
+- [Updating Coven](/install/updating)

--- a/docs/install/development-channels.md
+++ b/docs/install/development-channels.md
@@ -6,4 +6,83 @@ title: "Development channels"
 description: "Coven development channels: how to run pre-release builds, switch between stable and nightly, and pin a specific @opencoven/cli version per host."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Development channels
+
+Use this page when you need to test unreleased Coven changes or pin a host to a known package version.
+
+## Stable wrapper path
+
+For ordinary installs:
+
+```sh
+npm install -g @opencoven/cli
+coven doctor
+```
+
+Pin a specific published version when reproducing user reports:
+
+```sh
+npm install -g @opencoven/cli@<version>
+coven --version
+coven doctor
+```
+
+Replace `<version>` with a concrete version from the package registry or release notes you are investigating.
+
+## Source channel
+
+For unreleased changes:
+
+```sh
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+git checkout <branch-or-tag>
+cargo run -p coven-cli -- doctor
+```
+
+Use an isolated state directory so development builds do not disturb your normal daemon:
+
+```sh
+export COVEN_HOME="$PWD/.coven-dev"
+cargo run -p coven-cli -- daemon start
+cargo run -p coven-cli -- run codex "describe this repo"
+```
+
+## Switching channels
+
+Stop the daemon before switching between wrapper installs and source builds:
+
+```sh
+coven daemon stop
+```
+
+Then run the target channel's doctor command:
+
+```sh
+coven doctor
+```
+
+or from source:
+
+```sh
+cargo run -p coven-cli -- doctor
+```
+
+## Verification
+
+After switching channels:
+
+```sh
+coven --version
+coven doctor
+coven daemon restart
+coven daemon status
+```
+
+If you are using a source checkout, run the same commands through Cargo or copy the release binary to the `coven` location you intend to test.
+
+## Related
+
+- [Updating Coven](/install/updating)
+- [Install from source](/install/from-source)
+- [COVEN_HOME layout](/daemon/coven-home)

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -6,4 +6,83 @@ title: "Docker"
 description: "Run Coven in Docker: a containerized daemon plus harness CLIs, with bind mounts for COVEN_HOME and the project root for each session."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Docker
+
+Docker is an advanced setup path. This repository does not define a canonical Coven application image in the install docs; build your own image when you need container isolation for CI, demos, or a homelab.
+
+Use native installs for normal workstation use: [macOS](/install/macos), [Linux](/install/linux), [Windows](/install/windows), or [WSL2](/install/wsl2).
+
+## Minimal source-built image
+
+Create a Dockerfile in your own deployment repo:
+
+```Dockerfile
+FROM rust:1-bookworm AS build
+WORKDIR /src
+COPY . .
+RUN cargo build -p coven-cli --release
+
+FROM debian:bookworm-slim
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates nodejs npm git \
+  && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/coven /usr/local/bin/coven
+ENV COVEN_HOME=/var/lib/coven
+WORKDIR /workspace
+CMD ["coven", "doctor"]
+```
+
+Build it from a Coven source checkout:
+
+```sh
+docker build -t coven-local .
+```
+
+## Run with explicit mounts
+
+```sh
+mkdir -p "$HOME/.coven-container"
+docker run --rm -it \
+  -e COVEN_HOME=/var/lib/coven \
+  -v "$HOME/.coven-container:/var/lib/coven" \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  coven-local coven doctor
+```
+
+For real harness work, the container must also contain and authenticate the harness CLI. Provider credentials remain owned by that harness, not by Coven.
+
+## First container session
+
+```sh
+docker run --rm -it \
+  -e COVEN_HOME=/var/lib/coven \
+  -v "$HOME/.coven-container:/var/lib/coven" \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  coven-local coven daemon start
+```
+
+Then run a session in the same mounted environment:
+
+```sh
+docker run --rm -it \
+  -e COVEN_HOME=/var/lib/coven \
+  -v "$HOME/.coven-container:/var/lib/coven" \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  coven-local coven run codex "describe this repo"
+```
+
+## Notes
+
+- Bind-mount `COVEN_HOME` if you want session history to survive container exits.
+- Bind-mount the project root you intend to run in.
+- Do not expose the Coven daemon socket over TCP by default.
+- Run `coven doctor` inside the same image and environment that will launch sessions.
+
+## Related
+
+- [Headless server](/install/headless-server)
+- [Podman](/install/podman)
+- [COVEN_HOME layout](/daemon/coven-home)

--- a/docs/install/from-source.md
+++ b/docs/install/from-source.md
@@ -6,4 +6,87 @@ title: "Install from source"
 description: "Build and install Coven from source: clone the repo, build the Rust daemon and CLI with cargo, and drop the binary on PATH for daily use."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Install from source
+
+Use a source checkout when you are contributing to Coven, testing unreleased changes, or running on a platform where the npm native package is not available.
+
+## Requirements
+
+- Rust stable.
+- Git.
+- A supported shell for your platform.
+- At least one harness CLI if you want to launch real sessions.
+
+## Build and verify
+
+```sh
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build --workspace
+cargo run -p coven-cli -- doctor
+```
+
+Run the binary through Cargo while developing:
+
+```sh
+cargo run -p coven-cli -- daemon start
+cargo run -p coven-cli -- run codex "describe this repo"
+cargo run -p coven-cli -- sessions
+```
+
+## Install the built binary
+
+After building, copy the release binary to a directory on `PATH`:
+
+```sh
+cargo build -p coven-cli --release
+mkdir -p "$HOME/.local/bin"
+cp target/release/coven "$HOME/.local/bin/coven"
+coven doctor
+```
+
+On Windows, copy `target\release\coven.exe` to a directory on `PATH`.
+
+## Harness setup
+
+Install and authenticate a harness in the same shell environment:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Then run:
+
+```sh
+coven doctor
+```
+
+## Development checks
+
+Before changing daemon, session, attach, or ritual behavior, run the workspace checks described in [Getting started](/GETTING-STARTED) and [Documentation maintenance](/DOCS-MAINTENANCE).
+
+For docs-only install work:
+
+```sh
+python scripts/check-secrets.py
+git diff --check
+```
+
+For code work:
+
+```sh
+cargo fmt --check
+cargo test --workspace --locked
+```
+
+## Related
+
+- [Install via npm](/install/npm)
+- [Install via cargo](/install/cargo)
+- [Linux install](/install/linux)

--- a/docs/install/headless-server.md
+++ b/docs/install/headless-server.md
@@ -6,4 +6,94 @@ title: "Headless server"
 description: "Install Coven on a headless server: daemon-only setup, no TUI, with systemd or launchd supervision and remote access through SSH tunnels."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Headless server
+
+On a headless host, install Coven the same way as Linux, then operate it through SSH and explicit daemon commands.
+
+```sh
+npm install -g @opencoven/cli
+coven doctor
+```
+
+If the npm native package is not available on the server distribution, use [Install from source](/install/from-source).
+
+## Server layout
+
+Choose a dedicated user and keep state under that user's home directory:
+
+```sh
+export COVEN_HOME="$HOME/.coven"
+mkdir -p "$COVEN_HOME"
+coven doctor
+```
+
+Keep `COVEN_HOME` on a local disk owned by the service user. Avoid sharing one state directory between multiple Unix users.
+
+## Harness setup
+
+Install and authenticate the harness CLI as the same user that will run Coven:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Run:
+
+```sh
+coven doctor
+```
+
+## Daemon lifecycle
+
+Start and inspect the daemon over SSH:
+
+```sh
+coven daemon start
+coven daemon status
+```
+
+Restart after updates or environment changes:
+
+```sh
+coven daemon restart
+coven doctor
+```
+
+Stop it before changing ownership, moving `COVEN_HOME`, or rebuilding the binary:
+
+```sh
+coven daemon stop
+```
+
+## First remote session
+
+```sh
+cd /path/to/project
+coven run codex "summarize the current branch"
+coven sessions
+```
+
+Use `coven attach <session-id>` to follow a live session from a later SSH connection.
+
+## Supervisor note
+
+The CLI daemon commands are the stable operational surface. If you wrap them with systemd, launchd, tmux, or another supervisor, keep the environment explicit:
+
+```sh
+COVEN_HOME="$HOME/.coven" coven daemon start
+```
+
+Make sure the supervisor has the same `PATH` that exposes `coven`, `codex`, and `claude`.
+
+## Related
+
+- [Linux install](/install/linux)
+- [COVEN_HOME layout](/daemon/coven-home)
+- [Daemon lifecycle](/daemon/lifecycle)
+- [Troubleshooting](/TROUBLESHOOTING)

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -6,4 +6,110 @@ title: "Install overview"
 description: "Install overview for Coven: pick a platform and a method (npm, cargo, Docker, Nix, source) and verify the daemon with coven doctor."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Install overview
+
+Use this page to pick the right Coven install path, then verify the setup the same way on every platform:
+
+```sh
+coven doctor
+coven daemon start
+coven daemon status
+```
+
+After the daemon is running, launch the first session from a project directory:
+
+```sh
+cd /path/to/project
+coven run codex "describe this repo"
+```
+
+Or use Claude Code:
+
+```sh
+coven run claude "describe this repo"
+```
+
+## Choose your route
+
+| Environment | Recommended path | Notes |
+| --- | --- | --- |
+| macOS Apple Silicon | [npm wrapper](/install/npm) or [macOS install](/install/macos) | Uses the universal `@opencoven/cli` package and the native macOS package. |
+| glibc-based Linux x64 | [npm wrapper](/install/npm) or [Linux install](/install/linux) | Alpine/musl is not part of the npm binary target today; build from source there. |
+| Windows x64 | [Windows install](/install/windows) | Run Coven and harness CLIs from the same PowerShell, Windows Terminal, or native Windows shell. |
+| WSL2 | [WSL2 install](/install/wsl2) | Treat WSL2 as a Linux environment and keep `COVEN_HOME` on the WSL filesystem. |
+| Contributor checkout | [Install from source](/install/from-source) | Use this for unreleased changes and local development. |
+| Rust-first install | [Install via cargo](/install/cargo) | Build the Rust CLI yourself and put the binary on `PATH`. |
+| Server or automation host | [Headless server](/install/headless-server) | Use daemon commands over SSH or supervisor-managed shells. |
+| macOS background service | [launchd service](/install/launchd) | Optional user-agent wrapper around `coven daemon start`. |
+| Linux background service | [systemd unit](/install/systemd) | Optional user service wrapper around `coven daemon start`. |
+| Raspberry Pi | [Raspberry Pi](/install/raspberry-pi) | Build from source on arm64 and keep state on persistent storage. |
+| Container experiments | [Docker](/install/docker) or [Podman](/install/podman) | Build your own image; bind-mount state and project roots explicitly. |
+| Nix-managed shell | [Nix](/install/nix) | Use Nix to pin prerequisites, then build or run Coven inside that shell. |
+
+## Baseline requirements
+
+- Node.js 18+ for the npm wrapper path.
+- Git for source checkouts and project-root detection.
+- Rust stable only when building from source or with cargo.
+- At least one supported harness CLI on `PATH`: Codex or Claude Code.
+
+Install and authenticate a harness before expecting `coven run` to launch work:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Then run:
+
+```sh
+coven doctor
+```
+
+`doctor` reports store readiness, daemon/socket status, project-root hints, and whether supported harness CLIs are available from the same shell.
+
+## State directory
+
+By default, Coven stores local state under `<home>/.coven`. Override it only when you need a separate state root:
+
+```sh
+export COVEN_HOME="$HOME/.coven"
+coven doctor
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven"
+coven doctor
+```
+
+See [COVEN_HOME layout](/daemon/coven-home) for what lives inside that directory.
+
+## Common verification loop
+
+Use the same loop after install, after updates, and after changing harness auth:
+
+```sh
+coven --version
+coven doctor
+coven daemon restart
+coven daemon status
+cd /path/to/project
+coven run codex "say hello from Coven"
+coven sessions
+```
+
+If `doctor` reports a missing harness after installation, open a new terminal so `PATH` refreshes, then run `coven doctor` again from the shell where you will use Coven.
+
+## Related
+
+- [Getting started](/GETTING-STARTED)
+- [Quickstart](/start/quickstart)
+- [Troubleshooting](/TROUBLESHOOTING)
+- [CLI reference](/reference/cli)

--- a/docs/install/launchd.md
+++ b/docs/install/launchd.md
@@ -6,4 +6,87 @@ title: "launchd service"
 description: "Run the Coven daemon under launchd on macOS: write a plist, load it, and have launchctl supervise the daemon across reboots and crashes."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# launchd service
+
+Use a launchd user agent when you want the Coven daemon started automatically for your macOS user. Install and verify Coven manually first:
+
+```sh
+npm install -g @opencoven/cli
+coven doctor
+coven daemon start
+coven daemon status
+coven daemon stop
+```
+
+## User agent plist
+
+Create the LaunchAgents directory:
+
+```sh
+mkdir -p "$HOME/Library/LaunchAgents"
+```
+
+Write `~/Library/LaunchAgents/coven.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>coven</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>coven</string>
+    <string>daemon</string>
+    <string>start</string>
+  </array>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>COVEN_HOME</key>
+    <string>$HOME/.coven</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>
+```
+
+Replace `$HOME` with your absolute home path before loading the plist. launchd does not expand shell variables inside plist strings.
+
+Load and verify:
+
+```sh
+launchctl bootstrap gui/UID ~/Library/LaunchAgents/coven.plist
+launchctl kickstart -k gui/UID/coven
+coven daemon status
+```
+
+Replace `UID` with the output of `id -u`.
+
+Unload:
+
+```sh
+launchctl bootout gui/UID/coven
+```
+
+## PATH and harnesses
+
+launchd uses a smaller environment than your interactive shell. If `coven`, `codex`, or `claude` is installed in a user-local directory, prefer absolute paths in `ProgramArguments` or add a `PATH` entry under `EnvironmentVariables`.
+
+After changing the plist:
+
+```sh
+launchctl bootout gui/UID/coven
+launchctl bootstrap gui/UID ~/Library/LaunchAgents/coven.plist
+coven doctor
+```
+
+## Related
+
+- [macOS install](/install/macos)
+- [COVEN_HOME layout](/daemon/coven-home)
+- [Updating Coven](/install/updating)

--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -6,4 +6,94 @@ title: "Linux install"
 description: "Install Coven on Linux: install the @opencoven/cli wrapper, place the daemon binary on PATH, and verify the install with coven doctor."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Linux install
+
+Use the npm wrapper on glibc-based Linux x64 systems:
+
+```sh
+npm install -g @opencoven/cli
+coven --version
+coven doctor
+```
+
+The universal wrapper selects the native Linux x64 package. Alpine and other musl-based environments should use [Install from source](/install/from-source).
+
+## Baseline packages
+
+Install Node.js 18+ for the npm wrapper. Install Git for project-root detection and source checkouts.
+
+Debian or Ubuntu:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y nodejs npm git ca-certificates
+```
+
+Fedora:
+
+```sh
+sudo dnf install -y nodejs npm git ca-certificates
+```
+
+Arch:
+
+```sh
+sudo pacman -S --needed nodejs npm git ca-certificates
+```
+
+## Harness setup
+
+Install and authenticate at least one harness CLI:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Run `coven doctor` from the same shell after installing harnesses.
+
+## First session
+
+```sh
+cd /path/to/project
+coven daemon start
+coven daemon status
+coven run codex "describe this repo"
+coven sessions
+```
+
+Use Claude Code instead with:
+
+```sh
+coven run claude "describe this repo"
+```
+
+## COVEN_HOME
+
+The default state directory is:
+
+```sh
+$HOME/.coven
+```
+
+Keep it on the Linux filesystem, not a network mount, when possible. To override:
+
+```sh
+export COVEN_HOME="$HOME/.local/share/coven"
+coven doctor
+```
+
+## Server use
+
+For a non-desktop host, start with this page, then read [Headless server](/install/headless-server) for daemon lifecycle and SSH-oriented operation.
+
+## Related
+
+- [Install via npm](/install/npm)
+- [WSL2 install](/install/wsl2)
+- [Install from source](/install/from-source)

--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -6,4 +6,88 @@ title: "macOS install"
 description: "Install Coven on macOS: install the @opencoven/cli wrapper, place the daemon binary on PATH, and supervise the daemon with launchd."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# macOS install
+
+Use the npm wrapper on macOS unless you are developing Coven itself.
+
+```sh
+npm install -g @opencoven/cli
+coven --version
+coven doctor
+```
+
+The universal wrapper selects the native macOS package for Apple Silicon. On other macOS hosts, use the source install path unless the release matrix adds a matching native package.
+
+## Harness setup
+
+Install and authenticate at least one harness CLI from the same shell where you run Coven:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Then verify:
+
+```sh
+coven doctor
+```
+
+If `doctor` reports a missing harness, open a new terminal and check the command directly:
+
+```sh
+command -v codex
+command -v claude
+```
+
+## First session
+
+```sh
+cd /path/to/project
+coven daemon start
+coven daemon status
+coven run codex "describe this repo"
+coven sessions
+```
+
+Use `coven run claude "describe this repo"` when Claude Code is the configured harness.
+
+## COVEN_HOME
+
+The default state directory is:
+
+```sh
+$HOME/.coven
+```
+
+To isolate state for a demo, test account, or project:
+
+```sh
+export COVEN_HOME="$HOME/.coven-demo"
+coven doctor
+coven daemon start
+```
+
+Keep `COVEN_HOME` on a local disk owned by your user. See [COVEN_HOME layout](/daemon/coven-home).
+
+## Source install for contributors
+
+```sh
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build --workspace
+cargo run -p coven-cli -- doctor
+```
+
+Use [Install from source](/install/from-source) for the full contributor path.
+
+## Related
+
+- [Install via npm](/install/npm)
+- [Updating Coven](/install/updating)
+- [Troubleshooting](/TROUBLESHOOTING)

--- a/docs/install/nix.md
+++ b/docs/install/nix.md
@@ -6,4 +6,78 @@ title: "Nix"
 description: "Install Coven with Nix: a reproducible flake-based setup that pins the daemon, CLI, and supported harnesses across hosts and developer machines."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Nix
+
+Use Nix to pin build prerequisites and harness tooling around a source checkout. This repository does not currently use this page to promise an official Coven flake output.
+
+For the shortest install, use [Install via npm](/install/npm). For reproducible development shells, use the pattern below.
+
+## Development shell
+
+Create a local `flake.nix` in your own workspace:
+
+```nix
+{
+  description = "Coven development shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      devShells.${system}.default = pkgs.mkShell {
+        packages = [
+          pkgs.rustc
+          pkgs.cargo
+          pkgs.pkg-config
+          pkgs.openssl
+          pkgs.nodejs_22
+          pkgs.git
+        ];
+      };
+    };
+}
+```
+
+Enter the shell and build from source:
+
+```sh
+nix develop
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build --workspace
+cargo run -p coven-cli -- doctor
+```
+
+## Harness setup
+
+Install harness CLIs inside the environment where you run Coven, or add them to your Nix shell when available from your package set.
+
+For npm-managed harnesses:
+
+```sh
+npm install -g @openai/codex
+codex login
+npm install -g @anthropic-ai/claude-code
+claude doctor
+coven doctor
+```
+
+## State isolation
+
+Use an explicit state directory per Nix shell or host:
+
+```sh
+export COVEN_HOME="$PWD/.coven-state"
+coven doctor
+```
+
+Do not commit `.coven-state` or any other `COVEN_HOME` contents.
+
+## Related
+
+- [Install from source](/install/from-source)
+- [Install via cargo](/install/cargo)
+- [COVEN_HOME layout](/daemon/coven-home)

--- a/docs/install/npm.md
+++ b/docs/install/npm.md
@@ -3,7 +3,77 @@ summary: "Install the @opencoven/cli wrapper from npm."
 read_when:
   - Using npm or pnpm to install Coven
 title: "Install via npm"
-description: "Install Coven with npm: run npm install -g @opencoven/cli to fetch the wrapper plus a prebuilt native daemon binary for macOS or Linux."
+description: "Install Coven with npm: run npm install -g @opencoven/cli to fetch the wrapper plus a prebuilt native daemon binary for supported macOS, Linux, and Windows targets."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Install via npm
+
+The fastest workstation install is the universal npm wrapper:
+
+```sh
+npm install -g @opencoven/cli
+coven --version
+coven doctor
+```
+
+The wrapper exposes the `coven` command and selects the native package for the current platform.
+
+## Supported npm targets
+
+| Platform | Native package |
+| --- | --- |
+| macOS Apple Silicon | `@opencoven/cli-macos` |
+| glibc-based Linux x64 | `@opencoven/cli-linux-x64` |
+| Windows x64 | `@opencoven/cli-windows` |
+
+If the wrapper cannot find the native package, reinstall without disabling optional dependencies:
+
+```sh
+npm uninstall -g @opencoven/cli
+npm install -g @opencoven/cli
+coven doctor
+```
+
+On Linux, use a glibc-based distribution for the prebuilt package. For Alpine or another musl-based environment, use [Install from source](/install/from-source).
+
+## Install harness CLIs
+
+Coven supervises existing harness CLIs. Install and authenticate at least one:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Run `coven doctor` again after harness installation. If a harness is still missing, open a new terminal and verify the harness command is on `PATH` in that same shell.
+
+## First run
+
+```sh
+cd /path/to/project
+coven doctor
+coven daemon start
+coven run codex "describe this repo"
+coven sessions
+```
+
+Use Claude Code instead when that is the authenticated harness:
+
+```sh
+coven run claude "describe this repo"
+```
+
+## Updating
+
+```sh
+npm update -g @opencoven/cli
+coven daemon restart
+coven doctor
+```
+
+See [Updating Coven](/install/updating) before updating shared automation hosts or long-running daemon environments.

--- a/docs/install/podman.md
+++ b/docs/install/podman.md
@@ -6,4 +6,72 @@ title: "Podman"
 description: "Run Coven under Podman: a rootless containerized daemon plus harness CLIs, with bind mounts for COVEN_HOME and the project root per session."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Podman
+
+Podman is useful for rootless container experiments and homelab hosts. For ordinary workstation setup, prefer the native platform pages.
+
+This page assumes you build a local image from the Coven source checkout. There is no install-docs promise of an official Podman image.
+
+## Build a local image
+
+Use the Dockerfile pattern from [Docker](/install/docker), then build with Podman:
+
+```sh
+podman build -t coven-local .
+```
+
+## Run doctor with persistent state
+
+```sh
+mkdir -p "$HOME/.coven-container"
+podman run --rm -it \
+  -e COVEN_HOME=/var/lib/coven \
+  -v "$HOME/.coven-container:/var/lib/coven:Z" \
+  -v "$PWD:/workspace:Z" \
+  -w /workspace \
+  coven-local coven doctor
+```
+
+Drop the `:Z` label suffix on systems that do not use SELinux.
+
+## Harness setup
+
+Install and authenticate harness CLIs inside the container image or in a derived image:
+
+```Dockerfile
+RUN npm install -g @openai/codex @anthropic-ai/claude-code
+```
+
+Then verify inside the same container environment:
+
+```sh
+podman run --rm -it \
+  -e COVEN_HOME=/var/lib/coven \
+  -v "$HOME/.coven-container:/var/lib/coven:Z" \
+  -v "$PWD:/workspace:Z" \
+  -w /workspace \
+  coven-local coven doctor
+```
+
+## First session
+
+```sh
+podman run --rm -it \
+  -e COVEN_HOME=/var/lib/coven \
+  -v "$HOME/.coven-container:/var/lib/coven:Z" \
+  -v "$PWD:/workspace:Z" \
+  -w /workspace \
+  coven-local coven run codex "describe this repo"
+```
+
+## Notes
+
+- Rootless Podman changes UID/GID mappings. Keep mounted state owned by the user that runs Podman.
+- Use one mounted `COVEN_HOME` per environment.
+- Run `coven doctor` after every image or mount change.
+
+## Related
+
+- [Docker](/install/docker)
+- [Headless server](/install/headless-server)
+- [Linux install](/install/linux)

--- a/docs/install/raspberry-pi.md
+++ b/docs/install/raspberry-pi.md
@@ -6,4 +6,85 @@ title: "Raspberry Pi"
 description: "Install Coven on a Raspberry Pi: arm64 daemon binary, COVEN_HOME on persistent storage, and systemd supervision for headless agent work."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Raspberry Pi
+
+Raspberry Pi is a source-build path today. Use a 64-bit Raspberry Pi OS image and keep `COVEN_HOME` on persistent local storage.
+
+## Install prerequisites
+
+```sh
+sudo apt-get update
+sudo apt-get install -y git curl build-essential pkg-config libssl-dev nodejs npm ca-certificates
+```
+
+Install Rust stable if it is not already present:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. "$HOME/.cargo/env"
+```
+
+## Build Coven
+
+```sh
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build -p coven-cli --release
+mkdir -p "$HOME/.local/bin"
+cp target/release/coven "$HOME/.local/bin/coven"
+coven doctor
+```
+
+Make sure `$HOME/.local/bin` is on `PATH`.
+
+## Harness setup
+
+Install only harness CLIs that support your Pi architecture and auth flow. Then verify from the same shell:
+
+```sh
+coven doctor
+```
+
+If Codex or Claude Code is installed with npm:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+## State and daemon
+
+Use an explicit state directory:
+
+```sh
+export COVEN_HOME="$HOME/.coven"
+coven daemon start
+coven daemon status
+```
+
+For always-on operation, use [systemd unit](/install/systemd) after the manual `coven doctor` path works.
+
+## First session
+
+```sh
+cd /path/to/project
+coven run codex "describe this repo"
+coven sessions
+```
+
+## Notes
+
+- Build times can be long on small Pi models.
+- Keep swap and disk space healthy before building Rust dependencies.
+- Avoid storing `COVEN_HOME` on removable media that may disappear while the daemon is running.
+
+## Related
+
+- [Linux install](/install/linux)
+- [Headless server](/install/headless-server)
+- [systemd unit](/install/systemd)

--- a/docs/install/systemd.md
+++ b/docs/install/systemd.md
@@ -6,4 +6,82 @@ title: "systemd unit"
 description: "Run the Coven daemon under systemd on Linux: a unit file, environment for COVEN_HOME, and journalctl access to daemon logs across reboots."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# systemd unit
+
+Use a systemd user unit when you want the Coven daemon available after login on a Linux workstation or server. Install Coven and verify it manually first:
+
+```sh
+npm install -g @opencoven/cli
+coven doctor
+coven daemon start
+coven daemon status
+coven daemon stop
+```
+
+## User unit
+
+Create the user unit directory:
+
+```sh
+mkdir -p "$HOME/.config/systemd/user"
+```
+
+Write `~/.config/systemd/user/coven-daemon.service`:
+
+```ini
+[Unit]
+Description=Coven daemon
+After=default.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+Environment=COVEN_HOME=%h/.coven
+ExecStart=/usr/bin/env coven daemon start
+ExecStop=/usr/bin/env coven daemon stop
+ExecReload=/usr/bin/env coven daemon restart
+
+[Install]
+WantedBy=default.target
+```
+
+Load and start it:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user enable --now coven-daemon.service
+systemctl --user status coven-daemon.service
+coven daemon status
+```
+
+If you need the user service to start without an active login session, enable linger for that Linux user:
+
+```sh
+loginctl enable-linger "$USER"
+```
+
+## PATH and harnesses
+
+The service must resolve the same commands that `coven doctor` reports from your shell. If `coven`, `codex`, or `claude` is installed under a user-local path, add an explicit `Environment=PATH=...` line to the unit.
+
+After changing PATH, harness auth, or `COVEN_HOME`:
+
+```sh
+systemctl --user daemon-reload
+systemctl --user restart coven-daemon.service
+coven doctor
+```
+
+## Logs
+
+```sh
+journalctl --user -u coven-daemon.service --since today
+```
+
+Use `coven daemon status` as the product-level health check; systemd only tells you whether the wrapper command ran.
+
+## Related
+
+- [Linux install](/install/linux)
+- [Headless server](/install/headless-server)
+- [COVEN_HOME layout](/daemon/coven-home)

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -6,4 +6,94 @@ title: "Uninstalling Coven"
 description: "Uninstall Coven cleanly: stop the daemon, remove the wrapper, and decide whether to keep or wipe COVEN_HOME and the session ledger."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Uninstalling Coven
+
+Uninstall has two separate decisions:
+
+1. Remove the `coven` command.
+2. Keep or delete `COVEN_HOME`, which contains local session history, sockets, logs, and keys.
+
+Stop the daemon first:
+
+```sh
+coven daemon stop
+```
+
+## npm wrapper
+
+```sh
+npm uninstall -g @opencoven/cli
+```
+
+Verify the command is gone:
+
+```sh
+command -v coven
+```
+
+PowerShell:
+
+```powershell
+Get-Command coven
+```
+
+If another install path still exposes `coven`, remove that binary or adjust `PATH`.
+
+## Source or cargo install
+
+Remove the binary you copied onto `PATH`:
+
+```sh
+rm "$HOME/.local/bin/coven"
+```
+
+Windows PowerShell:
+
+```powershell
+Remove-Item "$env:USERPROFILE\.local\bin\coven.exe"
+```
+
+Adjust the path if you installed the binary somewhere else.
+
+## Keep or delete state
+
+To preserve sessions for a later reinstall, leave `COVEN_HOME` in place.
+
+To delete the default state directory on macOS, Linux, or WSL2:
+
+```sh
+rm -rf "$HOME/.coven"
+```
+
+PowerShell:
+
+```powershell
+Remove-Item -Recurse -Force "$env:USERPROFILE\.coven"
+```
+
+Only delete `COVEN_HOME` after confirming there are no sessions, logs, or local keys you need to keep.
+
+## Services
+
+If you installed a launchd user agent:
+
+```sh
+launchctl bootout gui/UID/coven
+rm ~/Library/LaunchAgents/coven.plist
+```
+
+Replace `UID` with the output of `id -u`.
+
+If you installed a systemd user unit:
+
+```sh
+systemctl --user disable --now coven-daemon.service
+rm "$HOME/.config/systemd/user/coven-daemon.service"
+systemctl --user daemon-reload
+```
+
+## Related
+
+- [COVEN_HOME layout](/daemon/coven-home)
+- [Install overview](/install/index)
+- [Troubleshooting](/TROUBLESHOOTING)

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -6,4 +6,107 @@ title: "Updating Coven"
 description: "Update Coven safely: upgrade the @opencoven/cli wrapper, drain or stop the daemon, migrate the store, and verify the contract version on restart."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# Updating Coven
+
+Update the wrapper or binary, restart the daemon, then run the same verification loop you used at install time.
+
+## npm wrapper
+
+```sh
+npm update -g @opencoven/cli
+coven --version
+coven daemon restart
+coven doctor
+```
+
+If the native package is missing after update, reinstall the wrapper without disabling optional dependencies:
+
+```sh
+npm uninstall -g @opencoven/cli
+npm install -g @opencoven/cli
+coven doctor
+```
+
+## Source checkout
+
+```sh
+cd /path/to/coven
+git pull --ff-only
+cargo build -p coven-cli --release
+cp target/release/coven "$HOME/.local/bin/coven"
+coven daemon restart
+coven doctor
+```
+
+On Windows, copy `target\release\coven.exe` to the directory where your shell resolves `coven`.
+
+## Harness updates
+
+Coven supervises harness CLIs; it does not own their provider credentials. Update and verify harnesses separately:
+
+```sh
+npm update -g @openai/codex
+codex login
+```
+
+```sh
+npm update -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Then run:
+
+```sh
+coven doctor
+```
+
+## Verification loop
+
+```sh
+coven --version
+coven doctor
+coven daemon restart
+coven daemon status
+cd /path/to/project
+coven run codex "say hello from the updated Coven install"
+coven sessions
+```
+
+Use `coven run claude ...` when Claude Code is your active harness.
+
+## Rollback notes
+
+Before changing package source, binary location, or `COVEN_HOME`, stop the daemon:
+
+```sh
+coven daemon stop
+```
+
+If an update leaves the daemon unreachable, run:
+
+```sh
+coven daemon restart
+coven doctor
+```
+
+If `doctor` points at a `PATH` problem, open a new shell and verify:
+
+```sh
+command -v coven
+command -v codex
+command -v claude
+```
+
+PowerShell:
+
+```powershell
+Get-Command coven
+Get-Command codex
+Get-Command claude
+```
+
+## Related
+
+- [Install overview](/install/index)
+- [Troubleshooting](/TROUBLESHOOTING)
+- [Daemon lifecycle](/daemon/lifecycle)

--- a/docs/install/windows.md
+++ b/docs/install/windows.md
@@ -17,6 +17,8 @@ coven doctor
 
 The wrapper exposes the `coven` command and launches the native Windows binary when the release package includes one for your platform. `coven doctor` is the first verification step: it checks local state and reports whether supported harness CLIs such as Codex or Claude Code are available on `PATH`.
 
+Use native Windows and WSL2 as separate Coven environments. If you install Coven in PowerShell, install the harness CLIs in PowerShell too. If you install Coven inside WSL2, follow [WSL2 install](/install/wsl2) and keep the daemon state inside WSL.
+
 ## First run
 
 From a project directory:
@@ -37,6 +39,20 @@ coven sessions
 
 Install and authenticate at least one harness CLI before expecting `coven run` to launch work. If `coven doctor` reports a missing harness, install that tool, open a new terminal so `PATH` is refreshed, and run `coven doctor` again.
 
+Codex:
+
+```powershell
+npm install -g @openai/codex
+codex login
+```
+
+Claude Code:
+
+```powershell
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
 ## Windows notes
 
 - `coven doctor` should work in PowerShell even when the `HOME` environment variable is absent. Coven resolves its default store from `COVEN_HOME`, `HOME`, `USERPROFILE`, `HOMEDRIVE` + `HOMEPATH`, or the platform home directory.
@@ -49,11 +65,24 @@ coven doctor
 ```
 
 - Run Coven and your harness CLI from the same environment. A harness installed only inside WSL2 is not available to native Windows PowerShell unless you expose it separately.
-- If terminal input behaves oddly, update to the latest wrapper and run `coven tui` again. The Windows TUI filters key-press events so typed characters, arrows, and Enter should be handled once.
+- If terminal input behaves oddly, update the wrapper and run `coven tui` again. The Windows TUI filters key-press events so typed characters, arrows, and Enter should be handled once.
+
+## Verification loop
+
+```powershell
+coven --version
+coven doctor
+coven daemon restart
+coven daemon status
+cd C:\path\to\project
+coven run codex "describe this repo"
+coven sessions
+```
 
 ## Related
 
 - [Get started with Coven](/GETTING-STARTED)
+- [Install overview](/install/index)
 - [Coven TUI](/start/coven-tui)
 - [Troubleshooting](/TROUBLESHOOTING)
 - [CLI reference](/reference/cli)

--- a/docs/install/wsl2.md
+++ b/docs/install/wsl2.md
@@ -6,4 +6,74 @@ title: "WSL2 install"
 description: "Install Coven inside WSL2: run the Linux daemon binary, pin COVEN_HOME on the WSL filesystem, and connect Windows clients to the socket."
 ---
 
-Stub — fill in with Coven-specific install steps. See [Install overview](/install/index) for the canonical layout.
+# WSL2 install
+
+Inside WSL2, install Coven as Linux software. Keep Coven, harness CLIs, project files, and `COVEN_HOME` in the WSL environment for the least surprising daemon and PTY behavior.
+
+```sh
+npm install -g @opencoven/cli
+coven --version
+coven doctor
+```
+
+The npm wrapper uses the Linux x64 native package when your WSL distribution is glibc-based.
+
+## Recommended layout
+
+Use Linux paths for projects and state:
+
+```sh
+mkdir -p "$HOME/code"
+cd "$HOME/code"
+export COVEN_HOME="$HOME/.coven"
+```
+
+Avoid putting active Coven state under `/mnt/c` because Windows filesystem semantics can make socket, permission, and file-watch behavior harder to reason about.
+
+## Harness setup
+
+Install harness CLIs inside WSL2:
+
+```sh
+npm install -g @openai/codex
+codex login
+```
+
+```sh
+npm install -g @anthropic-ai/claude-code
+claude doctor
+```
+
+Native Windows harness installs do not automatically appear inside WSL2. Run `coven doctor` from WSL after installing harnesses.
+
+## First session
+
+```sh
+cd "$HOME/code/project"
+coven daemon start
+coven daemon status
+coven run codex "describe this repo"
+coven sessions
+```
+
+## WSL2 versus native Windows
+
+Pick one environment for each working session:
+
+- Native Windows: install Coven and harness CLIs in PowerShell or Windows Terminal; use [Windows install](/install/windows).
+- WSL2: install Coven and harness CLIs inside the Linux distro; use Linux paths and Linux `COVEN_HOME`.
+
+Do not point native Windows Coven and WSL2 Coven at the same state directory.
+
+## Source fallback
+
+If the npm native package is not available for your WSL distribution:
+
+```sh
+git clone https://github.com/OpenCoven/coven.git
+cd coven
+cargo build --workspace
+cargo run -p coven-cli -- doctor
+```
+
+See [Install from source](/install/from-source).

--- a/docs/reference/cli-daemon.md
+++ b/docs/reference/cli-daemon.md
@@ -6,4 +6,93 @@ title: "coven daemon"
 description: "Reference for coven daemon: start, stop, restart, and status subcommands for the Rust daemon process that owns sessions and the local socket API."
 ---
 
-Stub — fill in.
+`coven daemon` manages the local background process that owns session runtime,
+socket API state, and health reporting.
+
+```sh
+coven daemon status
+```
+
+## Commands
+
+| Command | Action |
+| --- | --- |
+| `coven daemon start` | Start the daemon if it is not already running. Reuses a verified live daemon. |
+| `coven daemon status` | Print stopped/running/stale status, pid, socket path, and health flag. |
+| `coven daemon restart` | Stop the current daemon if present, then start a daemon with the current binary. |
+| `coven daemon stop` | Stop the daemon for the active `COVEN_HOME`. |
+| `coven daemon serve` | Hidden foreground server entrypoint used by the background launcher and supervisors. |
+
+## First-run sequence
+
+```sh
+coven doctor
+coven daemon start
+coven daemon status
+```
+
+Expected running output:
+
+```text
+coven daemon status=running ok=true pid=12345 socket=/home/alex/.coven/coven.sock
+```
+
+`ok=true` means the daemon health endpoint responded through the local socket.
+
+## Restart after upgrades
+
+Restart after replacing the CLI binary, changing `PATH`, or switching
+`COVEN_HOME`:
+
+```sh
+coven --version
+coven daemon restart
+coven daemon status
+```
+
+The restarted process uses the executable that launched the command. This keeps
+npm, cargo, and source-checkout installs from accidentally leaving an old daemon
+behind.
+
+## State directory
+
+Daemon metadata and the socket live under the active `COVEN_HOME`.
+
+macOS/Linux/WSL2:
+
+```sh
+export COVEN_HOME="$HOME/.coven"
+coven daemon status
+```
+
+PowerShell:
+
+```powershell
+$env:COVEN_HOME="$env:USERPROFILE\.coven"
+coven daemon status
+```
+
+Keep `COVEN_HOME` on a local per-user filesystem. For WSL2, use the WSL
+filesystem, not a mounted Windows path. For containers, bind-mount a persistent
+directory if sessions must survive container restarts.
+
+## Supervisor use
+
+For systemd, launchd, tmux, or container entrypoints, prefer the foreground
+server command inside the supervisor:
+
+```sh
+coven daemon serve
+```
+
+Use `coven daemon status` from an interactive shell with the same `COVEN_HOME`
+to verify the supervised daemon.
+
+## Troubleshooting
+
+- `status=stopped`: run `coven daemon start`.
+- `status=stale`: run `coven daemon stop`, then `coven daemon start`.
+- Permission errors: verify the daemon user owns `COVEN_HOME`.
+- Version drift: run `coven --version`, then `coven daemon restart`.
+
+See [Daemon will not start](/help/daemon-wont-start) for deeper recovery steps.

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -6,4 +6,93 @@ title: "coven doctor"
 description: "Reference for coven doctor: the first command to run after install. It checks COVEN_HOME, the socket, harness PATH, and the SQLite store."
 ---
 
-Stub — fill in.
+`coven doctor` is the first command to run after installing Coven, changing
+`PATH`, authenticating a harness, or moving `COVEN_HOME`.
+
+```sh
+coven doctor
+```
+
+The command is read-only. It prints local setup state and a next step without
+starting a session.
+
+## What it checks
+
+| Section | Meaning |
+| --- | --- |
+| `Store` | The active Coven state directory. Defaults to `<home>/.coven` unless `COVEN_HOME` is set. |
+| `Project` | The current git/project root when the command runs inside a project. |
+| `Daemon` | Whether the background daemon is stopped, running, or stale. |
+| `Repos` | Configured repositories from Coven repo settings, if present. |
+| `Harnesses` | Supported harness executables that are visible on this shell's `PATH`. |
+| `Familiars` | Configured familiar identities from `familiars.toml`, if present. |
+| `Next steps` | The safest next command based on the detected state. |
+
+## Expected first-run loop
+
+```sh
+coven --version
+coven doctor
+coven daemon start
+coven daemon status
+cd /path/to/project
+coven run codex "explain this repo in 5 bullets"
+```
+
+If you use Claude Code instead:
+
+```sh
+coven run claude "explain this repo in 5 bullets"
+```
+
+## Missing harness output
+
+When neither supported harness is visible, `doctor` prints install hints for
+Codex and Claude Code:
+
+```sh
+npm install -g @openai/codex
+codex login
+npm install -g @anthropic-ai/claude-code
+claude doctor
+coven doctor
+```
+
+If you installed a harness in another shell, open a new terminal and run
+`coven doctor` again. Coven can only launch CLIs that are visible from the
+environment where the daemon/session starts.
+
+## Daemon status
+
+`doctor` summarizes daemon state, but use the daemon command for scriptable
+status:
+
+```sh
+coven daemon status
+```
+
+Typical output:
+
+```text
+coven daemon status=running ok=true pid=12345 socket=/home/alex/.coven/coven.sock
+```
+
+`status=stopped` means no background daemon is running yet. Start it with:
+
+```sh
+coven daemon start
+```
+
+`status=stale` means metadata exists for a process/socket that no longer looks
+healthy. Try:
+
+```sh
+coven daemon stop
+coven daemon start
+```
+
+## Exit behavior
+
+`coven doctor` should exit successfully when it can inspect the environment,
+even if it reports missing harnesses or a stopped daemon. Treat the printed
+status as the diagnostic result.

--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const criticalDocs = [
+  'docs/help/harness-not-found.md',
+  'docs/help/daemon-wont-start.md',
+  'docs/help/diagnostics-bundle.md',
+  'docs/help/paths.md',
+  'docs/help/permissions.md',
+  'docs/help/session-stuck.md',
+  'docs/help/filing-issues.md',
+  'docs/help/community.md',
+  'docs/reference/cli-doctor.md',
+  'docs/reference/cli-daemon.md',
+  'docs/daemon/coven-home.md',
+  'docs/daemon/health.md'
+];
+
+function readRepoFile(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('critical onboarding support docs are concrete, not stubs', () => {
+  for (const path of criticalDocs) {
+    const text = readRepoFile(path);
+    assert.doesNotMatch(text, /^Stub -- fill in\.?$/m, `${path} must not be a stub`);
+    assert.doesNotMatch(text, /^Stub . fill in\.?$/m, `${path} must not be a stub`);
+    assert.match(text, /coven [a-z-]+/i, `${path} must include at least one concrete coven command`);
+    assert.ok(text.length > 1200, `${path} must include actionable setup detail`);
+  }
+});
+
+test('install docs link COVEN_HOME users to the daemon state guide', () => {
+  const installDir = new URL('../docs/install/', import.meta.url);
+  const installDocs = readdirSync(installDir)
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => `docs/install/${name}`);
+
+  for (const path of installDocs) {
+    const text = readRepoFile(path);
+    assert.doesNotMatch(text, /\/install\/coven-home\b/, `${path} must not link to missing install route`);
+  }
+
+  assert.match(readRepoFile('docs/install/index.md'), /\/daemon\/coven-home\b/);
+});
+
+test('ci runs npm onboarding smoke on every published platform', () => {
+  const workflow = readRepoFile('.github/workflows/ci.yml');
+  assert.match(workflow, /name:\s+npm onboarding smoke/i);
+  assert.match(workflow, /ubuntu-latest/);
+  assert.match(workflow, /macos-26/);
+  assert.doesNotMatch(workflow, /os:\s+macos-latest/);
+  assert.match(workflow, /windows-latest/);
+  assert.match(workflow, /node scripts\/test-cli-prepublish\.mjs --target=\$\{\{ matrix\.npm-target \}\} --skip-build --skip-secrets-scan/);
+  assert.match(workflow, /COVEN_NPM_DRY_RUN_VERSION:\s+999\.0\.0\s*(?:\n|$)/);
+});
+
+test('npm onboarding smoke exercises daemon lifecycle with isolated state', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /COVEN_HOME:\s*path\.join\(tempDir,\s*'coven-home'\)/);
+  assert.match(script, /\['daemon',\s*'start'\]/);
+  assert.match(script, /\['daemon',\s*'status'\]/);
+  assert.match(script, /\['daemon',\s*'stop'\]/);
+  assert.match(script, /\['sessions',\s*'--plain'\]/);
+  assert.match(script, /status=running/);
+  assert.match(script, /ok=true/);
+});
+
+test('npm onboarding smoke launches Windows cmd shims through a shell', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /function spawnOptionsForCommand\(/);
+  assert.match(script, /shell:\s*platform === 'win32'/);
+  assert.match(script, /spawnOptionsForCommand\(options/);
+  assert.match(script, /spawnSync\(command,\s*args,\s*\{\s*\.\.\.spawnOptionsForCommand\(\)/);
+  assert.match(script, /spawnSync\('npm',\s*\['view'[\s\S]*?\.\.\.spawnOptionsForCommand\(\)/);
+  assert.match(script, /spawnSync\('npm',\s*\['pack'[\s\S]*?\.\.\.spawnOptionsForCommand\(\)/);
+});
+
+test('npm onboarding smoke verifies first-run missing-harness guidance deterministically', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /function firstRunSmokePath\(/);
+  assert.match(script, /PATH:\s*firstRunSmokePath\(wrapperBin\)/);
+  assert.match(script, /Install and authenticate at least one harness in this same shell/);
+  assert.match(script, /npm install -g @openai\/codex && codex login/);
+  assert.match(script, /npm install -g @anthropic-ai\/claude-code && claude doctor/);
+});
+
+test('npm onboarding smoke runs onboarding guardrails before packaging', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /scripts\/onboarding-docs-test\.mjs/);
+  assert.match(script, /scripts\/publish-npm-test\.mjs/);
+});
+
+test('npm onboarding smoke avoids deprecated optional dependency install flag', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /'--omit=optional'/);
+  assert.doesNotMatch(script, /'--no-optional'/);
+});
+
+test('npm onboarding smoke bounds subprocess hangs', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /DEFAULT_COMMAND_TIMEOUT_MS/);
+  assert.match(script, /timeout:\s*options\.timeoutMs \?\? DEFAULT_COMMAND_TIMEOUT_MS/);
+  assert.match(script, /ETIMEDOUT/);
+});
+
+test('npm onboarding smoke does not pipe-capture Windows daemon start', () => {
+  const script = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(script, /function runDaemonStart\(/);
+  assert.match(script, /process\.platform === 'win32'/);
+  assert.match(script, /run\(wrapperBin, \['daemon', 'start'\]/);
+  assert.match(script, /runCapture\(wrapperBin, \['daemon', 'status'\]/);
+});

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { defaultTargetName, isOidcContext, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
+import { defaultTargetName, isMainModule, isOidcContext, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
@@ -89,6 +90,24 @@ test('wrapper binary maps windows x64 to windows native package and exe binary',
   assert.match(bin, /process\.platform === 'win32' \? 'coven\.exe' : 'coven'/);
 });
 
+test('install docs do not claim macOS x64 support unless the wrapper maps darwin x64', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const wrapperBin = readFileSync(binPath, 'utf8');
+  const supportsDarwinX64 = wrapperBin.includes("'darwin-x64'");
+  const docText = [
+    ['..', 'README.md'],
+    ['..', 'docs', 'install', 'index.md'],
+    ['..', 'docs', 'install', 'npm.md'],
+    ['..', 'docs', 'install', 'macos.md']
+  ]
+    .map((parts) => readFileSync(new URL(parts.join('/'), import.meta.url), 'utf8'))
+    .join('\n');
+
+  if (!supportsDarwinX64) {
+    assert.doesNotMatch(docText, /macOS (?:arm64 or )?x64|macOS \(arm64 \+ x64\)|Intel Macs/i);
+  }
+});
+
 test('release workflow builds and dry-runs linux x64 package', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
@@ -99,6 +118,18 @@ test('release workflow builds and dry-runs linux x64 package', () => {
   assert.match(workflow, /rust-target: x86_64-unknown-linux-gnu/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=linux-x64 --skip-build --publish --skip-wrapper/);
+});
+
+test('release workflow builds macOS package on arm64 runner', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /npm-target: macos/);
+  assert.match(workflow, /rust-target: aarch64-apple-darwin/);
+  assert.match(workflow, /runner: macos-26/);
+  assert.doesNotMatch(workflow, /runner: macos-latest/);
 });
 
 test('release workflow builds and dry-runs windows package', () => {
@@ -325,6 +356,22 @@ test('prepublish smoke has explicit dry-run version override and registry failur
 
   assert.match(script, /COVEN_NPM_DRY_RUN_VERSION/);
   assert.match(script, /Could not read current \$\{packageName\} version/);
+});
+
+test('publish-npm entrypoint detection works with filesystem paths', () => {
+  const scriptPath = fileURLToPath(new URL('publish-npm.mjs', import.meta.url));
+  assert.equal(isMainModule(scriptPath, pathToFileURL(scriptPath).href), true);
+  assert.equal(isMainModule(scriptPath, import.meta.url), false);
+});
+
+test('publish-npm uses Windows shell resolution for command shims', () => {
+  const scriptPath = new URL('publish-npm.mjs', import.meta.url);
+  const script = readFileSync(scriptPath, 'utf8');
+
+  assert.match(script, /function spawnOptionsForCommand\(/);
+  assert.match(script, /shell:\s*platform === 'win32'/);
+  assert.match(script, /spawnSync\(command,\s*args,\s*\{\s*\.\.\.spawnOptionsForCommand\(\)/);
+  assert.match(script, /spawnSync\('npm',\s*\['view'[\s\S]*?\.\.\.spawnOptionsForCommand\(\)/);
 });
 
 test('packageVersionPublished returns true when npm view exits 0 (version exists on registry)', () => {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from 'node:child_process';
 import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -34,8 +34,12 @@ const targets = {
   }
 };
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule()) {
   main();
+}
+
+export function isMainModule(argv1 = process.argv[1], moduleUrl = import.meta.url) {
+  return Boolean(argv1) && moduleUrl === pathToFileURL(argv1).href;
 }
 
 function main() {
@@ -110,6 +114,7 @@ export function packageVersionPublished(packageName, version, runner = npmViewRu
 
 function npmViewRunner(packageName, version) {
   return spawnSync('npm', ['view', `${packageName}@${version}`, 'version'], {
+    ...spawnOptionsForCommand(),
     cwd: repoRoot,
     env: process.env,
     stdio: ['ignore', 'ignore', 'ignore']
@@ -263,6 +268,7 @@ function run(command, args, options = {}) {
   const printable = [command, ...args].join(' ');
   console.log(`$ ${printable}`);
   const result = spawnSync(command, args, {
+    ...spawnOptionsForCommand(),
     cwd: options.cwd ?? repoRoot,
     env: options.env ?? process.env,
     stdio: 'inherit'
@@ -290,6 +296,12 @@ export function publishEnv(dryRun, env = process.env) {
   return {
     ...env,
     NODE_AUTH_TOKEN: authToken
+  };
+}
+
+function spawnOptionsForCommand(platform = process.platform) {
+  return {
+    shell: platform === 'win32'
   };
 }
 

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -3,14 +3,14 @@
 //
 // What it does:
 //   1. Verifies prerequisites (node, npm, cargo).
-//   2. Runs the secrets scan and the publish-npm.mjs unit tests.
+//   2. Runs the secrets scan, onboarding guardrails, and publish-npm.mjs unit tests.
 //   3. Stages the dist tree by running publish-npm.mjs in --dry-run mode
 //      (which also runs `cargo build --release --target <rust-target>` unless
 //      --skip-build is passed) and lets `npm publish --dry-run` validate the
 //      platform + wrapper tarballs.
-//   5. `npm pack`s the native and wrapper packages, installs them into a fresh
+//   4. `npm pack`s the native and wrapper packages, installs them into a fresh
 //      temp project, and invokes the wrapper bin to confirm the native binary
-//      is resolved and executable.
+//      is resolved, executable, and can start the daemon with isolated state.
 //
 // Flags:
 //   --target=<name>       Override the npm target (macos, linux-x64, windows).
@@ -21,9 +21,8 @@
 //   --with-cargo-gates    Also run `cargo fmt --check`, `cargo clippy`, and
 //                         `cargo test --workspace --locked` (the CI verify
 //                         gates). Off by default to keep local runs fast.
-//   --skip-secrets-scan   Skip `python3 scripts/check-secrets.py`. Useful while
-//                         the repo has known pre-existing high-entropy hits
-//                         in committed test fixtures; CI still runs it.
+//   --skip-secrets-scan   Skip `python3 scripts/check-secrets.py` for local
+//                         iteration; CI still runs it.
 //   --keep-tempdir        Leave the temp install dir on disk for inspection.
 //   COVEN_NPM_DRY_RUN_VERSION=vX.Y.Z
 //                         Override the synthesized dry-run version when the
@@ -32,7 +31,7 @@
 // Exit code is non-zero on the first failing step.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -42,6 +41,7 @@ import { defaultTargetName } from './publish-npm.mjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const distRoot = path.join(repoRoot, 'npm', 'dist');
+const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
 const PLATFORM_TARGETS = {
   macos: { packageName: '@opencoven/cli-macos', binaryName: 'coven' },
@@ -93,8 +93,8 @@ if (!skipSecretsScan) {
   });
 }
 
-step('publish-npm.mjs unit tests', () => {
-  run('node', ['--test', 'scripts/publish-npm-test.mjs']);
+step('onboarding and publish guardrails', () => {
+  run('node', ['--test', 'scripts/onboarding-docs-test.mjs', 'scripts/publish-npm-test.mjs']);
 });
 
 if (withCargoGates) {
@@ -155,9 +155,9 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     `${JSON.stringify({ name: 'coven-prepublish-test', private: true, version: '0.0.0' }, null, 2)}\n`
   );
 
-  // --no-optional avoids npm trying to fetch the optional native package by
+  // --omit=optional avoids npm trying to fetch the optional native package by
   // version from the public registry; we install the local tarball directly.
-  run('npm', ['install', '--no-package-lock', '--no-optional', platformTgz, wrapperTgz], {
+  run('npm', ['install', '--no-package-lock', '--omit=optional', platformTgz, wrapperTgz], {
     cwd: tempDir
   });
 
@@ -171,26 +171,66 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     fail(`wrapper bin not present at ${wrapperBin} after install`);
   }
 
-  const versionOutput = runCapture(wrapperBin, ['--version']);
+  const smokeEnv = {
+    ...process.env,
+    COVEN_HOME: path.join(tempDir, 'coven-home'),
+    PATH: firstRunSmokePath(wrapperBin)
+  };
+  mkdirSync(smokeEnv.COVEN_HOME, { recursive: true });
+
+  const versionOutput = runCapture(wrapperBin, ['--version'], { env: smokeEnv });
   if (!versionOutput.stdout.trim()) {
     fail('`coven --version` produced no output');
   }
   console.log(`coven --version => ${versionOutput.stdout.trim()}`);
 
-  const doctorOutput = runCapture(wrapperBin, ['doctor']);
+  const doctorOutput = runCapture(wrapperBin, ['doctor'], { env: smokeEnv });
   if (!doctorOutput.stdout.includes('Coven doctor')) {
     fail(
       `\`coven doctor\` did not print the expected banner.\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`
     );
   }
-  console.log('coven doctor banner present');
+  for (const expected of [
+    'Install and authenticate at least one harness in this same shell',
+    'npm install -g @openai/codex && codex login',
+    'npm install -g @anthropic-ai/claude-code && claude doctor'
+  ]) {
+    if (!doctorOutput.stdout.includes(expected)) {
+      fail(`\`coven doctor\` missing first-run setup guidance "${expected}".\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`);
+    }
+  }
+  console.log('coven doctor first-run setup guidance present');
 
-  const helpOutput = runCapture(wrapperBin, ['--help']);
+  const helpOutput = runCapture(wrapperBin, ['--help'], { env: smokeEnv });
   if (helpOutput.status !== 0) {
     fail(`\`coven --help\` exited with ${helpOutput.status}\nstderr:\n${helpOutput.stderr}`);
   }
   if (!helpOutput.stdout.toLowerCase().includes('usage')) {
     fail(`\`coven --help\` missing usage section.\nstdout:\n${helpOutput.stdout}`);
+  }
+
+  let daemonStarted = false;
+  try {
+    const startOutput = runDaemonStart(wrapperBin, smokeEnv);
+    daemonStarted = true;
+    if (startOutput && !startOutput.stdout.includes('status=running')) {
+      fail(`\`coven daemon start\` did not report status=running.\nstdout:\n${startOutput.stdout}\nstderr:\n${startOutput.stderr}`);
+    }
+
+    const statusOutput = runCapture(wrapperBin, ['daemon', 'status'], { env: smokeEnv });
+    if (!statusOutput.stdout.includes('status=running') || !statusOutput.stdout.includes('ok=true')) {
+      fail(`\`coven daemon status\` did not report a healthy running daemon.\nstdout:\n${statusOutput.stdout}\nstderr:\n${statusOutput.stderr}`);
+    }
+
+    const sessionsOutput = runCapture(wrapperBin, ['sessions', '--plain'], { env: smokeEnv });
+    if (!sessionsOutput.stdout.includes('No active Coven sessions yet.')) {
+      fail(`\`coven sessions --plain\` did not report an empty fresh store.\nstdout:\n${sessionsOutput.stdout}\nstderr:\n${sessionsOutput.stderr}`);
+    }
+    console.log('coven daemon lifecycle verified');
+  } finally {
+    if (daemonStarted) {
+      runCapture(wrapperBin, ['daemon', 'stop'], { env: smokeEnv });
+    }
   }
 });
 
@@ -224,6 +264,7 @@ function synthesizeDryRunVersion(packageName) {
   }
 
   const view = spawnSync('npm', ['view', packageName, 'version', '--silent'], {
+    ...spawnOptionsForCommand(),
     stdio: ['ignore', 'pipe', 'pipe'],
     encoding: 'utf8'
   });
@@ -252,7 +293,14 @@ function synthesizeDryRunVersion(packageName) {
 }
 
 function ensureCommand(command, args) {
-  const result = spawnSync(command, args, { stdio: 'pipe' });
+  const result = spawnSync(command, args, {
+    ...spawnOptionsForCommand(),
+    stdio: 'pipe',
+    timeout: DEFAULT_COMMAND_TIMEOUT_MS
+  });
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail(`required command \`${command}\` timed out after ${DEFAULT_COMMAND_TIMEOUT_MS}ms`);
+  }
   if (result.status !== 0) {
     fail(`required command \`${command}\` not available: ${result.error?.message ?? `exit ${result.status}`}`);
   }
@@ -261,9 +309,14 @@ function ensureCommand(command, args) {
 
 function npmPack(packageDir) {
   const result = spawnSync('npm', ['pack', '--silent', '--pack-destination', packageDir], {
+    ...spawnOptionsForCommand(),
     cwd: packageDir,
-    stdio: ['ignore', 'pipe', 'inherit']
+    stdio: ['ignore', 'pipe', 'inherit'],
+    timeout: DEFAULT_COMMAND_TIMEOUT_MS
   });
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail(`npm pack timed out after ${DEFAULT_COMMAND_TIMEOUT_MS}ms in ${packageDir}`);
+  }
   if (result.status !== 0) {
     fail(`npm pack failed in ${packageDir} (exit ${result.status})`);
   }
@@ -283,10 +336,15 @@ function run(command, commandArgs, options = {}) {
   const printable = [command, ...commandArgs].join(' ');
   console.log(`$ ${printable}`);
   const result = spawnSync(command, commandArgs, {
+    ...spawnOptionsForCommand(options),
     cwd: options.cwd ?? repoRoot,
     env: options.env ?? process.env,
-    stdio: 'inherit'
+    stdio: 'inherit',
+    timeout: options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
   });
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail(`${printable} timed out after ${options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS}ms`);
+  }
   if (result.error) {
     fail(`${printable} failed: ${result.error.message}`);
   }
@@ -299,11 +357,18 @@ function runCapture(command, commandArgs, options = {}) {
   const printable = [command, ...commandArgs].join(' ');
   console.log(`$ ${printable}`);
   const result = spawnSync(command, commandArgs, {
+    ...spawnOptionsForCommand(options),
     cwd: options.cwd ?? repoRoot,
     env: options.env ?? process.env,
     stdio: ['ignore', 'pipe', 'pipe'],
-    encoding: 'utf8'
+    encoding: 'utf8',
+    timeout: options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
   });
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail(
+      `${printable} timed out after ${options.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS}ms\nstdout:\n${result.stdout ?? ''}\nstderr:\n${result.stderr ?? ''}`
+    );
+  }
   if (result.error) {
     fail(`${printable} failed: ${result.error.message}`);
   }
@@ -311,6 +376,31 @@ function runCapture(command, commandArgs, options = {}) {
     fail(`${printable} exited with ${result.status}\nstderr:\n${result.stderr}`);
   }
   return result;
+}
+
+function runDaemonStart(wrapperBin, smokeEnv) {
+  if (process.platform === 'win32') {
+    // Capturing stdout from npm's Windows .cmd shim can keep the pipe open
+    // while the background daemon is alive. Run start attached to this process,
+    // then verify health via a separate captured status command below.
+    run(wrapperBin, ['daemon', 'start'], { env: smokeEnv });
+    return undefined;
+  }
+  return runCapture(wrapperBin, ['daemon', 'start'], { env: smokeEnv });
+}
+
+function spawnOptionsForCommand(options = {}, platform = process.platform) {
+  return {
+    shell: platform === 'win32',
+    ...options.spawnOptions
+  };
+}
+
+function firstRunSmokePath(wrapperBin) {
+  return [
+    path.dirname(wrapperBin),
+    path.dirname(process.execPath)
+  ].join(path.delimiter);
 }
 
 function fail(message) {

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -31,7 +31,7 @@
 // Exit code is non-zero on the first failing step.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary
- expand install/help/daemon/reference onboarding docs from stubs into platform-specific setup and recovery guidance
- improve `coven doctor` first-run missing-harness guidance with a smoke test
- add npm onboarding smoke coverage across macOS, Linux, and Windows release-package paths

## Verification
- `node --test scripts/onboarding-docs-test.mjs scripts/publish-npm-test.mjs`
- `python -m unittest scripts/check-secrets-test.py`
- `cargo test -p coven-cli --test smoke doctor_ --locked`
- `cargo fmt --check`
- `git diff --check`
- `python scripts/check-secrets.py`
- `cargo build --release --target aarch64-apple-darwin`
- `COVEN_NPM_DRY_RUN_VERSION=999.0.0 node scripts/test-cli-prepublish.mjs --target=macos --skip-build`