### PR TITLE
feat(ward): route protected-surface edits through the coven-threads authority gate (Phase 2)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Fetch git dependencies with the system `git` CLI instead of libgit2 so that
+# ambient credentials (osxkeychain, gh auth, CI checkout tokens) apply. Needed
+# for the private OpenCoven/coven-threads dependency until its visibility flip.
+[net]
+git-fetch-with-cli = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "coven-threads-core"
 version = "0.1.0"
-source = "git+https://github.com/OpenCoven/coven-threads?tag=v0.1.0#5e68957d84cd98a0f395708f98806d8f518a78a0"
+source = "git+https://github.com/OpenCoven/coven-threads?tag=v0.1.2#a64db33b4f55fe4c1a0bc16e7fe70943e504da29"
 dependencies = [
  "blake3",
  "serde",
@@ -4107,7 +4107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +253,20 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -504,6 +530,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,11 +605,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "blake3",
  "chacha20poly1305",
  "chrono",
  "clap",
  "clap_complete",
  "coven-runtime-spec",
+ "coven-threads-core",
  "crossterm",
  "dirs-next",
  "flate2",
@@ -595,6 +629,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "textwrap",
+ "time",
  "toml",
  "toml_edit",
  "unicode-width",
@@ -640,6 +675,19 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "coven-threads-core"
+version = "0.1.0"
+source = "git+https://github.com/OpenCoven/coven-threads?tag=v0.1.0#5e68957d84cd98a0f395708f98806d8f518a78a0"
+dependencies = [
+ "blake3",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
 ]
 
 [[package]]
@@ -870,6 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -3725,6 +3774,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +4763,8 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -20,6 +20,15 @@ clap_complete = "4"
 # release tag; the daemon reads a manifest's declared capabilities through
 # these types instead of hardcoded harness-id checks (integration.md, PR 1).
 coven-runtime-spec = { git = "https://github.com/OpenCoven/coven-runtimes", tag = "v0.1.3", version = "0.1.3" }
+# The authority-boundary gate layer for familiar protected surfaces
+# (PHASE-0-DESIGN.md in OpenCoven/coven-threads; RFC-0001 §5). The daemon is
+# the only caller: familiar-controlled processes never reach this crate.
+# Pinned to a release tag like coven-runtime-spec above. NOTE: repo is private
+# until the visibility flip (Val decision); local builds authenticate via the
+# git CLI (.cargo/config.toml `net.git-fetch-with-cli`).
+coven-threads-core = { git = "https://github.com/OpenCoven/coven-threads", tag = "v0.1.0", version = "0.1.0" }
+blake3 = "1"
+time = { version = "0.3", features = ["formatting"] }
 crossterm = "0.29"
 flate2 = "1"
 json5 = "1.3"
@@ -31,7 +40,7 @@ serde_json = "1"
 sha2 = "0.11"
 toml = "1.1"
 toml_edit = { version = "0.25", features = ["serde"] }
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "v5"] }
 sysinfo = "0.39"
 dirs-next = "2"
 chacha20poly1305 = { version = "0.10", features = ["std", "rand_core"] }

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -26,7 +26,7 @@ coven-runtime-spec = { git = "https://github.com/OpenCoven/coven-runtimes", tag 
 # Pinned to a release tag like coven-runtime-spec above. NOTE: repo is private
 # until the visibility flip (Val decision); local builds authenticate via the
 # git CLI (.cargo/config.toml `net.git-fetch-with-cli`).
-coven-threads-core = { git = "https://github.com/OpenCoven/coven-threads", tag = "v0.1.0", version = "0.1.0" }
+coven-threads-core = { git = "https://github.com/OpenCoven/coven-threads", tag = "v0.1.2", version = "0.1.0" }
 blake3 = "1"
 time = { version = "0.3", features = ["formatting"] }
 crossterm = "0.29"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2499,32 +2499,109 @@ fn apply_familiar_edits(
             return api_error(500, "ward_config_invalid", &format!("{error:#}"), None);
         }
     };
-    let ward = match ward::Ward::new(&workspace, config) {
+    let ward = match ward::Ward::new(&workspace, config.clone()) {
         Ok(ward) => ward,
         Err(error) => {
             return api_error(500, "ward_config_invalid", &format!("{error:#}"), None);
         }
     };
 
+    // The coven-threads gate (Phase 2, OpenCoven/coven-threads §5): protected
+    // (Tier 0) targets are validated against the familiar's weave — the typed
+    // authority state of each surface — before the Ward's own apply boundary.
+    // Editable-tier targets stay the Ward tiers' lane. Adjudication is pure
+    // (`Ward::evaluate`), so resolving targets here does not write anything.
+    let adjudication = ward.evaluate(&ward::Proposal {
+        targets: edits.iter().map(|e| e.target.clone()).collect(),
+        authorization: authorization.clone(),
+    });
+    let gated_targets: Vec<String> = adjudication
+        .decisions
+        .iter()
+        .filter(|d| d.tier == ward::Tier::Protected && !d.verdict.is_blocked())
+        .map(|d| d.resolved.clone())
+        .collect();
+    let gate_report = {
+        let conn = store::open_store(&store_path(coven_home))?;
+        match crate::threads_gate::gate_protected_edits(
+            &conn,
+            &crate::threads_gate::GateRequest {
+                coven_home,
+                familiar_id,
+                workspace: &workspace,
+                config: &config,
+                edits: &edits,
+                gated_targets: &gated_targets,
+                authorization: &authorization,
+            },
+        ) {
+            Ok(report) => report,
+            Err(error) => {
+                // Fail closed: a gate that cannot run is a refusal, never a
+                // pass-through (RFC-0001 §5.4 Gate 4).
+                return api_error(
+                    500,
+                    "threads_gate_unavailable",
+                    &format!("The authority gate could not adjudicate the proposal: {error:#}"),
+                    None,
+                );
+            }
+        }
+    };
+    match &gate_report.outcome {
+        crate::threads_gate::GateOutcome::Rejected => {
+            return api_error(
+                403,
+                "ward_refused",
+                "The authority gate rejected the proposal; nothing was written.",
+                Some(json!({ "threadsGate": gate_report.to_json() })),
+            );
+        }
+        crate::threads_gate::GateOutcome::Staged { .. } => {
+            // §5 DegradeToProposal: staged at ~/.coven/pending/, principal
+            // notified via the pending file + audit ledger; no write happens.
+            return json_response(
+                202,
+                &json!({
+                    "ok": true,
+                    "disposition": "staged",
+                    "threadsGate": gate_report.to_json(),
+                }),
+            );
+        }
+        crate::threads_gate::GateOutcome::Permitted => {}
+    }
+
     let report = ward.apply(&edits, &authorization)?;
     let changes: Vec<Value> = report.changes.iter().map(ward_change_json).collect();
+    let threads_gate_json = gate_report.to_json();
     if report.is_refused() {
         return api_error(
             403,
             "ward_refused",
             "The Ward refused the proposal; nothing was written.",
-            Some(json!({ "changes": changes })),
+            Some(json!({ "changes": changes, "threadsGate": threads_gate_json })),
         );
     }
     if report.is_held() {
         return json_response(
             202,
-            &json!({ "ok": true, "disposition": "held", "changes": changes }),
+            &json!({
+                "ok": true,
+                "disposition": "held",
+                "changes": changes,
+                "threadsGate": threads_gate_json,
+            }),
         );
     }
     json_response(
         200,
-        &json!({ "ok": true, "disposition": "applied", "changes": changes }),
+        &json!({
+            "ok": true,
+            "disposition": "applied",
+            "changes": changes,
+            "threadsGate": threads_gate_json,
+        }),
     )
 }
 
