### PR TITLE
docs: list copilot in remaining harness enumerations and document --add-dir

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,15 +87,15 @@ Shipped:
 - `coven doctor` setup checks.
 - Local daemon lifecycle: `coven daemon start/status/restart/stop`.
 - Project-root and cwd boundary guard.
-- Built-in Codex and Claude Code harness adapters.
-- PTY-backed `coven run codex|claude <prompt>` sessions.
+- Built-in Codex, Claude Code, and GitHub Copilot CLI harness adapters.
+- PTY-backed `coven run codex|claude|copilot <prompt>` sessions.
 - SQLite-backed session metadata and event log.
 - Session browser and rituals: **Rejoin**, **View Log**, **Summon**, **Archive**, **Sacrifice**.
 - Scriptable and human session output: `coven sessions`, `--plain`, and `--all`.
 - Local HTTP-over-Unix-socket API for CastCodes and advanced local clients.
 - Versioned `coven.daemon.v1` API contract with named apiVersion, machine-readable capabilities, structured errors, and monotonic event cursors. See [`docs/API-CONTRACT.md`](/API-CONTRACT).
 - Compatibility tests for the external OpenClaw bridge against versioned daemon responses.
-- First-run recovery hints for missing Codex or Claude Code CLIs.
+- First-run recovery hints for missing Codex, Claude Code, or GitHub Copilot CLIs.
 - Real CLI smoke coverage for daemon restart, attach replay, kill, archive, summon, and sacrifice flows.
 - Install verification and release wiring for macOS, Linux x64, and Windows x64 npm package paths.
 - Published npm wrapper packages:

--- a/docs/concepts/features.md
+++ b/docs/concepts/features.md
@@ -11,7 +11,7 @@ description: "Feature reference for the Coven runtime: project-rooted launches, 
     Every session pins a canonical project root. Cwd must canonicalize inside that root.
   </Card>
   <Card title="Harness-neutral PTYs" icon="terminal">
-    Codex and Claude Code today; Hermes, Aider, Gemini, Cline tomorrow.
+    Codex, Claude Code, and GitHub Copilot CLI today; Hermes, Aider, Gemini, Cline tomorrow.
   </Card>
   <Card title="Append-only event log" icon="scroll">
     Output, exit, and metadata events stored in SQLite for replay.

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -81,14 +81,16 @@ coven run claude "explain this repo in 5 bullets"
 
 ## Missing harness output
 
-When neither supported harness is visible, `doctor` prints install hints for
-Codex and Claude Code:
+When no supported harness is visible, `doctor` prints a per-harness install
+hint. For Codex, Claude Code, and GitHub Copilot CLI those hints boil down to:
 
 ```sh
 npm install -g @openai/codex
 codex login
 npm install -g @anthropic-ai/claude-code
 claude doctor
+npm install -g @github/copilot
+copilot login
 coven doctor
 ```
 

