### PR TITLE
fix: CLI UX polish — front-door guards, session-ref UX, output discipline, honest help

### DIFF
--- a/CHAT-QUICKSTART.md
+++ b/CHAT-QUICKSTART.md
@@ -1,153 +1,56 @@
-# Coven Chat TUI — Quick Start Guide
+# Coven Interactive UI — Quick Start
 
-## Build
+`coven` (and its explicit forms `coven chat` / `coven tui`) opens the
+interactive Coven UI. The UI is provided by the separate
+[`coven-code`](https://github.com/OpenCoven/coven-code) front-end; the `coven`
+binary finds it on `PATH` or under `~/.coven-code/bin` and hands the terminal
+over to it.
+
+## Install
 
 ```bash
-cd /path/to/coven
-cargo build -p coven-cli
+# The Coven CLI
+npm install -g @opencoven/cli
+
+# The interactive front-end
+npm install -g @opencoven/coven-code
+# or:
+curl -fsSL https://github.com/OpenCoven/coven-code/releases/latest/download/install.sh | bash
 ```
 
 ## Run
 
 ```bash
-./target/debug/coven chat
+cd /path/to/your/project
+coven
 ```
 
-## Try These
+If `coven-code` is not installed, `coven` prints the install commands above
+instead of opening the UI.
 
-### 1. See Help
-```
-Type: /help
-Press: Enter
-→ Shows all available commands
-```
+## Prefer plain commands?
 
-### 2. Send a Message
-```
-Type: Hey, what can you do?
-Press: Enter
-→ Message appears with "You:" prefix
-→ Mock response from agent
-```
+Everything the UI does is also available as explicit CLI commands:
 
-### 3. Clear Chat
-```
-Type: /clear
-Press: Enter
-→ Chat history cleared
-```
-
-### 4. Switch Agent
-```
-Type: /agent Sage
-Press: Enter
-→ Agent switches to Sage
-```
-
-### 5. Scroll History
-```
-Press: Up arrow
-→ Scroll chat history up
-Press: Down arrow
-→ Scroll back down
-```
-
-### 6. Exit
-```
-Type: /exit
-Press: Enter
-Or
-Press: Ctrl+C
-→ Graceful exit, terminal restored
-```
-
-## Layout
-
-```
-┌─────────────────────────────────────┐
-│ 🔮  Agent: Nova  |  Connection: ●   │  ← Status bar
-├─────────────────────────────────────┤
-│ System: Welcome to Coven Chat!      │
-│ You: /help                          │
-│ System: Available commands:         │
-│  /help - Show this help             │
-│  /clear - Clear chat history        │
-│  /agent <name> - Switch agent       │
-│  /exit - Quit                       │
-│                                     │
-├─────────────────────────────────────┤
-│ Message or type / for commands      │
-│ ┌─────────────────────────────────┐ │
-│ │ _                               │ │  ← Input (cursor shown)
-│ └─────────────────────────────────┘ │
-└─────────────────────────────────────┘
-```
-
-## Features (MVP)
-
-- ✅ Natural message input
-- ✅ Scrollable history
-- ✅ Slash commands
-- ✅ Agent switching
-- ✅ SSH-compatible
-- ✅ No external dependencies
-- ✅ Clean terminal exit
-
-## What's Not Ready Yet (Phase 2)
-
-- 🔄 Real gateway connection (coming soon)
-- 🔄 Streaming token responses
-- 🔄 Agent discovery from gateway
-- 🔄 Session attachment
-- 🔄 Memory context display
-- 🔄 Code syntax highlighting
-- 🔄 Message export
-
-## Troubleshooting
-
-### Binary Not Found
 ```bash
-cargo build -p coven-cli first
+coven doctor                      # check your setup
+coven run codex "fix the tests"   # launch a recorded session
+coven sessions                    # browse sessions (plain table when piped)
+coven attach <session-id-prefix>  # follow a session
 ```
 
-### Terminal Corruption on Exit
+You can also hand a task straight to Cast — Coven shows a plan card, then runs
+it in a recorded session:
+
 ```bash
-Just run the app again — it restores properly
+coven "explain this repo in 5 bullets"
 ```
 
-### Slow/Laggy Input
+## Legacy in-process shell
+
+The previous built-in slash shell is deprecated and will be removed. If you
+need it during the transition:
+
 ```bash
-Normal behavior — event loop polls every 100ms
-Real agent responses will be streamed (Phase 2)
+COVEN_LEGACY_TUI=1 coven
 ```
-
-### Can't Type in SSH Session
-```bash
-Normal limitation of non-PTY environments
-Terminal requires interactive TTY
-```
-
-## Next Session (Phase 2)
-
-1. Gateway WebSocket integration
-2. Real agent responses (not mock)
-3. Token-by-token streaming
-4. Connection health monitoring
-5. Auto-reconnect
-
-## Commands Reference
-
-| Command | Shortcut | Effect |
-|---------|----------|--------|
-| `/help` | `/h` | Show all commands |
-| `/clear` | `/c` | Clear chat history |
-| `/agent <name>` | `/a <name>` | Switch to agent |
-| `/exit` | `/q`, `/exit` | Quit |
-| Ctrl+C | - | Immediate exit |
-| Up/Down arrows | - | Scroll history |
-
----
-
-**Built with:** Ratatui (Rust TUI framework) + Tokio async runtime
-
-**Status:** MVP Complete ✅ → Production Ready for Phase 2

--- a/README.md
+++ b/README.md
@@ -168,16 +168,20 @@ cargo run -p coven-cli -- doctor
 
 ## Quick Start
 
-### Option A — Interactive menu (recommended for new users)
+### Option A — Interactive UI (recommended for new users)
 
 ```bash
 cd /path/to/your/project
 coven
 # or explicitly:
-coven tui
+coven chat
 ```
 
-The menu opens with a **Start here** guide, checks your local setup, and shows the safest first command to try. Type a task directly (e.g., `fix the failing tests`) or use slash commands like `/run codex fix the failing tests`. Press `h` or type `/help` for examples.
+Bare `coven` opens the interactive Coven UI, which is provided by the separate
+[`coven-code`](https://github.com/OpenCoven/coven-code) front-end (`npm install -g
+@opencoven/coven-code`). If it isn't installed, `coven` prints the install
+command. You can also pass a task directly — `coven "fix the failing tests"` —
+and Coven will show a plan card and run it in a recorded session.
 
 ### Option B — Direct commands
 
@@ -218,11 +222,22 @@ Choose a repo, choose a harness, get a verified patch.
 
 ### Core commands
 
-| Command        | Action                                                |
-| -------------- | ----------------------------------------------------- |
-| `coven`        | Open the beginner-friendly interactive menu           |
-| `coven tui`    | Explicitly open the slash-command TUI                 |
-| `coven doctor` | Detect supported harness CLIs and print install hints |
+| Command          | Action                                                          |
+| ---------------- | --------------------------------------------------------------- |
+| `coven`          | Open the interactive Coven UI (requires `coven-code`)           |
+| `coven "<task>"` | Plan and run a free-text task in a recorded session (Cast flow) |
+| `coven chat`     | Explicitly open the interactive Coven UI                        |
+| `coven tui`      | Same as `coven chat`                                            |
+| `coven doctor`   | Detect supported harness CLIs and print install hints           |
+
+### Harness adapters
+
+| Command                       | Action                                        |
+| ----------------------------- | --------------------------------------------- |
+| `coven adapter list`          | List configured harness adapters              |
+| `coven adapter list --json`   | Adapter reports as JSON                       |
+| `coven adapter doctor [id]`   | Diagnose all adapters, or one adapter id      |
+| `coven adapter install <id>`  | Install a trusted local adapter recipe        |
 
 ### Daemon lifecycle
 
@@ -263,6 +278,9 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven archive <session-id>`                   | Hide a non-running session while preserving its events           |
 | `coven sacrifice <session-id> --yes`           | Permanently delete a non-running session and its events          |
 
+> `attach`, `summon`, `archive`, and `sacrifice` accept a unique prefix of the
+> session id (e.g. `coven attach 9099`), so you don't have to paste full UUIDs.
+
 > **Session rituals are intentionally explicit.** Archive is reversible and keeps the full event ledger. Summon brings an archived session back. Sacrifice is destructive, refuses live sessions, and requires `--yes` so beginners don't delete work by accident.
 
 | Ritual        | Reversible? | Works on             | Description                                                  |
@@ -285,6 +303,18 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven pc cache clear --confirm` | Clear `~/Library/Caches` and `/Library/Caches` (requires `--confirm`) |
 
 > All read operations are side-effect-free. Write operations (kill, cache clear) require `--confirm` and cannot be bypassed. Termination is SIGTERM only — no SIGKILL.
+
+### Parallel work protocol (worktrees, claims, hooks)
+
+| Command                     | Action                                                        |
+| --------------------------- | ------------------------------------------------------------- |
+| `coven wt <branch>`         | Create or enter a worktree in the sibling `<repo>.wt` dir     |
+| `coven wt --list`           | List worktrees with claim and dirty state                     |
+| `coven wt --doctor`         | Report protocol layout and hook issues                        |
+| `coven wt --prune-merged`   | Remove clean worktrees whose branches are merged              |
+| `coven claim acquire <b>`   | Claim a branch for the current agent (TTL-bounded)            |
+| `coven claim status`        | Show active and expired claims for this repository            |
+| `coven hooks install`       | Install the protocol's pre-commit and pre-push git hooks      |
 
 ### Other
 
@@ -669,7 +699,7 @@ coven doctor
 | Daemon won't start                          | Run `coven daemon restart`; check `$COVEN_HOME` ownership and permissions              |
 | Session browser shows a table, not a UI     | Terminal isn't interactive; use `coven sessions --manage` to force the browser         |
 | `cwd` rejected at launch                    | The working directory resolves outside the project root; use a path inside it          |
-| Stale "running" sessions after daemon crash | Run `coven sessions --all`; archive or sacrifice orphaned records                      |
+| Stale "running" sessions after daemon crash | Run `coven daemon restart` to mark dead sessions `orphaned`, then archive or sacrifice them via `coven sessions --all` |
 | Sessions feel slow / daemon sluggish        | Run `coven pc status` to check system pressure; `coven pc top --n 10` for CPU culprits |
 | `coven attach` won't accept input           | The session is not live; attach replays logs for completed or archived sessions        |
 | Secret scan fails                           | Remove the secret from your working tree; rotate it if it entered git history          |

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -50,7 +50,7 @@ const DEFAULT_TITLE_CHARS: usize = 48;
 #[command(version = env!("COVEN_VERSION_DESC"))]
 #[command(about = "Run project-scoped coding agents without memorizing harness commands")]
 #[command(
-    long_about = "Coven runs Codex, Claude Code, and future harnesses inside a local, project-scoped session ledger. Run `coven` with no arguments for a beginner-friendly menu."
+    long_about = "Coven runs Codex, Claude Code, and future harnesses inside a local, project-scoped session ledger. Run `coven` with no arguments to open the interactive Coven UI (requires the coven-code front-end), or pass a free-text task to plan and run it directly."
 )]
 struct Cli {
     #[command(subcommand)]
@@ -60,16 +60,16 @@ struct Cli {
         num_args = 0..,
         trailing_var_arg = true,
         allow_hyphen_values = true,
-        help = "Task to run through Cast when no subcommand is provided"
+        help = "Free-text task to cast when no subcommand is given: Coven plans it, asks you to confirm, then runs it in a session"
     )]
     prompt: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    #[command(about = "Interactive chat with Coven agents")]
+    #[command(about = "Open the interactive Coven UI (requires coven-code)")]
     Chat,
-    #[command(about = "Open the slash-command TUI")]
+    #[command(about = "Open the interactive Coven UI (same as `coven chat`)")]
     Tui,
     #[command(about = "Check local setup and print next steps")]
     Doctor,
@@ -97,7 +97,11 @@ enum Command {
         cwd: Option<PathBuf>,
         #[arg(long, help = "Readable title for `coven sessions`")]
         title: Option<String>,
-        #[arg(long, help = "Create the session record without launching the harness")]
+        #[arg(
+            long,
+            conflicts_with = "continue_session",
+            help = "Create the session record without launching the harness"
+        )]
         detach: bool,
         #[arg(
             long = "continue",
@@ -124,13 +128,13 @@ enum Command {
         #[arg(
             long,
             value_name = "ID",
-            help = "Familiar id to inject as identity context (e.g. charm). \nThe harness-agnostic identity preamble is injected via each harness's \npreferred mechanism (--system-prompt flag or prompt prefix)."
+            help = "Familiar id to inject as identity context (e.g. charm). The identity preamble is injected via each harness's preferred mechanism (--system-prompt flag or prompt prefix)."
         )]
         familiar: Option<String>,
         #[arg(
             long,
             value_name = "ID",
-            help = "Model to run the harness on. Accepts a namespaced id (e.g. \nopenai/gpt-5.5, anthropic/claude-...); Coven strips the provider/ \nprefix and forwards the bare id to the harness's native model flag \n(codex/claude --model). Adapters that declare no model mechanism warn \nand continue. Echoed back in the stream-json system.init `model` field."
+            help = "Model to run the harness on. Accepts a namespaced id (e.g. openai/gpt-5.5, anthropic/claude-...); Coven strips the provider/ prefix and forwards the bare id to the harness's native model flag (codex/claude --model). Adapters that declare no model mechanism warn and continue. Echoed back in the stream-json system.init `model` field."
         )]
         model: Option<String>,
         #[arg(
@@ -164,7 +168,7 @@ enum Command {
         )]
         stream_json_input: bool,
     },
-    #[command(about = "List or search recent Coven sessions")]
+    #[command(about = "List or search recent Coven sessions", alias = "session")]
     Sessions {
         #[command(subcommand)]
         command: Option<SessionsCommand>,
@@ -174,7 +178,7 @@ enum Command {
         manage: bool,
         #[arg(long, conflicts_with_all = ["manage", "json"], help = "Print a plain table instead of the session browser")]
         plain: bool,
-        #[arg(long, conflicts_with_all = ["manage", "plain"], help = "Print sessions as JSON for clients such as comux")]
+        #[arg(long, conflicts_with_all = ["manage", "plain"], help = "Print sessions as JSON (machine-readable)")]
         json: bool,
     },
     #[command(about = "Manage local log retention")]
@@ -182,7 +186,11 @@ enum Command {
         #[command(subcommand)]
         command: LogsCommand,
     },
-    #[command(about = "Create, list, diagnose, and prune Coven worktrees")]
+    #[command(
+        about = "Create, list, diagnose, and prune Coven worktrees",
+        alias = "worktree",
+        alias = "worktrees"
+    )]
     Wt {
         #[arg(
             help = "Branch to create or enter in the sibling <repo>.wt directory",
@@ -210,13 +218,27 @@ enum Command {
         command: HooksCommand,
     },
     #[command(about = "Replay/follow a session and forward input to live daemon sessions")]
-    Attach { session_id: String },
+    Attach {
+        #[arg(help = "Session id, or a unique prefix of one (list ids with `coven sessions`)")]
+        session_id: String,
+    },
     #[command(about = "Summon an archived session back, then replay/follow it")]
-    Summon { session_id: String },
+    Summon {
+        #[arg(
+            help = "Session id, or a unique prefix of one (list ids with `coven sessions --all`)"
+        )]
+        session_id: String,
+    },
     #[command(about = "Archive a completed session without deleting its events")]
-    Archive { session_id: String },
+    Archive {
+        #[arg(help = "Session id, or a unique prefix of one (list ids with `coven sessions`)")]
+        session_id: String,
+    },
     #[command(about = "Permanently delete a non-running session and its events")]
     Sacrifice {
+        #[arg(
+            help = "Session id, or a unique prefix of one (list ids with `coven sessions --all`)"
+        )]
         session_id: String,
         #[arg(long, help = "Confirm permanent deletion")]
         yes: bool,
@@ -233,14 +255,23 @@ enum Command {
         harness: Option<String>,
         #[arg(
             long,
-            help = "Verification profile: auto, pnpm-check, targeted-test, diff-only"
+            value_name = "PROFILE",
+            value_parser = ["auto", "pnpm-check", "targeted-test", "diff-only"],
+            help = "Verification profile to run after the harness finishes"
         )]
         verify: Option<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Never prompt; requires issue text and --harness, and fails instead of asking"
+        )]
         non_interactive: bool,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Print the plan and repair brief without launching the harness"
+        )]
         dry_run: bool,
-        #[arg(long)]
+        // Accepted for compatibility; patch sessions are always kept today.
+        #[arg(long, hide = true)]
         keep_session: bool,
     },
     #[command(about = "Diagnose and relieve macOS system pressure")]
@@ -254,9 +285,9 @@ enum Command {
 enum SessionsCommand {
     #[command(about = "Full-text search session event payloads")]
     Search {
-        #[arg(help = "FTS5 query (e.g. `phoenix OR rises`)")]
+        #[arg(help = "Full-text query (FTS5 syntax, e.g. `phoenix OR rises`)")]
         query: String,
-        #[arg(long, help = "Print SearchHit JSON for clients")]
+        #[arg(long, help = "Print search hits as JSON (machine-readable)")]
         json: bool,
     },
 }
@@ -282,9 +313,13 @@ enum AdapterCommand {
 
 #[derive(Subcommand, Debug)]
 enum DaemonCommand {
+    #[command(about = "Start the background daemon that hosts live sessions")]
     Start,
+    #[command(about = "Restart the background daemon")]
     Restart,
+    #[command(about = "Show whether the daemon is running")]
     Status,
+    #[command(about = "Stop the background daemon")]
     Stop,
     #[command(hide = true)]
     Serve {
@@ -486,8 +521,72 @@ fn run_cli(cli: Cli) -> Result<()> {
 }
 
 fn run_bare_prompt(prompt: &[String]) -> Result<()> {
+    // The bare-prompt catch-all swallows anything clap doesn't recognize, so
+    // it has to do its own front-door validation: reject stray flags, catch
+    // near-miss subcommand typos, and refuse to launch a harness when nobody
+    // is at the terminal to confirm or cancel the cast.
+    if let Some(first) = prompt.first() {
+        if first.starts_with('-') {
+            anyhow::bail!(
+                "unrecognized flag `{first}`; run `coven --help` to see available flags and commands"
+            );
+        }
+    }
+    if let [token] = prompt {
+        if let Some(suggestion) = near_miss_subcommand(token) {
+            anyhow::bail!(
+                "unrecognized subcommand `{token}`; did you mean `coven {suggestion}`? \
+                 (to run `{token}` as a task instead, use `coven run <harness> \"{token}\"`)"
+            );
+        }
+    }
+    if !io::stdin().is_terminal() {
+        anyhow::bail!(
+            "refusing to cast without an interactive terminal to confirm the plan; \
+             use `coven run <harness> \"<task>\"` for scripted runs"
+        );
+    }
     let prompt = joined_prompt(prompt)?;
     tui::shell::run_cast_spell(&prompt)