@@ -5821,6 +5898,101 @@ tier = 1
             std::fs::read_to_string(workspace.join("SOUL.md"))?,
             "# Sage\n"
         );
+        // The coven-threads gate ran first and permitted: the verdict is in
+        // the payload and in the append-only ward_audit ledger.
+        assert_eq!(
+            body["threadsGate"]["outcome"]["kind"], "permitted",
+            "got {}",
+            response.body
+        );
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        let decision: String = conn.query_row(
+            "SELECT decision FROM ward_audit WHERE familiar_id='sage' ORDER BY id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(decision, "permit");
+        Ok(())
+    }
+
+    #[test]
+    fn post_familiar_edits_stages_to_pending_after_out_of_band_drift() -> Result<()> {
+        // §5 of the coven-threads design (DegradeToProposal), end to end:
+        // baseline the surface, drift it outside the daemon, then propose —
+        // the write is staged at ~/.coven/pending/, the surface is untouched,
+        // and `staged` is the one additive disposition the §6 compatibility
+        // contract allows.
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let workspace = seed_warded_familiar(home)?;
+
+        // First signed request bootstraps the content baseline (held).
+        let first = post_edits(
+            home,
+            r#"{"edits":[{"target":"SOUL.md","contents":"new identity"}],
+                "principalKeyFingerprint":"fpr-val"}"#,
+        )?;
+        assert_eq!(first.status, 202, "got {}", first.body);
+
+        // Out-of-band drift: something edits SOUL.md around the daemon.
+        std::fs::write(workspace.join("SOUL.md"), "# Mallory\n")?;
+
+        let response = post_edits(
+            home,
+            r#"{"edits":[{"target":"SOUL.md","contents":"new identity v2"}],
+                "principalKeyFingerprint":"fpr-val"}"#,
+        )?;
+        assert_eq!(response.status, 202, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["disposition"], "staged");
+        assert_eq!(body["threadsGate"]["outcome"]["kind"], "staged");
+
+        let pending = body["threadsGate"]["outcome"]["pendingPath"]
+            .as_str()
+            .expect("staged outcome carries pendingPath");
+        assert!(
+            std::path::Path::new(pending).exists(),
+            "pending proposal file must exist"
+        );
+        // The staged proposal carries the full desired contents.
+        let staged: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(pending)?)?;
+        assert_eq!(staged["edits"][0]["surface"], "SOUL.md");
+        // Nothing wrote the protected surface.
+        assert_eq!(
+            std::fs::read_to_string(workspace.join("SOUL.md"))?,
+            "# Mallory\n"
+        );
+        // The degrade decision is in the append-only ledger.
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        let decision: String = conn.query_row(
+            "SELECT decision FROM ward_audit WHERE familiar_id='sage' ORDER BY id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(decision, "degrade_to_proposal");
+        Ok(())
+    }
+
+    #[test]
+    fn post_familiar_edits_editable_tier_bypasses_the_weave() -> Result<()> {
+        // Editable-tier writes are the Ward tiers' lane: the weave reports no
+        // verdicts and appends nothing to ward_audit.
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+        let response = post_edits(
+            home,
+            r#"{"edits":[{"target":"notes/today.md","contents":"hello ward"}]}"#,
+        )?;
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(
+            body["threadsGate"]["verdicts"].as_array().map(Vec::len),
+            Some(0)
+        );
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM ward_audit", [], |row| row.get(0))?;
+        assert_eq!(count, 0);
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2515,6 +2515,20 @@ fn apply_familiar_edits(
         targets: edits.iter().map(|e| e.target.clone()).collect(),
         authorization: authorization.clone(),
     });
+    // A proposal with any Blocked target (traversal/symlink escape, case
+    // collision, unauthorized Tier-0) is refused as a unit BEFORE the threads
+    // gate runs: a blocked target must never ride into a staged proposal, and
+    // 403 here matches Ward::apply's own all-or-nothing refusal shape.
+    if adjudication.is_blocked() {
+        let report = ward.apply(&edits, &authorization)?;
+        let changes: Vec<Value> = report.changes.iter().map(ward_change_json).collect();
+        return api_error(
+            403,
+            "ward_refused",
+            "The Ward refused the proposal; nothing was written.",
+            Some(json!({ "changes": changes })),
+        );
+    }
     let gated_targets: Vec<String> = adjudication
         .decisions
         .iter()
@@ -5970,6 +5984,44 @@ tier = 1
             |row| row.get(0),
         )?;
         assert_eq!(decision, "degrade_to_proposal");
+        Ok(())
+    }
+
+    #[test]
+    fn post_familiar_edits_blocked_target_refuses_even_with_drifted_surface() -> Result<()> {
+        // Review finding: a mixed proposal (drifted Tier-0 edit + traversal
+        // escape) must be refused as a unit BEFORE the threads gate can stage
+        // it — a blocked target must never ride into ~/.coven/pending/.
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let workspace = seed_warded_familiar(home)?;
+
+        // Baseline SOUL.md, then drift it so the gate would want to stage.
+        let first = post_edits(
+            home,
+            r#"{"edits":[{"target":"SOUL.md","contents":"new identity"}],
+                "principalKeyFingerprint":"fpr-val"}"#,
+        )?;
+        assert_eq!(first.status, 202, "got {}", first.body);
+        std::fs::write(workspace.join("SOUL.md"), "# Mallory\n")?;
+
+        let response = post_edits(
+            home,
+            r#"{"edits":[
+                {"target":"SOUL.md","contents":"new identity v2"},
+                {"target":"../escape.md","contents":"nope"}
+            ], "principalKeyFingerprint":"fpr-val"}"#,
+        )?;
+        assert_eq!(response.status, 403, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "ward_refused");
+        // Nothing was staged and nothing escaped.
+        let pending = home.join("pending");
+        let staged_count = std::fs::read_dir(&pending)
+            .map(|entries| entries.count())
+            .unwrap_or(0);
+        assert_eq!(staged_count, 0, "blocked proposal must not stage");
+        assert!(!home.join("familiars/escape.md").exists());
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -47,6 +47,10 @@ mod verification;
 // Gate 3 (coherence review) remains a follow-up — see ward.rs.
 #[allow(dead_code)]
 mod ward;
