### PR TITLE
[codex] docs: add OpenCoven IP protection records

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,3 +125,66 @@ python scripts/check-secrets.py
 ```
 
 For package releases, also verify package contents with a dry run and attach checksums for native binaries.
+
+---
+
+## OpenCoven DCO and Patent Terms
+
+Thank you for your interest in contributing. OpenCoven is MIT licensed and community-driven. We want contributing to be easy, open, and safe for everyone.
+
+## Developer Certificate of Origin (DCO)
+
+OpenCoven uses the **Developer Certificate of Origin (DCO) v1.1** for all contributions. This is a lightweight mechanism — not a CLA — that asks you to certify that you have the right to submit what you're submitting.
+
+By making a contribution to this project, you certify that:
+
+> (a) The contribution was created in whole or in part by you and you have the right to submit it under the open source license indicated in the file; or
+>
+> (b) The contribution is based upon previous work that, to the best of your knowledge, is covered under an appropriate open source license and you have the right under that license to submit that work with modifications, whether created in whole or in part by you, under the same open source license (unless you are permitted to submit under a different license), as indicated in the file; or
+>
+> (c) The contribution was provided directly to you by some other person who certified (a), (b) or (c) and you have not modified it.
+>
+> (d) You understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information you submit with it, including your sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+
+### How to Sign Off
+
+Add a `Signed-off-by` line to your commit message:
+
+```
+git commit -s -m "Your commit message"
+```
+
+This produces:
+
+```
+Your commit message
+
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+### Patent Non-Assertion
+
+By contributing, you additionally agree not to assert any patent claims — now held or later acquired — against this project or its users that arise from your contribution. See [PATENTS](./PATENTS) for the full non-assertion pledge.
+
+## What We're Looking For
+
+- Bug fixes and reliability improvements
+- Documentation and example improvements
+- New skills, tools, and integrations
+- Performance improvements
+- Community-requested features
+
+## What We're Not
+
+OpenCoven is not a contribution vehicle for proprietary forks. If you are building a closed-source derivative of OpenCoven's architecture, please do not use contribution as a means to learn implementation details that are not yet public. We welcome genuine collaborators.
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Make your changes with signed-off commits: `git commit -s`
+4. Open a pull request with a clear description
+
+## Questions?
+
+Join the Discord: https://discord.gg/OpenCoven

