### PR TITLE
refactor(harness): adopt coven-runtime-spec capabilities (integration PR 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "coven-runtime-spec",
  "crossterm",
  "dirs-next",
  "flate2",
@@ -629,6 +630,16 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "coven-runtime-spec"
+version = "0.1.3"
+source = "git+https://github.com/OpenCoven/coven-runtimes?tag=v0.1.3#83181fcffcc23c48e0c3c5ece068c6694fdd9d72"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -16,6 +16,10 @@ base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+# Runtime capability model shared with the coven-runtimes registry. Pinned to a
+# release tag; the daemon reads a manifest's declared capabilities through
+# these types instead of hardcoded harness-id checks (integration.md, PR 1).
+coven-runtime-spec = { git = "https://github.com/OpenCoven/coven-runtimes", tag = "v0.1.3" }
 crossterm = "0.29"
 flate2 = "1"
 json5 = "1.3"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -19,7 +19,7 @@ clap_complete = "4"
 # Runtime capability model shared with the coven-runtimes registry. Pinned to a
 # release tag; the daemon reads a manifest's declared capabilities through
 # these types instead of hardcoded harness-id checks (integration.md, PR 1).
-coven-runtime-spec = { git = "https://github.com/OpenCoven/coven-runtimes", tag = "v0.1.3" }
+coven-runtime-spec = { git = "https://github.com/OpenCoven/coven-runtimes", tag = "v0.1.3", version = "0.1.3" }
 crossterm = "0.29"
 flate2 = "1"
 json5 = "1.3"

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
+use coven_runtime_spec::Capabilities;
 use serde::{Deserialize, Serialize};
 
 pub const EXTERNAL_ADAPTER_MANIFEST_ENV: &str = "COVEN_HARNESS_ADAPTER_MANIFEST";
@@ -133,12 +134,26 @@ impl<'a> HarnessLaunchOptions<'a> {
     }
 }
 
+/// Declared capabilities for a configured harness id. Built-in harnesses
+/// declare theirs in [`built_in_harness_specs`]; ids that don't match a
+/// built-in (external adapters, unknown ids) get the conservative baseline
+/// (all off), which matches today's behavior — external adapters can't
+/// declare capabilities until the manifest loader learns to read them
+/// (coven-runtimes integration.md, PR 2).
+fn declared_capabilities(harness_id: &str) -> Capabilities {
+    built_in_harness_specs()
+        .into_iter()
+        .find(|spec| spec.id == harness_id)
+        .map(|spec| spec.capabilities)
+        .unwrap_or(Capabilities::BASELINE)
+}
+
 /// Whether the harness CLI has a long-lived JSON-streaming mode the daemon
 /// can keep alive across chat turns. Claude does (`stream-json`); codex
 /// doesn't (only one-shot `codex exec`). Unix kills the stream process tree
 /// with process groups; Windows uses a Job Object owned by the daemon.
 pub fn harness_supports_stream_mode(harness_id: &str) -> bool {
-    harness_id == "claude"
+    declared_capabilities(harness_id).stream
 }
 
 /// Hint passed when a chat turn wants to participate in a multi-turn
@@ -170,15 +185,15 @@ impl ConversationHint {
 /// session ids (e.g. codex) return `false`; the chat app captures the id from
 /// the first turn's output instead. See `docs/chat-persistence.md`.
 pub fn harness_supports_preassigned_session_id(harness_id: &str) -> bool {
-    harness_id == "claude"
+    declared_capabilities(harness_id).preassigned_session_id
 }
 
 pub fn harness_supports_think(harness_id: &str) -> bool {
-    harness_id == "claude"
+    declared_capabilities(harness_id).think
 }
 
 pub fn harness_supports_speed(harness_id: &str) -> bool {
-    harness_id == "claude"
+    declared_capabilities(harness_id).speed
 }
 
 /// How a harness translates a `Permission` into its native sandbox flag.
@@ -221,6 +236,13 @@ pub struct HarnessCommandSpec {
     /// means the harness declares no sandbox mechanism, so `--permission` is a
     /// warned no-op for it (mirrors `model_flag`).
     pub sandbox: Option<SandboxMapping>,
+    /// Behavioral capabilities (stream mode, session pre-assignment, think,
+    /// speed). Shared type with the coven-runtimes manifest spec so built-in
+    /// harnesses and external adapters declare what they can do through the
+    /// same struct instead of hardcoded harness-id checks. External adapters
+    /// currently get the conservative baseline (all off); reading these from
+    /// the manifest is the follow-up loader change (integration.md, PR 2).
+    pub capabilities: Capabilities,
 }
 
 impl HarnessCommandSpec {
@@ -397,6 +419,10 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 full: "danger-full-access".to_string(),
                 read_only: "read-only".to_string(),
             }),
+            // One-shot `codex exec` only: no stream-json mode, no session
+            // pre-assignment (ids are captured from the first turn's output),
+            // no think/speed toggles.
+            capabilities: Capabilities::BASELINE,
         },
         HarnessCommandSpec {
             id: "claude".to_string(),
@@ -418,6 +444,15 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 full: "bypassPermissions".to_string(),
                 read_only: "plan".to_string(),
             }),
