### PR TITLE
feat(cli): unify coven-code as a managed engine (Phase 0+1)

### DIFF
--- a/crates/coven-cli/src/engine.rs
+++ b/crates/coven-cli/src/engine.rs
@@ -1,0 +1,297 @@
+//! Managed engine (coven-code) resolution and version gating.
+//!
+//! LICENSE BOUNDARY: the engine is GPL-3.0; coven is MIT. The engine is
+//! always a separate process launched by path — never a Cargo dependency.
+//! Do not add any claurst-* crate to this workspace.
+
+use anyhow::{anyhow, bail, Context, Result};
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[cfg(windows)]
+pub const ENGINE_BIN_NAME: &str = "coven-code.exe";
+#[cfg(not(windows))]
+pub const ENGINE_BIN_NAME: &str = "coven-code";
+
+/// Oldest engine this coven build can drive (contract v1 surfaces).
+// used by Task 1.2+
+#[allow(dead_code)]
+pub const MIN_ENGINE_VERSION: (u64, u64, u64) = (0, 6, 1);
+
+#[derive(Debug)]
+pub enum EngineSource {
+    EnvOverride, // COVEN_ENGINE_BIN
+    Managed,     // ~/.coven/engine/<current>/
+    PathLookup,  // coven-code on PATH
+    LegacyHome,  // ~/.coven-code/bin/ (pre-unification installs)
+}
+
+// used by Task 1.2+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct ResolvedEngine {
+    pub path: PathBuf,
+    pub source: EngineSource,
+}
+
+pub fn resolve() -> Option<ResolvedEngine> {
+    let env_override = std::env::var_os("COVEN_ENGINE_BIN");
+    let path_var = std::env::var_os("PATH");
+    let home = dirs_next::home_dir();
+    resolve_from(
+        env_override.as_deref(),
+        path_var.as_deref(),
+        home.as_deref(),
+    )
+}
+
+pub fn resolve_from(
+    env_override: Option<&OsStr>,
+    path_var: Option<&OsStr>,
+    home: Option<&Path>,
+) -> Option<ResolvedEngine> {
+    // 1. COVEN_ENGINE_BIN explicit override
+    if let Some(override_path) = env_override {
+        let p = PathBuf::from(override_path);
+        if is_executable(&p) {
+            return Some(ResolvedEngine {
+                path: p,
+                source: EngineSource::EnvOverride,
+            });
+        }
+        // Set but not executable: fall through to next source
+    }
+
+    // 2. Managed ~/.coven/engine/<current>/ENGINE_BIN_NAME
+    if let Some(home) = home {
+        let current_file = home.join(".coven").join("engine").join("current");
+        if let Ok(version) = std::fs::read_to_string(&current_file) {
+            let version = version.trim();
+            if !version.is_empty() {
+                let candidate = home
+                    .join(".coven")
+                    .join("engine")
+                    .join(version)
+                    .join(ENGINE_BIN_NAME);
+                if is_executable(&candidate) {
+                    return Some(ResolvedEngine {
+                        path: candidate,
+                        source: EngineSource::Managed,
+                    });
+                }
+            }
+        }
+    }
+
+    // 3. PATH lookup (honor Windows multi-name)
+    if let Some(path_var) = path_var {
+        for dir in std::env::split_paths(path_var) {
+            for name in engine_bin_names() {
+                let candidate = dir.join(name);
+                if is_executable(&candidate) {
+                    return Some(ResolvedEngine {
+                        path: candidate,
+                        source: EngineSource::PathLookup,
+                    });
+                }
+            }
+        }
+    }
+
+    // 4. Legacy ~/.coven-code/bin/ (pre-unification installs)
+    if let Some(home) = home {
+        let bin_dir = home.join(".coven-code").join("bin");
+        for name in engine_bin_names() {
+            let candidate = bin_dir.join(name);
+            if is_executable(&candidate) {
+                return Some(ResolvedEngine {
+                    path: candidate,
+                    source: EngineSource::LegacyHome,
+                });
+            }
+        }
+    }
+
+    None
+}
+
+/// Resolve or produce the single actionable "engine missing" error.
+// used by Task 1.2+
+#[allow(dead_code)]
+pub fn require() -> Result<ResolvedEngine> {
+    resolve().ok_or_else(|| {
+        anyhow!(
+            "The Coven engine is not installed.\n\n  Run: coven engine install\n\n\
+             (or set COVEN_ENGINE_BIN to an existing coven-code binary)"
+        )
+    })
+}
+
+// used by Task 1.2+
+#[allow(dead_code)]
+pub fn engine_version(binary: &Path) -> Result<(u64, u64, u64)> {
+    let out = Command::new(binary)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("failed to run {} --version", binary.display()))?;
+    if !out.status.success() {
+        bail!("{} --version exited nonzero", binary.display());
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    parse_version_output(&text)
+        .ok_or_else(|| anyhow!("unparseable engine version output: {text:?}"))
+}
+
+pub fn parse_version_output(text: &str) -> Option<(u64, u64, u64)> {
+    // Take the last whitespace-separated token, strip a leading 'v',
+    // split on '.' into 3 parts, parse patch up to the first non-digit.
+    // e.g. "coven-code 0.6.1\n" -> Some((0, 6, 1))
+    //      "coven-code 0.6.1-rc1" -> Some((0, 6, 1))
+    //      "garbage" -> None
+    let token = text.split_whitespace().last()?;
+    let token = token.strip_prefix('v').unwrap_or(token);
+    let mut parts = token.splitn(3, '.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch_str = parts.next()?;
+    // Parse patch up to the first non-digit character
+    let digit_end = patch_str
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(patch_str.len());
+    let patch = patch_str[..digit_end].parse::<u64>().ok()?;
+    Some((major, minor, patch))
+}
+
+// used by Task 1.2+
+#[allow(dead_code)]
+pub fn version_meets_minimum(v: (u64, u64, u64)) -> bool {
+    v >= MIN_ENGINE_VERSION
+}
+
+/// Returns the list of candidate binary names to look up, in priority order.
+/// On Windows: exe, cmd, bat shims. On non-Windows: just the bare name.
+fn engine_bin_names() -> &'static [&'static str] {
+    if cfg!(windows) {
+        &["coven-code.exe", "coven-code.cmd", "coven-code.bat"]
+    } else {
+        &["coven-code"]
+    }
+}
+
+/// Check whether a path is an executable file.
+/// Unix: file must exist and have at least one executable bit set.
+/// Non-Unix: file must exist (is_file()).
+fn is_executable(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|m| m.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn touch_exec(path: &std::path::Path) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+
+    #[test]
+    fn managed_engine_wins_over_path_and_legacy() {
+        let home = tempfile::tempdir().unwrap();
+        let managed = home
+            .path()
+            .join(".coven/engine/0.6.1")
+            .join(ENGINE_BIN_NAME);
+        let legacy = home.path().join(".coven-code/bin").join(ENGINE_BIN_NAME);
+        touch_exec(&managed);
+        touch_exec(&legacy);
+        fs::write(home.path().join(".coven/engine/current"), "0.6.1").unwrap();
+        let r = resolve_from(None, None, Some(home.path())).unwrap();
+        assert_eq!(r.path, managed);
+        assert!(matches!(r.source, EngineSource::Managed));
+    }
+
+    #[test]
+    fn env_override_beats_everything() {
+        let home = tempfile::tempdir().unwrap();
+        let custom = home.path().join("custom-engine");
+        touch_exec(&custom);
+        let r = resolve_from(Some(custom.as_os_str()), None, Some(home.path())).unwrap();
+        assert!(matches!(r.source, EngineSource::EnvOverride));
+        assert_eq!(r.path, custom);
+    }
+
+    #[test]
+    fn falls_back_to_legacy_home_dir() {
+        let home = tempfile::tempdir().unwrap();
+        let legacy = home.path().join(".coven-code/bin").join(ENGINE_BIN_NAME);
+        touch_exec(&legacy);
+        let r = resolve_from(None, None, Some(home.path())).unwrap();
+        assert!(matches!(r.source, EngineSource::LegacyHome));
+    }
+
+    #[test]
+    fn resolves_none_when_absent() {
+        let home = tempfile::tempdir().unwrap();
+        assert!(resolve_from(None, None, Some(home.path())).is_none());
+    }
+
+    #[test]
+    fn parses_clap_version_line() {
+        assert_eq!(parse_version_output("coven-code 0.6.1\n"), Some((0, 6, 1)));
+        assert_eq!(parse_version_output("garbage"), None);
+    }
+
+    #[test]
+    fn min_version_gate() {
+        assert!(version_meets_minimum((0, 6, 1)));
+        assert!(!version_meets_minimum((0, 5, 9)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn env_override_non_executable_falls_through() {
+        let home = tempfile::tempdir().unwrap();
+        let not_exec = home.path().join("not-exec");
+        fs::write(&not_exec, b"").unwrap(); // written without the exec bit
+        let legacy = home.path().join(".coven-code/bin").join(ENGINE_BIN_NAME);
+        touch_exec(&legacy);
+        let r = resolve_from(Some(not_exec.as_os_str()), None, Some(home.path())).unwrap();
+        assert!(matches!(r.source, EngineSource::LegacyHome));
+    }
+
+    #[test]
+    fn whitespace_only_current_file_is_ignored() {
+        let home = tempfile::tempdir().unwrap();
+        // A managed binary exists, but `current` is blank → managed source must be skipped.
+        let managed = home
+            .path()
+            .join(".coven/engine/0.6.1")
+            .join(ENGINE_BIN_NAME);
+        touch_exec(&managed);
+        fs::write(home.path().join(".coven/engine/current"), "  \n").unwrap();
+        let legacy = home.path().join(".coven-code/bin").join(ENGINE_BIN_NAME);
+        touch_exec(&legacy);
+        let r = resolve_from(None, None, Some(home.path())).unwrap();
+        assert!(matches!(r.source, EngineSource::LegacyHome));
+    }
+}

--- a/crates/coven-cli/src/engine.rs
+++ b/crates/coven-cli/src/engine.rs
@@ -15,8 +15,6 @@ pub const ENGINE_BIN_NAME: &str = "coven-code.exe";
 pub const ENGINE_BIN_NAME: &str = "coven-code";
 
 /// Oldest engine this coven build can drive (contract v1 surfaces).
-// used by Task 1.2+
-#[allow(dead_code)]
 pub const MIN_ENGINE_VERSION: (u64, u64, u64) = (0, 6, 1);
 
 #[derive(Debug)]
@@ -27,7 +25,7 @@ pub enum EngineSource {
     LegacyHome,  // ~/.coven-code/bin/ (pre-unification installs)
 }
 
-// used by Task 1.2+
+// used by Task 1.3+
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct ResolvedEngine {
@@ -117,7 +115,7 @@ pub fn resolve_from(
 }
 
 /// Resolve or produce the single actionable "engine missing" error.
-// used by Task 1.2+
+// used by Task 1.3+
 #[allow(dead_code)]
 pub fn require() -> Result<ResolvedEngine> {
     resolve().ok_or_else(|| {
@@ -128,8 +126,6 @@ pub fn require() -> Result<ResolvedEngine> {
     })
 }
 
-// used by Task 1.2+
-#[allow(dead_code)]
 pub fn engine_version(binary: &Path) -> Result<(u64, u64, u64)> {
     let out = Command::new(binary)
         .arg("--version")
@@ -163,10 +159,28 @@ pub fn parse_version_output(text: &str) -> Option<(u64, u64, u64)> {
     Some((major, minor, patch))
 }
 
-// used by Task 1.2+
-#[allow(dead_code)]
 pub fn version_meets_minimum(v: (u64, u64, u64)) -> bool {
     v >= MIN_ENGINE_VERSION
+}
+
+/// Human-readable error when the resolved engine is older than the minimum.
+/// Pure (no I/O) so it can be unit-tested; used by the delegation handshake.
+pub fn engine_too_old_message(
+    binary: &Path,
+    actual: (u64, u64, u64),
+    min: (u64, u64, u64),
+) -> String {
+    format!(
+        "The Coven engine at {} is version {}.{}.{}, older than the minimum \
+         {}.{}.{} this coven build requires.\n\n  Run: coven engine install",
+        binary.display(),
+        actual.0,
+        actual.1,
+        actual.2,
+        min.0,
+        min.1,
+        min.2,
+    )
 }
 
 /// Returns the list of candidate binary names to look up, in priority order.
@@ -277,6 +291,28 @@ mod tests {
         touch_exec(&legacy);
         let r = resolve_from(Some(not_exec.as_os_str()), None, Some(home.path())).unwrap();
         assert!(matches!(r.source, EngineSource::LegacyHome));
+    }
+
+    #[test]
+    fn path_lookup_finds_windows_cmd_shim_name() {
+        // The resolver's PathLookup must honor every platform bin-name, mirroring
+        // the npm .cmd shim discovery the old main.rs helper covered.
+        let names = engine_bin_names();
+        if cfg!(windows) {
+            assert!(names.contains(&"coven-code.cmd"));
+        } else {
+            assert_eq!(names, &["coven-code"]);
+        }
+    }
+
+    #[test]
+    fn engine_too_old_message_names_version_and_install_command() {
+        let msg =
+            engine_too_old_message(std::path::Path::new("/x/coven-code"), (0, 5, 9), (0, 6, 1));
+        assert!(msg.contains("0.5.9"));
+        assert!(msg.contains("0.6.1"));
+        assert!(msg.contains("coven engine install"));
+        assert!(msg.contains("/x/coven-code"));
     }
 
     #[test]

--- a/crates/coven-cli/src/engine.rs
+++ b/crates/coven-cli/src/engine.rs
@@ -25,8 +25,6 @@ pub enum EngineSource {
     LegacyHome,  // ~/.coven-code/bin/ (pre-unification installs)
 }
 
-// used by Task 1.3+
-#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ResolvedEngine {
     pub path: PathBuf,
@@ -115,8 +113,6 @@ pub fn resolve_from(
 }
 
 /// Resolve or produce the single actionable "engine missing" error.
-// used by Task 1.3+
-#[allow(dead_code)]
 pub fn require() -> Result<ResolvedEngine> {
     resolve().ok_or_else(|| {
         anyhow!(

--- a/crates/coven-cli/src/engine_install.rs
+++ b/crates/coven-cli/src/engine_install.rs
@@ -1,0 +1,237 @@
+//! Engine download/verify/install. The release ships COMPRESSED ARCHIVES
+//! (.tar.gz on unix, .zip on windows), each containing a single `coven-code`
+//! binary at the root. Flow: download archive (curl) -> verify archive
+//! sha256 (sha2 crate) -> extract inner binary (tar) -> atomically install.
+//! Shelling out to curl+tar avoids adding archive/http Rust crates and
+//! matches the official install.sh. The pinned checksum is of the ARCHIVE.
+
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Dev-mode default engine version, used when `coven engine install` is run
+/// without `--version` and before Task 2.1's engine.lock provides the pin.
+pub const DEFAULT_ENGINE_VERSION: &str = "0.6.1";
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum InstallOutcome {
+    Installed,
+    AlreadyPresent,
+}
+
+pub fn artifact_name(os: &str, arch: &str) -> String {
+    match os {
+        "windows" => format!("coven-code-windows-{arch}.zip"),
+        _ => format!("coven-code-{os}-{arch}.tar.gz"),
+    }
+}
+
+pub fn inner_binary_name(os: &str) -> &'static str {
+    if os == "windows" {
+        "coven-code.exe"
+    } else {
+        "coven-code"
+    }
+}
+
+pub fn release_url(version: &str, artifact: &str) -> String {
+    format!("https://github.com/OpenCoven/coven-code/releases/download/v{version}/{artifact}")
+}
+
+pub fn current_platform() -> Result<(&'static str, &'static str)> {
+    let os = match std::env::consts::OS {
+        "macos" => "macos",
+        "linux" => "linux",
+        "windows" => "windows",
+        other => bail!("unsupported platform for managed engine install: {other}"),
+    };
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        other => bail!("unsupported architecture: {other}"),
+    };
+    Ok((os, arch))
+}
+
+/// Removes scratch paths (the downloaded archive and the extraction stage
+/// dir) when it drops — on success or on any early `?`/`bail!` return. The
+/// final installed binary lives in `dest_dir`, not in these paths, so
+/// unconditional cleanup is correct.
+struct ScratchGuard {
+    paths: Vec<PathBuf>,
+}
+
+impl ScratchGuard {
+    fn new() -> Self {
+        Self { paths: Vec::new() }
+    }
+    fn watch(&mut self, path: PathBuf) {
+        self.paths.push(path);
+    }
+}
+
+impl Drop for ScratchGuard {
+    fn drop(&mut self) {
+        for path in &self.paths {
+            if path.is_dir() {
+                let _ = std::fs::remove_dir_all(path);
+            } else {
+                let _ = std::fs::remove_file(path);
+            }
+        }
+    }
+}
+
+/// Download, verify, extract, and activate the engine. Returns the installed
+/// binary path and whether it was freshly installed or already present.
+/// `expected_sha256` is the sha256 of the ARCHIVE; `None` skips
+/// verification with a loud warning (dev mode).
+pub fn install(
+    version: &str,
+    expected_sha256: Option<&str>,
+    force: bool,
+) -> Result<(PathBuf, InstallOutcome)> {
+    let home = dirs_next::home_dir().context("cannot determine home directory")?;
+    let engine_root = home.join(".coven").join("engine");
+    let dest_dir = engine_root.join(version);
+    let dest = dest_dir.join(crate::engine::ENGINE_BIN_NAME);
+    if dest.exists() && !force {
+        activate(&engine_root, version)?;
+        return Ok((dest, InstallOutcome::AlreadyPresent));
+    }
+    let (os, arch) = current_platform()?;
+    let artifact = artifact_name(os, arch);
+    let url = release_url(version, &artifact);
+
+    std::fs::create_dir_all(&dest_dir)
+        .with_context(|| format!("creating {}", dest_dir.display()))?;
+
+    let mut scratch = ScratchGuard::new();
+
+    // 1. Download the archive.
+    let archive = dest_dir.join(&artifact);
+    scratch.watch(archive.clone());
+    let status = Command::new("curl")
+        .args(["-fSL", "--retry", "3", "-o"])
+        .arg(&archive)
+        .arg(&url)
+        .status()
+        .context("failed to run curl (required for engine install)")?;
+    if !status.success() {
+        bail!("download failed: {url}");
+    }
+
+    // 2. Verify the ARCHIVE checksum BEFORE extraction (fail closed).
+    let bytes = std::fs::read(&archive)
+        .with_context(|| format!("reading downloaded archive {}", archive.display()))?;
+    let digest = hex_digest(&bytes);
+    match expected_sha256 {
+        Some(expected) if !digest.eq_ignore_ascii_case(expected) => {
+            bail!(
+                "checksum mismatch for {artifact}: expected {expected}, got {digest}. Refusing to install."
+            );
+        }
+        None => eprintln!(
+            "warning: no pinned checksum for {artifact}; installing unverified (dev mode)"
+        ),
+        _ => {}
+    }
+
+    // `.stage` is a fixed per-version path; concurrent `install` of the SAME
+    // version would race here. That is not a supported scenario (the fast-path
+    // above returns when the binary already exists), so no lock is taken.
+
+    // 3. Extract the inner binary using the system `tar`. On macOS this is
+    //    bsdtar (also reads .zip); on Linux it is GNU tar. The non-Windows
+    //    artifact is always .tar.gz, so .zip is only ever extracted on
+    //    Windows, where tar.exe (bsdtar) handles it.
+    let stage_dir = dest_dir.join(".stage");
+    scratch.watch(stage_dir.clone());
+    let _ = std::fs::remove_dir_all(&stage_dir);
+    std::fs::create_dir_all(&stage_dir)
+        .with_context(|| format!("creating stage dir {}", stage_dir.display()))?;
+    let untar = Command::new("tar")
+        .arg("-xf")
+        .arg(&archive)
+        .arg("-C")
+        .arg(&stage_dir)
+        .status()
+        .context("failed to run tar (required to unpack the engine archive)")?;
+    if !untar.success() {
+        bail!("failed to extract {artifact}");
+    }
+    let extracted = stage_dir.join(inner_binary_name(os));
+    if !extracted.is_file() {
+        bail!(
+            "archive {artifact} did not contain the expected binary {}",
+            inner_binary_name(os)
+        );
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&extracted, std::fs::Permissions::from_mode(0o755))?;
+    }
+    std::fs::rename(&extracted, &dest)?; // atomic within the same dir
+
+    // 4. Publish the `current` pointer. The scratch guard cleans up the
+    //    archive and stage dir when it drops at function end.
+    activate(&engine_root, version)?;
+    Ok((dest, InstallOutcome::Installed))
+}
+
+fn activate(engine_root: &Path, version: &str) -> Result<()> {
+    // `current` is a plain text file (not a symlink): identical on Windows,
+    // written via temp+rename for atomicity.
+    let tmp = engine_root.join("current.tmp");
+    std::fs::write(&tmp, version)?;
+    std::fs::rename(tmp, engine_root.join("current"))?;
+    Ok(())
+}
+
+fn hex_digest(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn artifact_name_is_a_platform_archive() {
+        assert_eq!(
+            artifact_name("macos", "aarch64"),
+            "coven-code-macos-aarch64.tar.gz"
+        );
+        assert_eq!(
+            artifact_name("linux", "x86_64"),
+            "coven-code-linux-x86_64.tar.gz"
+        );
+        assert_eq!(
+            artifact_name("windows", "x86_64"),
+            "coven-code-windows-x86_64.zip"
+        );
+    }
+
+    #[test]
+    fn inner_binary_name_matches_platform() {
+        assert_eq!(inner_binary_name("linux"), "coven-code");
+        assert_eq!(inner_binary_name("windows"), "coven-code.exe");
+    }
+
+    #[test]
+    fn release_url_targets_the_engine_repo() {
+        assert_eq!(
+            release_url("0.6.1", "coven-code-macos-aarch64.tar.gz"),
+            "https://github.com/OpenCoven/coven-code/releases/download/v0.6.1/coven-code-macos-aarch64.tar.gz"
+        );
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -20,6 +20,7 @@ mod coven_calls;
 mod daemon;
 mod encrypted_artifacts;
 mod engine;
+mod engine_install;
 mod eval_loop;
 mod executor_node;
 mod familiar_identity;
@@ -104,6 +105,11 @@ enum Command {
     Adapter {
         #[command(subcommand)]
         command: AdapterCommand,
+    },
+    #[command(about = "Manage the Coven engine (the interactive agent runtime)")]
+    Engine {
+        #[command(subcommand)]
+        command: EngineCommand,
     },
     #[command(about = "Manage the local Coven daemon")]
     Daemon {
@@ -392,6 +398,24 @@ enum DaemonCommand {
 }
 
 #[derive(Subcommand, Debug)]
+enum EngineCommand {
+    #[command(about = "Show resolved engine path, source, version, and pin state")]
+    Status {
+        #[arg(long, help = "Emit JSON")]
+        json: bool,
+    },
+    #[command(about = "Download and install the pinned engine into ~/.coven/engine")]
+    Install {
+        #[arg(long, help = "Install a specific version instead of the default")]
+        version: Option<String>,
+        #[arg(long, help = "Reinstall even if already present")]
+        force: bool,
+    },
+    #[command(about = "Print the engine binary path coven will use (exit 1 if none)")]
+    Which,
+}
+
+#[derive(Subcommand, Debug)]
 enum LogsCommand {
     #[command(about = "Prune expired raw artifacts and old redacted event logs")]
     Prune {
@@ -521,6 +545,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             Ok(())
         }
         Some(Command::Adapter { command }) => run_adapter_command(command),
+        Some(Command::Engine { command }) => run_engine_command(command),
         Some(Command::Daemon { command }) => run_daemon_command(command),
         Some(Command::Executor { command }) => run_executor_command(command),
         Some(Command::Run {
@@ -1545,6 +1570,88 @@ fn run_vacuum_command() -> Result<()> {
         store_path.display()
     );
     Ok(())
+}
+
+fn run_engine_command(command: EngineCommand) -> Result<()> {
+    match command {
+        EngineCommand::Status { json } => engine_status(json),
+        EngineCommand::Install { version, force } => {
+            let version =
+                version.unwrap_or_else(|| engine_install::DEFAULT_ENGINE_VERSION.to_string());
+            // Task 2.1 will thread the pinned checksum here; None = dev mode.
+            let (path, outcome) = engine_install::install(&version, None, force)?;
+            match outcome {
+                engine_install::InstallOutcome::Installed => {
+                    println!("Installed Coven engine {version} at {}", path.display());
+                }
+                engine_install::InstallOutcome::AlreadyPresent => {
+                    println!(
+                        "Coven engine {version} already present at {} (use --force to reinstall)",
+                        path.display()
+                    );
+                }
+            }
+            Ok(())
+        }
+        EngineCommand::Which => match engine::resolve() {
+            Some(resolved) => {
+                println!("{}", resolved.path.display());
+                Ok(())
+            }
+            None => {
+                std::process::exit(1);
+            }
+        },
+    }
+}
+
+fn engine_source_label(source: &engine::EngineSource) -> &'static str {
+    match source {
+        engine::EngineSource::EnvOverride => "COVEN_ENGINE_BIN override",
+        engine::EngineSource::Managed => "managed (~/.coven/engine)",
+        engine::EngineSource::PathLookup => "PATH",
+        engine::EngineSource::LegacyHome => "legacy (~/.coven-code/bin)",
+    }
+}
+
+fn engine_status(json: bool) -> Result<()> {
+    match engine::resolve() {
+        Some(resolved) => {
+            let version = engine::engine_version(&resolved.path).ok();
+            let version_str = version
+                .map(|(a, b, c)| format!("{a}.{b}.{c}"))
+                .unwrap_or_else(|| "unknown".to_string());
+            if json {
+                let obj = serde_json::json!({
+                    "installed": true,
+                    "path": resolved.path.display().to_string(),
+                    "source": engine_source_label(&resolved.source),
+                    "version": version_str,
+                    "pin": serde_json::Value::Null, // Task 2.1
+                });
+                println!("{}", serde_json::to_string_pretty(&obj)?);
+            } else {
+                println!("Coven engine");
+                println!("  Path:    {}", resolved.path.display());
+                println!("  Source:  {}", engine_source_label(&resolved.source));
+                println!("  Version: {version_str}");
+                println!("  Pin:     none (dev)"); // Task 2.1 fills this in
+            }
+            Ok(())
+        }
+        None => {
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({"installed": false}))?
+                );
+            } else {
+                println!("Coven engine: not installed");
+                println!("  Run: coven engine install");
+            }
+            Ok(())
+        }
+    }
 }
 
 fn run_daemon_command(command: DaemonCommand) -> Result<()> {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -328,6 +328,30 @@ enum Command {
         #[command(subcommand)]
         command: Option<pc::PcCommand>,
     },
+    #[command(
+        about = "Manage model provider credentials (Anthropic, Codex) — runs in the Coven engine"
+    )]
+    Auth {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
+        args: Vec<OsString>,
+    },
+    #[command(about = "List available models — runs in the Coven engine")]
+    Models {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
+        args: Vec<OsString>,
+    },
+    #[command(
+        about = "Start the Agent Client Protocol server (stdio JSON-RPC) — runs in the Coven engine"
+    )]
+    Acp {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
+        args: Vec<OsString>,
+    },
+    #[command(about = "Run any Coven engine subcommand directly (escape hatch)")]
+    Code {
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
+        args: Vec<OsString>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -648,6 +672,10 @@ fn run_cli(cli: Cli) -> Result<()> {
             keep_session,
         ),
         Some(Command::Pc { command }) => pc::run_pc_command(command),
+        Some(Command::Auth { args }) => run_engine_passthrough(Some("auth"), &args),
+        Some(Command::Models { args }) => run_engine_passthrough(Some("models"), &args),
+        Some(Command::Acp { args }) => run_engine_passthrough(Some("acp"), &args),
+        Some(Command::Code { args }) => run_engine_passthrough(None, &args),
     }
 }
 
@@ -911,6 +939,49 @@ fn coven_code_binary() -> Option<PathBuf> {
     engine::resolve().map(|resolved| resolved.path)
 }
 
+/// Build a `Command` for the engine binary with the standard parent-context
+/// env. Callers add their own args.
+fn engine_command(binary: &Path) -> std::process::Command {
+    let mut command = std::process::Command::new(binary);
+    command.env("COVEN_PARENT", "coven");
+    // Forward COVEN_HOME only when explicitly set; otherwise the engine derives
+    // the same default from HOME/USERPROFILE that coven would.
+    if let Some(home) = std::env::var_os("COVEN_HOME") {
+        command.env("COVEN_HOME", home);
+    }
+    command
+}
+
+/// Run the engine command, replacing this process on unix (exec) or spawning
+/// and propagating the exit code elsewhere. Returns only on failure.
+fn exec_engine(mut command: std::process::Command) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = command.exec();
+        Err(anyhow!("failed to exec coven-code: {err}"))
+    }
+    #[cfg(not(unix))]
+    {
+        let status = command
+            .status()
+            .map_err(|e| anyhow!("failed to launch coven-code: {e}"))?;
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}
+
+/// Exec the engine with an optional fixed leading subcommand plus user args.
+/// Used for curated passthroughs (auth/models/acp) and the raw `code` hatch.
+fn run_engine_passthrough(lead: Option<&str>, args: &[OsString]) -> Result<()> {
+    let engine = engine::require()?;
+    let mut command = engine_command(&engine.path);
+    if let Some(lead) = lead {
+        command.arg(lead);
+    }
+    command.args(args);
+    exec_engine(command)
+}
+
 /// Exec `coven-code` in place of the current process. Returns only on failure;
 /// on success the child takes over this PID and stdio.
 fn try_delegate_to_coven_code(binary: &Path) -> Result<()> {
@@ -929,7 +1000,7 @@ fn try_delegate_to_coven_code(binary: &Path) -> Result<()> {
         Err(_) => {}
     }
 
-    let mut command = std::process::Command::new(binary);
+    let mut command = engine_command(binary);
     // Pass through every flag the user supplied to `coven`/`coven tui` so
     // any future coven-code substrate flags work end-to-end. We strip argv[0]
     // and the optional leading `tui` subcommand because coven-code expects
@@ -942,29 +1013,7 @@ fn try_delegate_to_coven_code(binary: &Path) -> Result<()> {
         args.remove(0);
     }
     command.args(args);
-    command.env("COVEN_PARENT", "coven");
-    // Forward COVEN_HOME only when explicitly set; otherwise the engine derives
-    // the same default from HOME/USERPROFILE that coven would.
-    if let Some(home) = std::env::var_os("COVEN_HOME") {
-        command.env("COVEN_HOME", home);
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        let err = command.exec();
-        // exec only returns on failure.
-        Err(anyhow!("failed to exec coven-code: {err}"))
-    }
-
-    #[cfg(not(unix))]
-    {
-        let status = command
-            .status()
-            .map_err(|e| anyhow!("failed to launch coven-code: {e}"))?;
-        // A signal-terminated child has no code; treat it as failure.
-        std::process::exit(status.code().unwrap_or(1));
-    }
+    exec_engine(command)
 }
 
 fn interactive_shell_route(
@@ -4138,5 +4187,27 @@ mod tests {
         assert!(!should_offer_auto_install(false, true, false, false)); // piped stdout
         assert!(!should_offer_auto_install(true, true, true, false)); // already installed
         assert!(!should_offer_auto_install(false, true, true, true)); // opt-out
+    }
+
+    #[test]
+    fn passthrough_subcommands_are_registered_and_unique() {
+        // Drives off the real Cli definition so it can't silently rot as commands
+        // are added. clap guarantees subcommand-name uniqueness at construction
+        // (Cli::command() would panic on a duplicate), so asserting each passthrough
+        // resolves to exactly one registered subcommand catches an accidental
+        // rename or a collision with a future coven-owned command.
+        use clap::CommandFactory;
+        let cmd = Cli::command();
+        let names: Vec<String> = cmd
+            .get_subcommands()
+            .map(|s| s.get_name().to_string())
+            .collect();
+        for passthrough in ["auth", "models", "acp", "code"] {
+            assert_eq!(
+                names.iter().filter(|n| n.as_str() == passthrough).count(),
+                1,
+                "passthrough `{passthrough}` must be exactly one registered subcommand"
+            );
+        }
     }
 }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1096,12 +1096,39 @@ fn run_doctor() -> Result<()> {
         healthy = false;
     }
 
-    println!("\nInteractive UI:");
-    match coven_code_binary() {
-        Some(path) => println!("  [OK] coven-code found at {}", path.display()),
+    println!("\nEngine:");
+    match engine::resolve() {
+        Some(resolved) => {
+            println!(
+                "  [OK] {} ({})",
+                resolved.path.display(),
+                engine_source_label(&resolved.source)
+            );
+            match engine::engine_version(&resolved.path) {
+                Ok(version) => {
+                    let (a, b, c) = version;
+                    let (min_a, min_b, min_c) = engine::MIN_ENGINE_VERSION;
+                    if engine::version_meets_minimum(version) {
+                        println!("       version {a}.{b}.{c} (minimum {min_a}.{min_b}.{min_c})");
+                    } else {
+                        healthy = false;
+                        println!(
+                            "  [!!] version {a}.{b}.{c} is older than the minimum {min_a}.{min_b}.{min_c} — run: coven engine install"
+                        );
+                    }
+                }
+                Err(_) => println!("       version: unknown (could not run the engine)"),
+            }
+            println!("       pin: none (dev)"); // Task 2.1 fills this from engine.lock
+            match engine_auth_summary(&resolved.path) {
+                Some(true) => println!("       auth: logged in"),
+                Some(false) => println!("       auth: not logged in — run `coven auth login`"),
+                None => println!("       auth: check skipped"),
+            }
+        }
         None => {
             healthy = false;
-            println!("  [!!] coven-code is missing — `coven` and `coven chat` need it");
+            println!("  [!!] the Coven engine is missing — `coven` and `coven chat` need it");
             for line in coven_code_install_instructions(target_shell()).lines() {
                 println!("     {line}");
             }
@@ -1715,6 +1742,46 @@ fn engine_source_label(source: &engine::EngineSource) -> &'static str {
         engine::EngineSource::PathLookup => "PATH",
         engine::EngineSource::LegacyHome => "legacy (~/.coven-code/bin)",
     }
+}
+
+/// Query the engine's auth state via `auth status --json`, bounded to ~5s so a
+/// hung engine never hangs `coven doctor`. Returns `Some(logged_in)` on a clean
+/// parse, or `None` if the check couldn't be completed (spawn/timeout/parse
+/// failure) — the caller treats `None` as a skipped, non-blocking check.
+fn engine_auth_summary(binary: &Path) -> Option<bool> {
+    use std::io::Read;
+    use std::process::Stdio;
+    use std::time::{Duration, Instant};
+
+    let mut child = std::process::Command::new(binary)
+        .args(["auth", "status", "--json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => return None,
+        }
+    }
+
+    // `auth status --json` output is a few hundred bytes — far under the pipe
+    // buffer — so reading after exit cannot deadlock.
+    let mut buf = String::new();
+    child.stdout.take()?.read_to_string(&mut buf).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&buf).ok()?;
+    json.get("loggedIn")?.as_bool()
 }
 
 fn engine_status(json: bool) -> Result<()> {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
 #[cfg(unix)]
 use std::io::Read;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -771,8 +771,8 @@ fn target_shell() -> TargetShell {
 
 fn missing_coven_code_error_message(shell: TargetShell) -> String {
     format!(
-        "coven-code is required for the interactive Coven UI but was not found on PATH \
-         or under ~/.coven-code/bin.\n\n\
+        "The Coven engine is required for the interactive Coven UI but was not found on PATH, \
+         under ~/.coven/engine, or ~/.coven-code/bin.\n\n\
          Install it with:\n\
          {install}\n\n\
          If you need the legacy slash shell temporarily, run:\n\
@@ -800,10 +800,10 @@ fn legacy_tui_warning_message(shell: TargetShell) -> String {
 fn coven_code_install_instructions(shell: TargetShell) -> &'static str {
     match shell {
         TargetShell::Posix => {
-            "  npm install -g @opencoven/coven-code\n  curl -fsSL https://github.com/OpenCoven/coven-code/releases/latest/download/install.sh | bash"
+            "  coven engine install\n  (manual: curl -fsSL https://github.com/OpenCoven/coven-code/releases/latest/download/install.sh | bash)"
         }
         TargetShell::PowerShell => {
-            "  npm install -g @opencoven/coven-code\n  irm https://github.com/OpenCoven/coven-code/releases/latest/download/install.ps1 | iex"
+            "  coven engine install\n  (manual: irm https://github.com/OpenCoven/coven-code/releases/latest/download/install.ps1 | iex)"
         }
     }
 }
@@ -826,69 +826,30 @@ fn legacy_tui_opted_in() -> bool {
     )
 }
 
-/// Locate the `coven-code` binary on PATH or in `~/.coven-code/bin/`.
+/// Locate the engine binary via the managed-engine resolver.
+/// Kept as a thin shim so existing call sites don't churn.
 fn coven_code_binary() -> Option<PathBuf> {
-    let path_var = std::env::var_os("PATH");
-    let home = dirs_next::home_dir();
-    coven_code_binary_from(path_var.as_deref(), home.as_deref())
-}
-
-fn coven_code_binary_from(path_var: Option<&OsStr>, home: Option<&Path>) -> Option<PathBuf> {
-    let names: &[&str] = if cfg!(windows) {
-        &["coven-code.exe", "coven-code.cmd", "coven-code.bat"]
-    } else {
-        &["coven-code"]
-    };
-    coven_code_binary_from_names(path_var, home, names)
-}
-
-fn coven_code_binary_from_names(
-    path_var: Option<&OsStr>,
-    home: Option<&Path>,
-    names: &[&str],
-) -> Option<PathBuf> {
-    if let Some(path_var) = path_var {
-        for dir in std::env::split_paths(path_var) {
-            for name in names {
-                let candidate = dir.join(name);
-                if is_executable_file(&candidate) {
-                    return Some(candidate);
-                }
-            }
-        }
-    }
-    if let Some(home) = home {
-        let bin_dir = home.join(".coven-code").join("bin");
-        for name in names {
-            let candidate = bin_dir.join(name);
-            if is_executable_file(&candidate) {
-                return Some(candidate);
-            }
-        }
-    }
-    None
-}
-
-fn is_executable_file(path: &Path) -> bool {
-    if !path.is_file() {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::metadata(path)
-            .map(|m| m.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false)
-    }
-    #[cfg(not(unix))]
-    {
-        true
-    }
+    engine::resolve().map(|resolved| resolved.path)
 }
 
 /// Exec `coven-code` in place of the current process. Returns only on failure;
 /// on success the child takes over this PID and stdio.
 fn try_delegate_to_coven_code(binary: &Path) -> Result<()> {
+    // Refuse engines older than the minimum the contract requires.
+    match engine::engine_version(binary) {
+        Ok(version) if !engine::version_meets_minimum(version) => {
+            return Err(anyhow!(engine::engine_too_old_message(
+                binary,
+                version,
+                engine::MIN_ENGINE_VERSION
+            )));
+        }
+        Ok(_) => {}
+        // If we can't read the version, don't block launch — proceed and let the
+        // engine speak for itself. (A pin-drift warning is added in Task 2.1.)
+        Err(_) => {}
+    }
+
     let mut command = std::process::Command::new(binary);
     // Pass through every flag the user supplied to `coven`/`coven tui` so
     // any future coven-code substrate flags work end-to-end. We strip argv[0]
@@ -902,6 +863,12 @@ fn try_delegate_to_coven_code(binary: &Path) -> Result<()> {
         args.remove(0);
     }
     command.args(args);
+    command.env("COVEN_PARENT", "coven");
+    // Forward COVEN_HOME only when explicitly set; otherwise the engine derives
+    // the same default from HOME/USERPROFILE that coven would.
+    if let Some(home) = std::env::var_os("COVEN_HOME") {
+        command.env("COVEN_HOME", home);
+    }
 
     #[cfg(unix)]
     {
@@ -2702,6 +2669,7 @@ mod tests {
         MagicalTuiMove, MagicalTuiRequest, MAGICAL_TUI_MAX_INNER_WIDTH,
     };
     use crossterm::event::KeyEventKind;
+    use std::ffi::OsStr;
     use std::sync::{Mutex, OnceLock};
 
     fn env_lock() -> &'static Mutex<()> {
@@ -3938,11 +3906,11 @@ mod tests {
 
     #[test]
     fn missing_coven_code_error_includes_install_instructions() {
-        // The error message is the primary onboarding surface when coven-code
-        // is absent, so it must list at least one concrete install path and
-        // mention the legacy escape hatch.
+        // The error message is the primary onboarding surface when the engine
+        // is absent, so it must lead with the unified command and mention the
+        // fallback script and the legacy escape hatch.
         let msg = missing_coven_code_error_message(TargetShell::Posix);
-        assert!(msg.contains("npm install -g @opencoven/coven-code"));
+        assert!(msg.contains("coven engine install"));
         assert!(msg.contains("install.sh"));
         assert!(msg.contains("COVEN_LEGACY_TUI=1"));
     }
@@ -3951,40 +3919,11 @@ mod tests {
     fn missing_coven_code_error_includes_windows_powershell_instructions() {
         let msg = missing_coven_code_error_message(TargetShell::PowerShell);
 
+        assert!(msg.contains("coven engine install"));
         assert!(msg.contains("irm https://github.com/OpenCoven/coven-code/releases/latest/download/install.ps1 | iex"));
         assert!(msg.contains("$env:COVEN_LEGACY_TUI = \"1\""));
         assert!(msg.contains("Remove-Item Env:COVEN_LEGACY_TUI"));
         assert!(!msg.contains("install.sh | bash"));
-    }
-
-    #[test]
-    fn coven_code_binary_lookup_returns_none_for_empty_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        assert!(coven_code_binary_from(Some(OsStr::new("")), Some(tmp.path())).is_none());
-    }
-
-    #[test]
-    fn coven_code_binary_lookup_finds_windows_npm_cmd_shim() {
-        let tmp = tempfile::tempdir().unwrap();
-        let shim = tmp.path().join("coven-code.cmd");
-        std::fs::write(&shim, "@echo off\r\n").unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut permissions = std::fs::metadata(&shim).unwrap().permissions();
-            permissions.set_mode(0o755);
-            std::fs::set_permissions(&shim, permissions).unwrap();
-        }
-        let path_var = std::env::join_paths([tmp.path()]).unwrap();
-
-        assert_eq!(
-            coven_code_binary_from_names(
-                Some(path_var.as_os_str()),
-                None,
-                &["coven-code.exe", "coven-code.cmd", "coven-code.bat"]
-            ),
-            Some(shim)
-        );
     }
 
     fn sample_daemon_status() -> daemon::DaemonStatus {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -771,7 +771,61 @@ fn run_shared_interactive_shell() -> Result<()> {
 
     match coven_code_binary() {
         Some(binary) => try_delegate_to_coven_code(&binary),
-        None => Err(missing_coven_code_error()),
+        None => {
+            let offer = should_offer_auto_install(
+                false,
+                io::stdin().is_terminal(),
+                io::stdout().is_terminal(),
+                auto_install_opted_out(),
+            );
+            if offer {
+                match prompt_and_install_engine()? {
+                    Some(path) => try_delegate_to_coven_code(&path),
+                    None => Err(missing_coven_code_error()),
+                }
+            } else {
+                Err(missing_coven_code_error())
+            }
+        }
+    }
+}
+
+/// Whether to offer auto-installing the engine. Interactive only, and never
+/// when an engine is already present or the user opted out.
+fn should_offer_auto_install(
+    engine_present: bool,
+    stdin_tty: bool,
+    stdout_tty: bool,
+    opt_out: bool,
+) -> bool {
+    !engine_present && stdin_tty && stdout_tty && !opt_out
+}
+
+/// `COVEN_NO_AUTO_INSTALL=1` (or `=true`) disables the first-run install prompt
+/// (used by CI and non-interactive automation).
+fn auto_install_opted_out() -> bool {
+    matches!(
+        std::env::var("COVEN_NO_AUTO_INSTALL").as_deref(),
+        Ok("1") | Ok("true")
+    )
+}
+
+/// Ask the user (on a known-TTY) whether to install the engine now. Returns
+/// the installed binary path on yes, `None` if the user declined. Propagates
+/// install errors.
+fn prompt_and_install_engine() -> Result<Option<PathBuf>> {
+    eprintln!("The Coven engine is required for the interactive UI and isn't installed yet.");
+    eprint!("Download and install it now (~40 MB)? [Y/n] ");
+    io::stderr().flush().ok();
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    let answer = answer.trim();
+    if answer.is_empty() || answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes") {
+        let (path, _) =
+            engine_install::install(engine_install::DEFAULT_ENGINE_VERSION, None, false)?;
+        Ok(Some(path))
+    } else {
+        Ok(None)
     }
 }
 
@@ -4075,5 +4129,14 @@ mod tests {
         assert_eq!(value["pid"], serde_json::Value::Null);
         assert_eq!(value["socket"], serde_json::Value::Null);
         assert_eq!(value["started_at"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn auto_install_only_offered_interactively() {
+        assert!(should_offer_auto_install(false, true, true, false));
+        assert!(!should_offer_auto_install(false, false, true, false)); // piped stdin
+        assert!(!should_offer_auto_install(false, true, false, false)); // piped stdout
+        assert!(!should_offer_auto_install(true, true, true, false)); // already installed
+        assert!(!should_offer_auto_install(false, true, true, true)); // opt-out
     }
 }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -19,6 +19,7 @@ mod control_plane;
 mod coven_calls;
 mod daemon;
 mod encrypted_artifacts;
+mod engine;
 mod eval_loop;
 mod executor_node;
 mod familiar_identity;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,6 +177,16 @@ desktop/apps -> Coven -> chat/intake client UI updates
 - Session browser actions surface readable choices: **Rejoin**, **View Log**, **Summon**, **Archive**, and **Sacrifice**.
 - `coven attach|summon|archive|sacrifice <session-id>` remain explicit lower-level verbs for scripts and copy/paste workflows.
 
+## Managed engine
+
+Coven drives `coven-code` as a separately-installed engine process — it is
+never linked or imported as a library. The process boundary is also the license
+boundary (coven: MIT; coven-code: GPL-3.0). The exact CLI flags, environment
+variables, stream-json events, and exit codes that constitute the integration
+surface are specified in [`docs/ENGINE-CONTRACT.md`](ENGINE-CONTRACT.md);
+any breaking change to that surface requires a coordinated version bump in both
+repositories.
+
 ## Distribution snapshot
 
 The npm wrapper packages are live for early adopters:

--- a/docs/ENGINE-CONTRACT.md
+++ b/docs/ENGINE-CONTRACT.md
@@ -1,0 +1,99 @@
+---
+title: "Coven ↔ Engine Compatibility Contract (v1)"
+summary: "The invocation surfaces, environment contract, and stream-json protocol that coven uses when driving a coven-code engine. Covers CLI surfaces, auth, streaming, and exit codes."
+read_when:
+  - Adding or changing a CLI surface that coven invokes
+  - Implementing engine resolver or MIN_ENGINE_VERSION enforcement
+  - Writing contract tests against golden stream fixtures
+description: "Versioned compatibility boundary between coven and a coven-code engine binary: invocation surfaces, environment variables, stream-json event types, and exit codes."
+---
+
+# Coven ↔ Engine Compatibility Contract (v1)
+
+Coven invokes the engine (coven-code) ONLY through these surfaces. Any breaking
+change to them requires bumping `contract_version` here and in coven's
+`MIN_ENGINE_VERSION` gate. The engine CI runs coven's contract tests (Phase 2).
+
+## Version
+
+`contract_version: 1`. Enforcement lives in coven's engine resolver
+(`crates/coven-cli/src/engine.rs`, `MIN_ENGINE_VERSION` — forthcoming in
+Phase 1), which refuses to launch engines older than the minimum compatible
+version.
+
+## Invocation surfaces
+
+1. `coven-code` (no args) — interactive TUI, exits 0 on quit
+2. `coven-code --version` — stdout: `coven-code <semver>` (single line, no trailing
+   text); example: `coven-code 0.6.1`
+3. `coven-code --print <prompt>` — headless; `<prompt>` is the positional `[PROMPT]`
+   arg (not an option value); result to stdout; exit 0
+4. `coven-code --print --input-format stream-json --output-format stream-json` —
+   long-lived stream loop; one JSON frame per line on stdin; exits on stdin EOF
+5. `coven-code --resume <id>` — resume a previous session by ID (omit ID to resume
+   most recent)
+6. `coven-code --session-id <tag>` — attach a tracking tag to a headless run (for
+   logs/hooks); NOT the same as --resume — does not pin or restore a session
+7. `coven-code --model <id>` / `--append-system-prompt <text>` / `--cwd <dir>` —
+   accepted and honored; coven passes values through unvalidated
+8. `coven-code --permission-mode {default|accept-edits|bypass-permissions|plan}` —
+   accepted and honored; coven passes the value through unvalidated
+9. `coven-code auth status --json` — machine-readable auth state; coven reads only
+   the `loggedIn` boolean; additional fields may be present and are ignored;
+   exit 0 = logged in, 1 = not
+
+   Minimal example:
+   ```json
+   {"loggedIn": false}
+   ```
+
+10. `coven-code acp` — Agent Client Protocol server on stdio; newline-delimited
+    JSON-RPC 2.0 (verified via source: `crates/acp/src/connection.rs`); subcommand
+    accepts no flags and produces no --help output — it is a fast-path in the CLI
+    dispatcher
+
+## Environment
+
+- `COVEN_PARENT=coven`        set by coven on every delegated invocation
+- `COVEN_HOME`                coven state root, forwarded when set
+- `COVEN_DAEMON_SOCKET`       daemon UDS path, forwarded when the daemon is up
+- `COVEN_CODE_*`              engine-owned namespace; coven never overrides
+
+## Stream-json events (subset coven parses)
+
+Coven parses the following event types from the engine's stdout stream (surface 4).
+Type names are verbatim from the engine protocol:
+
+- `system` (subtype `init`) — emitted once at stream startup; carries `cwd`,
+  `session_id`, `tools`, and `model`
+- `user` — echoed user message frame; carries `message.role`, `message.content`,
+  and `session_id`
+- `assistant` — model response; carries `message.role`, `message.content` (text
+  blocks or tool-use blocks), `session_id`, and `stop_reason`
+- `tool_result` — outcome of a tool execution; carries `tool_use_id`, `content`,
+  `is_error`, and `session_id`
+- `result` — terminal frame closing each turn; carries `subtype`
+  (`success` or `error_during_execution`), `duration_ms`, `is_error`, `num_turns`,
+  `session_id`, and `error`
+
+Event schemas: see [docs/STREAM-JSON.md](STREAM-JSON.md).
+
+Note: STREAM-JSON.md documents the output (engine → coven) side of the protocol.
+For input frames (coven → engine on stdin), see the Input frames section below.
+
+### Input frames (stdin, surface 4)
+
+Two shapes are accepted per `stream_mode.rs`:
+
+- Primary (Claude/Coven) shape: `{"type":"user","message":{"role":"user","content":<string or text-block array>}}`
+  triggers a turn.
+- Legacy shape: `{"role":"user"|"assistant","content":"..."}` — `assistant` frames
+  append as prefill without running a turn.
+
+Unknown `type` values are silently ignored. Formal schema forthcoming with the
+Phase 2 golden fixtures (`coven/tests/fixtures/engine/` —
+forthcoming — added in Phase 2 with the contract test suite).
+
+## Exit codes (headless)
+
+0 = completed; 1 = errored / budget exceeded; others reserved

--- a/docs/ENGINE-CONTRACT.md
+++ b/docs/ENGINE-CONTRACT.md
@@ -55,8 +55,10 @@ version.
 ## Environment
 
 - `COVEN_PARENT=coven`        set by coven on every delegated invocation
-- `COVEN_HOME`                coven state root, forwarded when set
-- `COVEN_DAEMON_SOCKET`       daemon UDS path, forwarded when the daemon is up
+- `COVEN_HOME`                coven state root, actively forwarded when set
+- `COVEN_DAEMON_SOCKET`       daemon UDS path; inherited through the environment
+                              (coven does not clear env), reserved for the
+                              Phase 3 daemon-session notifier
 - `COVEN_CODE_*`              engine-owned namespace; coven never overrides
 
 ## Stream-json events (subset coven parses)


### PR DESCRIPTION
## Summary

Phase 1 of unifying the OpenCoven CLIs: make **`coven` the single user-facing CLI**, driving `coven-code` (the "engine") as a **separate managed process — never linked**. This is the "one surface, two processes" model.

**Why a process boundary, not one binary:** `coven` is MIT; the engine is GPL-3.0 (inherited from upstream Claurst, not unilaterally relicensable). Statically linking the engine's crates would force the combined binary to GPL. Invoking the engine at arm's length as a subprocess keeps each work under its own license — the ripgrep-in-VS-Code / containerd-under-Docker pattern. This PR adds **no new dependencies** and **no dependency on any `claurst-*` crate**.

Full design + all 6 phases: `docs/superpowers/plans/2026-07-12-coven-cli-unification.md` (in the coven-code repo). The compatibility contract is `docs/ENGINE-CONTRACT.md` here.

## What's in this PR (Phase 0 + Phase 1)

- **`docs/ENGINE-CONTRACT.md`** (contract_version 1) — the exact CLI/env/stream surfaces coven relies on, each verified against the real engine binary.
- **`crates/coven-cli/src/engine.rs`** — managed-engine resolver: `COVEN_ENGINE_BIN` → managed `~/.coven/engine/current` → PATH → legacy `~/.coven-code/bin`; version gate (`MIN_ENGINE_VERSION` 0.6.1) with a `--version` handshake at delegation.
- **`crates/coven-cli/src/engine_install.rs`** — `coven engine install`: downloads the platform release archive (`.tar.gz`/`.zip`) via `curl`, verifies the archive SHA-256 **before** extraction (fails closed on mismatch), extracts via `tar`, atomically installs into `~/.coven/engine/<ver>/`. RAII scratch-cleanup on every exit.
- **`coven engine status | install | which`**, **first-run auto-install prompt** (TTY-gated, `COVEN_NO_AUTO_INSTALL` opt-out), **passthroughs** `coven auth | models | acp` and the raw `coven code` escape hatch, and a **doctor `Engine:` section** (source, version-vs-minimum, pin placeholder, auth via a 5s-bounded `auth status --json` probe — auth is non-blocking).

## Behavior

- `npm i -g @opencoven/cli && coven` → offers to install the engine, then opens the TUI. Zero separate coven-code install step.
- Delegation forwards `COVEN_PARENT=coven` (+ `COVEN_HOME` when set) and refuses engines older than the minimum with an actionable message.
- The managed engine wins resolution over a PATH copy, so `coven engine install` is authoritative.

## Verification

- `cargo test -p coven-cli` — **999 + 4 + 4 + 20 + 1 passed, 0 failed** (rebased onto current `main`).
- `cargo clippy -p coven-cli --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- **Live smoke:** `coven engine install --version 0.6.1` downloads + extracts + runs (`coven-code 0.6.1`); `coven code --version`, `coven auth status --json`, `coven models` reach the engine; `coven doctor` shows the Engine section and exits 0 with auth logged-out.

## Review process

Each task was implemented TDD-style and passed a two-stage review (spec compliance + code quality) with fixes looped back in; a final whole-branch review confirmed the license boundary, cross-task consistency (single-sourced `MIN_ENGINE_VERSION`/`DEFAULT_ENGINE_VERSION`, install-writes-where-resolve-reads), and commit hygiene. All 8 commits are signed.

## Not in this PR (later phases)

Pinned `engine.lock` + cross-repo contract-test CI (Phase 2), engine-as-first-class-harness with daemon-ledgered sessions (Phase 3), state/config/auth unification under `~/.coven` (Phase 4), brand/UX sweep (Phase 5). Pin placeholders are honest `// Task 2.1` markers, not half-built.

## Companion

The engine-side contract pointer (COVEN.md + AGENTS.md) is a small separate PR against `OpenCoven/coven-code`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