+}
+
+/// Suggest a subcommand (or alias) within a small edit distance of the given
+/// word. Guards the bare-prompt catch-all: without this, `coven sesions`
+/// would be cast as an AI task instead of surfacing a typo.
+fn near_miss_subcommand(word: &str) -> Option<String> {
+    use clap::CommandFactory;
+    let needle = word.to_ascii_lowercase();
+    let mut best: Option<(usize, String)> = None;
+    for subcommand in Cli::command().get_subcommands() {
+        let names = std::iter::once(subcommand.get_name().to_string())
+            .chain(subcommand.get_all_aliases().map(str::to_string));
+        for name in names {
+            let threshold = if name.len() <= 4 { 1 } else { 2 };
+            let distance = edit_distance(&needle, &name);
+            if distance > 0
+                && distance <= threshold
+                && best.as_ref().is_none_or(|(d, _)| distance < *d)
+            {
+                best = Some((distance, name));
+            }
+        }
+    }
+    best.map(|(_, name)| name)
+}
+
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut previous: Vec<usize> = (0..=b.len()).collect();
+    for (i, &ca) in a.iter().enumerate() {
+        let mut current = vec![i + 1];
+        for (j, &cb) in b.iter().enumerate() {
+            let substitution = previous[j] + usize::from(ca != cb);
+            current.push(substitution.min(previous[j + 1] + 1).min(current[j] + 1));
+        }
+        previous = current;
+    }
+    previous[b.len()]
 }
 
 fn run_sessions_search(query: &str, json: bool) -> Result<()> {
@@ -530,6 +629,13 @@ fn run_shared_interactive_shell() -> Result<()> {
             InteractiveShellRoute::Chat => tui::chat::run_chat(),
             InteractiveShellRoute::PlainCast => tui::shell::run(),
         };
+    }
+
+    if !(io::stdin().is_terminal() && io::stdout().is_terminal()) {
+        anyhow::bail!(
+            "the interactive Coven UI needs a real terminal (stdin/stdout are not TTYs).\n\
+             Try instead: coven doctor · coven sessions --plain · coven run <harness> \"<task>\""
+        );
     }
 
     match coven_code_binary() {
@@ -704,7 +810,8 @@ fn try_delegate_to_coven_code(binary: &Path) -> Result<()> {
         let status = command
             .status()
             .map_err(|e| anyhow!("failed to launch coven-code: {e}"))?;
-        std::process::exit(status.code().unwrap_or(0));
+        // A signal-terminated child has no code; treat it as failure.
+        std::process::exit(status.code().unwrap_or(1));
     }
 }
 
