### PR TITLE
docs: fix broken links and stale harness claims in entry-point docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,7 +669,7 @@ comux is a standalone terminal cockpit that proved the tmux-cockpit model for pa
 | [Public roadmap](docs/ROADMAP.md)                       | Shipped, now, next, and later milestones                              |
 | [Product spec](docs/PRODUCT-SPEC.md)                    | Product requirements and design decisions                             |
 | [MVP plan](docs/MVP-PLAN.md)                            | Current MVP scope and checklist                                       |
-| [Future harnesses](docs/FUTURE-HARNESSES.md)            | Research notes for upcoming adapter work                              |
+| [Future harnesses](docs/reference/future-harnesses.md)  | Research notes for upcoming adapter work                              |
 | [Brand assets](docs/BRAND.md)                           | Logo, colors, and usage guidance                                      |
 | [Design system](DESIGN.md)                              | Full brand reference: palette, typography, iconography                |
 | [Brand adherence checklist](docs/BRANDING-ADHERENCE.md) | Checklist for brand-compliant contributions                           |

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -267,7 +267,7 @@ coven adapter doctor claude
 
 ## Adding a new adapter
 
-1. Start with a research note in `docs/FUTURE-HARNESSES.md` or a dedicated `docs/harnesses/<id>.md` page.
+1. Start with a research note in `docs/reference/future-harnesses.md` or a dedicated `docs/harnesses/<id>.md` page.
 2. Document the exact CLI contract: install, auth/setup, interactive launch, one-shot prompt launch, quiet/programmatic output mode, resume/session behavior, and unsupported modes.
 3. Add command-construction tests before changing user-facing docs to say the harness is supported.
 4. Add `coven adapter doctor` / `coven doctor` detection and setup hints.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ description: "Coven powers CastCodes with local-first project-scoped harness ses
   <div>
     <p class="home-intro-kicker"><strong>Coven powers CastCodes.</strong></p>
     <p><strong>CastCodes is the local-first AI coding workspace users open. Coven is the local runtime underneath: project-scoped harness sessions, append-only events, logs, artifacts, and authority boundaries.</strong></p>
-    <p>Run Codex, Claude Code, and future harnesses as visible CastCodes lanes. Inspect the work, preserve context, verify changes, and merge with confidence.</p>
+    <p>Run Codex, Claude Code, GitHub Copilot CLI, and future harnesses as visible CastCodes lanes. Inspect the work, preserve context, verify changes, and merge with confidence.</p>
   </div>
 </div>
 
@@ -31,7 +31,7 @@ description: "Coven powers CastCodes with local-first project-scoped harness ses
     Daemon, PTY supervision, project-root validation, sessions, events, and local socket authority.
   </Card>
   <Card title="CLI reference" href="/reference/cli" icon="terminal">
-    Current `coven` commands: run, sessions, attach, daemon, doctor, archive, summon, and sacrifice.
+    Core verbs — doctor, daemon, run, sessions, attach — plus the archive, summon, and sacrifice rituals and the rest of the command surface.
   </Card>
 </Columns>
 
@@ -44,7 +44,7 @@ Coven is a **local-first runtime substrate**: a single Rust daemon that owns har
 **What makes it different today?**
 
 - **Local-first** — the daemon, the store, and the socket all live under `$COVEN_HOME`. No cloud relay, no daemon OAuth.
-- **Harness-neutral** — Codex and Claude Code today, with a documented adapter bar for future harnesses. Same lifecycle, same rituals.
+- **Harness-neutral** — Codex, Claude Code, and GitHub Copilot CLI today, with a documented adapter bar for future harnesses. Same lifecycle, same rituals.
 - **Project-rooted** — every launch carries an explicit project root and canonicalized working directory. The Rust daemon revalidates each request.
 - **Inspectable** — sessions and events are SQLite rows you can browse with `coven sessions`, replay with `coven attach`, or sacrifice when you no longer need them.
 - **MIT licensed** — packaged for early adopters under `@opencoven/*`, command always `coven`.
@@ -60,6 +60,7 @@ flowchart LR
   C["Advanced / legacy clients"] -.-> B
   B --> F["Codex PTY"]
   B --> G["Claude Code PTY"]
