### PR TITLE
docs: reference pages for claim, wt, hooks, engine, logs, vacuum, executor

### DIFF
--- a/docs/reference/cli-claim.md
+++ b/docs/reference/cli-claim.md
@@ -1,0 +1,88 @@
+---
+summary: "TTL-bounded branch claims for parallel agent sessions."
+read_when:
+  - Looking up claim
+  - Coordinating multiple agent sessions on one checkout
+title: "coven claim"
+description: "Reference for coven claim: acquire, release, heartbeat, canary, and status for the TTL-bounded claims that stop parallel agent sessions from duplicating work, plus the managed hooks that enforce them."
+---
+
+Parallel agent sessions (Codex, Claude Code, familiars) frequently work on the
+same checkout at once. Claims are shared, TTL-bounded locks that make intent
+visible before code changes exist, so two sessions do not independently build
+the same issue.
+
+```sh
+coven claim status              # what is already taken?
+coven claim acquire issue-42    # claim before touching code
+coven claim heartbeat issue-42  # extend the TTL on long tasks
+coven claim release issue-42    # release when the PR merges or you stop
+```
+
+Claim tokens are free-form. Prefer shared, issue-keyed tokens (`issue-42`)
+over working-branch names, which other sessions cannot predict.
+
+## Where claims live
+
+Claims are files under `<git-common-dir>/agent-claims/`, so every worktree of
+the repository sees the same registry. The claiming identity comes from
+`COVEN_AGENT_ID` (falling back to `USER`). A claim expires after one hour by
+default; override with `COVEN_CLAIM_TTL_SECONDS`.
+
+- `acquire` fails while another agent's claim is active.
+- `release` refuses to remove another agent's active claim.
+- `heartbeat` re-acquires or extends your own claim for another TTL window.
+- `canary <branch>` records the current HEAD in `<git-common-dir>/AGENT_HEAD_AT_START`
+  so the managed pre-commit hook can detect history rewrites.
+
+## Scriptable status
+
+```sh
+coven claim status --json
+```
+
+```json
+{
+  "claims": [
+    {
+      "branch": "issue-42",
+      "agent_id": "buns",
+      "state": "active",
+      "acquired_at": 1784078000,
+      "acquired_at_rfc3339": "2026-07-15T01:53:20Z",
+      "expires_at": 1784081600,
+      "expires_at_rfc3339": "2026-07-15T02:53:20Z",
+      "head": "852b794..."
+    }
+  ]
+}
+```
+
+`state` is `active` or `expired`; expired claims stay listed until the token
+is re-acquired or released.
+
+## Enforcement: coven hooks install
+
+```sh
+coven hooks install
+```
+
+installs managed `pre-commit` and `pre-push` hooks into
+`<git-common-dir>/hooks/`, shared by all worktrees. Installation refuses to
+touch tracked hook directories: when `core.hooksPath` is set, run the Coven
+checks from that hook directory instead (or move the tracked hook to
+`.git/hooks/<hook>.local` and unset `core.hooksPath`). The managed hooks:
+
+- **pre-commit** refuses commits on the protected primary branch
+  (`COVEN_PRIMARY_BRANCH`, default `main`) unless
+  `COVEN_ALLOW_PRIMARY_COMMIT=1`; refuses commits on a branch actively
+  claimed by another agent; and trips when the `claim canary` HEAD is no
+  longer an ancestor of the current HEAD. An executable
+  `hooks/pre-commit.local` is chained afterwards, so existing hooks (for
+  example the gitleaks secret scan) keep running.
+- **pre-push** protects the primary branch and branches matching
+  `COVEN_PROTECTED_REGEX` (default `^(release|hotfix)/`) behind an explicit
+  merge-intent phrase (`COVEN_MERGE_PHRASE`).
+
+`coven wt --doctor` reports whether the managed hooks are installed — see
+[cli-wt](cli-wt.md).

