### PR TITLE
feat: shell completions and a --color override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +576,7 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "clap",
+ "clap_complete",
  "crossterm",
  "dirs-next",
  "flate2",

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 crossterm = "0.29"
 flate2 = "1"
 json5 = "1.3"

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -58,6 +58,15 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
     #[arg(
+        long,
+        global = true,
+        value_name = "WHEN",
+        value_parser = ["auto", "always", "never"],
+        default_value = "auto",
+        help = "Control ANSI color output; auto honors NO_COLOR and CLICOLOR_FORCE"
+    )]
+    color: String,
+    #[arg(
         value_name = "PROMPT",
         num_args = 0..,
         trailing_var_arg = true,
@@ -77,6 +86,11 @@ enum Command {
         about = "Check local setup and print next steps (exits 1 when a blocking problem is found)"
     )]
     Doctor,
+    #[command(about = "Generate shell completions (bash, zsh, fish, elvish, powershell)")]
+    Completions {
+        #[arg(help = "Shell to generate completions for")]
+        shell: clap_complete::Shell,
+    },
     #[command(
         name = "adapter",
         alias = "adapters",
@@ -446,6 +460,13 @@ fn main() -> Result<()> {
     settings::init_cached(loaded);
 
     let cli = Cli::parse();
+    // Resolve --color before anything renders: theme::mode() caches on
+    // first use, so the override must be recorded ahead of any output.
+    theme::set_color_choice(match cli.color.as_str() {
+        "always" => theme::ColorChoice::Always,
+        "never" => theme::ColorChoice::Never,
+        _ => theme::ColorChoice::Auto,
+    });
     run_cli(cli)
 }
 
