### PR TITLE
test(harness): guard adapter-env reads with env_lock to fix tempdir race

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1570,6 +1570,9 @@ mod tests {
 
     #[test]
     fn command_parts_for_known_harnesses_append_interactive_prompt() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         assert_eq!(
             command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::Interactive)?,
             (
@@ -1589,6 +1592,9 @@ mod tests {
 
     #[test]
     fn command_parts_for_known_harnesses_use_noninteractive_entrypoints() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         assert_eq!(
             command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?,
             (
@@ -1619,6 +1625,9 @@ mod tests {
 
     #[test]
     fn dash_prefixed_prompts_stay_positional_behind_double_dash() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         // A prompt starting with `-` must never parse as harness flags.
         for mode in [
             HarnessLaunchMode::Interactive,
@@ -1677,6 +1686,9 @@ mod tests {
 
     #[test]
     fn command_parts_reject_unknown_harnesses() {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         assert!(
             command_parts_for_harness("shell", "hello", HarnessLaunchMode::Interactive)
                 .unwrap_err()
@@ -1907,6 +1919,9 @@ mod tests {
     /// `stream_args()` produced, now read from its declared `stream_args`.
     #[test]
     fn claude_stream_launch_args_unchanged_after_declaration() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (program, args) = command_parts_for_harness_with_conversation(
             "claude",
             "hello",
@@ -2201,6 +2216,9 @@ mod tests {
 
     #[test]
     fn claude_init_hint_attaches_session_id_flag_in_print_mode() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let hint = ConversationHint::Init {
             id: "abc-123".to_string(),
         };
@@ -2230,6 +2248,9 @@ mod tests {
 
     #[test]
     fn claude_resume_hint_attaches_resume_flag_in_print_mode() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let hint = ConversationHint::Resume {
             id: "abc-123".to_string(),
         };
@@ -2259,6 +2280,9 @@ mod tests {
 
     #[test]
     fn interactive_mode_ignores_conversation_hint() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let hint = ConversationHint::Init {
             id: "abc-123".to_string(),
         };
@@ -2283,6 +2307,9 @@ mod tests {
     #[test]
     fn codex_init_hint_falls_through_to_default_args_so_codex_can_assign_its_own_id(
     ) -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let hint = ConversationHint::Init {
             id: "abc-123".to_string(),
         };
@@ -2313,6 +2340,9 @@ mod tests {
 
     #[test]
     fn codex_resume_hint_uses_exec_resume_subcommand_with_id() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let hint = ConversationHint::Resume {
             id: "019e5998-7130-7872-8d96-a6b67c5b6406".to_string(),
         };
@@ -2345,6 +2375,9 @@ mod tests {
 
     #[test]
     fn claude_stream_mode_preserves_permission_prompts_by_default() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (program, args) = command_parts_for_harness_with_conversation(
             "claude",
             "hello",
@@ -2386,6 +2419,9 @@ mod tests {
 
     #[test]
     fn non_claude_harnesses_do_not_get_permission_bypass() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (_, args) =
             command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?;
         assert!(!args
@@ -2453,6 +2489,9 @@ mod tests {
 
     #[test]
     fn codex_forwards_model_before_prompt_with_prefix_stripped() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (program, args) = command_parts_for_harness_with_conversation(
             "codex",
             "fix tests",
@@ -2487,6 +2526,9 @@ mod tests {
 
     #[test]
     fn claude_forwards_model_with_prefix_stripped() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (_, args) = command_parts_for_harness_with_conversation(
             "claude",
             "hi",
@@ -2513,6 +2555,9 @@ mod tests {
 
     #[test]
     fn claude_think_maps_to_effort_high() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (_, args) = command_parts_for_harness_with_conversation(
             "claude",
             "hi",
@@ -2539,6 +2584,9 @@ mod tests {
 
     #[test]
     fn claude_speed_maps_to_effort_levels() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (_, fast_args) = command_parts_for_harness_with_conversation(
             "claude",
             "hi",
@@ -2569,6 +2617,9 @@ mod tests {
 
     #[test]
     fn codex_ignores_think_and_speed_launch_hints() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let with_hints = command_parts_for_harness_with_conversation(
             "codex",
             "fix tests",
@@ -2590,6 +2641,9 @@ mod tests {
 
     #[test]
     fn no_model_leaves_args_unchanged() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let with_model = command_parts_for_harness_with_conversation(
             "codex",
             "fix tests",
@@ -2699,6 +2753,9 @@ mod tests {
 
     #[test]
     fn codex_forwards_permission_before_prompt() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (_, args) = command_parts_for_harness_with_conversation(
             "codex",
             "fix tests",
@@ -2723,6 +2780,9 @@ mod tests {
 
     #[test]
     fn claude_forwards_permission_full_maps_to_bypass() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let (_, args) = command_parts_for_harness_with_conversation(
             "claude",
             "hi",
@@ -2749,6 +2809,9 @@ mod tests {
 
     #[test]
     fn no_permission_leaves_args_unchanged() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let with_opt = command_parts_for_harness_with_conversation(
             "codex",
             "fix tests",
@@ -2871,6 +2934,9 @@ mod tests {
 
     #[test]
     fn none_hint_matches_legacy_command_parts() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
         let with_none = command_parts_for_harness_with_conversation(
             "claude",
             "hello",


### PR DESCRIPTION
Closes #344.

## Problem

`harness::tests` mutate process-global adapter env vars (`COVEN_HARNESS_ADAPTER_DIRS` / `_MANIFEST`) under a shared `env_lock()` mutex — but **22 tests that only *read* spec resolution** (`command_parts_for_harness`, the built-in spec builders) ran without taking the lock. `cargo test` runs a module's tests concurrently, so a reader could observe a sibling test's half-torn-down tempdir manifest and blow up:

```
Error: failed to read harness adapter manifest
/tmp/.tmpXXXX/adapters/codex-compatible.json: No such file or directory (os error 2)
```

This is exactly what reddened CI on #343 — a daemon change that touched no harness code but reshuffled the in-binary test schedule enough to surface the latent race. (Confirmed benign there: main went green on the merge commit `8df3e610`.)

## Fix

Take `env_lock().lock()` at the top of every spec-resolving test, so reads serialize against the mutators that install/remove the tempdir manifests. Test-only change; **no production code touched** (diff is `crates/coven-cli/src/harness.rs` tests module only).

## Validation

- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo test --workspace --locked` ✓ · secret scan (pre-commit gitleaks) ✓
- **Stress:** ran `cargo test -p coven-cli harness::` 5× in a row — 55/55 each time, no flake.
- Verified no test ends up double-locking the non-reentrant mutex (per-function guard count audited: 31 tests, exactly one guard each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)