### PR TITLE
fix(windows): bridge Codex stream JSON over pipes

### DIFF
--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -47,7 +47,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 interprocess = "2"
 widestring = "1"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_System_Threading", "Win32_System_JobObjects"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_System_JobObjects"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use coven_runtime_spec::{Capabilities, SandboxMapping, StreamArgs};
 use serde::{Deserialize, Serialize};
 
@@ -951,6 +951,41 @@ pub fn command_parts_for_harness_with_conversation(
     familiar: Option<&FamiliarContext>,
     options: HarnessLaunchOptions<'_>,
 ) -> Result<(String, Vec<String>)> {
+    command_parts_for_harness_with_conversation_inner(
+        harness_id, prompt, mode, hint, familiar, options, false,
+    )
+}
+
+/// Build a one-shot Codex command whose `exec` subcommand is explicitly in
+/// its supported JSONL mode. This belongs in command construction, rather
+/// than a later argv scan, so user values such as `--model exec` or a prompt
+/// literally equal to `--json` cannot be mistaken for syntax.
+pub fn command_parts_for_codex_json_with_conversation(
+    harness_id: &str,
+    prompt: &str,
+    mode: HarnessLaunchMode,
+    hint: Option<&ConversationHint>,
+    familiar: Option<&FamiliarContext>,
+    options: HarnessLaunchOptions<'_>,
+) -> Result<(String, Vec<String>)> {
+    if harness_id != "codex" {
+        anyhow::bail!("Codex JSON command construction requested for `{harness_id}`");
+    }
+    command_parts_for_harness_with_conversation_inner(
+        harness_id, prompt, mode, hint, familiar, options, true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn command_parts_for_harness_with_conversation_inner(
+    harness_id: &str,
+    prompt: &str,
+    mode: HarnessLaunchMode,
+    hint: Option<&ConversationHint>,
+    familiar: Option<&FamiliarContext>,
+    options: HarnessLaunchOptions<'_>,
+    codex_json: bool,
+) -> Result<(String, Vec<String>)> {
     let specs = configured_harness_specs()?;
     let configured_ids = specs
         .iter()
@@ -1015,6 +1050,10 @@ pub fn command_parts_for_harness_with_conversation(
             ));
         }
         // Harness doesn't support stream: fall through to non-interactive.
+        let mut args = spec.prompt_args(&effective_prompt, HarnessLaunchMode::NonInteractive);
+        if codex_json {
+            add_codex_exec_json_flag(&spec, &mut args)?;
+        }
         return Ok((
             program,
             with_claude_permission_flags(
@@ -1023,7 +1062,7 @@ pub fn command_parts_for_harness_with_conversation(
                     &model_args,
                     &sandbox_args,
                     &launch_option_args,
-                    spec.prompt_args(&effective_prompt, HarnessLaunchMode::NonInteractive),
+                    args,
                 )),
             ),
         ));
@@ -1031,6 +1070,9 @@ pub fn command_parts_for_harness_with_conversation(
 
     if let Some(hint) = hint {
         if let Some(mut args) = continuity_args(&spec, mode, hint) {
+            if codex_json {
+                add_codex_exec_json_flag(&spec, &mut args)?;
+            }
             // Inject identity via --system-prompt for harnesses that support it.
             if let (Some(flag), Some(f)) = (spec.system_prompt_flag.as_deref(), familiar) {
                 args.insert(0, f.identity_preamble());
@@ -1051,6 +1093,9 @@ pub fn command_parts_for_harness_with_conversation(
     }
 
     let mut args = spec.prompt_args(&effective_prompt, mode);
+    if codex_json {
+        add_codex_exec_json_flag(&spec, &mut args)?;
+    }
     // Inject identity via --system-prompt for harnesses that support it,
     // prepending before the prompt args.
     if let (Some(flag), Some(f)) = (spec.system_prompt_flag.as_deref(), familiar) {
@@ -1069,6 +1114,25 @@ pub fn command_parts_for_harness_with_conversation(
             )),
         ),
     ))
+}
+
+/// Add `--json` directly after Codex's declared `exec` subcommand while the
+/// argument vector still consists only of harness-owned prefix args plus the
+/// final prompt. Launch options are prepended later, and the prompt is behind
+/// `--`, so neither can affect this structural insertion point.
+fn add_codex_exec_json_flag(spec: &HarnessCommandSpec, args: &mut Vec<String>) -> Result<()> {
+    let exec_index = spec
+        .non_interactive_prompt_prefix_args
+        .iter()
+        .position(|arg| arg == "exec")
+        .context("Codex adapter must declare an `exec` non-interactive subcommand")?;
+    if args.get(exec_index).map(String::as_str) != Some("exec") {
+        anyhow::bail!(
+            "Codex adapter's constructed command no longer contains `exec` at its declared position"
+        );
+    }
+    args.insert(exec_index + 1, "--json".to_string());
+    Ok(())
 }
 
 fn launch_option_args(harness_id: &str, options: HarnessLaunchOptions<'_>) -> Vec<String> {
@@ -2482,6 +2546,41 @@ mod tests {
         let model_pos = args.iter().position(|a| a == "--model").unwrap();
         let prompt_pos = args.iter().position(|a| a == "fix tests").unwrap();
         assert!(model_pos < prompt_pos);
+        Ok(())
+    }
+
+    #[test]
+    fn codex_json_mode_inserts_flag_at_the_declared_subcommand_not_user_values(
+    ) -> anyhow::Result<()> {
+        // Both values deliberately look like CLI syntax. The model value comes
+        // before the real `exec` subcommand, while the prompt is protected by
+        // the trailing `--` separator. JSON mode must be constructed from the
+        // harness spec, never by scanning those user-controlled entries.
+        let (_, args) = command_parts_for_codex_json_with_conversation(
+            "codex",
+            "--json",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                model: Some("openai/exec"),
+                ..Default::default()
+            },
+        )?;
+        assert_eq!(
+            args,
+            vec![
+                "--model".to_string(),
+                "exec".to_string(),
+                "exec".to_string(),
+                "--json".to_string(),
+                "--skip-git-repo-check".to_string(),
+                "--color".to_string(),
+                "never".to_string(),
+                "--".to_string(),
+                "--json".to_string(),
+            ]
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1932,9 +1932,10 @@ fn run_session(
 
     let (record, is_resume) = if let Some(ref id) = resumed_id {
         // Verify the session exists; reuse its row.
-        let existing = store::list_sessions_including_archived(&conn)?
-            .into_iter()
-            .find(|s| &s.id == id);
+        let existing = match store::get_session(&conn, id)? {
+            Some(record) => Some(record),
+            None => store::get_latest_session_by_conversation_id(&conn, id)?,
+        };
         match existing {
             Some(mut r) => {
                 // Mutate updated_at to now; keep labels/visibility/title from the original.
@@ -2031,6 +2032,7 @@ fn run_session(
                 is_error: false,
                 num_turns: 1,
                 session_id: record.id.clone(),
+                harness_session_id: None,
                 error: None,
             }))?;
         }
@@ -2045,10 +2047,9 @@ fn run_session(
         &current_timestamp(),
     )?;
 
-    // Claude's native stream-json: pipe its JSONL events through ours
-    // between the init/result frames we already emit. The codex / generic
-    // path below cannot do this because codex doesn't speak stream-json, so we
-    // branch here after resolving the harness to claude.
+    // Claude's native long-lived stream-json: pipe its JSONL events through
+    // ours between the init/result frames we already emit. Codex's `--json`
+    // protocol is one-shot and is bridged below after the harness is resolved.
     if stream_json && selected_harness.id == "claude" {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
@@ -2081,6 +2082,7 @@ fn run_session(
                     is_error: true,
                     num_turns: 1,
                     session_id: record.id.clone(),
+                    harness_session_id: None,
                     error: Some(format!("{error:#}")),
                 }))?;
                 return Err(error);
@@ -2105,6 +2107,7 @@ fn run_session(
             is_error,
             num_turns: 1,
             session_id: record.id.clone(),
+            harness_session_id: None,
             error: None,
         }))?;
         if archive {
@@ -2131,9 +2134,20 @@ fn run_session(
     }
 
     let conversation_hint = if is_resume {
-        Some(harness::ConversationHint::Resume {
-            id: record.id.clone(),
-        })
+        // Cave historically resumes through Coven's stable ledger id. Codex
+        // requires its own thread id, which we capture from `thread.started`
+        // and persist on the ledger row after the first turn. Accepting either
+        // form above keeps existing clients compatible while direct callers
+        // may pass the native thread id too.
+        let resume_id = if selected_harness.id == "codex" {
+            record
+                .conversation_id
+                .clone()
+                .unwrap_or_else(|| record.id.clone())
+        } else {
+            record.id.clone()
+        };
+        Some(harness::ConversationHint::Resume { id: resume_id })
     } else {
         None
     };
@@ -2151,15 +2165,113 @@ fn run_session(
     } else {
         harness_launch_mode_for_stdio(&selected_harness.id)
     };
-    let command = pty_runner::build_harness_command_with_conversation(
-        &selected_harness.id,
-        &effective_prompt,
-        &cwd,
-        launch_mode,
-        conversation_hint.as_ref(),
-        familiar_for_args,
-        launch_options,
-    )?;
+    let command = if stream_json && selected_harness.id == "codex" {
+        pty_runner::build_codex_json_harness_command_with_conversation(
+            &selected_harness.id,
+            &effective_prompt,
+            &cwd,
+            launch_mode,
+            conversation_hint.as_ref(),
+            familiar_for_args,
+            launch_options,
+        )?
+    } else {
+        pty_runner::build_harness_command_with_conversation(
+            &selected_harness.id,
+            &effective_prompt,
+            &cwd,
+            launch_mode,
+            conversation_hint.as_ref(),
+            familiar_for_args,
+            launch_options,
+        )?
+    };
+    if stream_json && selected_harness.id == "codex" {
+        let output_session_id = record.id.clone();
+        let outcome = pty_runner::stream_codex_json(&command, move |text| {
+            emit_stream_event(&stream_json::Event::Assistant(
+                stream_json::AssistantMessage {
+                    message: stream_json::MessageBody {
+                        role: "assistant".into(),
+                        content: vec![stream_json::ContentBlock::Text {
+                            text: text.to_string(),
+                        }],
+                    },
+                    session_id: output_session_id.clone(),
+                    stop_reason: Some("end_turn".into()),
+                },
+            ))
+        });
+        let outcome = match outcome {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                store::update_session_status(
+                    &conn,
+                    &record.id,
+                    FAILED_SESSION_STATUS,
+                    None,
+                    &current_timestamp(),
+                )?;
+                emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+                    subtype: "error_during_execution".into(),
+                    duration_ms: stream_started.elapsed().as_millis() as u64,
+                    is_error: true,
+                    num_turns: 1,
+                    session_id: record.id.clone(),
+                    harness_session_id: None,
+                    error: Some(format!("{error:#}")),
+                }))?;
+                return Err(error);
+            }
+        };
+        if let Some(thread_id) = outcome.harness_session_id.as_deref() {
+            store::update_session_conversation_id(
+                &conn,
+                &record.id,
+                thread_id,
+                &current_timestamp(),
+            )?;
+        }
+        let is_error =
+            outcome.error.is_some() || outcome.process.exit_code.is_some_and(|code| code != 0);
+        store::update_session_status(
+            &conn,
+            &record.id,
+            if is_error {
+                FAILED_SESSION_STATUS
+            } else {
+                outcome.process.status
+            },
+            outcome.process.exit_code,
+            &current_timestamp(),
+        )?;
+        emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+            subtype: if is_error {
+                "error_during_execution".into()
+            } else {
+                "success".into()
+            },
+            duration_ms: stream_started.elapsed().as_millis() as u64,
+            is_error,
+            num_turns: 1,
+            session_id: record.id.clone(),
+            harness_session_id: outcome.harness_session_id.clone(),
+            error: outcome.error.clone(),
+        }))?;
+        if archive {
+            let archived_at = current_timestamp();
+            store::archive_session(&conn, &record.id, &archived_at)?;
+        }
+        if is_error {
+            let exit_code = outcome
+                .process
+                .exit_code
+                .filter(|code| *code != 0)
+                .unwrap_or(1);
+            exit_with_session_code(exit_code, true);
+        }
+        return Ok(());
+    }
     // Preserve the JSONL-only captured-output contract from #315 on
     // non-Windows platforms. Windows Codex must bypass ConPTY and use the
     // verified ordinary-pipe path so Cave receives a terminal response.
