### PR TITLE
fix(tui): legacy chat paper cuts — Ctrl+C draft, help clipping, /attach prefixes

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -900,19 +900,21 @@ impl App {
             return InterruptOutcome::Quit;
         }
 
-        // First press: cancel everything cancellable, then arm exit.
-        let had_pending = self.cancel_pending_cast_confirmation();
-        let had_input = !self.input.is_empty();
-        let interrupted_session = self.interrupt_active_session();
-        self.input.clear();
-        self.cursor_pos = 0;
-        self.slash_suggestion_index = 0;
-        self.slash_popup_dismissed = false;
-
-        let advisory = if interrupted_session {
-            "Interrupt sent. Press Ctrl+C again to exit."
-        } else if had_pending || had_input {
+        // First press: clear the most transient state and stop there, so a
+        // Ctrl+C meant to discard a draft or a Cast prompt never tears down
+        // live work. Only when there is nothing composed to clear does the
+        // first press interrupt the running session. Priority: pending Cast
+        // confirmation → draft input → active session.
+        let advisory = if self.cancel_pending_cast_confirmation() {
             "Cleared. Press Ctrl+C again to exit."
+        } else if !self.input.is_empty() {
+            self.input.clear();
+            self.cursor_pos = 0;
+            self.slash_suggestion_index = 0;
+            self.slash_popup_dismissed = false;
+            "Cleared. Press Ctrl+C again to exit."
+        } else if self.interrupt_active_session() {
+            "Interrupt sent. Press Ctrl+C again to exit."
         } else {
             "Press Ctrl+C again to exit."
         };
@@ -1158,8 +1160,39 @@ impl App {
         }
     }
 
