### PR TITLE
fix: CLI hardening follow-ups from #297 — prompt argv separator, session kill verb, honest doctor exit codes

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -301,10 +301,13 @@ impl HarnessCommandSpec {
             HarnessLaunchMode::Stream => &self.non_interactive_prompt_prefix_args,
         };
 
+        // The prompt is user data: a prompt starting with `-` must reach the
+        // harness as the positional argument, not be parsed as flags, so it
+        // always rides behind an options terminator.
         prefix_args
             .iter()
             .cloned()
-            .chain(std::iter::once(prompt.to_string()))
+            .chain(["--".to_string(), prompt.to_string()])
             .collect()
     }
 }
@@ -908,8 +911,10 @@ pub fn command_parts_for_harness_with_conversation(
                 &model_args,
                 &sandbox_args,
                 &launch_option_args,
+                // `--` before the prompt for the same reason as `prompt_args`:
+                // user data must not parse as harness flags.
                 args.into_iter()
-                    .chain(std::iter::once(effective_prompt))
+                    .chain(["--".to_string(), effective_prompt])
                     .collect(),
             ));
             return Ok((program, with_claude_permission_flags(harness_id, args)));
@@ -1389,11 +1394,17 @@ mod tests {
     fn command_parts_for_known_harnesses_append_interactive_prompt() -> anyhow::Result<()> {
         assert_eq!(
             command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::Interactive)?,
-            ("codex".to_string(), vec!["fix tests".to_string()])
+            (
+                "codex".to_string(),
+                vec!["--".to_string(), "fix tests".to_string()]
+            )
         );
         assert_eq!(
             command_parts_for_harness("claude", "polish ui", HarnessLaunchMode::Interactive)?,
-            ("claude".to_string(), vec!["polish ui".to_string()])
+            (
+                "claude".to_string(),
+                vec!["--".to_string(), "polish ui".to_string()]
+            )
         );
         Ok(())
     }
@@ -1409,6 +1420,7 @@ mod tests {
                     "--skip-git-repo-check".to_string(),
                     "--color".to_string(),
                     "never".to_string(),
+                    "--".to_string(),
                     "fix tests".to_string(),
                 ]
             )
@@ -1417,9 +1429,37 @@ mod tests {
             command_parts_for_harness("claude", "polish ui", HarnessLaunchMode::NonInteractive)?,
             (
                 "claude".to_string(),
-                vec!["--print".to_string(), "polish ui".to_string()]
+                vec![
+                    "--print".to_string(),
+                    "--".to_string(),
+                    "polish ui".to_string()
+                ]
             )
         );
+        Ok(())
+    }
+
+    #[test]
+    fn dash_prefixed_prompts_stay_positional_behind_double_dash() -> anyhow::Result<()> {
+        // A prompt starting with `-` must never parse as harness flags.
+        for mode in [
+            HarnessLaunchMode::Interactive,
+            HarnessLaunchMode::NonInteractive,
+        ] {
+            for harness in ["codex", "claude"] {
+                let (_, args) = command_parts_for_harness(harness, "--version; rm -rf /", mode)?;
+                let separator = args
+                    .iter()
+                    .position(|a| a == "--")
+                    .expect("args must contain the options terminator");
+                assert_eq!(args[separator + 1], "--version; rm -rf /");
+                assert_eq!(
+                    args.len(),
+                    separator + 2,
+                    "prompt must be the final argv entry"
+                );
+            }
+        }
         Ok(())
     }
 
@@ -1442,11 +1482,16 @@ mod tests {
 
         assert_eq!(
             spec.prompt_args("hello", HarnessLaunchMode::Interactive),
-            vec!["chat".to_string(), "hello".to_string()]
+            vec!["chat".to_string(), "--".to_string(), "hello".to_string()]
         );
         assert_eq!(
             spec.prompt_args("hello", HarnessLaunchMode::NonInteractive),
-            vec!["exec".to_string(), "-q".to_string(), "hello".to_string()]
+            vec![
+                "exec".to_string(),
+                "-q".to_string(),
+                "--".to_string(),
+                "hello".to_string()
+            ]
         );
     }
 
@@ -1515,6 +1560,7 @@ mod tests {
                     "coven".to_string(),
                     "-Q".to_string(),
                     "-q".to_string(),
+                    "--".to_string(),
                     "audit repo".to_string(),
                 ]
             )
@@ -1811,6 +1857,7 @@ mod tests {
                     "--print".to_string(),
                     "--session-id".to_string(),
                     "abc-123".to_string(),
+                    "--".to_string(),
                     "hello".to_string(),
                 ]
             )
@@ -1839,6 +1886,7 @@ mod tests {
                     "--print".to_string(),
                     "--resume".to_string(),
                     "abc-123".to_string(),
+                    "--".to_string(),
                     "follow up".to_string(),
                 ]
             )
@@ -1861,7 +1909,10 @@ mod tests {
         );
         assert_eq!(
             parts.unwrap(),
-            ("claude".to_string(), vec!["hello".to_string()])
+            (
+                "claude".to_string(),
+                vec!["--".to_string(), "hello".to_string()]
+            )
         );
         Ok(())
     }
@@ -1889,6 +1940,7 @@ mod tests {
                     "--skip-git-repo-check".to_string(),
                     "--color".to_string(),
                     "never".to_string(),
+                    "--".to_string(),
                     "fix tests".to_string(),
                 ]
             )
