### PR TITLE
feat(ward): pending-proposal read surface — API + coven ward pending (Gate 3 PR 3)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -268,6 +268,20 @@ pub fn handle_request_with_runtime(
             apply_familiar_edits(coven_home, id, body)
         }
         ("GET", "/threads/weaves") => threads_weaves_response(coven_home),
+        ("GET", "/threads/proposals") => threads_proposals_response(coven_home, None),
+        ("GET", path) if path.starts_with("/threads/proposals/") => {
+            let id = path.trim_start_matches("/threads/proposals/");
+            if id.is_empty() || id.contains('/') {
+                api_error(
+                    400,
+                    "invalid_request",
+                    "Proposal id is required and must not contain '/'.",
+                    None,
+                )
+            } else {
+                threads_proposals_response(coven_home, Some(id))
+            }
+        }
         ("POST", path) if path.starts_with("/threads/proposals/") && path.ends_with("/approve") => {
             let id = path
                 .trim_start_matches("/threads/proposals/")
@@ -2791,6 +2805,101 @@ fn familiar_ward_response(coven_home: &Path, familiar_id: &str) -> Result<ApiRes
 }
 
 const DEGRADED_WARD_CONFIG_UNPARSEABLE: &str = "ward-config-unparseable";
+
+/// `GET /api/v1/threads/proposals[/:id]` — the pending-proposal read surface
+/// (Gate 3 PR 3, `docs/design/ward-gate3-coherence.md` G3.3).
+///
+/// Lists what is waiting at `~/.coven/pending/` for the principal: both
+/// authority-lane (Tier-0 `DegradeToProposal`) and coherence-lane (Tier-1
+/// hold) proposals, distinguished by `reviewKind` (absent in a staged file ⇒
+/// `authority`). A missing directory is an empty list; an unreadable or
+/// corrupt pending file is reported as a `degraded` entry rather than
+/// aborting the fleet read (same posture as `/threads/weaves`).
+fn threads_proposals_response(coven_home: &Path, id: Option<&str>) -> Result<ApiResponse> {
+    let pending_dir = coven_home.join("pending");
+    let entries = match fs::read_dir(&pending_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return match id {
+                None => json_response(200, &json!({ "proposals": [] })),
+                Some(id) => api_error(
+                    404,
+                    "proposal_not_found",
+                    "No pending proposal with that id.",
+                    Some(json!({ "id": id })),
+                ),
+            }
+        }
+        Err(err) => return Err(err).with_context(|| format!("reading {}", pending_dir.display())),
+    };
+
+    let mut proposals = Vec::new();
+    for entry in entries {
+        let path = entry?.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let file_name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let parsed: Option<(coven_threads_core::PendingProposal, Value)> =
+            fs::read_to_string(&path).ok().and_then(|raw| {
+                let value: Value = serde_json::from_str(&raw).ok()?;
+                let proposal = serde_json::from_str(&raw).ok()?;
+                Some((proposal, value))
+            });
+        let Some((proposal, raw_value)) = parsed else {
+            proposals.push(json!({
+                "degraded": { "file": file_name, "reason": "proposal-unparseable" },
+            }));
+            continue;
+        };
+        let review_kind = raw_value
+            .get("reviewKind")
+            .and_then(Value::as_str)
+            .unwrap_or("authority")
+            .to_string();
+        let familiar_id = human_familiar_id_for_weave(coven_home, proposal.familiar_id)?;
+        let targets: Vec<String> = proposal
+            .edits
+            .iter()
+            .map(|edit| edit.surface.as_str().to_string())
+            .collect();
+        let format = time::format_description::well_known::Rfc3339;
+        proposals.push(json!({
+            "proposalId": proposal.id.0.to_string(),
+            "familiarId": familiar_id,
+            "reviewKind": review_kind,
+            "writer": proposal.writer.as_str(),
+            "stagedAt": proposal.staged_at.format(&format).ok(),
+            "targets": targets,
+        }));
+    }
+
+    match id {
+        None => {
+            // Stable order for scripts: newest first, degraded entries last.
+            proposals.sort_by(|a, b| {
+                let staged = |v: &Value| v["stagedAt"].as_str().map(str::to_owned);
+                staged(b).cmp(&staged(a))
+            });
+            json_response(200, &json!({ "proposals": proposals }))
+        }
+        Some(id) => match proposals
+            .into_iter()
+            .find(|proposal| proposal["proposalId"] == id)
+        {
+            Some(proposal) => json_response(200, &json!({ "proposal": proposal })),
+            None => api_error(
+                404,
+                "proposal_not_found",
+                "No pending proposal with that id.",
+                Some(json!({ "id": id })),
+            ),
+        },
+    }
+}
 
 fn threads_weaves_response(coven_home: &Path) -> Result<ApiResponse> {
     let conn = store::open_store(&store_path(coven_home))?;
@@ -6380,6 +6489,59 @@ tier = 2
             let body: serde_json::Value = serde_json::from_str(&response.body)?;
             assert_eq!(body["error"]["code"], "invalid_request");
         }