+    /// Resolve a session reference to a full id. Accepts an exact id or a
+    /// unique prefix of one among the loaded sessions (the `/sessions` overlay
+    /// shows 8-char prefixes), mirroring the CLI ritual verbs. Returns the
+    /// input unchanged when nothing matches so the daemon lookup produces the
+    /// authoritative error, or when a prefix is ambiguous (reported here).
+    fn resolve_session_reference(&mut self, reference: &str) -> Option<String> {
+        if self.sessions.iter().any(|s| s.id == reference) {
+            return Some(reference.to_string());
+        }
+        let matches: Vec<&str> = self
+            .sessions
+            .iter()
+            .filter(|s| s.id.starts_with(reference))
+            .map(|s| s.id.as_str())
+            .collect();
+        match matches.as_slice() {
+            [only] => Some((*only).to_string()),
+            [] => Some(reference.to_string()),
+            many => {
+                self.push_system_message(&format!(
+                    "Session id prefix `{reference}` is ambiguous ({} matches); use more characters.",
+                    many.len()
+                ));
+                None
+            }
+        }
+    }
+
     pub(super) fn attach_session(&mut self, session_id: &str) {
-        match self.client.get_session(session_id) {
+        let Some(session_id) = self.resolve_session_reference(session_id) else {
+            return;
+        };
+        match self.client.get_session(&session_id) {
             Ok(session) => {
                 self.active_session_id = Some(session.id.clone());
                 self.active_session_harness = Some(session.harness.clone());
@@ -2636,6 +2669,25 @@ mod tests {
         assert!(!frame.contains("/trace"), "dead command leaked:\n{frame}");
         assert!(!frame.contains("/mem"), "dead command leaked:\n{frame}");
         assert!(!frame.contains("/debug"), "dead command leaked:\n{frame}");
+    }
+
+    #[test]
+    fn help_overlay_shows_the_full_keys_section_on_a_tall_terminal() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.show_help = true;
+
+        // Tall enough to hold every section: the Keys bindings at the very
+        // bottom must not clip (they did under the old fixed height cap).
+        let frame = render_app_plain(&mut app, 90, 42);
+
+        assert!(frame.contains("Keys"), "Keys header missing:\n{frame}");
+        assert!(frame.contains("Ctrl+L"), "Ctrl+L binding clipped:\n{frame}");
+        assert!(frame.contains("Ctrl+D"), "Ctrl+D binding clipped:\n{frame}");
+        assert!(
+            frame.contains("Exit Coven chat"),
+            "last Keys row clipped:\n{frame}"
+        );
     }
 
     #[test]
@@ -4619,6 +4671,54 @@ mod tests {
     }
 
     #[test]
+    fn attach_resolves_a_unique_id_prefix_from_the_overlay() {
+        let full_id = "9099a1b2-3c4d-5e6f-7a8b-9c0d1e2f3a4b";
+        let client =
+            RecordingChatClient::with_session(test_session(full_id, "codex", "Live", "running"));
+        let (mut app, mirror) = app_with_client(client);
+        // The `/sessions` overlay lists an 8-char prefix; attaching by that
+        // prefix must resolve to the full session id.
+        app.sessions = vec![test_session(full_id, "codex", "Live", "running")];
+
+        app.handle_slash_command("/attach 9099a1b2");
+
+        assert_eq!(app.active_session_id(), Some(full_id));
+        assert!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .any(|call| call == &format!("get:{full_id}")),
+            "attach should look the full id up, not the prefix: {:?}",
+            mirror.calls.borrow()
+        );
+    }
+
+    #[test]
+    fn attach_reports_an_ambiguous_prefix_without_attaching() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.sessions = vec![
+            test_session("abc11111-0000", "codex", "One", "running"),
+            test_session("abc22222-0000", "codex", "Two", "running"),
+        ];
+
+        app.handle_slash_command("/attach abc");
+
+        assert_eq!(app.active_session_id(), None);
+        assert!(
+            app.messages
+                .iter()
+                .any(|message| message.content.contains("ambiguous")),
+            "ambiguous prefix should be reported: {:?}",
+            app.messages
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn chat_output_events_are_terminal_sanitized_and_coalesced() {
         let client = RecordingChatClient::with_session(test_session(
             "session-1",
@@ -5193,6 +5293,66 @@ mod tests {
             .messages
             .iter()
             .any(|message| message.content.contains("Press Ctrl+C again to exit")));
+    }
+
+    #[test]
+    fn handle_interrupt_with_draft_clears_it_without_killing_the_session() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Live work",
+            "running",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.input = "half-typed message".to_string();
+        app.cursor_pos = app.input.len();
+
+        let outcome = app.handle_interrupt();
+
+        assert_eq!(outcome, InterruptOutcome::Cancelled);
+        // The draft is discarded...
+        assert!(app.input.is_empty());
+        assert_eq!(app.cursor_pos, 0);
+        // ...but the live session is untouched: no kill was sent and it is
+        // still the active session.
+        assert!(
+            !mirror
+                .calls
+                .borrow()
+                .iter()
+                .any(|call| call.starts_with("kill:")),
+            "clearing a draft must not kill the live session: {:?}",
+            mirror.calls.borrow()
+        );
+        assert_eq!(app.active_session_id.as_deref(), Some("session-1"));
+    }
+
+    #[test]
+    fn handle_interrupt_without_draft_interrupts_the_active_session() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "codex",
+            "Live work",
+            "running",
+        ));
+        let (mut app, mirror) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+
+        let outcome = app.handle_interrupt();
+
+        assert_eq!(outcome, InterruptOutcome::Cancelled);
+        // With nothing composed to clear, the first press interrupts the
+        // running session.
+        assert!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .any(|call| call == "kill:session-1"),
+            "with no draft, Ctrl+C should interrupt the session: {:?}",
+            mirror.calls.borrow()
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -687,17 +687,12 @@ fn hint_bar_spans<'a>(app: &App) -> Vec<Span<'a>> {
 }
 
 fn render_help_overlay(f: &mut Frame, area: Rect) {
-    let overlay_width = 60u16.min(area.width.saturating_sub(4));
-    // Fits Basics(5) + Agents(2) + System(2) + Sessions(4) + Output(3) +
-    // Keys(6) plus section headers and separators. Clamps to the
-    // terminal so very short windows still render something useful even if
-    // the bottom rows clip.
-    let overlay_height = 34u16.min(area.height.saturating_sub(4));
-    let x = (area.width.saturating_sub(overlay_width)) / 2;
-    let y = (area.height.saturating_sub(overlay_height)) / 2;
-    let popup_area = Rect::new(x, y, overlay_width, overlay_height);
-
-    f.render_widget(Clear, popup_area);
+    // Wide enough that the longest `command  description` row (~67 cols) does
+    // not wrap: an accurate one-row-per-entry layout is what lets the
+    // content-based height below show every section without clipping. On a
+    // terminal narrower than this the overlay clamps and rows may wrap, but
+    // the height still uses all available rows.
+    let overlay_width = 76u16.min(area.width.saturating_sub(4));
 
     let help_items = vec![
         (
@@ -770,6 +765,17 @@ fn render_help_overlay(f: &mut Frame, area: Rect) {
         }
         lines.push(Line::from(""));
     }
+
+    // Size the overlay to the content (+2 for the top/bottom border) so the
+    // Keys section at the bottom is never clipped on a terminal tall enough
+    // to hold it. Only genuinely short windows fall back to clamping.
+    let desired_height = lines.len() as u16 + 2;
+    let overlay_height = desired_height.min(area.height.saturating_sub(2));
+    let x = (area.width.saturating_sub(overlay_width)) / 2;
+    let y = (area.height.saturating_sub(overlay_height)) / 2;
+    let popup_area = Rect::new(x, y, overlay_width, overlay_height);
+
+    f.render_widget(Clear, popup_area);
 
     let help_block = Block::default()
         .title(Span::styled(
@@ -926,7 +932,10 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
                 Span::styled(format!(" {:<7} ", rep.harness), theme::ratatui_style(DIM)),
                 Span::styled(turn_badge, theme::ratatui_style(DIM)),
                 Span::styled(
-                    truncate_for_width(&rep.id, 12),
+                    // Show a clean id prefix (no ellipsis) so what's on screen
+                    // is a valid, copy-pasteable argument for `/attach`, which
+                    // resolves unique prefixes.
+                    attachable_id_prefix(&rep.id),
                     theme::ratatui_style(PRIMARY),
                 ),
                 Span::styled("  ", theme::ratatui_style(DIM)),
@@ -1126,6 +1135,13 @@ fn cursor_line_col(input: &str, cursor_pos: usize) -> (usize, usize) {
 
 fn input_line_count(input: &str) -> usize {
     input.bytes().filter(|byte| *byte == b'\n').count() + 1
+}
+
+/// The first 8 characters of a session id — long enough to be unique across a
+/// user's session list in practice, short enough to fit the overlay column,
+/// and (unlike an ellipsis-truncated id) a valid prefix `/attach` can resolve.
+fn attachable_id_prefix(id: &str) -> String {
+    id.chars().take(8).collect()
 }
 
 fn truncate_for_width(value: &str, max_width: usize) -> String {
@@ -1700,6 +1716,19 @@ mod tests {
         let wide = truncate_for_width("表表abc", 4);
         assert!(UnicodeWidthStr::width(wide.as_str()) <= 4);
         assert!(wide.ends_with('\u{2026}'));
+    }
+
+    #[test]
+    fn attachable_id_prefix_is_a_clean_eight_char_prefix() {
+        // A clean prefix (no ellipsis) that is a valid `/attach` argument.
+        assert_eq!(
+            attachable_id_prefix("9099a1b2-3c4d-5e6f-7a8b-9c0d1e2f3a4b"),
+            "9099a1b2"
+        );
+        // Shorter-than-8 ids pass through unchanged.
+        assert_eq!(attachable_id_prefix("abc"), "abc");
+        // No ellipsis is ever appended.
+        assert!(!attachable_id_prefix("9099a1b2-3c4d").contains('\u{2026}'));
     }
 
     #[test]


### PR DESCRIPTION
Closes #310 (from the #297 UX audit, follow-up 7). Lower priority — the legacy chat TUI is behind `COVEN_LEGACY_TUI` now that coven-code is the flagship UI — but while the flag exists these are real paper cuts.

## 1. Ctrl+C kills live work while clearing a draft

`handle_interrupt` unconditionally killed the active session on the first press *and* cleared the draft. Now it escalates in priority order — **pending Cast confirmation → draft input → active session** — and stops after the first thing it clears. A second press within the rearm window still exits. So Ctrl+C with a half-typed message discards the draft and leaves the running session alone.

## 2. Help overlay clips its Keys section

The overlay used a fixed height cap shorter than its content, so the bottom bindings (`Ctrl+L`, `Ctrl+D`) were cut off with no way to scroll. It's now sized to its content height (+borders), and widened so the longest `command  description` row no longer wraps — wrapping is what had made a naive line-count height undercount the real rows.

## 3. `/sessions` ids can't be `/attach`ed

The overlay showed an ellipsis-truncated id (`9099a1b2-3c…`) that `/attach` couldn't consume. Now it shows a clean 8-char prefix, and `/attach` resolves a unique prefix to the full session id (ambiguous prefixes are reported), mirroring the CLI ritual verbs' prefix handling.

## Testing

- Ctrl+C with a draft clears it and sends no kill (session stays active); with no draft, the press interrupts the session.
- Help overlay renders its full Keys section (`Ctrl+L`, `Ctrl+D`, `Exit Coven chat`) on a tall terminal.
- `/attach` resolves a unique prefix to the full id; an ambiguous prefix is reported without attaching; unit test for the id-prefix helper.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p coven-cli` (945 unit + 19 smoke), `scripts/check-secrets.py` — all green.

Rebased on current main (through #311 and the RUSTSEC-2026-0204 crossbeam bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)