### PR TITLE
test: allow for Windows PowerShell cold start (deflake #407)

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -2789,7 +2789,10 @@ exit 0
         };
         let mut assistant = Vec::new();
 
-        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(2), |text| {
+        // PowerShell can take several seconds to cold-start on a loaded
+        // Windows runner. This test exercises stdin and JSONL framing, not the
+        // activity deadline, so leave enough headroom for process startup.
+        let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(10), |text| {
             assistant.push(text.to_string());
             Ok(())
         })?;


### PR DESCRIPTION
Closes #407.

`codex_json_batch_shim_uses_stdin_and_emits_assistant_text` flaked twice on windows-latest (PR #384 run 29398604398, PR #406 run 29589644625) with `os error 2`: the fake-codex batch shim invokes PowerShell, which can take several seconds to cold-start on a loaded runner — the test's 2s activity deadline killed the child before `args.txt` was written. The test exercises stdin transport and JSONL framing, not the activity deadline, so the fix raises the deadline to 10s with a comment.

This is @romgenie's fix, **cherry-picked verbatim from PR #402 (48a0e41)** with authorship preserved, so the deflake lands independently of that PR's remaining review items (it will dedupe cleanly when #402 rebases/merges).

## Testing
- `cargo fmt --check` ✓, `cargo clippy -p coven-cli --all-targets -- -D warnings` ✓
- `cargo test -p coven-cli pty_runner::` ✓ (23/23 on unix; the changed test is `#[cfg(windows)]` — windows-latest CI on this PR is the authoritative check)
- Deadline change only affects test headroom; production timeouts untouched.