### PR TITLE
fix: make veto-deadline recovery test deterministic

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -9620,13 +9620,16 @@ tier = 0
         let temp = tempfile::tempdir()?;
         let home = temp.path();
         let veto = coven_threads_core::VetoWindow::new(
-            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(300),
             std::time::Duration::ZERO,
         );
-        let (_, proposal_id) = stage_scheduled_reviewed_edit(
+        // Stage in the past so the veto deadline (staged_at + 300s) has
+        // already elapsed by the time recovery runs — no wall-clock sleep.
+        let staged_at = time::OffsetDateTime::now_utc() - time::Duration::minutes(10);
+        let (pending_path, proposal_id) = stage_scheduled_reviewed_edit(
             home,
             coven_threads_core::ApprovalPath::FamiliarCoherence { veto },
-            time::OffsetDateTime::now_utc(),
+            staged_at,
         )?;
         set_proposal_decision_failpoint(Some((
             ProposalDecisionFailpoint::ClaimBeforeValidation,
@@ -9641,7 +9644,26 @@ tier = 0
             Some(&decision_body),
         );
         assert!(interrupted.is_err());
-        std::thread::sleep(std::time::Duration::from_millis(2_100));
+
+        // The interrupted claim durably recorded claimed_at = wall-clock now,
+        // which is after the backdated deadline. Recovery judges veto
+        // timeliness by the durable claimed_at alone, so pin it inside the
+        // window to model a claim that landed before the deadline. This keeps
+        // the scenario — timely claim, post-deadline replay — deterministic
+        // instead of racing a real clock (flaky on slow CI runners, #455).
+        let raw = std::fs::read_to_string(&pending_path)?;
+        let mut value: Value = serde_json::from_str(&raw)?;
+        let mut request = proposal_decision_request(&value)?
+            .context("interrupted reject left a durable decision request")?;
+        request.claimed_at = staged_at + time::Duration::seconds(1);
+        value
+            .as_object_mut()
+            .context("pending proposal is a JSON object")?
+            .insert(
+                "decisionRequest".to_string(),
+                serde_json::to_value(&request)?,
+            );
+        std::fs::write(&pending_path, serde_json::to_vec_pretty(&value)?)?;
 
         let recovered = process_due_threads_proposals(home)?;
         assert_eq!(recovered, 1);


### PR DESCRIPTION
Closes #455.

## What

Makes `api::tests::threads_scheduler_recovers_veto_claimed_before_deadline` deterministic. It has been failing repeatedly on `windows-latest` (three consecutive failures on PR #459's runs, plus the occurrences tracked in #455) and is currently the top CI flake.

## Root cause

The test staged a proposal with a **real 2-second veto window** and relied on two wall-clock races:

1. **Stage → claim latency.** The interrupted `POST /reject` durably records `claimed_at = now_utc()` *before* the `ClaimBeforeValidation` failpoint fires. Recovery judges veto timeliness by that durable `claimed_at` against `veto_deadline = staged_at + 2s` (`proposal_decision_semantics` reject arm → `proposal-veto-window-closed`). On a slow Windows runner, staging + one `GET /threads/proposals` + the `POST` can take longer than 2 s, so the claim lands *after* the deadline and recovery legitimately vetoes nothing — `recovered == 0`, the assertion fails. This is the observed CI failure.
2. **Fixed 2.1 s sleep** to get past the deadline before replaying recovery.

The issue suggested widening the sleep, but the sleep isn't the racing part — the stage-to-claim latency is, and no fixed window is safe against arbitrary runner stalls.

## Fix

Drive both timing conditions through durable state instead of the wall clock, following the idioms the sibling scheduler tests already use (300 s window, backdated `staged_at`):

- Stage with `staged_at = now - 10 min` and a 300 s window, so the veto deadline has *already elapsed* when recovery runs — the 2.1 s sleep is deleted.
- After the interrupted reject, pin the durable `decisionRequest.claimed_at` to `staged_at + 1s` (round-tripping the module's own `ProposalDecisionRequest` type), modelling a claim that landed inside the window. Recovery reads `claimed_at` verbatim from the durable request, so this exercises exactly the recovery-semantics path the test exists to cover: *timely claim, post-deadline replay*.

No production code changes — test-only diff.

## Verification

- `cargo test -p coven-cli threads_scheduler` — 5/5 pass; the test now runs in ~60 ms (was ~2.1 s+).
- Ran the fixed test 5× consecutively — stable.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `python scripts/check-secrets.py` — all green.
