### PR TITLE
fix: keep --stream-json stdout JSONL-only on non-claude harnesses

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1978,16 +1978,42 @@ fn run_session(
         .as_ref()
         .filter(|s| s.system_prompt_flag.is_some())
         .and(familiar_ctx.as_ref());
+    // Stream mode's stdout contract is JSONL-only, so it always launches the
+    // one-shot non-interactive entrypoint regardless of TTY detection — an
+    // interactive TUI behind a JSONL pipe would be garbage either way.
+    let launch_mode = if stream_json {
+        harness::HarnessLaunchMode::NonInteractive
+    } else {
+        harness_launch_mode_for_stdio()
+    };
     let command = pty_runner::build_harness_command_with_conversation(
         &selected_harness.id,
         &effective_prompt,
         &cwd,
-        harness_launch_mode_for_stdio(),
+        launch_mode,
         conversation_hint.as_ref(),
         familiar_for_args,
         launch_options,
     )?;
-    match pty_runner::run_attached(&command) {
+    // Stream mode captures the harness instead of attaching it to the PTY:
+    // raw harness bytes on stdout would interleave with the JSONL frames and
+    // corrupt the stream for every consumer (#307). The captured text is
+    // re-emitted below as an `assistant` frame.
+    let (run_result, captured_output) = if stream_json {
+        match pty_runner::run_captured(&command) {
+            Ok(captured) => (
+                Ok(pty_runner::PtyRunResult {
+                    status: captured.status,
+                    exit_code: captured.exit_code,
+                }),
+                Some(captured.output),
+            ),
+            Err(error) => (Err(error), None),
+        }
+    } else {
+        (pty_runner::run_attached(&command), None)
+    };
+    match run_result {
         Ok(result) => {
             store::update_session_status(
                 &conn,
@@ -1997,6 +2023,18 @@ fn run_session(
                 &current_timestamp(),
             )?;
             if stream_json {
+                if let Some(text) = captured_output.filter(|text| !text.trim().is_empty()) {
+                    emit_stream_event(&stream_json::Event::Assistant(
+                        stream_json::AssistantMessage {
+                            message: stream_json::MessageBody {
+                                role: "assistant".into(),
+                                content: vec![stream_json::ContentBlock::Text { text }],
+                            },
+                            session_id: record.id.clone(),
+                            stop_reason: None,
+                        },
+                    ))?;
+                }
                 let is_error = result.exit_code.is_some_and(|c| c != 0);
                 emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
                     subtype: if is_error {

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -101,6 +101,59 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
     run_attached_with_pty_system(command, pty_system.as_ref())
 }
 
+/// Result of a fully captured (no-PTY) one-shot harness run. Stream-json
+/// callers wrap `output` into JSONL events; this function writes nothing to
+/// the parent's stdout.
+pub struct CapturedRunResult {
+    pub status: &'static str,
+    pub exit_code: Option<i32>,
+    pub output: String,
+}
+
+/// Run `command` to completion with stdout captured and stdin closed. Used
+/// by `coven run --stream-json` on harnesses without a native stream-json
+/// mode: the documented stdout contract is JSONL-only, so harness output
+/// must never reach stdout directly. No PTY is allocated — the harness sees
+/// plain pipes (the non-interactive entrypoints already disable color), so
+/// the capture stays free of ANSI echo. Captured stderr is forwarded to the
+/// parent's stderr — out of band of the stream contract — so auth/setup
+/// errors stay visible.
+pub fn run_captured(command: &HarnessCommand) -> Result<CapturedRunResult> {
+    let output = std::process::Command::new(&command.program)
+        .args(&command.args)
+        .current_dir(&command.cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to spawn harness `{}` in captured mode",
+                command.program
+            )
+        })?;
+
+    if !output.stderr.is_empty() {
+        let mut stderr = io::stderr().lock();
+        let _ = stderr.write_all(&output.stderr);
+        let _ = stderr.flush();
+    }
+
+    // A signal-killed child reports no code; map it to exit 1 so the result
+    // event and script gating register the failure.
+    let exit_code = Some(output.status.code().unwrap_or(1));
+    let status = if output.status.success() {
+        "completed"
+    } else {
+        "failed"
+    };
+    Ok(CapturedRunResult {
+        status,
+        exit_code,
+        output: String::from_utf8_lossy(&output.stdout).into_owned(),
+    })
+}
+
 /// Run `claude` in its native stream-JSON mode, framed by the caller (which
 /// emits Coven's own `system.init` / `result` around the call).
 ///

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -360,6 +360,71 @@ fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
 }
 
 #[test]
+fn stream_json_on_non_claude_harness_keeps_stdout_jsonl_only() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin)?;
+    write_fake_codex(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
+    let coven = coven_bin();
+
+    let output = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["run", "codex", "--stream-json", "hello stream"],
+    )?;
+
+    assert_success("stream-json codex run", &output);
+
+    // The core #307 contract: every stdout line is a JSON frame — no raw
+    // harness bytes interleaved.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let frames: Vec<Value> = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            serde_json::from_str(line).unwrap_or_else(|error| {
+                panic!(
+                    "non-JSON line on stream-json stdout: {line:?} ({error})\nfull stdout:\n{stdout}"
+                )
+            })
+        })
+        .collect();
+
+    assert_eq!(
+        frames
+            .first()
+            .map(|f| (f["type"].clone(), f["subtype"].clone())),
+        Some(("system".into(), "init".into())),
+        "first frame must be system/init: {frames:?}"
+    );
+    let user = frames
+        .iter()
+        .find(|f| f["type"] == "user")
+        .expect("stream must contain the synthesized user frame");
+    assert_eq!(user["message"]["content"][0]["text"], "hello stream");
+    let assistant = frames
+        .iter()
+        .find(|f| f["type"] == "assistant")
+        .expect("captured harness output must surface as an assistant frame");
+    let assistant_text = assistant["message"]["content"][0]["text"]
+        .as_str()
+        .expect("assistant frame carries text content");
+    assert!(
+        assistant_text.contains("fake codex complete"),
+        "assistant frame should carry the harness output; got {assistant_text:?}"
+    );
+    let last = frames.last().expect("stream must end with a result frame");
+    assert_eq!(last["type"], "result");
+    assert_eq!(last["subtype"], "success");
+    assert_eq!(last["is_error"], false);
+    Ok(())
+}
+
+#[test]
 fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -381,10 +446,16 @@ fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     );
     assert!(coven_home.join("adapters").join("hermes.json").exists());
 