--- a/docs/reference/cli-engine.md
+++ b/docs/reference/cli-engine.md
@@ -1,0 +1,55 @@
+---
+summary: "Manage the Coven engine (the interactive agent runtime)."
+read_when:
+  - Looking up engine
+  - Installing or pinning the coven-code engine
+title: "coven engine"
+description: "Reference for coven engine: show the resolved engine path, source, version, and pin state; install the pinned engine into ~/.coven/engine; and print the engine binary path for scripts."
+---
+
+The engine is the `coven-code` binary that powers the interactive surfaces
+(`coven`, `coven chat`) and the engine passthrough commands (`coven auth`,
+`coven models`, `coven acp`, `coven code`). Coven pins a known-good engine
+version and can manage the install itself.
+
+```sh
+coven engine status          # resolved path, source, version, pin state
+coven engine install         # install the pinned version into ~/.coven/engine
+coven engine which           # print the binary path (exit 1 if none)
+```
+
+## Status
+
+`coven engine status --json`:
+
+```json
+{
+  "installed": true,
+  "path": "/home/alex/.coven/engine/0.6.1/coven-code",
+  "source": "managed install",
+  "version": "0.6.1",
+  "pin": "0.6.1"
+}
+```
+
+When no engine resolves, the JSON is `{ "installed": false }` and the prose
+output points at `coven engine install`.
+
+## Install
+
+`coven engine install` downloads the pinned engine release into
+`~/.coven/engine`. `--version <v>` installs a specific version instead of the
+pin; `--force` reinstalls even when the version is already present.
+
+## Which
+
+`coven engine which` prints only the resolved binary path, for scripts and
+editor integrations:
+
+```sh
+"$(coven engine which)" --version
+```
+
+It exits 1 when no engine is installed. `coven doctor` reports the same
+resolution together with the minimum supported engine version — see
+[cli-doctor](cli-doctor.md).

--- a/docs/reference/cli-executor.md
+++ b/docs/reference/cli-executor.md
@@ -1,0 +1,50 @@
+---
+summary: "Stateless executor-node protocol commands (coven.executor.v1)."
+read_when:
+  - Looking up executor
+  - Wiring a machine into the hub as an executor node
+title: "coven executor"
+description: "Reference for coven executor probe and run-job: the stateless coven.executor.v1 protocol commands a hub invokes over SSH or a private network to poll availability and dispatch jobs."
+---
+
+`coven executor` implements the executor side of the multi-host protocol
+(`coven.executor.v1`). These commands are not meant for interactive use: the
+**hub** invokes them over an outbound transport (SSH or a local process
+launch). Executors never push registration or heartbeats to the hub.
+
+```sh
+coven executor probe     # print this node's availability envelope as JSON
+coven executor run-job   # run one hub-dispatched job from a JSON spec on stdin
+```
+
+## Probe
+
+`probe` prints a JSON availability envelope — `protocolVersion`, `role`
+(`stationary_executor` or `compute_executor`), advertised `capabilities`,
+`available`, `queuePressure` (always 0: stateless executors hold no durable
+queue; the hub owns queues), `covenVersion`, and `probedAt`. The node's
+advertised role and capabilities come from the optional
+`<covenHome>/executor.json`; an absent config means a stationary executor
+with base capabilities. The hub polls the probe via
+`POST /api/v1/hub/nodes/:id/poll` and fails closed when the advertised role
+does not match the registration.
+
+## Run-job
+
+`run-job` reads one job spec from stdin — argv, cwd, env, stdin payload, and
+opaque hub context, everything the node needs with no local durable
+authority — executes it, and replies on stdout with a normalized result
+envelope (stdout/stderr/exit metadata). Transport failures are normalized
+into the same envelope shape by the hub-side dispatcher, so
+`coven hub dispatch <jobId>` always has a record to show.
+
+## Operating executors
+
+Registration, dispatch, and recovery run through the hub API and CLI:
+
+- `coven hub nodes [<id>]`, `coven hub jobs [<id>]`, `coven hub dispatch
+  <jobId>` — read-side inspection ([cli-observe](cli-observe.md)).
+- `POST /api/v1/hub/nodes/:id/{poll,dispatch}` — hub-initiated transport.
+- [HUB-OPERATIONS](../HUB-OPERATIONS.md) — supervisor setup and restart
+  runbook; the multi-host spec lives in
+  `specs/coven-multi-host-daemon/TECH.md`.

