### PR TITLE
feat(cli): observability parity with Cave and the daemon API (status, familiars, skills, memory, research, calls, hub, session inspection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven chat`     | Explicitly open the interactive Coven UI                        |
 | `coven tui`      | Same as `coven chat`                                            |
 | `coven doctor`   | Detect supported harness CLIs and print install hints           |
+| `coven status`   | Ecosystem overview: daemon, sessions, familiars, skills, hub (alias: `coven overview`) |
+| `coven completions <shell>` | Generate shell completions (bash, zsh, fish, elvish, powershell) |
 
 ### Harness adapters
 
@@ -275,13 +277,19 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven sessions --plain`                       | Force plain table output for scripts or copying                  |
 | `coven sessions --json`                        | Output sessions as JSON                                          |
 | `coven sessions --json --all`                  | Output all sessions (including archived) as JSON                 |
+| `coven sessions search <query>`                | Full-text search recorded event payloads (`--json` for scripts)  |
+| `coven sessions show <session-id>`             | Show one session's record without attaching (`--json` for scripts) |
+| `coven sessions events <session-id>`           | List recorded events; `--after-seq`/`--limit` page the cursor    |
+| `coven sessions log <session-id>`              | Print a session's log lines without attaching                    |
 | `coven attach <session-id>`                    | Replay/follow session output and forward input                   |
 | `coven summon <session-id>`                    | Restore an archived session, then replay/follow it               |
 | `coven archive <session-id>`                   | Hide a non-running session while preserving its events           |
 | `coven sacrifice <session-id> --yes`           | Permanently delete a non-running session and its events          |
+| `coven kill <session-id>`                      | Kill a running session's process (its event log is kept)         |
 
-> `attach`, `summon`, `archive`, and `sacrifice` accept a unique prefix of the
-> session id (e.g. `coven attach 9099`), so you don't have to paste full UUIDs.
+> `attach`, `summon`, `archive`, `sacrifice`, `kill`, and the `sessions
+> show/events/log` subcommands accept a unique prefix of the session id
+> (e.g. `coven attach 9099`), so you don't have to paste full UUIDs.
 
 > **Session rituals are intentionally explicit.** Archive is reversible and keeps the full event ledger. Summon brings an archived session back. Sacrifice is destructive, refuses live sessions, and requires `--yes` so beginners don't delete work by accident.
 
@@ -306,6 +314,25 @@ Choose a repo, choose a harness, get a verified patch.
 
 > All read operations are side-effect-free. Write operations (kill, cache clear) require `--confirm` and cannot be bypassed. Termination is SIGTERM only — no SIGKILL.
 
+### Coven observability (Cave parity from the terminal)
+
+Everything the CovenCave dashboard reads is also visible from the CLI. All of
+these are read-only, work without a running daemon, and take `--json` for
+machine-readable output that carries the same body as the daemon API route.
+
+| Command                        | Action                                                    | API route              |
+| ------------------------------ | --------------------------------------------------------- | ---------------------- |
+| `coven status`                 | Daemon, sessions, familiars, skills, research, hub at a glance | `/health` + `/overview` |
+| `coven familiars`              | Familiar roster from `~/.coven/familiars.toml`            | `/familiars`           |
+| `coven skills`                 | Installed skills from `~/.coven/skills/`                  | `/skills`              |
+| `coven memory`                 | Familiar memory files from `~/.coven/memory/`             | `/memory`              |
+| `coven research`               | Research loop log from `~/.coven/research/results.tsv`    | `/research`            |
+| `coven calls [<id>]`           | Coven Calls delegation ledger (list or one call)          | `/coven-calls[/:id]`   |
+| `coven hub status`             | Hub role, node availability, queue depth                  | `/hub/status`          |
+| `coven hub nodes`              | Registered executor nodes                                 | `/hub/nodes`           |
+| `coven hub jobs [--state <s>]` | Hub jobs, optionally filtered by state                    | `/hub/jobs`            |
+| `coven hub routing`            | Job→node routing decisions                                | `/hub/routing`         |
+
 ### Parallel work protocol (worktrees, claims, hooks)
 
 | Command                     | Action                                                        |
@@ -315,6 +342,8 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven wt --doctor`         | Report protocol layout and hook issues                        |
 | `coven wt --prune-merged`   | Remove clean worktrees whose branches are merged              |
 | `coven claim acquire <b>`   | Claim a branch for the current agent (TTL-bounded)            |
+| `coven claim release <b>`   | Release this agent's claim for a branch                       |
+| `coven claim heartbeat <b>` | Extend this agent's claim TTL for a branch                    |
 | `coven claim status`        | Show active and expired claims for this repository            |
 | `coven hooks install`       | Install the protocol's pre-commit and pre-push git hooks      |
 
@@ -324,6 +353,7 @@ Choose a repo, choose a harness, get a verified patch.
 | ---------------------- | ------------------------------------------------------- |
 | `coven patch openclaw` | Open the OpenClaw repair rescue loop                    |
 | `coven logs prune`     | Manually prune session logs and raw encrypted artifacts |
+| `coven vacuum`         | Repair and compact the local Coven session store        |
 
 ---
 
@@ -346,6 +376,16 @@ The daemon exposes a versioned HTTP API over a Unix socket. The current public c
 | `/api/v1/sessions/:id/log`               | `GET`  | Redacted log preview for a session                          |
 | `/api/v1/sessions/:id/input`             | `POST` | Forward input to a live session                             |
 | `/api/v1/sessions/:id/kill`              | `POST` | Kill a live session                                         |
+| `/api/v1/overview`                       | `GET`  | Ecosystem counts (sessions, familiars, skills, research)    |
+| `/api/v1/familiars`                      | `GET`  | Familiar roster (`coven familiars`)                         |
+| `/api/v1/skills`                         | `GET`  | Installed skills (`coven skills`)                           |
+| `/api/v1/memory`                         | `GET`  | Familiar memory files (`coven memory`)                      |
+| `/api/v1/research`                       | `GET`  | Research loop log (`coven research`)                        |
+| `/api/v1/coven-calls`                    | `GET`  | Coven Calls delegation ledger (`coven calls`)               |
+| `/api/v1/hub/status`                     | `GET`  | Hub role, node availability, queue depth (`coven hub status`) |
+| `/api/v1/hub/nodes`                      | `GET`  | Registered executor nodes (`coven hub nodes`)               |
+| `/api/v1/hub/jobs`                       | `GET`  | Hub jobs, `?state=` filter (`coven hub jobs`)               |
+| `/api/v1/hub/routing`                    | `GET`  | Job→node routing table (`coven hub routing`)                |
 | `/api/v1/actions`                        | `POST` | Route a control-plane action (advanced clients)             |
 | `/api/v1/travel/profiles`                | `POST` | Generate a read-only travel profile for offline laptop work |
 | `/api/v1/travel/deltas`                  | `POST` | Upload offline travel results for hub reconciliation        |

--- a/README.md
+++ b/README.md
@@ -322,16 +322,16 @@ machine-readable output that carries the same body as the daemon API route.
 
 | Command                        | Action                                                    | API route              |
 | ------------------------------ | --------------------------------------------------------- | ---------------------- |
-| `coven status`                 | Daemon, sessions, familiars, skills, research, hub at a glance | `/health` + `/overview` |
-| `coven familiars`              | Familiar roster from `~/.coven/familiars.toml`            | `/familiars`           |
-| `coven skills`                 | Installed skills from `~/.coven/skills/`                  | `/skills`              |
-| `coven memory`                 | Familiar memory files from `~/.coven/memory/`             | `/memory`              |
-| `coven research`               | Research loop log from `~/.coven/research/results.tsv`    | `/research`            |
-| `coven calls [<id>]`           | Coven Calls delegation ledger (list or one call)          | `/coven-calls[/:id]`   |
-| `coven hub status`             | Hub role, node availability, queue depth                  | `/hub/status`          |
-| `coven hub nodes`              | Registered executor nodes                                 | `/hub/nodes`           |
-| `coven hub jobs [--state <s>]` | Hub jobs, optionally filtered by state                    | `/hub/jobs`            |
-| `coven hub routing`            | Job→node routing decisions                                | `/hub/routing`         |
+| `coven status`                 | Daemon, sessions, familiars, skills, research, hub at a glance | `/api/v1/health` + `/api/v1/overview` |
+| `coven familiars`              | Familiar roster from `~/.coven/familiars.toml`            | `/api/v1/familiars`           |
+| `coven skills`                 | Installed skills from `~/.coven/skills/`                  | `/api/v1/skills`              |
+| `coven memory`                 | Familiar memory files from `~/.coven/memory/`             | `/api/v1/memory`              |
+| `coven research`               | Research loop log from `~/.coven/research/results.tsv`    | `/api/v1/research`            |
+| `coven calls [<id>]`           | Coven Calls delegation ledger (list or one call)          | `/api/v1/coven-calls[/:id]`   |
+| `coven hub status`             | Hub role, node availability, queue depth                  | `/api/v1/hub/status`          |
+| `coven hub nodes`              | Registered executor nodes                                 | `/api/v1/hub/nodes`           |
+| `coven hub jobs [--state <s>]` | Hub jobs, optionally filtered by state                    | `/api/v1/hub/jobs`            |
+| `coven hub routing`            | Job→node routing decisions                                | `/api/v1/hub/routing`         |
 
 ### Parallel work protocol (worktrees, claims, hooks)
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Choose a repo, choose a harness, get a verified patch.
 | `coven chat`     | Explicitly open the interactive Coven UI                        |
 | `coven tui`      | Same as `coven chat`                                            |
 | `coven doctor`   | Detect supported harness CLIs and print install hints           |
-| `coven status`   | Ecosystem overview: daemon, sessions, familiars, skills, hub (alias: `coven overview`) |
+| `coven status`   | Ecosystem overview: daemon, sessions, familiars, skills, research, hub (alias: `coven overview`) |
 | `coven completions <shell>` | Generate shell completions (bash, zsh, fish, elvish, powershell) |
 
 ### Harness adapters

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::Write, path::Path};
+use std::{borrow::Cow, collections::HashSet, io::Write, path::Path};
 
 use anyhow::{Context, Result};
 use base64::Engine;
@@ -1936,20 +1936,47 @@ struct OverviewDto {
 fn overview_response(coven_home: &Path) -> Result<ApiResponse> {
     let conn = store::open_store(&store_path(coven_home))?;
     let sessions = store::list_sessions(&conn)?;
-    let open_sessions = sessions
+    let open: Vec<&store::SessionRecord> = sessions
         .iter()
         .filter(|s| s.status == "running" || s.status == "active")
-        .count() as u32;
+        .collect();
+    let open_sessions = open.len() as u32;
+
+    // Dashboard semantics: a partial overview beats a 500, so unreadable
+    // side sources degrade to empty. The leaf routes (/familiars, /skills,
+    // /research) still report their own read errors loudly.
+    let familiars = crate::cockpit_sources::read_familiars(coven_home).unwrap_or_default();
+    let skills = crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
+    let research = crate::cockpit_sources::read_research(coven_home).unwrap_or_default();
+
+    let roster: HashSet<&str> = familiars.iter().map(|f| f.id.as_str()).collect();
+    let active_familiars = open
+        .iter()
+        .filter_map(|s| s.familiar_id.as_deref())
+        .filter(|id| roster.contains(id))
+        .collect::<HashSet<_>>()
+        .len() as u32;
+
+    let average_skill_score = if skills.is_empty() {
+        0
+    } else {
+        let sum: f64 = skills.iter().map(|s| s.score).sum();
+        (sum / skills.len() as f64).round() as u32
+    };
+
     json_response(
         200,
         &OverviewDto {
-            active_familiars: 0,
-            total_familiars: 0,
+            active_familiars,
+            total_familiars: familiars.len() as u32,
             open_sessions,
-            skills_count: 0,
-            average_skill_score: 0,
-            research_iterations: 0,
-            last_research_delta: 0,
+            skills_count: skills.len() as u32,
+            average_skill_score,
+            research_iterations: research.len() as u32,
+            last_research_delta: research
+                .last()
+                .map(|row| row.delta.round() as i32)
+                .unwrap_or(0),
         },
     )
 }
@@ -5146,6 +5173,93 @@ mod tests {
         assert_eq!(body["open_sessions"], 2);
         assert_eq!(body["active_familiars"], 0);
         assert_eq!(body["skills_count"], 0);
+        Ok(())
+    }
+
+    #[test]
+    fn get_overview_counts_familiars_skills_and_research_from_local_sources() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+
+        std::fs::write(
+            home.join("familiars.toml"),
+            r#"
+[[familiar]]
+id = "charm"
+display_name = "Charm"
+role = "steward"
+description = "keeps the hearth"
+
+[[familiar]]
+id = "sage"
+display_name = "Sage"
+role = "researcher"
+description = "digs deep"
+"#,
+        )?;
+
+        for skill in ["eval-loop", "stream-scribe"] {
+            let dir = home.join("skills").join(skill);
+            std::fs::create_dir_all(&dir)?;
+            std::fs::write(
+                dir.join("metadata.json"),
+                format!(r#"{{"name":"{skill}","description":"a skill","version":"1.0.0"}}"#),
+            )?;
+        }
+
+        let research_dir = home.join("research");
+        std::fs::create_dir_all(&research_dir)?;
+        std::fs::write(
+            research_dir.join("results.tsv"),
+            "1\tharness capabilities\t7.5\t1.5\tcontinue\tnotes.md\n\
+             2\tstream continuity\t9.0\t2.0\tadopt\tnotes.md\n",
+        )?;
+
+        let conn = store::open_store(&store_path(home))?;
+        let now = "2026-01-01T00:00:00Z";
+        for (id, status, familiar) in [
+            ("s1", "running", Some("charm")),
+            ("s2", "running", Some("charm")),
+            ("s3", "running", Some("ghost-not-in-roster")),
+            ("s4", "ended", Some("sage")),
+        ] {
+            store::insert_session(
+                &conn,
+                &store::SessionRecord {
+                    id: id.into(),
+                    project_root: "/tmp".into(),
+                    harness: "claude".into(),
+                    title: "t".into(),
+                    status: status.into(),
+                    exit_code: None,
+                    archived_at: None,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                    conversation_id: None,
+                    familiar_id: familiar.map(str::to_string),
+                    labels: Vec::new(),
+                    visibility: "private".to_string(),
+                    external: false,
+                    transcript_path: None,
+                },
+            )?;
+        }
+        drop(conn);
+
+        let response = handle_request("GET", "/api/v1/overview", home, None)?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["open_sessions"], 3);
+        assert_eq!(body["total_familiars"], 2);
+        // Only roster familiars with an open session count as active: charm
+        // (running twice, deduped); sage's session ended; the ghost id is not
+        // in the roster.
+        assert_eq!(body["active_familiars"], 1);
+        assert_eq!(body["skills_count"], 2);
+        // Skill scores are stubbed at 0.0 until scoring lands.
+        assert_eq!(body["average_skill_score"], 0);
+        assert_eq!(body["research_iterations"], 2);
+        assert_eq!(body["last_research_delta"], 2);
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -334,7 +334,7 @@ enum Command {
         command: Option<pc::PcCommand>,
     },
     #[command(
-        about = "Show what's happening across your coven: daemon, sessions, familiars, skills, hub",
+        about = "Show what's happening across your coven: daemon, sessions, familiars, skills, research, hub",
         alias = "overview"
     )]
     Status {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -427,9 +427,9 @@ enum SessionsCommand {
             value_name = "SEQ",
             help = "Only return events after this sequence cursor"
         )]
-        after_seq: Option<i64>,
+        after_seq: Option<u64>,
         #[arg(long, value_name = "N", help = "Return at most N events")]
-        limit: Option<i64>,
+        limit: Option<u64>,
         #[arg(long, help = "Print the event envelope as JSON (machine-readable)")]
         json: bool,
     },

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -26,6 +26,7 @@ mod executor_node;
 mod familiar_identity;
 mod harness;
 mod hub;
+mod observe;
 mod openclaw_repo;
 mod parallel_protocol;
 mod patch;
@@ -59,6 +60,11 @@ const DEFAULT_TITLE_CHARS: usize = 48;
 #[command(
     long_about = "Coven runs Codex, Claude Code, and future harnesses inside a local, project-scoped session ledger. Run `coven` with no arguments to open the interactive Coven UI (requires the coven-code front-end), or pass a free-text task to plan and run it directly."
 )]
+#[command(after_help = "Common first steps:
+  coven doctor                    check your local setup and harnesses
+  coven run codex \"<task>\"        run a task in a recorded session
+  coven sessions                  browse recorded sessions
+  coven status                    see daemon, sessions, familiars, and hub at a glance")]
 struct Cli {
     #[command(subcommand)]
     command: Option<Command>,
@@ -328,6 +334,49 @@ enum Command {
         command: Option<pc::PcCommand>,
     },
     #[command(
+        about = "Show what's happening across your coven: daemon, sessions, familiars, skills, hub",
+        alias = "overview"
+    )]
+    Status {
+        #[arg(long, help = "Print status as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(
+        about = "List the familiar roster from ~/.coven/familiars.toml",
+        alias = "familiar"
+    )]
+    Familiars {
+        #[arg(long, help = "Print familiars as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "List installed skills from ~/.coven/skills/", alias = "skill")]
+    Skills {
+        #[arg(long, help = "Print skills as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "List familiar memory files from ~/.coven/memory/")]
+    Memory {
+        #[arg(long, help = "Print memory files as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Show the research loop log from ~/.coven/research/")]
+    Research {
+        #[arg(long, help = "Print research rows as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Show the Coven Calls delegation ledger", alias = "call")]
+    Calls {
+        #[arg(help = "Call id for a detail view (omit to list all calls)")]
+        id: Option<String>,
+        #[arg(long, help = "Print calls as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Inspect the multi-host hub control plane (read-only)")]
+    Hub {
+        #[command(subcommand)]
+        command: HubCommand,
+    },
+    #[command(
         about = "Manage model provider credentials (Anthropic, Codex) — runs in the Coven engine"
     )]
     Auth {
@@ -360,6 +409,66 @@ enum SessionsCommand {
         #[arg(help = "Full-text query (FTS5 syntax, e.g. `phoenix OR rises`)")]
         query: String,
         #[arg(long, help = "Print search hits as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Show one session's record (metadata, status, ritual state)")]
+    Show {
+        #[arg(help = "Session id, or a unique prefix of one (list ids with `coven sessions`)")]
+        session_id: String,
+        #[arg(long, help = "Print the session record as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "List a session's recorded events (redacted payloads)")]
+    Events {
+        #[arg(help = "Session id, or a unique prefix of one (list ids with `coven sessions`)")]
+        session_id: String,
+        #[arg(
+            long,
+            value_name = "SEQ",
+            help = "Only return events after this sequence cursor"
+        )]
+        after_seq: Option<i64>,
+        #[arg(long, value_name = "N", help = "Return at most N events")]
+        limit: Option<i64>,
+        #[arg(long, help = "Print the event envelope as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Print a session's log lines without attaching")]
+    Log {
+        #[arg(help = "Session id, or a unique prefix of one (list ids with `coven sessions`)")]
+        session_id: String,
+        #[arg(long, help = "Print log lines as JSON (machine-readable)")]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum HubCommand {
+    #[command(about = "Show hub role, node availability, and queue depth")]
+    Status {
+        #[arg(long, help = "Print hub status as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "List registered executor nodes")]
+    Nodes {
+        #[arg(long, help = "Print nodes as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "List hub jobs")]
+    Jobs {
+        #[arg(
+            long,
+            value_name = "STATE",
+            value_parser = ["queued", "assigned", "held", "completed", "failed", "cancelled"],
+            help = "Only show jobs in this state"
+        )]
+        state: Option<String>,
+        #[arg(long, help = "Print jobs as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Show the job→node routing table")]
+    Routing {
+        #[arg(long, help = "Print routes as JSON (machine-readable)")]
         json: bool,
     },
 }
@@ -645,7 +754,33 @@ fn run_cli(cli: Cli) -> Result<()> {
                 query,
                 json: search_json,
             }) => run_sessions_search(&query, search_json),
+            Some(SessionsCommand::Show {
+                session_id,
+                json: show_json,
+            }) => observe::run_session_show(&session_id, show_json),
+            Some(SessionsCommand::Events {
+                session_id,
+                after_seq,
+                limit,
+                json: events_json,
+            }) => observe::run_session_events(&session_id, after_seq, limit, events_json),
+            Some(SessionsCommand::Log {
+                session_id,
+                json: log_json,
+            }) => observe::run_session_log(&session_id, log_json),
             None => tui::sessions::run_command(all, manage, plain, json),
+        },
+        Some(Command::Status { json }) => observe::run_status(json),
+        Some(Command::Familiars { json }) => observe::run_familiars(json),
+        Some(Command::Skills { json }) => observe::run_skills(json),
+        Some(Command::Memory { json }) => observe::run_memory(json),
+        Some(Command::Research { json }) => observe::run_research(json),
+        Some(Command::Calls { id, json }) => observe::run_calls(id.as_deref(), json),
+        Some(Command::Hub { command }) => match command {
+            HubCommand::Status { json } => observe::run_hub_status(json),
+            HubCommand::Nodes { json } => observe::run_hub_nodes(json),
+            HubCommand::Jobs { state, json } => observe::run_hub_jobs(state.as_deref(), json),
+            HubCommand::Routing { json } => observe::run_hub_routing(json),
         },
         Some(Command::Logs { command }) => run_logs_command(command),
         Some(Command::Vacuum) => run_vacuum_command(),
@@ -3281,6 +3416,144 @@ mod tests {
         assert_eq!(near_miss_subcommand("sessons").as_deref(), Some("sessions"));
         assert_eq!(near_miss_subcommand("docter").as_deref(), Some("doctor"));
         assert_eq!(near_miss_subcommand("attch").as_deref(), Some("attach"));
+    }
+
+    #[test]
+    fn near_miss_subcommand_catches_observability_command_typos() {
+        assert_eq!(near_miss_subcommand("stauts").as_deref(), Some("status"));
+        assert_eq!(
+            near_miss_subcommand("familars").as_deref(),
+            Some("familiars")
+        );
+        assert_eq!(near_miss_subcommand("skils").as_deref(), Some("skills"));
+        assert_eq!(
+            near_miss_subcommand("overveiw").as_deref(),
+            Some("overview")
+        );
+    }
+
+    #[test]
+    fn cli_parses_observability_commands() {
+        assert!(matches!(
+            Cli::parse_from(["coven", "status"]).command,
+            Some(Command::Status { json: false })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "overview", "--json"]).command,
+            Some(Command::Status { json: true })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "familiars"]).command,
+            Some(Command::Familiars { json: false })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "skills", "--json"]).command,
+            Some(Command::Skills { json: true })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "memory"]).command,
+            Some(Command::Memory { json: false })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "research"]).command,
+            Some(Command::Research { json: false })
+        ));
+        match Cli::parse_from(["coven", "calls", "call-1", "--json"]).command {
+            Some(Command::Calls { id, json }) => {
+                assert_eq!(id.as_deref(), Some("call-1"));
+                assert!(json);
+            }
+            other => panic!("expected calls command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_hub_subcommands() {
+        assert!(matches!(
+            Cli::parse_from(["coven", "hub", "status"]).command,
+            Some(Command::Hub {
+                command: HubCommand::Status { json: false }
+            })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "hub", "nodes", "--json"]).command,
+            Some(Command::Hub {
+                command: HubCommand::Nodes { json: true }
+            })
+        ));
+        match Cli::parse_from(["coven", "hub", "jobs", "--state", "queued"]).command {
+            Some(Command::Hub {
+                command: HubCommand::Jobs { state, json },
+            }) => {
+                assert_eq!(state.as_deref(), Some("queued"));
+                assert!(!json);
+            }
+            other => panic!("expected hub jobs command, got {other:?}"),
+        }
+        assert!(matches!(
+            Cli::parse_from(["coven", "hub", "routing"]).command,
+            Some(Command::Hub {
+                command: HubCommand::Routing { json: false }
+            })
+        ));
+    }
+
+    #[test]
+    fn cli_rejects_unknown_hub_job_state() {
+        assert!(Cli::try_parse_from(["coven", "hub", "jobs", "--state", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn cli_parses_sessions_inspection_subcommands() {
+        match Cli::parse_from(["coven", "sessions", "show", "sess-1", "--json"]).command {
+            Some(Command::Sessions {
+                command: Some(SessionsCommand::Show { session_id, json }),
+                ..
+            }) => {
+                assert_eq!(session_id, "sess-1");
+                assert!(json);
+            }
+            other => panic!("expected sessions show, got {other:?}"),
+        }
+        match Cli::parse_from([
+            "coven",
+            "sessions",
+            "events",
+            "sess-1",
+            "--after-seq",
+            "7",
+            "--limit",
+            "50",
+        ])
+        .command
+        {
+            Some(Command::Sessions {
+                command:
+                    Some(SessionsCommand::Events {
+                        session_id,
+                        after_seq,
+                        limit,
+                        json,
+                    }),
+                ..
+            }) => {
+                assert_eq!(session_id, "sess-1");
+                assert_eq!(after_seq, Some(7));
+                assert_eq!(limit, Some(50));
+                assert!(!json);
+            }
+            other => panic!("expected sessions events, got {other:?}"),
+        }
+        match Cli::parse_from(["coven", "sessions", "log", "sess-1"]).command {
+            Some(Command::Sessions {
+                command: Some(SessionsCommand::Log { session_id, json }),
+                ..
+            }) => {
+                assert_eq!(session_id, "sess-1");
+                assert!(!json);
+            }
+            other => panic!("expected sessions log, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -1221,6 +1221,27 @@ mod tests {
             out.contains("No routing decisions recorded."),
             "unexpected routing render: {out}"
         );
+
+        // Assign the job so the routing table gains a row, then confirm the
+        // renderer surfaces the live envelope's route fields.
+        let assign = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/hub/jobs/job-1/assign",
+            temp.path(),
+            None,
+            Some(r#"{"nodeId":"node_a"}"#),
+        )?;
+        anyhow::ensure!(assign.status == 200, "assign: {}", assign.body);
+
+        let routing = get_body(temp.path(), "/api/v1/hub/routing")?;
+        let out = render_hub_routing(&routing);
+        assert!(out.contains("job-1"), "routed jobId lost: {out}");
+        assert!(out.contains("node_a"), "routed nodeId lost: {out}");
+
+        let assigned = get_body(temp.path(), "/api/v1/hub/jobs?state=assigned")?;
+        let out = render_hub_jobs(&assigned);
+        assert!(out.contains("job-1"), "assigned job lost: {out}");
+        assert!(out.contains("node_a"), "assigned node lost: {out}");
         Ok(())
     }
 

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -700,8 +700,8 @@ fn render_session_detail(body: &Value) -> String {
 
 pub(crate) fn run_session_events(
     reference: &str,
-    after_seq: Option<i64>,
-    limit: Option<i64>,
+    after_seq: Option<u64>,
+    limit: Option<u64>,
     json: bool,
 ) -> Result<()> {
     let coven_home = coven_home_dir()?;

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -1,0 +1,1283 @@
+// observe.rs — read-path CLI commands with Cave/daemon API parity.
+//
+// Every command here renders through the in-process API router
+// (`api::handle_request`), so `--json` output carries exactly the body the
+// daemon socket serves for the same route (pretty-printed) and the human
+// tables are a rendering of that same body — one source of truth for shapes.
+//
+// These are offline reads: the audited routes re-read `~/.coven` files or
+// the SQLite store per request and hold no daemon state, so going through
+// the router in-process cannot disagree with a running daemon.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+use crate::{api, coven_home_dir, daemon, theme};
+
+/// Column cap for free-text table cells (descriptions, requests, reasons).
+const TEXT_CELL_LIMIT: usize = 48;
+
+// ── API access ───────────────────────────────────────────────────────────────
+
+fn api_get(coven_home: &Path, path: &str) -> Result<Value> {
+    api_get_with_daemon(coven_home, path, None)
+}
+
+fn api_get_with_daemon(
+    coven_home: &Path,
+    path: &str,
+    daemon_status: Option<daemon::DaemonStatus>,
+) -> Result<Value> {
+    let response = api::handle_request("GET", path, coven_home, daemon_status)?;
+    let body: Value = serde_json::from_str(&response.body)
+        .with_context(|| format!("failed to parse API response for {path}"))?;
+    if response.status >= 400 {
+        let code = body
+            .pointer("/error/code")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown_error");
+        let message = body
+            .pointer("/error/message")
+            .and_then(Value::as_str)
+            .unwrap_or("Request failed.");
+        bail!("{message} ({code})");
+    }
+    Ok(body)
+}
+
+fn print_json(body: &Value) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(body).context("failed to serialize response as JSON")?
+    );
+    Ok(())
+}
+
+// ── Table rendering ──────────────────────────────────────────────────────────
+
+/// Render fixed-width columns with two-space gutters. Widths fit the widest
+/// cell so full ids always survive; pass pre-truncated cells for free text.
+fn render_table(headers: &[&str], rows: &[Vec<String>]) -> String {
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.chars().count()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if let Some(width) = widths.get_mut(i) {
+                *width = (*width).max(cell.chars().count());
+            }
+        }
+    }
+    let mut out = String::new();
+    let render_row = |cells: Vec<String>| -> String {
+        let mut line = String::new();
+        let last = cells.len().saturating_sub(1);
+        for (i, cell) in cells.iter().enumerate() {
+            if i == last {
+                // No trailing padding on the final column.
+                line.push_str(cell);
+            } else {
+                let pad = widths[i].saturating_sub(cell.chars().count());
+                line.push_str(cell);
+                line.extend(std::iter::repeat_n(' ', pad + 2));
+            }
+        }
+        line.trim_end().to_string()
+    };
+    out.push_str(&render_row(
+        headers.iter().map(|h| h.to_string()).collect::<Vec<_>>(),
+    ));
+    out.push('\n');
+    for row in rows {
+        out.push_str(&render_row(row.clone()));
+        out.push('\n');
+    }
+    out
+}
+
+fn str_cell(value: &Value, key: &str) -> String {
+    match value.get(key) {
+        Some(Value::String(s)) => s.clone(),
+        Some(Value::Null) | None => "—".to_string(),
+        Some(other) => other.to_string(),
+    }
+}
+
+// ── coven status ─────────────────────────────────────────────────────────────
+
+pub(crate) fn run_status(json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    let daemon_state = daemon::background_server_status(&coven_home)?;
+    let live = match &daemon_state {
+        Some(daemon::DaemonStatusState::Running(status)) => Some(status.clone()),
+        _ => None,
+    };
+    let health = api_get_with_daemon(&coven_home, "/api/v1/health", live)?;
+    let overview = api_get(&coven_home, "/api/v1/overview")?;
+    if json {
+        // CLI-level composition of the two stable API bodies; see
+        // docs/reference/cli-observe.md.
+        return print_json(&serde_json::json!({
+            "health": health,
+            "overview": overview,
+        }));
+    }
+    print!(
+        "{}",
+        render_status(daemon_state.as_ref(), &health, &overview)
+    );
+    Ok(())
+}
+
+fn render_status(
+    daemon_state: Option<&daemon::DaemonStatusState>,
+    health: &Value,
+    overview: &Value,
+) -> String {
+    let mut out = String::new();
+    out.push_str("Coven status\n\n");
+
+    let daemon_line = match daemon_state {
+        Some(daemon::DaemonStatusState::Running(status)) => {
+            format!("running (pid {}, socket {})", status.pid, status.socket)
+        }
+        Some(daemon::DaemonStatusState::Stale(status)) => format!(
+            "stale (pid {} is gone) — run `coven daemon restart`",
+            status.pid
+        ),
+        None => "not running — start it with `coven daemon start`".to_string(),
+    };
+    out.push_str(&format!("  daemon     {daemon_line}\n"));
+    out.push_str(&format!(
+        "  version    {}\n",
+        health
+            .get("covenVersion")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+    ));
+
+    let count = |key: &str| overview.get(key).and_then(Value::as_u64).unwrap_or(0);
+    out.push_str(&format!("  sessions   {} open\n", count("open_sessions")));
+    let total_familiars = count("total_familiars");
+    if total_familiars == 0 {
+        out.push_str("  familiars  none — add [[familiar]] entries to ~/.coven/familiars.toml\n");
+    } else {
+        out.push_str(&format!(
+            "  familiars  {} active / {} total\n",
+            count("active_familiars"),
+            total_familiars
+        ));
+    }
+    out.push_str(&format!(
+        "  skills     {} installed\n",
+        count("skills_count")
+    ));
+    let research_iterations = count("research_iterations");
+    if research_iterations > 0 {
+        out.push_str(&format!(
+            "  research   {} iterations (last Δ {})\n",
+            research_iterations,
+            overview
+                .get("last_research_delta")
+                .and_then(Value::as_i64)
+                .unwrap_or(0)
+        ));
+    }
+    if let Some(hub) = health.get("hub") {
+        let nodes_total = hub.get("nodesTotal").and_then(Value::as_u64).unwrap_or(0);
+        if nodes_total > 0 {
+            out.push_str(&format!(
+                "  hub        {}/{} nodes available (details: coven hub status)\n",
+                hub.get("nodesAvailable")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(0),
+                nodes_total
+            ));
+        }
+    }
+
+    out.push_str("\nNext: coven sessions · coven familiars · coven run <harness> \"<task>\"\n");
+    out
+}
+
+// ── coven familiars / skills / memory / research ─────────────────────────────
+
+pub(crate) fn run_familiars(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/familiars")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_familiars(&body));
+    Ok(())
+}
+
+fn render_familiars(body: &Value) -> String {
+    let familiars = body.as_array().cloned().unwrap_or_default();
+    if familiars.is_empty() {
+        return "No familiars configured.\n\
+                Add [[familiar]] entries to ~/.coven/familiars.toml to build your roster.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = familiars
+        .iter()
+        .map(|f| {
+            vec![
+                str_cell(f, "id"),
+                str_cell(f, "display_name"),
+                str_cell(f, "role"),
+                str_cell(f, "status"),
+                str_cell(f, "memory_freshness"),
+                theme::fit_chars(&str_cell(f, "description"), TEXT_CELL_LIMIT),
+            ]
+        })
+        .collect();
+    let mut out = render_table(
+        &["ID", "NAME", "ROLE", "STATUS", "MEMORY", "DESCRIPTION"],
+        &rows,
+    );
+    out.push_str(&format!(
+        "\n{} familiar(s) · roster file: ~/.coven/familiars.toml\n",
+        familiars.len()
+    ));
+    out
+}
+
+pub(crate) fn run_skills(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/skills")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_skills(&body));
+    Ok(())
+}
+
+fn render_skills(body: &Value) -> String {
+    let skills = body.as_array().cloned().unwrap_or_default();
+    if skills.is_empty() {
+        return "No skills installed.\n\
+                Skills live under ~/.coven/skills/<id>/metadata.json.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = skills
+        .iter()
+        .map(|s| {
+            vec![
+                str_cell(s, "id"),
+                str_cell(s, "version"),
+                str_cell(s, "category"),
+                str_cell(s, "owner"),
+                theme::fit_chars(&str_cell(s, "description"), TEXT_CELL_LIMIT),
+            ]
+        })
+        .collect();
+    let mut out = render_table(
+        &["ID", "VERSION", "CATEGORY", "OWNER", "DESCRIPTION"],
+        &rows,
+    );
+    out.push_str(&format!("\n{} skill(s)\n", skills.len()));
+    out
+}
+
+pub(crate) fn run_memory(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/memory")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_memory(&body));
+    Ok(())
+}
+
+fn render_memory(body: &Value) -> String {
+    let files = body.as_array().cloned().unwrap_or_default();
+    if files.is_empty() {
+        return "No memory files.\n\
+                Familiars keep durable notes under ~/.coven/memory/<familiar>/.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = files
+        .iter()
+        .map(|m| {
+            vec![
+                str_cell(m, "familiar_id"),
+                str_cell(m, "title"),
+                str_cell(m, "updated_at"),
+                theme::fit_chars(&str_cell(m, "excerpt"), TEXT_CELL_LIMIT),
+            ]
+        })
+        .collect();
+    let mut out = render_table(&["FAMILIAR", "TITLE", "UPDATED", "EXCERPT"], &rows);
+    out.push_str(&format!("\n{} memory file(s)\n", files.len()));
+    out
+}
+
+pub(crate) fn run_research(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/research")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_research(&body));
+    Ok(())
+}
+
+fn render_research(body: &Value) -> String {
+    let rows_json = body.as_array().cloned().unwrap_or_default();
+    if rows_json.is_empty() {
+        return "No research log.\n\
+                Rows come from ~/.coven/research/results.tsv.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = rows_json
+        .iter()
+        .map(|r| {
+            vec![
+                r.get("iteration")
+                    .and_then(Value::as_u64)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "—".to_string()),
+                theme::fit_chars(&str_cell(r, "topic"), TEXT_CELL_LIMIT),
+                str_cell(r, "score"),
+                str_cell(r, "delta"),
+                str_cell(r, "decision"),
+                str_cell(r, "source"),
+            ]
+        })
+        .collect();
+    let mut out = render_table(
+        &["ITER", "TOPIC", "SCORE", "DELTA", "DECISION", "SOURCE"],
+        &rows,
+    );
+    out.push_str(&format!("\n{} research iteration(s)\n", rows_json.len()));
+    out
+}
+
+// ── coven calls ──────────────────────────────────────────────────────────────
+
+pub(crate) fn run_calls(id: Option<&str>, json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    match id {
+        Some(id) => {
+            let body = api_get(&coven_home, &format!("/api/v1/coven-calls/{id}"))?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_call_detail(&body));
+        }
+        None => {
+            let body = api_get(&coven_home, "/api/v1/coven-calls")?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_calls(&body));
+        }
+    }
+    Ok(())
+}
+
+fn render_calls(body: &Value) -> String {
+    let calls = body
+        .get("calls")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if calls.is_empty() {
+        return "No delegation calls recorded.\n\
+                Calls appear here when one familiar delegates work to another through Cast.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = calls
+        .iter()
+        .map(|c| {
+            vec![
+                str_cell(c, "id"),
+                format!(
+                    "{} → {}",
+                    str_cell(c, "callerFamiliarId"),
+                    str_cell(c, "calleeFamiliarId")
+                ),
+                str_cell(c, "status"),
+                str_cell(c, "createdAt"),
+                theme::fit_chars(&str_cell(c, "request"), TEXT_CELL_LIMIT),
+            ]
+        })
+        .collect();
+    let mut out = render_table(&["ID", "CALL", "STATUS", "CREATED", "REQUEST"], &rows);
+    out.push_str(&format!(
+        "\n{} call(s) · detail: coven calls <id>\n",
+        calls.len()
+    ));
+    out
+}
+
+fn render_call_detail(body: &Value) -> String {
+    let call = body.get("call").cloned().unwrap_or(Value::Null);
+    let mut out = String::new();
+    out.push_str(&format!("Coven call {}\n\n", str_cell(&call, "id")));
+    out.push_str(&format!(
+        "  caller     {}\n",
+        str_cell(&call, "callerFamiliarId")
+    ));
+    out.push_str(&format!(
+        "  callee     {}\n",
+        str_cell(&call, "calleeFamiliarId")
+    ));
+    out.push_str(&format!("  status     {}\n", str_cell(&call, "status")));
+    out.push_str(&format!("  created    {}\n", str_cell(&call, "createdAt")));
+    if call.get("endedAt").and_then(Value::as_str).is_some() {
+        out.push_str(&format!("  ended      {}\n", str_cell(&call, "endedAt")));
+    }
+    if let Some(session) = call.get("sessionId").and_then(Value::as_str) {
+        out.push_str(&format!(
+            "  session    {session} (coven sessions show {session})\n"
+        ));
+    }
+    out.push_str(&format!(
+        "\n  request\n    {}\n",
+        str_cell(&call, "request")
+    ));
+    if let Some(artifact) = call.get("artifact").and_then(Value::as_str) {
+        out.push_str(&format!("\n  artifact\n    {artifact}\n"));
+    }
+    out
+}
+
+// ── coven hub ────────────────────────────────────────────────────────────────
+
+pub(crate) fn run_hub_status(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/hub/status")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_hub_status(&body));
+    Ok(())
+}
+
+fn render_hub_status(body: &Value) -> String {
+    let mut out = String::new();
+    out.push_str("Hub status\n\n");
+    out.push_str(&format!("  role       {}\n", str_cell(body, "role")));
+    out.push_str(&format!("  hub id     {}\n", str_cell(body, "hubId")));
+    let total = body.get("nodesTotal").and_then(Value::as_u64).unwrap_or(0);
+    let available = body
+        .get("nodesAvailable")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    out.push_str(&format!("  nodes      {available}/{total} available\n"));
+    if let Some(queue) = body.get("globalQueue") {
+        let n = |key: &str| queue.get(key).and_then(Value::as_u64).unwrap_or(0);
+        out.push_str(&format!(
+            "  queue      {} queued · {} assigned · {} held ({} total)\n",
+            n("queued"),
+            n("assigned"),
+            n("held"),
+            n("total")
+        ));
+    }
+    if total == 0 {
+        out.push_str(
+            "\nNo executor nodes registered — this daemon is running single-host.\n\
+             See docs/HUB-OPERATIONS.md to register nodes.\n",
+        );
+        return out;
+    }
+    let nodes = body
+        .get("nodes")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let rows: Vec<Vec<String>> = nodes
+        .iter()
+        .map(|n| {
+            vec![
+                str_cell(n, "nodeId"),
+                str_cell(n, "available"),
+                str_cell(n, "queuePressure"),
+                str_cell(n, "lastHealthAt"),
+            ]
+        })
+        .collect();
+    out.push('\n');
+    out.push_str(&render_table(
+        &["NODE", "AVAILABLE", "PRESSURE", "LAST HEALTH"],
+        &rows,
+    ));
+    out
+}
+
+pub(crate) fn run_hub_nodes(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/hub/nodes")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_hub_nodes(&body));
+    Ok(())
+}
+
+fn render_hub_nodes(body: &Value) -> String {
+    let nodes = body
+        .get("nodes")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if nodes.is_empty() {
+        return "No executor nodes registered.\n\
+                Register nodes over the hub API — see docs/HUB-OPERATIONS.md.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = nodes
+        .iter()
+        .map(|n| {
+            let capabilities = n
+                .get("capabilities")
+                .and_then(Value::as_array)
+                .map(|caps| {
+                    caps.iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(",")
+                })
+                .unwrap_or_else(|| "—".to_string());
+            vec![
+                str_cell(n, "nodeId"),
+                str_cell(n, "role"),
+                str_cell(n, "transport"),
+                str_cell(n, "available"),
+                str_cell(n, "queuePressure"),
+                capabilities,
+                str_cell(n, "updatedAt"),
+            ]
+        })
+        .collect();
+    let mut out = render_table(
+        &[
+            "NODE",
+            "ROLE",
+            "TRANSPORT",
+            "AVAILABLE",
+            "PRESSURE",
+            "CAPABILITIES",
+            "UPDATED",
+        ],
+        &rows,
+    );
+    out.push_str(&format!("\n{} node(s)\n", nodes.len()));
+    out
+}
+
+pub(crate) fn run_hub_jobs(state: Option<&str>, json: bool) -> Result<()> {
+    let path = match state {
+        Some(state) => format!("/api/v1/hub/jobs?state={state}"),
+        None => "/api/v1/hub/jobs".to_string(),
+    };
+    let body = api_get(&coven_home_dir()?, &path)?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_hub_jobs(&body));
+    Ok(())
+}
+
+fn render_hub_jobs(body: &Value) -> String {
+    let jobs = body
+        .get("jobs")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if jobs.is_empty() {
+        return "No hub jobs found.\n\
+                Jobs are enqueued over the hub API — see docs/HUB-OPERATIONS.md.\n"
+            .to_string();
+    }
+    let rows: Vec<Vec<String>> = jobs
+        .iter()
+        .map(|j| {
+            vec![
+                str_cell(j, "jobId"),
+                str_cell(j, "state"),
+                str_cell(j, "priority"),
+                str_cell(j, "assignedNodeId"),
+                str_cell(j, "loopId"),
+                str_cell(j, "updatedAt"),
+            ]
+        })
+        .collect();
+    let mut out = render_table(
+        &["JOB", "STATE", "PRIORITY", "NODE", "LOOP", "UPDATED"],
+        &rows,
+    );
+    out.push_str(&format!(
+        "\n{} job(s) · filter with --state <queued|assigned|held|completed|failed|cancelled>\n",
+        jobs.len()
+    ));
+    out
+}
+
+pub(crate) fn run_hub_routing(json: bool) -> Result<()> {
+    let body = api_get(&coven_home_dir()?, "/api/v1/hub/routing")?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_hub_routing(&body));
+    Ok(())
+}
+
+fn render_hub_routing(body: &Value) -> String {
+    let routes = body
+        .get("routes")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if routes.is_empty() {
+        return "No routing decisions recorded.\n".to_string();
+    }
+    let rows: Vec<Vec<String>> = routes
+        .iter()
+        .map(|r| {
+            vec![
+                str_cell(r, "jobId"),
+                str_cell(r, "nodeId"),
+                str_cell(r, "decisionId"),
+                theme::fit_chars(&str_cell(r, "reason"), TEXT_CELL_LIMIT),
+                str_cell(r, "updatedAt"),
+            ]
+        })
+        .collect();
+    let mut out = render_table(&["JOB", "NODE", "DECISION", "REASON", "UPDATED"], &rows);
+    out.push_str(&format!("\n{} route(s)\n", routes.len()));
+    out
+}
+
+// ── coven sessions show/events/log ───────────────────────────────────────────
+
+pub(crate) fn run_session_show(reference: &str, json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    let session_id = resolve_full_session_id(reference)?;
+    let body = api_get(&coven_home, &format!("/api/v1/sessions/{session_id}"))?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_session_detail(&body));
+    Ok(())
+}
+
+fn render_session_detail(body: &Value) -> String {
+    let mut out = String::new();
+    let id = str_cell(body, "id");
+    out.push_str(&format!("Session {id}\n\n"));
+    out.push_str(&format!("  title       {}\n", str_cell(body, "title")));
+    out.push_str(&format!("  status      {}\n", str_cell(body, "status")));
+    out.push_str(&format!("  harness     {}\n", str_cell(body, "harness")));
+    out.push_str(&format!(
+        "  project     {}\n",
+        str_cell(body, "project_root")
+    ));
+    if let Some(familiar) = body.get("familiar_id").and_then(Value::as_str) {
+        out.push_str(&format!("  familiar    {familiar}\n"));
+    }
+    if let Some(labels) = body.get("labels").and_then(Value::as_array) {
+        if !labels.is_empty() {
+            let joined = labels
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ");
+            out.push_str(&format!("  labels      {joined}\n"));
+        }
+    }
+    out.push_str(&format!("  visibility  {}\n", str_cell(body, "visibility")));
+    out.push_str(&format!("  created     {}\n", str_cell(body, "created_at")));
+    out.push_str(&format!("  updated     {}\n", str_cell(body, "updated_at")));
+    if let Some(exit_code) = body.get("exit_code").and_then(Value::as_i64) {
+        out.push_str(&format!("  exit code   {exit_code}\n"));
+    }
+    if let Some(archived) = body.get("archived_at").and_then(Value::as_str) {
+        out.push_str(&format!("  archived    {archived}\n"));
+    }
+    out.push_str(&format!(
+        "\nNext: coven attach {id} · coven sessions events {id} · coven sessions log {id}\n"
+    ));
+    out
+}
+
+pub(crate) fn run_session_events(
+    reference: &str,
+    after_seq: Option<i64>,
+    limit: Option<i64>,
+    json: bool,
+) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    let session_id = resolve_full_session_id(reference)?;
+    let mut query = Vec::new();
+    if let Some(after_seq) = after_seq {
+        query.push(format!("afterSeq={after_seq}"));
+    }
+    if let Some(limit) = limit {
+        query.push(format!("limit={limit}"));
+    }
+    let path = if query.is_empty() {
+        format!("/api/v1/sessions/{session_id}/events")
+    } else {
+        format!("/api/v1/sessions/{session_id}/events?{}", query.join("&"))
+    };
+    let body = api_get(&coven_home, &path)?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_session_events(&body));
+    Ok(())
+}
+
+fn render_session_events(body: &Value) -> String {
+    let events = body
+        .get("events")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if events.is_empty() {
+        return "No events recorded for this session yet.\n".to_string();
+    }
+    let rows: Vec<Vec<String>> = events
+        .iter()
+        .map(|e| {
+            let payload = e
+                .get("payload_json")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .replace(['\n', '\r'], " ");
+            vec![
+                e.get("seq")
+                    .and_then(Value::as_i64)
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "—".to_string()),
+                str_cell(e, "created_at"),
+                str_cell(e, "kind"),
+                theme::fit_chars(payload.trim(), 64),
+            ]
+        })
+        .collect();
+    let mut out = render_table(&["SEQ", "CREATED", "KIND", "PAYLOAD"], &rows);
+    let mut footer = format!("\n{} event(s)", events.len());
+    if body.get("hasMore").and_then(Value::as_bool) == Some(true) {
+        if let Some(cursor) = body.pointer("/nextCursor/afterSeq").and_then(Value::as_i64) {
+            footer.push_str(&format!(" · more: --after-seq {cursor}"));
+        }
+    }
+    footer.push('\n');
+    out.push_str(&footer);
+    out
+}
+
+pub(crate) fn run_session_log(reference: &str, json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    let session_id = resolve_full_session_id(reference)?;
+    let body = api_get(&coven_home, &format!("/api/v1/sessions/{session_id}/log"))?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_session_log(&body));
+    Ok(())
+}
+
+fn render_session_log(body: &Value) -> String {
+    let lines = body.as_array().cloned().unwrap_or_default();
+    if lines.is_empty() {
+        return "No log lines recorded for this session yet.\n".to_string();
+    }
+    let mut out = String::new();
+    for line in &lines {
+        out.push_str(&format!(
+            "{} [{}] {}\n",
+            str_cell(line, "ts"),
+            str_cell(line, "level"),
+            str_cell(line, "message")
+        ));
+    }
+    out
+}
+
+/// Resolve a full or unique-prefix session reference to a full session id,
+/// reusing the lifecycle commands' resolver so hints stay consistent.
+fn resolve_full_session_id(reference: &str) -> Result<String> {
+    let store_path = crate::coven_store_path()?;
+    let conn = crate::store::open_store(&store_path)?;
+    let session = crate::resolve_session_ref(&conn, reference)?;
+    Ok(session.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn render_table_pads_columns_and_trims_trailing_space() {
+        let out = render_table(
+            &["ID", "NAME"],
+            &[
+                vec!["a".to_string(), "Alpha".to_string()],
+                vec!["longer-id".to_string(), "B".to_string()],
+            ],
+        );
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines[0], "ID         NAME");
+        assert_eq!(lines[1], "a          Alpha");
+        assert_eq!(lines[2], "longer-id  B");
+    }
+
+    #[test]
+    fn render_status_shows_counts_and_daemon_state() {
+        let health = json!({
+            "covenVersion": "1.2.3",
+            "hub": { "nodesTotal": 2, "nodesAvailable": 1 }
+        });
+        let overview = json!({
+            "open_sessions": 3,
+            "active_familiars": 1,
+            "total_familiars": 2,
+            "skills_count": 4,
+            "research_iterations": 5,
+            "last_research_delta": 2
+        });
+        let out = render_status(None, &health, &overview);
+        assert!(out.contains("daemon     not running — start it with `coven daemon start`"));
+        assert!(out.contains("version    1.2.3"));
+        assert!(out.contains("sessions   3 open"));
+        assert!(out.contains("familiars  1 active / 2 total"));
+        assert!(out.contains("skills     4 installed"));
+        assert!(out.contains("research   5 iterations (last Δ 2)"));
+        assert!(out.contains("hub        1/2 nodes available"));
+        assert!(out.contains("Next: coven sessions"));
+    }
+
+    #[test]
+    fn render_status_teaches_first_run_users() {
+        let health = json!({ "covenVersion": "1.2.3" });
+        let overview = json!({
+            "open_sessions": 0,
+            "active_familiars": 0,
+            "total_familiars": 0,
+            "skills_count": 0,
+            "research_iterations": 0,
+            "last_research_delta": 0
+        });
+        let out = render_status(None, &health, &overview);
+        assert!(out.contains("familiars  none — add [[familiar]] entries"));
+        // Zero-iteration research and zero-node hub stay quiet.
+        assert!(!out.contains("research"));
+        assert!(!out.contains("hub "));
+    }
+
+    #[test]
+    fn render_familiars_lists_roster_and_hints_file() {
+        let body = json!([
+            {
+                "id": "charm",
+                "display_name": "Charm",
+                "role": "steward",
+                "status": "offline",
+                "memory_freshness": "2d ago",
+                "description": "keeps the hearth"
+            }
+        ]);
+        let out = render_familiars(&body);
+        assert!(out.contains("ID"));
+        assert!(out.contains("charm"));
+        assert!(out.contains("steward"));
+        assert!(out.contains("1 familiar(s)"));
+        assert!(out.contains("~/.coven/familiars.toml"));
+    }
+
+    #[test]
+    fn render_familiars_empty_state_teaches_setup() {
+        let out = render_familiars(&json!([]));
+        assert!(out.contains("No familiars configured."));
+        assert!(out.contains("familiars.toml"));
+    }
+
+    #[test]
+    fn render_skills_lists_inventory() {
+        let body = json!([
+            {
+                "id": "eval-loop",
+                "version": "1.0.0",
+                "category": "general",
+                "owner": "coven",
+                "description": "run the eval loop"
+            }
+        ]);
+        let out = render_skills(&body);
+        assert!(out.contains("eval-loop"));
+        assert!(out.contains("1 skill(s)"));
+    }
+
+    #[test]
+    fn render_memory_and_research_have_empty_hints() {
+        assert!(render_memory(&json!([])).contains("~/.coven/memory/"));
+        assert!(render_research(&json!([])).contains("results.tsv"));
+    }
+
+    #[test]
+    fn render_calls_lists_delegations_with_arrow() {
+        let body = json!({
+            "ok": true,
+            "calls": [{
+                "id": "call-1",
+                "callerFamiliarId": "nova",
+                "calleeFamiliarId": "sage",
+                "status": "running",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "request": "summarize the release notes"
+            }]
+        });
+        let out = render_calls(&body);
+        assert!(out.contains("nova → sage"));
+        assert!(out.contains("running"));
+        assert!(out.contains("coven calls <id>"));
+    }
+
+    #[test]
+    fn render_call_detail_links_session_inspection() {
+        let body = json!({
+            "ok": true,
+            "call": {
+                "id": "call-1",
+                "callerFamiliarId": "nova",
+                "calleeFamiliarId": "sage",
+                "status": "completed",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "endedAt": "2026-01-01T01:00:00Z",
+                "sessionId": "sess-9",
+                "request": "summarize",
+                "artifact": "done"
+            }
+        });
+        let out = render_call_detail(&body);
+        assert!(out.contains("caller     nova"));
+        assert!(out.contains("ended      2026-01-01T01:00:00Z"));
+        assert!(out.contains("coven sessions show sess-9"));
+        assert!(out.contains("artifact"));
+    }
+
+    #[test]
+    fn render_hub_status_single_host_explains_itself() {
+        let body = json!({
+            "role": "hub",
+            "hubId": "hub_1",
+            "nodesTotal": 0,
+            "nodesAvailable": 0,
+            "globalQueue": { "queued": 0, "assigned": 0, "held": 0, "total": 0 },
+            "nodes": []
+        });
+        let out = render_hub_status(&body);
+        assert!(out.contains("single-host"));
+        assert!(out.contains("docs/HUB-OPERATIONS.md"));
+    }
+
+    #[test]
+    fn render_hub_status_lists_nodes_when_registered() {
+        let body = json!({
+            "role": "hub",
+            "hubId": "hub_1",
+            "nodesTotal": 1,
+            "nodesAvailable": 1,
+            "globalQueue": { "queued": 2, "assigned": 1, "held": 0, "total": 3 },
+            "nodes": [{
+                "nodeId": "node_a",
+                "available": true,
+                "queuePressure": 0,
+                "lastHealthAt": "2026-01-01T00:00:00Z"
+            }]
+        });
+        let out = render_hub_status(&body);
+        assert!(out.contains("nodes      1/1 available"));
+        assert!(out.contains("2 queued · 1 assigned · 0 held (3 total)"));
+        assert!(out.contains("node_a"));
+    }
+
+    #[test]
+    fn render_hub_jobs_hints_state_filter() {
+        let body = json!({
+            "jobs": [{
+                "jobId": "job-1",
+                "state": "queued",
+                "priority": 5,
+                "assignedNodeId": null,
+                "loopId": null,
+                "updatedAt": "2026-01-01T00:00:00Z"
+            }]
+        });
+        let out = render_hub_jobs(&body);
+        assert!(out.contains("job-1"));
+        assert!(out.contains("--state <queued|assigned|held|completed|failed|cancelled>"));
+    }
+
+    #[test]
+    fn render_session_detail_suggests_next_commands() {
+        let body = json!({
+            "id": "sess-1",
+            "title": "fix auth",
+            "status": "running",
+            "harness": "codex",
+            "project_root": "/tmp/project",
+            "visibility": "private",
+            "created_at": "2026-01-01T00:00:00Z",
+            "updated_at": "2026-01-01T00:05:00Z",
+            "labels": ["auth", "bug"],
+            "familiar_id": "charm"
+        });
+        let out = render_session_detail(&body);
+        assert!(out.contains("Session sess-1"));
+        assert!(out.contains("title       fix auth"));
+        assert!(out.contains("familiar    charm"));
+        assert!(out.contains("labels      auth, bug"));
+        assert!(out.contains("coven attach sess-1"));
+        assert!(out.contains("coven sessions events sess-1"));
+    }
+
+    #[test]
+    fn render_session_events_shows_cursor_hint_when_more() {
+        let body = json!({
+            "events": [{
+                "seq": 7,
+                "id": "evt-7",
+                "session_id": "sess-1",
+                "kind": "pty_output",
+                "payload_json": "{\"text\":\"hello\\nworld\"}",
+                "created_at": "2026-01-01T00:00:00Z"
+            }],
+            "nextCursor": { "afterSeq": 7 },
+            "hasMore": true
+        });
+        let out = render_session_events(&body);
+        assert!(out.contains("pty_output"));
+        assert!(!out.contains('\r'));
+        assert!(out.contains("--after-seq 7"));
+    }
+
+    #[test]
+    fn render_session_log_prints_ts_level_message_lines() {
+        let body = json!([
+            { "ts": "2026-01-01T00:00:00Z", "level": "info", "message": "hello" }
+        ]);
+        let out = render_session_log(&body);
+        assert_eq!(out, "2026-01-01T00:00:00Z [info] hello\n");
+    }
+
+    // ── End-to-end parity: seeded home → real API body → renderer ───────────
+    //
+    // These tests exist to catch key drift: if a DTO field is renamed on the
+    // API side, the rendered output loses real values and the assertions
+    // below fail — the fixture-only tests above cannot see that.
+
+    fn get_body(home: &Path, path: &str) -> Result<Value> {
+        let response = crate::api::handle_request("GET", path, home, None)?;
+        anyhow::ensure!(
+            response.status < 400,
+            "GET {path} failed with {}: {}",
+            response.status,
+            response.body
+        );
+        serde_json::from_str(&response.body).map_err(Into::into)
+    }
+
+    #[test]
+    fn familiars_renderer_matches_live_api_body() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(
+            temp.path().join("familiars.toml"),
+            "[[familiar]]\n\
+             id = \"charm\"\n\
+             display_name = \"Charm\"\n\
+             role = \"steward\"\n\
+             description = \"keeps the hearth\"\n",
+        )?;
+        let body = get_body(temp.path(), "/api/v1/familiars")?;
+        let out = render_familiars(&body);
+        assert!(out.contains("charm"), "id column lost: {out}");
+        assert!(out.contains("Charm"), "display_name column lost: {out}");
+        assert!(out.contains("steward"), "role column lost: {out}");
+        assert!(out.contains("keeps the hearth"), "description lost: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn skills_renderer_matches_live_api_body() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let dir = temp.path().join("skills").join("eval-loop");
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(
+            dir.join("metadata.json"),
+            r#"{"name":"eval-loop","description":"run the loop","version":"2.0.0","author":"coven","category":"ops"}"#,
+        )?;
+        let body = get_body(temp.path(), "/api/v1/skills")?;
+        let out = render_skills(&body);
+        assert!(out.contains("eval-loop"), "id lost: {out}");
+        assert!(out.contains("2.0.0"), "version lost: {out}");
+        assert!(out.contains("ops"), "category lost: {out}");
+        assert!(out.contains("run the loop"), "description lost: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn memory_renderer_matches_live_api_body() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let dir = temp.path().join("memory").join("charm");
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(dir.join("hearth-notes.md"), "# Hearth\nembers burning\n")?;
+        let body = get_body(temp.path(), "/api/v1/memory")?;
+        let out = render_memory(&body);
+        assert!(out.contains("charm"), "familiar_id lost: {out}");
+        assert!(out.contains("hearth-notes"), "title lost: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn research_renderer_matches_live_api_body() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let dir = temp.path().join("research");
+        std::fs::create_dir_all(&dir)?;
+        std::fs::write(
+            dir.join("results.tsv"),
+            "3\tstream continuity\t9.0\t2.5\tadopt\tnotes.md\n",
+        )?;
+        let body = get_body(temp.path(), "/api/v1/research")?;
+        let out = render_research(&body);
+        assert!(out.contains("stream continuity"), "topic lost: {out}");
+        assert!(out.contains("adopt"), "decision lost: {out}");
+        assert!(out.contains("2.5"), "delta lost: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn calls_renderer_matches_live_api_body() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let call_id = crate::coven_calls::emit_running(
+            temp.path(),
+            "nova",
+            "sage",
+            "summarize the release notes",
+            Some("sess-9"),
+        )?;
+        let list = get_body(temp.path(), "/api/v1/coven-calls")?;
+        let out = render_calls(&list);
+        assert!(out.contains("nova → sage"), "caller/callee lost: {out}");
+        assert!(out.contains("running"), "status lost: {out}");
+
+        let detail = get_body(temp.path(), &format!("/api/v1/coven-calls/{call_id}"))?;
+        let out = render_call_detail(&detail);
+        assert!(out.contains("caller     nova"), "caller lost: {out}");
+        assert!(
+            out.contains("coven sessions show sess-9"),
+            "session link lost: {out}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn hub_renderers_match_live_api_bodies() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let register = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/hub/nodes",
+            temp.path(),
+            None,
+            Some(
+                r#"{"nodeId":"node_a","role":"compute_executor","transport":"ssh","capabilities":["gpu"]}"#,
+            ),
+        )?;
+        anyhow::ensure!(register.status == 201, "register: {}", register.body);
+        let enqueue = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/hub/jobs",
+            temp.path(),
+            None,
+            Some(r#"{"jobId":"job-1","requiredCapabilities":["gpu"],"priority":5}"#),
+        )?;
+        anyhow::ensure!(enqueue.status == 201, "enqueue: {}", enqueue.body);
+
+        let status = get_body(temp.path(), "/api/v1/hub/status")?;
+        let out = render_hub_status(&status);
+        assert!(out.contains("role       hub"), "role lost: {out}");
+        assert!(
+            out.contains("nodes      1/1 available"),
+            "nodes lost: {out}"
+        );
+        assert!(out.contains("1 queued"), "queue lost: {out}");
+        assert!(out.contains("node_a"), "node row lost: {out}");
+
+        let nodes = get_body(temp.path(), "/api/v1/hub/nodes")?;
+        let out = render_hub_nodes(&nodes);
+        assert!(out.contains("node_a"), "nodeId lost: {out}");
+        assert!(out.contains("compute_executor"), "role lost: {out}");
+        assert!(out.contains("gpu"), "capabilities lost: {out}");
+
+        let jobs = get_body(temp.path(), "/api/v1/hub/jobs?state=queued")?;
+        let out = render_hub_jobs(&jobs);
+        assert!(out.contains("job-1"), "jobId lost: {out}");
+        assert!(out.contains("queued"), "state lost: {out}");
+
+        let routing = get_body(temp.path(), "/api/v1/hub/routing")?;
+        let out = render_hub_routing(&routing);
+        assert!(
+            out.contains("No routing decisions recorded."),
+            "unexpected routing render: {out}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn session_renderers_match_live_api_bodies() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let conn = crate::store::open_store(&home.join(crate::STORE_FILE_NAME))?;
+        crate::store::insert_session(
+            &conn,
+            &crate::store::SessionRecord {
+                id: "sess-live".into(),
+                project_root: "/tmp/project".into(),
+                harness: "codex".into(),
+                title: "fix auth".into(),
+                status: "running".into(),
+                exit_code: None,
+                archived_at: None,
+                created_at: "2026-01-01T00:00:00Z".into(),
+                updated_at: "2026-01-01T00:05:00Z".into(),
+                conversation_id: None,
+                familiar_id: Some("charm".into()),
+                labels: vec!["auth".into()],
+                visibility: "private".into(),
+                external: false,
+                transcript_path: None,
+            },
+        )?;
+        crate::store::insert_event_with_privacy(
+            &conn,
+            home,
+            &crate::store::EventRecord {
+                seq: 0,
+                id: "evt-1".into(),
+                session_id: "sess-live".into(),
+                kind: "output".into(),
+                payload_json: r#"{"data":"hello world"}"#.into(),
+                created_at: "2026-01-01T00:01:00Z".into(),
+            },
+        )?;
+        drop(conn);
+
+        let detail = get_body(home, "/api/v1/sessions/sess-live")?;
+        let out = render_session_detail(&detail);
+        assert!(out.contains("Session sess-live"), "id lost: {out}");
+        assert!(out.contains("title       fix auth"), "title lost: {out}");
+        assert!(out.contains("familiar    charm"), "familiar lost: {out}");
+        assert!(out.contains("labels      auth"), "labels lost: {out}");
+
+        let events = get_body(home, "/api/v1/sessions/sess-live/events?limit=10")?;
+        let out = render_session_events(&events);
+        assert!(out.contains("output"), "kind lost: {out}");
+        assert!(out.contains("hello world"), "payload lost: {out}");
+
+        let log = get_body(home, "/api/v1/sessions/sess-live/log")?;
+        let out = render_session_log(&log);
+        assert!(out.contains("2026-01-01T00:01:00Z"), "ts lost: {out}");
+        Ok(())
+    }
+}

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -151,6 +151,21 @@ coven sessions --json
 coven sessions --json --all
 ```
 
+To inspect one session without attaching (unique id prefixes work):
+
+```sh
+coven sessions show <session-id>
+coven sessions events <session-id> --limit 100
+coven sessions log <session-id>
+```
+
+To see the whole coven at a glance — daemon, open sessions, familiars,
+skills, and hub — run:
+
+```sh
+coven status
+```
+
 ## Attach, archive, summon, and sacrifice
 
 Lower-level session verbs remain available:

--- a/docs/HUB-OPERATIONS.md
+++ b/docs/HUB-OPERATIONS.md
@@ -36,12 +36,16 @@ Nothing needs to be replayed manually: reopening the store reloads the
 registry and queues. After a restart, verify recovery with:
 
 ```sh
-curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/hub/status
+coven hub status
 ```
 
 and confirm `role`, `hubId`, node availability, and queue depths match
-expectations. `GET /api/v1/health` includes the same summary in its `hub`
-block.
+expectations (`--json` gives the raw `GET /api/v1/hub/status` body; the raw
+route is also reachable with
+`curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/hub/status`).
+`GET /api/v1/health` includes the same summary in its `hub` block, and
+`coven hub nodes` / `coven hub jobs --state held` drill into the recovered
+registry and queues.
 
 ## Supervisor setup
 
@@ -125,11 +129,13 @@ respects a clean `coven daemon stop`.
    need to be told; the hub polls/dispatches, so held work resumes when the
    hub is back.
 2. **Crash recovery:** the supervisor restarts the daemon automatically.
-   Check `GET /api/v1/hub/status` and confirm:
+   Check `coven hub status` and confirm:
    - `nodesTotal` matches your registered fleet;
    - jobs that were `assigned` are still `assigned` (or `held` if their
-     executor's health has gone stale in the meantime);
-   - `executorQueues` still lists work for offline executors.
+     executor's health has gone stale in the meantime) —
+     `coven hub jobs --state held` lists the held set;
+   - `executorQueues` still lists work for offline executors
+     (`coven hub status --json`).
 3. **Executor loss while the hub was down:** report the executor's health
    (`POST /api/v1/hub/nodes/:id/health` with `available: false`). Its
    assigned jobs transition to `held` and stay in its subqueue until the node

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -1,0 +1,114 @@
+---
+summary: "Read-path observability commands: status, familiars, skills, memory, research, calls, hub, and session inspection."
+read_when:
+  - Checking what your coven is doing from a terminal
+  - Scripting against Cave-parity read views
+title: "coven observability commands"
+description: "Reference for coven status, familiars, skills, memory, research, calls, hub, and sessions show/events/log: terminal parity with the CovenCave dashboard and the daemon API."
+---
+
+# Observability commands
+
+Everything the CovenCave dashboard reads is also visible from the terminal.
+These commands are **read-only**, work **without a running daemon** (they read
+the same `~/.coven` files and SQLite store the daemon serves), and each takes
+`--json` for machine-readable output that carries the same body as the
+corresponding daemon API route.
+
+| Command | Human view | `--json` body |
+|---|---|---|
+| `coven status` | Ecosystem overview | `{ "health": …, "overview": … }` composition of `GET /api/v1/health` and `GET /api/v1/overview` |
+| `coven familiars` | Roster table | `GET /api/v1/familiars` |
+| `coven skills` | Skill inventory | `GET /api/v1/skills` |
+| `coven memory` | Memory file table | `GET /api/v1/memory` |
+| `coven research` | Research loop log | `GET /api/v1/research` |
+| `coven calls [<id>]` | Delegation ledger (list or detail) | `GET /api/v1/coven-calls[/:id]` |
+| `coven hub status` | Hub role, nodes, queue depth | `GET /api/v1/hub/status` |
+| `coven hub nodes` | Executor node table | `GET /api/v1/hub/nodes` |
+| `coven hub jobs [--state <s>]` | Job table | `GET /api/v1/hub/jobs[?state=s]` |
+| `coven hub routing` | Routing decisions | `GET /api/v1/hub/routing` |
+| `coven sessions show <id>` | One session's record | `GET /api/v1/sessions/:id` |
+| `coven sessions events <id>` | Recorded events (redacted) | `GET /api/v1/sessions/:id/events` |
+| `coven sessions log <id>` | Log lines | `GET /api/v1/sessions/:id/log` |
+
+## coven status
+
+The "what is my coven doing" front door. Complements `coven doctor`
+(is my *setup* healthy?) with runtime state:
+
+```text
+Coven status
+
+  daemon     running (pid 63321, socket /Users/alice/.coven/coven.sock)
+  version    0.1.7
+  sessions   3 open
+  familiars  1 active / 2 total
+  skills     4 installed
+  research   12 iterations (last Δ 2)
+  hub        1/2 nodes available (details: coven hub status)
+
+Next: coven sessions · coven familiars · coven run <harness> "<task>"
+```
+
+- The `familiars` line counts a familiar as **active** when it has an open
+  session; the roster comes from `~/.coven/familiars.toml`.
+- The `research` line appears only when the research log has rows; the `hub`
+  line appears only when executor nodes are registered — a fresh single-host
+  install stays quiet instead of alarming.
+- `coven overview` is an alias for readers coming from the API route name.
+
+`coven status --json` prints a CLI-level composition of the two stable API
+bodies (this shape is owned by the CLI, like `coven daemon status --json`):
+
+```json
+{
+  "health": { "ok": true, "apiVersion": "coven.daemon.v1", "…": "…" },
+  "overview": { "open_sessions": 3, "total_familiars": 2, "…": "…" }
+}
+```
+
+The `health.daemon` block reflects a *live* daemon only; a stale status file
+shows up as `daemon: null` here, while `coven daemon status --json` reports
+the `stale` state explicitly.
+
+## Session inspection without a PTY
+
+`coven attach` replays and follows interactively. For scripts, CI, and quick
+glances, the `sessions` subcommands read the same ledger non-interactively:
+
+```bash
+coven sessions show 9099                   # metadata; unique id prefixes work
+coven sessions events 9099 --limit 100     # recorded events, redacted payloads
+coven sessions events 9099 --after-seq 42  # resume from a cursor
+coven sessions log 9099                    # replay-style log lines, then exit
+```
+
+`events --json` returns the paginated envelope
+`{ "events": [...], "nextCursor": { "afterSeq": n }, "hasMore": bool }` —
+the same contract as `GET /api/v1/sessions/:id/events`, so a shell loop can
+page with `--after-seq` exactly like an API client. Event payloads are
+redacted by default before display, matching the API.
+
+## Hub operations without curl
+
+`coven hub` replaces hand-rolled `curl --unix-socket` calls for the read side
+of hub operations (see [HUB-OPERATIONS](../HUB-OPERATIONS.md) for the
+write-side protocol, which stays machine-to-machine):
+
+```bash
+coven hub status                 # role, hubId, node availability, queue depth
+coven hub nodes                  # registered executors with capabilities
+coven hub jobs --state queued    # global queue by state
+coven hub routing                # job→node routing decisions
+```
+
+## Empty states teach setup
+
+Each command's empty state points at the file or flow that populates it, so a
+fresh install can navigate the ecosystem without reading source:
+
+```text
+$ coven familiars
+No familiars configured.
+Add [[familiar]] entries to ~/.coven/familiars.toml to build your roster.
+```

--- a/docs/reference/cli-sessions.md
+++ b/docs/reference/cli-sessions.md
@@ -11,6 +11,9 @@ description: "Reference for coven sessions: list, inspect, filter, and export Co
 ```bash
 coven sessions [--manage | --plain | --json] [--all]
 coven sessions search <query> [--json]
+coven sessions show <session-id> [--json]
+coven sessions events <session-id> [--after-seq <SEQ>] [--limit <N>] [--json]
+coven sessions log <session-id> [--json]
 ```
 
 `coven sessions` is the safest way to find a session id before attaching,
@@ -45,6 +48,21 @@ coven sessions search "session stuck" --json
 
 `coven sessions search` runs full-text search over recorded event payloads. Use
 the JSON form when a client needs stable fields instead of terminal snippets.
+
+## Inspecting one session
+
+```bash
+coven sessions show 9099                   # record metadata; unique prefixes work
+coven sessions events 9099 --limit 100     # recorded events, redacted payloads
+coven sessions events 9099 --after-seq 42  # resume from a sequence cursor
+coven sessions log 9099                    # replay-style log lines, then exit
+```
+
+These are the non-interactive counterparts to `coven attach`: they print and
+exit, so scripts and CI can read a session without a PTY. `events --json`
+returns the same paginated envelope as `GET /api/v1/sessions/:id/events`
+(`events`, `nextCursor.afterSeq`, `hasMore`). See
+[observability commands](cli-observe.md) for the full read-path surface.
 
 ## Lifecycle commands
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,7 +4,7 @@ read_when:
   - Looking up a Coven CLI flag
   - Scripting against the Coven CLI
 title: "Coven CLI reference"
-description: "Reference for the coven CLI commands: doctor, daemon, run, sessions, attach, archive, kill, summon, sacrifice, view, and TUI command flags."
+description: "Reference for the coven CLI commands: doctor, status, daemon, run, sessions, attach, archive, kill, summon, sacrifice, familiars, skills, hub, and TUI command flags."
 ---
 
 
@@ -30,6 +30,13 @@ flowchart TB
   Root --> Hooks["hooks"]
   Root --> Pc["pc (macOS-first)"]
   Root --> Completions["completions"]
+  Root --> Status["status [--json]"]
+  Root --> Familiars["familiars [--json]"]
+  Root --> Skills["skills [--json]"]
+  Root --> Memory["memory [--json]"]
+  Root --> Research["research [--json]"]
+  Root --> Calls["calls [id] [--json]"]
+  Root --> Hub["hub"]
 
   Daemon --> DStart["start"]
   Daemon --> DStatus["status [--json]"]
@@ -43,6 +50,15 @@ flowchart TB
   Sessions --> SJson["--json"]
   Sessions --> SAll["--all"]
   Sessions --> SManage["--manage"]
+  Sessions --> SSearch["search &lt;query&gt;"]
+  Sessions --> SShow["show &lt;id&gt;"]
+  Sessions --> SEvents["events &lt;id&gt;"]
+  Sessions --> SLog["log &lt;id&gt;"]
+
+  Hub --> HubStatus["status [--json]"]
+  Hub --> HubNodes["nodes [--json]"]
+  Hub --> HubJobs["jobs [--state s] [--json]"]
+  Hub --> HubRouting["routing [--json]"]
 
   Patch --> POpenclaw["openclaw &lt;prompt&gt;"]
 
@@ -75,9 +91,12 @@ flowchart TB
 | `coven` | Open the beginner-friendly interactive menu. |
 | `coven tui` | Explicitly open the slash-command TUI. |
 | `coven doctor` | Check local setup; exits 1 when a blocking problem is found. |
+| `coven status` | Ecosystem overview: daemon, sessions, familiars, skills, research, hub. Alias: `coven overview`. |
 | `coven daemon start/status/restart/stop` | Manage the local daemon. |
 | `coven run <harness> <prompt>` | Launch a project-scoped harness session. Current harness ids: `codex`, `claude`. |
 | `coven sessions` | Open the session browser; supports `--plain`, `--json`, `--all`, and `--manage`. |
+| `coven sessions search <query>` | Full-text search recorded event payloads. |
+| `coven sessions show/events/log <session-id>` | Inspect one session without attaching; see [cli-observe](cli-observe.md). |
 | `coven attach <session-id>` | Replay/follow session output and forward input when live. |
 | `coven summon <session-id>` | Restore an archived session, then replay/follow it. |
 | `coven archive <session-id>` | Hide a non-running session while preserving events. |
@@ -93,6 +112,8 @@ flowchart TB
 | `coven hooks install` | Install local protocol hooks that block unsafe commits and protected pushes. |
 | `coven pc` | macOS-first diagnostics and explicit `--confirm` relief operations. |
 | `coven completions <shell>` | Print shell completions for bash, zsh, fish, elvish, or powershell. |
+| `coven familiars/skills/memory/research/calls` | Read-path Cave parity views; see [cli-observe](cli-observe.md). |
+| `coven hub status/nodes/jobs/routing` | Read-only hub control-plane inspection; see [cli-observe](cli-observe.md). |
 
 ## Common flags by command
 
@@ -101,6 +122,9 @@ flowchart TB
 | `coven run` | `--cwd <path>`, `--title <text>`, `--detach`, `--model <id>`, `--think`, `--speed fast\|balanced\|thorough` |
 | `coven daemon status` | `--json` |
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
+| `coven sessions events` | `--after-seq <SEQ>`, `--limit <N>`, `--json` |
+| `coven status` / `familiars` / `skills` / `memory` / `research` / `calls` | `--json` |
+| `coven hub jobs` | `--state <queued\|assigned\|held\|completed\|failed\|cancelled>`, `--json` |
 | `coven sacrifice` | `--yes` (required) |
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
 | `coven wt` | `--list`, `--json` (with `--list`), `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,7 +4,7 @@ read_when:
   - Looking up a Coven CLI flag
   - Scripting against the Coven CLI
 title: "Coven CLI reference"
-description: "Reference for the coven CLI commands: doctor, status, daemon, run, sessions, attach, archive, kill, summon, sacrifice, familiars, skills, hub, and TUI command flags."
+description: "Reference for the coven CLI commands: doctor, status, daemon, run, sessions, attach, archive, kill, summon, sacrifice, familiars, skills, memory, research, calls, hub, and TUI command flags."
 ---
 
 

--- a/docs/superpowers/specs/2026-07-14-cli-observability-parity-design.md
+++ b/docs/superpowers/specs/2026-07-14-cli-observability-parity-design.md
@@ -66,9 +66,10 @@ Related UX findings:
 ### D1 — Render through the in-process API handler
 
 New CLI read commands call `api::handle_request_with_body` directly (the same
-router the daemon serves), then either print the body verbatim (`--json`) or
-parse it to render a human view. This makes `--json` byte-equal to the daemon
-API by construction, with one source of truth for shapes.
+router the daemon serves), then either print the body (`--json`,
+pretty-printed) or parse it to render a human view. This makes `--json`
+value-equal to the daemon API by construction, with one source of truth for
+shapes.
 
 - *Alternative considered:* calling `cockpit_sources`/`hub` functions directly —
   rejected: CLI and API shapes drift independently.

--- a/docs/superpowers/specs/2026-07-14-cli-observability-parity-design.md
+++ b/docs/superpowers/specs/2026-07-14-cli-observability-parity-design.md
@@ -127,8 +127,7 @@ Naming notes (devil's advocate round):
 
 `overview_response` computes from the same sources the sibling routes use:
 
-- `total_familiars` = familiars list length; `active_familiars` = entries whose
-  `status` is `active`.
+- `total_familiars` = familiars list length; `active_familiars` = distinct roster familiars referenced by an open session (`running`/`active`).
 - `skills_count` = skills list length; `average_skill_score` = rounded mean of
   skill scores (0 when empty — scores are stubbed at 0.0 today, so this stays 0
   until scoring lands, which is honest).

--- a/docs/superpowers/specs/2026-07-14-cli-observability-parity-design.md
+++ b/docs/superpowers/specs/2026-07-14-cli-observability-parity-design.md
@@ -1,0 +1,195 @@
+# CLI observability parity with Cave and the daemon API — design
+
+- **Date:** 2026-07-14
+- **Issue:** [#366](https://github.com/OpenCoven/coven/issues/366)
+- **Status:** approved for implementation (autopilot objective; assumptions stated inline)
+
+## Problem
+
+CovenCave and the daemon socket API expose user-relevant read surfaces that the
+CLI cannot reach. A terminal-only user or a script cannot see what Cave sees
+without hand-rolled `curl --unix-socket` calls — which is literally what
+`docs/HUB-OPERATIONS.md` instructs today. The gaps, from the parity audit:
+
+| Surface                | API route                                    | CLI before this design           |
+| ---------------------- | -------------------------------------------- | -------------------------------- |
+| Ecosystem overview     | `GET /api/v1/overview`                       | none — and endpoint returns hardcoded zero counts |
+| Familiars roster       | `GET /api/v1/familiars`                      | none                             |
+| Skills inventory       | `GET /api/v1/skills`                         | none                             |
+| Memory files           | `GET /api/v1/memory`                         | none                             |
+| Research log           | `GET /api/v1/research`                       | none                             |
+| Coven Calls ledger     | `GET /api/v1/coven-calls[/:id]`              | none                             |
+| Hub status/nodes/jobs/routing | `GET /api/v1/hub/*`                   | none (docs say use `curl`)       |
+| Session detail         | `GET /api/v1/sessions/:id`                   | no non-interactive inspect       |
+| Session events         | `GET /api/v1/sessions/:id/events`            | interactive `attach` replay only |
+| Session log            | `GET /api/v1/sessions/:id/log`               | interactive replay only          |
+
+Related UX findings:
+
+- README Commands Reference omits shipped commands (`kill`, `vacuum`,
+  `completions`, `sessions search`, `claim release|heartbeat|canary`).
+- `docs/reference/cli.md` front matter names a `view` command that does not exist.
+- `coven --help` lists a long flat command list with no workflow orientation
+  for first-run users.
+
+## Goals
+
+1. Every read surface Cave renders is reachable from the CLI, for humans
+   (tables/prose) and machines (`--json`).
+2. `GET /api/v1/overview` reports real counts instead of zeros, so Cave and the
+   CLI both benefit.
+3. Session detail, events, and log become scriptable without a PTY.
+4. Docs and help teach the surface: README reference completeness, hub ops via
+   CLI, onboarding examples in `--help`.
+5. Tests cover parsing, rendering, and CLI↔API parity for every new command.
+
+## Non-goals (deliberate)
+
+- **Travel, scheduler, actions, executor dispatch write paths** — these are
+  machine-to-machine protocol surfaces (`coven.executor.v1`, travel sync,
+  control-plane actions). Human CLI wrappers would invite misuse; ops docs
+  cover the protocol. Revisit on demand.
+- **`PUT /familiars/:id/icon`** — a Cave glyph-picker concern, not a terminal one.
+- **TUI chat panes for familiars/skills/etc.** — the chat UI is the engine's
+  surface (`coven-code`); this design keeps the substrate CLI scriptable and
+  leaves engine UX to the engine.
+- **`GET /cast-codes`** — cast codes are chat-input affordances; the chat UI
+  surfaces them contextually.
+- **Fixing the shadowed `GET /capabilities` route** (the
+  `crate::capabilities::get_all` arm is unreachable behind the control-plane
+  literal arm). Changing which body that route returns is a client-visible
+  behavior change and deserves its own issue and contract note, not a rider on
+  a parity PR.
+
+## Design
+
+### D1 — Render through the in-process API handler
+
+New CLI read commands call `api::handle_request_with_body` directly (the same
+router the daemon serves), then either print the body verbatim (`--json`) or
+parse it to render a human view. This makes `--json` byte-equal to the daemon
+API by construction, with one source of truth for shapes.
+
+- *Alternative considered:* calling `cockpit_sources`/`hub` functions directly —
+  rejected: CLI and API shapes drift independently.
+- *Alternative considered:* connecting to the daemon socket — rejected: these
+  routes read files/SQLite fresh per request, the daemon adds a liveness
+  dependency for offline reads, and `coven sessions` already established the
+  direct-read pattern.
+- *Devil's advocate:* could in-process reads disagree with a running daemon?
+  No: the audited handlers (`overview`, `familiars`, `skills`, `memory`,
+  `research`, `coven-calls`, `hub/*`, `sessions*` GETs) hold no daemon state;
+  they re-read the store or `~/.coven` files per request.
+
+### D2 — Command surface
+
+```
+coven status [--json]                      # composite: daemon health + overview counts + hub summary
+coven familiars [--json]                   # GET /api/v1/familiars
+coven skills [--json]                      # GET /api/v1/skills
+coven memory [--json]                      # GET /api/v1/memory
+coven research [--json]                    # GET /api/v1/research
+coven calls [<id>] [--json]                # GET /api/v1/coven-calls[/:id]
+coven hub status|nodes|jobs|routing [--json] [--state <s>]   # GET /api/v1/hub/*
+coven sessions show <id> [--json]          # GET /api/v1/sessions/:id
+coven sessions events <id> [--json] [--after-seq N] [--limit N]
+coven sessions log <id> [--json]
+```
+
+Naming notes (devil's advocate round):
+
+- `coven status` vs `coven daemon status`: the daemon command reports one
+  process; `coven status` is the ecosystem dashboard and *includes* the daemon
+  line. Precedent: `git status`, `gh status`. `overview` is an alias so the
+  API-name crowd can type what they read.
+- `coven calls` reads as "Coven Calls" naturally; single positional id gives
+  the detail view like the API's `/:id`.
+- `coven memory` does not clash with the separate `coven-memory` binary.
+- Session subcommands are explicit words (`show`, `events`, `log`) rather than
+  a bare id positional, so flags never fight positional parsing. All three
+  accept unique id prefixes via the existing `resolve_session_ref`.
+- `hub jobs --state` mirrors the API's `?state=` filter instead of inventing a
+  new spelling.
+
+### D3 — JSON contracts
+
+- Leaf commands print the **exact API body**, pretty-printed (repo convention:
+  `serde_json::to_string_pretty`, like `sessions --json`, `adapter list --json`).
+- `coven status --json` is a **CLI-level composition** documented as such:
+  `{ "health": <GET /api/v1/health body>, "overview": <GET /api/v1/overview body> }`.
+  Precedent: `coven daemon status --json` already defines a CLI-owned JSON
+  shape. Composing the two stable bodies avoids inventing a third contract for
+  the same data.
+- Human views parse the same body they would print — no second read path.
+
+### D4 — Real overview counts
+
+`overview_response` computes from the same sources the sibling routes use:
+
+- `total_familiars` = familiars list length; `active_familiars` = entries whose
+  `status` is `active`.
+- `skills_count` = skills list length; `average_skill_score` = rounded mean of
+  skill scores (0 when empty — scores are stubbed at 0.0 today, so this stays 0
+  until scoring lands, which is honest).
+- `research_iterations` = research row count; `last_research_delta` = final
+  row's delta rounded to i32.
+- `open_sessions` unchanged.
+
+The DTO keeps its exact field set and snake_case serialization — no shape
+change for Cave, only real numbers. Failures reading any source degrade to 0
+rather than failing the endpoint (dashboard semantics: partial data beats a
+500; the leaf endpoints still surface their own read errors loudly).
+
+### D5 — Human rendering
+
+Fixed-width table lines matching `format_session_line` conventions; theme
+colors via `theme::` helpers only where already idiomatic (status tokens);
+plain output stays pipe-friendly (no ANSI when not a TTY — existing
+`theme::mode()` behavior). Empty states teach next steps, matching the
+`sessions` empty-state convention (e.g. no familiars → point at
+`~/.coven/familiars.toml` docs).
+
+### D6 — Onboarding & help UX
+
+- Top-level `after_help` on the clap `Cli`: a four-line "common first steps"
+  block (`doctor` → `run codex "…"` → `sessions` → `status`).
+- Near-miss suggestions already iterate the live clap command list, so new
+  commands are covered automatically; add typo tests (`familars`, `stauts`,
+  `overveiw` alias resolution) to pin it.
+- README Commands Reference gains the new commands **and** the shipped-but-
+  undocumented ones (`kill`, `vacuum`, `completions`, `sessions search`,
+  `claim release|heartbeat|canary`).
+- `docs/reference/cli.md` drops the phantom `view` command from its
+  description; new reference page `docs/reference/cli-observe.md` covers the
+  read-path commands; `docs/HUB-OPERATIONS.md` leads with `coven hub status`
+  and keeps `curl` as the raw-protocol alternative.
+
+### D7 — Code placement
+
+New module `crates/coven-cli/src/observe.rs` owns command handlers and pure
+render functions (main.rs is already 4k+ lines; renderers as pure
+`&Value -> String` functions keep them unit-testable). `main.rs` gains only
+enum variants + dispatch lines. Sessions subcommands land next to the existing
+`SessionsCommand::Search` arm.
+
+## Testing
+
+- **Parse tests:** `Cli::parse_from` for every new command/flag combination,
+  including conflicts (`--json` with positional id, `--after-seq` without
+  `events` is rejected by clap structure).
+- **Render tests:** pure renderers fed fixture JSON assert table headers,
+  rows, and empty-state hints.
+- **Parity tests:** seed a temp `COVEN_HOME` (familiars.toml, skills dir,
+  memory tree, research.tsv, coven-calls.json, hub + session store rows);
+  assert CLI JSON output equals the API body for each route.
+- **Overview test:** seeded home yields real counts through
+  `GET /api/v1/overview` (extends the existing route test that pinned zeros).
+- **Near-miss tests:** new-command typos resolve as suggestions.
+- Gates: `cargo fmt --check`, `clippy --workspace --all-targets -- -D warnings`,
+  `cargo test --workspace --locked`, `python scripts/check-secrets.py`.
+
+## Rollout
+
+Single PR, commits staged per checkpoint (overview fix → status → cockpit
+commands → hub → sessions detail → docs/UX). No migrations, no daemon protocol
+changes, additive CLI surface only.


### PR DESCRIPTION
## Context

- Summary: Every read surface CovenCave renders — overview, familiars, skills, memory, research, Coven Calls, hub control-plane, session detail/events/log — is now reachable from the CLI, for humans (tables with teaching empty states) and machines (`--json` carrying the same body as the daemon API route). Also fixes `GET /api/v1/overview` returning hardcoded zero counts, so Cave's dashboard benefits too.
- Files changed: `crates/coven-cli/src/observe.rs` (new), `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/api.rs`, README, `docs/reference/cli-observe.md` (new), `docs/reference/cli.md`, `docs/reference/cli-sessions.md`, `docs/HUB-OPERATIONS.md`, `docs/GETTING-STARTED.md`, design spec under `docs/superpowers/specs/`.
- Closes #366

## Implementation

- Approach: new commands render through the **in-process API router** (`api::handle_request`), so `--json` output is the daemon API body for the same route (pretty-printed) and the human tables are a rendering of that same body — one source of truth for shapes, no daemon required for these offline reads (same pattern as `coven sessions` reading the store directly). Full parity matrix, alternatives, and devil's-advocate notes are in the committed design spec.
- User-visible behavior:
  - `coven status` (alias `overview`) — daemon, sessions, familiars, skills, research, hub at a glance; first-run empty states teach next steps; `--json` is a documented `{health, overview}` composition (precedent: `coven daemon status --json`).
  - `coven familiars | skills | memory | research [--json]`
  - `coven calls [<id>] [--json]` — Coven Calls delegation ledger
  - `coven hub status|nodes|jobs|routing [--json] [--state <s>]` — hub ops without hand-rolled `curl --unix-socket` (HUB-OPERATIONS runbook now leads with the CLI)
  - `coven sessions show|events|log <id>` — non-interactive session inspection, unique-prefix id resolution, `--after-seq`/`--limit` cursor paging matching the API envelope
  - `GET /api/v1/overview` now computes real counts (`active_familiars` = distinct roster familiars with an open session, so it can never exceed `total_familiars`); unreadable side sources degrade to 0 (dashboard semantics) while leaf routes still fail loudly
  - Top-level `--help` gains a four-line "Common first steps" footer; near-miss typo suggestions cover the new commands automatically
- Compatibility notes: additive CLI surface; no API shape changes (overview keeps its exact field set — real numbers only). New top-level words (`status`, `familiars`, `skills`, `memory`, `research`, `calls`, `hub`) shadow *unquoted* multi-word cast prompts starting with those words — same tradeoff the existing `kill`/`patch`/`run` words already made; quoted prompts (`coven "memory leak…"`, the documented cast form) are unaffected.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (1070+ tests; re-run after rebase onto #341)
- [x] `python3 scripts/check-secrets.py` (current tree + history clean)
- [x] Additional manual checks: smoke-tested against an isolated `COVEN_HOME` — empty first-run states, populated roster/skills/memory/research/calls, hub single-host + registered-node states, `sessions show/events/log` against a `--detach` session including unique-prefix and not-found error paths; verified quoted cast prompts still parse as prompts; verified `--help`/`-h` output.

## Risk and Rollback

- Risk level: Low — read-only command surface plus one endpoint count fix. The riskiest piece is the overview computation; it degrades to zeros on unreadable sources rather than erroring, covered by two endpoint tests.
- Rollback plan: revert the branch commits; no migrations, no protocol changes, no client contract changes.

## Agent Handoff

- Current state: complete and green; each command has renderer unit tests plus end-to-end parity tests that feed live API bodies from seeded temp homes into the renderers (catches DTO key drift — this caught the `research/results.tsv` path and the bare-array log envelope during development).
- Follow-ups:
  - The `GET /api/v1/capabilities` route literal arm shadows the later `crate::capabilities::get_all` arm (harness capability aggregate is unreachable through the router; `?refresh=1` handling is dead there). Left untouched because changing that route's body is a client-visible behavior change — will file as its own issue.
  - Skill `score`/rate fields are stubbed at 0.0 upstream; `average_skill_score` honestly reports 0 until scoring lands.
  - TUI chat panes for these views are deliberately out of scope (engine surface).
- Known gaps: `coven status --json` composes two API bodies rather than proxying a single route — documented as CLI-owned in `docs/reference/cli-observe.md`.
