### PR TITLE
fix(daemon): reap sessions stranded in 'created' after a dead launch

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -427,6 +427,7 @@ pub fn handle_request_with_runtime(
         }
         ("GET", "/sessions") => {
             let conn = store::open_store(&store_path(coven_home))?;
+            reap_stale_created_sessions_throttled(&conn);
             let sessions = store::list_sessions(&conn)?;
             json_response(200, &sessions)
         }
@@ -2246,6 +2247,37 @@ fn session_action_id<'a>(path: &'a str, suffix: &str) -> &'a str {
 
 pub(crate) fn current_timestamp() -> String {
     Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true)
+}
+
+/// The daemon has no periodic maintenance loop, so the sessions list — the
+/// endpoint Cave polls constantly — doubles as the reap tick for rows a dead
+/// `coven run` stranded in `created` (#342). Throttled so back-to-back polls
+/// don't each pay a write, and best-effort: a failed repair never fails the
+/// read it piggybacks on. Startup recovery covers daemons nobody lists.
+const STALE_CREATED_REAP_INTERVAL_SECS: u64 = 60;
+
+fn reap_stale_created_sessions_throttled(conn: &rusqlite::Connection) {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static LAST_REAP_EPOCH_SECS: AtomicU64 = AtomicU64::new(0);
+
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs())
+        .unwrap_or(0);
+    let last = LAST_REAP_EPOCH_SECS.load(Ordering::Relaxed);
+    if now_secs.saturating_sub(last) < STALE_CREATED_REAP_INTERVAL_SECS {
+        return;
+    }
+    if LAST_REAP_EPOCH_SECS
+        .compare_exchange(last, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        // Another connection claimed this tick.
+        return;
+    }
+    let cutoff = (Utc::now() - Duration::seconds(crate::daemon::STALE_CREATED_TTL_SECS))
+        .to_rfc3339_opts(SecondsFormat::Nanos, true);
+    let _ = store::mark_stale_created_sessions_failed(conn, &cutoff, &current_timestamp());
 }
 
 pub(crate) fn api_error(

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -986,6 +986,23 @@ pub fn recover_orphaned_sessions(coven_home: &Path, updated_at: &str) -> Result<
     crate::store::mark_running_sessions_orphaned(&conn, updated_at)
 }
 
+/// TTL before a `created` row with no live owner is declared dead (#342).
+/// Generous on purpose: `coven run` writes the store directly, so a launch
+/// can be legitimately mid-registration while the daemon boots or serves —
+/// a blanket sweep would clobber it, an age check cannot.
+pub const STALE_CREATED_TTL_SECS: i64 = 600;
+
+/// Companion to [`recover_orphaned_sessions`] for the other unowned state:
+/// rows a dead `coven run` left in `created` (registered, never launched —
+/// fork exhaustion, missing adapter, crash). Nothing owns such a row, so no
+/// exit path will ever fail it; only age proves it dead.
+pub fn recover_stale_created_sessions(coven_home: &Path, updated_at: &str) -> Result<usize> {
+    let conn = crate::store::open_store(&coven_home.join("coven.sqlite3"))?;
+    let cutoff = (chrono::Utc::now() - chrono::Duration::seconds(STALE_CREATED_TTL_SECS))
+        .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+    crate::store::mark_stale_created_sessions_failed(&conn, &cutoff, updated_at)
+}
+
 pub fn write_status(coven_home: &Path, status: &DaemonStatus) -> Result<()> {
     ensure_private_coven_home(coven_home)?;
     let json = serde_json::to_string_pretty(status).context("failed to serialize daemon status")?;
@@ -2041,6 +2058,7 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         ),
     );
     recover_orphaned_sessions(coven_home, &started_at)?;
+    recover_stale_created_sessions(coven_home, &started_at)?;
     let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
         coven_home.to_path_buf(),
     ));
@@ -3213,6 +3231,36 @@ mod tests {
         assert_eq!(updated, 1);
         assert_eq!(session_status(&sessions, "running"), "orphaned");
         assert_eq!(session_status(&sessions, "killed"), "killed");
+        Ok(())
+    }
+
+    #[test]
+    fn recovers_stale_created_sessions_as_failed() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        // Helper's fixed 2026-04-27 created_at sits far past the TTL → stale.
+        let mut stale = session_record("stale-created");
+        stale.status = "created".to_string();
+        // A row registered "just now" is inside the TTL and must survive —
+        // its `coven run` may still be launching.
+        let mut fresh = session_record("fresh-created");
+        fresh.status = "created".to_string();
+        fresh.created_at = crate::api::current_timestamp();
+        let mut completed = session_record("completed");
+        completed.status = "completed".to_string();
+        crate::store::insert_session(&conn, &stale)?;
+        crate::store::insert_session(&conn, &fresh)?;
+        crate::store::insert_session(&conn, &completed)?;
+        drop(conn);
+
+        let updated = recover_stale_created_sessions(temp_dir.path(), "2026-04-27T08:00:00Z")?;
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        let sessions = crate::store::list_sessions(&conn)?;
+
+        assert_eq!(updated, 1);
+        assert_eq!(session_status(&sessions, "stale-created"), "failed");
+        assert_eq!(session_status(&sessions, "fresh-created"), "created");
+        assert_eq!(session_status(&sessions, "completed"), "completed");
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1676,6 +1676,30 @@ pub fn mark_running_sessions_orphaned(conn: &Connection, updated_at: &str) -> Re
     Ok(updated)
 }
 
