### PR TITLE
feat: route scheduler decisions and redispatch against the persistent hub node registry

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -994,6 +994,42 @@ struct SchedulerRedispatchRequest {
     nodes: Vec<SchedulerNodeInput>,
 }
 
+/// Load scheduler candidates from the persistent hub node registry (#301).
+/// Used when a scheduler request omits its `nodes` snapshot, so ad-hoc
+/// snapshots and hub-registered nodes share one source of truth. Subqueue
+/// contents come from the persistent per-executor queues.
+fn scheduler_nodes_from_registry(conn: &rusqlite::Connection) -> Result<Vec<SchedulerNodeInput>> {
+    let queued_by_node: std::collections::HashMap<String, Vec<String>> =
+        store::list_executor_queues(conn)?
+            .into_iter()
+            .map(|queue| {
+                let job_ids: Vec<String> =
+                    serde_json::from_str(&queue.job_ids_json).unwrap_or_default();
+                (queue.node_id, job_ids)
+            })
+            .collect();
+    Ok(store::list_nodes(conn)?
+        .into_iter()
+        .map(|node| {
+            let capabilities: Vec<String> =
+                serde_json::from_str(&node.capabilities_json).unwrap_or_default();
+            SchedulerNodeInput {
+                queued_job_ids: queued_by_node
+                    .get(&node.node_id)
+                    .cloned()
+                    .unwrap_or_default(),
+                node_id: node.node_id,
+                role: node.role,
+                available: node.available,
+                capabilities,
+                queue_pressure: node.queue_pressure,
+                battery_percent: None,
+                power_source: None,
+            }
+        })
+        .collect())
+}
+
 fn scheduler_decision(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
     let payload = match parse_body(body) {
         Ok(payload) => payload,
@@ -1001,7 +1037,7 @@ fn scheduler_decision(coven_home: &Path, body: Option<&str>) -> Result<ApiRespon
             return api_error(400, "invalid_request", &error.to_string(), None);
         }
     };
-    let request: SchedulerDecisionRequest = match serde_json::from_value(payload) {
+    let mut request: SchedulerDecisionRequest = match serde_json::from_value(payload) {
         Ok(request) => request,
         Err(error) => {
             return api_error(400, "invalid_request", &error.to_string(), None);
@@ -1010,12 +1046,19 @@ fn scheduler_decision(coven_home: &Path, body: Option<&str>) -> Result<ApiRespon
     if request.job_id.trim().is_empty() {
         return api_error(400, "invalid_request", "jobId is required.", None);
     }
+    let conn = store::open_store(&store_path(coven_home))?;
+    let nodes_source = if request.nodes.is_empty() {
+        request.nodes = scheduler_nodes_from_registry(&conn)?;
+        "hub_registry"
+    } else {
+        "request_snapshot"
+    };
     if request.nodes.is_empty() {
         return api_error(
             409,
             "no_scheduler_target",
-            "No scheduler nodes were supplied.",
-            Some(json!({ "jobId": request.job_id })),
+            "No scheduler nodes were supplied and the hub node registry is empty.",
+            Some(json!({ "jobId": request.job_id, "nodesSource": nodes_source })),
         );
     }
 
@@ -1072,6 +1115,7 @@ fn scheduler_decision(coven_home: &Path, body: Option<&str>) -> Result<ApiRespon
         "queuePressure": queue_pressure_label(target_node.queue_pressure),
         "travelState": travel_state,
         "taskWeight": request.task_weight.unwrap_or_else(|| "normal".to_string()),
+        "nodesSource": nodes_source,
     });
     let reason = format!(
         "{} has required capability set and {} queue pressure",
@@ -1089,7 +1133,6 @@ fn scheduler_decision(coven_home: &Path, body: Option<&str>) -> Result<ApiRespon
         inputs_json: inputs.to_string(),
         created_at: now,
     };
-    let conn = store::open_store(&store_path(coven_home))?;
     store::insert_scheduler_decision(&conn, &record)?;
     let response = scheduler_decision_response(&record)?;
     json_response(201, &response)
@@ -1115,7 +1158,7 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
             return api_error(400, "invalid_request", &error.to_string(), None);
         }
     };
