### PR TITLE
feat: add coven vacuum command and POST /store/vacuum for session store repair

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -354,6 +354,7 @@ pub fn handle_request_with_runtime(
         ("GET", "/research") => {
             json_response(200, &crate::cockpit_sources::read_research(coven_home)?)
         }
+        ("POST", "/store/vacuum") => vacuum_store(coven_home),
         ("POST", "/travel/profiles") => generate_travel_profile(coven_home, body),
         ("POST", "/travel/deltas") => {
             let q = query.unwrap_or_default();
@@ -504,6 +505,18 @@ fn normalize_api_route(route: &str) -> ApiRoute<'_> {
 
 fn store_path(coven_home: &Path) -> std::path::PathBuf {
     coven_home.join("coven.sqlite3")
+}
+
+fn vacuum_store(coven_home: &Path) -> Result<ApiResponse> {
+    let report = store::vacuum_store_path(&store_path(coven_home))?;
+    json_response(
+        200,
+        &json!({
+            "ok": true,
+            "eventIndexRebuilt": report.event_index_rebuilt,
+            "integrityCheck": report.integrity_check,
+        }),
+    )
 }
 
 fn generate_travel_profile(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
@@ -3047,6 +3060,54 @@ mod tests {
             serde_json::json!(["job-persistent-loop", "job-followup"])
         );
         assert_eq!(body["nodeAvailability"][0]["available"], false);
+        Ok(())
+    }
+
+    #[test]
+    fn routes_store_vacuum_request_to_repair_response() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let conn = store::open_store(&store_path(home))?;
+        store::insert_session(
+            &conn,
+            &store::SessionRecord {
+                id: "session-1".into(),
+                project_root: "/repo".into(),
+                harness: "codex".into(),
+                title: "demo".into(),
+                status: "completed".into(),
+                exit_code: Some(0),
+                archived_at: Some("2026-01-01T00:00:00Z".into()),
+                created_at: "2026-01-01T00:00:00Z".into(),
+                updated_at: "2026-01-01T00:00:00Z".into(),
+                conversation_id: None,
+                familiar_id: None,
+                labels: Vec::new(),
+                visibility: "private".to_string(),
+            },
+        )?;
+        store::insert_json_event(
+            &conn,
+            "session-1",
+            "output",
+            &json!({"text": "phoenix rises"}),
+            "2026-01-01T00:00:01Z",
+        )?;
+        conn.execute(
+            "INSERT INTO events_fts(events_fts) VALUES('delete-all')",
+            [],
+        )?;
+        assert!(store::search_events(&conn, "phoenix")?.is_empty());
+        drop(conn);
+
+        let response = handle_request("POST", "/api/v1/store/vacuum", home, None)?;
+
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["eventIndexRebuilt"], true);
+        let conn = store::open_store(&store_path(home))?;
+        assert_eq!(store::search_events(&conn, "phoenix")?.len(), 1);
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -508,15 +508,26 @@ fn store_path(coven_home: &Path) -> std::path::PathBuf {
 }
 
 fn vacuum_store(coven_home: &Path) -> Result<ApiResponse> {
-    let report = store::vacuum_store_path(&store_path(coven_home))?;
-    json_response(
-        200,
-        &json!({
-            "ok": true,
-            "eventIndexRebuilt": report.event_index_rebuilt,
-            "integrityCheck": report.integrity_check,
-        }),
-    )
+    let store_path = store_path(coven_home);
+    match store::vacuum_store_path(&store_path) {
+        Ok(report) => json_response(
+            200,
+            &json!({
+                "ok": true,
+                "eventIndexRebuilt": report.event_index_rebuilt,
+                "integrityCheck": report.integrity_check,
+            }),
+        ),
+        Err(error) => api_error(
+            500,
+            "store_vacuum_failed",
+            "Failed to vacuum Coven store.",
+            Some(json!({
+                "storePath": store_path.display().to_string(),
+                "error": error.to_string(),
+            })),
+        ),
+    }
 }
 
 fn generate_travel_profile(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -211,6 +211,8 @@ enum Command {
         #[command(subcommand)]
         command: LogsCommand,
     },
+    #[command(about = "Repair and compact the local Coven session store")]
+    Vacuum,
     #[command(
         about = "Create, list, diagnose, and prune Coven worktrees",
         alias = "worktree",
@@ -540,6 +542,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             None => tui::sessions::run_command(all, manage, plain, json),
         },
         Some(Command::Logs { command }) => run_logs_command(command),
+        Some(Command::Vacuum) => run_vacuum_command(),
         Some(Command::Wt {
             branch,
             list,
@@ -1529,6 +1532,22 @@ fn run_executor_command(command: ExecutorCommand) -> Result<()> {
             Ok(())
         }
     }
+}
+
+fn run_vacuum_command() -> Result<()> {
+    let store_path = coven_store_path()?;
+    let report = store::vacuum_store_path(&store_path)?;
+    let integrity = if report.integrity_check.iter().any(|line| line != "ok") {
+        report.integrity_check.join("; ")
+    } else {
+        "ok".to_string()
+    };
+    println!(
+        "vacuumed store={} eventIndexRebuilt={} integrity={integrity}",
+        store_path.display(),
+        report.event_index_rebuilt
+    );
+    Ok(())
 }
 
 fn run_daemon_command(command: DaemonCommand) -> Result<()> {
@@ -3357,6 +3376,9 @@ mod tests {
             }
             other => panic!("expected sacrifice command, got {other:?}"),
         }
+
+        let vacuum = Cli::parse_from(["coven", "vacuum"]);
+        assert!(matches!(vacuum.command, Some(Command::Vacuum)));
     }
 
     #[test]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -211,6 +211,13 @@ pub struct SearchHit {
     pub created_at: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoreVacuumReport {
+    pub event_index_rebuilt: bool,
+    pub integrity_check: Vec<String>,
+}
+
 #[derive(Debug, Default)]
 pub struct EventsQueryOptions {
     pub after_seq: Option<i64>,
@@ -1854,6 +1861,55 @@ pub fn search_events(conn: &Connection, query: &str) -> Result<Vec<SearchHit>> {
     Ok(out)
 }
 
+pub fn vacuum_store_path(path: &Path) -> Result<StoreVacuumReport> {
+    let conn = Connection::open(path)
+        .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
+    conn.execute_batch(
+        "PRAGMA busy_timeout = 5000;
+         PRAGMA foreign_keys = ON;",
+    )
+    .context("failed to configure Coven store vacuum")?;
+
+    let event_index_rebuilt = sqlite_object_exists(&conn, "table", "events_fts")?;
+    if event_index_rebuilt {
+        conn.execute("INSERT INTO events_fts(events_fts) VALUES('rebuild')", [])
+            .context("failed to rebuild events_fts")?;
+    }
+
+    conn.execute_batch("PRAGMA optimize; VACUUM;")
+        .context("failed to vacuum Coven store")?;
+    let _ = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
+    let integrity_check = pragma_integrity_check(&conn)?;
+
+    Ok(StoreVacuumReport {
+        event_index_rebuilt,
+        integrity_check,
+    })
+}
+
+fn sqlite_object_exists(conn: &Connection, object_type: &str, name: &str) -> Result<bool> {
+    conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master WHERE type = ?1 AND name = ?2
+        )",
+        params![object_type, name],
+        |row| row.get::<_, bool>(0),
+    )
+    .with_context(|| format!("failed to inspect sqlite object {name}"))
+}
+
+fn pragma_integrity_check(conn: &Connection) -> Result<Vec<String>> {
+    let mut stmt = conn
+        .prepare("PRAGMA integrity_check")
+        .context("failed to prepare integrity_check")?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .context("failed to run integrity_check")?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed to read integrity_check")?;
+    Ok(rows)
+}
+
 pub fn insert_event(conn: &Connection, record: &EventRecord) -> Result<()> {
     let config = PrivacyConfig::default();
     let redacted_payload = privacy::redact_payload_json_with_config(&record.payload_json, &config);
@@ -3222,6 +3278,38 @@ mod tests {
             )
             .optional()?;
         assert_eq!(complete, None);
+        Ok(())
+    }
+
+    #[test]
+    fn vacuum_rebuilds_stale_event_fts_index() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let path = temp.path().join("test.sqlite3");
+        let conn = open_store(&path)?;
+        conn.execute(
+            "INSERT INTO sessions(id, project_root, harness, title, status, created_at, updated_at)
+             VALUES('s1', '/tmp', 'codex', 't', 'created', '2026-01-01', '2026-01-01')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO events(id, session_id, kind, payload_json, created_at)
+             VALUES('e1', 's1', 'stdout', '{\"text\":\"phoenix rises\"}', '2026-01-01')",
+            [],
+        )?;
+        conn.execute(
+            "INSERT INTO events_fts(events_fts) VALUES('delete-all')",
+            [],
+        )?;
+        assert!(search_events(&conn, "phoenix")?.is_empty());
+        drop(conn);
+
+        let report = vacuum_store_path(&path)?;
+
+        assert!(report.event_index_rebuilt);
+        let conn = open_store(&path)?;
+        let hits = search_events(&conn, "phoenix")?;
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].event_id, "e1");
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1862,13 +1862,7 @@ pub fn search_events(conn: &Connection, query: &str) -> Result<Vec<SearchHit>> {
 }
 
 pub fn vacuum_store_path(path: &Path) -> Result<StoreVacuumReport> {
-    let conn = Connection::open(path)
-        .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
-    conn.execute_batch(
-        "PRAGMA busy_timeout = 5000;
-         PRAGMA foreign_keys = ON;",
-    )
-    .context("failed to configure Coven store vacuum")?;
+    let conn = open_store(path)?;
 
     let event_index_rebuilt = sqlite_object_exists(&conn, "table", "events_fts")?;
     if event_index_rebuilt {

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -53,6 +53,7 @@ Negotiate against `apiVersion` and `capabilities` before depending on session or
 | `GET /api/v1/events?sessionId=...` | Read session events. |
 | `POST /api/v1/sessions/:id/input` | Forward input to a live session. |
 | `POST /api/v1/sessions/:id/kill` | Kill a live session. |
+| `POST /api/v1/store/vacuum` | Rebuild the event FTS index and compact the SQLite store. |
 
 Detailed shapes live in the [API reference](/reference/api).
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -45,6 +45,7 @@ flowchart LR
 | POST | `/api/v1/sessions/:id/input` | Forward input to a live session. | `{ data }` | `{ ok, accepted }` | `400 invalid_request` (malformed body / missing or non-string `data`), `404 session_not_found`, `409 session_not_live`, `500 send_input_failed` |
 | POST | `/api/v1/sessions/:id/kill` | Kill a live session. | — | `{ ok, accepted }` | `404 session_not_found`, `409 session_not_live`, `500 kill_failed` |
 | GET | `/api/v1/events` | Read paginated redacted session events. | — (`?sessionId`, `?afterSeq`, `?afterEventId`, `?limit`) | `{ events, nextCursor, hasMore }` | `400 invalid_request` |
+| POST | `/api/v1/store/vacuum` | Rebuild the event FTS index and compact the SQLite store. | — | `{ ok, eventIndexRebuilt, integrityCheck }` | `500` for SQLite repair failures |
 
 All error responses use the structured envelope documented in [API contract](/API-CONTRACT#structured-error-envelope).
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -24,6 +24,7 @@ flowchart TB
   Root --> Kill["kill"]
   Root --> Patch["patch"]
   Root --> Logs["logs"]
+  Root --> Vacuum["vacuum"]
   Root --> Wt["wt"]
   Root --> Claim["claim"]
   Root --> Hooks["hooks"]
@@ -84,6 +85,7 @@ flowchart TB
 | `coven kill <session-id>` | Kill a running session's process; keeps the event log. |
 | `coven patch openclaw <prompt>` | Local OpenClaw rescue loop. Does not commit or push. |
 | `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs. |
+| `coven vacuum` | Rebuild the session event FTS index, compact the SQLite store, and print integrity status. |
 | `coven wt <branch>` | Create or enter a sibling `<repo>.wt/<branch-slug>` git worktree. |
 | `coven wt --list/--doctor/--prune-merged/--prune-stale DAYS` | Inspect and clean Coven protocol worktrees. |
 | `coven claim acquire/release/heartbeat/canary <branch>` | Manage TTL-bounded branch ownership for the current agent. |
@@ -147,6 +149,13 @@ Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
 - Redacted operational event logs default to 30 days.
 - `--dry-run` prints counts only.
 - `--raw-days <N>` and `--event-days <N>` override the configured retention for one run.
+
+## Store repair
+
+`coven vacuum` is a local housekeeping command for the session ledger. It rebuilds the
+`events_fts` index, runs SQLite `VACUUM`, truncates the WAL when possible, and prints
+the final integrity check. Use it before retrying `coven sacrifice <id> --yes` when
+SQLite reports a malformed event index.
 
 ## Parallel Work Protocol
 


### PR DESCRIPTION
## What

Resurrects stashed WIP (stash from 2026-06-09, rebased onto current `main`) adding local session-store repair:

- `store::vacuum_store_path` — rebuilds the `events_fts` index, runs `PRAGMA optimize` + `VACUUM`, truncates the WAL when possible, and returns the final `integrity_check` report
- `coven vacuum` CLI command printing store path, index-rebuild status, and integrity
- `POST /api/v1/store/vacuum` daemon route returning `{ ok, eventIndexRebuilt, integrityCheck }`
- Docs: `docs/reference/cli.md`, `docs/reference/api.md`, `docs/daemon/socket-api.md`

## Why

Gives users a recovery path when SQLite reports a malformed FTS index (e.g. before retrying `coven sacrifice <id> --yes`), without hand-editing the store.

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --locked` ✅ (941 passed; includes 2 new tests: `routes_store_vacuum_request_to_repair_response`, `vacuum_rebuilds_stale_event_fts_index`)
- `python scripts/check-secrets.py` ✅