+            // Long-lived stream-json mode, `--session-id`/`--resume`
+            // pre-assignment, and think/speed via `--effort`. These declared
+            // values replace the former `harness_id == "claude"` checks.
+            capabilities: Capabilities {
+                stream: true,
+                preassigned_session_id: true,
+                think: true,
+                speed: true,
+            },
         },
     ]
 }
@@ -738,6 +773,9 @@ impl ExternalHarnessAdapterSpec {
             // External adapters declare no sandbox mechanism today, so
             // `coven run --permission` warns and continues for them.
             sandbox: None,
+            // Conservative baseline (all off) until the loader reads
+            // `capabilities` from the manifest (integration.md, PR 2).
+            capabilities: Capabilities::BASELINE,
         })
     }
 }
@@ -1478,6 +1516,7 @@ mod tests {
             model_flag: None,
             model_arg_template: None,
             sandbox: None,
+            capabilities: Capabilities::BASELINE,
         };
 
         assert_eq!(
@@ -2071,6 +2110,23 @@ mod tests {
         }
     }
 
+    /// The capability model replaces the former `harness_id == "claude"`
+    /// string checks: claude declares everything, codex stays baseline, and
+    /// anything else (external adapters, unknown ids) is baseline until the
+    /// manifest loader learns to read `capabilities` (integration.md, PR 2).
+    #[test]
+    fn built_in_capabilities_match_former_string_checks() {
+        let claude = declared_capabilities("claude");
+        assert!(claude.stream);
+        assert!(claude.preassigned_session_id);
+        assert!(claude.think);
+        assert!(claude.speed);
+
+        assert!(declared_capabilities("codex").is_baseline());
+        assert!(declared_capabilities("hermes").is_baseline());
+        assert!(declared_capabilities("unknown").is_baseline());
+    }
+
     #[test]
     fn codex_forwards_model_before_prompt_with_prefix_stripped() -> anyhow::Result<()> {
         let (program, args) = command_parts_for_harness_with_conversation(
@@ -2309,6 +2365,7 @@ mod tests {
             model_flag: None,
             model_arg_template: None,
             sandbox: None,
+            capabilities: Capabilities::BASELINE,
         };
         assert!(!spec.supports_permission());
         assert!(spec.sandbox_args(Permission::Full).is_empty());

--- a/deny.toml
+++ b/deny.toml
@@ -44,8 +44,10 @@ multiple-versions = "warn"
 wildcards = "deny"
 
 [sources]
-# Only the official crates.io registry is trusted. Reject unknown registries
-# and any git sources (there are none today).
+# Only the official crates.io registry is trusted, plus the first-party
+# OpenCoven runtime-spec crate (pinned to a release tag in Cargo.toml).
+# Reject unknown registries and any other git sources.
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/OpenCoven/coven-runtimes"]


### PR DESCRIPTION
## Context

- Summary: Adopt the shared `coven-runtime-spec` capability model in the harness layer — PR 1 of the coordinated integration described in [coven-runtimes `docs/integration.md`](https://github.com/OpenCoven/coven-runtimes/blob/main/docs/integration.md). The four `harness_supports_*` predicates stop being `harness_id == "claude"` string checks and become reads of a `capabilities` field that built-ins and (in PR 2) manifest adapters declare through the same struct.
- Files changed: `crates/coven-cli/src/harness.rs`, `crates/coven-cli/Cargo.toml`, `Cargo.lock`, `deny.toml`

## Implementation

- Approach: `HarnessCommandSpec` gains `capabilities: coven_runtime_spec::Capabilities`. Built-ins declare their real values (claude: stream/preassigned_session_id/think/speed all on; codex: baseline). `ExternalHarnessAdapterSpec::into_spec` sets the conservative baseline. The predicates resolve `declared_capabilities(id)` from the built-in specs, so unknown/external ids stay all-off — byte-for-byte the same decisions as the old string checks. New test `built_in_capabilities_match_former_string_checks` pins that equivalence.
- User-visible behavior: none. Pure refactor.
- Compatibility notes: dependency pinned to the coven-runtimes `v0.1.3` release tag; `deny.toml` gets a scoped `allow-git` for `https://github.com/OpenCoven/coven-runtimes` only. Existing external adapter manifests deserialize and behave unchanged.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — 981 tests green
- [x] `python3 scripts/check-secrets.py` — clean
- [x] Additional manual checks: `cargo deny check sources` → `sources ok`

## Risk and Rollback

- Risk level: low — no behavior change; the predicate equivalence is test-pinned.
- Rollback plan: revert the commit; no data or config migration involved.

## Agent Handoff

- Current state: capabilities are data on `HarnessCommandSpec`; predicates read them; built-ins populated.
- Follow-ups: PR 2 per integration.md — parse `capabilities`, `sandbox`, and `stream_args` from external adapter manifests and honor them (manifest-declared streaming runtimes, e.g. the newly accepted `coven-code` and `copilot` registry entries, then stream without core edits).
- Known gaps: external adapters remain baseline until PR 2; `stream_args` are still claude-hardcoded in `pty_runner::stream_claude`.
