### PR TITLE
refactor(paths): consolidate coven-home and engine-root resolution

### DIFF
--- a/crates/coven-cli/src/engine.rs
+++ b/crates/coven-cli/src/engine.rs
@@ -101,15 +101,12 @@ pub fn resolve_from(
 
     // 2. Managed ~/.coven/engine/<current>/ENGINE_BIN_NAME
     if let Some(home) = home {
-        let current_file = home.join(".coven").join("engine").join("current");
+        let engine_root = crate::paths::managed_engine_root(home);
+        let current_file = engine_root.join("current");
         if let Ok(version) = std::fs::read_to_string(&current_file) {
             let version = version.trim();
             if !version.is_empty() {
-                let candidate = home
-                    .join(".coven")
-                    .join("engine")
-                    .join(version)
-                    .join(ENGINE_BIN_NAME);
+                let candidate = engine_root.join(version).join(ENGINE_BIN_NAME);
                 if is_executable(&candidate) {
                     return Some(ResolvedEngine {
                         path: candidate,

--- a/crates/coven-cli/src/engine_install.rs
+++ b/crates/coven-cli/src/engine_install.rs
@@ -86,7 +86,7 @@ impl Drop for ScratchGuard {
 /// (dev mode).
 pub fn install(version: &str, force: bool) -> Result<(PathBuf, InstallOutcome)> {
     let home = dirs_next::home_dir().context("cannot determine home directory")?;
-    let engine_root = home.join(".coven").join("engine");
+    let engine_root = crate::paths::managed_engine_root(&home);
     let dest_dir = engine_root.join(version);
     let dest = dest_dir.join(crate::engine::ENGINE_BIN_NAME);
     if dest.exists() && !force {

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -888,10 +888,7 @@ pub fn trusted_adapter_manifest_matches_recipe(path: &Path, adapter_id: &str) ->
 }
 
 fn coven_home_from_process_env() -> Option<PathBuf> {
-    env::var_os("COVEN_HOME")
-        .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .or_else(|| dirs_next::home_dir().map(|home| home.join(crate::DEFAULT_COVEN_HOME_DIR)))
+    crate::paths::coven_home_dir().ok()
 }
 
 fn adapter_manifest_paths_in_dir(dir: &Path) -> Vec<PathBuf> {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -30,6 +30,7 @@ mod observe;
 mod openclaw_repo;
 mod parallel_protocol;
 mod patch;
+mod paths;
 mod pc;
 mod privacy;
 mod project;
@@ -52,7 +53,8 @@ mod ward;
 // Ward::apply on the same write path; see threads_gate.rs.
 mod threads_gate;
 
-pub(crate) const DEFAULT_COVEN_HOME_DIR: &str = ".coven";
+pub(crate) use paths::{coven_home_dir, DEFAULT_COVEN_HOME_DIR};
+
 pub(crate) const STORE_FILE_NAME: &str = "coven.sqlite3";
 const DEFAULT_SESSION_STATUS: &str = "created";
 const RUNNING_SESSION_STATUS: &str = "running";
@@ -3747,56 +3749,6 @@ fn coven_store_path_if_exists() -> Result<Option<PathBuf>> {
     Ok(store_path.exists().then_some(store_path))
 }
 
-fn coven_home_dir() -> Result<PathBuf> {
-    coven_home_from_env(
-        std::env::var_os("COVEN_HOME"),
-        std::env::var_os("HOME"),
-        std::env::var_os("USERPROFILE"),
-        std::env::var_os("HOMEDRIVE"),
-        std::env::var_os("HOMEPATH"),
-        dirs_next::home_dir().map(OsString::from),
-    )
-}
-
-fn coven_home_from_env(
-    coven_home: Option<OsString>,
-    home: Option<OsString>,
-    user_profile: Option<OsString>,
-    home_drive: Option<OsString>,
-    home_path: Option<OsString>,
-    platform_home: Option<OsString>,
-) -> Result<PathBuf> {
-    if let Some(coven_home) = coven_home.filter(|value| !value.is_empty()) {
-        return Ok(PathBuf::from(coven_home));
-    }
-
-    let home = home
-        .filter(|value| !value.is_empty())
-        .or_else(|| user_profile.filter(|value| !value.is_empty()))
-        .or_else(|| windows_home_from_drive_and_path(home_drive, home_path))
-        .or_else(|| platform_home.filter(|value| !value.is_empty()))
-        .ok_or_else(|| {
-            anyhow!(
-                "could not find a home directory for Coven. Set COVEN_HOME to choose a store path, \
-for example `COVEN_HOME=$HOME/.coven` on macOS/Linux or \
-`$env:COVEN_HOME=\"$env:USERPROFILE\\.coven\"` in PowerShell."
-            )
-        })?;
-    Ok(PathBuf::from(home).join(DEFAULT_COVEN_HOME_DIR))
-}
-
-fn windows_home_from_drive_and_path(
-    home_drive: Option<OsString>,
-    home_path: Option<OsString>,
-) -> Option<OsString> {
-    let drive = home_drive?.into_string().ok()?;
-    let path = home_path?.into_string().ok()?;
-    if drive.is_empty() || path.is_empty() {
-        return None;
-    }
-    Some(OsString::from(format!("{drive}{path}")))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -4230,54 +4182,6 @@ mod tests {
             session_title(None, prompt),
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV"
         );
-    }
-
-    #[test]
-    fn coven_home_from_env_respects_coven_home() -> Result<()> {
-        let path = coven_home_from_env(
-            Some(OsString::from("/tmp/custom-coven-home")),
-            Some(OsString::from("/tmp/ignored-home")),
-            None,
-            None,
-            None,
-            None,
-        )?;
-
-        assert_eq!(path, PathBuf::from("/tmp/custom-coven-home"));
-        Ok(())
-    }
-
-    #[test]
-    fn coven_home_from_env_defaults_under_home() -> Result<()> {
-        let path = coven_home_from_env(
-            None,
-            Some(OsString::from("/tmp/user-home")),
-            None,
-            None,
-            None,
-            None,
-        )?;
-
-        assert_eq!(path, PathBuf::from("/tmp/user-home").join(".coven"));
-        Ok(())
-    }
-
-    #[test]
-    fn coven_home_from_env_uses_windows_drive_and_path_when_needed() -> Result<()> {
-        let path = coven_home_from_env(
-            None,
-            None,
-            None,
-            Some(OsString::from("C:")),
-            Some(OsString::from("\\Users\\hostname")),
-            None,
-        )?;
-
-        assert_eq!(
-            path,
-            PathBuf::from("C:\\Users\\hostname").join(DEFAULT_COVEN_HOME_DIR)
-        );
-        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -53,7 +53,7 @@ mod ward;
 // Ward::apply on the same write path; see threads_gate.rs.
 mod threads_gate;
 
-pub(crate) use paths::{coven_home_dir, DEFAULT_COVEN_HOME_DIR};
+pub(crate) use paths::coven_home_dir;
 
 pub(crate) const STORE_FILE_NAME: &str = "coven.sqlite3";
 const DEFAULT_SESSION_STATUS: &str = "created";
@@ -4860,7 +4860,10 @@ mod tests {
         let _home = EnvVarGuard::remove("HOME");
         let _user_profile = EnvVarGuard::set("USERPROFILE", &user_profile);
 
-        assert_eq!(coven_home_dir()?, user_profile.join(DEFAULT_COVEN_HOME_DIR));
+        assert_eq!(
+            coven_home_dir()?,
+            user_profile.join(paths::DEFAULT_COVEN_HOME_DIR)
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/paths.rs
+++ b/crates/coven-cli/src/paths.rs
@@ -1,0 +1,171 @@
+//! Single source of truth for Coven's on-disk path policy.
+//!
+//! Every `.coven`-family location is resolved here so the fallback chain
+//! cannot drift between call sites (CLI, daemon plumbing, TUI, engine
+//! management). Two roots exist on purpose:
+//!
+//! - **Coven home** ([`coven_home_dir`]) — `$COVEN_HOME`, else
+//!   `<user home>/.coven`. Holds the store, daemon state, and exports.
+//! - **Managed engine root** ([`managed_engine_root`]) — always
+//!   `<user home>/.coven/engine`, *independent of* `$COVEN_HOME`, because the
+//!   managed engine install is per-user, not per-store
+//!   (see `docs/ENGINE-CONTRACT.md`).
+//!
+//! User *settings* live under the XDG config dir instead (see
+//! [`crate::settings`]); that is a deliberate third root, not drift.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Result};
+
+pub(crate) const DEFAULT_COVEN_HOME_DIR: &str = ".coven";
+
+/// Resolve the Coven home directory from the process environment.
+///
+/// Chain: `COVEN_HOME` → `HOME` → `USERPROFILE` → `HOMEDRIVE`+`HOMEPATH` →
+/// platform home. Fails (rather than guessing a cwd-relative path) when no
+/// home can be determined.
+pub(crate) fn coven_home_dir() -> Result<PathBuf> {
+    coven_home_from_env(
+        std::env::var_os("COVEN_HOME"),
+        std::env::var_os("HOME"),
+        std::env::var_os("USERPROFILE"),
+        std::env::var_os("HOMEDRIVE"),
+        std::env::var_os("HOMEPATH"),
+        dirs_next::home_dir().map(OsString::from),
+    )
+}
+
+fn coven_home_from_env(
+    coven_home: Option<OsString>,
+    home: Option<OsString>,
+    user_profile: Option<OsString>,
+    home_drive: Option<OsString>,
+    home_path: Option<OsString>,
+    platform_home: Option<OsString>,
+) -> Result<PathBuf> {
+    if let Some(coven_home) = coven_home.filter(|value| !value.is_empty()) {
+        return Ok(PathBuf::from(coven_home));
+    }
+
+    let home = home
+        .filter(|value| !value.is_empty())
+        .or_else(|| user_profile.filter(|value| !value.is_empty()))
+        .or_else(|| windows_home_from_drive_and_path(home_drive, home_path))
+        .or_else(|| platform_home.filter(|value| !value.is_empty()))
+        .ok_or_else(|| {
+            anyhow!(
+                "could not find a home directory for Coven. Set COVEN_HOME to choose a store path, \
+for example `COVEN_HOME=$HOME/.coven` on macOS/Linux or \
+`$env:COVEN_HOME=\"$env:USERPROFILE\\.coven\"` in PowerShell."
+            )
+        })?;
+    Ok(PathBuf::from(home).join(DEFAULT_COVEN_HOME_DIR))
+}
+
+fn windows_home_from_drive_and_path(
+    home_drive: Option<OsString>,
+    home_path: Option<OsString>,
+) -> Option<OsString> {
+    let drive = home_drive?.into_string().ok()?;
+    let path = home_path?.into_string().ok()?;
+    if drive.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some(OsString::from(format!("{drive}{path}")))
+}
+
+/// The managed engine root under a user home: `<home>/.coven/engine`.
+///
+/// Deliberately keyed on the *user home*, not `$COVEN_HOME` — the managed
+/// engine is a per-user install shared by every store.
+pub(crate) fn managed_engine_root(home: &Path) -> PathBuf {
+    home.join(DEFAULT_COVEN_HOME_DIR).join("engine")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn coven_home_from_env_respects_coven_home() -> Result<()> {
+        let path = coven_home_from_env(
+            Some(OsString::from("/tmp/custom-coven-home")),
+            Some(OsString::from("/tmp/ignored-home")),
+            None,
+            None,
+            None,
+            None,
+        )?;
+
+        assert_eq!(path, PathBuf::from("/tmp/custom-coven-home"));
+        Ok(())
+    }
+
+    #[test]
+    fn coven_home_from_env_defaults_under_home() -> Result<()> {
+        let path = coven_home_from_env(
+            None,
+            Some(OsString::from("/tmp/user-home")),
+            None,
+            None,
+            None,
+            None,
+        )?;
+
+        assert_eq!(path, PathBuf::from("/tmp/user-home").join(".coven"));
+        Ok(())
+    }
+
+    #[test]
+    fn coven_home_from_env_uses_windows_drive_and_path_when_needed() -> Result<()> {
+        let path = coven_home_from_env(
+            None,
+            None,
+            None,
+            Some(OsString::from("C:")),
+            Some(OsString::from("\\Users\\hostname")),
+            None,
+        )?;
+
+        assert_eq!(
+            path,
+            PathBuf::from("C:\\Users\\hostname").join(DEFAULT_COVEN_HOME_DIR)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn coven_home_from_env_ignores_empty_values() -> Result<()> {
+        let path = coven_home_from_env(
+            Some(OsString::new()),
+            Some(OsString::new()),
+            Some(OsString::from("/tmp/profile-home")),
+            None,
+            None,
+            None,
+        )?;
+
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/profile-home").join(DEFAULT_COVEN_HOME_DIR)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn coven_home_from_env_fails_without_any_home() {
+        let err = coven_home_from_env(None, None, None, None, None, None)
+            .expect_err("must fail closed instead of guessing a path");
+        assert!(err.to_string().contains("COVEN_HOME"));
+    }
+
+    #[test]
+    fn managed_engine_root_is_user_home_scoped() {
+        assert_eq!(
+            managed_engine_root(Path::new("/tmp/user-home")),
+            PathBuf::from("/tmp/user-home/.coven/engine")
+        );
+    }
+}

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -870,9 +870,8 @@ impl App {
                     "Quest planned for: {goal}. Cast will run each phase through this composer; start with the design phase prompt when ready."
                 ));
             }
-            CastIntent::Observe { view } => {
-                let home = self.resolved_coven_home();
-                match crate::observe::view_text(&home, view) {
+            CastIntent::Observe { view } => match self.resolved_coven_home() {
+                Some(home) => match crate::observe::view_text(&home, view) {
                     Ok(text) => {
                         self.push_system_message(text.trim_end());
                         self.push_system_message(&format!(
@@ -886,8 +885,14 @@ impl App {
                             view.command()
                         ));
                     }
+                },
+                None => {
+                    self.push_system_message(&format!(
+                        "Could not resolve the Coven home (set COVEN_HOME). The same data is available via `{}`.",
+                        view.command()
+                    ));
                 }
-            }
+            },
             CastIntent::Quit => return SlashCommandResult::Quit,
         }
         SlashCommandResult::Handled
@@ -1338,13 +1343,12 @@ impl App {
 
     /// The Coven home for store-backed views and exports: the app-pinned
     /// home (always set in production via [`App::new`]), else environment
-    /// resolution, else the bare default directory name as a display-safe
-    /// last resort when no home exists at all.
-    fn resolved_coven_home(&self) -> PathBuf {
+    /// resolution. `None` when no home can be determined — callers fail
+    /// closed rather than guessing a cwd-relative path.
+    fn resolved_coven_home(&self) -> Option<PathBuf> {
         self.coven_home
             .clone()
             .or_else(|| crate::coven_home_dir().ok())
-            .unwrap_or_else(|| PathBuf::from(crate::DEFAULT_COVEN_HOME_DIR))
     }
 
     fn push_doctor_summary(&mut self) {
@@ -1353,11 +1357,14 @@ impl App {
             .and_then(|cwd| project::canonical_project_root(&cwd).ok())
             .map(|root| root.display().to_string())
             .unwrap_or_else(|| "not inside a git/project root yet".to_string());
-        let store_path = self.resolved_coven_home();
+        let store_path = self
+            .resolved_coven_home()
+            .map(|home| home.display().to_string())
+            .unwrap_or_else(|| "unresolved — set COVEN_HOME".to_string());
         let harnesses = harness::built_in_harnesses();
         let mut lines = vec![
             "Doctor".to_string(),
-            format!("  Store    {}", store_path.display()),
+            format!("  Store    {store_path}"),
             format!("  Project  {project}"),
             "  Harnesses".to_string(),
         ];
@@ -1883,7 +1890,13 @@ impl App {
             return;
         }
 
-        let export_dir = self.resolved_coven_home().join("exports");
+        let Some(coven_home) = self.resolved_coven_home() else {
+            self.push_system_message(
+                "Export failed: could not resolve the Coven home (set COVEN_HOME).",
+            );
+            return;
+        };
+        let export_dir = coven_home.join("exports");
         if std::fs::create_dir_all(&export_dir).is_err() {
             self.push_system_message("Failed to create export directory.");
             return;

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 
 use super::client::{
-    coven_home_dir, ChatClient, ChatDaemonStatus, ChatEventQuery, DaemonChatClient, LaunchRequest,
+    ChatClient, ChatDaemonStatus, ChatEventQuery, DaemonChatClient, LaunchRequest,
 };
 use super::persistence;
 use super::settings::{self, ChatSettings, StreamingMode};
@@ -252,15 +252,16 @@ pub(super) const SLASH_COMMANDS: &[SlashCommand] = &[
 pub(super) const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 impl App {
-    pub(super) fn new() -> Self {
+    pub(super) fn new() -> anyhow::Result<Self> {
         let agents = discover_agents();
         let active_agent = agents.iter().position(|a| a.available);
-        Self::new_with_state(
+        let coven_home = crate::coven_home_dir()?;
+        Ok(Self::new_with_state(
             agents,
             active_agent,
-            Box::<DaemonChatClient>::default(),
-            Some(coven_home_dir()),
-        )
+            Box::new(DaemonChatClient::with_coven_home(coven_home.clone())),
+            Some(coven_home),
+        ))
     }
 
     pub(super) fn new_with_state(
@@ -870,7 +871,7 @@ impl App {
                 ));
             }
             CastIntent::Observe { view } => {
-                let home = self.coven_home.clone().unwrap_or_else(coven_home_dir);
+                let home = self.resolved_coven_home();
                 match crate::observe::view_text(&home, view) {
                     Ok(text) => {
                         self.push_system_message(text.trim_end());
@@ -1335,13 +1336,24 @@ impl App {
         }
     }
 
+    /// The Coven home for store-backed views and exports: the app-pinned
+    /// home (always set in production via [`App::new`]), else environment
+    /// resolution, else the bare default directory name as a display-safe
+    /// last resort when no home exists at all.
+    fn resolved_coven_home(&self) -> PathBuf {
+        self.coven_home
+            .clone()
+            .or_else(|| crate::coven_home_dir().ok())
+            .unwrap_or_else(|| PathBuf::from(crate::DEFAULT_COVEN_HOME_DIR))
+    }
+
     fn push_doctor_summary(&mut self) {
         let project = std::env::current_dir()
             .ok()
             .and_then(|cwd| project::canonical_project_root(&cwd).ok())
             .map(|root| root.display().to_string())
             .unwrap_or_else(|| "not inside a git/project root yet".to_string());
-        let store_path = self.coven_home.clone().unwrap_or_else(coven_home_dir);
+        let store_path = self.resolved_coven_home();
         let harnesses = harness::built_in_harnesses();
         let mut lines = vec![
             "Doctor".to_string(),
@@ -1871,8 +1883,7 @@ impl App {
             return;
         }
 
-        let home = dirs_next::home_dir().unwrap_or_default();
-        let export_dir = home.join(".coven").join("exports");
+        let export_dir = self.resolved_coven_home().join("exports");
         if std::fs::create_dir_all(&export_dir).is_err() {
             self.push_system_message("Failed to create export directory.");
             return;

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -116,16 +116,16 @@ pub(crate) struct DaemonChatClient {
     api_checked: bool,
 }
 
-impl Default for DaemonChatClient {
-    fn default() -> Self {
-        Self {
-            coven_home: coven_home_dir(),
-            api_checked: false,
-        }
-    }
-}
-
 impl DaemonChatClient {
+    /// Resolve a client from the process environment. Fails when no Coven
+    /// home can be determined instead of guessing a cwd-relative `.coven`.
+    pub(crate) fn detect() -> anyhow::Result<Self> {
+        Ok(Self {
+            coven_home: crate::paths::coven_home_dir()?,
+            api_checked: false,
+        })
+    }
+
     /// Construct a client pinned to a specific Coven home directory. Used by
     /// the Cast follower when it needs to spin up a second client on a
     /// background thread without re-detecting `$COVEN_HOME`.
@@ -476,13 +476,6 @@ fn daemon_error(status: u16, body: &str) -> anyhow::Error {
         }
     }
     anyhow!("Coven daemon rejected request with HTTP {status}")
-}
-
-pub(super) fn coven_home_dir() -> PathBuf {
-    std::env::var_os("COVEN_HOME")
-        .map(PathBuf::from)
-        .or_else(|| dirs_next::home_dir().map(|home| home.join(".coven")))
-        .unwrap_or_else(|| PathBuf::from(".coven"))
 }
 
 fn session_title(prompt: &str) -> String {

--- a/crates/coven-cli/src/tui/chat/mod.rs
+++ b/crates/coven-cli/src/tui/chat/mod.rs
@@ -32,7 +32,7 @@ use events::run_event_loop;
 
 pub fn run_chat() -> Result<()> {
     let mut terminal = TerminalSession::enter()?;
-    let mut app = App::new();
+    let mut app = App::new()?;
     let result = run_event_loop(&mut terminal, &mut app);
     // Tear down long-lived stream sessions (claude --stream-json) before
     // we release the terminal. Covers every normal exit path — /exit,

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1192,7 +1192,7 @@ pub(crate) fn render_chat_frame_plain_for_test(width: u16, height: u16) -> Strin
         agents,
         Some(0),
         Box::new(DaemonChatClient::with_coven_home(std::env::temp_dir())),
-        None,
+        Some(std::env::temp_dir()),
     );
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1763,7 +1763,7 @@ mod tests {
             Box::new(crate::tui::chat::client::DaemonChatClient::with_coven_home(
                 std::env::temp_dir(),
             )),
-            None,
+            Some(std::env::temp_dir()),
         );
         app.show_help = true;
         app.help_scroll = scroll;

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1188,7 +1188,12 @@ pub(crate) fn render_chat_frame_plain_for_test(width: u16, height: u16) -> Strin
         harness: "codex".to_string(),
         available: true,
     }];
-    let mut app = App::new_with_state(agents, Some(0), Box::<DaemonChatClient>::default(), None);
+    let mut app = App::new_with_state(
+        agents,
+        Some(0),
+        Box::new(DaemonChatClient::with_coven_home(std::env::temp_dir())),
+        None,
+    );
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).expect("test terminal");
     terminal
@@ -1755,7 +1760,9 @@ mod tests {
         let mut app = App::new_with_state(
             agents,
             Some(0),
-            Box::<crate::tui::chat::client::DaemonChatClient>::default(),
+            Box::new(crate::tui::chat::client::DaemonChatClient::with_coven_home(
+                std::env::temp_dir(),
+            )),
             None,
         );
         app.show_help = true;

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -393,7 +393,7 @@ fn dispatch_cast_plan(plan: CastPlan) -> Result<()> {
             }
         }
         CastIntent::KillSession { session_id } => {
-            let mut client = DaemonChatClient::default();
+            let mut client = DaemonChatClient::detect()?;
             client.kill_session(&session_id)?;
             CastOutcome {
                 request: request_text,
@@ -1165,7 +1165,7 @@ fn dispatch_via_daemon(
         conversation_id: None,
     };
 
-    let mut client = DaemonChatClient::default();
+    let mut client = DaemonChatClient::detect()?;
     let session = client.launch_session(launch).with_context(|| {
         format!(
             "Cast failed to launch {} session via the daemon",
@@ -1419,7 +1419,7 @@ fn attach_via_daemon(
     request_text: &str,
     origin: AttachOrigin,
 ) -> Result<CastOutcome> {
-    let mut client = DaemonChatClient::default();
+    let mut client = DaemonChatClient::detect()?;
     let session = client
         .get_session(session_id)
         .with_context(|| format!("Cast could not look up session `{session_id}` via the daemon"))?;


### PR DESCRIPTION
## Summary

Closes #396 (found by the workstream-3 CLI-vs-daemon duplication survey).

Four independent "where is coven home?" implementations had drifted. New `paths` module is the single source of truth; `main.rs` re-exports `coven_home_dir`/`DEFAULT_COVEN_HOME_DIR` so its ~20 call sites are untouched.

| Site | Before | After |
|---|---|---|
| `main.rs` | canonical chain (COVEN_HOME → HOME → USERPROFILE → HOMEDRIVE/HOMEPATH → platform) | moved verbatim to `paths.rs` |
| `tui/chat/client.rs` | COVEN_HOME → `~/.coven` → **silent cwd-relative `.coven`** | `DaemonChatClient::detect()` — fails closed, no cwd guess |
| `harness.rs` | COVEN_HOME → platform home only | delegates (gains Windows profile chain) |
| `engine.rs` + `engine_install.rs` | each hand-built `~/.coven/engine` | shared `managed_engine_root()` (still user-home-keyed by design — per-user engine install; documented) |
| `tui/chat/app.rs` exports | hardcoded `~/.coven/exports`, ignored COVEN_HOME | `<coven home>/exports` |

Behavior notes (all fail-closed or consistency wins, called out per the issue):
- The chat TUI no longer invents a cwd-relative `.coven` when no home resolves — `App::new`/cast paths surface the same actionable error the CLI already used.
- Chat exports and the harness env resolver now respect `COVEN_HOME` like every other surface.
- Settings stay XDG-based (`settings.rs`) and `daemon.rs`/`pc/relief.rs` plain-home uses are intentionally untouched (non-`.coven` paths).

## Testing
- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --locked` ✓ (1194 passed, 0 failed; resolver tests moved to `paths.rs` + new empty-env filtering, no-home failure, and engine-root cases)
- `python scripts/check-secrets.py` ✓