### PR TITLE
test: copy shim stdin with findstr instead of PowerShell (deflake #407)

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -3511,11 +3511,15 @@ exit 0
     fn codex_json_batch_shim_uses_stdin_and_emits_assistant_text() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let batch = temp_dir.path().join("fake-codex.cmd");
+        // Copy stdin with findstr (a native, always-present binary with no
+        // cold start): PowerShell's multi-second startup on loaded runners
+        // outlived even a 10s activity deadline and flaked this test twice
+        // (issue #407).
         std::fs::write(
             &batch,
             concat!(
                 "@echo off\r\n",
-                "\"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -Command \"$inputStream=[Console]::OpenStandardInput(); $outputStream=[IO.File]::Open('stdin.txt',[IO.FileMode]::Create); $inputStream.CopyTo($outputStream); $outputStream.Dispose()\"\r\n",
+                "\"%SystemRoot%\\System32\\findstr.exe\" \"^\" > stdin.txt\r\n",
                 "echo %* > args.txt\r\n",
                 "echo {\"type\":\"thread.started\",\"thread_id\":\"thread-456\"}\r\n",
                 "echo {\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"reply from Codex\"}}\r\n",
@@ -3536,9 +3540,9 @@ exit 0
         };
         let mut assistant = Vec::new();
 
-        // PowerShell can take several seconds to cold-start on a loaded
-        // Windows runner. This test exercises stdin and JSONL framing, not the
-        // activity deadline, so leave enough headroom for process startup.
+        // Generous headroom for shim process startup on a loaded Windows
+        // runner (issue #407). This test exercises stdin and JSONL framing,
+        // not the activity deadline.
         let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(10), |text| {
             assistant.push(text.to_string());
             Ok(())

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -512,7 +512,9 @@ description = "Windows Codex regression fixture"
         &fake_codex,
         concat!(
             "@echo off\r\n",
-            "\"%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\" -NoProfile -Command \"$inputStream=[Console]::OpenStandardInput(); $outputStream=[IO.File]::Open('stdin.txt',[IO.FileMode]::Create); $inputStream.CopyTo($outputStream); $outputStream.Dispose()\"\r\n",
+            // findstr copies stdin without PowerShell's multi-second cold
+            // start, which flaked the sibling pty_runner test (issue #407).
+            "\"%SystemRoot%\\System32\\findstr.exe\" \"^\" > stdin.txt\r\n",
             "echo %* > args.txt\r\n",
             "echo {\"type\":\"thread.started\",\"thread_id\":\"thread-789\"}\r\n",
             "echo {\"type\":\"turn.started\"}\r\n",


### PR DESCRIPTION
Fixes #407 (reopened).

The flake recurred on PR #422 (run 29639095135) **with the 10s deadline present**: the fake-codex batch shims copy stdin via PowerShell, whose cold start on a loaded windows-latest runner can outlive even 10s — the child gets killed before writing `args.txt`, and the test dies with `os error 2`.

Fix the mechanism instead of the headroom: copy stdin with `findstr` (`"%SystemRoot%\System32\findstr.exe" "^" > stdin.txt`) — a native, always-present binary with effectively zero startup. `"^"` matches every line, so stdin is copied verbatim until EOF. Applied to both shims (pty_runner unit test + stream_json_integration fixture); the 10s deadline stays as generic startup headroom.

## Testing
- `cargo fmt --check` ✓ · `cargo clippy -p coven-cli --all-targets -- -D warnings` ✓
- `cargo test -p coven-cli pty_runner::` ✓ (29/29 on unix; both changed shims are Windows-only fixtures — windows-latest CI on this PR is the authoritative check)