### PR TITLE
fix(ci): secret guard false positives on Rust let-bindings and release URLs

### DIFF
--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -394,5 +394,80 @@ class SecretGuardLockfileTests(unittest.TestCase):
         )
 
 
+class SecretGuardRustLetBindingTests(unittest.TestCase):
+    def test_rust_let_call_bindings_do_not_trigger_generic_assignment(self) -> None:
+        text = "\n".join(
+            [
+                "    let token = text.split_whitespace().last()?;",
+                "    let token = token.strip_prefix('v').unwrap_or(token);",
+                "    let mut secret = std::env::args().nth(1).unwrap_or_default();",
+                "    let password: String = prompt_hidden(\"Password: \")?;",
+                "    let api_key = format!(\"{prefix}-{suffix}\");",
+            ]
+        )
+
+        hits = check_secrets.scan_text(text, "crates/coven-cli/src/engine.rs")
+
+        self.assertEqual(hits, [])
+
+    def test_rust_let_with_literal_value_still_triggers_generic_assignment(self) -> None:
+        hits = check_secrets.scan_text(
+            'let token = "hunter2hunter2hunter2";', "crates/coven-cli/src/engine.rs"
+        )
+
+        self.assertEqual(
+            hits, [("crates/coven-cli/src/engine.rs", 1, "generic_assignment")]
+        )
+
+    def test_rust_let_with_bare_blob_still_triggers_generic_assignment(self) -> None:
+        # Assembled at runtime so the fixture itself doesn't look like a secret
+        # assignment to source-level scanners; the scanned LINE is what matters.
+        blob = "SGVsbG9" + "Xb3JsZFRoaXNJc05vdEFDYWxs"
+        hits = check_secrets.scan_text(f"let token = {blob};", "src/lib.rs")
+
+        self.assertEqual(
+            hits,
+            [
+                ("src/lib.rs", 1, "generic_assignment"),
+                ("src/lib.rs", 1, "high_entropy"),
+            ],
+        )
+
+    def test_other_rules_still_apply_to_let_call_binding_lines(self) -> None:
+        hits = check_secrets.scan_text(
+            'let token = mint("ghp_0123456789abcdefghij123456");', "src/lib.rs"
+        )
+
+        self.assertEqual(hits, [("src/lib.rs", 1, "github_token")])
+
+
+class SecretGuardReleaseUrlTests(unittest.TestCase):
+    def test_opencoven_release_download_urls_do_not_trigger_high_entropy(self) -> None:
+        text = (
+            '            "https://github.com/OpenCoven/coven-code/releases/download'
+            '/v0.6.1/coven-code-macos-aarch64.tar.gz"'
+        )
+
+        hits = check_secrets.scan_text(text, "crates/coven-cli/src/engine_install.rs")
+
+        self.assertEqual(hits, [])
+
+    def test_non_opencoven_release_urls_still_trigger_high_entropy(self) -> None:
+        blob = "m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aB" + "EuIqOwPz9RkTlVxCyNmS3HdG7fA"
+        text = f"https://github.com/NotOpenCoven/repo/releases/download/v1/{blob}"
+
+        hits = check_secrets.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "high_entropy")])
+
+    def test_overlong_release_artifact_segment_still_triggers_high_entropy(self) -> None:
+        blob = "m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aB" * 3
+        text = f"https://github.com/OpenCoven/coven-code/releases/download/v1/{blob}"
+
+        hits = check_secrets.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "high_entropy")])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -51,6 +51,15 @@ ENV_SECRET_REFERENCE = re.compile(
     r"(?i)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*[\"']?"
     r"\$\{?[A-Z0-9_]+(?:[:?][^\"']*)?\}?"
 )
+# A Rust `let` binding whose right-hand side begins with a call expression
+# (identifier chain followed by `(`, e.g. `let token = text.split_whitespace()`).
+# The secret-sounding name binds the RESULT of code that runs later; the line
+# cannot contain a credential literal. A quoted or bare-blob RHS does not match
+# this shape and still trips `generic_assignment`.
+RUST_LET_CALL_BINDING = re.compile(
+    r"^\s*let\s+(?:mut\s+)?[A-Za-z_][A-Za-z0-9_]*\s*(?::[^=]{1,64})?=\s*"
+    r"[A-Za-z_][A-Za-z0-9_]*(?:(?:::|\.)[A-Za-z_][A-Za-z0-9_]*)*!?\("
+)
 
 
 def sh(*args: str) -> str:
