### PR TITLE
fix: use trusted Windows taskkill path

### DIFF
--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -47,7 +47,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 interprocess = "2"
 widestring = "1"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_System_JobObjects"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -543,7 +543,10 @@ fn trusted_windows_taskkill_path() -> Option<PathBuf> {
         buffer.truncate(len);
     }
 
-    Some(PathBuf::from(std::ffi::OsString::from_wide(&buffer)).join("taskkill.exe"))
+    let path = PathBuf::from(std::ffi::OsString::from_wide(&buffer)).join("taskkill.exe");
+    // A missing binary (or an unexpected system directory) must surface as
+    // "no trusted taskkill" rather than a silently ignored spawn failure.
+    path.is_file().then_some(path)
 }
 
 #[cfg(windows)]

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -476,13 +476,15 @@ impl CodexProcessTree {
                 // A Job Object can be unavailable when a parent policy forbids
                 // assignment. Fall back to Windows' documented tree kill for
                 // npm's cmd.exe -> node.exe -> codex.exe chain.
-                let pid = self.pid.to_string();
-                let _ = std::process::Command::new("taskkill")
-                    .args(["/PID", &pid, "/T", "/F"])
-                    .stdin(Stdio::null())
-                    .stdout(Stdio::null())
-                    .stderr(Stdio::null())
-                    .status();
+                if let Some(taskkill) = trusted_windows_taskkill_path() {
+                    let pid = self.pid.to_string();
+                    let _ = std::process::Command::new(taskkill)
+                        .args(["/PID", &pid, "/T", "/F"])
+                        .stdin(Stdio::null())
+                        .stdout(Stdio::null())
+                        .stderr(Stdio::null())
+                        .status();
+                }
             }
         }
         let _ = child.kill();
@@ -517,6 +519,31 @@ impl Drop for CodexProcessTree {
             unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
         }
     }
+}
+
+#[cfg(windows)]
+fn trusted_windows_taskkill_path() -> Option<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::System::SystemInformation::GetSystemDirectoryW;
+
+    let mut buffer = vec![0u16; 260];
+    let len = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) };
+    if len == 0 {
+        return None;
+    }
+    let len = len as usize;
+    if len >= buffer.len() {
+        buffer.resize(len + 1, 0);
+        let len = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) };
+        if len == 0 || len as usize >= buffer.len() {
+            return None;
+        }
+        buffer.truncate(len as usize);
+    } else {
+        buffer.truncate(len);
+    }
+
+    Some(PathBuf::from(std::ffi::OsString::from_wide(&buffer)).join("taskkill.exe"))
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
### Motivation
- The Windows fallback for terminating Codex process trees previously invoked `taskkill` by bare executable name, which allows PATH/current-directory executable search hijacking in attacker-controlled workspaces. 
- The change hardens the fallback by resolving `taskkill.exe` from the system directory so the trusted System32 binary is used when Job Object termination is unavailable.

### Description
- Replace the bare `taskkill` invocation with a call that first resolves a trusted `%SystemRoot%\System32\taskkill.exe` via `GetSystemDirectoryW` and uses that absolute path when available. 
- Add a new `trusted_windows_taskkill_path()` helper that returns a `PathBuf` to `taskkill.exe` from the system directory. 
- Update the Windows `windows-sys` dependency features to include `Win32_System_SystemInformation` required for `GetSystemDirectoryW`.
- Preserve existing behavior when resolution fails by skipping the insecure fallback and still attempting to `Child::kill()`.

### Testing
- Ran `cargo fmt --check` which passed. 
- Ran `cargo test -p coven-cli codex_json_runner_times_out_and_reaps_a_silent_child --locked -- --nocapture` which passed. 
- Ran `cargo clippy -p coven-cli --all-targets -- -D warnings` which passed for the package. 
- Ran `python scripts/check-secrets.py` which passed. 
- Full workspace `cargo test` and `cargo clippy --workspace` were blocked by an external proxy failure while fetching prebuilt binaries for a native dependency, and `cargo check --target x86_64-pc-windows-gnu` could not be completed because the Windows target installation was blocked by a download error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5610e59ed88327a1d190668f5f058f)