### PR TITLE
docs: link merge guide from docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -187,4 +187,7 @@ coven daemon restart
   <Card title="Roadmap" href="/ROADMAP" icon="map">
     Current milestones, adapter direction, and public product boundaries.
   </Card>
+  <Card title="Merge guide" href="/MERGE-GUIDE" icon="git-merge">
+    Claims, worktrees, local gates, scoped PRs, and squash-merge attribution.
+  </Card>
 </Columns>


### PR DESCRIPTION
## What

Adds a **Merge guide** card to the Learn more section of `docs/index.md`, surfacing the new `docs/MERGE-GUIDE.md` (landed in #372) from the docs landing page.

## Why

#372 added the guide but nothing linked to it from the index — contributors would only find it by browsing the docs directory.

## Verification (docs-only)

- `git diff --check` — clean
- gitleaks pre-commit hook — 0 findings
- 3-line diff; card format matches existing Learn more entries