@@ -771,10 +878,23 @@ fn run_doctor() -> Result<()> {
         let marker = if harness.available { "OK" } else { "!!" };
         println!(
             "  [{marker}] {:<18} `{}` is {status} ({})",
-            harness.label, harness.executable, harness.source
+            harness.label,
+            harness.executable,
+            adapter_source_label(&harness.source)
         );
         if !harness.available {
             println!("       {}", harness.install_hint);
+        }
+    }
+
+    println!("\nInteractive UI:");
+    match coven_code_binary() {
+        Some(path) => println!("  [OK] coven-code found at {}", path.display()),
+        None => {
+            println!("  [!!] coven-code is missing — `coven` and `coven chat` need it");
+            for line in coven_code_install_instructions(target_shell()).lines() {
+                println!("     {line}");
+            }
         }
     }
 
@@ -790,9 +910,21 @@ fn run_doctor() -> Result<()> {
         println!("  Claude Code: npm install -g @anthropic-ai/claude-code && claude doctor");
         println!("  If PATH changed, open a new terminal and run `coven doctor` again.");
         println!("  Then run: coven daemon start");
-        println!("  Install docs: docs/install/index.md");
+        println!(
+            "  Install docs: https://github.com/OpenCoven/coven/blob/main/docs/install/index.md"
+        );
     }
     Ok(())