-    let request: SchedulerRedispatchRequest = match serde_json::from_value(payload) {
+    let mut request: SchedulerRedispatchRequest = match serde_json::from_value(payload) {
         Ok(request) => request,
         Err(error) => {
             return api_error(400, "invalid_request", &error.to_string(), None);
@@ -1127,6 +1170,13 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
     if request.job_id.trim().is_empty() {
         return api_error(400, "invalid_request", "jobId is required.", None);
     }
+    let conn = store::open_store(&store_path(coven_home))?;
+    let nodes_source = if request.nodes.is_empty() {
+        request.nodes = scheduler_nodes_from_registry(&conn)?;
+        "hub_registry"
+    } else {
+        "request_snapshot"
+    };
     let Some(current_node) = request
         .nodes
         .iter()
@@ -1135,8 +1185,15 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
         return api_error(
             400,
             "invalid_request",
-            "currentNodeId must refer to a supplied node.",
-            Some(json!({ "currentNodeId": request.current_node_id })),
+            if nodes_source == "hub_registry" {
+                "currentNodeId must refer to a node in the hub registry."
+            } else {
+                "currentNodeId must refer to a supplied node."
+            },
+            Some(json!({
+                "currentNodeId": request.current_node_id,
+                "nodesSource": nodes_source,
+            })),
         );
     };
     let preserved_job_ids = if current_node.queued_job_ids.is_empty() {
@@ -1202,6 +1259,7 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
         "failedNodeId": request.current_node_id,
         "loopResumable": request.loop_resumable,
         "nodeAvailability": node_availability,
+        "nodesSource": nodes_source,
     });
     let now = current_timestamp();
     let decision_id = format!("sched_{}", Uuid::new_v4());
@@ -1215,7 +1273,6 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
         inputs_json: inputs.to_string(),
         created_at: now.clone(),
     };
-    let conn = store::open_store(&store_path(coven_home))?;
     store::insert_scheduler_decision(&conn, &record)?;
     let preserved_job_ids_json =
         serde_json::to_string(&preserved_job_ids).context("failed to serialize preserved queue")?;
@@ -1244,6 +1301,17 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
             updated_at: now.clone(),
         },
     )?;
+    // When the job is tracked in the hub's persistent global queue, keep the
+    // hub job, routing table, and executor subqueues consistent with this
+    // redispatch decision (#301).
+    let hub_job_synced = crate::hub::apply_redispatch_outcome(
+        &conn,
+        &request.job_id,
+        target["nodeId"].as_str(),
+        &decision_id,
+        &reason,
+        &now,
+    )?;
     json_response(
         202,
         &json!({
@@ -1258,6 +1326,7 @@ fn scheduler_redispatch(coven_home: &Path, body: Option<&str>) -> Result<ApiResp
                 "jobIds": preserved_job_ids,
             },
             "nodeAvailability": node_availability,
+            "hubJobSynced": hub_job_synced,
             "createdAt": now,
         }),
     )

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -117,6 +117,61 @@ fn sync_executor_queue(conn: &Connection, node_id: &str, now: &str) -> Result<Ve
     Ok(job_ids)
 }
 
+/// Bring the hub's persistent job, routing-table, and subqueue state in line
+/// with a scheduler redispatch outcome. Returns `false` when the job is not
+/// tracked in the hub's global queue (snapshot-only simulation flows), in
+/// which case nothing is touched.
+pub(crate) fn apply_redispatch_outcome(
+    conn: &Connection,
+    job_id: &str,
+    target_node_id: Option<&str>,
+    decision_id: &str,
+    reason: &str,
+    now: &str,
+) -> Result<bool> {
+    let Some(job) = store::get_hub_job(conn, job_id)? else {
+        return Ok(false);
+    };
+    if TERMINAL_JOB_STATES.contains(&job.state.as_str()) {
+        return Ok(false);
+    }
+    let previous_node_id = job.assigned_node_id.clone();
+    match target_node_id {
+        Some(target) => {
+            store::update_hub_job_state(conn, job_id, JOB_STATE_ASSIGNED, Some(target), now)?;
+            store::upsert_route(
+                conn,
+                &store::RouteRecord {
+                    job_id: job_id.to_string(),
+                    node_id: target.to_string(),
+                    decision_id: Some(decision_id.to_string()),
+                    reason: reason.to_string(),
+                    created_at: now.to_string(),
+                    updated_at: now.to_string(),
+                },
+            )?;
+            sync_executor_queue(conn, target, now)?;
+            if let Some(previous) = previous_node_id.filter(|previous| previous != target) {
+                sync_executor_queue(conn, &previous, now)?;
+            }
+        }
+        None => {
+            // Paused: hold the job on its current node without losing state.
+            store::update_hub_job_state(
+                conn,
+                job_id,
+                JOB_STATE_HELD,
+                previous_node_id.as_deref(),
+                now,
+            )?;
+            if let Some(previous) = previous_node_id {
+                sync_executor_queue(conn, &previous, now)?;
+            }
+        }
+    }
+    Ok(true)
+}
+
 pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
     let conn = store::open_store(&store_path(coven_home))?;
     let nodes = store::list_nodes(&conn)?;