@@ -1920,6 +1972,7 @@ mod tests {
                     "never".to_string(),
                     "resume".to_string(),
                     "019e5998-7130-7872-8d96-a6b67c5b6406".to_string(),
+                    "--".to_string(),
                     "follow up".to_string(),
                 ]
             )
@@ -2041,6 +2094,7 @@ mod tests {
                 "--skip-git-repo-check".to_string(),
                 "--color".to_string(),
                 "never".to_string(),
+                "--".to_string(),
                 "fix tests".to_string(),
             ]
         );
@@ -2070,6 +2124,7 @@ mod tests {
                 "--model".to_string(),
                 "claude-sonnet-4".to_string(),
                 "--print".to_string(),
+                "--".to_string(),
                 "hi".to_string(),
             ]
         );
@@ -2095,6 +2150,7 @@ mod tests {
                 "--effort".to_string(),
                 "high".to_string(),
                 "--print".to_string(),
+                "--".to_string(),
                 "hi".to_string(),
             ]
         );
@@ -2302,6 +2358,7 @@ mod tests {
                 "--permission-mode".to_string(),
                 "bypassPermissions".to_string(),
                 "--print".to_string(),
+                "--".to_string(),
                 "hi".to_string(),
             ]
         );
@@ -2369,6 +2426,7 @@ mod tests {
                     "-c".to_string(),
                     "model=gpt-5.5".to_string(),
                     "run".to_string(),
+                    "--".to_string(),
                     "do it".to_string(),
                 ]
             )
@@ -2423,7 +2481,7 @@ mod tests {
             parts?,
             (
                 "plainadapter".to_string(),
-                vec!["run".to_string(), "do it".to_string()]
+                vec!["run".to_string(), "--".to_string(), "do it".to_string()]
             )
         );
         Ok(())

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -73,7 +73,9 @@ enum Command {
     Chat,
     #[command(about = "Open the interactive Coven UI (same as `coven chat`)")]
     Tui,
-    #[command(about = "Check local setup and print next steps")]
+    #[command(
+        about = "Check local setup and print next steps (exits 1 when a blocking problem is found)"
+    )]
     Doctor,
     #[command(
         name = "adapter",
@@ -209,7 +211,7 @@ enum Command {
         branch: Option<String>,
         #[arg(long, conflicts_with_all = ["doctor", "prune_merged", "prune_stale"], help = "List worktrees with claim and dirty state")]
         list: bool,
-        #[arg(long, conflicts_with_all = ["list", "prune_merged", "prune_stale"], help = "Report protocol layout and hook issues")]
+        #[arg(long, conflicts_with_all = ["list", "prune_merged", "prune_stale"], help = "Report protocol layout and hook issues (exits 1 when issues are found)")]
         doctor: bool,
         #[arg(long, conflicts_with_all = ["list", "doctor", "prune_stale"], help = "Remove clean worktrees whose branches are merged into the primary branch")]
         prune_merged: bool,
@@ -251,6 +253,11 @@ enum Command {
         session_id: String,
         #[arg(long, help = "Confirm permanent deletion")]
         yes: bool,
+    },
+    #[command(about = "Kill a running session's process (its event log is kept)")]
+    Kill {
+        #[arg(help = "Session id, or a unique prefix of one (list ids with `coven sessions`)")]
+        session_id: String,
     },
     #[command(about = "Guided repair flow for a registered repo")]
     Patch {
@@ -308,7 +315,9 @@ enum AdapterCommand {
         #[arg(long, help = "Print adapter reports as JSON")]
         json: bool,
     },
-    #[command(about = "Diagnose all adapters, or one adapter id")]
+    #[command(
+        about = "Diagnose all adapters, or one adapter id (exits 1 if any listed adapter is unavailable)"
+    )]
     Doctor {
         #[arg(help = "Adapter id to diagnose")]
         adapter: Option<String>,
@@ -515,6 +524,7 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Summon { session_id }) => summon_session_command(&session_id),
         Some(Command::Archive { session_id }) => archive_session_command(&session_id),
         Some(Command::Sacrifice { session_id, yes }) => sacrifice_session_command(&session_id, yes),