@@ -101,9 +110,16 @@ def is_local_path_like_token(token: str) -> bool:
 
 def is_public_repo_url_like_token(token: str) -> bool:
     normalized = token.strip("/")
-    return normalized.startswith("github.com/OpenCoven/coven/") and (
-        "/blob/" in normalized or "/tree/" in normalized
-    )
+    if not re.match(r"github\.com/OpenCoven/[A-Za-z0-9_.-]+/", normalized):
+        return False
+    if "/blob/" in normalized or "/tree/" in normalized:
+        return True
+    # Release-artifact URLs (…/releases/download/<tag>/<artifact>): tags and
+    # artifact filenames are short path segments; cap each so a token-like
+    # blob smuggled into a fake artifact name still trips the entropy rule.
+    if "/releases/download/" in normalized:
+        return all(len(part) <= 64 for part in normalized.split("/"))
+    return False
 
 
 def is_opencoven_repo_relative_path_token(token: str) -> bool:
@@ -234,6 +250,8 @@ def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
             if name == "generic_assignment" and ENV_SECRET_READ.search(line):
                 continue
             if name == "generic_assignment" and ENV_SECRET_REFERENCE.search(line):
+                continue
+            if name == "generic_assignment" and RUST_LET_CALL_BINDING.match(line):
                 continue
             if name == "generic_assignment" and "grep" in line and re.search(r"-[A-Za-z]*E\b", line):
                 continue


### PR DESCRIPTION
## Context

- Summary: `Secret guard` fails on all four engine-unification branches (#346, `feat/engine-lock`, `feat/engine-harness`, `feat/engine-ledger`) on false positives from two shapes in the new engine code. Because the guard also scans branch history, fixing flagged lines at a branch tip cannot clear history findings — the recognizers themselves need to learn the shapes.
- Files changed: `scripts/check-secrets.py`, `scripts/check-secrets-test.py`
- Closes #350

## Implementation

- Approach: two tight FP-shape recognizers, mirroring the existing `ENV_SECRET_READ`/`is_*_token` pattern:
  1. `generic_assignment` skips a Rust `let` binding whose RHS begins with a call expression (`let token = text.split_whitespace().last()?;`). The secret-sounding name binds the result of code that runs later; the line cannot contain a credential literal. A quoted-literal or bare-blob RHS does not match the shape and still trips. The skip is rule-scoped: other rules (e.g. `github_token`) still fire on the same line.
  2. `is_public_repo_url_like_token` widens from `OpenCoven/coven` to `OpenCoven/<repo>` and additionally recognizes `/releases/download/` URLs, with every path segment capped at 64 chars so a token-like blob smuggled into a fake artifact name still trips the entropy rule. `blob|tree` behavior is otherwise unchanged.
- User-visible behavior: none (CI-only).
- Compatibility notes: strictly reduces false positives; negative tests pin that literal assignments, bare blobs, embedded real token shapes, non-OpenCoven release URLs, and overlong artifact segments all still flag.

## Verification

- [x] `cargo fmt --check` — n/a, no Rust changes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — n/a, no Rust changes
- [x] `cargo test --workspace --locked` — n/a, no Rust changes
- [x] `python3 scripts/check-secrets.py` — clean (current + history)
- [x] Additional manual checks:
  - `python3 scripts/check-secrets-test.py` — 42 tests, all pass (7 new); fixture blobs assembled at runtime so the repo gitleaks pre-commit hook stays clean
  - Patched scanner replayed over every branch-introduced blob of the four engine branches: `feat/managed-engine` 10 → 0 findings; `feat/engine-lock`, `feat/engine-harness`, `feat/engine-ledger` 0 findings each

## Risk and Rollback

- Risk level: low — two additive recognizers with pinned negative tests; the scanner scripts themselves are in `EXCLUDED_PATHS` so history scanning is unaffected by this change landing.
- Rollback plan: revert the commit; the guard returns to its previous (stricter, false-positive-prone) behavior.

## Agent Handoff

- Current state: complete; unblocks Secret guard on #346 and the three other engine branches once merged (they pick up the fixed scanner through the PR merge ref — update the branch or re-run CI).
- Follow-ups: none.
- Known gaps: `RUST_LET_CALL_BINDING` doesn't recognize turbofish RHS (`Vec::<u8>::new()`); such lines keep flagging, which errs on the strict side.