@@ -1569,6 +1624,161 @@ exit 2
         assert_eq!(poll["heldSubqueue"]["jobIds"][0], "job_held_by_poll");
         let (_, job) = get(&temp, "/api/v1/hub/jobs/job_held_by_poll")?;
         assert_eq!(job["state"], "held");
+        Ok(())
+    }
+    #[test]
+    fn scheduler_decision_falls_back_to_hub_registry_when_nodes_omitted() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        // Empty registry and no snapshot: fail closed.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/scheduler/decisions",
+            r#"{"jobId":"job_reg","requiredCapabilities":["gpu"]}"#,
+        )?;
+        assert_eq!(status, 409);
+        assert_eq!(body["error"]["code"], "no_scheduler_target");
+
+        register_gpu_node(&temp, "node_gpu")?;
+        let (status, body) = post(
+            &temp,
+            "/api/v1/scheduler/decisions",
+            r#"{"jobId":"job_reg","requiredCapabilities":["gpu"]}"#,
+        )?;
+        assert_eq!(status, 201);
+        assert_eq!(body["target"]["nodeId"], "node_gpu");
+        assert_eq!(body["inputs"]["nodesSource"], "hub_registry");
+        Ok(())
+    }
+
+    #[test]
+    fn redispatch_uses_hub_registry_and_syncs_hub_job_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_primary")?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_move","requiredCapabilities":["gpu"],"loopId":"loop_move"}"#,
+        )?;
+        let (status, _) = post(&temp, "/api/v1/hub/jobs/job_move/assign", "{}")?;
+        assert_eq!(status, 200);
+
+        // Primary goes offline (job held), fallback joins the registry.
+        post(
+            &temp,
+            "/api/v1/hub/nodes/node_primary/health",
+            r#"{"available":false}"#,
+        )?;
+        register_gpu_node(&temp, "node_fallback")?;
+
+        // No `nodes` snapshot: candidates come from the persistent registry.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/scheduler/redispatch",
+            r#"{
+                "loopId":"loop_move",
+                "jobId":"job_move",
+                "currentNodeId":"node_primary",
+                "requiredCapabilities":["gpu"],
+                "loopResumable":true
+            }"#,
+        )?;
+        assert_eq!(status, 202);
+        assert_eq!(body["state"], "redispatched");
+        assert_eq!(body["target"]["nodeId"], "node_fallback");
+        assert_eq!(body["hubJobSynced"], true);
+        assert_eq!(body["inputs"].get("nodesSource"), None); // inputs not echoed here
+
+        // The hub's persistent job, routing, and subqueue state follow the
+        // redispatch decision.
+        let (_, job) = get(&temp, "/api/v1/hub/jobs/job_move")?;
+        assert_eq!(job["state"], "assigned");
+        assert_eq!(job["assignedNodeId"], "node_fallback");
+        assert_eq!(job["route"]["nodeId"], "node_fallback");
+        let (_, hub) = get(&temp, "/api/v1/hub/status")?;
+        let queues = hub["executorQueues"].as_array().unwrap();
+        let queue_for = |node: &str| {
+            queues
+                .iter()
+                .find(|queue| queue["nodeId"] == node)
+                .map(|queue| queue["jobIds"].clone())
+        };
+        assert_eq!(queue_for("node_fallback").unwrap()[0], "job_move");
+        assert_eq!(
+            queue_for("node_primary").unwrap().as_array().unwrap().len(),
+            0
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn redispatch_pause_holds_hub_job_without_losing_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_primary")?;
+        post(
+            &temp,
+            "/api/v1/hub/jobs",
+            r#"{"jobId":"job_stuck","requiredCapabilities":["gpu"],"loopId":"loop_stuck"}"#,
+        )?;
+        post(&temp, "/api/v1/hub/jobs/job_stuck/assign", "{}")?;
+        post(
+            &temp,
+            "/api/v1/hub/nodes/node_primary/health",
+            r#"{"available":false}"#,
+        )?;
+
+        // No alternate registry node: the loop pauses, and the hub job is
+        // held on its node instead of being dropped.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/scheduler/redispatch",
+            r#"{
+                "loopId":"loop_stuck",
+                "jobId":"job_stuck",
+                "currentNodeId":"node_primary",
+                "requiredCapabilities":["gpu"],
+                "loopResumable":true
+            }"#,
+        )?;
+        assert_eq!(status, 202);
+        assert_eq!(body["state"], "paused");
+        assert_eq!(body["hubJobSynced"], true);
+        assert_eq!(body["preservedSubqueue"]["jobIds"][0], "job_stuck");
+
+        let (_, job) = get(&temp, "/api/v1/hub/jobs/job_stuck")?;
+        assert_eq!(job["state"], "held");
+        assert_eq!(job["assignedNodeId"], "node_primary");
+        Ok(())
+    }
+
+    #[test]
+    fn redispatch_with_snapshot_nodes_reports_untracked_jobs_as_unsynced() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        // Snapshot-only simulation flow (#270 fixtures): job is not in the
+        // hub global queue, so no hub state is touched.
+        let (status, body) = post(
+            &temp,
+            "/api/v1/scheduler/redispatch",
+            r#"{
+                "loopId":"loop_sim",
+                "jobId":"job_sim",
+                "currentNodeId":"node_primary",
+                "requiredCapabilities":["gpu"],
+                "loopResumable":true,
+                "nodes":[
+                    {"nodeId":"node_primary","role":"compute_executor","available":false,
+                     "capabilities":["gpu"],"queuePressure":3,"queuedJobIds":["job_sim"]},
+                    {"nodeId":"node_fallback","role":"compute_executor","available":true,
+                     "capabilities":["gpu"],"queuePressure":1,"queuedJobIds":[]}
+                ]
+            }"#,
+        )?;
+        assert_eq!(status, 202);
+        assert_eq!(body["state"], "redispatched");
+        assert_eq!(body["target"]["nodeId"], "node_fallback");
+        assert_eq!(body["hubJobSynced"], false);
+        let (_, jobs) = get(&temp, "/api/v1/hub/jobs")?;
+        assert_eq!(jobs["jobs"].as_array().unwrap().len(), 0);
         Ok(())
     }
 }

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -487,13 +487,16 @@ Response `201`:
     "requiredCapabilities": ["gpu", "long-running-loop"],
     "queuePressure": "low",
     "travelState": "hub_active",
