### PR TITLE
feat(ward): stage Tier-1 coherence holds as pending proposals (Gate 3 PR 1)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2647,10 +2647,18 @@ fn apply_familiar_edits(
         // *solely* for Tier-1 coherence review is staged for the principal
         // instead of dead-ending. Any authorized-protected hold keeps the
         // plain `held` shape — mixed proposals stay all-or-nothing.
-        let coherence_only = report
-            .changes
-            .iter()
-            .all(|change| change.decision.verdict != ward::Verdict::AuthorizedProtectedChange);
+        // Stage only when every verdict is cleared-or-coherence — i.e. the
+        // *only* hold reason is Tier-1 review. Anything else (authorized
+        // protected changes today, future verdicts by default) keeps the
+        // plain held shape: fail closed toward the authority lane.
+        let coherence_only = report.changes.iter().all(|change| {
+            matches!(
+                change.decision.verdict,
+                ward::Verdict::Allow
+                    | ward::Verdict::AllowWithLog
+                    | ward::Verdict::RequiresCoherenceReview
+            )
+        });
         if coherence_only {
             let conn = store::open_store(&store_path(coven_home))?;
             let (pending_path, proposal_id) = crate::threads_gate::stage_coherence_proposal(

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2643,6 +2643,38 @@ fn apply_familiar_edits(
         );
     }
     if report.is_held() {
+        // Gate 3 (docs/design/ward-gate3-coherence.md G3.1): a proposal held
+        // *solely* for Tier-1 coherence review is staged for the principal
+        // instead of dead-ending. Any authorized-protected hold keeps the
+        // plain `held` shape — mixed proposals stay all-or-nothing.
+        let coherence_only = report
+            .changes
+            .iter()
+            .all(|change| change.decision.verdict != ward::Verdict::AuthorizedProtectedChange);
+        if coherence_only {
+            let conn = store::open_store(&store_path(coven_home))?;
+            let (pending_path, proposal_id) = crate::threads_gate::stage_coherence_proposal(
+                &conn,
+                coven_home,
+                familiar_id,
+                &workspace,
+                &config,
+                &edits,
+                &authorization,
+            )?;
+            return json_response(
+                202,
+                &json!({
+                    "ok": true,
+                    "disposition": "staged",
+                    "reviewKind": "coherence",
+                    "proposalId": proposal_id,
+                    "pendingPath": pending_path.display().to_string(),
+                    "changes": changes,
+                    "threadsGate": threads_gate_json,
+                }),
+            );
+        }
         return json_response(
             202,
             &json!({
@@ -6569,6 +6601,9 @@ tier = 1
         assert_eq!(response.status, 202, "got {}", response.body);
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
         assert_eq!(body["disposition"], "held");
+        // An authorized-protected hold is the authority lane's business —
+        // it must NOT be staged into the Gate-3 coherence lane.
+        assert!(body.get("reviewKind").is_none());
         assert_eq!(
             std::fs::read_to_string(workspace.join("SOUL.md"))?,
             "# Sage\n"
@@ -7117,13 +7152,50 @@ tier = 0
             r#"{"edits":[{"target":"reviewed/skill.md","contents":"tweak"}]}"#,
         )?;
 
+        // Gate 3 G3.1: a pure Tier-1 hold is staged for coherence review
+        // instead of dead-ending as a bare hold. Nothing is written.
         assert_eq!(response.status, 202, "got {}", response.body);
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
-        assert_eq!(body["disposition"], "held");
+        assert_eq!(body["disposition"], "staged");
+        assert_eq!(body["reviewKind"], "coherence");
         assert_eq!(
             body["changes"][0]["verdict"]["kind"],
             "requiresCoherenceReview"
         );
+        assert!(!workspace.join("reviewed/skill.md").exists());
+
+        // The pending file exists, carries the sidecar marker, and still
+        // parses as the core PendingProposal type (marker is additive).
+        let pending_path =
+            std::path::PathBuf::from(body["pendingPath"].as_str().expect("pendingPath present"));
+        let raw = std::fs::read_to_string(&pending_path)?;
+        let staged: serde_json::Value = serde_json::from_str(&raw)?;
+        assert_eq!(staged["reviewKind"], "coherence");
+        let parsed: coven_threads_core::PendingProposal = serde_json::from_str(&raw)?;
+        assert_eq!(parsed.id.0.to_string(), body["proposalId"]);
+        assert_eq!(parsed.edits.len(), 1);
+
+        // One proposal_submitted row landed in the append-only ledger.
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM ward_audit WHERE event_type = 'proposal_submitted' \
+             AND decision = 'staged:coherence'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(count, 1);
+
+        // Fail-closed until Gate-3 resolution (PR 4) lands: approving a
+        // coherence proposal 409s; nothing is written.
+        let proposal_id = body["proposalId"].as_str().expect("proposalId");
+        let approve = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/threads/proposals/{proposal_id}/approve"),
+            home,
+            None,
+            Some("{}"),
+        )?;
+        assert_eq!(approve.status, 409, "got {}", approve.body);
         assert!(!workspace.join("reviewed/skill.md").exists());
         Ok(())
     }

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -216,8 +216,11 @@ pub fn gate_protected_edits(conn: &Connection, req: &GateRequest<'_>) -> Result<
             coven_home,
             &familiar_uuid,
             &request_writer,
-            thread_id,
-            fray,
+            StagingLane {
+                thread_id,
+                fray,
+                review_kind: None,
+            },
             edits,
             now,
         )?;
@@ -563,12 +566,94 @@ pub(crate) fn append_audit_row(
     Ok(())
 }
 
+/// Stage a proposal held **solely** for Gate-3 coherence review (Tier-1
+/// targets) as a pending proposal beside the Tier-0 authority lane
+/// (`docs/design/ward-gate3-coherence.md` G3.1).
+///
+/// Tier-1 surfaces are deliberately not woven, so the staged record carries
+/// `FrayOrSnap::NotCovered { channel: Mutation }` — literally true: no thread
+/// covers the surface — under a fresh `ThreadId`, plus the `reviewKind:
+/// "coherence"` sidecar marker the decide path branches on. One
+/// `proposal_submitted` row lands in the append-only `ward_audit` ledger.
+/// Resolution is PR 4 of the design; until then the existing decide-path
+/// guards keep approval fail-closed.
+pub fn stage_coherence_proposal(
+    conn: &Connection,
+    coven_home: &Path,
+    familiar_id: &str,
+    workspace: &Path,
+    config: &ward::WardConfig,
+    edits: &[ward::FileEdit],
+    authorization: &ward::Authorization,
+) -> Result<(PathBuf, String)> {
+    let request_writer = match &authorization.principal_signature_fingerprint {
+        Some(fp) => threads::WriterId::new(format!("principal:{fp}")),
+        None => threads::WriterId::new("client:unsigned"),
+    };
+    let now = time::OffsetDateTime::now_utc();
+    // Read-only weave view: coherence staging must not bootstrap baselines.
+    let state = build_weave_state(conn, familiar_id, workspace, config, &[], false)?;
+    let (pending_path, proposal_id) = stage_pending_proposal(
+        coven_home,
+        &state.familiar_uuid,
+        &request_writer,
+        StagingLane {
+            thread_id: threads::ThreadId::new(),
+            fray: threads::FrayOrSnap::NotCovered {
+                channel: threads::Channel::Mutation,
+            },
+            review_kind: Some("coherence"),
+        },
+        edits,
+        now,
+    )?;
+
+    let files_touched = serde_json::to_string(
+        &edits
+            .iter()
+            .map(|edit| edit.target.as_str())
+            .collect::<Vec<_>>(),
+    )?;
+    let format = time::format_description::well_known::Rfc3339;
+    let now_text = now.format(&format)?;
+    conn.execute(
+        "INSERT INTO ward_audit (
+            event_type, proposal_id, familiar_id, ward_version, ward_hash,
+            tier, decision, approver, diff_hash, files_touched, channel,
+            thread_id, submitted_at, decided_at
+        ) VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, NULL, NULL, ?7, ?8, NULL, ?9, ?9)",
+        rusqlite::params![
+            threads::AuditEventType::ProposalSubmitted.tag(),
+            proposal_id,
+            familiar_id,
+            state.weave.weave_hash(),
+            i64::from(u8::from(ward::Tier::Reviewed)),
+            "staged:coherence",
+            files_touched,
+            format!("{:?}", threads::Channel::Mutation).to_lowercase(),
+            now_text,
+        ],
+    )
+    .context("appending proposal_submitted audit for coherence staging")?;
+
+    Ok((pending_path, proposal_id))
+}
+
+/// Which review lane a staged proposal belongs to, plus the thread evidence
+/// recorded with it.
+struct StagingLane {
+    thread_id: threads::ThreadId,
+    fray: threads::FrayOrSnap,
+    /// `Some("coherence")` writes the sidecar marker; `None` is the
+    /// authority lane (absent field ⇒ authority for existing files).
+    review_kind: Option<&'static str>,
+}
+
 fn stage_pending_proposal(
     coven_home: &Path,
     familiar_uuid: &threads::FamiliarId,
     writer: &threads::WriterId,
-    thread_id: threads::ThreadId,
-    fray: threads::FrayOrSnap,
+    lane: StagingLane,
     edits: &[ward::FileEdit],
     now: time::OffsetDateTime,
 ) -> Result<(PathBuf, String)> {
@@ -577,8 +662,8 @@ fn stage_pending_proposal(
         familiar_id: *familiar_uuid,
         writer: writer.clone(),
         channel: threads::Channel::Mutation,
-        thread_id,
-        fray,
+        thread_id: lane.thread_id,
+        fray: lane.fray,
         edits: edits
             .iter()
             .map(|edit| threads::StagedEdit {
@@ -593,7 +678,19 @@ fn stage_pending_proposal(
     std::fs::create_dir_all(&pending_dir)
         .with_context(|| format!("creating {}", pending_dir.display()))?;
     let path = pending_dir.join(proposal.file_name());
-    let body = serde_json::to_vec_pretty(&proposal).context("serializing pending proposal")?;
+    let body = if let Some(kind) = lane.review_kind {
+        // The marker rides beside the core type's fields (additive; readers
+        // treat an absent field as "authority", so existing files and the
+        // core deserializer keep working unchanged).
+        let mut value = serde_json::to_value(&proposal).context("serializing pending proposal")?;
+        value
+            .as_object_mut()
+            .context("pending proposal serialized as a non-object")?
+            .insert("reviewKind".to_string(), serde_json::json!(kind));
+        serde_json::to_vec_pretty(&value).context("serializing pending proposal")?
+    } else {
+        serde_json::to_vec_pretty(&proposal).context("serializing pending proposal")?
+    };
     // Atomic sibling-staged write, same discipline as the Ward's own writes.
     let staged = path.with_extension("json.staged");
     std::fs::write(&staged, &body)

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -593,12 +593,13 @@ pub fn stage_coherence_proposal(
     let now = time::OffsetDateTime::now_utc();
     // Read-only weave view: coherence staging must not bootstrap baselines.
     let state = build_weave_state(conn, familiar_id, workspace, config, &[], false)?;
+    let thread_id = threads::ThreadId::new();
     let (pending_path, proposal_id) = stage_pending_proposal(
         coven_home,
         &state.familiar_uuid,
         &request_writer,
         StagingLane {
-            thread_id: threads::ThreadId::new(),
+            thread_id,
             fray: threads::FrayOrSnap::NotCovered {
                 channel: threads::Channel::Mutation,
             },
@@ -621,7 +622,7 @@ pub fn stage_coherence_proposal(
             event_type, proposal_id, familiar_id, ward_version, ward_hash,
             tier, decision, approver, diff_hash, files_touched, channel,
             thread_id, submitted_at, decided_at
-        ) VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, NULL, NULL, ?7, ?8, NULL, ?9, ?9)",
+        ) VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, NULL, NULL, ?7, ?8, ?10, ?9, ?9)",
         rusqlite::params![
             threads::AuditEventType::ProposalSubmitted.tag(),
             proposal_id,
@@ -632,6 +633,7 @@ pub fn stage_coherence_proposal(
             files_touched,
             format!("{:?}", threads::Channel::Mutation).to_lowercase(),
             now_text,
+            thread_id.0.to_string(),
         ],
     )
     .context("appending proposal_submitted audit for coherence staging")?;
@@ -678,18 +680,22 @@ fn stage_pending_proposal(
     std::fs::create_dir_all(&pending_dir)
         .with_context(|| format!("creating {}", pending_dir.display()))?;
     let path = pending_dir.join(proposal.file_name());
-    let body = if let Some(kind) = lane.review_kind {
-        // The marker rides beside the core type's fields (additive; readers
-        // treat an absent field as "authority", so existing files and the
-        // core deserializer keep working unchanged).
-        let mut value = serde_json::to_value(&proposal).context("serializing pending proposal")?;
-        value
-            .as_object_mut()
-            .context("pending proposal serialized as a non-object")?
-            .insert("reviewKind".to_string(), serde_json::json!(kind));
-        serde_json::to_vec_pretty(&value).context("serializing pending proposal")?
-    } else {
-        serde_json::to_vec_pretty(&proposal).context("serializing pending proposal")?
+    let body = {
+        /// On-disk pending-proposal shape: the core type plus the optional
+        /// lane marker (absent ⇒ authority, so existing files and the core
+        /// deserializer keep working unchanged).
+        #[derive(serde::Serialize)]
+        struct StagedProposalFile<'a> {
+            #[serde(flatten)]
+            proposal: &'a threads::PendingProposal,
+            #[serde(rename = "reviewKind", skip_serializing_if = "Option::is_none")]
+            review_kind: Option<&'static str>,
+        }
+        serde_json::to_vec_pretty(&StagedProposalFile {
+            proposal: &proposal,
+            review_kind: lane.review_kind,
+        })
+        .context("serializing pending proposal")?
     };
     // Atomic sibling-staged write, same discipline as the Ward's own writes.
     let staged = path.with_extension("json.staged");


### PR DESCRIPTION
Closes #424 — implementation PR 1 of [`docs/design/ward-gate3-coherence.md`](../blob/main/docs/design/ward-gate3-coherence.md) (#415, umbrella #335), scoped exactly to the design's decomposition item 1.

## What

- **Tier-1 holds stop dead-ending (G3.1):** `POST /api/v1/familiars/:id/edits` proposals held *solely* for `RequiresCoherenceReview` are staged at `~/.coven/pending/` via a new `stage_coherence_proposal` — fresh `ThreadId` + `FrayOrSnap::NotCovered{Mutation}` (literally true: Tier-1 surfaces are unwoven) — and answer `202 { disposition: "staged", reviewKind: "coherence", proposalId, pendingPath }`.
- **Sidecar marker:** `reviewKind` rides beside the core `PendingProposal` fields as an additive JSON field (absent ⇒ authority) — verified in-test that the file still parses as the core type, so existing pending files and the upstream deserializer are untouched.
- **Audit:** one `proposal_submitted` row (decision `staged:coherence`, tier 1) in the append-only `ward_audit` ledger.
- **Boundaries preserved:** authorized-protected (Tier-0) holds keep the plain `held` shape — mixed proposals stay all-or-nothing in the authority lane; approving a coherence proposal is fail-closed `409` via the existing empty-gated-targets guard until design PR 4 (resolution) lands; rejection already works. Non-goals from #421 untouched (nothing auto-approves).
- `StagingLane` bundles per-lane thread evidence (clippy max-args, no `#[allow]`).

## Testing
- `cargo fmt --check` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `python scripts/check-secrets.py` ✓
- `cargo test --workspace --locked` ✓ **1236 passed / 0 failed** — the Tier-1 hold test now proves: staged shape, marker present, core-type round-trip, audit row, approve-409 fail-closed, nothing written; the authorized-hold test additionally pins `reviewKind` absent.