### PR TITLE
feat(tui): observe views in Cast and chat — /status, /familiars, /skills, /memory, /research, /calls, /hub

### DIFF
--- a/CHAT-QUICKSTART.md
+++ b/CHAT-QUICKSTART.md
@@ -34,6 +34,7 @@ Everything the UI does is also available as explicit CLI commands:
 
 ```bash
 coven doctor                      # check your setup
+coven status                      # daemon, sessions, familiars, skills, hub at a glance
 coven run codex "fix the tests"   # launch a recorded session
 coven sessions                    # browse sessions (plain table when piped)
 coven attach <session-id-prefix>  # follow a session

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3890,6 +3890,7 @@ mod tests {
                 "/tui",
                 "/doctor",
                 "/daemon",
+                "/status",
                 "/run",
                 "/patch",
                 "/sessions",
@@ -3930,7 +3931,7 @@ mod tests {
 
     #[test]
     fn magical_tui_frame_surfaces_command_rail_and_snapshot_for_newcomers() {
-        let frame = render_magical_tui_frame_plain(5);
+        let frame = render_magical_tui_frame_plain(6);
 
         // Two-lane body: left command rail + right snapshot lane.
         assert!(frame.contains("Commands"));
@@ -4040,9 +4041,9 @@ mod tests {
     fn magical_tui_frame_windows_long_command_list_with_scroll_hint() {
         // Selection sits well past the visible window — scroll hint must
         // appear and the selected slash must still be in the rendered rail.
-        let frame = render_magical_tui_frame_plain(12); // /sacrifice
+        let frame = render_magical_tui_frame_plain(13); // /sacrifice
         assert!(frame.contains("/sacrifice"));
-        assert!(frame.contains("of 14"));
+        assert!(frame.contains("of 15"));
     }
 
     #[test]

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -61,9 +61,11 @@ impl ObserveView {
     }
 }
 
-/// Render a view's human text against an explicit Coven home. This is the
-/// single render path shared by the CLI commands, the Cast shell, and the
-/// chat UI's system messages.
+/// Render a view's human text against an explicit Coven home. For every
+/// view in [`ObserveView`] this is the single render path — the CLI
+/// command, the Cast shell, and the chat UI all call it, so the surfaces
+/// cannot drift. (CLI-only leaves like `hub nodes/jobs/routing` and the
+/// `calls <id>` detail live outside the view enum and render directly.)
 pub(crate) fn view_text(coven_home: &Path, view: ObserveView) -> Result<String> {
     Ok(match view {
         ObserveView::Status => {
@@ -266,11 +268,11 @@ fn render_status(
 // ── coven familiars / skills / memory / research ─────────────────────────────
 
 pub(crate) fn run_familiars(json: bool) -> Result<()> {
-    let body = api_get(&coven_home_dir()?, "/api/v1/familiars")?;
+    let coven_home = coven_home_dir()?;
     if json {
-        return print_json(&body);
+        return print_json(&api_get(&coven_home, "/api/v1/familiars")?);
     }
-    print!("{}", render_familiars(&body));
+    print!("{}", view_text(&coven_home, ObserveView::Familiars)?);
     Ok(())
 }
 
@@ -306,11 +308,11 @@ fn render_familiars(body: &Value) -> String {
 }
 
 pub(crate) fn run_skills(json: bool) -> Result<()> {
-    let body = api_get(&coven_home_dir()?, "/api/v1/skills")?;
+    let coven_home = coven_home_dir()?;
     if json {
-        return print_json(&body);
+        return print_json(&api_get(&coven_home, "/api/v1/skills")?);
     }
-    print!("{}", render_skills(&body));
+    print!("{}", view_text(&coven_home, ObserveView::Skills)?);
     Ok(())
 }
 
@@ -342,11 +344,11 @@ fn render_skills(body: &Value) -> String {
 }
 
 pub(crate) fn run_memory(json: bool) -> Result<()> {
-    let body = api_get(&coven_home_dir()?, "/api/v1/memory")?;
+    let coven_home = coven_home_dir()?;
     if json {
-        return print_json(&body);
+        return print_json(&api_get(&coven_home, "/api/v1/memory")?);
     }
-    print!("{}", render_memory(&body));
+    print!("{}", view_text(&coven_home, ObserveView::Memory)?);
     Ok(())
 }
 
@@ -374,11 +376,11 @@ fn render_memory(body: &Value) -> String {
 }
 
 pub(crate) fn run_research(json: bool) -> Result<()> {
-    let body = api_get(&coven_home_dir()?, "/api/v1/research")?;
+    let coven_home = coven_home_dir()?;
     if json {
-        return print_json(&body);
+        return print_json(&api_get(&coven_home, "/api/v1/research")?);
     }
-    print!("{}", render_research(&body));
+    print!("{}", view_text(&coven_home, ObserveView::Research)?);
     Ok(())
 }
 
@@ -426,11 +428,10 @@ pub(crate) fn run_calls(id: Option<&str>, json: bool) -> Result<()> {
             print!("{}", render_call_detail(&body));
         }
         None => {
-            let body = api_get(&coven_home, "/api/v1/coven-calls")?;
             if json {
-                return print_json(&body);
+                return print_json(&api_get(&coven_home, "/api/v1/coven-calls")?);
             }
-            print!("{}", render_calls(&body));
+            print!("{}", view_text(&coven_home, ObserveView::Calls)?);
         }
     }
     Ok(())
@@ -506,11 +507,11 @@ fn render_call_detail(body: &Value) -> String {
 // ── coven hub ────────────────────────────────────────────────────────────────
 
 pub(crate) fn run_hub_status(json: bool) -> Result<()> {
-    let body = api_get(&coven_home_dir()?, "/api/v1/hub/status")?;
+    let coven_home = coven_home_dir()?;
     if json {
-        return print_json(&body);
+        return print_json(&api_get(&coven_home, "/api/v1/hub/status")?);
     }
-    print!("{}", render_hub_status(&body));
+    print!("{}", view_text(&coven_home, ObserveView::HubStatus)?);
     Ok(())
 }
 

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -19,6 +19,72 @@ use crate::{api, coven_home_dir, daemon, theme};
 /// Column cap for free-text table cells (descriptions, requests, reasons).
 const TEXT_CELL_LIMIT: usize = 48;
 
+/// Which read-only view to render. Mirrors the top-level CLI observability
+/// commands one-to-one; the Cast shell and the chat UI reuse these views so
+/// every surface renders the same data the same way.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ObserveView {
+    Status,
+    Familiars,
+    Skills,
+    Memory,
+    Research,
+    Calls,
+    HubStatus,
+}
+
+impl ObserveView {
+    /// The CLI command this view mirrors, shown on plan/outcome cards so
+    /// users learn the scriptable spelling.
+    pub(crate) fn command(self) -> &'static str {
+        match self {
+            ObserveView::Status => "coven status",
+            ObserveView::Familiars => "coven familiars",
+            ObserveView::Skills => "coven skills",
+            ObserveView::Memory => "coven memory",
+            ObserveView::Research => "coven research",
+            ObserveView::Calls => "coven calls",
+            ObserveView::HubStatus => "coven hub status",
+        }
+    }
+
+    pub(crate) fn headline(self) -> &'static str {
+        match self {
+            ObserveView::Status => "Show the coven status overview",
+            ObserveView::Familiars => "List the familiar roster",
+            ObserveView::Skills => "List installed skills",
+            ObserveView::Memory => "List familiar memory files",
+            ObserveView::Research => "Show the research loop log",
+            ObserveView::Calls => "Show the Coven Calls ledger",
+            ObserveView::HubStatus => "Show hub control-plane status",
+        }
+    }
+}
+
+/// Render a view's human text against an explicit Coven home. This is the
+/// single render path shared by the CLI commands, the Cast shell, and the
+/// chat UI's system messages.
+pub(crate) fn view_text(coven_home: &Path, view: ObserveView) -> Result<String> {
+    Ok(match view {
+        ObserveView::Status => {
+            let daemon_state = daemon::background_server_status(coven_home)?;
+            let live = match &daemon_state {
+                Some(daemon::DaemonStatusState::Running(status)) => Some(status.clone()),
+                _ => None,
+            };
+            let health = api_get_with_daemon(coven_home, "/api/v1/health", live)?;
+            let overview = api_get(coven_home, "/api/v1/overview")?;
+            render_status(daemon_state.as_ref(), &health, &overview)
+        }
+        ObserveView::Familiars => render_familiars(&api_get(coven_home, "/api/v1/familiars")?),
+        ObserveView::Skills => render_skills(&api_get(coven_home, "/api/v1/skills")?),
+        ObserveView::Memory => render_memory(&api_get(coven_home, "/api/v1/memory")?),
+        ObserveView::Research => render_research(&api_get(coven_home, "/api/v1/research")?),
+        ObserveView::Calls => render_calls(&api_get(coven_home, "/api/v1/coven-calls")?),
+        ObserveView::HubStatus => render_hub_status(&api_get(coven_home, "/api/v1/hub/status")?),
+    })
+}
+
 // ── API access ───────────────────────────────────────────────────────────────
 
 fn api_get(coven_home: &Path, path: &str) -> Result<Value> {
@@ -107,14 +173,14 @@ fn str_cell(value: &Value, key: &str) -> String {
 
 pub(crate) fn run_status(json: bool) -> Result<()> {
     let coven_home = coven_home_dir()?;
-    let daemon_state = daemon::background_server_status(&coven_home)?;
-    let live = match &daemon_state {
-        Some(daemon::DaemonStatusState::Running(status)) => Some(status.clone()),
-        _ => None,
-    };
-    let health = api_get_with_daemon(&coven_home, "/api/v1/health", live)?;
-    let overview = api_get(&coven_home, "/api/v1/overview")?;
     if json {
+        let daemon_state = daemon::background_server_status(&coven_home)?;
+        let live = match &daemon_state {
+            Some(daemon::DaemonStatusState::Running(status)) => Some(status.clone()),
+            _ => None,
+        };
+        let health = api_get_with_daemon(&coven_home, "/api/v1/health", live)?;
+        let overview = api_get(&coven_home, "/api/v1/overview")?;
         // CLI-level composition of the two stable API bodies; see
         // docs/reference/cli-observe.md.
         return print_json(&serde_json::json!({
@@ -122,10 +188,7 @@ pub(crate) fn run_status(json: bool) -> Result<()> {
             "overview": overview,
         }));
     }
-    print!(
-        "{}",
-        render_status(daemon_state.as_ref(), &health, &overview)
-    );
+    print!("{}", view_text(&coven_home, ObserveView::Status)?);
     Ok(())
 }
 

--- a/crates/coven-cli/src/tui/cast/intent.rs
+++ b/crates/coven-cli/src/tui/cast/intent.rs
@@ -7,6 +7,8 @@
 
 use anyhow::{anyhow, Result};
 
+pub(crate) use crate::observe::ObserveView;
+
 /// A first-party Coven harness Cast knows how to route to without asking.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum CastHarness {
@@ -88,6 +90,12 @@ pub(crate) enum CastIntent {
     Quest {
         goal: String,
     },
+    /// Read-only observability view (`coven status`, `coven familiars`, …)
+    /// rendered inline in the Cast shell. Same read path as the CLI
+    /// commands — see `observe.rs`.
+    Observe {
+        view: ObserveView,
+    },
     Quit,
 }
 
@@ -158,6 +166,27 @@ fn parse_slash_command(input: &str) -> Result<Option<CastIntent>> {
             CastIntent::SacrificeSession { session_id }
         })?,
         "/quest" => parse_quest_slash(rest)?,
+        "/status" | "/overview" => CastIntent::Observe {
+            view: ObserveView::Status,
+        },
+        "/familiars" => CastIntent::Observe {
+            view: ObserveView::Familiars,
+        },
+        "/skills" => CastIntent::Observe {
+            view: ObserveView::Skills,
+        },
+        "/memory" => CastIntent::Observe {
+            view: ObserveView::Memory,
+        },
+        "/research" => CastIntent::Observe {
+            view: ObserveView::Research,
+        },
+        "/calls" => CastIntent::Observe {
+            view: ObserveView::Calls,
+        },
+        "/hub" => CastIntent::Observe {
+            view: ObserveView::HubStatus,
+        },
         "/quit" | "/exit" => CastIntent::Quit,
         unknown => {
             return Err(anyhow!(
@@ -174,8 +203,31 @@ fn parse_plain_command(input: &str) -> Option<CastIntent> {
             Some(CastIntent::OpenSessions)
         }
         "all sessions" | "show all sessions" => Some(CastIntent::OpenAllSessions),
-        "doctor" | "status" | "health" => Some(CastIntent::Doctor),
+        "doctor" | "health" => Some(CastIntent::Doctor),
         "daemon" | "daemon status" => Some(CastIntent::DaemonStatus),
+        // `status` means the ecosystem overview, matching `coven status`;
+        // setup checks stay on `doctor`/`health`.
+        "status" | "overview" => Some(CastIntent::Observe {
+            view: ObserveView::Status,
+        }),
+        "familiars" | "familiar" | "roster" => Some(CastIntent::Observe {
+            view: ObserveView::Familiars,
+        }),
+        "skills" | "skill" => Some(CastIntent::Observe {
+            view: ObserveView::Skills,
+        }),
+        "memory" => Some(CastIntent::Observe {
+            view: ObserveView::Memory,
+        }),
+        "research" => Some(CastIntent::Observe {
+            view: ObserveView::Research,
+        }),
+        "calls" | "coven calls" => Some(CastIntent::Observe {
+            view: ObserveView::Calls,
+        }),
+        "hub" | "hub status" => Some(CastIntent::Observe {
+            view: ObserveView::HubStatus,
+        }),
         "help" | "?" => Some(CastIntent::Help),
         "quit" | "exit" | "q" | "bye" => Some(CastIntent::Quit),
         "tui" | "menu" | "home" => Some(CastIntent::OpenTui),
@@ -454,6 +506,72 @@ mod tests {
     fn plain_keyword_doctor_runs_doctor() {
         assert_eq!(intent("doctor"), CastIntent::Doctor);
         assert_eq!(intent("DOCTOR"), CastIntent::Doctor);
+    }
+
+    #[test]
+    fn observe_slash_commands_mirror_cli_views() {
+        for (spell, view) in [
+            ("/status", ObserveView::Status),
+            ("/overview", ObserveView::Status),
+            ("/familiars", ObserveView::Familiars),
+            ("/skills", ObserveView::Skills),
+            ("/memory", ObserveView::Memory),
+            ("/research", ObserveView::Research),
+            ("/calls", ObserveView::Calls),
+            ("/hub", ObserveView::HubStatus),
+        ] {
+            assert_eq!(intent(spell), CastIntent::Observe { view }, "spell {spell}");
+        }
+    }
+
+    #[test]
+    fn plain_status_means_the_ecosystem_overview_not_doctor() {
+        // `coven status` is the ecosystem overview; the shell must agree.
+        // Setup checks remain reachable via `doctor` / `health`.
+        assert_eq!(
+            intent("status"),
+            CastIntent::Observe {
+                view: ObserveView::Status
+            }
+        );
+        assert_eq!(
+            intent("overview"),
+            CastIntent::Observe {
+                view: ObserveView::Status
+            }
+        );
+        assert_eq!(intent("health"), CastIntent::Doctor);
+    }
+
+    #[test]
+    fn plain_observe_keywords_route_to_views() {
+        for (spell, view) in [
+            ("familiars", ObserveView::Familiars),
+            ("roster", ObserveView::Familiars),
+            ("skills", ObserveView::Skills),
+            ("memory", ObserveView::Memory),
+            ("research", ObserveView::Research),
+            ("calls", ObserveView::Calls),
+            ("coven calls", ObserveView::Calls),
+            ("hub", ObserveView::HubStatus),
+            ("hub status", ObserveView::HubStatus),
+        ] {
+            assert_eq!(intent(spell), CastIntent::Observe { view }, "spell {spell}");
+        }
+    }
+
+    #[test]
+    fn observe_views_advertise_their_cli_commands() {
+        assert_eq!(ObserveView::Status.command(), "coven status");
+        assert_eq!(ObserveView::HubStatus.command(), "coven hub status");
+        // Multi-word prompts that merely start with an observe keyword stay
+        // natural spells — only exact keywords open views.
+        assert_eq!(
+            intent("memory leak in the daemon"),
+            CastIntent::NaturalSpell {
+                prompt: "memory leak in the daemon".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use attach::{
 };
 pub(crate) use follow::{follow_until_exit, CastSessionExit, FollowerObserver, FollowerPacer};
 pub(crate) use gate::{evaluate_gate, GateOutcome};
-pub(crate) use intent::{parse_spell, CastHarness, CastIntent};
+pub(crate) use intent::{parse_spell, CastHarness, CastIntent, ObserveView};
 pub(crate) use outcome::CastOutcome;
 pub(crate) use plan::{build_plan, CastPlan};
 pub(crate) use quest::{

--- a/crates/coven-cli/src/tui/cast/plan.rs
+++ b/crates/coven-cli/src/tui/cast/plan.rs
@@ -185,6 +185,14 @@ where
             CastStep::new(CastStepKind::Inform, "Walk through `coven patch openclaw`"),
         ),
         CastIntent::Quest { ref goal } => quest_plan(goal, intent.clone(), &default_harness),
+        CastIntent::Observe { view } => simple_plan(
+            intent,
+            view.headline(),
+            CastStep::new(
+                CastStepKind::Inform,
+                format!("Read-only view; same data as `{}`", view.command()),
+            ),
+        ),
         CastIntent::Quit => simple_plan(
             intent,
             "Close Cast without changing anything",
@@ -517,6 +525,29 @@ mod tests {
             .steps
             .iter()
             .any(|step| step.kind == CastStepKind::LaunchSession));
+    }
+
+    #[test]
+    fn observe_plans_are_safe_informational_reads() {
+        for view in [
+            crate::observe::ObserveView::Status,
+            crate::observe::ObserveView::Familiars,
+            crate::observe::ObserveView::HubStatus,
+        ] {
+            let plan = build_plan(CastIntent::Observe { view }, none).unwrap();
+            assert_eq!(plan.risk(), CastRisk::Safe, "view {view:?}");
+            assert_eq!(plan.headline, view.headline());
+            assert!(
+                plan.steps
+                    .iter()
+                    .all(|step| step.kind == CastStepKind::Inform),
+                "observe steps must be informational, view {view:?}"
+            );
+            assert!(
+                plan.steps[0].note.contains(view.command()),
+                "plan should teach the scriptable command, view {view:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -869,6 +869,24 @@ impl App {
                     "Quest planned for: {goal}. Cast will run each phase through this composer; start with the design phase prompt when ready."
                 ));
             }
+            CastIntent::Observe { view } => {
+                let home = self.coven_home.clone().unwrap_or_else(coven_home_dir);
+                match crate::observe::view_text(&home, view) {
+                    Ok(text) => {
+                        self.push_system_message(text.trim_end());
+                        self.push_system_message(&format!(
+                            "Scriptable form: `{}` (add --json for machines).",
+                            view.command()
+                        ));
+                    }
+                    Err(err) => {
+                        self.push_system_message(&format!(
+                            "Could not read that view: {err:#}. The same data is available via `{}`.",
+                            view.command()
+                        ));
+                    }
+                }
+            }
             CastIntent::Quit => return SlashCommandResult::Quit,
         }
         SlashCommandResult::Handled

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1890,20 +1890,13 @@ fn run_tui_help() -> Result<()> {
     Ok(())
 }
 
-/// Render a read-only observability view inline. Same read path as the
-/// matching `coven <view>` command (see `observe.rs`), so the shell and
-/// the CLI can never disagree.
+/// Render a read-only observability view inline. Same single render path
+/// as the matching `coven <view>` command (`observe::view_text`), so the
+/// shell and the CLI can never disagree.
 fn run_observe_view(view: cast::ObserveView) -> Result<()> {
-    use cast::ObserveView;
-    match view {
-        ObserveView::Status => crate::observe::run_status(false),
-        ObserveView::Familiars => crate::observe::run_familiars(false),
-        ObserveView::Skills => crate::observe::run_skills(false),
-        ObserveView::Memory => crate::observe::run_memory(false),
-        ObserveView::Research => crate::observe::run_research(false),
-        ObserveView::Calls => crate::observe::run_calls(None, false),
-        ObserveView::HubStatus => crate::observe::run_hub_status(false),
-    }
+    let coven_home = crate::coven_home_dir()?;
+    print!("{}", crate::observe::view_text(&coven_home, view)?);
+    Ok(())
 }
 
 fn run_new_user_start_here() -> Result<()> {

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -39,6 +39,7 @@ pub(crate) enum MagicalTuiAction {
     OpenTui,
     Doctor,
     DaemonStatus,
+    CovenStatus,
     RunHarness,
     PatchOpenClaw,
     Sessions,
@@ -155,6 +156,14 @@ pub(crate) fn magical_tui_items() -> &'static [MagicalTuiItem] {
             description: "See whether the local Coven daemon is awake",
             command: "coven daemon status",
             action: MagicalTuiAction::DaemonStatus,
+        },
+        MagicalTuiItem {
+            key: "s",
+            slash: "/status",
+            label: "Coven status",
+            description: "Sessions, familiars, skills, research, and hub at a glance",
+            command: "coven status",
+            action: MagicalTuiAction::CovenStatus,
         },
         MagicalTuiItem {
             key: "4",
@@ -448,6 +457,19 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             CastOutcome::for_request(request_text)
         }
         CastIntent::Quest { goal } => dispatch_cast_quest(&plan, &goal)?,
+        CastIntent::Observe { view } => {
+            run_observe_view(view)?;
+            CastOutcome {
+                request: request_text,
+                launched: Some(view.headline().to_string()),
+                session_id: None,
+                next_step: Some(format!(
+                    "Scriptable form: `{}` (add --json for machines)",
+                    view.command()
+                )),
+                notes: vec![],
+            }
+        }
         CastIntent::Quit => {
             let primary = theme::fg(theme::PRIMARY);
             let reset = theme::reset();
@@ -1629,6 +1651,7 @@ fn run_magical_tui_action(action: MagicalTuiAction) -> Result<()> {
         MagicalTuiAction::OpenTui => run(),
         MagicalTuiAction::Doctor => run_doctor(),
         MagicalTuiAction::DaemonStatus => run_daemon_command(DaemonCommand::Status { json: false }),
+        MagicalTuiAction::CovenStatus => run_observe_view(cast::ObserveView::Status),
         MagicalTuiAction::RunHarness => run_guided_harness_session(),
         MagicalTuiAction::PatchOpenClaw => {
             run_patch(None, vec![], None, None, None, false, false, true)
@@ -1863,7 +1886,24 @@ fn run_tui_help() -> Result<()> {
     println!("  /sessions");
     println!("  /attach <session-id>");
     println!("  /doctor");
+    println!("  /status · /familiars · /skills · /memory · /research · /calls · /hub");
     Ok(())
+}
+
+/// Render a read-only observability view inline. Same read path as the
+/// matching `coven <view>` command (see `observe.rs`), so the shell and
+/// the CLI can never disagree.
+fn run_observe_view(view: cast::ObserveView) -> Result<()> {
+    use cast::ObserveView;
+    match view {
+        ObserveView::Status => crate::observe::run_status(false),
+        ObserveView::Familiars => crate::observe::run_familiars(false),
+        ObserveView::Skills => crate::observe::run_skills(false),
+        ObserveView::Memory => crate::observe::run_memory(false),
+        ObserveView::Research => crate::observe::run_research(false),
+        ObserveView::Calls => crate::observe::run_calls(None, false),
+        ObserveView::HubStatus => crate::observe::run_hub_status(false),
+    }
 }
 
 fn run_new_user_start_here() -> Result<()> {

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -112,3 +112,14 @@ $ coven familiars
 No familiars configured.
 Add [[familiar]] entries to ~/.coven/familiars.toml to build your roster.
 ```