+  B --> L["Copilot CLI PTY"]
   B --> H["Future harness PTYs"]
   B --> I[("SQLite session ledger")]
   B --> J[("Append-only event log")]
@@ -71,7 +72,7 @@ The daemon is the single source of truth for sessions, PTY lifecycle, and capabi
 
 <Columns>
   <Card title="Harness-neutral runtime" icon="layers" href="/HARNESS-ADAPTERS">
-    Codex and Claude Code launched through one supervised PTY layer.
+    Codex, Claude Code, and GitHub Copilot CLI launched through one supervised PTY layer.
   </Card>
   <Card title="Project-scoped sessions" icon="folder-tree" href="/SESSION-LIFECYCLE">
     Every session pins a canonical project root and refuses to wander.
@@ -103,7 +104,7 @@ The daemon is the single source of truth for sessions, PTY lifecycle, and capabi
     ```bash
     coven doctor
     ```
-    `doctor` reports whether `codex` and `claude` are on `PATH`, whether the daemon socket can bind, and what to install next.
+    `doctor` reports whether harness CLIs such as `codex`, `claude`, and `copilot` are on `PATH`, whether the daemon socket can bind, and what to install next.
   </Step>
   <Step title="Start the daemon">
     ```bash


### PR DESCRIPTION
## Context

- Summary: UX/readability audit fixes for docs entry points — repairs the dangling `docs/FUTURE-HARNESSES.md` link, updates stale harness-support claims in `docs/index.md` to include GitHub Copilot CLI, and rewrites the stale CLI-reference card copy. In-place edits only; no files moved, renamed, or deleted.
- Files changed: `README.md`, `docs/HARNESS-ADAPTERS.md`, `docs/index.md`
- Closes #446

## Implementation

- Approach:
  - `README.md:672` doc-map row now links `docs/reference/future-harnesses.md` (the file that actually exists); `docs/FUTURE-HARNESSES.md` does not.
  - `docs/HARNESS-ADAPTERS.md` "Adding a new adapter" step 1 path reference updated the same way. (`docs/MVP-PLAN.md` references left alone — historical doc, gets a banner in #447.)
  - `docs/index.md`: "Harness-neutral" bullet, hero paragraph, capability card, PTY diagram, and the `coven doctor` quick-start blurb now name Codex, Claude Code, **and GitHub Copilot CLI** — matching `built_in_harness_specs()` in `crates/coven-cli/src/harness.rs` (id `copilot`) and the README Features section.
  - `docs/index.md` CLI-reference card no longer enumerates a stale 8-command list; it now describes core verbs + rituals and points at the full reference, so it stays accurate as the surface grows.
  - Relative-link sweep across root `*.md` and `docs/` (excluding `docs/es`, `docs/ru`, `docs/dist`, generated trees) with a throwaway resolver script: the FUTURE-HARNESSES row was the only broken relative link; zero remain after the fix. Site-absolute routes (`/FUTURE-HARNESSES` etc.) and external URLs were out of scope by design.
- User-visible behavior: docs-only; entry-point pages stop 404ing on the future-harnesses link and stop under-claiming harness support.
- Compatibility notes: none — no route/path changes, no file moves.

## Verification

- [x] `python3 scripts/check-secrets.py` — passed (no current-tree or history findings)
- [x] `git diff --check` — clean
- [x] `node --test scripts/onboarding-docs-test.mjs` — 13/13 pass
- [x] Additional manual checks: link-sweep script validated against unfixed `main` (correctly reports the README:672 break) and against this branch (0 broken); every replacement target opened and confirmed topically correct; README doc-map table column alignment preserved.

(Cargo gates not run locally: docs-only diff, no Rust/TS source touched.)

## Risk and Rollback

- Risk level: Low — three markdown files, copy-only changes.
- Rollback plan: revert the squash commit.

## Agent Handoff

- Current state: complete; all docs gates green locally.
- Follow-ups: #447 (README slimming + duplicated doc-pair reconciliation) stacks on this.
- Known gaps: `specs/coven-harness-capabilities/PRODUCT.md` mentions `FUTURE-HARNESSES.md` in prose (inline code, not links) — left as-is, specs are historical snapshots. `docs/es`/`docs/ru` translations still lag English; noted for the #447 maintenance-doc update.