### PR TITLE
fix: forward models through daemon sessions

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -92,6 +92,10 @@ pub struct SessionLaunch {
     pub project_root: String,
     pub cwd: String,
     pub harness: String,
+    /// Optional namespaced model id (for example `openai/gpt-5.6-sol`). The
+    /// runtime keeps the provider prefix here and lets the harness adapter
+    /// normalize it for the underlying CLI.
+    pub model: Option<String>,
     pub launch_mode: HarnessLaunchMode,
     pub prompt: String,
     pub title: String,
@@ -1724,6 +1728,12 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         );
     }
     let launch_mode = launch_mode_from_payload(&payload)?;
+    let model = payload
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(ToOwned::to_owned);
     let prompt = required_string(&payload, "prompt")?;
     let title = payload
         .get("title")
@@ -1757,6 +1767,7 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         project_root: canonical_project_root.to_string_lossy().into_owned(),
         cwd: canonical_cwd.to_string_lossy().into_owned(),
         harness,
+        model,
         launch_mode,
         prompt,
         title,
@@ -4280,6 +4291,7 @@ mod tests {
             "projectRoot": project_root,
             "cwd": cwd,
             "harness": "codex",
+            "model": "openai/gpt-5.6-sol",
             "prompt": "hello coven",
             "title": "Demo"
         })
@@ -4299,6 +4311,10 @@ mod tests {
         assert!(response.body.contains(r#""status":"running""#));
         assert_eq!(runtime.launches.borrow().len(), 1);
         assert_eq!(runtime.launches.borrow()[0].harness, "codex");
+        assert_eq!(
+            runtime.launches.borrow()[0].model.as_deref(),
+            Some("openai/gpt-5.6-sol")
+        );
         assert_eq!(
             runtime.launches.borrow()[0].launch_mode,
             HarnessLaunchMode::Interactive
@@ -4348,6 +4364,7 @@ mod tests {
             runtime.launches.borrow()[0].launch_mode,
             HarnessLaunchMode::NonInteractive
         );
+        assert!(runtime.launches.borrow()[0].model.is_none());
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -259,9 +259,10 @@ impl SessionRuntime for LiveSessionRuntime {
             launch.launch_mode,
             launch.conversation.as_ref(),
             familiar_ctx.as_ref(),
-            // The daemon launch path does not carry model/think/speed selection
-            // yet; `coven run` drives those foreground flags.
-            crate::harness::HarnessLaunchOptions::default(),
+            crate::harness::HarnessLaunchOptions {
+                model: launch.model.as_deref(),
+                ..Default::default()
+            },
         )?;
         let observer = self
             .coven_home
@@ -2833,6 +2834,7 @@ mod tests {
             project_root: "/tmp/x".to_string(),
             cwd: "/tmp/x".to_string(),
             harness: "codex".to_string(),
+            model: None,
             launch_mode: crate::harness::HarnessLaunchMode::Stream,
             prompt: "hello".to_string(),
             title: "stream codex (should be rejected)".to_string(),

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -262,6 +262,21 @@ Unknown action ids return `400` and fail closed:
 }
 ```
 
+## `POST /api/v1/sessions`
+
+Launches a daemon-managed harness session. `model` is optional; when present,
+the daemon forwards the namespaced id through the selected harness adapter.
+Clients that omit it retain the harness's own default model.
+
+```json
+{
+  "projectRoot": "/repo",
+  "harness": "codex",
+  "model": "openai/gpt-5.6-sol",
+  "prompt": "Fix the tests"
+}
+```
+
 ## Session record shape (`v1`)
 
 In `v1`, session responses stay as raw JSON objects using the Rust daemon's snake_case field names.


### PR DESCRIPTION
## Context

- Summary: Daemon-backed sessions ignored model selection even though foreground `coven run --model` supported it.
- Files changed: `crates/coven-cli/src/api.rs`, `crates/coven-cli/src/daemon.rs`, `docs/API-CONTRACT.md`
- Tracking: Coven Cave bead `cave-e27`

## Implementation

- Approach: Accept an optional namespaced `model` in `POST /api/v1/sessions`, carry it through `SessionLaunch`, and pass it into `HarnessLaunchOptions`.
- User-visible behavior: Task and workflow clients can launch daemon sessions on the same selected model used by foreground chat.
- Compatibility notes: The field is optional; omitted or blank values preserve the harness default.

## Verification

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — local WSL image has no C linker; CI is authoritative
- [ ] `cargo test --workspace --locked` — local WSL image has no C linker; CI is authoritative
- [ ] `python3 scripts/check-secrets.py` — full history scan still running locally; CI is authoritative
- [x] `git diff --check`
- [x] API unit coverage asserts provided and omitted model behavior

## Risk and Rollback

- Risk level: Low. The API field is optional and uses the existing harness model normalization path.
- Rollback plan: Revert this PR; clients sending `model` remain compatible with older daemons because unknown JSON fields are ignored.

## Agent Handoff

- Current state: Draft pending CI.
- Follow-ups: Land the linked Coven Cave client PR after this daemon contract is available.
- Known gaps: No local Rust link/test execution in this WSL image because `cc` and Windows interop are unavailable.