### PR TITLE
fix: unbreak npm onboarding smoke after #324's prose daemon-status output

### DIFF
--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -18,19 +18,20 @@ coven daemon status
 Typical healthy output:
 
 ```text
-coven daemon status=running ok=true pid=12345 socket=/home/alex/.coven/coven.sock
+Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
 ```
 
 `running` means Coven found daemon metadata and verified the process/socket.
-`ok=true` means the daemon health response succeeded.
+For scripts, `coven daemon status --json` adds an `ok` field that reports
+whether the daemon health response succeeded.
 
 ## Status values
 
 | Status | Meaning | Next step |
 | --- | --- | --- |
-| `status=stopped` | No daemon metadata is present. | Run `coven daemon start`. |
-| `status=running ok=true` | The daemon is reachable. | Run `coven doctor` or start a session. |
-| `status=stale ok=false` | Metadata exists, but the daemon no longer looks healthy. | Run `coven daemon stop`, then `coven daemon start`. |
+| `not running` | No daemon metadata is present. | Run `coven daemon start`. |
+| `running` | The daemon is reachable. | Run `coven doctor` or start a session. |
+| `stale` | Metadata exists, but the daemon no longer looks healthy. | Run `coven daemon stop`, then `coven daemon start`. |
 
 ## First-run health check
 

--- a/docs/help/daemon-wont-start.md
+++ b/docs/help/daemon-wont-start.md
@@ -17,7 +17,7 @@ coven doctor
 coven daemon status
 ```
 
-`status=stopped` is not an error. Start it:
+`Coven daemon: not running` is not an error. Start it:
 
 ```sh
 coven daemon start
@@ -35,7 +35,7 @@ coven daemon restart
 coven daemon status
 ```
 
-If `status=running ok=true` appears, continue with:
+If `Coven daemon: running (pid …, socket …)` appears, continue with:
 
 ```sh
 coven run codex "say hello from Coven"

--- a/docs/reference/cli-daemon.md
+++ b/docs/reference/cli-daemon.md
@@ -34,10 +34,12 @@ coven daemon status
 Expected running output:
 
 ```text
-coven daemon status=running ok=true pid=12345 socket=/home/alex/.coven/coven.sock
+Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
 ```
 
-`ok=true` means the daemon health endpoint responded through the local socket.
+For scripts, `coven daemon status --json` prints the same state as JSON with an
+`ok` field that reports whether the daemon health endpoint responded through
+the local socket.
 
 ## Restart after upgrades
 
@@ -90,8 +92,8 @@ to verify the supervised daemon.
 
 ## Troubleshooting
 
-- `status=stopped`: run `coven daemon start`.
-- `status=stale`: run `coven daemon stop`, then `coven daemon start`.
+- `not running`: run `coven daemon start`.
+- `stale`: run `coven daemon stop`, then `coven daemon start`.
 - Permission errors: verify the daemon user owns `COVEN_HOME`.
 - Version drift: run `coven --version`, then `coven daemon restart`.
 

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -68,22 +68,22 @@ environment where the daemon/session starts.
 status:
 
 ```sh
-coven daemon status
+coven daemon status --json
 ```
 
-Typical output:
+Typical human output from `coven daemon status`:
 
 ```text
-coven daemon status=running ok=true pid=12345 socket=/home/alex/.coven/coven.sock
+Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
 ```
 
-`status=stopped` means no background daemon is running yet. Start it with:
+`not running` means no background daemon is running yet. Start it with:
 
 ```sh
 coven daemon start
 ```
 
