### PR TITLE
feat: hub node registry, routing table, and persistent job queues (#266)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -30,8 +30,18 @@ pub struct HealthCapabilities {
     pub events: bool,
     pub travel: bool,
     pub scheduler: bool,
+    pub hub: bool,
     pub event_cursor: String,
     pub structured_errors: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HubHealth {
+    pub role: String,
+    pub hub_id: String,
+    pub nodes_total: usize,
+    pub nodes_available: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -42,6 +52,10 @@ pub struct HealthResponse {
     pub coven_version: String,
     pub capabilities: HealthCapabilities,
     pub daemon: Option<DaemonStatus>,
+    /// Hub control-plane summary (role + node availability). `None` when the
+    /// response is built without store access (e.g. CLI status printing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hub: Option<HubHealth>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,11 +140,21 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
             events: true,
             travel: true,
             scheduler: true,
+            hub: true,
             event_cursor: "sequence".to_string(),
             structured_errors: true,
         },
         daemon,
+        hub: None,
     }
+}
+
+fn health_response_with_hub(coven_home: &Path, daemon: Option<DaemonStatus>) -> HealthResponse {
+    let mut response = health_response(daemon);
+    if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
+        response.hub = serde_json::from_value(summary).ok();
+    }
+    response
 }
 
 #[allow(dead_code)]
@@ -187,7 +211,7 @@ pub fn handle_request_with_runtime(
                 "supportedApiVersions": SUPPORTED_API_VERSIONS,
             }),
         ),
