### PR TITLE
fix(cli): delegate --version to the native binary in the npm wrapper

### DIFF
--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -14,10 +14,6 @@ const binaryName = process.platform === 'win32' ? 'coven.exe' : 'coven';
 const platformKey = `${process.platform}-${process.arch}`;
 const packageName = PLATFORM_PACKAGES[platformKey];
 
-function wrapperVersion() {
-  return require('../package.json').version;
-}
-
 function resolveBinary() {
   if (!packageName) {
     throw new Error(
@@ -42,11 +38,11 @@ try {
   process.exit(1);
 }
 
+// Delegate every argument — including a lone --version/-V — to the native
+// binary, which renders the full `coven vX (engine coven-code …, pinned …)`
+// line. (The wrapper previously short-circuited --version to its own
+// package.json version, which shadowed that output for npm installs.)
 const args = process.argv.slice(2);
-if (args.length === 1 && (args[0] === '--version' || args[0] === '-V')) {
-  console.log(wrapperVersion());
-  process.exit(0);
-}
 
 const child = spawn(binary, args, {
   stdio: 'inherit',


### PR DESCRIPTION
## Summary

Fast-follow for v0.1.0: `coven --version` on an npm install printed just `0.1.0` instead of the rich `coven v0.1.0 (engine coven-code v0.7.0, pinned v0.7.0)` line that #364 built into the Rust binary.

Root cause: the npm wrapper (`npm/coven/bin/coven.js`, the source of `@opencoven/cli`) short-circuited a lone `--version`/`-V` to its own `package.json` version and never spawned the native binary — shadowing #364's output for the dominant install path.

## Fix
- Remove the `--version`/`-V` short-circuit; delegate **all** args to the native binary. `resolveBinary()` already runs first, so the binary is guaranteed present — the short-circuit had no fallback purpose.
- Drop the now-unused `wrapperVersion()` helper.

## Verification
- `node --check` passes; `require` still used (`require.resolve`).
- Prepublish smoke test (`scripts/test-cli-prepublish.mjs`) asserts `--version` is non-empty — still true (now the binary's line).
- Ships in **v0.1.1**; still pins engine 0.7.0 (unchanged `engine.lock`).