@@ -2217,6 +2329,7 @@ fn run_session(
                     is_error,
                     num_turns: 1,
                     session_id: record.id.clone(),
+                    harness_session_id: None,
                     error: None,
                 }))?;
             }
@@ -2247,6 +2360,7 @@ fn run_session(
                     is_error: true,
                     num_turns: 1,
                     session_id: record.id.clone(),
+                    harness_session_id: None,
                     error: Some(format!("{error:#}")),
                 }))?;
             }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1,7 +1,14 @@
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::mpsc::{self, RecvTimeoutError};
 use std::thread;
+use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::sync::atomic::{AtomicI32, Ordering};
+#[cfg(unix)]
+use std::sync::{Mutex, MutexGuard};
 
 use anyhow::{Context, Result};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
@@ -19,6 +26,19 @@ pub struct HarnessCommand {
 pub struct PtyRunResult {
     pub status: &'static str,
     pub exit_code: Option<i32>,
+}
+
+/// Outcome of Coven's one-shot `codex exec --json` bridge.
+///
+/// `harness_session_id` is the Codex thread id, not Coven's ledger session
+/// id. Callers keep the two separate so they can expose a stable Coven id yet
+/// resume the actual Codex conversation on a later turn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexJsonRunResult {
+    pub process: PtyRunResult,
+    pub harness_session_id: Option<String>,
+    pub error: Option<String>,
+    pub emitted_assistant: bool,
 }
 
 pub struct DetachedPtySession {
@@ -81,14 +101,74 @@ pub fn build_harness_command_with_conversation(
     familiar: Option<&crate::harness::FamiliarContext>,
     options: crate::harness::HarnessLaunchOptions<'_>,
 ) -> Result<HarnessCommand> {
-    let (program, mut args) = crate::harness::command_parts_for_harness_with_conversation(
+    build_harness_command_with_conversation_inner(
         harness_id,
         prompt,
+        cwd,
         mode,
         conversation,
         familiar,
         options,
-    )?;
+        false,
+    )
+}
+
+/// Build the dedicated one-shot Codex JSON command used by the stream bridge.
+/// Keeping JSON-mode construction here makes the actual Codex `exec` token
+/// explicit before user-controlled launch values or the trailing prompt are
+/// added to argv.
+#[allow(clippy::too_many_arguments)]
+pub fn build_codex_json_harness_command_with_conversation(
+    harness_id: &str,
+    prompt: &str,
+    cwd: &Path,
+    mode: crate::harness::HarnessLaunchMode,
+    conversation: Option<&crate::harness::ConversationHint>,
+    familiar: Option<&crate::harness::FamiliarContext>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
+) -> Result<HarnessCommand> {
+    build_harness_command_with_conversation_inner(
+        harness_id,
+        prompt,
+        cwd,
+        mode,
+        conversation,
+        familiar,
+        options,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_harness_command_with_conversation_inner(
+    harness_id: &str,
+    prompt: &str,
+    cwd: &Path,
+    mode: crate::harness::HarnessLaunchMode,
+    conversation: Option<&crate::harness::ConversationHint>,
+    familiar: Option<&crate::harness::FamiliarContext>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
+    codex_json: bool,
+) -> Result<HarnessCommand> {
+    let (program, mut args) = if codex_json {
+        crate::harness::command_parts_for_codex_json_with_conversation(
+            harness_id,
+            prompt,
+            mode,
+            conversation,
+            familiar,
+            options,
+        )?
+    } else {
+        crate::harness::command_parts_for_harness_with_conversation(
+            harness_id,
+            prompt,
+            mode,
+            conversation,
+            familiar,
+            options,
+        )?
+    };
     let familiar_prompt;
     let stdin_prompt_text = if harness_id == "codex" {
         if let Some(familiar) = familiar {
@@ -163,6 +243,772 @@ fn write_stdin_prompt(child: &mut std::process::Child, prompt: Option<&[u8]>) ->
     result
 }
 
+const CODEX_JSON_ACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+const CODEX_POST_EXIT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+const CODEX_CHILD_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const CODEX_STDERR_TAIL_BYTES: usize = 8 * 1024;
+
+// `codex exec --json` runs in a separate Unix session so a timeout can clean
+// up an npm/Node/Codex tree in one operation. That also means a TERM sent to
+// coven itself would otherwise leave the child group behind. The scoped guard
+// below records the cancellation in an async-signal-safe handler; the runner
+// then performs ordinary cleanup and emits its terminal result.
+#[cfg(unix)]
+static CODEX_JSON_CANCELLATION_SIGNAL: AtomicI32 = AtomicI32::new(0);
+#[cfg(unix)]
+static CODEX_JSON_PROCESS_GROUP: AtomicI32 = AtomicI32::new(0);
+#[cfg(unix)]
+static CODEX_JSON_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(unix)]
+extern "C" fn record_codex_json_cancellation(signal: libc::c_int) {
+    // Atomic operations and kill(2) are async-signal-safe. The supervisor
+    // turns the flag into a failed ledger/result update on its next <=50 ms
+    // poll; killing the group here prevents a detached Codex descendant from
+    // surviving if that poll is delayed.
+    let process_group = CODEX_JSON_PROCESS_GROUP.load(Ordering::Relaxed);
+    if process_group > 0 {
+        unsafe {
+            let _ = libc::kill(-process_group, libc::SIGKILL);
+        }
+    }
+    CODEX_JSON_CANCELLATION_SIGNAL.store(signal, Ordering::Relaxed);
+}
+
+/// Temporarily converts TERM/INT/HUP into a supervised bridge cancellation.
+///
+/// Signal dispositions are process-global, so runs in one process are
+/// serialized while the guard is installed. The old dispositions are restored
+/// before releasing that lock, preserving normal signal behavior for other
+/// Coven commands and unit tests.
+#[cfg(unix)]
+struct CodexCancellationGuard {
+    _lock: MutexGuard<'static, ()>,
+    previous_handlers: Vec<(libc::c_int, libc::sigaction)>,
+}
+
+#[cfg(unix)]
+impl CodexCancellationGuard {
+    fn install() -> Result<Self> {
+        let lock = CODEX_JSON_CANCELLATION_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        CODEX_JSON_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+        CODEX_JSON_PROCESS_GROUP.store(0, Ordering::Relaxed);
+
+        let mut previous_handlers = Vec::with_capacity(3);
+        for signal in [libc::SIGTERM, libc::SIGINT, libc::SIGHUP] {
+            // SAFETY: sigaction is the POSIX interface for installing a signal
+            // handler. The handler uses only atomics and kill(2), and each
+            // successful installation retains the prior disposition for Drop.
+            unsafe {
+                let mut action: libc::sigaction = std::mem::zeroed();
+                action.sa_sigaction = record_codex_json_cancellation as *const () as usize;
+                libc::sigemptyset(&mut action.sa_mask);
+                action.sa_flags = 0;
+                let mut previous: libc::sigaction = std::mem::zeroed();
+                if libc::sigaction(signal, &action, &mut previous) != 0 {
+                    for (installed_signal, installed_previous) in previous_handlers.iter().rev() {
+                        let _ = libc::sigaction(
+                            *installed_signal,
+                            installed_previous,
+                            std::ptr::null_mut(),
+                        );
+                    }
+                    CODEX_JSON_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+                    return Err(std::io::Error::last_os_error()).with_context(|| {
+                        format!("failed to install Codex cancellation handler for signal {signal}")
+                    });
+                }
+                previous_handlers.push((signal, previous));
+            }
+        }
+
+        Ok(Self {
+            _lock: lock,
+            previous_handlers,
+        })
+    }
+
+    fn arm(&self, process_group: u32) {
+        CODEX_JSON_PROCESS_GROUP.store(process_group as i32, Ordering::Relaxed);
+    }
+
+    fn disarm(&self) {
+        CODEX_JSON_PROCESS_GROUP.store(0, Ordering::Relaxed);
+    }
+
+    fn cancelled_signal(&self) -> Option<libc::c_int> {
+        let signal = CODEX_JSON_CANCELLATION_SIGNAL.load(Ordering::Relaxed);
+        (signal != 0).then_some(signal)
+    }
+}
+
+#[cfg(unix)]
+impl Drop for CodexCancellationGuard {
+    fn drop(&mut self) {
+        CODEX_JSON_PROCESS_GROUP.store(0, Ordering::Relaxed);
+        // SAFETY: every entry was captured from a successful sigaction call
+        // in install. Restoring it here makes the scope transparent once the
+        // bridge has reaped its child tree.
+        unsafe {
+            for (signal, previous) in self.previous_handlers.iter().rev() {
+                let _ = libc::sigaction(*signal, previous, std::ptr::null_mut());
+            }
+        }
+        CODEX_JSON_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+    }
+}
+
+#[cfg(not(unix))]
+struct CodexCancellationGuard;
+
+#[cfg(not(unix))]
+impl CodexCancellationGuard {
+    fn install() -> Result<Self> {
+        Ok(Self)
+    }
+
+    fn arm(&self, _process_group: u32) {}
+
+    fn disarm(&self) {}
+}
+
+#[cfg(unix)]
+fn codex_cancellation_error(guard: &CodexCancellationGuard) -> Option<String> {
+    guard.cancelled_signal().map(|signal| {
+        let name = match signal {
+            libc::SIGTERM => "SIGTERM",
+            libc::SIGINT => "SIGINT",
+            libc::SIGHUP => "SIGHUP",
+            _ => "a termination signal",
+        };
+        format!("Codex turn cancelled by {name}; the process tree was terminated")
+    })
+}
+
+#[cfg(not(unix))]
+fn codex_cancellation_error(_guard: &CodexCancellationGuard) -> Option<String> {
+    None
+}
+
+fn codex_json_activity_timeout() -> Duration {
+    // Integration tests execute the real `coven` binary, not the unit-test
+    // crate, so `cfg(test)` cannot inject a short deadline into that child.
+    // Keep this hook out of release builds while still making the terminal
+    // timeout/result/ledger path testable without waiting five minutes.
+    #[cfg(debug_assertions)]
+    if let Some(timeout_ms) = std::env::var("COVEN_TEST_CODEX_JSON_IDLE_TIMEOUT_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .filter(|timeout_ms| *timeout_ms > 0)
+    {
+        return Duration::from_millis(timeout_ms);
+    }
+    CODEX_JSON_ACTIVITY_TIMEOUT
+}
+
+enum CodexStdoutMessage {
+    Line(String),
+    ReadError(String),
+}
+
+enum CodexRunnerMessage {
+    Stdout(CodexStdoutMessage),
+    StdoutClosed,
+    StderrClosed(Vec<u8>),
+    StdinComplete(std::result::Result<(), String>),
+}
+
+#[derive(Default)]
+struct CodexJsonState {
+    harness_session_id: Option<String>,
+    protocol_error: Option<String>,
+    emitted_assistant: bool,
+}
+
+/// Owns the direct Codex child and all of its descendants while a one-shot
+/// JSON turn is running. A Node/npm wrapper can outlive or outspawn the direct
+/// launcher, so a plain `Child::kill()` is not enough to guarantee pipe EOF.
+struct CodexProcessTree {
+    pid: u32,
+    terminated: bool,
+    #[cfg(windows)]
+    job_handle: Option<windows_sys::Win32::Foundation::HANDLE>,
+}
+
+impl CodexProcessTree {
+    fn attach(child: &std::process::Child) -> Self {
+        let pid = child.id();
+        #[cfg(windows)]
+        let job_handle = codex_job_object_for_process(child);
+        Self {
+            pid,
+            terminated: false,
+            #[cfg(windows)]
+            job_handle,
+        }
+    }
+
+    fn terminate(&mut self, child: &mut std::process::Child) {
+        if self.terminated {
+            return;
+        }
+        self.terminated = true;
+        #[cfg(unix)]
+        {
+            terminate_codex_unix_process_group(self.pid);
+        }
+        #[cfg(windows)]
+        {
+            let terminated_by_job = self
+                .job_handle
+                .take()
+                .map(|job| {
+                    let succeeded = unsafe {
+                        windows_sys::Win32::System::JobObjects::TerminateJobObject(job, 1) != 0
+                    };
+                    unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+                    succeeded
+                })
+                .unwrap_or(false);
+            if !terminated_by_job {
+                // A Job Object can be unavailable when a parent policy forbids
+                // assignment. Fall back to Windows' documented tree kill for
+                // npm's cmd.exe -> node.exe -> codex.exe chain.
+                let pid = self.pid.to_string();
+                let _ = std::process::Command::new("taskkill")
+                    .args(["/PID", &pid, "/T", "/F"])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .status();
+            }
+        }
+        let _ = child.kill();
+    }
+}
+
+#[cfg(unix)]
+fn terminate_codex_unix_process_group(pid: u32) {
+    // The launch config puts the child at the head of a new session, so the
+    // negative pid reaches its wrapper and every descendant.
+    let _ = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+}
+
+#[cfg(unix)]
+impl Drop for CodexProcessTree {
+    fn drop(&mut self) {
+        if !self.terminated {
+            // A wrapper can exit after detaching a descendant that has already
+            // closed stdout/stderr. There is then no pipe timeout to trigger
+            // terminate(), but this one-shot runner still owns that group.
+            terminate_codex_unix_process_group(self.pid);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for CodexProcessTree {
+    fn drop(&mut self) {
+        if let Some(job) = self.job_handle.take() {
+            // The job is configured with KILL_ON_JOB_CLOSE, so an abrupt
+            // coven.exe exit also cleans up npm/Node/Codex descendants.
+            unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+        }
+    }
+}
+
+#[cfg(windows)]
+fn codex_job_object_for_process(
+    child: &std::process::Child,
+) -> Option<windows_sys::Win32::Foundation::HANDLE> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        },
+    };
+
+    unsafe {
+        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        if job == INVALID_HANDLE_VALUE || job == 0 as _ {
+            return None;
+        }
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let limits_set = SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &limits as *const _ as *const std::ffi::c_void,
+            size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        ) != 0;
+        // Child already owns the CreateProcess handle with the permissions
+        // required for assignment, avoiding a pid reuse race through
+        // OpenProcess.
+        let assigned = AssignProcessToJobObject(job, child.as_raw_handle() as _) != 0;
+        if !limits_set || !assigned {
+            CloseHandle(job);
+            return None;
+        }
+        Some(job)
+    }
+}
+
+fn configure_codex_json_command(_command: &mut std::process::Command) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            _command.pre_exec(|| {
+                // Isolate this turn in a fresh process group. A timeout can
+                // then kill the npm/Node/native Codex tree in one signal.
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+}
+
+/// Run one non-interactive Codex turn through its supported JSONL protocol.
+///
+/// This intentionally uses ordinary OS pipes on every platform. In
+/// particular, Windows npm installs expose `codex.cmd`; putting that shim
+/// behind ConPTY can stall before the real Node/Codex process starts. The
+/// existing command builder keeps a Windows prompt on stdin (`codex exec -`),
+/// so this runner neither needs a shell nor puts user text in a batch command
+/// line.
+pub fn stream_codex_json<F>(command: &HarnessCommand, on_assistant: F) -> Result<CodexJsonRunResult>
+where
+    F: FnMut(&str) -> Result<()>,
+{
+    stream_codex_json_with_timeouts(
+        command,
+        codex_json_activity_timeout(),
+        CODEX_POST_EXIT_DRAIN_TIMEOUT,
+        on_assistant,
+    )
+}
+
+#[cfg(test)]
+fn stream_codex_json_with_timeout<F>(
+    command: &HarnessCommand,
+    activity_timeout: Duration,
+    on_assistant: F,
+) -> Result<CodexJsonRunResult>
+where
+    F: FnMut(&str) -> Result<()>,
+{
+    stream_codex_json_with_timeouts(
+        command,
+        activity_timeout,
+        CODEX_POST_EXIT_DRAIN_TIMEOUT,
+        on_assistant,
+    )
+}
+
+fn stream_codex_json_with_timeouts<F>(
+    command: &HarnessCommand,
+    activity_timeout: Duration,
+    post_exit_drain_timeout: Duration,
+    mut on_assistant: F,
+) -> Result<CodexJsonRunResult>
+where
+    F: FnMut(&str) -> Result<()>,
+{
+    let prompt_separator = command
+        .args
+        .iter()
+        .position(|arg| arg == "--")
+        .context("Codex JSON bridge expected a prompt separator")?;
+    if !command.args[..prompt_separator]
+        .iter()
+        .any(|arg| arg == "--json")
+    {
+        anyhow::bail!("Codex JSON bridge expected `--json` to be constructed before the prompt");
+    }
+
+    let mut child_command = std::process::Command::new(&command.program);
+    child_command
+        .args(&command.args)
+        .current_dir(&command.cwd)
+        .stdin(if command.stdin_prompt.is_some() {
+            Stdio::piped()
+        } else {
+            // A one-shot prompt is already an argv positional on non-Windows
+            // hosts. Do not inherit Coven's stdin: Codex may otherwise wait
+            // for additional input after a completed request.
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    configure_codex_json_command(&mut child_command);
+    let cancellation = CodexCancellationGuard::install()?;
+    if let Some(error) = codex_cancellation_error(&cancellation) {
+        anyhow::bail!(error);
+    }
+    let mut child = child_command.spawn().with_context(|| {
+        format!(
+            "failed to spawn harness `{}` in Codex JSON mode",
+            command.program()
+        )
+    })?;
+    let mut process_tree = CodexProcessTree::attach(&child);
+    cancellation.arm(process_tree.pid);
+
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            process_tree.terminate(&mut child);
+            let _ = child.wait();
+            anyhow::bail!("Codex JSON runner did not expose stdout");
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            process_tree.terminate(&mut child);
+            let _ = child.wait();
+            anyhow::bail!("Codex JSON runner did not expose stderr");
+        }
+    };
+
+    let (sender, receiver) = mpsc::channel();
+    let stdin_pending = if let Some(prompt) = command.stdin_prompt.clone() {
+        let stdin = match child.stdin.take() {
+            Some(stdin) => stdin,
+            None => {
+                process_tree.terminate(&mut child);
+                let _ = child.wait();
+                anyhow::bail!("Codex JSON runner did not expose stdin for its prompt");
+            }
+        };
+        let sender = sender.clone();
+        thread::spawn(move || {
+            let result = (|| -> std::io::Result<()> {
+                let mut stdin = stdin;
+                stdin.write_all(&prompt)?;
+                stdin.flush()
+            })()
+            .map_err(|error| format!("failed writing Codex prompt to stdin: {error}"));
+            let _ = sender.send(CodexRunnerMessage::StdinComplete(result));
+        });
+        true
+    } else {
+        false
+    };
+
+    let stdout_sender = sender.clone();
+    thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let message = match line {
+                Ok(line) => CodexStdoutMessage::Line(line),
+                Err(error) => CodexStdoutMessage::ReadError(error.to_string()),
+            };
+            if stdout_sender
+                .send(CodexRunnerMessage::Stdout(message))
+                .is_err()
+            {
+                return;
+            }
+        }
+        let _ = stdout_sender.send(CodexRunnerMessage::StdoutClosed);
+    });
+    let stderr_sender = sender.clone();
+    thread::spawn(move || {
+        let mut reader = BufReader::new(stderr);
+        let mut tail = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(count) => {
+                    append_bounded_tail(&mut tail, &buffer[..count], CODEX_STDERR_TAIL_BYTES)
+                }
+                Err(_) => break,
+            }
+        }
+        let _ = stderr_sender.send(CodexRunnerMessage::StderrClosed(tail));
+    });
+    drop(sender);
+
+    let mut state = CodexJsonState::default();
+    let mut last_activity = Instant::now();
+    let mut status = None;
+    let mut post_exit_deadline = None;
+    let mut stdout_closed = false;
+    let mut stderr_tail = None;
+    let mut stdin_complete = !stdin_pending;
+
+    loop {
+        if let Some(error) = codex_cancellation_error(&cancellation) {
+            state.protocol_error.get_or_insert(error);
+            process_tree.terminate(&mut child);
+            status = Some(
+                child
+                    .wait()
+                    .context("failed waiting for cancelled Codex process")?,
+            );
+            break;
+        }
+        if status.is_none() {
+            status = child
+                .try_wait()
+                .context("failed polling Codex JSON process")?;
+            if status.is_some() {
+                post_exit_deadline = Some(Instant::now() + post_exit_drain_timeout);
+            }
+        }
+        if status.is_some() && stdout_closed && stderr_tail.is_some() && stdin_complete {
+            break;
+        }
+
+        let remaining = if let Some(deadline) = post_exit_deadline {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or_default();
+            if remaining.is_zero() {
+                state.protocol_error.get_or_insert_with(|| {
+                    "Codex exited but its output pipes remained open; terminated remaining process tree"
+                        .to_string()
+                });
+                process_tree.terminate(&mut child);
+                break;
+            }
+            remaining
+        } else {
+            let remaining = activity_timeout
+                .checked_sub(last_activity.elapsed())
+                .unwrap_or_default();
+            if remaining.is_zero() {
+                state.protocol_error.get_or_insert_with(|| {
+                    format!(
+                        "Codex produced no machine-readable activity for {} seconds; the process was terminated",
+                        activity_timeout.as_secs()
+                    )
+                });
+                process_tree.terminate(&mut child);
+                status = Some(
+                    child
+                        .wait()
+                        .context("failed waiting for timed-out Codex process")?,
+                );
+                break;
+            }
+            remaining
+        };
+
+        match receiver.recv_timeout(remaining.min(CODEX_CHILD_POLL_INTERVAL)) {
+            Ok(CodexRunnerMessage::Stdout(CodexStdoutMessage::Line(line))) => {
+                match handle_codex_json_line(&line, &mut state, &mut on_assistant) {
+                    Ok(true) => last_activity = Instant::now(),
+                    Ok(false) => {}
+                    Err(error) => {
+                        process_tree.terminate(&mut child);
+                        let _ = child.wait();
+                        return Err(error);
+                    }
+                }
+                if state.protocol_error.is_some() {
+                    process_tree.terminate(&mut child);
+                    status = Some(
+                        child
+                            .wait()
+                            .context("failed waiting for failed Codex turn")?,
+                    );
+                    break;
+                }
+            }
+            Ok(CodexRunnerMessage::Stdout(CodexStdoutMessage::ReadError(error))) => {
+                state
+                    .protocol_error
+                    .get_or_insert_with(|| format!("failed reading Codex JSON output: {error}"));
+                process_tree.terminate(&mut child);
+                status = Some(
+                    child
+                        .wait()
+                        .context("failed waiting for Codex after stdout error")?,
+                );
+                break;
+            }
+            Ok(CodexRunnerMessage::StdoutClosed) => stdout_closed = true,
+            Ok(CodexRunnerMessage::StderrClosed(tail)) => stderr_tail = Some(tail),
+            Ok(CodexRunnerMessage::StdinComplete(Ok(()))) => stdin_complete = true,
+            Ok(CodexRunnerMessage::StdinComplete(Err(error))) => {
+                state.protocol_error.get_or_insert(error);
+                process_tree.terminate(&mut child);
+                status = Some(
+                    child
+                        .wait()
+                        .context("failed waiting for Codex after stdin write error")?,
+                );
+                break;
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => {
+                // Keep polling the child/deadline. Detached reader threads may
+                // have gone away immediately after their final event.
+            }
+        }
+    }
+
+    // A signal can arrive just after the final polling iteration. Honor it
+    // before reporting a completed turn so cancellation always reaches the
+    // ledger and terminal result when the runner still owns the child tree.
+    if let Some(error) = codex_cancellation_error(&cancellation) {
+        state.protocol_error.get_or_insert(error);
+        process_tree.terminate(&mut child);
+    }
+
+    let status = match status {
+        Some(status) => status,
+        None => child
+            .wait()
+            .context("failed waiting for Codex JSON process")?,
+    };
+    let stderr_tail = stderr_tail.unwrap_or_default();
+
+    if !status.success() && state.protocol_error.is_none() {
+        let code = status
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "an unknown status".to_string());
+        let stderr = String::from_utf8_lossy(&stderr_tail).trim().to_string();
+        let message = if stderr.is_empty() {
+            format!("Codex exited with {code}")
+        } else {
+            format!("Codex exited with {code}: {stderr}")
+        };
+        state.protocol_error = Some(message);
+    }
+    if !state.emitted_assistant && state.protocol_error.is_none() {
+        state.protocol_error = Some("Codex completed without an assistant message".to_string());
+    }
+    let failed = !status.success() || state.protocol_error.is_some();
+    let exit_code = if failed {
+        status.code().filter(|code| *code != 0).or(Some(1))
+    } else {
+        status.code()
+    };
+    // The direct child has reached a terminal status. Do not leave its former
+    // pid armed in the async signal handler during the final return/drop
+    // window, where a recycled pid could otherwise be targeted.
+    cancellation.disarm();
+
+    Ok(CodexJsonRunResult {
+        process: PtyRunResult {
+            status: if failed { "failed" } else { "completed" },
+            exit_code,
+        },
+        harness_session_id: state.harness_session_id,
+        error: state.protocol_error,
+        emitted_assistant: state.emitted_assistant,
+    })
+}
+
+/// Parse one Codex JSONL frame. Returns whether it was a well-formed Codex
+/// event, which is the unit that resets the runner's activity deadline.
+fn handle_codex_json_line<F>(
+    line: &str,
+    state: &mut CodexJsonState,
+    on_assistant: &mut F,
+) -> Result<bool>
+where
+    F: FnMut(&str) -> Result<()>,
+{
+    let Ok(event) = serde_json::from_str::<serde_json::Value>(line) else {
+        // `--json` promises JSONL. Ignore an unexpected diagnostic here rather
+        // than contaminating Coven's own stdout protocol; if Codex produces no
+        // valid activity, the bounded timeout reports it.
+        return Ok(false);
+    };
+    let Some(kind) = event.get("type").and_then(serde_json::Value::as_str) else {
+        return Ok(false);
+    };
+    match kind {
+        "thread.started" => {
+            if let Some(thread_id) = event.get("thread_id").and_then(serde_json::Value::as_str) {
+                state.harness_session_id = Some(thread_id.to_string());
+            }
+        }
+        "item.completed" => {
+            let Some(item) = event.get("item") else {
+                return Ok(true);
+            };
+            if item.get("type").and_then(serde_json::Value::as_str) == Some("agent_message") {
+                if let Some(text) = item.get("text").and_then(serde_json::Value::as_str) {
+                    if !text.is_empty() {
+                        on_assistant(text)?;
+                        state.emitted_assistant = true;
+                    }
+                }
+            }
+        }
+        "turn.failed" | "error" => {
+            if let Some(message) = codex_event_error_message(&event) {
+                state.protocol_error.get_or_insert(message);
+            } else {
+                state.protocol_error.get_or_insert_with(|| {
+                    format!("Codex reported {kind} without an error message")
+                });
+            }
+        }
+        _ => {}
+    }
+    Ok(true)
+}
+
+fn append_bounded_tail(tail: &mut Vec<u8>, chunk: &[u8], max_bytes: usize) {
+    if chunk.len() >= max_bytes {
+        tail.clear();
+        tail.extend_from_slice(&chunk[chunk.len() - max_bytes..]);
+        return;
+    }
+    let excess = tail
+        .len()
+        .saturating_add(chunk.len())
+        .saturating_sub(max_bytes);
+    if excess > 0 {
+        tail.drain(..excess);
+    }
+    tail.extend_from_slice(chunk);
+}
+
+fn codex_event_error_message(event: &serde_json::Value) -> Option<String> {
+    if let Some(error) = event.get("error") {
+        match error {
+            serde_json::Value::String(message) if !message.trim().is_empty() => {
+                return Some(message.clone());
+            }
+            serde_json::Value::Object(_) => {
+                if let Some(message) = error
+                    .get("message")
+                    .and_then(serde_json::Value::as_str)
+                    .filter(|message| !message.trim().is_empty())
+                {
+                    return Some(message.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    // Codex currently emits some `type:"error"` frames as
+    // `{ "message": "..." }` rather than nesting the message under `error`.
+    // Keep the bridge tolerant of both documented JSONL shapes.
+    event
+        .get("message")
+        .and_then(serde_json::Value::as_str)
+        .filter(|message| !message.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
 pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
     let pty_system = native_pty_system();
     run_attached_with_pty_system(command, pty_system.as_ref())
@@ -173,8 +1019,8 @@ pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
 /// handed to `on_output` in order and is guaranteed valid UTF-8 (codepoints
 /// split across reads are reassembled by `drain_detached_output`).
 ///
-/// This is the `--stream-json` path for harnesses without a native
-/// stream-json protocol (codex, external adapters): stdout must stay
+/// This is the `--stream-json` path for external harnesses without a native
+/// machine-readable bridge: stdout must stay
 /// JSONL-only, so the raw PTY output (ANSI escapes, prompts, partial lines)
 /// is wrapped into `output` events by the caller rather than interleaving
 /// with the frames (#307). Stdin is still forwarded to the PTY, matching
@@ -964,6 +1810,321 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn codex_json_runner_normalizes_agent_message_and_captures_thread() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_codex = temp_dir.path().join("fake-codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-123"}'
+printf '%s\n' '{"type":"turn.started"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"Coven reply"}}'
+printf '%s\n' '{"type":"turn.completed"}'
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+        let command = HarnessCommand {
+            program: fake_codex.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--model".to_string(),
+                "gpt-5.5".to_string(),
+                "--".to_string(),
+                "reply exactly once".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+        };
+        let mut assistant = Vec::new();
+
+        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(1), |text| {
+            assistant.push(text.to_string());
+            Ok(())
+        })?;
+
+        assert_eq!(
+            std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
+            "exec\n--json\n--model\ngpt-5.5\n--\nreply exactly once\n"
+        );
+        assert_eq!(assistant, vec!["Coven reply"]);
+        assert_eq!(outcome.harness_session_id.as_deref(), Some("thread-123"));
+        assert!(outcome.emitted_assistant);
+        assert!(outcome.error.is_none());
+        assert_eq!(outcome.process.exit_code, Some(0));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_json_runner_times_out_and_reaps_a_silent_child() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_codex = temp_dir.path().join("fake-codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+echo $$ > child.pid
+exec sleep 10
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+        let command = HarnessCommand {
+            program: fake_codex.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "prompt".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+        };
+
+        let started = Instant::now();
+        let outcome =
+            stream_codex_json_with_timeout(&command, Duration::from_millis(25), |_| Ok(()))?;
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("terminated")));
+        let pid = std::fs::read_to_string(temp_dir.path().join("child.pid"))?;
+        let pid = pid.trim();
+        let alive = std::process::Command::new("kill")
+            .args(["-0", pid])
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        assert!(!alive, "timed-out child {pid} should be reaped");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_json_runner_times_out_while_a_large_prompt_is_still_writing() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_codex = temp_dir.path().join("silent-codex");
+        std::fs::write(&fake_codex, "#!/bin/sh\nexec sleep 10\n")?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+        let command = HarnessCommand {
+            program: fake_codex.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "-".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            // Far larger than an anonymous-pipe buffer. A synchronous write
+            // would block indefinitely because the fake harness never reads.
+            stdin_prompt: Some(vec![b'x'; 1024 * 1024]),
+        };
+
+        let started = Instant::now();
+        let outcome =
+            stream_codex_json_with_timeout(&command, Duration::from_millis(25), |_| Ok(()))?;
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("terminated")));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_json_runner_reaps_a_pipe_holding_descendant_after_wrapper_exit() -> anyhow::Result<()>
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_codex = temp_dir.path().join("wrapper-codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+sleep 10 &
+echo $! > descendant.pid
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+        let command = HarnessCommand {
+            program: fake_codex.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "prompt".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+        };
+
+        let started = Instant::now();
+        let outcome = stream_codex_json_with_timeouts(
+            &command,
+            Duration::from_secs(1),
+            Duration::from_millis(25),
+            |_| Ok(()),
+        )?;
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("pipes remained open")));
+        let pid = std::fs::read_to_string(temp_dir.path().join("descendant.pid"))?;
+        let pid = pid.trim();
+        let mut alive = true;
+        for _ in 0..20 {
+            alive = std::process::Command::new("kill")
+                .args(["-0", pid])
+                .stderr(Stdio::null())
+                .status()
+                .map(|status| status.success())
+                .unwrap_or(false);
+            if !alive {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            !alive,
+            "descendant {pid} should be reaped with its process group"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_json_runner_reaps_a_closed_pipe_descendant_after_wrapper_exit() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_codex = temp_dir.path().join("wrapper-codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+sleep 10 </dev/null >/dev/null 2>&1 &
+echo $! > descendant.pid
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-closed-pipe"}'
+printf '%s\n' '{"type":"item.completed","item":{"type":"agent_message","text":"reply before wrapper failure"}}'
+exit 23
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+        let command = HarnessCommand {
+            program: fake_codex.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "prompt".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+        };
+        let mut assistant = Vec::new();
+
+        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(1), |text| {
+            assistant.push(text.to_string());
+            Ok(())
+        })?;
+
+        assert_eq!(assistant, vec!["reply before wrapper failure"]);
+        assert_eq!(outcome.process.status, "failed");
+        assert_eq!(outcome.process.exit_code, Some(23));
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("Codex exited with 23")));
+        let pid = std::fs::read_to_string(temp_dir.path().join("descendant.pid"))?;
+        let pid = pid.trim();
+        let mut alive = true;
+        for _ in 0..20 {
+            alive = std::process::Command::new("kill")
+                .args(["-0", pid])
+                .stderr(Stdio::null())
+                .status()
+                .map(|status| status.success())
+                .unwrap_or(false);
+            if !alive {
+                break;
+            }
+            thread::sleep(Duration::from_millis(25));
+        }
+        assert!(
+            !alive,
+            "closed-pipe descendant {pid} should be reaped with its process group"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_json_runner_synthesizes_nonzero_exit_for_protocol_error() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = fake_claude_spawn_guard();
+        let temp_dir = tempfile::tempdir()?;
+        let fake_codex = temp_dir.path().join("failed-codex");
+        std::fs::write(
+            &fake_codex,
+            r#"#!/bin/sh
+printf '%s\n' '{"type":"turn.failed","error":{"message":"fake turn failure"}}'
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+        let command = HarnessCommand {
+            program: fake_codex.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "prompt".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+        };
+
+        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(1), |_| Ok(()))?;
+
+        assert_eq!(outcome.process.status, "failed");
+        assert_eq!(outcome.process.exit_code, Some(1));
+        assert_eq!(outcome.error.as_deref(), Some("fake turn failure"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn stream_claude_forwards_jsonl_and_returns_exit_code() -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
@@ -1369,6 +2530,29 @@ exit 0
         assert_eq!(stdin_prompt.as_deref(), Some(prompt.as_bytes()));
     }
 
+    #[test]
+    fn codex_top_level_error_message_is_preserved() -> anyhow::Result<()> {
+        let mut state = CodexJsonState::default();
+        let mut assistant = Vec::new();
+
+        let valid = handle_codex_json_line(
+            r#"{"type":"error","message":"request rejected by Codex"}"#,
+            &mut state,
+            &mut |text| {
+                assistant.push(text.to_string());
+                Ok(())
+            },
+        )?;
+
+        assert!(valid);
+        assert_eq!(
+            state.protocol_error.as_deref(),
+            Some("request rejected by Codex")
+        );
+        assert!(assistant.is_empty());
+        Ok(())
+    }
+
     #[cfg(windows)]
     #[test]
     fn windows_codex_stdin_prompt_keeps_familiar_identity() -> anyhow::Result<()> {
@@ -1437,6 +2621,98 @@ exit 0
         assert_eq!(result.status, "completed");
         assert_eq!(result.exit_code, Some(0));
         assert!(String::from_utf8(captured.lock().unwrap().clone())?.contains("hello from stdin"));
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_json_batch_shim_uses_stdin_and_emits_assistant_text() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let batch = temp_dir.path().join("fake-codex.cmd");
+        std::fs::write(
+            &batch,
+            concat!(
+                "@echo off\r\n",
+                "\"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -Command \"$inputStream=[Console]::OpenStandardInput(); $outputStream=[IO.File]::Open('stdin.txt',[IO.FileMode]::Create); $inputStream.CopyTo($outputStream); $outputStream.Dispose()\"\r\n",
+                "echo %* > args.txt\r\n",
+                "echo {\"type\":\"thread.started\",\"thread_id\":\"thread-456\"}\r\n",
+                "echo {\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"reply from Codex\"}}\r\n",
+                "echo {\"type\":\"turn.completed\"}\r\n",
+                "exit /b 0\r\n"
+            ),
+        )?;
+        let command = HarnessCommand {
+            program: batch.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "-".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: Some(b"first line\nsecond line\n".to_vec()),
+        };
+        let mut assistant = Vec::new();
+
+        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(2), |text| {
+            assistant.push(text.to_string());
+            Ok(())
+        })?;
+
+        let args = std::fs::read_to_string(temp_dir.path().join("args.txt"))?;
+        assert!(
+            args.contains("exec --json -- -"),
+            "unexpected argv: {args:?}"
+        );
+        assert!(
+            !args.contains("first line") && !args.contains("second line"),
+            "the multiline user prompt must not reach cmd.exe argv: {args:?}"
+        );
+        let stdin = std::fs::read_to_string(temp_dir.path().join("stdin.txt"))?;
+        assert!(
+            stdin.contains("first line"),
+            "missing first stdin line: {stdin:?}"
+        );
+        assert!(
+            stdin.contains("second line"),
+            "missing second stdin line: {stdin:?}"
+        );
+        assert_eq!(assistant, vec!["reply from Codex"]);
+        assert_eq!(outcome.harness_session_id.as_deref(), Some("thread-456"));
+        assert!(outcome.error.is_none());
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn codex_json_batch_shim_times_out_while_large_prompt_is_still_writing() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let batch = temp_dir.path().join("silent-codex.cmd");
+        std::fs::write(&batch, "@echo off\r\n:spin\r\ngoto spin\r\n")?;
+        let command = HarnessCommand {
+            program: batch.to_string_lossy().into_owned(),
+            args: vec![
+                "exec".to_string(),
+                "--json".to_string(),
+                "--".to_string(),
+                "-".to_string(),
+            ],
+            cwd: temp_dir.path().to_path_buf(),
+            // The shim deliberately never reads stdin. This payload exceeds
+            // the anonymous-pipe buffer, proving the activity deadline also
+            // covers a blocked prompt writer rather than only stdout reads.
+            stdin_prompt: Some(vec![b'x'; 1024 * 1024]),
+        };
+
+        let started = Instant::now();
+        let outcome =
+            stream_codex_json_with_timeout(&command, Duration::from_millis(50), |_| Ok(()))?;
+
+        assert!(started.elapsed() < Duration::from_secs(3));
+        assert!(outcome
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("terminated")));
         Ok(())
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -853,8 +853,13 @@ where
             }
             Err(RecvTimeoutError::Timeout) => {}
             Err(RecvTimeoutError::Disconnected) => {
-                // Keep polling the child/deadline. Detached reader threads may
-                // have gone away immediately after their final event.
+                // All sender threads are gone (pipes closed, stdin written),
+                // but the child may still be running with its stdio closed.
+                // recv_timeout returns immediately on a disconnected channel,
+                // so sleep explicitly to keep the child/deadline polling at
+                // its normal cadence instead of busy-spinning until the
+                // activity timeout fires.
+                thread::sleep(remaining.min(CODEX_CHILD_POLL_INTERVAL));
             }
         }
     }