-        ("GET", "/health") => json_response(200, &health_response(daemon)),
+        ("GET", "/health") => json_response(200, &health_response_with_hub(coven_home, daemon)),
         ("GET", "/capabilities") => json_response(200, &control_plane::capabilities()),
         ("GET", "/overview") => overview_response(coven_home),
         ("POST", "/actions") => {
@@ -339,6 +363,41 @@ pub fn handle_request_with_runtime(
         }
         ("POST", "/scheduler/decisions") => scheduler_decision(coven_home, body),
         ("POST", "/scheduler/redispatch") => scheduler_redispatch(coven_home, body),
+        ("GET", "/hub/status") => crate::hub::hub_status(coven_home),
+        ("POST", "/hub/nodes") => crate::hub::register_node(coven_home, body),
+        ("GET", "/hub/nodes") => crate::hub::list_nodes(coven_home),
+        ("POST", path) if path.starts_with("/hub/nodes/") && path.ends_with("/health") => {
+            let node_id = path
+                .trim_start_matches("/hub/nodes/")
+                .trim_end_matches("/health");
+            crate::hub::report_node_health(coven_home, node_id, body)
+        }
+        ("GET", path) if path.starts_with("/hub/nodes/") => {
+            let node_id = path.trim_start_matches("/hub/nodes/");
+            crate::hub::get_node(coven_home, node_id)
+        }
+        ("POST", "/hub/jobs") => crate::hub::enqueue_job(coven_home, body),
+        ("GET", "/hub/jobs") => {
+            let q = query.unwrap_or_default();
+            crate::hub::list_jobs(coven_home, q)
+        }
+        ("POST", path) if path.starts_with("/hub/jobs/") && path.ends_with("/assign") => {
+            let job_id = path
+                .trim_start_matches("/hub/jobs/")
+                .trim_end_matches("/assign");
+            crate::hub::assign_job(coven_home, job_id, body)
+        }
+        ("POST", path) if path.starts_with("/hub/jobs/") && path.ends_with("/complete") => {
+            let job_id = path
+                .trim_start_matches("/hub/jobs/")
+                .trim_end_matches("/complete");
+            crate::hub::complete_job(coven_home, job_id, body)
+        }
+        ("GET", path) if path.starts_with("/hub/jobs/") => {
+            let job_id = path.trim_start_matches("/hub/jobs/");
+            crate::hub::get_job(coven_home, job_id)
+        }
+        ("GET", "/hub/routing") => crate::hub::list_routing_table(coven_home),
         ("GET", path) if path.starts_with("/scheduler/decisions/") => {
             let decision_id = path.trim_start_matches("/scheduler/decisions/");
             get_scheduler_decision(coven_home, decision_id)
@@ -2045,7 +2104,7 @@ fn update_familiar_icon(
     }
 }
 
-fn parse_body(body: Option<&str>) -> Result<Value> {
+pub(crate) fn parse_body(body: Option<&str>) -> Result<Value> {
     match body.filter(|body| !body.trim().is_empty()) {
         Some(body) => serde_json::from_str(body).context("failed to parse request body"),
         None => Ok(json!({})),
@@ -2059,7 +2118,7 @@ fn split_path_query(path: &str) -> (&str, Option<&str>) {
     }
 }
 
-fn query_param<'a>(query: &'a str, key: &str) -> Option<&'a str> {
+pub(crate) fn query_param<'a>(query: &'a str, key: &str) -> Option<&'a str> {
     query.split('&').find_map(|part| {
         let (candidate, value) = part.split_once('=')?;
         (candidate == key).then_some(value)
@@ -2076,7 +2135,7 @@ pub(crate) fn current_timestamp() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true)
 }
 
-fn api_error(
+pub(crate) fn api_error(
     status: u16,
     code: &str,
     message: &str,
@@ -2092,7 +2151,7 @@ fn api_error(
     json_response(status, &json!({ "error": error }))
 }
 
-fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiResponse> {
+pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiResponse> {
     Ok(ApiResponse {
         status,
         content_type: "application/json",
@@ -2115,9 +2174,11 @@ mod tests {
         assert!(response.capabilities.events);
         assert!(response.capabilities.travel);
         assert!(response.capabilities.scheduler);
+        assert!(response.capabilities.hub);
         assert_eq!(response.capabilities.event_cursor, "sequence");
         assert!(response.capabilities.structured_errors);
         assert_eq!(response.daemon, None);
+        assert_eq!(response.hub, None);
     }
 
     #[test]
@@ -2143,6 +2204,8 @@ mod tests {
         assert!(response.body.contains(r#""sessions":true"#));
         assert!(response.body.contains(r#""travel":true"#));
         assert!(response.body.contains(r#""scheduler":true"#));
+        assert!(response.body.contains(r#""hub":true"#));
+        assert!(response.body.contains(r#""role":"hub""#));
         assert!(response.body.contains(r#""structuredErrors":true"#));
         Ok(())
     }

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -1,0 +1,859 @@
+//! Hub control-plane state for multi-host mode (#266).
+//!
+//! The hub owns the durable node registry, routing table, global job queue,
+//! and per-executor subqueues described in `specs/coven-multi-host-daemon`.
+//! All state persists in the Coven SQLite store, so a daemon restart reloads
+//! the registry and queues without losing loop/job assignments. Executor
+//! nodes that go unavailable keep their subqueue held on the hub until they
+//! recover or the scheduler explicitly redispatches their work.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+use crate::{
+    api::{api_error, current_timestamp, json_response, parse_body, ApiResponse},
+    store,
+};
+
+/// Store-meta key shared with travel profile generation so the hub identity
+/// reported by `/hub/status` matches the `sourceHub.hubId` embedded in
+/// generated travel profiles.
+pub const HUB_ID_META_KEY: &str = "travel_source_hub_id";
+
+pub const HUB_ROLE: &str = "hub";
+
+const JOB_STATE_QUEUED: &str = "queued";
+const JOB_STATE_ASSIGNED: &str = "assigned";
+const JOB_STATE_HELD: &str = "held";
+const TERMINAL_JOB_STATES: [&str; 3] = ["completed", "failed", "cancelled"];
+
+fn store_path(coven_home: &Path) -> std::path::PathBuf {
+    coven_home.join("coven.sqlite3")
+}
+
+fn hub_id(conn: &Connection) -> Result<String> {
+    store::get_or_insert_store_meta(conn, HUB_ID_META_KEY, &format!("hub_{}", Uuid::new_v4()))
+}
+
+fn parse_capabilities(json_text: &str) -> Vec<String> {
+    serde_json::from_str(json_text).unwrap_or_default()
+}
+
+fn node_response(node: &store::NodeRecord) -> Value {
+    json!({
+        "nodeId": node.node_id,
+        "role": node.role,
+        "transport": node.transport,
+        "capabilities": parse_capabilities(&node.capabilities_json),
+        "available": node.available,
+        "queuePressure": node.queue_pressure,
+        "lastHealthAt": node.last_health_at,
+        "registeredAt": node.registered_at,
+        "updatedAt": node.updated_at,
+    })
+}
+
+fn job_response(job: &store::HubJobRecord) -> Value {
+    json!({
+        "jobId": job.job_id,
+        "state": job.state,
+        "priority": job.priority,
+        "requiredCapabilities": parse_capabilities(&job.required_capabilities_json),
+        "assignedNodeId": job.assigned_node_id,
+        "loopId": job.loop_id,
+        "payload": serde_json::from_str::<Value>(&job.payload_json).unwrap_or(Value::Null),
+        "createdAt": job.created_at,
+        "updatedAt": job.updated_at,
+    })
+}
+
+fn route_response(route: &store::RouteRecord) -> Value {
+    json!({
+        "jobId": route.job_id,
+        "nodeId": route.node_id,
+        "decisionId": route.decision_id,
+        "reason": route.reason,
+        "createdAt": route.created_at,
+        "updatedAt": route.updated_at,
+    })
+}
+
+/// Rebuild the persistent subqueue for a node from its assigned/held jobs and
+/// refresh the node's stored queue pressure. Held jobs stay in the subqueue so
+/// an unavailable executor never loses assigned work.
+fn sync_executor_queue(conn: &Connection, node_id: &str, now: &str) -> Result<Vec<String>> {
+    let job_ids: Vec<String> = store::list_hub_jobs_for_node(conn, node_id)?
+        .into_iter()
+        .filter(|job| job.state == JOB_STATE_ASSIGNED || job.state == JOB_STATE_HELD)
+        .map(|job| job.job_id)
+        .collect();
+    let job_ids_json =
+        serde_json::to_string(&job_ids).context("failed to serialize executor subqueue")?;
+    store::upsert_executor_queue(
+        conn,
+        &store::ExecutorQueueRecord {
+            node_id: node_id.to_string(),
+            job_ids_json,
+            updated_at: now.to_string(),
+        },
+    )?;
+    if let Some(mut node) = store::get_node(conn, node_id)? {
+        node.queue_pressure = job_ids.len() as i64;
+        node.updated_at = now.to_string();
+        store::upsert_node(conn, &node)?;
+    }
+    Ok(job_ids)
+}
+
+pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let nodes = store::list_nodes(&conn)?;
+    let available = nodes.iter().filter(|node| node.available).count();
+    Ok(json!({
+        "role": HUB_ROLE,
+        "hubId": hub_id(&conn)?,
+        "nodesTotal": nodes.len(),
+        "nodesAvailable": available,
+    }))
+}
+
+pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let nodes = store::list_nodes(&conn)?;
+    let jobs = store::list_hub_jobs(&conn, None)?;
+    let queues = store::list_executor_queues(&conn)?;
+    let count_state = |state: &str| jobs.iter().filter(|job| job.state == state).count();
+    let node_views: Vec<Value> = nodes.iter().map(node_response).collect();
+    let queue_views: Vec<Value> = queues
+        .iter()
+        .map(|queue| {
+            let job_ids: Vec<String> = parse_capabilities(&queue.job_ids_json);
+            json!({
+                "nodeId": queue.node_id,
+                "jobIds": job_ids,
+                "updatedAt": queue.updated_at,
+            })
+        })
+        .collect();
+    json_response(
+        200,
+        &json!({
+            "role": HUB_ROLE,
+            "hubId": hub_id(&conn)?,
+            "nodes": node_views,
+            "nodesTotal": nodes.len(),
+            "nodesAvailable": nodes.iter().filter(|node| node.available).count(),
+            "globalQueue": {
+                "queued": count_state(JOB_STATE_QUEUED),
+                "assigned": count_state(JOB_STATE_ASSIGNED),
+                "held": count_state(JOB_STATE_HELD),
+                "total": jobs.len(),
+            },
+            "executorQueues": queue_views,
+        }),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RegisterNodeRequest {
+    node_id: String,
+    role: String,
+    #[serde(default)]
+    transport: Option<String>,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    #[serde(default = "default_true")]
+    available: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let request: RegisterNodeRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    if request.node_id.trim().is_empty() {
+        return api_error(400, "invalid_request", "nodeId is required.", None);
+    }
+    if request.role.trim().is_empty() {
+        return api_error(400, "invalid_request", "role is required.", None);
+    }
+    let conn = store::open_store(&store_path(coven_home))?;
+    let now = current_timestamp();
+    let existing = store::get_node(&conn, &request.node_id)?;
+    let capabilities_json = serde_json::to_string(&request.capabilities)
+        .context("failed to serialize node capabilities")?;
+    let record = store::NodeRecord {
+        node_id: request.node_id.clone(),
+        role: request.role,
+        transport: request
+            .transport
+            .filter(|transport| !transport.trim().is_empty())
+            .unwrap_or_else(|| "ssh".to_string()),
+        capabilities_json,
+        available: request.available,
+        queue_pressure: existing
+            .as_ref()
+            .map(|node| node.queue_pressure)
+            .unwrap_or(0),
+        last_health_at: now.clone(),
+        registered_at: existing
+            .as_ref()
+            .map(|node| node.registered_at.clone())
+            .unwrap_or_else(|| now.clone()),
+        updated_at: now,
+    };
+    store::upsert_node(&conn, &record)?;
+    json_response(
+        if existing.is_some() { 200 } else { 201 },
+        &node_response(&record),
+    )
+}
+
+pub fn list_nodes(coven_home: &Path) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let nodes: Vec<Value> = store::list_nodes(&conn)?
+        .iter()
+        .map(node_response)
+        .collect();
+    json_response(200, &json!({ "nodes": nodes }))
+}
+
+pub fn get_node(coven_home: &Path, node_id: &str) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    match store::get_node(&conn, node_id)? {
+        Some(node) => json_response(200, &node_response(&node)),
+        None => api_error(
+            404,
+            "node_not_found",
+            "Node was not found in the hub registry.",
+            Some(json!({ "nodeId": node_id })),
+        ),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NodeHealthRequest {
+    available: bool,
+    #[serde(default)]
+    capabilities: Option<Vec<String>>,
+}
+
+/// Record an executor health report. Availability transitions move the node's
+/// assigned jobs between `assigned` and `held` without ever dropping them from
+/// the executor subqueue, so an offline node holds its work durably.
+pub fn report_node_health(
+    coven_home: &Path,
+    node_id: &str,
+    body: Option<&str>,
+) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let request: NodeHealthRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(mut node) = store::get_node(&conn, node_id)? else {
+        return api_error(
+            404,
+            "node_not_found",
+            "Node was not found in the hub registry.",
+            Some(json!({ "nodeId": node_id })),
+        );
+    };
+    let now = current_timestamp();
+    node.available = request.available;
+    node.last_health_at = now.clone();
+    node.updated_at = now.clone();
+    if let Some(capabilities) = request.capabilities {
+        node.capabilities_json = serde_json::to_string(&capabilities)
+            .context("failed to serialize node capabilities")?;
+    }
+    store::upsert_node(&conn, &node)?;
+
+    let (from_state, to_state) = if request.available {
+        (JOB_STATE_HELD, JOB_STATE_ASSIGNED)
+    } else {
+        (JOB_STATE_ASSIGNED, JOB_STATE_HELD)
+    };
+    let mut transitioned = Vec::new();
+    for job in store::list_hub_jobs_for_node(&conn, node_id)? {
+        if job.state == from_state {
+            store::update_hub_job_state(&conn, &job.job_id, to_state, Some(node_id), &now)?;
+            transitioned.push(job.job_id);
+        }
+    }
+    let held_job_ids = sync_executor_queue(&conn, node_id, &now)?;
+    let node =
+        store::get_node(&conn, node_id)?.context("node disappeared while reporting health")?;
+    json_response(
+        200,
+        &json!({
+            "node": node_response(&node),
+            "heldSubqueue": {
+                "nodeId": node_id,
+                "jobIds": held_job_ids,
+            },
+            "transitionedJobs": {
+                "from": from_state,
+                "to": to_state,
+                "jobIds": transitioned,
+            },
+        }),
+    )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EnqueueJobRequest {
+    #[serde(default)]
+    job_id: Option<String>,
+    #[serde(default)]
+    required_capabilities: Vec<String>,
+    #[serde(default)]
+    priority: i64,
+    #[serde(default)]
+    loop_id: Option<String>,
+    #[serde(default)]
+    payload: Option<Value>,
+}
+
+pub fn enqueue_job(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let request: EnqueueJobRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let job_id = request
+        .job_id
+        .filter(|id| !id.trim().is_empty())
+        .unwrap_or_else(|| format!("job_{}", Uuid::new_v4()));
+    let conn = store::open_store(&store_path(coven_home))?;
+    if store::get_hub_job(&conn, &job_id)?.is_some() {
+        return api_error(
+            409,
+            "job_already_queued",
+            "A job with this id already exists in the global queue.",
+            Some(json!({ "jobId": job_id })),
+        );
+    }
+    let now = current_timestamp();
+    let record = store::HubJobRecord {
+        job_id,
+        state: JOB_STATE_QUEUED.to_string(),
+        priority: request.priority,
+        required_capabilities_json: serde_json::to_string(&request.required_capabilities)
+            .context("failed to serialize required capabilities")?,
+        assigned_node_id: None,
+        loop_id: request.loop_id,
+        payload_json: request.payload.unwrap_or(Value::Null).to_string(),
+        created_at: now.clone(),
+        updated_at: now,
+    };
+    store::upsert_hub_job(&conn, &record)?;
+    json_response(201, &job_response(&record))
+}
+
+pub fn list_jobs(coven_home: &Path, query: &str) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let state = crate::api::query_param(query, "state");
+    let jobs: Vec<Value> = store::list_hub_jobs(&conn, state)?
+        .iter()
+        .map(job_response)
+        .collect();
+    json_response(200, &json!({ "jobs": jobs }))
+}
+
+pub fn get_job(coven_home: &Path, job_id: &str) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    match store::get_hub_job(&conn, job_id)? {
+        Some(job) => {
+            let route = store::get_route(&conn, job_id)?;
+            let mut body = job_response(&job);
+            body["route"] = route.as_ref().map(route_response).unwrap_or(Value::Null);
+            json_response(200, &body)
+        }
+        None => api_error(
+            404,
+            "job_not_found",
+            "Job was not found in the hub queue.",
+            Some(json!({ "jobId": job_id })),
+        ),
+    }
+}
+
+fn hub_role_rank(role: &str) -> i32 {
+    match role {
+        "compute_executor" => 0,
+        "stationary_executor" => 1,
+        "hub" => 2,
+        "laptop_local" => 3,
+        _ => 4,
+    }
+}
+
+fn node_supports(node: &store::NodeRecord, required: &[String]) -> bool {
+    let capabilities = parse_capabilities(&node.capabilities_json);
+    required
+        .iter()
+        .all(|capability| capabilities.iter().any(|owned| owned == capability))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AssignJobRequest {
+    #[serde(default)]
+    node_id: Option<String>,
+}
+
+/// Assign a queued (or held) job to an executor from the persistent node
+/// registry, recording the routing decision in the routing table and the
+/// scheduler decision log.
+pub fn assign_job(coven_home: &Path, job_id: &str, body: Option<&str>) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let request: AssignJobRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(job) = store::get_hub_job(&conn, job_id)? else {
+        return api_error(
+            404,
+            "job_not_found",
+            "Job was not found in the hub queue.",
+            Some(json!({ "jobId": job_id })),
+        );
+    };
+    if TERMINAL_JOB_STATES.contains(&job.state.as_str()) {
+        return api_error(
+            409,
+            "job_not_assignable",
+            "Job has already reached a terminal state.",
+            Some(json!({ "jobId": job_id, "state": job.state })),
+        );
+    }
+    let required = parse_capabilities(&job.required_capabilities_json);
+    let nodes = store::list_nodes(&conn)?;
+    let target = match request.node_id {
+        Some(node_id) => {
+            let Some(node) = nodes.iter().find(|node| node.node_id == node_id) else {
+                return api_error(
+                    404,
+                    "node_not_found",
+                    "Requested node was not found in the hub registry.",
+                    Some(json!({ "nodeId": node_id })),
+                );
+            };
+            if !node.available {
+                return api_error(
+                    409,
+                    "node_unavailable",
+                    "Requested node is not available.",
+                    Some(json!({ "nodeId": node_id })),
+                );
+            }
+            if !node_supports(node, &required) {
+                return api_error(
+                    409,
+                    "node_missing_capabilities",
+                    "Requested node does not satisfy the job's required capabilities.",
+                    Some(json!({ "nodeId": node_id, "requiredCapabilities": required })),
+                );
+            }
+            node.clone()
+        }
+        None => {
+            let mut candidates: Vec<&store::NodeRecord> = nodes
+                .iter()
+                .filter(|node| node.available)
+                .filter(|node| node_supports(node, &required))
+                .collect();
+            candidates.sort_by(|left, right| {
+                left.queue_pressure
+                    .cmp(&right.queue_pressure)
+                    .then_with(|| hub_role_rank(&left.role).cmp(&hub_role_rank(&right.role)))
+                    .then_with(|| left.node_id.cmp(&right.node_id))
+            });
+            match candidates.first() {
+                Some(node) => (*node).clone(),
+                None => {
+                    return api_error(
+                        409,
+                        "no_available_node",
+                        "No available registered node satisfies the job's required capabilities.",
+                        Some(json!({
+                            "jobId": job_id,
+                            "requiredCapabilities": required,
+                        })),
+                    );
+                }
+            }
+        }
+    };
+
+    let now = current_timestamp();
+    let previous_node_id = job.assigned_node_id.clone();
+    let decision_id = format!("sched_{}", Uuid::new_v4());
+    let reason = format!(
+        "{} selected from hub registry by capability match and queue pressure",
+        target.node_id
+    );
+    store::insert_scheduler_decision(
+        &conn,
+        &store::SchedulerDecisionRecord {
+            id: decision_id.clone(),
+            job_id: job_id.to_string(),
+            target_role: target.role.clone(),
+            target_node_id: Some(target.node_id.clone()),
+            target_json: json!({ "role": target.role, "nodeId": target.node_id }).to_string(),
+            reason: reason.clone(),
+            inputs_json: json!({
+                "requiredCapabilities": required,
+                "queuePressure": target.queue_pressure,
+                "source": "hub_registry",
+            })
+            .to_string(),
+            created_at: now.clone(),
+        },
+    )?;
+    store::update_hub_job_state(
+        &conn,
+        job_id,
+        JOB_STATE_ASSIGNED,
+        Some(&target.node_id),
+        &now,
+    )?;
+    store::upsert_route(
+        &conn,
+        &store::RouteRecord {
+            job_id: job_id.to_string(),
+            node_id: target.node_id.clone(),
+            decision_id: Some(decision_id.clone()),
+            reason: reason.clone(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        },
+    )?;
+    sync_executor_queue(&conn, &target.node_id, &now)?;
+    if let Some(previous) = previous_node_id.filter(|previous| previous != &target.node_id) {
+        sync_executor_queue(&conn, &previous, &now)?;
+    }
+    let job = store::get_hub_job(&conn, job_id)?.context("job disappeared during assignment")?;
+    let mut body = job_response(&job);
+    body["decisionId"] = json!(decision_id);
+    body["reason"] = json!(reason);
+    json_response(200, &body)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CompleteJobRequest {
+    #[serde(default)]
+    state: Option<String>,
+}
+
+pub fn complete_job(coven_home: &Path, job_id: &str, body: Option<&str>) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let request: CompleteJobRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let state = request.state.unwrap_or_else(|| "completed".to_string());
+    if !TERMINAL_JOB_STATES.contains(&state.as_str()) {
+        return api_error(
+            400,
+            "invalid_request",
+            "state must be `completed`, `failed`, or `cancelled`.",
+            Some(json!({ "state": state })),
+        );
+    }
+    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(job) = store::get_hub_job(&conn, job_id)? else {
+        return api_error(
+            404,
+            "job_not_found",
+            "Job was not found in the hub queue.",
+            Some(json!({ "jobId": job_id })),
+        );
+    };
+    let now = current_timestamp();
+    let assigned_node_id = job.assigned_node_id.clone();
+    store::update_hub_job_state(&conn, job_id, &state, assigned_node_id.as_deref(), &now)?;
+    if let Some(node_id) = assigned_node_id {
+        sync_executor_queue(&conn, &node_id, &now)?;
+    }
+    let job = store::get_hub_job(&conn, job_id)?.context("job disappeared during completion")?;
+    json_response(200, &job_response(&job))
+}
+
+pub fn list_routing_table(coven_home: &Path) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let routes: Vec<Value> = store::list_routes(&conn)?
+        .iter()
+        .map(route_response)
+        .collect();
+    json_response(200, &json!({ "routes": routes }))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::api::{handle_request, handle_request_with_body};
+
+    fn post(
+        temp: &tempfile::TempDir,
+        path: &str,
+        body: &str,
+    ) -> anyhow::Result<(u16, serde_json::Value)> {
+        let response = handle_request_with_body("POST", path, temp.path(), None, Some(body))?;
+        Ok((response.status, serde_json::from_str(&response.body)?))
+    }
+
+    fn get(temp: &tempfile::TempDir, path: &str) -> anyhow::Result<(u16, serde_json::Value)> {
+        let response = handle_request("GET", path, temp.path(), None)?;
+        Ok((response.status, serde_json::from_str(&response.body)?))
+    }
+
+    fn register_gpu_node(temp: &tempfile::TempDir, node_id: &str) -> anyhow::Result<()> {
+        let (status, _) = post(
+            temp,
+            "/api/v1/hub/nodes",
+            &format!(
+                r#"{{"nodeId":"{node_id}","role":"compute_executor","transport":"ssh","capabilities":["gpu","long-running-loop"]}}"#
+            ),
+        )?;
+        assert_eq!(status, 201);
+        Ok(())
+    }
+
+    #[test]
+    fn hub_status_exposes_role_and_node_availability() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_a")?;
+        register_gpu_node(&temp, "node_b")?;
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_b/health",
+            r#"{"available":false}"#,
+        )?;
+        assert_eq!(status, 200);
+        assert_eq!(body["node"]["available"], false);
+
+        let (status, body) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(status, 200);
+        assert_eq!(body["role"], "hub");
+        assert!(body["hubId"].as_str().unwrap().starts_with("hub_"));
+        assert_eq!(body["nodesTotal"], 2);
+        assert_eq!(body["nodesAvailable"], 1);
+        let nodes = body["nodes"].as_array().unwrap();
+        assert_eq!(nodes.len(), 2);
+
+        // The generic health endpoint also exposes the hub role and
+        // node-availability summary.
+        let (status, health) = get(&temp, "/api/v1/health")?;
+        assert_eq!(status, 200);
+        assert_eq!(health["capabilities"]["hub"], true);
+        assert_eq!(health["hub"]["role"], "hub");
+        assert_eq!(health["hub"]["nodesTotal"], 2);
+        assert_eq!(health["hub"]["nodesAvailable"], 1);
+        Ok(())
+    }
+
+    #[test]
+    fn global_queue_routes_job_to_capable_node_and_records_routing_table() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_gpu")?;
+        let (status, _) = post(
+            &temp,
+            "/api/v1/hub/nodes",
+            r#"{"nodeId":"node_cpu","role":"stationary_executor","capabilities":["shell"]}"#,
+        )?;
+        assert_eq!(status, 201);
+
+        let (status, job) = post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_1","requiredCapabilities":["gpu"],"priority":5,"loopId":"loop_1"}"#,
+        )?;
+        assert_eq!(status, 201);
+        assert_eq!(job["state"], "queued");
+
+        let (status, assigned) = post(&temp, "/api/v1/hub/jobs/job_1/assign", "{}")?;
+        assert_eq!(status, 200);
+        assert_eq!(assigned["state"], "assigned");
+        assert_eq!(assigned["assignedNodeId"], "node_gpu");
+        assert!(assigned["decisionId"]
+            .as_str()
+            .unwrap()
+            .starts_with("sched_"));
+
+        let (status, routing) = get(&temp, "/api/v1/hub/routing")?;
+        assert_eq!(status, 200);
+        let routes = routing["routes"].as_array().unwrap();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0]["jobId"], "job_1");
+        assert_eq!(routes[0]["nodeId"], "node_gpu");
+
+        let (status, job) = get(&temp, "/api/v1/hub/jobs/job_1")?;
+        assert_eq!(status, 200);
+        assert_eq!(job["route"]["nodeId"], "node_gpu");
+
+        // Node queue pressure reflects the persistent subqueue.
+        let (_, node) = get(&temp, "/api/v1/hub/nodes/node_gpu")?;
+        assert_eq!(node["queuePressure"], 1);
+        Ok(())
+    }
+
+    #[test]
+    fn assign_rejects_when_no_registered_node_matches_capabilities() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_gpu")?;
+        let (_, _) = post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_arm","requiredCapabilities":["arm64"]}"#,
+        )?;
+        let (status, body) = post(&temp, "/api/v1/hub/jobs/job_arm/assign", "{}")?;
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "no_available_node");
+        Ok(())
+    }
+
+    #[test]
+    fn duplicate_job_ids_are_rejected() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (status, _) = post(&temp, "/api/v1/hub/jobs", r#"{"jobId":"job_dup"}"#)?;
+        assert_eq!(status, 201);
+        let (status, body) = post(&temp, "/api/v1/hub/jobs", r#"{"jobId":"job_dup"}"#)?;
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "job_already_queued");
+        Ok(())
+    }
+
+    #[test]
+    fn unavailable_executor_holds_subqueue_without_losing_job_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_gpu")?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_loop","requiredCapabilities":["gpu"],"loopId":"loop_9"}"#,
+        )?;
+        let (status, _) = post(&temp, "/api/v1/hub/jobs/job_loop/assign", "{}")?;
+        assert_eq!(status, 200);
+
+        // Executor disappears: assigned work transitions to held, and the
+        // per-executor subqueue keeps the job.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_gpu/health",
+            r#"{"available":false}"#,
+        )?;
+        assert_eq!(status, 200);
+        assert_eq!(body["transitionedJobs"]["to"], "held");
+        assert_eq!(body["heldSubqueue"]["jobIds"][0], "job_loop");
+
+        let (_, job) = get(&temp, "/api/v1/hub/jobs/job_loop")?;
+        assert_eq!(job["state"], "held");
+        assert_eq!(job["assignedNodeId"], "node_gpu");
+        assert_eq!(job["loopId"], "loop_9");
+
+        let (_, hub) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(hub["globalQueue"]["held"], 1);
+        assert_eq!(hub["executorQueues"][0]["jobIds"][0], "job_loop");
+
+        // Executor recovers: held work resumes without loss.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_gpu/health",
+            r#"{"available":true}"#,
+        )?;
+        assert_eq!(status, 200);
+        assert_eq!(body["transitionedJobs"]["to"], "assigned");
+        let (_, job) = get(&temp, "/api/v1/hub/jobs/job_loop")?;
+        assert_eq!(job["state"], "assigned");
+        Ok(())
+    }
+
+    #[test]
+    fn hub_state_persists_to_disk_and_reloads_after_restart() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_gpu")?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_persist","requiredCapabilities":["gpu"]}"#,
+        )?;
+        post(&temp, "/api/v1/hub/jobs/job_persist/assign", "{}")?;
+        let (_, before) = get(&temp, "/api/v1/hub/status")?;
+
+        // Simulate a daemon restart: reopen the store from disk on a fresh
+        // connection and confirm the registry, queue, and routing reload.
+        let conn = crate::store::open_store(&temp.path().join("coven.sqlite3"))?;
+        let nodes = crate::store::list_nodes(&conn)?;
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].node_id, "node_gpu");
+        let jobs = crate::store::list_hub_jobs(&conn, Some("assigned"))?;
+        assert_eq!(jobs.len(), 1);
+        assert_eq!(jobs[0].job_id, "job_persist");
+        let routes = crate::store::list_routes(&conn)?;
+        assert_eq!(routes.len(), 1);
+        drop(conn);
+
+        let (_, after) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(before["hubId"], after["hubId"]);
+        assert_eq!(after["globalQueue"]["assigned"], 1);
+        assert_eq!(after["executorQueues"][0]["jobIds"][0], "job_persist");
+        Ok(())
+    }
+
+    #[test]
+    fn completed_jobs_leave_the_executor_subqueue() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_gpu")?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_done","requiredCapabilities":["gpu"]}"#,
+        )?;
+        post(&temp, "/api/v1/hub/jobs/job_done/assign", "{}")?;
+        let (status, job) = post(
+            &temp,
+            "/api/v1/hub/jobs/job_done/complete",
+            r#"{"state":"completed"}"#,
+        )?;
+        assert_eq!(status, 200);
+        assert_eq!(job["state"], "completed");
+        let (_, node) = get(&temp, "/api/v1/hub/nodes/node_gpu")?;
+        assert_eq!(node["queuePressure"], 0);
+        let (status, body) = post(&temp, "/api/v1/hub/jobs/job_done/assign", "{}")?;
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "job_not_assignable");
+        Ok(())
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -22,6 +22,7 @@ mod encrypted_artifacts;
 mod eval_loop;
 mod familiar_identity;
 mod harness;
