### PR TITLE
fix: add next-step hints to CLI errors and standardize empty states

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1100,6 +1100,7 @@ fn run_sessions_search(query: &str, json: bool) -> Result<()> {
     // `transcript_indexed_at` is set the ingest function is a no-op.
     let coven_home = coven_home_dir()?;
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+    let mut ingest_warned = false;
     match store::list_uningest_external_sessions(&conn) {
         Ok(pending) => {
             for (session_id, _transcript_path) in pending {
@@ -1111,13 +1112,21 @@ fn run_sessions_search(query: &str, json: bool) -> Result<()> {
                         "warning: run_sessions_search: failed to ingest transcript for session \
                          {session_id}: {e}"
                     );
+                    ingest_warned = true;
                 }
             }
         }
         Err(e) => {
             // Non-fatal: fall through to search without transcript data.
             eprintln!("warning: run_sessions_search: failed to list un-ingested sessions: {e}");
+            ingest_warned = true;
         }
+    }
+    if ingest_warned {
+        eprintln!(
+            "note: fresh TUI session transcripts may not be searchable until ingest completes; \
+             rerun the search in a moment"
+        );
     }
 
     let hits = store::search_events(&conn, query)?;
@@ -2198,14 +2207,18 @@ fn run_patch(
     let git_state = openclaw_repo::inspect_git_state(&detected_repo.root)?;
     let issue = match joined_optional_issue(issue)? {
         Some(issue) => issue,
-        None if non_interactive => anyhow::bail!("issue text is required with --non-interactive"),
+        None if non_interactive => anyhow::bail!(
+            "issue text is required with --non-interactive; pass it as arguments, e.g. `coven patch openclaw \"fix the failing test\" --non-interactive --harness codex`"
+        ),
         None => {
             prompt_for_required_line(&format!("What is broken in {}? ", detected_repo.repo_name))?
         }
     };
     let harness_id = match harness {
         Some(harness) => patch::HarnessId::parse(&harness)?,
-        None if non_interactive => anyhow::bail!("--harness is required with --non-interactive"),
+        None if non_interactive => anyhow::bail!(
+            "--harness is required with --non-interactive; add `--harness codex` (or claude, or copilot)"
+        ),
         None => choose_default_harness()?,
     };
     let verification_profile = patch::VerificationProfile::parse(verify.as_deref())?;
@@ -2313,7 +2326,9 @@ fn joined_optional_issue(issue: Vec<String>) -> Result<Option<String>> {
     }
     let joined = issue.join(" ").trim().to_string();
     if joined.is_empty() {
-        anyhow::bail!("issue text must not be empty when provided");
+        anyhow::bail!(
+            "issue text must not be empty when provided; describe what is broken, e.g. `coven patch openclaw \"fix the failing gateway auth test\"`"
+        );
     }
     Ok(Some(joined))
 }
@@ -2327,7 +2342,7 @@ fn prompt_for_required_line(prompt: &str) -> Result<String> {
         .context("failed to read input")?;
     let line = line.trim().to_string();
     if line.is_empty() {
-        anyhow::bail!("a response is required");
+        anyhow::bail!("a response is required; type a non-empty answer, or press Ctrl-C to cancel");
     }
     Ok(line)
 }
@@ -2856,7 +2871,9 @@ fn run_ward_command(command: WardCommand) -> Result<()> {
             )?;
             ward_migrate::print_report(&report);
             if report.has_errors() {
-                bail!("one or more Ward migrations failed or were unmigratable");
+                bail!(
+                    "one or more Ward migrations failed or were unmigratable; see the report above for per-familiar details"
+                );
             }
         }
     }
@@ -3008,7 +3025,7 @@ fn run_session(
     };
 
     if prompt_args.is_empty() && continue_session.is_none() {
-        anyhow::bail!("nothing to do: pass a prompt, or use --continue [ID] to resume a session");
+        anyhow::bail!("nothing to do; pass a prompt, or use --continue [ID] to resume a session");
     }
 
     let selected_harness = selected_available_harness(harness_id)?;
@@ -3161,7 +3178,10 @@ fn run_session(
                 r.updated_at = now.clone();
                 (r, true)
             }
-            None => anyhow::bail!("session {} not found in local store", id),
+            None => anyhow::bail!(
+                "session `{}` not found in local store; run `coven sessions --all` to list session ids",
+                id
+            ),
         }
     } else {
         let r = store::SessionRecord {
@@ -3694,7 +3714,9 @@ pub(crate) fn summon_only_command(session_id: &str) -> Result<store::SessionReco
         store::summon_session(&conn, &session_id, &current_timestamp())?;
         eprintln!("summoned session from the archive");
         let Some(session) = store::get_session(&conn, &session_id)? else {
-            anyhow::bail!("session `{session_id}` not found");
+            anyhow::bail!(
+                "session `{session_id}` not found; run `coven sessions --all` to list session ids"
+            );
         };
         return Ok(session);
     }
@@ -3768,7 +3790,9 @@ fn post_session_kill(coven_home: &Path, session_id: &str) -> Result<()> {
             "the daemon has no live process for session `{session_id}`; {}",
             STALE_RUNNING_HINT
         ),
-        status => anyhow::bail!("Coven daemon rejected the kill with HTTP {status}"),
+        status => anyhow::bail!(
+            "Coven daemon rejected the kill with HTTP {status}; check `coven daemon status` and `coven sessions` for session state"
+        ),
     }
 }
 
