### PR TITLE
fix: tolerate legacy familiar records without descriptions

### DIFF
--- a/crates/coven-cli/src/cockpit_sources.rs
+++ b/crates/coven-cli/src/cockpit_sources.rs
@@ -56,6 +56,9 @@ struct FamiliarEntry {
     /// treat anything else as an emoji literal.
     icon: Option<String>,
     role: String,
+    // Older CovenCave versions omitted this field for blank descriptions.
+    // Keep those registries readable while preserving a stable string in the API.
+    #[serde(default)]
     description: String,
     pronouns: Option<String>,
     active_channel: Option<String>,
@@ -544,6 +547,40 @@ description = "Builds and debugs."
         // No `icon` field set in this fixture — must round-trip as None.
         assert!(out[0].icon.is_none());
         assert!(out[1].icon.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn read_familiars_defaults_legacy_missing_descriptions() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        fs::write(
+            temp.path().join(FAMILIARS_CONFIG_FILE),
+            r#"
+[[familiar]]
+id = "ash"
+display_name = "Ash"
+emoji = "ph:flask-fill"
+role = "Familiar"
+harness = "codex"
+model = "openai/gpt-5.5"
+
+[[familiar]]
+id = "briar"
+display_name = "Briar"
+emoji = "ph:code-fill"
+role = "Familiar"
+harness = "codex"
+model = "openai/gpt-5.5"
+"#,
+        )?;
+
+        let familiars = read_familiars(temp.path())?;
+
+        assert_eq!(familiars.len(), 2);
+        assert_eq!(familiars[0].id, "ash");
+        assert_eq!(familiars[0].description, "");
+        assert_eq!(familiars[1].id, "briar");
+        assert_eq!(familiars[1].description, "");
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2193,14 +2193,25 @@ where
     }
     let body = read_http_body(&mut reader, headers.content_length)?;
     let (method, path) = parse_request_line(&request_line)?;
-    let response = crate::api::handle_request_with_runtime(
+    let response = match crate::api::handle_request_with_runtime(
         method,
         path,
         coven_home,
         status,
         body.as_deref(),
         runtime,
-    )?;
+    ) {
+        Ok(response) => response,
+        Err(error) => {
+            eprintln!("coven daemon: API request failed: {error:#}");
+            crate::api::api_error(
+                500,
+                "internal_error",
+                "The daemon could not process the request.",
+                None,
+            )?
+        }
+    };
     let reason = http_reason_phrase(response.status);
     let http = format!(
         "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -2940,6 +2951,51 @@ mod tests {
         let response = String::from_utf8(output).expect("utf8");
         assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
         assert!(response.contains("\"apiVersion\""), "got: {response}");
+    }
+
+    #[test]
+    fn handle_http_stream_returns_json_error_for_malformed_familiar_registry() -> Result<()> {
+        use crate::api::NoopSessionRuntime;
+        use std::io::Cursor;
+
+        let temp = tempfile::tempdir()?;
+        std::fs::write(temp.path().join("familiars.toml"), "[[familiar]\n")?;
+        let request = b"GET /api/v1/familiars HTTP/1.1\r\nHost: coven\r\n\r\n";
+        let mut stream = Cursor::new(Vec::from(&request[..]));
+        let mut output = Vec::new();
+
+        handle_http_stream(
+            &mut stream,
+            &mut output,
+            temp.path(),
+            None,
+            &NoopSessionRuntime,
+            None,
+            false,
+        )?;
+
+        let response = String::from_utf8(output)?;
+        let (headers, body) = response
+            .split_once("\r\n\r\n")
+            .expect("HTTP response must include a body");
+        assert!(
+            headers.starts_with("HTTP/1.1 500 Internal Server Error"),
+            "got: {response}"
+        );
+        assert!(
+            headers.contains("Content-Type: application/json"),
+            "got: {response}"
+        );
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(body)?,
+            serde_json::json!({
+                "error": {
+                    "code": "internal_error",
+                    "message": "The daemon could not process the request.",
+                }
+            })
+        );
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -4150,6 +4206,147 @@ mod tests {
             assert!(response.contains("\"apiVersion\""), "got: {response}");
         }
         server.join().expect("server thread")?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn malformed_familiar_registry_returns_json_error_over_windows_named_pipe() -> Result<()> {
+        use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
+        use std::io::Write;
+        use std::thread;
+
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(temp_dir.path().join("familiars.toml"), "[[familiar]\n")?;
+        let pipe_name = windows_pipe_name(temp_dir.path());
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .create_sync()
+            .expect("bind pipe");
+        let home = temp_dir.path().to_path_buf();
+        let runtime = LiveSessionRuntime::default();
+        let server = thread::spawn(move || {
+            let conn = listener.incoming().next().expect("accept").expect("stream");
+            handle_http_stream(&conn, &conn, &home, None, &runtime, None, false)
+        });
+
+        let client_name = pipe_name
+            .to_ns_name::<GenericNamespaced>()
+            .expect("client pipe name");
+        let mut client = Stream::connect(client_name).expect("connect");
+        client
+            .write_all(b"GET /api/v1/familiars HTTP/1.1\r\nHost: coven\r\n\r\n")
+            .expect("write request");
+        client.flush().expect("flush");
+        let (status, response) =
+            read_windows_pipe_http_response(client, Duration::from_secs(5), MAX_SOCKET_BODY_BYTES)?;
+
+        server.join().expect("server thread")?;
+        assert_eq!(status, 500);
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&response)?,
+            serde_json::json!({
+                "error": {
+                    "code": "internal_error",
+                    "message": "The daemon could not process the request.",
+                }
+            })
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn legacy_familiar_registry_returns_roster_over_windows_named_pipe() -> Result<()> {
+        use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
+        use std::io::Write;
+        use std::thread;
+
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("familiars.toml"),
+            r#"
+[[familiar]]
+id = "ash"
+display_name = "Ash"
+emoji = "ph:flask-fill"
+role = "Familiar"
+harness = "codex"
+model = "openai/gpt-5.5"
+
+[[familiar]]
+id = "briar"
+display_name = "Briar"
+emoji = "ph:code-fill"
+role = "Familiar"
+harness = "codex"
+model = "openai/gpt-5.5"
+"#,
+        )?;
+
+        let pipe_name = windows_pipe_name(temp_dir.path());
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .create_sync()
+            .expect("bind pipe");
+        let home = temp_dir.path().to_path_buf();
+        let runtime = LiveSessionRuntime::default();
+        let server = thread::spawn(move || {
+            let conn = listener.incoming().next().expect("accept").expect("stream");
+            handle_http_stream(&conn, &conn, &home, None, &runtime, None, false)
+        });
+
+        let client_name = pipe_name
+            .to_ns_name::<GenericNamespaced>()
+            .expect("client pipe name");
+        let mut client = Stream::connect(client_name).expect("connect");
+        client
+            .write_all(b"GET /api/v1/familiars HTTP/1.1\r\nHost: coven\r\n\r\n")
+            .expect("write request");
+        client.flush().expect("flush");
+        let (status, response) =
+            read_windows_pipe_http_response(client, Duration::from_secs(5), MAX_SOCKET_BODY_BYTES)?;
+
+        server.join().expect("server thread")?;
+        assert_eq!(status, 200);
+        let familiars: serde_json::Value = serde_json::from_slice(&response)?;
+        assert_eq!(
+            familiars,
+            serde_json::json!([
+                {
+                    "id": "ash",
+                    "name": "ash",
+                    "display_name": "Ash",
+                    "emoji": "ph:flask-fill",
+                    "role": "Familiar",
+                    "description": "",
+                    "status": "offline",
+                    "last_seen": "—",
+                    "active_sessions": 0,
+                    "memory_freshness": "—",
+                },
+                {
+                    "id": "briar",
+                    "name": "briar",
+                    "display_name": "Briar",
+                    "emoji": "ph:code-fill",
+                    "role": "Familiar",
+                    "description": "",
+                    "status": "offline",
+                    "last_seen": "—",
+                    "active_sessions": 0,
+                    "memory_freshness": "—",
+                },
+            ])
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Fix legacy `familiars.toml` records that omit `description`.

## Root Cause

Older Cave writer paths could omit `description`. Coven treated the field as required, then an API error escaped the Windows named-pipe transport and Cave displayed a roster retry state.

## Changes

- Default missing descriptions to an empty string while preserving legacy roster fields.
- Convert daemon request failures into structured JSON `500` responses.
- Cover both legacy `200` roster and malformed `500` paths over real Windows named pipes.

## Validation

- `cargo fmt --check`
- Targeted Windows named-pipe legacy roster test
- Targeted Windows malformed-registry tests
- Source-level Cave UI loaded Ash and Briar from a legacy description-less registry; human verified.

## Limitation

`cargo clippy --workspace --all-targets -- -D warnings` remains blocked by the existing `daemon_lifecycle_lock_path` dead-code warning at `daemon.rs:852`, reproduced on upstream base `a478894`.