+mod hub;
 mod openclaw_repo;
 mod parallel_protocol;
 mod patch;

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -130,6 +130,42 @@ pub struct ExecutorQueueRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeRecord {
+    pub node_id: String,
+    pub role: String,
+    pub transport: String,
+    pub capabilities_json: String,
+    pub available: bool,
+    pub queue_pressure: i64,
+    pub last_health_at: String,
+    pub registered_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HubJobRecord {
+    pub job_id: String,
+    pub state: String,
+    pub priority: i64,
+    pub required_capabilities_json: String,
+    pub assigned_node_id: Option<String>,
+    pub loop_id: Option<String>,
+    pub payload_json: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RouteRecord {
+    pub job_id: String,
+    pub node_id: String,
+    pub decision_id: Option<String>,
+    pub reason: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RepositoryRecord {
     pub id: String,
     pub path: String,
@@ -303,6 +339,51 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             job_ids_json TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
+
+        CREATE TABLE IF NOT EXISTS node_registry (
+            node_id TEXT PRIMARY KEY NOT NULL,
+            role TEXT NOT NULL,
+            transport TEXT NOT NULL,
+            capabilities_json TEXT NOT NULL,
+            available INTEGER NOT NULL DEFAULT 0,
+            queue_pressure INTEGER NOT NULL DEFAULT 0,
+            last_health_at TEXT NOT NULL,
+            registered_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_node_registry_available
+            ON node_registry(available, queue_pressure);
+
+        CREATE TABLE IF NOT EXISTS hub_jobs (
+            job_id TEXT PRIMARY KEY NOT NULL,
+            state TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0,
+            required_capabilities_json TEXT NOT NULL,
+            assigned_node_id TEXT,
+            loop_id TEXT,
+            payload_json TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_hub_jobs_state
+            ON hub_jobs(state, priority DESC, created_at);
+
+        CREATE INDEX IF NOT EXISTS idx_hub_jobs_assigned_node
+            ON hub_jobs(assigned_node_id, state);
+
+        CREATE TABLE IF NOT EXISTS routing_table (
+            job_id TEXT PRIMARY KEY NOT NULL,
+            node_id TEXT NOT NULL,
+            decision_id TEXT,
+            reason TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_routing_table_node
+            ON routing_table(node_id, updated_at DESC);
 
         CREATE TABLE IF NOT EXISTS loop_state (
             loop_id TEXT PRIMARY KEY NOT NULL,
@@ -982,6 +1063,316 @@ pub fn get_executor_queue(conn: &Connection, node_id: &str) -> Result<Option<Exe
     )
     .optional()
     .with_context(|| format!("failed to read executor queue {node_id}"))
+}
+
+pub fn list_executor_queues(conn: &Connection) -> Result<Vec<ExecutorQueueRecord>> {
+    let mut statement = conn
+        .prepare(
+            "SELECT node_id, job_ids_json, updated_at
+             FROM executor_queue
+             ORDER BY node_id",
+        )
+        .context("failed to prepare executor queue list")?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(ExecutorQueueRecord {
+                node_id: row.get(0)?,
+                job_ids_json: row.get(1)?,
+                updated_at: row.get(2)?,
+            })
+        })
+        .context("failed to list executor queues")?;
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.context("failed to read executor queue row")?);
+    }
+    Ok(records)
+}
+
+pub fn upsert_node(conn: &Connection, record: &NodeRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO node_registry (
+            node_id,
+            role,
+            transport,
+            capabilities_json,
+            available,
+            queue_pressure,
+            last_health_at,
+            registered_at,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ON CONFLICT(node_id) DO UPDATE SET
+            role = excluded.role,
+            transport = excluded.transport,
+            capabilities_json = excluded.capabilities_json,
+            available = excluded.available,
+            queue_pressure = excluded.queue_pressure,
+            last_health_at = excluded.last_health_at,
+            updated_at = excluded.updated_at",
+        params![
+            &record.node_id,
+            &record.role,
+            &record.transport,
+            &record.capabilities_json,
+            if record.available { 1 } else { 0 },
+            record.queue_pressure,
+            &record.last_health_at,
+            &record.registered_at,
+            &record.updated_at,
+        ],
+    )
+    .with_context(|| format!("failed to upsert node {}", record.node_id))?;
+    Ok(())
+}
+
+fn node_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<NodeRecord> {
+    let available: i64 = row.get(4)?;
+    Ok(NodeRecord {
+        node_id: row.get(0)?,
+        role: row.get(1)?,
+        transport: row.get(2)?,
+        capabilities_json: row.get(3)?,
+        available: available != 0,
+        queue_pressure: row.get(5)?,
+        last_health_at: row.get(6)?,
+        registered_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+const NODE_COLUMNS: &str = "node_id, role, transport, capabilities_json, available, \
+     queue_pressure, last_health_at, registered_at, updated_at";
+
+pub fn get_node(conn: &Connection, node_id: &str) -> Result<Option<NodeRecord>> {
+    conn.query_row(
+        &format!("SELECT {NODE_COLUMNS} FROM node_registry WHERE node_id = ?1 LIMIT 1"),
+        params![node_id],
+        node_from_row,
+    )
+    .optional()
+    .with_context(|| format!("failed to read node {node_id}"))
+}
+
+pub fn list_nodes(conn: &Connection) -> Result<Vec<NodeRecord>> {
+    let mut statement = conn
+        .prepare(&format!(
+            "SELECT {NODE_COLUMNS} FROM node_registry ORDER BY node_id"
+        ))
+        .context("failed to prepare node registry list")?;
+    let rows = statement
+        .query_map([], node_from_row)
+        .context("failed to list node registry")?;
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.context("failed to read node registry row")?);
+    }
+    Ok(records)
+}
+
+pub fn upsert_hub_job(conn: &Connection, record: &HubJobRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO hub_jobs (
+            job_id,
+            state,
+            priority,
+            required_capabilities_json,
+            assigned_node_id,
+            loop_id,
+            payload_json,
+            created_at,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ON CONFLICT(job_id) DO UPDATE SET
+            state = excluded.state,
+            priority = excluded.priority,
+            required_capabilities_json = excluded.required_capabilities_json,
+            assigned_node_id = excluded.assigned_node_id,
+            loop_id = excluded.loop_id,
+            payload_json = excluded.payload_json,
+            updated_at = excluded.updated_at",
+        params![
+            &record.job_id,
+            &record.state,
+            record.priority,
+            &record.required_capabilities_json,
+            &record.assigned_node_id,
+            &record.loop_id,
+            &record.payload_json,
+            &record.created_at,
+            &record.updated_at,
+        ],
+    )
+    .with_context(|| format!("failed to upsert hub job {}", record.job_id))?;
+    Ok(())
+}
+
+fn hub_job_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<HubJobRecord> {
+    Ok(HubJobRecord {
+        job_id: row.get(0)?,
+        state: row.get(1)?,
+        priority: row.get(2)?,
+        required_capabilities_json: row.get(3)?,
+        assigned_node_id: row.get(4)?,
+        loop_id: row.get(5)?,
+        payload_json: row.get(6)?,
+        created_at: row.get(7)?,
+        updated_at: row.get(8)?,
+    })
+}
+
+const HUB_JOB_COLUMNS: &str = "job_id, state, priority, required_capabilities_json, \
+     assigned_node_id, loop_id, payload_json, created_at, updated_at";
+
+pub fn get_hub_job(conn: &Connection, job_id: &str) -> Result<Option<HubJobRecord>> {
+    conn.query_row(
+        &format!("SELECT {HUB_JOB_COLUMNS} FROM hub_jobs WHERE job_id = ?1 LIMIT 1"),
+        params![job_id],
+        hub_job_from_row,
+    )
+    .optional()
+    .with_context(|| format!("failed to read hub job {job_id}"))
+}
+
+pub fn list_hub_jobs(conn: &Connection, state: Option<&str>) -> Result<Vec<HubJobRecord>> {
+    let mut records = Vec::new();
+    match state {
+        Some(state) => {
+            let mut statement = conn
+                .prepare(&format!(
+                    "SELECT {HUB_JOB_COLUMNS} FROM hub_jobs
+                     WHERE state = ?1
+                     ORDER BY priority DESC, created_at, job_id"
+                ))
+                .context("failed to prepare hub job list")?;
+            let rows = statement
+                .query_map(params![state], hub_job_from_row)
+                .context("failed to list hub jobs")?;
+            for row in rows {
+                records.push(row.context("failed to read hub job row")?);
+            }
+        }
+        None => {
+            let mut statement = conn
+                .prepare(&format!(
+                    "SELECT {HUB_JOB_COLUMNS} FROM hub_jobs
+                     ORDER BY priority DESC, created_at, job_id"
+                ))
+                .context("failed to prepare hub job list")?;
+            let rows = statement
+                .query_map([], hub_job_from_row)
+                .context("failed to list hub jobs")?;
+            for row in rows {
+                records.push(row.context("failed to read hub job row")?);
+            }
+        }
+    }
+    Ok(records)
+}
+
+pub fn list_hub_jobs_for_node(conn: &Connection, node_id: &str) -> Result<Vec<HubJobRecord>> {
+    let mut statement = conn
+        .prepare(&format!(
+            "SELECT {HUB_JOB_COLUMNS} FROM hub_jobs
+             WHERE assigned_node_id = ?1
+             ORDER BY priority DESC, created_at, job_id"
+        ))
+        .context("failed to prepare hub job node list")?;
+    let rows = statement
+        .query_map(params![node_id], hub_job_from_row)
+        .context("failed to list hub jobs for node")?;
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.context("failed to read hub job row")?);
+    }
+    Ok(records)
+}
+
+pub fn update_hub_job_state(
+    conn: &Connection,
+    job_id: &str,
+    state: &str,
+    assigned_node_id: Option<&str>,
+    updated_at: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE hub_jobs
+         SET state = ?2, assigned_node_id = ?3, updated_at = ?4
+         WHERE job_id = ?1",
+        params![job_id, state, assigned_node_id, updated_at],
+    )
+    .with_context(|| format!("failed to update hub job {job_id}"))?;
+    Ok(())
+}
+
+pub fn upsert_route(conn: &Connection, record: &RouteRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO routing_table (
+            job_id,
+            node_id,
+            decision_id,
+            reason,
+            created_at,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+        ON CONFLICT(job_id) DO UPDATE SET
+            node_id = excluded.node_id,
+            decision_id = excluded.decision_id,
+            reason = excluded.reason,
+            updated_at = excluded.updated_at",
+        params![
+            &record.job_id,
+            &record.node_id,
+            &record.decision_id,
+            &record.reason,
+            &record.created_at,
+            &record.updated_at,
+        ],
+    )
+    .with_context(|| format!("failed to upsert route for job {}", record.job_id))?;
+    Ok(())
+}
+
+fn route_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<RouteRecord> {
+    Ok(RouteRecord {
+        job_id: row.get(0)?,
+        node_id: row.get(1)?,
+        decision_id: row.get(2)?,
+        reason: row.get(3)?,
+        created_at: row.get(4)?,
+        updated_at: row.get(5)?,
+    })
+}
+
+pub fn get_route(conn: &Connection, job_id: &str) -> Result<Option<RouteRecord>> {
+    conn.query_row(
+        "SELECT job_id, node_id, decision_id, reason, created_at, updated_at
+         FROM routing_table
+         WHERE job_id = ?1
+         LIMIT 1",
+        params![job_id],
+        route_from_row,
+    )
+    .optional()
+    .with_context(|| format!("failed to read route for job {job_id}"))
+}
+
+pub fn list_routes(conn: &Connection) -> Result<Vec<RouteRecord>> {
+    let mut statement = conn
+        .prepare(
+            "SELECT job_id, node_id, decision_id, reason, created_at, updated_at
+             FROM routing_table
+             ORDER BY updated_at DESC, job_id",
+        )
+        .context("failed to prepare routing table list")?;
+    let rows = statement
+        .query_map([], route_from_row)
+        .context("failed to list routing table")?;
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(row.context("failed to read routing table row")?);
+    }
+    Ok(records)
 }
 
 pub fn upsert_scheduler_loop_state(

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -35,6 +35,7 @@ The Coven daemon socket API is a public compatibility boundary for comux and ext
     "events": true,
     "travel": true,
     "scheduler": true,
+    "hub": true,
     "eventCursor": "sequence",
     "structuredErrors": true
   },