@@ -1891,11 +1896,13 @@ exec sleep 10
             stdin_prompt: None,
         };
 
+        // The activity budget must outlive shell startup so the script can
+        // record its pid before the runner kills the group; a 25ms budget
+        // loses that race deterministically on macOS (~180ms cold start).
         let started = Instant::now();
-        let outcome =
-            stream_codex_json_with_timeout(&command, Duration::from_millis(25), |_| Ok(()))?;
+        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(1), |_| Ok(()))?;
 
-        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(started.elapsed() < Duration::from_secs(5));
         assert!(outcome
             .error
             .as_deref()

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1663,6 +1663,30 @@ pub fn update_session_status(
     Ok(())
 }
 
+/// Persist the harness-native id that continues a multi-turn conversation.
+///
+/// Coven's `id` remains the stable ledger/session id exposed to callers.
+/// Harnesses such as Codex mint a different id for their own resume API, so
+/// callers can safely keep passing the Coven id while the runner resolves the
+/// native conversation id internally.
+pub fn update_session_conversation_id(
+    conn: &Connection,
+    session_id: &str,
+    conversation_id: &str,
+    updated_at: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE sessions
+         SET conversation_id = ?2,
+             updated_at = ?3
+         WHERE id = ?1",
+        params![session_id, conversation_id, updated_at],
+    )
+    .with_context(|| format!("failed to update conversation id for session {session_id}"))?;
+
+    Ok(())
+}
+
 pub fn mark_running_sessions_orphaned(conn: &Connection, updated_at: &str) -> Result<usize> {
     let updated = conn
         .execute(
@@ -1690,6 +1714,30 @@ pub fn get_session(conn: &Connection, session_id: &str) -> Result<Option<Session
         .query_row(params![session_id], session_record_from_row)
         .optional()
         .with_context(|| format!("failed to read session {session_id}"))
+}
+
+/// Resolve the most recently updated ledger row for a harness-native
+/// conversation id. This keeps `--continue <Codex thread id>` compatible with
+/// callers that persist the native id instead of Coven's ledger id.
+pub fn get_latest_session_by_conversation_id(
+    conn: &Connection,
+    conversation_id: &str,
+) -> Result<Option<SessionRecord>> {
+    let mut statement = conn
+        .prepare(&format!(
+            "SELECT
+                {SESSION_COLUMNS}
+            FROM sessions
+            WHERE conversation_id = ?1
+            ORDER BY updated_at DESC, created_at DESC
+            LIMIT 1",
+        ))
+        .context("failed to prepare conversation session lookup query")?;
+
+    statement
+        .query_row(params![conversation_id], session_record_from_row)
+        .optional()
+        .with_context(|| format!("failed to read conversation {conversation_id}"))
 }
 
 pub fn list_sessions(conn: &Connection) -> Result<Vec<SessionRecord>> {
@@ -3143,6 +3191,27 @@ mod tests {
         )?;
         let hit = latest_active_for_project(&conn, "/p")?;
         assert_eq!(hit.as_deref(), Some("newer"));
+        Ok(())
+    }
+
+    #[test]
+    fn native_conversation_id_round_trips_for_resume_lookup() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+        insert_session(&conn, &session_record("ledger-1", "2026-01-01T00:00:00Z"))?;
+
+        update_session_conversation_id(
+            &conn,
+            "ledger-1",
+            "codex-thread-123",
+            "2026-01-02T00:00:00Z",
+        )?;
+
+        let ledger = get_session(&conn, "ledger-1")?.expect("ledger row should exist");
+        assert_eq!(ledger.conversation_id.as_deref(), Some("codex-thread-123"));
+        let resumed = get_latest_session_by_conversation_id(&conn, "codex-thread-123")?
+            .expect("native thread id should resolve back to the ledger row");
+        assert_eq!(resumed.id, "ledger-1");
         Ok(())
     }
 

