### PR TITLE
fix: prose daemon-status lines — complete #311 item 3

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -946,20 +946,15 @@ fn run_doctor() -> Result<()> {
     println!("\nDaemon:");
     match daemon::background_server_status(&home)? {
         Some(daemon::DaemonStatusState::Running(status)) => {
-            let health = api::health_response(Some(status.clone()));
-            println!(
-                "  status=running ok={} pid={} socket={}",
-                health.ok, status.pid, status.socket
-            );
+            // `ok` is always true for a live daemon, so the prose "Running"
+            // already conveys it; the `--json` path keeps the field.
+            println!("  Running (pid {}, socket {})", status.pid, status.socket);
         }
         Some(daemon::DaemonStatusState::Stale(status)) => {
             healthy = false;
-            println!(
-                "  status=stale ok=false pid={} socket={}",
-                status.pid, status.socket
-            );
+            println!("  Stale (pid {}, socket {})", status.pid, status.socket);
         }
-        None => println!("  status=stopped"),
+        None => println!("  Not running"),
     }
 
     let repos_config = repos_config::load_with_settings(&home, settings::cached())?;
@@ -1565,7 +1560,7 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
             let status =
                 daemon::ensure_background_server(&home, &current_exe, current_timestamp())?;
             println!(
-                "coven daemon status=running pid={} socket={}",
+                "Coven daemon: running (pid {}, socket {})",
                 status.pid, status.socket
             );
         }
@@ -1576,12 +1571,12 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 daemon::restart_background_server(&home, &current_exe, current_timestamp())?;
             if was_running {
                 println!(
-                    "coven daemon status=restarted pid={} socket={}",
+                    "Coven daemon: restarted (pid {}, socket {})",
                     status.pid, status.socket
                 );
             } else {
                 println!(
-                    "coven daemon status=running pid={} socket={}",
+                    "Coven daemon: running (pid {}, socket {})",
                     status.pid, status.socket
                 );
             }