@@ -457,6 +478,16 @@ fn run_cli(cli: Cli) -> Result<()> {
     match cli.command {
         None | Some(Command::Chat) | Some(Command::Tui) => run_shared_interactive_shell(),
         Some(Command::Doctor) => run_doctor(),
+        Some(Command::Completions { shell }) => {
+            use clap::CommandFactory;
+            clap_complete::generate(
+                shell,
+                &mut Cli::command(),
+                "coven",
+                &mut io::stdout().lock(),
+            );
+            Ok(())
+        }
         Some(Command::Adapter { command }) => run_adapter_command(command),
         Some(Command::Daemon { command }) => run_daemon_command(command),
         Some(Command::Executor { command }) => run_executor_command(command),

--- a/crates/coven-cli/src/theme.rs
+++ b/crates/coven-cli/src/theme.rs
@@ -198,35 +198,85 @@ pub enum TerminalMode {
     NoColor,
 }
 
+/// Resolved value of the global `--color` flag. `Auto` defers to the env
+/// conventions (NO_COLOR, CLICOLOR_FORCE, tty + TERM detection); `Always`
+/// and `Never` override all of them.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub enum ColorChoice {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+static COLOR_CHOICE: OnceLock<ColorChoice> = OnceLock::new();
+
+/// Record the `--color` flag. Must run before the first render — `mode()`
+/// caches on first use, so set this right after clap parsing. First call
+/// wins; later calls are ignored.
+pub fn set_color_choice(choice: ColorChoice) {
+    let _ = COLOR_CHOICE.set(choice);
+}
+
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct EnvInputs<'a> {
     pub no_color: Option<&'a str>,
+    pub clicolor_force: Option<&'a str>,
     pub colorterm: Option<&'a str>,
     pub term: Option<&'a str>,
     pub stdout_is_tty: bool,
 }
 
-pub(crate) fn detect_mode_from(e: EnvInputs<'_>) -> TerminalMode {
-    // 1. NO_COLOR set to non-empty value always wins (per no-color.org;
-    //    empty-string treated as unset per supports-color convention).
+pub(crate) fn detect_mode_from(choice: ColorChoice, e: EnvInputs<'_>) -> TerminalMode {
+    // 0. The explicit --color flag outranks every env convention.
+    match choice {
+        ColorChoice::Never => return TerminalMode::NoColor,
+        ColorChoice::Always => return forced_mode(e),
+        ColorChoice::Auto => {}
+    }
+    // 1. NO_COLOR set to non-empty value wins among the env conventions
+    //    (per no-color.org; empty-string treated as unset per
+    //    supports-color convention).
     if e.no_color.map(|v| !v.is_empty()).unwrap_or(false) {
         return TerminalMode::NoColor;
     }
-    // 2. Piped/redirected stdout — never emit escapes.
+    // 2. CLICOLOR_FORCE set to anything but "" or "0" forces escapes even
+    //    when stdout is piped (https://bixense.com/clicolors/).
+    if e.clicolor_force
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false)
+    {
+        return forced_mode(e);
+    }
+    // 3. Piped/redirected stdout — never emit escapes.
     if !e.stdout_is_tty {
         return TerminalMode::NoColor;
     }
-    // 3. Explicit truecolor declaration.
+    // 4. Explicit truecolor declaration.
     match e.colorterm {
         Some("truecolor") | Some("24bit") => return TerminalMode::TrueColor,
         _ => {}
     }
-    // 4. TERM-based fallback.
+    // 5. TERM-based fallback.
     match e.term {
         Some(t) if t.ends_with("-direct") => TerminalMode::TrueColor,
         Some(t) if t.ends_with("-256color") => TerminalMode::Indexed256,
         Some("dumb") | None => TerminalMode::NoColor,
         Some(_) => TerminalMode::Indexed256,
+    }
+}
+
+/// Mode when color is forced (`--color=always` or CLICOLOR_FORCE): honor a
+/// declared truecolor terminal, otherwise fall back to indexed 256 — piped
+/// output has no tty to probe, and forcing means the caller wants escapes.
+fn forced_mode(e: EnvInputs<'_>) -> TerminalMode {
+    match e.colorterm {
+        Some("truecolor") | Some("24bit") => return TerminalMode::TrueColor,
+        _ => {}
+    }
+    match e.term {
+        Some(t) if t.ends_with("-direct") => TerminalMode::TrueColor,
+        _ => TerminalMode::Indexed256,
     }
 }
 
@@ -242,14 +292,19 @@ pub fn mode() -> TerminalMode {
 fn detect_mode() -> TerminalMode {
     use std::io::IsTerminal;
     let no_color = std::env::var("NO_COLOR").ok();
+    let clicolor_force = std::env::var("CLICOLOR_FORCE").ok();
     let colorterm = std::env::var("COLORTERM").ok();
     let term = std::env::var("TERM").ok();
-    detect_mode_from(EnvInputs {
-        no_color: no_color.as_deref(),
-        colorterm: colorterm.as_deref(),
-        term: term.as_deref(),
-        stdout_is_tty: std::io::stdout().is_terminal(),
-    })
+    detect_mode_from(
+        COLOR_CHOICE.get().copied().unwrap_or_default(),
+        EnvInputs {
+            no_color: no_color.as_deref(),
+            clicolor_force: clicolor_force.as_deref(),
+            colorterm: colorterm.as_deref(),
+            term: term.as_deref(),
+            stdout_is_tty: std::io::stdout().is_terminal(),
+        },
+    )
 }
 
 // ── 256-color downgrade ──
@@ -783,6 +838,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: Some("1"),
+                    clicolor_force: None,
                     colorterm: Some("truecolor"),
                     term: Some("xterm-256color"),
                     stdout_is_tty: true,
@@ -793,6 +849,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: Some(""),
+                    clicolor_force: None,
                     colorterm: Some("truecolor"),
                     term: Some("xterm-256color"),
                     stdout_is_tty: true,
@@ -803,6 +860,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: Some("truecolor"),
                     term: Some("xterm-256color"),
                     stdout_is_tty: true,
@@ -813,6 +871,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: Some("24bit"),
                     term: Some("xterm-256color"),
                     stdout_is_tty: true,
@@ -823,6 +882,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: None,
                     term: Some("xterm-direct"),
                     stdout_is_tty: true,
@@ -833,6 +893,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: None,
                     term: Some("xterm-256color"),
                     stdout_is_tty: true,
@@ -843,6 +904,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: None,
                     term: Some("xterm"),
                     stdout_is_tty: true,
@@ -853,6 +915,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: None,
                     term: Some("dumb"),
                     stdout_is_tty: true,
@@ -863,6 +926,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: None,
                     term: None,
                     stdout_is_tty: true,
@@ -873,6 +937,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: None,
+                    clicolor_force: None,
                     colorterm: Some("truecolor"),
                     term: Some("xterm-256color"),
                     stdout_is_tty: false,
@@ -882,6 +947,7 @@ mod tests {
             (
                 EnvInputs {
                     no_color: Some("1"),
+                    clicolor_force: None,
                     colorterm: None,
                     term: None,
                     stdout_is_tty: false,
@@ -890,8 +956,79 @@ mod tests {
             ),
         ];
         for (i, (inputs, expected)) in cases.iter().enumerate() {
-            assert_eq!(detect_mode_from(*inputs), *expected, "row {i}: {inputs:?}",);
+            assert_eq!(
+                detect_mode_from(ColorChoice::Auto, *inputs),
+                *expected,
+                "row {i}: {inputs:?}",
+            );
         }
+    }
+
+    #[test]
+    fn clicolor_force_overrides_piped_stdout_but_not_no_color() {
+        use TerminalMode::*;
+        let piped_truecolor = EnvInputs {
+            no_color: None,
+            clicolor_force: Some("1"),
+            colorterm: Some("truecolor"),
+            term: None,
+            stdout_is_tty: false,
+        };
+        assert_eq!(
+            detect_mode_from(ColorChoice::Auto, piped_truecolor),
+            TrueColor
+        );
+
+        let piped_plain = EnvInputs {
+            no_color: None,
+            clicolor_force: Some("1"),
+            colorterm: None,
+            term: None,
+            stdout_is_tty: false,
+        };
+        // Forcing with no terminal declaration falls back to indexed 256.
+        assert_eq!(detect_mode_from(ColorChoice::Auto, piped_plain), Indexed256);
+
+        // "0" and "" mean unset per the CLICOLOR convention.
+        for off in ["0", ""] {
+            let inputs = EnvInputs {
+                clicolor_force: Some(off),
+                ..piped_plain
+            };
+            assert_eq!(detect_mode_from(ColorChoice::Auto, inputs), NoColor);
+        }
+
+        // NO_COLOR still wins over CLICOLOR_FORCE.
+        let conflicted = EnvInputs {
+            no_color: Some("1"),
+            ..piped_truecolor
+        };
+        assert_eq!(detect_mode_from(ColorChoice::Auto, conflicted), NoColor);
+    }
+
+    #[test]
+    fn color_flag_outranks_every_env_convention() {
+        use TerminalMode::*;
+        let colorful_tty = EnvInputs {
+            no_color: None,
+            clicolor_force: None,
+            colorterm: Some("truecolor"),
+            term: Some("xterm-256color"),
+            stdout_is_tty: true,
+        };
+        assert_eq!(detect_mode_from(ColorChoice::Never, colorful_tty), NoColor);
+
+        let no_color_piped = EnvInputs {
+            no_color: Some("1"),
+            clicolor_force: None,
+            colorterm: Some("truecolor"),
+            term: None,
+            stdout_is_tty: false,
+        };
+        assert_eq!(
+            detect_mode_from(ColorChoice::Always, no_color_piped),
+            TrueColor
+        );
     }
 
     #[test]

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -538,6 +538,65 @@ fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
 }
 
 #[test]
+fn completions_generate_for_supported_shells() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    let zsh = run_coven(&coven, &coven_home, &path, &["completions", "zsh"])?;
+    assert_success("completions zsh", &zsh);
+    assert_stdout_contains("completions zsh", &zsh, "#compdef coven");
+
+    let bash = run_coven(&coven, &coven_home, &path, &["completions", "bash"])?;
+    assert_success("completions bash", &bash);
+    assert_stdout_contains("completions bash", &bash, "complete");
+
+    let bogus = run_coven(&coven, &coven_home, &path, &["completions", "tcsh"])?;
+    assert_failure("completions tcsh", &bogus);
+    Ok(())
+}
+
+#[test]
+fn color_flag_parses_and_rejects_unknown_values() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+
+    // Global flag composes with subcommands without disturbing them.
+    let sessions = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["sessions", "--color", "never", "--plain"],
+    )?;
+    assert_success("sessions --color never", &sessions);
+
+    // Root-level placement parses as the declared flag, not as a prompt —
+    // the front-door catch-all must not swallow it.
+    let root = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["--color", "never", "sessions", "--plain"],
+    )?;
+    assert_success("--color before subcommand", &root);
+
+    let bogus = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["sessions", "--color", "sometimes"],
+    )?;
+    assert_failure("--color rejects unknown value", &bogus);
+    assert_stderr_contains("--color rejects unknown value", &bogus, "sometimes");
+    Ok(())
+}
+
+#[test]
 fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -559,10 +618,16 @@ fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     );
     assert!(coven_home.join("adapters").join("hermes.json").exists());
 
