### PR TITLE
feat: support every Cave-trusted registry runtime in the CLI and coven chat

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -25,6 +25,12 @@ pub struct HarnessSummary {
     pub manifest_path: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChatHarnessSummary {
+    pub summary: HarnessSummary,
+    pub supports_chat_resume: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HarnessLaunchMode {
     Interactive,
@@ -218,23 +224,15 @@ pub fn harness_supports_preassigned_session_id(harness_id: &str) -> bool {
 /// not a persistence key — sessions never become loadable under a
 /// pre-assigned id, so chat's pick-the-id-up-front flow cannot resume it.
 /// Verified empirically against engine 0.7.0.
-pub fn harness_supports_chat_resume(harness_id: &str) -> bool {
-    if harness_id == crate::engine::ENGINE_HARNESS_ID {
+fn spec_supports_chat_resume(spec: &HarnessCommandSpec) -> bool {
+    if spec.id == crate::engine::ENGINE_HARNESS_ID {
         return false;
     }
 
-    static SPECS: std::sync::OnceLock<Vec<HarnessCommandSpec>> = std::sync::OnceLock::new();
-    let specs = SPECS
-        .get_or_init(|| configured_harness_specs().unwrap_or_else(|_| built_in_harness_specs()));
-
-    specs
-        .iter()
-        .find(|spec| spec.id == harness_id)
-        .and_then(|spec| spec.continuity_args.as_ref())
-        .is_some_and(|continuity| {
-            continuity.has_resume_launch()
-                && (continuity.session_id_flag().is_some() || harness_id == "codex")
-        })
+    spec.continuity_args.as_ref().is_some_and(|continuity| {
+        continuity.has_resume_launch()
+            && (continuity.session_id_flag().is_some() || spec.id == "codex")
+    })
 }
 
 pub fn harness_supports_think(harness_id: &str) -> bool {
@@ -520,6 +518,16 @@ impl HarnessSummary {
             source: spec.source,
             manifest_path: spec.manifest_path,
             capabilities: spec.capabilities,
+        }
+    }
+}
+
+impl ChatHarnessSummary {
+    fn from_spec(spec: HarnessCommandSpec) -> Self {
+        let supports_chat_resume = spec_supports_chat_resume(&spec);
+        Self {
+            summary: HarnessSummary::from_spec(spec),
+            supports_chat_resume,
         }
     }
 }
@@ -834,6 +842,20 @@ fn configured_harnesses_from(adapter_env: &AdapterEnv) -> Result<Vec<HarnessSumm
         .into_iter()
         .map(HarnessSummary::from_spec)
         .collect())
+}
+
+pub(crate) fn configured_chat_harnesses() -> Result<Vec<ChatHarnessSummary>> {
+    Ok(configured_harness_specs()?
+        .into_iter()
+        .map(ChatHarnessSummary::from_spec)
+        .collect())
+}
+
+pub(crate) fn built_in_chat_harnesses() -> Vec<ChatHarnessSummary> {
+    built_in_harness_specs()
+        .into_iter()
+        .map(ChatHarnessSummary::from_spec)
+        .collect()
 }
 
 pub fn unsupported_harness_message(harness_id: &str, configured_ids: &[&str]) -> String {
@@ -2748,24 +2770,29 @@ mod tests {
         let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
         let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
         let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+        let harnesses = configured_chat_harnesses()?;
+        let supports_resume = |id: &str| {
+            harnesses
+                .iter()
+                .find(|harness| harness.summary.id == id)
+                .is_some_and(|harness| harness.supports_chat_resume)
+        };
 
         // Built-ins: claude/copilot pre-assign ids, codex captures its id
         // from first-turn output.
-        assert!(harness_supports_chat_resume("claude"));
-        assert!(harness_supports_chat_resume("codex"));
-        assert!(harness_supports_chat_resume("copilot"));
+        assert!(supports_resume("claude"));
+        assert!(supports_resume("codex"));
+        assert!(supports_resume("copilot"));
         // The engine declares continuity args for `coven run` flows, but its
         // `--session-id` is a tracking tag, not a persistence key, so chat
         // resume stays off (see the carve-out on the function).
-        assert!(!harness_supports_chat_resume(
-            crate::engine::ENGINE_HARNESS_ID
-        ));
+        assert!(!supports_resume(crate::engine::ENGINE_HARNESS_ID));
         // Installed adapters follow their declared continuity args.
-        assert!(harness_supports_chat_resume("grok"));
-        assert!(!harness_supports_chat_resume("opencode"));
+        assert!(supports_resume("grok"));
+        assert!(!supports_resume("opencode"));
         // Unknown / not-installed ids resolve to no spec, hence no resume.
-        assert!(!harness_supports_chat_resume("hermes"));
-        assert!(!harness_supports_chat_resume("not-a-real-harness"));
+        assert!(!supports_resume("hermes"));
+        assert!(!supports_resume("not-a-real-harness"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1124,7 +1124,9 @@ const OPENCODE_ADAPTER_MANIFEST: &str = r#"{
       "id": "opencode",
       "label": "OpenCode",
       "executable": "opencode",
-      "interactive_prompt_prefix_args": [],
+      "interactive_prompt_prefix_args": [
+        "run"
+      ],
       "non_interactive_prompt_prefix_args": [
         "run"
       ],

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -202,6 +202,37 @@ pub fn harness_supports_preassigned_session_id(harness_id: &str) -> bool {
     declared_capabilities(harness_id).preassigned_session_id
 }
 
+/// Whether a chat turn launched against this harness can reuse the prior
+/// turn's conversation via the harness CLI's session-resume mechanism. See
+/// `docs/chat-persistence.md` for the per-harness mechanics.
+///
+/// Data-driven off the configured spec's declared `continuity_args`
+/// (built-ins and installed adapter manifests alike): resume needs a
+/// declared resume launch shape plus a way to learn the session id — either
+/// pre-assignment via `session_id_flag` (claude, copilot, grok) or codex's
+/// chat-side capture of the `session id:` banner from first-turn output.
+///
+/// The engine (`coven-code`) is carved out even though it declares
+/// continuity args: those serve resume-by-*engine-assigned* id (`coven run`
+/// flows), but per ENGINE-CONTRACT.md its `--session-id` is a tracking tag,
+/// not a persistence key — sessions never become loadable under a
+/// pre-assigned id, so chat's pick-the-id-up-front flow cannot resume it.
+/// Verified empirically against engine 0.7.0.
+pub fn harness_supports_chat_resume(harness_id: &str) -> bool {
+    if harness_id == crate::engine::ENGINE_HARNESS_ID {
+        return false;
+    }
+    configured_harness_specs()
+        .unwrap_or_else(|_| built_in_harness_specs())
+        .into_iter()
+        .find(|spec| spec.id == harness_id)
+        .and_then(|spec| spec.continuity_args)
+        .is_some_and(|continuity| {
+            continuity.has_resume_launch()
+                && (continuity.session_id_flag().is_some() || harness_id == "codex")
+        })
+}
+
 pub fn harness_supports_think(harness_id: &str) -> bool {
     declared_capabilities(harness_id).think
 }
@@ -971,6 +1002,7 @@ pub fn known_adapter_manifest(adapter_id: &str) -> Option<&'static str> {
     match adapter_id {
         "grok" => Some(GROK_BUILD_ADAPTER_MANIFEST),
         "hermes" => Some(HERMES_ADAPTER_MANIFEST),
+        "opencode" => Some(OPENCODE_ADAPTER_MANIFEST),
         _ => None,
     }
 }
@@ -1048,8 +1080,46 @@ const HERMES_ADAPTER_MANIFEST: &str = r#"{
 }
 "#;
 
+// OpenCode's adapter recipe, kept byte-identical to the accepted
+// `coven-runtimes` registry manifest (`registry/runtimes/opencode/0.1.0.json`)
+// so a Cave-installed `$COVEN_HOME/adapters/opencode.json` passes the
+// byte-equality trust check (`trusted_adapter_manifest_matches_recipe`) and
+// `coven adapter install opencode` produces the same artifact the Cave does.
+// Update both places together when the registry accepts a new version.
+//
+// OpenCode runs one-shot through `opencode run` and keeps all project
+// configuration (system prompts, tools) in its own config files, so the
+// recipe declares no system-prompt flag, no sandbox mapping, and no
+// continuity args — chat resume is intentionally unavailable (see
+// `docs/chat-persistence.md`).
+const OPENCODE_ADAPTER_MANIFEST: &str = r#"{
+  "adapters": [
+    {
+      "id": "opencode",
+      "label": "OpenCode",
+      "executable": "opencode",
+      "interactive_prompt_prefix_args": [],
+      "non_interactive_prompt_prefix_args": [
+        "run"
+      ],
+      "install_hint": "Install OpenCode from https://opencode.ai/docs/cli (e.g. `npm i -g opencode-ai`) and ensure `opencode` resolves on PATH. Verify with `opencode run --help` — the similarly-named Go app some package managers ship has no `run` subcommand and will not work.",
+      "model_flag": "--model",
+      "capabilities": {
+        "stream": false,
+        "preassigned_session_id": false,
+        "think": false,
+        "speed": false
+      },
+      "version": "0.1.0",
+      "homepage": "https://opencode.ai",
+      "description": "OpenCode runtime adapter for Coven. Drives `opencode run` in non-interactive mode; system prompts and tools are configured via the OpenCode project config (AGENTS.md / opencode.json), not via CLI flags."
+    }
+  ]
+}
+"#;
+
 pub fn known_adapter_recipe_names() -> &'static [&'static str] {
-    &["grok", "hermes"]
+    &["grok", "hermes", "opencode"]
 }
 
 fn load_external_harness_specs(
@@ -2335,10 +2405,18 @@ mod tests {
     }
 
     #[test]
+    fn unsupported_opencode_message_points_to_trusted_recipe() {
+        let message = unsupported_harness_message("opencode", &["codex", "claude"]);
+
+        assert!(message.contains("coven adapter install opencode"));
+        assert!(message.contains("coven adapter doctor opencode"));
+    }
+
+    #[test]
     fn unsupported_message_for_an_unknown_harness_lists_every_recipe() {
         let message = unsupported_harness_message("not-a-real-harness", &["codex"]);
 
-        assert!(message.contains("Known installable adapter recipes: grok, hermes."));
+        assert!(message.contains("Known installable adapter recipes: grok, hermes, opencode."));
     }
 
     #[test]
@@ -2515,6 +2593,175 @@ mod tests {
 
         assert!(!args.contains(&"--permission-mode".to_string()));
         assert!(!args.contains(&"--sandbox".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_recipe_matches_registry_contract() -> anyhow::Result<()> {
+        let specs = parse_external_harness_specs(
+            OPENCODE_ADAPTER_MANIFEST,
+            Path::new("opencode.json"),
+            &built_in_harness_specs(),
+        )?;
+        let opencode = specs
+            .iter()
+            .find(|spec| spec.id == "opencode")
+            .expect("OpenCode recipe should parse");
+
+        assert_eq!(opencode.label, "OpenCode");
+        assert_eq!(opencode.executable, "opencode");
+        // OpenCode keeps system prompts and tools in its own project config
+        // (AGENTS.md / opencode.json); there is no flag surface for them.
+        assert_eq!(opencode.prompt_flag, None);
+        assert_eq!(opencode.system_prompt_flag, None);
+        assert_eq!(
+            opencode.model_args("anthropic/claude-sonnet-4-5"),
+            ["--model", "claude-sonnet-4-5"]
+        );
+        // Non-interactive one-shots ride `opencode run` with the prompt as a
+        // positional behind the options terminator.
+        assert_eq!(
+            opencode.prompt_args("fix tests", HarnessLaunchMode::NonInteractive),
+            ["run", "--", "fix tests"]
+        );
+        assert!(!opencode.capabilities.stream);
+        assert!(!opencode.capabilities.preassigned_session_id);
+        assert!(!opencode.capabilities.think);
+        assert!(!opencode.capabilities.speed);
+        // No sandbox mapping declared: permission requests yield no argv.
+        assert!(opencode.sandbox_args(Permission::Full).is_empty());
+        assert!(opencode.sandbox_args(Permission::ReadOnly).is_empty());
+        // No continuity args declared: conversation hints yield no argv, so
+        // chat resume stays off for OpenCode.
+        assert_eq!(
+            continuity_args(
+                opencode,
+                HarnessLaunchMode::NonInteractive,
+                &ConversationHint::Init {
+                    id: "11111111-2222-4333-8444-555555555555".to_string(),
+                },
+            ),
+            None
+        );
+        assert_eq!(
+            continuity_args(
+                opencode,
+                HarnessLaunchMode::NonInteractive,
+                &ConversationHint::Resume {
+                    id: "11111111-2222-4333-8444-555555555555".to_string(),
+                },
+            ),
+            None
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn opencode_recipe_is_byte_identical_to_its_installed_form() {
+        // `trusted_adapter_manifest_matches_recipe` trusts a
+        // `$COVEN_HOME/adapters/opencode.json` only when it byte-equals the
+        // embedded recipe, and the Cave installs the registry manifest
+        // verbatim — so the recipe must parse cleanly and round-trip as-is.
+        assert_eq!(
+            known_adapter_manifest("opencode"),
+            Some(OPENCODE_ADAPTER_MANIFEST)
+        );
+        assert!(OPENCODE_ADAPTER_MANIFEST.ends_with("}\n"));
+    }
+
+    #[test]
+    fn installed_opencode_recipe_constructs_complete_launch_argv() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = trusted_adapter_dir(&coven_home);
+        fs::create_dir_all(&adapter_dir)?;
+        fs::write(
+            trusted_adapter_manifest_path(&coven_home, "opencode"),
+            OPENCODE_ADAPTER_MANIFEST,
+        )?;
+
+        let _guard = lock_env();
+        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
+        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+        let familiar = FamiliarContext {
+            id: "charm".to_string(),
+            display_name: "Charm".to_string(),
+            role: None,
+        };
+
+        let parts = command_parts_for_harness_with_conversation(
+            "opencode",
+            "fix tests",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            Some(&familiar),
+            HarnessLaunchOptions {
+                model: Some("anthropic/claude-sonnet-4-5"),
+                permission: Some(Permission::ReadOnly),
+                ..Default::default()
+            },
+        )?;
+
+        // No system-prompt flag: identity prepends to the prompt. No sandbox
+        // mapping: the permission request forwards no argv (the run layer
+        // warns instead).
+        assert_eq!(
+            parts,
+            (
+                "opencode".to_string(),
+                vec![
+                    "--model".to_string(),
+                    "claude-sonnet-4-5".to_string(),
+                    "run".to_string(),
+                    "--".to_string(),
+                    format!(
+                        "{preamble}\n\nfix tests",
+                        preamble = familiar.identity_preamble()
+                    ),
+                ],
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn chat_resume_support_is_driven_by_declared_continuity() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let coven_home = temp_dir.path().join("coven-home");
+        let adapter_dir = trusted_adapter_dir(&coven_home);
+        fs::create_dir_all(&adapter_dir)?;
+        fs::write(
+            trusted_adapter_manifest_path(&coven_home, "grok"),
+            GROK_BUILD_ADAPTER_MANIFEST,
+        )?;
+        fs::write(
+            trusted_adapter_manifest_path(&coven_home, "opencode"),
+            OPENCODE_ADAPTER_MANIFEST,
+        )?;
+
+        let _guard = lock_env();
+        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
+        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
+        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+
+        // Built-ins: claude/copilot pre-assign ids, codex captures its id
+        // from first-turn output.
+        assert!(harness_supports_chat_resume("claude"));
+        assert!(harness_supports_chat_resume("codex"));
+        assert!(harness_supports_chat_resume("copilot"));
+        // The engine declares continuity args for `coven run` flows, but its
+        // `--session-id` is a tracking tag, not a persistence key, so chat
+        // resume stays off (see the carve-out on the function).
+        assert!(!harness_supports_chat_resume(
+            crate::engine::ENGINE_HARNESS_ID
+        ));
+        // Installed adapters follow their declared continuity args.
+        assert!(harness_supports_chat_resume("grok"));
+        assert!(!harness_supports_chat_resume("opencode"));
+        // Unknown / not-installed ids resolve to no spec, hence no resume.
+        assert!(!harness_supports_chat_resume("hermes"));
+        assert!(!harness_supports_chat_resume("not-a-real-harness"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -845,7 +845,11 @@ fn configured_harnesses_from(adapter_env: &AdapterEnv) -> Result<Vec<HarnessSumm
 }
 
 pub(crate) fn configured_chat_harnesses() -> Result<Vec<ChatHarnessSummary>> {
-    Ok(configured_harness_specs()?
+    configured_chat_harnesses_from(&AdapterEnv::from_process())
+}
+
+fn configured_chat_harnesses_from(adapter_env: &AdapterEnv) -> Result<Vec<ChatHarnessSummary>> {
+    Ok(configured_harness_specs_from(adapter_env)?
         .into_iter()
         .map(ChatHarnessSummary::from_spec)
         .collect())
@@ -2708,17 +2712,18 @@ mod tests {
             OPENCODE_ADAPTER_MANIFEST,
         )?;
 
-        let _guard = lock_env();
-        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
-        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
-        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
+        let specs = configured_harness_specs_from(&AdapterEnv {
+            coven_home: Some(coven_home),
+            ..Default::default()
+        })?;
         let familiar = FamiliarContext {
             id: "charm".to_string(),
             display_name: "Charm".to_string(),
             role: None,
         };
 
-        let parts = command_parts_for_harness_with_conversation(
+        let parts = command_parts_in_specs(
+            &specs,
             "opencode",
             "fix tests",
             HarnessLaunchMode::NonInteractive,
@@ -2768,11 +2773,10 @@ mod tests {
             OPENCODE_ADAPTER_MANIFEST,
         )?;
 
-        let _guard = lock_env();
-        let _manifest_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_MANIFEST_ENV);
-        let _dirs_guard = EnvVarGuard::remove(EXTERNAL_ADAPTER_DIRS_ENV);
-        let _coven_home_guard = EnvVarGuard::set("COVEN_HOME", &coven_home);
-        let harnesses = configured_chat_harnesses()?;
+        let harnesses = configured_chat_harnesses_from(&AdapterEnv {
+            coven_home: Some(coven_home),
+            ..Default::default()
+        })?;
         let supports_resume = |id: &str| {
             harnesses
                 .iter()

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -222,11 +222,14 @@ pub fn harness_supports_chat_resume(harness_id: &str) -> bool {
     if harness_id == crate::engine::ENGINE_HARNESS_ID {
         return false;
     }
-    configured_harness_specs()
-        .unwrap_or_else(|_| built_in_harness_specs())
-        .into_iter()
+
+    static SPECS: std::sync::OnceLock<Vec<HarnessCommandSpec>> = std::sync::OnceLock::new();
+    let specs = SPECS.get_or_init(|| configured_harness_specs().unwrap_or_else(|_| built_in_harness_specs()));
+
+    specs
+        .iter()
         .find(|spec| spec.id == harness_id)
-        .and_then(|spec| spec.continuity_args)
+        .and_then(|spec| spec.continuity_args.as_ref())
         .is_some_and(|continuity| {
             continuity.has_resume_launch()
                 && (continuity.session_id_flag().is_some() || harness_id == "codex")

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -224,7 +224,8 @@ pub fn harness_supports_chat_resume(harness_id: &str) -> bool {
     }
 
     static SPECS: std::sync::OnceLock<Vec<HarnessCommandSpec>> = std::sync::OnceLock::new();
-    let specs = SPECS.get_or_init(|| configured_harness_specs().unwrap_or_else(|_| built_in_harness_specs()));
+    let specs = SPECS
+        .get_or_init(|| configured_harness_specs().unwrap_or_else(|_| built_in_harness_specs()));
 
     specs
         .iter()

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -612,7 +612,7 @@ enum AdapterCommand {
     },
     #[command(about = "Install a trusted local adapter recipe")]
     Install {
-        #[arg(help = "Adapter recipe to install, e.g. hermes")]
+        #[arg(help = "Adapter recipe to install (grok, hermes, or opencode)")]
         adapter: String,
     },
 }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -4989,6 +4989,28 @@ mod tests {
     }
 
     #[test]
+    fn adapter_install_help_does_not_duplicate_the_recipe_registry() {
+        use clap::CommandFactory;
+
+        let mut cmd = Cli::command();
+        let adapter = cmd
+            .find_subcommand_mut("adapter")
+            .expect("adapter subcommand exists");
+        let install = adapter
+            .find_subcommand_mut("install")
+            .expect("adapter install subcommand exists");
+        let help = install.render_long_help().to_string();
+
+        assert!(help.contains("Adapter recipe to install"));
+        for recipe in harness::known_adapter_recipe_names() {
+            assert!(
+                !help.contains(recipe),
+                "adapter install help must not hardcode recipe `{recipe}`:\n{help}"
+            );
+        }
+    }
+
+    #[test]
     fn cli_accepts_attach_command() {
         let cli = Cli::parse_from(["coven", "attach", "session-1"]);
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -612,7 +612,7 @@ enum AdapterCommand {
     },
     #[command(about = "Install a trusted local adapter recipe")]
     Install {
-        #[arg(help = "Adapter recipe to install (grok, hermes, or opencode)")]
+        #[arg(help = "Adapter recipe to install")]
         adapter: String,
     },
 }

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -83,6 +83,7 @@ pub struct AgentInfo {
     pub label: String,
     pub harness: String,
     pub available: bool,
+    pub supports_chat_resume: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1211,7 +1212,12 @@ impl App {
         &mut self,
         harness: &str,
     ) -> Option<harness::ConversationHint> {
-        if !harness::harness_supports_chat_resume(harness) {
+        if !self
+            .agents
+            .iter()
+            .find(|agent| agent.harness == harness)
+            .is_some_and(|agent| agent.supports_chat_resume)
+        {
             return None;
         }
         if let Some(id) = self.harness_conversation_ids.get(harness) {
@@ -1485,10 +1491,8 @@ impl App {
         // Configured = built-ins plus installed adapter manifests; fall back
         // to built-ins on a manifest load error and surface the error so users
         // can diagnose why installed adapters are missing without a launch attempt.
-        let (harnesses, harness_load_err) = match harness::configured_harnesses() {
-            Ok(h) => (h, None),
-            Err(e) => (harness::built_in_harnesses(), Some(e.to_string())),
-        };
+        let (harnesses, harness_load_err) =
+            doctor_harness_inventory(harness::configured_harnesses());
         let mut lines = vec![
             "Doctor".to_string(),
             format!("  Store    {store_path}"),
@@ -2530,16 +2534,26 @@ pub(super) fn discover_agents() -> Vec<AgentInfo> {
     // opencode, …), so every runtime `coven run` accepts is selectable in
     // chat. A manifest load error falls back to built-ins only — the launch
     // path re-reads the manifests and surfaces the error with full context.
-    harness::configured_harnesses()
-        .unwrap_or_else(|_| harness::built_in_harnesses())
+    harness::configured_chat_harnesses()
+        .unwrap_or_else(|_| harness::built_in_chat_harnesses())
         .into_iter()
         .map(|h| AgentInfo {
-            id: h.id.to_string(),
-            label: h.label.to_string(),
-            harness: h.id.to_string(),
-            available: h.available,
+            id: h.summary.id.to_string(),
+            label: h.summary.label.to_string(),
+            harness: h.summary.id.to_string(),
+            available: h.summary.available,
+            supports_chat_resume: h.supports_chat_resume,
         })
         .collect()
+}
+
+fn doctor_harness_inventory(
+    configured: anyhow::Result<Vec<harness::HarnessSummary>>,
+) -> (Vec<harness::HarnessSummary>, Option<String>) {
+    match configured {
+        Ok(harnesses) => (harnesses, None),
+        Err(error) => (harness::built_in_harnesses(), Some(error.to_string())),
+    }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -3076,6 +3090,7 @@ mod tests {
             label: id.to_string(),
             harness: id.to_string(),
             available,
+            supports_chat_resume: matches!(id, "claude" | "codex" | "copilot"),
         }
     }
 
@@ -3372,6 +3387,42 @@ mod tests {
         assert!(
             !transcript.contains("Run `coven doctor`"),
             "doctor should run inline, not hand the user back to the shell:\n{transcript}"
+        );
+    }
+
+    #[test]
+    fn doctor_harness_inventory_preserves_manifest_errors_with_builtin_fallback() {
+        let (harnesses, error) =
+            doctor_harness_inventory(Err(anyhow::anyhow!("manifest.json: invalid JSON")));
+
+        assert!(
+            !harnesses.is_empty(),
+            "built-in fallback must remain available"
+        );
+        assert_eq!(
+            error.as_deref(),
+            Some("manifest.json: invalid JSON"),
+            "doctor must retain the configured-harness error for display"
+        );
+    }
+
+    #[test]
+    fn conversation_hint_uses_discovered_resume_support_without_reloading_manifests() {
+        let mut app = app_with_agents(vec![AgentInfo {
+            id: "custom-resume".to_string(),
+            label: "Custom Resume".to_string(),
+            harness: "custom-resume".to_string(),
+            available: true,
+            supports_chat_resume: true,
+        }]);
+        app.harness_conversation_ids
+            .insert("custom-resume".to_string(), "persisted-session".to_string());
+
+        assert_eq!(
+            app.conversation_hint_for_harness("custom-resume"),
+            Some(harness::ConversationHint::Resume {
+                id: "persisted-session".to_string()
+            })
         );
     }
 
@@ -5028,10 +5079,10 @@ mod tests {
         ));
     }
 
-    // Chat-resume support moved to `harness::harness_supports_chat_resume`,
-    // driven by each configured spec's declared continuity args; the
-    // hermetic coverage (built-ins, installed grok/opencode adapters, the
-    // coven-code carve-out) lives in `harness.rs`'s
+    // Chat-resume support is captured during agent discovery from each
+    // configured spec's declared continuity args; the hermetic coverage
+    // (built-ins, installed grok/opencode adapters, the coven-code carve-out)
+    // lives in `harness.rs`'s
     // `chat_resume_support_is_driven_by_declared_continuity`.
 
     #[test]

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1134,7 +1134,7 @@ impl App {
         // making the user retype.
         self.last_chat_prompt = Some(prompt.to_string());
 
-        // Fast path for stream-mode harnesses (today: claude). If we
+        // Fast path for stream-mode harnesses (claude, coven-code). If we
         // already have a long-lived stream session for this harness, send
         // the next user message into it instead of cold-starting a new
         // daemon session.
@@ -1202,8 +1202,8 @@ impl App {
 
     /// Decide whether a launch for `harness` should ride a resumable chat
     /// session, and if so produce the right hint. For harnesses where we can
-    /// pre-assign the session id (claude/copilot `--session-id`) the first
-    /// turn sends
+    /// pre-assign the session id (claude/copilot/grok `--session-id`) the
+    /// first turn sends
     /// `Init` with a freshly generated UUID. For harnesses that auto-assign
     /// (codex) the first turn sends no hint and the id is captured from
     /// output afterwards via `maybe_capture_codex_session_id`.
@@ -1211,7 +1211,7 @@ impl App {
         &mut self,
         harness: &str,
     ) -> Option<harness::ConversationHint> {
-        if !harness_supports_chat_resume(harness) {
+        if !harness::harness_supports_chat_resume(harness) {
             return None;
         }
         if let Some(id) = self.harness_conversation_ids.get(harness) {
@@ -1482,7 +1482,10 @@ impl App {
             .resolved_coven_home()
             .map(|home| home.display().to_string())
             .unwrap_or_else(|| "unresolved — set COVEN_HOME".to_string());
-        let harnesses = harness::built_in_harnesses();
+        // Configured = built-ins plus installed adapter manifests; fall back
+        // to built-ins on a manifest load error (the launch path surfaces it).
+        let harnesses =
+            harness::configured_harnesses().unwrap_or_else(|_| harness::built_in_harnesses());
         let mut lines = vec![
             "Doctor".to_string(),
             format!("  Store    {store_path}"),
@@ -1519,16 +1522,16 @@ impl App {
         let home = std::env::var("HOME")
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|_| std::path::PathBuf::from("/tmp"));
-        for (harness_id, label) in &[
-            ("codex", "Codex"),
-            ("claude", "Claude"),
-            ("copilot", "Copilot"),
-        ] {
-            let m = match *harness_id {
+        for harness in &harnesses {
+            let m = match harness.id.as_str() {
                 "codex" => crate::capabilities::scan_codex_capabilities(&home),
                 "claude" => crate::capabilities::scan_claude_capabilities(&home),
+                "coven-code" => crate::capabilities::scan_coven_code_capabilities(&home),
                 "copilot" => crate::capabilities::scan_copilot_capabilities(&home),
-                other => unreachable!("unhandled capabilities row for harness `{other}`"),
+                "opencode" => crate::capabilities::scan_opencode_capabilities(&home),
+                // Adapters without a capability scanner (grok, hermes, …)
+                // have no instructions/skills/plugins convention to inspect.
+                _ => continue,
             };
             let instr = if m.global_instructions.present {
                 "✓"
@@ -1537,6 +1540,7 @@ impl App {
             };
             let skills_n = m.skills.len();
             let plugins_n = m.plugins.len();
+            let label = &harness.label;
             lines.push(format!(
                 "    {label:<11} instructions {instr}  automations {skills_n}  plugins {plugins_n}"
             ));
@@ -2511,10 +2515,15 @@ fn is_api_mismatch_error(message: &str) -> bool {
     message.contains("Coven daemon API mismatch")
 }
 
-// ── Discover agents from built-in harnesses ────────────────────────────────
+// ── Discover agents from configured harnesses ──────────────────────────────
 
 pub(super) fn discover_agents() -> Vec<AgentInfo> {
-    harness::built_in_harnesses()
+    // Configured = built-ins plus installed adapter manifests (grok, hermes,
+    // opencode, …), so every runtime `coven run` accepts is selectable in
+    // chat. A manifest load error falls back to built-ins only — the launch
+    // path re-reads the manifests and surfaces the error with full context.
+    harness::configured_harnesses()
+        .unwrap_or_else(|_| harness::built_in_harnesses())
         .into_iter()
         .map(|h| AgentInfo {
             id: h.id.to_string(),
@@ -2579,13 +2588,6 @@ fn short_session_id(session_id: &str) -> String {
 fn should_keep_launch_inline(plan: &CastPlan) -> bool {
     !matches!(plan.intent, CastIntent::NaturalSpell { .. })
         || !matches!(plan.risk(), CastRisk::Safe)
-}
-
-/// Whether a chat turn launched against this harness should reuse the prior
-/// turn's conversation via the harness CLI's session-resume mechanism. See
-/// `docs/chat-persistence.md` for the per-harness mechanics.
-fn harness_supports_chat_resume(harness: &str) -> bool {
-    matches!(harness, "claude" | "codex" | "copilot" | "grok")
 }
 
 /// Whether `data` (a chunk of harness output) indicates the harness rejected
@@ -5018,14 +5020,11 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn chat_resume_covers_all_built_in_pty_harnesses() {
-        assert!(harness_supports_chat_resume("claude"));
-        assert!(harness_supports_chat_resume("codex"));
-        assert!(harness_supports_chat_resume("copilot"));
-        assert!(harness_supports_chat_resume("grok"));
-        assert!(!harness_supports_chat_resume("hermes"));
-    }
+    // Chat-resume support moved to `harness::harness_supports_chat_resume`,
+    // driven by each configured spec's declared continuity args; the
+    // hermetic coverage (built-ins, installed grok/opencode adapters, the
+    // coven-code carve-out) lives in `harness.rs`'s
+    // `chat_resume_support_is_driven_by_declared_continuity`.
 
     #[test]
     fn copilot_stats_lines_hide_from_chat_transcript() {

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -1483,9 +1483,12 @@ impl App {
             .map(|home| home.display().to_string())
             .unwrap_or_else(|| "unresolved — set COVEN_HOME".to_string());
         // Configured = built-ins plus installed adapter manifests; fall back
-        // to built-ins on a manifest load error (the launch path surfaces it).
-        let harnesses =
-            harness::configured_harnesses().unwrap_or_else(|_| harness::built_in_harnesses());
+        // to built-ins on a manifest load error and surface the error so users
+        // can diagnose why installed adapters are missing without a launch attempt.
+        let (harnesses, harness_load_err) = match harness::configured_harnesses() {
+            Ok(h) => (h, None),
+            Err(e) => (harness::built_in_harnesses(), Some(e.to_string())),
+        };
         let mut lines = vec![
             "Doctor".to_string(),
             format!("  Store    {store_path}"),
@@ -1501,6 +1504,11 @@ impl App {
             lines.push(format!(
                 "    {:<11} `{}` is {status}",
                 harness.label, harness.executable
+            ));
+        }
+        if let Some(err) = harness_load_err {
+            lines.push(format!(
+                "  [warn] adapter manifests could not be loaded (showing built-ins only): {err}"
             ));
         }
         let next = harnesses

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1340,6 +1340,7 @@ pub(crate) fn render_chat_frame_plain_for_test(width: u16, height: u16) -> Strin
         label: "codex".to_string(),
         harness: "codex".to_string(),
         available: true,
+        supports_chat_resume: true,
     }];
     let mut app = App::new_with_state(
         agents,
@@ -1909,6 +1910,7 @@ mod tests {
             label: "codex".to_string(),
             harness: "codex".to_string(),
             available: true,
+            supports_chat_resume: true,
         }];
         let mut app = App::new_with_state(
             agents,

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -10,7 +10,10 @@ extend the mechanism to additional harnesses.
 | `claude` | ✅ stream-mode | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose` daemon process per chat, plus `--session-id <uuid>` on the first turn and `--resume <uuid>` for cross-restart continuation. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). Unix kills the stream process tree with `setsid()` + `kill(-pid, SIGKILL)`; Windows uses a Job Object owned by the daemon. |
 | `codex` | ✅ per-turn | Chat runs plain `codex exec …`; it captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. `coven run codex --stream-json` separately uses Codex's one-shot `exec --json` protocol, but Codex has no long-lived stream mode, so each chat turn cold-starts. |
 | `copilot` | ✅ per-turn | Chat pre-assigns a UUID on turn 1 (`copilot --session-id <uuid> --prompt=…`) and sends the same `--session-id <uuid>` on later turns. Copilot has no long-lived stream mode, so each chat turn cold-starts. `--session-id` resumes an existing session *or* creates a fresh one under that id, so stale ids self-heal instead of erroring. |
+| `coven-code` | ⚠️ in-chat only | Stream-mode keeps the conversation alive within one `coven chat` (turns 2..N ride the long-lived engine process's stdin), but there is no cross-restart resume: the engine's `--session-id` is a tracking tag, not a persistence key — sessions only become loadable under *engine-assigned* ids (see ENGINE-CONTRACT.md) — so chat's pre-assign flow can never reclaim a prior thread, and `harness::harness_supports_chat_resume` carves the engine out explicitly. |
 | `grok` (experimental recipe) | ✅ per-turn | Chat pre-assigns a UUID on turn 1 (`grok … --session-id <uuid> --single=…`) and cold-starts later turns with `--resume <uuid>`. Unlike Copilot, the two flags are not interchangeable: `--session-id` refuses an id that already exists ("Session ID … is already in use") and `--resume` refuses an id that doesn't ("Session does not exist"), so stale ids are handled by the auto-recovery arm below rather than self-healing. Note: chat launches pass no `--permission` (true of every harness), which leaves Grok in its auto-cancel default — chat turns are read-and-answer only; see `docs/harnesses/grok-build.md`. |
+| `hermes` (recipe) | ❌ | The Hermes adapter manifest declares no continuity args, so every chat turn is an independent `hermes-coven chat … -Q` one-shot. |
+| `opencode` (recipe) | ❌ | The OpenCode adapter manifest declares no continuity args (`opencode run` one-shots; session state lives in OpenCode's own storage, not behind a resume flag surface), so every chat turn is independent. |
 
 Conversations persist across `coven chat` invocations on a per-project basis:
 on startup the chat seeds its in-memory map from
@@ -185,20 +188,26 @@ CLI's own session API avoids both problems.
    (`--resume` only binds its value as `--resume=<id>`, which the token-pair
    continuity form can't emit).
 
-2. **Extend `continuity_args` in `crates/coven-cli/src/harness.rs`.** Add a
-   new arm to the `match spec.id` block translating `Init` and `Resume` into
-   the harness's actual CLI args. Both existing arms are good templates:
-   `"claude"` for pre-assigned ids, `"codex"` for the auto-assign +
-   capture-from-output flow (`Init` returns `None` so the default args run,
-   `Resume` injects `resume <id>` after the prefix args).
+2. **Declare `continuity_args` on the spec.** For a built-in, fill in the
+   `ContinuityArgs` struct on its entry in `built_in_harness_specs()`
+   (`crates/coven-cli/src/harness.rs`); for an adapter manifest, add the
+   `continuity_args` object to the manifest JSON. Pre-assigned-id harnesses
+   (claude-style) set `session_id_flag` (and the `preassigned_session_id`
+   capability); auto-assigning harnesses (codex-style) leave
+   `session_id_flag` null and declare only the resume launch shape via
+   `resume_prefix_args` / `resume_flag`. The shared `continuity_args`
+   function translates `Init`/`Resume` hints into argv from those
+   declarations — there is no per-harness `match` to extend.
 
-3. **Tell the chat app the new harness supports resume.** Add the id to
-   `harness_supports_chat_resume` in
-   `crates/coven-cli/src/tui/chat/app.rs`. If the harness pre-assigns ids
-   (claude-style), also add it to
-   `harness::harness_supports_preassigned_session_id` so the chat generates a
-   UUID upfront. Auto-assigning harnesses (codex-style) need *no* entry
-   there.
+3. **Chat picks it up from the declaration.**
+   `harness::harness_supports_chat_resume` derives chat-resume support from
+   the configured spec's declared continuity args — there is no hardcoded
+   id list to edit. Two caveats: auto-assigning harnesses (no
+   `session_id_flag`) also need chat-side output capture before resume can
+   work (step 4) — today that capture is codex-specific, so the function
+   recognizes codex alone among them; and the engine (`coven-code`) is
+   explicitly carved out because its `--session-id` is a tracking tag
+   rather than a persistence key (see the Status table).
 
 4. **For auto-assigning harnesses, wire output capture.** Codex uses
    `extract_codex_session_id` (scans for `session id: <uuid>` lines) called

--- a/docs/chat-persistence.md
+++ b/docs/chat-persistence.md
@@ -10,8 +10,8 @@ extend the mechanism to additional harnesses.
 | `claude` | ✅ stream-mode | Long-lived `claude --print --input-format stream-json --output-format stream-json --verbose` daemon process per chat, plus `--session-id <uuid>` on the first turn and `--resume <uuid>` for cross-restart continuation. Turn 1 spawns + sends initial user envelope; turns 2..N pipe a new user envelope into the same stdin (no cold-start). Unix kills the stream process tree with `setsid()` + `kill(-pid, SIGKILL)`; Windows uses a Job Object owned by the daemon. |
 | `codex` | ✅ per-turn | Chat runs plain `codex exec …`; it captures `session id: <uuid>` from output and feeds it back as `codex exec … resume <uuid> <prompt>` on later turns. `coven run codex --stream-json` separately uses Codex's one-shot `exec --json` protocol, but Codex has no long-lived stream mode, so each chat turn cold-starts. |
 | `copilot` | ✅ per-turn | Chat pre-assigns a UUID on turn 1 (`copilot --session-id <uuid> --prompt=…`) and sends the same `--session-id <uuid>` on later turns. Copilot has no long-lived stream mode, so each chat turn cold-starts. `--session-id` resumes an existing session *or* creates a fresh one under that id, so stale ids self-heal instead of erroring. |
-| `coven-code` | ⚠️ in-chat only | Stream-mode keeps the conversation alive within one `coven chat` (turns 2..N ride the long-lived engine process's stdin), but there is no cross-restart resume: the engine's `--session-id` is a tracking tag, not a persistence key — sessions only become loadable under *engine-assigned* ids (see ENGINE-CONTRACT.md) — so chat's pre-assign flow can never reclaim a prior thread, and `harness::harness_supports_chat_resume` carves the engine out explicitly. |
-| `grok` (experimental recipe) | ✅ per-turn | Chat pre-assigns a UUID on turn 1 (`grok … --session-id <uuid> --single=…`) and cold-starts later turns with `--resume <uuid>`. Unlike Copilot, the two flags are not interchangeable: `--session-id` refuses an id that already exists ("Session ID … is already in use") and `--resume` refuses an id that doesn't ("Session does not exist"), so stale ids are handled by the auto-recovery arm below rather than self-healing. Note: chat launches pass no `--permission` (true of every harness), which leaves Grok in its auto-cancel default — chat turns are read-and-answer only; see `docs/harnesses/grok-build.md`. |
+| `coven-code` | ⚠️ in-chat only | Stream-mode keeps the conversation alive within one `coven chat` (turns 2..N ride the long-lived engine process's stdin), but there is no cross-restart resume: the engine's `--session-id` is a tracking tag, not a persistence key — sessions only become loadable under *engine-assigned* ids (see [ENGINE-CONTRACT.md](ENGINE-CONTRACT.md)) — so chat's pre-assign flow can never reclaim a prior thread. The configured-harness discovery predicate records `supports_chat_resume: false` for the engine in the chat agent inventory. |
+| `grok` (experimental recipe) | ✅ per-turn | Chat pre-assigns a UUID on turn 1 (`grok … --session-id <uuid> --single=…`) and cold-starts later turns with `--resume <uuid>`. Unlike Copilot, the two flags are not interchangeable: `--session-id` refuses an id that already exists ("Session ID … is already in use") and `--resume` refuses an id that doesn't ("Session does not exist"), so stale ids are handled by the auto-recovery arm below rather than self-healing. Note: chat launches pass no `--permission` (true of every harness), which leaves Grok in its auto-cancel default — chat turns are read-and-answer only; see the [Grok Build harness guide](harnesses/grok-build.md). |
 | `hermes` (recipe) | ❌ | The Hermes adapter manifest declares no continuity args, so every chat turn is an independent `hermes-coven chat … -Q` one-shot. |
 | `opencode` (recipe) | ❌ | The OpenCode adapter manifest declares no continuity args (`opencode run` one-shots; session state lives in OpenCode's own storage, not behind a resume flag surface), so every chat turn is independent. |
 
@@ -200,14 +200,18 @@ CLI's own session API avoids both problems.
    declarations — there is no per-harness `match` to extend.
 
 3. **Chat picks it up from the declaration.**
-   `harness::harness_supports_chat_resume` derives chat-resume support from
-   the configured spec's declared continuity args — there is no hardcoded
-   id list to edit. Two caveats: auto-assigning harnesses (no
-   `session_id_flag`) also need chat-side output capture before resume can
-   work (step 4) — today that capture is codex-specific, so the function
-   recognizes codex alone among them; and the engine (`coven-code`) is
-   explicitly carved out because its `--session-id` is a tracking tag
-   rather than a persistence key (see the Status table).
+   `harness::configured_chat_harnesses` maps each configured spec through the
+   internal `spec_supports_chat_resume` predicate. `discover_agents()` copies
+   that result into `AgentInfo.supports_chat_resume`, and
+   `conversation_hint_for_harness` consults the in-memory agent inventory on
+   each turn — there is no hardcoded id list or per-turn manifest read. A new
+   chat app reruns discovery and sees updated adapter manifests. Two caveats:
+   auto-assigning harnesses (no `session_id_flag`) also need chat-side output
+   capture before resume can work (step 4) — today that capture is
+   codex-specific, so the predicate recognizes codex alone among them; and
+   the engine (`coven-code`) is explicitly carved out because its
+   `--session-id` is a tracking tag rather than a persistence key (see the
+   Status table).
 
 4. **For auto-assigning harnesses, wire output capture.** Codex uses
    `extract_codex_session_id` (scans for `session id: <uuid>` lines) called

--- a/docs/harnesses/index.md
+++ b/docs/harnesses/index.md
@@ -26,6 +26,9 @@ A **harness** is an external coding-agent CLI that Coven can launch and supervis
   <Card title="Grok Build (experimental)" href="/harnesses/grok-build" icon="terminal">
     Trusted xAI Grok Build recipe. Installable harness id `grok`.
   </Card>
+  <Card title="OpenCode (recipe)" href="/harnesses/opencode" icon="code">
+    Trusted OpenCode registry recipe. Installable harness id `opencode`.
+  </Card>
   <Card title="Future harnesses" href="/FUTURE-HARNESSES" icon="compass">
     Hermes, Aider, Gemini CLI, Cline — adapter direction and roadmap signals.
   </Card>
@@ -40,6 +43,7 @@ flowchart LR
   Adapter --> ClaudeAdapter[Claude adapter]
   Adapter --> CopilotAdapter[Copilot adapter]
   Adapter -. recipe .-> GrokAdapter[Grok Build adapter]
+  Adapter -. recipe .-> OpenCodeAdapter[OpenCode adapter]
   Adapter -. future .-> Future[Hermes / Aider / Gemini]
   OpenClaw[OpenClaw] --> Bridge["OpenClaw bridge plugin"]
   Bridge --> Coven
@@ -47,6 +51,7 @@ flowchart LR
   ClaudeAdapter --> ClaudePty[Claude Code PTY]
   CopilotAdapter --> CopilotPty[Copilot CLI PTY]
   GrokAdapter --> GrokPty[Grok Build PTY]
+  OpenCodeAdapter --> OpenCodePty[OpenCode PTY]
 ```
 
 ## What every harness has in common
@@ -100,5 +105,6 @@ Grok Build is an experimental opt-in recipe rather than a bundled default. See [
 - [Provider auth boundary](/harnesses/provider-auth)
 - [OpenClaw bridge](/harnesses/openclaw)
 - [Grok Build adapter](/harnesses/grok-build)
+- [OpenCode adapter](/harnesses/opencode)
 - [Harness adapter guide](/HARNESS-ADAPTERS)
 - [Future harness notes](/FUTURE-HARNESSES)

--- a/docs/harnesses/installing.md
+++ b/docs/harnesses/installing.md
@@ -37,6 +37,8 @@ Other CLIs (Hermes, Aider, Gemini CLI, Cline, custom commands) are **not** bundl
 
 Grok Build has a reviewed **experimental recipe** but is not bundled by default. Install the Grok CLI and authenticate first, then run `coven adapter install grok`; see [Grok Build](/harnesses/grok-build) for the complete setup and permission mapping.
 
+OpenCode has an accepted **registry recipe** and is likewise not bundled. Install the OpenCode CLI (`npm i -g opencode-ai`) first, then run `coven adapter install opencode`; see [OpenCode](/harnesses/opencode) for the adapter contract and chat behavior.
+
 ## Step-by-step install
 
 <Steps>

--- a/docs/harnesses/opencode.md
+++ b/docs/harnesses/opencode.md
@@ -1,0 +1,76 @@
+---
+summary: "Trusted OpenCode adapter recipe for running the OpenCode CLI through Coven."
+read_when:
+  - Installing the OpenCode adapter
+  - Reviewing OpenCode launch, prompt, and session behavior
+title: "OpenCode (recipe)"
+description: "Install and use Coven's trusted OpenCode adapter recipe without promoting OpenCode to a bundled default harness."
+---
+
+OpenCode is available through a trusted, installable Coven adapter recipe. It is **not** a bundled default harness: users opt in with `coven adapter install opencode`. The recipe is byte-identical to the accepted [`coven-runtimes`](https://github.com/OpenCoven/coven-runtimes) registry manifest (`registry/runtimes/opencode/0.1.0.json`), so a manifest installed by Coven Cave and one installed by the CLI are the same trusted artifact.
+
+Coven does not embed or fork OpenCode; it launches the installed CLI's `run` subcommand and reads its output like any other one-shot coding-agent CLI.
+
+The Coven harness id is `opencode`; the executable is `opencode`.
+
+## Install
+
+<Steps>
+  <Step title="Install the OpenCode CLI">
+    ```bash
+    npm i -g opencode-ai
+    ```
+
+    Other install paths are documented at https://opencode.ai/docs/cli. Verify with `opencode run --help` — the similarly-named Go app some package managers ship has **no** `run` subcommand and will not work with this adapter.
+
+    Then finish OpenCode's own provider auth:
+
+    ```bash
+    opencode auth login
+    ```
+  </Step>
+  <Step title="Install the trusted Coven recipe">
+    ```bash
+    coven adapter install opencode
+    coven adapter doctor opencode
+    ```
+
+    The first command writes the versioned recipe to `COVEN_HOME/adapters/opencode.json`. Coven only loads the file while it exactly matches its bundled trusted recipe.
+  </Step>
+  <Step title="Run a project-scoped session">
+    ```bash
+    cd /path/to/project
+    coven run opencode "explain this repository"
+    ```
+  </Step>
+</Steps>
+
+## Adapter contract
+
+| Coven behavior | OpenCode argv |
+|---|---|
+| One-shot prompt | `run -- <prompt>` |
+| Model selection | `--model <model>` (Coven strips a leading `provider/` namespace before forwarding) |
+| Familiar identity | prepended to the prompt (no system-prompt flag) |
+| Sandbox / permission | none — `coven run opencode --permission …` warns and forwards no flag |
+| Session resume | none — every launch is an independent `opencode run` |
+
+OpenCode keeps system prompts, tool registries, and permissions in its own project configuration (`AGENTS.md`, `opencode.json`), not behind CLI flags, so the adapter intentionally declares no system-prompt, sandbox, or continuity surface. Configure those in the OpenCode project itself.
+
+## Chat behavior
+
+`coven chat` lists OpenCode once the recipe is installed and the binary is on `PATH`. Because the adapter declares no continuity args, chat resume is off: each chat turn is an independent `opencode run` with no carried conversation. See [Chat conversation persistence](/chat-persistence) for the per-harness resume matrix.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `coven adapter doctor opencode` reports `missing` | Binary not on the daemon's `PATH` | Install with `npm i -g opencode-ai`, then `coven daemon restart`. |
+| `opencode run` errors with unknown command | The Go `opencode` app is shadowing the Node CLI | `which -a opencode` and remove or reorder the duplicate. |
+| Adapter listed but launches fail with auth errors | OpenCode provider auth incomplete | Run `opencode auth login`; Coven never touches provider credentials. |
+
+## Related
+
+- [Installing harness CLIs](/harnesses/installing)
+- [Harness adapters](/HARNESS-ADAPTERS)
+- [Chat conversation persistence](/chat-persistence)


### PR DESCRIPTION
## Context

- Summary: The Cave treats every runtime accepted into the `coven-runtimes` registry as chat-trusted (codex, claude, copilot, grok, hermes, opencode), but the CLI lagged: no opencode trusted recipe, `coven chat` never listed installed adapters, and chat-resume support was a hardcoded id list. This lands full runtime parity, especially in `coven chat`.
- Files changed: `crates/coven-cli/src/harness.rs`, `crates/coven-cli/src/tui/chat/app.rs`, `crates/coven-cli/src/main.rs`, `docs/chat-persistence.md`, `docs/harnesses/{opencode.md,installing.md,index.md}`
- Closes #473

## Implementation

- Approach:
  - **opencode trusted recipe** (`harness.rs`): new `OPENCODE_ADAPTER_MANIFEST` embedded **byte-identical** to the accepted registry manifest (`registry/runtimes/opencode/0.1.0.json`), wired into `known_adapter_manifest` + `known_adapter_recipe_names`. A Cave-installed `adapters/opencode.json` therefore passes the byte-equality trust check, and `coven adapter install opencode` produces the same artifact.
  - **Chat agent discovery** (`app.rs`): `discover_agents()` uses `configured_chat_harnesses()` and chat `/doctor` uses `configured_harnesses()` (built-ins + installed manifests), both with a built-in-only fallback on manifest load errors. Installed adapters (grok, hermes, opencode) are therefore selectable in chat, and `/doctor` capability rows follow the configured list with coven-code + opencode scanners.
  - **Data-driven chat resume**: the hardcoded `matches!(harness, "claude" | "codex" | "copilot" | "grok")` is replaced by `spec_supports_chat_resume`, evaluated while `configured_chat_harnesses()` builds the per-App agent inventory. `discover_agents()` stores the result on `AgentInfo.supports_chat_resume`, so turns perform no manifest I/O. Documented carve-out for `coven-code`: per ENGINE-CONTRACT.md its `--session-id` is a tracking tag, not a persistence key — sessions only load under engine-assigned ids — so chat's pre-assign flow cannot resume it (verified empirically against engine 0.7.0; in-chat continuity still works via stream mode).
- User-visible behavior:
  - `coven adapter install opencode` now works (previously "unknown adapter recipe").
  - `coven chat` lists installed adapters in the agent picker; grok chat-resume now only advertises when the grok adapter is actually configured.
  - Chat `/doctor` shows all configured harnesses and adds Coven Code / OpenCode capability rows.
  - `coven adapter install --help` intentionally stays generic so it cannot drift as recipes change. Invalid-recipe errors enumerate `known_adapter_recipe_names()` from the authoritative recipe registry, while `coven adapter list` reports the adapters actually configured on the machine.
- Compatibility notes: no behavior change for built-ins (claude/codex/copilot resume exactly as before; coven-code chat resume stays off as before). opencode declares no continuity/sandbox/system-prompt surface, matching the registry contract. No API or daemon changes.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p coven-cli` (1314 passed, 0 failed, 1 ignored; integration suites passed; new coverage includes the opencode recipe contract, installed argv, recipe byte identity, and hermetic chat-resume discovery through injected `AdapterEnv` snapshots)
- [x] `python3 scripts/check-secrets.py` (current tree + history clean)
- [x] Additional manual checks: debug build smoke test — `coven adapter install opencode` → `adapter list` shows `opencode ready (manifest from …)` → `adapter doctor opencode` exits 0 with `[OK] OpenCode`.

## Risk and Rollback

- Risk level: Low. Recipe is additive; chat discovery falls back to built-ins on manifest errors; resume predicate reproduces the previous truth table for all built-ins and installed grok.
- Rollback plan: revert the single commit; no migrations or persisted-state changes.

## Agent Handoff

- Current state: complete and green locally; claim `issue-473` held until merge.
- Follow-ups: none required. Optional future: hermes/grok recipe metadata sync with the registry (cosmetic diffs only, intentionally skipped to avoid reinstall noise); openclaw stays excluded (no accepted registry entry).
- Known gaps: copilot's registry manifest claims `stream: true` but the CLI built-in (verified against the real CLI) keeps `stream: false` — intentionally not flipped here.