@@ -42,11 +43,17 @@ The Coven daemon socket API is a public compatibility boundary for comux and ext
     "pid": 12345,
     "startedAt": "2026-05-09T06:43:00Z",
     "socket": "/Users/alice/.coven/coven.sock"
+  },
+  "hub": {
+    "role": "hub",
+    "hubId": "hub_01J...",
+    "nodesTotal": 2,
+    "nodesAvailable": 1
   }
 }
 ```
 
-If the daemon metadata is unavailable, `daemon` may be `null`.
+If the daemon metadata is unavailable, `daemon` may be `null`. The `hub` block reports the daemon's control-plane role and node availability summary; full node detail lives at `GET /api/v1/hub/status`.
 
 ### Capability fields
 
@@ -56,6 +63,7 @@ If the daemon metadata is unavailable, `daemon` may be `null`.
 | `events`          | boolean | Events API (`/events`) is available.                             |
 | `travel`          | boolean | Travel profile, delta, and state APIs are available.             |
 | `scheduler`       | boolean | Scheduler decision and recovery APIs are available.              |
+| `hub`             | boolean | Hub control-plane APIs (node registry, routing, queues) are available. |
 | `eventCursor`     | string  | Cursor type supported; `"sequence"` means `afterSeq` is stable.  |
 | `structuredErrors`| boolean | All errors use the `{ error: { code, message, details } }` shape.|
 
@@ -124,6 +132,13 @@ All API errors use the following stable envelope. Clients must branch on `error.
 | `no_scheduler_target`  | 409         | No available scheduler node matches the requested capabilities and policy. |
 | `scheduler_decision_not_found` | 404 | Scheduler decision id does not exist.            |
 | `scheduler_loop_not_found` | 404     | Scheduler loop state does not exist.             |
