### PR TITLE
feat(daemon): register externally-owned sessions in the ledger (Phase 3, Track B)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -432,6 +432,11 @@ pub fn handle_request_with_runtime(
             json_response(200, &sessions)
         }
         ("POST", "/sessions") => launch_session(coven_home, body, runtime),
+        ("POST", "/sessions/external") => register_external_session(coven_home, body),
+        ("POST", path) if path.starts_with("/sessions/") && path.ends_with("/complete") => {
+            let session_id = session_action_id(path, "/complete");
+            complete_external_session(coven_home, session_id, body)
+        }
         ("POST", path) if path.starts_with("/sessions/") && path.ends_with("/input") => {
             let session_id = session_action_id(path, "/input");
             record_input(coven_home, session_id, body, runtime)
@@ -796,6 +801,8 @@ fn upload_travel_delta(coven_home: &Path, body: Option<&str>, query: &str) -> Re
             familiar_id: Some(profile.familiar_id.clone()),
             labels: vec!["travel".to_string(), "offline-delta".to_string()],
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         },
     )?;
     if let Some(events) = payload.get("events").and_then(Value::as_array) {
@@ -1514,6 +1521,8 @@ fn launch_session(
         familiar_id: familiar_ctx.as_ref().map(|familiar| familiar.id.clone()),
         labels: Vec::new(),
         visibility: "private".to_string(),
+        external: false,
+        transcript_path: None,
     };
     store::insert_session(&conn, &record)?;
     if let Err(error) = runtime.launch_session(&launch) {
@@ -1545,6 +1554,117 @@ fn launch_session(
         }
     }
     json_response(201, &record)
+}
+
+fn register_external_session(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let id = match required_string(&payload, "id") {
+        Ok(id) => id,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let project_root = match required_string(&payload, "projectRoot") {
+        Ok(r) => r,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let harness = match required_string(&payload, "harness") {
+        Ok(h) => h,
+        Err(error) => return api_error(400, "invalid_request", &error.to_string(), None),
+    };
+    let title = payload
+        .get("title")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("External session")
+        .to_string();
+    let transcript_path = payload
+        .get("transcriptPath")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let now = current_timestamp();
+    let record = store::SessionRecord {
+        id,
+        project_root,
+        harness,
+        title,
+        status: "running".to_string(),
+        exit_code: None,
+        archived_at: None,
+        created_at: now.clone(),
+        updated_at: now,
+        conversation_id: None,
+        familiar_id: None,
+        labels: Vec::new(),
+        visibility: "private".to_string(),
+        external: true,
+        transcript_path,
+    };
+    let conn = store::open_store(&store_path(coven_home))?;
+    // Idempotent: if a row with this id already exists, return 200 with the
+    // existing record rather than failing.
+    let inserted = store::insert_session_if_absent(&conn, &record)?;
+    let status = if inserted { 201 } else { 200 };
+    // Re-read so the response always reflects the persisted row.
+    let persisted = store::get_session(&conn, &record.id)?.unwrap_or(record);
+    // If the insert was skipped (inserted == false) and the existing row is
+    // NOT external, a daemon-managed session already holds this id — reject
+    // rather than silently aliasing it.
+    if !inserted && !persisted.external {
+        return api_error(
+            409,
+            "session_id_conflict",
+            "A daemon-managed session with this id already exists.",
+            Some(json!({ "sessionId": &persisted.id })),
+        );
+    }
+    json_response(status, &persisted)
+}
+
+fn complete_external_session(
+    coven_home: &Path,
+    session_id: &str,
+    body: Option<&str>,
+) -> Result<ApiResponse> {
+    let payload: Value = body
+        .and_then(|b| serde_json::from_str(b).ok())
+        .unwrap_or(Value::Null);
+    let exit_code: Option<i32> = payload
+        .get("exitCode")
+        .and_then(Value::as_i64)
+        .map(|c| c as i32);
+    let status = match exit_code {
+        Some(code) if code != 0 => "failed",
+        _ => "completed",
+    };
+    let conn = store::open_store(&store_path(coven_home))?;
+    match store::get_session(&conn, session_id)? {
+        None => api_error(
+            404,
+            "session_not_found",
+            "Session was not found.",
+            Some(json!({ "sessionId": session_id })),
+        ),
+        Some(session) if !session.external => api_error(
+            422,
+            "not_external_session",
+            "POST /sessions/<id>/complete is only valid for externally-registered sessions. Use POST /sessions/<id>/kill for daemon-managed sessions.",
+            Some(json!({ "sessionId": session_id })),
+        ),
+        Some(_) => {
+            store::update_session_status(
+                &conn,
+                session_id,
+                status,
+                exit_code,
+                &current_timestamp(),
+            )?;
+            let updated = store::get_session(&conn, session_id)?.expect("session vanished");
+            json_response(200, &updated)
+        }
+    }
 }
 
 fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
@@ -1757,6 +1877,14 @@ fn kill_session(
     if session.status != "running" {
         return session_not_live_response(session_id);
     }
+    if session.external {
+        return api_error(
+            422,
+            "external_session_not_killable",
+            "External sessions are not managed by the daemon; use POST /sessions/<id>/complete to mark them finished.",
+            Some(json!({ "sessionId": session_id })),
+        );
+    }
 
     // Same structured-error pattern as the launch + input handlers: a
     // runtime kill failure (libc::kill returning EPERM, etc.) must
@@ -1946,6 +2074,8 @@ fn ensure_cockpit_session(conn: &rusqlite::Connection) -> Result<()> {
         familiar_id: None,
         labels: Vec::new(),
         visibility: "private".to_string(),
+        external: false,
+        transcript_path: None,
     };
     store::insert_session_if_absent(conn, &record)?;
     Ok(())
@@ -3127,6 +3257,8 @@ mod tests {
                 familiar_id: None,
                 labels: Vec::new(),
                 visibility: "private".to_string(),
+                external: false,
+                transcript_path: None,
             },
         )?;
         store::insert_json_event(
@@ -3313,6 +3445,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         crate::store::insert_session(&conn, &session)?;
 
@@ -4349,6 +4483,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         crate::store::insert_session(&conn, &session)?;
         Ok(())
@@ -4654,6 +4790,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         store::insert_session(&conn, &session)?;
         insert_event(&conn, home, "sess-log", "input", json!({"text": "hello"}))?;
@@ -4692,6 +4830,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         store::insert_session(&conn, &session)?;
         let fake = fake_openai_key();
@@ -4735,6 +4875,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         store::insert_session(&conn, &session)?;
         drop(conn);
@@ -4772,6 +4914,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         store::insert_session(&conn, &session)?;
         insert_event(
@@ -4886,6 +5030,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         store::insert_session(&conn, &session)?;
         drop(conn);
@@ -4987,6 +5133,8 @@ mod tests {
                     familiar_id: None,
                     labels: Vec::new(),
                     visibility: "private".to_string(),
+                    external: false,
+                    transcript_path: None,
                 },
             )?;
         }
@@ -5265,6 +5413,280 @@ icon = "ph:leaf-fill"
         assert_eq!(response.status, 404);
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
         assert_eq!(body["error"]["code"], "call_not_found");
+        Ok(())
+    }
+
+    #[test]
+    fn register_external_session_returns_201_with_external_flag() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let body = json!({
+            "id": "engine-sess-abc",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": "Engine TUI session",
+            "transcriptPath": "/tmp/engine-sess-abc.jsonl"
+        })
+        .to_string();
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&body),
+        )?;
+
+        assert_eq!(response.status, 201, "unexpected body: {}", response.body);
+        let record: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(record["id"], "engine-sess-abc");
+        assert_eq!(record["status"], "running");
+        assert_eq!(record["external"], true);
+        assert_eq!(record["transcript_path"], "/tmp/engine-sess-abc.jsonl");
+
+        // Verify idempotency: a second POST with the same id returns 200, not 201.
+        let response2 = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&body),
+        )?;
+        assert_eq!(
+            response2.status, 200,
+            "idempotent re-register should return 200"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn register_external_session_empty_title_defaults_to_external_session() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        // Empty string title should fall back to "External session".
+        let body_empty = json!({
+            "id": "engine-sess-empty-title",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": ""
+        })
+        .to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&body_empty),
+        )?;
+        assert_eq!(response.status, 201, "unexpected body: {}", response.body);
+        let record: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(
+            record["title"], "External session",
+            "empty title should default to \"External session\""
+        );
+
+        // Whitespace-only title should also fall back to "External session".
+        let body_ws = json!({
+            "id": "engine-sess-ws-title",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": "   "
+        })
+        .to_string();
+        let response_ws = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&body_ws),
+        )?;
+        assert_eq!(
+            response_ws.status, 201,
+            "unexpected body: {}",
+            response_ws.body
+        );
+        let record_ws: serde_json::Value = serde_json::from_str(&response_ws.body)?;
+        assert_eq!(
+            record_ws["title"], "External session",
+            "whitespace-only title should default to \"External session\""
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn complete_external_session_with_exit_0_marks_completed() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        // Register the session first.
+        let reg_body = json!({
+            "id": "engine-sess-complete",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": "will complete"
+        })
+        .to_string();
+        handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&reg_body),
+        )?;
+
+        // Complete with exitCode 0.
+        let complete_body = json!({ "exitCode": 0 }).to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/engine-sess-complete/complete",
+            temp.path(),
+            None,
+            Some(&complete_body),
+        )?;
+
+        assert_eq!(response.status, 200, "body: {}", response.body);
+        let record: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(record["status"], "completed");
+        Ok(())
+    }
+
+    #[test]
+    fn complete_external_session_with_nonzero_exit_marks_failed() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        let reg_body = json!({
+            "id": "engine-sess-fail",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": "will fail"
+        })
+        .to_string();
+        handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&reg_body),
+        )?;
+
+        let complete_body = json!({ "exitCode": 1 }).to_string();
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/engine-sess-fail/complete",
+            temp.path(),
+            None,
+            Some(&complete_body),
+        )?;
+
+        assert_eq!(response.status, 200, "body: {}", response.body);
+        let record: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(record["status"], "failed");
+        Ok(())
+    }
+
+    #[test]
+    fn complete_unknown_session_returns_404() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/no-such-session-id/complete",
+            temp.path(),
+            None,
+            Some(r#"{"exitCode": 0}"#),
+        )?;
+
+        assert_eq!(response.status, 404);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "session_not_found");
+        Ok(())
+    }
+
+    #[test]
+    fn kill_external_session_returns_422() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        // Register an external session so it's in the store as running+external.
+        let reg_body = json!({
+            "id": "ext-kill-guard",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": "external session"
+        })
+        .to_string();
+        handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&reg_body),
+        )?;
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/api/v1/sessions/ext-kill-guard/kill",
+            temp.path(),
+            None,
+            None,
+            &NoopSessionRuntime,
+        )?;
+
+        assert_eq!(response.status, 422, "body: {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "external_session_not_killable");
+        assert_eq!(body["error"]["details"]["sessionId"], "ext-kill-guard");
+        Ok(())
+    }
+
+    #[test]
+    fn complete_non_external_session_returns_422() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        // Insert a daemon-managed (non-external) running session.
+        insert_test_session(temp.path(), "daemon-sess")?;
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/daemon-sess/complete",
+            temp.path(),
+            None,
+            Some(r#"{"exitCode": 0}"#),
+        )?;
+
+        assert_eq!(response.status, 422, "body: {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "not_external_session");
+        assert_eq!(body["error"]["details"]["sessionId"], "daemon-sess");
+        Ok(())
+    }
+
+    #[test]
+    fn register_external_session_conflicts_with_daemon_session_returns_409() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+
+        // Insert a daemon-managed session with the id we're about to try to register.
+        insert_test_session(temp.path(), "shared-id")?;
+
+        let reg_body = json!({
+            "id": "shared-id",
+            "projectRoot": temp.path().to_string_lossy(),
+            "harness": "engine",
+            "title": "should conflict"
+        })
+        .to_string();
+
+        let response = handle_request_with_body(
+            "POST",
+            "/api/v1/sessions/external",
+            temp.path(),
+            None,
+            Some(&reg_body),
+        )?;
+
+        assert_eq!(response.status, 409, "body: {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "session_id_conflict");
+        assert_eq!(body["error"]["details"]["sessionId"], "shared-id");
         Ok(())
     }
 }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -3957,6 +3957,8 @@ mod tests {
                 familiar_id: None,
                 labels: Vec::new(),
                 visibility: "private".to_string(),
+                external: false,
+                transcript_path: None,
             },
         )?;
         let listener = bind_api_socket(temp_dir.path())?;
