### PR TITLE
fix(ci): deflake windows pty batch shim + smoke session-kill wait (threads-0ip)

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -628,9 +628,10 @@ fn record_session_exit(
                 } else {
                     result.status
                 };
-            crate::store::update_session_status(
+            crate::store::update_session_status_if_current(
                 &conn,
                 session_id,
+                "running",
                 persisted_status,
                 result.exit_code,
                 &crate::api::current_timestamp(),

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -3548,7 +3548,7 @@ exit 0
             Ok(())
         })?;
 
-        let args = std::fs::read_to_string(temp_dir.path().join("args.txt"))?;
+        let args = read_side_effect_file(temp_dir.path().join("args.txt"))?;
         assert!(
             args.contains("exec --json -- -"),
             "unexpected argv: {args:?}"
@@ -3557,7 +3557,7 @@ exit 0
             !args.contains("first line") && !args.contains("second line"),
             "the multiline user prompt must not reach cmd.exe argv: {args:?}"
         );
-        let stdin = std::fs::read_to_string(temp_dir.path().join("stdin.txt"))?;
+        let stdin = read_side_effect_file(temp_dir.path().join("stdin.txt"))?;
         assert!(
             stdin.contains("first line"),
             "missing first stdin line: {stdin:?}"
@@ -3570,6 +3570,29 @@ exit 0
         assert_eq!(outcome.harness_session_id.as_deref(), Some("thread-456"));
         assert!(outcome.error.is_none());
         Ok(())
+    }
+
+    #[cfg(windows)]
+    fn read_side_effect_file(path: PathBuf) -> anyhow::Result<String> {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut last_error = None;
+        while Instant::now() < deadline {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => return Ok(contents),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    last_error = Some(error);
+                    thread::sleep(Duration::from_millis(25));
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| format!("failed reading {path:?}"))
+                }
+            }
+        }
+        match last_error {
+            Some(error) => Err(error)
+                .with_context(|| format!("timed out waiting for batch side-effect file {path:?}")),
+            None => anyhow::bail!("timed out waiting for batch side-effect file {path:?}"),
+        }
     }
 
     #[cfg(windows)]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1717,6 +1717,28 @@ pub fn update_session_status(
     Ok(())
 }
 
+pub fn update_session_status_if_current(
+    conn: &Connection,
+    session_id: &str,
+    current_status: &str,
+    status: &str,
+    exit_code: Option<i32>,
+    updated_at: &str,
+) -> Result<bool> {
+    let affected = conn
+        .execute(
+            "UPDATE sessions
+             SET status = ?3,
+                 exit_code = ?4,
+                 updated_at = ?5
+             WHERE id = ?1 AND status = ?2",
+            params![session_id, current_status, status, exit_code, updated_at],
+        )
+        .with_context(|| format!("failed to update session {session_id}"))?;
+
+    Ok(affected > 0)
+}
+
 /// Persist the harness-native id that continues a multi-turn conversation.
 ///
 /// Coven's `id` remains the stable ledger/session id exposed to callers.
@@ -2950,6 +2972,38 @@ mod tests {
         assert_eq!(sessions[0].status, "completed");
         assert_eq!(sessions[0].exit_code, Some(0));
         assert_eq!(sessions[0].updated_at, "2026-04-27T06:01:00Z");
+        Ok(())
+    }
+
+    #[test]
+    fn conditionally_updates_session_status_only_from_expected_current_status() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        let mut session = session_record("session-1", "2026-04-27T06:00:00Z");
+        session.status = "running".to_string();
+        insert_session(&conn, &session)?;
+
+        assert!(update_session_status_if_current(
+            &conn,
+            "session-1",
+            "running",
+            "killed",
+            None,
+            "2026-04-27T06:01:00Z",
+        )?);
+        assert!(!update_session_status_if_current(
+            &conn,
+            "session-1",
+            "running",
+            "failed",
+            Some(1),
+            "2026-04-27T06:02:00Z",
+        )?);
+
+        let stored = get_session(&conn, "session-1")?.expect("session should exist");
+        assert_eq!(stored.status, "killed");
+        assert_eq!(stored.exit_code, None);
+        assert_eq!(stored.updated_at, "2026-04-27T06:01:00Z");
         Ok(())
     }
 

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -11,6 +11,7 @@ use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use serde_json::{json, Value};
 
 #[test]
@@ -1320,18 +1321,26 @@ fn wait_for_session_status(
     session_id: &str,
     expected_status: &str,
 ) -> anyhow::Result<()> {
+    let mut last_observed = None;
     wait_until(
         &format!("session {session_id} status {expected_status}"),
         || {
             let (_status, body) =
                 unix_http_request(coven_home, "GET", &format!("/sessions/{session_id}"), None)?;
             let body = serde_json::from_str::<Value>(&body)?;
+            last_observed = Some(body.to_string());
             Ok(body
                 .get("status")
                 .and_then(Value::as_str)
                 .is_some_and(|status| status == expected_status))
         },
     )
+    .with_context(|| {
+        format!(
+            "last observed session response: {}",
+            last_observed.unwrap_or_else(|| "<none>".to_string())
+        )
+    })
 }
 
 fn wait_for_event_text(coven_home: &Path, session_id: &str, needle: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- threads-0ip: deflake the Windows Codex JSON batch-shim test by condition-waiting for the batch side-effect files before asserting their contents.
- Fix the session-kill race by making daemon exit persistence atomically update only sessions still marked `running`, so a concurrent `kill` status cannot be overwritten by a stale exit recorder.
- Add smoke wait diagnostics with the last observed session response.

## Root cause
- Windows PR #422/main failure in `pty_runner::tests::codex_json_batch_shim_uses_stdin_and_emits_assistant_text` was `Error: The system cannot find the file specified. (os error 2)`, not an assertion. The test read `args.txt`/`stdin.txt` immediately after the shim outcome; on Windows this observed a missing side-effect file intermittently. The fix waits for those exact files and still asserts their contents.
- Ubuntu release-gates failure in `smoke_daemon_session_replay_and_safe_session_rituals` was `Error: timed out waiting for session ... status killed`. `record_session_exit` read `running` then later wrote exit status non-atomically, so it could race with `/kill` writing `killed` and overwrite that terminal status. The store update is now compare-and-set on `status = running`.

## Tests / gates
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- Targeted: `cargo test -p coven-cli conditionally_updates_session_status_only_from_expected_current_status -- --nocapture`
- Targeted: `cargo test -p coven-cli exit_event_does_not_overwrite_killed_session_status -- --nocapture`
- Targeted: `cargo test -p coven-cli --test smoke smoke_daemon_session_replay_and_safe_session_rituals -- --nocapture`
- Local smoke loop before fix: 20/20 passed on macOS; Windows-only pty test filtered on macOS.
- Tried `cargo check --workspace --target x86_64-pc-windows-msvc`; local cross-check is blocked by missing MSVC/Windows C headers for `ring` (`assert.h` not found), so CI remains the Windows verification.

No tests quarantined.
