### PR TITLE
chore: bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## What

Lockfile-only patch bump of the transitive dep `crossbeam-epoch` (via rayon → faer/gemm → coven-memory) to clear [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `fmt::Display` of `Atomic`/`Shared` null pointers, fixed in 0.9.20).

## Why now

The advisory published after main's last CI run, so the **Dependency audit** check currently fails on every PR (#313 and #315 are blocked on it). Main itself is unaffected code-wise; this just updates `Cargo.lock`.

## Gates

- `cargo fmt --check` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --workspace --locked` — pass (one pre-existing environmental failure on this machine, `adapter_install_hermes_writes_trusted_manifest`, caused by a real `hermes` in `~/.local/bin`; passes with CI-like PATH)
- `python3 scripts/check-secrets.py` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)