@@ -1593,17 +1588,16 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
             } else {
                 match &state {
                     Some(daemon::DaemonStatusState::Running(status)) => {
-                        let health = api::health_response(Some(status.clone()));
                         println!(
-                            "coven daemon status=running ok={} pid={} socket={}",
-                            health.ok, status.pid, status.socket
+                            "Coven daemon: running (pid {}, socket {})",
+                            status.pid, status.socket
                         );
                     }
                     Some(daemon::DaemonStatusState::Stale(status)) => println!(
-                        "coven daemon status=stale ok=false pid={} socket={}",
+                        "Coven daemon: stale (pid {}, socket {})",
                         status.pid, status.socket
                     ),
-                    None => println!("coven daemon status=stopped"),
+                    None => println!("Coven daemon: not running"),
                 }
             }
             if state.is_none() {
@@ -1615,9 +1609,9 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
         }
         DaemonCommand::Stop => {
             if daemon::stop_background_server(&home)? {
-                println!("coven daemon status=stopped");
+                println!("Coven daemon: stopped");
             } else {
-                println!("coven daemon was not running");
+                println!("Coven daemon: was not running");
             }
         }
         DaemonCommand::Serve { tcp } => {

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -39,7 +39,7 @@ fn daemon_status_clears_stale_metadata_when_daemon_is_gone() -> anyhow::Result<(
     assert_stdout_contains(
         "daemon status with stale metadata",
         &output,
-        "status=stopped",
+        "Coven daemon: not running",
     );
     assert!(
         !coven_home.join("daemon.json").exists(),
@@ -66,7 +66,7 @@ fn daemon_status_clears_corrupt_metadata_when_daemon_is_gone() -> anyhow::Result
     assert_stdout_contains(
         "daemon status with corrupt metadata",
         &output,
-        "status=stopped",
+        "Coven daemon: not running",
     );
     assert!(
         !coven_home.join("daemon.json").exists(),
@@ -105,7 +105,7 @@ fn daemon_status_recovers_corrupt_metadata_from_live_daemon_health() -> anyhow::
     assert_stdout_contains(
         "daemon status with live corrupt metadata",
         &output,
-        "status=running",
+        "Coven daemon: running",
     );
     let recovered = fs::read_to_string(&status_path)?;
     let recovered: Value = serde_json::from_str(&recovered)?;
@@ -532,8 +532,8 @@ fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
 
     assert_success("doctor with live daemon", &output);
     assert_stdout_contains("doctor with live daemon", &output, "Daemon:");
-    assert_stdout_contains("doctor with live daemon", &output, "status=running");
-    assert_stdout_contains("doctor with live daemon", &output, "socket=");
+    assert_stdout_contains("doctor with live daemon", &output, "Running (pid ");
+    assert_stdout_contains("doctor with live daemon", &output, ", socket ");
     Ok(())
 }
 
@@ -781,13 +781,13 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
 
     let start = run_coven(&coven, &coven_home, &path, &["daemon", "start"])?;
     assert_success("daemon start", &start);
-    assert_stdout_contains("daemon start", &start, "status=running");
+    assert_stdout_contains("daemon start", &start, "Coven daemon: running");
 
     wait_for_daemon_health(&coven_home)?;
 
     let status = run_coven(&coven, &coven_home, &path, &["daemon", "status"])?;
     assert_success("daemon status", &status);
-    assert_stdout_contains("daemon status", &status, "status=running");
+    assert_stdout_contains("daemon status", &status, "Coven daemon: running");
 
     let status_json = run_coven(&coven, &coven_home, &path, &["daemon", "status", "--json"])?;
     assert_success("daemon status --json", &status_json);
@@ -819,7 +819,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
 
     let restart = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
     assert_success("daemon restart", &restart);
-    assert_stdout_contains("daemon restart", &restart, "status=restarted");
+    assert_stdout_contains("daemon restart", &restart, "Coven daemon: restarted");
     wait_for_daemon_health(&coven_home)?;
 
     let restarted_status = run_coven(&coven, &coven_home, &path, &["daemon", "status"])?;
@@ -827,7 +827,7 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
     assert_stdout_contains(
         "daemon restarted status",
         &restarted_status,
-        "status=running",
+        "Coven daemon: running",
     );
 
     let attach = run_coven(&coven, &coven_home, &path, &["attach", &replay_session])?;
@@ -908,11 +908,15 @@ fn smoke_daemon_session_replay_and_safe_session_rituals() -> anyhow::Result<()> 
 
     let stop = run_coven(&coven, &coven_home, &path, &["daemon", "stop"])?;
     assert_success("daemon stop", &stop);
-    assert_stdout_contains("daemon stop", &stop, "status=stopped");
+    assert_stdout_contains("daemon stop", &stop, "Coven daemon: stopped");
 
     let stopped = run_coven(&coven, &coven_home, &path, &["daemon", "status"])?;
     assert_success("daemon stopped status", &stopped);
-    assert_stdout_contains("daemon stopped status", &stopped, "status=stopped");
+    assert_stdout_contains(
+        "daemon stopped status",
+        &stopped,
+        "Coven daemon: not running",
+    );
 
     Ok(())
 }


### PR DESCRIPTION
Completes the third item of #311. PR #319 landed items 1 (`^D` artifact on piped `coven run`) and 2 (neutral patch-cancel voice), but merged before item 3 could be pushed, so #311 auto-closed with the `key=value` status lines still on main. This lands item 3.

## Change

The human daemon-status output still spoke in telemetry voice — `status=running ok=true pid=… socket=…`, `status=stopped`, etc. Every human path is now prose, consistent with the output discipline from #297:

- `coven doctor` daemon block → `  Running (pid N, socket …)` / `  Stale (pid N, socket …)` / `  Not running`
- `coven daemon start` / `restart` → `Coven daemon: running (pid N, socket …)` / `Coven daemon: restarted (…)`
- `coven daemon status` → `Coven daemon: running (…)` / `Coven daemon: stale (…)` / `Coven daemon: not running`
- `coven daemon stop` → `Coven daemon: stopped` / `Coven daemon: was not running`

The `--json` output added in #308 is the machine surface and is **untouched**. The 11 exact-string `smoke.rs` assertions on the old `status=` strings are updated to the new prose.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked` (full suite, 940+ tests), `scripts/check-secrets.py` — all green.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)