+| `node_not_found`       | 404         | Node id does not exist in the hub registry.      |
+| `node_unavailable`     | 409         | Requested assignment target node is not available. |
+| `node_missing_capabilities` | 409    | Requested assignment target node lacks required capabilities. |
+| `job_not_found`        | 404         | Job id does not exist in the hub queue.          |
+| `job_already_queued`   | 409         | A job with the same id already exists in the global queue. |
+| `job_not_assignable`   | 409         | Job has already reached a terminal state.        |
+| `no_available_node`    | 409         | No available registered node satisfies the job's required capabilities. |
 
 ## Capability catalog shape (`v1`)
 
@@ -547,6 +562,150 @@ If the loop is not resumable or no alternate node matches, `state` is `paused` a
 ### `GET /api/v1/scheduler/loops/:loopId`
 
 Returns the persisted redispatch/pause state with the same fields as `POST /api/v1/scheduler/redispatch`, plus `updatedAt`, or `404 scheduler_loop_not_found`.
+
+## Hub control-plane shapes (`v1`)
+
+The hub control plane is the durable multi-host state described in `specs/coven-multi-host-daemon`: a persistent node registry, a routing table, a global job queue, and per-executor subqueues. All hub state persists in the daemon SQLite store and reloads after a daemon restart. Unlike the `POST /api/v1/scheduler/decisions` route (which evaluates a caller-supplied node snapshot), hub job assignment routes against the persistent registry.
+
+### `POST /api/v1/hub/nodes`
+
+Registers a node or re-registers an existing one (updating role, transport, capabilities, and availability). Returns `201` for a new node and `200` for a re-registration.
+
+Request:
+
+```json
+{
+  "nodeId": "compute-primary",
+  "role": "compute_executor",
+  "transport": "ssh",
+  "capabilities": ["gpu", "long-running-loop"],
+  "available": true
+}
+```
+
+Response:
+
+```json
+{
+  "nodeId": "compute-primary",
+  "role": "compute_executor",
+  "transport": "ssh",
+  "capabilities": ["gpu", "long-running-loop"],
+  "available": true,
+  "queuePressure": 0,
+  "lastHealthAt": "2026-07-06T12:00:00Z",
+  "registeredAt": "2026-07-06T12:00:00Z",
+  "updatedAt": "2026-07-06T12:00:00Z"
+}
+```
+
+`transport` defaults to `"ssh"`. `queuePressure` is hub-computed from the node's persistent subqueue and cannot be set by the caller.
+
+### `GET /api/v1/hub/nodes` and `GET /api/v1/hub/nodes/:nodeId`
+
+List all registered nodes (`{ "nodes": [ ... ] }`) or fetch one node record. Unknown ids return `404 node_not_found`.
+
+### `POST /api/v1/hub/nodes/:nodeId/health`
+
+Records an executor health report and updates `lastHealthAt`:
+
+```json
+{
+  "available": false,
+  "capabilities": ["gpu", "long-running-loop"]
+}
+```
+
+Availability transitions move the node's jobs between `assigned` and `held` without removing them from the node's persistent subqueue:
+
+- `available: false` — every `assigned` job on the node becomes `held`; the subqueue and loop ids are preserved.
+- `available: true` — every `held` job on the node returns to `assigned`.
+
+Response:
+
+```json
+{
+  "node": { "nodeId": "compute-primary", "available": false, "queuePressure": 1 },
+  "heldSubqueue": { "nodeId": "compute-primary", "jobIds": ["job_01J..."] },
+  "transitionedJobs": { "from": "assigned", "to": "held", "jobIds": ["job_01J..."] }
+}
+```
+
+### `POST /api/v1/hub/jobs`
+
+Enqueues a job on the persistent global queue with state `queued`. `jobId` is optional (the hub generates `job_<uuid>` when omitted). Duplicate ids return `409 job_already_queued`.
+
+```json
+{
+  "jobId": "job_01J...",
+  "requiredCapabilities": ["gpu"],
+  "priority": 5,
+  "loopId": "loop_01J...",
+  "payload": { "kind": "loop-run" }
+}
+```
+
+Job states: `queued`, `assigned`, `held`, and the terminal states `completed`, `failed`, `cancelled`.
+
+### `GET /api/v1/hub/jobs?state=...` and `GET /api/v1/hub/jobs/:jobId`
+
+List queued jobs (optionally filtered by `state`, ordered by priority then age) or fetch one job. The single-job response includes the job's routing-table entry under `route` (or `null` when unrouted).
+
+### `POST /api/v1/hub/jobs/:jobId/assign`
+
+Assigns the job to an executor from the persistent node registry. With an empty body, the hub picks the best available node by capability match, then lowest queue pressure, then role rank (`compute_executor` before `stationary_executor` before `hub` before `laptop_local`). Passing `{ "nodeId": "..." }` forces a specific registered node (`409 node_unavailable` / `409 node_missing_capabilities` when it cannot take the job).
+
+On success the hub persists, in one pass:
+
+- the job's state (`assigned`) and `assignedNodeId`;
+- a routing-table entry mapping the job to the node;
+- a scheduler decision record (readable at `GET /api/v1/scheduler/decisions/:id`); and
+- the target node's rebuilt subqueue and queue pressure.
+
+If no registered node qualifies, the call returns `409 no_available_node` and the job stays `queued`.
+
+### `POST /api/v1/hub/jobs/:jobId/complete`
+
+Marks a job terminal (`{ "state": "completed" | "failed" | "cancelled" }`, defaulting to `completed`), removes it from its executor subqueue, and refreshes the node's queue pressure. Terminal jobs cannot be reassigned (`409 job_not_assignable`).
+
+### `GET /api/v1/hub/routing`
+
+Returns the persistent routing table:
+
+```json
+{
+  "routes": [
+    {
+      "jobId": "job_01J...",
+      "nodeId": "compute-primary",
+      "decisionId": "sched_01J...",
+      "reason": "compute-primary selected from hub registry by capability match and queue pressure",
+      "createdAt": "2026-07-06T12:00:00Z",
+      "updatedAt": "2026-07-06T12:00:00Z"
+    }
+  ]
+}
+```
+
+### `GET /api/v1/hub/status`
+
+Returns the hub role, identity, node availability, and queue depths:
+
+```json
+{
+  "role": "hub",
+  "hubId": "hub_01J...",
+  "nodes": [ { "nodeId": "compute-primary", "available": true, "queuePressure": 1 } ],
+  "nodesTotal": 1,
+  "nodesAvailable": 1,
+  "globalQueue": { "queued": 0, "assigned": 1, "held": 0, "total": 1 },
+  "executorQueues": [ { "nodeId": "compute-primary", "jobIds": ["job_01J..."], "updatedAt": "2026-07-06T12:00:00Z" } ]
+}
+```
+
+`hubId` is the same stable identity embedded as `sourceHub.hubId` in generated travel profiles.
+
+Restart and supervision guidance for hub daemons lives in [`HUB-OPERATIONS.md`](HUB-OPERATIONS.md).
 
 ## Raw artifact access (`v1`)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -51,6 +51,19 @@ Versioned clients should use the `/api/v1` prefix:
 | `GET /api/v1/sessions/:id/log` | Read bounded redacted log previews |
 | `POST /api/v1/sessions/:id/input` | Forward input to a live session |
 | `POST /api/v1/sessions/:id/kill` | Kill a live session |