-    "taskWeight": "heavyweight"
+    "taskWeight": "heavyweight",
+    "nodesSource": "request_snapshot"
   },
   "createdAt": "2026-07-04T12:00:00Z"
 }
 ```
 
 The daemon filters unavailable nodes, required capability misses, low-battery `laptop_local` nodes during travel, and heavyweight laptop-local work while `travelState` is `travel_local` or `travel_stale` unless explicitly allowed.
+
+`nodes` is optional. When it is omitted or empty, candidates are loaded from the persistent hub node registry instead (`inputs.nodesSource` is `"hub_registry"`); supplying a `nodes` snapshot keeps the request fully deterministic for failure simulations. An empty snapshot with an empty registry returns `409 no_scheduler_target`.
 
 ### `GET /api/v1/scheduler/decisions/:id`
 
@@ -555,11 +558,21 @@ Response `202`:
       "queuePressure": "medium"
     }
   ],
+  "hubJobSynced": true,
   "createdAt": "2026-07-04T12:00:00Z"
 }
 ```
 
 If the loop is not resumable or no alternate node matches, `state` is `paused` and `target` is `{ "role": "paused", "nodeId": null }`. In both cases, the failed node subqueue is preserved.
+
+`nodes` is optional. When omitted or empty, both the failed node and the redispatch candidates are resolved from the persistent hub node registry, with subqueue contents taken from the persistent per-executor queues (`inputs.nodesSource` on the persisted decision is `"hub_registry"`). If `currentNodeId` is not in the registry either, the call fails with `400 invalid_request`.
+
+`hubJobSynced` reports whether the job is tracked in the hub's persistent global queue. When `true`, the redispatch also updated hub state so the outcome is visible at `GET /api/v1/hub/jobs/:jobId` and `GET /api/v1/hub/status`:
+
+- `redispatched` — the job becomes `assigned` to the new node, the routing table points at it, and both nodes' subqueues are rebuilt.
+- `paused` — the job becomes `held` on its current node without leaving that node's subqueue.
+
+Snapshot-only jobs (not enqueued via `POST /api/v1/hub/jobs`) leave hub state untouched (`hubJobSynced: false`), which keeps deterministic failure-simulation fixtures independent of the registry.
 
 ### `GET /api/v1/scheduler/loops/:loopId`
 
