### PR TITLE
feat: --json for wt --list, claim status, daemon status, pc top/disk; human-readable claim dates

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -217,6 +217,8 @@ enum Command {
         prune_merged: bool,
         #[arg(long, value_name = "DAYS", conflicts_with_all = ["list", "doctor", "prune_merged"], help = "Remove clean worktrees not modified for DAYS")]
         prune_stale: Option<u64>,
+        #[arg(long, requires = "list", help = "With --list, print worktrees as JSON")]
+        json: bool,
     },
     #[command(about = "Manage TTL-bounded agent branch claims")]
     Claim {
@@ -344,7 +346,10 @@ enum DaemonCommand {
     #[command(about = "Restart the background daemon")]
     Restart,
     #[command(about = "Show whether the daemon is running")]
-    Status,
+    Status {
+        #[arg(long, help = "Print daemon status as JSON")]
+        json: bool,
+    },
     #[command(about = "Stop the background daemon")]
     Stop,
     #[command(hide = true)]
@@ -405,7 +410,10 @@ enum ClaimCommand {
         branch: String,
     },
     #[command(about = "Show active and expired claims for this repository")]
-    Status,
+    Status {
+        #[arg(long, help = "Print claims as JSON (timestamps stay epoch seconds)")]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -503,19 +511,21 @@ fn run_cli(cli: Cli) -> Result<()> {
             doctor,
             prune_merged,
             prune_stale,
+            json,
         }) => parallel_protocol::run_wt_command(
             branch.as_deref(),
             list,
             doctor,
             prune_merged,
             prune_stale,
+            json,
         ),
         Some(Command::Claim { command }) => match command {
             ClaimCommand::Acquire { branch } => parallel_protocol::claim_acquire(&branch),
             ClaimCommand::Release { branch } => parallel_protocol::claim_release(&branch),
             ClaimCommand::Heartbeat { branch } => parallel_protocol::claim_heartbeat(&branch),
             ClaimCommand::Canary { branch } => parallel_protocol::claim_canary(&branch),
-            ClaimCommand::Status => parallel_protocol::claim_status(),
+            ClaimCommand::Status { json } => parallel_protocol::claim_status(json),
         },
         Some(Command::Hooks { command }) => match command {
             HooksCommand::Install => parallel_protocol::hooks_install(),
@@ -1516,20 +1526,56 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 );
             }
         }
-        DaemonCommand::Status => match daemon::background_server_status(&home)? {
+        DaemonCommand::Status { json } => match daemon::background_server_status(&home)? {
             Some(daemon::DaemonStatusState::Running(status)) => {
                 let health = api::health_response(Some(status.clone()));
-                println!(
-                    "coven daemon status=running ok={} pid={} socket={}",
-                    health.ok, status.pid, status.socket
-                );
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "status": "running",
+                            "ok": health.ok,
+                            "pid": status.pid,
+                            "socket": status.socket,
+                        }))?
+                    );
+                } else {
+                    println!(
+                        "coven daemon status=running ok={} pid={} socket={}",
+                        health.ok, status.pid, status.socket
+                    );
+                }
             }
-            Some(daemon::DaemonStatusState::Stale(status)) => println!(
-                "coven daemon status=stale ok=false pid={} socket={}",
-                status.pid, status.socket
-            ),
+            Some(daemon::DaemonStatusState::Stale(status)) => {
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "status": "stale",
+                            "ok": false,
+                            "pid": status.pid,
+                            "socket": status.socket,
+                        }))?
+                    );
+                } else {
+                    println!(
+                        "coven daemon status=stale ok=false pid={} socket={}",
+                        status.pid, status.socket
+                    );
+                }
+            }
             None => {
-                println!("coven daemon status=stopped");
+                if json {
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&serde_json::json!({
+                            "status": "stopped",
+                            "ok": false,
+                        }))?
+                    );
+                } else {
+                    println!("coven daemon status=stopped");
+                }
                 eprintln!(
                     "start it with `coven daemon start` (optional — `coven run` works without it)"
                 );

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -36,11 +36,12 @@ pub(crate) fn run_wt_command(
     doctor: bool,
     prune_merged: bool,
     prune_stale: Option<u64>,
+    json: bool,
 ) -> Result<()> {
     let repo = Repo::discover()?;
     match (branch, list, doctor, prune_merged, prune_stale) {
         (Some(branch), false, false, false, None) => wt_enter_or_create(&repo, branch),
-        (None, true, false, false, None) => wt_list(&repo),
+        (None, true, false, false, None) => wt_list(&repo, json),
         (None, false, true, false, None) => wt_doctor(&repo),
         (None, false, false, true, None) => wt_prune_merged(&repo),
         (None, false, false, false, Some(days)) => wt_prune_stale(&repo, days),
@@ -63,7 +64,7 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
                 "{} is already claimed by {} until {}",
                 branch,
                 existing.agent_id,
-                existing.expires_at
+                format_epoch(existing.expires_at)
             );
         }
     }