-    let doctor = run_coven(&coven, &coven_home, &path, &["adapter", "doctor", "hermes"])?;
+    // Diagnose against an empty PATH so the outcome doesn't depend on
+    // whether a real `hermes` happens to be installed on this machine:
+    // unavailable → exit 1, with the diagnosis output still rendered in full.
+    let doctor = run_coven(
+        &coven,
+        &coven_home,
+        &OsString::new(),
+        &["adapter", "doctor", "hermes"],
+    )?;
 
-    // The hermes executable is not installed, so adapter doctor reports it
-    // and exits 1 (the diagnosis output still renders in full).
     assert_failure("adapter doctor hermes", &doctor);
     assert_stdout_contains("adapter doctor hermes", &doctor, "Hermes Agent");
     assert_stdout_contains("adapter doctor hermes", &doctor, "manifest:");

--- a/docs/STREAM-JSON.md
+++ b/docs/STREAM-JSON.md
@@ -21,7 +21,11 @@ Code work unchanged against Coven CLI.
 {"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]},"session_id":"...","parent_tool_use_id":null}
 ```
 
-### `assistant` - emitted by stream-capable harnesses (claude)
+### `assistant` - harness output
+
+Stream-capable harnesses (claude) emit these incrementally; non-stream
+harnesses produce one `assistant` event carrying their captured text output
+(see "Harness behavior" below).
 
 ```json
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"..."}]},"session_id":"...","stop_reason":"end_turn"}
@@ -64,11 +68,12 @@ non-stream harnesses the flag is accepted but no stdin forwarding occurs.
   on this path; claude emits its own when it processes the prompt.
 
 - **codex** and other non-stream harnesses: Coven synthesizes
-  `system.init` + `user` + `result`. The harness's text output is not
-  exposed as `assistant` events in this mode (use `coven attach <id>` for
-  streamed text). In practice `--stream-json` for codex is most useful with
-  `--detach`, which records the session without launching the harness and
-  emits init+user+result immediately.
+  `system.init` + `user`, runs the harness fully captured — no PTY, so raw
+  harness bytes never interleave with the JSONL stream — and emits the
+  collected text output as a single `assistant` event before the closing
+  `result`. Harness stderr is forwarded to Coven's stderr, out of band of
+  the stream. `--detach` still records the session without launching the
+  harness and emits init+user+result immediately.
 
 ## Stability
 


### PR DESCRIPTION
Closes #307 (from the #297 UX audit, follow-up 1).

## Problem

With non-claude harnesses, `coven run --stream-json` ran the harness attached to the PTY: raw harness bytes hit stdout interleaved with the JSONL frames, corrupting the stream the docs declare stable. Consumers parsing line-delimited JSON got garbage whenever the harness wasn't claude.

## Fix

- **Stream mode always launches the one-shot non-interactive entrypoint** — TTY detection no longer applies; an interactive TUI behind a JSONL pipe was never meaningful.
- **The harness runs fully captured** (`pty_runner::run_captured`, no PTY): stdout is collected, never forwarded. No PTY also means no ANSI echo (non-interactive entrypoints already disable color). Signal-killed children map to exit 1, matching the existing delegation rule.
- **Captured output becomes a single `assistant` frame** before the closing `result`, so consumers now get the harness text *in* the stream (previously documented as unavailable). Additive per STREAM-JSON.md's stability policy; the doc's Harness-behavior section is updated.
- **Harness stderr forwards to coven's stderr** — visible, but out of band of the stream contract.

The human (non-stream) path is untouched: still attached PTY.

## Testing

- New smoke test drives a fake codex through `coven run codex --stream-json` and asserts **every stdout line parses as JSON** with the init → user → assistant → result sequence and the harness output inside the assistant frame. This fails against the old attached-PTY behavior.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `scripts/check-secrets.py` — all green.

## Drive-by test-determinism fix

`adapter_install_hermes_writes_trusted_manifest` (from #306) diagnosed hermes against the real PATH, so its expected exit-1 flipped on machines that actually have a `hermes` binary (observed locally). It now diagnoses against an empty PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)