### PR TITLE
feat(harness): integration PR 3 stream continuity manifests

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -19,6 +19,7 @@ pub struct HarnessSummary {
     pub executable: String,
     pub available: bool,
     pub install_hint: String,
+    pub capabilities: Capabilities,
     pub source: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_path: Option<String>,
@@ -251,6 +252,58 @@ pub struct HarnessCommandSpec {
     /// flags). Required when `capabilities.stream`; shared type with the
     /// coven-runtimes manifest spec.
     pub stream_args: Option<StreamArgs>,
+    /// One-shot non-interactive session-continuity args. This mirrors
+    /// `stream_args` for cold-started turns: adapters declare how to initialize
+    /// or resume an upstream conversation without Coven hardcoding ids.
+    pub continuity_args: Option<ContinuityArgs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContinuityArgs {
+    #[serde(default, alias = "initPrefixArgs")]
+    pub init_prefix_args: Vec<String>,
+    #[serde(default, alias = "resumePrefixArgs")]
+    pub resume_prefix_args: Vec<String>,
+    #[serde(
+        default,
+        alias = "sessionIdFlag",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub session_id_flag: Option<String>,
+    #[serde(default, alias = "resumeFlag", skip_serializing_if = "Option::is_none")]
+    pub resume_flag: Option<String>,
+}
+
+impl ContinuityArgs {
+    fn session_id_flag(&self) -> Option<&str> {
+        self.session_id_flag
+            .as_deref()
+            .map(str::trim)
+            .filter(|flag| !flag.is_empty())
+    }
+
+    fn resume_flag(&self) -> Option<&str> {
+        self.resume_flag
+            .as_deref()
+            .map(str::trim)
+            .filter(|flag| !flag.is_empty())
+    }
+
+    fn has_init_launch(&self) -> bool {
+        self.session_id_flag().is_some()
+            || self
+                .init_prefix_args
+                .iter()
+                .any(|arg| !arg.trim().is_empty())
+    }
+
+    fn has_resume_launch(&self) -> bool {
+        self.resume_flag().is_some()
+            || self
+                .resume_prefix_args
+                .iter()
+                .any(|arg| !arg.trim().is_empty())
+    }
 }
 
 impl HarnessCommandSpec {
@@ -353,6 +406,7 @@ impl HarnessSummary {
             install_hint: spec.install_hint,
             source: spec.source,
             manifest_path: spec.manifest_path,
+            capabilities: spec.capabilities,
         }
     }
 }
@@ -426,6 +480,18 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
             // no think/speed toggles.
             capabilities: Capabilities::BASELINE,
             stream_args: None,
+            continuity_args: Some(ContinuityArgs {
+                init_prefix_args: Vec::new(),
+                resume_prefix_args: vec![
+                    "exec".to_string(),
+                    "--skip-git-repo-check".to_string(),
+                    "--color".to_string(),
+                    "never".to_string(),
+                    "resume".to_string(),
+                ],
+                session_id_flag: None,
+                resume_flag: None,
+            }),
         },
         HarnessCommandSpec {
             id: "claude".to_string(),
@@ -471,6 +537,12 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 session_id_flag: Some("--session-id".to_string()),
                 resume_flag: Some("--resume".to_string()),
             }),
+            continuity_args: Some(ContinuityArgs {
+                init_prefix_args: vec!["--print".to_string()],
+                resume_prefix_args: vec!["--print".to_string()],
+                session_id_flag: Some("--session-id".to_string()),
+                resume_flag: Some("--resume".to_string()),
+            }),
         },
         HarnessCommandSpec {
             id: crate::engine::ENGINE_HARNESS_ID.to_string(),
@@ -506,6 +578,12 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                     "--output-format".to_string(),
                     "stream-json".to_string(),
                 ],
+                session_id_flag: Some("--session-id".to_string()),
+                resume_flag: Some("--resume".to_string()),
+            }),
+            continuity_args: Some(ContinuityArgs {
+                init_prefix_args: vec!["--print".to_string()],
+                resume_prefix_args: vec!["--print".to_string()],
                 session_id_flag: Some("--session-id".to_string()),
                 resume_flag: Some("--resume".to_string()),
             }),
@@ -770,6 +848,9 @@ struct ExternalHarnessAdapterSpec {
     /// Stream-json launch args. Required when `capabilities.stream`.
     #[serde(default, alias = "streamArgs")]
     stream_args: Option<StreamArgs>,
+    /// One-shot non-interactive continuity args.
+    #[serde(default, alias = "continuityArgs")]
+    continuity_args: Option<ContinuityArgs>,
 }
 
 impl ExternalHarnessAdapterSpec {
@@ -839,16 +920,40 @@ impl ExternalHarnessAdapterSpec {
             }
             _ => {}
         }
+        if let Some(args) = &self.continuity_args {
+            if !args.has_init_launch() && !args.has_resume_launch() {
+                anyhow::bail!(
+                    "external harness adapter `{id}` in {} provides `continuity_args` but \
+                     no usable init or resume launch args",
+                    manifest_path.display()
+                );
+            }
+            if args.session_id_flag().is_some() && !self.capabilities.preassigned_session_id {
+                anyhow::bail!(
+                    "external harness adapter `{id}` in {} provides \
+                     `continuity_args.session_id_flag` but \
+                     `capabilities.preassigned_session_id` is false (dead config)",
+                    manifest_path.display()
+                );
+            }
+        }
+        let stream_session_id_flag = self
+            .stream_args
+            .as_ref()
+            .and_then(|args| args.session_id_flag.as_deref())
+            .map(str::trim)
+            .filter(|flag| !flag.is_empty());
+        let continuity_session_id_flag = self
+            .continuity_args
+            .as_ref()
+            .and_then(ContinuityArgs::session_id_flag);
         if self.capabilities.preassigned_session_id