--- a/crates/coven-cli/src/stream_json.rs
+++ b/crates/coven-cli/src/stream_json.rs
@@ -94,15 +94,16 @@ pub struct ToolResult {
     pub session_id: String,
 }
 
-/// Raw output captured from a harness that has no native stream-json
-/// protocol (codex, external adapters). In `--stream-json` mode those
-/// harnesses run on a PTY; every captured chunk is wrapped in one `output`
-/// frame so stdout stays JSONL-only instead of interleaving raw PTY bytes
-/// with the stream (#307). `text` is the raw PTY text: it may contain ANSI
-/// escape sequences, carriage returns, and partial lines, and chunk
-/// boundaries follow PTY reads rather than line breaks. Each chunk is
-/// guaranteed valid UTF-8 (codepoints split across reads are reassembled
-/// before wrapping).
+/// Raw output captured from an external harness that has no native
+/// machine-readable protocol. In `--stream-json` mode those adapters run on a
+/// PTY; every captured chunk is wrapped in one `output` frame so stdout stays
+/// JSONL-only instead of interleaving raw PTY bytes with the stream (#307).
+/// `text` is the raw PTY text: it may contain ANSI escape sequences,
+/// carriage returns, and partial lines, and chunk boundaries follow PTY reads
+/// rather than line breaks. Each chunk is guaranteed valid UTF-8 (codepoints
+/// split across reads are reassembled before wrapping). Codex is deliberately
+/// not in this category: its `codex exec --json` frames are normalized into
+/// `assistant` events by the dedicated pipe bridge.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct HarnessOutput {
     pub text: String,
