### PR TITLE
Fix Windows Cave and Codex session reliability

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -3341,11 +3341,15 @@ mod tests {
         assert_eq!(runtime.launches.borrow()[0].prompt, "hello coven");
         assert_eq!(
             runtime.launches.borrow()[0].project_root,
-            project_root.canonicalize()?.to_string_lossy()
+            project::canonical_project_root(&project_root)?.to_string_lossy()
         );
         assert_eq!(
             runtime.launches.borrow()[0].cwd,
-            cwd.canonicalize()?.to_string_lossy()
+            project::resolve_inside_root(
+                &project::canonical_project_root(&project_root)?,
+                Some(&cwd)
+            )?
+            .to_string_lossy()
         );
         assert!(list.body.contains(r#""title":"Demo""#));
         Ok(())

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1469,11 +1469,7 @@ pub(crate) fn read_windows_pipe_http_response(
     std::thread::Builder::new()
         .name("coven-pipe-response".into())
         .spawn(move || {
-            let result = read_http_response_with_deadline(
-                &mut stream,
-                Duration::from_secs(24 * 60 * 60),
-                max_body_bytes,
-            );
+            let result = read_http_response_with_deadline(&mut stream, timeout, max_body_bytes);
             let _ = tx.send(result);
         })
         .context("failed to spawn Windows pipe response reader")?;
@@ -2440,7 +2436,10 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
         os::windows::local_socket::ListenerOptionsExt,
     };
-    use std::sync::Arc;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
     let _ = tcp_addr; // TCP not wired on Windows in this prototype
 
@@ -2469,6 +2468,8 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         coven_home.to_path_buf(),
     ));
 
+    const MAX_INFLIGHT: usize = 64;
+    let inflight = Arc::new(AtomicUsize::new(0));
     for conn in listener.incoming() {
         let stream = match conn {
             Ok(s) => s,
@@ -2480,7 +2481,30 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         let conn_home = coven_home.to_path_buf();
         let conn_status = status.clone();
         let conn_runtime = Arc::clone(&runtime);
-        if let Err(error) = std::thread::Builder::new()
+        if inflight.load(Ordering::Relaxed) >= MAX_INFLIGHT {
+            // Backpressure at capacity by serving on the accept thread rather
+            // than allowing stalled clients to create unbounded OS threads.
+            let _ = stream.set_recv_timeout(Some(SOCKET_IO_TIMEOUT));
+            let _ = stream.set_send_timeout(Some(SOCKET_IO_TIMEOUT));
+            if let Err(error) = handle_http_stream(
+                &stream,
+                &stream,
+                &conn_home,
+                Some(conn_status),
+                conn_runtime.as_ref(),
+                Some(MAX_SOCKET_BODY_BYTES),
+                false,
+            ) {
+                if !is_client_disconnect(&error) {
+                    eprintln!("coven daemon: pipe connection error: {error:#}");
+                }
+            }
+            continue;
+        }
+
+        inflight.fetch_add(1, Ordering::Relaxed);
+        let conn_inflight = Arc::clone(&inflight);
+        let spawn_result = std::thread::Builder::new()
             .name("coven-windows-api".into())
             .spawn(move || {
                 // Bound each transaction and isolate it so a stalled client
@@ -2500,8 +2524,10 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
                         eprintln!("coven daemon: pipe connection error: {error:#}");
                     }
                 }
-            })
-        {
+                conn_inflight.fetch_sub(1, Ordering::Relaxed);
+            });
+        if let Err(error) = spawn_result {
+            inflight.fetch_sub(1, Ordering::Relaxed);
             eprintln!("coven daemon: failed to spawn pipe handler: {error:#}");
         }
     }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -281,36 +281,8 @@ impl SessionRuntime for LiveSessionRuntime {
                     launch.harness
                 );
             }
-            let piped = pty_runner::spawn_piped_with_observer(&command, observer)?;
-            #[cfg(windows)]
-            let job_handle = {
-                use windows_sys::Win32::{
-                    Foundation::INVALID_HANDLE_VALUE,
-                    System::{
-                        JobObjects::{AssignProcessToJobObject, CreateJobObjectW},
-                        Threading::{OpenProcess, PROCESS_ALL_ACCESS},
-                    },
-                };
-                // SAFETY: Windows API calls; handles are owned by PipedKiller.
-                unsafe {
-                    let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
-                    if job != INVALID_HANDLE_VALUE && job != 0 as _ {
-                        let ph = OpenProcess(PROCESS_ALL_ACCESS, 0, piped.pid);
-                        if ph != INVALID_HANDLE_VALUE && ph != 0 as _ {
-                            AssignProcessToJobObject(job, ph);
-                            windows_sys::Win32::Foundation::CloseHandle(ph);
-                        }
-                        Some(job)
-                    } else {
-                        None
-                    }
-                }
-            };
-            let mut killer_box: Box<dyn RuntimeKiller> = Box::new(PipedKiller {
-                pid: piped.pid,
-                #[cfg(windows)]
-                job_handle,
-            });
+            let piped = pty_runner::spawn_piped_with_observer(&command, observer, true)?;
+            let mut killer_box = piped_killer(piped.pid);
             let mut input = piped.input;
             // Send the launch's prompt as the first stream-json user
             // message so the chat doesn't need a separate send call right
@@ -335,6 +307,23 @@ impl SessionRuntime for LiveSessionRuntime {
                 LiveSessionKind::Stream,
                 input,
                 killer_box,
+            );
+        }
+
+        // ConPTY can terminate one-shot `codex exec` children immediately on
+        // Windows (observed as u32::MAX with no output). These sessions do not
+        // need a terminal: the prompt is already in argv and stdout/stderr are
+        // machine-drained. Ordinary pipes match direct `codex exec`, preserve
+        // output observation, and let the child reach a real exit status.
+        #[cfg(windows)]
+        if launch.launch_mode == crate::harness::HarnessLaunchMode::NonInteractive {
+            let piped = pty_runner::spawn_piped_with_observer(&command, observer, false)?;
+            let killer = piped_killer(piped.pid);
+            return self.register_kind(
+                launch.id.clone(),
+                LiveSessionKind::Pty,
+                piped.input,
+                killer,
             );
         }
 
@@ -421,6 +410,38 @@ impl SessionRuntime for LiveSessionRuntime {
             .map_err(|_| anyhow::anyhow!("live session killer lock poisoned"))?;
         killer.kill()
     }