--- a/docs/reference/cli-logs.md
+++ b/docs/reference/cli-logs.md
@@ -1,0 +1,41 @@
+---
+summary: "Prune raw artifacts and old redacted event logs."
+read_when:
+  - Looking up logs prune
+  - Tuning local log retention
+title: "coven logs"
+description: "Reference for coven logs prune: retention windows for raw artifacts and redacted session events, dry-run reporting, and the COVEN_* environment overrides."
+---
+
+Session events are stored redacted; sensitive raw artifacts are kept
+separately with a short retention window. `coven logs prune` applies both
+retention windows to the local store.
+
+```sh
+coven logs prune --dry-run     # report what would be pruned
+coven logs prune               # prune expired rows
+```
+
+## Retention windows
+
+| Data | Default | Flag | Environment override |
+| --- | --- | --- | --- |
+| Raw artifacts | 7 days | `--raw-days <N>` | `COVEN_RAW_ARTIFACT_RETENTION_DAYS` |
+| Redacted events | 30 days | `--event-days <N>` | `COVEN_LOG_RETENTION_DAYS` |
+
+Flags win over configuration; both windows are clamped to at least 1 day.
+Defaults can also be set in the privacy section of the Coven settings — see
+[SETTINGS](../SETTINGS.md).
+
+## Output
+
+```text
+$ coven logs prune --dry-run
+logs prune dryRun=true rawArtifacts=3 events=120 rawDays=7 eventDays=30
+
+$ coven logs prune
+logs pruned rawArtifacts=3 events=120 rawCutoff=2026-07-08T... eventCutoff=2026-06-15T...
+```
+
+For store repair and compaction (rebuilding the event index, integrity
+checks), see [cli-vacuum](cli-vacuum.md).

--- a/docs/reference/cli-vacuum.md
+++ b/docs/reference/cli-vacuum.md
@@ -1,0 +1,31 @@
+---
+summary: "Repair and compact the local Coven session store."
+read_when:
+  - Looking up vacuum
+  - Repairing the session store after corruption
+title: "coven vacuum"
+description: "Reference for coven vacuum: rebuild the session event index, run a SQLite integrity check, and compact the local Coven store."
+---
+
+`coven vacuum` repairs and compacts the local session store
+(`<covenHome>/coven.sqlite3`): it rebuilds the full-text event index when
+needed and runs a SQLite integrity check.
+
+```sh
+coven vacuum
+```
+
+```text
+Coven store: vacuumed (event index rebuilt, integrity ok, path /home/alex/.coven/coven.sqlite3)
+```
+
+Run it when `coven sessions search` misbehaves or after unclean shutdowns.
+The command is safe to run while the daemon is stopped; prefer stopping the
+daemon first for large repairs.
+
+The daemon exposes the same operation as `POST /api/v1/store/vacuum`, which
+returns `{ ok, eventIndexRebuilt, integrityCheck }` — see the
+[API reference](api.md).
+
+For retention pruning of raw artifacts and old events, see
+[cli-logs](cli-logs.md).