@@ -116,6 +117,11 @@ pub struct RunResult {
     pub is_error: bool,
     pub num_turns: u32,
     pub session_id: String,
+    /// Harness-native conversation id, when the harness creates one. For
+    /// Codex this is the `thread_id` emitted by `codex exec --json`; it is
+    /// distinct from Coven's stable ledger `session_id` and can be supplied
+    /// back to the harness on a later resume.
+    pub harness_session_id: Option<String>,
     pub error: Option<String>,
 }
 
@@ -177,6 +183,7 @@ mod tests {
             is_error: false,
             num_turns: 1,
             session_id: "s1".into(),
+            harness_session_id: None,
             error: None,
         });
         let mut buf = Vec::new();
@@ -188,6 +195,7 @@ mod tests {
         assert_eq!(v["is_error"], false);
         assert_eq!(v["num_turns"], 1);
         assert_eq!(v["session_id"], "s1");
+        assert!(v.get("harness_session_id").is_some());
         assert!(v.get("error").is_some(), "null error field is preserved");
     }
 
@@ -355,6 +363,7 @@ mod tests {
                 is_error: false,
                 num_turns: 0,
                 session_id: "s1".into(),
+                harness_session_id: None,
                 error: None,
             }),
         )

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -32,27 +32,44 @@ fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
     let project_root = temp_dir.path().join("project");
     fs::create_dir_all(&project_root).expect("failed to create project root");
 