@@ -76,7 +77,10 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
         head: current_head().ok(),
     };
     write_claim(&repo, &claim)?;
-    println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
+    println!(
+        "claimed {branch} for {agent_id} until {}",
+        format_epoch(claim.expires_at)
+    );
     Ok(())
 }
 
@@ -125,7 +129,7 @@ pub(crate) fn claim_heartbeat(branch: &str) -> Result<()> {
     write_claim(&repo, &claim)?;
     println!(
         "heartbeat {branch} for {agent_id} until {}",
-        claim.expires_at
+        format_epoch(claim.expires_at)
     );
     Ok(())
 }
@@ -140,19 +144,42 @@ pub(crate) fn claim_canary(branch: &str) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn claim_status() -> Result<()> {
+pub(crate) fn claim_status(json: bool) -> Result<()> {
     let repo = Repo::discover()?;
     let claims_dir = repo.common_dir.join("agent-claims");
-    if !claims_dir.exists() {
-        println!("No claims.");
+    let now = unix_now();
+    let mut claims = if claims_dir.exists() {
+        fs::read_dir(&claims_dir)?
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    claims.sort_by(|a, b| a.branch.cmp(&b.branch));
+
+    if json {
+        // Timestamps stay epoch seconds on the JSON path; the human table
+        // below renders them as dates.
+        let entries = claims
+            .iter()
+            .map(|claim| {
+                serde_json::json!({
+                    "branch": claim.branch,
+                    "agent": claim.agent_id,
+                    "state": if claim.is_active(now) { "active" } else { "expired" },
+                    "acquired_at": claim.acquired_at,
+                    "expires_at": claim.expires_at,
+                })
+            })
+            .collect::<Vec<_>>();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::Value::Array(entries))?
+        );
         return Ok(());
     }
-    let now = unix_now();
-    let mut claims = fs::read_dir(&claims_dir)?
-        .filter_map(|entry| entry.ok())
-        .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
-        .collect::<Vec<_>>();
-    claims.sort_by(|a, b| a.branch.cmp(&b.branch));
+
     if claims.is_empty() {
         println!("No claims.");
         return Ok(());
@@ -166,10 +193,21 @@ pub(crate) fn claim_status() -> Result<()> {
         };
         println!(
             "{:<32} {:<20} {:<10} {}",
-            claim.branch, claim.agent_id, state, claim.expires_at
+            claim.branch,
+            claim.agent_id,
+            state,
+            format_epoch(claim.expires_at)
         );
     }
     Ok(())
+}
+
+/// Render an epoch-seconds timestamp as an RFC 3339 UTC date for human
+/// output. The JSON paths keep raw epoch values.
+fn format_epoch(secs: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(secs as i64, 0)
+        .map(|date| date.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| secs.to_string())
 }
 
 pub(crate) fn hooks_install() -> Result<()> {
@@ -219,8 +257,29 @@ fn wt_enter_or_create(repo: &Repo, branch: &str) -> Result<()> {
     Ok(())
 }
 
-fn wt_list(repo: &Repo) -> Result<()> {
+fn wt_list(repo: &Repo, json: bool) -> Result<()> {
     let worktrees = list_worktrees()?;
+    if json {
+        let mut entries = Vec::with_capacity(worktrees.len());
+        for worktree in &worktrees {
+            entries.push(serde_json::json!({
+                "branch": worktree.branch,
+                "dirty": worktree_dirty(&worktree.path)?,
+                "claim": worktree
+                    .branch
+                    .as_deref()
+                    .and_then(|branch| read_claim(repo, branch).ok().flatten())
+                    .filter(|claim| claim.is_active(unix_now()))
+                    .map(|claim| claim.agent_id),
+                "path": worktree.path.to_string_lossy(),
+            }));
+        }
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::Value::Array(entries))?
+        );
+        return Ok(());
+    }
     println!("{:<32} {:<8} {:<20} path", "branch", "dirty", "claim");
     for worktree in worktrees {
         let branch = worktree.branch.as_deref().unwrap_or("(detached)");
@@ -721,3 +780,14 @@ if [ "$consume_intent" = "1" ]; then
   rm -f "$intent_file"
 fi
 "#;
+
+#[cfg(test)]
+mod tests {
+    use super::format_epoch;
+
+    #[test]
+    fn format_epoch_renders_rfc3339_utc() {
+        assert_eq!(format_epoch(0), "1970-01-01T00:00:00Z");
+        assert_eq!(format_epoch(1_782_432_000), "2026-06-26T00:00:00Z");
+    }
+}

--- a/crates/coven-cli/src/pc/display.rs
+++ b/crates/coven-cli/src/pc/display.rs
@@ -110,17 +110,57 @@ fn print_proc(p: &ProcessInfo, format: &OutputFormat) {
 }
 
 pub fn print_top(snap: &SystemSnapshot, n: usize, format: &OutputFormat) {
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", format_top_json(snap, n));
+        return;
+    }
     println!("── Top {} Processes (by CPU) ────────────────", n);
     for proc in snap.processes.iter().take(n) {
         print_proc(proc, format);
     }
 }
 
-pub fn print_disk_usage(snap: &SystemSnapshot) {
+fn format_top_json(snap: &SystemSnapshot, n: usize) -> String {
+    let value = json!({
+        "processes": snap.processes.iter().take(n).map(|p| {
+            let mut entry = json!({
+                "pid": p.pid,
+                "name": p.name,
+                "cpu_pct": p.cpu_pct,
+                "memory_mb": p.memory_mb,
+            });
+            if let Some(argv) = &p.argv {
+                entry["argv"] = json!(argv);
+            }
+            entry
+        }).collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).expect("process list JSON serialization cannot fail")
+}
+
+pub fn print_disk_usage(snap: &SystemSnapshot, format: &OutputFormat) {
+    if matches!(format, OutputFormat::Json) {
+        println!("{}", format_disk_json(snap));
+        return;
+    }
     println!("── Disk Usage ──────────────────────────────");
     for disk in &snap.disks {
         print_disk(disk);
     }
+}
+
+fn format_disk_json(snap: &SystemSnapshot) -> String {
+    let value = json!({
+        "disks": snap.disks.iter().map(|d| {
+            json!({
+                "mount": d.mount,
+                "total_gb": d.total_gb,
+                "available_gb": d.available_gb,
+                "used_pct": d.used_pct,
+            })
+        }).collect::<Vec<_>>(),
+    });
+    serde_json::to_string_pretty(&value).expect("disk list JSON serialization cannot fail")
 }
 
 fn format_json(snap: &SystemSnapshot) -> String {
@@ -202,6 +242,47 @@ mod tests {
         assert_eq!(value["cpu_usage_pct"], 12.5);
         assert_eq!(value["processes"][0]["name"], "proc \"quoted\"\u{7}");
         assert_eq!(value["disks"][0]["mount"], "/Volumes/name \"quoted\"\u{7}");
+    }
+
+    #[test]
+    fn top_json_serializes_processes_with_optional_argv() {
+        let mut snap = sample_snapshot();
+        snap.processes[0].argv = Some(vec!["proc".to_string(), "--flag".to_string()]);
+        let body = format_top_json(&snap, 10);
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["processes"][0]["pid"], 42);
+        assert_eq!(value["processes"][0]["argv"][1], "--flag");
+
+        snap.processes[0].argv = None;
+        let body = format_top_json(&snap, 10);
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert!(value["processes"][0].get("argv").is_none());
+    }
+
+    #[test]
+    fn top_json_honors_the_requested_count() {
+        let mut snap = sample_snapshot();
+        let second = ProcessInfo {
+            pid: 43,
+            name: "other".to_string(),
+            cpu_pct: 1.0,
+            memory_mb: 32,
+            argv: None,
+        };
+        snap.processes.push(second);
+        let body = format_top_json(&snap, 1);
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        assert_eq!(value["processes"].as_array().map(Vec::len), Some(1));
+    }
+
+    #[test]
+    fn disk_json_serializes_all_disks() {
+        let body = format_disk_json(&sample_snapshot());
+        let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+
+        assert_eq!(value["disks"][0]["mount"], "/Volumes/name \"quoted\"\u{7}");
+        assert_eq!(value["disks"][0]["used_pct"], 60.0);
     }
 
     #[test]

--- a/crates/coven-cli/src/pc/mod.rs
+++ b/crates/coven-cli/src/pc/mod.rs
@@ -20,9 +20,14 @@ pub enum PcCommand {
         n: usize,
         #[arg(long, help = "Include full command-line arguments")]
         verbose: bool,
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
     },
     #[command(about = "Disk usage breakdown")]
-    Disk,
+    Disk {
+        #[arg(long, help = "Output as JSON")]
+        json: bool,
+    },
     #[command(about = "Kill a process by PID (requires --confirm)")]
     Kill {
         #[arg(help = "Process ID to terminate")]
@@ -62,18 +67,25 @@ pub fn run_pc_command(command: Option<PcCommand>) -> Result<()> {
             };
             display::print_status(&snap, &fmt);
         }
-        Some(PcCommand::Top { n, verbose }) => {
+        Some(PcCommand::Top { n, verbose, json }) => {
             let snap = diagnostics::snapshot(verbose)?;
-            let fmt = if verbose {
+            let fmt = if json {
+                OutputFormat::Json
+            } else if verbose {
                 OutputFormat::Verbose
             } else {
                 OutputFormat::Compact
             };
             display::print_top(&snap, n, &fmt);
         }
-        Some(PcCommand::Disk) => {
+        Some(PcCommand::Disk { json }) => {
             let snap = diagnostics::snapshot(false)?;
-            display::print_disk_usage(&snap);
+            let fmt = if json {
+                OutputFormat::Json
+            } else {
+                OutputFormat::Compact
+            };
+            display::print_disk_usage(&snap, &fmt);
         }
         Some(PcCommand::Kill { pid, confirm }) => {
             relief::kill_by_pid(pid, confirm)?;

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -420,7 +420,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             }
         }
         CastIntent::DaemonStatus => {
-            run_daemon_command(DaemonCommand::Status)?;
+            run_daemon_command(DaemonCommand::Status { json: false })?;
             CastOutcome {
                 request: request_text,
                 launched: Some("Coven daemon status".to_string()),
@@ -1624,7 +1624,7 @@ fn run_magical_tui_action(action: MagicalTuiAction) -> Result<()> {
         MagicalTuiAction::Help => run_tui_help(),
         MagicalTuiAction::OpenTui => run(),
         MagicalTuiAction::Doctor => run_doctor(),
-        MagicalTuiAction::DaemonStatus => run_daemon_command(DaemonCommand::Status),
+        MagicalTuiAction::DaemonStatus => run_daemon_command(DaemonCommand::Status { json: false }),
         MagicalTuiAction::RunHarness => run_guided_harness_session(),
         MagicalTuiAction::PatchOpenClaw => {
             run_patch(None, vec![], None, None, None, false, false, true)

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -25,6 +25,25 @@ fn wt_creates_sibling_worktree_and_lists_protocol_state() -> anyhow::Result<()> 
     assert_success("coven wt --list", &list);
     assert_stdout_contains("coven wt --list", &list, "feature/demo");
     assert_stdout_contains("coven wt --list", &list, "feature-demo");
+
+    let json_list = repo.coven(["wt", "--list", "--json"])?;
+    assert_success("coven wt --list --json", &json_list);
+    let entries: serde_json::Value =
+        serde_json::from_slice(&json_list.stdout).expect("wt --list --json emits valid JSON");
+    let entry = entries
+        .as_array()
+        .expect("wt --list --json emits an array")
+        .iter()
+        .find(|entry| entry["branch"] == "feature/demo")
+        .expect("listing includes the created worktree");
+    assert_eq!(entry["dirty"], false);
+    assert_eq!(entry["claim"], serde_json::Value::Null);
+    assert!(
+        entry["path"]
+            .as_str()
+            .is_some_and(|path| path.ends_with("feature-demo")),
+        "worktree path should be reported: {entry}"
+    );
     Ok(())
 }
 
@@ -50,6 +69,27 @@ fn claim_acquire_blocks_other_agent_until_release() -> anyhow::Result<()> {
     assert_success("claim status", &status);
     assert_stdout_contains("claim status", &status, "feature/demo");
     assert_stdout_contains("claim status", &status, "cody");
+    // Human expiry renders as an RFC 3339 UTC date, not raw epoch seconds.
+    assert!(
+        String::from_utf8_lossy(&status.stdout)
+            .lines()
+            .any(|line| line.contains("cody") && line.ends_with('Z') && line.contains('T')),
+        "claim status should render the expiry as a date:\n{}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    let json_status = repo.coven(["claim", "status", "--json"])?;
+    assert_success("claim status --json", &json_status);
+    let claims: serde_json::Value =
+        serde_json::from_slice(&json_status.stdout).expect("claim status --json emits valid JSON");
+    let claim = &claims.as_array().expect("claims array")[0];
+    assert_eq!(claim["branch"], "feature/demo");
+    assert_eq!(claim["agent"], "cody");
+    assert_eq!(claim["state"], "active");
+    assert!(
+        claim["expires_at"].is_u64() && claim["acquired_at"].is_u64(),
+        "JSON timestamps stay epoch seconds: {claim}"
+    );
 
     let released = repo.coven_with_env(
         ["claim", "release", "feature/demo"],

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -142,6 +142,36 @@ fn daemon_start_is_idempotent_when_daemon_is_already_running() -> anyhow::Result
         second_pid, first_pid,
         "daemon start should reuse the verified running daemon instead of spawning another serve process"
     );
+
+    let status = run_coven(&coven, &coven_home, &path, &["daemon", "status", "--json"])?;
+    assert_success("daemon status --json while running", &status);
+    let status: Value = serde_json::from_slice(&status.stdout)
+        .expect("daemon status --json emits valid JSON on stdout");
+    assert_eq!(status["status"], "running");
+    assert_eq!(status["ok"], true);
+    assert_eq!(status["pid"].as_u64(), Some(first_pid));
+    assert!(status["socket"].is_string());
+    Ok(())
+}
+
+#[test]
+fn daemon_status_json_reports_stopped() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+
+    let output = run_coven(
+        &coven_bin(),
+        &coven_home,
+        &std::env::var_os("PATH").unwrap_or_default(),
+        &["daemon", "status", "--json"],
+    )?;
+
+    assert_success("daemon status --json stopped", &output);
+    let status: Value = serde_json::from_slice(&output.stdout)
+        .expect("daemon status --json emits valid JSON on stdout");
+    assert_eq!(status["status"], "stopped");
+    assert_eq!(status["ok"], false);
     Ok(())
 }
 
@@ -381,10 +411,16 @@ fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     );
     assert!(coven_home.join("adapters").join("hermes.json").exists());
 
-    let doctor = run_coven(&coven, &coven_home, &path, &["adapter", "doctor", "hermes"])?;
+    // Diagnose against an empty PATH so the outcome doesn't depend on
+    // whether a real `hermes` happens to be installed on this machine:
+    // unavailable → exit 1, with the diagnosis output still rendered in full.
+    let doctor = run_coven(
+        &coven,
+        &coven_home,
+        &OsString::new(),
+        &["adapter", "doctor", "hermes"],
+    )?;
 
-    // The hermes executable is not installed, so adapter doctor reports it
-    // and exits 1 (the diagnosis output still renders in full).
     assert_failure("adapter doctor hermes", &doctor);
     assert_stdout_contains("adapter doctor hermes", &doctor, "Hermes Agent");
     assert_stdout_contains("adapter doctor hermes", &doctor, "manifest:");

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -65,10 +65,11 @@ environment where the daemon/session starts.
 ## Daemon status
 
 `doctor` summarizes daemon state, but use the daemon command for scriptable
-status:
+status (`--json` for structured output):
 
 ```sh
 coven daemon status
+coven daemon status --json
 ```
 
 Typical output:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,16 +98,19 @@ flowchart TB
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sacrifice` | `--yes` (required) |
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
-| `coven wt` | `--list`, `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |
+| `coven wt` | `--list [--json]`, `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |
+| `coven claim status` | `--json` |
+| `coven daemon status` | `--json` |
 | `coven pc kill` | `--confirm` (required) |
 | `coven pc cache clear` | `--confirm` (required) |
-| `coven pc top` | `--n <N>`, `--verbose` |
+| `coven pc top` | `--n <N>`, `--verbose`, `--json` |
+| `coven pc disk` | `--json` |
 | `coven pc status` | `--json` |
 
 ## Flag conventions
 
 - **Project-scoped commands** accept `--cwd <path>` for a launch directory inside the project root.
-- **Machine-readable output** is per-command today: `coven sessions` accepts `--plain` and `--json`; `coven sessions search`, `coven adapter list`, and `coven pc status` accept `--json`. Other tabular commands (`wt --list`, `claim status`, `daemon status`, `pc top`, `pc disk`) print human tables only.
+- **Machine-readable output** is per-command today: `coven sessions` accepts `--plain` and `--json`; `coven sessions search`, `coven adapter list`, `coven daemon status`, `coven wt --list`, `coven claim status`, `coven pc status`, `coven pc top`, and `coven pc disk` accept `--json`. Timestamps in JSON output stay epoch seconds; human tables render them as RFC 3339 dates.
 - **Session id arguments** (`attach`, `summon`, `archive`, `sacrifice`, `kill`) accept a unique prefix of the id.
 - **Destructive commands** require `--yes` (or `--confirm` for `coven pc` relief).
 - **Daemon-touching commands** print install/repair hints when the socket is missing.


### PR DESCRIPTION
Closes #308 (from the #297 UX audit, follow-up 5).

## What's added

| Command | JSON shape |
|---|---|
| `coven wt --list --json` | `[{branch, dirty, claim, path}]` — `branch` null when detached, `claim` null when unclaimed |
| `coven claim status --json` | `[{branch, agent, state, acquired_at, expires_at}]` — epoch seconds preserved; empty state emits `[]` |
| `coven daemon status --json` | `{status: running\|stale\|stopped, ok, pid?, socket?}` |
| `coven pc top --json` | `{processes: [{pid, name, cpu_pct, memory_mb, argv?}]}` — `argv` with `--verbose`, honors `--n` |
| `coven pc disk --json` | `{disks: [{mount, total_gb, available_gb, used_pct}]}` |

## Human-path fix

`claim status` printed raw epoch seconds in the `expires` column; acquire/heartbeat confirmations and the already-claimed refusal did the same. All now render RFC 3339 UTC dates (`2026-07-06T22:35:00Z`); epoch values remain available via `--json`.

Human table/status formats are otherwise unchanged (the `daemon status` key=value line stays — it's existing scrape surface; #311 handles voice cleanup separately now that `--json` exists).

## Testing

- Integration: `wt --list --json` and `claim status --json` parsed and field-asserted in `tests/parallel_protocol.rs`; `daemon status --json` asserted for running (piggybacked on the idempotent-start smoke) and stopped states; pc formatters unit-tested (argv presence, `--n` bound, valid JSON with metacharacter names).
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `scripts/check-secrets.py` — all green.
- Hands-on: stopped daemon JSON, `pc top/disk --json` verified against the debug binary.

Note: includes the same one-hunk hermes-doctor empty-PATH test fix as #312 (identical content; merges cleanly in either order). The Dependency audit gate needs the crossbeam-epoch bump PR merged first — unrelated RUSTSEC-2026-0204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)