### PR TITLE
feat(hub): CLI detail views for hub jobs, nodes, and dispatches

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -456,21 +456,33 @@ enum HubCommand {
         #[arg(long, help = "Print hub status as JSON (machine-readable)")]
         json: bool,
     },
-    #[command(about = "List registered executor nodes")]
+    #[command(about = "List registered executor nodes, or show one node")]
     Nodes {
+        #[arg(help = "Node id for a detail view (omit to list all nodes)")]
+        id: Option<String>,
         #[arg(long, help = "Print nodes as JSON (machine-readable)")]
         json: bool,
     },
-    #[command(about = "List hub jobs")]
+    #[command(about = "List hub jobs, or show one job")]
     Jobs {
+        #[arg(help = "Job id for a detail view (omit to list jobs)")]
+        id: Option<String>,
         #[arg(
             long,
             value_name = "STATE",
             value_parser = ["queued", "assigned", "held", "completed", "failed", "cancelled"],
-            help = "Only show jobs in this state"
+            conflicts_with = "id",
+            help = "Only show jobs in this state (list mode only)"
         )]
         state: Option<String>,
         #[arg(long, help = "Print jobs as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Show the executor dispatch record for a job")]
+    Dispatch {
+        #[arg(help = "Job id whose dispatch record to show (list ids with `coven hub jobs`)")]
+        job_id: String,
+        #[arg(long, help = "Print the dispatch record as JSON (machine-readable)")]
         json: bool,
     },
     #[command(about = "Show the job→node routing table")]
@@ -787,8 +799,11 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Calls { id, json }) => observe::run_calls(id.as_deref(), json),
         Some(Command::Hub { command }) => match command {
             HubCommand::Status { json } => observe::run_hub_status(json),
-            HubCommand::Nodes { json } => observe::run_hub_nodes(json),
-            HubCommand::Jobs { state, json } => observe::run_hub_jobs(state.as_deref(), json),
+            HubCommand::Nodes { id, json } => observe::run_hub_nodes(id.as_deref(), json),
+            HubCommand::Jobs { id, state, json } => {
+                observe::run_hub_jobs(id.as_deref(), state.as_deref(), json)
+            }
+            HubCommand::Dispatch { job_id, json } => observe::run_hub_dispatch(&job_id, json),
             HubCommand::Routing { json } => observe::run_hub_routing(json),
         },
         Some(Command::Logs { command }) => run_logs_command(command),
