### PR TITLE
fix: legacy chat TUI Ctrl+C draft-clear, help overlay, attachable session ids (#310)

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -83,6 +83,10 @@ pub(super) struct App {
     pub(super) input_mode: InputMode,
     pub(super) agent_select_index: usize,
     pub(super) show_help: bool,
+    /// Vertical scroll offset (in lines) for the help overlay so its full
+    /// key/command list stays reachable on short terminals. Clamped to the
+    /// content during render.
+    pub(super) help_scroll: u16,
     pub(super) spinner_frame: usize,
     pub(super) is_responding: bool,
     pub(super) last_tick: Instant,
@@ -306,6 +310,7 @@ impl App {
             input_mode: InputMode::Normal,
             agent_select_index: 0,
             show_help: false,
+            help_scroll: 0,
             spinner_frame: 0,
             is_responding: false,
             last_tick: Instant::now(),
@@ -662,7 +667,7 @@ impl App {
 
         match cmd.as_str() {
             "/help" | "/h" => {
-                self.show_help = !self.show_help;
+                self.toggle_help();
                 SlashCommandResult::Handled
             }
             "/clear" | "/cls" => {
@@ -723,7 +728,7 @@ impl App {
                 SlashCommandResult::Handled
             }
             "/palette" | "/commands" => {
-                self.show_help = !self.show_help;
+                self.toggle_help();
                 SlashCommandResult::Handled
             }
             "/stream" | "/streaming" => {
@@ -843,9 +848,13 @@ impl App {
             CastIntent::SacrificeSession { session_id } => self.sacrifice_session(&session_id),
             CastIntent::Doctor => self.push_doctor_summary(),
             CastIntent::DaemonStatus => self.push_daemon_status_summary(),
-            CastIntent::Help => self.show_help = true,
+            CastIntent::Help => {
+                self.show_help = true;
+                self.help_scroll = 0;
+            }
             CastIntent::StartHere | CastIntent::OpenTui => {
                 self.show_help = true;
+                self.help_scroll = 0;
                 self.push_system_message(
                     "Command discovery is open. Type a task, /run <harness> <task>, /sessions, or /help.",
                 );
@@ -888,11 +897,39 @@ impl App {
         SlashCommandResult::Handled
     }
 
-    /// Handle a Ctrl+C press. The first press clears modal/composer state and
-    /// arms an exit confirmation; a second press inside [`INTERRUPT_REARM_WINDOW`]
-    /// returns [`InterruptOutcome::Quit`] so the caller can break out.
+    /// Toggle the help overlay, resetting its scroll so it always opens at the
+    /// top of the command list.
+    pub(super) fn toggle_help(&mut self) {
+        self.show_help = !self.show_help;
+        self.help_scroll = 0;
+    }
+
+    /// Handle a Ctrl+C press.
+    ///
+    /// A non-empty composer draft is the least-destructive thing to cancel, so
+    /// the first Ctrl+C only clears the draft and stops there — a stray ^C
+    /// while typing never tears down a running session or exits. It also does
+    /// not arm the exit window, so the ladder restarts cleanly from the empty
+    /// draft.
+    ///
+    /// With an empty draft the press escalates: it cancels any modal state,
+    /// interrupts the active session, and arms an exit confirmation. A second
+    /// empty-draft press inside [`INTERRUPT_REARM_WINDOW`] returns
+    /// [`InterruptOutcome::Quit`] so the caller can break out.
     pub(super) fn handle_interrupt(&mut self) -> InterruptOutcome {
         let now = Instant::now();
+
+        // Draft first: clearing it protects live work and does not arm exit.
+        if !self.input.is_empty() {
+            self.input.clear();
+            self.cursor_pos = 0;
+            self.slash_suggestion_index = 0;
+            self.slash_popup_dismissed = false;
+            self.last_interrupt_at = None;
+            self.push_system_message("Draft cleared. Ctrl+C again to interrupt or exit.");
+            return InterruptOutcome::Cancelled;
+        }
+
         if self
             .last_interrupt_at
             .is_some_and(|t| now.duration_since(t) <= INTERRUPT_REARM_WINDOW)
@@ -900,18 +937,15 @@ impl App {
             return InterruptOutcome::Quit;
         }
 
-        // First press: cancel everything cancellable, then arm exit.
+        // Empty draft: cancel everything cancellable, then arm exit.
         let had_pending = self.cancel_pending_cast_confirmation();
-        let had_input = !self.input.is_empty();
         let interrupted_session = self.interrupt_active_session();
-        self.input.clear();
-        self.cursor_pos = 0;
         self.slash_suggestion_index = 0;
         self.slash_popup_dismissed = false;
 
         let advisory = if interrupted_session {
             "Interrupt sent. Press Ctrl+C again to exit."
-        } else if had_pending || had_input {
+        } else if had_pending {
             "Cleared. Press Ctrl+C again to exit."
         } else {
             "Press Ctrl+C again to exit."
@@ -1158,8 +1192,51 @@ impl App {
         }
     }
 
+    /// Resolve a full session id or a unique id *prefix* to a session record.
+    ///
+    /// Mirrors the CLI's `resolve_session_ref` (session-ref rituals, #297): an
+    /// exact id wins, a single prefix match is accepted, an ambiguous prefix
+    /// lists the candidates, and a miss reports not-found. This keeps `/attach`
+    /// able to consume the short ids the `/sessions` overlay renders.
+    fn resolve_session_reference(
+        &mut self,
+        reference: &str,
+    ) -> Result<store::SessionRecord, String> {
+        // Exact id: trust the daemon directly so ids that aren't in the last
+        // listing (e.g. just launched) still attach without a round-trip.
+        if let Ok(session) = self.client.get_session(reference) {
+            return Ok(session);
+        }
+        if reference.is_empty() {
+            return Err("Usage: /attach <session-id>".to_string());
+        }
+        let sessions = self
+            .client
+            .list_sessions()
+            .map_err(|error| error.to_string())?;
+        let mut matches = sessions
+            .into_iter()
+            .filter(|session| session.id.starts_with(reference));
+        let Some(first) = matches.next() else {
+            return Err(format!(
+                "session `{reference}` not found; open /sessions to list ids"
+            ));
+        };
+        let rest: Vec<store::SessionRecord> = matches.collect();
+        if rest.is_empty() {
+            return Ok(first);
+        }
+        let ids: Vec<String> = std::iter::once(first.id.clone())
+            .chain(rest.iter().take(4).map(|session| session.id.clone()))
+            .collect();
+        Err(format!(
+            "session id prefix `{reference}` is ambiguous; it matches: {}",
+            ids.join(", ")
+        ))
+    }
+
     pub(super) fn attach_session(&mut self, session_id: &str) {
-        match self.client.get_session(session_id) {
+        match self.resolve_session_reference(session_id) {
             Ok(session) => {
                 self.active_session_id = Some(session.id.clone());
                 self.active_session_harness = Some(session.harness.clone());
@@ -5178,21 +5255,51 @@ mod tests {
     }
 
     #[test]
-    fn handle_interrupt_first_press_clears_input_and_arms_exit_advisory() {
+    fn first_ctrl_c_with_draft_clears_it_without_arming_exit() {
         let client = RecordingChatClient::default();
         let (mut app, _) = app_with_client(client);
         app.input = "in-flight prompt".to_string();
         app.cursor_pos = app.input.len();
 
-        let outcome = app.handle_interrupt();
-
-        assert_eq!(outcome, InterruptOutcome::Cancelled);
+        // First press with a non-empty draft only clears the draft.
+        assert_eq!(app.handle_interrupt(), InterruptOutcome::Cancelled);
         assert!(app.input.is_empty());
         assert_eq!(app.cursor_pos, 0);
         assert!(app
             .messages
             .iter()
-            .any(|message| message.content.contains("Press Ctrl+C again to exit")));
+            .any(|message| message.content.contains("Draft cleared")));
+
+        // The draft-clear did NOT arm exit: the next (empty-draft) press
+        // escalates by arming, and only the one after that quits — so a stray
+        // ^C while typing can never fall straight through to an exit.
+        assert_eq!(app.handle_interrupt(), InterruptOutcome::Cancelled);
+        assert_eq!(app.handle_interrupt(), InterruptOutcome::Quit);
+    }
+
+    #[test]
+    fn first_ctrl_c_with_draft_does_not_kill_running_session() {
+        let session = test_session("abc-123", "codex", "task", "running");
+        let client = RecordingChatClient::with_session(session.clone());
+        let calls = client.calls.clone();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some(session.id.clone());
+        app.input = "wait, don't kill it".to_string();
+        app.cursor_pos = app.input.len();
+
+        assert_eq!(app.handle_interrupt(), InterruptOutcome::Cancelled);
+
+        assert!(app.input.is_empty(), "draft should be cleared");
+        assert_eq!(
+            app.active_session_id.as_deref(),
+            Some("abc-123"),
+            "clearing a draft must leave the running session attached",
+        );
+        let recorded = calls.borrow().clone();
+        assert!(
+            !recorded.iter().any(|call| call == "kill:abc-123"),
+            "draft-clear must not tear down live work, got: {recorded:?}",
+        );
     }
 
     #[test]
@@ -5248,6 +5355,54 @@ mod tests {
             recorded.iter().any(|call| call == "kill:xyz-9"),
             "expected kill call from Esc-style interrupt, got: {recorded:?}",
         );
+    }
+
+    #[test]
+    fn attach_resolves_unique_session_id_prefix() {
+        // A full session id longer than the /sessions overlay's 12-char id
+        // column: the overlay shows only the first 12 chars, so `/attach`
+        // must resolve that prefix back to the full id.
+        let full = "abcd1234-0000-0000-0000-000000000000";
+        let session = test_session(full, "codex", "task", "running");
+        let client = RecordingChatClient::with_session(session);
+        let (mut app, _) = app_with_client(client);
+
+        // Mirrors the overlay's `session_id_prefix(id, 12)` display budget.
+        let shown = &full[..12];
+        assert_eq!(shown, "abcd1234-000");
+
+        app.attach_session(shown);
+
+        assert_eq!(
+            app.active_session_id.as_deref(),
+            Some(full),
+            "a displayed id prefix must attach to the full session",
+        );
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("Attached to daemon session")));
+    }
+
+    #[test]
+    fn attach_reports_ambiguous_session_id_prefix_without_attaching() {
+        let first = test_session("dupe-1111-aaaa", "codex", "task-a", "running");
+        let second = test_session("dupe-2222-bbbb", "claude", "task-b", "running");
+        let client = RecordingChatClient::with_session(first);
+        client.sessions.borrow_mut().push(second);
+        let (mut app, _) = app_with_client(client);
+
+        // "dupe-" prefixes both sessions: no exact id, ambiguous prefix.
+        app.attach_session("dupe-");
+
+        assert!(
+            app.active_session_id.is_none(),
+            "an ambiguous prefix must not attach anything",
+        );
+        assert!(app
+            .messages
+            .iter()
+            .any(|message| message.content.contains("ambiguous")));
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/events.rs
+++ b/crates/coven-cli/src/tui/chat/events.rs
@@ -61,6 +61,22 @@ pub(super) fn run_event_loop(
                         match key.code {
                             KeyCode::Esc | KeyCode::Char('q') => {
                                 app.show_help = false;
+                                app.help_scroll = 0;
+                            }
+                            // Scroll the overlay so the full binding list is
+                            // reachable on short terminals. Over-scroll is
+                            // clamped to the content during render.
+                            KeyCode::Up | KeyCode::Char('k') => {
+                                app.help_scroll = app.help_scroll.saturating_sub(1);
+                            }
+                            KeyCode::Down | KeyCode::Char('j') => {
+                                app.help_scroll = app.help_scroll.saturating_add(1);
+                            }
+                            KeyCode::PageUp => {
+                                app.help_scroll = app.help_scroll.saturating_sub(10);
+                            }
+                            KeyCode::PageDown => {
+                                app.help_scroll = app.help_scroll.saturating_add(10);
                             }
                             _ => {}
                         }
@@ -108,7 +124,7 @@ pub(super) fn run_event_loop(
                             return Ok(());
                         }
                         KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                            app.show_help = !app.show_help;
+                            app.toggle_help();
                         }
                         // Ctrl+L = clear the visible transcript, the standard
                         // shell/Claude-Code muscle-memory keybind.

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -60,7 +60,7 @@ pub(super) fn render_ui(f: &mut Frame, app: &mut App) {
     }
 
     if app.show_help {
-        render_help_overlay(f, area);
+        render_help_overlay(f, app, area);
     }
 
     if app.input_mode == InputMode::AgentSelect {
@@ -686,19 +686,7 @@ fn hint_bar_spans<'a>(app: &App) -> Vec<Span<'a>> {
     ]
 }
 
-fn render_help_overlay(f: &mut Frame, area: Rect) {
-    let overlay_width = 60u16.min(area.width.saturating_sub(4));
-    // Fits Basics(5) + Agents(2) + System(2) + Sessions(4) + Output(3) +
-    // Keys(6) plus section headers and separators. Clamps to the
-    // terminal so very short windows still render something useful even if
-    // the bottom rows clip.
-    let overlay_height = 34u16.min(area.height.saturating_sub(4));
-    let x = (area.width.saturating_sub(overlay_width)) / 2;
-    let y = (area.height.saturating_sub(overlay_height)) / 2;
-    let popup_area = Rect::new(x, y, overlay_width, overlay_height);
-
-    f.render_widget(Clear, popup_area);
-
+fn render_help_overlay(f: &mut Frame, app: &mut App, area: Rect) {
     let help_items = vec![
         (
             "Basics",
@@ -747,7 +735,7 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
                 ("Tab", "Complete the highlighted slash suggestion"),
                 ("Up / Down", "Browse history or the slash popup"),
                 ("Esc", "Cancel popup, input, or running session"),
-                ("Ctrl+C", "Cancel; press twice within 2s to exit"),
+                ("Ctrl+C", "Clear draft; else cancel, twice to exit"),
                 ("Ctrl+L", "Clear the visible transcript"),
                 ("Ctrl+D", "Exit Coven chat"),
             ],
@@ -771,6 +759,27 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
         lines.push(Line::from(""));
     }
 
+    // Size the overlay to its content so the whole list — including the Keys
+    // section that used to clip — shows on a tall terminal. 72 cols keeps the
+    // widest "cmd  description" row on one line (no wrap), so the logical line
+    // count matches display rows and the scroll math stays exact.
+    let overlay_width = 72u16.min(area.width.saturating_sub(4)).max(1);
+    let content_len = lines.len() as u16;
+    let max_overlay_height = area.height.saturating_sub(2).max(3);
+    let overlay_height = (content_len + 2).min(max_overlay_height);
+    let x = (area.width.saturating_sub(overlay_width)) / 2;
+    let y = (area.height.saturating_sub(overlay_height)) / 2;
+    let popup_area = Rect::new(x, y, overlay_width, overlay_height);
+
+    // When the terminal is too short for the full list, let Up/Down/PageUp/
+    // PageDown scroll it. Clamp the offset to the last page so over-scroll
+    // can't push the content entirely out of view.
+    let inner_height = overlay_height.saturating_sub(2);
+    let max_scroll = content_len.saturating_sub(inner_height);
+    app.help_scroll = app.help_scroll.min(max_scroll);
+
+    f.render_widget(Clear, popup_area);
+
     let help_block = Block::default()
         .title(Span::styled(
             " \u{2731} Coven Commands ",
@@ -783,7 +792,8 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
 
     let help_widget = Paragraph::new(Text::from(lines))
         .block(help_block)
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.help_scroll, 0));
 
     f.render_widget(help_widget, popup_area);
 }
@@ -926,7 +936,7 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
                 Span::styled(format!(" {:<7} ", rep.harness), theme::ratatui_style(DIM)),
                 Span::styled(turn_badge, theme::ratatui_style(DIM)),
                 Span::styled(
-                    truncate_for_width(&rep.id, 12),
+                    session_id_prefix(&rep.id, 12),
                     theme::ratatui_style(PRIMARY),
                 ),
                 Span::styled("  ", theme::ratatui_style(DIM)),
@@ -1126,6 +1136,19 @@ fn cursor_line_col(input: &str, cursor_pos: usize) -> (usize, usize) {
 
 fn input_line_count(input: &str) -> usize {
     input.bytes().filter(|byte| *byte == b'\n').count() + 1
+}
+
+/// Render a session id as a short but still-attachable prefix. Unlike
+/// [`truncate_for_width`], this never appends an ellipsis: what's shown is a
+/// literal id prefix the user can type into `/attach`, which resolves unique
+/// prefixes the same way the CLI session-ref rituals do (#297). Session ids are
+/// ASCII UUIDs, so a `max_chars` character budget equals the display width.
+fn session_id_prefix(id: &str, max_chars: usize) -> String {
+    if id.chars().count() <= max_chars {
+        id.to_string()
+    } else {
+        id.chars().take(max_chars).collect()
+    }
 }
 
 fn truncate_for_width(value: &str, max_width: usize) -> String {
@@ -1700,6 +1723,79 @@ mod tests {
         let wide = truncate_for_width("表表abc", 4);
         assert!(UnicodeWidthStr::width(wide.as_str()) <= 4);
         assert!(wide.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn session_id_prefix_returns_clean_attachable_prefix() {
+        let id = "abcd1234-0000-0000-0000-000000000000";
+        let shown = session_id_prefix(id, 12);
+
+        assert_eq!(shown, "abcd1234-000");
+        // No ellipsis: the shown text is a literal, typeable prefix of the id
+        // (unlike `truncate_for_width`, which appends '…').
+        assert!(!shown.contains('\u{2026}'));
+        assert!(id.starts_with(&shown));
+        // Short ids pass through untouched.
+        assert_eq!(session_id_prefix("short", 12), "short");
+    }
+
+    /// Render the chat with the help overlay open at a given size / scroll and
+    /// return the flattened buffer text.
+    fn help_overlay_plain(width: u16, height: u16, scroll: u16) -> String {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let agents = vec![crate::tui::chat::app::AgentInfo {
+            id: "codex".to_string(),
+            label: "codex".to_string(),
+            harness: "codex".to_string(),
+            available: true,
+        }];
+        let mut app = App::new_with_state(
+            agents,
+            Some(0),
+            Box::<crate::tui::chat::client::DaemonChatClient>::default(),
+            None,
+        );
+        app.show_help = true;
+        app.help_scroll = scroll;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).expect("test terminal");
+        terminal
+            .draw(|frame| render_ui(frame, &mut app))
+            .expect("render help overlay");
+        buffer_to_plain_text(terminal.backend().buffer())
+    }
+
+    #[test]
+    fn help_overlay_shows_every_key_binding_on_a_tall_terminal() {
+        // A tall terminal sizes the overlay to its content, so nothing in the
+        // Keys section clips — the previous hard-coded height cut it off.
+        let frame = help_overlay_plain(80, 44, 0);
+
+        assert!(frame.contains("Basics"));
+        assert!(frame.contains("Keys"));
+        assert!(
+            frame.contains("Ctrl+D"),
+            "the last Keys binding must be visible: {frame}"
+        );
+        assert!(frame.contains("Complete the highlighted slash suggestion"));
+    }
+
+    #[test]
+    fn help_overlay_scroll_reveals_bindings_clipped_on_a_short_terminal() {
+        // Too short for the full list: the Keys section clips at the top.
+        let top = help_overlay_plain(80, 16, 0);
+        assert!(
+            !top.contains("Ctrl+D"),
+            "Keys section should be below the fold at scroll 0: {top}"
+        );
+
+        // Over-scrolling is clamped to the last page, which brings the tail —
+        // including the final Ctrl+D binding — into view.
+        let bottom = help_overlay_plain(80, 16, u16::MAX);
+        assert!(
+            bottom.contains("Ctrl+D"),
+            "scrolling should reveal the clipped bindings: {bottom}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Context

- Summary: Fixes the three legacy chat-TUI paper cuts from the #297 UX audit. The legacy in-process chat TUI lives behind `COVEN_LEGACY_TUI` (coven-code is the flagship), but while the flag exists these are real bugs. Changes are scoped to `crates/coven-cli/src/tui/chat/`; no coven-code or non-TUI code is touched.
- Files changed: `crates/coven-cli/src/tui/chat/app.rs`, `crates/coven-cli/src/tui/chat/events.rs`, `crates/coven-cli/src/tui/chat/render.rs`
- Closes #310

## Implementation

### 1. Ctrl+C no longer kills live work when clearing a draft
`App::handle_interrupt` now treats a non-empty composer draft as the least-destructive thing to cancel: the first Ctrl+C clears the draft and stops there — it does **not** interrupt the running session and does **not** arm the exit window. Only an empty-draft Ctrl+C escalates (cancel pending modal, interrupt the active session, arm exit), and a second empty-draft press within ~2s still quits. So from a draft it takes `Ctrl+C` (clear) → `Ctrl+C` (arm/interrupt) → `Ctrl+C` (exit); the existing two-press exit for an empty composer is unchanged. The `Keys` help line for `Ctrl+C` was updated to match.

### 2. Help overlay no longer clips its Keys section
`render_help_overlay` now sizes the overlay to its content so the whole command list (including the previously clipped `Keys` section) shows on a tall terminal, and it scrolls when the terminal is too short. Added a `help_scroll` offset to `App`, wired `Up`/`Down`/`j`/`k`/`PageUp`/`PageDown` in the help branch of the event loop, and clamp the offset to the last page during render. The overlay is widened to 72 cols so the widest row never wraps, keeping scroll math exact. Help open/close resets the scroll via a small `toggle_help` helper.

### 3. `/sessions` ids are now attachable
The `/sessions` overlay rendered `truncate_for_width(&rep.id, 12)`, which appended a `…` ellipsis — not a usable prefix. It now renders a clean `session_id_prefix(&rep.id, 12)` (a literal 12-char prefix, no ellipsis). `attach_session` resolves a unique id **prefix** the same way the CLI's `resolve_session_ref` does (#297): an exact id wins, a single prefix match is accepted, an ambiguous prefix lists candidates, and a miss reports not-found. Exact-id attaches still short-circuit through `get_session`, so existing call paths are unchanged.

- User-visible behavior: Ctrl+C with text in the box clears the draft instead of tearing down the session; the help overlay shows every binding (scrollable on short terminals); the short ids shown in `/sessions` can be typed straight into `/attach`.
- Compatibility notes: Behavior change is confined to the legacy TUI behind `COVEN_LEGACY_TUI`. No API, store, or npm/TS changes.

## Verification

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — pass (no warnings, no new `#[allow]`)
- [x] `cargo test --workspace --locked` — pass (run with `~/.local/bin` filtered from PATH to match CI; `adapter_install_hermes_writes_trusted_manifest` passes under that condition)
- [x] `python3 scripts/check-secrets.py` — pass ("Secret guard passed: no current-tree or history findings.")
- [x] Additional manual checks: new unit tests below all pass.

New tests:
- `app::tests::first_ctrl_c_with_draft_clears_it_without_arming_exit`
- `app::tests::first_ctrl_c_with_draft_does_not_kill_running_session`
- `app::tests::attach_resolves_unique_session_id_prefix`
- `app::tests::attach_reports_ambiguous_session_id_prefix_without_attaching`
- `render::tests::session_id_prefix_returns_clean_attachable_prefix`
- `render::tests::help_overlay_shows_every_key_binding_on_a_tall_terminal`
- `render::tests::help_overlay_scroll_reveals_bindings_clipped_on_a_short_terminal`

The existing `handle_interrupt_first_press_clears_input_and_arms_exit_advisory` test was rewritten into `first_ctrl_c_with_draft_clears_it_without_arming_exit` to assert the new draft-clear semantics (and that it does not fall through to exit).

## Risk and Rollback

- Risk level: low — scoped to the legacy TUI behind a flag; no data or protocol changes.
- Rollback plan: revert this commit.

## Agent Handoff

- Current state: all four gates green; branch pushed.
- Follow-ups: none required.
- Known gaps: the help-overlay sizing/scroll is exercised by render tests via `TestBackend`; scroll math is exact only when rows don't wrap (guaranteed at width ≥ ~76, where the overlay hits its 72-col target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)