### PR TITLE
feat(daemon): add `--allow-host` for hosted-familiar Tailscale access (#398)

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1746,6 +1746,7 @@ pub fn serve_next_tcp_connection(
     coven_home: &Path,
     status: Option<DaemonStatus>,
     runtime: &dyn SessionRuntime,
+    allowed_hosts: &[String],
 ) -> Result<()> {
     let (stream, _) = listener
         .accept()
@@ -1764,7 +1765,7 @@ pub fn serve_next_tcp_connection(
         status,
         runtime,
         Some(MAX_TCP_BODY_BYTES),
-        true,
+        HostGuard::Loopback { allowed_hosts },
     )
 }
 
@@ -2016,8 +2017,18 @@ fn acquire_serve_lock(coven_home: &Path) -> Result<std::fs::File> {
 }
 
 #[cfg(unix)]
-pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&str>) -> Result<()> {
+pub fn serve_forever(
+    coven_home: &Path,
+    started_at: String,
+    tcp_addr: Option<&str>,
+    allowed_hosts: &[String],
+) -> Result<()> {
     use std::sync::Arc;
+    // `--allow-host` only widens the TCP guard; it is meaningless without `--tcp`.
+    // Warn rather than fail so a stray flag doesn't take the daemon down.
+    if !allowed_hosts.is_empty() && tcp_addr.is_none() {
+        eprintln!("coven daemon: --allow-host has no effect without --tcp; ignoring");
+    }
     // First thing, before touching the socket or the store: take the
     // single-writer serve lock and hold it for the whole process lifetime. It
     // is the authoritative guard against two daemons writing one SQLite store —
@@ -2068,6 +2079,7 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
         let tcp_home = coven_home.to_path_buf();
         let tcp_status = status.clone();
         let tcp_runtime = Arc::clone(&runtime);
+        let tcp_allowed_hosts: Vec<String> = allowed_hosts.to_vec();
         // TCP accept errors are logged and the loop continues — misbehaving
         // network clients should not bring down the daemon. The Unix loop
         // below uses the same strategy: a single malformed local request must
@@ -2080,6 +2092,7 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
                     &tcp_home,
                     Some(tcp_status.clone()),
                     tcp_runtime.as_ref(),
+                    &tcp_allowed_hosts,
                 ) {
                     // A client hanging up mid-response is expected under SSE +
                     // polling load; don't log it or throttle the accept loop.
@@ -2174,6 +2187,16 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
     }
 }
 