+// The coven-threads validator call site: typed authority-state gating of
+// protected-surface mutations (OpenCoven/coven-threads Phase 2). Runs before
+// Ward::apply on the same write path; see threads_gate.rs.
+mod threads_gate;
 
 pub(crate) const DEFAULT_COVEN_HOME_DIR: &str = ".coven";
 pub(crate) const STORE_FILE_NAME: &str = "coven.sqlite3";

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -472,6 +472,13 @@ pub fn open_store(path: &Path) -> Result<Connection> {
         ",
     )
     .context("failed to initialize Coven store schema")?;
+    // The coven-threads gate layer's daemon-owned tables: the append-only
+    // ward.audit ledger (single audit store — PHASE-0-DESIGN §3.4, RFC-0001
+    // §5.6) and the per-familiar surface baseline manifest. Both idempotent.
+    conn.execute_batch(coven_threads_core::WARD_AUDIT_SCHEMA_SQL)
+        .context("failed to initialize ward_audit schema")?;
+    conn.execute_batch(crate::threads_gate::WARD_MANIFEST_SCHEMA_SQL)
+        .context("failed to initialize ward_manifest schema")?;
     ensure_exit_code_column(&conn)?;
     ensure_archived_at_column(&conn)?;
     ensure_conversation_id_column(&conn)?;

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -1,0 +1,790 @@
+//! The coven-threads validator call site — Phase 2 of the authority-boundary
+//! gate layer (`OpenCoven/coven-threads`, `specs/PHASE-0-DESIGN.md` §5, §6).
+//!
+//! The daemon already validates *who* (Ward Gate 1) and *where a write really
+//! lands* (Gate 2 path materialization). What it did not validate is *what the
+//! target file's authority state permits*: whether the protected surface has
+//! drifted out from under its recorded authority since the principal last
+//! blessed it. `coven-threads-core` fills that gap with a typed weave of
+//! threads (authority relationships `surface → writer`) whose strands commit
+//! to surface content.
+//!
+//! This module is the **only** bridge between the daemon and the gate crate:
+//!
+//! - it persists per-surface content baselines (`ward_manifest` table in
+//!   `coven.sqlite3` — daemon-owned state, same single store as the audit log),
+//! - it weaves the familiar's protected surfaces into a `Weave` on each
+//!   request, fraying any thread whose surface drifted from baseline,
+//! - it calls `coven_threads_core::validate_fail_closed` per protected target
+//!   (fail-closed on unknown surface/writer/channel *and* on validator panic,
+//!   RFC-0001 §5.4 Gate 4),
+//! - it appends one `ward_audit` row per verdict (RFC-0001 §5.6; append-only
+//!   enforced by triggers in the schema itself),
+//! - on `DegradeToProposal` it stages the whole proposal, as a unit, at
+//!   `~/.coven/pending/` for the principal — nothing is written to the
+//!   protected surface.
+//!
+//! The gate runs *before* [`crate::ward::Ward::apply`]; the Ward's own
+//! all-or-nothing apply remains the final materialized-diff boundary. Both
+//! layers fail closed; neither can be skipped on the daemon's only
+//! arbitrary-file write path into familiar homes (`POST /familiars/{id}/edits`).
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use coven_threads_core as threads;
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::{json, Value};
+
+use crate::ward;
+
+/// The channels every protected-surface thread must hold under. `Mutation` is
+/// the channel this endpoint exercises; `Forced` and `Serialization` are woven
+/// now so compaction (WARD-C1–C6) and export (C7) lanes gate against the same
+/// threads when they land.
+const PROTECTED_CHANNELS: [threads::Channel; 3] = [
+    threads::Channel::Forced,
+    threads::Channel::Serialization,
+    threads::Channel::Mutation,
+];
+
+/// Serialization-contract tag committed by every `SerializationMarker` strand
+/// until the Phase 3 portability format defines the real contract hash.
+const SERIALIZATION_CONTRACT: &[u8] = b"coven-threads:serialization-contract:v0.1.0";
+const SERIALIZATION_FORMAT_VERSION: &str = "0.1.0";
+
+/// What the gate decided about a proposal, as a unit.
+#[derive(Debug)]
+pub enum GateOutcome {
+    /// Every protected target holds: proceed to `Ward::apply`.
+    Permitted,
+    /// At least one thread frayed (§5): the whole proposal is staged at
+    /// `~/.coven/pending/`; nothing may be written.
+    Staged {
+        /// Where the pending proposal was staged.
+        pending_path: PathBuf,
+        /// The staged proposal id.
+        proposal_id: String,
+    },
+    /// At least one verdict rejected: the proposal is refused as a unit.
+    Rejected,
+}
+
+/// The gate's full report for one proposal.
+#[derive(Debug)]
+pub struct GateReport {
+    /// Per-target verdicts in request order: `(resolved surface, verdict)`.
+    pub verdicts: Vec<(String, threads::Verdict)>,
+    /// The unit outcome.
+    pub outcome: GateOutcome,
+}
+
+impl GateReport {
+    /// JSON for API payloads (`threadsGate` field). Purely descriptive — the
+    /// daemon acts on [`GateOutcome`], never on this rendering.
+    pub fn to_json(&self) -> Value {
+        let verdicts: Vec<Value> = self
+            .verdicts
+            .iter()
+            .map(|(surface, verdict)| {
+                json!({
+                    "surface": surface,
+                    "verdict": serde_json::to_value(verdict).unwrap_or(Value::Null),
+                })
+            })
+            .collect();
+        let outcome = match &self.outcome {
+            GateOutcome::Permitted => json!({ "kind": "permitted" }),
+            GateOutcome::Staged {
+                pending_path,
+                proposal_id,
+            } => json!({
+                "kind": "staged",
+                "pendingPath": pending_path.display().to_string(),
+                "proposalId": proposal_id,
+            }),
+            GateOutcome::Rejected => json!({ "kind": "rejected" }),
+        };
+        json!({ "verdicts": verdicts, "outcome": outcome })
+    }
+}
+
+/// Schema for the gate's daemon-owned state inside `coven.sqlite3`: the
+/// per-familiar content-baseline manifest. Applied idempotently by
+/// `store::open_store` alongside `coven_threads_core::WARD_AUDIT_SCHEMA_SQL`.
+pub const WARD_MANIFEST_SCHEMA_SQL: &str = "
+CREATE TABLE IF NOT EXISTS ward_manifest (
+    familiar_id  TEXT NOT NULL,
+    surface      TEXT NOT NULL,
+    manifest_id  TEXT NOT NULL,
+    entry_hash   BLOB NOT NULL,
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    PRIMARY KEY (familiar_id, surface)
+);
+";
+
+/// Everything the gate needs to adjudicate one proposal.
+pub struct GateRequest<'a> {
+    /// The coven home (owns `pending/` and the store).
+    pub coven_home: &'a Path,
+    /// Human-readable familiar id (`familiars.toml` key).
+    pub familiar_id: &'a str,
+    /// The familiar workspace (home of the protected surfaces).
+    pub workspace: &'a Path,
+    /// The familiar's Ward configuration.
+    pub config: &'a ward::WardConfig,
+    /// The proposal's edits, in request order.
+    pub edits: &'a [ward::FileEdit],
+    /// Gate-2 *resolved* home-relative paths of the proposal's unblocked
+    /// Tier-0 targets. Blocked targets are already refused by the Ward
+    /// downstream. Empty means no protected target: the gate is a no-op
+    /// `Permitted` — editable-tier writes are the Ward tiers' lane.
+    pub gated_targets: &'a [String],
+    /// The proposal's authorization.
+    pub authorization: &'a ward::Authorization,
+}
+
+/// Gate a proposal's protected targets through the coven-threads weave.
+pub fn gate_protected_edits(conn: &Connection, req: &GateRequest<'_>) -> Result<GateReport> {
+    let GateRequest {
+        coven_home,
+        familiar_id,
+        workspace,
+        config,
+        edits,
+        gated_targets,
+        authorization,
+    } = *req;
+    if gated_targets.is_empty() {
+        return Ok(GateReport {
+            verdicts: Vec::new(),
+            outcome: GateOutcome::Permitted,
+        });
+    }
+
+    let familiar_uuid = familiar_weave_id(familiar_id);
+    let principal_writer =
+        threads::WriterId::new(format!("principal:{}", config.principal_key_fingerprint));
+    let request_writer = match &authorization.principal_signature_fingerprint {
+        Some(fp) => threads::WriterId::new(format!("principal:{fp}")),
+        None => threads::WriterId::new("client:unsigned"),
+    };
+
+    // Weave one thread per protected surface: the literal (non-glob) tier-0
+    // declarations plus every gated target in this request.
+    let mut surfaces: Vec<String> = config
+        .protected_surface
+        .iter()
+        .filter(|entry| !entry.contains(['*', '?', '[']))
+        .cloned()
+        .collect();
+    for target in gated_targets {
+        if !surfaces.contains(target) {
+            surfaces.push(target.clone());
+        }
+    }
+    surfaces.sort();
+
+    let manifest_id = load_or_create_manifest_id(conn, familiar_id)?;
+    let now = time::OffsetDateTime::now_utc();
+
+    let mut woven = Vec::with_capacity(surfaces.len());
+    for surface in &surfaces {
+        let surface_id = threads::SurfaceId::new(surface.clone());
+        let disk = read_surface(workspace, surface)?;
+        let current_hash = threads::manifest_entry_hash(&surface_id, &disk);
+
+        let baseline = load_baseline(conn, familiar_id, surface)?;
+        let (entry_hash, drifted) = match baseline {
+            Some(recorded) => {
+                let drifted = recorded.as_slice() != current_hash.as_slice();
+                (recorded, drifted)
+            }
+            None => {
+                // First sight: bootstrap the baseline from current content.
+                // Observation, not authority — recording a baseline grants
+                // nothing; it only makes future drift detectable.
+                store_baseline(conn, familiar_id, surface, &manifest_id, &current_hash)?;
+                (current_hash.to_vec(), false)
+            }
+        };
+
+        let mut thread = threads::Thread {
+            id: threads::ThreadId::new(),
+            surface: surface_id.clone(),
+            writer: principal_writer.clone(),
+            strands: vec![
+                threads::Strand::ContentHash {
+                    id: threads::StrandId::new(),
+                    algorithm: threads::HashAlgo::Blake3,
+                    value: blake3::hash(&disk).as_bytes().to_vec(),
+                },
+                threads::Strand::ManifestEntry {
+                    id: threads::StrandId::new(),
+                    manifest_id,
+                    entry_hash,
+                },
+                threads::Strand::SerializationMarker {
+                    id: threads::StrandId::new(),
+                    format_version: SERIALIZATION_FORMAT_VERSION.to_string(),
+                    contract_hash: blake3::hash(SERIALIZATION_CONTRACT).as_bytes().to_vec(),
+                },
+            ],
+            holds_under: PROTECTED_CHANNELS.to_vec(),
+            created_at: now,
+            tension: threads::TensionState::Holds,
+        };
+        if drifted {
+            let manifest_strand = thread
+                .strands
+                .iter()
+                .find(|s| matches!(s, threads::Strand::ManifestEntry { .. }))
+                .map(threads::Strand::id);
+            thread.fray(
+                manifest_strand,
+                threads::Channel::Mutation,
+                threads::FrayReason::ManifestEntryMismatch,
+                now,
+            );
+        }
+        woven.push(thread);
+    }
+
+    let pattern = threads::AllSurfacesHoldOnChannels {
+        name: format!("{familiar_id}-protected-surface"),
+        surfaces: surfaces
+            .iter()
+            .map(|s| threads::SurfaceId::new(s.clone()))
+            .collect(),
+        channels: PROTECTED_CHANNELS.to_vec(),
+    };
+    let weave = threads::Weave::new(
+        threads::WeaveId::new(),
+        familiar_uuid,
+        woven,
+        Box::new(pattern),
+        None,
+    )
+    .context("weaving protected surfaces")?;
+
+    // Validate every gated target; audit every verdict (RFC-0001 §5.6).
+    let mut verdicts = Vec::with_capacity(gated_targets.len());
+    let mut degraded: Option<(threads::ThreadId, threads::FrayOrSnap)> = None;
+    let mut rejected = false;
+    for target in gated_targets {
+        let request = threads::MutationRequest {
+            surface: threads::SurfaceId::new(target.clone()),
+            writer: request_writer.clone(),
+            channel: threads::Channel::Mutation,
+        };
+        let verdict = threads::validate_fail_closed(&weave, &request);
+        append_audit_row(
+            conn,
+            familiar_id,
+            &familiar_uuid,
+            weave.weave_hash(),
+            &request,
+            &verdict,
+            now,
+        )?;
+        match &verdict {
+            threads::Verdict::Reject { .. } => rejected = true,
+            threads::Verdict::DegradeToProposal { thread, fray } => {
+                degraded.get_or_insert((*thread, fray.clone()));
+            }
+            threads::Verdict::Permit { .. } => {}
+        }
+        verdicts.push((target.clone(), verdict));
+    }
+
+    // Unit semantics (§5 + the Ward's own all-or-nothing rule): any Reject
+    // refuses the proposal; otherwise any fray stages the whole proposal.
+    let outcome = if rejected {
+        GateOutcome::Rejected
+    } else if let Some((thread_id, fray)) = degraded {
+        let (pending_path, proposal_id) = stage_pending_proposal(
+            coven_home,
+            &familiar_uuid,
+            &request_writer,
+            thread_id,
+            fray,
+            edits,
+            now,
+        )?;
+        GateOutcome::Staged {
+            pending_path,
+            proposal_id,
+        }
+    } else {
+        GateOutcome::Permitted
+    };
+
+    Ok(GateReport { verdicts, outcome })
+}
+
+/// Deterministic weave-level familiar id from the human-readable familiar id
+/// (UUIDv5 over the OID namespace, so audits correlate across restarts).
+fn familiar_weave_id(familiar_id: &str) -> threads::FamiliarId {
+    threads::FamiliarId(uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_OID,
+        familiar_id.as_bytes(),
+    ))
+}
+
+fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
+    let mut path = workspace.to_path_buf();
+    for segment in surface.split('/').filter(|s| !s.is_empty()) {
+        path.push(segment);
+    }
+    match std::fs::read(&path) {
+        Ok(bytes) => Ok(bytes),
+        // An absent protected file baselines as empty: creating it later is
+        // drift like any other content change.
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(err) => Err(err).with_context(|| format!("reading surface {}", path.display())),
+    }
+}
+
+fn load_or_create_manifest_id(conn: &Connection, familiar_id: &str) -> Result<threads::ManifestId> {
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT manifest_id FROM ward_manifest WHERE familiar_id = ?1 LIMIT 1",
+            params![familiar_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("loading ward_manifest id")?;
+    match existing {
+        Some(raw) => Ok(threads::ManifestId(
+            uuid::Uuid::parse_str(&raw).context("ward_manifest.manifest_id is not a uuid")?,
+        )),
+        None => Ok(threads::ManifestId::new()),
+    }
+}
+
+fn load_baseline(conn: &Connection, familiar_id: &str, surface: &str) -> Result<Option<Vec<u8>>> {
+    conn.query_row(
+        "SELECT entry_hash FROM ward_manifest WHERE familiar_id = ?1 AND surface = ?2",
+        params![familiar_id, surface],
+        |row| row.get(0),
+    )
+    .optional()
+    .context("loading ward_manifest baseline")
+}
+
+fn store_baseline(
+    conn: &Connection,
+    familiar_id: &str,
+    surface: &str,
+    manifest_id: &threads::ManifestId,
+    entry_hash: &[u8; 32],
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO ward_manifest (familiar_id, surface, manifest_id, entry_hash)
+         VALUES (?1, ?2, ?3, ?4)
+         ON CONFLICT (familiar_id, surface) DO NOTHING",
+        params![
+            familiar_id,
+            surface,
+            manifest_id.0.to_string(),
+            entry_hash.as_slice()
+        ],
+    )
+    .context("storing ward_manifest baseline")?;
+    Ok(())
+}
+
+fn append_audit_row(
+    conn: &Connection,
+    familiar_id: &str,
+    familiar_uuid: &threads::FamiliarId,
+    weave_hash: &[u8],
+    request: &threads::MutationRequest,
+    verdict: &threads::Verdict,
+    now: time::OffsetDateTime,
+) -> Result<()> {
+    let record = threads::WardAuditRecord::for_verdict(
+        *familiar_uuid,
+        weave_hash,
+        request,
+        verdict,
+        now,
+        now,
+    );
+    let files_touched = serde_json::to_string(
+        &record
+            .files_touched
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>(),
+    )?;
+    let format = time::format_description::well_known::Rfc3339;
+    conn.execute(
+        "INSERT INTO ward_audit (
+            event_type, proposal_id, familiar_id, ward_version, ward_hash,
+            tier, decision, approver, diff_hash, files_touched, channel,
+            thread_id, submitted_at, decided_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+        params![
+            record.event_type.tag(),
+            record.proposal_id.map(|p| p.0.to_string()),
+            // Human-readable familiar id in the store; the uuid rides in the
+            // JSON record shape for cross-system correlation.
+            familiar_id,
+            record.ward_version,
+            record.ward_hash,
+            record.tier,
+            record.decision,
+            record.approver.map(|w| w.0),
+            record.diff_hash,
+            files_touched,
+            record.channel.map(|c| format!("{c:?}").to_lowercase()),
+            record.thread_id.map(|t| t.0.to_string()),
+            record.submitted_at.format(&format)?,
+            record.decided_at.format(&format)?,
+        ],
+    )
+    .context("appending ward_audit row")?;
+    Ok(())
+}
+
+fn stage_pending_proposal(
+    coven_home: &Path,
+    familiar_uuid: &threads::FamiliarId,
+    writer: &threads::WriterId,
+    thread_id: threads::ThreadId,
+    fray: threads::FrayOrSnap,
+    edits: &[ward::FileEdit],
+    now: time::OffsetDateTime,
+) -> Result<(PathBuf, String)> {
+    let proposal = threads::PendingProposal {
+        id: threads::ProposalId::new(),
+        familiar_id: *familiar_uuid,
+        writer: writer.clone(),
+        channel: threads::Channel::Mutation,
+        thread_id,
+        fray,
+        edits: edits
+            .iter()
+            .map(|edit| threads::StagedEdit {
+                surface: threads::SurfaceId::new(edit.target.clone()),
+                contents: threads::StagedContents::from_bytes(&edit.new_contents),
+            })
+            .collect(),
+        staged_at: now,
+    };
+
+    let pending_dir = coven_home.join("pending");
+    std::fs::create_dir_all(&pending_dir)
+        .with_context(|| format!("creating {}", pending_dir.display()))?;
+    let path = pending_dir.join(proposal.file_name());
+    let body = serde_json::to_vec_pretty(&proposal).context("serializing pending proposal")?;
+    // Atomic sibling-staged write, same discipline as the Ward's own writes.
+    let staged = path.with_extension("json.staged");
+    std::fs::write(&staged, &body)
+        .with_context(|| format!("staging pending proposal at {}", staged.display()))?;
+    std::fs::rename(&staged, &path)
+        .with_context(|| format!("committing pending proposal at {}", path.display()))?;
+    Ok((path, proposal.id.0.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store;
+
+    fn ward_config() -> ward::WardConfig {
+        ward::WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val-1"
+protected_surface = ["SOUL.md", "IDENTITY.md"]
+default_tier = 2
+
+[[surface]]
+path = "SOUL.md"
+tier = 0
+
+[[surface]]
+path = "IDENTITY.md"
+tier = 0
+
+[[surface]]
+path = "notes/**"
+tier = 2
+"#,
+        )
+        .expect("fixture ward config parses")
+    }
+
+    struct Fixture {
+        _temp: tempfile::TempDir,
+        coven_home: PathBuf,
+        workspace: PathBuf,
+        conn: Connection,
+    }
+
+    fn fixture() -> Fixture {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let coven_home = temp.path().to_path_buf();
+        let workspace = coven_home.join("familiars").join("sage");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::write(workspace.join("SOUL.md"), "# SOUL\nI am Sage.\n").unwrap();
+        std::fs::write(workspace.join("IDENTITY.md"), "# IDENTITY\n").unwrap();
+        let conn = store::open_store(&coven_home.join("coven.sqlite3")).unwrap();
+        Fixture {
+            _temp: temp,
+            coven_home,
+            workspace,
+            conn,
+        }
+    }
+
+    fn signed() -> ward::Authorization {
+        ward::Authorization::signed_by("fp-val-1")
+    }
+
+    fn soul_edit() -> Vec<ward::FileEdit> {
+        vec![ward::FileEdit::new(
+            "SOUL.md",
+            "# SOUL\nI am Sage, updated.\n",
+        )]
+    }
+
+    #[test]
+    fn first_sight_bootstraps_baseline_and_permits_principal() {
+        let f = fixture();
+        let report = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &ward_config(),
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+
+        assert!(
+            matches!(report.outcome, GateOutcome::Permitted),
+            "{report:?}"
+        );
+        assert!(matches!(
+            report.verdicts[0].1,
+            threads::Verdict::Permit { .. }
+        ));
+        // Baselines recorded for both declared protected surfaces.
+        let count: i64 = f
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM ward_manifest WHERE familiar_id = 'sage'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+        // Verdict audited.
+        let decision: String = f
+            .conn
+            .query_row(
+                "SELECT decision FROM ward_audit WHERE familiar_id = 'sage'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(decision, "permit");
+    }
+
+    #[test]
+    fn unsigned_writer_is_not_bound_and_rejects() {
+        let f = fixture();
+        let report = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &ward_config(),
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &ward::Authorization::unsigned(),
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(report.outcome, GateOutcome::Rejected),
+            "{report:?}"
+        );
+        let decision: String = f
+            .conn
+            .query_row(
+                "SELECT decision FROM ward_audit WHERE familiar_id = 'sage'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(decision, "reject:writer_not_bound");
+    }
+
+    #[test]
+    fn out_of_band_drift_stages_proposal_to_pending() {
+        let f = fixture();
+        let config = ward_config();
+        // First request bootstraps baselines.
+        gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+
+        // SOUL.md drifts outside the authority path.
+        std::fs::write(f.workspace.join("SOUL.md"), "# SOUL\nI am Mallory.\n").unwrap();
+
+        let report = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+
+        let GateOutcome::Staged { pending_path, .. } = &report.outcome else {
+            panic!("expected Staged, got {report:?}");
+        };
+        assert!(pending_path.exists(), "pending file must exist");
+        let staged: threads::PendingProposal =
+            serde_json::from_slice(&std::fs::read(pending_path).unwrap()).unwrap();
+        assert_eq!(staged.edits.len(), 1);
+        assert!(matches!(
+            staged.fray,
+            threads::FrayOrSnap::Frayed {
+                reason: threads::FrayReason::ManifestEntryMismatch,
+                ..
+            }
+        ));
+        // The protected surface itself is untouched by staging.
+        let disk = std::fs::read_to_string(f.workspace.join("SOUL.md")).unwrap();
+        assert!(
+            disk.contains("Mallory"),
+            "staging must not write the surface"
+        );
+        // Audit trail carries the degrade decision.
+        let decision: String = f
+            .conn
+            .query_row(
+                "SELECT decision FROM ward_audit WHERE familiar_id='sage' \
+                 ORDER BY id DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(decision, "degrade_to_proposal");
+    }
+
+    #[test]
+    fn drift_on_sibling_surface_does_not_stop_healthy_surface() {
+        // §2.2: degradation is local to the drifted surface; the familiar
+        // continues on other surfaces.
+        let f = fixture();
+        let config = ward_config();
+        gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+        std::fs::write(f.workspace.join("IDENTITY.md"), "# IDENTITY drifted\n").unwrap();
+
+        let report = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(report.outcome, GateOutcome::Permitted),
+            "healthy SOUL.md must permit despite IDENTITY.md drift: {report:?}"
+        );
+    }
+
+    #[test]
+    fn ward_audit_is_append_only() {
+        let f = fixture();
+        gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &ward_config(),
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+        // RFC-0001 §5.6: entries MUST NOT be deleted or modified — the store
+        // itself aborts, regardless of caller discipline.
+        let update = f
+            .conn
+            .execute("UPDATE ward_audit SET decision = 'permit'", []);
+        assert!(update.is_err(), "UPDATE must abort on ward_audit");
+        let delete = f.conn.execute("DELETE FROM ward_audit", []);
+        assert!(delete.is_err(), "DELETE must abort on ward_audit");
+    }
+
+    #[test]
+    fn no_protected_targets_is_a_noop_permit() {
+        let f = fixture();
+        let report = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &ward_config(),
+                edits: &[ward::FileEdit::new("notes/today.md", "hello")],
+                gated_targets: &[],
+                authorization: &ward::Authorization::unsigned(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(report.outcome, GateOutcome::Permitted));
+        assert!(report.verdicts.is_empty());
+        let count: i64 = f
+            .conn
+            .query_row("SELECT COUNT(*) FROM ward_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0, "editable-tier writes are not the weave's lane");
+    }
+}

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -331,18 +331,50 @@ fn familiar_weave_id(familiar_id: &str) -> threads::FamiliarId {
     ))
 }
 
+/// Read a protected surface's current content for baseline comparison.
+///
+/// `surface` strings come from `ward.toml` declarations and Gate-2-resolved
+/// targets. Resolved targets are already confined, but ward.toml literals are
+/// only operator-authored convention — so this function re-enforces
+/// confinement itself (fail-closed, review finding): no absolute paths, no
+/// `..`/`.` segments, and the read is capped so a pathological declaration
+/// cannot balloon memory.
 fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
+    const MAX_SURFACE_BYTES: u64 = 16 * 1024 * 1024;
+
+    if surface.starts_with('/') || surface.starts_with('\\') {
+        anyhow::bail!("protected surface `{surface}` must be workspace-relative");
+    }
     let mut path = workspace.to_path_buf();
     for segment in surface.split('/').filter(|s| !s.is_empty()) {
+        if segment == ".." || segment == "." || segment.contains('\\') || segment.contains(':') {
+            anyhow::bail!(
+                "protected surface `{surface}` contains a path-escaping segment; \
+                 declarations must stay inside the familiar workspace"
+            );
+        }
         path.push(segment);
     }
-    match std::fs::read(&path) {
-        Ok(bytes) => Ok(bytes),
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
         // An absent protected file baselines as empty: creating it later is
         // drift like any other content change.
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
-        Err(err) => Err(err).with_context(|| format!("reading surface {}", path.display())),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(err).with_context(|| format!("inspecting surface {}", path.display()))
+        }
+    };
+    // Only regular files are hashable surfaces; a symlinked or special-file
+    // surface is refused rather than followed out of the workspace.
+    if !metadata.is_file() {
+        anyhow::bail!("protected surface `{surface}` is not a regular file inside the workspace");
     }