-    // Fake codex that behaves like a TUI-ish harness on a PTY: colored
+    // A manifest-backed external adapter that behaves like a TUI-ish harness
+    // on a PTY: colored
     // banner, carriage-return progress updates, a partial line that looks
     // like broken JSON, then a completion marker. Before #307 all of this
     // leaked raw onto stdout between the JSONL frames.
     let fake_bin = temp_dir.path().join("bin");
     fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
-    let fake_codex = fake_bin.join("codex");
+    let fake_harness = fake_bin.join("fake-pty");
     fs::write(
-        &fake_codex,
+        &fake_harness,
         "#!/bin/sh\n\
-         printf '\\033[1;32mfake codex banner\\033[0m\\n'\n\
+         printf '\\033[1;32mfake pty banner\\033[0m\\n'\n\
          printf 'progress 1/2\\rprogress 2/2\\n'\n\
          printf '{\"not\":\"terminated'\n\
-         printf '\\nfake codex noise complete\\n'\n",
+         printf '\\nfake pty noise complete\\n'\n",
     )
-    .expect("failed to write fake codex");
-    let mut permissions = fs::metadata(&fake_codex)
-        .expect("failed to stat fake codex")
+    .expect("failed to write fake PTY harness");
+    let mut permissions = fs::metadata(&fake_harness)
+        .expect("failed to stat fake PTY harness")
         .permissions();
     permissions.set_mode(0o755);
-    fs::set_permissions(&fake_codex, permissions).expect("failed to chmod fake codex");
+    fs::set_permissions(&fake_harness, permissions).expect("failed to chmod fake PTY harness");
+    let manifest = temp_dir.path().join("adapters.json");
+    fs::write(
+        &manifest,
+        r#"{
+  "adapters": [{
+    "id": "fakepty",
+    "label": "Fake PTY",
+    "executable": "fake-pty",
+    "interactive_prompt_prefix_args": [],
+    "non_interactive_prompt_prefix_args": [],
+    "install_hint": "test fixture",
+    "system_prompt_flag": null
+  }]
+}"#,
+    )
+    .expect("failed to write external adapter manifest");
 
     let mut paths = vec![fake_bin.clone()];
     if let Some(existing) = std::env::var_os("PATH") {
@@ -61,9 +78,10 @@ fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
     let path = std::env::join_paths(paths).expect("test PATH should be joinable");
 
     let out = Command::new(env!("CARGO_BIN_EXE_coven"))
-        .args(["run", "codex", "--stream-json", "--", "ping"])
+        .args(["run", "fakepty", "--stream-json", "--", "ping"])
         .current_dir(&project_root)
         .env("COVEN_HOME", &coven_home)
+        .env("COVEN_HARNESS_ADAPTER_MANIFEST", &manifest)
         .env("PATH", &path)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -73,7 +91,7 @@ fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
 
     assert!(
         out.status.success(),
-        "coven run codex --stream-json failed: status={:?} stdout={} stderr={}",
+        "coven run fakepty --stream-json failed: status={:?} stdout={} stderr={}",
         out.status,
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),
@@ -130,7 +148,7 @@ fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
         })
         .collect();
     assert!(
-        output_text.contains("fake codex banner"),
+        output_text.contains("fake pty banner"),
         "captured PTY output should include the harness banner; got {output_text:?}",
     );
     assert!(
@@ -142,8 +160,574 @@ fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
         "broken-JSON PTY noise must ride inside output frames, not the stream; got {output_text:?}",
     );
     assert!(
-        output_text.contains("fake codex noise complete"),
+        output_text.contains("fake pty noise complete"),
         "captured PTY output should include the completion marker; got {output_text:?}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn codex_json_stream_normalizes_assistant_and_thread_id() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex");