+/// Whether `handle_http_stream` runs its CSRF/DNS-rebinding guard, and if so
+/// which non-loopback hosts it tolerates. The Unix socket is filesystem-gated
+/// and skips the check (`Disabled`); the TCP transport enforces loopback plus
+/// the operator's `--allow-host` allowlist (`Loopback`).
+#[derive(Clone, Copy)]
+enum HostGuard<'a> {
+    Disabled,
+    Loopback { allowed_hosts: &'a [String] },
+}
+
 fn handle_http_stream<R, W>(
     read: R,
     mut write: W,
@@ -2181,7 +2204,7 @@ fn handle_http_stream<R, W>(
     status: Option<DaemonStatus>,
     runtime: &dyn SessionRuntime,
     max_body_bytes: Option<usize>,
-    enforce_loopback_guard: bool,
+    guard: HostGuard<'_>,
 ) -> Result<()>
 where
     R: Read,
@@ -2194,12 +2217,22 @@ where
     // and DNS-rebinding: a real CLI/proxy client never sends a cross-origin
     // Origin, and a rebinding attack arrives with a non-loopback Host. The Unix
     // socket is filesystem-gated and skips this.
-    if enforce_loopback_guard {
-        if !host_is_loopback(headers.host.as_deref()) {
-            return write_forbidden(&mut write, "Host header must be a loopback address.");
+    //
+    // `allowed_hosts` (from `--allow-host`) widens the guard by an exact-match
+    // allowlist so a trusted reverse proxy — e.g. `tailscale serve`, which
+    // forwards a fixed tailnet FQDN it cannot rewrite — can reach the API. The
+    // bind stays loopback and the API stays unauthenticated; the operator is
+    // asserting an authenticated transport (Tailscale/SSH) fronts that host.
+    if let HostGuard::Loopback { allowed_hosts } = guard {
+        let host = headers.host.as_deref();
+        if !host_is_loopback(host) && !host_in_allowlist(host, allowed_hosts) {
+            return write_forbidden(
+                &mut write,
+                "Host header must be a loopback or allowed address.",
+            );
         }
         if let Some(origin) = headers.origin.as_deref() {
-            if !origin_is_loopback(origin) {
+            if !origin_is_loopback(origin) && !origin_in_allowlist(origin, allowed_hosts) {
                 return write_forbidden(&mut write, "Cross-origin requests are not allowed.");
             }
         }
@@ -2259,6 +2292,36 @@ fn host_is_loopback(host: Option<&str>) -> bool {
 fn origin_is_loopback(origin: &str) -> bool {
     match origin.trim().split_once("://") {
         Some((_scheme, rest)) => is_loopback_host(strip_port(rest)),
+        None => false,
+    }
+}
+
+/// Exact (case-insensitive, port-insensitive) match of a request `Host` against
+/// the `--allow-host` allowlist. Hostnames are case-insensitive; ports are
+/// stripped on both sides. No wildcards — a rebinding attacker must control the
+/// exact host the operator vouched for, which they cannot forge over the
+/// authenticated transport that fronts it.
+fn host_in_allowlist(host: Option<&str>, allowed: &[String]) -> bool {
+    match host {
+        Some(h) => {
+            let h = strip_port(h.trim());
+            allowed
+                .iter()
+                .any(|a| strip_port(a.trim()).eq_ignore_ascii_case(h))
+        }
+        None => false,
+    }
+}
+
+/// Same allowlist check applied to a request `Origin` (`scheme://host[:port]`).
+fn origin_in_allowlist(origin: &str, allowed: &[String]) -> bool {
+    match origin.trim().split_once("://") {
+        Some((_scheme, rest)) => {
+            let h = strip_port(rest);
+            allowed
+                .iter()
+                .any(|a| strip_port(a.trim()).eq_ignore_ascii_case(h))
+        }
         None => false,
     }
 }
@@ -2345,7 +2408,7 @@ fn serve_accepted_connection(
         status,
         runtime,
         Some(MAX_SOCKET_BODY_BYTES),
-        false,
+        HostGuard::Disabled,
     )
 }
 
@@ -2449,7 +2512,12 @@ pub(crate) fn windows_pipe_name(coven_home: &Path) -> String {
 }
 
 #[cfg(windows)]
-pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&str>) -> Result<()> {
+pub fn serve_forever(
+    coven_home: &Path,
+    started_at: String,
+    tcp_addr: Option<&str>,
+    allowed_hosts: &[String],
+) -> Result<()> {
     use interprocess::{
         local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
         os::windows::local_socket::ListenerOptionsExt,
@@ -2460,6 +2528,7 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
     };
 
     let _ = tcp_addr; // TCP not wired on Windows in this prototype
+    let _ = allowed_hosts; // only meaningful on the (Unix) TCP transport
 
     let status = DaemonStatus {
         pid: std::process::id(),
@@ -2511,7 +2580,7 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
                 Some(conn_status),
                 conn_runtime.as_ref(),
                 Some(MAX_SOCKET_BODY_BYTES),
-                false,
+                HostGuard::Disabled,
             ) {
                 if !is_client_disconnect(&error) {
                     eprintln!("coven daemon: pipe connection error: {error:#}");
@@ -2536,7 +2605,7 @@ pub fn serve_forever(coven_home: &Path, started_at: String, tcp_addr: Option<&st
                     Some(conn_status),
                     conn_runtime.as_ref(),
                     Some(MAX_SOCKET_BODY_BYTES),
-                    false,
+                    HostGuard::Disabled,
                 ) {
                     if !is_client_disconnect(&error) {
                         eprintln!("coven daemon: pipe connection error: {error:#}");
@@ -2952,7 +3021,7 @@ mod tests {
             None,
             &runtime,
             None,
-            false,
+            HostGuard::Disabled,
         )
         .expect("handle ok");
         let response = String::from_utf8(output).expect("utf8");
@@ -2983,7 +3052,7 @@ mod tests {
             None,
             &runtime,
             Some(MAX_TCP_BODY_BYTES),
-            false,
+            HostGuard::Disabled,
         )
         .expect("handle ok");
         let response = String::from_utf8(output).expect("utf8");
@@ -3011,7 +3080,7 @@ mod tests {
             None,
             &NoopSessionRuntime,
             Some(MAX_TCP_BODY_BYTES),
-            true,
+            HostGuard::Loopback { allowed_hosts: &[] },
         )
         .expect("handle ok");
         let response = String::from_utf8(output).expect("utf8");
@@ -3038,7 +3107,7 @@ mod tests {
             None,
             &NoopSessionRuntime,
             Some(MAX_TCP_BODY_BYTES),
-            true,
+            HostGuard::Loopback { allowed_hosts: &[] },
         )
         .expect("handle ok");
         let response = String::from_utf8(output).expect("utf8");
@@ -3046,6 +3115,94 @@ mod tests {
             response.starts_with("HTTP/1.1 403 Forbidden"),
             "got: {response}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handle_http_stream_allow_host_permits_listed_host_and_origin() {
+        use crate::api::NoopSessionRuntime;
+        use std::io::Cursor;
+        let temp = tempfile::tempdir().expect("tempdir");
+        ensure_private_coven_home(temp.path()).expect("ensure home");
+        // A Tailscale-served request: the proxy forwards the tailnet FQDN as both
+        // Host and Origin. Neither is loopback, but both are on the allowlist.
+        let request = b"GET /api/v1/health HTTP/1.1\r\nHost: coven-host.taile46e90.ts.net\r\nOrigin: https://coven-host.taile46e90.ts.net\r\n\r\n";
+        let mut stream = Cursor::new(Vec::from(&request[..]));
+        let mut output: Vec<u8> = Vec::new();
+        let allowed = vec!["coven-host.taile46e90.ts.net".to_string()];
+        handle_http_stream(
+            &mut stream,
+            &mut output,
+            temp.path(),
+            None,
+            &NoopSessionRuntime,
+            Some(MAX_TCP_BODY_BYTES),
+            HostGuard::Loopback {
+                allowed_hosts: &allowed,
+            },
+        )
+        .expect("handle ok");
+        let response = String::from_utf8(output).expect("utf8");
+        assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handle_http_stream_allow_host_still_blocks_unlisted_host() {
+        use crate::api::NoopSessionRuntime;
+        use std::io::Cursor;
+        let temp = tempfile::tempdir().expect("tempdir");
+        ensure_private_coven_home(temp.path()).expect("ensure home");
+        // Allowlisting one host must not open the guard for a different one.
+        let request = b"GET /api/v1/health HTTP/1.1\r\nHost: evil.example\r\n\r\n";
+        let mut stream = Cursor::new(Vec::from(&request[..]));
+        let mut output: Vec<u8> = Vec::new();
+        let allowed = vec!["coven-host.taile46e90.ts.net".to_string()];
+        handle_http_stream(
+            &mut stream,
+            &mut output,
+            temp.path(),
+            None,
+            &NoopSessionRuntime,
+            Some(MAX_TCP_BODY_BYTES),
+            HostGuard::Loopback {
+                allowed_hosts: &allowed,
+            },
+        )
+        .expect("handle ok");
+        let response = String::from_utf8(output).expect("utf8");
+        assert!(
+            response.starts_with("HTTP/1.1 403 Forbidden"),
+            "got: {response}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn host_and_origin_allowlist_match_is_case_and_port_insensitive() {
+        let allowed = vec!["Coven-Host.Taile46E90.TS.net".to_string()];
+        // Host: case-insensitive, and a forwarded port must not defeat the match.
+        assert!(host_in_allowlist(
+            Some("coven-host.taile46e90.ts.net:3000"),
+            &allowed
+        ));
+        assert!(host_in_allowlist(
+            Some("COVEN-HOST.TAILE46E90.TS.NET"),
+            &allowed
+        ));
+        // Origin: scheme is stripped, host compared the same way.
+        assert!(origin_in_allowlist(
+            "https://coven-host.taile46e90.ts.net",
+            &allowed
+        ));
+        // Non-members and an empty allowlist never match.
+        assert!(!host_in_allowlist(Some("evil.example"), &allowed));
+        assert!(!host_in_allowlist(
+            Some("coven-host.taile46e90.ts.net"),
+            &[]
+        ));
+        assert!(!host_in_allowlist(None, &allowed));
+        assert!(!origin_in_allowlist("https://evil.example", &allowed));
     }
 
     #[cfg(unix)]
@@ -3082,7 +3239,7 @@ mod tests {
             None,
             &NoopSessionRuntime,
             Some(MAX_TCP_BODY_BYTES),
-            true,
+            HostGuard::Loopback { allowed_hosts: &[] },
         )
         .expect("handle ok");
         let response = String::from_utf8(output).expect("utf8");
@@ -3106,7 +3263,7 @@ mod tests {
             None,
             &NoopSessionRuntime,
             None,
-            false,
+            HostGuard::Disabled,
         )
         .expect("handle ok");
         let response = String::from_utf8(output).expect("utf8");
@@ -3127,7 +3284,8 @@ mod tests {
         let coven_home = temp.path().to_path_buf();
         let server = thread::spawn(move || {
             let runtime = NoopSessionRuntime;
-            serve_next_tcp_connection(&listener, &coven_home, None, &runtime).expect("serve tcp");
+            serve_next_tcp_connection(&listener, &coven_home, None, &runtime, &[])
+                .expect("serve tcp");
         });
 
         let mut client = TcpStream::connect(addr).expect("connect");
@@ -4173,7 +4331,7 @@ mod tests {
                     Some(status.clone()),
                     &runtime,
                     None,
-                    false,
+                    HostGuard::Disabled,
                 )?;
             }
             Ok::<_, anyhow::Error>(())

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -599,6 +599,17 @@ enum DaemonCommand {
                     interfaces or untrusted networks."
         )]
         tcp: Option<String>,
+        #[arg(
+            long = "allow-host",
+            value_name = "HOST",
+            help = "Also accept this Host/Origin header on the --tcp listener, in \
+                    addition to loopback (repeatable). For a trusted reverse proxy \
+                    that forwards a fixed hostname it cannot rewrite — e.g. a \
+                    Tailscale-served FQDN. Exact host match. The API is still \
+                    unauthenticated, so only add a host fronted by an authenticated \
+                    transport (Tailscale/SSH); the bind stays loopback."
+        )]
+        allow_host: Vec<String>,
     },
 }
 
@@ -2597,18 +2608,19 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 println!("Coven daemon: was not running");
             }
         }
-        DaemonCommand::Serve { tcp } => {
+        DaemonCommand::Serve { tcp, allow_host } => {
             #[cfg(unix)]
             {
-                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref())?;
+                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref(), &allow_host)?;
             }
             #[cfg(windows)]
             {
-                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref())?;
+                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref(), &allow_host)?;
             }
             #[cfg(not(any(unix, windows)))]
             {
                 let _ = tcp;
+                let _ = allow_host;
                 anyhow::bail!(
                     "coven daemon server is only implemented on Unix-like systems and Windows for now"
                 );

--- a/docs/daemon/cloud-host-runbook.md
+++ b/docs/daemon/cloud-host-runbook.md
@@ -73,8 +73,37 @@ curl -fsSL https://tailscale.com/install.sh | sh
 sudo tailscale up --hostname coven-host
 ```
 
-Now expose the loopback API **into the Tailnet only** — the daemon stays bound
-to `127.0.0.1`; `tailscale serve` proxies to it:
+Your familiar's Tailnet address is now `coven-host.<your-tailnet>.ts.net` (find
+`<your-tailnet>` with `tailscale status --json | jq -r .Self.DNSName`).
+
+**Allow that hostname on the daemon.** The TCP API defends against DNS-rebinding
+by rejecting any request whose `Host` header is not loopback — and `tailscale
+serve` forwards the original Tailnet FQDN, which it cannot rewrite. So without
+this step the proxied request 403s with `Host header must be a loopback or
+allowed address.` Add the FQDN to the daemon's allowlist with `--allow-host` (a
+systemd drop-in keeps the shipped unit intact):
+
+```sh
+sudo systemctl edit coven-daemon
+```
+
+In the editor, set (substitute your FQDN):
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/coven daemon serve --tcp 127.0.0.1:3000 \
+  --allow-host coven-host.<your-tailnet>.ts.net
+```
+
+```sh
+sudo systemctl restart coven-daemon
+```
+
+The bind stays on `127.0.0.1` and the API stays unauthenticated — `--allow-host`
+only tells the guard to trust that one proxied hostname; Tailscale is still the
+boundary. Now expose the loopback API **into the Tailnet only** — the daemon
+stays bound to `127.0.0.1`; `tailscale serve` proxies to it:
 
 ```sh
 sudo tailscale serve --bg http://127.0.0.1:3000
@@ -89,6 +118,10 @@ curl -fsS https://coven-host.<your-tailnet>.ts.net/api/v1/health
 That URL is your familiar in the cloud. It is reachable only by devices you have
 authorized in Tailscale, over an encrypted WireGuard link, and Tailscale
 terminates TLS for you.
+
+> Prefer not to allowlist a hostname? Skip `tailscale serve` and reach the
+> daemon over an **SSH tunnel** instead — it presents `Host: 127.0.0.1`, so the
+> loopback guard passes untouched. See [Remote access](/daemon/remote-access).
 
 ## 4. Lock the public interface (backstop)
 

--- a/docs/daemon/coven-daemon.service
+++ b/docs/daemon/coven-daemon.service
@@ -23,6 +23,10 @@ Environment=COVEN_HOME=/var/lib/coven
 
 # The one and only daemon instance on this host. The API is unauthenticated,
 # so it MUST bind loopback. Tailscale (see runbook) fronts it for remote reach.
+# To reach it over `tailscale serve`, append `--allow-host <fqdn>.ts.net` here
+# (a `systemctl edit` drop-in is cleanest) so the loopback guard trusts the
+# proxied Tailnet hostname — see cloud-host-runbook.md step 3. The SSH-tunnel
+# path needs no change.
 ExecStart=/usr/local/bin/coven daemon serve --tcp 127.0.0.1:3000
 
 # Single-instance discipline: coven refuses to take over a healthy socket, but

--- a/docs/daemon/remote-access.md
+++ b/docs/daemon/remote-access.md
@@ -21,12 +21,18 @@ Two patterns, both keeping the API on loopback:
   curl -fsS http://127.0.0.1:3000/api/v1/health
   ```
 
-  Requires `coven daemon serve --tcp 127.0.0.1:3000` running on the host.
+  Requires `coven daemon serve --tcp 127.0.0.1:3000` running on the host. The
+  tunnel presents `Host: 127.0.0.1`, so the daemon's loopback guard passes with
+  no extra configuration.
 
 - **Tailscale** — always-on, reachable from your phone and every device on your
   Tailnet. This is the recommended setup for a hosted familiar; the full,
   systemd-supervised deploy is in the
-  [Cloud host runbook](/daemon/cloud-host-runbook).
+  [Cloud host runbook](/daemon/cloud-host-runbook). One extra step versus the SSH
+  tunnel: `tailscale serve` forwards the Tailnet FQDN as the `Host` header, which
+  the loopback guard rejects, so start the daemon with `--allow-host
+  <host>.<your-tailnet>.ts.net` to trust that one proxied hostname. The bind
+  stays on loopback; Tailscale remains the boundary.
 
 Never bind `--tcp` to a non-loopback or public address to achieve remote access
 — the API is unauthenticated. Let SSH or Tailscale be the boundary.


### PR DESCRIPTION
## What & why

A hosted familiar fronted by `tailscale serve` (per the cloud-host runbook, #394) currently **403s** on every request:

```
{"ok":false,"error":{"code":"forbidden","message":"Host header must be a loopback address."}}
```

The TCP API's DNS-rebinding guard accepts only a loopback `Host`, and `tailscale serve` forwards the Tailnet FQDN it cannot rewrite. So the always-on / phone path — the point of a hosted familiar — never worked as documented. (SSH tunnels were fine; they present `Host: 127.0.0.1`.)

Verified live on a GCE VM: daemon healthy on loopback (`{"ok":true,...}`), `tailscale serve` wired, tailnet request 403s — then passes once the FQDN is allowlisted.

## Change

- **`coven daemon serve --allow-host <HOST>`** (repeatable): extends the loopback `Host`/`Origin` guard with an **exact-match** allowlist (case- and port-insensitive, no wildcards).
- Guard policy is now a `HostGuard` enum (`Disabled` for the filesystem-gated Unix socket, `Loopback { allowed_hosts }` for TCP), which also keeps `handle_http_stream` within clippy's argument budget.
- Bind stays loopback; API stays unauthenticated. `--allow-host` only tells the guard to trust a hostname the operator vouches for behind an authenticated transport (Tailscale/SSH). Warns if given without `--tcp`.
- Docs: runbook step 3 now shows the `systemctl edit` drop-in adding `--allow-host`; `remote-access.md` + the unit comment note the SSH-tunnel path needs no change.

## Tests / gates

- New: allowlisted host+origin passes; unlisted host still 403s; matching is case/port-insensitive.
- `cargo fmt --check`, `cargo clippy -p coven-cli --all-targets -D warnings`, `cargo test -p coven-cli` (1158 passed), `check-secrets.py` — all clean.

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)