+}
+
+fn piped_killer(pid: u32) -> Box<dyn RuntimeKiller> {
+    #[cfg(windows)]
+    let job_handle = {
+        use windows_sys::Win32::{
+            Foundation::INVALID_HANDLE_VALUE,
+            System::{
+                JobObjects::{AssignProcessToJobObject, CreateJobObjectW},
+                Threading::{OpenProcess, PROCESS_ALL_ACCESS},
+            },
+        };
+        // SAFETY: Windows API calls; handles are owned by PipedKiller.
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job != INVALID_HANDLE_VALUE && job != 0 as _ {
+                let ph = OpenProcess(PROCESS_ALL_ACCESS, 0, pid);
+                if ph != INVALID_HANDLE_VALUE && ph != 0 as _ {
+                    AssignProcessToJobObject(job, ph);
+                    windows_sys::Win32::Foundation::CloseHandle(ph);
+                }
+                Some(job)
+            } else {
+                None
+            }
+        }
+    };
+    Box::new(PipedKiller {
+        pid,
+        #[cfg(windows)]
+        job_handle,
+    })
 }
 
 /// Wrap raw user text in claude's stream-json user-message envelope and
@@ -1399,13 +1420,20 @@ fn daemon_health_reports_pid_windows(pipe_name: &str, expected_pid: u32) -> Resu
 
 #[cfg(windows)]
 fn daemon_status_from_windows_pipe(pipe_name: &str) -> Result<Option<DaemonStatus>> {
-    use interprocess::local_socket::{prelude::*, GenericNamespaced, Stream};
-    use std::io::{Read, Write};
+    use interprocess::{
+        local_socket::{prelude::*, ConnectOptions, GenericNamespaced},
+        ConnectWaitMode,
+    };
+    use std::io::Write;
 
     let name = pipe_name
         .to_ns_name::<GenericNamespaced>()
         .context("failed to parse pipe name for health check")?;
-    let mut stream = match Stream::connect(name) {
+    let mut stream = match ConnectOptions::new()
+        .name(name)
+        .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(2)))
+        .connect_sync()
+    {
         Ok(s) => s,
         Err(_) => return Ok(None),
     };
@@ -1415,20 +1443,143 @@ fn daemon_status_from_windows_pipe(pipe_name: &str) -> Result<Option<DaemonStatu
     stream
         .flush()
         .context("failed to flush Windows health request")?;
-    let mut response = String::new();
-    stream
-        .read_to_string(&mut response)
-        .context("failed to read Windows health response")?;
-    let Some((_, body)) = response.split_once("\r\n\r\n") else {
-        return Ok(None);
-    };
+    // Windows named pipes do not support read timeouts in interprocess.
+    // Supervise the blocking framed read from another thread so doctor/status
+    // still return deterministically when a daemon accepts but never replies.
+    // Reading to EOF is incorrect for HTTP and used to hang indefinitely when
+    // the daemon kept the pipe instance alive after writing its response.
+    let (_status, body) =
+        read_windows_pipe_http_response(stream, Duration::from_secs(2), MAX_SOCKET_BODY_BYTES)?;
     let body: DaemonHealthStatus =
-        serde_json::from_str(body).context("failed to parse Windows health response")?;
+        serde_json::from_slice(&body).context("failed to parse Windows health response")?;
     if body.ok {
         Ok(body.daemon)
     } else {
         Ok(None)
     }
+}
+
+#[cfg(windows)]
+pub(crate) fn read_windows_pipe_http_response(
+    mut stream: interprocess::local_socket::Stream,
+    timeout: Duration,
+    max_body_bytes: usize,
+) -> Result<(u16, Vec<u8>)> {
+    let (tx, rx) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("coven-pipe-response".into())
+        .spawn(move || {
+            let result = read_http_response_with_deadline(
+                &mut stream,
+                Duration::from_secs(24 * 60 * 60),
+                max_body_bytes,
+            );
+            let _ = tx.send(result);
+        })
+        .context("failed to spawn Windows pipe response reader")?;
+    match rx.recv_timeout(timeout) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            anyhow::bail!("timed out reading Coven daemon HTTP response")
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            anyhow::bail!("Coven daemon HTTP response reader stopped unexpectedly")
+        }
+    }
+}
+
+/// Read one HTTP response without relying on the peer closing the transport.
+///
+/// Local sockets and especially Windows named pipes may remain open after a
+/// response. HTTP/1.1 frames the body with Content-Length, so consume exactly
+/// that many bytes. The reader is expected to be nonblocking; WouldBlock is
+/// retried until `timeout` expires.
+pub(crate) fn read_http_response_with_deadline<R: Read>(
+    reader: &mut R,
+    timeout: Duration,
+    max_body_bytes: usize,
+) -> Result<(u16, Vec<u8>)> {
+    const MAX_RESPONSE_HEADERS: usize = 64 * 1024;
+
+    let deadline = Instant::now() + timeout;
+    let mut received = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 4096];
+    let mut framing: Option<(u16, usize, usize)> = None;
+
+    loop {
+        if let Some((status, body_start, content_length)) = framing {
+            if received.len() >= body_start + content_length {
+                return Ok((
+                    status,
+                    received[body_start..body_start + content_length].to_vec(),
+                ));
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out reading Coven daemon HTTP response");
+        }
+
+        match reader.read(&mut chunk) {
+            Ok(0) => anyhow::bail!(
+                "Coven daemon closed the connection before its HTTP response completed"
+            ),
+            Ok(n) => {
+                received.extend_from_slice(&chunk[..n]);
+                if framing.is_none() {
+                    if received.len() > MAX_RESPONSE_HEADERS {
+                        anyhow::bail!("Coven daemon HTTP response headers exceeded {MAX_RESPONSE_HEADERS} bytes");
+                    }
+                    if let Some(header_end) = find_http_header_end(&received) {
+                        let status = response_status(&received[..header_end])?;
+                        let content_length = response_content_length(&received[..header_end])?;
+                        if content_length > max_body_bytes {
+                            anyhow::bail!(
+                                "Coven daemon HTTP response body exceeded {max_body_bytes} bytes"
+                            );
+                        }
+                        framing = Some((status, header_end + 4, content_length));
+                    }
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error).context("failed to read Windows health response"),
+        }
+    }
+}
+
+fn response_status(headers: &[u8]) -> Result<u16> {
+    let headers =
+        std::str::from_utf8(headers).context("daemon HTTP response headers were not UTF-8")?;
+    headers
+        .split("\r\n")
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .context("daemon HTTP response omitted its status")?
+        .parse::<u16>()
+        .context("daemon HTTP response had an invalid status")
+}
+
+fn find_http_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn response_content_length(headers: &[u8]) -> Result<usize> {
+    let headers =
+        std::str::from_utf8(headers).context("daemon HTTP response headers were not UTF-8")?;
+    headers
+        .split("\r\n")
+        .skip(1)
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim())
+        })
+        .context("daemon HTTP response omitted Content-Length")?
+        .parse::<usize>()
+        .context("daemon HTTP response had an invalid Content-Length")
 }
 
 #[cfg(unix)]
@@ -1506,9 +1657,10 @@ pub const MAX_TCP_BODY_BYTES: usize = 1024 * 1024;
 /// memory. 4 MiB is generous for any legitimate request payload.
 pub const MAX_SOCKET_BODY_BYTES: usize = 4 * 1024 * 1024;
 