@@ -567,7 +580,7 @@ Returns the persisted redispatch/pause state with the same fields as `POST /api/
 
 ## Hub control-plane shapes (`v1`)
 
-The hub control plane is the durable multi-host state described in `specs/coven-multi-host-daemon`: a persistent node registry, a routing table, a global job queue, and per-executor subqueues. All hub state persists in the daemon SQLite store and reloads after a daemon restart. Unlike the `POST /api/v1/scheduler/decisions` route (which evaluates a caller-supplied node snapshot), hub job assignment routes against the persistent registry.
+The hub control plane is the durable multi-host state described in `specs/coven-multi-host-daemon`: a persistent node registry, a routing table, a global job queue, and per-executor subqueues. All hub state persists in the daemon SQLite store and reloads after a daemon restart. Hub job assignment routes against the persistent registry; the `POST /api/v1/scheduler/*` routes also fall back to the registry whenever a request omits its `nodes` snapshot.
 
 ### `POST /api/v1/hub/nodes`
 


### PR DESCRIPTION
## Context

- Summary: Follow-up to #266/#269 — the scheduler routes (`POST /api/v1/scheduler/decisions`, `POST /api/v1/scheduler/redispatch`) previously only evaluated caller-supplied `nodes` snapshots, while hub job assignment used the persistent node registry. This PR unifies them: when a request omits `nodes`, candidates come from the registry, and redispatch outcomes now update the hub's persistent job/routing/subqueue state.
- Files changed: `crates/coven-cli/src/api.rs`, `crates/coven-cli/src/hub.rs`, `docs/API-CONTRACT.md`
- Closes #301

## Implementation

- Approach: A `scheduler_nodes_from_registry` helper converts registry `NodeRecord`s (plus persistent per-executor subqueues) into scheduler candidates when `nodes` is empty. A new `hub::apply_redispatch_outcome` keeps hub state consistent after redispatch decisions.
- User-visible behavior:
  - `nodes` is now optional on both scheduler routes; `inputs.nodesSource` records `hub_registry` vs `request_snapshot`.
  - Redispatch of a hub-tracked job: `redispatched` → job `assigned` to the new node with routing-table update and rebuilt subqueues; `paused` → job `held` on its node without leaving the subqueue. Response exposes `hubJobSynced`.
  - Snapshot-only jobs (#270 fixtures) leave hub state untouched (`hubJobSynced: false`).
- Compatibility notes: Additive — explicit `nodes` snapshots behave exactly as before; new response/inputs fields are additive.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (923 passed; 4 new tests cover registry fallback for decisions and redispatch, pause-hold semantics, and snapshot-path isolation)
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: existing #270 failure-simulation tests pass unchanged.

## Risk and Rollback

- Risk level: Low — additive fallback path; deterministic snapshot path untouched.
- Rollback plan: Revert the commit.

## Agent Handoff

- Current state: Scheduler and hub share one source of truth for node availability.
- Follow-ups: None planned.
- Known gaps: Registry-sourced candidates have no battery/power data (registry doesn't store it), so travel battery policy only applies to snapshot-supplied laptop nodes.