+/// Companion reaper to [`mark_running_sessions_orphaned`]: `coven run`
+/// inserts the session row as `created` and only flips it to `running`
+/// right before launching the harness. A run process that dies between
+/// those two writes (fork exhaustion, missing adapter, crash) leaves a row
+/// no process owns, so only age can prove it dead. Rows created before the
+/// cutoff become `failed`; newer rows stay untouched so a slow-but-live
+/// launch is never clobbered.
+pub fn mark_stale_created_sessions_failed(
+    conn: &Connection,
+    created_before: &str,
+    updated_at: &str,
+) -> Result<usize> {
+    let updated = conn
+        .execute(
+            "UPDATE sessions
+             SET status = 'failed',
+                 updated_at = ?2
+             WHERE status = 'created' AND created_at < ?1",
+            params![created_before, updated_at],
+        )
+        .context("failed to mark stale created sessions failed")?;
+    Ok(updated)
+}
+
 pub fn get_session(conn: &Connection, session_id: &str) -> Result<Option<SessionRecord>> {
     let mut statement = conn
         .prepare(&format!(
@@ -2532,6 +2556,38 @@ mod tests {
         assert_eq!(running.status, "orphaned");
         assert_eq!(running.updated_at, "2026-04-27T07:00:00Z");
         assert_eq!(killed.status, "killed");
+        Ok(())
+    }
+
+    #[test]
+    fn marks_only_stale_created_sessions_failed() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        let mut stale = session_record("stale-created", "2026-04-27T06:00:00Z");
+        stale.status = "created".to_string();
+        let mut fresh = session_record("fresh-created", "2026-04-27T06:55:00Z");
+        fresh.status = "created".to_string();
+        let mut running = session_record("running", "2026-04-27T06:00:00Z");
+        running.status = "running".to_string();
+        insert_session(&conn, &stale)?;
+        insert_session(&conn, &fresh)?;
+        insert_session(&conn, &running)?;
+
+        // Cutoff falls between the stale and fresh rows' created_at, so only
+        // the stale row is provably dead.
+        let updated = mark_stale_created_sessions_failed(
+            &conn,
+            "2026-04-27T06:50:00Z",
+            "2026-04-27T07:00:00Z",
+        )?;
+        let sessions = list_sessions(&conn)?;
+        let by_id = |id: &str| sessions.iter().find(|session| session.id == id).unwrap();
+
+        assert_eq!(updated, 1);
+        assert_eq!(by_id("stale-created").status, "failed");
+        assert_eq!(by_id("stale-created").updated_at, "2026-04-27T07:00:00Z");
+        assert_eq!(by_id("fresh-created").status, "created");
+        assert_eq!(by_id("running").status, "running");
         Ok(())
     }
 


### PR DESCRIPTION
Closes #342.

## Problem

`coven run` inserts the session row as `created` and only flips it to `running` right before launching the harness. A run process that dies between those two writes — fork exhaustion, missing adapter, crash — leaves a row **no process owns**. Startup recovery only handled `running → orphaned`; nothing ever touched `created`, so the rows sat there forever (observed: 2×"ping" rows stuck 14+ hours, coven-cave beads cave-zef7/cave-7acp).

## Fix — mirrors the existing orphan-recovery pattern

- **`store::mark_stale_created_sessions_failed(conn, created_before, updated_at)`** — `created` rows older than the cutoff become `failed` (exit code stays NULL). Newer rows survive: `coven run` writes the store directly, independent of daemon lifecycle, so a launch can be legitimately mid-registration while the daemon boots — only age proves a row dead. Timestamps come from one producer in one format, so the lexicographic comparison is sound.
- **`daemon::recover_stale_created_sessions`** (10-minute TTL) — runs at daemon startup beside `recover_orphaned_sessions`.
- **Read-repair on `GET /sessions`** — the daemon has no periodic maintenance loop, and Cave polls this endpoint constantly, so it doubles as the reap tick: throttled to one attempt per 60s via atomic compare-exchange (concurrent connections can't double-fire), and best-effort — a failed repair never fails the read it piggybacks on.

## Validation

- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo test --workspace --locked` ✓ · `scripts/check-secrets.py` ✓
- New tests: `store::tests::marks_only_stale_created_sessions_failed` (stale flips with bumped `updated_at`; fresh `created` and `running` rows untouched) and `daemon::tests::recovers_stale_created_sessions_as_failed` (real-clock TTL: old row reaps, just-registered row survives).

Companion Cave-side mitigation already shipped as coven-cave#3023 (sweeps its own turn's orphans on the send failure path); this closes the leak at the source for every client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)