@@ -4122,6 +4124,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         }
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1599,6 +1599,8 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         familiar_id: None,
         labels: Vec::new(),
         visibility: "private".to_string(),
+        external: false,
+        transcript_path: None,
     };
     store::insert_session(&conn, &record)?;
     let metadata = serde_json::json!({
@@ -2223,6 +2225,8 @@ fn run_session(
             familiar_id: familiar_ctx.as_ref().map(|f| f.id.clone()),
             labels,
             visibility: visibility.unwrap_or("private").to_string(),
+            external: false,
+            transcript_path: None,
         };
         (r, false)
     };
@@ -2706,7 +2710,13 @@ fn attach_session(session_id: &str) -> Result<()> {
         );
     }
 
-    maybe_spawn_input_forwarder(home.clone(), session_id.to_string());
+    if session.external {
+        eprintln!(
+            "interactive engine session — attach shows the recorded ledger, not the live terminal."
+        );
+    } else {
+        maybe_spawn_input_forwarder(home.clone(), session_id.to_string());
+    }
 
     let mut seen = HashSet::new();
     loop {
@@ -3063,6 +3073,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
         store::insert_session(&conn, &record)?;
         record.id = "aaab2222-0000-0000-0000-000000000000".to_string();
@@ -4041,6 +4053,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
 
         assert_eq!(
@@ -4065,6 +4079,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         };
 
         let rendered = render_sessions_json(&[session])?;
@@ -4180,6 +4196,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         }
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -45,6 +45,15 @@ pub struct SessionRecord {
     pub labels: Vec<String>,
     #[serde(default = "default_visibility")]
     pub visibility: String,
+    /// True when the session was launched outside the daemon (e.g. by the
+    /// coven engine TUI) and registered via POST /sessions/external. The
+    /// daemon does not own the PTY; it only holds the ledger row.
+    #[serde(default)]
+    pub external: bool,
+    /// Absolute path to the transcript file written by an external session.
+    /// Only meaningful when `external` is true.
+    #[serde(default)]
+    pub transcript_path: Option<String>,
 }
 
 fn default_visibility() -> String {
@@ -251,7 +260,9 @@ pub fn open_store(path: &Path) -> Result<Connection> {
             conversation_id TEXT,
             labels TEXT,
             visibility TEXT NOT NULL DEFAULT 'private',
-            familiar_id TEXT
+            familiar_id TEXT,
+            external INTEGER NOT NULL DEFAULT 0,
+            transcript_path TEXT
         );
 
         CREATE TABLE IF NOT EXISTS events (
@@ -470,6 +481,7 @@ pub fn open_store(path: &Path) -> Result<Connection> {
     ensure_visibility_column(&conn)?;
     ensure_familiar_id_column(&conn)?;
     ensure_node_registry_dispatch_columns(&conn)?;
+    ensure_session_external_columns(&conn)?;
 
     backfill_events_fts_if_needed(&conn)?;
 
@@ -560,6 +572,22 @@ fn ensure_event_privacy_columns(conn: &Connection) -> Result<()> {
         "events",
         "sensitive",
         "ALTER TABLE events ADD COLUMN sensitive INTEGER NOT NULL DEFAULT 0",
+    )?;
+    Ok(())
+}
+
+fn ensure_session_external_columns(conn: &Connection) -> Result<()> {
+    ensure_column(
+        conn,
+        "sessions",
+        "external",
+        "ALTER TABLE sessions ADD COLUMN external INTEGER NOT NULL DEFAULT 0",
+    )?;
+    ensure_column(
+        conn,
+        "sessions",
+        "transcript_path",
+        "ALTER TABLE sessions ADD COLUMN transcript_path TEXT",
     )?;
     Ok(())
 }
@@ -1588,8 +1616,9 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
     conn.execute(
         "INSERT INTO sessions (
             id, project_root, harness, title, status, exit_code, archived_at,
-            created_at, updated_at, conversation_id, labels, visibility, familiar_id
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            created_at, updated_at, conversation_id, labels, visibility, familiar_id,
+            external, transcript_path
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
         params![
             &record.id,
             &record.project_root,
@@ -1604,6 +1633,8 @@ pub fn insert_session(conn: &Connection, record: &SessionRecord) -> Result<()> {
             labels_json,
             &record.visibility,
             &record.familiar_id,
+            record.external as i32,
+            &record.transcript_path,
         ],
     )
     .with_context(|| format!("failed to insert session {}", record.id))?;
@@ -1621,8 +1652,9 @@ pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Re
         .execute(
             "INSERT OR IGNORE INTO sessions (
                 id, project_root, harness, title, status, exit_code, archived_at,
-                created_at, updated_at, conversation_id, labels, visibility, familiar_id
-            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+                created_at, updated_at, conversation_id, labels, visibility, familiar_id,
+                external, transcript_path
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
             params![
                 &record.id,
                 &record.project_root,
@@ -1637,6 +1669,8 @@ pub fn insert_session_if_absent(conn: &Connection, record: &SessionRecord) -> Re
                 labels_json,
                 &record.visibility,
                 &record.familiar_id,
+                record.external as i32,
+                &record.transcript_path,
             ],
         )
         .with_context(|| format!("failed to upsert session {}", record.id))?;
@@ -1669,7 +1703,8 @@ pub fn mark_running_sessions_orphaned(conn: &Connection, updated_at: &str) -> Re
             "UPDATE sessions
              SET status = 'orphaned',
                  updated_at = ?1
-             WHERE status = 'running'",
+             WHERE status = 'running'
+               AND external = 0",
             params![updated_at],
         )
         .context("failed to mark running sessions orphaned")?;
@@ -1752,6 +1787,8 @@ fn list_sessions_with_archive_filter(
     Ok(sessions)
 }
 
+// NOTE: column ORDER here must stay in sync with the positional indices in
+// `session_record_from_row`; append new columns at the END only.
 const SESSION_COLUMNS: &str = "id,
                 project_root,
                 harness,
@@ -1764,7 +1801,9 @@ const SESSION_COLUMNS: &str = "id,
                 conversation_id,
                 labels,
                 visibility,
-                familiar_id";
+                familiar_id,
+                external,
+                transcript_path";
 
 fn session_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRecord> {
     let labels_str: Option<String> = row.get(10)?;
@@ -1781,6 +1820,7 @@ fn session_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionR
         })?
         .unwrap_or_default();
     let visibility: String = row.get(11)?;
+    let external_int: i32 = row.get(13)?;
     Ok(SessionRecord {
         id: row.get(0)?,
         project_root: row.get(1)?,
@@ -1795,6 +1835,8 @@ fn session_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionR
         familiar_id: row.get(12)?,
         labels,
         visibility,
+        external: external_int != 0,
+        transcript_path: row.get(14)?,
     })
 }
 