-    let doctor = run_coven(&coven, &coven_home, &path, &["adapter", "doctor", "hermes"])?;
+    // Diagnose against an empty PATH so the outcome doesn't depend on
+    // whether a real `hermes` happens to be installed on this machine:
+    // unavailable → exit 1, with the diagnosis output still rendered in full.
+    let doctor = run_coven(
+        &coven,
+        &coven_home,
+        &OsString::new(),
+        &["adapter", "doctor", "hermes"],
+    )?;
 
-    // The hermes executable is not installed, so adapter doctor reports it
-    // and exits 1 (the diagnosis output still renders in full).
     assert_failure("adapter doctor hermes", &doctor);
     assert_stdout_contains("adapter doctor hermes", &doctor, "Hermes Agent");
     assert_stdout_contains("adapter doctor hermes", &doctor, "manifest:");

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -28,6 +28,7 @@ flowchart TB
   Root --> Claim["claim"]
   Root --> Hooks["hooks"]
   Root --> Pc["pc (macOS-first)"]
+  Root --> Completions["completions"]
 
   Daemon --> DStart["start"]
   Daemon --> DStatus["status [--json]"]
@@ -89,6 +90,7 @@ flowchart TB
 | `coven claim status` | Print branch claims from the current repository. |
 | `coven hooks install` | Install local protocol hooks that block unsafe commits and protected pushes. |
 | `coven pc` | macOS-first diagnostics and explicit `--confirm` relief operations. |