+        Some(Command::Kill { session_id }) => kill_session_command(&session_id),
         Some(Command::Patch {
             name,
             issue,
@@ -845,8 +855,14 @@ fn interactive_shell_route(
     }
 }
 
+/// Exits 1 when a blocking problem is found (stale daemon, broken registered
+/// repo, no harness available, missing coven-code) so scripts can gate on
+/// `coven doctor && …`. Individual missing harnesses print `[!!]` but don't
+/// fail the check while another harness is available — one working harness
+/// makes coven usable.
 fn run_doctor() -> Result<()> {
     let home = coven_home_dir()?;
+    let mut healthy = true;
     println!("Coven doctor");
     println!("Store: {}", home.display());
     match std::env::current_dir()
@@ -867,6 +883,7 @@ fn run_doctor() -> Result<()> {
             );
         }
         Some(daemon::DaemonStatusState::Stale(status)) => {
+            healthy = false;
             println!(
                 "  status=stale ok=false pid={} socket={}",
                 status.pid, status.socket
@@ -880,6 +897,9 @@ fn run_doctor() -> Result<()> {
         println!("\nRepos ({}):", repos_config::config_path(&home).display());
         for (name, path) in repos_config.entries() {
             let ok = path.is_dir() && path.join(".git").exists();
+            if !ok {
+                healthy = false;
+            }
             let marker = if ok { "OK" } else { "!!" };
             println!("  [{marker}] {name:<16} {}", path.display());
         }
@@ -904,11 +924,15 @@ fn run_doctor() -> Result<()> {
             println!("       {}", harness.install_hint);
         }
     }
+    if !harnesses.iter().any(|harness| harness.available) {
+        healthy = false;
+    }
 
     println!("\nInteractive UI:");
     match coven_code_binary() {
         Some(path) => println!("  [OK] coven-code found at {}", path.display()),
         None => {
+            healthy = false;
             println!("  [!!] coven-code is missing — `coven` and `coven chat` need it");
             for line in coven_code_install_instructions(target_shell()).lines() {
                 println!("     {line}");
@@ -931,6 +955,10 @@ fn run_doctor() -> Result<()> {
         println!(
             "  Install docs: https://github.com/OpenCoven/coven/blob/main/docs/install/index.md"
         );
+    }
+    if !healthy {
+        println!("\nDoctor found problems; review the failing checks above.");
+        exit_checks_failed();
     }
     Ok(())
 }
@@ -1047,7 +1075,7 @@ fn run_adapter_doctor(adapter: Option<&str>) -> Result<()> {
     }
 
     println!("Coven adapter doctor");
-    for harness in filtered {
+    for harness in &filtered {
         let marker = if harness.available { "OK" } else { "!!" };
         let status = if harness.available {
             "ready"
@@ -1064,6 +1092,10 @@ fn run_adapter_doctor(adapter: Option<&str>) -> Result<()> {
         if !harness.available {
             println!("       {}", harness.install_hint);
         }
+    }
+    if filtered.iter().any(|harness| !harness.available) {
+        println!("\nAdapter doctor found unavailable adapters; see the [!!] lines above.");
+        exit_checks_failed();
     }
     Ok(())
 }
@@ -1556,6 +1588,16 @@ fn should_synthesize_stream_user_event(
     harness_id: &str,
 ) -> bool {
     stream_json && !expanded_prompt.is_empty() && (detach || harness_id != "claude")
+}
+
+/// Doctor-style commands print their findings and exit 1 directly so scripts
+/// can gate on them (`coven doctor && …`); routing an Err through anyhow
+/// would append a redundant `Error:` line after output that already explains
+/// the failure.
+pub(crate) fn exit_checks_failed() -> ! {
+    let _ = io::stdout().flush();
+    let _ = io::stderr().flush();
+    std::process::exit(1);
 }
 
 /// Exit with the failed session's exit code so scripts can gate on
@@ -2052,7 +2094,7 @@ fn archive_session_command(session_id: &str) -> Result<()> {
     let session_id = session.id.as_str();
     if session.status == RUNNING_SESSION_STATUS {
         anyhow::bail!(
-            "session `{session_id}` is still running; stop it before archiving ({STALE_RUNNING_HINT})"
+            "session `{session_id}` is still running; kill it first with `coven kill {session_id}` ({STALE_RUNNING_HINT})"
         );
     }
     if session.archived_at.is_some() {
@@ -2104,7 +2146,7 @@ fn sacrifice_session_command(session_id: &str, yes: bool) -> Result<()> {
     let session_id = session.id.as_str();
     if session.status == RUNNING_SESSION_STATUS {
         anyhow::bail!(
-            "session `{session_id}` is still running; do not sacrifice live work ({STALE_RUNNING_HINT})"
+            "session `{session_id}` is still running; do not sacrifice live work — kill it first with `coven kill {session_id}` ({STALE_RUNNING_HINT})"
         );
     }
     confirm_sacrifice(session_id, yes)?;
@@ -2122,6 +2164,52 @@ fn confirm_sacrifice(session_id: &str, yes: bool) -> Result<()> {
             "sacrifice permanently deletes session `{session_id}` and its events; rerun with --yes to confirm"
         )
     }
+}
+
+/// Kill a running session's harness process through the daemon (which owns
+/// the PTY), then let the daemon record the `killed` status and kill event.
+/// Store-only verbs like archive/sacrifice can't do this: killing needs the
+/// live runtime.
+fn kill_session_command(session_id: &str) -> Result<()> {
+    let home = coven_home_dir()?;
+    let conn = store::open_store(&home.join(STORE_FILE_NAME))?;
+    let session = resolve_session_ref(&conn, session_id)?;
+    let session_id = session.id.as_str();
+    if session.status != RUNNING_SESSION_STATUS {
+        anyhow::bail!(
+            "session `{session_id}` is not running (status: {}); only running sessions can be killed",
+            session.status
+        );
+    }
+
+    post_session_kill(&home, session_id)?;
+    println!("killed session {session_id}");
+    println!(
+        "Its event log is kept; archive it with `coven archive {session_id}` once you are done with it."
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+fn post_session_kill(coven_home: &Path, session_id: &str) -> Result<()> {
+    let status = post_daemon_request(coven_home, &format!("/sessions/{session_id}/kill"), "{}")
+        .with_context(|| format!("failed to reach the Coven daemon; {}", STALE_RUNNING_HINT))?;
+    match status {
+        200..=299 => Ok(()),
+        // The store said running but the daemon has no live process: the
+        // status is stale (process died externally, or the daemon restarted
+        // without recovering it).
+        409 => anyhow::bail!(
+            "the daemon has no live process for session `{session_id}`; {}",
+            STALE_RUNNING_HINT
+        ),
+        status => anyhow::bail!("Coven daemon rejected the kill with HTTP {status}"),
+    }
+}
+
+#[cfg(not(unix))]
+fn post_session_kill(_coven_home: &Path, _session_id: &str) -> Result<()> {
+    anyhow::bail!("`coven kill` is only implemented on Unix-like systems for now")
 }
 
 fn attach_session(session_id: &str) -> Result<()> {
@@ -2216,12 +2304,29 @@ fn maybe_spawn_input_forwarder(coven_home: PathBuf, session_id: String) {
 
 #[cfg(unix)]
 fn send_session_input(coven_home: &Path, session_id: &str, data: &str) -> Result<()> {
+    let body = serde_json::json!({ "data": data }).to_string();
+    let status = post_daemon_request(coven_home, &format!("/sessions/{session_id}/input"), &body)?;
+    if (200..300).contains(&status) {
+        Ok(())
+    } else {
+        anyhow::bail!("Coven daemon rejected input with HTTP {status}")
+    }
+}
+
+#[cfg(not(unix))]
+fn send_session_input(_coven_home: &Path, _session_id: &str, _data: &str) -> Result<()> {
+    anyhow::bail!("Coven attach input forwarding is only implemented on Unix-like systems for now")
+}
+
+/// POST a JSON body to the daemon's Unix-socket HTTP API and return the
+/// response status code. Callers map status codes to their own error copy.
+#[cfg(unix)]
+fn post_daemon_request(coven_home: &Path, path: &str, body: &str) -> Result<u16> {
     use std::os::unix::net::UnixStream;
 
     let socket = daemon::daemon_socket_path(coven_home);
-    let body = serde_json::json!({ "data": data }).to_string();
     let request = format!(
-        "POST /sessions/{session_id}/input HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        "POST {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
         body.len(),
         body
     );
@@ -2233,35 +2338,25 @@ fn send_session_input(coven_home: &Path, session_id: &str, data: &str) -> Result
     })?;
     stream
         .write_all(request.as_bytes())
-        .context("failed to write Coven input request")?;
+        .context("failed to write Coven daemon request")?;
     stream
         .shutdown(std::net::Shutdown::Write)
-        .context("failed to finish Coven input request")?;
+        .context("failed to finish Coven daemon request")?;
     let mut response = String::new();
     stream
         .read_to_string(&mut response)
-        .context("failed to read Coven input response")?;
-    ensure_successful_http_response(&response)
-}
-
-#[cfg(not(unix))]
-fn send_session_input(_coven_home: &Path, _session_id: &str, _data: &str) -> Result<()> {
-    anyhow::bail!("Coven attach input forwarding is only implemented on Unix-like systems for now")
+        .context("failed to read Coven daemon response")?;
+    parse_http_status(&response)
 }
 
 #[cfg(unix)]
-fn ensure_successful_http_response(response: &str) -> Result<()> {
-    let status = response
+fn parse_http_status(response: &str) -> Result<u16> {
+    response
         .lines()
         .next()
         .and_then(|line| line.split_whitespace().nth(1))
         .and_then(|status| status.parse::<u16>().ok())
-        .context("invalid Coven daemon response")?;
-    if (200..300).contains(&status) {
-        Ok(())
-    } else {
-        anyhow::bail!("Coven daemon rejected input with HTTP {status}")
-    }
+        .context("invalid Coven daemon response")
 }
 
 fn selected_available_harness(harness_id: &str) -> Result<harness::HarnessSummary> {
@@ -3281,9 +3376,16 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn successful_http_response_accepts_2xx_only() {
-        assert!(ensure_successful_http_response("HTTP/1.1 202 Accepted\r\n\r\n{}").is_ok());
-        assert!(ensure_successful_http_response("HTTP/1.1 409 Conflict\r\n\r\n{}").is_err());
+    fn daemon_response_status_line_parses_to_code() {
+        assert_eq!(
+            parse_http_status("HTTP/1.1 202 Accepted\r\n\r\n{}").ok(),
+            Some(202)
+        );
+        assert_eq!(
+            parse_http_status("HTTP/1.1 409 Conflict\r\n\r\n{}").ok(),
+            Some(409)
+        );
+        assert!(parse_http_status("garbage").is_err());
     }
 
     #[test]

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -252,24 +252,33 @@ fn wt_doctor(repo: &Repo) -> Result<()> {
     println!("repo: {}", repo.root.display());
     println!("worktree root: {}", worktree_root(repo)?.display());
     println!("claims: {}", repo.common_dir.join("agent-claims").display());
+    let mut hooks_missing = false;
     for hook in ["pre-commit", "pre-push"] {
         let path = repo.common_dir.join("hooks").join(hook);
-        let status = if hook_is_managed(&path)? {
-            "OK"
-        } else {
-            "missing"
-        };
+        let managed = hook_is_managed(&path)?;
+        if !managed {
+            hooks_missing = true;
+        }
+        let status = if managed { "OK" } else { "missing" };
         println!("hook {hook}: {status}");
     }
+    if hooks_missing {
+        println!("install the managed hooks with `coven hooks install`");
+    }
+    let mut layout_ok = true;
     for worktree in list_worktrees()? {
         let expected_root = worktree_root(repo)?;
         if worktree.path != repo.root && !worktree.path.starts_with(&expected_root) {
+            layout_ok = false;
             println!(
                 "layout warning: {} is outside {}",
                 worktree.path.display(),
                 expected_root.display()
             );
         }
+    }
+    if hooks_missing || !layout_ok {
+        crate::exit_checks_failed();
     }
     Ok(())
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -225,6 +225,9 @@ fn stream_claude_with_program_and_permission_bypass<W: Write>(
     } else {
         args.extend(["--session-id".to_string(), session_id.to_string()]);
     }
+    // `--` keeps a user prompt starting with `-` from parsing as claude flags
+    // (same shield as `HarnessCommandSpec::prompt_args`).
+    args.push("--".to_string());
     args.push(prompt.to_string());
     let args = crate::harness::sanitize_argv_for_platform(args);
 
@@ -673,7 +676,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(command.program(), "codex");
-        assert_eq!(command.args(), &["hello; rm -rf /"]);
+        assert_eq!(command.args(), &["--", "hello; rm -rf /"]);
         assert_eq!(command.cwd(), cwd);
     }
 
@@ -749,7 +752,7 @@ exit 7
         // which is the bug this commit fixes.
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\n--\nhello prompt\n"
         );
         assert_eq!(
             String::from_utf8(out)?,
@@ -795,7 +798,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
+            "-p\n--input-format\nstream-json\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\n--\nhello prompt\n"
         );
         Ok(())
     }
@@ -835,7 +838,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\nhello prompt\n"
+            "-p\n--permission-mode\nbypassPermissions\n--output-format\nstream-json\n--verbose\n--session-id\nsession-456\n--\nhello prompt\n"
         );
         Ok(())
     }
@@ -878,7 +881,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\nhello again\n"
+            "-p\n--output-format\nstream-json\n--verbose\n--resume\nsession-789\n--\nhello again\n"
         );
         Ok(())
     }
@@ -921,7 +924,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--model\nclaude-sonnet-4\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--model\nclaude-sonnet-4\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\n--\nhello prompt\n"
         );
         Ok(())
     }
@@ -963,7 +966,7 @@ exit 0
 
         assert_eq!(
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
-            "-p\n--effort\nhigh\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\nhello prompt\n"
+            "-p\n--effort\nhigh\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\n--\nhello prompt\n"
         );
         Ok(())
     }
@@ -1086,9 +1089,9 @@ exit 0
 
         assert_eq!(command.program(), "claude");
         #[cfg(windows)]
-        assert_eq!(command.args(), &["\"explain ^&^& exit\""]);
+        assert_eq!(command.args(), &["--", "\"explain ^&^& exit\""]);
         #[cfg(not(windows))]
-        assert_eq!(command.args(), &["explain && exit"]);
+        assert_eq!(command.args(), &["--", "explain && exit"]);
         assert_eq!(command.cwd(), cwd);
     }
 }

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -250,7 +250,11 @@ role = "Voice, Social, and Presence Familiar"
 description = "Keeps the coven sociable."
 "#,
     )?;
-    let path = std::env::var_os("PATH").unwrap_or_default();
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin)?;
+    write_fake_codex(&fake_bin)?;
+    write_fake_coven_code(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
     let coven = coven_bin();
 
     let output = run_coven(&coven, &coven_home, &path, &["doctor"])?;
@@ -271,7 +275,11 @@ fn doctor_reports_no_familiars_when_manifest_absent() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
     fs::create_dir_all(&coven_home)?;
-    let path = std::env::var_os("PATH").unwrap_or_default();
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin)?;
+    write_fake_codex(&fake_bin)?;
+    write_fake_coven_code(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
     let coven = coven_bin();
 
     let output = run_coven(&coven, &coven_home, &path, &["doctor"])?;
@@ -292,7 +300,14 @@ fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<(
 
     let output = run_coven(&coven, &coven_home, &empty_path, &["doctor"])?;
 
-    assert_success("doctor without harnesses", &output);
+    // No harness available is a blocking problem: doctor must exit 1 so
+    // scripts can gate on it, while still printing the full setup loop.
+    assert_failure("doctor without harnesses", &output);
+    assert_stdout_contains(
+        "doctor without harnesses",
+        &output,
+        "Doctor found problems; review the failing checks above.",
+    );
     assert_stdout_contains("doctor without harnesses", &output, "Harnesses:");
     assert_stdout_contains("doctor without harnesses", &output, "`codex` is missing");
     assert_stdout_contains("doctor without harnesses", &output, "`claude` is missing");
@@ -319,7 +334,11 @@ fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<(
 fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
-    let path = std::env::var_os("PATH").unwrap_or_default();
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin)?;
+    write_fake_codex(&fake_bin)?;
+    write_fake_coven_code(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
     let coven = coven_bin();
     let _daemon_guard = DaemonGuard {
         coven: coven.clone(),
@@ -364,9 +383,16 @@ fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
 
     let doctor = run_coven(&coven, &coven_home, &path, &["adapter", "doctor", "hermes"])?;
 
-    assert_success("adapter doctor hermes", &doctor);
+    // The hermes executable is not installed, so adapter doctor reports it
+    // and exits 1 (the diagnosis output still renders in full).
+    assert_failure("adapter doctor hermes", &doctor);
     assert_stdout_contains("adapter doctor hermes", &doctor, "Hermes Agent");
     assert_stdout_contains("adapter doctor hermes", &doctor, "manifest:");
+    assert_stdout_contains(
+        "adapter doctor hermes",
+        &doctor,
+        "Adapter doctor found unavailable adapters",
+    );
     Ok(())
 }
 
@@ -529,14 +555,15 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
     )?;
     wait_for_event_text(&coven_home, &kill_session, "fake codex ready for kill")?;
 
-    let (kill_status, kill_body) = unix_http_request(
-        &coven_home,
-        "POST",
-        &format!("/sessions/{kill_session}/kill"),
-        None,
-    )?;
-    assert_eq!(kill_status, 202, "unexpected kill response: {kill_body}");
+    let kill = run_coven(&coven, &coven_home, &path, &["kill", &kill_session])?;
+    assert_success("kill", &kill);
+    assert_stdout_contains("kill", &kill, "killed session");
     wait_for_session_status(&coven_home, &kill_session, "killed")?;
+
+    // A second kill must refuse: the session is no longer running.
+    let rekill = run_coven(&coven, &coven_home, &path, &["kill", &kill_session])?;
+    assert_failure("rekill refused", &rekill);
+    assert_stderr_contains("rekill refused", &rekill, "is not running");
 
     let archive = run_coven(&coven, &coven_home, &path, &["archive", &kill_session])?;
     assert_success("archive", &archive);
@@ -649,6 +676,24 @@ fn assert_success(label: &str, output: &Output) {
     );
 }
 
+fn assert_failure(label: &str, output: &Output) {
+    assert!(
+        !output.status.success(),
+        "{label} unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_stderr_contains(label: &str, output: &Output, needle: &str) {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(needle),
+        "{label} stderr did not contain {needle:?}\nstdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
 fn assert_stdout_contains(label: &str, output: &Output, needle: &str) {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -680,6 +725,9 @@ fn write_fake_codex(fake_bin: &Path) -> anyhow::Result<()> {
     fs::write(
         &codex,
         r#"#!/bin/sh
+# Consume the options terminator like the real CLI: coven passes prompts
+# behind `--` so dash-prefixed prompts stay positional.
+if [ "$1" = "--" ]; then shift; fi
 if [ "$*" = "hold-for-kill" ]; then
   printf 'fake codex ready for kill\n'
   exec sleep 300
@@ -690,6 +738,17 @@ printf 'fake codex complete: %s\n' "$*"
     let mut permissions = fs::metadata(&codex)?.permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&codex, permissions)?;
+    Ok(())
+}
+
+/// Doctor exits 1 when coven-code is missing, so doctor tests that expect a
+/// healthy environment plant a fake alongside the fake harness.
+fn write_fake_coven_code(fake_bin: &Path) -> anyhow::Result<()> {
+    let coven_code = fake_bin.join("coven-code");
+    fs::write(&coven_code, "#!/bin/sh\nexit 0\n")?;
+    let mut permissions = fs::metadata(&coven_code)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&coven_code, permissions)?;
     Ok(())
 }
 

--- a/docs/help/session-stuck.md
+++ b/docs/help/session-stuck.md
@@ -49,6 +49,16 @@ coven sessions --plain --all
 
 ## Safe cleanup choices
 
+Kill stops a running session's harness process while keeping its event log:
+
+```sh
+coven kill <session-id>
+```
+
+If kill reports the session is not live even though `coven sessions` says
+`running`, the process died externally; `coven daemon restart` marks it
+orphaned.
+
 Archive hides a completed session without deleting events:
 
 ```sh

--- a/docs/reference/cli-archive.md
+++ b/docs/reference/cli-archive.md
@@ -17,8 +17,8 @@ of the active list without deleting their history.
 
 ## Behavior
 
-`coven archive` refuses a running session. Stop or let the harness finish before
-archiving.
+`coven archive` refuses a running session. Kill it first with
+`coven kill <session-id>`, or let the harness finish before archiving.
 
 For a non-running session, archive sets the session's `archived_at` timestamp and
 preserves the session record plus append-only event log. The session disappears

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -93,6 +93,19 @@ coven daemon start
 
 ## Exit behavior
 
-`coven doctor` should exit successfully when it can inspect the environment,
-even if it reports missing harnesses or a stopped daemon. Treat the printed
-status as the diagnostic result.
+`coven doctor` exits `0` when the environment can run Coven end to end, so
+scripts can gate on it (`coven doctor && …`). It exits `1` when it finds a
+blocking problem:
+
+- no supported harness is available on `PATH`
+- the daemon is stale (`running` and `stopped` are both healthy states)
+- a registered repo entry points at a missing or non-git path
+- `coven-code` is missing
+
+A missing harness prints a `[!!]` line with an install hint but does not fail
+the check while another harness is available — one working harness makes Coven
+usable.
+
+`coven adapter doctor` is stricter about its own subject: it exits `1` if any
+listed adapter is unavailable. `coven wt --doctor` exits `1` when managed hooks
+are missing or a worktree sits outside the protocol layout.

--- a/docs/reference/cli-kill.md
+++ b/docs/reference/cli-kill.md
@@ -1,0 +1,53 @@
+---
+summary: "Kill a running session's process."
+read_when:
+  - Looking up kill
+title: "coven kill"
+description: "Reference for coven kill: stop a running session's harness process through the daemon while keeping the session record and its event log."
+---
+
+## Usage
+
+```bash
+coven kill <session-id>
+```
+
+Kill stops a running session's harness process. The daemon (which owns the
+process) performs the kill, marks the session `killed`, and records a kill
+event. The session record and its append-only event log are kept.
+
+## Behavior
+
+`coven kill` only acts on running sessions. For anything else it refuses:
+
+```text
+session `<session-id>` is not running (status: completed); only running sessions can be killed
+```
+
+After a kill, the session shows up as `killed` in `coven sessions`. Clean it up
+like any other finished session:
+
+```bash
+coven archive <session-id>
+coven sacrifice <session-id> --yes
+```
+
+## Stale "running" sessions
+
+A session whose process died externally keeps `status=running` until daemon
+startup recovery marks it orphaned. If `coven kill` cannot reach a live
+process for the session, run:
+
+```bash
+coven daemon restart
+```
+
+then check `coven sessions` again.
+
+## Related
+
+- [Session lifecycle](/SESSION-LIFECYCLE)
+- [Sessions](/reference/cli-sessions)
+- [Attach](/reference/cli-attach)
+- [Archive](/reference/cli-archive)
+- [Sacrifice](/reference/cli-sacrifice)

--- a/docs/reference/cli-sacrifice.md
+++ b/docs/reference/cli-sacrifice.md
@@ -24,11 +24,12 @@ to rerun with confirmation.
 The command also refuses live sessions:
 
 ```text
-session `<session-id>` is still running; do not sacrifice live work
+session `<session-id>` is still running; do not sacrifice live work — kill it first with `coven kill <session-id>`
 ```
 
 Use `coven attach <session-id>` or `coven daemon status` first if you are not
-sure whether the harness is still running.
+sure whether the harness is still running. If the session really should stop,
+`coven kill <session-id>` ends its process while keeping the event log.
 
 ## What gets deleted
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -21,6 +21,7 @@ flowchart TB
   Root --> Summon["summon"]
   Root --> Archive["archive"]
   Root --> Sacrifice["sacrifice"]
+  Root --> Kill["kill"]
   Root --> Patch["patch"]
   Root --> Logs["logs"]
   Root --> Wt["wt"]
@@ -71,7 +72,7 @@ flowchart TB
 |---|---|
 | `coven` | Open the beginner-friendly interactive menu. |
 | `coven tui` | Explicitly open the slash-command TUI. |
-| `coven doctor` | Detect supported harness CLIs and print install hints. |
+| `coven doctor` | Check local setup; exits 1 when a blocking problem is found. |
 | `coven daemon start/status/restart/stop` | Manage the local daemon. |
 | `coven run <harness> <prompt>` | Launch a project-scoped harness session. Current harness ids: `codex`, `claude`. |
 | `coven sessions` | Open the session browser; supports `--plain`, `--json`, `--all`, and `--manage`. |
@@ -79,6 +80,7 @@ flowchart TB
 | `coven summon <session-id>` | Restore an archived session, then replay/follow it. |
 | `coven archive <session-id>` | Hide a non-running session while preserving events. |
 | `coven sacrifice <session-id> --yes` | Permanently delete a non-running session. |
+| `coven kill <session-id>` | Kill a running session's process; keeps the event log. |
 | `coven patch openclaw <prompt>` | Local OpenClaw rescue loop. Does not commit or push. |
 | `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs. |
 | `coven wt <branch>` | Create or enter a sibling `<repo>.wt/<branch-slug>` git worktree. |
@@ -106,7 +108,7 @@ flowchart TB
 
 - **Project-scoped commands** accept `--cwd <path>` for a launch directory inside the project root.
 - **Machine-readable output** is per-command today: `coven sessions` accepts `--plain` and `--json`; `coven sessions search`, `coven adapter list`, and `coven pc status` accept `--json`. Other tabular commands (`wt --list`, `claim status`, `daemon status`, `pc top`, `pc disk`) print human tables only.
-- **Session id arguments** (`attach`, `summon`, `archive`, `sacrifice`) accept a unique prefix of the id.
+- **Session id arguments** (`attach`, `summon`, `archive`, `sacrifice`, `kill`) accept a unique prefix of the id.
 - **Destructive commands** require `--yes` (or `--confirm` for `coven pc` relief).
 - **Daemon-touching commands** print install/repair hints when the socket is missing.
 

--- a/docs/rituals/index.md
+++ b/docs/rituals/index.md
@@ -19,6 +19,9 @@ Rituals are Coven's human-friendly session-management verbs. Ritual names are pr
   <Card title="Sacrifice" href="/rituals/sacrifice" icon="flame">
     Permanently delete a non-running session and its events.
   </Card>
+  <Card title="Kill" href="/reference/cli-kill" icon="octagon-x">
+    Stop a running session's process. Events preserved.
+  </Card>
 </Columns>
 
 ## Why ritual names?
@@ -38,12 +41,14 @@ Plain `delete` would invite muscle-memory mistakes. Plain `hide` would lose the 
 | Archive | yes, refuses live | yes, via summon | no |
 | Summon | n/a | n/a | no |
 | Sacrifice | yes, refuses live | **no** | requires `--yes` |
+| Kill | only acts on live | events preserved | no |
 
-The session browser surfaces every ritual as a labeled action. The CLI exposes them as explicit verbs (`coven archive <id>`, `coven summon <id>`, `coven sacrifice <id> --yes`).
+The session browser surfaces every ritual as a labeled action. The CLI exposes them as explicit verbs (`coven archive <id>`, `coven summon <id>`, `coven sacrifice <id> --yes`, `coven kill <id>`).
 
 ## Related
 
 - [Session lifecycle](/sessions/lifecycle)
+- [CLI: coven kill](/reference/cli-kill)
 - [CLI: coven archive](/reference/cli-archive)
 - [CLI: coven summon](/reference/cli-summon)
 - [CLI: coven sacrifice](/reference/cli-sacrifice)

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -189,7 +189,18 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
   }
   console.log(`coven --version => ${versionOutput.stdout.trim()}`);
 
-  const doctorOutput = runCapture(wrapperBin, ['doctor'], { env: smokeEnv });
+  // A bare runner has no harness installed, so doctor correctly reports a
+  // blocking problem and exits 1. The smoke asserts the first-run report,
+  // not a provisioned environment.
+  const doctorOutput = runCapture(wrapperBin, ['doctor'], {
+    env: smokeEnv,
+    allowedExitCodes: [1]
+  });
+  if (doctorOutput.status !== 1) {
+    fail(
+      `\`coven doctor\` on a bare runner should exit 1 (no harness available); got ${doctorOutput.status}\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`
+    );
+  }
   if (!doctorOutput.stdout.includes('Coven doctor')) {
     fail(
       `\`coven doctor\` did not print the expected banner.\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`
@@ -198,13 +209,14 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
   for (const expected of [
     'Install and authenticate at least one harness in this same shell',
     'npm install -g @openai/codex && codex login',
-    'npm install -g @anthropic-ai/claude-code && claude doctor'
+    'npm install -g @anthropic-ai/claude-code && claude doctor',
+    'Doctor found problems; review the failing checks above.'
   ]) {
     if (!doctorOutput.stdout.includes(expected)) {
       fail(`\`coven doctor\` missing first-run setup guidance "${expected}".\nstdout:\n${doctorOutput.stdout}\nstderr:\n${doctorOutput.stderr}`);
     }
   }
-  console.log('coven doctor first-run setup guidance present');
+  console.log('coven doctor first-run setup guidance present (exit 1 on bare runner)');
 
   const helpOutput = runCapture(wrapperBin, ['--help'], { env: smokeEnv });
   if (helpOutput.status !== 0) {
@@ -377,7 +389,7 @@ function runCapture(command, commandArgs, options = {}) {
   if (result.error) {
     fail(`${printable} failed: ${result.error.message}`);
   }
-  if (result.status !== 0) {
+  if (result.status !== 0 && !(options.allowedExitCodes ?? []).includes(result.status)) {
     fail(`${printable} exited with ${result.status}\nstderr:\n${result.stderr}`);
   }
   return result;


### PR DESCRIPTION
Lands the top three deferred follow-ups from the #297 UX audit (items 2–4 of the PR body's follow-up list).

## 1. Prompts ride behind `--` (argv injection)

Cast/run passed user prompts as raw argv, so a prompt starting with `-` reached codex/claude as flags. Every spawn site now inserts an options terminator before the prompt:

- `HarnessCommandSpec::prompt_args` (interactive + non-interactive paths, all adapters)
- the conversation-continuity path (`--resume`/`exec resume` turns)
- the claude stream-json one-shot path in `pty_runner`

New regression test asserts a `--version; rm -rf /` prompt stays the final positional for both built-in harnesses in both launch modes. The fake-codex smoke fixture consumes `--` the way the real CLIs do.

## 2. `coven kill <session-id>`

The daemon already had `POST /sessions/:id/kill` (and the TUI a `/kill` command), but the CLI had no stop verb — the archive/sacrifice "still running" refusals were a documented dead end. Now:

- `coven kill` resolves id prefixes (same `resolve_session_ref` as the other rituals), refuses non-running sessions with the status named, and kills through the daemon socket (transport factored out of `send_session_input` into `post_daemon_request`).
- A 409 from the daemon (store says running, no live process) maps to the stale-session remedy (`coven daemon restart`).
- Archive/sacrifice refusals now say `kill it first with \`coven kill <id>\``.
- The rituals smoke test drives kill → rekill-refusal → archive → summon → sacrifice end to end through the CLI verb.

## 3. Doctor commands exit 1 on failure

`doctor`, `adapter doctor`, and `wt --doctor` always exited 0, so scripts couldn't gate on them. Semantics:

- **`coven doctor`** — exits 1 on blocking problems: no harness available, stale daemon, broken registered repo entry, missing coven-code. A missing harness still prints `[!!]` + hint but doesn't fail while another harness works (one working harness makes coven usable; matches the Next-steps logic).
- **`coven adapter doctor`** — exits 1 if any listed adapter is unavailable (the subject *is* the adapter).
- **`coven wt --doctor`** — exits 1 on missing managed hooks (now prints the `coven hooks install` remedy) or layout violations.

Help text declares the exit semantics; `docs/reference/cli-doctor.md`'s "Exit behavior" section (which documented the old always-0 behavior) is rewritten. Doctor smoke tests now plant fake `codex`/`coven-code` binaries so exit codes are deterministic on CI and dev machines.

## Docs

`reference/cli.md` (tree, tables, prefix note), new `reference/cli-kill.md`, `rituals/index.md` (kill card + safety row), `reference/cli-archive.md`, `reference/cli-sacrifice.md`, `reference/cli-doctor.md`, `help/session-stuck.md`. English docs only; ru/es translations not touched.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked` (924 unit + integration incl. updated smoke suite), `scripts/check-secrets.py` — all green.
- Hands-on against a scratch `COVEN_HOME`: `kill --help`, unknown-id refusal (exit 1 with remedy), doctor with empty PATH prints the setup loop and exits 1.

## Remaining follow-ups from #297 (still open)

stream-json PTY pollution on non-claude harnesses (#1), `--json` coverage gaps (#5), shell completions / color override (#6), legacy chat TUI issues (#7), misc polish (#8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)