### PR TITLE
fix: allow repo-relative OpenCoven paths in secret guard

### DIFF
--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -137,6 +137,21 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
 
+    def test_opencoven_repo_relative_paths_do_not_trigger_high_entropy(self) -> None:
+        text = (
+            "Consume `OpenCoven/coven/skills/familiar-board-stewardship/` by symlink.\n"
+            "Canonical source: OpenCoven/coven/docs/familiars/board-stewardship.md"
+        )
+
+        hits = check_secrets.scan_text(text, "docs/familiars/board-stewardship.md")
+
+        self.assertEqual(hits, [])
+
+    def test_repo_relative_path_heuristic_still_rejects_other_mixed_case_tokens(self) -> None:
+        token = "OpenCoven/covenLikeFakePayloadMixedCase1234567890"
+
+        self.assertFalse(check_secrets.is_opencoven_repo_relative_path_token(token))
+
     def test_github_advisory_links_do_not_trigger_high_entropy(self) -> None:
         text = (
             "Resolved advisory "

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -108,7 +108,19 @@ def is_public_repo_url_like_token(token: str) -> bool:
 
 def is_opencoven_repo_relative_path_token(token: str) -> bool:
     normalized = token.strip("/")
-    return normalized.startswith("OpenCoven/coven/") and len(normalized.split("/")) >= 4
+    if not normalized.startswith("OpenCoven/coven/"):
+        return False
+    # Keep this allowlist tight: only permit path-ish characters (no `+`/`@`) and
+    # reject mixed-case-within-a-segment / extremely long segments that look token-like.
+    if not re.fullmatch(r"OpenCoven/coven/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+){1,}", normalized):
+        return False
+    for part in normalized.split("/")[2:]:
+        if len(part) > 64:
+            return False
+        letters = "".join(ch for ch in part if ch.isalpha())
+        if letters and not (letters.islower() or letters.isupper()):
+            return False
+    return True
 
 
 def is_github_advisory_url_like_token(token: str) -> bool:

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -106,6 +106,11 @@ def is_public_repo_url_like_token(token: str) -> bool:
     )
 
 
+def is_opencoven_repo_relative_path_token(token: str) -> bool:
+    normalized = token.strip("/")
+    return normalized.startswith("OpenCoven/coven/") and len(normalized.split("/")) >= 4
+
+
 def is_github_advisory_url_like_token(token: str) -> bool:
     normalized = token.strip("/")
     return normalized.startswith("github.com/advisories/GHSA-")
@@ -206,6 +211,7 @@ def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
             if (
                 is_local_path_like_token(token)
                 or is_public_repo_url_like_token(token)
+                or is_opencoven_repo_relative_path_token(token)
                 or is_github_advisory_url_like_token(token)
                 or is_github_commit_url_like_token(token)
                 or is_github_action_sha_ref_token(token)


### PR DESCRIPTION
## Summary
- allow repo-relative OpenCoven/coven/... paths in the release secret guard
- add regression coverage for the familiar board stewardship path that blocked v0.0.51
- keep other mixed-case non-path tokens rejected

## Verification
- python3 scripts/check-secrets-test.py
- python3 scripts/check-secrets.py
- git diff --check

Release context: v0.0.51 tag run failed in Release gates at python3 scripts/check-secrets.py with current high_entropy hits for docs/familiars/board-stewardship.md and skills/familiar-board-stewardship/SKILL.md.