+| `GET /api/v1/hub/status` | Read hub role, node availability, and queue depths |
+| `POST /api/v1/hub/nodes` | Register or re-register an executor node |
+| `GET /api/v1/hub/nodes` | List registered nodes |
+| `GET /api/v1/hub/nodes/:id` | Fetch one registered node |
+| `POST /api/v1/hub/nodes/:id/health` | Record an executor health report (holds/resumes its subqueue) |
+| `POST /api/v1/hub/jobs` | Enqueue a job on the persistent global queue |
+| `GET /api/v1/hub/jobs?state=...` | List queued jobs |
+| `GET /api/v1/hub/jobs/:id` | Fetch one job with its routing entry |
+| `POST /api/v1/hub/jobs/:id/assign` | Assign a job to an executor from the node registry |
+| `POST /api/v1/hub/jobs/:id/complete` | Mark a job completed/failed/cancelled |
+| `GET /api/v1/hub/routing` | Read the persistent routing table |
+
+Full request/response shapes for the hub control plane (node registry, routing table, global and per-executor queues) live in [`API-CONTRACT.md`](API-CONTRACT.md); hub restart and supervision guidance lives in [`HUB-OPERATIONS.md`](HUB-OPERATIONS.md).
 
 Unversioned routes currently remain as legacy aliases during the early MVP window, but new clients should not rely on them.
 
