### PR TITLE
fix: guide unconfigured engine auth

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1326,8 +1326,14 @@ fn run_engine_passthrough(lead: Option<&str>, args: &[OsString]) -> Result<()> {
 /// checking it here prevents the wrapper from launching a browser-bound flow
 /// that cannot succeed on a normal installation.
 fn run_auth_command(args: &[OsString]) -> Result<()> {
+    if auth_login_requested(args) && auth_help_requested(args) {
+        // The pinned engine accepts raw auth args and would otherwise treat
+        // `--help` as a login request, so answer this wrapper-level help here.
+        println!("{}", anthropic_oauth_login_help_message());
+        return Ok(());
+    }
+
     if auth_login_requested(args)
-        && !auth_help_requested(args)
         && !configured_oauth_client_id(
             std::env::var_os(COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID).as_deref(),
         )
@@ -1364,6 +1370,16 @@ Use one of these supported paths instead:\n\
   - ChatGPT/Codex: run `coven code codex login`.\n\n\
 If you operate a registered Coven Code OAuth client, set \
 COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID and run `coven auth login` again."
+    )
+}
+
+fn anthropic_oauth_login_help_message() -> String {
+    format!(
+        "Usage: coven auth login [--console] [--label <name>]\n\n\
+Authenticate Coven Code through Anthropic OAuth. This requires a registered Coven Code OAuth \
+client ID in {COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID}.\n\n\
+  --console       Use the Anthropic Console OAuth flow.\n\
+  --label <name>  Give the authenticated account profile a name."
     )
 }
 
@@ -5816,7 +5832,7 @@ mod tests {
     }
 
     #[test]
-    fn auth_login_help_is_forwarded_without_oauth_configuration() {
+    fn auth_login_help_lists_login_options() {
         assert!(auth_login_requested(&[
             OsString::from("login"),
             OsString::from("--help"),
@@ -5829,6 +5845,11 @@ mod tests {
             OsString::from("login"),
             OsString::from("-h"),
         ]));
+        let help = anthropic_oauth_login_help_message();
+        assert!(help.contains("Usage: coven auth login"));
+        assert!(help.contains(COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID));
+        assert!(help.contains("--console"));
+        assert!(help.contains("--label"));
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 #[cfg(unix)]
 use std::io::Read;
 use std::io::{self, BufRead, IsTerminal, Write};
@@ -61,6 +61,7 @@ const DEFAULT_SESSION_STATUS: &str = "created";
 const RUNNING_SESSION_STATUS: &str = "running";
 const FAILED_SESSION_STATUS: &str = "failed";
 const DEFAULT_TITLE_CHARS: usize = 48;
+const COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID: &str = "COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID";
 
 #[derive(Parser, Debug)]
 #[command(name = "coven")]
@@ -974,7 +975,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             keep_session,
         ),
         Some(Command::Pc { command }) => pc::run_pc_command(command),
-        Some(Command::Auth { args }) => run_engine_passthrough(Some("auth"), &args),
+        Some(Command::Auth { args }) => run_auth_command(&args),
         Some(Command::Models { args }) => run_engine_passthrough(Some("models"), &args),
         Some(Command::Acp { args }) => run_engine_passthrough(Some("acp"), &args),
         Some(Command::Code { args }) => run_engine_passthrough(None, &args),
@@ -1316,6 +1317,48 @@ fn run_engine_passthrough(lead: Option<&str>, args: &[OsString]) -> Result<()> {
     }
     command.args(args);
     exec_engine(command)
+}
+
+/// Run the curated Coven Code auth entry point.
+///
+/// `auth login` is Anthropic OAuth, not a generic interactive credential
+/// wizard. The engine correctly requires a registered OAuth client ID, but
+/// checking it here prevents the wrapper from launching a browser-bound flow
+/// that cannot succeed on a normal installation.
+fn run_auth_command(args: &[OsString]) -> Result<()> {
+    if auth_login_requested(args)
+        && !configured_oauth_client_id(
+            std::env::var_os(COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID).as_deref(),
+        )
+    {
+        bail!(anthropic_oauth_client_id_required_message());
+    }
+
+    run_engine_passthrough(Some("auth"), args)
+}
+
+fn auth_login_requested(args: &[OsString]) -> bool {
+    matches!(args.first().and_then(|arg| arg.to_str()), Some("login"))
+}
+
+fn configured_oauth_client_id(client_id: Option<&OsStr>) -> bool {
+    client_id
+        .and_then(OsStr::to_str)
+        .is_some_and(|client_id| !client_id.trim().is_empty())
+}
+
+fn anthropic_oauth_client_id_required_message() -> String {
+    format!(
+        "Coven Code's Anthropic OAuth login is not configured for this installation.\n\n\
+`coven auth login` requires a registered Coven Code OAuth client ID in \
+{COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID}. Do not set an arbitrary client ID.\n\n\
+Use one of these supported paths instead:\n\
+  - Anthropic API: set ANTHROPIC_API_KEY, then start Coven Code.\n\
+  - Claude Code: install and authenticate `claude`, then run `coven run claude <prompt>`.\n\
+  - ChatGPT/Codex: run `coven code codex login`.\n\n\
+If you operate a registered Coven Code OAuth client, set \
+COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID and run `coven auth login` again."
+    )
 }
 
 /// Exec `coven-code` in place of the current process. Returns only on failure;
@@ -1790,7 +1833,10 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             Some(false) => DoctorCheck::warn(
                 "credentials:engine",
                 "not logged in",
-                Some("run: coven auth login".to_string()),
+                Some(
+                    "set ANTHROPIC_API_KEY, authenticate Claude Code, or configure OAuth then run: coven auth login"
+                        .to_string(),
+                ),
             ),
             None => DoctorCheck::warn("credentials:engine", "auth check skipped", None),
         });