+
+## In the interactive surfaces
+
+The same views are reachable without leaving the interactive surfaces: the
+Cast composer and the chat UI accept `/status` (alias `/overview`),
+`/familiars`, `/skills`, `/memory`, `/research`, `/calls`, and `/hub`, plus the
+bare words (`status`, `familiars`, `roster`, …). Every card shows the
+scriptable `coven <view>` spelling so the terminal form stays discoverable.
+`status` in a composer means this ecosystem overview; setup checks stay on
+`doctor`/`health`.
+


### PR DESCRIPTION
## Context

- Summary: Extends #367's observability parity to the **interactive surfaces**: the Cast composer and the chat UI can now open the same read-only views (`/status`, `/familiars`, `/skills`, `/memory`, `/research`, `/calls`, `/hub`) that the CLI commands render, through the same read path, so the three surfaces can never disagree. Also fixes a consistency bug #367 introduced: the Cast shell's plain word `status` used to run *doctor*, which now contradicted `coven status`.
- Files changed: `crates/coven-cli/src/observe.rs`, `crates/coven-cli/src/tui/cast/{intent,plan,mod}.rs`, `crates/coven-cli/src/tui/shell.rs`, `crates/coven-cli/src/tui/chat/app.rs`, `crates/coven-cli/src/main.rs` (palette test pins), `CHAT-QUICKSTART.md`, `docs/reference/cli-observe.md`.
- **Stacked on #367** (base branch `feat/366-cli-observability-parity`; retarget to `main` + rebase after it lands). Refs #366.