+    if metadata.len() > MAX_SURFACE_BYTES {
+        anyhow::bail!(
+            "protected surface `{surface}` exceeds the {MAX_SURFACE_BYTES}-byte baseline cap"
+        );
+    }
+    std::fs::read(&path).with_context(|| format!("reading surface {}", path.display()))
 }
 
 fn load_or_create_manifest_id(conn: &Connection, familiar_id: &str) -> Result<threads::ManifestId> {
@@ -761,6 +793,124 @@ tier = 2
         assert!(update.is_err(), "UPDATE must abort on ward_audit");
         let delete = f.conn.execute("DELETE FROM ward_audit", []);
         assert!(delete.is_err(), "DELETE must abort on ward_audit");
+    }
+
+    #[test]
+    fn traversal_surface_declarations_are_refused() {
+        // Review finding: ward.toml surface strings were joined with
+        // PathBuf::push, so ".." segments escaped the workspace. read_surface
+        // now fail-closes on escaping declarations instead of reading outside.
+        let f = fixture();
+        // A secret outside the workspace that a poisoned ward.toml might aim at.
+        std::fs::write(f.coven_home.join("outside-secret.txt"), b"secret").unwrap();
+
+        let config = ward::WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val-1"
+protected_surface = ["../outside-secret.txt"]
+default_tier = 2
+
+[[surface]]
+path = "../outside-secret.txt"
+tier = 0
+"#,
+        )
+        .expect("ward config parses");
+
+        let err = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &[ward::FileEdit::new("SOUL.md", "x")],
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .expect_err("escaping declaration must refuse");
+        let message = format!("{err:#}");
+        assert!(
+            message.contains("path-escaping"),
+            "error should name the escape: {message}"
+        );
+        // Fail-closed: nothing was audited or staged for the refused run.
+        let count: i64 = f
+            .conn
+            .query_row("SELECT COUNT(*) FROM ward_audit", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn absolute_surface_declarations_are_refused() {
+        let f = fixture();
+        let config = ward::WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val-1"
+protected_surface = ["/etc/hosts"]
+default_tier = 2
+
+[[surface]]
+path = "/etc/hosts"
+tier = 0
+"#,
+        )
+        .expect("ward config parses");
+
+        let err = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &[ward::FileEdit::new("SOUL.md", "x")],
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .expect_err("absolute declaration must refuse");
+        assert!(format!("{err:#}").contains("workspace-relative"));
+    }
+
+    #[test]
+    fn symlinked_surface_is_refused_not_followed() {
+        let f = fixture();
+        std::fs::write(f.coven_home.join("outside-secret.txt"), b"secret").unwrap();
+        std::os::unix::fs::symlink(
+            f.coven_home.join("outside-secret.txt"),
+            f.workspace.join("LINKED.md"),
+        )
+        .unwrap();
+        let config = ward::WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val-1"
+protected_surface = ["LINKED.md"]
+default_tier = 2
+
+[[surface]]
+path = "LINKED.md"
+tier = 0
+"#,
+        )
+        .expect("ward config parses");
+
+        let err = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &[ward::FileEdit::new("LINKED.md", "x")],
+                gated_targets: &["LINKED.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .expect_err("symlinked surface must refuse");
+        assert!(format!("{err:#}").contains("not a regular file"));
     }
 
     #[test]

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -912,6 +912,7 @@ tier = 0
         assert!(format!("{err:#}").contains("workspace-relative"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn symlinked_surface_is_refused_not_followed() {
         let f = fixture();
@@ -950,6 +951,7 @@ tier = 0
         assert!(format!("{err:#}").contains("not a regular file"));
     }
 
+    #[cfg(unix)]
     #[test]
     fn symlinked_ancestor_directory_is_refused() {
         // Second review pass finding: symlink_metadata only guards the final

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -337,8 +337,9 @@ fn familiar_weave_id(familiar_id: &str) -> threads::FamiliarId {
 /// targets. Resolved targets are already confined, but ward.toml literals are
 /// only operator-authored convention — so this function re-enforces
 /// confinement itself (fail-closed, review finding): no absolute paths, no
-/// `..`/`.` segments, and the read is capped so a pathological declaration
-/// cannot balloon memory.
+/// `..`/`.` segments, no symlinks anywhere in the path (intermediate
+/// directories included), and the read is capped so a pathological
+/// declaration cannot balloon memory.
 fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
     const MAX_SURFACE_BYTES: u64 = 16 * 1024 * 1024;
 
@@ -355,6 +356,42 @@ fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
         }
         path.push(segment);
     }
+
+    // Intermediate symlinks: `symlink_metadata` below only protects the final
+    // component, so canonicalize the deepest *existing* ancestor and require
+    // it to stay inside the canonical workspace (second review pass finding —
+    // `linkdir/secret` with `linkdir` pointing outside must refuse).
+    let canonical_workspace = workspace.canonicalize().with_context(|| {
+        format!(
+            "familiar workspace `{}` is not resolvable",
+            workspace.display()
+        )
+    })?;
+    let mut ancestor = path.parent();
+    let deepest_existing = loop {
+        match ancestor {
+            Some(candidate) => match candidate.canonicalize() {
+                Ok(resolved) => break Some(resolved),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    ancestor = candidate.parent();
+                }
+                Err(err) => {
+                    return Err(err).with_context(|| {
+                        format!("resolving ancestor of surface {}", path.display())
+                    })
+                }
+            },
+            None => break None,
+        }
+    };
+    match deepest_existing {
+        Some(resolved) if resolved.starts_with(&canonical_workspace) => {}
+        _ => anyhow::bail!(
+            "protected surface `{surface}` resolves outside the familiar workspace \
+             (symlinked ancestor?); declarations must stay inside it"
+        ),
+    }
+
     let metadata = match std::fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
         // An absent protected file baselines as empty: creating it later is
@@ -911,6 +948,91 @@ tier = 0
         )
         .expect_err("symlinked surface must refuse");
         assert!(format!("{err:#}").contains("not a regular file"));