@@ -3880,7 +3904,9 @@ fn send_session_input(coven_home: &Path, session_id: &str, data: &str) -> Result
     if (200..300).contains(&status) {
         Ok(())
     } else {
-        anyhow::bail!("Coven daemon rejected input with HTTP {status}")
+        anyhow::bail!(
+            "Coven daemon rejected input with HTTP {status}; check `coven daemon status` and `coven sessions` for session state"
+        )
     }
 }
 
@@ -3959,7 +3985,9 @@ fn joined_prompt(prompt_args: &[String]) -> Result<String> {
     let prompt = prompt_args.join(" ");
     let prompt = prompt.trim();
     if prompt.is_empty() {
-        anyhow::bail!("prompt must not be empty");
+        anyhow::bail!(
+            "prompt must not be empty; quote a task string, e.g. `coven run codex \"fix the failing tests\"`"
+        );
     }
     Ok(prompt.to_string())
 }

--- a/crates/coven-cli/src/pc/display.rs
+++ b/crates/coven-cli/src/pc/display.rs
@@ -76,11 +76,17 @@ fn print_human(snap: &SystemSnapshot, format: &OutputFormat) {
     println!("  ⏱  Uptime   {}", format_uptime(snap.uptime_secs));
 
     println!("\n── Disk ────────────────────────────────────");
+    if snap.disks.is_empty() {
+        println!("  No disks detected.");
+    }
     for disk in &snap.disks {
         print_disk(disk);
     }
 
     println!("\n── Top Processes (by CPU) ──────────────────");
+    if snap.processes.is_empty() {
+        println!("  No processes to show.");
+    }
     for proc in snap.processes.iter().take(10) {
         print_proc(proc, format);
     }
@@ -115,6 +121,9 @@ pub fn print_top(snap: &SystemSnapshot, n: usize, format: &OutputFormat) {
         return;
     }
     println!("── Top {} Processes (by CPU) ────────────────", n);
+    if snap.processes.is_empty() {
+        println!("  No processes to show.");
+    }
     for proc in snap.processes.iter().take(n) {
         print_proc(proc, format);
     }
@@ -126,6 +135,9 @@ pub fn print_disk_usage(snap: &SystemSnapshot, format: &OutputFormat) {
         return;
     }
     println!("── Disk Usage ──────────────────────────────");
+    if snap.disks.is_empty() {
+        println!("  No disks detected.");
+    }
     for disk in &snap.disks {
         print_disk(disk);
     }


### PR DESCRIPTION
## Context

- Summary: UX audit #449 (follow-up to #448, stacked after #454 merged) found high-traffic error messages with no next step and inconsistent empty-state output. This PR standardizes both on the existing exemplars (`no supported harness is available; run \`coven doctor\` for setup guidance`, `session \`{id}\` not found; run \`coven sessions --all\` ...`).
- Files changed: `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/pc/display.rs`
- Closes #449

## Implementation

- Approach: human-facing strings only; no control flow, exit codes, or `--json` bodies changed. The Cancelled no-`Error:`-prefix contract is untouched.
- **Error sites upgraded** (semicolon + next step, lowercase leaf voice):
  - `prompt must not be empty` → adds `quote a task string, e.g. \`coven run codex "fix the failing tests"\`` (existing test asserts the stable prefix and still passes)
  - patch `--non-interactive` bails: issue-text bail now shows the full command shape; `--harness` bail names the flag values (codex/claude/copilot)
  - `issue text must not be empty when provided` → adds an example invocation
  - `a response is required` → `type a non-empty answer, or press Ctrl-C to cancel`
  - `session {} not found in local store` and summon's `session \`{id}\` not found` → aligned with the `coven sessions --all` exemplar
  - daemon kill/input HTTP rejections → append `check \`coven daemon status\` and \`coven sessions\` for session state`
  - Ward migrate summary bail → `see the report above for per-familiar details`
  - run's `nothing to do:` → `nothing to do;` (punctuation aligned with the standard)
- **Empty states**: sessions/status/familiars/skills/memory/research/calls/hub/ward surfaces already print explicit empty lines (verified each renderer in `observe.rs` and `tui/sessions.rs`) — left alone. `coven pc` / `pc top` / `pc disk` printed bare section headers on zero rows; they now print one-line `No processes to show.` / `No disks detected.` (human mode only).
- **Search ingest hint**: `coven sessions search` now prints one stderr note after ingest warnings that fresh TUI transcripts may not be searchable until ingest completes.
- **Deliberate skips** (kept terse on purpose): `--detach`/`--continue` conflict (clap's `conflicts_with` produces the user-facing error first), non-Unix/Windows platform stubs (kill/attach-input/daemon-serve — factual limits with no next step), ambiguous session-prefix bail (already lists candidate ids), `no active session to continue` (already has a next step), kill's `is not running (status: ...)` (already states the blocking status inline), and other modules' errors (out of scope for a reviewable diff).
- Compatibility notes: stderr-only additions in `--json`-capable paths; stdout JSON bodies byte-identical.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (1269 + suite green)
- [x] `python3 scripts/check-secrets.py` (passed: no current-tree or history findings)
- [x] Additional manual checks: grepped every changed fragment for pinned test assertions (only `prompt must not be empty` is pinned, as a prefix, and still passes); verified Cancelled contract block unmodified.

## Risk and Rollback

- Risk level: low — message-string and stderr-hint diff.
- Rollback plan: revert the single commit.

## Agent Handoff

- Current state: complete; ready for review. Stacked after #448/#454 (merged).
- Follow-ups: none planned; error copy in other crates/modules could get the same treatment in a future audit.
- Known gaps: hub `routing` empty state has no next-step line (registering routes isn't a CLI action; kept one factual line).