### PR TITLE
feat: add --json to wt --list, claim status, daemon status, pc top/disk (#308)

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -211,6 +211,12 @@ enum Command {
         branch: Option<String>,
         #[arg(long, conflicts_with_all = ["doctor", "prune_merged", "prune_stale"], help = "List worktrees with claim and dirty state")]
         list: bool,
+        #[arg(
+            long,
+            requires = "list",
+            help = "Print worktrees as JSON (machine-readable; requires --list)"
+        )]
+        json: bool,
         #[arg(long, conflicts_with_all = ["list", "prune_merged", "prune_stale"], help = "Report protocol layout and hook issues (exits 1 when issues are found)")]
         doctor: bool,
         #[arg(long, conflicts_with_all = ["list", "doctor", "prune_stale"], help = "Remove clean worktrees whose branches are merged into the primary branch")]
@@ -344,7 +350,10 @@ enum DaemonCommand {
     #[command(about = "Restart the background daemon")]
     Restart,
     #[command(about = "Show whether the daemon is running")]
-    Status,
+    Status {
+        #[arg(long, help = "Print daemon status as JSON (machine-readable)")]
+        json: bool,
+    },
     #[command(about = "Stop the background daemon")]
     Stop,
     #[command(hide = true)]
@@ -405,7 +414,10 @@ enum ClaimCommand {
         branch: String,
     },
     #[command(about = "Show active and expired claims for this repository")]
-    Status,
+    Status {
+        #[arg(long, help = "Print claims as JSON (machine-readable)")]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -500,12 +512,14 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Wt {
             branch,
             list,
+            json,
             doctor,
             prune_merged,
             prune_stale,
         }) => parallel_protocol::run_wt_command(
             branch.as_deref(),
             list,
+            json,
             doctor,
             prune_merged,
             prune_stale,
@@ -515,7 +529,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             ClaimCommand::Release { branch } => parallel_protocol::claim_release(&branch),
             ClaimCommand::Heartbeat { branch } => parallel_protocol::claim_heartbeat(&branch),
             ClaimCommand::Canary { branch } => parallel_protocol::claim_canary(&branch),
-            ClaimCommand::Status => parallel_protocol::claim_status(),
+            ClaimCommand::Status { json } => parallel_protocol::claim_status(json),
         },
         Some(Command::Hooks { command }) => match command {
             HooksCommand::Install => parallel_protocol::hooks_install(),
@@ -1516,25 +1530,33 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 );
             }
         }
-        DaemonCommand::Status => match daemon::background_server_status(&home)? {
-            Some(daemon::DaemonStatusState::Running(status)) => {
-                let health = api::health_response(Some(status.clone()));
-                println!(
-                    "coven daemon status=running ok={} pid={} socket={}",
-                    health.ok, status.pid, status.socket
-                );
+        DaemonCommand::Status { json } => {
+            let state = daemon::background_server_status(&home)?;
+            if json {
+                println!("{}", render_daemon_status_json(state.as_ref())?);
+            } else {
+                match &state {
+                    Some(daemon::DaemonStatusState::Running(status)) => {
+                        let health = api::health_response(Some(status.clone()));
+                        println!(
+                            "coven daemon status=running ok={} pid={} socket={}",
+                            health.ok, status.pid, status.socket
+                        );
+                    }
+                    Some(daemon::DaemonStatusState::Stale(status)) => println!(
+                        "coven daemon status=stale ok=false pid={} socket={}",
+                        status.pid, status.socket
+                    ),
+                    None => println!("coven daemon status=stopped"),
+                }
             }
-            Some(daemon::DaemonStatusState::Stale(status)) => println!(
-                "coven daemon status=stale ok=false pid={} socket={}",
-                status.pid, status.socket
-            ),
-            None => {
-                println!("coven daemon status=stopped");
+            if state.is_none() {
+                // Hint goes to stderr so `--json` stdout stays parseable.
                 eprintln!(
                     "start it with `coven daemon start` (optional — `coven run` works without it)"
                 );
             }
-        },
+        }
         DaemonCommand::Stop => {
             if daemon::stop_background_server(&home)? {
                 println!("coven daemon status=stopped");
@@ -1561,6 +1583,38 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+/// Machine-readable form of `coven daemon status`. Field names are stable
+/// snake_case; `pid`, `socket`, and `started_at` are null when stopped.
+fn render_daemon_status_json(state: Option<&daemon::DaemonStatusState>) -> Result<String> {
+    let value = match state {
+        Some(daemon::DaemonStatusState::Running(status)) => {
+            let health = api::health_response(Some(status.clone()));
+            serde_json::json!({
+                "status": "running",
+                "ok": health.ok,
+                "pid": status.pid,
+                "socket": status.socket,
+                "started_at": status.started_at,
+            })
+        }
+        Some(daemon::DaemonStatusState::Stale(status)) => serde_json::json!({
+            "status": "stale",
+            "ok": false,
+            "pid": status.pid,
+            "socket": status.socket,
+            "started_at": status.started_at,
+        }),
+        None => serde_json::json!({
+            "status": "stopped",
+            "ok": false,
+            "pid": null,
+            "socket": null,
+            "started_at": null,
+        }),
+    };
+    serde_json::to_string_pretty(&value).context("failed to serialize daemon status as JSON")
 }
 
 fn harness_launch_mode_for_stdio() -> harness::HarnessLaunchMode {
@@ -3732,5 +3786,49 @@ mod tests {
             ),
             Some(shim)
         );
+    }
+
+    fn sample_daemon_status() -> daemon::DaemonStatus {
+        daemon::DaemonStatus {
+            pid: 4242,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            socket: "/tmp/coven.sock".to_string(),
+        }
+    }
+
+    #[test]
+    fn daemon_status_json_reports_running_daemon() {
+        let state = daemon::DaemonStatusState::Running(sample_daemon_status());
+        let body = render_daemon_status_json(Some(&state)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["status"], "running");
+        assert_eq!(value["ok"], true);
+        assert_eq!(value["pid"], 4242);
+        assert_eq!(value["socket"], "/tmp/coven.sock");
+        assert_eq!(value["started_at"], "2026-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn daemon_status_json_reports_stale_daemon() {
+        let state = daemon::DaemonStatusState::Stale(sample_daemon_status());
+        let body = render_daemon_status_json(Some(&state)).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["status"], "stale");
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["pid"], 4242);
+    }
+
+    #[test]
+    fn daemon_status_json_reports_stopped_daemon_with_null_fields() {
+        let body = render_daemon_status_json(None).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["status"], "stopped");
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["pid"], serde_json::Value::Null);
+        assert_eq!(value["socket"], serde_json::Value::Null);
+        assert_eq!(value["started_at"], serde_json::Value::Null);
     }
 }

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, SecondsFormat};
 const CLAIM_TTL_SECONDS: u64 = 60 * 60;
 const DEFAULT_PRIMARY_BRANCH: &str = "main";
 const MANAGED_HOOK_MARKER: &str = "Coven Parallel Work Protocol managed hook";