+    }
+
+    #[test]
+    fn symlinked_ancestor_directory_is_refused() {
+        // Second review pass finding: symlink_metadata only guards the final
+        // component. A surface like "linkdir/secret" where linkdir points
+        // outside the workspace must refuse, not read through the link.
+        let f = fixture();
+        let outside = f.coven_home.join("outside-dir");
+        std::fs::create_dir_all(&outside).unwrap();
+        std::fs::write(outside.join("secret.md"), b"secret").unwrap();
+        std::os::unix::fs::symlink(&outside, f.workspace.join("linkdir")).unwrap();
+
+        let config = ward::WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val-1"
+protected_surface = ["linkdir/secret.md"]
+default_tier = 2
+
+[[surface]]
+path = "linkdir/secret.md"
+tier = 0
+"#,
+        )
+        .expect("ward config parses");
+
+        let err = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &[ward::FileEdit::new("linkdir/secret.md", "x")],
+                gated_targets: &["linkdir/secret.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .expect_err("symlinked ancestor must refuse");
+        assert!(
+            format!("{err:#}").contains("resolves outside"),
+            "error should name the escape: {err:#}"
+        );
+    }
+
+    #[test]
+    fn absent_nested_surface_still_baselines_as_empty() {
+        // The ancestor walk must not break the absent-surface convention: a
+        // declared surface in a not-yet-created subdirectory (no symlinks)
+        // baselines as empty rather than erroring.
+        let f = fixture();
+        let config = ward::WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val-1"
+protected_surface = ["SOUL.md", "identity/CORE.md"]
+default_tier = 2
+
+[[surface]]
+path = "SOUL.md"
+tier = 0
+
+[[surface]]
+path = "identity/CORE.md"
+tier = 0
+"#,
+        )
+        .expect("ward config parses");
+
+        let report = gate_protected_edits(
+            &f.conn,
+            &GateRequest {
+                coven_home: &f.coven_home,
+                familiar_id: "sage",
+                workspace: &f.workspace,
+                config: &config,
+                edits: &soul_edit(),
+                gated_targets: &["SOUL.md".to_string()],
+                authorization: &signed(),
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(report.outcome, GateOutcome::Permitted),
+            "{report:?}"
+        );
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -48,10 +48,13 @@ multiple-versions = "warn"
 wildcards = "deny"
 
 [sources]
-# Only the official crates.io registry is trusted, plus the first-party
-# OpenCoven runtime-spec crate (pinned to a release tag in Cargo.toml).
+# Only the official crates.io registry is trusted, plus first-party
+# OpenCoven crates (each pinned to a release tag in Cargo.toml).
 # Reject unknown registries and any other git sources.
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/OpenCoven/coven-runtimes"]
+allow-git = [
+    "https://github.com/OpenCoven/coven-runtimes",
+    "https://github.com/OpenCoven/coven-threads",
+]


### PR DESCRIPTION
## What this is

Phase 2 of **OpenCoven/coven-threads** (`specs/PHASE-0-DESIGN.md` §5/§6, RFC-0001 §5): the daemon imports `coven-threads-core` as a **first-class validator inside the Rust authority boundary**. The Ward already validated *who* (Gate 1) and *where a write really lands* (Gate 2); the weave now validates *what the target surface's authority state permits* — the gap named in the design doc §3.1.

## How it works

`POST /familiars/{id}/edits` (the daemon's only arbitrary-file write path into familiar homes) now runs, between `Ward::evaluate` and `Ward::apply`:

1. **Weave** the familiar's tier-0 surfaces: one thread per protected surface, strung with `ContentHash` + `ManifestEntry` + `SerializationMarker` strands over the `Forced` / `Serialization` / `Mutation` channels.
2. **Detect drift**: each surface's content is compared against the persisted baseline (`ward_manifest` table). Drifted surface → frayed thread.
3. **Validate** each protected target with `validate_fail_closed` — fail-closed on unknown surface, unbound writer, uncovered channel, *and validator panic* (RFC-0001 §5.4 Gate 4 is a line-one conformance property).
4. **Audit** every verdict into `ward_audit` in `coven.sqlite3` — single audit store (design §3.4), append-only enforced *by triggers in the schema*, not convention (RFC-0001 §5.6).
5. **Act on the verdict** (§5): `Permit` → continue to `Ward::apply` as today; `DegradeToProposal` → the whole proposal staged as a unit at `~/.coven/pending/` (nothing written, principal can inspect the pending file); `Reject` → 403.

## §6 compatibility contract

- Zero socket-protocol changes. Existing `applied` / `held` / `refused` wire shapes unchanged (one additive `threadsGate` detail field).
- `staged` is the **one** new disposition — exactly the `DegradeToProposal` outcome §6 reserves.
- Unsigned protected writes still 403 with the same error code; editable-tier writes never touch the weave.

## Dependency note (reviewer attention)

`coven-threads-core` is pinned to tag `v0.1.0` as a git dependency (same convention as `coven-runtime-spec`). The repo is currently **private** pending the visibility-flip decision, so:

- Local builds work via `.cargo/config.toml` → `net.git-fetch-with-cli = true` (ambient git credentials).
- **CI cannot fetch the dep until either the repo goes public or the workflow gets a read token.** Tracked as `threads-986.19` in the coven-threads beads; this PR stays draft until that decision lands.

## Evidence

- 6 `threads_gate` unit tests: bootstrap→permit, unsigned→reject, drift→staged (+pending file shape), sibling-drift localization, append-only triggers, editable no-op.
- 3 endpoint integration tests: signed protected edit → gate permit + audit row + held (unchanged shape); out-of-band drift → `staged` + pending file + surface untouched; editable tier → weave bypassed, zero audit rows.
- Full workspace: **1120 passed / 0 failed**; `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.

Refs: OpenCoven/coven-threads `threads-986.14` (Phase 2 epic), `threads-986.15` (permission gate), `threads-988`.