@@ -3527,17 +3542,49 @@ mod tests {
         assert!(matches!(
             Cli::parse_from(["coven", "hub", "nodes", "--json"]).command,
             Some(Command::Hub {
-                command: HubCommand::Nodes { json: true }
+                command: HubCommand::Nodes {
+                    id: None,
+                    json: true
+                }
             })
         ));
+        match Cli::parse_from(["coven", "hub", "nodes", "node_a"]).command {
+            Some(Command::Hub {
+                command: HubCommand::Nodes { id, json },
+            }) => {
+                assert_eq!(id.as_deref(), Some("node_a"));
+                assert!(!json);
+            }
+            other => panic!("expected hub nodes detail command, got {other:?}"),
+        }
         match Cli::parse_from(["coven", "hub", "jobs", "--state", "queued"]).command {
             Some(Command::Hub {
-                command: HubCommand::Jobs { state, json },
+                command: HubCommand::Jobs { id, state, json },
             }) => {
+                assert_eq!(id, None);
                 assert_eq!(state.as_deref(), Some("queued"));
                 assert!(!json);
             }
             other => panic!("expected hub jobs command, got {other:?}"),
+        }
+        match Cli::parse_from(["coven", "hub", "jobs", "job-1", "--json"]).command {
+            Some(Command::Hub {
+                command: HubCommand::Jobs { id, state, json },
+            }) => {
+                assert_eq!(id.as_deref(), Some("job-1"));
+                assert_eq!(state, None);
+                assert!(json);
+            }
+            other => panic!("expected hub jobs detail command, got {other:?}"),
+        }
+        match Cli::parse_from(["coven", "hub", "dispatch", "job-1"]).command {
+            Some(Command::Hub {
+                command: HubCommand::Dispatch { job_id, json },
+            }) => {
+                assert_eq!(job_id, "job-1");
+                assert!(!json);
+            }
+            other => panic!("expected hub dispatch command, got {other:?}"),
         }
         assert!(matches!(
             Cli::parse_from(["coven", "hub", "routing"]).command,
@@ -3550,6 +3597,13 @@ mod tests {
     #[test]
     fn cli_rejects_unknown_hub_job_state() {
         assert!(Cli::try_parse_from(["coven", "hub", "jobs", "--state", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn cli_rejects_hub_job_detail_combined_with_state_filter() {
+        assert!(
+            Cli::try_parse_from(["coven", "hub", "jobs", "job-1", "--state", "queued"]).is_err()
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -567,12 +567,24 @@ fn render_hub_status(body: &Value) -> String {
     out
 }
 
-pub(crate) fn run_hub_nodes(json: bool) -> Result<()> {
-    let body = api_get(&coven_home_dir()?, "/api/v1/hub/nodes")?;
-    if json {
-        return print_json(&body);
+pub(crate) fn run_hub_nodes(id: Option<&str>, json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    match id {
+        Some(id) => {
+            let body = api_get(&coven_home, &format!("/api/v1/hub/nodes/{id}"))?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_hub_node_detail(&body));
+        }
+        None => {
+            let body = api_get(&coven_home, "/api/v1/hub/nodes")?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_hub_nodes(&body));
+        }
     }
-    print!("{}", render_hub_nodes(&body));
     Ok(())
 }
 
@@ -623,16 +635,89 @@ fn render_hub_nodes(body: &Value) -> String {
         ],
         &rows,
     );
-    out.push_str(&format!("\n{} node(s)\n", nodes.len()));
+    out.push_str(&format!(
+        "\n{} node(s) · detail: coven hub nodes <id>\n",
+        nodes.len()
+    ));
     out
 }
 
-pub(crate) fn run_hub_jobs(state: Option<&str>, json: bool) -> Result<()> {
+/// Joined string list from a JSON array field, or an em dash when absent.
+fn list_cell(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|joined| !joined.is_empty())
+        .unwrap_or_else(|| "—".to_string())
+}
+
+fn render_hub_node_detail(node: &Value) -> String {
+    let node_id = str_cell(node, "nodeId");
+    let mut out = String::new();
+    out.push_str(&format!("Hub node {node_id}\n\n"));
+    out.push_str(&format!("  role          {}\n", str_cell(node, "role")));
+    out.push_str(&format!(
+        "  transport     {}\n",
+        str_cell(node, "transport")
+    ));
+    out.push_str(&format!(
+        "  available     {}\n",
+        str_cell(node, "available")
+    ));
+    out.push_str(&format!(
+        "  pressure      {}\n",
+        str_cell(node, "queuePressure")
+    ));
+    out.push_str(&format!(
+        "  capabilities  {}\n",
+        list_cell(node, "capabilities")
+    ));
+    out.push_str(&format!(
+        "  last health   {}\n",
+        str_cell(node, "lastHealthAt")
+    ));
+    if node.get("lastError").and_then(Value::as_str).is_some() {
+        out.push_str(&format!(
+            "  last error    {}\n",
+            str_cell(node, "lastError")
+        ));
+    }
+    out.push_str(&format!(
+        "  registered    {}\n",
+        str_cell(node, "registeredAt")
+    ));
+    out.push_str(&format!(
+        "  updated       {}\n",
+        str_cell(node, "updatedAt")
+    ));
+    out.push_str(&format!(
+        "\n  jobs: coven hub jobs --state assigned · full record: coven hub nodes {node_id} --json\n"
+    ));
+    out
+}
+
+pub(crate) fn run_hub_jobs(id: Option<&str>, state: Option<&str>, json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    if let Some(id) = id {
+        let body = api_get(&coven_home, &format!("/api/v1/hub/jobs/{id}"))?;
+        if json {
+            return print_json(&body);
+        }
+        print!("{}", render_hub_job_detail(&body));
+        return Ok(());
+    }
     let path = match state {
         Some(state) => format!("/api/v1/hub/jobs?state={state}"),
         None => "/api/v1/hub/jobs".to_string(),
     };
-    let body = api_get(&coven_home_dir()?, &path)?;
+    let body = api_get(&coven_home, &path)?;
     if json {
         return print_json(&body);
     }
@@ -669,8 +754,93 @@ fn render_hub_jobs(body: &Value) -> String {
         &rows,
     );
     out.push_str(&format!(
-        "\n{} job(s) · filter with --state <queued|assigned|held|completed|failed|cancelled>\n",
+        "\n{} job(s) · detail: coven hub jobs <id> · filter with --state <queued|assigned|held|completed|failed|cancelled>\n",
         jobs.len()
+    ));
+    out
+}
+
+/// Character budget for free-text/JSON previews in detail views. Wider than
+/// [`TEXT_CELL_LIMIT`] because detail lines own the whole row; `--json` is the
+/// escape hatch for the full record.
+const DETAIL_TEXT_LIMIT: usize = 160;
+
+fn render_hub_job_detail(job: &Value) -> String {
+    let job_id = str_cell(job, "jobId");
+    let mut out = String::new();
+    out.push_str(&format!("Hub job {job_id}\n\n"));
+    out.push_str(&format!("  state      {}\n", str_cell(job, "state")));
+    out.push_str(&format!("  priority   {}\n", str_cell(job, "priority")));
+    out.push_str(&format!(
+        "  requires   {}\n",
+        list_cell(job, "requiredCapabilities")
+    ));
+    out.push_str(&format!(
+        "  node       {}\n",
+        str_cell(job, "assignedNodeId")
+    ));
+    out.push_str(&format!("  loop       {}\n", str_cell(job, "loopId")));
+    out.push_str(&format!("  created    {}\n", str_cell(job, "createdAt")));
+    out.push_str(&format!("  updated    {}\n", str_cell(job, "updatedAt")));
+    if let Some(route) = job.get("route").filter(|route| !route.is_null()) {
+        out.push_str("\n  route\n");
+        out.push_str(&format!("    node       {}\n", str_cell(route, "nodeId")));
+        out.push_str(&format!(
+            "    decision   {}\n",
+            str_cell(route, "decisionId")
+        ));
+        out.push_str(&format!(
+            "    reason     {}\n",
+            theme::fit_chars(&str_cell(route, "reason"), DETAIL_TEXT_LIMIT)
+        ));
+    }
+    if let Some(payload) = job.get("payload").filter(|payload| !payload.is_null()) {
+        out.push_str(&format!(
+            "\n  payload\n    {}\n",
+            theme::fit_chars(&payload.to_string(), DETAIL_TEXT_LIMIT)
+        ));
+    }
+    out.push_str(&format!(
+        "\n  dispatch record: coven hub dispatch {job_id} · full record: coven hub jobs {job_id} --json\n"
+    ));
+    out
+}
+
+pub(crate) fn run_hub_dispatch(job_id: &str, json: bool) -> Result<()> {
+    let body = api_get(
+        &coven_home_dir()?,
+        &format!("/api/v1/hub/dispatches/{job_id}"),
+    )?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_hub_dispatch(&body));
+    Ok(())
+}
+
+fn render_hub_dispatch(body: &Value) -> String {
+    let job_id = str_cell(body, "jobId");
+    let mut out = String::new();
+    out.push_str(&format!("Executor dispatch {job_id}\n\n"));
+    out.push_str(&format!("  node       {}\n", str_cell(body, "nodeId")));
+    out.push_str(&format!("  status     {}\n", str_cell(body, "status")));
+    out.push_str(&format!("  created    {}\n", str_cell(body, "createdAt")));
+    out.push_str(&format!("  updated    {}\n", str_cell(body, "updatedAt")));
+    if let Some(job) = body.get("job").filter(|job| !job.is_null()) {
+        out.push_str(&format!(
+            "\n  job spec\n    {}\n",
+            theme::fit_chars(&job.to_string(), DETAIL_TEXT_LIMIT)
+        ));
+    }
+    match body.get("envelope").filter(|envelope| !envelope.is_null()) {
+        Some(envelope) => out.push_str(&format!(
+            "\n  result envelope\n    {}\n",
+            theme::fit_chars(&envelope.to_string(), DETAIL_TEXT_LIMIT)
+        )),
+        None => out.push_str("\n  result envelope\n    — (no result reported yet)\n"),
+    }
+    out.push_str(&format!(
+        "\n  full record: coven hub dispatch {job_id} --json\n"
     ));
     out
 }
@@ -1307,6 +1477,103 @@ mod tests {
         assert!(out.contains("job-1"), "assigned job lost: {out}");
         assert!(out.contains("node_a"), "assigned node lost: {out}");
         Ok(())
+    }
+
+    #[test]
+    fn hub_detail_renderers_match_live_api_bodies() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let register = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/hub/nodes",
+            temp.path(),
+            None,
+            Some(
+                r#"{"nodeId":"node_a","role":"compute_executor","transport":"ssh","capabilities":["gpu"]}"#,
+            ),
+        )?;
+        anyhow::ensure!(register.status == 201, "register: {}", register.body);
+        let enqueue = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/hub/jobs",
+            temp.path(),
+            None,
+            Some(r#"{"jobId":"job-1","requiredCapabilities":["gpu"],"priority":5}"#),
+        )?;
+        anyhow::ensure!(enqueue.status == 201, "enqueue: {}", enqueue.body);
+        let assign = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/hub/jobs/job-1/assign",
+            temp.path(),
+            None,
+            Some(r#"{"nodeId":"node_a"}"#),
+        )?;
+        anyhow::ensure!(assign.status == 200, "assign: {}", assign.body);
+
+        let node = get_body(temp.path(), "/api/v1/hub/nodes/node_a")?;
+        let out = render_hub_node_detail(&node);
+        assert!(out.contains("Hub node node_a"), "node id lost: {out}");
+        assert!(out.contains("compute_executor"), "role lost: {out}");
+        assert!(out.contains("gpu"), "capabilities lost: {out}");
+        assert!(
+            out.contains("coven hub nodes node_a --json"),
+            "json hint lost: {out}"
+        );
+
+        let job = get_body(temp.path(), "/api/v1/hub/jobs/job-1")?;
+        let out = render_hub_job_detail(&job);
+        assert!(out.contains("Hub job job-1"), "job id lost: {out}");
+        assert!(out.contains("assigned"), "state lost: {out}");
+        assert!(out.contains("node_a"), "assigned node lost: {out}");
+        assert!(out.contains("route"), "route section lost: {out}");
+        assert!(
+            out.contains("coven hub dispatch job-1"),
+            "dispatch hint lost: {out}"
+        );
+
+        // Persist a dispatch record directly: the dispatch route runs a live
+        // transport, which a unit test must not do.
+        let conn = crate::store::open_store(&temp.path().join(crate::STORE_FILE_NAME))?;
+        crate::store::upsert_executor_dispatch(
+            &conn,
+            &crate::store::ExecutorDispatchRecord {
+                job_id: "job-1".into(),
+                node_id: "node_a".into(),
+                status: "completed".into(),
+                job_json: r#"{"jobId":"job-1","command":["echo","ok"]}"#.into(),
+                envelope_json: Some(
+                    r#"{"jobId":"job-1","status":"completed","exitCode":0}"#.into(),
+                ),
+                created_at: "2026-01-01T00:00:00Z".into(),
+                updated_at: "2026-01-01T00:00:05Z".into(),
+            },
+        )?;
+        let dispatch = get_body(temp.path(), "/api/v1/hub/dispatches/job-1")?;
+        let out = render_hub_dispatch(&dispatch);
+        assert!(
+            out.contains("Executor dispatch job-1"),
+            "dispatch id lost: {out}"
+        );
+        assert!(out.contains("node_a"), "dispatch node lost: {out}");
+        assert!(out.contains("completed"), "dispatch status lost: {out}");
+        assert!(out.contains("exitCode"), "envelope lost: {out}");
+        Ok(())
+    }
+
+    #[test]
+    fn render_hub_dispatch_marks_missing_envelope() {
+        let out = render_hub_dispatch(&json!({
+            "jobId": "job-2",
+            "nodeId": "node_a",
+            "status": "dispatched",
+            "job": {"command": ["true"]},
+            "envelope": null,
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+        }));
+        assert!(
+            out.contains("no result reported yet"),
+            "missing-envelope state lost: {out}"
+        );
     }
 
     #[test]

--- a/docs/HUB-OPERATIONS.md
+++ b/docs/HUB-OPERATIONS.md
@@ -45,7 +45,10 @@ route is also reachable with
 `curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/hub/status`).
 `GET /api/v1/health` includes the same summary in its `hub` block, and
 `coven hub nodes` / `coven hub jobs --state held` drill into the recovered
-registry and queues.
+registry and queues. For a single record, `coven hub nodes <id>`,
+`coven hub jobs <id>`, and `coven hub dispatch <jobId>` mirror the
+`GET /api/v1/hub/nodes/:id`, `/hub/jobs/:id`, and `/hub/dispatches/:jobId`
+routes (add `--json` for the raw body).
 
 ## Supervisor setup
 

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -98,9 +98,15 @@ write-side protocol, which stays machine-to-machine):
 ```bash
 coven hub status                 # role, hubId, node availability, queue depth
 coven hub nodes                  # registered executors with capabilities
+coven hub nodes <id>             # one node: transport, health, capabilities
 coven hub jobs --state queued    # global queue by state
+coven hub jobs <id>              # one job: state, route, payload preview
+coven hub dispatch <jobId>       # executor dispatch record + result envelope
 coven hub routing                # job→node routing decisions
 ```
+
+Every verb takes `--json`, which prints the matching `/api/v1/hub/*` response
+body unchanged, so scripts and humans read the same contract.
 
 ## Empty states teach setup
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,7 +113,8 @@ flowchart TB
 | `coven pc` | macOS-first diagnostics and explicit `--confirm` relief operations. |
 | `coven completions <shell>` | Print shell completions for bash, zsh, fish, elvish, or powershell. |
 | `coven familiars/skills/memory/research/calls` | Read-path Cave parity views; see [cli-observe](cli-observe.md). |
-| `coven hub status/nodes/jobs/routing` | Read-only hub control-plane inspection; see [cli-observe](cli-observe.md). |
+| `coven hub status/nodes/jobs/routing` | Read-only hub control-plane inspection; `nodes <id>` and `jobs <id>` show one record; see [cli-observe](cli-observe.md). |
+| `coven hub dispatch <jobId>` | Show a job's executor dispatch record and result envelope. |
 
 ## Common flags by command
 
@@ -124,7 +125,7 @@ flowchart TB
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sessions events` | `--after-seq <SEQ>`, `--limit <N>`, `--json` |
 | `coven status` / `familiars` / `skills` / `memory` / `research` / `calls` | `--json` |
-| `coven hub jobs` | `--state <queued\|assigned\|held\|completed\|failed\|cancelled>`, `--json` |
+| `coven hub jobs` | `--state <queued\|assigned\|held\|completed\|failed\|cancelled>` (list mode), `[id]` positional for a detail view, `--json` |
 | `coven sacrifice` | `--yes` (required) |
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
 | `coven wt` | `--list`, `--json` (with `--list`), `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |


### PR DESCRIPTION
Closes #375.

## What

Read-only hub detail views so operators can inspect a single node, job, or executor dispatch without `curl --unix-socket`:

- `coven hub nodes <id>` → `GET /api/v1/hub/nodes/:id`
- `coven hub jobs <id>` → `GET /api/v1/hub/jobs/:id` (includes the job's route)
- `coven hub dispatch <jobId>` → `GET /api/v1/hub/dispatches/:jobId` (job spec + result envelope)

All three follow the observe.rs pattern: rendering goes through in-process `api::handle_request`, and `--json` prints the daemon API body unchanged. Human output stays prose. List footers now hint the detail spelling (`detail: coven hub jobs <id>`), matching the `coven calls <id>` convention.

## Why

The daemon has served these GET routes since #266/#312, but `HubCommand` was list-only — the only per-entity inspection path was raw curl, breaking the "hub operations without curl" promise in `docs/reference/cli-observe.md`. Found via the usability/integration gap matrix (CLI verbs × daemon routes × reference docs); tracked as #375.

## Notes

- CLI stays strictly read-only: writes remain executor-protocol-only (`coven.executor.v1`).
- `--state` conflicts with the positional job id (`coven hub jobs job-1 --state queued` is rejected).
- Docs updated: `docs/reference/cli-observe.md`, `docs/reference/cli.md`, `docs/HUB-OPERATIONS.md`.

## Validation

- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --locked` — new tests `hub_detail_renderers_match_live_api_bodies`, `render_hub_dispatch_marks_missing_envelope`, extended `cli_parses_hub_subcommands`, `cli_rejects_hub_job_detail_combined_with_state_filter` all pass. (Pre-existing on origin/main in this sandbox: `hub::tests::hub_polls_and_dispatches_outbound_and_records_executor_state` and `poll_fails_closed_when_executor_advertises_a_mismatched_role` fail locally without this change — transport-script environment issue, not touched here.)
- `python scripts/check-secrets.py` ✓
- Smoke: `coven hub nodes --json` on empty home → `{"nodes": []}`; `coven hub jobs no-such-job` → `Error: Job was not found in the hub queue. (job_not_found)` exit 1.
