### PR TITLE
fix(api): isolate Cave threads weaves fleet reads (threads-vmf)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2755,8 +2755,18 @@ fn threads_weaves_response(coven_home: &Path) -> Result<ApiResponse> {
     let mut entries = Vec::new();
     for familiar in crate::cockpit_sources::read_familiars(coven_home)? {
         let workspace = crate::cockpit_sources::familiar_workspace(coven_home, &familiar.id);
-        let Some(config) = ward::WardConfig::load(&workspace)? else {
-            continue;
+        let config = match ward::WardConfig::load(&workspace) {
+            Ok(Some(config)) => config,
+            Ok(None) => continue,
+            Err(error) => {
+                let message = format!(
+                    "threads/weaves: skipping familiar {} because ward config failed to load: {error:#}",
+                    familiar.id
+                );
+                eprintln!("coven daemon: {message}");
+                crate::daemon::append_daemon_recovery_log(coven_home, &message);
+                continue;
+            }
         };
         let state = crate::threads_gate::build_weave_state(
             &conn,
@@ -6732,6 +6742,39 @@ tier = 1
             .as_array()
             .is_some_and(|v| !v.is_empty()));
         assert!(entry["weave"]["pattern_descriptor"]["name"].is_string());
+        Ok(())
+    }
+
+    #[test]
+    fn threads_weaves_skips_malformed_ward_without_aborting_fleet_read() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        let cody_workspace = home.join("familiars").join("cody");
+        std::fs::create_dir_all(&cody_workspace)?;
+        std::fs::write(cody_workspace.join("SOUL.md"), "# Cody\n")?;
+        std::fs::write(
+            cody_workspace.join("ward.toml"),
+            r#"protected_surface = ["SOUL.md"]
+
+[[surface]]
+path = "SOUL.md"
+tier = 0
+"#,
+        )?;
+
+        let response = handle_request("GET", "/api/v1/threads/weaves", home, None)?;
+
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        let entries = body.as_array().expect("weaves response is an array");
+        assert_eq!(
+            entries.len(),
+            1,
+            "malformed cody ward must not abort or appear"
+        );
+        assert_eq!(entries[0]["weave"]["familiar_id"], "sage");
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1848,12 +1848,10 @@ pub fn bind_api_socket(coven_home: &Path) -> Result<UnixListener> {
     Ok(listener)
 }
 
-#[cfg(unix)]
 pub fn daemon_recovery_log_path(coven_home: &Path) -> PathBuf {
     coven_home.join("daemon-recovery.log")
 }
 
-#[cfg(unix)]
 pub fn append_daemon_recovery_log(coven_home: &Path, msg: &str) {
     let path = daemon_recovery_log_path(coven_home);
     let line = format!("[{}] {}\n", crate::api::current_timestamp(), msg);
@@ -2245,14 +2243,23 @@ where
     }
     let body = read_http_body(&mut reader, headers.content_length)?;
     let (method, path) = parse_request_line(&request_line)?;
-    let response = crate::api::handle_request_with_runtime(
+    let response = match crate::api::handle_request_with_runtime(
         method,
         path,
         coven_home,
         status,
         body.as_deref(),
         runtime,
-    )?;
+    ) {
+        Ok(response) => response,
+        Err(error) => {
+            append_daemon_recovery_log(
+                coven_home,
+                &format!("API handler error for {method} {path}: {error:#}"),
+            );
+            return write_internal_server_error(&mut write, &format!("{error:#}"));
+        }
+    };
     let reason = http_reason_phrase(response.status);
     let http = format!(
         "HTTP/1.1 {} {}\r\nContent-Type: {}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
@@ -2265,6 +2272,26 @@ where
     write
         .write_all(http.as_bytes())
         .context("failed to write API response")?;
+    Ok(())
+}
+
+fn write_internal_server_error<W: Write>(write: &mut W, message: &str) -> Result<()> {
+    let body = serde_json::json!({
+        "ok": false,
+        "error": {
+            "code": "internal_error",
+            "message": message,
+        },
+    })
+    .to_string();
+    let http = format!(
+        "HTTP/1.1 500 Internal Server Error\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    write
+        .write_all(http.as_bytes())
+        .context("failed to write 500 response")?;
     Ok(())
 }
 
@@ -3231,6 +3258,42 @@ mod tests {
         let response = String::from_utf8(output).expect("utf8");
         assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
         assert!(response.contains("\"apiVersion\""), "got: {response}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn handle_http_stream_converts_api_handler_error_to_json_500() {
+        use crate::api::NoopSessionRuntime;
+        use std::io::Cursor;
+        let temp = tempfile::tempdir().expect("tempdir");
+        ensure_private_coven_home(temp.path()).expect("ensure home");
+        std::fs::write(temp.path().join("familiars.toml"), "not = [valid")
+            .expect("write malformed config");
+        let request = b"GET /api/v1/familiars HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n";
+        let mut stream = Cursor::new(Vec::from(&request[..]));
+        let mut output: Vec<u8> = Vec::new();
+        let runtime = NoopSessionRuntime;
+
+        handle_http_stream(
+            &mut stream,
+            &mut output,
+            temp.path(),
+            None,
+            &runtime,
+            None,
+            HostGuard::Disabled,
+        )
+        .expect("handler errors should still write an HTTP response");
+
+        let response = String::from_utf8(output).expect("utf8");
+        assert!(
+            response.starts_with("HTTP/1.1 500 Internal Server Error"),
+            "got: {response}"
+        );
+        assert!(
+            response.contains(r#""code":"internal_error""#),
+            "got: {response}"
+        );
     }
 
     #[cfg(unix)]
@@ -4660,7 +4723,6 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(unix)]
     #[test]
     fn append_daemon_recovery_log_creates_and_appends() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;


### PR DESCRIPTION
## Summary
- Fixes bead threads-vmf.
- Keeps GET /api/v1/threads/weaves fleet reads isolated when one familiar has a legacy/malformed ward.toml.
- Converts API handler errors in the HTTP socket dispatcher into HTTP 500 JSON error envelopes instead of closing the socket with an empty reply.

## Root cause
The empty reply was an Err path, not a panic: threads_weaves_response propagated WardConfig::load errors with `?`, and daemon::handle_http_stream also propagated handle_request_with_runtime errors with `?`, so the socket handler returned before writing any HTTP response.

## Isolation choice
For malformed per-familiar ward configs, /threads/weaves now logs the familiar id to stderr and daemon-recovery.log, skips that familiar, and continues returning healthy weave entries. I chose log+skip rather than fabricating a degraded RawWeaveEntry because malformed Ward v0.1 configs cannot produce authoritative Phase-2 weave state; migration/surfacing belongs to the separate config-migration lane.

## Tests
- api::tests::threads_weaves_skips_malformed_ward_without_aborting_fleet_read
- daemon::tests::handle_http_stream_converts_api_handler_error_to_json_500
- cargo test -p coven-cli threads_ --locked

## Gates
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- python scripts/check-secrets.py