+}
+
+/// Human label for an adapter spec's `source` field. The raw value ("bundled")
+/// reads as a contradiction next to a missing executable ("missing (bundled)").
+fn adapter_source_label(source: &str) -> &str {
+    if source == "bundled" {
+        "built-in adapter"
+    } else {
+        source
+    }
 }
 
 /// Surface the configured familiars so operators can confirm which identities
@@ -868,7 +1000,11 @@ fn run_adapter_list(json: bool) -> Result<()> {
             .unwrap_or_default();
         println!(
             "  {:<18} {:<10} `{}` {}{}",
-            harness.id, availability, harness.executable, harness.source, manifest
+            harness.id,
+            availability,
+            harness.executable,
+            adapter_source_label(&harness.source),
+            manifest
         );
     }
     Ok(())
@@ -1324,7 +1460,12 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 "coven daemon status=stale ok=false pid={} socket={}",
                 status.pid, status.socket
             ),
-            None => println!("coven daemon status=stopped"),
+            None => {
+                println!("coven daemon status=stopped");
+                eprintln!(
+                    "start it with `coven daemon start` (optional — `coven run` works without it)"
+                );
+            }
         },
         DaemonCommand::Stop => {
             if daemon::stop_background_server(&home)? {
@@ -1379,6 +1520,18 @@ fn should_synthesize_stream_user_event(
     harness_id: &str,
 ) -> bool {
     stream_json && !expanded_prompt.is_empty() && (detach || harness_id != "claude")
+}
+
+/// Exit with the failed session's exit code so scripts can gate on
+/// `coven run ... && next-step`. The ledger has already recorded the failure
+/// and, on stream paths, the JSONL result event has already been emitted.
+fn exit_with_session_code(exit_code: i32, stream_json: bool) -> ! {
+    if !stream_json {
+        eprintln!("session failed (exit code {exit_code})");
+    }
+    let _ = io::stdout().flush();
+    let _ = io::stderr().flush();
+    std::process::exit(exit_code);
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1713,6 +1866,9 @@ fn run_session(
             let archived_at = current_timestamp();
             store::archive_session(&conn, &record.id, &archived_at)?;
         }
+        if is_error {
+            exit_with_session_code(exit_code, true);
+        }
         return Ok(());
     }
 
@@ -1784,6 +1940,9 @@ fn run_session(
                     println!("\nArchived session {} at {archived_at}", record.id);
                 }
             }
+            if let Some(code) = result.exit_code.filter(|code| *code != 0) {
+                exit_with_session_code(code, stream_json);
+            }
             Ok(())
         }
         Err(error) => {
@@ -1809,14 +1968,60 @@ fn run_session(
     }
 }
 