@@ -72,6 +85,9 @@ Event payloads returned by `/events`, `/sessions/:id/events`, and `/sessions/:id
   "capabilities": {
     "sessions": true,
     "events": true,
+    "travel": true,
+    "scheduler": true,
+    "hub": true,
     "eventCursor": "sequence",
     "structuredErrors": true
   },
@@ -79,11 +95,17 @@ Event payloads returned by `/events`, `/sessions/:id/events`, and `/sessions/:id
     "pid": 12345,
     "startedAt": "2026-05-09T12:00:00Z",
     "socket": "/Users/example/.coven/coven.sock"
+  },
+  "hub": {
+    "role": "hub",
+    "hubId": "hub_01J...",
+    "nodesTotal": 2,
+    "nodesAvailable": 1
   }
 }
 ```
 
-When no daemon metadata is available, `daemon` is `null`.
+When no daemon metadata is available, `daemon` is `null`. The `hub` block summarizes the daemon's control-plane role and node availability; full node and queue detail lives at `GET /api/v1/hub/status`.
 
 ## Control-plane capabilities
 

--- a/docs/HUB-OPERATIONS.md
+++ b/docs/HUB-OPERATIONS.md
@@ -1,0 +1,154 @@
+---
+title: "Hub operations — supervision, watchdog, and restart guidance"
+summary: "Running a Coven daemon as a server hub: what control-plane state survives restarts, systemd/launchd supervisor setup, and the restart runbook."
+read_when:
+  - Deploying a Coven hub on a server machine
+  - Recovering hub queue/registry state after a crash or reboot
+---
+
+# Hub operations — supervision, watchdog, and restart guidance
+
+This guide covers running a Coven daemon as a **server hub**: the durable,
+canonical home for the node registry, routing table, global job queue, and
+per-executor subqueues (see `specs/coven-multi-host-daemon` and
+[`API-CONTRACT.md`](API-CONTRACT.md) "Hub control-plane shapes").
+
+The short version: hub state is already durable, so your only operational job
+is making sure the daemon process comes back after a crash or reboot. Use your
+platform supervisor for that — do not hand-roll restart loops.
+
+## What survives a restart (and what doesn't)
+
+All hub control-plane state persists in `<covenHome>/coven.sqlite3`
+(WAL mode):
+
+| State | Survives restart | Notes |
+| --- | --- | --- |
+| Node registry | Yes | Roles, transports, capabilities, availability, last health. |
+| Global job queue | Yes | `queued` / `assigned` / `held` states, priorities, loop ids. |
+| Per-executor subqueues | Yes | Held work on unavailable executors is preserved. |
+| Routing table | Yes | Job-to-node assignments and decision references. |
+| Scheduler decisions and loop state | Yes | Explanation records for Cave/debugging. |
+| Travel profiles and deltas | Yes | See travel-mode contract. |
+| Live harness PTY sessions | No | In-flight local sessions are marked orphaned on restart; queue and loop state is unaffected. |
+
+Nothing needs to be replayed manually: reopening the store reloads the
+registry and queues. After a restart, verify recovery with:
+
+```sh
+curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/hub/status
+```
+
+and confirm `role`, `hubId`, node availability, and queue depths match
+expectations. `GET /api/v1/health` includes the same summary in its `hub`
+block.
+
+## Supervisor setup
+
+Run the hub under a process supervisor with restart-on-failure. The daemon's
+own `coven daemon start` backgrounding is fine for laptops; a server hub
+should use the OS supervisor so restarts also survive reboots.
+
+### systemd (Linux servers)
+
+`~/.config/systemd/user/coven-hub.service`:
+
+```ini
+[Unit]
+Description=Coven hub daemon
+After=network.target
+
+[Service]
+# `daemon serve` runs in the foreground, which is what systemd wants.
+ExecStart=%h/.local/bin/coven daemon serve
+Restart=on-failure
+RestartSec=2
+# Give the store time to checkpoint WAL on shutdown.
+TimeoutStopSec=15
+# The hub is same-user local; do not widen socket exposure here.
+NoNewPrivileges=true
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it:
+
+```sh
+systemctl --user enable --now coven-hub.service
+loginctl enable-linger "$USER"   # keep the user manager alive without a login session
+```
+
+`Restart=on-failure` with a short `RestartSec` is the watchdog: if the daemon
+crashes, systemd restarts it and the hub reloads its registry and queues from
+the store.
+
+### launchd (macOS servers)
+
+`~/Library/LaunchAgents/dev.opencoven.hub.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>dev.opencoven.hub</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/coven</string>
+    <string>daemon</string>
+    <string>serve</string>
+  </array>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key><false/>
+  </dict>
+  <key>RunAtLoad</key><true/>
+</dict>
+</plist>
+```
+
+Load it:
+
+```sh
+launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/dev.opencoven.hub.plist
+```
+
+`KeepAlive` with `SuccessfulExit=false` restarts the daemon on crashes but
+respects a clean `coven daemon stop`.
+
+## Restart runbook
+
+1. **Planned restart:** `systemctl --user restart coven-hub` (or
+   `launchctl kickstart -k gui/$(id -u)/dev.opencoven.hub`). Executors do not
+   need to be told; the hub polls/dispatches, so held work resumes when the
+   hub is back.
+2. **Crash recovery:** the supervisor restarts the daemon automatically.
+   Check `GET /api/v1/hub/status` and confirm:
+   - `nodesTotal` matches your registered fleet;
+   - jobs that were `assigned` are still `assigned` (or `held` if their
+     executor's health has gone stale in the meantime);
+   - `executorQueues` still lists work for offline executors.
+3. **Executor loss while the hub was down:** report the executor's health
+   (`POST /api/v1/hub/nodes/:id/health` with `available: false`). Its
+   assigned jobs transition to `held` and stay in its subqueue until the node
+   recovers or the scheduler redispatches
+   (`POST /api/v1/scheduler/redispatch`).
+4. **Store integrity:** if SQLite reports corruption (unexpected after crash
+   thanks to WAL, but possible with disk failure), restore
+   `coven.sqlite3` + `coven.sqlite3-wal` from backup as a unit. Never edit
+   queue tables by hand while the daemon is running.
+
+## Safety boundaries
+
+Unchanged from the single-host model:
+
+- Do **not** expose `<covenHome>/coven.sock` over TCP, and do not run
+  `daemon serve --tcp` on non-loopback interfaces — the API is
+  unauthenticated.
+- The supervisor must run the daemon as the same user that owns
+  `<covenHome>`; the daemon fails closed on foreign-owned homes/sockets.
+- Hub-to-executor transports are explicit (SSH/private network) and are the
+  subject of the spoke protocol work (#267); supervision of executor daemons
+  follows the same pattern as this document on each executor host.


### PR DESCRIPTION
## Context

- Summary: Phase 1A of the multi-host daemon architecture (`specs/coven-multi-host-daemon`). The hub daemon now owns durable control-plane state: a persistent node registry, a routing table, a global job queue, and per-executor subqueues, all backed by the SQLite store so a daemon restart reloads them without losing loop/job state.
- Files changed: `crates/coven-cli/src/hub.rs` (new), `crates/coven-cli/src/store.rs`, `crates/coven-cli/src/api.rs`, `crates/coven-cli/src/main.rs`, `docs/API-CONTRACT.md`, `docs/API.md`, `docs/HUB-OPERATIONS.md` (new)
- Closes #266

## Implementation

- Approach: Followed the existing travel/scheduler (#268/#269) store+api patterns. New `node_registry`, `hub_jobs`, and `routing_table` tables with CRUD in `store.rs`; a new `hub` module owns the control-plane handlers; `api.rs` dispatches `/api/v1/hub/*` routes. Job assignment routes against the **persistent** registry (capability match → lowest queue pressure → role rank) and records a scheduler decision for explainability, unlike `POST /scheduler/decisions` which evaluates a caller-supplied node snapshot.
- User-visible behavior:
  - `POST/GET /api/v1/hub/nodes`, `POST /api/v1/hub/nodes/:id/health`, `POST/GET /api/v1/hub/jobs`, `POST /api/v1/hub/jobs/:id/assign|complete`, `GET /api/v1/hub/routing`, `GET /api/v1/hub/status`.
  - `GET /api/v1/health` now advertises `capabilities.hub` and a `hub` block with role, hub id, and node availability (acceptance: health/status APIs expose hub role and node availability).
  - Executors reported unavailable **hold** their subqueues: assigned jobs transition to `held` (loop ids and assignments preserved) and resume to `assigned` on recovery (acceptance: unavailable executors hold subqueues without losing loop/job state).
  - `docs/HUB-OPERATIONS.md` adds systemd/launchd watchdog setup and a restart runbook (acceptance: server watchdog/supervisor restart guidance).
  - `hubId` reuses the store-meta identity already embedded in travel profiles, so `/hub/status` and `sourceHub.hubId` agree.
- Compatibility notes: Purely additive — new tables use `CREATE TABLE IF NOT EXISTS`, new health fields are additive (`hub` is skipped when absent), no existing routes or shapes changed.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (886 passed, incl. 8 new hub tests)
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: hub test suite covers registry+routing persistence across a simulated restart (fresh store connection reload), hold/resume transitions, no-capable-node and duplicate-job rejection, and completed jobs leaving the subqueue.

## Risk and Rollback

- Risk level: Low — additive API surface and schema; existing behavior untouched.
- Rollback plan: Revert the commit; the added tables are inert if unused.

## Agent Handoff

- Current state: Phase 1A complete; hub control-plane state is durable and queryable.
- Follow-ups: #267 (stateless spoke protocol + SSH dispatcher) will consume the registry/queues; scheduler redispatch could be taught to read the persistent registry instead of request-supplied node snapshots.
- Known gaps: No hub-to-node transport/auth yet (explicitly Phase 1B scope); `queuePressure` is derived from subqueue length, not executor self-reports.