--- a/docs/reference/cli-wt.md
+++ b/docs/reference/cli-wt.md
@@ -1,0 +1,74 @@
+---
+summary: "Create, list, diagnose, and prune Coven protocol worktrees."
+read_when:
+  - Looking up wt
+  - Isolating parallel agent sessions in worktrees
+title: "coven wt"
+description: "Reference for coven wt: create or enter a branch worktree in the sibling <repo>.wt directory, list worktrees with claim and dirty state, run the layout doctor, and prune merged or stale worktrees."
+---
+
+`coven wt` keeps every parallel session in its own git worktree so git
+operations do not race. Worktrees live in a sibling directory named after the
+repository: a repo at `~/src/coven` keeps its worktrees under
+`~/src/coven.wt/<branch>`.
+
+```sh
+coven wt fix/output-polish   # create (or re-enter) a worktree for the branch
+coven wt --list              # branch, dirty state, active claim, path
+coven wt --doctor            # layout + hook check; exits 1 on problems
+coven wt --prune-merged      # remove clean worktrees merged into the primary
+coven wt --prune-stale 14    # remove clean worktrees untouched for 14 days
+```
+
+Exactly one action per invocation. `coven worktree` and `coven worktrees` are
+aliases.
+
+## Creating and entering
+
+`coven wt <branch>` prints the worktree path. If the worktree already exists
+it is reused; if the branch exists it is checked out, otherwise the branch is
+created. The printed path is designed for command substitution:
+
+```sh
+cd "$(coven wt fix/output-polish)"
+```
+
+## Listing with claims
+
+`--list` joins each worktree against the shared claim registry (see
+[cli-claim](cli-claim.md)) and the working-tree state:
+
+```sh
+coven wt --list --json
+```
+
+```json
+{
+  "worktrees": [
+    {
+      "branch": "fix/output-polish",
+      "dirty": false,
+      "claimed_by": "buns",
+      "path": "/home/alex/src/coven.wt/fix/output-polish"
+    }
+  ]
+}
+```
+
+`claimed_by` is null unless an active (unexpired) claim exists for the
+branch.
+
+## Doctor
+
+`--doctor` prints the repo root, the expected worktree root, the claims
+directory, and whether the managed `pre-commit`/`pre-push` hooks are
+installed. It warns about worktrees outside the `<repo>.wt` layout and exits
+1 when hooks are missing or the layout is broken — install the hooks with
+`coven hooks install` ([cli-claim](cli-claim.md)).
+
+## Pruning
+
+Both prune modes only ever remove **clean** worktrees. `--prune-merged`
+removes worktrees whose branches are merged into the primary branch
+(`COVEN_PRIMARY_BRANCH`, default `main`); `--prune-stale <DAYS>` removes
+worktrees not modified for the given number of days.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -103,13 +103,15 @@ flowchart TB
 | `coven sacrifice <session-id> --yes` | Permanently delete a non-running session. |
 | `coven kill <session-id>` | Kill a running session's process; keeps the event log. |
 | `coven patch openclaw <prompt>` | Local OpenClaw rescue loop. Does not commit or push. |