@@ -2558,7 +2604,7 @@ fn credentials_lines(
         }
         Some(Some(false)) => {
             lines.push(
-                "  [!!] Coven Code (engine) — not logged in; run `coven auth login`".to_string(),
+                "  [!!] Coven Code (engine) — not logged in; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
             );
         }
         Some(None) => {
@@ -3902,7 +3948,6 @@ mod tests {
         MagicalTuiMove, MagicalTuiRequest, MAGICAL_TUI_MAX_INNER_WIDTH,
     };
     use crossterm::event::KeyEventKind;
-    use std::ffi::OsStr;
     use std::sync::{Mutex, OnceLock};
 
     fn env_lock() -> &'static Mutex<()> {
@@ -5743,8 +5788,34 @@ mod tests {
         let lines = credentials_lines(Some(Some(false)), &[]);
         assert_eq!(lines.len(), 1);
         assert!(lines[0].contains("not logged in"), "got: {}", lines[0]);
-        assert!(lines[0].contains("coven auth login"), "got: {}", lines[0]);
+        assert!(lines[0].contains("ANTHROPIC_API_KEY"), "got: {}", lines[0]);
+        assert!(lines[0].contains("Claude Code"), "got: {}", lines[0]);
         assert!(lines[0].contains("[!!]"), "got: {}", lines[0]);
+    }
+
+    #[test]
+    fn auth_login_requires_a_nonempty_oauth_client_id() {
+        let args = vec![OsString::from("login")];
+        assert!(auth_login_requested(&args));
+        assert!(!configured_oauth_client_id(None));
+        assert!(!configured_oauth_client_id(Some(OsStr::new("   "))));
+        assert!(configured_oauth_client_id(Some(OsStr::new("client-id"))));
+    }
+
+    #[test]
+    fn auth_passthrough_only_blocks_the_anthropic_login_subcommand() {
+        assert!(!auth_login_requested(&[]));
+        assert!(!auth_login_requested(&[OsString::from("status")]));
+        assert!(!auth_login_requested(&[OsString::from("--help")]));
+    }
+
+    #[test]
+    fn missing_oauth_client_message_lists_supported_auth_paths() {
+        let message = anthropic_oauth_client_id_required_message();
+        assert!(message.contains(COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID));
+        assert!(message.contains("ANTHROPIC_API_KEY"));
+        assert!(message.contains("coven run claude"));
+        assert!(message.contains("coven code codex login"));
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1327,6 +1327,7 @@ fn run_engine_passthrough(lead: Option<&str>, args: &[OsString]) -> Result<()> {
 /// that cannot succeed on a normal installation.
 fn run_auth_command(args: &[OsString]) -> Result<()> {
     if auth_login_requested(args)
+        && !auth_help_requested(args)
         && !configured_oauth_client_id(
             std::env::var_os(COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID).as_deref(),
         )
@@ -1339,6 +1340,11 @@ fn run_auth_command(args: &[OsString]) -> Result<()> {
 
 fn auth_login_requested(args: &[OsString]) -> bool {
     matches!(args.first().and_then(|arg| arg.to_str()), Some("login"))
+}
+
+fn auth_help_requested(args: &[OsString]) -> bool {
+    args.iter()
+        .any(|arg| matches!(arg.to_str(), Some("--help") | Some("-h")))
 }
 
 fn configured_oauth_client_id(client_id: Option<&OsStr>) -> bool {
@@ -5807,6 +5813,22 @@ mod tests {
         assert!(!auth_login_requested(&[]));
         assert!(!auth_login_requested(&[OsString::from("status")]));
         assert!(!auth_login_requested(&[OsString::from("--help")]));
+    }
+
+    #[test]
+    fn auth_login_help_is_forwarded_without_oauth_configuration() {
+        assert!(auth_login_requested(&[
+            OsString::from("login"),
+            OsString::from("--help"),
+        ]));
+        assert!(auth_help_requested(&[
+            OsString::from("login"),
+            OsString::from("--help"),
+        ]));
+        assert!(auth_help_requested(&[
+            OsString::from("login"),
+            OsString::from("-h"),
+        ]));
     }
 
     #[test]

--- a/docs/harnesses/provider-auth.md
+++ b/docs/harnesses/provider-auth.md
@@ -14,7 +14,7 @@ Coven supervises harness PTYs. It never reads, proxies, persists, or mints provi
 
 - Provider tokens live wherever the harness already puts them — typically `~/.codex/`, `~/.config/anthropic/`, `~/.copilot/`, or a system keychain managed by that CLI.
 - The Coven daemon never reads them, never stores them in SQLite, never forwards them over the socket API, and never logs them into the event ledger.
-- `coven doctor` only checks whether the harness binary exists; it does **not** test provider credentials. Each harness already ships its own `login` / `doctor` for that.
+- `coven doctor` reports the Coven Code engine's login state, but only checks whether each external harness binary exists; it does **not** test provider credentials for those harnesses. Each harness already ships its own `login` / `doctor` for that.
 - Treat Coven as having **zero** knowledge of provider auth state. The boundary is intentional.
 
 ## Why Coven refuses to own credentials

--- a/docs/harnesses/provider-auth.md
+++ b/docs/harnesses/provider-auth.md
@@ -44,6 +44,27 @@ The arrow that matters is the missing one: the daemon has no dotted line into th
 
 `coven run codex|claude <prompt>` launches the harness with an empty argument vector apart from the validated prompt and adapter prefix args. It does not inject `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or any token-bearing env var. If the harness needs a credential, it reads it the same way it would when launched directly from your shell.
 
+### Coven Code engine
+
+`coven auth ...` is a convenience pass-through to the separate Coven Code
+engine. It is not a daemon credential store and it does not change the
+credential boundary for `coven run` harness sessions.
+
+`coven auth login` specifically starts Coven Code's **Anthropic OAuth** flow.
+That flow is available only when the operator has registered a Coven Code OAuth
+client and set its client ID in `COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID`. A normal
+installation should not set an arbitrary client ID just to make the command run.
+
+Without that OAuth configuration, use one of the supported alternatives:
+
+- Set `ANTHROPIC_API_KEY` for a direct Anthropic API account, then start Coven
+  Code.
+- Authenticate the official Claude Code CLI and use `coven run claude <prompt>`.
+- Run `coven code codex login` for ChatGPT/Codex authentication.
+
+`coven doctor` reports the engine's login state and points to these alternatives
+instead of suggesting an OAuth login that cannot succeed.
+
 ### Daemon API
 
 `POST /api/v1/sessions` accepts a project root, cwd, harness id, prompt, and optional title. There is no field for an API key, OAuth token, refresh token, account id, or organization id. The schema is documented in [API contract](/API-CONTRACT) — none of those fields exist.


### PR DESCRIPTION
## Summary

- fail before forwarding `coven auth login` to an Anthropic OAuth flow when no Coven Code OAuth client ID is configured
- point the doctor credentials hint at API-key, Claude Code, and configured-OAuth paths
- document the engine auth boundary and supported alternatives

## Root cause

`coven auth login` blindly delegated to Coven Code. Its Anthropic OAuth login requires `COVEN_CODE_ANTHROPIC_OAUTH_CLIENT_ID`, so a normal installation reached a browser-login path that could not succeed.

## User impact

Users now receive an actionable local error before the engine starts the unusable OAuth flow. Existing deployments with a registered client ID continue to delegate to the engine unchanged.

## Validation

- `cargo fmt --check`
- `git diff --check`
- targeted current-tree secret scan
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked` (1,219 passed; 1 ignored)
- built CLI runtime checks: unconfigured `coven auth login` fails before engine launch with the supported alternatives; `coven auth status` and configured-client `coven auth login` pass through to normal engine resolution
- GitHub CI passed on Ubuntu, Windows, macOS, Linux x64, and Windows npm onboarding
- the repository-wide historical secret scan was started, but stopped after two minutes with no findings/output because it scans every historical blob serially; CI passed the full secret gate