+/// Resolve a full session id or a unique id prefix to a session record.
+/// Exact matches win; otherwise a single prefix match is accepted, an
+/// ambiguous prefix lists the candidates, and a miss points at `coven
+/// sessions` so the user can find a real id.
+fn resolve_session_ref(
+    conn: &rusqlite::Connection,
+    reference: &str,
+) -> Result<store::SessionRecord> {
+    if let Some(session) = store::get_session(conn, reference)? {
+        return Ok(session);
+    }
+    if !reference.is_empty() {
+        let matches: Vec<store::SessionRecord> = store::list_sessions_including_archived(conn)?
+            .into_iter()
+            .filter(|session| session.id.starts_with(reference))
+            .collect();
+        match matches.len() {
+            0 => {}
+            1 => return Ok(matches.into_iter().next().expect("one match")),
+            _ => {
+                let ids: Vec<String> = matches
+                    .iter()
+                    .take(5)
+                    .map(|session| session.id.clone())
+                    .collect();
+                anyhow::bail!(
+                    "session id prefix `{reference}` is ambiguous; it matches: {}",
+                    ids.join(", ")
+                );
+            }
+        }
+    }
+    anyhow::bail!("session `{reference}` not found; run `coven sessions --all` to list session ids")
+}
+
+/// Remedy line for the archive/sacrifice "still running" refusals: a session
+/// whose process died externally keeps status=running until daemon startup
+/// recovery marks it orphaned.
+const STALE_RUNNING_HINT: &str =
+    "if its process is already gone, run `coven daemon restart` to mark it orphaned, then retry";
+
 fn archive_session_command(session_id: &str) -> Result<()> {
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
-    let Some(session) = store::get_session(&conn, session_id)? else {
-        anyhow::bail!("session `{session_id}` not found");
-    };
+    let session = resolve_session_ref(&conn, session_id)?;
+    let session_id = session.id.as_str();
     if session.status == RUNNING_SESSION_STATUS {
-        anyhow::bail!("session `{session_id}` is still running; stop it before archiving");
+        anyhow::bail!(
+            "session `{session_id}` is still running; stop it before archiving ({STALE_RUNNING_HINT})"
+        );
+    }
+    if session.archived_at.is_some() {
+        println!("session was already archived; nothing to do");
+        return Ok(());
     }
 
     store::archive_session(&conn, session_id, &current_timestamp())?;
@@ -1839,14 +2044,13 @@ fn summon_session_command(session_id: &str) -> Result<()> {
 pub(crate) fn summon_only_command(session_id: &str) -> Result<store::SessionRecord> {
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
-    let Some(session) = store::get_session(&conn, session_id)? else {
-        anyhow::bail!("session `{session_id}` not found");
-    };
+    let session = resolve_session_ref(&conn, session_id)?;
+    let session_id = session.id.clone();
 
     if session.archived_at.is_some() {
-        store::summon_session(&conn, session_id, &current_timestamp())?;
+        store::summon_session(&conn, &session_id, &current_timestamp())?;
         eprintln!("summoned session from the archive");
-        let Some(session) = store::get_session(&conn, session_id)? else {
+        let Some(session) = store::get_session(&conn, &session_id)? else {
             anyhow::bail!("session `{session_id}` not found");
         };
         return Ok(session);
@@ -1856,15 +2060,18 @@ pub(crate) fn summon_only_command(session_id: &str) -> Result<store::SessionReco
 }
 
 fn sacrifice_session_command(session_id: &str, yes: bool) -> Result<()> {
-    confirm_sacrifice(session_id, yes)?;
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
-    let Some(session) = store::get_session(&conn, session_id)? else {
-        anyhow::bail!("session `{session_id}` not found");
-    };
+    // Resolve before asking for confirmation so a typo'd id fails immediately
+    // instead of after the user has already agreed to a permanent delete.
+    let session = resolve_session_ref(&conn, session_id)?;
+    let session_id = session.id.as_str();
     if session.status == RUNNING_SESSION_STATUS {
-        anyhow::bail!("session `{session_id}` is still running; do not sacrifice live work");
+        anyhow::bail!(
+            "session `{session_id}` is still running; do not sacrifice live work ({STALE_RUNNING_HINT})"
+        );
     }
+    confirm_sacrifice(session_id, yes)?;
 
     store::sacrifice_session(&conn, session_id)?;
     println!("sacrificed session; its event log was permanently deleted");
@@ -1885,14 +2092,21 @@ fn attach_session(session_id: &str) -> Result<()> {
     let home = coven_home_dir()?;
     let store_path = home.join(STORE_FILE_NAME);
     let conn = store::open_store(&store_path)?;
-    let Some(session) = store::get_session(&conn, session_id)? else {
-        anyhow::bail!("session `{session_id}` not found");
-    };
+    let session = resolve_session_ref(&conn, session_id)?;
+    let session_id = session.id.as_str();
 
     eprintln!(
-        "attached to session status={} harness={} title={} ",
-        session.status, session.harness, session.title
+        "attached to session {} ({}, \"{}\", status: {})",
+        session_id, session.harness, session.title, session.status
     );
+    if session.status == RUNNING_SESSION_STATUS {
+        eprintln!("following live output; Ctrl+C detaches (the session keeps running)");
+    } else {
+        eprintln!(
+            "session is not running; replaying its recorded output (resume it with `coven run {} --continue {}`)",
+            session.harness, session_id
+        );
+    }
 
     maybe_spawn_input_forwarder(home.clone(), session_id.to_string());
 
@@ -2200,6 +2414,69 @@ mod tests {
         )];
         let browser_frame = tui::sessions::render_browser_frame_plain_for_test(&sessions, 0, 0);
         assert!(browser_frame.contains("Session browser"));
+    }
+
+    #[test]
+    fn near_miss_subcommand_catches_common_typos() {
+        assert_eq!(near_miss_subcommand("sesions").as_deref(), Some("sessions"));
+        assert_eq!(near_miss_subcommand("sessons").as_deref(), Some("sessions"));
+        assert_eq!(near_miss_subcommand("docter").as_deref(), Some("doctor"));
+        assert_eq!(near_miss_subcommand("attch").as_deref(), Some("attach"));
+    }
+
+    #[test]
+    fn near_miss_subcommand_ignores_ordinary_prompts() {
+        assert_eq!(near_miss_subcommand("refactor"), None);
+        assert_eq!(near_miss_subcommand("hello"), None);
+        assert_eq!(near_miss_subcommand("explain"), None);
+    }
+
+    #[test]
+    fn edit_distance_matches_expected_values() {
+        assert_eq!(edit_distance("sessions", "sessions"), 0);
+        assert_eq!(edit_distance("sesions", "sessions"), 1);
+        assert_eq!(edit_distance("", "run"), 3);
+        assert_eq!(edit_distance("chat", "wt"), 3);
+    }
+
+    #[test]
+    fn resolve_session_ref_accepts_unique_prefix_and_rejects_ambiguity() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = store::open_store(&temp_dir.path().join("store.sqlite3"))?;
+        let mut record = store::SessionRecord {
+            id: "aaaa1111-0000-0000-0000-000000000000".to_string(),
+            project_root: "/tmp/project".to_string(),
+            harness: "codex".to_string(),
+            title: "first".to_string(),
+            status: "completed".to_string(),
+            exit_code: Some(0),
+            archived_at: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+            conversation_id: None,
+            familiar_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
+        };
+        store::insert_session(&conn, &record)?;
+        record.id = "aaab2222-0000-0000-0000-000000000000".to_string();
+        record.title = "second".to_string();
+        store::insert_session(&conn, &record)?;
+
+        // Unique prefix resolves; exact id resolves; ambiguous and unknown fail.
+        assert_eq!(
+            resolve_session_ref(&conn, "aaaa")?.id,
+            "aaaa1111-0000-0000-0000-000000000000"
+        );
+        assert_eq!(
+            resolve_session_ref(&conn, "aaab2222-0000-0000-0000-000000000000")?.id,
+            "aaab2222-0000-0000-0000-000000000000"
+        );
+        let ambiguous = resolve_session_ref(&conn, "aaa").unwrap_err();
+        assert!(ambiguous.to_string().contains("ambiguous"));
+        let missing = resolve_session_ref(&conn, "zzzz").unwrap_err();
+        assert!(missing.to_string().contains("coven sessions --all"));
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -44,10 +44,11 @@ pub(crate) fn run_wt_command(
         (None, false, true, false, None) => wt_doctor(&repo),
         (None, false, false, true, None) => wt_prune_merged(&repo),
         (None, false, false, false, Some(days)) => wt_prune_stale(&repo, days),
-        (None, false, false, false, None) => {
-            println!("Usage: coven wt <branch> | --list | --doctor | --prune-merged | --prune-stale DAYS");
-            Ok(())
-        }
+        // Unreachable today (clap requires one action), but fail loudly if
+        // that constraint ever loosens instead of printing usage with exit 0.
+        (None, false, false, false, None) => anyhow::bail!(
+            "usage: coven wt <branch> | --list | --doctor | --prune-merged | --prune-stale DAYS"
+        ),
         _ => anyhow::bail!("choose exactly one `coven wt` action"),
     }
 }
@@ -440,6 +441,14 @@ impl Claim {
 
 impl Repo {
     fn discover() -> Result<Self> {
+        if !git_success(["rev-parse", "--is-inside-work-tree"]) {
+            let cwd = std::env::current_dir()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|_| "<unknown>".to_string());
+            anyhow::bail!(
+                "this command needs a git repository; run it inside one (current directory: {cwd})"
+            );
+        }
         let root = PathBuf::from(git_stdout(["rev-parse", "--show-toplevel"])?.trim());
         let common = PathBuf::from(git_stdout(["rev-parse", "--git-common-dir"])?.trim());
         let common_dir = if common.is_absolute() {
@@ -519,8 +528,8 @@ fn git_stdout<const N: usize>(args: [&str; N]) -> Result<String> {
     if !output.status.success() {
         anyhow::bail!(
             "git failed: {}\n{}",
-            String::from_utf8_lossy(&output.stderr),
-            String::from_utf8_lossy(&output.stdout)
+            String::from_utf8_lossy(&output.stderr).trim_end(),
+            String::from_utf8_lossy(&output.stdout).trim_end()
         );
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
@@ -543,8 +552,8 @@ fn run_git<const N: usize, const M: usize>(args: [&str; N], path_args: [&Path; M
     if !output.status.success() {
         anyhow::bail!(
             "git failed: {}\n{}",
-            String::from_utf8_lossy(&output.stderr),
-            String::from_utf8_lossy(&output.stdout)
+            String::from_utf8_lossy(&output.stderr).trim_end(),
+            String::from_utf8_lossy(&output.stdout).trim_end()
         );
     }
     Ok(())

--- a/crates/coven-cli/src/tui/cast/render.rs
+++ b/crates/coven-cli/src/tui/cast/render.rs
@@ -367,11 +367,13 @@ fn plan_footer_hint(plan: &CastPlan) -> &'static str {
     use crate::tui::cast::intent::CastIntent;
 
     if matches!(plan.intent, CastIntent::SacrificeSession { .. }) {
-        return "type sacrifice to confirm · esc cancels";
+        return "type sacrifice to confirm · anything else cancels";
     }
     match plan.risk() {
-        CastRisk::Safe => "press enter to cast · esc cancels",
-        CastRisk::Confirm => "review the risk note · y/N to confirm · esc cancels",
+        // Safe plans proceed without a keypress (the gate only stops
+        // Confirm-risk plans), so don't promise an Enter that is never read.
+        CastRisk::Safe => "casting now · Ctrl+C interrupts",
+        CastRisk::Confirm => "review the risk note · y/N to confirm",
         CastRisk::Reject => "Cast will not run this · type to reframe",
     }
 }

--- a/crates/coven-cli/src/tui/sessions.rs
+++ b/crates/coven-cli/src/tui/sessions.rs
@@ -126,17 +126,20 @@ fn list_sessions_plain(include_archived: bool) -> Result<()> {
         } else {
             println!("No active Coven sessions yet.");
         }
-        println!("Start or inspect with:");
-        println!("  coven doctor");
-        println!("  coven run codex \"explain this repo in 5 bullets\"");
-        println!("  coven sessions --all");
+        // Hints go to stderr so `coven sessions --plain | ...` stays a clean table.
+        eprintln!("Start or inspect with:");
+        eprintln!("  coven doctor");
+        if let Some(harness) = crate::default_harness_id() {
+            eprintln!("  coven run {harness} \"explain this repo in 5 bullets\"");
+        }
+        eprintln!("  coven sessions --all");
     } else {
         println!(
             "{:<id_width$} {:<10} {:<8} {:<8} TITLE",
             "SESSION",
             "STATUS",
             "HARNESS",
-            "RITUAL",
+            "STATE",
             id_width = PLAIN_SESSION_ID_COLUMN_WIDTH
         );
         println!(
@@ -144,18 +147,19 @@ fn list_sessions_plain(include_archived: bool) -> Result<()> {
             "-------",
             "------",
             "-------",
-            "------",
+            "-----",
             id_width = PLAIN_SESSION_ID_COLUMN_WIDTH
         );
         for session in sessions {
             println!("{}", format_session_line(&session));
         }
-        println!("\nRituals:");
-        println!(
+        // Cheat-sheet goes to stderr so the stdout table stays parseable.
+        eprintln!("\nRituals:");
+        eprintln!(
             "  coven summon <session-id>       # restore archived session, then replay/follow"
         );
-        println!("  coven archive <session-id>      # hide from active list, keep events");
-        println!("  coven sacrifice <session-id> --yes  # permanently delete non-running session");
+        eprintln!("  coven archive <session-id>      # hide from active list, keep events");
+        eprintln!("  coven sacrifice <session-id> --yes  # permanently delete non-running session");
     }
 
     Ok(())

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -310,7 +310,7 @@ fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<(
     assert_stdout_contains(
         "doctor without harnesses",
         &output,
-        "Install docs: docs/install/index.md",
+        "Install docs: https://github.com/OpenCoven/coven/blob/main/docs/install/index.md",
     );
     Ok(())
 }

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -51,6 +51,12 @@ Hide a non-running session from the active list while preserving its record and 
 
 A discoverable daemon or adapter feature returned by `GET /api/v1/capabilities`.
 
+## Cast
+
+Coven's plan-then-run flow for free-text tasks. `coven "<task>"` parses the
+task into an intent, shows a plan card (spell, harness, risk), gates anything
+destructive behind confirmation, then runs it in a recorded session.
+
 ## CastCodes
 
 The local-first AI coding workspace powered by Coven. CastCodes is the primary public proof surface: the product users open to run visible lanes, inspect work, review diffs, verify changes, and decide what lands.
@@ -91,6 +97,13 @@ The local Rust process that owns live session state and the socket API.
 
 An append-only record for session output, exit, or metadata.
 
+## Familiar
+
+A named agent identity with a role and memory, declared in
+`~/.coven/familiars.toml`. `coven run <harness> --familiar <id>` injects the
+familiar's identity preamble into the session; `coven doctor` lists configured
+familiars and their memory freshness.
+
 ## Harness
 
 A supported coding-agent CLI that Coven can launch and supervise.
@@ -119,6 +132,12 @@ The default `coven` and `coven tui` interface. Accepts free-form task text or sl
 
 Write-side operations in `coven pc` that mutate system state (process termination, cache deletion). Always require an explicit `--confirm` flag.
 
+## Ritual
+
+Any of the explicit session lifecycle verbs: Archive, Summon, Sacrifice, and
+Rejoin (reattach). See each entry for what it does and whether it is
+reversible.
+
 ## Sacrifice
 
 Permanently delete a non-running session and its events.
@@ -130,6 +149,11 @@ A Coven-owned record of one harness run.
 ## Socket API
 
 The local HTTP-over-Unix-socket API exposed by the daemon.
+
+## Spell
+
+The free-text task a user gives Cast (e.g. `coven "fix the failing tests"`).
+The Cast plan card shows the spell alongside the chosen harness and risk level.
 
 ## Summon
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -105,7 +105,8 @@ flowchart TB
 ## Flag conventions
 
 - **Project-scoped commands** accept `--cwd <path>` for a launch directory inside the project root.
-- **Pipe-friendly commands** accept `--plain` for tables and `--json` for machine output.
+- **Machine-readable output** is per-command today: `coven sessions` accepts `--plain` and `--json`; `coven sessions search`, `coven adapter list`, and `coven pc status` accept `--json`. Other tabular commands (`wt --list`, `claim status`, `daemon status`, `pc top`, `pc disk`) print human tables only.
+- **Session id arguments** (`attach`, `summon`, `archive`, `sacrifice`) accept a unique prefix of the id.
 - **Destructive commands** require `--yes` (or `--confirm` for `coven pc` relief).
 - **Daemon-touching commands** print install/repair hints when the socket is missing.
 


### PR DESCRIPTION
## Summary

Result of a comprehensive UI/UX review of the coven CLI (help surface, first-run/onboarding, error paths, TUI live surfaces, output/exit-code discipline — each audited hands-on against a scratch `HOME` plus code review). This PR lands the high-value, low-risk fixes; the remaining findings are listed at the bottom as follow-up candidates.

## Worst failure mode fixed (P0)

The top-level `[PROMPT]...` catch-all swallowed everything clap didn't recognize, so with stdin at `/dev/null`:

- `coven sesions` → **launched a real Codex session** (typo became an AI task; Cast's "press enter to cast" gate fails open on EOF), left an orphaned `running` session behind, and auto-spawned a daemon.
- `coven --json` → same: unknown flags became prompts.
- `coven run` exited **0** even when the harness session failed — `coven run ... && deploy` in CI proceeded past failures.

Now: typos get a did-you-mean error, stray flags error, Cast refuses to run without an interactive terminal, and `coven run` exits with the harness exit code (stream-json result events are unchanged; a one-line `session failed (exit code N)` goes to stderr on the human path).

## Other fixes

**Session rituals** — `attach`/`summon`/`archive`/`sacrifice` accept unique id prefixes (`coven attach 9099`); `sacrifice` validates the id *before* demanding `--yes`; `archive` is idempotent; the "still running" refusals now explain the `coven daemon restart` orphan-recovery remedy (previously a dead end: the error said "stop it" but no stop verb exists); `attach` says whether it's following or replaying and how to detach/resume.

**Scripting** — `sessions` plain-table hints move to stderr so stdout stays parseable; `RITUAL` column renamed `STATE` (the value was `active`/`archived`, not a ritual); signal-killed coven-code delegation exits 1; `wt`/`claim`/`hooks` outside a git repo print a one-line remedy instead of raw `git failed: fatal:` output.

**Honest help** — bare `coven`/`chat`/`tui` all delegate to coven-code, but help still promised a "beginner-friendly menu" and described chat/tui as different UIs; `daemon start/restart/status/stop`, three `patch` flags, and four `SESSION_ID` positionals had empty help; `--verify` now validated at parse time; `--detach`/`--continue` conflict enforced by clap (was checked after printing a success header); dead `--keep-session` hidden (threaded into `PatchRequest` but never read — happy to remove it outright if you prefer); `session`/`worktree(s)` aliases; non-TTY bare `coven` prints guidance instead of `os error 6`.

**Doctor** — checks for coven-code (the flagship entry point previously had no doctor coverage), renders `built-in adapter` instead of the contradictory `missing (bundled)`, links install docs by URL (the repo-relative path meant nothing to npm users), and the sessions empty-state hint picks a harness that's actually installed.

**Docs** — README Option A describes the coven-code UI; commands reference gains adapter + parallel-work tables; stale-session troubleshooting includes the recovery step; CHAT-QUICKSTART rewritten (it documented a retired mock MVP with agents "Nova/Sage"); GLOSSARY gains Cast/spell/familiar/ritual; cli.md states real `--plain`/`--json` coverage.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked` (897 tests, 4 new: near-miss suggestions, edit distance, prefix resolution incl. ambiguity), `scripts/check-secrets.py` — all green.
- Hands-on verification against a scratch HOME: typo guard, flag guard, non-TTY cast refusal, non-TTY bare-coven message, daemon/patch help, prefix miss copy, plain-table stdout/stderr split, and exit-code propagation via a fake harness exiting 7 (`EXIT=7` observed).

## Follow-up candidates (found in review, intentionally not in this PR)

1. **`--stream-json` on non-claude harnesses interleaves raw PTY bytes with JSONL on stdout** (docs declare the stream stable) — needs captured-PTY routing.
2. **Cast passes prompts as raw argv** — a prompt starting with `-` reaches codex as flags; should be passed after `--`.
3. **No kill/stop verb for sessions** (API already has `POST /sessions/:id/kill`).
4. **doctor/adapter-doctor/wt-doctor always exit 0** even when everything is broken — scripts can't gate on them.
5. **`--json` coverage gaps**: `wt --list`, `claim status`, `daemon status`, `pc top/disk`; `claim status` prints raw epoch seconds.
6. **No shell completions** (`clap_complete`) and no `CLICOLOR_FORCE`/`--color` override.
7. **Legacy chat TUI issues** (Ctrl+C kills the running session even when clearing a draft; help overlay clips its Keys section; `/sessions` overlay shows truncated ids that `/attach` can't use) — lower priority given the coven-code transition.
8. `^D` artifact echoed on piped `coven run`; `patch` cancellation surfaces as an `Error:`; key=value dev-log voice on some human status lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)