### PR TITLE
feat: add stateless executor protocol and hub-owned SSH dispatcher

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -31,6 +31,7 @@ pub struct HealthCapabilities {
     pub travel: bool,
     pub scheduler: bool,
     pub hub: bool,
+    pub executor_dispatch: bool,
     pub event_cursor: String,
     pub structured_errors: bool,
 }
@@ -141,6 +142,7 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
             travel: true,
             scheduler: true,
             hub: true,
+            executor_dispatch: true,
             event_cursor: "sequence".to_string(),
             structured_errors: true,
         },
@@ -371,6 +373,22 @@ pub fn handle_request_with_runtime(
                 .trim_start_matches("/hub/nodes/")
                 .trim_end_matches("/health");
             crate::hub::report_node_health(coven_home, node_id, body)
+        }
+        ("POST", path) if path.starts_with("/hub/nodes/") && path.ends_with("/poll") => {
+            let node_id = path
+                .trim_start_matches("/hub/nodes/")
+                .trim_end_matches("/poll");
+            crate::hub::poll_node(coven_home, node_id)
+        }
+        ("POST", path) if path.starts_with("/hub/nodes/") && path.ends_with("/dispatch") => {
+            let node_id = path
+                .trim_start_matches("/hub/nodes/")
+                .trim_end_matches("/dispatch");
+            crate::hub::dispatch_to_node(coven_home, node_id, body)
+        }
+        ("GET", path) if path.starts_with("/hub/dispatches/") => {
+            let job_id = path.trim_start_matches("/hub/dispatches/");
+            crate::hub::get_dispatch(coven_home, job_id)
         }
         ("GET", path) if path.starts_with("/hub/nodes/") => {
             let node_id = path.trim_start_matches("/hub/nodes/");
@@ -2175,6 +2193,7 @@ mod tests {
         assert!(response.capabilities.travel);
         assert!(response.capabilities.scheduler);
         assert!(response.capabilities.hub);
+        assert!(response.capabilities.executor_dispatch);
         assert_eq!(response.capabilities.event_cursor, "sequence");
         assert!(response.capabilities.structured_errors);
         assert_eq!(response.daemon, None);
@@ -2205,6 +2224,7 @@ mod tests {
         assert!(response.body.contains(r#""travel":true"#));
         assert!(response.body.contains(r#""scheduler":true"#));
         assert!(response.body.contains(r#""hub":true"#));
+        assert!(response.body.contains(r#""executorDispatch":true"#));
         assert!(response.body.contains(r#""role":"hub""#));
         assert!(response.body.contains(r#""structuredErrors":true"#));
         Ok(())

--- a/crates/coven-cli/src/executor_node.rs
+++ b/crates/coven-cli/src/executor_node.rs
@@ -1,0 +1,1198 @@
+//! Shared stateless executor protocol (`coven.executor.v1`) and the
+//! hub-owned dispatcher that drives it over SSH or a local process
+//! transport.
+//!
+//! Protocol invariants (multi-host spec, issue #267):
+//! - The hub is the only side that initiates contact. It polls executor
+//!   availability with `coven executor probe` and dispatches work with
+//!   `coven executor run-job`, both invoked over an outbound transport
+//!   (SSH or a private-network process launch). Executors never push
+//!   registration or heartbeats to the hub.
+//! - A dispatched job carries everything the executor needs (argv, cwd,
+//!   env, stdin payload, and opaque hub-provided context) so the node can
+//!   run it without local durable authority.
+//! - Executors reply on stdout with a normalized result envelope carrying
+//!   stdout/stderr/exit metadata; transport failures are normalized into
+//!   the same envelope shape by the hub-side dispatcher.
+//! - Stationary and compute executors share this base protocol and only
+//!   differ in the role and capabilities they advertise.
+
+use std::{
+    collections::BTreeMap,
+    io::{Read, Write},
+    path::Path,
+    process::Stdio,
+    time::{Duration, Instant},
+};
+
+use anyhow::{bail, Context, Result};
+use chrono::{SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const EXECUTOR_PROTOCOL_VERSION: &str = "coven.executor.v1";
+pub const ROLE_STATIONARY_EXECUTOR: &str = "stationary_executor";
+pub const ROLE_COMPUTE_EXECUTOR: &str = "compute_executor";
+
+pub const RESULT_STATUS_COMPLETED: &str = "completed";
+pub const RESULT_STATUS_FAILED: &str = "failed";
+pub const RESULT_STATUS_TIMEOUT: &str = "timeout";
+pub const RESULT_STATUS_REJECTED: &str = "rejected";
+pub const RESULT_STATUS_TRANSPORT_ERROR: &str = "transport_error";
+
+pub const DEFAULT_JOB_TIMEOUT_SECONDS: u64 = 300;
+const PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+/// Extra transport allowance beyond the job timeout so the executor-side
+/// timeout (which produces a normalized `timeout` envelope) wins over a
+/// blunt transport kill.
+const DISPATCH_TIMEOUT_GRACE_SECONDS: u64 = 30;
+/// Cap captured stdout/stderr so result envelopes stay bounded.
+const MAX_CAPTURED_OUTPUT_BYTES: usize = 1_048_576;
+
+const DEFAULT_EXECUTOR_CAPABILITIES: [&str; 1] = ["shell"];
+
+pub fn is_executor_role(role: &str) -> bool {
+    role == ROLE_STATIONARY_EXECUTOR || role == ROLE_COMPUTE_EXECUTOR
+}
+
+/// Availability envelope returned by `coven executor probe`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutorProbe {
+    pub protocol_version: String,
+    pub role: String,
+    pub capabilities: Vec<String>,
+    pub available: bool,
+    pub queue_pressure: i64,
+    pub coven_version: String,
+    pub probed_at: String,
+}
+
+/// Job context dispatched by the hub. Carries everything the stateless
+/// executor needs; the executor never reads hub-authoritative state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutorJob {
+    pub protocol_version: String,
+    pub job_id: String,
+    #[serde(default)]
+    pub hub_id: Option<String>,
+    #[serde(default)]
+    pub required_capabilities: Vec<String>,
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub cwd: Option<String>,
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    #[serde(default)]
+    pub stdin: Option<String>,
+    #[serde(default)]
+    pub timeout_seconds: Option<u64>,
+    /// Opaque hub-provided context (memory/workspace/policy excerpts).
+    /// The executor treats it as data; it is the hub's job to scope it.
+    #[serde(default)]
+    pub context: Option<Value>,
+}
+
+/// Normalized result envelope returned by `coven executor run-job` (and
+/// synthesized by the dispatcher for transport failures).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutorResultEnvelope {
+    pub protocol_version: String,
+    pub job_id: String,
+    pub status: String,
+    pub exit_code: Option<i64>,
+    pub stdout: String,
+    pub stderr: String,
+    pub started_at: String,
+    pub finished_at: String,
+    pub duration_ms: i64,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// Hub-side node link configuration persisted in the node registry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum TransportConfig {
+    /// Outbound SSH dispatch: `ssh <target> coven executor ...`.
+    #[serde(rename_all = "camelCase")]
+    Ssh {
+        host: String,
+        #[serde(default)]
+        user: Option<String>,
+        #[serde(default)]
+        port: Option<u16>,
+        #[serde(default)]
+        identity_file: Option<String>,
+        /// Remote executor entrypoint; defaults to `coven`.
+        #[serde(default)]
+        remote_program: Option<String>,
+    },
+    /// Private-network/local process dispatch (also the deterministic
+    /// test seam): run `<program> [args..] executor ...` directly.
+    #[serde(rename_all = "camelCase")]
+    Local {
+        program: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessOutput {
+    pub exit_code: Option<i64>,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+}
+
+/// Outbound hub-to-executor transport. Implementations must never expose
+/// the local daemon socket; they run the executor protocol subcommands on
+/// the remote side and relay stdio.
+pub trait ExecutorTransport {
+    fn describe(&self) -> String;
+    fn run(
+        &self,
+        protocol_args: &[&str],
+        stdin: Option<&str>,
+        timeout: Duration,
+    ) -> Result<ProcessOutput>;
+}
+
+pub fn build_transport(config: &TransportConfig) -> Result<Box<dyn ExecutorTransport>> {
+    match config {
+        TransportConfig::Ssh {
+            host,
+            user,
+            port,
+            identity_file,
+            remote_program,
+        } => Ok(Box::new(SshTransport::new(
+            host,
+            user.as_deref(),
+            *port,
+            identity_file.as_deref(),
+            remote_program.as_deref(),
+        )?)),
+        TransportConfig::Local { program, args } => {
+            if program.trim().is_empty() {
+                bail!("local transport program must not be empty");
+            }
+            Ok(Box::new(LocalProcessTransport {
+                program: program.clone(),
+                args: args.clone(),
+            }))
+        }
+    }
+}
+
+/// Hub-owned SSH dispatcher transport. Connections are always outbound
+/// from the hub, batch-mode only (no interactive prompts), and fail
+/// closed on unknown host keys so node identity stays pinned to the
+/// operator-managed `known_hosts`.
+pub struct SshTransport {
+    host: String,
+    user: Option<String>,
+    port: Option<u16>,
+    identity_file: Option<String>,
+    remote_program: String,
+}
+
+impl SshTransport {
+    pub fn new(
+        host: &str,
+        user: Option<&str>,
+        port: Option<u16>,
+        identity_file: Option<&str>,
+        remote_program: Option<&str>,
+    ) -> Result<Self> {
+        let host = host.trim();
+        if host.is_empty() {
+            bail!("ssh transport host must not be empty");
+        }
+        // Refuse values that OpenSSH would parse as options.
+        if host.starts_with('-') {
+            bail!("ssh transport host must not start with '-'");
+        }
+        let user = user.map(str::trim);
+        if user.is_some_and(|user| user.is_empty() || user.starts_with('-')) {
+            bail!("ssh transport user must not be empty or start with '-'");
+        }
+        let identity_file = identity_file.map(str::trim);
+        if identity_file.is_some_and(|path| path.is_empty() || path.starts_with('-')) {
+            bail!("ssh transport identity file must not be empty or start with '-'");
+        }
+        let remote_program = remote_program.map_or("coven", str::trim);
+        if remote_program.is_empty() || remote_program.starts_with('-') {
+            bail!("ssh transport remote program must not be empty or start with '-'");
+        }
+        Ok(Self {
+            host: host.to_string(),
+            user: user.map(str::to_string),
+            port,
+            identity_file: identity_file.map(str::to_string),
+            remote_program: remote_program.to_string(),
+        })
+    }
+
+    pub fn argv(&self, protocol_args: &[&str]) -> Vec<String> {
+        let mut argv = vec![
+            "ssh".to_string(),
+            "-o".to_string(),
+            "BatchMode=yes".to_string(),
+            "-o".to_string(),
+            "StrictHostKeyChecking=yes".to_string(),
+            "-o".to_string(),
+            "ConnectTimeout=10".to_string(),
+        ];
+        if let Some(port) = self.port {
+            argv.push("-p".to_string());
+            argv.push(port.to_string());
+        }
+        if let Some(identity_file) = &self.identity_file {
+            argv.push("-i".to_string());
+            argv.push(identity_file.clone());
+        }
+        match &self.user {
+            Some(user) => argv.push(format!("{user}@{}", self.host)),
+            None => argv.push(self.host.clone()),
+        }
+        argv.push(self.remote_program.clone());
+        argv.extend(protocol_args.iter().map(|arg| arg.to_string()));
+        argv
+    }
+}
+
+impl ExecutorTransport for SshTransport {
+    fn describe(&self) -> String {
+        match &self.user {
+            Some(user) => format!("ssh {user}@{}", self.host),
+            None => format!("ssh {}", self.host),
+        }
+    }
+
+    fn run(
+        &self,
+        protocol_args: &[&str],
+        stdin: Option<&str>,
+        timeout: Duration,
+    ) -> Result<ProcessOutput> {
+        let argv = self.argv(protocol_args);
+        let mut command = std::process::Command::new(&argv[0]);
+        command.args(&argv[1..]);
+        run_process_with_timeout(&mut command, stdin, timeout)
+            .with_context(|| format!("ssh dispatch to {} failed", self.describe()))
+    }
+}
+
+/// Runs the executor protocol against a local program. Used for
+/// same-host/private-network dispatch and as the deterministic test seam.
+pub struct LocalProcessTransport {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+impl ExecutorTransport for LocalProcessTransport {
+    fn describe(&self) -> String {
+        format!("local {}", self.program)
+    }
+
+    fn run(
+        &self,
+        protocol_args: &[&str],
+        stdin: Option<&str>,
+        timeout: Duration,
+    ) -> Result<ProcessOutput> {
+        let mut command = std::process::Command::new(&self.program);
+        command.args(&self.args);
+        command.args(protocol_args);
+        run_process_with_timeout(&mut command, stdin, timeout)
+            .with_context(|| format!("local dispatch via {} failed", self.program))
+    }
+}
+
+/// Hub-side availability poll: runs `executor probe` over the transport
+/// and validates the returned envelope. Errors mean "unavailable"; the
+/// caller records last-known state in the node registry.
+pub fn poll_executor(transport: &dyn ExecutorTransport) -> Result<ExecutorProbe> {
+    let output = transport.run(&["executor", "probe"], None, PROBE_TIMEOUT)?;
+    if output.timed_out {
+        bail!("executor probe timed out via {}", transport.describe());
+    }
+    if output.exit_code != Some(0) {
+        bail!(
+            "executor probe exited with {:?} via {}: {}",
+            output.exit_code,
+            transport.describe(),
+            output.stderr.trim()
+        );
+    }
+    let probe: ExecutorProbe = serde_json::from_str(output.stdout.trim()).with_context(|| {
+        format!(
+            "executor probe returned malformed envelope: {}",
+            output.stdout
+        )
+    })?;
+    if probe.protocol_version != EXECUTOR_PROTOCOL_VERSION {
+        bail!(
+            "executor probe protocol version mismatch: expected {EXECUTOR_PROTOCOL_VERSION}, got {}",
+            probe.protocol_version
+        );
+    }
+    if !is_executor_role(&probe.role) {
+        bail!("executor probe advertised unknown role {}", probe.role);
+    }
+    Ok(probe)
+}
+
+/// Hub-side dispatch: sends the job spec on stdin to `executor run-job`
+/// over the transport and always returns a normalized result envelope.
+/// Transport failures become `transport_error` envelopes so callers see
+/// one shape regardless of where the failure happened.
+pub fn dispatch_job(
+    transport: &dyn ExecutorTransport,
+    job: &ExecutorJob,
+) -> ExecutorResultEnvelope {
+    let started = Instant::now();
+    let started_at = current_timestamp();
+    let payload = match serde_json::to_string(job) {
+        Ok(payload) => payload,
+        Err(error) => {
+            return transport_error_envelope(
+                &job.job_id,
+                &started_at,
+                started,
+                format!("failed to serialize job spec: {error}"),
+                String::new(),
+                String::new(),
+            );
+        }
+    };
+    let job_timeout = job.timeout_seconds.unwrap_or(DEFAULT_JOB_TIMEOUT_SECONDS);
+    let transport_timeout =
+        Duration::from_secs(job_timeout.saturating_add(DISPATCH_TIMEOUT_GRACE_SECONDS));
+    let output = match transport.run(&["executor", "run-job"], Some(&payload), transport_timeout) {
+        Ok(output) => output,
+        Err(error) => {
+            return transport_error_envelope(
+                &job.job_id,
+                &started_at,
+                started,
+                format!("transport failure via {}: {error:#}", transport.describe()),
+                String::new(),
+                String::new(),
+            );
+        }
+    };
+    if output.timed_out {
+        return transport_error_envelope(
+            &job.job_id,
+            &started_at,
+            started,
+            format!("transport timed out via {}", transport.describe()),
+            output.stdout,
+            output.stderr,
+        );
+    }
+    let envelope: ExecutorResultEnvelope = match serde_json::from_str(output.stdout.trim()) {
+        Ok(envelope) => envelope,
+        Err(error) => {
+            return transport_error_envelope(
+                &job.job_id,
+                &started_at,
+                started,
+                format!("executor returned malformed result envelope: {error}"),
+                output.stdout,
+                output.stderr,
+            );
+        }
+    };
+    if envelope.protocol_version != EXECUTOR_PROTOCOL_VERSION {
+        return transport_error_envelope(
+            &job.job_id,
+            &started_at,
+            started,
+            format!(
+                "result envelope protocol version mismatch: expected {EXECUTOR_PROTOCOL_VERSION}, got {}",
+                envelope.protocol_version
+            ),
+            output.stdout,
+            output.stderr,
+        );
+    }
+    if envelope.status != RESULT_STATUS_REJECTED && envelope.job_id != job.job_id {
+        return transport_error_envelope(
+            &job.job_id,
+            &started_at,
+            started,
+            format!(
+                "result envelope job id mismatch: expected {}, got {}",
+                job.job_id, envelope.job_id
+            ),
+            output.stdout,
+            output.stderr,
+        );
+    }
+    envelope
+}
+
+fn transport_error_envelope(
+    job_id: &str,
+    started_at: &str,
+    started: Instant,
+    error: String,
+    stdout: String,
+    stderr: String,
+) -> ExecutorResultEnvelope {
+    ExecutorResultEnvelope {
+        protocol_version: EXECUTOR_PROTOCOL_VERSION.to_string(),
+        job_id: job_id.to_string(),
+        status: RESULT_STATUS_TRANSPORT_ERROR.to_string(),
+        exit_code: None,
+        stdout,
+        stderr,
+        started_at: started_at.to_string(),
+        finished_at: current_timestamp(),
+        duration_ms: i64::try_from(started.elapsed().as_millis()).unwrap_or(i64::MAX),
+        error: Some(error),
+    }
+}
+
+/// Executor-node configuration (`<covenHome>/executor.json`). Optional;
+/// absent config means a stationary executor with base capabilities.
+/// This is the only executor-side file the protocol reads: it describes
+/// what the node advertises, not any hub-authoritative state.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutorNodeConfig {
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub capabilities: Option<Vec<String>>,
+}
+
+pub fn load_node_config(coven_home: &Path) -> Result<ExecutorNodeConfig> {
+    let path = coven_home.join("executor.json");
+    if !path.exists() {
+        return Ok(ExecutorNodeConfig::default());
+    }
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("failed to read executor config {}", path.display()))?;
+    serde_json::from_str(&raw)
+        .with_context(|| format!("failed to parse executor config {}", path.display()))
+}
+
+/// Executor-side availability envelope for `coven executor probe`.
+pub fn build_probe(coven_home: &Path) -> Result<ExecutorProbe> {
+    let config = load_node_config(coven_home)?;
+    let role = config
+        .role
+        .unwrap_or_else(|| ROLE_STATIONARY_EXECUTOR.to_string());
+    if !is_executor_role(&role) {
+        bail!(
+            "executor role must be `{ROLE_STATIONARY_EXECUTOR}` or `{ROLE_COMPUTE_EXECUTOR}`, got `{role}`"
+        );
+    }
+    let capabilities = config.capabilities.unwrap_or_else(|| {
+        DEFAULT_EXECUTOR_CAPABILITIES
+            .iter()
+            .map(|capability| capability.to_string())
+            .collect()
+    });
+    Ok(ExecutorProbe {
+        protocol_version: EXECUTOR_PROTOCOL_VERSION.to_string(),
+        role,
+        capabilities,
+        available: true,
+        // Stateless executors run dispatched jobs synchronously per
+        // connection and hold no durable queue; the hub owns queues.
+        queue_pressure: 0,
+        coven_version: env!("CARGO_PKG_VERSION").to_string(),
+        probed_at: current_timestamp(),
+    })
+}
+
+/// Executor-side entrypoint for `coven executor run-job`: parses the job
+/// spec from the stdin payload and always produces an envelope, even for
+/// malformed input.
+pub fn run_job_from_stdin_payload(payload: &str) -> ExecutorResultEnvelope {
+    match serde_json::from_str::<ExecutorJob>(payload) {
+        Ok(job) => run_job(&job),
+        Err(error) => rejected_envelope("", format!("malformed job spec on stdin: {error}")),
+    }
+}
+
+/// Runs one dispatched job. Deliberately stateless: no store access, no
+/// hub-authoritative writes — the job spec is the entire context.
+pub fn run_job(job: &ExecutorJob) -> ExecutorResultEnvelope {
+    if job.protocol_version != EXECUTOR_PROTOCOL_VERSION {
+        return rejected_envelope(
+            &job.job_id,
+            format!(
+                "job protocol version mismatch: expected {EXECUTOR_PROTOCOL_VERSION}, got {}",
+                job.protocol_version
+            ),
+        );
+    }
+    if job.job_id.trim().is_empty() {
+        return rejected_envelope("", "job id must not be empty".to_string());
+    }
+    let Some(program) = job.command.first() else {
+        return rejected_envelope(&job.job_id, "job command must not be empty".to_string());
+    };
+    if let Some(cwd) = &job.cwd {
+        if !Path::new(cwd).is_dir() {
+            return rejected_envelope(
+                &job.job_id,
+                format!("job cwd does not exist on this executor: {cwd}"),
+            );
+        }
+    }
+
+    let started = Instant::now();
+    let started_at = current_timestamp();
+    let mut command = std::process::Command::new(program);
+    command.args(&job.command[1..]);
+    if let Some(cwd) = &job.cwd {
+        command.current_dir(cwd);
+    }
+    for (key, value) in &job.env {
+        command.env(key, value);
+    }
+    let timeout = Duration::from_secs(job.timeout_seconds.unwrap_or(DEFAULT_JOB_TIMEOUT_SECONDS));
+    let output = match run_process_with_timeout(&mut command, job.stdin.as_deref(), timeout) {
+        Ok(output) => output,
+        Err(error) => {
+            return rejected_envelope(
+                &job.job_id,
+                format!("failed to launch job command: {error:#}"),
+            );
+        }
+    };
+    let status = if output.timed_out {
+        RESULT_STATUS_TIMEOUT
+    } else if output.exit_code == Some(0) {
+        RESULT_STATUS_COMPLETED
+    } else {
+        RESULT_STATUS_FAILED
+    };
+    ExecutorResultEnvelope {
+        protocol_version: EXECUTOR_PROTOCOL_VERSION.to_string(),
+        job_id: job.job_id.clone(),
+        status: status.to_string(),
+        exit_code: output.exit_code,
+        stdout: output.stdout,
+        stderr: output.stderr,
+        started_at,
+        finished_at: current_timestamp(),
+        duration_ms: i64::try_from(started.elapsed().as_millis()).unwrap_or(i64::MAX),
+        error: if output.timed_out {
+            Some(format!("job exceeded timeout of {}s", timeout.as_secs()))
+        } else {
+            None
+        },
+    }
+}
+
+fn rejected_envelope(job_id: &str, error: String) -> ExecutorResultEnvelope {
+    let now = current_timestamp();
+    ExecutorResultEnvelope {
+        protocol_version: EXECUTOR_PROTOCOL_VERSION.to_string(),
+        job_id: job_id.to_string(),
+        status: RESULT_STATUS_REJECTED.to_string(),
+        exit_code: None,
+        stdout: String::new(),
+        stderr: String::new(),
+        started_at: now.clone(),
+        finished_at: now,
+        duration_ms: 0,
+        error: Some(error),
+    }
+}
+
+fn current_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn run_process_with_timeout(
+    command: &mut std::process::Command,
+    stdin: Option<&str>,
+    timeout: Duration,
+) -> Result<ProcessOutput> {
+    command
+        .stdin(if stdin.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().context("failed to spawn process")?;
+
+    let stdin_writer = stdin.map(|payload| {
+        let mut handle = child.stdin.take().expect("stdin was requested as piped");
+        let payload = payload.as_bytes().to_vec();
+        std::thread::spawn(move || {
+            let _ = handle.write_all(&payload);
+        })
+    });
+    let stdout_reader = spawn_capped_reader(child.stdout.take().expect("stdout is piped"));
+    let stderr_reader = spawn_capped_reader(child.stderr.take().expect("stderr is piped"));
+
+    let deadline = Instant::now() + timeout;
+    let mut timed_out = false;
+    let exit_status = loop {
+        match child.try_wait().context("failed to poll process")? {
+            Some(status) => break Some(status),
+            None => {
+                if Instant::now() >= deadline {
+                    timed_out = true;
+                    let _ = child.kill();
+                    break child.wait().ok();
+                }
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+    };
+    if let Some(writer) = stdin_writer {
+        let _ = writer.join();
+    }
+    let stdout = stdout_reader
+        .join()
+        .unwrap_or_else(|_| String::from("<stdout reader panicked>"));
+    let stderr = stderr_reader
+        .join()
+        .unwrap_or_else(|_| String::from("<stderr reader panicked>"));
+    let exit_code = if timed_out {
+        None
+    } else {
+        exit_status.and_then(|status| status.code()).map(i64::from)
+    };
+    Ok(ProcessOutput {
+        exit_code,
+        stdout,
+        stderr,
+        timed_out,
+    })
+}
+
+fn spawn_capped_reader<R: Read + Send + 'static>(mut source: R) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut buffer = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            match source.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(read) => {
+                    let remaining = MAX_CAPTURED_OUTPUT_BYTES.saturating_sub(buffer.len());
+                    let take = read.min(remaining);
+                    buffer.extend_from_slice(&chunk[..take]);
+                    // Keep draining past the cap so the child never blocks
+                    // on a full pipe.
+                }
+                Err(_) => break,
+            }
+        }
+        let mut text = String::from_utf8_lossy(&buffer).into_owned();
+        if buffer.len() >= MAX_CAPTURED_OUTPUT_BYTES {
+            text.push_str("\n<output truncated>");
+        }
+        text
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shell_command(script: &str) -> Vec<String> {
+        #[cfg(unix)]
+        {
+            vec!["/bin/sh".to_string(), "-c".to_string(), script.to_string()]
+        }
+        #[cfg(windows)]
+        {
+            vec!["cmd".to_string(), "/C".to_string(), script.to_string()]
+        }
+    }
+
+    fn job_with_command(command: Vec<String>) -> ExecutorJob {
+        ExecutorJob {
+            protocol_version: EXECUTOR_PROTOCOL_VERSION.to_string(),
+            job_id: "job_test".to_string(),
+            hub_id: Some("hub_test".to_string()),
+            required_capabilities: vec![],
+            command,
+            cwd: None,
+            env: BTreeMap::new(),
+            stdin: None,
+            timeout_seconds: Some(30),
+            context: None,
+        }
+    }
+
+    #[test]
+    fn probe_defaults_to_stationary_role_with_base_capabilities() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+
+        let probe = build_probe(temp_dir.path())?;
+
+        assert_eq!(probe.protocol_version, EXECUTOR_PROTOCOL_VERSION);
+        assert_eq!(probe.role, ROLE_STATIONARY_EXECUTOR);
+        assert_eq!(probe.capabilities, vec!["shell".to_string()]);
+        assert!(probe.available);
+        assert_eq!(probe.queue_pressure, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn probe_reads_role_and_capabilities_from_executor_config() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("executor.json"),
+            r#"{"role":"compute_executor","capabilities":["shell","gpu","long-running-loop"]}"#,
+        )?;
+
+        let probe = build_probe(temp_dir.path())?;
+
+        assert_eq!(probe.role, ROLE_COMPUTE_EXECUTOR);
+        assert_eq!(
+            probe.capabilities,
+            vec![
+                "shell".to_string(),
+                "gpu".to_string(),
+                "long-running-loop".to_string()
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn probe_rejects_unknown_role() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("executor.json"),
+            r#"{"role":"authority_hub"}"#,
+        )?;
+
+        let error = build_probe(temp_dir.path()).unwrap_err();
+
+        assert!(error.to_string().contains("executor role must be"));
+        Ok(())
+    }
+
+    #[test]
+    fn stationary_and_compute_probes_share_the_same_envelope_shape() -> Result<()> {
+        let stationary_dir = tempfile::tempdir()?;
+        let compute_dir = tempfile::tempdir()?;
+        std::fs::write(
+            compute_dir.path().join("executor.json"),
+            r#"{"role":"compute_executor","capabilities":["gpu"]}"#,
+        )?;
+
+        let stationary = serde_json::to_value(build_probe(stationary_dir.path())?)?;
+        let compute = serde_json::to_value(build_probe(compute_dir.path())?)?;
+
+        let field_names = |value: &Value| {
+            value
+                .as_object()
+                .expect("probe serializes to an object")
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(field_names(&stationary), field_names(&compute));
+        assert_eq!(stationary["protocolVersion"], compute["protocolVersion"]);
+        assert_ne!(stationary["role"], compute["role"]);
+        assert_ne!(stationary["capabilities"], compute["capabilities"]);
+        Ok(())
+    }
+
+    #[test]
+    fn run_job_returns_completed_envelope_with_captured_output() {
+        let job = job_with_command(shell_command("echo job-ran"));
+
+        let envelope = run_job(&job);
+
+        assert_eq!(envelope.protocol_version, EXECUTOR_PROTOCOL_VERSION);
+        assert_eq!(envelope.job_id, "job_test");
+        assert_eq!(envelope.status, RESULT_STATUS_COMPLETED);
+        assert_eq!(envelope.exit_code, Some(0));
+        assert!(envelope.stdout.contains("job-ran"));
+        assert!(envelope.error.is_none());
+        assert!(envelope.duration_ms >= 0);
+        assert!(!envelope.started_at.is_empty());
+        assert!(!envelope.finished_at.is_empty());
+    }
+
+    #[test]
+    fn run_job_reports_failed_status_with_exit_code_and_stderr() {
+        #[cfg(unix)]
+        let script = "echo boom 1>&2; exit 3";
+        #[cfg(windows)]
+        let script = "echo boom 1>&2 & exit /b 3";
+        let job = job_with_command(shell_command(script));
+
+        let envelope = run_job(&job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_FAILED);
+        assert_eq!(envelope.exit_code, Some(3));
+        assert!(envelope.stderr.contains("boom"));
+    }
+
+    #[test]
+    fn run_job_applies_env_and_cwd_and_stdin_from_the_job_spec() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        #[cfg(unix)]
+        let script = "printf '%s|%s|' \"$COVEN_JOB_FLAVOR\" \"$PWD\"; cat";
+        #[cfg(windows)]
+        let script = "echo %COVEN_JOB_FLAVOR% & more";
+        let mut job = job_with_command(shell_command(script));
+        job.cwd = Some(temp_dir.path().to_string_lossy().into_owned());
+        job.env
+            .insert("COVEN_JOB_FLAVOR".to_string(), "midnight".to_string());
+        job.stdin = Some("from-the-hub".to_string());
+
+        let envelope = run_job(&job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_COMPLETED);
+        assert!(envelope.stdout.contains("midnight"));
+        assert!(envelope.stdout.contains("from-the-hub"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_job_times_out_and_reports_timeout_status() {
+        let mut job = job_with_command(shell_command("sleep 20"));
+        job.timeout_seconds = Some(1);
+
+        let envelope = run_job(&job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_TIMEOUT);
+        assert_eq!(envelope.exit_code, None);
+        assert!(envelope.error.as_deref().unwrap().contains("timeout"));
+    }
+
+    #[test]
+    fn run_job_rejects_protocol_version_mismatch() {
+        let mut job = job_with_command(shell_command("echo never-runs"));
+        job.protocol_version = "coven.executor.v99".to_string();
+
+        let envelope = run_job(&job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_REJECTED);
+        assert!(envelope
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("protocol version mismatch"));
+    }
+
+    #[test]
+    fn run_job_rejects_empty_command_and_missing_cwd() {
+        let mut empty_command = job_with_command(vec![]);
+        empty_command.job_id = "job_empty".to_string();
+        let empty_envelope = run_job(&empty_command);
+        assert_eq!(empty_envelope.status, RESULT_STATUS_REJECTED);
+
+        let mut missing_cwd = job_with_command(shell_command("echo never-runs"));
+        missing_cwd.cwd = Some("/definitely/not/a/real/coven/cwd".to_string());
+        let cwd_envelope = run_job(&missing_cwd);
+        assert_eq!(cwd_envelope.status, RESULT_STATUS_REJECTED);
+        assert!(cwd_envelope.error.as_deref().unwrap().contains("cwd"));
+    }
+
+    #[test]
+    fn run_job_from_stdin_payload_rejects_malformed_json() {
+        let envelope = run_job_from_stdin_payload("this is not a job spec");
+
+        assert_eq!(envelope.status, RESULT_STATUS_REJECTED);
+        assert_eq!(envelope.job_id, "");
+        assert!(envelope
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("malformed job spec"));
+    }
+
+    #[test]
+    fn ssh_transport_builds_batch_mode_pinned_argv() -> Result<()> {
+        let transport = SshTransport::new(
+            "executor.internal",
+            Some("coven"),
+            Some(2222),
+            Some("/home/coven/.ssh/id_ed25519"),
+            None,
+        )?;
+
+        let argv = transport.argv(&["executor", "probe"]);
+
+        assert_eq!(
+            argv,
+            vec![
+                "ssh",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "StrictHostKeyChecking=yes",
+                "-o",
+                "ConnectTimeout=10",
+                "-p",
+                "2222",
+                "-i",
+                "/home/coven/.ssh/id_ed25519",
+                "coven@executor.internal",
+                "coven",
+                "executor",
+                "probe",
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ssh_transport_rejects_option_injection_shaped_values() {
+        assert!(SshTransport::new("-oProxyCommand=evil", None, None, None, None).is_err());
+        assert!(SshTransport::new("host", Some("-badflag"), None, None, None).is_err());
+        assert!(SshTransport::new("host", None, None, Some("-i-evil"), None).is_err());
+        assert!(SshTransport::new("host", None, None, None, Some("-notaprogram")).is_err());
+        assert!(SshTransport::new("", None, None, None, None).is_err());
+        // Whitespace-only values must fail closed too.
+        assert!(SshTransport::new("host", Some("  "), None, None, None).is_err());
+        assert!(SshTransport::new("host", None, None, Some("  "), None).is_err());
+        assert!(SshTransport::new("host", None, None, None, Some("  ")).is_err());
+    }
+
+    #[test]
+    fn transport_config_round_trips_ssh_and_local_kinds() -> Result<()> {
+        let ssh: TransportConfig = serde_json::from_str(
+            r#"{"kind":"ssh","host":"executor.internal","user":"coven","port":22}"#,
+        )?;
+        assert!(matches!(ssh, TransportConfig::Ssh { .. }));
+
+        let local: TransportConfig =
+            serde_json::from_str(r#"{"kind":"local","program":"/usr/local/bin/coven"}"#)?;
+        assert!(matches!(local, TransportConfig::Local { .. }));
+
+        assert!(build_transport(&ssh).is_ok());
+        assert!(build_transport(&local).is_ok());
+        assert!(build_transport(&TransportConfig::Local {
+            program: "  ".to_string(),
+            args: vec![],
+        })
+        .is_err());
+        Ok(())
+    }
+
+    struct ScriptedTransport {
+        exit_code: Option<i64>,
+        stdout: String,
+        stderr: String,
+        timed_out: bool,
+        fail: bool,
+    }
+
+    impl ScriptedTransport {
+        fn replying(stdout: &str) -> Self {
+            Self {
+                exit_code: Some(0),
+                stdout: stdout.to_string(),
+                stderr: String::new(),
+                timed_out: false,
+                fail: false,
+            }
+        }
+    }
+
+    impl ExecutorTransport for ScriptedTransport {
+        fn describe(&self) -> String {
+            "scripted".to_string()
+        }
+
+        fn run(
+            &self,
+            _protocol_args: &[&str],
+            _stdin: Option<&str>,
+            _timeout: Duration,
+        ) -> Result<ProcessOutput> {
+            if self.fail {
+                bail!("network unreachable");
+            }
+            Ok(ProcessOutput {
+                exit_code: self.exit_code,
+                stdout: self.stdout.clone(),
+                stderr: self.stderr.clone(),
+                timed_out: self.timed_out,
+            })
+        }
+    }
+
+    fn scripted_envelope_json(job_id: &str, protocol_version: &str) -> String {
+        serde_json::to_string(&ExecutorResultEnvelope {
+            protocol_version: protocol_version.to_string(),
+            job_id: job_id.to_string(),
+            status: RESULT_STATUS_COMPLETED.to_string(),
+            exit_code: Some(0),
+            stdout: "remote output".to_string(),
+            stderr: String::new(),
+            started_at: "2026-07-06T00:00:00Z".to_string(),
+            finished_at: "2026-07-06T00:00:01Z".to_string(),
+            duration_ms: 1000,
+            error: None,
+        })
+        .expect("envelope serializes")
+    }
+
+    #[test]
+    fn dispatch_job_returns_the_executor_result_envelope() {
+        let job = job_with_command(vec!["true".to_string()]);
+        let transport = ScriptedTransport::replying(&scripted_envelope_json(
+            "job_test",
+            EXECUTOR_PROTOCOL_VERSION,
+        ));
+
+        let envelope = dispatch_job(&transport, &job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_COMPLETED);
+        assert_eq!(envelope.job_id, "job_test");
+        assert_eq!(envelope.stdout, "remote output");
+    }
+
+    #[test]
+    fn dispatch_job_normalizes_transport_failures_into_envelopes() {
+        let job = job_with_command(vec!["true".to_string()]);
+        let transport = ScriptedTransport {
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+            fail: true,
+        };
+
+        let envelope = dispatch_job(&transport, &job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_TRANSPORT_ERROR);
+        assert_eq!(envelope.job_id, "job_test");
+        assert!(envelope
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("network unreachable"));
+    }
+
+    #[test]
+    fn dispatch_job_flags_job_id_and_protocol_mismatches() {
+        let job = job_with_command(vec!["true".to_string()]);
+
+        let wrong_id = ScriptedTransport::replying(&scripted_envelope_json(
+            "job_other",
+            EXECUTOR_PROTOCOL_VERSION,
+        ));
+        let envelope = dispatch_job(&wrong_id, &job);
+        assert_eq!(envelope.status, RESULT_STATUS_TRANSPORT_ERROR);
+        assert!(envelope
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("job id mismatch"));
+
+        let wrong_version =
+            ScriptedTransport::replying(&scripted_envelope_json("job_test", "coven.executor.v99"));
+        let envelope = dispatch_job(&wrong_version, &job);
+        assert_eq!(envelope.status, RESULT_STATUS_TRANSPORT_ERROR);
+        assert!(envelope
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("protocol version mismatch"));
+    }
+
+    #[test]
+    fn dispatch_job_flags_malformed_result_envelopes() {
+        let job = job_with_command(vec!["true".to_string()]);
+        let transport = ScriptedTransport::replying("mostly noise, not json");
+
+        let envelope = dispatch_job(&transport, &job);
+
+        assert_eq!(envelope.status, RESULT_STATUS_TRANSPORT_ERROR);
+        assert!(envelope
+            .error
+            .as_deref()
+            .unwrap()
+            .contains("malformed result envelope"));
+    }
+
+    #[test]
+    fn poll_executor_parses_and_validates_the_probe_envelope() -> Result<()> {
+        let probe_json = serde_json::to_string(&ExecutorProbe {
+            protocol_version: EXECUTOR_PROTOCOL_VERSION.to_string(),
+            role: ROLE_COMPUTE_EXECUTOR.to_string(),
+            capabilities: vec!["shell".to_string(), "gpu".to_string()],
+            available: true,
+            queue_pressure: 2,
+            coven_version: "0.0.0".to_string(),
+            probed_at: "2026-07-06T00:00:00Z".to_string(),
+        })?;
+        let transport = ScriptedTransport::replying(&probe_json);
+
+        let probe = poll_executor(&transport)?;
+
+        assert_eq!(probe.role, ROLE_COMPUTE_EXECUTOR);
+        assert_eq!(probe.queue_pressure, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn poll_executor_rejects_bad_versions_roles_and_exit_codes() {
+        let bad_version = ScriptedTransport::replying(
+            r#"{"protocolVersion":"coven.executor.v99","role":"compute_executor","capabilities":[],"available":true,"queuePressure":0,"covenVersion":"0.0.0","probedAt":"2026-07-06T00:00:00Z"}"#,
+        );
+        assert!(poll_executor(&bad_version)
+            .unwrap_err()
+            .to_string()
+            .contains("protocol version mismatch"));
+
+        let bad_role = ScriptedTransport::replying(
+            r#"{"protocolVersion":"coven.executor.v1","role":"authority_hub","capabilities":[],"available":true,"queuePressure":0,"covenVersion":"0.0.0","probedAt":"2026-07-06T00:00:00Z"}"#,
+        );
+        assert!(poll_executor(&bad_role)
+            .unwrap_err()
+            .to_string()
+            .contains("unknown role"));
+
+        let nonzero_exit = ScriptedTransport {
+            exit_code: Some(255),
+            stdout: String::new(),
+            stderr: "connection refused".to_string(),
+            timed_out: false,
+            fail: false,
+        };
+        assert!(poll_executor(&nonzero_exit)
+            .unwrap_err()
+            .to_string()
+            .contains("exited"));
+    }
+
+    #[test]
+    fn local_transport_runs_the_protocol_arguments() -> Result<()> {
+        #[cfg(unix)]
+        let transport = LocalProcessTransport {
+            program: "/bin/sh".to_string(),
+            args: vec!["-c".to_string(), "echo \"$0 $1\"".to_string()],
+        };
+        #[cfg(windows)]
+        let transport = LocalProcessTransport {
+            program: "cmd".to_string(),
+            args: vec!["/C".to_string(), "echo".to_string()],
+        };
+
+        let output = transport.run(&["executor", "probe"], None, Duration::from_secs(10))?;
+
+        assert_eq!(output.exit_code, Some(0));
+        assert!(output.stdout.contains("executor probe"));
+        Ok(())
+    }
+}

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 
 use crate::{
     api::{api_error, current_timestamp, json_response, parse_body, ApiResponse},
-    store,
+    executor_node, store,
 };
 
 /// Store-meta key shared with travel profile generation so the hub identity
@@ -45,14 +45,21 @@ fn parse_capabilities(json_text: &str) -> Vec<String> {
 }
 
 fn node_response(node: &store::NodeRecord) -> Value {
+    let transport_config: Value = node
+        .transport_config_json
+        .as_deref()
+        .and_then(|raw| serde_json::from_str(raw).ok())
+        .unwrap_or(Value::Null);
     json!({
         "nodeId": node.node_id,
         "role": node.role,
         "transport": node.transport,
+        "transportConfig": transport_config,
         "capabilities": parse_capabilities(&node.capabilities_json),
         "available": node.available,
         "queuePressure": node.queue_pressure,
         "lastHealthAt": node.last_health_at,
+        "lastError": node.last_error,
         "registeredAt": node.registered_at,
         "updatedAt": node.updated_at,
     })
@@ -166,6 +173,10 @@ struct RegisterNodeRequest {
     role: String,
     #[serde(default)]
     transport: Option<String>,
+    /// Structured hub-outbound dispatch config. Required before the hub can
+    /// poll or dispatch to this node over SSH/private network.
+    #[serde(default)]
+    transport_config: Option<executor_node::TransportConfig>,
     #[serde(default)]
     capabilities: Vec<String>,
     #[serde(default = "default_true")]
@@ -196,6 +207,24 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
     let existing = store::get_node(&conn, &request.node_id)?;
     let capabilities_json = serde_json::to_string(&request.capabilities)
         .context("failed to serialize node capabilities")?;
+    let transport_config_json = match &request.transport_config {
+        Some(config) => {
+            if let Err(error) = executor_node::build_transport(config) {
+                return api_error(
+                    400,
+                    "invalid_request",
+                    &format!("transportConfig is invalid: {error}"),
+                    None,
+                );
+            }
+            Some(serde_json::to_string(config).context("failed to serialize transport config")?)
+        }
+        // Preserve a previously registered dispatch config when the
+        // re-registration omits it.
+        None => existing
+            .as_ref()
+            .and_then(|node| node.transport_config_json.clone()),
+    };
     let record = store::NodeRecord {
         node_id: request.node_id.clone(),
         role: request.role,
@@ -203,6 +232,7 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
             .transport
             .filter(|transport| !transport.trim().is_empty())
             .unwrap_or_else(|| "ssh".to_string()),
+        transport_config_json,
         capabilities_json,
         available: request.available,
         queue_pressure: existing
@@ -210,6 +240,7 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
             .map(|node| node.queue_pressure)
             .unwrap_or(0),
         last_health_at: now.clone(),
+        last_error: None,
         registered_at: existing
             .as_ref()
             .map(|node| node.registered_at.clone())
@@ -288,18 +319,8 @@ pub fn report_node_health(
     }
     store::upsert_node(&conn, &node)?;
 
-    let (from_state, to_state) = if request.available {
-        (JOB_STATE_HELD, JOB_STATE_ASSIGNED)
-    } else {
-        (JOB_STATE_ASSIGNED, JOB_STATE_HELD)
-    };
-    let mut transitioned = Vec::new();
-    for job in store::list_hub_jobs_for_node(&conn, node_id)? {
-        if job.state == from_state {
-            store::update_hub_job_state(&conn, &job.job_id, to_state, Some(node_id), &now)?;
-            transitioned.push(job.job_id);
-        }
-    }
+    let (from_state, to_state, transitioned) =
+        transition_jobs_for_availability(&conn, node_id, request.available, &now)?;
     let held_job_ids = sync_executor_queue(&conn, node_id, &now)?;
     let node =
         store::get_node(&conn, node_id)?.context("node disappeared while reporting health")?;
@@ -316,6 +337,349 @@ pub fn report_node_health(
                 "to": to_state,
                 "jobIds": transitioned,
             },
+        }),
+    )
+}
+
+/// Move a node's jobs between `assigned` and `held` when its availability
+/// changes. Jobs are never dropped: an unavailable node's work is held on
+/// the hub until the node recovers or the scheduler redispatches it.
+fn transition_jobs_for_availability(
+    conn: &rusqlite::Connection,
+    node_id: &str,
+    available: bool,
+    now: &str,
+) -> Result<(&'static str, &'static str, Vec<String>)> {
+    let (from_state, to_state) = if available {
+        (JOB_STATE_HELD, JOB_STATE_ASSIGNED)
+    } else {
+        (JOB_STATE_ASSIGNED, JOB_STATE_HELD)
+    };
+    let mut transitioned = Vec::new();
+    for job in store::list_hub_jobs_for_node(conn, node_id)? {
+        if job.state == from_state {
+            store::update_hub_job_state(conn, &job.job_id, to_state, Some(node_id), now)?;
+            transitioned.push(job.job_id);
+        }
+    }
+    Ok((from_state, to_state, transitioned))
+}
+
+/// Hub-initiated availability poll (#267): connect outbound to the executor
+/// over its registered transport, run `coven executor probe`, and record the
+/// advertised role/capabilities plus last-known availability. Executors never
+/// push health to the hub — this poll (and dispatch) is how the registry
+/// learns about them. Poll failures are recorded, never fatal.
+pub fn poll_node(coven_home: &Path, node_id: &str) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(mut node) = store::get_node(&conn, node_id)? else {
+        return api_error(
+            404,
+            "node_not_found",
+            "Node was not found in the hub registry.",
+            Some(json!({ "nodeId": node_id })),
+        );
+    };
+    let transport = match build_node_transport(&node) {
+        Ok(transport) => transport,
+        Err(response) => return response,
+    };
+    let now = current_timestamp();
+    node.last_health_at = now.clone();
+    node.updated_at = now.clone();
+
+    let poll_result = executor_node::poll_executor(transport.as_ref()).and_then(|probe| {
+        if probe.role != node.role {
+            anyhow::bail!(
+                "executor advertised role {} but is registered as {}",
+                probe.role,
+                node.role
+            );
+        }
+        Ok(probe)
+    });
+    match poll_result {
+        Ok(probe) => {
+            node.capabilities_json = serde_json::to_string(&probe.capabilities)
+                .context("failed to serialize probed capabilities")?;
+            node.available = probe.available;
+            node.last_error = None;
+            store::upsert_node(&conn, &node)?;
+            transition_jobs_for_availability(&conn, node_id, probe.available, &now)?;
+            let held_job_ids = sync_executor_queue(&conn, node_id, &now)?;
+            let node = store::get_node(&conn, node_id)?.context("node disappeared during poll")?;
+            json_response(
+                200,
+                &json!({
+                    "nodeId": node.node_id,
+                    "ok": true,
+                    "probe": probe,
+                    "heldSubqueue": {
+                        "nodeId": node_id,
+                        "jobIds": held_job_ids,
+                    },
+                    "node": node_response(&node),
+                }),
+            )
+        }
+        Err(error) => {
+            node.available = false;
+            node.last_error = Some(format!("{error:#}"));
+            store::upsert_node(&conn, &node)?;
+            transition_jobs_for_availability(&conn, node_id, false, &now)?;
+            let held_job_ids = sync_executor_queue(&conn, node_id, &now)?;
+            let node = store::get_node(&conn, node_id)?.context("node disappeared during poll")?;
+            json_response(
+                200,
+                &json!({
+                    "nodeId": node.node_id,
+                    "ok": false,
+                    "error": format!("{error:#}"),
+                    "heldSubqueue": {
+                        "nodeId": node_id,
+                        "jobIds": held_job_ids,
+                    },
+                    "node": node_response(&node),
+                }),
+            )
+        }
+    }
+}
+
+fn build_node_transport(
+    node: &store::NodeRecord,
+) -> std::result::Result<Box<dyn executor_node::ExecutorTransport>, Result<ApiResponse>> {
+    let Some(raw) = node.transport_config_json.as_deref() else {
+        return Err(api_error(
+            409,
+            "node_transport_not_configured",
+            "Node has no dispatch transport configured; re-register it with a transportConfig.",
+            Some(json!({ "nodeId": node.node_id })),
+        ));
+    };
+    let config: executor_node::TransportConfig = match serde_json::from_str(raw) {
+        Ok(config) => config,
+        Err(error) => {
+            return Err(api_error(
+                500,
+                "node_transport_invalid",
+                &format!("Stored transport config could not be parsed: {error}"),
+                Some(json!({ "nodeId": node.node_id })),
+            ));
+        }
+    };
+    match executor_node::build_transport(&config) {
+        Ok(transport) => Ok(transport),
+        Err(error) => Err(api_error(
+            500,
+            "node_transport_invalid",
+            &format!("Stored transport config could not be used: {error}"),
+            Some(json!({ "nodeId": node.node_id })),
+        )),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DispatchJobRequest {
+    #[serde(default)]
+    job_id: Option<String>,
+    command: Vec<String>,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    env: std::collections::BTreeMap<String, String>,
+    #[serde(default)]
+    stdin: Option<String>,
+    #[serde(default)]
+    timeout_seconds: Option<u64>,
+    #[serde(default)]
+    required_capabilities: Vec<String>,
+    #[serde(default)]
+    context: Option<Value>,
+}
+
+/// Hub-outbound job dispatch (#267). The job spec sent to the executor
+/// carries the full context (argv, cwd, env, stdin, opaque context blob) so
+/// the stateless node needs no local durable authority; the executor's
+/// normalized result envelope is persisted with the dispatch record. When
+/// `jobId` names a queued hub job, its state is advanced from the envelope.
+pub fn dispatch_to_node(
+    coven_home: &Path,
+    node_id: &str,
+    body: Option<&str>,
+) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let request: DispatchJobRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    if request.command.is_empty() {
+        return api_error(400, "invalid_request", "command must not be empty.", None);
+    }
+    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(mut node) = store::get_node(&conn, node_id)? else {
+        return api_error(
+            404,
+            "node_not_found",
+            "Node was not found in the hub registry.",
+            Some(json!({ "nodeId": node_id })),
+        );
+    };
+    let known_capabilities = parse_capabilities(&node.capabilities_json);
+    let missing: Vec<&String> = request
+        .required_capabilities
+        .iter()
+        .filter(|required| !known_capabilities.contains(required))
+        .collect();
+    if !missing.is_empty() {
+        return api_error(
+            409,
+            "executor_capability_mismatch",
+            "Executor node does not advertise the required capabilities.",
+            Some(json!({
+                "nodeId": node_id,
+                "requiredCapabilities": request.required_capabilities,
+                "knownCapabilities": known_capabilities,
+                "missingCapabilities": missing,
+            })),
+        );
+    }
+    let transport = match build_node_transport(&node) {
+        Ok(transport) => transport,
+        Err(response) => return response,
+    };
+    let job_id = request
+        .job_id
+        .filter(|job_id| !job_id.trim().is_empty())
+        .unwrap_or_else(|| format!("job_{}", Uuid::new_v4()));
+    let job = executor_node::ExecutorJob {
+        protocol_version: executor_node::EXECUTOR_PROTOCOL_VERSION.to_string(),
+        job_id: job_id.clone(),
+        hub_id: Some(hub_id(&conn)?),
+        required_capabilities: request.required_capabilities,
+        command: request.command,
+        cwd: request.cwd,
+        env: request.env,
+        stdin: request.stdin,
+        timeout_seconds: request.timeout_seconds,
+        context: request.context,
+    };
+    let job_json = serde_json::to_string(&job).context("failed to serialize job spec")?;
+    let now = current_timestamp();
+    // Persist before dispatching so a hub crash mid-dispatch leaves evidence.
+    store::upsert_executor_dispatch(
+        &conn,
+        &store::ExecutorDispatchRecord {
+            job_id: job_id.clone(),
+            node_id: node_id.to_string(),
+            status: "dispatched".to_string(),
+            job_json: job_json.clone(),
+            envelope_json: None,
+            created_at: now.clone(),
+            updated_at: now.clone(),
+        },
+    )?;
+
+    let envelope = executor_node::dispatch_job(transport.as_ref(), &job);
+    let envelope_json =
+        serde_json::to_string(&envelope).context("failed to serialize result envelope")?;
+    let finished = current_timestamp();
+    store::upsert_executor_dispatch(
+        &conn,
+        &store::ExecutorDispatchRecord {
+            job_id: job_id.clone(),
+            node_id: node_id.to_string(),
+            status: envelope.status.clone(),
+            job_json,
+            envelope_json: Some(envelope_json),
+            created_at: now.clone(),
+            updated_at: finished.clone(),
+        },
+    )?;
+
+    // Advance a matching hub-queue job from the envelope. A transport error
+    // leaves the job assigned/held so no work is lost.
+    if store::get_hub_job(&conn, &job_id)?.is_some() {
+        let hub_state = match envelope.status.as_str() {
+            executor_node::RESULT_STATUS_COMPLETED => Some("completed"),
+            executor_node::RESULT_STATUS_FAILED
+            | executor_node::RESULT_STATUS_TIMEOUT
+            | executor_node::RESULT_STATUS_REJECTED => Some("failed"),
+            _ => None,
+        };
+        if let Some(state) = hub_state {
+            store::update_hub_job_state(&conn, &job_id, state, Some(node_id), &finished)?;
+        }
+    }
+
+    // A dispatch doubles as an availability observation.
+    let unreachable = envelope.status == executor_node::RESULT_STATUS_TRANSPORT_ERROR;
+    node.available = !unreachable;
+    node.last_health_at = finished.clone();
+    node.last_error = if unreachable {
+        envelope.error.clone()
+    } else {
+        None
+    };
+    node.updated_at = finished.clone();
+    store::upsert_node(&conn, &node)?;
+    transition_jobs_for_availability(&conn, node_id, !unreachable, &finished)?;
+    sync_executor_queue(&conn, node_id, &finished)?;
+
+    if unreachable {
+        return api_error(
+            502,
+            "executor_unreachable",
+            "Executor node could not be reached or returned an invalid envelope.",
+            Some(json!({
+                "nodeId": node_id,
+                "jobId": job_id,
+                "envelope": envelope,
+            })),
+        );
+    }
+    json_response(
+        200,
+        &json!({
+            "jobId": job_id,
+            "nodeId": node_id,
+            "createdAt": now,
+            "envelope": envelope,
+        }),
+    )
+}
+
+pub fn get_dispatch(coven_home: &Path, job_id: &str) -> Result<ApiResponse> {
+    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(record) = store::get_executor_dispatch(&conn, job_id)? else {
+        return api_error(
+            404,
+            "executor_job_not_found",
+            "Executor job dispatch record was not found.",
+            Some(json!({ "jobId": job_id })),
+        );
+    };
+    let job: Value = serde_json::from_str(&record.job_json).context("failed to parse job spec")?;
+    let envelope: Value = match &record.envelope_json {
+        Some(envelope_json) => {
+            serde_json::from_str(envelope_json).context("failed to parse result envelope")?
+        }
+        None => Value::Null,
+    };
+    json_response(
+        200,
+        &json!({
+            "jobId": record.job_id,
+            "nodeId": record.node_id,
+            "status": record.status,
+            "job": job,
+            "envelope": envelope,
+            "createdAt": record.created_at,
+            "updatedAt": record.updated_at,
         }),
     )
 }
@@ -854,6 +1218,357 @@ mod tests {
         let (status, body) = post(&temp, "/api/v1/hub/jobs/job_done/assign", "{}")?;
         assert_eq!(status, 409);
         assert_eq!(body["error"]["code"], "job_not_assignable");
+        Ok(())
+    }
+
+    fn register_dispatchable_node(
+        temp: &tempfile::TempDir,
+        node_id: &str,
+        role: &str,
+        program: &str,
+        capabilities: &str,
+    ) -> anyhow::Result<(u16, serde_json::Value)> {
+        post(
+            temp,
+            "/api/v1/hub/nodes",
+            &format!(
+                r#"{{
+                    "nodeId":"{node_id}",
+                    "role":"{role}",
+                    "transport":"local",
+                    "transportConfig":{{"kind":"local","program":"{program}"}},
+                    "capabilities":{capabilities}
+                }}"#
+            ),
+        )
+    }
+
+    #[test]
+    fn node_registration_validates_and_exposes_the_dispatch_transport() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        let (status, node) = register_dispatchable_node(
+            &temp,
+            "node_stationary",
+            "stationary_executor",
+            "/usr/local/bin/coven",
+            r#"["shell"]"#,
+        )?;
+        assert_eq!(status, 201);
+        assert_eq!(node["transportConfig"]["kind"], "local");
+        assert_eq!(node["lastError"], serde_json::Value::Null);
+
+        // An SSH config shaped like an option injection must be rejected.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes",
+            r#"{
+                "nodeId":"node_evil",
+                "role":"stationary_executor",
+                "transportConfig":{"kind":"ssh","host":"-oProxyCommand=evil"}
+            }"#,
+        )?;
+        assert_eq!(status, 400);
+        assert!(body["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("transportConfig is invalid"));
+
+        // Re-registering without a transportConfig preserves the stored one.
+        let (status, node) = post(
+            &temp,
+            "/api/v1/hub/nodes",
+            r#"{"nodeId":"node_stationary","role":"stationary_executor","capabilities":["shell","browser"]}"#,
+        )?;
+        assert_eq!(status, 200);
+        assert_eq!(node["transportConfig"]["kind"], "local");
+        Ok(())
+    }
+
+    #[test]
+    fn poll_requires_a_configured_dispatch_transport() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_gpu")?;
+
+        let (status, body) = post(&temp, "/api/v1/hub/nodes/node_gpu/poll", "{}")?;
+
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "node_transport_not_configured");
+        Ok(())
+    }
+
+    #[test]
+    fn poll_records_last_known_unavailability_when_executor_is_unreachable() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_dispatchable_node(
+            &temp,
+            "node_gone",
+            "stationary_executor",
+            "/definitely/not/a/real/coven-executor-binary",
+            r#"["shell"]"#,
+        )?;
+
+        let (status, body) = post(&temp, "/api/v1/hub/nodes/node_gone/poll", "{}")?;
+
+        assert_eq!(status, 200);
+        assert_eq!(body["ok"], false);
+        assert_eq!(body["node"]["available"], false);
+        assert!(!body["node"]["lastError"].as_str().unwrap().is_empty());
+        assert!(body["node"]["lastHealthAt"].as_str().unwrap().contains('T'));
+        Ok(())
+    }
+
+    #[test]
+    fn poll_and_dispatch_return_404_for_unregistered_nodes() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        let (status, body) = post(&temp, "/api/v1/hub/nodes/node_missing/poll", "{}")?;
+        assert_eq!(status, 404);
+        assert_eq!(body["error"]["code"], "node_not_found");
+
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_missing/dispatch",
+            r#"{"command":["echo","hi"]}"#,
+        )?;
+        assert_eq!(status, 404);
+        assert_eq!(body["error"]["code"], "node_not_found");
+
+        let (status, body) = get(&temp, "/api/v1/hub/dispatches/job_missing")?;
+        assert_eq!(status, 404);
+        assert_eq!(body["error"]["code"], "executor_job_not_found");
+        Ok(())
+    }
+
+    #[test]
+    fn dispatch_rejects_jobs_whose_capabilities_the_node_does_not_advertise() -> anyhow::Result<()>
+    {
+        let temp = tempfile::tempdir()?;
+        register_dispatchable_node(
+            &temp,
+            "node_stationary",
+            "stationary_executor",
+            "/usr/local/bin/coven",
+            r#"["shell"]"#,
+        )?;
+
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_stationary/dispatch",
+            r#"{"command":["train"],"requiredCapabilities":["gpu"]}"#,
+        )?;
+
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "executor_capability_mismatch");
+        assert_eq!(body["error"]["details"]["missingCapabilities"][0], "gpu");
+        Ok(())
+    }
+
+    #[test]
+    fn dispatch_marks_node_unreachable_on_transport_failure_and_keeps_the_record(
+    ) -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_dispatchable_node(
+            &temp,
+            "node_gone",
+            "compute_executor",
+            "/definitely/not/a/real/coven-executor-binary",
+            r#"["shell"]"#,
+        )?;
+
+        let (status, body) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_gone/dispatch",
+            r#"{"jobId":"job_lost","command":["echo","hi"]}"#,
+        )?;
+        assert_eq!(status, 502);
+        assert_eq!(body["error"]["code"], "executor_unreachable");
+        assert_eq!(
+            body["error"]["details"]["envelope"]["status"],
+            "transport_error"
+        );
+
+        // The dispatch record persists even when the transport failed.
+        let (status, job) = get(&temp, "/api/v1/hub/dispatches/job_lost")?;
+        assert_eq!(status, 200);
+        assert_eq!(job["status"], "transport_error");
+        assert_eq!(job["nodeId"], "node_gone");
+
+        let (_, node) = get(&temp, "/api/v1/hub/nodes/node_gone")?;
+        assert_eq!(node["available"], false);
+        assert!(!node["lastError"].as_str().unwrap().is_empty());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn write_fake_executor_script(dir: &std::path::Path) -> anyhow::Result<std::path::PathBuf> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let script = dir.join("fake-executor");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+if [ "$1" = "executor" ] && [ "$2" = "probe" ]; then
+  printf '{"protocolVersion":"coven.executor.v1","role":"compute_executor","capabilities":["shell","gpu"],"available":true,"queuePressure":1,"covenVersion":"0.0.0","probedAt":"2026-07-06T00:00:00Z"}\n'
+  exit 0
+fi
+if [ "$1" = "executor" ] && [ "$2" = "run-job" ]; then
+  job=$(cat)
+  id=$(printf '%s' "$job" | sed -n 's/.*"jobId":"\([^"]*\)".*/\1/p')
+  printf '{"protocolVersion":"coven.executor.v1","jobId":"%s","status":"completed","exitCode":0,"stdout":"remote job output","stderr":"","startedAt":"2026-07-06T00:00:00Z","finishedAt":"2026-07-06T00:00:01Z","durationMs":1000,"error":null}\n' "$id"
+  exit 0
+fi
+exit 2
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&script)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&script, permissions)?;
+        Ok(script)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hub_polls_and_dispatches_outbound_and_records_executor_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let script = write_fake_executor_script(temp.path())?;
+        register_dispatchable_node(
+            &temp,
+            "node_compute",
+            "compute_executor",
+            &script.to_string_lossy(),
+            r#"["shell"]"#,
+        )?;
+
+        // Hub-initiated poll refreshes capability metadata and availability.
+        let (status, poll) = post(&temp, "/api/v1/hub/nodes/node_compute/poll", "{}")?;
+        assert_eq!(status, 200);
+        assert_eq!(poll["ok"], true);
+        assert_eq!(poll["probe"]["role"], "compute_executor");
+        assert_eq!(poll["node"]["available"], true);
+        assert_eq!(
+            poll["node"]["capabilities"],
+            serde_json::json!(["shell", "gpu"])
+        );
+        assert_eq!(poll["node"]["lastError"], serde_json::Value::Null);
+
+        // Outbound dispatch returns the executor's normalized envelope and
+        // persists the dispatch record with the full-context job spec.
+        let (status, dispatch) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_compute/dispatch",
+            r#"{
+                "command":["echo","hello"],
+                "requiredCapabilities":["gpu"],
+                "context":{"workspaceId":"workspace-1"}
+            }"#,
+        )?;
+        assert_eq!(status, 200);
+        let job_id = dispatch["jobId"].as_str().unwrap().to_string();
+        assert!(job_id.starts_with("job_"));
+        assert_eq!(dispatch["envelope"]["status"], "completed");
+        assert_eq!(dispatch["envelope"]["jobId"], job_id.as_str());
+        assert_eq!(dispatch["envelope"]["exitCode"], 0);
+        assert_eq!(dispatch["envelope"]["stdout"], "remote job output");
+
+        let (status, job) = get(&temp, &format!("/api/v1/hub/dispatches/{job_id}"))?;
+        assert_eq!(status, 200);
+        assert_eq!(job["status"], "completed");
+        assert_eq!(job["job"]["protocolVersion"], "coven.executor.v1");
+        assert!(job["job"]["hubId"].as_str().unwrap().starts_with("hub_"));
+        assert_eq!(job["job"]["context"]["workspaceId"], "workspace-1");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dispatch_advances_a_matching_hub_queue_job_from_the_envelope() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let script = write_fake_executor_script(temp.path())?;
+        register_dispatchable_node(
+            &temp,
+            "node_compute",
+            "compute_executor",
+            &script.to_string_lossy(),
+            r#"["gpu","long-running-loop"]"#,
+        )?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_queue_1","requiredCapabilities":["gpu"]}"#,
+        )?;
+        post(&temp, "/api/v1/hub/jobs/job_queue_1/assign", "{}")?;
+
+        let (status, dispatch) = post(
+            &temp,
+            "/api/v1/hub/nodes/node_compute/dispatch",
+            r#"{"jobId":"job_queue_1","command":["echo","work"],"requiredCapabilities":["gpu"]}"#,
+        )?;
+        assert_eq!(status, 200);
+        assert_eq!(dispatch["envelope"]["status"], "completed");
+
+        // The hub-queue job advanced to completed and left the subqueue.
+        let (_, job) = get(&temp, "/api/v1/hub/jobs/job_queue_1")?;
+        assert_eq!(job["state"], "completed");
+        let (_, node) = get(&temp, "/api/v1/hub/nodes/node_compute")?;
+        assert_eq!(node["queuePressure"], 0);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn poll_fails_closed_when_executor_advertises_a_mismatched_role() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let script = write_fake_executor_script(temp.path())?;
+        // Register the fake compute executor as stationary.
+        register_dispatchable_node(
+            &temp,
+            "node_mislabeled",
+            "stationary_executor",
+            &script.to_string_lossy(),
+            r#"["shell"]"#,
+        )?;
+
+        let (status, poll) = post(&temp, "/api/v1/hub/nodes/node_mislabeled/poll", "{}")?;
+
+        assert_eq!(status, 200);
+        assert_eq!(poll["ok"], false);
+        assert_eq!(poll["node"]["available"], false);
+        assert!(poll["node"]["lastError"]
+            .as_str()
+            .unwrap()
+            .contains("advertised role"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn poll_going_unavailable_holds_the_executor_subqueue() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let script = write_fake_executor_script(temp.path())?;
+        register_dispatchable_node(
+            &temp,
+            "node_compute",
+            "compute_executor",
+            &script.to_string_lossy(),
+            r#"["gpu","long-running-loop"]"#,
+        )?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_held_by_poll","requiredCapabilities":["gpu"]}"#,
+        )?;
+        post(&temp, "/api/v1/hub/jobs/job_held_by_poll/assign", "{}")?;
+
+        // Break the transport, then poll: the node goes unavailable and its
+        // assigned job is held on the hub without being dropped.
+        std::fs::remove_file(&script)?;
+        let (status, poll) = post(&temp, "/api/v1/hub/nodes/node_compute/poll", "{}")?;
+        assert_eq!(status, 200);
+        assert_eq!(poll["ok"], false);
+        assert_eq!(poll["heldSubqueue"]["jobIds"][0], "job_held_by_poll");
+        let (_, job) = get(&temp, "/api/v1/hub/jobs/job_held_by_poll")?;
+        assert_eq!(job["state"], "held");
         Ok(())
     }
 }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -20,6 +20,7 @@ mod coven_calls;
 mod daemon;
 mod encrypted_artifacts;
 mod eval_loop;
+mod executor_node;
 mod familiar_identity;
 mod harness;
 mod hub;
@@ -87,6 +88,13 @@ enum Command {
     Daemon {
         #[command(subcommand)]
         command: DaemonCommand,
+    },
+    #[command(
+        about = "Stateless executor-node protocol commands (hub-dispatched over SSH/private network)"
+    )]
+    Executor {
+        #[command(subcommand)]
+        command: ExecutorCommand,
     },
     #[command(about = "Launch a project-scoped harness session")]
     Run {
@@ -313,6 +321,14 @@ enum AdapterCommand {
 }
 
 #[derive(Subcommand, Debug)]
+enum ExecutorCommand {
+    #[command(about = "Print this node's executor availability envelope as JSON")]
+    Probe,
+    #[command(about = "Run one hub-dispatched job from a JSON spec on stdin")]
+    RunJob,
+}
+
+#[derive(Subcommand, Debug)]
 enum DaemonCommand {
     #[command(about = "Start the background daemon that hosts live sessions")]
     Start,
@@ -422,6 +438,7 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Doctor) => run_doctor(),
         Some(Command::Adapter { command }) => run_adapter_command(command),
         Some(Command::Daemon { command }) => run_daemon_command(command),
+        Some(Command::Executor { command }) => run_executor_command(command),
         Some(Command::Run {
             harness,
             prompt,
@@ -1417,6 +1434,24 @@ fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u
         "logs pruned rawArtifacts={raw_pruned} events={events_pruned} rawCutoff={raw_cutoff} eventCutoff={event_cutoff}"
     );
     Ok(())
+}
+
+fn run_executor_command(command: ExecutorCommand) -> Result<()> {
+    match command {
+        ExecutorCommand::Probe => {
+            let home = coven_home_dir()?;
+            let probe = executor_node::build_probe(&home)?;
+            println!("{}", serde_json::to_string(&probe)?);
+            Ok(())
+        }
+        ExecutorCommand::RunJob => {
+            let payload =
+                io::read_to_string(io::stdin()).context("failed to read job spec from stdin")?;
+            let envelope = executor_node::run_job_from_stdin_payload(&payload);
+            println!("{}", serde_json::to_string(&envelope)?);
+            Ok(())
+        }
+    }
 }
 
 fn run_daemon_command(command: DaemonCommand) -> Result<()> {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -134,11 +134,27 @@ pub struct NodeRecord {
     pub node_id: String,
     pub role: String,
     pub transport: String,
+    /// Structured hub-outbound dispatch config (`executor_node::TransportConfig`
+    /// JSON). `None` means the node cannot be polled/dispatched yet.
+    pub transport_config_json: Option<String>,
     pub capabilities_json: String,
     pub available: bool,
     pub queue_pressure: i64,
     pub last_health_at: String,
+    /// Last hub-initiated poll/dispatch failure, cleared on success.
+    pub last_error: Option<String>,
     pub registered_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutorDispatchRecord {
+    pub job_id: String,
+    pub node_id: String,
+    pub status: String,
+    pub job_json: String,
+    pub envelope_json: Option<String>,
+    pub created_at: String,
     pub updated_at: String,
 }
 
@@ -344,16 +360,31 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             node_id TEXT PRIMARY KEY NOT NULL,
             role TEXT NOT NULL,
             transport TEXT NOT NULL,
+            transport_config_json TEXT,
             capabilities_json TEXT NOT NULL,
             available INTEGER NOT NULL DEFAULT 0,
             queue_pressure INTEGER NOT NULL DEFAULT 0,
             last_health_at TEXT NOT NULL,
+            last_error TEXT,
             registered_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
 
         CREATE INDEX IF NOT EXISTS idx_node_registry_available
             ON node_registry(available, queue_pressure);
+
+        CREATE TABLE IF NOT EXISTS executor_dispatches (
+            job_id TEXT PRIMARY KEY NOT NULL,
+            node_id TEXT NOT NULL,
+            status TEXT NOT NULL,
+            job_json TEXT NOT NULL,
+            envelope_json TEXT,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_executor_dispatches_node
+            ON executor_dispatches(node_id, updated_at DESC);
 
         CREATE TABLE IF NOT EXISTS hub_jobs (
             job_id TEXT PRIMARY KEY NOT NULL,
@@ -431,6 +462,7 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_labels_column(&conn)?;
     ensure_visibility_column(&conn)?;
     ensure_familiar_id_column(&conn)?;
+    ensure_node_registry_dispatch_columns(&conn)?;
 
     backfill_events_fts_if_needed(&conn)?;
 
@@ -704,6 +736,24 @@ fn ensure_familiar_id_column(conn: &Connection) -> Result<()> {
         [],
     )
     .context("failed to create sessions.familiar_id index")?;
+    Ok(())
+}
+
+/// Stores created at the initial node_registry schema (#266) predate the
+/// hub-outbound dispatch columns (#267); add them idempotently.
+fn ensure_node_registry_dispatch_columns(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "node_registry",
+        "transport_config_json",
+        "ALTER TABLE node_registry ADD COLUMN transport_config_json TEXT",
+    )?;
+    ensure_column(
+        conn,
+        "node_registry",
+        "last_error",
+        "ALTER TABLE node_registry ADD COLUMN last_error TEXT",
+    )?;
     Ok(())
 }
 
@@ -1095,29 +1145,35 @@ pub fn upsert_node(conn: &Connection, record: &NodeRecord) -> Result<()> {
             node_id,
             role,
             transport,
+            transport_config_json,
             capabilities_json,
             available,
             queue_pressure,
             last_health_at,
+            last_error,
             registered_at,
             updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
         ON CONFLICT(node_id) DO UPDATE SET
             role = excluded.role,
             transport = excluded.transport,
+            transport_config_json = excluded.transport_config_json,
             capabilities_json = excluded.capabilities_json,
             available = excluded.available,
             queue_pressure = excluded.queue_pressure,
             last_health_at = excluded.last_health_at,
+            last_error = excluded.last_error,
             updated_at = excluded.updated_at",
         params![
             &record.node_id,
             &record.role,
             &record.transport,
+            &record.transport_config_json,
             &record.capabilities_json,
             if record.available { 1 } else { 0 },
             record.queue_pressure,
             &record.last_health_at,
+            &record.last_error,
             &record.registered_at,
             &record.updated_at,
         ],
@@ -1127,22 +1183,24 @@ pub fn upsert_node(conn: &Connection, record: &NodeRecord) -> Result<()> {
 }
 
 fn node_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<NodeRecord> {
-    let available: i64 = row.get(4)?;
+    let available: i64 = row.get(5)?;
     Ok(NodeRecord {
         node_id: row.get(0)?,
         role: row.get(1)?,
         transport: row.get(2)?,
-        capabilities_json: row.get(3)?,
+        transport_config_json: row.get(3)?,
+        capabilities_json: row.get(4)?,
         available: available != 0,
-        queue_pressure: row.get(5)?,
-        last_health_at: row.get(6)?,
-        registered_at: row.get(7)?,
-        updated_at: row.get(8)?,
+        queue_pressure: row.get(6)?,
+        last_health_at: row.get(7)?,
+        last_error: row.get(8)?,
+        registered_at: row.get(9)?,
+        updated_at: row.get(10)?,
     })
 }
 
-const NODE_COLUMNS: &str = "node_id, role, transport, capabilities_json, available, \
-     queue_pressure, last_health_at, registered_at, updated_at";
+const NODE_COLUMNS: &str = "node_id, role, transport, transport_config_json, capabilities_json, \
+     available, queue_pressure, last_health_at, last_error, registered_at, updated_at";
 
 pub fn get_node(conn: &Connection, node_id: &str) -> Result<Option<NodeRecord>> {
     conn.query_row(
@@ -1168,6 +1226,63 @@ pub fn list_nodes(conn: &Connection) -> Result<Vec<NodeRecord>> {
         records.push(row.context("failed to read node registry row")?);
     }
     Ok(records)
+}
+
+pub fn upsert_executor_dispatch(conn: &Connection, record: &ExecutorDispatchRecord) -> Result<()> {
+    conn.execute(
+        "INSERT INTO executor_dispatches (
+            job_id,
+            node_id,
+            status,
+            job_json,
+            envelope_json,
+            created_at,
+            updated_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+        ON CONFLICT(job_id) DO UPDATE SET
+            node_id = excluded.node_id,
+            status = excluded.status,
+            job_json = excluded.job_json,
+            envelope_json = excluded.envelope_json,
+            updated_at = excluded.updated_at",
+        params![
+            &record.job_id,
+            &record.node_id,
+            &record.status,
+            &record.job_json,
+            &record.envelope_json,
+            &record.created_at,
+            &record.updated_at,
+        ],
+    )
+    .with_context(|| format!("failed to upsert executor dispatch {}", record.job_id))?;
+    Ok(())
+}
+
+pub fn get_executor_dispatch(
+    conn: &Connection,
+    job_id: &str,
+) -> Result<Option<ExecutorDispatchRecord>> {
+    conn.query_row(
+        "SELECT job_id, node_id, status, job_json, envelope_json, created_at, updated_at
+         FROM executor_dispatches
+         WHERE job_id = ?1
+         LIMIT 1",
+        params![job_id],
+        |row| {
+            Ok(ExecutorDispatchRecord {
+                job_id: row.get(0)?,
+                node_id: row.get(1)?,
+                status: row.get(2)?,
+                job_json: row.get(3)?,
+                envelope_json: row.get(4)?,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
+            })
+        },
+    )
+    .optional()
+    .with_context(|| format!("failed to read executor dispatch {job_id}"))
 }
 
 pub fn upsert_hub_job(conn: &Connection, record: &HubJobRecord) -> Result<()> {
@@ -2109,6 +2224,72 @@ mod tests {
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "session-1");
+        Ok(())
+    }
+
+    #[test]
+    fn node_dispatch_transport_and_last_error_persist_across_reopen() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+        let conn = open_store(&path)?;
+        let node = NodeRecord {
+            node_id: "node-gpu".to_string(),
+            role: "compute_executor".to_string(),
+            transport: "ssh".to_string(),
+            transport_config_json: Some(r#"{"kind":"ssh","host":"executor.internal"}"#.to_string()),
+            capabilities_json: r#"["shell","gpu"]"#.to_string(),
+            available: false,
+            queue_pressure: 0,
+            last_health_at: "2026-07-06T00:00:00Z".to_string(),
+            last_error: Some("connection refused".to_string()),
+            registered_at: "2026-07-06T00:00:00Z".to_string(),
+            updated_at: "2026-07-06T00:00:00Z".to_string(),
+        };
+        upsert_node(&conn, &node)?;
+        drop(conn);
+
+        let reopened = open_store(&path)?;
+        let record = get_node(&reopened, "node-gpu")?.expect("node persists");
+        assert_eq!(
+            record.transport_config_json.as_deref(),
+            Some(r#"{"kind":"ssh","host":"executor.internal"}"#)
+        );
+        assert_eq!(record.last_error.as_deref(), Some("connection refused"));
+        Ok(())
+    }
+
+    #[test]
+    fn executor_dispatch_records_persist_envelopes_across_reopen() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+        let conn = open_store(&path)?;
+        let dispatched = ExecutorDispatchRecord {
+            job_id: "job-1".to_string(),
+            node_id: "node-gpu".to_string(),
+            status: "dispatched".to_string(),
+            job_json: r#"{"jobId":"job-1"}"#.to_string(),
+            envelope_json: None,
+            created_at: "2026-07-06T00:00:00Z".to_string(),
+            updated_at: "2026-07-06T00:00:00Z".to_string(),
+        };
+        upsert_executor_dispatch(&conn, &dispatched)?;
+
+        let mut completed = dispatched.clone();
+        completed.status = "completed".to_string();
+        completed.envelope_json = Some(r#"{"status":"completed"}"#.to_string());
+        completed.updated_at = "2026-07-06T00:01:00Z".to_string();
+        upsert_executor_dispatch(&conn, &completed)?;
+        drop(conn);
+
+        let reopened = open_store(&path)?;
+        let record = get_executor_dispatch(&reopened, "job-1")?.expect("dispatch persists");
+        assert_eq!(record.status, "completed");
+        assert_eq!(
+            record.envelope_json.as_deref(),
+            Some(r#"{"status":"completed"}"#)
+        );
+        assert_eq!(record.created_at, "2026-07-06T00:00:00Z");
+        assert!(get_executor_dispatch(&reopened, "job-missing")?.is_none());
         Ok(())
     }
 

--- a/crates/coven-cli/tests/executor_protocol.rs
+++ b/crates/coven-cli/tests/executor_protocol.rs
@@ -1,0 +1,141 @@
+//! Integration coverage for the stateless executor protocol
+//! (`coven.executor.v1`): the real `coven` binary must answer hub-issued
+//! `executor probe` and `executor run-job` invocations with the shared
+//! envelopes, for both stationary and compute roles.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use serde_json::{json, Value};
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+fn run_probe(coven_home: &Path) -> anyhow::Result<Output> {
+    Command::new(coven_bin())
+        .args(["executor", "probe"])
+        .env("COVEN_HOME", coven_home)
+        .output()
+        .map_err(Into::into)
+}
+
+fn run_job(coven_home: &Path, job: &Value) -> anyhow::Result<Value> {
+    let mut child = Command::new(coven_bin())
+        .args(["executor", "run-job"])
+        .env("COVEN_HOME", coven_home)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child
+        .stdin
+        .take()
+        .expect("stdin is piped")
+        .write_all(job.to_string().as_bytes())?;
+    let output = child.wait_with_output()?;
+    assert!(
+        output.status.success(),
+        "executor run-job failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
+
+fn shell_command(script: &str) -> Value {
+    #[cfg(unix)]
+    {
+        json!(["/bin/sh", "-c", script])
+    }
+    #[cfg(windows)]
+    {
+        json!(["cmd", "/C", script])
+    }
+}
+
+#[test]
+fn executor_probe_defaults_to_stationary_availability_envelope() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+
+    let output = run_probe(temp_dir.path())?;
+
+    assert!(output.status.success());
+    let probe: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(probe["protocolVersion"], "coven.executor.v1");
+    assert_eq!(probe["role"], "stationary_executor");
+    assert_eq!(probe["capabilities"], json!(["shell"]));
+    assert_eq!(probe["available"], true);
+    assert_eq!(probe["queuePressure"], 0);
+    assert!(probe["covenVersion"].as_str().is_some());
+    assert!(probe["probedAt"].as_str().unwrap().contains('T'));
+    Ok(())
+}
+
+#[test]
+fn executor_probe_advertises_configured_compute_capabilities() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(
+        temp_dir.path().join("executor.json"),
+        r#"{"role":"compute_executor","capabilities":["shell","gpu","long-running-loop"]}"#,
+    )?;
+
+    let output = run_probe(temp_dir.path())?;
+
+    assert!(output.status.success());
+    let probe: Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(probe["role"], "compute_executor");
+    assert_eq!(
+        probe["capabilities"],
+        json!(["shell", "gpu", "long-running-loop"])
+    );
+    Ok(())
+}
+
+#[test]
+fn executor_run_job_returns_normalized_result_envelope() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let job = json!({
+        "protocolVersion": "coven.executor.v1",
+        "jobId": "job_integration",
+        "hubId": "hub_integration",
+        "command": shell_command("echo dispatched-by-the-hub"),
+        "timeoutSeconds": 60
+    });
+
+    let envelope = run_job(temp_dir.path(), &job)?;
+
+    assert_eq!(envelope["protocolVersion"], "coven.executor.v1");
+    assert_eq!(envelope["jobId"], "job_integration");
+    assert_eq!(envelope["status"], "completed");
+    assert_eq!(envelope["exitCode"], 0);
+    assert!(envelope["stdout"]
+        .as_str()
+        .unwrap()
+        .contains("dispatched-by-the-hub"));
+    assert_eq!(envelope["stderr"], "");
+    assert!(envelope["startedAt"].as_str().unwrap().contains('T'));
+    assert!(envelope["finishedAt"].as_str().unwrap().contains('T'));
+    assert!(envelope["durationMs"].as_i64().is_some());
+    Ok(())
+}
+
+#[test]
+fn executor_run_job_rejects_unknown_protocol_versions() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let job = json!({
+        "protocolVersion": "coven.executor.v99",
+        "jobId": "job_future",
+        "command": shell_command("echo never-runs")
+    });
+
+    let envelope = run_job(temp_dir.path(), &job)?;
+
+    assert_eq!(envelope["status"], "rejected");
+    assert!(envelope["error"]
+        .as_str()
+        .unwrap()
+        .contains("protocol version mismatch"));
+    Ok(())
+}

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -36,6 +36,7 @@ The Coven daemon socket API is a public compatibility boundary for comux and ext
     "travel": true,
     "scheduler": true,
     "hub": true,
+    "executorDispatch": true,
     "eventCursor": "sequence",
     "structuredErrors": true
   },
@@ -64,6 +65,7 @@ If the daemon metadata is unavailable, `daemon` may be `null`. The `hub` block r
 | `travel`          | boolean | Travel profile, delta, and state APIs are available.             |
 | `scheduler`       | boolean | Scheduler decision and recovery APIs are available.              |
 | `hub`             | boolean | Hub control-plane APIs (node registry, routing, queues) are available. |
+| `executorDispatch`| boolean | Hub-outbound executor poll/dispatch APIs are available.          |
 | `eventCursor`     | string  | Cursor type supported; `"sequence"` means `afterSeq` is stable.  |
 | `structuredErrors`| boolean | All errors use the `{ error: { code, message, details } }` shape.|
 
@@ -578,6 +580,13 @@ Request:
   "nodeId": "compute-primary",
   "role": "compute_executor",
   "transport": "ssh",
+  "transportConfig": {
+    "kind": "ssh",
+    "host": "compute-primary.internal",
+    "user": "coven",
+    "port": 22,
+    "identityFile": "/home/coven/.ssh/id_ed25519"
+  },
   "capabilities": ["gpu", "long-running-loop"],
   "available": true
 }
@@ -590,16 +599,18 @@ Response:
   "nodeId": "compute-primary",
   "role": "compute_executor",
   "transport": "ssh",
+  "transportConfig": { "kind": "ssh", "host": "compute-primary.internal", "user": "coven", "port": 22, "identityFile": "/home/coven/.ssh/id_ed25519" },
   "capabilities": ["gpu", "long-running-loop"],
   "available": true,
   "queuePressure": 0,
   "lastHealthAt": "2026-07-06T12:00:00Z",
+  "lastError": null,
   "registeredAt": "2026-07-06T12:00:00Z",
   "updatedAt": "2026-07-06T12:00:00Z"
 }
 ```
 
-`transport` defaults to `"ssh"`. `queuePressure` is hub-computed from the node's persistent subqueue and cannot be set by the caller.
+`transport` defaults to `"ssh"`. `queuePressure` is hub-computed from the node's persistent subqueue and cannot be set by the caller. `transportConfig` is the structured hub-outbound dispatch link (`kind: "ssh"` or `kind: "local"` for private-network/same-host process dispatch); it is validated at registration, required before the hub can poll or dispatch to the node, and preserved when a re-registration omits it.
 
 ### `GET /api/v1/hub/nodes` and `GET /api/v1/hub/nodes/:nodeId`
 
@@ -630,6 +641,79 @@ Response:
   "transitionedJobs": { "from": "assigned", "to": "held", "jobIds": ["job_01J..."] }
 }
 ```
+
+### `POST /api/v1/hub/nodes/:nodeId/poll`
+
+Hub-initiated availability poll for the stateless executor protocol (`coven.executor.v1`). The hub connects **outbound** over the node's registered `transportConfig` (SSH batch mode with pinned host keys, or a local/private-network process launch), runs `coven executor probe`, and records the advertised capabilities plus last-known availability. Executors never push registration or heartbeats to the hub.
+
+The response always returns `200` with the poll outcome; failures are recorded on the node (`available: false`, `lastError`), never fatal:
+
+```json
+{
+  "nodeId": "compute-primary",
+  "ok": true,
+  "probe": {
+    "protocolVersion": "coven.executor.v1",
+    "role": "compute_executor",
+    "capabilities": ["shell", "gpu"],
+    "available": true,
+    "queuePressure": 0,
+    "covenVersion": "0.0.0",
+    "probedAt": "2026-07-06T12:00:00Z"
+  },
+  "heldSubqueue": { "nodeId": "compute-primary", "jobIds": [] },
+  "node": { "nodeId": "compute-primary", "available": true }
+}
+```
+
+Availability transitions from a poll move the node's jobs between `assigned` and `held` exactly like a health report. A probe that advertises a role different from the registered one fails closed (`ok: false`, node unavailable). Nodes registered without a `transportConfig` return `409 node_transport_not_configured`.
+
+### `POST /api/v1/hub/nodes/:nodeId/dispatch`
+
+Hub-outbound job dispatch. The hub sends a full-context job spec (argv, cwd, env, stdin payload, timeout, opaque `context` blob) to `coven executor run-job` on the node, so the stateless executor needs no local durable authority.
+
+Request:
+
+```json
+{
+  "jobId": "job_01J...",
+  "command": ["sh", "-c", "…"],
+  "cwd": "/work/checkout",
+  "env": { "KEY": "value" },
+  "stdin": "optional payload",
+  "timeoutSeconds": 300,
+  "requiredCapabilities": ["gpu"],
+  "context": { "workspaceId": "workspace_01J..." }
+}
+```
+
+`jobId` is optional (the hub generates `job_<uuid>` when omitted). Required capabilities are checked against the node's last-known capability metadata (`409 executor_capability_mismatch`). The executor replies with a normalized result envelope, persisted with the dispatch record:
+
+```json
+{
+  "jobId": "job_01J...",
+  "nodeId": "compute-primary",
+  "createdAt": "2026-07-06T12:00:00Z",
+  "envelope": {
+    "protocolVersion": "coven.executor.v1",
+    "jobId": "job_01J...",
+    "status": "completed",
+    "exitCode": 0,
+    "stdout": "…",
+    "stderr": "…",
+    "startedAt": "2026-07-06T12:00:00Z",
+    "finishedAt": "2026-07-06T12:00:05Z",
+    "durationMs": 5000,
+    "error": null
+  }
+}
+```
+
+Envelope `status` is one of `completed`, `failed`, `timeout`, `rejected`, or `transport_error` (synthesized by the hub-side dispatcher when the node is unreachable or replies with a malformed envelope, returned as `502 executor_unreachable` with the envelope in `details`). A dispatch doubles as an availability observation, and when `jobId` names a job on the hub queue, that job's state advances from the envelope (`completed`, or `failed` for `failed`/`timeout`/`rejected`); a transport error leaves the queued job held so no work is lost.
+
+### `GET /api/v1/hub/dispatches/:jobId`
+
+Returns the persisted dispatch record — full job spec, normalized result envelope (or `null` while in flight), status, node id, and timestamps — or `404 executor_job_not_found`.
 
 ### `POST /api/v1/hub/jobs`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -56,6 +56,9 @@ Versioned clients should use the `/api/v1` prefix:
 | `GET /api/v1/hub/nodes` | List registered nodes |
 | `GET /api/v1/hub/nodes/:id` | Fetch one registered node |
 | `POST /api/v1/hub/nodes/:id/health` | Record an executor health report (holds/resumes its subqueue) |
+| `POST /api/v1/hub/nodes/:id/poll` | Poll executor availability outbound over its dispatch transport |
+| `POST /api/v1/hub/nodes/:id/dispatch` | Dispatch a job outbound to a stateless executor |
+| `GET /api/v1/hub/dispatches/:jobId` | Fetch a persisted dispatch record (job spec + result envelope) |
 | `POST /api/v1/hub/jobs` | Enqueue a job on the persistent global queue |
 | `GET /api/v1/hub/jobs?state=...` | List queued jobs |
 | `GET /api/v1/hub/jobs/:id` | Fetch one job with its routing entry |

--- a/specs/coven-multi-host-daemon/PRODUCT.md
+++ b/specs/coven-multi-host-daemon/PRODUCT.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft v0.1 - 2026-07-04
 **Owner:** Coven runtime - Coven Cave
-**Tracks:** GitHub issues #264, #265, #268, #269, #270
+**Tracks:** GitHub issues #264, #265, #267, #268, #269, #270
 
 ## Problem
 
@@ -221,6 +221,7 @@ The current local daemon model remains valid for single-machine use, but these c
 
 - #264 tracks the epic.
 - #265 is satisfied by this product/technical spec pair.
+- #267 implements the stateless executor protocol and SSH dispatcher.
 - #268 implements travel profile and reconcile APIs.
 - #269 implements scheduler intelligence and loop redispatch.
 - #270 implements failure simulations and release gates.

--- a/specs/coven-multi-host-daemon/TECH.md
+++ b/specs/coven-multi-host-daemon/TECH.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft v0.1 - 2026-07-04
 **Owner:** Coven runtime - Coven Cave
-**Tracks:** GitHub issues #264, #265, #268, #269, #270
+**Tracks:** GitHub issues #264, #265, #267, #268, #269, #270
 
 ## Design constraints
 
@@ -223,6 +223,110 @@ Valid states:
 - `handoff_pending`
 - `syncing_delta`
 - `hub_resumed`
+
+## Executor protocol and SSH dispatcher
+
+The stateless executor protocol is versioned as `coven.executor.v1` and is
+shared by stationary and compute executor roles. The hub is the only side
+that initiates contact:
+
+- The hub polls availability by running `coven executor probe` on the node
+  over an outbound transport. Executors never push registration or
+  heartbeats to the hub.
+- The hub dispatches work by running `coven executor run-job` and sending
+  the job spec on stdin.
+- Transports are hub-owned: `ssh` (batch mode, `StrictHostKeyChecking=yes`,
+  outbound only) or `local` (private-network/same-host process launch).
+  The raw daemon socket is never exposed.
+
+### Probe envelope (`coven executor probe`)
+
+```json
+{
+  "protocolVersion": "coven.executor.v1",
+  "role": "compute_executor",
+  "capabilities": ["shell", "gpu"],
+  "available": true,
+  "queuePressure": 0,
+  "covenVersion": "0.0.0",
+  "probedAt": "2026-07-06T00:00:00Z"
+}
+```
+
+Both executor roles share this envelope; they differ only in the role and
+capabilities they advertise (configured in `<covenHome>/executor.json`).
+
+### Job spec (stdin of `coven executor run-job`)
+
+```json
+{
+  "protocolVersion": "coven.executor.v1",
+  "jobId": "job_01J...",
+  "hubId": "hub_01J...",
+  "requiredCapabilities": ["gpu"],
+  "command": ["sh", "-c", "…"],
+  "cwd": "/work/checkout",
+  "env": {"KEY": "value"},
+  "stdin": "optional payload",
+  "timeoutSeconds": 300,
+  "context": {"workspaceId": "workspace_01J..."}
+}
+```
+
+The job spec carries everything the executor needs (argv, cwd, env, stdin
+payload, and opaque hub-provided context), so the node runs it without
+local durable authority. `run-job` reads no hub-authoritative state.
+
+### Result envelope (stdout of `coven executor run-job`)
+
+```json
+{
+  "protocolVersion": "coven.executor.v1",
+  "jobId": "job_01J...",
+  "status": "completed",
+  "exitCode": 0,
+  "stdout": "…",
+  "stderr": "…",
+  "startedAt": "2026-07-06T00:00:00Z",
+  "finishedAt": "2026-07-06T00:00:05Z",
+  "durationMs": 5000,
+  "error": null
+}
+```
+
+`status` is one of `completed`, `failed`, `timeout`, `rejected`, or
+`transport_error` (the last is synthesized by the hub-side dispatcher when
+the node is unreachable or replies with a malformed envelope, so callers
+always see one shape).
+
+### Hub routes
+
+- `GET /api/v1/hub/nodes` — registry with capability metadata and last-known
+  availability.
+- `POST /api/v1/hub/nodes` — operator registers/updates a node (role,
+  capabilities, and the structured `transportConfig` dispatch link).
+  Live availability is earned through hub-initiated polls.
+- `POST /api/v1/hub/nodes/:nodeId/poll` — hub polls the executor outbound and
+  records capabilities, availability, and last error; availability
+  transitions hold/resume the node's persistent subqueue.
+- `POST /api/v1/hub/nodes/:nodeId/dispatch` — hub dispatches a job outbound,
+  persists the dispatch record plus normalized envelope, treats the
+  attempt as an availability observation, and advances a matching
+  hub-queue job from the envelope.
+- `GET /api/v1/hub/dispatches/:jobId` — durable dispatch record (job spec,
+  envelope, status).
+
+Acceptance coverage for #267:
+
+- hub dispatches jobs outbound over SSH/private network;
+- hub polls executor availability; executors never push to the hub;
+- job specs carry full context so executor nodes need no local durable
+  authority;
+- executors return stdout/stderr/result metadata in a normalized envelope;
+- the hub records executor capability metadata and last-known
+  availability; and
+- stationary and compute roles share the base protocol while advertising
+  different capabilities.
 
 ## Scheduler
 
@@ -472,7 +576,8 @@ Hard requirements:
 ## Implementation order
 
 1. Land this spec (#265).
-2. Add hub-owned travel profile generation and offline delta reconciliation APIs (#268).
-3. Add scheduler decision model and debug output (#269).
-4. Add failure simulations and release gates (#270).
-5. Wire Cave UI to explicit travel/handoff/scheduler state.
+2. Add the stateless executor protocol and hub-owned SSH dispatcher (#267).
+3. Add hub-owned travel profile generation and offline delta reconciliation APIs (#268).
+4. Add scheduler decision model and debug output (#269).
+5. Add failure simulations and release gates (#270).
+6. Wire Cave UI to explicit travel/handoff/scheduler state.


### PR DESCRIPTION
## Context

- Summary: Implements Phase 1B of the multi-host daemon architecture — the shared stateless executor protocol (`coven.executor.v1`) and the hub-owned SSH dispatcher — **integrated with the #266 hub control plane that landed in #298**. The hub is the only side that initiates contact: it polls executor availability and dispatches jobs outbound over SSH or a local/private-network process transport; executors never push registration or heartbeats.
- Files changed: `crates/coven-cli/src/executor_node.rs` (new protocol + transports + dispatcher), `crates/coven-cli/src/hub.rs` (poll/dispatch handlers on the #298 registry), `crates/coven-cli/src/api.rs` (routes + `executorDispatch` capability), `crates/coven-cli/src/store.rs` (node `transportConfig`/`lastError` columns + `executor_dispatches`), `crates/coven-cli/src/main.rs` (`coven executor probe|run-job`), `crates/coven-cli/tests/executor_protocol.rs`, `docs/API-CONTRACT.md`, `docs/API.md`, `specs/coven-multi-host-daemon/{TECH,PRODUCT}.md`.
- Closes #267

## Implementation

- Approach:
  - **Protocol** (`executor_node.rs`): probe envelope (role, capabilities, availability), full-context job spec (argv, cwd, env, stdin, timeout, opaque hub `context` — everything the stateless node needs, no local durable authority), normalized result envelope (`completed|failed|timeout|rejected|transport_error` with stdout/stderr/exit metadata, bounded capture). Stationary and compute roles share the protocol and differ only in advertised role/capabilities (`<covenHome>/executor.json`). Executor side is `coven executor probe` / `coven executor run-job` (stdin spec → stdout envelope), which reads no hub-authoritative state.
  - **Dispatcher**: hub-outbound `SshTransport` (BatchMode, `StrictHostKeyChecking=yes` pinned host keys, ConnectTimeout, option-injection guards + trimmed/validated fields) plus a `local` process transport for same-host/private-network dispatch and deterministic tests. Transport failures normalize into `transport_error` envelopes so callers always see one shape.
  - **Hub integration (built on #298)**: `node_registry` gains a validated structured `transportConfig` (preserved when re-registration omits it) and `lastError`; `executor_dispatches` persists the job spec + envelope for every dispatch (written before dispatch so a hub crash leaves evidence). `POST /hub/nodes/:id/poll` runs the outbound probe, records capability metadata + last-known availability, fails closed on advertised-role mismatch, and holds/resumes the node's subqueue exactly like a health report. `POST /hub/nodes/:id/dispatch` checks required capabilities against last-known metadata, doubles as an availability observation, and advances a matching hub-queue job from the envelope (transport errors leave the job held — no work lost). `GET /hub/dispatches/:jobId` returns the durable record.
- User-visible behavior: new routes above; new `coven executor` subcommands; health capabilities advertise `executorDispatch`; `POST /hub/nodes` accepts `transportConfig`.
- Compatibility notes: additive only — new columns use the existing `ensure_column` migration path for stores created at the #298 schema; no existing route or envelope changed.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (927 tests; 40+ new across protocol unit tests, store persistence-across-reopen, hub poll/dispatch/registry tests with a fake executor, and real-binary integration tests for `executor probe`/`run-job`)
- [x] `python3 scripts/check-secrets.py` (green on current tree + history after #300)
- [x] Additional manual checks: acceptance criteria mapped to tests — outbound dispatch (`hub_polls_and_dispatches_outbound_and_records_executor_state`), poll-only availability (executors never push; `poll_records_last_known_unavailability...`), full-context jobs (`executor_run_job_returns_normalized_result_envelope`), normalized envelopes (`dispatch_job_normalizes_transport_failures_into_envelopes`), capability/availability recording, shared base protocol across roles (`stationary_and_compute_probes_share_the_same_envelope_shape`), queue preservation on failed polls (`poll_going_unavailable_holds_the_executor_subqueue`).

## Risk and Rollback

- Risk level: Low–medium — additive surface; the only touched existing path is `report_node_health`'s job-transition logic, extracted into a shared helper (behavior covered by the pre-existing #298 tests, all passing). SSH dispatch fails closed; executor results are recorded as data, never applied as authority.
- Rollback plan: revert the single commit; new columns/tables are inert if unused.

## Agent Handoff

- Current state: Phase 1B acceptance criteria implemented on top of the #298 hub control plane; rebased on main including the #300 secret-guard fix.
- Follow-ups: periodic hub-side poll sweep; Cave surfacing of node availability/dispatch records; wiring scheduler decisions to registry snapshots.
- Known gaps: executor-side `queuePressure` in probes is informational (hub-computed subqueue pressure is authoritative per the #298 model); dispatch is synchronous per request.