### PR TITLE
feat(ward-migrate): compile-or-reject v0.1 identity invariants; bump coven-threads-core pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "coven-threads-core"
 version = "0.2.0"
-source = "git+https://github.com/OpenCoven/coven-threads?rev=7da030d#7da030d63468e87c986e74d12e589f4c6283e8fe"
+source = "git+https://github.com/OpenCoven/coven-threads?rev=6fa360b#6fa360b780d62539dfc2841251de8865ccdb95f3"
 dependencies = [
  "blake3",
  "serde",
@@ -4107,7 +4107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -24,7 +24,7 @@ coven-runtime-spec = { git = "https://github.com/OpenCoven/coven-runtimes", tag 
 # (PHASE-0-DESIGN.md in OpenCoven/coven-threads; RFC-0001 §5). The daemon is
 # the only caller: familiar-controlled processes never reach this crate.
 # Pinned to the reviewed Phase 5 core revision until its 0.2 release tag lands.
-coven-threads-core = { git = "https://github.com/OpenCoven/coven-threads", rev = "7da030d", version = "0.2.0" }
+coven-threads-core = { git = "https://github.com/OpenCoven/coven-threads", rev = "6fa360b", version = "0.2.0" }
 blake3 = "1"
 time = { version = "0.3", features = ["formatting"] }
 crossterm = "0.29"

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -145,6 +145,27 @@ fn migrate_one(
 
     let phase2_error = match WardConfig::from_toml_str(&raw) {
         Ok(_) => {
+            // A-1 guard: WardConfig tolerates unknown fields, so a file can
+            // parse as valid Phase-2 while still carrying a v0.1
+            // `[protected].invariants` remnant. Phase-2 has no invariants
+            // surface — blessing such a hybrid as AlreadyMigrated would
+            // silently ignore identity declarations. Fail closed instead.
+            let remnants = v01_invariant_remnants(&raw);
+            if let Some(remnants) = remnants {
+                return Ok(MigrationEntry {
+                    familiar_id: familiar_id.to_string(),
+                    workspace: workspace.to_path_buf(),
+                    status: MigrationStatus::Unmigratable,
+                    protected_files: Vec::new(),
+                    editable_paths: Vec::new(),
+                    translated_globs: Vec::new(),
+                    invariant_dispositions: Vec::new(),
+                    generated_toml: None,
+                    message: format!(
+                        "ward.toml parses as Phase-2 but retains a v0.1 [protected].invariants remnant ({remnants} declaration(s)); Phase-2 has no invariants surface, so these would be silently inert — remove the remnant or restore the v0.1 file and re-run migration"
+                    ),
+                });
+            }
             return Ok(MigrationEntry {
                 familiar_id: familiar_id.to_string(),
                 workspace: workspace.to_path_buf(),
@@ -186,7 +207,7 @@ fn migrate_one(
             protected_files: Vec::new(),
             editable_paths: Vec::new(),
             translated_globs: Vec::new(),
-                invariant_dispositions: Vec::new(),
+            invariant_dispositions: Vec::new(),
             generated_toml: None,
             message: format!(
                 "unmigratable ward.toml: not Phase-2 ({phase2_error:#}) and not recognized Ward v0.1"
@@ -233,7 +254,7 @@ fn migrate_one(
         .collect();
     if !rejection_reasons.is_empty() {
         let message = format!(
-            "v0.1 [protected].invariants rejected explicitly ({} of {} declarations): {}",
+            "v0.1 [protected].invariants rejected explicitly ({} rejection(s) across {} declaration(s)): {}",
             rejection_reasons.len(),
             legacy_invariants.len(),
             rejection_reasons.join("; "),
@@ -361,6 +382,18 @@ fn migrate_one(
             "migrated Ward v0.1{}",
             invariant_summary_suffix(&invariant_dispositions)
         ),
+    })
+}
+
+/// Detects a v0.1 `[protected].invariants` remnant in a raw ward.toml
+/// document. Returns `Some(declaration_count)` when the key is present
+/// (a non-array value counts as one remnant), `None` when absent.
+fn v01_invariant_remnants(raw: &str) -> Option<usize> {
+    let value: toml::Value = toml::from_str(raw).ok()?;
+    let invariants = value.get("protected")?.get("invariants")?;
+    Some(match invariants.as_array() {
+        Some(array) => array.len(),
+        None => 1,
     })
 }
 
@@ -733,7 +766,7 @@ paths = ["notes/"]
         assert_eq!(entry.status, MigrationStatus::Unmigratable);
         assert!(entry
             .message
-            .contains("v0.1 [protected].invariants rejected explicitly (2 of 2 declarations)"));
+            .contains("v0.1 [protected].invariants rejected explicitly (2 rejection(s) across 2 declaration(s))"));
         assert!(entry.message.contains("invariant[0]"));
         assert!(entry.message.contains("invariant[1]"));
         assert!(entry
@@ -835,6 +868,47 @@ paths = ["notes/"]
         assert_eq!(entry.status, MigrationStatus::Migrated);
         assert!(entry.invariant_dispositions.is_empty());
         assert!(!entry.message.contains("identity invariant"));
+        Ok(())
+    }
+
+    #[test]
+    fn hybrid_phase2_ward_with_v01_invariant_remnant_fails_closed() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        fs::write(workspace.join("ward.toml"), synthetic_v01())?;
+        run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        // Graft a v0.1 invariants remnant onto the migrated Phase-2 file;
+        // WardConfig tolerates unknown fields, so it still parses as Phase-2.
+        let migrated = fs::read_to_string(workspace.join("ward.toml"))?;
+        let hybrid =
+            format!("{migrated}\n[protected]\ninvariants = [\"familiar.name == 'Nova'\"]\n");
+        fs::write(workspace.join("ward.toml"), &hybrid)?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(report.has_errors());
+        let entry = &report.entries[0];
+        assert_eq!(entry.status, MigrationStatus::Unmigratable);
+        assert!(entry
+            .message
+            .contains("retains a v0.1 [protected].invariants remnant (1 declaration(s))"));
+        // Fail closed: hybrid file left untouched for the principal to fix.
+        assert_eq!(fs::read_to_string(workspace.join("ward.toml"))?, hybrid);
         Ok(())
     }
 

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -36,15 +36,19 @@ pub struct MigrationEntry {
     pub protected_files: Vec<String>,
     pub editable_paths: Vec<String>,
     pub translated_globs: Vec<(String, String)>,
-    /// Per-declaration disposition for v0.1 `[protected].invariants`:
-    /// each retired declaration either compiled deterministically into a
-    /// typed identity invariant or was rejected explicitly. Never silent.
+    /// Fidelity records for v0.1 `[protected].invariants`: each entry is
+    /// either a compiled typed-fact disposition or an explicit rejection
+    /// reason. Rejections may be per-declaration or set-level (e.g. missing
+    /// mandatory fields, duplicate facts). Never silent.
     pub invariant_dispositions: Vec<InvariantDisposition>,
     pub generated_toml: Option<String>,
     pub message: String,
 }
 
-/// Fidelity record for one retired v0.1 invariant declaration.
+/// Fidelity record for a v0.1 `[protected].invariants` entry or compile
+/// result. A `Rejected` variant may represent either a per-declaration
+/// failure or a set-level compiler error (e.g. missing mandatory field,
+/// duplicate fact); inspect `reason` for details.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InvariantDisposition {
     /// Compiled deterministically by `coven-threads-core`. Records the
@@ -259,9 +263,8 @@ fn migrate_one(
         .collect();
     if !rejection_reasons.is_empty() {
         let message = format!(
-            "v0.1 [protected].invariants rejected explicitly ({} rejection(s) across {} declaration(s)): {}",
+            "v0.1 [protected].invariants rejected explicitly ({} rejection(s)): {}",
             rejection_reasons.len(),
-            legacy_invariants.len(),
             rejection_reasons.join("; "),
         );
         return Ok(MigrationEntry {
@@ -336,7 +339,17 @@ fn migrate_one(
             translated_globs,
             invariant_dispositions: invariant_dispositions.clone(),
             generated_toml: Some(generated_toml),
-message: "would migrate Ward v0.1".to_string(),
+            message: format!(
+                "would migrate Ward v0.1{}",
+                if invariant_dispositions.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "; {} retired identity invariant(s) compiled deterministically (dry-run: backup not written, not carried into Phase-2 ward.toml)",
+                        invariant_dispositions.len()
+                    )
+                }
+            ),
         });
     }
 
@@ -768,7 +781,7 @@ paths = ["notes/"]
         assert_eq!(entry.status, MigrationStatus::Unmigratable);
         assert!(entry
             .message
-            .contains("v0.1 [protected].invariants rejected explicitly (2 rejection(s) across 2 declaration(s))"));
+            .contains("v0.1 [protected].invariants rejected explicitly (2 rejection(s))"));
         assert!(entry.message.contains("invariant[0]"));
         assert!(entry.message.contains("invariant[1]"));
         assert!(entry

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -162,7 +162,12 @@ fn migrate_one(
                     invariant_dispositions: Vec::new(),
                     generated_toml: None,
                     message: format!(
-                        "ward.toml parses as Phase-2 but retains a v0.1 [protected].invariants remnant ({remnants} declaration(s)); Phase-2 has no invariants surface, so these would be silently inert — remove the remnant or restore the v0.1 file and re-run migration"
+                        "ward.toml parses as Phase-2 but retains a v0.1 [protected].invariants remnant ({}); Phase-2 has no invariants surface, so these would be silently inert — remove the remnant or restore the v0.1 file and re-run migration",
+                        if remnants == 0 {
+                            "empty list".to_string()
+                        } else {
+                            format!("{remnants} declaration(s)")
+                        }
                     ),
                 });
             }

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -336,10 +336,7 @@ fn migrate_one(
             translated_globs,
             invariant_dispositions: invariant_dispositions.clone(),
             generated_toml: Some(generated_toml),
-            message: format!(
-                "would migrate Ward v0.1{}",
-                invariant_summary_suffix(&invariant_dispositions)
-            ),
+message: "would migrate Ward v0.1".to_string(),
         });
     }
 

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -3,6 +3,7 @@ use std::io::{ErrorKind, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
+use coven_threads_core::IdentityInvariantSet;
 use serde::Deserialize;
 
 use crate::ward::{SurfaceEntry, Tier, WardConfig, WARD_CONFIG_FILE};
@@ -35,8 +36,22 @@ pub struct MigrationEntry {
     pub protected_files: Vec<String>,
     pub editable_paths: Vec<String>,
     pub translated_globs: Vec<(String, String)>,
+    /// Per-declaration disposition for v0.1 `[protected].invariants`:
+    /// each retired declaration either compiled deterministically into a
+    /// typed identity invariant or was rejected explicitly. Never silent.
+    pub invariant_dispositions: Vec<InvariantDisposition>,
     pub generated_toml: Option<String>,
     pub message: String,
+}
+
+/// Fidelity record for one retired v0.1 invariant declaration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InvariantDisposition {
+    /// Compiled deterministically by `coven-threads-core`. Records the
+    /// typed fact and operator, not the principal's expected value.
+    Compiled { fact: String, operator: String },
+    /// Rejected explicitly with the compiler's reason.
+    Rejected { reason: String },
 }
 
 #[derive(Debug, Clone)]
@@ -67,6 +82,8 @@ struct LegacyWardConfig {
 struct LegacyProtected {
     #[serde(default)]
     files: Vec<String>,
+    #[serde(default)]
+    invariants: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -118,6 +135,7 @@ fn migrate_one(
                 protected_files: Vec::new(),
                 editable_paths: Vec::new(),
                 translated_globs: Vec::new(),
+                invariant_dispositions: Vec::new(),
                 generated_toml: None,
                 message: "no ward".to_string(),
             });
@@ -134,6 +152,7 @@ fn migrate_one(
                 protected_files: Vec::new(),
                 editable_paths: Vec::new(),
                 translated_globs: Vec::new(),
+                invariant_dispositions: Vec::new(),
                 generated_toml: None,
                 message: "already migrated".to_string(),
             });
@@ -151,6 +170,7 @@ fn migrate_one(
                 protected_files: Vec::new(),
                 editable_paths: Vec::new(),
                 translated_globs: Vec::new(),
+                invariant_dispositions: Vec::new(),
                 generated_toml: None,
                 message: format!("unmigratable ward.toml: {error}"),
             });
@@ -166,6 +186,7 @@ fn migrate_one(
             protected_files: Vec::new(),
             editable_paths: Vec::new(),
             translated_globs: Vec::new(),
+                invariant_dispositions: Vec::new(),
             generated_toml: None,
             message: format!(
                 "unmigratable ward.toml: not Phase-2 ({phase2_error:#}) and not recognized Ward v0.1"
@@ -183,19 +204,53 @@ fn migrate_one(
                 protected_files: Vec::new(),
                 editable_paths: Vec::new(),
                 translated_globs: Vec::new(),
+                invariant_dispositions: Vec::new(),
                 generated_toml: None,
                 message: format!("unmigratable Ward v0.1 tables: {error:#}"),
             });
         }
     };
-    let protected_files = legacy
+    let (protected_files, legacy_invariants) = legacy
         .protected
-        .map(|protected| protected.files)
+        .map(|protected| (protected.files, protected.invariants))
         .unwrap_or_default();
     let editable_paths = legacy
         .editable
         .map(|editable| editable.paths)
         .unwrap_or_default();
+
+    // Fidelity gate for retired v0.1 identity invariants: every declaration
+    // must compile deterministically through coven-threads-core or the
+    // migration fails closed with each rejection spelled out. Dropping them
+    // silently is not an option.
+    let invariant_dispositions = compile_invariant_dispositions(&legacy_invariants);
+    let rejection_reasons: Vec<String> = invariant_dispositions
+        .iter()
+        .filter_map(|disposition| match disposition {
+            InvariantDisposition::Rejected { reason } => Some(reason.clone()),
+            InvariantDisposition::Compiled { .. } => None,
+        })
+        .collect();
+    if !rejection_reasons.is_empty() {
+        let message = format!(
+            "v0.1 [protected].invariants rejected explicitly ({} of {} declarations): {}",
+            rejection_reasons.len(),
+            legacy_invariants.len(),
+            rejection_reasons.join("; "),
+        );
+        return Ok(MigrationEntry {
+            familiar_id: familiar_id.to_string(),
+            workspace: workspace.to_path_buf(),
+            status: MigrationStatus::Unmigratable,
+            protected_files,
+            editable_paths,
+            translated_globs: Vec::new(),
+            invariant_dispositions,
+            generated_toml: None,
+            message,
+        });
+    }
+
     let mut translated_globs = Vec::new();
     let translated_editable: Vec<String> = editable_paths
         .iter()
@@ -239,6 +294,7 @@ fn migrate_one(
             protected_files,
             editable_paths,
             translated_globs,
+            invariant_dispositions: invariant_dispositions.clone(),
             generated_toml: Some(generated_toml),
             message: format!("generated Phase-2 ward.toml failed validation: {error:#}"),
         });
