### PR TITLE
feat(run): repeatable --add-dir harness trust passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven run <harness> <prompt> --model <id>`    | Forward a model override to the harness                          |
 | `coven run <harness> <prompt> --think`         | Request deeper reasoning when the harness supports it            |
 | `coven run <harness> <prompt> --speed <level>` | Set a latency/reasoning hint: `fast`, `balanced`, or `thorough`  |
+| `coven run <harness> <prompt> --add-dir <dir>` | Trust an additional directory (repeatable); maps to the harness's native `--add-dir` flag |
 | `coven run <harness> --continue`               | Resume the latest active session for this project                |
 | `coven run <harness> --continue <id>`          | Resume a specific session by id                                  |
 | `coven run <harness> <prompt> --detach`        | Create the session record without launching the harness          |

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -121,6 +121,12 @@ pub struct HarnessLaunchOptions<'a> {
     /// sandbox flag when the spec declares one. `Option<Permission>` stays
     /// `Copy` because `Permission` is `Copy`.
     pub permission: Option<Permission>,
+    /// Additional directories the harness should trust beyond its cwd
+    /// (`coven run --add-dir <DIR>`, repeatable). Each entry forwards as
+    /// `[add_dir_flag, <dir>]` when the spec declares an add-dir mechanism;
+    /// harnesses that declare none make the flag a warned no-op. Blank
+    /// entries are skipped. A shared slice keeps the struct `Copy`.
+    pub add_dirs: &'a [String],
 }
 
 impl<'a> HarnessLaunchOptions<'a> {
@@ -243,6 +249,14 @@ pub struct HarnessCommandSpec {
     /// means the harness declares no sandbox mechanism, so `--permission` is a
     /// warned no-op for it (mirrors `model_flag`).
     pub sandbox: Option<SandboxMapping>,
+    /// CLI flag name that grants the harness access to an additional directory
+    /// beyond its cwd (e.g. `Some("--add-dir")` for Codex, Claude, and the
+    /// engine). When set, each `coven run --add-dir <DIR>` repeats as
+    /// `[flag, <dir>]` ahead of the prompt so granted project roots are real
+    /// grants, not advisory prompt text. `None` means the harness declares no
+    /// such mechanism, so `--add-dir` is a warned no-op for it (mirrors
+    /// `model_flag`).
+    pub add_dir_flag: Option<String>,
     /// Behavioral capabilities (stream mode, session pre-assignment, think,
     /// speed). Shared type with the coven-runtimes manifest spec so built-in
     /// harnesses and external adapters declare what they can do through the
@@ -342,6 +356,28 @@ impl HarnessCommandSpec {
             Some(mapping) => mapping.args(permission.to_spec()),
             None => Vec::new(),
         }
+    }
+
+    /// Whether this harness declares a native way to trust additional
+    /// directories. Adapters that declare none make `coven run --add-dir` a
+    /// warned no-op.
+    pub fn supports_add_dir(&self) -> bool {
+        self.add_dir_flag.is_some()
+    }
+
+    /// Translate requested additional directories into argv tokens for this
+    /// harness: one `[flag, <dir>]` pair per non-blank entry. Returns an empty
+    /// vec when the harness declares no add-dir mechanism (caller decides
+    /// whether to warn).
+    pub fn add_dir_args(&self, dirs: &[String]) -> Vec<String> {
+        let Some(flag) = self.add_dir_flag.as_deref() else {
+            return Vec::new();
+        };
+        dirs.iter()
+            .map(|dir| dir.trim())
+            .filter(|dir| !dir.is_empty())
+            .flat_map(|dir| [flag.to_string(), dir.to_string()])
+            .collect()
     }
 }
 
@@ -475,6 +511,10 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 full: "danger-full-access".to_string(),
                 read_only: "read-only".to_string(),
             }),
+            // `codex exec --add-dir <DIR>` (repeatable): additional writable
+            // directories alongside the workspace. Verified against the
+            // installed codex CLI.
+            add_dir_flag: Some("--add-dir".to_string()),
             // One-shot `codex exec` only: no stream-json mode, no session
             // pre-assignment (ids are captured from the first turn's output),
             // no think/speed toggles.
@@ -513,6 +553,10 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 full: "bypassPermissions".to_string(),
                 read_only: "plan".to_string(),
             }),
+            // `claude --add-dir <directories...>` (repeatable): additional
+            // directories tools may access. Verified against the installed
+            // claude CLI.
+            add_dir_flag: Some("--add-dir".to_string()),
             // Long-lived stream-json mode, `--session-id`/`--resume`
             // pre-assignment, and think/speed via `--effort`. These declared
             // values replace the former `harness_id == "claude"` checks.
@@ -564,6 +608,9 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 full: "bypass-permissions".to_string(),
                 read_only: "plan".to_string(),
             }),
+            // `coven-code --add-dir <DIR>` (repeatable), mirroring Claude
+            // Code's flag. Verified against the installed engine binary.
+            add_dir_flag: Some("--add-dir".to_string()),
             capabilities: Capabilities {
                 stream: true,
                 preassigned_session_id: true,
@@ -845,6 +892,10 @@ struct ExternalHarnessAdapterSpec {
     /// Omit and `coven run --permission` stays a warned no-op.
     #[serde(default)]
     sandbox: Option<SandboxMapping>,
+    /// CLI flag that trusts an additional directory (repeated per dir).
+    /// Omit and `coven run --add-dir` stays a warned no-op.
+    #[serde(default, alias = "addDirFlag")]
+    add_dir_flag: Option<String>,
     /// Stream-json launch args. Required when `capabilities.stream`.
     #[serde(default, alias = "streamArgs")]
     stream_args: Option<StreamArgs>,
@@ -1008,6 +1059,10 @@ impl ExternalHarnessAdapterSpec {
                 .map(|tmpl| tmpl.trim().to_string())
                 .filter(|tmpl| !tmpl.is_empty()),
             sandbox: self.sandbox,
+            add_dir_flag: self
+                .add_dir_flag
+                .map(|flag| flag.trim().to_string())
+                .filter(|flag| !flag.is_empty()),
             capabilities: self.capabilities,
             stream_args: self.stream_args,
             continuity_args: self.continuity_args,
@@ -1157,6 +1212,10 @@ fn command_parts_for_harness_with_conversation_inner(
         Some(p) => spec.sandbox_args(p),
         None => Vec::new(),
     };
+    // Additional trusted directories forward as repeated native add-dir flags
+    // ahead of the prompt positional, mirroring model selection. Harnesses
+    // that declare no add-dir mechanism yield no args (the run layer warns).
+    let add_dir_args: Vec<String> = spec.add_dir_args(options.add_dirs);
     let launch_option_args = launch_option_args(harness_id, options);
 
     // Resolve effective prompt: inject familiar identity preamble when present.
@@ -1187,6 +1246,7 @@ fn command_parts_for_harness_with_conversation_inner(
                     sanitize_argv_for_platform(prepend_launch_args(
                         &model_args,
                         &sandbox_args,
+                        &add_dir_args,
                         &launch_option_args,
                         args,
                     )),
@@ -1205,6 +1265,7 @@ fn command_parts_for_harness_with_conversation_inner(
                 sanitize_argv_for_platform(prepend_launch_args(
                     &model_args,
                     &sandbox_args,
+                    &add_dir_args,
                     &launch_option_args,
                     args,
                 )),
@@ -1225,6 +1286,7 @@ fn command_parts_for_harness_with_conversation_inner(
             let args = sanitize_argv_for_platform(prepend_launch_args(
                 &model_args,
                 &sandbox_args,
+                &add_dir_args,
                 &launch_option_args,
                 // `--` before the prompt for the same reason as `prompt_args`:
                 // user data must not parse as harness flags.
@@ -1253,6 +1315,7 @@ fn command_parts_for_harness_with_conversation_inner(
             sanitize_argv_for_platform(prepend_launch_args(
                 &model_args,
                 &sandbox_args,
+                &add_dir_args,
                 &launch_option_args,
                 args,
             )),
@@ -1295,16 +1358,23 @@ fn launch_option_args(harness_id: &str, options: HarnessLaunchOptions<'_>) -> Ve
 fn prepend_launch_args(
     model_args: &[String],
     sandbox_args: &[String],
+    add_dir_args: &[String],
     option_args: &[String],
     args: Vec<String>,
 ) -> Vec<String> {
-    if model_args.is_empty() && sandbox_args.is_empty() && option_args.is_empty() {
+    if model_args.is_empty()
+        && sandbox_args.is_empty()
+        && add_dir_args.is_empty()
+        && option_args.is_empty()
+    {
         return args;
     }
-    let mut out =
-        Vec::with_capacity(model_args.len() + sandbox_args.len() + option_args.len() + args.len());
+    let mut out = Vec::with_capacity(
+        model_args.len() + sandbox_args.len() + add_dir_args.len() + option_args.len() + args.len(),
+    );
     out.extend_from_slice(model_args);
     out.extend_from_slice(sandbox_args);
+    out.extend_from_slice(add_dir_args);
     out.extend_from_slice(option_args);
     out.extend(args);
     out
@@ -1899,6 +1969,7 @@ mod tests {
             model_flag: None,
             model_arg_template: None,
             sandbox: None,
+            add_dir_flag: None,
             capabilities: Capabilities::BASELINE,
             stream_args: None,
             continuity_args: None,
@@ -2104,6 +2175,58 @@ mod tests {
             copi.sandbox_args(Permission::ReadOnly),
             vec!["--deny-tool".to_string(), "write".to_string()]
         );
+        Ok(())
+    }
+
+    /// A manifest adapter can declare its native add-dir trust flag (either
+    /// key casing); omitting it keeps `--add-dir` a warned no-op.
+    #[test]
+    fn manifest_add_dir_flag_maps_repeatable_dirs() -> anyhow::Result<()> {
+        let raw = r#"{
+          "adapters": [
+            {
+              "id": "copi",
+              "label": "Copi",
+              "executable": "copi",
+              "interactive_prompt_prefix_args": ["-i"],
+              "non_interactive_prompt_prefix_args": ["-s", "-p"],
+              "install_hint": "Install copi.",
+              "addDirFlag": "--allow-dir"
+            }
+          ]
+        }"#;
+        let specs =
+            parse_external_harness_specs(raw, Path::new("copi.json"), &built_in_harness_specs())?;
+        let copi = &specs[0];
+        assert!(copi.supports_add_dir());
+        assert_eq!(
+            copi.add_dir_args(&["/tmp/a".to_string(), "/tmp/b".to_string()]),
+            vec![
+                "--allow-dir".to_string(),
+                "/tmp/a".to_string(),
+                "--allow-dir".to_string(),
+                "/tmp/b".to_string(),
+            ]
+        );
+
+        let without = r#"{
+          "adapters": [
+            {
+              "id": "plain",
+              "label": "Plain",
+              "executable": "plain",
+              "interactive_prompt_prefix_args": [],
+              "non_interactive_prompt_prefix_args": ["run"],
+              "install_hint": "Install plain."
+            }
+          ]
+        }"#;
+        let specs = parse_external_harness_specs(
+            without,
+            Path::new("plain.json"),
+            &built_in_harness_specs(),
+        )?;
+        assert!(!specs[0].supports_add_dir());
         Ok(())
     }
 
@@ -3298,6 +3421,7 @@ mod tests {
             model_flag: None,
             model_arg_template: None,
             sandbox: None,
+            add_dir_flag: None,
             capabilities: Capabilities::BASELINE,
             stream_args: None,
             continuity_args: None,
@@ -3305,6 +3429,172 @@ mod tests {
         assert!(!spec.supports_permission());
         assert!(spec.sandbox_args(Permission::Full).is_empty());
         assert!(spec.sandbox_args(Permission::ReadOnly).is_empty());
+    }
+
+    #[test]
+    fn spec_without_add_dir_mechanism_is_an_add_dir_noop() {
+        let spec = HarnessCommandSpec {
+            id: "future".to_string(),
+            label: "Future Harness".to_string(),
+            executable: "future".to_string(),
+            interactive_prompt_prefix_args: Vec::new(),
+            non_interactive_prompt_prefix_args: vec!["run".to_string()],
+            install_hint: "Install the future harness.".to_string(),
+            source: "manifest".to_string(),
+            manifest_path: None,
+            system_prompt_flag: None,
+            model_flag: None,
+            model_arg_template: None,
+            sandbox: None,
+            add_dir_flag: None,
+            capabilities: Capabilities::BASELINE,
+            stream_args: None,
+            continuity_args: None,
+        };
+        assert!(!spec.supports_add_dir());
+        assert!(spec.add_dir_args(&["/tmp/other".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn codex_forwards_add_dirs_before_prompt() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
+        let add_dirs = vec!["/tmp/roots/a".to_string(), "/tmp/roots/b".to_string()];
+        let (_, args) = command_parts_for_harness_with_conversation(
+            "codex",
+            "fix tests",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                add_dirs: &add_dirs,
+                ..Default::default()
+            },
+        )?;
+        assert_eq!(
+            args,
+            vec![
+                "--add-dir".to_string(),
+                "/tmp/roots/a".to_string(),
+                "--add-dir".to_string(),
+                "/tmp/roots/b".to_string(),
+                "exec".to_string(),
+                "--skip-git-repo-check".to_string(),
+                "--color".to_string(),
+                "never".to_string(),
+                "--".to_string(),
+                "fix tests".to_string(),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn claude_stream_mode_forwards_add_dirs() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
+        // Blank entries are skipped; real dirs forward as repeated
+        // `--add-dir <DIR>` pairs ahead of the declared stream args,
+        // matching the non-stream path (`HarnessCommandSpec::add_dir_args`).
+        let add_dirs = vec!["/tmp/roots/a".to_string(), "  ".to_string()];
+        let (_, args) = command_parts_for_harness_with_conversation(
+            "claude",
+            "hello prompt",
+            HarnessLaunchMode::Stream,
+            Some(&ConversationHint::Init {
+                id: "session-123".to_string(),
+            }),
+            None,
+            HarnessLaunchOptions {
+                add_dirs: &add_dirs,
+                ..Default::default()
+            },
+        )?;
+        let position = args
+            .iter()
+            .position(|arg| arg == "--add-dir")
+            .expect("stream args must carry --add-dir");
+        assert_eq!(args[position + 1], "/tmp/roots/a");
+        assert_eq!(
+            args.iter().filter(|arg| *arg == "--add-dir").count(),
+            1,
+            "blank add-dir entries are skipped: {args:?}"
+        );
+        assert!(
+            args.iter().any(|arg| arg == "--session-id"),
+            "stream init args expected: {args:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn claude_forwards_add_dirs_after_permission() -> anyhow::Result<()> {
+        // Spec resolution reads the adapter env vars; hold the shared env
+        // lock so a concurrent test's tempdir manifest never vanishes mid-read.
+        let _guard = env_lock().lock().unwrap();
+        let add_dirs = vec!["/tmp/roots/a".to_string()];
+        let (_, args) = command_parts_for_harness_with_conversation(
+            "claude",
+            "hi",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                permission: Some(Permission::ReadOnly),
+                add_dirs: &add_dirs,
+                ..Default::default()
+            },
+        )?;
+        assert_eq!(
+            args,
+            vec![
+                "--permission-mode".to_string(),
+                "plan".to_string(),
+                "--add-dir".to_string(),
+                "/tmp/roots/a".to_string(),
+                "--print".to_string(),
+                "--".to_string(),
+                "hi".to_string(),
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn blank_add_dirs_leave_args_unchanged() -> anyhow::Result<()> {
+        let blank = vec!["   ".to_string(), String::new()];
+        let with_blank_dirs = command_parts_for_harness_with_conversation(
+            "codex",
+            "fix tests",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                add_dirs: &blank,
+                ..Default::default()
+            },
+        )?;
+        let legacy =
+            command_parts_for_harness("codex", "fix tests", HarnessLaunchMode::NonInteractive)?;
+        assert_eq!(with_blank_dirs, legacy, "blank add-dirs are a no-op");
+        Ok(())
+    }
+
+    #[test]
+    fn built_in_harnesses_declare_add_dir_flag() {
+        // Cave forwards granted project roots via repeatable `--add-dir`;
+        // every built-in harness CLI supports the flag natively (verified
+        // against codex, claude, and the coven-code engine binaries).
+        for spec in built_in_harness_specs() {
+            assert_eq!(
+                spec.add_dir_flag.as_deref(),
+                Some("--add-dir"),
+                "built-in `{}` must declare an add-dir mechanism",
+                spec.id
+            );
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -193,6 +193,12 @@ enum Command {
         )]
         permission: Option<String>,
         #[arg(
+            long = "add-dir",
+            value_name = "DIR",
+            help = "Additional directory the harness may access beyond its cwd; repeat the flag for multiple directories. Maps to each harness's native trust flag (codex/claude/coven-code --add-dir). Harnesses with no add-dir mechanism warn and continue."
+        )]
+        add_dir: Vec<String>,
+        #[arg(
             long,
             help = "Emit JSONL events on stdout (system.init / user / assistant / tool_result / result)"
         )]
@@ -615,6 +621,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             think,
             speed,
             permission,
+            add_dir,
             stream_json,
             stream_json_input,
         }) => run_session(
@@ -632,6 +639,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             think,
             speed.as_deref(),
             permission.as_deref(),
+            add_dir,
             stream_json,
             stream_json_input,
         ),
@@ -2192,6 +2200,7 @@ fn run_session(
     think: bool,
     speed: Option<&str>,
     permission: Option<&str>,
+    add_dirs: Vec<String>,
     stream_json: bool,
     stream_json_input: bool,
 ) -> Result<()> {
@@ -2292,11 +2301,29 @@ fn run_session(
             );
         }
     }
+    // Requested additional trusted directories. Blank entries are skipped by
+    // the arg builder; harnesses that declare no add-dir mechanism warn
+    // (don't error) so a grant degrades gracefully instead of failing the run.
+    let requested_add_dirs: Vec<String> = add_dirs
+        .iter()
+        .map(|dir| dir.trim().to_string())
+        .filter(|dir| !dir.is_empty())
+        .collect();
+    if let Some(s) = spec.as_ref() {
+        if !requested_add_dirs.is_empty() && !s.supports_add_dir() {
+            eprintln!(
+                "warning: harness `{}` declares no add-dir mechanism; --add-dir is ignored \
+                 (declare add_dir_flag in the adapter manifest to enable it)",
+                s.id
+            );
+        }
+    }
     let launch_options = harness::HarnessLaunchOptions {
         model: requested_model,
         think,
         speed: requested_speed,
         permission: requested_permission,
+        add_dirs: &requested_add_dirs,
     };
 
     let effective_prompt = match (&familiar_ctx, spec.as_ref()) {
@@ -3949,6 +3976,45 @@ mod tests {
             Some(Command::Run { detach, .. }) => assert!(detach),
             other => panic!("expected run command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cli_run_accepts_repeatable_add_dir() {
+        let cli = Cli::parse_from([
+            "coven",
+            "run",
+            "codex",
+            "hello",
+            "--add-dir",
+            "/tmp/roots/a",
+            "--add-dir",
+            "/tmp/roots/b",
+        ]);
+        match cli.command {
+            Some(Command::Run { add_dir, .. }) => assert_eq!(
+                add_dir,
+                vec!["/tmp/roots/a".to_string(), "/tmp/roots/b".to_string()]
+            ),
+            other => panic!("expected run command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_help_advertises_add_dir_for_capability_probes() {
+        use clap::CommandFactory;
+        // Cave gates granted-root forwarding on `coven run --help` matching
+        // /(^|\s)--add-dir(?![\w-])/m; the flag must render in the help text.
+        let mut cmd = Cli::command();
+        let run = cmd
+            .find_subcommand_mut("run")
+            .expect("run subcommand exists");
+        let help = run.render_long_help().to_string();
+        assert!(
+            help.lines().any(|line| line
+                .split_whitespace()
+                .any(|token| token == "--add-dir" || token.starts_with("--add-dir <"))),
+            "run --help must advertise --add-dir for Cave's capability probe:\n{help}"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1211,6 +1211,8 @@ fn dispatch_via_local_pty(
         None,
         // permission: the cast/shell path uses the harness default.
         None,
+        // add-dirs: the cast/shell path grants no extra directories.
+        Vec::new(),
         false,
         false,
     )?;
@@ -1906,6 +1908,8 @@ fn run_guided_harness_session() -> Result<()> {
         None,
         // permission: the cast/shell path uses the harness default.
         None,
+        // add-dirs: the cast/shell path grants no extra directories.
+        Vec::new(),
         false,
         false,
     )

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -127,8 +127,12 @@ adapters deserialize unchanged with everything off):
   `{ "full_args": ["--allow-all"], "read_only_args": ["--deny-tool", "write"] }`.
 - `coven adapter list --json` includes the declared `capabilities` block for
   every bundled or manifest adapter, using the same field names as manifests.
+- `add_dir_flag` (alias `addDirFlag`) names the harness's native flag for
+  trusting an additional directory beyond its cwd. Each
+  `coven run --add-dir <DIR>` repeats as `[flag, <dir>]` ahead of the prompt
+  (the bundled Codex, Claude, and engine adapters all declare `--add-dir`).
 - Adapters that declare none of this keep today's conservative behavior:
-  one-shot launches only, `--permission` is a warned no-op.
+  one-shot launches only, `--permission` and `--add-dir` are warned no-ops.
 
 Accepted, conformance-tested manifests for real runtimes live in the
 [coven-runtimes canonical registry](https://github.com/OpenCoven/coven-runtimes).


### PR DESCRIPTION
## Summary

Implements the coven side of Cave's granted-roots forwarding (bead `cave-t1ta`, companion to OpenCoven/coven-cave#2969): `coven run` now accepts a repeatable `--add-dir <DIR>` and forwards each directory to the harness's native trust flag, so granted project roots become real filesystem grants instead of advisory prompt text.

## What changed

- **CLI**: `coven run --add-dir <DIR>` (repeatable). Advertised in `run --help`, which is exactly what Cave's capability probe gates forwarding on (`covenRunSupportsAddDirFlag`).
- **Spec**: new `add_dir_flag` on `HarnessCommandSpec`; built-in codex, claude, and coven-code engine all declare `--add-dir` (verified against each installed binary: `codex exec --add-dir`, `claude --add-dir`, `coven-code --add-dir`).
- **Arg assembly**: add-dir pairs ride ahead of the prompt positional alongside model/sandbox args in every launch mode (one-shot, continuity, stream), plus the dedicated claude stream-json path.
- **External adapters**: manifests declare `add_dir_flag` / `addDirFlag`; adapters that declare none make `--add-dir` a warned no-op (mirrors `--model` / `--permission` degradation).
- **Docs**: README run table + `docs/HARNESS-ADAPTERS.md` field reference.

## Testing

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace --locked`: 1048/1048 coven-cli tests pass (note: run with `COVEN_HARNESS_ADAPTER_DIRS` unset; a stale `coven-code.json` external adapter in that dir conflicts with the new built-in engine id and fails ~40 pre-existing tests regardless of this change)
- `python3 scripts/check-secrets.py` clean
- New tests: codex/claude forwarding + ordering, blank no-op, spec-without-mechanism no-op, built-ins-declare-flag, manifest `addDirFlag` parse, claude stream-json forwarding, repeatable clap parse, and a `run --help` render test asserting the probe contract.
- Manual: `./target/debug/coven run --help` matches Cave's probe regex `/(^|\\s)--add-dir(?![\\w-])/m` → `true`.

## Readiness

- Scope: CLI flag + spec plumbing only; no daemon API surface change.
- Risk: low — absent flag preserves existing argv byte-for-byte (empty-args early return).
- Follow-up: Cave side already merged and probe-gated, so this activates forwarding on release.