@@ -2560,6 +2602,41 @@ mod tests {
     }
 
     #[test]
+    fn orphan_reaper_skips_external_sessions() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+
+        // A normal running session: should be orphaned.
+        let mut non_external = session_record("non-external-running", "2026-04-27T06:00:00Z");
+        non_external.status = "running".to_string();
+        non_external.external = false;
+
+        // An external running session: must NOT be orphaned.
+        let mut external = session_record("external-running", "2026-04-27T06:00:00Z");
+        external.status = "running".to_string();
+        external.external = true;
+
+        insert_session(&conn, &non_external)?;
+        insert_session(&conn, &external)?;
+
+        let updated = mark_running_sessions_orphaned(&conn, "2026-04-27T07:00:00Z")?;
+        assert_eq!(updated, 1, "only the non-external session should be reaped");
+
+        let sessions = list_sessions(&conn)?;
+        let ne = sessions
+            .iter()
+            .find(|s| s.id == "non-external-running")
+            .unwrap();
+        let ex = sessions
+            .iter()
+            .find(|s| s.id == "external-running")
+            .unwrap();
+        assert_eq!(ne.status, "orphaned");
+        assert_eq!(ex.status, "running", "external session must stay running");
+        Ok(())
+    }
+
+    #[test]
     fn marks_only_stale_created_sessions_failed() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let conn = open_store(&temp_dir.path().join("coven.db"))?;
