### PR TITLE
docs(daemon): cloud-host runbook + systemd unit for a hosted familiar

### DIFF
--- a/docs/daemon/cloud-host-runbook.md
+++ b/docs/daemon/cloud-host-runbook.md
@@ -1,0 +1,133 @@
+---
+summary: "Run one always-on Coven daemon on a cloud VM, reachable only over your Tailnet."
+read_when:
+  - Hosting a familiar you reach from your phone or another machine
+  - Standing up an always-on daemon on a server
+title: "Cloud host runbook"
+description: "Minimal-lift runbook for hosting the Coven daemon on a cloud VM: a single systemd-supervised `coven daemon serve` bound to loopback, fronted by Tailscale so the unauthenticated API is never exposed to the public internet."
+---
+
+Host one familiar as an always-on daemon on a cheap VM and reach it from
+anywhere on your Tailnet. No new service to build — the "cloud agent" is just
+`coven daemon serve` under systemd.
+
+## Trust model (read this first)
+
+The daemon's HTTP API is **unauthenticated** — the `--tcp` flag's own help says
+so. Its only auth check is filesystem permissions on the local socket
+(see [Auth posture](/daemon/auth-posture) and [Trust boundary](/daemon/trust-boundary)).
+
+So the network boundary is **Tailscale**, not the daemon:
+
+- Bind the TCP API to `127.0.0.1` only. Never a `0.0.0.0` or public address.
+- Tailscale (WireGuard, device-authenticated) is what carries remote traffic.
+- The host firewall blocks the public interface as a backstop.
+
+Do not "just open port 3000." Anyone who reaches that port owns your familiar.
+
+## What you need
+
+- A small Linux VM (1 vCPU / 1 GB is plenty to start). Ubuntu/Debian assumed.
+- A [Tailscale](https://tailscale.com) account (free tier is fine).
+- Coven **v0.0.40 or newer** — earlier builds have the socket-takeover orphan
+  storm. Confirm with `coven --version`.
+
+## 1. Create a service user + install the binary
+
+```sh
+sudo useradd --system --create-home --home-dir /var/lib/coven --shell /usr/sbin/nologin coven
+# Install the coven binary to /usr/local/bin (adjust to your install method):
+sudo install -m 0755 ./coven /usr/local/bin/coven
+coven --version   # must be >= v0.0.40
+```
+
+`COVEN_HOME` will be `/var/lib/coven` (set in the unit). That is where the
+SQLite ledger, event log, and socket live — see [COVEN_HOME](/daemon/coven-home).
+
+## 2. Install the systemd unit
+
+Copy [`coven-daemon.service`](https://github.com/OpenCoven/coven/blob/main/docs/daemon/coven-daemon.service)
+to `/etc/systemd/system/`, then:
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now coven-daemon
+systemctl status coven-daemon        # should be active (running)
+```
+
+Confirm the API is up on loopback:
+
+```sh
+curl -fsS http://127.0.0.1:3000/api/v1/health | jq .
+```
+
+You should get the health envelope (see [Health](/daemon/health)). If it fails,
+tail logs with `journalctl -u coven-daemon -f` and see [Logs](/daemon/logs).
+
+## 3. Front it with Tailscale
+
+Install Tailscale and join the VM to your Tailnet:
+
+```sh
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --hostname coven-host
+```
+
+Now expose the loopback API **into the Tailnet only** — the daemon stays bound
+to `127.0.0.1`; `tailscale serve` proxies to it:
+
+```sh
+sudo tailscale serve --bg http://127.0.0.1:3000
+```
+
+From any other device on your Tailnet:
+
+```sh
+curl -fsS https://coven-host.<your-tailnet>.ts.net/api/v1/health
+```
+
+That URL is your familiar in the cloud. It is reachable only by devices you have
+authorized in Tailscale, over an encrypted WireGuard link, and Tailscale
+terminates TLS for you.
+
+## 4. Lock the public interface (backstop)
+
+Even with loopback binding, close everything but SSH and let Tailscale carry the
+rest:
+
+```sh
+sudo ufw default deny incoming
+sudo ufw allow ssh
+sudo ufw allow in on tailscale0
+sudo ufw enable
+```
+
+Port 3000 is never allowed from the public interface — it does not need to be,
+because the API only listens on `127.0.0.1`.
+
+## Operating it
+
+| Task | Command |
+| --- | --- |
+| Status | `systemctl status coven-daemon` / `coven daemon status` |
+| Follow logs | `journalctl -u coven-daemon -f` |
+| Restart | `sudo systemctl restart coven-daemon` |
+| Stop | `sudo systemctl stop coven-daemon` |
+| Effective COVEN_HOME | `sudo -u coven COVEN_HOME=/var/lib/coven coven doctor` |
+| Upgrade | stop, replace binary, start — see [Upgrades](/daemon/upgrades) |
+
+### One instance only
+
+systemd owns supervision. Do **not** run `coven daemon serve` or `coven daemon
+start` by hand on this host — a second `serve` against the live socket is the
+exact orphan-storm failure mode that older builds hit. If the daemon wedges,
+`systemctl restart coven-daemon` and check [Orphan recovery](/daemon/orphan-recovery).
+
+## When you outgrow this
+
+This is the minimal footing: one host, one familiar, loopback + Tailnet. When
+you want push to iOS, multi-peer routing, or an authenticated public surface,
+that is the `coven-relay` WebSocket relay's job (still a scaffold as of writing)
+— not a wider bind on this daemon. Keep `--tcp` on loopback regardless.
+
+See [Remote access](/daemon/remote-access) and [Safety model](/daemon/safety-model).

--- a/docs/daemon/coven-daemon.service
+++ b/docs/daemon/coven-daemon.service
@@ -1,0 +1,47 @@
+# coven-daemon.service — always-on Coven daemon for a cloud host.
+#
+# Install: /etc/systemd/system/coven-daemon.service
+# Runs `coven daemon serve` in the foreground under a dedicated, unprivileged
+# user, binding an UNAUTHENTICATED HTTP API to loopback only. The network
+# boundary is Tailscale, NOT this process — never change --tcp to a non-loopback
+# address. See cloud-host-runbook.md for the full deploy.
+
+[Unit]
+Description=Coven daemon (familiar runtime, loopback HTTP API)
+Documentation=https://github.com/OpenCoven/coven/blob/main/docs/daemon/cloud-host-runbook.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=coven
+Group=coven
+
+# systemd creates/owns /var/lib/coven (0700) for this user on start.
+StateDirectory=coven
+StateDirectoryMode=0700
+Environment=COVEN_HOME=/var/lib/coven
+
+# The one and only daemon instance on this host. The API is unauthenticated,
+# so it MUST bind loopback. Tailscale (see runbook) fronts it for remote reach.
+ExecStart=/usr/local/bin/coven daemon serve --tcp 127.0.0.1:3000
+
+# Single-instance discipline: coven refuses to take over a healthy socket, but
+# let systemd own supervision so nothing else spawns a second `daemon serve`.
+Restart=on-failure
+RestartSec=3
+TimeoutStopSec=30
+
+# --- Light hardening -------------------------------------------------------
+# Kept deliberately modest: a familiar runs agent workloads (PTYs, spawns
+# harnesses, writes into working repos). Aggressive sandboxing (ProtectSystem=
+# strict, SystemCallFilter, ProtectHome) WILL break those. Add more only after
+# you have confirmed your workloads still run.
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectKernelTunables=yes
+RestartPreventExitStatus=
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/daemon/coven-daemon.service
+++ b/docs/daemon/coven-daemon.service
@@ -41,7 +41,6 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 ProtectControlGroups=yes
 ProtectKernelTunables=yes
-RestartPreventExitStatus=
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/daemon/coven-daemon.service
+++ b/docs/daemon/coven-daemon.service
@@ -15,7 +15,6 @@ Wants=network-online.target
 [Service]
 Type=simple
 User=coven
-Group=coven
 
 # systemd creates/owns /var/lib/coven (0700) for this user on start.
 StateDirectory=coven

--- a/docs/daemon/index.md
+++ b/docs/daemon/index.md
@@ -76,5 +76,6 @@ The daemon validates every request, even from local clients. See [Authority boun
 - [Configuration](/daemon/configuration)
 - [Auth posture](/daemon/auth-posture)
 - [Remote access](/daemon/remote-access)
+- [Cloud host runbook](/daemon/cloud-host-runbook)
 - [Logs](/daemon/logs)
 - [Diagnostics](/daemon/diagnostics)

--- a/docs/daemon/remote-access.md
+++ b/docs/daemon/remote-access.md
@@ -6,4 +6,29 @@ title: "Remote access"
 description: "Guidance for exposing the Coven daemon socket beyond same-user local trust, and why remote access requires explicit transport instead of OAuth or tokens."
 ---
 
-Stub — fill in. See [Daemon overview](/daemon/index).
+The daemon exposes no OAuth, tokens, or cookies — its only auth check is local
+filesystem permissions on the socket (see [Auth posture](/daemon/auth-posture)).
+So reaching it from another machine means providing your own authenticated
+transport, never widening the daemon's own bind.
+
+Two patterns, both keeping the API on loopback:
+
+- **SSH tunnel** — ad hoc, nothing to install on the server:
+
+  ```sh
+  # On the client: forward local 3000 to the remote daemon's loopback API.
+  ssh -N -L 3000:127.0.0.1:3000 you@your-host
+  curl -fsS http://127.0.0.1:3000/api/v1/health
+  ```
+
+  Requires `coven daemon serve --tcp 127.0.0.1:3000` running on the host.
+
+- **Tailscale** — always-on, reachable from your phone and every device on your
+  Tailnet. This is the recommended setup for a hosted familiar; the full,
+  systemd-supervised deploy is in the
+  [Cloud host runbook](/daemon/cloud-host-runbook).
+
+Never bind `--tcp` to a non-loopback or public address to achieve remote access
+— the API is unauthenticated. Let SSH or Tailscale be the boundary.
+
+See [Daemon overview](/daemon/index) and [Safety model](/daemon/safety-model).


### PR DESCRIPTION
## What

Documents the minimal-lift path to run **one always-on Coven daemon on a cloud VM** — an "access your familiar in the cloud" setup — using only what the daemon already ships (`coven daemon serve --tcp`). No new service.

## Files

- **`docs/daemon/coven-daemon.service`** — systemd unit: dedicated `coven` user, `COVEN_HOME=/var/lib/coven` via `StateDirectory`, `--tcp 127.0.0.1:3000`, `Restart=on-failure`, and *deliberately light* sandboxing (a familiar runs agent workloads — PTYs, harness spawns, repo writes — that `ProtectSystem=strict`/syscall filters would break).
- **`docs/daemon/cloud-host-runbook.md`** — service user → install unit → `tailscale serve` → UFW backstop → operate/upgrade table.
- **`docs/daemon/remote-access.md`** — fills the former stub with SSH-tunnel + Tailscale patterns.
- **`docs/daemon/index.md`** — registers the runbook under Related.

## Key design decision

The `--tcp` API is **unauthenticated** (per the flag's own help), so the network boundary is **Tailscale, not the daemon**: bind loopback only, `tailscale serve` proxies the Tailnet → localhost, UFW closes the public interface. Nothing ever listens on a public address. Runbook also enforces single-instance discipline and a **v0.0.40 floor** for the socket-takeover fix.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)