--- a/docs/reference/cli-run.md
+++ b/docs/reference/cli-run.md
@@ -12,13 +12,14 @@ description: "Reference for coven run: one-shot harness execution that spawns a 
 coven run <harness> <prompt> [flags]
 ```
 
-`<harness>` is a configured harness id such as `codex` or `claude`.
+`<harness>` is a configured harness id such as `codex`, `claude`, or `copilot`.
 
 ## Common Flags
 
 | Flag | Behavior |
 |---|---|
 | `--cwd <path>` | Launch from a directory inside the resolved project root. |
+| `--add-dir <path>` | Grant the harness access to an additional directory beyond its cwd; repeat the flag for multiple directories. Maps to each harness's native trust flag (`--add-dir` for codex, claude, copilot, and coven-code). Harnesses with no add-dir mechanism warn and continue. |
 | `--title <text>` | Store a readable session title. |
 | `--model <id>` | Forward a model override to harnesses that declare model support. Namespaced ids such as `anthropic/claude-sonnet-4` are forwarded to the harness as the bare model id. |
 | `--think` | Request deeper reasoning. Claude maps this to `--effort high`; unsupported harnesses warn and continue. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -95,7 +95,7 @@ flowchart TB
 | `coven doctor` | Check local setup; exits 1 when a blocking problem is found. `--json` emits a `{ ok, blocking, checks, nextSteps }` envelope. |
 | `coven status` | Ecosystem overview: daemon, sessions, familiars, skills, research, hub. Alias: `coven overview`. |
 | `coven daemon start/status/restart/stop` | Manage the local daemon. |
-| `coven run <harness> <prompt>` | Launch a project-scoped harness session. Current harness ids: `codex`, `claude`. |
+| `coven run <harness> <prompt>` | Launch a project-scoped harness session. Current harness ids: `codex`, `claude`, `copilot`. |
 | `coven sessions` | Open the session browser; supports `--plain`, `--json`, `--all`, and `--manage`. |
 | `coven sessions search <query>` | Full-text search recorded event payloads. |
 | `coven sessions show/events/log <session-id>` | Inspect one session without attaching; see [cli-observe](cli-observe.md). |

--- a/docs/reference/harness-adapters.md
+++ b/docs/reference/harness-adapters.md
@@ -1,5 +1,5 @@
 ---
-summary: "The adapter shape Codex and Claude Code use today."
+summary: "The adapter shape Codex, Claude Code, and GitHub Copilot CLI use today."
 read_when:
   - Looking up adapter expectations
 title: "Harness adapters"

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -18,8 +18,8 @@ description: "Showcase landing for Coven: a local-first runtime that supervises 
 ## Highlights
 
 <Columns>
-  <Card title="Codex and Claude Code today" icon="layers" href="/harnesses">
-    Two supported harnesses, more on the way through the adapter spec.
+  <Card title="Codex, Claude Code, and Copilot CLI today" icon="layers" href="/harnesses">
+    Three supported harnesses, more on the way through the adapter spec.
   </Card>
   <Card title="Session JSON records" icon="braces" href="/sessions/comux-json">
     Session shape that CastCodes and advanced clients can replay.


### PR DESCRIPTION
## Context

- Summary: sweep the reference/topic docs that still enumerated only Codex and Claude Code where GitHub Copilot CLI is a shipped built-in harness, and document the `coven run --add-dir` flag. Follow-up flagged in the bodies of merged PRs #453/#454/#457.
- Files changed: docs/ROADMAP.md, docs/concepts/features.md, docs/reference/cli-doctor.md, docs/reference/cli-run.md, docs/reference/cli.md, docs/reference/harness-adapters.md, docs/start/showcase.md
- Closes #458

## Implementation

- Approach: docs-only, in-place edits verified against the code: harness ids from `crates/coven-cli/src/harness.rs` `built_in_harness_specs()` (codex, claude, copilot), copilot install hint from the copilot spec, `--add-dir` behavior from `main.rs:234-238`.
- User-visible behavior: docs only; no runtime change.
- Compatibility notes: deliberately untouched — docs/PRODUCT-SPEC.md + docs/MVP-PLAN.md (historical/spec voice), docs/OPERATIONAL-MODEL.md:97 (the OpenClaw plugin really does map only codex/claude ids today — verified in packages/openclaw-coven), docs/es + docs/ru (translation sync is a separate pass).

## Verification

- [ ] `cargo fmt --check` — n/a (docs-only)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — n/a (docs-only)
- [ ] `cargo test --workspace --locked` — n/a (docs-only)
- [x] `python3 scripts/check-secrets.py` — clean (current tree + history)
- [x] Additional manual checks: `git diff --check` clean; `node --test scripts/onboarding-docs-test.mjs` 13/13 pass; every replacement cross-checked against harness.rs/main.rs.

## Risk and Rollback

- Risk level: minimal (docs wording only).
- Rollback plan: revert the single squash commit.

## Agent Handoff

- Current state: complete; all stale two-harness enumerations outside historical/spec docs now list copilot.
- Follow-ups: es/ru locale sync still pending (tracked via docs/DOCS-MAINTENANCE.md note from #457).
- Known gaps: none known.
