### PR TITLE
feat(ward): expose a familiar's declared Ward surface via API and CLI

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -251,6 +251,14 @@ pub fn handle_request_with_runtime(
                 .trim_end_matches("/icon");
             update_familiar_icon(coven_home, id, body)
         }
+        // The declared Ward surface for one familiar — the read-side twin of
+        // the `/edits` write path below (same config, same fail-closed 404s).
+        ("GET", path) if path.starts_with("/familiars/") && path.ends_with("/ward") => {
+            let id = path
+                .trim_start_matches("/familiars/")
+                .trim_end_matches("/ward");
+            familiar_ward_response(coven_home, id)
+        }
         // The Ward-enforced write path into a familiar home. Every write is
         // adjudicated by `ward::Ward::apply` (Gates 1–2, fail-closed, audited).
         ("POST", path) if path.starts_with("/familiars/") && path.ends_with("/edits") => {
@@ -2679,6 +2687,59 @@ fn advance_applied_protected_baselines(
         crate::threads_gate::advance_surface_baseline(&conn, familiar_id, workspace, &surface)?;
     }
     Ok(())
+}
+
+/// `GET /familiars/{id}/ward` — the declared Ward surface for one familiar.
+///
+/// Read-only observability twin of [`apply_familiar_edits`]: it loads the same
+/// `ward.toml` the write path enforces and reports the tiers as adjudicated —
+/// no separate source of truth. Fail-closed shapes mirror the write path: an
+/// unknown familiar and a missing `ward.toml` are structured 404s, an invalid
+/// config is a 500 (`ward_config_invalid`), never a silent default.
+fn familiar_ward_response(coven_home: &Path, familiar_id: &str) -> Result<ApiResponse> {
+    let known = crate::cockpit_sources::read_familiars(coven_home)?
+        .into_iter()
+        .any(|familiar| familiar.id == familiar_id);
+    if !known {
+        return api_error(
+            404,
+            "familiar_not_found",
+            "No familiar with that id is declared in familiars.toml.",
+            Some(json!({ "id": familiar_id })),
+        );
+    }
+    let workspace = crate::cockpit_sources::familiar_workspace(coven_home, familiar_id);
+    let config = match ward::WardConfig::load(&workspace) {
+        Ok(Some(config)) => config,
+        Ok(None) => {
+            return api_error(
+                404,
+                "ward_not_configured",
+                "This familiar has no ward.toml; the Ward-enforced write path is unavailable.",
+                Some(json!({
+                    "id": familiar_id,
+                    "workspace": workspace.to_string_lossy(),
+                })),
+            );
+        }
+        Err(error) => {
+            return api_error(500, "ward_config_invalid", &format!("{error:#}"), None);
+        }
+    };
+    json_response(
+        200,
+        &json!({
+            "ok": true,
+            "familiarId": familiar_id,
+            "workspace": workspace.to_string_lossy(),
+            "ward": {
+                "principalKeyFingerprint": config.principal_key_fingerprint,
+                "defaultTier": config.default_tier,
+                "surface": config.surface,
+                "protectedSurface": config.protected_surface,
+            },
+        }),
+    )
 }
 
 fn threads_weaves_response(coven_home: &Path) -> Result<ApiResponse> {
@@ -6170,6 +6231,66 @@ description = "Reads and synthesizes."
 icon = "ph:leaf-fill"
 "#,
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_ward_route_reports_declared_surface() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+        let workspace = home.join("familiars").join("sage");
+        std::fs::create_dir_all(&workspace)?;
+        std::fs::write(
+            workspace.join("ward.toml"),
+            r#"principal_key_fingerprint = "SHA256:principal-key"
+protected_surface = ["SOUL.md"]
+
+[[surface]]
+path = "SOUL.md"
+tier = 0
+
+[[surface]]
+path = "memory/"
+tier = 2
+"#,
+        )?;
+
+        let response = handle_request("GET", "/api/v1/familiars/sage/ward", home, None)?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["familiarId"], "sage");
+        assert_eq!(
+            body["ward"]["principalKeyFingerprint"],
+            "SHA256:principal-key"
+        );
+        assert_eq!(body["ward"]["defaultTier"], 2);
+        assert_eq!(body["ward"]["surface"][0]["path"], "SOUL.md");
+        assert_eq!(body["ward"]["surface"][0]["tier"], 0);
+        assert_eq!(body["ward"]["surface"][1]["path"], "memory/");
+        assert_eq!(body["ward"]["surface"][1]["tier"], 2);
+        assert_eq!(body["ward"]["protectedSurface"][0], "SOUL.md");
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_ward_route_fails_closed_on_unknown_and_unconfigured() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_familiars_toml(home)?;
+
+        // Unknown familiar id.
+        let response = handle_request("GET", "/api/v1/familiars/ghost/ward", home, None)?;
+        assert_eq!(response.status, 404);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "familiar_not_found");
+
+        // Known familiar without a ward.toml.
+        let response = handle_request("GET", "/api/v1/familiars/sage/ward", home, None)?;
+        assert_eq!(response.status, 404);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "ward_not_configured");
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2697,6 +2697,14 @@ fn advance_applied_protected_baselines(
 /// unknown familiar and a missing `ward.toml` are structured 404s, an invalid
 /// config is a 500 (`ward_config_invalid`), never a silent default.
 fn familiar_ward_response(coven_home: &Path, familiar_id: &str) -> Result<ApiResponse> {
+    if familiar_id.is_empty() || familiar_id.contains('/') {
+        return api_error(
+            400,
+            "invalid_request",
+            "Familiar id is required and must not contain '/'.",
+            None,
+        );
+    }
     let known = crate::cockpit_sources::read_familiars(coven_home)?
         .into_iter()
         .any(|familiar| familiar.id == familiar_id);
@@ -6291,6 +6299,14 @@ tier = 2
         assert_eq!(response.status, 404);
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
         assert_eq!(body["error"]["code"], "ward_not_configured");
+
+        // Malformed ids are a 400, matching the /icon and /edits contract.
+        for path in ["/api/v1/familiars//ward", "/api/v1/familiars/a/b/ward"] {
+            let response = handle_request("GET", path, home, None)?;
+            assert_eq!(response.status, 400, "path {path}");
+            let body: serde_json::Value = serde_json::from_str(&response.body)?;
+            assert_eq!(body["error"]["code"], "invalid_request");
+        }
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -361,6 +361,8 @@ enum Command {
         alias = "familiar"
     )]
     Familiars {
+        #[arg(help = "Familiar id: show its declared Ward surface (tiers) instead of the roster")]
+        id: Option<String>,
         #[arg(long, help = "Print familiars as JSON (machine-readable)")]
         json: bool,
     },
@@ -864,7 +866,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             None => tui::sessions::run_command(all, manage, plain, json),
         },
         Some(Command::Status { json }) => observe::run_status(json),