-/// I/O timeout for Unix socket and Windows named pipe connections.
-/// Prevents a stalled or slow-writing client from holding a handler thread
-/// indefinitely.
+/// I/O timeout for Unix socket connections. The Windows named-pipe backend
+/// does not support transport timeouts; those requests use isolated handler
+/// threads and client-side response deadlines instead.
+#[cfg_attr(windows, allow(dead_code))]
 pub const SOCKET_IO_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[cfg(unix)]
@@ -2274,7 +2426,7 @@ fn owner_only_pipe_security_descriptor(
 }
 
 #[cfg(windows)]
-fn windows_pipe_name(coven_home: &Path) -> String {
+pub(crate) fn windows_pipe_name(coven_home: &Path) -> String {
     daemon_windows_pipe_name(coven_home)
 }
 
@@ -2293,9 +2445,6 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         started_at: started_at.clone(),
         socket: windows_pipe_name(coven_home),
     };
-    write_status(coven_home, &status)?;
-    recover_orphaned_sessions(coven_home, &started_at)?;
-
     let name = windows_pipe_name(coven_home)
         .to_ns_name::<GenericNamespaced>()
         .context("failed to create named pipe name")?;
@@ -2305,6 +2454,12 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         .security_descriptor(security_descriptor)
         .create_sync()
         .context("failed to bind Windows named pipe")?;
+
+    // Claim the pipe before mutating shared daemon/session state. A duplicate
+    // daemon must fail at bind without replacing the incumbent's daemon.json
+    // or marking sessions owned by that live daemon orphaned.
+    write_status(coven_home, &status)?;
+    recover_orphaned_sessions(coven_home, &started_at)?;
 
     let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
         coven_home.to_path_buf(),
@@ -2318,23 +2473,32 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
                 continue;
             }
         };
-        // Apply I/O timeouts to prevent stalled clients from blocking the handler.
-        let _ = stream.set_recv_timeout(Some(SOCKET_IO_TIMEOUT));
-        let _ = stream.set_send_timeout(Some(SOCKET_IO_TIMEOUT));
-        // Stream implements Read + Write via shared reference on Windows.
-        // The handler reads the full request before writing, so sharing &stream is safe.
-        if let Err(error) = handle_http_stream(
-            &stream,
-            &stream,
-            coven_home,
-            Some(status.clone()),
-            runtime.as_ref(),
-            Some(MAX_SOCKET_BODY_BYTES),
-            false,
-        ) {
-            if !is_client_disconnect(&error) {
-                eprintln!("coven daemon: pipe connection error: {error:#}");
-            }
+        let conn_home = coven_home.to_path_buf();
+        let conn_status = status.clone();
+        let conn_runtime = Arc::clone(&runtime);
+        if let Err(error) = std::thread::Builder::new()
+            .name("coven-windows-api".into())
+            .spawn(move || {
+                // Bound each transaction and isolate it so a stalled client
+                // cannot block accept or starve Cave's polling requests.
+                let _ = stream.set_recv_timeout(Some(SOCKET_IO_TIMEOUT));
+                let _ = stream.set_send_timeout(Some(SOCKET_IO_TIMEOUT));
+                if let Err(error) = handle_http_stream(
+                    &stream,
+                    &stream,
+                    &conn_home,
+                    Some(conn_status),
+                    conn_runtime.as_ref(),
+                    Some(MAX_SOCKET_BODY_BYTES),
+                    false,
+                ) {
+                    if !is_client_disconnect(&error) {
+                        eprintln!("coven daemon: pipe connection error: {error:#}");
+                    }
+                }
+            })
+        {
+            eprintln!("coven daemon: failed to spawn pipe handler: {error:#}");
         }
     }
     Ok(())
@@ -2364,6 +2528,14 @@ mod tests {
         }
     }
 
+    struct NeverReady;
+
+    impl Read for NeverReady {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::from(std::io::ErrorKind::WouldBlock))
+        }
+    }
+
     #[test]
     fn is_client_disconnect_ignores_real_faults() {
         // A genuine server-side error must still be logged.
@@ -2378,6 +2550,30 @@ mod tests {
         ))
         .context("handling request");
         assert!(!is_client_disconnect(&timed_out));
