### PR TITLE
fix: keep --stream-json stdout JSONL-only on non-claude harnesses (#307)

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1982,12 +1982,43 @@ fn run_session(
         &selected_harness.id,
         &effective_prompt,
         &cwd,
-        harness_launch_mode_for_stdio(),
+        if stream_json {
+            // stream-json is a machine protocol: always launch the harness
+            // one-shot/non-interactive, even when stdio happens to be a
+            // terminal. The claude pass-through above does the same (`-p`);
+            // launching a TUI here would leave the harness waiting on
+            // keystrokes for a screen that is never rendered.
+            harness::HarnessLaunchMode::NonInteractive
+        } else {
+            harness_launch_mode_for_stdio()
+        },
         conversation_hint.as_ref(),
         familiar_for_args,
         launch_options,
     )?;
-    match pty_runner::run_attached(&command) {
+    // Non-stream harnesses run on a PTY. In stream-json mode, mirroring the
+    // raw PTY bytes to stdout would interleave ANSI escapes / prompts /
+    // partial lines with the JSONL frames and corrupt the stream for every
+    // consumer (#307), so the PTY is captured instead and each chunk is
+    // wrapped in an `output` event. Emit failures inside the callback are
+    // ignored (the consumer may have closed the pipe mid-run); the `result`
+    // emission below surfaces a dead stdout as an error.
+    let attached = if stream_json {
+        let output_session_id = record.id.clone();
+        pty_runner::run_attached_captured(
+            &command,
+            Box::new(move |chunk| {
+                let _ =
+                    emit_stream_event(&stream_json::Event::Output(stream_json::HarnessOutput {
+                        text: String::from_utf8_lossy(&chunk).into_owned(),
+                        session_id: output_session_id.clone(),
+                    }));
+            }),
+        )
+    } else {
+        pty_runner::run_attached(&command)
+    };
+    match attached {
         Ok(result) => {
             store::update_session_status(
                 &conn,

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -101,6 +101,55 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
     run_attached_with_pty_system(command, pty_system.as_ref())
 }
 
+/// Run `command` on a PTY like `run_attached`, but capture the PTY output
+/// instead of mirroring the raw bytes to stdout. Each captured chunk is
+/// handed to `on_output` in order and is guaranteed valid UTF-8 (codepoints
+/// split across reads are reassembled by `drain_detached_output`).
+///
+/// This is the `--stream-json` path for harnesses without a native
+/// stream-json protocol (codex, external adapters): stdout must stay
+/// JSONL-only, so the raw PTY output (ANSI escapes, prompts, partial lines)
+/// is wrapped into `output` events by the caller rather than interleaving
+/// with the frames (#307). Stdin is still forwarded to the PTY, matching
+/// `run_attached`; raw terminal mode is never enabled because nothing is
+/// echoed back to the caller's terminal.
+pub fn run_attached_captured(
+    command: &HarnessCommand,
+    mut on_output: Box<dyn FnMut(Vec<u8>) + Send + 'static>,
+) -> Result<PtyRunResult> {
+    let pty_system = native_pty_system();
+    let pair = pty_system
+        .openpty(terminal_size())
+        .context("failed to open PTY")?;
+    let mut child = pair
+        .slave
+        .spawn_command(command.to_command_builder())
+        .with_context(|| format!("failed to spawn harness `{}`", command.program()))?;
+
+    drop(pair.slave);
+
+    let mut reader = pair
+        .master
+        .try_clone_reader()
+        .context("failed to clone PTY reader")?;
+    let mut writer = pair
+        .master
+        .take_writer()
+        .context("failed to open PTY writer")?;
+
+    thread::spawn(move || {
+        let mut stdin = io::stdin().lock();
+        let _ = io::copy(&mut stdin, &mut writer);
+    });
+
+    // Drain on this thread until the child closes its end of the PTY; EOF
+    // (or EIO on Linux) arrives when the child exits, so the wait below
+    // returns promptly.
+    drain_detached_output(&mut reader, Some(&mut on_output));
+
+    Ok(wait_for_child(&mut child))
+}
+
 /// Run `claude` in its native stream-JSON mode, framed by the caller (which
 /// emits Coven's own `system.init` / `result` around the call).
 ///

--- a/crates/coven-cli/src/stream_json.rs
+++ b/crates/coven-cli/src/stream_json.rs
@@ -21,6 +21,7 @@ pub enum Event {
     User(UserMessage),
     Assistant(AssistantMessage),
     ToolResult(ToolResult),
+    Output(HarnessOutput),
     Result(RunResult),
 }
 
@@ -90,6 +91,21 @@ pub struct ToolResult {
     pub tool_use_id: String,
     pub content: Vec<ContentBlock>,
     pub is_error: bool,
+    pub session_id: String,
+}
+
+/// Raw output captured from a harness that has no native stream-json
+/// protocol (codex, external adapters). In `--stream-json` mode those
+/// harnesses run on a PTY; every captured chunk is wrapped in one `output`
+/// frame so stdout stays JSONL-only instead of interleaving raw PTY bytes
+/// with the stream (#307). `text` is the raw PTY text: it may contain ANSI
+/// escape sequences, carriage returns, and partial lines, and chunk
+/// boundaries follow PTY reads rather than line breaks. Each chunk is
+/// guaranteed valid UTF-8 (codepoints split across reads are reassembled
+/// before wrapping).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HarnessOutput {
+    pub text: String,
     pub session_id: String,
 }
 
@@ -259,6 +275,35 @@ mod tests {
         });
         let mut buf = Vec::new();
         emit_event(&mut buf, &event).unwrap();
+        let mut reader = Cursor::new(buf);
+        let decoded = read_event(&mut reader).unwrap().unwrap();
+        assert_eq!(decoded, event);
+    }
+
+    #[test]
+    fn output_event_wire_shape_and_round_trip() {
+        // Raw PTY text keeps ANSI escapes / carriage returns / partial JSON
+        // verbatim inside the JSON string; the frame itself stays one valid
+        // JSONL line (#307).
+        let event = Event::Output(HarnessOutput {
+            text: "\u{1b}[1;32mbanner\u{1b}[0m\r\n{\"not\":\"terminated".into(),
+            session_id: "s1".into(),
+        });
+        let mut buf = Vec::new();
+        emit_event(&mut buf, &event).unwrap();
+        let line = String::from_utf8(buf.clone()).unwrap();
+        assert_eq!(
+            line.matches('\n').count(),
+            1,
+            "one frame must serialize to exactly one line: {line:?}"
+        );
+        let v: serde_json::Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(v["type"], "output");
+        assert_eq!(
+            v["text"],
+            "\u{1b}[1;32mbanner\u{1b}[0m\r\n{\"not\":\"terminated"
+        );
+        assert_eq!(v["session_id"], "s1");
         let mut reader = Cursor::new(buf);
         let decoded = read_event(&mut reader).unwrap().unwrap();
         assert_eq!(decoded, event);

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -11,6 +11,142 @@
 
 use std::process::{Command, Stdio};
 
+/// Regression test for #307: with a non-claude harness that spews raw PTY
+/// noise (ANSI escapes, carriage-return progress lines, partial/broken
+/// JSON), every line the CLI writes to stdout in `--stream-json` mode must
+/// still parse as JSON. The noise is captured off the PTY and wrapped in
+/// `output` events instead of interleaving with the frames.
+///
+/// Unlike its `#[ignore]`d siblings above, this test is hermetic (fake
+/// harness on PATH, temp `COVEN_HOME`, temp project cwd) and runs by
+/// default, matching the smoke-test conventions.
+#[cfg(unix)]
+#[test]
+fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+
+    // Fake codex that behaves like a TUI-ish harness on a PTY: colored
+    // banner, carriage-return progress updates, a partial line that looks
+    // like broken JSON, then a completion marker. Before #307 all of this
+    // leaked raw onto stdout between the JSONL frames.
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex");
+    fs::write(
+        &fake_codex,
+        "#!/bin/sh\n\
+         printf '\\033[1;32mfake codex banner\\033[0m\\n'\n\
+         printf 'progress 1/2\\rprogress 2/2\\n'\n\
+         printf '{\"not\":\"terminated'\n\
+         printf '\\nfake codex noise complete\\n'\n",
+    )
+    .expect("failed to write fake codex");
+    let mut permissions = fs::metadata(&fake_codex)
+        .expect("failed to stat fake codex")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).expect("failed to chmod fake codex");
+
+    let mut paths = vec![fake_bin.clone()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--stream-json", "--", "ping"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+
+    assert!(
+        out.status.success(),
+        "coven run codex --stream-json failed: status={:?} stdout={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("stdout not utf-8");
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(
+        lines.len() >= 3,
+        "expected at least system + user + result frames; got {lines:?}",
+    );
+
+    // The core #307 contract: EVERY stdout line is valid JSON, no matter
+    // what the harness wrote to its PTY.
+    let frames: Vec<serde_json::Value> = lines
+        .iter()
+        .map(|line| {
+            serde_json::from_str(line).unwrap_or_else(|error| {
+                panic!("stdout line is not valid JSON ({error}): {line:?}\nfull stdout:\n{stdout}")
+            })
+        })
+        .collect();
+
+    assert_eq!(frames[0]["type"], "system");
+    assert_eq!(frames[0]["subtype"], "init");
+    let session_id = frames[0]["session_id"]
+        .as_str()
+        .expect("system.init carries a session id")
+        .to_string();
+
+    assert_eq!(frames[1]["type"], "user");
+    assert_eq!(frames[1]["message"]["content"][0]["text"], "ping");
+
+    let last = frames.last().expect("at least one frame");
+    assert_eq!(last["type"], "result");
+    assert_eq!(last["subtype"], "success");
+    assert_eq!(last["is_error"], false);
+
+    // The PTY noise is not dropped: it rides inside `output` frames, raw
+    // text preserved (ANSI escapes and the broken-JSON fragment included),
+    // tagged with the session id.
+    let output_text: String = frames
+        .iter()
+        .filter(|frame| frame["type"] == "output")
+        .map(|frame| {
+            assert_eq!(
+                frame["session_id"], *session_id,
+                "output frames carry the session id: {frame}"
+            );
+            frame["text"]
+                .as_str()
+                .expect("output frames carry raw text")
+                .to_string()
+        })
+        .collect();
+    assert!(
+        output_text.contains("fake codex banner"),
+        "captured PTY output should include the harness banner; got {output_text:?}",
+    );
+    assert!(
+        output_text.contains("\u{1b}["),
+        "ANSI escapes are preserved verbatim inside output frames; got {output_text:?}",
+    );
+    assert!(
+        output_text.contains("{\"not\":\"terminated"),
+        "broken-JSON PTY noise must ride inside output frames, not the stream; got {output_text:?}",
+    );
+    assert!(
+        output_text.contains("fake codex noise complete"),
+        "captured PTY output should include the completion marker; got {output_text:?}",
+    );
+}
+
 #[test]
 #[ignore = "requires built coven binary; run with `cargo test -- --ignored`"]
 fn stream_json_emits_init_and_result_for_codex_dry_run() {

--- a/docs/STREAM-JSON.md
+++ b/docs/STREAM-JSON.md
@@ -4,8 +4,10 @@
 stdout. With `--stream-json-input`, user messages are read line-by-line from
 stdin as JSON (claude harness only).
 
-The schema matches `OpenClaw bridge-code` exactly; SDKs that target Coven
-Code work unchanged against Coven CLI.
+The schema matches `OpenClaw bridge-code`; SDKs that target Coven Code work
+unchanged against Coven CLI. Coven additionally emits the `output` event
+type (below) for harnesses without a native stream-json protocol; consumers
+should ignore event types they don't recognize.
 
 ## Event types
 
@@ -32,6 +34,21 @@ Code work unchanged against Coven CLI.
 ```json
 {"type":"tool_result","tool_use_id":"...","content":[{"type":"text","text":"..."}],"is_error":false,"session_id":"..."}
 ```
+
+### `output` - raw harness output from non-stream harnesses
+
+```json
+{"type":"output","text":"raw PTY text…","session_id":"..."}
+```
+
+Emitted only for harnesses without a native stream-json protocol (codex,
+external adapters). Coven runs those harnesses on a PTY and wraps every
+captured chunk in one `output` frame so stdout stays JSONL-only — raw PTY
+bytes never interleave with the stream. `text` is the raw PTY text: it may
+contain ANSI escape sequences, carriage returns, and partial lines, and
+chunk boundaries follow PTY reads rather than line breaks. Consumers that
+want clean text should concatenate the `text` fields in order and strip
+escapes. Never emitted on the claude pass-through path.
 
 ### `result` - emitted once at end
 
@@ -64,14 +81,22 @@ non-stream harnesses the flag is accepted but no stdin forwarding occurs.
   on this path; claude emits its own when it processes the prompt.
 
 - **codex** and other non-stream harnesses: Coven synthesizes
-  `system.init` + `user` + `result`. The harness's text output is not
-  exposed as `assistant` events in this mode (use `coven attach <id>` for
-  streamed text). In practice `--stream-json` for codex is most useful with
-  `--detach`, which records the session without launching the harness and
-  emits init+user+result immediately.
+  `system.init` + `user` + `result`, and wraps the harness's raw PTY
+  output in `output` frames between them. The harness always launches in
+  its one-shot/non-interactive form on this path (stream-json is a machine
+  protocol; a TUI would wait on keystrokes for a screen that is never
+  rendered). The output is not parsed into `assistant` events — `output`
+  carries the raw text, escapes and all.
+
+  stdout carries only JSONL frames regardless of harness; anything the
+  harness writes to its PTY rides inside `output` events instead of
+  leaking onto the stream.
 
 ## Stability
 
 This is a stable interface as of 2026-05. Additions are additive (new event
 types, new optional fields). Removals or breaking changes to existing event
 shapes require a major version bump of the CLI.
+
+The `output` event type was added 2026-07 as an additive change under this
+policy; consumers must ignore event types they don't recognize.

--- a/docs/reference/cli-run.md
+++ b/docs/reference/cli-run.md
@@ -29,7 +29,7 @@ coven run <harness> <prompt> [flags]
 | `--visibility <private\|workspace\|shared>` | Set session visibility metadata. |
 | `--archive` | Archive the session after the run completes. |
 | `--familiar <id>` | Inject familiar identity context. |
-| `--stream-json` | Emit Coven JSONL events on stdout. |
+| `--stream-json` | Emit Coven JSONL events on stdout. stdout carries only JSONL for every harness: non-stream harnesses (codex, external adapters) have their raw PTY output wrapped in `output` events. See `docs/STREAM-JSON.md`. |
 | `--stream-json-input` | With `--stream-json`, read JSONL user messages from stdin for Claude stream mode. |
 
 Examples:


### PR DESCRIPTION
## Context

- Summary: `--stream-json` promises stable JSONL on stdout, but non-claude harnesses (codex, external adapters) ran through `run_attached`, which mirrors raw PTY bytes to stdout — ANSI escapes, `\r` progress updates, and partial lines interleaved with the JSONL frames and corrupted the stream for any line-delimited-JSON consumer. From the #297 CLI UX audit (follow-up candidate 1).
- Files changed:
  - `crates/coven-cli/src/stream_json.rs` — new additive `output` event type (`Event::Output` / `HarnessOutput`) + wire-shape/round-trip test
  - `crates/coven-cli/src/pty_runner.rs` — new `run_attached_captured`: PTY run with output handed to a callback instead of mirrored to stdout
  - `crates/coven-cli/src/main.rs` — stream-json non-claude path routes through the captured runner, wrapping chunks in `output` frames; forces `NonInteractive` launch mode under `--stream-json`
  - `crates/coven-cli/tests/stream_json_integration.rs` — hermetic regression test with a noise-spewing fake codex
  - `docs/STREAM-JSON.md`, `docs/reference/cli-run.md` — document the `output` event and the JSONL-only stdout guarantee
- Closes #307

## Implementation

- Approach: **event-wrapping (captured-PTY routing), not stderr routing.** The stability section of `docs/STREAM-JSON.md` explicitly declares new event types an additive, non-breaking change, so the schema could naturally gain a raw-output event — the lossless option for consumers (the harness output still arrives, safely JSON-escaped, in order, tagged with the session id) versus stderr routing, which would lose ordering relative to the frames and mix harness output with Coven diagnostics. Existing event shapes are untouched.
  - New frame: `{"type":"output","text":"raw PTY text…","session_id":"…"}`. `text` is raw PTY text (may contain ANSI escapes, `\r`, partial lines); chunk boundaries follow PTY reads. Chunks are guaranteed valid UTF-8 (`drain_detached_output` reassembles codepoints split across reads).
  - `run_attached_captured` mirrors `run_attached` (same PTY spawn, same stdin forwarding) except output goes to the callback and raw terminal mode is never enabled (nothing is echoed back).
  - `--stream-json` now always launches non-stream harnesses in one-shot/non-interactive form even when stdio is a terminal: it is a machine protocol, and a TUI launch would sit waiting on keystrokes for a screen that is never rendered. The claude pass-through already behaves this way (`-p`).
- User-visible behavior: in `--stream-json` mode, stdout carries only valid JSONL for every harness. Non-claude harness output rides inside `output` events between the synthesized `system.init`/`user`/`result` frames instead of leaking raw onto the stream. Non-stream-json runs are unchanged.
- Compatibility notes: additive under the declared stability policy ("Additions are additive (new event types, new optional fields)"). No existing event shape changed. Consumers must ignore unrecognized event types (now stated explicitly in `docs/STREAM-JSON.md`). The previous raw interleaving was corrupt by definition, so nothing could have depended on it.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — all green (926 unit tests + integration suites). Note: `adapter_install_hermes_writes_trusted_manifest` fails on this dev machine on a *clean* checkout too because a real `hermes` binary exists in `~/.local/bin`; with that PATH entry filtered (CI conditions) the full workspace suite passes 100%.
- [x] `python3 scripts/check-secrets.py` — "Secret guard passed: no current-tree or history findings."
- [x] Additional manual checks: new regression test `stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise` verified to FAIL against the previous routing (stashed fix, raw ANSI banner broke JSON parsing) and pass with it.

## Risk and Rollback

- Risk level: low. The new code path is exercised only when `--stream-json` is set with a non-claude harness — exactly the path that was already broken. Claude pass-through, non-stream runs, daemon/chat paths are untouched.
- Rollback plan: revert the single commit; no schema/data migrations.

## Agent Handoff

- Current state: complete; all four local CI gates green.
- Follow-ups: remaining #297 audit items tracked separately (`--json` coverage, shell completions, legacy chat TUI). A future refinement could optionally coalesce `output` chunks into line-aligned frames, but raw chunking is lossless and simplest.
- Known gaps: `output` frames carry raw escapes by design; consumers wanting clean text must strip ANSI themselves (documented in `docs/STREAM-JSON.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
