### PR TITLE
docs: bump travel release notes to v0.0.52

### DIFF
--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -10,8 +10,8 @@ title: "Coven changelog and release notes"
 
 ### New features
 
-- **Travel mode foundations (v0.0.51).** The daemon now exposes `/api/v1/travel/profiles`, `/api/v1/travel/deltas`, and `/api/v1/travel/state` so laptop/offline clients can receive a gzip+base64 read-only profile, append offline results back to the hub, and surface handoff states without overwriting canonical memory. The profile artifact is written under `<covenHome>/travel/profiles/` and marked read-only. See [API contract](/API-CONTRACT) and `specs/coven-multi-host-daemon/`.
-- **Multi-host scheduler recovery routes (v0.0.51).** Added persisted scheduler decisions and redispatch state through `/api/v1/scheduler/decisions`, `/api/v1/scheduler/decisions/:id`, `/api/v1/scheduler/redispatch`, and `/api/v1/scheduler/loops/:loopId`. The scheduler avoids heavyweight laptop-local work in travel mode, blocks low-battery laptop-local routing, preserves failed executor subqueues, and can recover loop state after daemon restart. See [API contract](/API-CONTRACT).
+- **Travel mode foundations (v0.0.52).** The daemon now exposes `/api/v1/travel/profiles`, `/api/v1/travel/deltas`, and `/api/v1/travel/state` so laptop/offline clients can receive a gzip+base64 read-only profile, append offline results back to the hub, and surface handoff states without overwriting canonical memory. The profile artifact is written under `<covenHome>/travel/profiles/` and marked read-only. See [API contract](/API-CONTRACT) and `specs/coven-multi-host-daemon/`.
+- **Multi-host scheduler recovery routes (v0.0.52).** Added persisted scheduler decisions and redispatch state through `/api/v1/scheduler/decisions`, `/api/v1/scheduler/decisions/:id`, `/api/v1/scheduler/redispatch`, and `/api/v1/scheduler/loops/:loopId`. The scheduler avoids heavyweight laptop-local work in travel mode, blocks low-battery laptop-local routing, preserves failed executor subqueues, and can recover loop state after daemon restart. See [API contract](/API-CONTRACT).
 
 ### Updates
 


### PR DESCRIPTION
## Summary
- update the travel-mode release note labels from v0.0.51 to v0.0.52
- align docs with the release runbook's patch-bumped recovery path after the failed v0.0.51 gate

## Verification
- git diff --check
- rg -n "v0\.0\.51|v0\.0\.52" docs/reference/release-notes.md