### PR TITLE
fix: make env-mutating unit tests hermetic

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1265,10 +1265,13 @@ fn legacy_tui_instructions(shell: TargetShell) -> &'static str {
 /// `COVEN_LEGACY_TUI=1` (or `=true`) opts back into the in-process tui::shell.
 /// This is a transitional escape hatch, not the supported path.
 fn legacy_tui_opted_in() -> bool {
-    matches!(
-        std::env::var("COVEN_LEGACY_TUI").as_deref(),
-        Ok("1") | Ok("true")
-    )
+    legacy_tui_value_opts_in(std::env::var("COVEN_LEGACY_TUI").ok().as_deref())
+}
+
+/// Pure predicate behind [`legacy_tui_opted_in`], split out so tests can pin
+/// the opt-in rules without mutating process-global environment variables.
+fn legacy_tui_value_opts_in(value: Option<&str>) -> bool {
+    matches!(value, Some("1") | Some("true"))
 }
 
 /// Locate the engine binary via the managed-engine resolver.
@@ -5518,20 +5521,15 @@ mod tests {
 
     #[test]
     fn legacy_tui_opt_in_respects_env_var() {
-        // SAFETY: tests in this crate run on a single thread by default; if
-        // that ever changes, gate this behind a serial mutex.
-        let prev = std::env::var("COVEN_LEGACY_TUI").ok();
-        std::env::set_var("COVEN_LEGACY_TUI", "1");
-        assert!(legacy_tui_opted_in());
-        std::env::set_var("COVEN_LEGACY_TUI", "true");
-        assert!(legacy_tui_opted_in());
-        std::env::set_var("COVEN_LEGACY_TUI", "0");
-        assert!(!legacy_tui_opted_in());
-        std::env::remove_var("COVEN_LEGACY_TUI");
-        assert!(!legacy_tui_opted_in());
-        if let Some(v) = prev {
-            std::env::set_var("COVEN_LEGACY_TUI", v);
-        }
+        // Exercises the pure predicate instead of mutating COVEN_LEGACY_TUI in
+        // the process env: tests run multi-threaded by default, so unguarded
+        // set_var/remove_var races with every other env read in the binary.
+        assert!(legacy_tui_value_opts_in(Some("1")));
+        assert!(legacy_tui_value_opts_in(Some("true")));
+        assert!(!legacy_tui_value_opts_in(Some("0")));
+        assert!(!legacy_tui_value_opts_in(Some("TRUE")));
+        assert!(!legacy_tui_value_opts_in(Some("")));
+        assert!(!legacy_tui_value_opts_in(None));
     }
 
     #[test]

--- a/crates/coven-cli/src/repos_config.rs
+++ b/crates/coven-cli/src/repos_config.rs
@@ -1,4 +1,5 @@
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -75,15 +76,22 @@ impl ReposConfig {
 }
 
 fn expand_tilde(path: &Path) -> PathBuf {
+    expand_tilde_with_home(path, std::env::var_os("HOME"))
+}
+
+/// Injectable core of [`expand_tilde`], so tests can pin the expansion rules
+/// without swapping the process-global `HOME` variable.
+fn expand_tilde_with_home(path: &Path, home: Option<OsString>) -> PathBuf {
     let Some(s) = path.to_str() else {
         return path.to_path_buf();
     };
+    let home = home.filter(|v| !v.is_empty());
     if let Some(rest) = s.strip_prefix("~/") {
-        if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
+        if let Some(home) = home {
             return PathBuf::from(home).join(rest);
         }
     } else if s == "~" {
-        if let Some(home) = std::env::var_os("HOME").filter(|v| !v.is_empty()) {
+        if let Some(home) = home {
             return PathBuf::from(home);
         }
     }
@@ -141,18 +149,32 @@ path = "~/projects/example"
 "#,
         )?;
 
-        let prior_home = std::env::var_os("HOME");
-        // Safety: tests in this crate run single-threaded enough for HOME swap.
-        std::env::set_var("HOME", "/tmp/fake-home");
-        let resolved = load(temp.path())?.resolve("home_relative");
-        match prior_home {
-            Some(value) => std::env::set_var("HOME", value),
-            None => std::env::remove_var("HOME"),
-        }
+        // Inject HOME instead of swapping the process env: set_var races with
+        // parallel tests and a panic before restore leaks the fake value.
+        let config = load(temp.path())?;
+        let raw = &config
+            .repos
+            .get("home_relative")
+            .expect("entry parsed")
+            .path;
+        let home = || Some(OsString::from("/tmp/fake-home"));
 
         assert_eq!(
-            resolved,
-            Some(PathBuf::from("/tmp/fake-home/projects/example"))
+            expand_tilde_with_home(raw, home()),
+            PathBuf::from("/tmp/fake-home/projects/example")
+        );
+        assert_eq!(
+            expand_tilde_with_home(Path::new("~"), home()),
+            PathBuf::from("/tmp/fake-home")
+        );
+        // Missing or empty HOME leaves the path untouched.
+        assert_eq!(
+            expand_tilde_with_home(raw, None),
+            Path::new("~/projects/example")
+        );
+        assert_eq!(
+            expand_tilde_with_home(raw, Some(OsString::new())),
+            Path::new("~/projects/example")
         );
         Ok(())
     }


### PR DESCRIPTION
## What

Removes the last two unguarded process-env mutations from the coven-cli unit test suite by refactoring to injectable seams.

- **`main.rs`** — `legacy_tui_opt_in_respects_env_var` mutated `COVEN_LEGACY_TUI` with raw `set_var`/`remove_var` under a false "tests run on a single thread" premise (Rust test binaries are parallel by default), bypassing the module's own `env_lock()`/`EnvVarGuard`. Now tests a pure `legacy_tui_value_opts_in(Option<&str>)` predicate; `legacy_tui_opted_in()` is a thin env-reading wrapper.
- **`repos_config.rs`** — `resolve_expands_leading_tilde` swapped the process-global `HOME` and restored it manually — unguarded *and* not panic-safe (a failed assert leaks `/tmp/fake-home` into every later test). Now tests `expand_tilde_with_home(path, Option<OsString>)` directly.

## Why injection over locking

The existing `env_lock()` pattern serializes the race; injection deletes it. Pure seams also let coverage extend cheaply — added cases for `TRUE` (case sensitivity), empty value, bare `~`, and missing/empty `HOME`.

## Readiness

- `cargo fmt --check` ✅
- `cargo clippy -p coven-cli --all-targets -- -D warnings` ✅
- `cargo test -p coven-cli --bin coven legacy_tui` / `repos_config` ✅ (1 + 6 pass)
- `python scripts/check-secrets.py` ✅

No behavior change to the production code paths — `legacy_tui_opted_in` and `expand_tilde` read the same variables with the same semantics.