-            && self
-                .stream_args
-                .as_ref()
-                .and_then(|args| args.session_id_flag.as_deref())
-                .is_none_or(|flag| flag.trim().is_empty())
+            && stream_session_id_flag.is_none()
+            && continuity_session_id_flag.is_none()
         {
             anyhow::bail!(
                 "external harness adapter `{id}` in {} declares \
-                 `capabilities.preassigned_session_id` but no `stream_args.session_id_flag`",
+                 `capabilities.preassigned_session_id` but no session id flag",
                 manifest_path.display()
             );
         }
@@ -905,6 +1010,7 @@ impl ExternalHarnessAdapterSpec {
             sandbox: self.sandbox,
             capabilities: self.capabilities,
             stream_args: self.stream_args,
+            continuity_args: self.continuity_args,
         })
     }
 }
@@ -1291,30 +1397,26 @@ fn continuity_args(
     if mode != HarnessLaunchMode::NonInteractive {
         return None;
     }
-    match spec.id.as_str() {
-        id if id == "claude" || id == crate::engine::ENGINE_HARNESS_ID => {
-            let flag = match hint {
-                ConversationHint::Init { .. } => "--session-id",
-                ConversationHint::Resume { .. } => "--resume",
-            };
-            Some(vec![
-                "--print".to_string(),
-                flag.to_string(),
-                hint.id().to_string(),
-            ])
+    let declared = spec.continuity_args.as_ref()?;
+    match hint {
+        ConversationHint::Init { .. } => {
+            let flag = declared.session_id_flag()?;
+            let mut args = declared.init_prefix_args.clone();
+            args.push(flag.to_string());
+            args.push(hint.id().to_string());
+            Some(args)
         }
-        "codex" => match hint {
-            // Codex auto-assigns the session id on the first turn; we capture
-            // it from output and feed it back on subsequent turns.
-            ConversationHint::Init { .. } => None,
-            ConversationHint::Resume { id } => {
-                let mut args: Vec<String> = spec.non_interactive_prompt_prefix_args.to_vec();
-                args.push("resume".to_string());
-                args.push(id.clone());
-                Some(args)
+        ConversationHint::Resume { .. } => {
+            if !declared.has_resume_launch() {
+                return None;
             }
-        },
-        _ => None,
+            let mut args = declared.resume_prefix_args.clone();
+            if let Some(flag) = declared.resume_flag() {
+                args.push(flag.to_string());
+            }
+            args.push(hint.id().to_string());
+            Some(args)
+        }
     }
 }
 
@@ -1799,6 +1901,7 @@ mod tests {
             sandbox: None,
             capabilities: Capabilities::BASELINE,
             stream_args: None,
+            continuity_args: None,
         };
 
         assert_eq!(
@@ -2034,12 +2137,209 @@ mod tests {
                     "install_hint":"hint",
                     "capabilities":{"stream":true,"preassigned_session_id":true},
                     "stream_args":{"prefix_args":["-p"]}}]}"#,
-                "no `stream_args.session_id_flag`",
+                "no session id flag",
             ),
         ];
         for (raw, expected) in cases {
             let err = parse_external_harness_specs(raw, Path::new("x.json"), &built_ins)
                 .expect_err("invalid capability config must be rejected");
+            assert!(
+                err.to_string().contains(expected),
+                "expected `{expected}` in: {err:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn manifest_continuity_adapter_uses_declared_noninteractive_args() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let manifest = temp_dir.path().join("continuity.json");
+        fs::write(
+            &manifest,
+            r#"{
+              "adapters": [
+                {
+                  "id": "threaded",
+                  "label": "Threaded",
+                  "executable": "threaded",
+                  "interactive_prompt_prefix_args": [],
+                  "non_interactive_prompt_prefix_args": ["run"],
+                  "install_hint": "Install threaded.",
+                  "capabilities": { "preassigned_session_id": true },
+                  "continuity_args": {
+                    "init_prefix_args": ["run", "--json"],
+                    "resume_prefix_args": ["run", "--json"],
+                    "session_id_flag": "--session",
+                    "resume_flag": "--resume"
+                  }
+                }
+              ]
+            }"#,
+        )?;
+
+        let _guard = env_lock().lock().unwrap();
+        let previous_manifest = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let previous_dirs = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV);
+        env::set_var(EXTERNAL_ADAPTER_MANIFEST_ENV, &manifest);
+        env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV);
+
+        let init = command_parts_for_harness_with_conversation(
+            "threaded",
+            "hello",
+            HarnessLaunchMode::NonInteractive,
+            Some(&ConversationHint::Init {
+                id: "session-1".to_string(),
+            }),
+            None,
+            HarnessLaunchOptions::default(),
+        );
+        let resume = command_parts_for_harness_with_conversation(
+            "threaded",
+            "again",
+            HarnessLaunchMode::NonInteractive,
+            Some(&ConversationHint::Resume {
+                id: "session-1".to_string(),
+            }),
+            None,
+            HarnessLaunchOptions::default(),
+        );
+
+        restore_adapter_manifest_env(previous_manifest);
+        restore_adapter_dirs_env(previous_dirs);
+
+        assert_eq!(
+            init?,
+            (
+                "threaded".to_string(),
+                vec![
+                    "run".to_string(),
+                    "--json".to_string(),
+                    "--session".to_string(),
+                    "session-1".to_string(),
+                    "--".to_string(),
+                    "hello".to_string(),
+                ]
+            )
+        );
+        assert_eq!(
+            resume?,
+            (
+                "threaded".to_string(),
+                vec![
+                    "run".to_string(),
+                    "--json".to_string(),
+                    "--resume".to_string(),
+                    "session-1".to_string(),
+                    "--".to_string(),
+                    "again".to_string(),
+                ]
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn manifest_resume_only_continuity_allows_generated_session_ids() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let manifest = temp_dir.path().join("resume-only.json");
+        fs::write(
+            &manifest,
+            r#"{
+              "adapters": [
+                {
+                  "id": "resume-only",
+                  "label": "Resume Only",
+                  "executable": "resume-only",
+                  "interactive_prompt_prefix_args": [],
+                  "non_interactive_prompt_prefix_args": ["exec"],
+                  "install_hint": "Install resume-only.",
+                  "continuity_args": {
+                    "resume_prefix_args": ["exec", "resume"]
+                  }
+                }
+              ]
+            }"#,
+        )?;
+
+        let _guard = env_lock().lock().unwrap();
+        let previous_manifest = env::var_os(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let previous_dirs = env::var_os(EXTERNAL_ADAPTER_DIRS_ENV);
+        env::set_var(EXTERNAL_ADAPTER_MANIFEST_ENV, &manifest);
+        env::remove_var(EXTERNAL_ADAPTER_DIRS_ENV);
+
+        let init = command_parts_for_harness_with_conversation(
+            "resume-only",
+            "first",
+            HarnessLaunchMode::NonInteractive,
+            Some(&ConversationHint::Init {
+                id: "ignored".to_string(),
+            }),
+            None,
+            HarnessLaunchOptions::default(),
+        );
+        let resume = command_parts_for_harness_with_conversation(
+            "resume-only",
+            "again",
+            HarnessLaunchMode::NonInteractive,
+            Some(&ConversationHint::Resume {
+                id: "upstream-1".to_string(),
+            }),
+            None,
+            HarnessLaunchOptions::default(),
+        );
+
+        restore_adapter_manifest_env(previous_manifest);
+        restore_adapter_dirs_env(previous_dirs);
+
+        assert_eq!(
+            init?,
+            (
+                "resume-only".to_string(),
+                vec!["exec".to_string(), "--".to_string(), "first".to_string()]
+            )
+        );
+        assert_eq!(
+            resume?,
+            (
+                "resume-only".to_string(),
+                vec![
+                    "exec".to_string(),
+                    "resume".to_string(),
+                    "upstream-1".to_string(),
+                    "--".to_string(),
+                    "again".to_string(),
+                ]
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn manifest_continuity_rejects_dead_preassigned_session_config() {
+        let built_ins = built_in_harness_specs();
+        let cases: &[(&str, &str)] = &[
+            (
+                r#"{"adapters":[{"id":"x","label":"X","executable":"x",
+                    "interactive_prompt_prefix_args":[],
+                    "non_interactive_prompt_prefix_args":["run"],
+                    "install_hint":"hint",
+                    "continuity_args":{"init_prefix_args":["run"],"session_id_flag":"--session"}}]}"#,
+                "`continuity_args.session_id_flag` but `capabilities.preassigned_session_id` is false",
+            ),
+            (
+                r#"{"adapters":[{"id":"x","label":"X","executable":"x",
+                    "interactive_prompt_prefix_args":[],
+                    "non_interactive_prompt_prefix_args":["run"],
+                    "install_hint":"hint",
+                    "capabilities":{"preassigned_session_id":true},
+                    "continuity_args":{"init_prefix_args":["run"]}}]}"#,
+                "declares `capabilities.preassigned_session_id` but no session id flag",
+            ),
+        ];
+
+        for (raw, expected) in cases {
+            let err = parse_external_harness_specs(raw, Path::new("x.json"), &built_ins)
+                .expect_err("invalid continuity config must be rejected");
             assert!(
                 err.to_string().contains(expected),
                 "expected `{expected}` in: {err:#}"
@@ -2333,12 +2633,14 @@ mod tests {
             .unwrap();
         assert_eq!(codex.source, "bundled");
         assert!(codex.manifest_path.is_none());
+        assert_eq!(codex.capabilities, Capabilities::BASELINE);
 
         let custom = harnesses
             .iter()
             .find(|harness| harness.id == "solo-codex")
             .unwrap();
         assert_eq!(custom.source, "manifest");
+        assert_eq!(custom.capabilities, Capabilities::BASELINE);
         assert_eq!(
             custom.manifest_path.as_deref(),
             Some(manifest.to_string_lossy().as_ref())
@@ -2691,6 +2993,21 @@ mod tests {
     }
 
     #[test]
+    fn harness_summary_serializes_declared_capabilities() {
+        let harnesses = built_in_harnesses();
+        let json = serde_json::to_value(&harnesses).unwrap();
+
+        assert_eq!(json[0]["id"], "codex");
+        assert_eq!(json[0]["capabilities"]["stream"], false);
+        assert_eq!(json[0]["capabilities"]["preassigned_session_id"], false);
+        assert_eq!(json[1]["id"], "claude");
+        assert_eq!(json[1]["capabilities"]["stream"], true);
+        assert_eq!(json[1]["capabilities"]["preassigned_session_id"], true);
+        assert_eq!(json[1]["capabilities"]["think"], true);
+        assert_eq!(json[1]["capabilities"]["speed"], true);
+    }
+
+    #[test]
     fn codex_forwards_model_before_prompt_with_prefix_stripped() -> anyhow::Result<()> {
         // Spec resolution reads the adapter env vars; hold the shared env
         // lock so a concurrent test's tempdir manifest never vanishes mid-read.
@@ -2983,6 +3300,7 @@ mod tests {
             sandbox: None,
             capabilities: Capabilities::BASELINE,
             stream_args: None,
+            continuity_args: None,
         };
         assert!(!spec.supports_permission());
         assert!(spec.sandbox_args(Permission::Full).is_empty());

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -199,7 +199,7 @@ enum Command {
         #[arg(
             long,
             requires = "stream_json",
-            help = "Read JSONL user messages from stdin (claude harness only; requires --stream-json)"
+            help = "Read JSONL user messages from stdin (stream-capable harnesses only; requires --stream-json)"
         )]
         stream_json_input: bool,
     },
@@ -2148,9 +2148,9 @@ fn should_synthesize_stream_user_event(
     stream_json: bool,
     expanded_prompt: &str,
     detach: bool,
-    harness_id: &str,
+    stream_harness_passthrough: bool,
 ) -> bool {
-    stream_json && !expanded_prompt.is_empty() && (detach || harness_id != "claude")
+    stream_json && !expanded_prompt.is_empty() && (detach || !stream_harness_passthrough)
 }
 
 /// Doctor-style commands print their findings and exit 1 directly so scripts
@@ -2395,13 +2395,14 @@ fn run_session(
 
     // We synthesize the `user` event only on paths where the harness will
     // *not* emit it itself: detach (no harness runs) and codex / generic
-    // non-stream harnesses. The claude pass-through skips this so we don't
-    // duplicate the user message claude echoes through its native protocol.
+    // non-stream harnesses. Native pass-through skips this so we don't
+    // duplicate the user message the harness echoes through its protocol.
+    let stream_harness_passthrough = stream_json && selected_harness.capabilities.stream;
     let synthesize_user_event = should_synthesize_stream_user_event(
         stream_json,
         &expanded_prompt,
         detach,
-        &selected_harness.id,
+        stream_harness_passthrough,
     );
 
     if detach {
@@ -2445,24 +2446,44 @@ fn run_session(
         &current_timestamp(),
     )?;
 
-    // Claude's native long-lived stream-json: pipe its JSONL events through
-    // ours between the init/result frames we already emit. Codex's `--json`
-    // protocol is one-shot and is bridged below after the harness is resolved.
-    if stream_json && selected_harness.id == "claude" {
+    // Native stream-json harnesses pipe their JSONL events through ours between
+    // the init/result frames we already emit. Codex's declared non-stream
+    // JSONL protocol is one-shot and is bridged below after command
+    // construction; other non-stream harnesses take the captured PTY path so
+    // stdout stays JSONL-only.
+    if stream_harness_passthrough {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
-        let claude_system_prompt: Option<String> =
-            familiar_ctx.as_ref().map(|f| f.identity_preamble());
-        let exit_code = pty_runner::stream_claude(
-            &cwd,
-            &record.id,
-            is_resume,
+        let stream_conversation_hint = if is_resume {
+            harness::ConversationHint::Resume {
+                id: record.id.clone(),
+            }
+        } else {
+            harness::ConversationHint::Init {
+                id: record.id.clone(),
+            }
+        };
+        let familiar_for_args = spec
+            .as_ref()
+            .filter(|s| s.system_prompt_flag.is_some())
+            .and(familiar_ctx.as_ref());
+        let command = pty_runner::build_stream_harness_command_with_conversation(
+            &selected_harness.id,
             &effective_prompt,
+            &cwd,
             stream_json_input,
-            claude_system_prompt.as_deref(),
+            Some(&stream_conversation_hint),
+            familiar_for_args,
             launch_options,
-            &mut handle,
         );
+        let exit_code = command.and_then(|command| {
+            pty_runner::stream_harness(
+                &command,
+                stream_json_input,
+                &selected_harness.id,
+                &mut handle,
+            )
+        });
         drop(handle);
         let exit_code = match exit_code {
             Ok(code) => code,
@@ -3360,22 +3381,20 @@ mod tests {
     }
 
     #[test]
-    fn stream_json_user_event_synthesis_skips_live_claude_passthrough() {
+    fn stream_json_user_event_synthesis_skips_live_stream_passthrough() {
         assert!(should_synthesize_stream_user_event(
-            true, "hello", true, "claude"
+            true, "hello", true, false
         ));
         assert!(should_synthesize_stream_user_event(
-            true, "hello", false, "codex"
+            true, "hello", false, false
         ));
         assert!(!should_synthesize_stream_user_event(
-            true, "hello", false, "claude"
+            true, "hello", false, true
         ));
         assert!(!should_synthesize_stream_user_event(
-            false, "hello", false, "codex"
+            false, "hello", false, false
         ));
-        assert!(!should_synthesize_stream_user_event(
-            true, "", true, "codex"
-        ));
+        assert!(!should_synthesize_stream_user_event(true, "", true, false));
     }
 
     #[test]
@@ -4645,6 +4664,7 @@ mod tests {
             executable: id.to_string(),
             available,
             install_hint: String::new(),
+            capabilities: coven_runtime_spec::Capabilities::BASELINE,
             source: "built-in".to_string(),
             manifest_path: None,
         }
@@ -4719,6 +4739,7 @@ mod tests {
             executable: id.to_string(),
             available,
             install_hint: install_hint.to_string(),
+            capabilities: coven_runtime_spec::Capabilities::BASELINE,
             source: "built-in".to_string(),
             manifest_path: None,
         }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1014,6 +1014,51 @@ fn codex_event_error_message(event: &serde_json::Value) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn build_stream_harness_command_with_conversation(
+    harness_id: &str,
+    prompt: &str,
+    cwd: &Path,
+    forward_stdin: bool,
+    conversation: Option<&crate::harness::ConversationHint>,
+    familiar: Option<&crate::harness::FamiliarContext>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
+) -> Result<HarnessCommand> {
+    let (program, args) = crate::harness::command_parts_for_harness_with_conversation(
+        harness_id,
+        "",
+        crate::harness::HarnessLaunchMode::Stream,
+        conversation,
+        familiar,
+        options,
+    )?;
+    let mut args = stream_passthrough_args(args, forward_stdin);
+    args.extend(["--".to_string(), prompt.to_string()]);
+    let args = crate::harness::sanitize_argv_for_platform(args);
+    Ok(HarnessCommand {
+        program,
+        args,
+        cwd: cwd.to_path_buf(),
+        stdin_prompt: None,
+    })
+}
+
+fn stream_passthrough_args(args: Vec<String>, forward_stdin: bool) -> Vec<String> {
+    if forward_stdin {
+        return args;
+    }
+    let mut filtered = Vec::with_capacity(args.len());
+    let mut iter = args.into_iter().peekable();
+    while let Some(arg) = iter.next() {
+        if arg == "--input-format" && iter.peek().is_some_and(|next| next == "stream-json") {
+            let _ = iter.next();
+            continue;
+        }
+        filtered.push(arg);
+    }
+    filtered
+}
+
 pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
     let pty_system = native_pty_system();
     run_attached_with_pty_system(command, pty_system.as_ref())
@@ -1181,136 +1226,35 @@ pub fn run_piped_attached_captured(
     })
 }
 
-/// Run `claude` in its native stream-JSON mode, framed by the caller (which
-/// emits Coven's own `system.init` / `result` around the call).
-///
-/// `claude -p --input-format stream-json --output-format stream-json --verbose
-/// --session-id <id> <prompt>` already emits the Coven-compatible JSONL
-/// schema; we just forward each line untouched to `out`.
-///
-/// `is_resume` picks the session flag: `--session-id <id>` only CREATES
-/// sessions — passing an id that already exists fails with "Session ID
-/// <id> is already in use", which made every `coven run --continue` turn
-/// error and lose the conversation. Resumed turns use `--resume <id>`,
-/// which continues the session in place (in `-p` mode the id is kept, so
-/// the Coven session record id stays valid for the next turn).
-///
-/// When `forward_stdin` is true, lines on our stdin are piped to claude's
-/// stdin so callers can feed additional user messages mid-run. Stderr is
-/// inherited so claude's own diagnostics land on the terminal.
-#[allow(clippy::too_many_arguments)]
-pub fn stream_claude<W: Write>(
-    cwd: &Path,
-    session_id: &str,
-    is_resume: bool,
-    prompt: &str,
+/// Run a harness in its native stream-JSON mode, framed by the caller (which
+/// emits Coven's own `system.init` / `result` around the call). The command's
+/// argv is built from the harness declaration (`stream_args`, continuity,
+/// model, sandbox, and identity handling); this runner only spawns it and
+/// forwards each non-empty JSONL line unchanged to `out`.
+pub fn stream_harness<W: Write>(
+    command: &HarnessCommand,
     forward_stdin: bool,
-    system_prompt: Option<&str>,
-    options: crate::harness::HarnessLaunchOptions<'_>,
+    harness_id: &str,
     out: &mut W,
 ) -> Result<i32> {
-    stream_claude_with_program(
-        &crate::harness::spawn_executable_for_platform("claude"),
-        cwd,
-        session_id,
-        is_resume,
-        prompt,
+    stream_harness_with_program(
+        &command.program,
+        &command.cwd,
+        command.args.clone(),
         forward_stdin,
-        system_prompt,
-        options,
+        harness_id,
         out,
     )
 }
 
-#[allow(clippy::too_many_arguments)]
-fn stream_claude_with_program<W: Write>(
+fn stream_harness_with_program<W: Write>(
     program: &str,
     cwd: &Path,
-    session_id: &str,
-    is_resume: bool,
-    prompt: &str,
+    args: Vec<String>,
     forward_stdin: bool,
-    system_prompt: Option<&str>,
-    options: crate::harness::HarnessLaunchOptions<'_>,
+    harness_id: &str,
     out: &mut W,
 ) -> Result<i32> {
-    stream_claude_with_program_and_permission_bypass(
-        program,
-        cwd,
-        session_id,
-        is_resume,
-        prompt,
-        forward_stdin,
-        system_prompt,
-        options,
-        crate::harness::claude_permission_bypass_enabled(),
-        out,
-    )
-}
-
-#[allow(clippy::too_many_arguments)]
-fn stream_claude_with_program_and_permission_bypass<W: Write>(
-    program: &str,
-    cwd: &Path,
-    session_id: &str,
-    is_resume: bool,
-    prompt: &str,
-    forward_stdin: bool,
-    system_prompt: Option<&str>,
-    options: crate::harness::HarnessLaunchOptions<'_>,
-    permission_bypass_enabled: bool,
-    out: &mut W,
-) -> Result<i32> {
-    // `--input-format stream-json` makes claude read user messages as JSONL
-    // on stdin and IGNORE the positional <prompt>. We only want that mode
-    // when the caller is feeding stdin (long-lived chat); for one-shot turns
-    // we drop `--input-format stream-json` so the positional prompt is honored.
-    // Without this branch, one-shot turns hang on stdin then exit with no
-    // assistant text — the symptom that surfaces in Cave as
-    // `_The "claude" harness completed but produced no output._`
-    // Strip the `provider/` namespace so claude's `--model` gets a bare id,
-    // matching the non-stream path (`harness::normalize_model_id`).
-    let normalized_model: Option<&str> = options
-        .model
-        .map(str::trim)
-        .filter(|m| !m.is_empty())
-        .map(crate::harness::normalize_model_id);
-
-    let mut args: Vec<String> = vec!["-p".to_string()];
-    if permission_bypass_enabled {
-        args.extend([
-            "--permission-mode".to_string(),
-            "bypassPermissions".to_string(),
-        ]);
-    }
-    if forward_stdin {
-        args.extend(["--input-format".to_string(), "stream-json".to_string()]);
-    }
-    if let Some(sp) = system_prompt {
-        args.extend(["--system-prompt".to_string(), sp.to_string()]);
-    }
-    if let Some(m) = normalized_model {
-        args.extend(["--model".to_string(), m.to_string()]);
-    }
-    if let Some(effort) = options.claude_effort() {
-        args.extend(["--effort".to_string(), effort.to_string()]);
-    }
-    args.extend([
-        "--output-format".to_string(),
-        "stream-json".to_string(),
-        "--verbose".to_string(),
-    ]);
-    if is_resume {
-        args.extend(["--resume".to_string(), session_id.to_string()]);
-    } else {
-        args.extend(["--session-id".to_string(), session_id.to_string()]);
-    }
-    // `--` keeps a user prompt starting with `-` from parsing as claude flags
-    // (same shield as `HarnessCommandSpec::prompt_args`).
-    args.push("--".to_string());
-    args.push(prompt.to_string());
-    let args = crate::harness::sanitize_argv_for_platform(args);
-
     let mut child = std::process::Command::new(program)
         .args(&args)
         .current_dir(cwd)
@@ -1322,13 +1266,12 @@ fn stream_claude_with_program_and_permission_bypass<W: Write>(
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()
-        .context("failed to spawn claude in stream-json mode")?;
+        .with_context(|| format!("failed to spawn {harness_id} in stream-json mode"))?;
 
     if forward_stdin {
-        let mut child_stdin = child
-            .stdin
-            .take()
-            .expect("stdin requested but child has no piped stdin");
+        let Some(mut child_stdin) = child.stdin.take() else {
+            anyhow::bail!("stdin requested but {harness_id} has no piped stdin");
+        };
         thread::spawn(move || {
             let stdin = io::stdin();
             let mut handle = stdin.lock();
@@ -1348,19 +1291,105 @@ fn stream_claude_with_program_and_permission_bypass<W: Write>(
         });
     }
 
-    let child_stdout = child.stdout.take().expect("stdout was requested as piped");
+    let Some(child_stdout) = child.stdout.take() else {
+        anyhow::bail!("stdout requested but {harness_id} has no piped stdout");
+    };
     let reader = BufReader::new(child_stdout);
     for line in reader.lines() {
-        let line = line.context("reading claude stdout")?;
+        let line = line.with_context(|| format!("reading {harness_id} stdout"))?;
         if line.trim().is_empty() {
             continue;
         }
-        writeln!(out, "{line}").context("forwarding claude stdout")?;
-        out.flush().context("flushing claude stdout")?;
+        writeln!(out, "{line}").with_context(|| format!("forwarding {harness_id} stdout"))?;
+        out.flush()
+            .with_context(|| format!("flushing {harness_id} stdout"))?;
     }
 
-    let status = child.wait().context("waiting on claude")?;
+    let status = child
+        .wait()
+        .with_context(|| format!("waiting on {harness_id}"))?;
     Ok(status.code().unwrap_or(1))
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn stream_harness_with_claude_args<W: Write>(
+    program: &str,
+    cwd: &Path,
+    session_id: &str,
+    is_resume: bool,
+    prompt: &str,
+    forward_stdin: bool,
+    system_prompt: Option<&str>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
+    out: &mut W,
+) -> Result<i32> {
+    stream_harness_with_claude_args_and_permission_bypass(
+        program,
+        cwd,
+        session_id,
+        is_resume,
+        prompt,
+        forward_stdin,
+        system_prompt,
+        options,
+        false,
+        out,
+    )
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn stream_harness_with_claude_args_and_permission_bypass<W: Write>(
+    program: &str,
+    cwd: &Path,
+    session_id: &str,
+    is_resume: bool,
+    prompt: &str,
+    forward_stdin: bool,
+    system_prompt: Option<&str>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
+    permission_bypass_enabled: bool,
+    out: &mut W,
+) -> Result<i32> {
+    let normalized_model = options
+        .model
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+        .map(crate::harness::normalize_model_id);
+
+    let mut args = vec!["-p".to_string()];
+    if permission_bypass_enabled {
+        args.extend([
+            "--permission-mode".to_string(),
+            "bypassPermissions".to_string(),
+        ]);
+    }
+    if forward_stdin {
+        args.extend(["--input-format".to_string(), "stream-json".to_string()]);
+    }
+    if let Some(sp) = system_prompt {
+        args.extend(["--system-prompt".to_string(), sp.to_string()]);
+    }
+    if let Some(model) = normalized_model {
+        args.extend(["--model".to_string(), model.to_string()]);
+    }
+    if let Some(effort) = options.claude_effort() {
+        args.extend(["--effort".to_string(), effort.to_string()]);
+    }
+    args.extend([
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--verbose".to_string(),
+    ]);
+    if is_resume {
+        args.extend(["--resume".to_string(), session_id.to_string()]);
+    } else {
+        args.extend(["--session-id".to_string(), session_id.to_string()]);
+    }
+    args.extend(["--".to_string(), prompt.to_string()]);
+
+    stream_harness_with_program(program, cwd, args, forward_stdin, "claude", out)
 }
 
 #[allow(dead_code)]
@@ -2132,7 +2161,7 @@ exit 0
 
     #[cfg(unix)]
     #[test]
-    fn stream_claude_forwards_jsonl_and_returns_exit_code() -> anyhow::Result<()> {
+    fn stream_harness_claude_forwards_jsonl_and_returns_exit_code() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _guard = fake_claude_spawn_guard();
@@ -2152,7 +2181,7 @@ exit 7
         std::fs::set_permissions(&fake_claude, permissions)?;
 
         let mut out = Vec::new();
-        let code = stream_claude_with_program(
+        let code = stream_harness_with_claude_args(
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-123",
@@ -2182,7 +2211,76 @@ exit 7
 
     #[cfg(unix)]
     #[test]
-    fn stream_claude_includes_input_format_when_forwarding_stdin() -> anyhow::Result<()> {
+    fn stream_harness_forwards_declared_args_without_claude_rebuild() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_harness = temp_dir.path().join("fake-streamy");
+        std::fs::write(
+            &fake_harness,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"streamy"}]},"session_id":"session-123","stop_reason":"end_turn"}'
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_harness, permissions)?;
+
+        let mut out = Vec::new();
+        let code = stream_harness_with_program(
+            fake_harness.to_str().unwrap(),
+            temp_dir.path(),
+            vec![
+                "--jsonl".to_string(),
+                "--resume".to_string(),
+                "session-123".to_string(),
+                "--".to_string(),
+                "hello prompt".to_string(),
+            ],
+            false,
+            "streamy",
+            &mut out,
+        )?;
+
+        assert_eq!(code, 0);
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "--jsonl\n--resume\nsession-123\n--\nhello prompt\n"
+        );
+        assert_eq!(
+            String::from_utf8(out)?,
+            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"streamy\"}]},\"session_id\":\"session-123\",\"stop_reason\":\"end_turn\"}\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stream_passthrough_args_drop_stdin_format_for_one_shot_prompt() {
+        let args = vec![
+            "--print".to_string(),
+            "--input-format".to_string(),
+            "stream-json".to_string(),
+            "--output-format".to_string(),
+            "stream-json".to_string(),
+        ];
+
+        assert_eq!(
+            stream_passthrough_args(args.clone(), false),
+            vec![
+                "--print".to_string(),
+                "--output-format".to_string(),
+                "stream-json".to_string(),
+            ]
+        );
+        assert_eq!(stream_passthrough_args(args.clone(), true), args);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stream_harness_claude_includes_input_format_when_forwarding_stdin() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _guard = fake_claude_spawn_guard();
@@ -2200,7 +2298,7 @@ exit 0
         std::fs::set_permissions(&fake_claude, permissions)?;
 
         let mut out = Vec::new();
-        let _code = stream_claude_with_program(
+        let _code = stream_harness_with_claude_args(
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-456",
@@ -2224,7 +2322,7 @@ exit 0
 
     #[cfg(unix)]
     #[test]
-    fn stream_claude_honors_permission_bypass_opt_in() -> anyhow::Result<()> {
+    fn stream_harness_claude_honors_permission_bypass_opt_in() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _guard = fake_claude_spawn_guard();
@@ -2242,7 +2340,7 @@ exit 0
         std::fs::set_permissions(&fake_claude, permissions)?;
 
         let mut out = Vec::new();
-        let _code = stream_claude_with_program_and_permission_bypass(
+        let _code = stream_harness_with_claude_args_and_permission_bypass(
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-456",
@@ -2264,7 +2362,7 @@ exit 0
 
     #[cfg(unix)]
     #[test]
-    fn stream_claude_resumes_with_resume_flag_not_session_id() -> anyhow::Result<()> {
+    fn stream_harness_claude_resumes_with_resume_flag_not_session_id() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _guard = fake_claude_spawn_guard();
@@ -2282,7 +2380,7 @@ exit 0
         std::fs::set_permissions(&fake_claude, permissions)?;
 
         let mut out = Vec::new();
-        let _code = stream_claude_with_program(
+        let _code = stream_harness_with_claude_args(
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-789",
@@ -2307,7 +2405,7 @@ exit 0
 
     #[cfg(unix)]
     #[test]
-    fn stream_claude_forwards_model_with_prefix_stripped() -> anyhow::Result<()> {
+    fn stream_harness_claude_forwards_model_with_prefix_stripped() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _guard = fake_claude_spawn_guard();
@@ -2325,7 +2423,7 @@ exit 0
         std::fs::set_permissions(&fake_claude, permissions)?;
 
         let mut out = Vec::new();
-        let _code = stream_claude_with_program(
+        let _code = stream_harness_with_claude_args(
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-123",
@@ -2350,7 +2448,7 @@ exit 0
 
     #[cfg(unix)]
     #[test]
-    fn stream_claude_forwards_think_as_effort_high() -> anyhow::Result<()> {
+    fn stream_harness_claude_forwards_think_as_effort_high() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _guard = fake_claude_spawn_guard();
@@ -2368,7 +2466,7 @@ exit 0
         std::fs::set_permissions(&fake_claude, permissions)?;
 
         let mut out = Vec::new();
-        let _code = stream_claude_with_program(
+        let _code = stream_harness_with_claude_args(
             fake_claude.to_str().unwrap(),
             temp_dir.path(),
             "session-123",

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -28,8 +28,8 @@ A Coven harness adapter defines:
 - prompt argument shape for interactive mode;
 - prompt argument shape for non-interactive mode;
 - install/authentication hint for `coven doctor`; and
-- optional **declared behavior**: `capabilities`, `sandbox`, and
-  `stream_args` (the [coven-runtimes](https://github.com/OpenCoven/coven-runtimes)
+- optional **declared behavior**: `capabilities`, `sandbox`, `stream_args`,
+  and `continuity_args` (the [coven-runtimes](https://github.com/OpenCoven/coven-runtimes)
   manifest additions — see below).
 
 The current implementation expects the prompt to be the final command argument after any fixed prefix args. Keep that invariant unless the adapter explicitly documents a safer stdin or protocol mode.
@@ -98,6 +98,12 @@ adapters deserialize unchanged with everything off):
         "prefix_args": ["--print", "--input-format", "stream-json", "--output-format", "stream-json"],
         "session_id_flag": "--session-id",
         "resume_flag": "--resume"
+      },
+      "continuity_args": {
+        "init_prefix_args": ["--print"],
+        "resume_prefix_args": ["--print"],
+        "session_id_flag": "--session-id",
+        "resume_flag": "--resume"
       }
     }
   ]
@@ -108,11 +114,19 @@ adapters deserialize unchanged with everything off):
   long-lived stream-json mode, exactly like the bundled Claude adapter (which
   declares the same fields internally). `stream` requires `stream_args`;
   `stream_args` without `stream` is rejected as dead config.
-- `capabilities.preassigned_session_id` requires `stream_args.session_id_flag`.
+- `capabilities.preassigned_session_id` requires a session id flag in either
+  `stream_args` or `continuity_args`.
+- `continuity_args` tells one-shot non-interactive runs how to initialize or
+  resume an upstream conversation. `session_id_flag` is only valid when
+  `capabilities.preassigned_session_id` is true; resume-only adapters can omit
+  it and use `resume_prefix_args` to place the resumed session id as a
+  positional argument.
 - `sandbox` maps `coven run --permission <full|read-only>` to the harness's
   native flags. Two forms: a single `--flag value` pair per policy (shown
   above), or an argv list per policy for boolean/multi-token permission flags:
   `{ "full_args": ["--allow-all"], "read_only_args": ["--deny-tool", "write"] }`.
+- `coven adapter list --json` includes the declared `capabilities` block for
+  every bundled or manifest adapter, using the same field names as manifests.
 - Adapters that declare none of this keep today's conservative behavior:
   one-shot launches only, `--permission` is a warned no-op.
 

--- a/docs/STREAM-JSON.md
+++ b/docs/STREAM-JSON.md
@@ -2,7 +2,7 @@
 
 `coven run <harness> --stream-json` emits newline-delimited JSON events on
 stdout. With `--stream-json-input`, user messages are read line-by-line from
-stdin as JSON (claude harness only).
+stdin as JSON when the selected harness declares native stream support.
 
 The schema matches `OpenClaw bridge-code`; SDKs that target Coven Code work
 unchanged against Coven CLI. Coven additionally emits the `output` event
@@ -48,7 +48,7 @@ bytes never interleave with the stream. `text` is the raw PTY text: it may
 contain ANSI escape sequences, carriage returns, and partial lines, and
 chunk boundaries follow PTY reads rather than line breaks. Consumers that
 want clean text should concatenate the `text` fields in order and strip
-escapes. Never emitted on the claude pass-through path.
+escapes. Never emitted on the native stream pass-through path.
 
 ### `result` - emitted once at end
 
@@ -73,14 +73,16 @@ Each line is one JSON object with the same shape as the `user` event's
 
 `image` content blocks use `source.type = "path"` (local file) or
 `source.type = "base64"` (inline). `--stream-json-input` requires
-`--stream-json` and is only consumed when the harness is `claude`; for
-non-stream harnesses the flag is accepted but no stdin forwarding occurs.
+`--stream-json` and is only forwarded when the selected harness declares
+`capabilities.stream`; for non-stream harnesses the flag is accepted but no
+stdin forwarding occurs.
 
 ## Harness behavior
 
-- **claude**: passes through claude's native stream-json events, framed by
-  Coven's `system` and `result`. Coven does *not* synthesize a `user` event
-  on this path; claude emits its own when it processes the prompt.
+- **Stream-capable harnesses**: Coven launches the harness with its declared
+  `stream_args` and passes through the harness's native JSONL events, framed by
+  Coven's `system` and `result`. Coven does *not* synthesize a `user` event on
+  this path; the harness emits its own when it processes the prompt.
 
 - **codex**: Coven launches `codex exec --json` as a one-shot, ordinary-pipe
   process and translates completed Codex agent messages into Coven


### PR DESCRIPTION
## Context

- Summary: Integration PR 3 from PR #332's handoff. This removes the foreground `coven run --stream-json` Claude id gate, moves one-shot continuity into adapter declarations, and exposes declared harness capabilities in JSON adapter summaries.
- Files changed: `crates/coven-cli/src/harness.rs`, `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/pty_runner.rs`, `docs/HARNESS-ADAPTERS.md`, `docs/STREAM-JSON.md`
- Closes #

## Implementation

- Approach:
  - `HarnessSummary` now includes the declared `capabilities` block, so `coven adapter list --json` consumers can read `stream`, `preassigned_session_id`, `think`, and `speed` directly.
  - Foreground stream-json pass-through now gates on `selected_harness.capabilities.stream` and launches with argv built from declared `stream_args`; `pty_runner::stream_harness` only spawns the already-built command and forwards JSONL.
  - Added manifest-driven `continuity_args` for one-shot non-interactive init/resume behavior. Bundled Claude and Codex express their existing behavior through these declarations, and external manifests can do the same.
  - Added validation for invalid/dead continuity declarations and updated adapter/stream-json docs.
- User-visible behavior: stream-capable manifest adapters can use native foreground JSONL pass-through and one-shot continuity without Coven core id checks. Adapter JSON summaries include declared capabilities.
- Compatibility notes: legacy manifests remain valid because `continuity_args` defaults to absent. Codex and Claude argv behavior is test-pinned; non-stream harnesses continue using captured PTY `output` frames.

## Verification

- [x] `cargo fmt --all`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p coven-cli --quiet` — 983 passed, 1 ignored in unit tests; integration test binaries passed.
- [x] `cargo test --workspace --locked --quiet` — workspace tests passed.
- [x] `python3 scripts/check-secrets.py` — `Secret guard passed: no current-tree or history findings.`
- [x] Additional manual checks: `git diff --check`; targeted red/green tests for continuity manifest handling, stream harness passthrough, and stream user-event synthesis.

## Risk and Rollback

- Risk level: medium. This changes the foreground stream-json path and session continuity arg construction, but keeps built-in Claude/Codex behavior covered by tests and preserves non-stream fallback behavior.
- Rollback plan: revert this commit; manifests without the new fields and non-stream fallback behavior are otherwise unchanged.

## Agent Handoff

- Current state: PR #332's listed follow-ups are implemented in this branch: foreground stream-json pass-through is capability-gated, continuity is manifest-driven, and capabilities are present in adapter JSON summaries.
- Follow-ups: consider promoting `continuity_args` into `coven-runtime-spec` once the registry schema is ready for a tagged release.
- Known gaps: none known for integration PR 3.
