### PR TITLE
fix: output polish — no ^D on piped run, neutral patch-cancel voice, human exit marker

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -467,8 +467,33 @@ fn main() -> Result<()> {
         "never" => theme::ColorChoice::Never,
         _ => theme::ColorChoice::Auto,
     });
-    run_cli(cli)
+    if let Err(error) = run_cli(cli) {
+        // A user-initiated cancellation is a neutral outcome, not a failure:
+        // print it in plain voice (no `Error:` prefix) but keep a nonzero
+        // exit so scripts can still branch on it.
+        if let Some(cancelled) = error.downcast_ref::<Cancelled>() {
+            eprintln!("{}", cancelled.0);
+            std::process::exit(1);
+        }
+        eprintln!("Error: {error:#}");
+        std::process::exit(1);
+    }
+    Ok(())
 }
+
+/// A user chose to stop (answered "no" at a confirmation, aborted a flow).
+/// `main` prints its message without the `Error:` prefix so a deliberate
+/// cancel doesn't read as a crash; the exit code stays nonzero.
+#[derive(Debug)]
+struct Cancelled(String);
+
+impl std::fmt::Display for Cancelled {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for Cancelled {}
 
 fn run_cli(cli: Cli) -> Result<()> {
     if cli.command.is_none() && !cli.prompt.is_empty() {
@@ -1263,12 +1288,12 @@ fn run_patch(
     if request.git_state.is_dirty() && !request.non_interactive {
         println!("\nExisting changes were detected. Coven will not stash or overwrite them.");
         if !confirm_yes("Continue and ask the harness to preserve existing changes? [y/N] ")? {
-            anyhow::bail!("cancelled before harness launch");
+            return Err(Cancelled("Cancelled. The harness was not launched.".to_string()).into());
         }
     }
 
     if !request.non_interactive && !confirm_yes("Launch the harness now? [y/N] ")? {
-        anyhow::bail!("cancelled before harness launch");
+        return Err(Cancelled("Cancelled. The harness was not launched.".to_string()).into());
     }
 
     let session_id = launch_patch_session(&request)?;
@@ -2393,7 +2418,7 @@ fn printable_event_text(event: &store::EventRecord) -> Option<String> {
             let exit_code = payload
                 .get("exitCode")
                 .and_then(serde_json::Value::as_i64)
-                .map(|code| format!(" exitCode={code}"))
+                .map(|code| format!(" (exit code {code})"))
                 .unwrap_or_default();
             Some(format!("\n[coven session {status}{exit_code}]\n"))
         }
@@ -3474,6 +3499,22 @@ mod tests {
     }
 
     #[test]
+    fn cancelled_error_downcasts_and_keeps_its_message() {
+        // `main` relies on downcasting through anyhow to pick the neutral
+        // voice for a user cancel; guard that path and the message.
+        let err: anyhow::Error =
+            Cancelled("Cancelled. The harness was not launched.".to_string()).into();
+        let cancelled = err
+            .downcast_ref::<Cancelled>()
+            .expect("Cancelled must survive the anyhow round-trip");
+        assert_eq!(cancelled.0, "Cancelled. The harness was not launched.");
+        assert_eq!(
+            cancelled.to_string(),
+            "Cancelled. The harness was not launched."
+        );
+    }
+
+    #[test]
     fn printable_event_text_formats_exit_payload() {
         let event = store::EventRecord {
             seq: 0,
@@ -3486,7 +3527,7 @@ mod tests {
 
         assert_eq!(
             printable_event_text(&event).as_deref(),
-            Some("\n[coven session completed exitCode=0]\n")
+            Some("\n[coven session completed (exit code 0)]\n")
         );
     }
 

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -650,10 +650,18 @@ fn run_attached_with_pty_system(
         stdout.flush()
     });
 
-    thread::spawn(move || {
-        let mut stdin = io::stdin().lock();
-        let _ = io::copy(&mut stdin, &mut writer);
-    });
+    // Only forward stdin to the PTY when it is an interactive terminal. A
+    // one-shot `coven run` gets its prompt from argv, so a piped or
+    // redirected stdin carries nothing the harness needs — and copying it
+    // into the PTY makes the line discipline echo the EOF as a visible `^D`
+    // in the captured output. Interactive sessions still need the forward so
+    // the user can type.
+    if io::stdin().is_terminal() {
+        thread::spawn(move || {
+            let mut stdin = io::stdin().lock();
+            let _ = io::copy(&mut stdin, &mut writer);
+        });
+    }
 
     let exit_status = child.wait().context("failed to wait for harness process")?;
     let _ = output_thread.join();

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -597,6 +597,46 @@ fn color_flag_parses_and_rejects_unknown_values() -> anyhow::Result<()> {
 }
 
 #[test]
+fn piped_run_output_has_no_eof_control_artifact() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let project = temp_dir.path().join("project");
+    fs::create_dir_all(&project)?;
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin)?;
+    write_fake_codex(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
+
+    // stdin is /dev/null (a pipe/redirect, not a TTY): a one-shot run reads
+    // its prompt from argv, so nothing should be forwarded into the PTY and
+    // the line discipline must not echo an EOF as a visible `^D`.
+    let output = Command::new(coven_bin())
+        .args(["run", "codex", "hello polish"])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .current_dir(&project)
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert_success("piped run", &output);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("fake codex complete"),
+        "harness output should reach stdout: {stdout:?}"
+    );
+    assert!(
+        !output.stdout.contains(&0x04),
+        "piped run stdout must not contain a raw EOT (^D) byte: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("^D"),
+        "piped run stdout must not contain a visible ^D artifact: {stdout:?}"
+    );
+    Ok(())
+}
+
+#[test]
 fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -800,7 +840,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
     assert_stdout_contains(
         "attach replay",
         &attach,
-        "[coven session completed exitCode=0]",
+        "[coven session completed (exit code 0)]",
     );
 
     let kill_session = launch_daemon_session(


### PR DESCRIPTION
Closes #311 (from the #297 UX audit, follow-up 8). Three small output-discipline nits, bundled.

## 1. `^D` artifact on piped `coven run`

`run_attached` forwarded stdin into the harness PTY unconditionally. A one-shot `coven run` takes its prompt from argv, so a piped/redirected stdin carries nothing the harness needs — and copying it into the PTY made the line discipline echo the EOF as a visible `^D` in the captured output. Now stdin is forwarded only when it is a terminal; interactive runs (where the user types) are unchanged.

## 2. `patch` cancellation reads as a failure

Answering "no" at a patch confirmation bailed with `anyhow`, so it surfaced as `Error: cancelled before harness launch`. A deliberate cancel is a neutral outcome, not a crash. `main` now intercepts a typed `Cancelled` error and prints its message (`Cancelled. The harness was not launched.`) without the `Error:` prefix, while keeping a nonzero exit so scripts can still branch on it.

## 3. camelCase telemetry on a human line

The attach replay end marker rendered `[coven session completed exitCode=0]`. Now `[coven session completed (exit code 0)]`. (The daemon `status=…` line is intentionally left as-is — it's the documented scrape format and now has `--json`.)

## Testing

- Smoke test: piped `coven run` stdout carries the harness output with no raw EOT byte and no visible `^D`.
- Unit tests: the `Cancelled` anyhow round-trip/downcast, and the new exit-marker format.
- Hands-on: patch cancel prints the neutral line, exits 1, and emits no `Error:` prefix.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p coven-cli` (940 unit + 20 smoke), `scripts/check-secrets.py` — all green.

Rebased on current main (includes #307, #308, #309, and the RUSTSEC-2026-0204 crossbeam bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)