@@ -252,8 +308,12 @@ fn migrate_one(
             protected_files,
             editable_paths,
             translated_globs,
+            invariant_dispositions: invariant_dispositions.clone(),
             generated_toml: Some(generated_toml),
-            message: "would migrate Ward v0.1".to_string(),
+            message: format!(
+                "would migrate Ward v0.1{}",
+                invariant_summary_suffix(&invariant_dispositions)
+            ),
         });
     }
 
@@ -266,6 +326,7 @@ fn migrate_one(
             protected_files,
             editable_paths,
             translated_globs,
+            invariant_dispositions: invariant_dispositions.clone(),
             generated_toml: Some(generated_toml),
             message: format!("refusing to clobber existing {}", backup.display()),
         });
@@ -281,6 +342,7 @@ fn migrate_one(
             protected_files,
             editable_paths,
             translated_globs,
+            invariant_dispositions: invariant_dispositions.clone(),
             generated_toml: Some(generated_toml),
             message: format!("failed to write valid migrated ward.toml: {error:#}"),
         });
@@ -293,9 +355,52 @@ fn migrate_one(
         protected_files,
         editable_paths,
         translated_globs,
+        invariant_dispositions: invariant_dispositions.clone(),
         generated_toml: Some(generated_toml),
-        message: "migrated Ward v0.1".to_string(),
+        message: format!(
+            "migrated Ward v0.1{}",
+            invariant_summary_suffix(&invariant_dispositions)
+        ),
     })
