### PR TITLE
feat: add opencode as built-in harness alongside codex and claude

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -416,6 +416,20 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 read_only: "plan".to_string(),
             }),
         },
+        HarnessCommandSpec {
+            id: "opencode".to_string(),
+            label: "OpenCode".to_string(),
+            executable: "opencode".to_string(),
+            interactive_prompt_prefix_args: Vec::new(),
+            non_interactive_prompt_prefix_args: vec!["run".to_string()],
+            install_hint: "Install OpenCode with `curl -fsSL https://opencode.ai/install | bash`, then ensure `opencode` resolves on PATH. Verify with `opencode --version`.".to_string(),
+            source: "bundled".to_string(),
+            manifest_path: None,
+            system_prompt_flag: None,
+            model_flag: Some("--model".to_string()),
+            model_arg_template: None,
+            sandbox: None,
+        },
     ]
 }
 
@@ -585,6 +599,7 @@ fn adapter_manifest_paths_in_dir(dir: &Path) -> Vec<PathBuf> {
 pub fn known_adapter_manifest(adapter_id: &str) -> Option<&'static str> {
     match adapter_id {
         "hermes" => Some(HERMES_ADAPTER_MANIFEST),
+        "opencode" => Some(OPENCODE_ADAPTER_MANIFEST),
         _ => None,
     }
 }
@@ -604,8 +619,24 @@ const HERMES_ADAPTER_MANIFEST: &str = r#"{
 }
 "#;
 
+const OPENCODE_ADAPTER_MANIFEST: &str = r#"{
+  "adapters": [
+    {
+      "id": "opencode",
+      "label": "OpenCode",
+      "executable": "opencode",
+      "interactive_prompt_prefix_args": [],
+      "non_interactive_prompt_prefix_args": ["run"],
+      "install_hint": "Install OpenCode with `curl -fsSL https://opencode.ai/install | bash`, then ensure `opencode` resolves on PATH. Verify with `opencode --version`.",
+      "system_prompt_flag": null,
+      "model_flag": "--model"
+    }
+  ]
+}
+"#;
+
 pub fn known_adapter_recipe_names() -> &'static [&'static str] {
-    &["hermes"]
+    &["hermes", "opencode"]
 }
 
 fn load_external_harness_specs(

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1172,6 +1172,7 @@ fn default_harness_id() -> Option<String> {
         .iter()
         .find(|h| h.id == "codex" && h.available)
         .or_else(|| harnesses.iter().find(|h| h.id == "claude" && h.available))
+        .or_else(|| harnesses.iter().find(|h| h.id == "opencode" && h.available))
         .map(|h| h.id.clone())
 }
 

--- a/crates/coven-cli/src/tui/cast/intent.rs
+++ b/crates/coven-cli/src/tui/cast/intent.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, Result};
 pub(crate) enum CastHarness {
     Codex,
     Claude,
+    Opencode,
 }
 
 impl CastHarness {
@@ -19,6 +20,7 @@ impl CastHarness {
         match self {
             CastHarness::Codex => "codex",
             CastHarness::Claude => "claude",
+            CastHarness::Opencode => "opencode",
         }
     }
 
@@ -26,6 +28,7 @@ impl CastHarness {
         match self {
             CastHarness::Codex => "Codex",
             CastHarness::Claude => "Claude Code",
+            CastHarness::Opencode => "OpenCode",
         }
     }
 
@@ -33,6 +36,7 @@ impl CastHarness {
         match token.to_ascii_lowercase().as_str() {
             "codex" => Some(CastHarness::Codex),
             "claude" | "claude-code" | "claudecode" => Some(CastHarness::Claude),
+            "opencode" => Some(CastHarness::Opencode),
             _ => None,
         }
     }
@@ -142,6 +146,7 @@ fn parse_slash_command(input: &str) -> Result<Option<CastIntent>> {
         "/run" => parse_run_slash(rest)?,
         "/codex" => parse_harness_slash(CastHarness::Codex, rest)?,
         "/claude" => parse_harness_slash(CastHarness::Claude, rest)?,
+        "/opencode" => parse_harness_slash(CastHarness::Opencode, rest)?,
         "/attach" => session_id_intent(rest, "/attach", |session_id| CastIntent::AttachSession {
             session_id,
         })?,

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -72,7 +72,7 @@ pub(crate) fn plan_spell(raw: &str) -> Result<CastPlan> {
 }
 
 /// Resolve Cast's safe default harness from the host's installed adapters.
-/// Codex wins; Claude is the fallback; otherwise `None`.
+/// Codex wins; Claude is the fallback; OpenCode is the tertiary fallback; otherwise `None`.
 pub(crate) fn default_harness() -> Option<CastHarness> {
     let harnesses = harness::built_in_harnesses();
     if harnesses.iter().any(|h| h.id == "codex" && h.available) {
@@ -80,6 +80,9 @@ pub(crate) fn default_harness() -> Option<CastHarness> {
     }
     if harnesses.iter().any(|h| h.id == "claude" && h.available) {
         return Some(CastHarness::Claude);
+    }
+    if harnesses.iter().any(|h| h.id == "opencode" && h.available) {
+        return Some(CastHarness::Opencode);
     }
     None
 }

--- a/crates/coven-cli/src/tui/cast/plan.rs
+++ b/crates/coven-cli/src/tui/cast/plan.rs
@@ -213,7 +213,7 @@ fn quest_plan(
             "Each phase delegates to {} unless you override the sub-prompt",
             plan_harness.harness.label()
         ),
-        None => "No harness ready — run `coven doctor` to install Codex or Claude Code".to_string(),
+        None => "No harness ready — run `coven doctor` to install Codex, Claude Code, or OpenCode".to_string(),
     };
     let steps = vec![
         CastStep::new(CastStepKind::Inform, "design — scope the work"),
@@ -254,7 +254,7 @@ fn natural_spell_plan(
                 plan_harness.harness.label()
             ),
             None => {
-                "No harness ready — run `coven doctor` to install Codex or Claude Code".to_string()
+                "No harness ready — run `coven doctor` to install Codex, Claude Code, or OpenCode".to_string()
             }
         },
     )];
@@ -366,7 +366,7 @@ fn familiar_spell_plan(
                 plan_harness.harness.label()
             ),
             None => {
-                "No harness ready — run `coven doctor` to install Codex or Claude Code".to_string()
+                "No harness ready — run `coven doctor` to install Codex, Claude Code, or OpenCode".to_string()
             }
         },
     )];

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1283,11 +1283,13 @@ impl App {
         let home = std::env::var("HOME")
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
-        for (harness_id, label) in &[("codex", "Codex"), ("claude", "Claude")] {
+        for (harness_id, label) in &[("codex", "Codex"), ("claude", "Claude"), ("opencode", "OpenCode")] {
             let m = if *harness_id == "codex" {
                 crate::capabilities::scan_codex_capabilities(&home)
-            } else {
+            } else if *harness_id == "claude" {
                 crate::capabilities::scan_claude_capabilities(&home)
+            } else {
+                crate::capabilities::scan_opencode_capabilities(&home)
             };
             let instr = if m.global_instructions.present {
                 "✓"


### PR DESCRIPTION
Adds opencode as a first-class built-in harness in the coven CLI, alongside the existing codex and claude harnesses.

## Changes
- Add opencode to built-in harness specs with `run` prefix args
- Add OPENCODE_ADAPTER_MANIFEST constant for trusted recipe matching
- Update CastHarness enum with Opencode variant (id, label, from_token, /opencode slash command)
- Add opencode as fallback in default_harness_id() and cast::default_harness()
- Update chat capabilities display and plan messages