### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
RUSTSEC-2026-0204 (invalid pointer dereference in `fmt::Pointer`/`fmt::Display` impls) published against `crossbeam-epoch` 0.9.18, which we pull transitively via `rayon → crossbeam-deque` (from `faer`/`turbovec` under `coven-memory`). The cargo-deny **Dependency audit** gate now fails on every PR and on main — observed first on #312, which touches no dependencies.

Lockfile-only patch bump (`cargo update -p crossbeam-epoch`, 0.9.18 → 0.9.20). `cargo check --workspace --locked` and the secret scan pass locally; the full matrix runs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)