+    fs::write(
+        &fake_codex,
+        r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-unix-123"}'
+printf '%s\n' '{"type":"turn.started"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"reply for stream client"}}'
+printf '%s\n' '{"type":"turn.completed"}'
+"#,
+    )
+    .expect("failed to write fake codex");
+    let mut permissions = fs::metadata(&fake_codex)
+        .expect("failed to stat fake codex")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).expect("failed to chmod fake codex");
+
+    let mut paths = vec![fake_bin.clone()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            // Both values look like argv syntax. The Codex bridge must still
+            // put its own flag after the real exec subcommand.
+            "--model",
+            "openai/exec",
+            "--",
+            "--json",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+
+    assert!(
+        out.status.success(),
+        "coven run codex --stream-json failed: status={:?} stdout={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8(out.stdout).expect("stdout not utf-8");
+    let frames: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    assert_eq!(frames[0]["type"], "system");
+    assert_eq!(frames[1]["type"], "user");
+    assert_eq!(frames[1]["message"]["content"][0]["text"], "--json");
+    let assistant = frames
+        .iter()
+        .find(|frame| frame["type"] == "assistant")
+        .expect("Codex reply must be normalized to an assistant frame");
+    assert_eq!(
+        assistant["message"]["content"][0]["text"],
+        "reply for stream client"
+    );
+    let result = frames.last().expect("result should be last");
+    assert_eq!(result["type"], "result");
+    assert_eq!(result["is_error"], false);
+    assert_eq!(result["harness_session_id"], "thread-unix-123");
+    assert!(
+        !frames.iter().any(|frame| frame["type"] == "output"),
+        "native Codex JSON must not be rewrapped as raw output"
+    );
+    assert_eq!(
+        fs::read_to_string(project_root.join("args.txt")).expect("fake codex should record argv"),
+        "--model\nexec\nexec\n--json\n--skip-git-repo-check\n--color\nnever\n--\n--json\n",
+        "Codex must put its JSON option after the real exec subcommand"
+    );
+}
+
+/// A Codex protocol failure is a failed Coven run even when the Codex wrapper
+/// exits 0. The terminal CLI status and persisted ledger must agree so clients
+/// never see a failed turn recorded as a successful process exit.
+#[cfg(unix)]
+#[test]
+fn codex_json_turn_failure_with_zero_exit_marks_ledger_failed() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex");
+    fs::write(
+        &fake_codex,
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"thread.started","thread_id":"thread-failed-zero"}'
+printf '%s\n' '{"type":"turn.failed","error":{"message":"fixture turn failure"}}'
+exit 0
+"#,
+    )
+    .expect("failed to write fake codex");
+    let mut permissions = fs::metadata(&fake_codex)
+        .expect("failed to stat fake codex")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).expect("failed to chmod fake codex");
+
+    let mut paths = vec![fake_bin];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--stream-json", "--", "fail once"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+
+    assert!(
+        !out.status.success(),
+        "protocol failure must return non-zero: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8(out.stdout).expect("stdout not utf-8");
+    let frames: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    let result = frames.last().expect("result frame should be last");
+    assert_eq!(result["type"], "result");
+    assert_eq!(result["is_error"], true);
+    assert_eq!(result["error"], "fixture turn failure");
+
+    let session_id = frames[0]["session_id"]
+        .as_str()
+        .expect("system frame carries stable Coven id");
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3"))
+        .expect("failed to open Coven session ledger");
+    let (status, exit_code): (String, Option<i32>) = conn
+        .query_row(
+            "SELECT status, exit_code FROM sessions WHERE id = ?1",
+            [session_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("failed session should remain in the ledger");
+    assert_eq!(status, "failed");
+    assert_eq!(exit_code, Some(1));
+}
+
+/// Cancelling Coven itself must also reap the separate Unix Codex session
+/// group, then emit the terminal result that lets a bridge mark the session
+/// failed instead of leaving it `running` forever.
+#[cfg(unix)]
+#[test]
+fn codex_json_sigterm_reaps_descendants_and_marks_ledger_failed() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::time::{Duration, Instant};
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex");
+    fs::write(
+        &fake_codex,
+        r#"#!/bin/sh
+sleep 10 </dev/null >/dev/null 2>&1 &
+echo $! > descendant.pid
+while :; do sleep 1; done
+"#,
+    )
+    .expect("failed to write fake codex");
+    let mut permissions = fs::metadata(&fake_codex)
+        .expect("failed to stat fake codex")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).expect("failed to chmod fake codex");
+
+    let mut paths = vec![fake_bin];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+    let mut coven = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            "--",
+            "wait for cancellation",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn coven binary");
+
+    let descendant_path = project_root.join("descendant.pid");
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while !descendant_path.exists() && Instant::now() < deadline {
+        if let Some(status) = coven.try_wait().expect("failed polling coven") {
+            panic!("coven exited before Codex fixture was ready: {status}");
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        descendant_path.exists(),
+        "Codex fixture did not start before cancellation"
+    );
+    let signal_result = unsafe { libc::kill(coven.id() as libc::pid_t, libc::SIGTERM) };
+    assert_eq!(
+        signal_result,
+        0,
+        "failed to signal the Coven process: {}",
+        std::io::Error::last_os_error()
+    );
+    let out = coven
+        .wait_with_output()
+        .expect("failed waiting for cancelled coven");
+
+    assert!(
+        !out.status.success(),
+        "cancellation must return non-zero: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8(out.stdout).expect("stdout not utf-8");
+    let frames: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    let result = frames.last().expect("result frame should be last");
+    assert_eq!(result["type"], "result");
+    assert_eq!(result["is_error"], true);
+    assert!(
+        result["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("cancelled by SIGTERM")),
+        "cancellation detail should reach the client protocol: {result}"
+    );
+
+    let session_id = frames[0]["session_id"]
+        .as_str()
+        .expect("system frame carries stable Coven id");
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3"))
+        .expect("failed to open Coven session ledger");
+    let (status, exit_code): (String, Option<i32>) = conn
+        .query_row(
+            "SELECT status, exit_code FROM sessions WHERE id = ?1",
+            [session_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("cancelled session should remain in the ledger");
+    assert_eq!(status, "failed");
+    assert_eq!(exit_code, Some(1));
+
+    let descendant_pid = fs::read_to_string(&descendant_path)
+        .expect("failed to read descendant pid")
+        .trim()
+        .to_string();
+    let mut alive = true;
+    for _ in 0..80 {
+        alive = Command::new("kill")
+            .args(["-0", &descendant_pid])
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false);
+        if !alive {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert!(
+        !alive,
+        "cancelled Codex descendant {descendant_pid} should be reaped"
+    );
+}
+
+/// End-to-end Windows regression: an npm-style `codex.cmd` must receive a
+/// multiline prompt through stdin (not ConPTY/cmd argv), and the Coven CLI
+/// must surface the Codex JSON response as an `assistant` frame. The second
+/// invocation proves Cave can keep using the stable Coven ledger id while
+/// Coven resumes the native Codex thread internally.
+#[cfg(windows)]
+#[test]
+fn windows_codex_cmd_stream_json_emits_assistant_and_resumes_native_thread() {
+    use std::fs;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    fs::write(
+        coven_home.join("familiars.toml"),
+        r#"[[familiar]]
+id = "briar"
+display_name = "Briar"
+role = "Code and diagnostics"
+description = "Windows Codex regression fixture"
+"#,
+    )
+    .expect("failed to write familiar fixture");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex.cmd");
+    fs::write(
+        &fake_codex,
+        concat!(
+            "@echo off\r\n",
+            "\"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -Command \"$inputStream=[Console]::OpenStandardInput(); $outputStream=[IO.File]::Open('stdin.txt',[IO.FileMode]::Create); $inputStream.CopyTo($outputStream); $outputStream.Dispose()\"\r\n",
+            "echo %* > args.txt\r\n",
+            "echo {\"type\":\"thread.started\",\"thread_id\":\"thread-789\"}\r\n",
+            "echo {\"type\":\"turn.started\"}\r\n",
+            "echo {\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"reply for Cave\"}}\r\n",
+            "echo {\"type\":\"turn.completed\"}\r\n",
+            "exit /b 0\r\n"
+        ),
+    )
+    .expect("failed to write fake codex cmd");
+
+    let mut paths = vec![fake_bin.clone()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+    let prompt = "first line\nsecond line";
+    let first = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            "--familiar",
+            "briar",
+            "--",
+            prompt,
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .env("PATHEXT", ".CMD")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+
+    assert!(
+        first.status.success(),
+        "first Coven run failed: status={:?} stdout={} stderr={}",
+        first.status,
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr),
+    );
+    let first_stdout = String::from_utf8(first.stdout).expect("stdout not utf-8");
+    let frames: Vec<serde_json::Value> = first_stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    let ledger_id = frames[0]["session_id"]
+        .as_str()
+        .expect("system frame carries stable Coven id")
+        .to_string();
+    let assistant = frames
+        .iter()
+        .find(|frame| frame["type"] == "assistant")
+        .expect("Codex message must reach Coven assistant protocol");
+    assert_eq!(assistant["message"]["content"][0]["text"], "reply for Cave");
+    let result = frames.last().expect("result frame should be last");
+    assert_eq!(result["type"], "result");
+    assert_eq!(result["is_error"], false);
+    assert_eq!(result["harness_session_id"], "thread-789");
+    let first_args =
+        fs::read_to_string(project_root.join("args.txt")).expect("fake cmd should record argv");
+    assert!(
+        first_args.contains("--json"),
+        "expected Codex JSON flag: {first_args:?}"
+    );
+    assert!(
+        !first_args.contains("first line") && !first_args.contains("second line"),
+        "prompt must be kept out of cmd.exe argv: {first_args:?}"
+    );
+    let stdin = fs::read_to_string(project_root.join("stdin.txt"))
+        .expect("fake cmd should record stdin prompt");
+    assert!(
+        stdin.contains("[Identity: You are Briar, a Code and diagnostics. Respond as Briar, not as the underlying tool.]"),
+        "familiar preamble should reach Codex exactly once: stdin={stdin:?}, argv={first_args:?}, stream={first_stdout:?}"
+    );
+    assert_eq!(
+        stdin.matches("[Identity: You are Briar").count(),
+        1,
+        "familiar preamble must not be duplicated: {stdin:?}"
+    );
+    assert!(
+        stdin.contains("first line"),
+        "first prompt line missing: {stdin:?}"
+    );
+    assert!(
+        stdin.contains("second line"),
+        "second prompt line missing: {stdin:?}"
+    );
+
+    let second = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            "--continue",
+            &ledger_id,
+            "--",
+            "follow-up",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .env("PATHEXT", ".CMD")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn resumed coven binary");
+    assert!(
+        second.status.success(),
+        "resumed Coven run failed: status={:?} stdout={} stderr={}",
+        second.status,
+        String::from_utf8_lossy(&second.stdout),
+        String::from_utf8_lossy(&second.stderr),
+    );
+    let resumed_args = fs::read_to_string(project_root.join("args.txt"))
+        .expect("fake cmd should record resumed argv");
+    assert!(
+        resumed_args.contains("resume thread-789"),
+        "stable Coven id should resolve to the native Codex thread: {resumed_args:?}"
+    );
+}
+
+/// The no-output failure is exercised through the actual CLI, not just the
+/// runner, because CovenCave's observed failure mode was a session that stayed
+/// `running` forever with no terminal stream frame. The debug-only timeout
+/// override keeps this integration regression bounded.
+#[cfg(windows)]
+#[test]
+fn windows_silent_codex_cmd_emits_terminal_error_and_marks_session_failed() {
+    use std::fs;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    fs::write(
+        fake_bin.join("codex.cmd"),
+        "@echo off\r\n:spin\r\ngoto spin\r\n",
+    )
+    .expect("failed to write silent codex cmd");
+
+    let mut paths = vec![fake_bin];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+    let started = std::time::Instant::now();
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--stream-json", "--", "wait forever"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .env("PATHEXT", ".CMD")
+        .env("COVEN_TEST_CODEX_JSON_IDLE_TIMEOUT_MS", "150")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "silent npm shim should be cancelled promptly"
+    );
+    assert!(
+        !out.status.success(),
+        "timeout must return a non-zero CLI status: stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8(out.stdout).expect("stdout not utf-8");
+    let frames: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    assert_eq!(frames[0]["type"], "system");
+    assert_eq!(frames[1]["type"], "user");
+    assert!(
+        !frames.iter().any(|frame| frame["type"] == "assistant"),
+        "a silent Codex turn must not invent an assistant reply: {frames:?}"
+    );
+    let result = frames.last().expect("result frame should be last");
+    assert_eq!(result["type"], "result");
+    assert_eq!(result["is_error"], true);
+    assert!(
+        result["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("machine-readable activity")),
+        "timeout detail should reach the client protocol: {result}"
+    );
+
+    let session_id = frames[0]["session_id"]
+        .as_str()
+        .expect("system frame carries stable Coven id");
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3"))
+        .expect("failed to open Coven session ledger");
+    let (status, exit_code): (String, Option<i32>) = conn
+        .query_row(
+            "SELECT status, exit_code FROM sessions WHERE id = ?1",
+            [session_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .expect("timed-out session should remain in the ledger");
+    assert_eq!(status, "failed", "silent session must not remain running");
+    assert!(
+        exit_code.is_some_and(|code| code != 0),
+        "timed-out session must persist a non-zero exit code: {exit_code:?}"
     );
 }
 

--- a/docs/STREAM-JSON.md
+++ b/docs/STREAM-JSON.md
@@ -23,7 +23,7 @@ should ignore event types they don't recognize.
 {"type":"user","message":{"role":"user","content":[{"type":"text","text":"..."}]},"session_id":"...","parent_tool_use_id":null}
 ```
 
-### `assistant` - emitted by stream-capable harnesses (claude)
+### `assistant` - emitted for normalized harness replies
 
 ```json
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"..."}]},"session_id":"...","stop_reason":"end_turn"}
@@ -41,8 +41,8 @@ should ignore event types they don't recognize.
 {"type":"output","text":"raw PTY text…","session_id":"..."}
 ```
 
-Emitted only for harnesses without a native stream-json protocol (codex,
-external adapters). Coven runs those harnesses on a PTY and wraps every
+Emitted only for external harnesses without a native machine-readable
+protocol. Coven runs those harnesses on a PTY and wraps every
 captured chunk in one `output` frame so stdout stays JSONL-only — raw PTY
 bytes never interleave with the stream. `text` is the raw PTY text: it may
 contain ANSI escape sequences, carriage returns, and partial lines, and
@@ -53,12 +53,14 @@ escapes. Never emitted on the claude pass-through path.
 ### `result` - emitted once at end
 
 ```json
-{"type":"result","subtype":"success","duration_ms":1234,"is_error":false,"num_turns":1,"session_id":"...","error":null}
+{"type":"result","subtype":"success","duration_ms":1234,"is_error":false,"num_turns":1,"session_id":"...","harness_session_id":null,"error":null}
 ```
 
 `subtype` is `"success"` on a clean exit and `"error_during_execution"`
 otherwise. When `is_error` is true, `error` may contain a human-readable
-failure string.
+failure string. `harness_session_id` is optional/additive. When present, it
+is the harness's own resumable conversation id (for example Codex's
+`thread_id`), distinct from Coven's stable ledger `session_id`.
 
 ## Stdin protocol (`--stream-json-input`)
 
@@ -80,17 +82,25 @@ non-stream harnesses the flag is accepted but no stdin forwarding occurs.
   Coven's `system` and `result`. Coven does *not* synthesize a `user` event
   on this path; claude emits its own when it processes the prompt.
 
-- **codex** and other non-stream harnesses: Coven synthesizes
-  `system.init` + `user` + `result`, and wraps the harness's raw PTY
-  output in `output` frames between them. The harness always launches in
-  its one-shot/non-interactive form on this path (stream-json is a machine
-  protocol; a TUI would wait on keystrokes for a screen that is never
-  rendered). The output is not parsed into `assistant` events — `output`
-  carries the raw text, escapes and all.
+- **codex**: Coven launches `codex exec --json` as a one-shot, ordinary-pipe
+  process and translates completed Codex agent messages into Coven
+  `assistant` events. `thread.started.thread_id` is returned additively as
+  `result.harness_session_id` and stored internally for a later `--continue`.
+  This is deliberately not a PTY path: on Windows an npm-installed
+  `codex.cmd` reads its prompt through stdin (`codex exec -`), avoiding the
+  ConPTY/OpenConsole handoff while keeping multiline familiar prompts out of
+  the batch command line. A lack of valid Codex JSON activity is bounded by a
+  five-minute idle timeout (including a blocked prompt write) and ends with an
+  error `result`, rather than leaving a request running forever. Timeout,
+  protocol/wrapper failure, and Unix `SIGINT`/`SIGTERM`/`SIGHUP` cancellation
+  terminate the owned pipe process tree: a process group on Unix and a Windows
+  Job Object when assignment succeeds. On Windows where Job assignment is
+  unavailable, Coven uses `taskkill /T /F` for its own timeout/error cleanup;
+  an external forced process kill cannot run that fallback.
 
-  stdout carries only JSONL frames regardless of harness; anything the
-  harness writes to its PTY rides inside `output` events instead of
-  leaking onto the stream.
+- **other non-stream harnesses**: Coven synthesizes `system.init` + `user` +
+  `result`, and wraps raw PTY output in `output` frames between them. stdout
+  carries only JSONL frames; raw PTY bytes never leak onto the stream.
 
 ## Stability
 

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -8,7 +8,7 @@ extend the mechanism to additional harnesses.
 | Harness | Resume support | Mechanism |
 | --- | --- | --- |
 | `claude` | ✅ stream-mode | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose` daemon process per chat, plus `--session-id <uuid>` on the first turn and `--resume <uuid>` for cross-restart continuation. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). Unix kills the stream process tree with `setsid()` + `kill(-pid, SIGKILL)`; Windows uses a Job Object owned by the daemon. |
-| `codex` | ✅ per-turn | Turn 1 runs plain `codex exec …`; chat captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. Codex has no equivalent of stream-json so each turn cold-starts. |
+| `codex` | ✅ per-turn | Chat runs plain `codex exec …`; it captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. `coven run codex --stream-json` separately uses Codex's one-shot `exec --json` protocol, but Codex has no long-lived stream mode, so each chat turn cold-starts. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:
 on startup the chat seeds its in-memory map from

--- a/docs/harnesses/codex.md
+++ b/docs/harnesses/codex.md
@@ -4,11 +4,14 @@ read_when:
   - Setting up Codex for Coven
   - Diagnosing Codex-specific harness failures
 title: "Codex harness"
-description: "Run the OpenAI Codex CLI under Coven supervision with harness id codex, a project-rooted PTY, and the usual session, attach, and ritual flows."
+description: "Run the OpenAI Codex CLI under Coven supervision with harness id codex, project-rooted sessions, and the usual attach and ritual flows."
 ---
 
 
-Codex is OpenAI's coding-agent CLI. Coven wraps it in a project-rooted PTY so launches, attaches, and rituals work the same as for any other harness.
+Codex is OpenAI's coding-agent CLI. Coven uses a project-rooted PTY for
+interactive sessions, and Codex's JSON mode over ordinary pipes for machine
+streaming, so launches, attaches, and rituals work the same as for any other
+harness.
 
 | Field | Value |
 |---|---|
@@ -71,7 +74,9 @@ coven patch openclaw "fix Codex auth profile order after invalidated OAuth token
 |---|---|---|
 | `coven doctor` reports `codex` missing | Codex not on `PATH` | `npm install -g @openai/codex`, then re-run doctor. |
 | Codex prompts for login each run | Stale token | `codex login`. |
-| Session hangs at start | Codex waiting on TTY prompt | Detach with `Ctrl-]`, re-launch with `coven run` directly. |
+| Codex returns `invalid_value` for `reasoning.effort` | An obsolete `model_reasoning_effort` value in `%USERPROFILE%\.codex\config.toml` | Use a currently supported value such as `model_reasoning_effort = "xhigh"` rather than legacy `ultra`/`max`, then retry. Coven never reads or writes Codex credentials. |
+| CovenCave/direct `--stream-json` request hangs on Windows | Older Coven package launches npm's `codex.cmd` through the ConPTY/OpenConsole path | Update Coven to a release containing the piped Codex JSON bridge, then retry. `coven doctor` should still report Codex as ready. |
+| Interactive session waits for input | Codex is waiting on its terminal prompt | Detach with `Ctrl-]`, then re-launch with `coven run` directly. |
 
 ## How Coven supervises Codex
 
@@ -80,7 +85,7 @@ sequenceDiagram
   participant U as User
   participant C as coven CLI
   participant D as Coven daemon
-  participant Cx as Codex PTY
+  participant Cx as Codex process
   participant Op as OpenAI API
 
   U->>C: coven run codex "audit this repo"
@@ -95,7 +100,17 @@ sequenceDiagram
   C-->>U: print session id, switch to attach view
 ```
 
-The dotted line worth noticing: Coven never connects to the OpenAI API itself. The credential path is **Codex CLI ↔ OpenAI**, with Coven only observing the PTY output.
+The dotted line worth noticing: Coven never connects to the OpenAI API itself. The credential path is **Codex CLI ↔ OpenAI**, with Coven only supervising the local Codex process and its output.
+
+For `coven run codex --stream-json`, Coven instead runs `codex exec --json`
+through normal pipes and emits Coven `assistant` / `result` JSONL frames. On
+Windows this keeps the npm `.cmd` shim off ConPTY and supplies multiline
+prompts through stdin safely. The result carries Codex's native thread id as
+`harness_session_id`; Coven keeps that mapping so a later `--continue` can use
+the stable Coven session id. During that one-shot bridge, Unix
+`SIGINT`/`SIGTERM`/`SIGHUP` cancel the owned Codex process group and produce a
+failed terminal result. Windows uses an owned Job Object when assignment is
+available; otherwise Coven's timeout/error cleanup uses `taskkill /T /F`.
 
 
 ## Related

--- a/docs/reference/cli-run.md
+++ b/docs/reference/cli-run.md
@@ -29,7 +29,7 @@ coven run <harness> <prompt> [flags]
 | `--visibility <private\|workspace\|shared>` | Set session visibility metadata. |
 | `--archive` | Archive the session after the run completes. |
 | `--familiar <id>` | Inject familiar identity context. |
-| `--stream-json` | Emit Coven JSONL events on stdout. stdout carries only JSONL for every harness: non-stream harnesses (codex, external adapters) have their raw PTY output wrapped in `output` events. See `docs/STREAM-JSON.md`. |
+| `--stream-json` | Emit Coven JSONL events on stdout. Codex runs as `codex exec --json` over ordinary pipes and is normalized into `assistant` / `result` events; on Windows its npm `.cmd` shim receives the prompt on stdin rather than through ConPTY. Other external non-stream adapters have raw PTY output wrapped in `output` events. See `docs/STREAM-JSON.md`. |
 | `--stream-json-input` | With `--stream-json`, read JSONL user messages from stdin for Claude stream mode. |
 
 Examples:

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -18,6 +18,10 @@ title: "Coven changelog and release notes"
 - **CLI-login-only model selection (v0.0.53).** The model-selection docs now expose only the supported Codex CLI and Claude Code login paths. Provider/API-key option pages for OpenAI, Anthropic, Google, and local-model backends were removed from the selectable `/models` surface so clients and users are routed through `codex login` or `claude doctor` instead of raw provider credentials. See [Model selection](/models).
 - **Multi-host daemon specs.** Added PRODUCT and TECH specs for travel profiles, offline deltas, scheduler roles, redispatch, failure handling, and the issue mapping for the multi-host daemon track.
 
+### Bug fixes
+
+- **Windows Codex stream bridge.** `coven run codex --stream-json` now launches `codex exec --json` through ordinary pipes, so npm's `codex.cmd` no longer relies on the headless ConPTY/OpenConsole handoff. Completed Codex messages are normalized into Coven `assistant` events, native thread ids are retained for resume, and timeout, protocol failure, and Unix cancellation are bounded with owned process-tree cleanup instead of leaving a session running forever. Windows uses a Job Object when assignment succeeds and `taskkill /T /F` for Coven-supervised fallback cleanup. See [stream-JSON protocol](/STREAM-JSON) and [Codex harness notes](/harnesses/codex).
+
 ## Week of June 24, 2026
 
 ### New features


### PR DESCRIPTION
## Summary

Fixes CovenCave's Windows Codex no-reply failure.

The released CLI launched npm's `codex.cmd` through the ConPTY/OpenConsole path. The wrapper could stall before Codex started, leaving CovenCave with a running session and no terminal response.

This change:

- routes `coven run codex --stream-json` through one-shot `codex exec --json` over ordinary pipes;
- passes Windows prompts through stdin (`codex exec -`) so multiline familiar prompts never enter a batch-command argument;
- normalizes Codex JSONL agent messages into Coven `assistant` frames and emits a terminal `result`;
- stores the native Codex thread id separately from Coven's stable ledger id, so callers can keep using the ledger id with `--continue`;
- bounds silent/blocked launches, protocol errors, and Unix cancellation; failed protocol turns now persist a nonzero exit code;
- cleans up detached Unix process-group descendants and uses the existing Windows Job Object / `taskkill /T /F` fallback supervision;
- updates stream, Codex, CLI, persistence, troubleshooting, and release-note documentation.

## Before / after evidence

Before, the installed Windows CovenCave process tree used the released npm CLI and followed `coven.exe -> OpenConsole.exe`, without starting Codex.

After, the patched Windows binary produced a real JSONL `assistant` response and terminal success result, then resumed the same native thread through the stable Coven ledger id. A fresh native Tauri dev instance was launched with `COVEN_BIN` set to the patched target (not via `pnpm dev:app`), and human verification confirmed both a multiline Briar reply and retained follow-up context.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo test -p coven-cli --quiet` on Linux
- focused Linux JSON bridge, timeout, closed-pipe descendant, zero-exit protocol-error, and SIGTERM cancellation tests
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- `python3 scripts/check-secrets.py`
- Windows `cargo check -p coven-cli`
- Windows `stream_json_integration`: npm-style `.cmd`, multiline stdin, assistant/result, native-thread resume, and timeout/failed-ledger regressions
- real Windows Codex smoke and stable-ledger resume against the patched `coven.exe`
- native Windows Tauri human verification

## Caveat

When Windows Job Object assignment is unavailable, Coven's own timeout/error path uses `taskkill /T /F`. An unrelated external forced termination cannot run that fallback; guaranteed forced-stop tree cleanup in that case would require a CovenCave-side process-tree kill.