-| `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs. |
-| `coven vacuum` | Rebuild the session event FTS index, compact the SQLite store, and print integrity status. |
-| `coven wt <branch>` | Create or enter a sibling `<repo>.wt/<branch-slug>` git worktree. |
-| `coven wt --list/--doctor/--prune-merged/--prune-stale DAYS` | Inspect and clean Coven protocol worktrees. |
-| `coven claim acquire/release/heartbeat/canary <branch>` | Manage TTL-bounded branch ownership for the current agent. |
-| `coven claim status` | Print branch claims from the current repository. |
-| `coven hooks install` | Install local protocol hooks that block unsafe commits and protected pushes. |
+| `coven logs prune` | Prune expired encrypted raw artifacts and old redacted event logs; see [cli-logs](cli-logs.md). |
+| `coven vacuum` | Rebuild the session event FTS index, compact the SQLite store, and print integrity status; see [cli-vacuum](cli-vacuum.md). |
+| `coven wt <branch>` | Create or enter a sibling `<repo>.wt/<branch-slug>` git worktree; see [cli-wt](cli-wt.md). |
+| `coven wt --list/--doctor/--prune-merged/--prune-stale DAYS` | Inspect and clean Coven protocol worktrees; see [cli-wt](cli-wt.md). |
+| `coven claim acquire/release/heartbeat/canary <branch>` | Manage TTL-bounded branch ownership for the current agent; see [cli-claim](cli-claim.md). |
+| `coven claim status` | Print branch claims from the current repository; see [cli-claim](cli-claim.md). |
+| `coven hooks install` | Install local protocol hooks that block unsafe commits and protected pushes; see [cli-claim](cli-claim.md). |
+| `coven engine status/install/which` | Manage the pinned Coven engine (`coven-code`); see [cli-engine](cli-engine.md). |
+| `coven executor probe/run-job` | Stateless executor-node protocol commands, hub-dispatched over SSH; see [cli-executor](cli-executor.md). |
 | `coven pc` | macOS-first diagnostics and explicit `--confirm` relief operations. |
 | `coven completions <shell>` | Print shell completions for bash, zsh, fish, elvish, or powershell. |
 | `coven familiars/skills/memory/research/calls` | Read-path Cave parity views; see [cli-observe](cli-observe.md). |
@@ -130,6 +132,7 @@ flowchart TB
 | `coven logs prune` | `--dry-run`, `--raw-days <N>`, `--event-days <N>` |
 | `coven wt` | `--list`, `--json` (with `--list`), `--doctor`, `--prune-merged`, `--prune-stale <DAYS>` |
 | `coven claim status` | `--json` |
+| `coven engine status` | `--json` |
 | `coven pc kill` | `--confirm` (required) |
 | `coven pc cache clear` | `--confirm` (required) |
 | `coven pc top` | `--n <N>`, `--verbose`, `--json` |


### PR DESCRIPTION
Closes #374.

## What

Reference pages for the seven command surfaces that had full clap help but no `docs/reference` home — including the parallel-work commands AGENTS.md makes mandatory for every agent session:

| Page | Covers |
|---|---|
| `cli-claim.md` | `coven claim` acquire/release/heartbeat/canary/`status --json`; shared `<git-common-dir>/agent-claims/` registry; `COVEN_AGENT_ID`, `COVEN_CLAIM_TTL_SECONDS` (default 1h); `coven hooks install` and what the managed pre-commit/pre-push hooks enforce |
| `cli-wt.md` | sibling `<repo>.wt` layout, `--list --json` shape (branch/dirty/claimed_by/path), `--doctor` exit contract, prune modes (clean worktrees only) |
| `cli-engine.md` | `engine status --json` shape, managed install under `~/.coven/engine`, `engine which` for scripts |
| `cli-logs.md` | retention windows (raw 7d / events 30d), `--raw-days`/`--event-days` and `COVEN_*` env overrides, dry-run output |
| `cli-vacuum.md` | event index rebuild + integrity check, `POST /api/v1/store/vacuum` equivalence |
| `cli-executor.md` | `coven.executor.v1` probe/run-job envelopes, `executor.json` node config, hub-initiated transport pointers |

`cli.md`'s command map now links all of the above and gains `coven engine` and `coven executor` rows that were missing entirely; the flag table adds `engine status --json`.

## Accuracy

All semantics were sourced from the implementations, not the issue text: `parallel_protocol.rs` (TTL constant/env, claim file layout, hook scripts, `core.hooksPath` refusal, worktree root/slug, prune clean-only behavior), `engine.rs`/`engine_install.rs` (status JSON shape, managed dir), `main.rs` `prune_logs_command`/`run_vacuum_command` (defaults, output lines), `privacy.rs` (7/30-day defaults), and `executor_node.rs` (`build_probe` envelope fields).

## Validation

Docs-only change: no Rust/TS behavior touched. Secret scan clean (pre-commit gitleaks + `python scripts/check-secrets.py` runs in CI). Internal links use existing relative conventions (`cli-*.md`, `../HUB-OPERATIONS.md`, `../SETTINGS.md` all exist).
