### PR TITLE
fix: output polish — no `^D` artifact on piped runs, neutral patch cancel, prose status lines

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -922,19 +922,27 @@ fn run_doctor() -> Result<()> {
     match daemon::background_server_status(&home)? {
         Some(daemon::DaemonStatusState::Running(status)) => {
             let health = api::health_response(Some(status.clone()));
-            println!(
-                "  status=running ok={} pid={} socket={}",
-                health.ok, status.pid, status.socket
-            );
+            if health.ok {
+                println!(
+                    "  [OK] running — pid {}, socket {}",
+                    status.pid, status.socket
+                );
+            } else {
+                println!(
+                    "  [!!] running but failing health checks — pid {}, socket {}",
+                    status.pid, status.socket
+                );
+            }
         }
         Some(daemon::DaemonStatusState::Stale(status)) => {
             healthy = false;
             println!(
-                "  status=stale ok=false pid={} socket={}",
+                "  [!!] stale — pid {} no longer looks healthy (socket {})",
                 status.pid, status.socket
             );
+            println!("       Recover with `coven daemon restart`.");
         }
-        None => println!("  status=stopped"),
+        None => println!("  [OK] stopped — optional; start with `coven daemon start`"),
     }
 
     let repos_config = repos_config::load_with_settings(&home, settings::cached())?;
@@ -1263,12 +1271,12 @@ fn run_patch(
     if request.git_state.is_dirty() && !request.non_interactive {
         println!("\nExisting changes were detected. Coven will not stash or overwrite them.");
         if !confirm_yes("Continue and ask the harness to preserve existing changes? [y/N] ")? {
-            anyhow::bail!("cancelled before harness launch");
+            exit_patch_cancelled();
         }
     }
 
     if !request.non_interactive && !confirm_yes("Launch the harness now? [y/N] ")? {
-        anyhow::bail!("cancelled before harness launch");
+        exit_patch_cancelled();
     }
 
     let session_id = launch_patch_session(&request)?;
@@ -1386,6 +1394,15 @@ fn confirm_yes(prompt: &str) -> Result<bool> {
     Ok(matches!(line.trim(), "y" | "Y" | "yes" | "YES" | "Yes"))
 }
 
+/// The user declined a `coven patch` confirmation prompt. That's a neutral
+/// outcome, not a failure — report it in "cancelled" voice instead of the
+/// `Error:` prefix an `anyhow::bail!` would earn, but keep the exit code
+/// nonzero so scripts chaining on `patch` still see it didn't run.
+fn exit_patch_cancelled() -> ! {
+    println!("Cancelled. Nothing was launched.");
+    std::process::exit(1);
+}
+
 fn choose_default_harness() -> Result<patch::HarnessId> {
     let harnesses = harness::built_in_harnesses();
     if harnesses.iter().any(|h| h.id == "codex" && h.available) {
@@ -1500,7 +1517,9 @@ fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u
 
     if dry_run {
         println!(
-            "logs prune dryRun=true rawArtifacts={raw_count} events={event_count} rawDays={raw_days} eventDays={event_days}"
+            "Dry run: would prune {} and {} (raw artifacts kept {raw_days} days, events kept {event_days} days). Nothing was deleted.",
+            count_noun(u64::try_from(raw_count).unwrap_or_default(), "raw artifact"),
+            count_noun(u64::try_from(event_count).unwrap_or_default(), "event"),
         );
         return Ok(());
     }
@@ -1508,9 +1527,24 @@ fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u
     let raw_pruned = store::prune_sensitive_artifacts(&conn, &now, &raw_cutoff)?;
     let events_pruned = store::prune_events_older_than(&conn, &event_cutoff)?;
     println!(
-        "logs pruned rawArtifacts={raw_pruned} events={events_pruned} rawCutoff={raw_cutoff} eventCutoff={event_cutoff}"
+        "Pruned {} (older than {raw_cutoff}) and {} (older than {event_cutoff}).",
+        count_noun(
+            u64::try_from(raw_pruned).unwrap_or_default(),
+            "raw artifact"
+        ),
+        count_noun(u64::try_from(events_pruned).unwrap_or_default(), "event"),
     );
     Ok(())
+}
+
+/// `3 events`, `1 raw artifact` — count + noun with naive pluralization,
+/// for human status lines.
+fn count_noun(count: u64, noun: &str) -> String {
+    if count == 1 {
+        format!("1 {noun}")
+    } else {
+        format!("{count} {noun}s")
+    }
 }
 
 fn run_executor_command(command: ExecutorCommand) -> Result<()> {
@@ -2661,6 +2695,13 @@ mod tests {
         )];
         let browser_frame = tui::sessions::render_browser_frame_plain_for_test(&sessions, 0, 0);
         assert!(browser_frame.contains("Session browser"));
+    }
+
+    #[test]
+    fn count_noun_pluralizes_for_human_status_lines() {
+        assert_eq!(count_noun(0, "event"), "0 events");
+        assert_eq!(count_noun(1, "raw artifact"), "1 raw artifact");
+        assert_eq!(count_noun(3, "event"), "3 events");
     }
 
     #[test]

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -633,6 +633,16 @@ fn run_attached_with_pty_system(
 
     drop(pair.slave);
 
+    // When stdin is a pipe rather than a terminal, nobody is typing at the
+    // PTY — but the PTY line discipline still starts in canonical echo
+    // mode, so every byte we forward gets echoed back into the harness
+    // output. That includes the trailing newline + EOT that portable-pty
+    // writes when the master writer drops, which surfaced as a stray `^D`
+    // artifact on piped `coven run`. Turn echo off for the piped case.
+    if !io::stdin().is_terminal() {
+        disable_pty_echo(pair.master.as_ref());
+    }
+
     let mut reader = pair
         .master
         .try_clone_reader()
@@ -669,6 +679,28 @@ fn run_attached_with_pty_system(
         exit_code: Some(exit_code),
     })
 }
+
+/// Clear the ECHO flag on the PTY's line discipline. Best-effort: if the
+/// termios calls fail (or the platform can't expose the master fd) the run
+/// proceeds with echo on, which is the old behavior.
+#[cfg(unix)]
+fn disable_pty_echo(master: &dyn portable_pty::MasterPty) {
+    let Some(fd) = master.as_raw_fd() else {
+        return;
+    };
+    unsafe {
+        let mut termios = std::mem::MaybeUninit::<libc::termios>::zeroed().assume_init();
+        if libc::tcgetattr(fd, &mut termios) == 0 {
+            termios.c_lflag &= !libc::ECHO;
+            let _ = libc::tcsetattr(fd, libc::TCSANOW, &termios);
+        }
+    }
+}
+
+/// ConPTY has no termios-style echo to clear; the `^D` artifact is a Unix
+/// line-discipline behavior, so this is a no-op on Windows.
+#[cfg(not(unix))]
+fn disable_pty_echo(_master: &dyn portable_pty::MasterPty) {}
 
 struct RawModeGuard {
     enabled: bool,
@@ -743,6 +775,61 @@ mod tests {
         session.input.write_all(b"hello detached pty\n")?;
         session.input.flush()?;
         session.killer.kill()?;
+        Ok(())
+    }
+
+    /// Regression test for the `^D` artifact on piped `coven run`: with PTY
+    /// echo disabled, neither the forwarded input nor the newline + EOT that
+    /// portable-pty writes on master-writer drop may leak back into the
+    /// harness output stream.
+    #[cfg(unix)]
+    #[test]
+    fn disable_pty_echo_suppresses_input_and_eot_echo() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pty_system = native_pty_system();
+        let pair = pty_system.openpty(terminal_size())?;
+        let mut builder = CommandBuilder::new("cat");
+        builder.cwd(temp_dir.path().as_os_str());
+        let mut child = pair.slave.spawn_command(builder)?;
+        drop(pair.slave);
+
+        disable_pty_echo(pair.master.as_ref());
+
+        let mut reader = pair.master.try_clone_reader()?;
+        let output_thread = thread::spawn(move || {
+            let mut output = Vec::new();
+            let _ = reader.read_to_end(&mut output);
+            output
+        });
+
+        let mut writer = pair.master.take_writer()?;
+        writer.write_all(b"hi from a pipe\n")?;
+        writer.flush()?;
+        // Dropping the writer makes portable-pty send `\n` + VEOF, which
+        // tells `cat` to exit — and is exactly the byte pair that used to
+        // be echoed back as a stray `^D`.
+        drop(writer);
+
+        let _ = child.wait()?;
+        drop(pair.master);
+        let output = output_thread
+            .join()
+            .unwrap_or_else(|_| panic!("PTY reader thread panicked"));
+        let output = String::from_utf8_lossy(&output);
+
+        assert!(
+            output.contains("hi from a pipe"),
+            "cat's own stdout must still come through, got: {output:?}"
+        );
+        assert!(
+            !output.contains('\u{4}'),
+            "raw EOT byte leaked into PTY output: {output:?}"
+        );
+        assert_eq!(
+            output.matches("hi from a pipe").count(),
+            1,
+            "input must not be echoed a second time by the PTY: {output:?}"
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -532,8 +532,8 @@ fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
 
     assert_success("doctor with live daemon", &output);
     assert_stdout_contains("doctor with live daemon", &output, "Daemon:");
-    assert_stdout_contains("doctor with live daemon", &output, "status=running");
-    assert_stdout_contains("doctor with live daemon", &output, "socket=");
+    assert_stdout_contains("doctor with live daemon", &output, "[OK] running — pid ");
+    assert_stdout_contains("doctor with live daemon", &output, ", socket ");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Closes #311 (follow-up candidate 8 from the #297 CLI UX audit).

### 1. `^D` artifact on piped `coven run`
`portable-pty`'s master writer writes `\n` + VEOF on drop so the harness sees EOF — but with the PTY line discipline still in echo mode, that byte pair (and the piped input itself) was echoed back into the visible output as a stray `^D`. Attached runs now clear `ECHO` on the PTY when stdin is not a terminal. No-op on Windows (ConPTY has no termios echo) and when stdin is a real TTY. Regression test spawns `cat` under a real PTY and asserts no EOT byte and no double-echoed input.

### 2. `patch` cancellation surfaced as `Error:`
Declining either `coven patch` confirmation prompt used `anyhow::bail!`, which the top level printed as `Error: cancelled before harness launch`. A user-initiated cancel now prints a neutral `Cancelled. Nothing was launched.` — exit code stays `1` so scripts still see it didn't run.

### 3. key=value dev-log voice on human status lines
- `coven doctor`'s Daemon section now matches the rest of doctor's `[OK]`/`[!!]` prose (`[OK] running — pid 123, socket …`, stale gets a `coven daemon restart` remedy line).
- `coven logs prune` speaks prose (`Pruned 3 raw artifacts (older than …) and 12 events …`), with correct singular/plural.
- **Intentionally unchanged:** `coven daemon status` key=value output — docs describe it as the scriptable status surface (docs/daemon/health.md, cli-doctor.md), `scripts/test-cli-prepublish.mjs` and smoke tests parse it, and follow-up #297-candidate 5 (`--json` for `daemon status`) is the right place to migrate scripts before changing it.

## Testing
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `python scripts/check-secrets.py` — all green.
- New tests: `disable_pty_echo_suppresses_input_and_eot_echo` (real PTY), `count_noun_pluralizes_for_human_status_lines`; updated the doctor smoke assertion to the new prose.