+        Ok(())
+    }
+
+    #[test]
+    fn threads_proposals_lists_staged_coherence_proposal() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        // Empty state first: missing pending/ is an empty list, not an error.
+        let response = handle_request("GET", "/api/v1/threads/proposals", home, None)?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["proposals"], serde_json::json!([]));
+
+        // Stage a Tier-1 coherence proposal through the write path.
+        let staged = post_edits(
+            home,
+            r#"{"edits":[{"target":"reviewed/skill.md","contents":"tweak"}]}"#,
+        )?;
+        let staged_body: serde_json::Value = serde_json::from_str(&staged.body)?;
+        let proposal_id = staged_body["proposalId"].as_str().expect("id").to_string();
+
+        // The list surfaces it with lane, familiar, and targets.
+        let response = handle_request("GET", "/api/v1/threads/proposals", home, None)?;
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        let listed = &body["proposals"][0];
+        assert_eq!(listed["proposalId"], proposal_id.as_str());
+        assert_eq!(listed["familiarId"], "sage");
+        assert_eq!(listed["reviewKind"], "coherence");
+        assert_eq!(listed["targets"][0], "reviewed/skill.md");
+
+        // Detail returns the same record; unknown and malformed ids fail
+        // closed with the structured shapes.
+        let response = handle_request(
+            "GET",
+            &format!("/api/v1/threads/proposals/{proposal_id}"),
+            home,
+            None,
+        )?;
+        assert_eq!(response.status, 200);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["proposal"]["reviewKind"], "coherence");
+
+        let response = handle_request(
+            "GET",
+            "/api/v1/threads/proposals/00000000-0000-0000-0000-000000000000",
+            home,
+            None,
+        )?;
+        assert_eq!(response.status, 404);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "proposal_not_found");
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -271,12 +271,12 @@ pub fn handle_request_with_runtime(
         ("GET", "/threads/proposals") => threads_proposals_response(coven_home, None),
         ("GET", path) if path.starts_with("/threads/proposals/") => {
             let id = path.trim_start_matches("/threads/proposals/");
-            if id.is_empty() || id.contains('/') {
+            if Uuid::parse_str(id).is_err() {
                 api_error(
                     400,
                     "invalid_request",
-                    "Proposal id is required and must not contain '/'.",
-                    None,
+                    "Proposal id must be a UUID.",
+                    Some(serde_json::json!({ "id": id })),
                 )
             } else {
                 threads_proposals_response(coven_home, Some(id))
@@ -2860,7 +2860,15 @@ fn threads_proposals_response(coven_home: &Path, id: Option<&str>) -> Result<Api
             .and_then(Value::as_str)
             .unwrap_or("authority")
             .to_string();
-        let familiar_id = human_familiar_id_for_weave(coven_home, proposal.familiar_id)?;
+        let Some(familiar_id) = human_familiar_id_for_weave(coven_home, proposal.familiar_id)?
+        else {
+            // A proposal whose familiar vanished from familiars.toml cannot
+            // be decided; degrade it instead of emitting familiarId: null.
+            proposals.push(json!({
+                "degraded": { "file": file_name, "reason": "proposal-familiar-missing" },
+            }));
+            continue;
+        };
         let targets: Vec<String> = proposal
             .edits
             .iter()
@@ -2879,10 +2887,12 @@ fn threads_proposals_response(coven_home: &Path, id: Option<&str>) -> Result<Api
 
     match id {
         None => {
-            // Stable order for scripts: newest first, degraded entries last.
-            proposals.sort_by(|a, b| {
-                let staged = |v: &Value| v["stagedAt"].as_str().map(str::to_owned);
-                staged(b).cmp(&staged(a))
+            // Deterministic order for scripts: newest first, ties broken by
+            // proposal id, degraded entries (no stagedAt) last.
+            proposals.sort_by_cached_key(|value| {
+                let staged = value["stagedAt"].as_str().map(str::to_owned);
+                let id = value["proposalId"].as_str().unwrap_or_default().to_owned();
+                (std::cmp::Reverse(staged), id)
             });
             json_response(200, &json!({ "proposals": proposals }))
         }
@@ -6542,6 +6552,11 @@ tier = 2
         assert_eq!(response.status, 404);
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
         assert_eq!(body["error"]["code"], "proposal_not_found");
+
+        let response = handle_request("GET", "/api/v1/threads/proposals/not-a-uuid", home, None)?;
+        assert_eq!(response.status, 400);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "invalid_request");
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -648,6 +648,13 @@ enum EngineCommand {
 
 #[derive(Subcommand, Debug)]
 enum WardCommand {
+    #[command(about = "List pending Ward proposals awaiting the principal")]
+    Pending {
+        #[arg(help = "Proposal id: show one staged proposal instead of the list")]
+        id: Option<String>,
+        #[arg(long, help = "Print proposals as JSON (machine-readable)")]
+        json: bool,
+    },
     #[command(about = "Migrate Ward v0.1 ward.toml files to Phase-2 WardConfig")]
     Migrate {
         #[arg(long, value_name = "ID", help = "Only migrate the named familiar")]
@@ -2719,6 +2726,9 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
 
 fn run_ward_command(command: WardCommand) -> Result<()> {
     match command {
+        WardCommand::Pending { id, json } => {
+            return observe::run_ward_pending(id.as_deref(), json);
+        }
         WardCommand::Migrate {
             familiar,
             fingerprint,

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -522,9 +522,11 @@ fn render_ward_pending(body: &Value) -> String {
         .cloned()
         .unwrap_or_default();
     if proposals.is_empty() {
-        return "No pending Ward proposals.\n\
-                Held Tier-0/Tier-1 writes stage here for the principal's decision.\n"
-            .to_string();
+        return concat!(
+            "No pending Ward proposals.\n",
+            "Held Tier-0/Tier-1 writes stage here for the principal's decision.\n"
+        )
+        .to_string();
     }
     let mut out = String::new();
     out.push_str(&format!(

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -492,6 +492,105 @@ fn render_research(body: &Value) -> String {
     out
 }
 
+// ── coven ward pending ───────────────────────────────────────────────────────
+
+pub(crate) fn run_ward_pending(id: Option<&str>, json: bool) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    match id {
+        Some(id) => {
+            let body = api_get(&coven_home, &format!("/api/v1/threads/proposals/{id}"))?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_ward_proposal(&body["proposal"]));
+        }
+        None => {
+            let body = api_get(&coven_home, "/api/v1/threads/proposals")?;
+            if json {
+                return print_json(&body);
+            }
+            print!("{}", render_ward_pending(&body));
+        }
+    }
+    Ok(())
+}
+
+fn render_ward_pending(body: &Value) -> String {
+    let proposals = body
+        .get("proposals")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if proposals.is_empty() {
+        return "No pending Ward proposals.\n\
+                Held Tier-0/Tier-1 writes stage here for the principal's decision.\n"
+            .to_string();
+    }
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<38} {:<12} {:<10} {:<22} targets\n",
+        "proposal", "familiar", "review", "staged"
+    ));
+    for proposal in &proposals {
+        if let Some(degraded) = proposal.get("degraded") {
+            out.push_str(&format!(
+                "{:<38} (degraded: {})\n",
+                str_cell(degraded, "file"),
+                str_cell(degraded, "reason"),
+            ));
+            continue;
+        }
+        out.push_str(&format!(
+            "{:<38} {:<12} {:<10} {:<22} {}\n",
+            str_cell(proposal, "proposalId"),
+            str_cell(proposal, "familiarId"),
+            str_cell(proposal, "reviewKind"),
+            str_cell(proposal, "stagedAt"),
+            proposal
+                .get("targets")
+                .and_then(Value::as_array)
+                .map(|targets| targets
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .collect::<Vec<_>>()
+                    .join(", "))
+                .unwrap_or_default(),
+        ));
+    }
+    out.push_str(
+        "\nDecide with the daemon API: POST /api/v1/threads/proposals/<id>/approve|reject\n",
+    );
+    out
+}
+
+fn render_ward_proposal(proposal: &Value) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Ward proposal {}\n\n",
+        str_cell(proposal, "proposalId")
+    ));
+    out.push_str(&format!(
+        "  familiar   {}\n",
+        str_cell(proposal, "familiarId")
+    ));
+    out.push_str(&format!(
+        "  review     {}\n",
+        str_cell(proposal, "reviewKind")
+    ));
+    out.push_str(&format!("  writer     {}\n", str_cell(proposal, "writer")));
+    out.push_str(&format!(
+        "  staged     {}\n",
+        str_cell(proposal, "stagedAt")
+    ));
+    out.push_str("  targets\n");
+    if let Some(targets) = proposal.get("targets").and_then(Value::as_array) {
+        for target in targets.iter().filter_map(Value::as_str) {
+            out.push_str(&format!("    {target}\n"));
+        }
+    }
+    out
+}
+
 // ── coven calls ──────────────────────────────────────────────────────────────
 
 pub(crate) fn run_calls(id: Option<&str>, json: bool) -> Result<()> {

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -77,6 +77,21 @@ These power `coven status`, `coven familiars`, `coven skills`, `coven memory`, `
 | PUT | `/api/v1/familiars/:id/icon` | Update a familiar's icon glyph. | updated familiar | `400`, `404` |
 | POST | `/api/v1/familiars/:id/edits` | Ward-adjudicated writes into a familiar home (Gates 1–2, fail-closed, audited). | edit report | `400`, `403` (ward denial), `404` |
 
+## Ward proposals (threads)
+
+Held Ward writes stage at `~/.coven/pending/` for the principal —
+Tier-0 authority degradations and Tier-1 coherence holds, distinguished by
+`reviewKind` (`authority` / `coherence`). See
+[cli-ward](cli-ward.md) and `docs/design/ward-gate3-coherence.md`.
+
+| Method | Path | Purpose | Success | Errors |
+|---|---|---|---|---|
+| GET | `/api/v1/threads/weaves` | Per-familiar weave/authority state (degraded configs reported inline). | weave entries | — |
+| GET | `/api/v1/threads/proposals` | Pending proposals (unparseable files reported as `degraded` entries, newest first). | `{ proposals }` | — |
+| GET | `/api/v1/threads/proposals/:id` | One pending proposal. | `{ proposal }` | `400 invalid_request` / `404 proposal_not_found` |
+| POST | `/api/v1/threads/proposals/:id/approve` | Re-validate and apply a staged authority proposal (coherence approval lands with Gate 3 PR 4). | decision report | `400`, `404`, `409` |
+| POST | `/api/v1/threads/proposals/:id/reject` | Reject and remove a staged proposal (audited). | decision report | `400`, `404`, `409` |
+
 ## Skills: eval-loop
 
 | Method | Path | Purpose | Success | Errors |

--- a/docs/reference/cli-ward.md
+++ b/docs/reference/cli-ward.md
@@ -1,0 +1,47 @@
+---
+summary: "Inspect and manage the Ward proposal lifecycle: pending reads and config migration."
+read_when:
+  - Looking up ward
+  - Reviewing staged (held) Ward proposals
+title: "coven ward"
+description: "Reference for coven ward: list and inspect pending Ward proposals staged for the principal, and migrate v0.1 ward.toml files to the Phase-2 WardConfig dialect."
+---
+
+`coven ward` groups the Ward's principal-facing lifecycle verbs. Held writes
+into a familiar home never dead-end: the daemon stages them at
+`~/.coven/pending/` for the principal's decision, and `coven ward pending`
+is the supported way to see what is waiting.
+
+```sh
+coven ward pending             # table of staged proposals, newest first
+coven ward pending <id>        # one proposal in full
+coven ward pending --json      # exact daemon body (GET /api/v1/threads/proposals)
+coven ward migrate --apply     # migrate v0.1 ward.toml files to Phase-2
+```
+
+## Pending proposals
+
+Two lanes stage here, distinguished by `reviewKind`:
+
+- `authority` — a Tier-0 (protected) write whose thread frayed
+  (`DegradeToProposal`, coven-threads §5).
+- `coherence` — a Tier-1 (reviewed) write held for Gate-3 coherence review
+  (`docs/design/ward-gate3-coherence.md`).
+
+`--json` output is byte-for-byte the daemon body per the
+[observe contract](cli-observe.md). Unparseable pending files appear as
+`degraded` entries instead of aborting the read. Unknown ids fail with
+`proposal_not_found`.
+
+Decisions are daemon-API verbs today
+(`POST /api/v1/threads/proposals/<id>/approve|reject` — see
+[api](api.md)); approving a `coherence` proposal stays fail-closed until
+Gate 3's resolution stage lands. Nothing ever auto-approves — the principal
+is the sole approver (design Non-goals).
+
+## Migration
+
+`coven ward migrate` inspects (and with `--apply`, rewrites) v0.1
+`ward.toml` files into the Phase-2 `WardConfig` dialect. Use `--familiar
+<ID>` to scope to one familiar and `--fingerprint <FPR>` to set the
+principal binding. Exits non-zero if any migration fails.

--- a/docs/reference/cli-ward.md
+++ b/docs/reference/cli-ward.md
@@ -28,8 +28,8 @@ Two lanes stage here, distinguished by `reviewKind`:
 - `coherence` — a Tier-1 (reviewed) write held for Gate-3 coherence review
   (`docs/design/ward-gate3-coherence.md`).
 
-`--json` output is byte-for-byte the daemon body per the
-[observe contract](cli-observe.md). Unparseable pending files appear as
+`--json` output carries exactly the daemon body's data (pretty-printed) per
+the [observe contract](cli-observe.md). Unparseable pending files appear as
 `degraded` entries instead of aborting the read. Unknown ids fail with
 `proposal_not_found`.
 


### PR DESCRIPTION
Closes #427 — implementation PR 3 of `docs/design/ward-gate3-coherence.md` (#415, umbrella #335), after PR 1 (#425).

## What
- **`GET /api/v1/threads/proposals`** — lists what is staged at `~/.coven/pending/`: both lanes (`reviewKind`: `authority`/`coherence`, absent file field ⇒ authority), newest first; missing dir ⇒ `{proposals: []}`; unparseable files become `degraded` entries instead of aborting the fleet read (same posture as `/threads/weaves`).
- **`GET /api/v1/threads/proposals/:id`** — one proposal; `400 invalid_request` / `404 proposal_not_found` fail-closed shapes matching the familiar-id contract.
- **`coven ward pending [<id>] [--json]`** — observe.rs pattern (`--json` = exact daemon body), beside #419's `ward migrate`; empty state teaches the lifecycle; detail view prints lane/writer/staged/targets.
- **Docs:** `api.md` gains a Ward-proposals section (documenting the previously-undocumented `weaves` + `approve`/`reject` routes too) and a new `reference/cli-ward.md`.
- **Contract note:** this resolves the `pendingPath` question from the #425 review — `proposalId` is now resolvable through a supported read path.

## Testing
- fmt/clippy/secret-scan ✓ · `cargo test --workspace --locked` ✓ **1246/0** (new end-to-end test: empty list → stage a Tier-1 hold through the write path → list shows lane+targets → detail 200 → unknown id 404)
- Live-verified empty-state prose + `--json` parity