### PR TITLE
fix: prose output for coven vacuum and clarify eventIndexRebuilt semantics

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1562,10 +1562,14 @@ fn run_vacuum_command() -> Result<()> {
     } else {
         "ok".to_string()
     };
+    let index = if report.event_index_rebuilt {
+        "event index rebuilt"
+    } else {
+        "no event index to rebuild"
+    };
     println!(
-        "vacuumed store={} eventIndexRebuilt={} integrity={integrity}",
-        store_path.display(),
-        report.event_index_rebuilt
+        "Coven store: vacuumed ({index}, integrity {integrity}, path {})",
+        store_path.display()
     );
     Ok(())
 }

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -49,6 +49,10 @@ flowchart LR
 
 All error responses use the structured envelope documented in [API contract](/API-CONTRACT#structured-error-envelope).
 
+`eventIndexRebuilt` reports whether the `events_fts` index was present and rebuilt —
+the rebuild always runs when the index exists, so `true` does not imply the index
+was stale. `false` means the store has no `events_fts` table to rebuild.
+
 ## Always begin with health
 
 ```http

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -154,8 +154,8 @@ Supported shells: `bash`, `zsh`, `fish`, `elvish`, `powershell`.
 
 `coven vacuum` is a local housekeeping command for the session ledger. It rebuilds the
 `events_fts` index, runs SQLite `VACUUM`, truncates the WAL when possible, and prints
-the final integrity check. Use it before retrying `coven sacrifice <id> --yes` when
-SQLite reports a malformed event index.
+the final integrity check as a prose status line. Use it before retrying
+`coven sacrifice <id> --yes` when SQLite reports a malformed event index.
 
 ## Parallel Work Protocol
 


### PR DESCRIPTION
## What

Follow-ups from the #322 review (non-blocking nits, landed separately):

- `coven vacuum` now prints a prose status line matching the daemon-status convention from #324, instead of key=value output:
  ```
  Coven store: vacuumed (event index rebuilt, integrity ok, path /…/coven.sqlite3)
  ```
- `docs/reference/api.md` clarifies `eventIndexRebuilt` semantics: the rebuild runs unconditionally when the `events_fts` index exists, so `true` means "present and rebuilt", not "was stale"; `false` means there was no index to rebuild.
- `docs/reference/cli.md` notes the prose status line.

## Why

#324 moved human-facing CLI output to prose, reserving structured shapes for `--json`. `coven vacuum` merged (#322) with the old key=value style; this aligns it. The `eventIndexRebuilt` doc note prevents readers from inferring a staleness signal that the field doesn't carry.

## Validation

- `cargo fmt --check` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test --workspace --locked` ✅ (950 passed)
- `python scripts/check-secrets.py` ✅