--- a/PATENTS
+++ b/PATENTS
@@ -1,0 +1,46 @@
+# PATENTS
+
+## Patent Non-Assertion
+
+OpenCoven is MIT licensed. The maintainers of this project have not filed and do not intend to file patents on the architectural patterns, protocols, or mechanisms described in this repository.
+
+**Architectural concepts originating in this repository include, but are not limited to:**
+
+- The familiar identity model: a named, role-scoped agent persona resolved from a configuration manifest and attached to a session
+- The agent spawn harness: a structured dispatch pattern that validates and routes process execution through a defined set of primitives
+- The multi-agent orchestration substrate: composable, purpose-scoped agents ("familiars") coordinating through structured routing with shared session context
+- The session memory and continuity substrate (OpenTrust): durable, portable agent memory and session state with provenance tracking
+- The graded approval tier model: auto → familiar-review → human-review → human-required escalation for agent actions affecting protected resources
+
+**First publication dates:**
+
+| Concept | First committed | Repository |
+|---|---|---|
+| Familiar identity model | 2026-04-27 | github.com/OpenCoven/coven |
+| Agent spawn harness | 2026-04-27 | github.com/OpenCoven/coven |
+| Multi-agent familiar substrate | 2026-04-27 | github.com/OpenCoven/coven |
+| Graded approval tier model | 2026-06-19 | The Familiar Contract spec |
+
+These dates are verifiable from public GitHub commit history and repository creation records.
+
+## Non-Assertion Pledge
+
+The OpenCoven maintainers pledge not to assert any patent claims — now held or later acquired — against any person or organization that uses, implements, or builds upon the architectural patterns, protocols, or mechanisms described in this repository or its documentation, provided that use is consistent with the MIT License terms.
+
+## For Contributors
+
+By contributing to this repository, contributors agree that:
+
+1. They own the intellectual property they contribute, or have the right to contribute it
+2. They will not assert patent claims against this project or its users arising from their contributions
+3. Their contributions are made under the MIT License
+
+## Notice to Third Parties
+
+The architectural concepts documented in this repository and its commit history constitute prior art as of their respective commit dates. Any patent application filed after these dates that claims these concepts or their direct derivatives without acknowledgment of this prior art is incomplete.
+
+If you are aware of a patent application that may conflict with this prior art, please open an issue or contact the maintainers directly.
+
+---
+
+*This file is not legal advice. For legal questions regarding patents and open source, consult a qualified attorney.*

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,83 @@
+# PROVENANCE.md — OpenCoven Origin Record
+
+> This document exists to establish the clear, timestamped origin of the architectural ideas that define OpenCoven. It is a public record, not a legal claim. It is maintained so that future readers — contributors, users, researchers, patent examiners — can verify where these ideas came from and when.
+
+---
+
+## Origin
+
+**OpenCoven** was created by **Valentina Alexander** (`@BunsDev`) and first published publicly on **April 27, 2026** under the MIT License.
+
+- GitHub organization: https://github.com/OpenCoven
+- Website: https://OpenCoven.ai
+- Discord: https://discord.gg/OpenCoven
+- X / Twitter: https://x.com/OpenCvn
+- License: MIT (https://opensource.org/licenses/MIT)
+- Repository creation date: **2026-04-27** (verifiable via GitHub API: `https://api.github.com/repos/OpenCoven/coven`)
+
+This repository has no fork parent. It is an original work with no upstream source repository.
+
+---
+
+## Architectural Concepts and Their Origins
+
+### 1. The Familiar Identity Model
+**First appeared:** `coven-cli/src/familiar_identity.rs`, commit history from 2026-04-27
+
+A named, role-scoped agent persona — a "familiar" — resolved from a configuration manifest (`familiars.toml`) and attached to a session via a CLI flag or runtime config. Each familiar has an `id`, `display_name`, and `role`. The familiar model is the foundational identity primitive for multi-agent systems in OpenCoven.
+
+This concept was original to this repository. It has been independently acknowledged as prior art by third parties in their own published documentation.
+
+### 2. The Agent Spawn Harness
+**First appeared:** `pty_runner.rs:307` (`spawn_piped_with_observer`), commit history from 2026-04-27
+
+A structured dispatch pattern for launching configured agent/harness processes. The pattern validates a harness allowlist, canonicalizes working directory, checks session state, then dispatches to one of a defined set of low-level spawn primitives. This is the root pattern from which single-chokepoint process execution architectures in agent systems derive.
+
+### 3. The Multi-Agent Familiar Substrate
+**First appeared:** 2026-04-27, OpenCoven core architecture
+
+Composable, purpose-scoped agents ("familiars") that cooperate through structured routing, share session context, and are individually manageable. Each familiar has a defined lane; routing between familiars is explicit and traceable. This is not monolithic prompt-chaining — it is a hub-and-spoke orchestration model where each agent is a named, scoped participant.
+
+### 4. The Graded Approval Tier Model
+**First appeared:** The Familiar Contract RFC-0001 v0.2.0, authored by Valentina Alexander and Sage, **dated 2026-06-19**
+
+Defines a `ward.toml`-like structure with a `[protected]` partition (files/invariants an agent may not modify autonomously) and `[editable]` partition, gated by approval tiers: `auto → familiar_review → human_review → human_required`. Enforced by an authority layer separate from the familiar itself.
+
+### 5. Session Memory and Continuity Substrate (OpenTrust)
+**First published:** 2026 (active development)
+
+Durable, portable agent memory that persists across sessions, remains under user control, and maintains provenance of agent actions. Designed to be model-agnostic and provider-agnostic — memory is not stored on vendor servers unless the user chooses that. This is the trust layer that makes long-running agent systems auditable and recoverable.
+
+---
+
+## Third-Party Acknowledgments
+
+The following third-party projects have independently documented OpenCoven as a source or ancestor of their architectural concepts. These acknowledgments are recorded here as additional evidence of the originality and priority of OpenCoven's contributions:
+
+| Project | Documentation | Concepts acknowledged |
+|---|---|---|
+| `YogiSotho/warden` | `lineage/LINEAGE.md`, `docs/ops/patent/prior-art-search.md` | Spawn chokepoint (pty_runner.rs:307), familiar identity model (coven-cli/src/familiar_identity.rs:23-35), harness adapter contract, ledger shape, CLI skeleton. Warden's own prior-art search gives OpenCoven a "real, dated, public prior art" verdict for these elements. |
+
+The presence of these acknowledgments in third-party repositories is noted for the record and does not constitute an endorsement of those projects by OpenCoven maintainers.
+
+---
+
+## Maintainer
+
+**Valentina Alexander**
+- GitHub: [@BunsDev](https://github.com/BunsDev)
+- Role: Creator and Core Maintainer, OpenCoven
+- Also: Core Maintainer, OpenClaw; Developer Relations Engineer, Ritual Foundation
+
+---
+
+## Contributing to the Record
+
+If you are aware of prior art that predates any of the concepts listed here, please open an issue. We maintain this document honestly — if something was not original to us, we want to know and update the record accordingly.
+
+If you are aware of a patent application or trademark filing that cites or conflicts with the concepts documented here, please notify the maintainers immediately via the Discord or by opening a GitHub issue.
+
+---
+
+*Last updated: 2026-07-04*
+*This document does not constitute legal advice.*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,3 +37,54 @@ Default retention is short for raw encrypted artifacts and bounded for operation
 - Raw encrypted artifacts: 7 days.
 - Redacted event logs: 30 days.
 - Manual pruning: `coven logs prune`.
+
+---
+
+## OpenCoven Security Disclosure Addendum
+
+## Security Policy
+
+### Reporting a Vulnerability
+
+If you discover a security vulnerability in OpenCoven, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Contact the maintainers directly:
+- Discord: https://discord.gg/OpenCoven (DM @BunsDev)
+- Or open a GitHub Security Advisory on the repository
+
+We will acknowledge receipt within 48 hours and aim to address confirmed vulnerabilities within 14 days.
+
+### Scope
+
+Security reports are welcome for:
+- OpenCoven core harness and routing logic
+- OpenTrust memory and session substrate
+- Authentication and identity handling
+- Agent sandbox and execution boundaries
+- Any mechanism that could allow one agent or user to access another's context
+
+### Out of Scope
+
+- Issues in third-party dependencies (report to the dependency maintainer)
+- Issues in model provider APIs (report to the provider)
+
+### Our Commitment
+
+We take security seriously because OpenCoven handles personal context and agent execution on behalf of users. We will credit researchers who responsibly disclose vulnerabilities (with their permission).
+
+---
+
+## Architectural Security Properties
+
+The following properties are design goals of OpenCoven. If you find a way to violate them, that's a security report:
+
+1. **Session isolation** — one user's agent context must not be accessible to another user or agent without explicit permission
+2. **Memory ownership** — a user's stored memory and context must remain under their control
+3. **Agent identity integrity** — a familiar's identity must not be forgeable by another agent or external caller
+4. **Execution boundaries** — agent tool calls must not escape their intended scope
+
+---
+
+*Last updated: 2026-07-04*


### PR DESCRIPTION
## Summary

Adds the OpenCoven root IP protection and disclosure documents:

- `PATENTS`: patent non-assertion pledge and prior-art notice
- `PROVENANCE.md`: origin and publication record
- `CONTRIBUTING.md`: DCO and patent contribution terms, merged with any existing repo guidance
- `SECURITY.md`: responsible disclosure policy, merged with any existing repo guidance

## Validation

- Only root documentation files changed: `PATENTS`, `PROVENANCE.md`, `CONTRIBUTING.md`, `SECURITY.md`
- Internal-only source notes were not copied
- `git diff --check` passed locally
