### PR TITLE
feat(ward): coven ward migrate — v0.1 dialect to Phase-2 WardConfig (threads-v60)

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -48,6 +48,7 @@ mod verification;
 // Gate 3 (coherence review) remains a follow-up — see ward.rs.
 #[allow(dead_code)]
 mod ward;
+mod ward_migrate;
 // The coven-threads validator call site: typed authority-state gating of
 // protected-surface mutations (OpenCoven/coven-threads Phase 2). Runs before
 // Ward::apply on the same write path; see threads_gate.rs.
@@ -130,6 +131,11 @@ enum Command {
     Daemon {
         #[command(subcommand)]
         command: DaemonCommand,
+    },
+    #[command(about = "Inspect and migrate Ward configuration")]
+    Ward {
+        #[command(subcommand)]
+        command: WardCommand,
     },
     #[command(
         about = "Stateless executor-node protocol commands (hub-dispatched over SSH/private network)"
@@ -641,6 +647,23 @@ enum EngineCommand {
 }
 
 #[derive(Subcommand, Debug)]
+enum WardCommand {
+    #[command(about = "Migrate Ward v0.1 ward.toml files to Phase-2 WardConfig")]
+    Migrate {
+        #[arg(long, value_name = "ID", help = "Only migrate the named familiar")]
+        familiar: Option<String>,
+        #[arg(
+            long,
+            value_name = "FPR",
+            help = "Principal key fingerprint to write into migrated WardConfig"
+        )]
+        fingerprint: String,
+        #[arg(long, help = "Write changes; default is a dry-run report")]
+        apply: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum LogsCommand {
     #[command(about = "Prune expired raw artifacts and old redacted event logs")]
     Prune {
@@ -800,6 +823,7 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Adapter { command }) => run_adapter_command(command),
         Some(Command::Engine { command }) => run_engine_command(command),
         Some(Command::Daemon { command }) => run_daemon_command(command),
+        Some(Command::Ward { command }) => run_ward_command(command),
         Some(Command::Executor { command }) => run_executor_command(command),
         Some(Command::Run {
             harness,
@@ -2678,6 +2702,31 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 anyhow::bail!(
                     "coven daemon server is only implemented on Unix-like systems and Windows for now"
                 );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_ward_command(command: WardCommand) -> Result<()> {
+    match command {
+        WardCommand::Migrate {
+            familiar,
+            fingerprint,
+            apply,
+        } => {
+            let home = coven_home_dir()?;
+            let report = ward_migrate::run_migration(
+                &home,
+                ward_migrate::WardMigrateOptions {
+                    familiar,
+                    fingerprint,
+                    apply,
+                },
+            )?;
+            ward_migrate::print_report(&report);
+            if report.has_errors() {
+                bail!("one or more Ward migrations failed or were unmigratable");
             }
         }
     }
@@ -4887,6 +4936,36 @@ mod tests {
 
         let vacuum = Cli::parse_from(["coven", "vacuum"]);
         assert!(matches!(vacuum.command, Some(Command::Vacuum)));
+    }
+
+    #[test]
+    fn cli_parses_ward_migrate_options() {
+        let cli = Cli::parse_from([
+            "coven",
+            "ward",
+            "migrate",
+            "--familiar",
+            "nova",
+            "--fingerprint",
+            "SHA256:test-principal",
+            "--apply",
+        ]);
+
+        match cli.command {
+            Some(Command::Ward {
+                command:
+                    WardCommand::Migrate {
+                        familiar,
+                        fingerprint,
+                        apply,
+                    },
+            }) => {
+                assert_eq!(familiar.as_deref(), Some("nova"));
+                assert_eq!(fingerprint, "SHA256:test-principal");
+                assert!(apply);
+            }
+            other => panic!("expected ward migrate command, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -1,0 +1,628 @@
+use std::fs;
+use std::io::{ErrorKind, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde::Deserialize;
+
+use crate::ward::{SurfaceEntry, Tier, WardConfig, WARD_CONFIG_FILE};
+
+const V01_BACKUP_FILE: &str = "ward.toml.v01.bak";
+
+#[derive(Debug, Clone)]
+pub struct WardMigrateOptions {
+    pub familiar: Option<String>,
+    pub fingerprint: String,
+    pub apply: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MigrationStatus {
+    NoWard,
+    AlreadyMigrated,
+    WouldMigrate,
+    Migrated,
+    BackupExists,
+    Unmigratable,
+    ValidationFailed,
+}
+
+#[derive(Debug, Clone)]
+pub struct MigrationEntry {
+    pub familiar_id: String,
+    pub workspace: PathBuf,
+    pub status: MigrationStatus,
+    pub protected_files: Vec<String>,
+    pub editable_paths: Vec<String>,
+    pub translated_globs: Vec<(String, String)>,
+    pub generated_toml: Option<String>,
+    pub message: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    pub entries: Vec<MigrationEntry>,
+}
+
+impl MigrationReport {
+    pub fn has_errors(&self) -> bool {
+        self.entries.iter().any(|entry| {
+            matches!(
+                entry.status,
+                MigrationStatus::BackupExists
+                    | MigrationStatus::Unmigratable
+                    | MigrationStatus::ValidationFailed
+            )
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyWardConfig {
+    protected: Option<LegacyProtected>,
+    editable: Option<LegacyEditable>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyProtected {
+    #[serde(default)]
+    files: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LegacyEditable {
+    #[serde(default)]
+    paths: Vec<String>,
+}
+
+pub fn run_migration(coven_home: &Path, options: WardMigrateOptions) -> Result<MigrationReport> {
+    if options.fingerprint.trim().is_empty() {
+        bail!("--fingerprint is required and cannot be empty");
+    }
+
+    let mut entries = Vec::new();
+    for familiar in crate::cockpit_sources::read_familiars(coven_home)? {
+        if options
+            .familiar
+            .as_deref()
+            .is_some_and(|wanted| wanted != familiar.id)
+        {
+            continue;
+        }
+        let workspace = crate::cockpit_sources::familiar_workspace(coven_home, &familiar.id);
+        entries.push(migrate_one(
+            &familiar.id,
+            &workspace,
+            &options.fingerprint,
+            options.apply,
+        )?);
+    }
+
+    Ok(MigrationReport { entries })
+}
+
+fn migrate_one(
+    familiar_id: &str,
+    workspace: &Path,
+    fingerprint: &str,
+    apply: bool,
+) -> Result<MigrationEntry> {
+    let path = workspace.join(WARD_CONFIG_FILE);
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            return Ok(MigrationEntry {
+                familiar_id: familiar_id.to_string(),
+                workspace: workspace.to_path_buf(),
+                status: MigrationStatus::NoWard,
+                protected_files: Vec::new(),
+                editable_paths: Vec::new(),
+                translated_globs: Vec::new(),
+                generated_toml: None,
+                message: "no ward".to_string(),
+            });
+        }
+        Err(err) => return Err(err).with_context(|| format!("reading {}", path.display())),
+    };
+
+    let phase2_error = match WardConfig::from_toml_str(&raw) {
+        Ok(_) => {
+            return Ok(MigrationEntry {
+                familiar_id: familiar_id.to_string(),
+                workspace: workspace.to_path_buf(),
+                status: MigrationStatus::AlreadyMigrated,
+                protected_files: Vec::new(),
+                editable_paths: Vec::new(),
+                translated_globs: Vec::new(),
+                generated_toml: None,
+                message: "already migrated".to_string(),
+            });
+        }
+        Err(error) => error,
+    };
+
+    let value: toml::Value = match toml::from_str(&raw) {
+        Ok(value) => value,
+        Err(error) => {
+            return Ok(MigrationEntry {
+                familiar_id: familiar_id.to_string(),
+                workspace: workspace.to_path_buf(),
+                status: MigrationStatus::Unmigratable,
+                protected_files: Vec::new(),
+                editable_paths: Vec::new(),
+                translated_globs: Vec::new(),
+                generated_toml: None,
+                message: format!("unmigratable ward.toml: {error}"),
+            });
+        }
+    };
+
+    let is_v01 = value.get("meta").is_some() || value.get("protected").is_some();
+    if !is_v01 {
+        return Ok(MigrationEntry {
+            familiar_id: familiar_id.to_string(),
+            workspace: workspace.to_path_buf(),
+            status: MigrationStatus::Unmigratable,
+            protected_files: Vec::new(),
+            editable_paths: Vec::new(),
+            translated_globs: Vec::new(),
+            generated_toml: None,
+            message: format!(
+                "unmigratable ward.toml: not Phase-2 ({phase2_error:#}) and not recognized Ward v0.1"
+            ),
+        });
+    }
+
+    let legacy: LegacyWardConfig = match value.try_into() {
+        Ok(legacy) => legacy,
+        Err(error) => {
+            return Ok(MigrationEntry {
+                familiar_id: familiar_id.to_string(),
+                workspace: workspace.to_path_buf(),
+                status: MigrationStatus::Unmigratable,
+                protected_files: Vec::new(),
+                editable_paths: Vec::new(),
+                translated_globs: Vec::new(),
+                generated_toml: None,
+                message: format!("unmigratable Ward v0.1 tables: {error:#}"),
+            });
+        }
+    };
+    let protected_files = legacy
+        .protected
+        .map(|protected| protected.files)
+        .unwrap_or_default();
+    let editable_paths = legacy
+        .editable
+        .map(|editable| editable.paths)
+        .unwrap_or_default();
+    let mut translated_globs = Vec::new();
+    let translated_editable: Vec<String> = editable_paths
+        .iter()
+        .map(|path| {
+            let translated = translate_legacy_editable_path(path);
+            if translated != *path {
+                translated_globs.push((path.clone(), translated.clone()));
+            }
+            translated
+        })
+        .collect();
+
+    let config = WardConfig {
+        principal_key_fingerprint: fingerprint.to_string(),
+        protected_surface: protected_files.clone(),
+        surface: protected_files
+            .iter()
+            .cloned()
+            .map(|path| SurfaceEntry {
+                path,
+                tier: Tier::Protected,
+            })
+            .chain(
+                translated_editable
+                    .iter()
+                    .cloned()
+                    .map(|path| SurfaceEntry {
+                        path,
+                        tier: Tier::Logged,
+                    }),
+            )
+            .collect(),
+        default_tier: Tier::Logged,
+    };
+    let generated_toml = render_phase2_toml(&config)?;
+    if let Err(error) = WardConfig::from_toml_str(&generated_toml) {
+        return Ok(MigrationEntry {
+            familiar_id: familiar_id.to_string(),
+            workspace: workspace.to_path_buf(),
+            status: MigrationStatus::ValidationFailed,
+            protected_files,
+            editable_paths,
+            translated_globs,
+            generated_toml: Some(generated_toml),
+            message: format!("generated Phase-2 ward.toml failed validation: {error:#}"),
+        });
+    }
+
+    if !apply {
+        return Ok(MigrationEntry {
+            familiar_id: familiar_id.to_string(),
+            workspace: workspace.to_path_buf(),
+            status: MigrationStatus::WouldMigrate,
+            protected_files,
+            editable_paths,
+            translated_globs,
+            generated_toml: Some(generated_toml),
+            message: "would migrate Ward v0.1".to_string(),
+        });
+    }
+
+    let backup = workspace.join(V01_BACKUP_FILE);
+    if backup.exists() {
+        return Ok(MigrationEntry {
+            familiar_id: familiar_id.to_string(),
+            workspace: workspace.to_path_buf(),
+            status: MigrationStatus::BackupExists,
+            protected_files,
+            editable_paths,
+            translated_globs,
+            generated_toml: Some(generated_toml),
+            message: format!("refusing to clobber existing {}", backup.display()),
+        });
+    }
+
+    fs::write(&backup, raw.as_bytes()).with_context(|| format!("writing {}", backup.display()))?;
+    if let Err(error) = write_and_verify(&path, &raw, &generated_toml, workspace) {
+        let _ = fs::write(&path, raw.as_bytes());
+        return Ok(MigrationEntry {
+            familiar_id: familiar_id.to_string(),
+            workspace: workspace.to_path_buf(),
+            status: MigrationStatus::ValidationFailed,
+            protected_files,
+            editable_paths,
+            translated_globs,
+            generated_toml: Some(generated_toml),
+            message: format!("failed to write valid migrated ward.toml: {error:#}"),
+        });
+    }
+
+    Ok(MigrationEntry {
+        familiar_id: familiar_id.to_string(),
+        workspace: workspace.to_path_buf(),
+        status: MigrationStatus::Migrated,
+        protected_files,
+        editable_paths,
+        translated_globs,
+        generated_toml: Some(generated_toml),
+        message: "migrated Ward v0.1".to_string(),
+    })
+}
+
+fn render_phase2_toml(config: &WardConfig) -> Result<String> {
+    let mut out = format!(
+        "# Migrated from Ward v0.1 by `coven ward migrate` on {}; original preserved at ward.toml.v01.bak\n\n",
+        crate::api::current_timestamp()
+    );
+    out.push_str(&toml::to_string(config).context("serializing Phase-2 WardConfig")?);
+    Ok(out)
+}
+
+fn translate_legacy_editable_path(path: &str) -> String {
+    let normalized = path.trim().trim_start_matches("./").replace('\\', "/");
+    if normalized.ends_with('/') {
+        normalized
+    } else if let Some(prefix) = normalized.strip_suffix("/*") {
+        format!("{prefix}/**")
+    } else {
+        normalized
+    }
+}
+
+fn write_and_verify(path: &Path, original: &str, generated: &str, workspace: &Path) -> Result<()> {
+    let temp = path.with_file_name(format!(
+        "{}.migrate.tmp.{}",
+        WARD_CONFIG_FILE,
+        std::process::id()
+    ));
+    {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+            .with_context(|| format!("creating {}", temp.display()))?;
+        file.write_all(generated.as_bytes())
+            .with_context(|| format!("writing {}", temp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("syncing {}", temp.display()))?;
+    }
+    fs::rename(&temp, path)
+        .with_context(|| format!("renaming {} to {}", temp.display(), path.display()))?;
+    match WardConfig::load(workspace) {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => {
+            fs::write(path, original.as_bytes()).ok();
+            Err(anyhow!("migrated ward.toml disappeared after write"))
+        }
+        Err(error) => {
+            fs::write(path, original.as_bytes()).ok();
+            Err(error)
+        }
+    }
+}
+
+pub fn print_report(report: &MigrationReport) {
+    for entry in &report.entries {
+        println!(
+            "{}: {:?} — {} ({})",
+            entry.familiar_id,
+            entry.status,
+            entry.message,
+            entry.workspace.display()
+        );
+        println!(
+            "  target: {}",
+            entry.workspace.join(WARD_CONFIG_FILE).display()
+        );
+        if !entry.protected_files.is_empty() {
+            println!(
+                "  protected -> tier 0: {}",
+                entry.protected_files.join(", ")
+            );
+        }
+        if !entry.editable_paths.is_empty() {
+            println!("  editable -> tier 2: {}", entry.editable_paths.join(", "));
+        }
+        for (from, to) in &entry.translated_globs {
+            println!("  translated glob: {from} -> {to}");
+        }
+        if entry.generated_toml.is_some() {
+            let validation = if entry.status == MigrationStatus::ValidationFailed {
+                "failed"
+            } else {
+                "passed"
+            };
+            println!("  round-trip validation: {validation}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ward::{Authorization, Proposal, Tier, Ward, WardConfig};
+    use anyhow::Result;
+    use std::fs;
+    use std::path::Path;
+
+    fn seed_familiars(home: &Path) -> Result<std::path::PathBuf> {
+        let workspace = home.join("workspaces").join("familiars").join("nova");
+        fs::create_dir_all(&workspace)?;
+        fs::write(
+            home.join("familiars.toml"),
+            familiar_fixture_toml(&workspace),
+        )?;
+        Ok(workspace)
+    }
+
+    fn familiar_fixture_toml(workspace: &Path) -> String {
+        let workspace = workspace.display().to_string().replace('\\', "/");
+        format!(
+            r#"[[familiar]]
+id = "nova"
+display_name = "Nova"
+role = "Integration"
+description = "Synthetic migration fixture."
+workspace = "{}"
+"#,
+            workspace
+        )
+    }
+
+    fn synthetic_v01() -> &'static str {
+        r#"[meta]
+version = "0.1"
+owner = "nova"
+
+[protected]
+files = ["SOUL.md", "IDENTITY.md"]
+invariants = ["synthetic invariant one", "synthetic invariant two"]
+
+[editable]
+paths = ["skills/*/", "memory/*", "notes/"]
+harness_blocks = ["synthetic-harness"]
+
+[approval_tiers.tier0]
+required = ["principal"]
+
+[audit]
+append_only = true
+"#
+    }
+
+    fn load_migrated_config(workspace: &Path) -> Result<WardConfig> {
+        WardConfig::load(workspace)?.ok_or_else(|| anyhow::anyhow!("missing ward config"))
+    }
+
+    #[test]
+    fn familiar_fixture_toml_escapes_windows_workspace_paths() -> Result<()> {
+        let raw = familiar_fixture_toml(Path::new(
+            r"C:\Users\RUNNER~1\AppData\Local\Temp\.tmpqHnJfu\workspaces\familiars\nova",
+        ));
+
+        let parsed: toml::Value = toml::from_str(&raw)?;
+        assert_eq!(parsed["familiar"][0]["id"].as_str(), Some("nova"));
+        Ok(())
+    }
+
+    #[test]
+    fn dry_run_migrates_v01_to_valid_phase2_without_writing_and_matches_tiers() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        let original = synthetic_v01();
+        fs::write(workspace.join("ward.toml"), original)?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: None,
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: false,
+            },
+        )?;
+
+        assert!(!report.has_errors());
+        assert_eq!(report.entries.len(), 1);
+        assert_eq!(report.entries[0].status, MigrationStatus::WouldMigrate);
+        assert!(report.entries[0]
+            .translated_globs
+            .contains(&("memory/*".to_string(), "memory/**".to_string())));
+        assert_eq!(fs::read_to_string(workspace.join("ward.toml"))?, original);
+        assert!(!workspace.join("ward.toml.v01.bak").exists());
+
+        let generated = report.entries[0]
+            .generated_toml
+            .as_deref()
+            .expect("dry run includes generated toml");
+        assert!(generated.contains("Migrated from Ward v0.1"));
+        assert!(!generated.contains("invariants"));
+        assert!(!generated.contains("harness_blocks"));
+        assert!(!generated.contains("approval_tiers"));
+        assert!(!generated.contains("[audit]"));
+        let config = WardConfig::from_toml_str(generated)?;
+        assert_eq!(config.principal_key_fingerprint, "SHA256:test-principal");
+        assert_eq!(
+            config.protected_surface,
+            vec!["SOUL.md".to_string(), "IDENTITY.md".to_string()]
+        );
+        let tier0: Vec<_> = config
+            .surface
+            .iter()
+            .filter(|entry| entry.tier == Tier::Protected)
+            .map(|entry| entry.path.clone())
+            .collect();
+        assert_eq!(config.protected_surface, tier0);
+
+        let ward = Ward::new(workspace, config)?;
+        let outcome = ward.evaluate(&Proposal {
+            targets: vec![
+                "skills/rust/SKILL.md".to_string(),
+                "memory/deep/fact.md".to_string(),
+                "notes/today.md".to_string(),
+            ],
+            authorization: Authorization::default(),
+        });
+        assert!(outcome.decisions.iter().all(|d| d.tier == Tier::Logged));
+        Ok(())
+    }
+
+    #[test]
+    fn apply_writes_backup_and_valid_config_then_second_run_is_already_migrated() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        let original = synthetic_v01();
+        fs::write(workspace.join("ward.toml"), original)?;
+
+        let applied = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(!applied.has_errors());
+        assert_eq!(applied.entries[0].status, MigrationStatus::Migrated);
+        assert_eq!(
+            fs::read_to_string(workspace.join("ward.toml.v01.bak"))?,
+            original
+        );
+        let config = load_migrated_config(&workspace)?;
+        assert_eq!(config.principal_key_fingerprint, "SHA256:test-principal");
+
+        let second = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+        assert!(!second.has_errors());
+        assert_eq!(second.entries[0].status, MigrationStatus::AlreadyMigrated);
+        Ok(())
+    }
+
+    #[test]
+    fn existing_backup_refuses_without_clobbering() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        let original = synthetic_v01();
+        fs::write(workspace.join("ward.toml"), original)?;
+        fs::write(workspace.join("ward.toml.v01.bak"), "existing backup")?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: None,
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(report.has_errors());
+        assert_eq!(report.entries[0].status, MigrationStatus::BackupExists);
+        assert_eq!(fs::read_to_string(workspace.join("ward.toml"))?, original);
+        assert_eq!(
+            fs::read_to_string(workspace.join("ward.toml.v01.bak"))?,
+            "existing backup"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn garbage_ward_is_unmigratable_without_writing() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        fs::write(workspace.join("ward.toml"), "not = [valid")?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: None,
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(report.has_errors());
+        assert_eq!(report.entries[0].status, MigrationStatus::Unmigratable);
+        assert_eq!(
+            fs::read_to_string(workspace.join("ward.toml"))?,
+            "not = [valid"
+        );
+        assert!(!workspace.join("ward.toml.v01.bak").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn missing_ward_is_reported_as_no_ward_skip() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: None,
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(!report.has_errors());
+        assert_eq!(report.entries[0].status, MigrationStatus::NoWard);
+        assert!(!workspace.join("ward.toml").exists());
+        assert!(!workspace.join("ward.toml.v01.bak").exists());
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Implements bead threads-v60: `coven ward migrate [--familiar <id>] --fingerprint <fpr> [--apply]`.
- Enumerates familiars through `cockpit_sources::read_familiars` + `familiar_workspace`, so explicit workspace declarations are honored.
- Dry-run is default; `--apply` writes a byte-exact `ward.toml.v01.bak`, atomically replaces `ward.toml`, then reloads Phase-2 `WardConfig` and restores the original if validation fails.

## Dialect handling
- No `ward.toml`: report `NoWard`, write nothing.
- Already Phase-2: report `AlreadyMigrated`, write nothing.
- Ward v0.1 heuristic: root `[meta]` or `[protected]` table.
- Other invalid configs: report `Unmigratable`, include parse/schema error, write nothing.

## Translation rules
- `[protected].files` becomes both `protected_surface` and one `[[surface]]` tier `0` entry per file, constructed from the same list to satisfy Ward validation rule 6.
- `[editable].paths` becomes `[[surface]]` tier `2` entries.
- Paths ending `/` are left with the trailing slash; Ward’s real matcher compiles that as everything under the directory (`/**`).
- Paths ending `/*` translate to `/**` (for example `memory/*` -> `memory/**`) so v0.1 directory-wildcard intent keeps matching nested descendants under Ward’s `literal_separator` matcher.
- Paths ending `/*/` are left unchanged; Ward compiles the trailing slash so examples like `skills/*/` match files under each immediate skill directory (`skills/rust/SKILL.md`).
- v0.1-only sections (`invariants`, `harness_blocks`, `approval_tiers`, `audit`, `meta`) are backup-only and are not emitted into the Phase-2 file.

## Tests
- `ward_migrate::tests::dry_run_migrates_v01_to_valid_phase2_without_writing_and_matches_tiers`
- `ward_migrate::tests::apply_writes_backup_and_valid_config_then_second_run_is_already_migrated`
- `ward_migrate::tests::existing_backup_refuses_without_clobbering`
- `ward_migrate::tests::garbage_ward_is_unmigratable_without_writing`
- `ward_migrate::tests::missing_ward_is_reported_as_no_ward_skip`
- `tests::cli_parses_ward_migrate_options`

## Gates
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