+}
+
+/// Compiles retired v0.1 `[protected].invariants` declarations through the
+/// authoritative coven-threads-core compiler. Returns one disposition per
+/// outcome: every declaration in a compiling set is recorded as `Compiled`
+/// (typed fact + operator); a set that fails to compile yields the compiler's
+/// explicit `Rejected` reasons (parse errors are indexed per declaration;
+/// set-level violations such as duplicate facts or a missing mandatory
+/// name/person binding reject the set as a unit). An absent or empty list
+/// yields no dispositions: there is nothing to preserve and nothing to drop.
+fn compile_invariant_dispositions(declarations: &[String]) -> Vec<InvariantDisposition> {
+    if declarations.is_empty() {
+        return Vec::new();
+    }
+    match IdentityInvariantSet::compile(declarations) {
+        Ok(set) => set
+            .declarations()
+            .iter()
+            .map(|declaration| InvariantDisposition::Compiled {
+                fact: format!("{:?}", declaration.fact),
+                operator: format!("{:?}", declaration.operator),
+            })
+            .collect(),
+        Err(errors) => errors
+            .into_iter()
+            .map(|reason| InvariantDisposition::Rejected { reason })
+            .collect(),
+    }
+}
+
+fn invariant_summary_suffix(dispositions: &[InvariantDisposition]) -> String {
+    if dispositions.is_empty() {
+        return String::new();
+    }
+    format!(
+        "; {} retired identity invariant(s) compiled deterministically (preserved in {}, not carried into Phase-2 ward.toml)",
+        dispositions.len(),
+        V01_BACKUP_FILE,
+    )
 }
 
 fn render_phase2_toml(config: &WardConfig) -> Result<String> {
@@ -375,6 +480,16 @@ pub fn print_report(report: &MigrationReport) {
         for (from, to) in &entry.translated_globs {
             println!("  translated glob: {from} -> {to}");
         }
+        for disposition in &entry.invariant_dispositions {
+            match disposition {
+                InvariantDisposition::Compiled { fact, operator } => {
+                    println!("  invariant compiled: {fact} {operator}");
+                }
+                InvariantDisposition::Rejected { reason } => {
+                    println!("  invariant rejected: {reason}");
+                }
+            }
+        }
         if entry.generated_toml.is_some() {
             let validation = if entry.status == MigrationStatus::ValidationFailed {
                 "failed"
@@ -425,7 +540,13 @@ owner = "nova"
 
 [protected]
 files = ["SOUL.md", "IDENTITY.md"]
-invariants = ["synthetic invariant one", "synthetic invariant two"]
+invariants = [
+    "familiar.name == 'Nova'",
+    "familiar.person == \"Val Alexander\"",
+    "familiar.pronouns == 'they/them'",
+    "familiar.purpose includes 'authority boundary'",
+    "familiar.coven includes \"OpenCoven\"",
+]
 
 [editable]
 paths = ["skills/*/", "memory/*", "notes/"]
@@ -476,6 +597,23 @@ append_only = true
         assert!(report.entries[0]
             .translated_globs
             .contains(&("memory/*".to_string(), "memory/**".to_string())));
+        assert_eq!(
+            report.entries[0].invariant_dispositions,
+            [
+                ("Name", "Equals"),
+                ("Person", "Equals"),
+                ("Pronouns", "Equals"),
+                ("Purpose", "Includes"),
+                ("Coven", "Includes"),
+            ]
+            .map(|(fact, operator)| InvariantDisposition::Compiled {
+                fact: fact.to_string(),
+                operator: operator.to_string(),
+            })
+        );
+        assert!(report.entries[0]
+            .message
+            .contains("5 retired identity invariant(s) compiled deterministically"));
         assert_eq!(fs::read_to_string(workspace.join("ward.toml"))?, original);
         assert!(!workspace.join("ward.toml.v01.bak").exists());
 
@@ -484,6 +622,9 @@ append_only = true
             .as_deref()
             .expect("dry run includes generated toml");
         assert!(generated.contains("Migrated from Ward v0.1"));
+        // Retired invariants are compiled for fidelity and preserved in the
+        // v0.1 backup; the generated Phase-2 ward.toml has no invariants
+        // surface, so they must not leak into it.
         assert!(!generated.contains("invariants"));
         assert!(!generated.contains("harness_blocks"));
         assert!(!generated.contains("approval_tiers"));
@@ -550,6 +691,182 @@ append_only = true
         )?;
         assert!(!second.has_errors());
         assert_eq!(second.entries[0].status, MigrationStatus::AlreadyMigrated);
+        Ok(())
+    }
+
+    fn synthetic_v01_with_invariants(invariants_toml: &str) -> String {
+        format!(
+            r#"[meta]
+version = "0.1"
+owner = "nova"
+
+[protected]
+files = ["SOUL.md"]
+{invariants_toml}
+
+[editable]
+paths = ["notes/"]
+"#
+        )
+    }
+
+    #[test]
+    fn migration_rejects_unparseable_v01_invariants_explicitly_without_writing() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        let original = synthetic_v01_with_invariants(
+            r#"invariants = ["synthetic invariant one", "synthetic invariant two"]"#,
+        );
+        fs::write(workspace.join("ward.toml"), &original)?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(report.has_errors());
+        let entry = &report.entries[0];
+        assert_eq!(entry.status, MigrationStatus::Unmigratable);
+        assert!(entry
+            .message
+            .contains("v0.1 [protected].invariants rejected explicitly (2 of 2 declarations)"));
+        assert!(entry.message.contains("invariant[0]"));
+        assert!(entry.message.contains("invariant[1]"));
+        assert!(entry
+            .invariant_dispositions
+            .iter()
+            .all(|d| matches!(d, InvariantDisposition::Rejected { .. })));
+        assert_eq!(entry.invariant_dispositions.len(), 2);
+        assert!(entry.generated_toml.is_none());
+
+        // Fail closed: nothing written, nothing dropped.
+        assert_eq!(fs::read_to_string(workspace.join("ward.toml"))?, original);
+        assert!(!workspace.join("ward.toml.v01.bak").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn migration_rejects_each_invalid_invariant_shape_explicitly() -> Result<()> {
+        // One case per rejection lane in the coven-threads-core compiler;
+        // mandatory name/person cases mirror the retired-Ward corpus grammar.
+        let cases: &[(&str, &str)] = &[
+            (
+                r#"invariants = ["familiar.mood == 'sunny'", "familiar.name == 'Nova'", "familiar.person == 'Val'"]"#,
+                "unsupported identity fact",
+            ),
+            (
+                r#"invariants = ["familiar.name matches 'Nova'", "familiar.person == 'Val'"]"#,
+                "expected `==` or `includes` operator",
+            ),
+            (
+                r#"invariants = ["familiar.name == 'Nova'", "familiar.name == 'Supernova'", "familiar.person == 'Val'"]"#,
+                "duplicate Name identity invariant",
+            ),
+            (
+                r#"invariants = ["familiar.name == ''", "familiar.person == 'Val'"]"#,
+                "expected value must not be empty",
+            ),
+            (
+                r#"invariants = ["familiar.person == 'Val'"]"#,
+                "missing mandatory Name identity invariant",
+            ),
+            (
+                r#"invariants = ["familiar.name == 'Nova'"]"#,
+                "missing mandatory Person identity invariant",
+            ),
+        ];
+
+        for (invariants_toml, expected_reason) in cases {
+            let temp = tempfile::tempdir()?;
+            let workspace = seed_familiars(temp.path())?;
+            fs::write(
+                workspace.join("ward.toml"),
+                synthetic_v01_with_invariants(invariants_toml),
+            )?;
+
+            let report = run_migration(
+                temp.path(),
+                WardMigrateOptions {
+                    familiar: Some("nova".to_string()),
+                    fingerprint: "SHA256:test-principal".to_string(),
+                    apply: false,
+                },
+            )?;
+
+            let entry = &report.entries[0];
+            assert_eq!(
+                entry.status,
+                MigrationStatus::Unmigratable,
+                "case {invariants_toml:?} must fail closed"
+            );
+            assert!(
+                entry.message.contains(expected_reason),
+                "case {invariants_toml:?}: message {:?} must contain {expected_reason:?}",
+                entry.message
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn migration_without_invariants_migrates_with_no_dispositions() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        fs::write(
+            workspace.join("ward.toml"),
+            synthetic_v01_with_invariants(""),
+        )?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(!report.has_errors());
+        let entry = &report.entries[0];
+        assert_eq!(entry.status, MigrationStatus::Migrated);
+        assert!(entry.invariant_dispositions.is_empty());
+        assert!(!entry.message.contains("identity invariant"));
+        Ok(())
+    }
+
+    #[test]
+    fn apply_preserves_compiled_invariants_in_backup_only() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let workspace = seed_familiars(temp.path())?;
+        let original = synthetic_v01();
+        fs::write(workspace.join("ward.toml"), original)?;
+
+        let report = run_migration(
+            temp.path(),
+            WardMigrateOptions {
+                familiar: Some("nova".to_string()),
+                fingerprint: "SHA256:test-principal".to_string(),
+                apply: true,
+            },
+        )?;
+
+        assert!(!report.has_errors());
+        let entry = &report.entries[0];
+        assert_eq!(entry.status, MigrationStatus::Migrated);
+        assert_eq!(entry.invariant_dispositions.len(), 5);
+        assert!(entry
+            .message
+            .contains("preserved in ward.toml.v01.bak, not carried into Phase-2 ward.toml"));
+
+        // The declarations survive verbatim in the backup and only there.
+        let backup = fs::read_to_string(workspace.join("ward.toml.v01.bak"))?;
+        assert!(backup.contains("familiar.name == 'Nova'"));
+        let migrated = fs::read_to_string(workspace.join("ward.toml"))?;
+        assert!(!migrated.contains("invariants"));
         Ok(())
     }
 


### PR DESCRIPTION
## What

Closes the v0.1 invariant silent-drop gap in `coven ward migrate` and bumps the `coven-threads-core` pin to threads main. Implementation lane for **threads-uqx.8** (Phase 5 approval semantics, spec §7).

### 1. Migration invariant fidelity (`ward_migrate.rs`)

Previously `LegacyProtected` deserialized only `files`, so v0.1 `[protected].invariants` vanished without a trace — exactly the silent-drop anti-pattern the retired-Ward corpus exists to prevent. Now:

- **All declarations compile** (via `coven_threads_core::IdentityInvariantSet::compile`) → migration proceeds; per-declaration dispositions (typed fact + operator, no principal values) recorded in `MigrationEntry.invariant_dispositions` and rendered in the report; originals preserved verbatim in `ward.toml.v01.bak`. The generated Phase-2 `ward.toml` has no invariants surface, so they are never carried forward implicitly — the report says so.
- **Any declaration rejected** → migration fails closed (`Unmigratable`, nonzero exit) with the compiler's explicit indexed reasons; the v0.1 file is untouched and no backup is written.
- **No invariants** → nothing to preserve, no dispositions, no invariant chatter in the report.

### 2. Pin bump `7da030d` → `6fa360b`

The old rev was an unmerged feature-branch commit (pre-#15 squash). The new pin is coven-threads **main**, picking up the hardened core from threads PRs #15/#21/#22: tightened `MaterializedDiff::try_new` (rejects no-content and unchanged surfaces), approval/audit hardening, identity-invariant compiler. Daemon call sites verified compatible; full workspace green against the new pin.

## Tests

New coverage mirrors the phase-5 retired-Ward corpus grammar:

- five-shape fidelity: `name`/`person`/`pronouns`/`purpose`/`coven`, `==` and `includes`, single and double quotes — asserted disposition-by-disposition
- explicit rejection per compiler lane: unsupported fact, missing operator, duplicate fact, empty value, missing mandatory `name`, missing mandatory `person`
- fail-closed on rejection: no write, no backup, indexed reasons in the message
- apply path: originals verbatim in backup only; generated toml still contains no `invariants`
- no-invariants wards migrate cleanly with empty dispositions

## Validation

- `cargo fmt --check` ✓
- `cargo clippy --workspace --all-targets --locked -- -D warnings` ✓
- `cargo test --workspace --locked` ✓ (all 9 suites; 11 ward_migrate tests)

Beads: threads-uqx.8 (in_progress → evidence on merge). Claim: `threads-uqx-8` held.