-`status=stale` means metadata exists for a process/socket that no longer looks
+`stale` means metadata exists for a process/socket that no longer looks
 healthy. Try:
 
 ```sh

--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -176,8 +176,9 @@ test('npm onboarding smoke exercises daemon lifecycle with isolated state', () =
   assert.match(script, /\['daemon',\s*'status'\]/);
   assert.match(script, /\['daemon',\s*'stop'\]/);
   assert.match(script, /\['sessions',\s*'--plain'\]/);
-  assert.match(script, /status=running/);
-  assert.match(script, /ok=true/);
+  assert.match(script, /Coven daemon: running/);
+  assert.match(script, /\['daemon',\s*'status',\s*'--json'\]/);
+  assert.match(script, /statusJson\.ok !== true/);
 });
 
 test('npm onboarding smoke launches Windows cmd shims through a shell', () => {

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -230,13 +230,26 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
   try {
     const startOutput = runDaemonStart(wrapperBin, smokeEnv);
     daemonStarted = true;
-    if (startOutput && !startOutput.stdout.includes('status=running')) {
-      fail(`\`coven daemon start\` did not report status=running.\nstdout:\n${startOutput.stdout}\nstderr:\n${startOutput.stderr}`);
+    if (startOutput && !startOutput.stdout.includes('Coven daemon: running')) {
+      fail(`\`coven daemon start\` did not report a running daemon.\nstdout:\n${startOutput.stdout}\nstderr:\n${startOutput.stderr}`);
     }
 
     const statusOutput = runCapture(wrapperBin, ['daemon', 'status'], { env: smokeEnv });
-    if (!statusOutput.stdout.includes('status=running') || !statusOutput.stdout.includes('ok=true')) {
-      fail(`\`coven daemon status\` did not report a healthy running daemon.\nstdout:\n${statusOutput.stdout}\nstderr:\n${statusOutput.stderr}`);
+    if (!statusOutput.stdout.includes('Coven daemon: running')) {
+      fail(`\`coven daemon status\` did not report a running daemon.\nstdout:\n${statusOutput.stdout}\nstderr:\n${statusOutput.stderr}`);
+    }
+
+    // Health check goes through the machine surface: `--json` carries the
+    // `ok` flag that the human prose line intentionally no longer prints.
+    const statusJsonOutput = runCapture(wrapperBin, ['daemon', 'status', '--json'], { env: smokeEnv });
+    let statusJson;
+    try {
+      statusJson = JSON.parse(statusJsonOutput.stdout);
+    } catch {
+      fail(`\`coven daemon status --json\` did not print valid JSON.\nstdout:\n${statusJsonOutput.stdout}\nstderr:\n${statusJsonOutput.stderr}`);
+    }
+    if (statusJson.status !== 'running' || statusJson.ok !== true) {
+      fail(`\`coven daemon status --json\` did not report a healthy running daemon.\nstdout:\n${statusJsonOutput.stdout}\nstderr:\n${statusJsonOutput.stderr}`);
     }
 
     const sessionsOutput = runCapture(wrapperBin, ['sessions', '--plain'], { env: smokeEnv });


### PR DESCRIPTION
## Summary

Closes #326. Fixes the red `npm onboarding smoke` CI on `main` introduced by #324 (first red run: https://github.com/OpenCoven/coven/actions/runs/28844011183).

#324 converted the human `coven daemon start/status` lines to prose (`Coven daemon: running (pid …, socket …)`) and updated the Rust smoke tests, but missed the Node scripts and docs that consumed the old `status=running ok=true` shape.

## Changes

- **`scripts/test-cli-prepublish.mjs`** — asserts `Coven daemon: running` on the human path for `daemon start`/`daemon status`, and moves the health check to `coven daemon status --json` (the machine surface from #308), parsing `status === 'running' && ok === true`. The Windows no-pipe-capture guard (`startOutput && …`) is preserved.
- **`scripts/onboarding-docs-test.mjs`** — meta-assertions updated to require the new prose assertion and the `--json` health check.
- **Docs** — `docs/daemon/health.md`, `docs/reference/cli-daemon.md`, `docs/reference/cli-doctor.md`, `docs/help/daemon-wont-start.md` now show the current prose output and point scripts at `--json` for the `ok` flag.

## Verification

- `node --test scripts/onboarding-docs-test.mjs` — all pass.
- Against a fresh debug build with an isolated `COVEN_HOME`: `daemon start` → `Coven daemon: running (pid …, socket …)`; `daemon status --json` → `{\"status\":\"running\",\"ok\":true,…}`; `daemon stop` → `Coven daemon: stopped` — all matching the new assertions.
- `python scripts/check-secrets.py` — clean.
- No Rust changes, so `cargo` gates are unaffected (CI will confirm).

Claimed via `coven claim acquire issue-326` per AGENTS.md.