+    }
+
+    #[test]
+    fn http_response_reader_stops_at_content_length_without_eof() -> Result<()> {
+        let response = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\n{\"ok\":true}";
+        let mut reader = std::io::Cursor::new(response);
+
+        let (status, body) =
+            read_http_response_with_deadline(&mut reader, Duration::from_millis(100), 1024)?;
+
+        assert_eq!(status, 200);
+        assert_eq!(body, br#"{"ok":true}"#);
+        Ok(())
+    }
+
+    #[test]
+    fn http_response_reader_times_out_when_peer_never_responds() {
+        let started = Instant::now();
+        let error =
+            read_http_response_with_deadline(&mut NeverReady, Duration::from_millis(30), 1024)
+                .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"), "got: {error:#}");
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     #[cfg(unix)]
@@ -3863,7 +4059,7 @@ mod tests {
     #[test]
     fn serves_health_over_windows_named_pipe() -> Result<()> {
         use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
-        use std::io::{Read, Write};
+        use std::io::Write;
         use std::thread;
 
         let temp_dir = tempfile::tempdir()?;
@@ -3886,26 +4082,42 @@ mod tests {
         let home = temp_dir.path().to_path_buf();
         let runtime = LiveSessionRuntime::default();
         let server = thread::spawn(move || {
-            let conn = listener.incoming().next().expect("accept").expect("stream");
-            handle_http_stream(&conn, &conn, &home, Some(status), &runtime, None, false)
+            for _ in 0..2 {
+                let conn = listener.incoming().next().expect("accept").expect("stream");
+                handle_http_stream(
+                    &conn,
+                    &conn,
+                    &home,
+                    Some(status.clone()),
+                    &runtime,
+                    None,
+                    false,
+                )?;
+            }
+            Ok::<_, anyhow::Error>(())
         });
 
-        let client_name = pipe_name
-            .to_ns_name::<GenericNamespaced>()
-            .expect("client pipe name");
-        let mut client = Stream::connect(client_name).expect("connect");
-        client
-            .write_all(b"GET /api/v1/health HTTP/1.1\r\nHost: coven\r\n\r\n")
-            .expect("write request");
-        // Flush to ensure the server receives the full request before we start reading.
-        client.flush().expect("flush");
-        let mut response = String::new();
-        client.read_to_string(&mut response).expect("read response");
-
+        for _ in 0..2 {
+            let client_name = pipe_name
+                .clone()
+                .to_ns_name::<GenericNamespaced>()
+                .expect("client pipe name");
+            let mut client = Stream::connect(client_name).expect("connect");
+            client
+                .write_all(b"GET /api/v1/health HTTP/1.1\r\nHost: coven\r\n\r\n")
+                .expect("write request");
+            client.flush().expect("flush");
+            let (status_code, response) = read_windows_pipe_http_response(
+                client,
+                Duration::from_secs(1),
+                MAX_SOCKET_BODY_BYTES,
+            )
+            .expect("read response");
+            assert_eq!(status_code, 200);
+            let response = String::from_utf8(response)?;
+            assert!(response.contains("\"apiVersion\""), "got: {response}");
+        }
         server.join().expect("server thread")?;
-
-        assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
-        assert!(response.contains("\"apiVersion\""), "got: {response}");
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1494,6 +1494,7 @@ pub(crate) fn read_windows_pipe_http_response(
 /// response. HTTP/1.1 frames the body with Content-Length, so consume exactly
 /// that many bytes. The reader is expected to be nonblocking; WouldBlock is
 /// retried until `timeout` expires.
+#[cfg(any(windows, test))]
 pub(crate) fn read_http_response_with_deadline<R: Read>(
     reader: &mut R,
     timeout: Duration,
@@ -1550,6 +1551,7 @@ pub(crate) fn read_http_response_with_deadline<R: Read>(
     }
 }
 
+#[cfg(any(windows, test))]
 fn response_status(headers: &[u8]) -> Result<u16> {
     let headers =
         std::str::from_utf8(headers).context("daemon HTTP response headers were not UTF-8")?;
@@ -1562,10 +1564,12 @@ fn response_status(headers: &[u8]) -> Result<u16> {
         .context("daemon HTTP response had an invalid status")
 }
 
+#[cfg(any(windows, test))]
 fn find_http_header_end(bytes: &[u8]) -> Option<usize> {
     bytes.windows(4).position(|window| window == b"\r\n\r\n")
 }
 
+#[cfg(any(windows, test))]
 fn response_content_length(headers: &[u8]) -> Result<usize> {
     let headers =
         std::str::from_utf8(headers).context("daemon HTTP response headers were not UTF-8")?;

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1498,11 +1498,9 @@ mod tests {
         fs::create_dir_all(&npm_bin)?;
         fs::create_dir_all(&app_bin)?;
         fs::write(npm_bin.join("codex.cmd"), "@echo off\r\n")?;
-        let codex_exe = app_bin.join("codex.exe");
-        fs::write(&codex_exe, b"")?;
-        // The resolver uses the host's executable predicate so this Windows
-        // algorithm test also needs an executable bit on Unix CI.
-        make_executable(&codex_exe)?;
+        // Match the simulated PATHEXT spelling exactly so the Windows
+        // algorithm can be tested on a case-sensitive Unix filesystem.
+        fs::write(app_bin.join("codex.EXE"), b"")?;
 
         let resolved = resolve_executable_in_paths_for_windows(
             "codex",

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1327,7 +1327,7 @@ fn pathext_extensions() -> Vec<String> {
         .unwrap_or_else(|| vec![".COM".into(), ".EXE".into(), ".BAT".into(), ".CMD".into()])
 }
 
-#[cfg(any(windows, test))]
+#[cfg(windows)]
 fn windows_executable_candidates(
     path: &Path,
     executable: &str,

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1268,9 +1268,28 @@ where
         return None;
     }
 
-    paths.into_iter().find_map(|path| {
-        windows_executable_candidates(&path, executable, extensions.clone())
+    let paths: Vec<PathBuf> = paths.into_iter().collect();
+    if Path::new(executable).extension().is_some() {
+        return paths
             .into_iter()
+            .map(|path| path.join(executable))
+            .find(|candidate| candidate.is_file());
+    }
+
+    // Honor PATHEXT precedence globally. Cave intentionally prepends npm's
+    // shim directory to PATH, but Windows prefers a real .EXE over a later
+    // .CMD entry when PATHEXT lists .EXE first. Searching every extension per
+    // directory inverted that rule and selected codex.cmd, which cannot carry
+    // Cave's large multiline prompt safely through cmd.exe.
+    extensions.into_iter().find_map(|extension| {
+        let normalized = if extension.starts_with('.') {
+            extension
+        } else {
+            format!(".{extension}")
+        };
+        paths
+            .iter()
+            .map(|path| path.join(format!("{executable}{normalized}")))
             .find(|candidate| candidate.is_file())
     })
 }
@@ -1468,6 +1487,33 @@ mod tests {
         .expect("codex.cmd should be selected");
 
         assert_eq!(resolved, temp_dir.path().join("codex.cmd"));
+        Ok(())
+    }
+
+    #[test]
+    fn windows_spawn_resolution_honors_pathext_across_path_directories() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let npm_bin = temp_dir.path().join("npm");
+        let app_bin = temp_dir.path().join("app");
+        fs::create_dir_all(&npm_bin)?;
+        fs::create_dir_all(&app_bin)?;
+        fs::write(npm_bin.join("codex.cmd"), "@echo off\r\n")?;
+        fs::write(app_bin.join("codex.exe"), b"")?;
+
+        let resolved = resolve_executable_in_paths_for_windows(
+            "codex",
+            vec![npm_bin, app_bin.clone()],
+            vec![".EXE".to_string(), ".CMD".to_string()],
+        )
+        .expect("codex.exe should win PATHEXT precedence");
+
+        assert_eq!(
+            resolved.to_string_lossy().to_ascii_lowercase(),
+            app_bin
+                .join("codex.exe")
+                .to_string_lossy()
+                .to_ascii_lowercase()
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1498,7 +1498,11 @@ mod tests {
         fs::create_dir_all(&npm_bin)?;
         fs::create_dir_all(&app_bin)?;
         fs::write(npm_bin.join("codex.cmd"), "@echo off\r\n")?;
-        fs::write(app_bin.join("codex.exe"), b"")?;
+        let codex_exe = app_bin.join("codex.exe");
+        fs::write(&codex_exe, b"")?;
+        // The resolver uses the host's executable predicate so this Windows
+        // algorithm test also needs an executable bit on Unix CI.
+        make_executable(&codex_exe)?;
 
         let resolved = resolve_executable_in_paths_for_windows(
             "codex",

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1484,13 +1484,19 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         None,
         &current_timestamp(),
     )?;
+    let launch_mode = if stream_json {
+        // stream-json is a machine protocol: always launch one-shot.
+        harness::HarnessLaunchMode::NonInteractive
+    } else {
+        harness_launch_mode_for_stdio(&selected_harness.id)
+    };
     let command = pty_runner::build_harness_command(
         &selected_harness.id,
         &brief,
         &request.repo.root,
-        harness_launch_mode_for_stdio(&selected_harness.id),
+        launch_mode,
     )?;
-    let result = pty_runner::run_attached(&command)?;
+    let result = run_harness_attached(&command, launch_mode)?;
     store::update_session_status(
         &conn,
         &record.id,
@@ -1721,6 +1727,17 @@ fn harness_launch_mode(
     } else {
         harness::HarnessLaunchMode::NonInteractive
     }
+}
+
+fn run_harness_attached(
+    command: &pty_runner::HarnessCommand,
+    launch_mode: harness::HarnessLaunchMode,
+) -> Result<pty_runner::PtyRunResult> {
+    #[cfg(windows)]
+    if launch_mode == harness::HarnessLaunchMode::NonInteractive {
+        return pty_runner::run_piped_attached(command);
+    }
+    pty_runner::run_attached(command)
 }
 
 /// Lock stdout, emit one stream-JSON frame, release. Per-frame locking keeps
@@ -2130,20 +2147,12 @@ fn run_session(
         .as_ref()
         .filter(|s| s.system_prompt_flag.is_some())
         .and(familiar_ctx.as_ref());
+    let launch_mode = harness_launch_mode_for_stdio(&selected_harness.id);
     let command = pty_runner::build_harness_command_with_conversation(
         &selected_harness.id,
         &effective_prompt,
         &cwd,
-        if stream_json {
-            // stream-json is a machine protocol: always launch the harness
-            // one-shot/non-interactive, even when stdio happens to be a
-            // terminal. The claude pass-through above does the same (`-p`);
-            // launching a TUI here would leave the harness waiting on
-            // keystrokes for a screen that is never rendered.
-            harness::HarnessLaunchMode::NonInteractive
-        } else {
-            harness_launch_mode_for_stdio(&selected_harness.id)
-        },
+        launch_mode,
         conversation_hint.as_ref(),
         familiar_for_args,
         launch_options,
@@ -2168,7 +2177,7 @@ fn run_session(
             }),
         )
     } else {
-        pty_runner::run_attached(&command)
+        run_harness_attached(&command, launch_mode)
     };
     match attached {
         Ok(result) => {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1484,19 +1484,14 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         None,
         &current_timestamp(),
     )?;
-    let launch_mode = if stream_json {
-        // stream-json is a machine protocol: always launch one-shot.
-        harness::HarnessLaunchMode::NonInteractive
-    } else {
-        harness_launch_mode_for_stdio(&selected_harness.id)
-    };
+    let launch_mode = harness_launch_mode_for_stdio(&selected_harness.id);
     let command = pty_runner::build_harness_command(
         &selected_harness.id,
         &brief,
         &request.repo.root,
         launch_mode,
     )?;
-    let result = run_harness_attached(&command, launch_mode)?;
+    let result = run_harness_attached(&command, launch_mode, false)?;
     store::update_session_status(
         &conn,
         &record.id,
@@ -1732,10 +1727,11 @@ fn harness_launch_mode(
 fn run_harness_attached(
     command: &pty_runner::HarnessCommand,
     launch_mode: harness::HarnessLaunchMode,
+    stream_json: bool,
 ) -> Result<pty_runner::PtyRunResult> {
     #[cfg(windows)]
     if launch_mode == harness::HarnessLaunchMode::NonInteractive {
-        return pty_runner::run_piped_attached(command);
+        return pty_runner::run_piped_attached(command, stream_json);
     }
     pty_runner::run_attached(command)
 }
@@ -2147,7 +2143,12 @@ fn run_session(
         .as_ref()
         .filter(|s| s.system_prompt_flag.is_some())
         .and(familiar_ctx.as_ref());
-    let launch_mode = harness_launch_mode_for_stdio(&selected_harness.id);
+    let launch_mode = if stream_json {
+        // stream-json is a machine protocol: always launch one-shot.
+        harness::HarnessLaunchMode::NonInteractive
+    } else {
+        harness_launch_mode_for_stdio(&selected_harness.id)
+    };
     let command = pty_runner::build_harness_command_with_conversation(
         &selected_harness.id,
         &effective_prompt,
@@ -2157,29 +2158,7 @@ fn run_session(
         familiar_for_args,
         launch_options,
     )?;
-    // Non-stream harnesses run on a PTY. In stream-json mode, mirroring the
-    // raw PTY bytes to stdout would interleave ANSI escapes / prompts /
-    // partial lines with the JSONL frames and corrupt the stream for every
-    // consumer (#307), so the PTY is captured instead and each chunk is
-    // wrapped in an `output` event. Emit failures inside the callback are
-    // ignored (the consumer may have closed the pipe mid-run); the `result`
-    // emission below surfaces a dead stdout as an error.
-    let attached = if stream_json {
-        let output_session_id = record.id.clone();
-        pty_runner::run_attached_captured(
-            &command,
-            Box::new(move |chunk| {
-                let _ =
-                    emit_stream_event(&stream_json::Event::Output(stream_json::HarnessOutput {
-                        text: String::from_utf8_lossy(&chunk).into_owned(),
-                        session_id: output_session_id.clone(),
-                    }));
-            }),
-        )
-    } else {
-        run_harness_attached(&command, launch_mode)
-    };
-    match attached {
+    match run_harness_attached(&command, launch_mode, stream_json) {
         Ok(result) => {
             store::update_session_status(
                 &conn,

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -2180,7 +2180,21 @@ fn run_session(
         run_harness_attached(&command, launch_mode, false)
     };
     #[cfg(windows)]
-    let attached = run_harness_attached(&command, launch_mode, stream_json);
+    let attached = if stream_json {
+        let output_session_id = record.id.clone();
+        pty_runner::run_piped_attached_captured(
+            &command,
+            Box::new(move |chunk| {
+                let _ =
+                    emit_stream_event(&stream_json::Event::Output(stream_json::HarnessOutput {
+                        text: String::from_utf8_lossy(&chunk).into_owned(),
+                        session_id: output_session_id.clone(),
+                    }));
+            }),
+        )
+    } else {
+        run_harness_attached(&command, launch_mode, false)
+    };
 
     match attached {
         Ok(result) => {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1488,7 +1488,7 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         &selected_harness.id,
         &brief,
         &request.repo.root,
-        harness_launch_mode_for_stdio(),
+        harness_launch_mode_for_stdio(&selected_harness.id),
     )?;
     let result = pty_runner::run_attached(&command)?;
     store::update_session_status(
@@ -1694,8 +1694,29 @@ fn render_daemon_status_json(state: Option<&daemon::DaemonStatusState>) -> Resul
     serde_json::to_string_pretty(&value).context("failed to serialize daemon status as JSON")
 }
 
-fn harness_launch_mode_for_stdio() -> harness::HarnessLaunchMode {
-    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+fn harness_launch_mode_for_stdio(harness_id: &str) -> harness::HarnessLaunchMode {
+    harness_launch_mode(
+        harness_id,
+        io::stdin().is_terminal(),
+        io::stdout().is_terminal(),
+        cfg!(windows),
+    )
+}
+
+fn harness_launch_mode(
+    harness_id: &str,
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+    is_windows: bool,
+) -> harness::HarnessLaunchMode {
+    // `codex <prompt>` opens the long-lived interactive TUI. Under Coven's
+    // Windows ConPTY bridge that child can remain alive without reliably
+    // rendering or persisting its answer. The one-shot `codex exec` path is
+    // supported already and exits after printing the response, so prefer it
+    // for prompted Windows runs even when Coven itself owns a terminal.
+    if is_windows && harness_id == "codex" {
+        harness::HarnessLaunchMode::NonInteractive
+    } else if stdin_is_terminal && stdout_is_terminal {
         harness::HarnessLaunchMode::Interactive
     } else {
         harness::HarnessLaunchMode::NonInteractive
@@ -2121,7 +2142,7 @@ fn run_session(
             // keystrokes for a screen that is never rendered.
             harness::HarnessLaunchMode::NonInteractive
         } else {
-            harness_launch_mode_for_stdio()
+            harness_launch_mode_for_stdio(&selected_harness.id)
         },
         conversation_hint.as_ref(),
         familiar_for_args,
@@ -2941,6 +2962,30 @@ mod tests {
         assert_eq!(
             interactive_shell_route(Some(&Command::Chat), false, false),
             InteractiveShellRoute::PlainCast
+        );
+    }
+
+    #[test]
+    fn windows_codex_prompt_uses_completing_noninteractive_mode() {
+        assert_eq!(
+            harness_launch_mode("codex", true, true, true),
+            harness::HarnessLaunchMode::NonInteractive
+        );
+    }
+
+    #[test]
+    fn launch_mode_preserves_interactive_claude_and_non_windows_codex() {
+        assert_eq!(
+            harness_launch_mode("claude", true, true, true),
+            harness::HarnessLaunchMode::Interactive
+        );
+        assert_eq!(
+            harness_launch_mode("codex", true, true, false),
+            harness::HarnessLaunchMode::Interactive
+        );
+        assert_eq!(
+            harness_launch_mode("codex", false, true, false),
+            harness::HarnessLaunchMode::NonInteractive
         );
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1733,6 +1733,8 @@ fn run_harness_attached(
     if launch_mode == harness::HarnessLaunchMode::NonInteractive {
         return pty_runner::run_piped_attached(command, stream_json);
     }
+    #[cfg(not(windows))]
+    let _ = (launch_mode, stream_json);
     pty_runner::run_attached(command)
 }
 
@@ -2158,7 +2160,29 @@ fn run_session(
         familiar_for_args,
         launch_options,
     )?;
-    match run_harness_attached(&command, launch_mode, stream_json) {
+    // Preserve the JSONL-only captured-output contract from #315 on
+    // non-Windows platforms. Windows Codex must bypass ConPTY and use the
+    // verified ordinary-pipe path so Cave receives a terminal response.
+    #[cfg(not(windows))]
+    let attached = if stream_json {
+        let output_session_id = record.id.clone();
+        pty_runner::run_attached_captured(
+            &command,
+            Box::new(move |chunk| {
+                let _ =
+                    emit_stream_event(&stream_json::Event::Output(stream_json::HarnessOutput {
+                        text: String::from_utf8_lossy(&chunk).into_owned(),
+                        session_id: output_session_id.clone(),
+                    }));
+            }),
+        )
+    } else {
+        run_harness_attached(&command, launch_mode, false)
+    };
+    #[cfg(windows)]
+    let attached = run_harness_attached(&command, launch_mode, stream_json);
+
+    match attached {
         Ok(result) => {
             store::update_session_status(
                 &conn,

--- a/crates/coven-cli/src/project.rs
+++ b/crates/coven-cli/src/project.rs
@@ -1,7 +1,24 @@
 use std::path::{Path, PathBuf};
 
 pub fn canonical_project_root(path: &Path) -> anyhow::Result<PathBuf> {
-    Ok(path.canonicalize()?)
+    Ok(normalize_canonical_path(path.canonicalize()?))
+}
+
+#[cfg(windows)]
+fn normalize_canonical_path(path: PathBuf) -> PathBuf {
+    let value = path.to_string_lossy();
+    if let Some(rest) = value.strip_prefix(r"\\?\UNC\") {
+        return PathBuf::from(format!(r"\\{rest}"));
+    }
+    if let Some(rest) = value.strip_prefix(r"\\?\") {
+        return PathBuf::from(rest);
+    }
+    path
+}
+
+#[cfg(not(windows))]
+fn normalize_canonical_path(path: PathBuf) -> PathBuf {
+    path
 }
 
 pub fn resolve_inside_root(root: &Path, cwd: Option<&Path>) -> anyhow::Result<PathBuf> {
@@ -11,7 +28,7 @@ pub fn resolve_inside_root(root: &Path, cwd: Option<&Path>) -> anyhow::Result<Pa
         Some(cwd) => root.join(cwd),
         None => root.clone(),
     };
-    let candidate = candidate.canonicalize()?;
+    let candidate = normalize_canonical_path(candidate.canonicalize()?);
 
     if candidate == root || candidate.starts_with(&root) {
         Ok(candidate)
@@ -33,7 +50,7 @@ mod tests {
 
         let actual = canonical_project_root(&root)?;
 
-        assert_eq!(actual, root.canonicalize()?);
+        assert_eq!(actual, normalize_canonical_path(root.canonicalize()?));
         Ok(())
     }
 
@@ -45,7 +62,7 @@ mod tests {
 
         let actual = resolve_inside_root(&root, None)?;
 
-        assert_eq!(actual, root.canonicalize()?);
+        assert_eq!(actual, normalize_canonical_path(root.canonicalize()?));
         Ok(())
     }
 
@@ -59,7 +76,7 @@ mod tests {
 
         let actual = resolve_inside_root(&root, Some(Path::new("child")))?;
 
-        assert_eq!(actual, child.canonicalize()?);
+        assert_eq!(actual, normalize_canonical_path(child.canonicalize()?));
         Ok(())
     }
 
@@ -99,6 +116,17 @@ mod tests {
             error.to_string().contains("outside the Coven project root"),
             "unexpected error: {error:?}"
         );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonical_project_root_uses_node_compatible_windows_path() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let actual = canonical_project_root(temp_dir.path())?;
+
+        assert!(!actual.to_string_lossy().starts_with(r"\\?\"));
+        assert!(actual.is_absolute());
         Ok(())
     }
 

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -113,6 +113,7 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
 /// with the frames (#307). Stdin is still forwarded to the PTY, matching
 /// `run_attached`; raw terminal mode is never enabled because nothing is
 /// echoed back to the caller's terminal.
+#[cfg(not(windows))]
 pub fn run_attached_captured(
     command: &HarnessCommand,
     mut on_output: Box<dyn FnMut(Vec<u8>) + Send + 'static>,
@@ -154,6 +155,7 @@ pub fn run_attached_captured(
 /// pseudo-terminal. Windows Codex `exec` is reliable in this mode while its
 /// ConPTY child can stall before producing output. Inherited handles preserve
 /// the caller's stdout/stderr stream exactly (including Coven's JSON framing).
+#[cfg(windows)]
 pub fn run_piped_attached(
     command: &HarnessCommand,
     merge_stderr_to_stdout: bool,

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -360,6 +360,7 @@ pub struct PipedSession {
 pub fn spawn_piped_with_observer(
     command: &HarnessCommand,
     observer: Option<DetachedPtyObserver>,
+    wrap_stderr_as_stream_json: bool,
 ) -> Result<PipedSession> {
     use std::process::Command as StdCommand;
     use std::sync::{Arc, Mutex as StdMutex};
@@ -446,12 +447,16 @@ pub fn spawn_piped_with_observer(
                         _ => &buf[..],
                     };
                     let line = String::from_utf8_lossy(trimmed);
-                    let envelope = serde_json::json!({
-                        "type": "system",
-                        "subtype": "stderr",
-                        "text": line,
-                    });
-                    let mut payload = envelope.to_string();
+                    let mut payload = if wrap_stderr_as_stream_json {
+                        serde_json::json!({
+                            "type": "system",
+                            "subtype": "stderr",
+                            "text": line,
+                        })
+                        .to_string()
+                    } else {
+                        line.into_owned()
+                    };
                     payload.push('\n');
                     if let Ok(mut cb) = stderr_callback.lock() {
                         cb(payload.into_bytes());

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -215,6 +215,44 @@ pub fn run_piped_attached(
     })
 }
 
+/// Run a one-shot Windows harness through ordinary pipes while keeping stdout
+/// available for Coven's stream-JSON protocol. Codex writes its labeled
+/// transcript to stderr, so capture that stream and let the caller wrap it in
+/// JSON `output` events; discard Codex's duplicate plain stdout answer.
+#[cfg(windows)]
+pub fn run_piped_attached_captured(
+    command: &HarnessCommand,
+    mut on_output: Box<dyn FnMut(Vec<u8>) + Send + 'static>,
+) -> Result<PtyRunResult> {
+    let mut child = std::process::Command::new(&command.program)
+        .args(&command.args)
+        .current_dir(&command.cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "failed to spawn harness `{}` in captured piped mode",
+                command.program()
+            )
+        })?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .context("captured piped harness did not expose stderr")?;
+    drain_detached_output(&mut stderr, Some(&mut on_output));
+    let status = child.wait().context("failed waiting for piped harness")?;
+    Ok(PtyRunResult {
+        status: if status.success() {
+            "completed"
+        } else {
+            "failed"
+        },
+        exit_code: status.code(),
+    })
+}
+
 /// Run `claude` in its native stream-JSON mode, framed by the caller (which
 /// emits Coven's own `system.init` / `result` around the call).
 ///

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -150,6 +150,34 @@ pub fn run_attached_captured(
     Ok(wait_for_child(&mut child))
 }
 
+/// Run a one-shot harness directly on inherited stdio without allocating a
+/// pseudo-terminal. Windows Codex `exec` is reliable in this mode while its
+/// ConPTY child can stall before producing output. Inherited handles preserve
+/// the caller's stdout/stderr stream exactly (including Coven's JSON framing).
+pub fn run_piped_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
+    let status = std::process::Command::new(&command.program)
+        .args(&command.args)
+        .current_dir(&command.cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .with_context(|| {
+            format!(
+                "failed to spawn harness `{}` in piped mode",
+                command.program()
+            )
+        })?;
+    Ok(PtyRunResult {
+        status: if status.success() {
+            "completed"
+        } else {
+            "failed"
+        },
+        exit_code: status.code(),
+    })
+}
+
 /// Run `claude` in its native stream-JSON mode, framed by the caller (which
 /// emits Coven's own `system.init` / `result` around the call).
 ///

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -154,20 +154,55 @@ pub fn run_attached_captured(
 /// pseudo-terminal. Windows Codex `exec` is reliable in this mode while its
 /// ConPTY child can stall before producing output. Inherited handles preserve
 /// the caller's stdout/stderr stream exactly (including Coven's JSON framing).
-pub fn run_piped_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
-    let status = std::process::Command::new(&command.program)
+pub fn run_piped_attached(
+    command: &HarnessCommand,
+    merge_stderr_to_stdout: bool,
+) -> Result<PtyRunResult> {
+    let mut child = std::process::Command::new(&command.program)
         .args(&command.args)
         .current_dir(&command.cwd)
         .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
+        // In stream mode Codex duplicates its final answer on stdout while
+        // stderr carries the complete labeled transcript that Cave's filter
+        // consumes. Keep only the transcript to avoid rendering it twice.
+        .stdout(if merge_stderr_to_stdout {
+            Stdio::null()
+        } else {
+            Stdio::inherit()
+        })
+        .stderr(if merge_stderr_to_stdout {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        })
+        .spawn()
         .with_context(|| {
             format!(
                 "failed to spawn harness `{}` in piped mode",
                 command.program()
             )
         })?;
+
+    // Codex on Windows writes its complete `exec` transcript (including the
+    // final assistant response) to stderr. `coven run --stream-json` is a
+    // stdout protocol consumed by Cave, so forward that transcript to stdout
+    // for stream clients while continuing to drain it concurrently.
+    let stderr_forwarder = child.stderr.take().map(|mut stderr| {
+        thread::spawn(move || -> io::Result<()> {
+            let stdout = io::stdout();
+            let mut stdout = stdout.lock();
+            io::copy(&mut stderr, &mut stdout)?;
+            stdout.flush()
+        })
+    });
+
+    let status = child.wait().context("failed waiting for piped harness")?;
+    if let Some(forwarder) = stderr_forwarder {
+        forwarder
+            .join()
+            .map_err(|_| anyhow::anyhow!("stderr forwarding thread panicked"))?
+            .context("failed forwarding harness stderr to stdout")?;
+    }
     Ok(PtyRunResult {
         status: if status.success() {
             "completed"

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -6,10 +6,12 @@
 //! ledger-only mutations.
 
 #[cfg(unix)]
-use std::io::{Read, Write};
+use std::io::Read;
+#[cfg(any(unix, windows))]
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use anyhow::anyhow;
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -380,14 +382,65 @@ fn request_daemon(
     parse_http_response(&response)
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+fn request_daemon(
+    coven_home: &Path,
+    method: &str,
+    path: &str,
+    body: Option<Value>,
+) -> Result<HttpResponse> {
+    use interprocess::{
+        local_socket::{prelude::*, ConnectOptions, GenericNamespaced},
+        ConnectWaitMode,
+    };
+    use std::time::Duration;
+
+    let body = body.map(|value| value.to_string()).unwrap_or_default();
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let pipe_name = daemon::windows_pipe_name(coven_home);
+    let name = pipe_name
+        .clone()
+        .to_ns_name::<GenericNamespaced>()
+        .context("failed to parse Coven daemon pipe name")?;
+    let mut stream = ConnectOptions::new()
+        .name(name)
+        .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(5)))
+        .connect_sync()
+        .with_context(|| {
+            format!(
+                "failed to connect to Coven daemon pipe {pipe_name}; run `coven daemon start` and retry"
+            )
+        })?;
+    stream
+        .write_all(request.as_bytes())
+        .context("failed to write Coven daemon request")?;
+    stream
+        .flush()
+        .context("failed to flush Coven daemon request")?;
+    let (status, body) = daemon::read_windows_pipe_http_response(
+        stream,
+        Duration::from_secs(5),
+        daemon::MAX_SOCKET_BODY_BYTES,
+    )?;
+    let body = String::from_utf8(body).context("Coven daemon response body was not UTF-8")?;
+    if !(200..300).contains(&status) {
+        return Err(daemon_error(status, &body));
+    }
+    Ok(HttpResponse { status, body })
+}
+
+#[cfg(not(any(unix, windows)))]
 fn request_daemon(
     _coven_home: &Path,
     _method: &str,
     _path: &str,
     _body: Option<Value>,
 ) -> Result<HttpResponse> {
-    anyhow::bail!("Coven daemon chat is only implemented on Unix-like systems for now")
+    anyhow::bail!("Coven daemon chat is not implemented on this platform")
 }
 
 #[cfg(unix)]
@@ -411,7 +464,7 @@ fn parse_http_response(response: &str) -> Result<HttpResponse> {
     })
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn daemon_error(status: u16, body: &str) -> anyhow::Error {
     if let Ok(value) = serde_json::from_str::<Value>(body) {
         if let Some(message) = value
@@ -448,6 +501,44 @@ fn session_title(prompt: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_daemon_client_reads_framed_response_without_waiting_for_pipe_close() -> Result<()> {
+        use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
+        use std::io::{Read, Write};
+        use std::thread;
+        use std::time::{Duration, Instant};
+
+        let home = tempfile::tempdir()?;
+        let name = daemon::windows_pipe_name(home.path())
+            .to_ns_name::<GenericNamespaced>()
+            .context("pipe name")?;
+        let listener = ListenerOptions::new().name(name).create_sync()?;
+        let server = thread::spawn(move || -> Result<()> {
+            let mut stream = listener.incoming().next().context("accept ended")??;
+            let mut request = Vec::new();
+            let mut byte = [0_u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                stream.read_exact(&mut byte)?;
+                request.push(byte[0]);
+            }
+            stream.write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\n{\"ok\":true}",
+            )?;
+            stream.flush()?;
+            thread::sleep(Duration::from_millis(300));
+            Ok(())
+        });
+
+        let started = Instant::now();
+        let response = request_daemon(home.path(), "GET", "/api/v1/health", None)?;
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, r#"{"ok":true}"#);
+        assert!(started.elapsed() < Duration::from_millis(250));
+        server.join().expect("server thread")?;
+        Ok(())
+    }
 
     #[cfg(unix)]
     #[test]

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -527,7 +527,7 @@ mod tests {
                 b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\n{\"ok\":true}",
             )?;
             stream.flush()?;
-            thread::sleep(Duration::from_millis(300));
+            thread::sleep(Duration::from_secs(2));
             Ok(())
         });
 
@@ -535,7 +535,7 @@ mod tests {
         let response = request_daemon(home.path(), "GET", "/api/v1/health", None)?;
         assert_eq!(response.status, 200);
         assert_eq!(response.body, r#"{"ok":true}"#);
-        assert!(started.elapsed() < Duration::from_millis(250));
+        assert!(started.elapsed() < Duration::from_millis(1500));
         server.join().expect("server thread")?;
         Ok(())
     }


### PR DESCRIPTION
## What changed

- use `codex exec` for prompted Windows CLI runs
- add a real Windows named-pipe transport for Cave/chat instead of the Unix-only error branch
- parse HTTP responses by `Content-Length` rather than waiting for pipe EOF
- bound named-pipe connect and response waits so doctor/status/Cave cannot wait forever
- serve accepted Windows pipe connections on independent handler threads so one stalled client cannot starve polling
- claim the Windows pipe before writing daemon metadata or orphaning persisted sessions
- run Windows non-interactive daemon children with ordinary pipes instead of ConPTY
- preserve stdout/stderr observation, exit recording, and Windows Job Object cleanup
- normalize Windows extended-length project paths before exposing them to Cave
- honor PATHEXT across PATH directories so codex.exe wins over an earlier npm codex.CMD shim
- route the Windows Codex labeled transcript onto the Cave-consumed stdout channel without duplicating the final answer
- add regression coverage for framing, timeouts, repeated health requests, Windows Cave transport, launch mode, output persistence, terminal state, polling backoff, and rendering

## Root cause

Several Windows-specific gaps combined into the apparent Cave hang:

1. Cave's daemon client was compiled to return `Coven daemon chat is only implemented on Unix-like systems` on Windows.
2. Doctor/status read named-pipe HTTP responses with `read_to_string()`, waiting for EOF instead of the declared body length.
3. Pipe connection establishment was unbounded and the Windows daemon handled accepted clients serially.
4. A replacement daemon could mark live rows orphaned before proving it owned the pipe.
5. One-shot codex exec launched through ConPTY could terminate as u32::MAX with no captured output; direct piped execution works.
6. Windows PATH resolution selected an earlier npm codex.CMD shim even when PATHEXT preferred a later native .EXE, causing invalid batch argument failures.
7. Codex emitted its labeled transcript on stderr and a duplicate plain answer on stdout; Cave only recognized labeled assistant text on Coven's stdout channel, so successful runs were misreported as empty output.

## Impact

Cave can now launch non-interactive Codex work through the Windows daemon, poll persisted output events, observe terminal state, and recover from transient pipe failures. Doctor/status probes are framed and bounded. Claude and non-Windows launch behavior remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- focused Windows/Cave reliability tests: all passed
- full `cargo test -p coven-cli --quiet`: 825 passed, 11 failed, 1 ignored
- the 11 failures are pre-existing Windows assertions that expect literal `codex`/`claude` executable names while this machine resolves absolute `.EXE`/`.CMD` paths
- direct `codex exec hi` on the affected machine returns a response and exits successfully
- isolated daemon/API diagnostics reproduced both the original ConPTY failure and pipe starvation, which the new piped-launch and concurrent-handler paths address
- split-stream smoke after 7979630: exit 0, exactly one CAVE_FINAL_OK assistant line on stdout, zero stderr bytes, and a successful result event
- installed Cave session 470e0215-83fe-45d4-9f1d-7e065d863341: response persisted after 15,003ms with isError: false and no leftover Coven/Codex child

### Final installed-Cave verification

Cave was relaunched with `COVEN_BIN` pointing at the PR build. That exposed one final foreground CLI ConPTY path, now fixed in `8ba90c6`. The exact Cave-style command (`coven run codex --stream-json --model openai/gpt-5.5 ...`) then emitted init/user events, returned `CAVE_PIPE_OK`, emitted a successful result, and exited 0 in 17 seconds.



## Related work

- Partially addresses #329 (Windows PTY startup hang, zero-event running sessions, and extended-path leakage). The issue also covers Claude and should remain open until that path is independently verified.
- Related stream contract: #307 / #315.
- Related Windows/local transport hardening: #195 / #207, #242, and #243.