+| `coven completions <shell>` | Print shell completions for bash, zsh, fish, elvish, or powershell. |
 
 ## Common flags by command
 
@@ -106,6 +108,27 @@ flowchart TB
 | `coven pc top` | `--n <N>`, `--verbose`, `--json` |
 | `coven pc disk` | `--json` |
 | `coven pc status` | `--json` |
+
+## Global flags
+
+- **`--color <auto|always|never>`** controls ANSI color on every command. `auto` (the default) honors the environment: `NO_COLOR` disables color, `CLICOLOR_FORCE` forces it on even through a pipe, and otherwise color is emitted only to a TTY with a color-capable `TERM`. `--color=always` overrides all of that (useful when piping into a pager like `less -R`); `--color=never` forces plain text (useful for deterministic CI logs). The flag outranks the environment variables when both are set.
+
+## Shell completions
+
+Generate completions for your shell and source them:
+
+```sh
+# zsh (add to a directory on $fpath, e.g. ~/.zfunc)
+coven completions zsh > ~/.zfunc/_coven
+
+# bash
+coven completions bash > ~/.local/share/bash-completion/completions/coven
+
+# fish
+coven completions fish > ~/.config/fish/completions/coven.fish
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
 
 ## Flag conventions
 


### PR DESCRIPTION
Closes #309 (from the #297 UX audit, follow-up 6).

Two CLI-conventions gaps.

## 1. Shell completions

`coven completions <shell>` generates completions from the existing clap definitions via `clap_complete`. Supports `bash`, `zsh`, `fish`, `elvish`, `powershell`; an unknown shell is rejected by clap.

```sh
coven completions zsh > ~/.zfunc/_coven
```

## 2. Color control

A global `--color <auto|always|never>` flag plus `CLICOLOR_FORCE` support:

- `theme::detect_mode_from` now takes an explicit `ColorChoice` that outranks every env convention.
- `auto` (default) additionally honors `CLICOLOR_FORCE` (forces escapes through a pipe, per bixense.com/clicolors) alongside the existing `NO_COLOR` and tty+`TERM` detection.
- `--color=always` forces color (useful piping into `less -R`); `--color=never` forces plain (deterministic CI logs).
- `main` resolves the flag into `theme::set_color_choice` before any render, since `theme::mode()` caches on first use.

Precedence, high to low: `--color` flag → `NO_COLOR` → `CLICOLOR_FORCE` → tty + `TERM`.

## Testing

- Theme unit tests: `CLICOLOR_FORCE` precedence (forces over piped stdout, yields to `NO_COLOR`, `0`/`""` treated as off) and `--color` overriding every env convention.
- Smoke tests: completion generation for valid shells + a rejected one; `--color` parsing at both root and subcommand placement, and rejection of an unknown value.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `scripts/check-secrets.py` — all green. (One daemon-lifecycle smoke flaked under heavy local load from concurrent sessions; passes in isolation and on pristine main.)
- Hands-on: `completions zsh` emits `#compdef coven`; verified the `--color`/`CLICOLOR_FORCE`/`NO_COLOR` precedence resolves as documented.

Rebased on current main (includes #307, #308, and the RUSTSEC-2026-0204 crossbeam bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)