### PR TITLE
fix(hermes): forward models through adapter recipe

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -999,11 +999,12 @@ const HERMES_ADAPTER_MANIFEST: &str = r#"{
     {
       "id": "hermes",
       "label": "Hermes Agent",
-      "executable": "hermes",
-      "interactive_prompt_prefix_args": ["chat", "--source", "coven", "-q"],
-      "non_interactive_prompt_prefix_args": ["chat", "--source", "coven", "-Q", "-q"],
-      "install_hint": "Install Hermes Agent, add it to PATH, and complete Hermes setup before using this adapter.",
-      "system_prompt_flag": null
+      "executable": "hermes-coven",
+      "interactive_prompt_prefix_args": ["chat", "--source", "coven"],
+      "non_interactive_prompt_prefix_args": ["chat", "--source", "coven", "-Q"],
+      "install_hint": "Install Hermes Agent, add it to PATH, install the hermes-coven shim, and complete Hermes setup before using this adapter.",
+      "system_prompt_flag": null,
+      "model_flag": "--model"
     }
   ]
 }
@@ -3180,6 +3181,60 @@ mod tests {
     }
 
     #[test]
+    fn hermes_recipe_forwards_selected_models_before_the_shim_prompt() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = coven_home.join("adapters");
+        fs::create_dir_all(&adapter_dir)?;
+        fs::write(adapter_dir.join("hermes.json"), HERMES_ADAPTER_MANIFEST)?;
+
+        let _guard = env_lock().lock().unwrap();
+        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
+        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+
+        let selected = command_parts_for_harness_with_conversation(
+            "hermes",
+            "hello from Coven",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                model: Some("openai/gpt-5.6-terra"),
+                ..Default::default()
+            },
+        )?;
+        assert_eq!(selected.0, "hermes-coven");
+        assert_eq!(
+            selected.1,
+            vec![
+                "--model",
+                "gpt-5.6-terra",
+                "chat",
+                "--source",
+                "coven",
+                "-Q",
+                "--",
+                "hello from Coven",
+            ]
+        );
+
+        let inherited = command_parts_for_harness_with_conversation(
+            "hermes",
+            "hello from Coven",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions::default(),
+        )?;
+        assert_eq!(
+            inherited.1,
+            vec!["chat", "--source", "coven", "-Q", "--", "hello from Coven"]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn configured_harness_specs_load_trusted_coven_home_adapter_directory() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let coven_home = temp_dir.path().join("coven-home");
@@ -3246,7 +3301,7 @@ mod tests {
             .find(|spec| spec.id == "hermes")
             .expect("trusted source should parse bundled hermes recipe");
 
-        assert_eq!(hermes.executable, "hermes");
+        assert_eq!(hermes.executable, "hermes-coven");
         assert_eq!(
             hermes.manifest_path.as_deref(),
             Some(manifest_path.to_string_lossy().as_ref())

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -802,6 +802,14 @@ fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
         "Installed adapter `hermes`",
     );
     assert!(coven_home.join("adapters").join("hermes.json").exists());
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(coven_home.join("adapters").join("hermes.json"))?)?;
+    let adapter = manifest["adapters"]
+        .as_array()
+        .and_then(|adapters| adapters.first())
+        .expect("installed Hermes manifest contains one adapter");
+    assert_eq!(adapter["executable"], "hermes-coven");
+    assert_eq!(adapter["model_flag"], "--model");
 
     // Diagnose against an empty PATH so the outcome doesn't depend on
     // whether a real `hermes` happens to be installed on this machine:
@@ -971,7 +979,7 @@ fn adapter_install_hermes_replaces_existing_manifest() -> anyhow::Result<()> {
     assert_eq!(adapter.get("id").and_then(Value::as_str), Some("hermes"));
     assert_eq!(
         adapter.get("executable").and_then(Value::as_str),
-        Some("hermes")
+        Some("hermes-coven")
     );
     Ok(())
 }
@@ -1012,7 +1020,7 @@ fn adapter_install_hermes_replaces_existing_manifest_directory() -> anyhow::Resu
     assert_eq!(adapter.get("id").and_then(Value::as_str), Some("hermes"));
     assert_eq!(
         adapter.get("executable").and_then(Value::as_str),
-        Some("hermes")
+        Some("hermes-coven")
     );
     Ok(())
 }

--- a/docs/harnesses/hermes.md
+++ b/docs/harnesses/hermes.md
@@ -12,7 +12,13 @@ Hermes can be used as a research target for the generic external adapter system 
 
 ## Install the local adapter recipe
 
-Use the bundled recipe instead of hand-writing a manifest:
+Hermes receives task text through its `-q/--query` flag, while Coven sends
+ordinary adapter prompts after `--`. Install the maintained `hermes-coven` shim
+from [`coven-runtimes`](https://github.com/OpenCoven/coven-runtimes/tree/main/shims)
+into a directory on `PATH` before installing the bundled recipe. The shim
+rewrites only the prompt; selected `--model` arguments pass through unchanged.
+
+Then use the bundled recipe instead of hand-writing a manifest:
 
 ```sh
 coven adapter install hermes


### PR DESCRIPTION
Closes #441

## Summary
- Install the built-in Hermes recipe with `hermes-coven` and `model_flag: --model`.
- Forward a namespaced selected model as its bare value before the shim prompt terminator.
- Document the maintained shim prerequisite and cover selected/default model argv behavior.

Paired registry change: OpenCoven/coven-runtimes#31

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- Focused Windows-native `coven-cli` Hermes argv regression
- Focused bundled-manifest regression

The WSL C compiler cannot start (`libisl.so.23` missing). A full Windows-native `coven-cli` run has unrelated executable-resolution and PTY failures; the focused adapter tests pass.