## Implementation

- Approach: one new `CastIntent::Observe { view: ObserveView }`. `ObserveView` lives in `observe.rs` (the data layer) and is re-exported by `cast::intent`, keeping layering one-directional (tui → observe). A shared `observe::view_text(coven_home, view)` renders the human text for all surfaces; the CLI human path now goes through it too (no second render path).
- User-visible behavior:
  - Cast (`coven "<spell>"` and the composer): `/status` (alias `/overview`), `/familiars`, `/skills`, `/memory`, `/research`, `/calls`, `/hub`, plus bare words (`status`, `overview`, `familiars`, `roster`, `skills`, `memory`, `research`, `calls`, `hub`, `hub status`). Plan cards are Safe/Inform and name the scriptable `coven <view>` command.
  - Chat UI: views render as system messages, followed by a "Scriptable form: `coven <view>` (add --json for machines)" hint; read failures degrade to a hint message, never a crash.
  - Legacy palette (behind `COVEN_LEGACY_TUI=1`): one new "Coven status" entry (key `s`, `/status`).
  - `status`/`overview` in a composer now mean the ecosystem overview (CLI consistency); setup checks stay on `doctor`/`health`.
- Compatibility notes: multi-word prompts that merely *start* with a view word (e.g. `memory leak in the daemon`) still cast as natural spells — only exact keywords open views, pinned by test. `health` keeps its Doctor meaning for anyone who had `status`-as-doctor muscle memory.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (`-p coven-cli --all-targets` clean; workspace clean in #367 base)
- [x] `cargo test --workspace --locked` bin suite: 1083 passed, 0 failed
- [x] `python3 scripts/check-secrets.py` (hook-scanned on commit; full history scan green on the base branch)
- [x] Additional manual checks: PTY smoke of the live cast path — `coven "status"` under `script(1)` renders the status view with a populated `COVEN_HOME`; verified the palette windowing tests reflect the 15-item registry.

## Risk and Rollback

- Risk level: Low — read-only intents classified Safe/Inform; no daemon or API changes. The chat-UI arm is additive to an exhaustive match (compiler-enforced coverage).
- Rollback plan: revert the single commit; no migrations or contract changes.

## Agent Handoff

- Current state: complete and green on top of #367's head (including the reviewer-bot fixes, which were verified locally: fmt/clippy/1078 tests before this commit).
- Follow-ups: none beyond #367's list. If #367 squash-merges, retarget this PR to `main` and `git rebase --onto origin/main <old-base>`.
- Known gaps: the deprecated legacy shell got only a minimal palette entry by design — the investment went to Cast + chat, the surfaces that remain.