-        Some(Command::Familiars { json }) => observe::run_familiars(json),
+        Some(Command::Familiars { id, json }) => observe::run_familiars(id.as_deref(), json),
         Some(Command::Skills { json }) => observe::run_skills(json),
         Some(Command::Memory { json }) => observe::run_memory(json),
         Some(Command::Research { json }) => observe::run_research(json),
@@ -3922,7 +3924,17 @@ mod tests {
         ));
         assert!(matches!(
             Cli::parse_from(["coven", "familiars"]).command,
-            Some(Command::Familiars { json: false })
+            Some(Command::Familiars {
+                id: None,
+                json: false
+            })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "familiars", "nova", "--json"]).command,
+            Some(Command::Familiars {
+                id: Some(_),
+                json: true
+            })
         ));
         assert!(matches!(
             Cli::parse_from(["coven", "skills", "--json"]).command,

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -267,13 +267,90 @@ fn render_status(
 
 // ── coven familiars / skills / memory / research ─────────────────────────────
 
-pub(crate) fn run_familiars(json: bool) -> Result<()> {
+pub(crate) fn run_familiars(id: Option<&str>, json: bool) -> Result<()> {
     let coven_home = coven_home_dir()?;
-    if json {
-        return print_json(&api_get(&coven_home, "/api/v1/familiars")?);
+    match id {
+        Some(id) => {
+            let body = api_get(&coven_home, &format!("/api/v1/familiars/{id}/ward"))?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_familiar_ward(&body));
+        }
+        None => {
+            if json {
+                return print_json(&api_get(&coven_home, "/api/v1/familiars")?);
+            }
+            print!("{}", view_text(&coven_home, ObserveView::Familiars)?);
+        }
     }
-    print!("{}", view_text(&coven_home, ObserveView::Familiars)?);
     Ok(())
+}
+
+/// Human name for a Ward tier number (mirrors `ward::Tier`).
+fn tier_label(tier: u64) -> &'static str {
+    match tier {
+        0 => "protected",
+        1 => "reviewed",
+        2 => "logged",
+        3 => "free",
+        _ => "unknown",
+    }
+}
+
+fn render_familiar_ward(body: &Value) -> String {
+    let familiar = body
+        .get("familiarId")
+        .and_then(Value::as_str)
+        .unwrap_or("?");
+    let ward = body.get("ward").cloned().unwrap_or(Value::Null);
+    let mut out = String::new();
+    out.push_str(&format!("Familiar {familiar} — Ward surface\n\n"));
+    out.push_str(&format!(
+        "  workspace  {}\n",
+        body.get("workspace").and_then(Value::as_str).unwrap_or("?")
+    ));
+    out.push_str(&format!(
+        "  principal  {}\n",
+        str_cell(&ward, "principalKeyFingerprint")
+    ));
+    if let Some(tier) = ward.get("defaultTier").and_then(Value::as_u64) {
+        out.push_str(&format!(
+            "  unmatched  tier {tier} ({})\n",
+            tier_label(tier)
+        ));
+    }
+    let surface = ward
+        .get("surface")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    out.push_str(&format!("\n  {:<6} {:<10} path\n", "tier", ""));
+    for entry in &surface {
+        let tier = entry
+            .get("tier")
+            .and_then(Value::as_u64)
+            .unwrap_or(u64::MAX);
+        out.push_str(&format!(
+            "  {:<6} {:<10} {}\n",
+            tier,
+            tier_label(tier),
+            entry.get("path").and_then(Value::as_str).unwrap_or("?")
+        ));
+    }
+    let protected = ward
+        .get("protectedSurface")
+        .and_then(Value::as_array)
+        .map(|paths| {
+            paths
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_default();
+    out.push_str(&format!("\n  protected: {protected}\n"));
+    out
 }
 
 fn render_familiars(body: &Value) -> String {
@@ -1322,6 +1399,36 @@ mod tests {
         assert!(out.contains("nova → sage"));
         assert!(out.contains("running"));
         assert!(out.contains("coven calls <id>"));
+    }
+
+    #[test]
+    fn render_familiar_ward_shows_tiers_and_protected_surface() {
+        let body = json!({
+            "ok": true,
+            "familiarId": "sage",
+            "workspace": "/home/x/.coven/familiars/sage",
+            "ward": {
+                "principalKeyFingerprint": "SHA256:principal-key",
+                "defaultTier": 2,
+                "surface": [
+                    { "path": "SOUL.md", "tier": 0 },
+                    { "path": "memory/", "tier": 2 },
+                    { "path": "scratch/", "tier": 3 }
+                ],
+                "protectedSurface": ["SOUL.md"]
+            }
+        });
+        let text = render_familiar_ward(&body);
+
+        assert!(text.contains("Familiar sage — Ward surface"));
+        assert!(text.contains("/home/x/.coven/familiars/sage"));
+        assert!(text.contains("SHA256:principal-key"));
+        assert!(text.contains("tier 2 (logged)"));
+        assert!(text.contains("protected"));
+        assert!(text.contains("SOUL.md"));
+        assert!(text.contains("free"));
+        assert!(text.contains("scratch/"));
+        assert!(text.contains("protected: SOUL.md"));
     }
 
     #[test]

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -61,6 +61,7 @@ These power `coven status`, `coven familiars`, `coven skills`, `coven memory`, `
 |---|---|---|---|
 | GET | `/api/v1/overview` | Dashboard aggregate: open sessions, roster/skill/research counts. | overview object |
 | GET | `/api/v1/familiars` | Familiar roster from `familiars.toml`. | `FamiliarDto[]` |
+| GET | `/api/v1/familiars/:id/ward` | One familiar's declared Ward surface (tiers, protected paths, principal binding) — the read twin of `/familiars/:id/edits`. | `{ ok, familiarId, workspace, ward }` · `404 familiar_not_found` / `404 ward_not_configured` |
 | GET | `/api/v1/skills` | Installed skills from `~/.coven/skills/`. | `SkillDto[]` |
 | GET | `/api/v1/memory` | Familiar memory files from `~/.coven/memory/`. | memory list |
 | GET | `/api/v1/research` | Research loop log rows. | research list |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -61,7 +61,7 @@ These power `coven status`, `coven familiars`, `coven skills`, `coven memory`, `
 |---|---|---|---|
 | GET | `/api/v1/overview` | Dashboard aggregate: open sessions, roster/skill/research counts. | overview object |
 | GET | `/api/v1/familiars` | Familiar roster from `familiars.toml`. | `FamiliarDto[]` |
-| GET | `/api/v1/familiars/:id/ward` | One familiar's declared Ward surface (tiers, protected paths, principal binding) — the read twin of `/familiars/:id/edits`. | `{ ok, familiarId, workspace, ward }` · `404 familiar_not_found` / `404 ward_not_configured` |
+| GET | `/api/v1/familiars/:id/ward` | One familiar's declared Ward surface (tiers, protected paths, principal binding) — the read twin of `/familiars/:id/edits`. | `{ ok, familiarId, workspace, ward }` · `400 invalid_request` / `404 familiar_not_found` / `404 ward_not_configured` / `500 ward_config_invalid` |
 | GET | `/api/v1/skills` | Installed skills from `~/.coven/skills/`. | `SkillDto[]` |
 | GET | `/api/v1/memory` | Familiar memory files from `~/.coven/memory/`. | memory list |
 | GET | `/api/v1/research` | Research loop log rows. | research list |

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -18,7 +18,7 @@ corresponding daemon API route.
 | Command | Human view | `--json` body |
 |---|---|---|
 | `coven status` | Ecosystem overview | `{ "health": …, "overview": … }` composition of `GET /api/v1/health` and `GET /api/v1/overview` |
-| `coven familiars` | Roster table | `GET /api/v1/familiars` |
+| `coven familiars [<id>]` | Roster table, or one familiar's Ward surface (tiers, protected paths, principal binding) | `GET /api/v1/familiars[/:id/ward]` |
 | `coven skills` | Skill inventory | `GET /api/v1/skills` |
 | `coven memory` | Memory file table | `GET /api/v1/memory` |
 | `coven research` | Research loop log | `GET /api/v1/research` |
@@ -70,6 +70,34 @@ bodies (this shape is owned by the CLI, like `coven daemon status --json`):
 The `health.daemon` block reflects a *live* daemon only; a stale status file
 shows up as `daemon: null` here, while `coven daemon status --json` reports
 the `stale` state explicitly.
+
+## Ward surface inspection
+
+`coven familiars <id>` reads the same `ward.toml` the daemon's
+Ward-enforced write path (`POST /api/v1/familiars/:id/edits`) adjudicates —
+one source of truth for what a familiar's principal has protected:
+
+```text
+Familiar sage — Ward surface
+
+  workspace  /home/x/.coven/familiars/sage
+  principal  SHA256:principal-key
+  unmatched  tier 2 (logged)
+
+  tier              path
+  0      protected  SOUL.md
+  2      logged     memory/
+  3      free       scratch/
+
+  protected: SOUL.md
+```
+
+Tiers: `0` protected (Gate-1 principal signature required), `1` reviewed
+(held for Gate-3 coherence), `2` logged (written with a Gate-4 audit
+record), `3` free. `unmatched` is the tier assigned to paths no surface
+entry matches. An unknown id fails with `familiar_not_found`; a familiar
+without a `ward.toml` fails with `ward_not_configured` — the same
+fail-closed shapes the write path returns.
 
 ## Session inspection without a PTY
 


### PR DESCRIPTION
## Summary

Closes #416 (sub-issue of #335, control-plane observability). Ward adjudication outcomes were response-only: there was no way to *read* what a familiar's principal has protected without opening `ward.toml` by hand.

- **API:** `GET /api/v1/familiars/:id/ward` — the read twin of `POST /familiars/:id/edits`. Loads the exact `ward.toml` the write path enforces: `{ ok, familiarId, workspace, ward: { principalKeyFingerprint, defaultTier, surface: [{path, tier}], protectedSurface } }`. Fail-closed shapes mirror the write path: `404 familiar_not_found`, `404 ward_not_configured`, `500 ward_config_invalid` — never a silent default.
- **CLI:** `coven familiars <id> [--json]` (roster behavior for bare `coven familiars` unchanged). Renders through the in-process router per the observe.rs pattern, so `--json` is byte-for-byte the daemon body; the human view prints workspace, principal, unmatched tier, a tier/path table with labels (protected/reviewed/logged/free), and the protected list.
- **Docs:** `docs/reference/api.md` route row + `docs/reference/cli-observe.md` "Ward surface inspection" section with example output and tier semantics.

## Testing
- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓
- `cargo test --workspace --locked` ✓ (1227 passed, 0 failed; 4 new tests: 200 surface shape, 404 unknown-familiar + unconfigured, prose render, clap parse)
- Live-verified against a scratch `COVEN_HOME`: detail view, `--json` parity, and `familiar_not_found` exit-1 error