@@ -3182,6 +3259,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         }
     }
 
@@ -3480,5 +3559,86 @@ mod tests {
 
     fn fake_github_token() -> String {
         format!("ghp_{}", "b".repeat(40))
+    }
+
+    #[test]
+    fn external_session_fields_round_trip_via_get_and_list() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let conn = open_store(&temp.path().join("test.sqlite3"))?;
+
+        // Insert an external session with a transcript path.
+        let external = SessionRecord {
+            id: "ext-sess-1".to_string(),
+            project_root: "/tmp/proj".to_string(),
+            harness: "engine".to_string(),
+            title: "Engine run".to_string(),
+            status: "running".to_string(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-07-12T10:00:00Z".to_string(),
+            updated_at: "2026-07-12T10:00:00Z".to_string(),
+            conversation_id: None,
+            familiar_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
+            external: true,
+            transcript_path: Some("/tmp/proj/.claude/transcripts/ext-sess-1.jsonl".to_string()),
+        };
+        insert_session(&conn, &external)?;
+
+        // Insert a regular (non-external) session without a transcript path.
+        let internal = SessionRecord {
+            id: "int-sess-1".to_string(),
+            project_root: "/tmp/proj".to_string(),
+            harness: "codex".to_string(),
+            title: "Normal run".to_string(),
+            status: "created".to_string(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-07-12T10:01:00Z".to_string(),
+            updated_at: "2026-07-12T10:01:00Z".to_string(),
+            conversation_id: None,
+            familiar_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
+        };
+        insert_session(&conn, &internal)?;
+
+        // Round-trip via get_session.
+        let got_ext = get_session(&conn, "ext-sess-1")?.expect("external session should exist");
+        assert!(got_ext.external, "external flag should be true");
+        assert_eq!(
+            got_ext.transcript_path.as_deref(),
+            Some("/tmp/proj/.claude/transcripts/ext-sess-1.jsonl")
+        );
+
+        let got_int = get_session(&conn, "int-sess-1")?.expect("internal session should exist");
+        assert!(
+            !got_int.external,
+            "internal session external flag should be false"
+        );
+        assert!(
+            got_int.transcript_path.is_none(),
+            "internal session should have no transcript"
+        );
+
+        // Round-trip via list_sessions.
+        let all = list_sessions(&conn)?;
+        let ext_in_list = all
+            .iter()
+            .find(|s| s.id == "ext-sess-1")
+            .expect("ext in list");
+        let int_in_list = all
+            .iter()
+            .find(|s| s.id == "int-sess-1")
+            .expect("int in list");
+        assert!(ext_in_list.external);
+        assert!(!int_in_list.external);
+        assert!(ext_in_list.transcript_path.is_some());
+        assert!(int_in_list.transcript_path.is_none());
+
+        Ok(())
     }
 }

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -2623,6 +2623,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         }
     }
 

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1540,6 +1540,8 @@ mod tests {
             familiar_id: None,
             labels: Vec::new(),
             visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
         }
     }
 

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -581,6 +581,8 @@ fn create_local_quest_anchor(
         familiar_id: None,
         labels: Vec::new(),
         visibility: "private".to_string(),
+        external: false,
+        transcript_path: None,
     };
     store::insert_session(&conn, &record)?;
     let harness_label = default_harness

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -141,6 +141,9 @@ All API errors use the following stable envelope. Clients must branch on `error.
 | `job_already_queued`   | 409         | A job with the same id already exists in the global queue. |
 | `job_not_assignable`   | 409         | Job has already reached a terminal state.        |
 | `no_available_node`    | 409         | No available registered node satisfies the job's required capabilities. |
+| `session_id_conflict`  | 409         | `POST /sessions/external`: a daemon-managed (non-external) session with the supplied id already exists. |
+| `not_external_session` | 422         | `POST /sessions/:id/complete`: the session exists but is not an external session. Use `POST /sessions/:id/kill` for daemon-managed sessions. |
+| `external_session_not_killable` | 422 | `POST /sessions/:id/kill`: the session is external and not managed by the daemon; use `POST /sessions/:id/complete` instead. |
 
 ## Capability catalog shape (`v1`)
 
@@ -244,6 +247,8 @@ Endpoints that return this shape:
 - `GET /api/v1/sessions` → `SessionRecord[]`
 - `POST /api/v1/sessions` → `SessionRecord`
 - `GET /api/v1/sessions/:id` → `SessionRecord`
+- `POST /api/v1/sessions/external` → `SessionRecord`
+- `POST /api/v1/sessions/:id/complete` → `SessionRecord`
 
 ```json
 {
@@ -255,9 +260,80 @@ Endpoints that return this shape:
   "exit_code": null,
   "archived_at": null,
   "created_at": "2026-05-09T06:43:00Z",
-  "updated_at": "2026-05-09T06:43:05Z"
+  "updated_at": "2026-05-09T06:43:05Z",
+  "conversation_id": null,
+  "familiar_id": null,
+  "labels": [],
+  "visibility": "private",
+  "external": false,
+  "transcript_path": null
 }
 ```
+
+The `external` field is `true` for sessions registered via `POST /api/v1/sessions/external`; it is `false` for all daemon-launched sessions. The `transcript_path` field carries the absolute path to the external session's transcript file when provided at registration; it is `null` for daemon-launched sessions and for external sessions where no path was supplied.
+
+## `POST /api/v1/sessions/external`
+
+Registers a session that is already running outside the daemon (for example, the engine's interactive TUI). The daemon creates a ledger row with `external: true` and does not own the PTY or lifecycle.
+
+### Request body
+
+```json
+{
+  "id": "sess-engine-abc",
+  "projectRoot": "/repo",
+  "harness": "coven-code",
+  "title": "coven-code session",
+  "transcriptPath": "/repo/.claude/sessions/sess-engine-abc.jsonl"
+}
+```
+
+| Field            | Type   | Required | Description                                                                 |
+|------------------|--------|----------|-----------------------------------------------------------------------------|
+| `id`             | string | Yes      | Session id. Must be non-empty after trimming whitespace.                    |
+| `projectRoot`    | string | Yes      | Absolute path to the project root. Must be non-empty after trimming.       |
+| `harness`        | string | Yes      | Harness identifier (e.g. `"coven-code"`). Must be non-empty after trimming.|
+| `title`          | string | No       | Display title. Defaults to `"External session"` when absent or empty.      |
+| `transcriptPath` | string | No       | Absolute path to the external session's transcript file. Stored as-is; the daemon does not read or validate the path. |
+
+### Responses
+
+| Status | Condition                                                                                          |
+|--------|----------------------------------------------------------------------------------------------------|
+| `201`  | Session did not exist; row created. Body: the new `SessionRecord`.                                 |
+| `200`  | An external session with this id was already registered (idempotent re-register). Body: the existing `SessionRecord`. |
+| `409`  | `session_id_conflict` — a daemon-managed (non-external) session with this id already exists. The daemon refuses to alias it. |
+| `400`  | `invalid_request` — malformed JSON or a required field is missing or blank.                        |
+
+On success the response body is the full `SessionRecord` as described in [Session record shape (`v1`)](#session-record-shape-v1), with `external: true` and `status: "running"`.
+
+## `POST /api/v1/sessions/:id/complete`
+
+Marks an externally-registered session finished. The daemon updates the session status based on `exitCode` and returns the updated `SessionRecord`.
+
+### Request body
+
+```json
+{
+  "exitCode": 0
+}
+```
+
+| Field      | Type    | Required | Description                                                                                   |
+|------------|---------|----------|-----------------------------------------------------------------------------------------------|
+| `exitCode` | integer | No       | Process exit code. Absent, `null`, or `0` → status becomes `"completed"`. Any nonzero value → status becomes `"failed"`. |
+
+### Responses
+
+| Status | Condition                                                                                  |
+|--------|--------------------------------------------------------------------------------------------|
+| `200`  | Session updated. Body: the updated `SessionRecord` with the new `status` and `exit_code`.  |
+| `404`  | `session_not_found` — no session with this id exists.                                      |
+| `422`  | `not_external_session` — the session exists but was not registered as external. For daemon-managed sessions use `POST /api/v1/sessions/:id/kill`. |
+
+### Kill on an external session
+
+`POST /api/v1/sessions/:id/kill` returns `422 external_session_not_killable` when the target session has `external: true`. The kill endpoint is only valid for daemon-managed sessions.
 
 ## Event record shape and cursor pagination (`v1`)
 

--- a/docs/ENGINE-CONTRACT.md
+++ b/docs/ENGINE-CONTRACT.md
@@ -100,6 +100,40 @@ Unknown `type` values are silently ignored. Formal schema forthcoming with the
 Phase 2 golden fixtures (`coven/tests/fixtures/engine/` —
 forthcoming — added in Phase 2 with the contract test suite).
 
+## Daemon endpoints the engine calls
+
+This section documents the reverse direction: daemon API surfaces that the engine (coven-code) relies on, not surfaces that coven invokes on the engine. The integration is opt-in (`daemonLedger` setting in the engine) and best-effort — failures are logged but do not abort the session.
+
+Full request/response shapes, field validation rules, and error codes are defined in [`docs/API-CONTRACT.md`](API-CONTRACT.md).
+
+### `POST /api/v1/sessions/external`
+
+Called by the engine at session start to register the running session in the daemon ledger. The daemon does not launch or manage the process; it only holds the record.
+
+Key request fields (camelCase JSON body):
+
+| Field            | Required | Notes                                              |
+|------------------|----------|----------------------------------------------------|
+| `id`             | Yes      | Session id chosen by the engine (e.g. a UUID).     |
+| `projectRoot`    | Yes      | Absolute path to the project root.                 |
+| `harness`        | Yes      | Harness id, e.g. `"coven-code"`.                   |
+| `title`          | No       | Display title; defaults to `"External session"`.   |
+| `transcriptPath` | No       | Absolute path to the engine's transcript file.     |
+
+Returns `201` on first registration, `200` on idempotent re-registration with the same id, or `409 session_id_conflict` if a daemon-managed session already holds that id.
+
+### `POST /api/v1/sessions/<id>/complete`
+
+Called by the engine when the session ends to mark it finished in the daemon ledger.
+
+Key request fields (camelCase JSON body):
+
+| Field      | Required | Notes                                                                             |
+|------------|----------|-----------------------------------------------------------------------------------|
+| `exitCode` | No       | Integer exit code. Absent, `null`, or `0` → `"completed"`. Nonzero → `"failed"`. |
+
+Returns `200` with the updated session record on success, `404 session_not_found` if the id is unknown, or `422 not_external_session` if the session was not registered as external.
+
 ## Exit codes (headless)
 
 0 = completed; 1 = errored / budget exceeded; others reserved


### PR DESCRIPTION
Clean re-land of Phase 3 Track B on top of Phase 3A (#354). Supersedes stacked #349.

Adds daemon `POST /sessions/external` + `/sessions/:id/complete`, the external sessions-table column (migration-safe ALTER), external-session attach semantics (replay the ledger, not a live PTY), and API/engine contract docs.

Local: cargo test -p coven-cli 1026 passed, clippy/fmt/secret-guard clean.