@@ -30,9 +31,18 @@ struct Worktree {
     branch: Option<String>,
 }
 
+#[derive(Debug)]
+struct WorktreeRow {
+    branch: Option<String>,
+    dirty: bool,
+    claimed_by: Option<String>,
+    path: PathBuf,
+}
+
 pub(crate) fn run_wt_command(
     branch: Option<&str>,
     list: bool,
+    json: bool,
     doctor: bool,
     prune_merged: bool,
     prune_stale: Option<u64>,
@@ -40,7 +50,7 @@ pub(crate) fn run_wt_command(
     let repo = Repo::discover()?;
     match (branch, list, doctor, prune_merged, prune_stale) {
         (Some(branch), false, false, false, None) => wt_enter_or_create(&repo, branch),
-        (None, true, false, false, None) => wt_list(&repo),
+        (None, true, false, false, None) => wt_list(&repo, json),
         (None, false, true, false, None) => wt_doctor(&repo),
         (None, false, false, true, None) => wt_prune_merged(&repo),
         (None, false, false, false, Some(days)) => wt_prune_stale(&repo, days),
@@ -140,36 +150,78 @@ pub(crate) fn claim_canary(branch: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn claim_status() -> Result<()> {
+pub(crate) fn claim_status(json: bool) -> Result<()> {
     let repo = Repo::discover()?;
     let claims_dir = repo.common_dir.join("agent-claims");
-    if !claims_dir.exists() {
-        println!("No claims.");
+    let now = unix_now();
+    let mut claims = if claims_dir.exists() {
+        fs::read_dir(&claims_dir)?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    claims.sort_by(|a, b| a.branch.cmp(&b.branch));
+    if json {
+        println!("{}", render_claim_status_json(&claims, now)?);
         return Ok(());
     }
-    let now = unix_now();
-    let mut claims = fs::read_dir(&claims_dir)?
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
-        .collect::<Vec<_>>();
-    claims.sort_by(|a, b| a.branch.cmp(&b.branch));
     if claims.is_empty() {
         println!("No claims.");
         return Ok(());
     }
     println!("{:<32} {:<20} {:<10} expires", "branch", "agent", "state");
     for claim in claims {
-        let state = if claim.is_active(now) {
-            "active"
-        } else {
-            "expired"
-        };
-        println!(
-            "{:<32} {:<20} {:<10} {}",
-            claim.branch, claim.agent_id, state, claim.expires_at
-        );
+        println!("{}", format_claim_status_row(&claim, now));
     }
     Ok(())
+}
+
+fn format_claim_status_row(claim: &Claim, now: u64) -> String {
+    let state = if claim.is_active(now) {
+        "active"
+    } else {
+        "expired"
+    };
+    format!(
+        "{:<32} {:<20} {:<10} {}",
+        claim.branch,
+        claim.agent_id,
+        state,
+        format_epoch_utc(claim.expires_at)
+    )
+}
+
+fn render_claim_status_json(claims: &[Claim], now: u64) -> Result<String> {
+    let value = serde_json::json!({
+        "claims": claims
+            .iter()
+            .map(|claim| {
+                serde_json::json!({
+                    "branch": claim.branch,
+                    "agent_id": claim.agent_id,
+                    "state": if claim.is_active(now) { "active" } else { "expired" },
+                    "acquired_at": claim.acquired_at,
+                    "acquired_at_rfc3339": format_epoch_utc(claim.acquired_at),
+                    "expires_at": claim.expires_at,
+                    "expires_at_rfc3339": format_epoch_utc(claim.expires_at),
+                    "head": claim.head,
+                })
+            })
+            .collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).context("failed to serialize claims as JSON")
+}
+
+/// Render an epoch-seconds timestamp as RFC 3339 UTC (e.g. `2026-01-01T00:00:00Z`).
+/// Falls back to the raw epoch value if it does not fit a chrono timestamp.
+fn format_epoch_utc(epoch_seconds: u64) -> String {
+    i64::try_from(epoch_seconds)
+        .ok()
+        .and_then(|seconds| DateTime::from_timestamp(seconds, 0))
+        .map(|timestamp| timestamp.to_rfc3339_opts(SecondsFormat::Secs, true))
+        .unwrap_or_else(|| epoch_seconds.to_string())
 }
 
 pub(crate) fn hooks_install() -> Result<()> {
@@ -219,32 +271,56 @@ fn wt_enter_or_create(repo: &Repo, branch: &str) -> Result<()> {
     Ok(())
 }
 
-fn wt_list(repo: &Repo) -> Result<()> {
-    let worktrees = list_worktrees()?;
-    println!("{:<32} {:<8} {:<20} path", "branch", "dirty", "claim");
-    for worktree in worktrees {
-        let branch = worktree.branch.as_deref().unwrap_or("(detached)");
-        let dirty = if worktree_dirty(&worktree.path)? {
-            "dirty"
-        } else {
-            "clean"
-        };
-        let claim = worktree
+fn wt_list(repo: &Repo, json: bool) -> Result<()> {
+    let now = unix_now();
+    let mut rows = Vec::new();
+    for worktree in list_worktrees()? {
+        let dirty = worktree_dirty(&worktree.path)?;
+        let claimed_by = worktree
             .branch
             .as_deref()
             .and_then(|branch| read_claim(repo, branch).ok().flatten())
-            .filter(|claim| claim.is_active(unix_now()))
-            .map(|claim| claim.agent_id)
-            .unwrap_or_else(|| "-".to_string());
+            .filter(|claim| claim.is_active(now))
+            .map(|claim| claim.agent_id);
+        rows.push(WorktreeRow {
+            branch: worktree.branch,
+            dirty,
+            claimed_by,
+            path: worktree.path,
+        });
+    }
+    if json {
+        println!("{}", render_wt_list_json(&rows)?);
+        return Ok(());
+    }
+    println!("{:<32} {:<8} {:<20} path", "branch", "dirty", "claim");
+    for row in rows {
         println!(
             "{:<32} {:<8} {:<20} {}",
-            branch,
-            dirty,
-            claim,
-            worktree.path.display()
+            row.branch.as_deref().unwrap_or("(detached)"),
+            if row.dirty { "dirty" } else { "clean" },
+            row.claimed_by.as_deref().unwrap_or("-"),
+            row.path.display()
         );
     }
     Ok(())
+}
+
+fn render_wt_list_json(rows: &[WorktreeRow]) -> Result<String> {
+    let value = serde_json::json!({
+        "worktrees": rows
+            .iter()
+            .map(|row| {
+                serde_json::json!({
+                    "branch": row.branch,
+                    "dirty": row.dirty,
+                    "claimed_by": row.claimed_by,
+                    "path": row.path.to_string_lossy(),
+                })
+            })
+            .collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).context("failed to serialize worktrees as JSON")
 }
 
 fn wt_doctor(repo: &Repo) -> Result<()> {
@@ -721,3 +797,104 @@ if [ "$consume_intent" = "1" ]; then
   rm -f "$intent_file"
 fi
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 2026-01-01T00:00:00Z
+    const NEW_YEAR_2026_EPOCH: u64 = 1_767_225_600;
+
+    fn sample_claim() -> Claim {
+        Claim {
+            branch: "feat/sample".to_string(),
+            agent_id: "agent-a".to_string(),
+            acquired_at: NEW_YEAR_2026_EPOCH,
+            expires_at: NEW_YEAR_2026_EPOCH + 3600,
+            head: Some("abc123".to_string()),
+        }
+    }
+
+    #[test]
+    fn format_epoch_utc_renders_rfc3339() {
+        assert_eq!(
+            format_epoch_utc(NEW_YEAR_2026_EPOCH),
+            "2026-01-01T00:00:00Z"
+        );
+    }
+
+    #[test]
+    fn claim_status_row_renders_human_readable_expiry() {
+        let claim = sample_claim();
+        let row = format_claim_status_row(&claim, NEW_YEAR_2026_EPOCH);
+
+        assert!(row.contains("feat/sample"));
+        assert!(row.contains("agent-a"));
+        assert!(row.contains("active"));
+        assert!(row.contains("2026-01-01T01:00:00Z"));
+        assert!(!row.contains(&claim.expires_at.to_string()));
+    }
+
+    #[test]
+    fn claim_status_row_reports_expired_claims() {
+        let claim = sample_claim();
+        let row = format_claim_status_row(&claim, claim.expires_at + 1);
+
+        assert!(row.contains("expired"));
+    }
+
+    #[test]
+    fn claim_status_json_includes_epoch_and_rfc3339_fields() {
+        let claims = vec![sample_claim()];
+        let body = render_claim_status_json(&claims, NEW_YEAR_2026_EPOCH).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        let claim = &value["claims"][0];
+        assert_eq!(claim["branch"], "feat/sample");
+        assert_eq!(claim["agent_id"], "agent-a");
+        assert_eq!(claim["state"], "active");
+        assert_eq!(claim["acquired_at"], NEW_YEAR_2026_EPOCH);
+        assert_eq!(claim["acquired_at_rfc3339"], "2026-01-01T00:00:00Z");
+        assert_eq!(claim["expires_at"], NEW_YEAR_2026_EPOCH + 3600);
+        assert_eq!(claim["expires_at_rfc3339"], "2026-01-01T01:00:00Z");
+        assert_eq!(claim["head"], "abc123");
+    }
+
+    #[test]
+    fn claim_status_json_renders_empty_claims_list() {
+        let body = render_claim_status_json(&[], NEW_YEAR_2026_EPOCH).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["claims"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn wt_list_json_includes_expected_fields() {
+        let rows = vec![
+            WorktreeRow {
+                branch: Some("feat/sample".to_string()),
+                dirty: true,
+                claimed_by: Some("agent-a".to_string()),
+                path: PathBuf::from("/tmp/repo.wt/feat-sample"),
+            },
+            WorktreeRow {
+                branch: None,
+                dirty: false,
+                claimed_by: None,
+                path: PathBuf::from("/tmp/repo"),
+            },
+        ];
+        let body = render_wt_list_json(&rows).expect("render");
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        let worktrees = value["worktrees"].as_array().expect("worktrees array");
+        assert_eq!(worktrees.len(), 2);
+        assert_eq!(worktrees[0]["branch"], "feat/sample");
+        assert_eq!(worktrees[0]["dirty"], true);
+        assert_eq!(worktrees[0]["claimed_by"], "agent-a");
+        assert_eq!(worktrees[0]["path"], "/tmp/repo.wt/feat-sample");
+        assert_eq!(worktrees[1]["branch"], serde_json::Value::Null);
+        assert_eq!(worktrees[1]["dirty"], false);
+        assert_eq!(worktrees[1]["claimed_by"], serde_json::Value::Null);
+    }
+}

--- a/crates/coven-cli/src/pc/display.rs
+++ b/crates/coven-cli/src/pc/display.rs
@@ -110,17 +110,58 @@ fn print_proc(p: &ProcessInfo, format: &OutputFormat) {
 }
 
 pub fn print_top(snap: &SystemSnapshot, n: usize, format: &OutputFormat) {
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", format_top_json(snap, n));
+        return;
+    }
     println!("── Top {} Processes (by CPU) ────────────────", n);
     for proc in snap.processes.iter().take(n) {
         print_proc(proc, format);
     }
 }
 
-pub fn print_disk_usage(snap: &SystemSnapshot) {
+pub fn print_disk_usage(snap: &SystemSnapshot, format: &OutputFormat) {
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", format_disk_json(snap));
+        return;
+    }
     println!("── Disk Usage ──────────────────────────────");
     for disk in &snap.disks {
         print_disk(disk);
     }
+}
+
+fn format_top_json(snap: &SystemSnapshot, n: usize) -> String {
+    let value = json!({
+        "processes": snap.processes.iter().take(n).map(|p| {
+            let mut process = json!({
+                "pid": p.pid,
+                "name": p.name,
+                "cpu_pct": p.cpu_pct,
+                "memory_mb": p.memory_mb,
+            });
+            // argv is only captured when --verbose requested it.
+            if let Some(argv) = &p.argv {
+                process["argv"] = json!(argv);
+            }
+            process
+        }).collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).expect("process list JSON serialization cannot fail")
+}
+
+fn format_disk_json(snap: &SystemSnapshot) -> String {
+    let value = json!({
+        "disks": snap.disks.iter().map(|d| {
+            json!({
+                "mount": d.mount,
+                "total_gb": d.total_gb,
+                "available_gb": d.available_gb,
+                "used_pct": d.used_pct,
+            })
+        }).collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).expect("disk list JSON serialization cannot fail")
 }
 
 fn format_json(snap: &SystemSnapshot) -> String {
@@ -212,5 +253,61 @@ mod tests {
         assert!(!body.contains('🟢'));
         assert!(!body.contains('🟡'));
         assert!(!body.contains('🔴'));
+    }
+
+    #[test]
+    fn top_json_serializes_processes_with_expected_keys() {
+        let body = format_top_json(&sample_snapshot(), 10);
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        let processes = value["processes"].as_array().expect("processes array");
+        assert_eq!(processes.len(), 1);
+        assert_eq!(processes[0]["pid"], 42);
+        assert_eq!(processes[0]["name"], "proc \"quoted\"\u{7}");
+        assert_eq!(processes[0]["cpu_pct"], 3.5);
+        assert_eq!(processes[0]["memory_mb"], 64);
+        // argv was not captured (non-verbose snapshot), so the key is absent.
+        assert!(processes[0].get("argv").is_none());
+    }
+
+    #[test]
+    fn top_json_respects_process_limit_and_includes_argv_when_captured() {
+        let mut snap = sample_snapshot();
+        snap.processes = vec![
+            ProcessInfo {
+                pid: 1,
+                name: "one".to_string(),
+                cpu_pct: 9.0,
+                memory_mb: 10,
+                argv: Some(vec!["one".to_string(), "--flag".to_string()]),
+            },
+            ProcessInfo {
+                pid: 2,
+                name: "two".to_string(),
+                cpu_pct: 1.0,
+                memory_mb: 5,
+                argv: None,
+            },
+        ];
+
+        let body = format_top_json(&snap, 1);
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        let processes = value["processes"].as_array().expect("processes array");
+        assert_eq!(processes.len(), 1);
+        assert_eq!(processes[0]["argv"], serde_json::json!(["one", "--flag"]));
+    }
+
+    #[test]
+    fn disk_json_serializes_disks_with_expected_keys() {
+        let body = format_disk_json(&sample_snapshot());
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        let disks = value["disks"].as_array().expect("disks array");
+        assert_eq!(disks.len(), 1);
+        assert_eq!(disks[0]["mount"], "/Volumes/name \"quoted\"\u{7}");
+        assert_eq!(disks[0]["total_gb"], 100.0);
+        assert_eq!(disks[0]["available_gb"], 40.0);
+        assert_eq!(disks[0]["used_pct"], 60.0);
     }
 }

--- a/crates/coven-cli/src/pc/mod.rs
+++ b/crates/coven-cli/src/pc/mod.rs
@@ -20,9 +20,14 @@ pub enum PcCommand {
         n: usize,
         #[arg(long, help = "Include full command-line arguments")]
         verbose: bool,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     #[command(about = "Disk usage breakdown")]
-    Disk,
+    Disk {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
     #[command(about = "Kill a process by PID (requires --confirm)")]
     Kill {
         #[arg(help = "Process ID to terminate")]
@@ -62,18 +67,25 @@ pub fn run_pc_command(command: Option<PcCommand>) -> Result<()> {
             };
             display::print_status(&snap, &fmt);
         }
-        Some(PcCommand::Top { n, verbose }) => {
+        Some(PcCommand::Top { n, verbose, json }) => {
             let snap = diagnostics::snapshot(verbose)?;
-            let fmt = if verbose {
+            let fmt = if json {
+                OutputFormat::Json
+            } else if verbose {
                 OutputFormat::Verbose
             } else {
                 OutputFormat::Compact
             };
             display::print_top(&snap, n, &fmt);
         }
-        Some(PcCommand::Disk) => {
+        Some(PcCommand::Disk { json }) => {
             let snap = diagnostics::snapshot(false)?;
-            display::print_disk_usage(&snap);
+            let fmt = if json {
+                OutputFormat::Json
+            } else {
+                OutputFormat::Compact
+            };
+            display::print_disk_usage(&snap, &fmt);
         }
         Some(PcCommand::Kill { pid, confirm }) => {
             relief::kill_by_pid(pid, confirm)?;

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -420,7 +420,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             }
         }
         CastIntent::DaemonStatus => {
-            run_daemon_command(DaemonCommand::Status)?;
+            run_daemon_command(DaemonCommand::Status { json: false })?;
             CastOutcome {
                 request: request_text,
                 launched: Some("Coven daemon status".to_string()),
@@ -1624,7 +1624,7 @@ fn run_magical_tui_action(action: MagicalTuiAction) -> Result<()> {
         MagicalTuiAction::Help => run_tui_help(),
         MagicalTuiAction::OpenTui => run(),
         MagicalTuiAction::Doctor => run_doctor(),
-        MagicalTuiAction::DaemonStatus => run_daemon_command(DaemonCommand::Status),
+        MagicalTuiAction::DaemonStatus => run_daemon_command(DaemonCommand::Status { json: false }),
         MagicalTuiAction::RunHarness => run_guided_harness_session(),
         MagicalTuiAction::PatchOpenClaw => {
             run_patch(None, vec![], None, None, None, false, false, true)

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -236,6 +236,184 @@ fn daemon_serve_refuses_to_take_over_a_healthy_socket() -> anyhow::Result<()> {
 }
 
 #[test]
+fn daemon_status_json_reports_stopped_daemon_on_pure_stdout() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+
+    let output = run_coven(
+        &coven_bin(),
+        &coven_home,
+        &std::env::var_os("PATH").unwrap_or_default(),
+        &["daemon", "status", "--json"],
+    )?;
+
+    assert_success("daemon status --json when stopped", &output);
+    // Parsing the entire stdout proves it carries only the JSON document.
+    let value = parse_stdout_json("daemon status --json when stopped", &output)?;
+    assert_eq!(value.get("status").and_then(Value::as_str), Some("stopped"));
+    assert_eq!(value.get("ok").and_then(Value::as_bool), Some(false));
+    assert!(value.get("pid").is_some_and(Value::is_null));
+    assert!(value.get("socket").is_some_and(Value::is_null));
+    assert!(value.get("started_at").is_some_and(Value::is_null));
+    // The human hint stays on stderr so stdout remains parseable.
+    assert_stderr_contains(
+        "daemon status --json when stopped",
+        &output,
+        "coven daemon start",
+    );
+    Ok(())
+}
+
+#[test]
+fn wt_list_and_claim_status_emit_machine_readable_json() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let repo = temp_dir.path().join("repo");
+    fs::create_dir_all(&repo)?;
+    init_git_repo(&repo)?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+    let agent_env = [("COVEN_AGENT_ID", "smoke-agent")];
+
+    let acquire = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &repo,
+        &agent_env,
+        &["claim", "acquire", "smoke-branch"],
+    )?;
+    assert_success("claim acquire", &acquire);
+
+    let status_json = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &repo,
+        &agent_env,
+        &["claim", "status", "--json"],
+    )?;
+    assert_success("claim status --json", &status_json);
+    let value = parse_stdout_json("claim status --json", &status_json)?;
+    let claims = value
+        .get("claims")
+        .and_then(Value::as_array)
+        .expect("claim status JSON should include a claims array");
+    assert_eq!(claims.len(), 1);
+    let claim = &claims[0];
+    assert_eq!(
+        claim.get("branch").and_then(Value::as_str),
+        Some("smoke-branch")
+    );
+    assert_eq!(
+        claim.get("agent_id").and_then(Value::as_str),
+        Some("smoke-agent")
+    );
+    assert_eq!(claim.get("state").and_then(Value::as_str), Some("active"));
+    assert!(
+        claim.get("acquired_at").and_then(Value::as_u64).is_some(),
+        "claims JSON should keep the raw epoch value"
+    );
+    assert!(claim.get("expires_at").and_then(Value::as_u64).is_some());
+    let expires_rfc3339 = claim
+        .get("expires_at_rfc3339")
+        .and_then(Value::as_str)
+        .expect("claims JSON should include an RFC 3339 expiry")
+        .to_string();
+    assert!(
+        expires_rfc3339.contains('T') && expires_rfc3339.ends_with('Z'),
+        "expected RFC 3339 UTC expiry, got {expires_rfc3339:?}"
+    );
+
+    // The human table renders the same expiry as a readable timestamp, not
+    // raw epoch seconds.
+    let status_human = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &repo,
+        &agent_env,
+        &["claim", "status"],
+    )?;
+    assert_success("claim status", &status_human);
+    assert_stdout_contains("claim status", &status_human, &expires_rfc3339);
+    let raw_epoch = claim
+        .get("expires_at")
+        .and_then(Value::as_u64)
+        .expect("expires_at epoch")
+        .to_string();
+    assert_stdout_not_contains("claim status", &status_human, &raw_epoch);
+
+    let wt_json = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &repo,
+        &agent_env,
+        &["wt", "--list", "--json"],
+    )?;
+    assert_success("wt --list --json", &wt_json);
+    let value = parse_stdout_json("wt --list --json", &wt_json)?;
+    let worktrees = value
+        .get("worktrees")
+        .and_then(Value::as_array)
+        .expect("wt --list JSON should include a worktrees array");
+    assert!(!worktrees.is_empty(), "primary worktree should be listed");
+    let worktree = &worktrees[0];
+    assert!(worktree.get("branch").and_then(Value::as_str).is_some());
+    assert!(worktree.get("dirty").and_then(Value::as_bool).is_some());
+    assert!(worktree.get("claimed_by").is_some());
+    assert!(worktree.get("path").and_then(Value::as_str).is_some());
+    Ok(())
+}
+
+#[test]
+fn pc_top_and_disk_emit_machine_readable_json() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    let top = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["pc", "top", "--n", "3", "--json"],
+    )?;
+    assert_success("pc top --json", &top);
+    let value = parse_stdout_json("pc top --json", &top)?;
+    let processes = value
+        .get("processes")
+        .and_then(Value::as_array)
+        .expect("pc top JSON should include a processes array");
+    assert!(processes.len() <= 3, "--n should cap the process list");
+    if let Some(process) = processes.first() {
+        assert!(process.get("pid").and_then(Value::as_u64).is_some());
+        assert!(process.get("name").and_then(Value::as_str).is_some());
+        assert!(process.get("cpu_pct").and_then(Value::as_f64).is_some());
+        assert!(process.get("memory_mb").and_then(Value::as_u64).is_some());
+    }
+
+    let disk = run_coven(&coven, &coven_home, &path, &["pc", "disk", "--json"])?;
+    assert_success("pc disk --json", &disk);
+    let value = parse_stdout_json("pc disk --json", &disk)?;
+    let disks = value
+        .get("disks")
+        .and_then(Value::as_array)
+        .expect("pc disk JSON should include a disks array");
+    if let Some(disk) = disks.first() {
+        assert!(disk.get("mount").and_then(Value::as_str).is_some());
+        assert!(disk.get("total_gb").and_then(Value::as_f64).is_some());
+        assert!(disk.get("available_gb").and_then(Value::as_f64).is_some());
+        assert!(disk.get("used_pct").and_then(Value::as_f64).is_some());
+    }
+    Ok(())
+}
+
+#[test]
 fn doctor_lists_configured_familiars() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -506,6 +684,20 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
     assert_success("daemon status", &status);
     assert_stdout_contains("daemon status", &status, "status=running");
 
+    let status_json = run_coven(&coven, &coven_home, &path, &["daemon", "status", "--json"])?;
+    assert_success("daemon status --json", &status_json);
+    let status_value = parse_stdout_json("daemon status --json", &status_json)?;
+    assert_eq!(
+        status_value.get("status").and_then(Value::as_str),
+        Some("running")
+    );
+    assert!(status_value.get("pid").and_then(Value::as_u64).is_some());
+    assert!(status_value.get("socket").and_then(Value::as_str).is_some());
+    assert!(status_value
+        .get("started_at")
+        .and_then(Value::as_str)
+        .is_some());
+
     let replay_session = launch_daemon_session(
         &coven_home,
         &project_root,
@@ -664,6 +856,66 @@ fn run_coven(
         .env("PATH", path)
         .output()
         .map_err(Into::into)
+}
+
+/// Like `run_coven`, but runs from `cwd` with extra env vars — for commands
+/// that discover a git repository from the working directory.
+fn run_coven_in(
+    coven: &Path,
+    coven_home: &Path,
+    path: &OsString,
+    cwd: &Path,
+    envs: &[(&str, &str)],
+    args: &[&str],
+) -> anyhow::Result<Output> {
+    let mut command = Command::new(coven);
+    command
+        .args(args)
+        .env("COVEN_HOME", coven_home)
+        .env("PATH", path)
+        .current_dir(cwd);
+    for (key, value) in envs {
+        command.env(key, value);
+    }
+    command.output().map_err(Into::into)
+}
+
+/// Parse a command's entire stdout as one JSON document. Fails when anything
+/// besides the JSON document landed on stdout.
+fn parse_stdout_json(label: &str, output: &Output) -> anyhow::Result<Value> {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(stdout.trim()).map_err(|error| {
+        anyhow::anyhow!(
+            "{label} stdout was not a single JSON document: {error}\nstdout:\n{stdout}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn init_git_repo(repo: &Path) -> anyhow::Result<()> {
+    let git = |args: &[&str]| -> anyhow::Result<()> {
+        let output = Command::new("git").args(args).current_dir(repo).output()?;
+        anyhow::ensure!(
+            output.status.success(),
+            "git {args:?} failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Ok(())
+    };
+    git(&["init", "--initial-branch=main"])?;
+    git(&[
+        "-c",
+        "user.name=Coven Smoke",
+        "-c",
+        "user.email=smoke@example.invalid",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init",
+    ])?;
+    Ok(())
 }
 
 fn assert_success(label: &str, output: &Output) {

--- a/docs/reference/cli-daemon.md
+++ b/docs/reference/cli-daemon.md
@@ -18,7 +18,7 @@ coven daemon status
 | Command | Action |
 | --- | --- |
 | `coven daemon start` | Start the daemon if it is not already running. Reuses a verified live daemon. |
-| `coven daemon status` | Print stopped/running/stale status, pid, socket path, and health flag. |
+| `coven daemon status` | Print stopped/running/stale status, pid, socket path, and health flag. `--json` prints the same fields as one JSON document (`status`, `ok`, `pid`, `socket`, `started_at`). |
 | `coven daemon restart` | Stop the current daemon if present, then start a daemon with the current binary. |
 | `coven daemon stop` | Stop the daemon for the active `COVEN_HOME`. |
 | `coven daemon serve` | Hidden foreground server entrypoint used by the background launcher and supervisors. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -30,7 +30,7 @@ flowchart TB
   Root --> Pc["pc (macOS-first)"]
 
   Daemon --> DStart["start"]
-  Daemon --> DStatus["status"]
+  Daemon --> DStatus["status [--json]"]
   Daemon --> DRestart["restart"]
   Daemon --> DStop["stop"]
 
@@ -47,7 +47,7 @@ flowchart TB
   Logs --> LPrune["prune [--dry-run]"]
 
   Wt --> WtBranch["&lt;branch&gt;"]
-  Wt --> WtList["--list"]
+  Wt --> WtList["--list [--json]"]
   Wt --> WtDoctor["--doctor"]
   Wt --> WtPrune["--prune-merged / --prune-stale DAYS"]
 
@@ -55,13 +55,13 @@ flowchart TB
   Claim --> CRelease["release &lt;branch&gt;"]
   Claim --> CHeartbeat["heartbeat &lt;branch&gt;"]
   Claim --> CCanary["canary &lt;branch&gt;"]
-  Claim --> CStatus["status"]
+  Claim --> CStatus["status [--json]"]
 
   Hooks --> HInstall["install"]
 
   Pc --> PcStatus["status [--json]"]
-  Pc --> PcTop["top --n N"]
-  Pc --> PcDisk["disk"]
+  Pc --> PcTop["top --n N [--json]"]
+  Pc --> PcDisk["disk [--json]"]
   Pc --> PcKill["kill &lt;pid&gt; --confirm"]
   Pc --> PcCache["cache clear --confirm"]
 ```
@@ -95,19 +95,23 @@ flowchart TB
 | Command | Flags |
 |---|---|
 | `coven run` | `--cwd <path>`, `--title <text>`, `--detach`, `--model <id>`, `--think`, `--speed fast\|balanced\|thorough` |
+| `coven daemon status` | `--json` |
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sacrifice` | `--yes` (required) |
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
-| `coven wt` | `--list`, `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |
+| `coven wt` | `--list`, `--json` (with `--list`), `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |
+| `coven claim status` | `--json` |
 | `coven pc kill` | `--confirm` (required) |
 | `coven pc cache clear` | `--confirm` (required) |
-| `coven pc top` | `--n <N>`, `--verbose` |
+| `coven pc top` | `--n <N>`, `--verbose`, `--json` |
+| `coven pc disk` | `--json` |
 | `coven pc status` | `--json` |
 
 ## Flag conventions
 
 - **Project-scoped commands** accept `--cwd <path>` for a launch directory inside the project root.
-- **Machine-readable output** is per-command today: `coven sessions` accepts `--plain` and `--json`; `coven sessions search`, `coven adapter list`, and `coven pc status` accept `--json`. Other tabular commands (`wt --list`, `claim status`, `daemon status`, `pc top`, `pc disk`) print human tables only.
+- **Machine-readable output** is per-command today: `coven sessions` accepts `--plain` and `--json`; `coven sessions search`, `coven adapter list`, `coven daemon status`, `coven wt --list`, `coven claim status`, `coven pc status`, `coven pc top`, and `coven pc disk` accept `--json`. With `--json`, stdout carries only the JSON document; hints go to stderr.
+- **Timestamps**: `coven claim status` prints RFC 3339 UTC timestamps in the human table; its JSON form keeps the raw epoch seconds (`acquired_at`, `expires_at`) alongside `*_rfc3339` renderings.
 - **Session id arguments** (`attach`, `summon`, `archive`, `sacrifice`, `kill`) accept a unique prefix of the id.
 - **Destructive commands** require `--yes` (or `--confirm` for `coven pc` relief).
 - **Daemon-touching commands** print install/repair hints when the socket is missing.


### PR DESCRIPTION
## Context

- Summary: Adds `--json` output to the read commands that only printed human tables (`wt --list`, `claim status`, `daemon status`, `pc top`, `pc disk`), and makes `claim status` render human-readable RFC 3339 timestamps instead of raw epoch seconds on the human path. Follows the `--json` conventions established for `coven sessions` / `coven pc status` (#297): pretty-printed JSON document as the only stdout content, stable snake_case fields, hints on stderr.
- Files changed: `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/parallel_protocol.rs`, `crates/coven-cli/src/pc/mod.rs`, `crates/coven-cli/src/pc/display.rs`, `crates/coven-cli/src/tui/shell.rs`, `crates/coven-cli/tests/smoke.rs`, `docs/reference/cli.md`, `docs/reference/cli-daemon.md`
- Closes #308

## Implementation

- Approach: JSON is rendered at the data layer (rows/claims/snapshot structs), never by re-formatting the human tables. Each renderer is a pure function (`render_wt_list_json`, `render_claim_status_json`, `render_daemon_status_json`, `format_top_json`, `format_disk_json`) so it is unit-testable.
- User-visible behavior — new JSON schemas (all pretty-printed, snake_case):
  - `coven wt --list --json` → `{"worktrees": [{"branch": string|null, "dirty": bool, "claimed_by": string|null, "path": string}]}` (`--json` requires `--list`).
  - `coven claim status --json` → `{"claims": [{"branch", "agent_id", "state": "active"|"expired", "acquired_at": epoch_secs, "acquired_at_rfc3339", "expires_at": epoch_secs, "expires_at_rfc3339", "head": string|null}]}` — raw epoch values stay available per the issue; empty repo yields `{"claims": []}`.
  - `coven daemon status --json` → `{"status": "running"|"stale"|"stopped", "ok": bool, "pid": u32|null, "socket": string|null, "started_at": string|null}`; the `coven daemon start` hint moves to stderr so stdout stays parseable.
  - `coven pc top --n N --json` → `{"processes": [{"pid", "name", "cpu_pct", "memory_mb", "argv"?: [string]}]}` (`argv` present only when `--verbose` captured it).
  - `coven pc disk --json` → `{"disks": [{"mount", "total_gb", "available_gb", "used_pct"}]}` — same field names as `pc status --json`.
  - `coven claim status` (human) now prints `expires` as RFC 3339 UTC (e.g. `2026-01-01T01:00:00Z`) instead of raw epoch seconds.
- Compatibility notes: all human outputs are unchanged except the `claim status` expires column (issue-mandated). Exit codes and error paths unchanged. `docs/reference/cli.md` coverage tables and `docs/reference/cli-daemon.md` updated; no `ru/`/`es/` translations touched.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — all green. Note: on the dev machine `adapter_install_hermes_writes_trusted_manifest` (pre-existing, untouched by this PR) fails because a real `hermes` binary is installed in `~/.local/bin`; the suite passes fully with that PATH entry removed, matching CI.
- [x] `python3 scripts/check-secrets.py` — "Secret guard passed: no current-tree or history findings."
- [x] Additional manual checks: exercised `daemon status --json` (stopped), `wt --list --json`, `wt --json` (rejected without `--list`), `claim status --json` (empty), `pc disk --json`, and `claim status --help` from a debug build.

New tests:
- Unit: `parallel_protocol::tests::{format_epoch_utc_renders_rfc3339, claim_status_row_renders_human_readable_expiry, claim_status_row_reports_expired_claims, claim_status_json_includes_epoch_and_rfc3339_fields, claim_status_json_renders_empty_claims_list, wt_list_json_includes_expected_fields}`; `main::tests::{daemon_status_json_reports_running_daemon, daemon_status_json_reports_stale_daemon, daemon_status_json_reports_stopped_daemon_with_null_fields}`; `pc::display::tests::{top_json_serializes_processes_with_expected_keys, top_json_respects_process_limit_and_includes_argv_when_captured, disk_json_serializes_disks_with_expected_keys}`.
- Integration (`tests/smoke.rs`): `daemon_status_json_reports_stopped_daemon_on_pure_stdout`, `wt_list_and_claim_status_emit_machine_readable_json`, `pc_top_and_disk_emit_machine_readable_json`, plus a running-daemon `--json` assertion inside `smoke_daemon_session_replay_and_safe_session_rituals`. Each parses the entire stdout as one JSON document, proving nothing else lands on stdout.

## Risk and Rollback

- Risk level: Low — additive flags; the only human-output change is the `claim status` expires column, which had no test or script consumers in-repo.
- Rollback plan: revert the single commit; no migrations or persisted-format changes.

## Agent Handoff

- Current state: complete; all gates green locally.
- Follow-ups: `claim acquire`/`heartbeat` confirmation lines still print raw epoch `until <secs>` — left as-is (out of #308 scope; could reuse `format_epoch_utc`).
- Known gaps: none known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)