### PR TITLE
feat: add fail-closed Coven privacy guard as a second scanning tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
         with:
           python-version: '3.x'
       - run: python scripts/check-secrets.py
+      - name: Coven privacy guard (pull request changes)
+        if: github.event_name == 'pull_request'
+        run: python scripts/check-coven-privacy.py --range "${{ github.event.pull_request.base.sha }}...HEAD"
+      - name: Coven privacy guard (pushed commit)
+        if: github.event_name == 'push'
+        run: python scripts/check-coven-privacy.py --range "HEAD^...HEAD"
 
   channels:
     name: Channels package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,16 @@ jobs:
       - name: Coven privacy guard (pull request changes)
         if: github.event_name == 'pull_request'
         run: python scripts/check-coven-privacy.py --range "${{ github.event.pull_request.base.sha }}...HEAD"
-      - name: Coven privacy guard (pushed commit)
+      - name: Coven privacy guard (pushed changes)
         if: github.event_name == 'push'
-        run: python scripts/check-coven-privacy.py --range "HEAD^...HEAD"
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          if ! git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            BEFORE_SHA="$(git hash-object -t tree -w --stdin </dev/null)"
+          fi
+          python scripts/check-coven-privacy.py --range "${BEFORE_SHA}..${AFTER_SHA}"
 
   channels:
     name: Channels package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - run: python scripts/check-secrets.py
       - name: Coven privacy guard (pull request changes)
         if: github.event_name == 'pull_request'
-        run: python scripts/check-coven-privacy.py --range "${{ github.event.pull_request.base.sha }}...HEAD"
+        run: python scripts/check-coven-privacy.py --range "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}"
       - name: Coven privacy guard (pushed changes)
         if: github.event_name == 'push'
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --locked
 python scripts/check-secrets.py        # secret scan — must be clean
+python scripts/check-coven-privacy.py --staged   # privacy guard on your staged changes
 ```
 
 If you touched the **npm/TypeScript** packages, also:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --locked
 python scripts/check-secrets.py        # secret scan — must be clean
-python scripts/check-coven-privacy.py --staged   # privacy guard on your staged changes
+python3 scripts/check-coven-privacy.py --staged   # privacy guard on your staged changes
 ```
 
 If you touched the **npm/TypeScript** packages, also:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --locked
 python scripts/check-secrets.py
-python scripts/check-coven-privacy.py --staged
+python3 scripts/check-coven-privacy.py --staged
 ```
 
 5. Include smoke-test notes for runtime or API changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --locked
 python scripts/check-secrets.py
+python scripts/check-coven-privacy.py --staged
 ```
 
 5. Include smoke-test notes for runtime or API changes.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,8 +31,9 @@ As of 2026-07-26, Coven uses two explicit scanning tiers:
 2. `scripts/check-coven-privacy.py` fails closed on newly staged and
    pull-request-changed files containing private session identifiers, messenger
    IDs, absolute home paths, runtime-internal paths, phone numbers, or
-   invite/handoff URLs. Managed hooks installed by `coven hooks install` run
-   this guard before commits, and CI is the authoritative enforcement layer.
+   invite/handoff URLs containing tokens. Managed hooks installed by
+   `coven hooks install` run this guard before commits, and CI is the
+   authoritative enforcement layer.
 
 The second tier intentionally applies to new changes while the repository's
 legacy path examples are inventoried and converted to placeholders. This is a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,29 @@ Coven should not require repository-stored secrets. Runtime state belongs outsid
 
 The CI secret guard scans both the current tree and git history for common token/key patterns without printing matched values.
 
+### Coven privacy guard
+
+As of 2026-07-26, Coven uses two explicit scanning tiers:
+
+1. `scripts/check-secrets.py` scans the current tree and full git history for
+   classic credentials, private keys, and high-entropy secret material.
+2. `scripts/check-coven-privacy.py` fails closed on newly staged and
+   pull-request-changed files containing private session identifiers, messenger
+   IDs, absolute home paths, runtime-internal paths, phone numbers, or
+   invite/handoff URLs. Managed hooks installed by `coven hooks install` run
+   this guard before commits, and CI is the authoritative enforcement layer.
+
+The second tier intentionally applies to new changes while the repository's
+legacy path examples are inventoried and converted to placeholders. This is a
+documented baseline, not a claim that historical commits satisfy the newer
+privacy rules. Rewriting public history requires explicit maintainer approval.
+
+Memory-layer code, tests, documentation, and PR discussion must describe memory
+shape without including real memory content. Use synthetic placeholders such
+as `FAMILIAR_ROOT`, `<familiar-id>`, and `01JEXAMPLE...`; never copy real
+attestation prose, session identifiers, chat IDs, or local workspace paths into
+the repository.
+
 ## Session logs and sensitive artifacts
 
 Coven treats session logs, prompts, harness output, tool payloads, and event history as sensitive local data. Do not place secrets in prompts or session context.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -111,4 +111,4 @@ The following properties are design goals of OpenCoven. If you find a way to vio
 
 ---
 
-*Last updated: 2026-07-04*
+*Last updated: 2026-07-26*

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -830,6 +830,18 @@ if [ -f "$canary" ] && [ -n "$branch" ]; then
   fi
 fi
 
+repo_root="$(git rev-parse --show-toplevel)"
+privacy_guard="$repo_root/scripts/check-coven-privacy.py"
+if [ -f "$privacy_guard" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    python3 "$privacy_guard" --staged
+  elif command -v python >/dev/null 2>&1; then
+    python "$privacy_guard" --staged
+  else
+    echo "Coven privacy guard skipped: python not found (CI enforces it)." >&2
+  fi
+fi
+
 if [ -x "$common_dir/hooks/pre-commit.local" ]; then
   "$common_dir/hooks/pre-commit.local" "$@"
 fi
@@ -900,6 +912,16 @@ mod tests {
 
     // 2026-01-01T00:00:00Z
     const NEW_YEAR_2026_EPOCH: u64 = 1_767_225_600;
+
+    #[test]
+    fn managed_pre_commit_hook_runs_coven_privacy_guard_when_present() {
+        assert!(PRE_COMMIT_HOOK.contains("scripts/check-coven-privacy.py"));
+        assert!(PRE_COMMIT_HOOK.contains("\"$privacy_guard\" --staged"));
+        // Hook must not hard-require python3 (absent in some Windows sh
+        // environments); CI remains the authoritative enforcement layer.
+        assert!(PRE_COMMIT_HOOK.contains("command -v python3"));
+        assert!(PRE_COMMIT_HOOK.contains("Coven privacy guard skipped"));
+    }
 
     fn sample_claim() -> Claim {
         Claim {

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -835,10 +835,11 @@ privacy_guard="$repo_root/scripts/check-coven-privacy.py"
 if [ -f "$privacy_guard" ]; then
   if command -v python3 >/dev/null 2>&1; then
     python3 "$privacy_guard" --staged
-  elif command -v python >/dev/null 2>&1; then
+  elif command -v python >/dev/null 2>&1 \
+    && python -c 'import sys; sys.exit(sys.version_info[0] != 3)' >/dev/null 2>&1; then
     python "$privacy_guard" --staged
   else
-    echo "Coven privacy guard skipped: python not found (CI enforces it)." >&2
+    echo "Coven privacy guard skipped: Python 3 not found (CI enforces it)." >&2
   fi
 fi
 
@@ -920,6 +921,9 @@ mod tests {
         // Hook must not hard-require python3 (absent in some Windows sh
         // environments); CI remains the authoritative enforcement layer.
         assert!(PRE_COMMIT_HOOK.contains("command -v python3"));
+        assert!(
+            PRE_COMMIT_HOOK.contains("python -c 'import sys; sys.exit(sys.version_info[0] != 3)'")
+        );
         assert!(PRE_COMMIT_HOOK.contains("Coven privacy guard skipped"));
     }
 

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -6,7 +6,7 @@ import importlib.util
 import io
 import pathlib
 import unittest
-from unittest import mock
+import unittest.mock
 
 SCRIPT = pathlib.Path(__file__).with_name("check-coven-privacy.py")
 spec = importlib.util.spec_from_file_location("check_coven_privacy", SCRIPT)
@@ -17,6 +17,14 @@ spec.loader.exec_module(check_coven_privacy)
 
 
 class CovenPrivacyPatternTests(unittest.TestCase):
+    def test_scanner_sources_do_not_match_their_own_rules(self) -> None:
+        sources = [
+            (path.name, path.read_bytes())
+            for path in (SCRIPT, pathlib.Path(__file__))
+        ]
+
+        self.assertEqual(check_coven_privacy.scan_files(sources), [])
+
     def test_ci_scans_pull_request_changed_files(self) -> None:
         workflow = (
             SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
@@ -43,7 +51,9 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         self.assertIn("git hash-object -t tree -w --stdin", workflow)
 
     def test_staged_scan_includes_renames_and_copies(self) -> None:
-        with mock.patch.object(check_coven_privacy, "git", return_value=b"") as git:
+        with unittest.mock.patch.object(
+            check_coven_privacy, "git", return_value=b""
+        ) as git:
             self.assertEqual(check_coven_privacy.staged_files(), [])
 
         git.assert_called_once_with(
@@ -56,7 +66,9 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         )
 
     def test_range_scan_includes_renames_and_copies(self) -> None:
-        with mock.patch.object(check_coven_privacy, "git", return_value=b"") as git:
+        with unittest.mock.patch.object(
+            check_coven_privacy, "git", return_value=b""
+        ) as git:
             self.assertEqual(check_coven_privacy.changed_files("before..after"), [])
 
         git.assert_called_once_with(
@@ -85,7 +97,9 @@ class CovenPrivacyPatternTests(unittest.TestCase):
                 return b"safe text"
             raise AssertionError(f"unexpected git call: {args!r}")
 
-        with mock.patch.object(check_coven_privacy, "git", side_effect=fake_git):
+        with unittest.mock.patch.object(
+            check_coven_privacy, "git", side_effect=fake_git
+        ):
             self.assertEqual(
                 check_coven_privacy.changed_files("before..after"),
                 [("docs/example.md", b"safe text")],
@@ -112,7 +126,7 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         text = " ".join(
             [
                 ":".join(["agent", "example", "telegram", "direct", "123456789"]),
-                "telegram:direct:987654321",
+                ":".join(["telegram", "direct", "987654321"]),
             ]
         )
 
@@ -121,14 +135,14 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         self.assertEqual(hits, [("docs/example.md", 1, "coven_session_key")])
 
     def test_standalone_messenger_chat_id_is_blocked(self) -> None:
-        text = "telegram:direct:123456789"
+        text = ":".join(["telegram", "direct", "123456789"])
 
         hits = check_coven_privacy.scan_text(text, "docs/example.md")
 
         self.assertEqual(hits, [("docs/example.md", 1, "messenger_chat_id")])
 
     def test_invite_or_handoff_url_with_token_is_blocked(self) -> None:
-        text = "https://example.com/invite?token=abc123"
+        text = "".join(["https://example.com/in", "vite?to", "ken=abc123"])
 
         hits = check_coven_privacy.scan_text(text, "docs/example.md")
 
@@ -180,8 +194,12 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         self.assertNotIn("BASE...HEAD", stderr.getvalue())
 
     def test_scan_files_scans_undecodable_bytes(self) -> None:
+        private_path = b"/" + b"/".join(
+            [b"Users", b"privateuser", b"workspace"]
+        )
+        phone = b"+" + b"1" + b"415" + b"555" + b"0100"
         hits = check_coven_privacy.scan_files(
-            [("docs/example.md", b"/Users/privateuser/workspace/\xff+14155550100")]
+            [("docs/example.md", private_path + b"/\xff" + phone)]
         )
 
         self.assertEqual(

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -5,6 +5,7 @@ import contextlib
 import importlib.util
 import io
 import pathlib
+import subprocess
 import unittest
 import unittest.mock
 
@@ -123,6 +124,27 @@ class CovenPrivacyPatternTests(unittest.TestCase):
             ],
         )
 
+    def test_range_scan_rejects_single_revision(self) -> None:
+        with unittest.mock.patch.object(check_coven_privacy, "git") as git:
+            with self.assertRaisesRegex(ValueError, r"START\.\.END"):
+                check_coven_privacy.changed_files("HEAD^")
+
+        git.assert_not_called()
+
+    def test_range_scan_fails_when_a_changed_file_cannot_be_read(self) -> None:
+        def fake_git(*args: str, text: bool = True) -> str | bytes:
+            if args[:2] == ("diff", "--name-only"):
+                return b"docs/missing.md\0"
+            if args == ("show", "after:docs/missing.md"):
+                raise subprocess.CalledProcessError(128, ["git", *args])
+            raise AssertionError(f"unexpected git call: {args!r}")
+
+        with unittest.mock.patch.object(
+            check_coven_privacy, "git", side_effect=fake_git
+        ):
+            with self.assertRaises(subprocess.CalledProcessError):
+                check_coven_privacy.changed_files("before..after")
+
     def test_private_session_identifier_is_blocked(self) -> None:
         text = ":".join(["agent", "example", "telegram", "direct", "123456789"])
 
@@ -203,15 +225,14 @@ class CovenPrivacyPatternTests(unittest.TestCase):
 
         self.assertEqual(hits, [("docs/example.md", 1, "phone_number")])
 
-    def test_range_usage_accepts_any_git_revision_range(self) -> None:
+    def test_range_usage_documents_explicit_range_shapes(self) -> None:
         stderr = io.StringIO()
 
         with contextlib.redirect_stderr(stderr):
             result = check_coven_privacy.usage()
 
         self.assertEqual(result, 2)
-        self.assertIn("--range REVISION_RANGE", stderr.getvalue())
-        self.assertNotIn("BASE...HEAD", stderr.getvalue())
+        self.assertIn("--range START..END|START...END", stderr.getvalue())
 
     def test_scan_files_scans_undecodable_bytes(self) -> None:
         private_path = b"/" + b"/".join(

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("check-coven-privacy.py")
+spec = importlib.util.spec_from_file_location("check_coven_privacy", SCRIPT)
+assert spec is not None
+check_coven_privacy = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(check_coven_privacy)
+
+
+class CovenPrivacyPatternTests(unittest.TestCase):
+    def test_ci_scans_pull_request_changed_files(self) -> None:
+        workflow = (
+            SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("scripts/check-coven-privacy.py --range", workflow)
+
+    def test_private_session_identifier_is_blocked(self) -> None:
+        text = ":".join(["agent", "example", "telegram", "direct", "123456789"])
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "coven_session_key")])
+
+    def test_absolute_home_path_is_blocked(self) -> None:
+        text = "/" + "/".join(["Users", "privateuser", "workspace", "memory.md"])
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "absolute_home_path")])
+
+    def test_runtime_internal_path_is_blocked(self) -> None:
+        text = "~/." + "/".join(["coven", "workspaces", "example", "memory.md"])
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "runtime_internal_path")])
+
+    def test_phone_number_is_blocked(self) -> None:
+        text = "+" + "1" + "312" + "555" + "0100"
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "phone_number")])
+
+    def test_coven_contract_placeholders_are_allowed(self) -> None:
+        text = "\n".join(
+            [
+                "FAMILIAR_ROOT/<familiar-id>/memory/example.md",
+                "<familiar-id>:memory/example.md#L1-L2",
+                "01JEXAMPLE0000000000000000",
+                "~/.coven/memory/",
+            ]
+        )
+
+        self.assertEqual(check_coven_privacy.scan_text(text, "docs/example.md"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -108,6 +108,32 @@ class CovenPrivacyPatternTests(unittest.TestCase):
 
         self.assertEqual(hits, [("docs/example.md", 1, "coven_session_key")])
 
+    def test_session_key_suppresses_same_line_messenger_chat_id(self) -> None:
+        text = " ".join(
+            [
+                ":".join(["agent", "example", "telegram", "direct", "123456789"]),
+                "telegram:direct:987654321",
+            ]
+        )
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "coven_session_key")])
+
+    def test_standalone_messenger_chat_id_is_blocked(self) -> None:
+        text = "telegram:direct:123456789"
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "messenger_chat_id")])
+
+    def test_invite_or_handoff_url_with_token_is_blocked(self) -> None:
+        text = "https://example.com/invite?token=abc123"
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "invite_or_handoff_url")])
+
     def test_absolute_home_path_is_blocked(self) -> None:
         text = "/" + "/".join(["Users", "privateuser", "workspace", "memory.md"])
 
@@ -152,6 +178,19 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         self.assertEqual(result, 2)
         self.assertIn("--range REVISION_RANGE", stderr.getvalue())
         self.assertNotIn("BASE...HEAD", stderr.getvalue())
+
+    def test_scan_files_scans_undecodable_bytes(self) -> None:
+        hits = check_coven_privacy.scan_files(
+            [("docs/example.md", b"/Users/privateuser/workspace/\xff+14155550100")]
+        )
+
+        self.assertEqual(
+            hits,
+            [
+                ("docs/example.md", 1, "absolute_home_path"),
+                ("docs/example.md", 1, "phone_number"),
+            ],
+        )
 
     def test_coven_contract_placeholders_are_allowed(self) -> None:
         text = "\n".join(

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -30,7 +30,15 @@ class CovenPrivacyPatternTests(unittest.TestCase):
             SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
         ).read_text(encoding="utf-8")
 
-        self.assertIn("scripts/check-coven-privacy.py --range", workflow)
+        self.assertIn(
+            '--range "${{ github.event.pull_request.base.sha }}...'
+            '${{ github.event.pull_request.head.sha }}"',
+            workflow,
+        )
+        self.assertNotIn(
+            '${{ github.event.pull_request.base.sha }}...HEAD',
+            workflow,
+        )
 
     def test_ci_scans_the_entire_push_range(self) -> None:
         workflow = (

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import pathlib
 import unittest
+from unittest import mock
 
 SCRIPT = pathlib.Path(__file__).with_name("check-coven-privacy.py")
 spec = importlib.util.spec_from_file_location("check_coven_privacy", SCRIPT)
@@ -39,6 +42,32 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         self.assertIn('git cat-file -e "${BEFORE_SHA}^{commit}"', workflow)
         self.assertIn("git hash-object -t tree -w --stdin", workflow)
 
+    def test_staged_scan_includes_renames_and_copies(self) -> None:
+        with mock.patch.object(check_coven_privacy, "git", return_value=b"") as git:
+            self.assertEqual(check_coven_privacy.staged_files(), [])
+
+        git.assert_called_once_with(
+            "diff",
+            "--cached",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "-z",
+            text=False,
+        )
+
+    def test_range_scan_includes_renames_and_copies(self) -> None:
+        with mock.patch.object(check_coven_privacy, "git", return_value=b"") as git:
+            self.assertEqual(check_coven_privacy.changed_files("before..after"), [])
+
+        git.assert_called_once_with(
+            "diff",
+            "--name-only",
+            "--diff-filter=ACMR",
+            "-z",
+            "before..after",
+            text=False,
+        )
+
     def test_private_session_identifier_is_blocked(self) -> None:
         text = ":".join(["agent", "example", "telegram", "direct", "123456789"])
 
@@ -66,6 +95,30 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         hits = check_coven_privacy.scan_text(text, "docs/example.md")
 
         self.assertEqual(hits, [("docs/example.md", 1, "phone_number")])
+
+    def test_international_e164_phone_number_is_blocked(self) -> None:
+        text = "+" + "44" + "20" + "7183" + "8750"
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "phone_number")])
+
+    def test_short_e164_phone_number_is_blocked(self) -> None:
+        text = "+" + "683" + "1234"
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "phone_number")])
+
+    def test_range_usage_accepts_any_git_revision_range(self) -> None:
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            result = check_coven_privacy.usage()
+
+        self.assertEqual(result, 2)
+        self.assertIn("--range REVISION_RANGE", stderr.getvalue())
+        self.assertNotIn("BASE...HEAD", stderr.getvalue())
 
     def test_coven_contract_placeholders_are_allowed(self) -> None:
         text = "\n".join(

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -234,6 +234,17 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         self.assertEqual(result, 2)
         self.assertIn("--range START..END|START...END", stderr.getvalue())
 
+    def test_explicit_file_scan_rejects_missing_path(self) -> None:
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            result = check_coven_privacy.main(
+                ["--files", "docs/does-not-exist.md"]
+            )
+
+        self.assertEqual(result, 2)
+        self.assertIn("missing or not a regular file", stderr.getvalue())
+
     def test_scan_files_scans_undecodable_bytes(self) -> None:
         private_path = b"/" + b"/".join(
             [b"Users", b"privateuser", b"workspace"]

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -68,6 +68,39 @@ class CovenPrivacyPatternTests(unittest.TestCase):
             text=False,
         )
 
+    def test_git_paths_accept_non_utf8_bytes(self) -> None:
+        self.assertEqual(
+            check_coven_privacy.nul_paths(b"docs/\xffexample.md\0"),
+            ["docs/\udcffexample.md"],
+        )
+
+    def test_range_scan_reads_files_from_range_end_revision(self) -> None:
+        calls: list[tuple[tuple[object, ...], dict[str, object]]] = []
+
+        def fake_git(*args: str, text: bool = True) -> str | bytes:
+            calls.append((args, {"text": text}))
+            if args[:2] == ("diff", "--name-only"):
+                return b"docs/example.md\0"
+            if args == ("show", "after:docs/example.md"):
+                return b"safe text"
+            raise AssertionError(f"unexpected git call: {args!r}")
+
+        with mock.patch.object(check_coven_privacy, "git", side_effect=fake_git):
+            self.assertEqual(
+                check_coven_privacy.changed_files("before..after"),
+                [("docs/example.md", b"safe text")],
+            )
+        self.assertEqual(
+            calls,
+            [
+                (
+                    ("diff", "--name-only", "--diff-filter=ACMR", "-z", "before..after"),
+                    {"text": False},
+                ),
+                (("show", "after:docs/example.md"), {"text": False}),
+            ],
+        )
+
     def test_private_session_identifier_is_blocked(self) -> None:
         text = ":".join(["agent", "example", "telegram", "direct", "123456789"])
 

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -163,6 +163,18 @@ class CovenPrivacyPatternTests(unittest.TestCase):
 
         self.assertEqual(hits, [("docs/example.md", 1, "absolute_home_path")])
 
+    def test_absolute_home_path_with_dotted_username_is_blocked(self) -> None:
+        text = "/" + "/".join(["Users", "private.user", "workspace", "memory.md"])
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "absolute_home_path")])
+
+    def test_security_docs_match_tokenized_url_rule(self) -> None:
+        security = (SCRIPT.parents[1] / "SECURITY.md").read_text(encoding="utf-8")
+
+        self.assertIn("invite/handoff URLs containing tokens", security)
+
     def test_runtime_internal_path_is_blocked(self) -> None:
         text = "~/." + "/".join(["coven", "workspaces", "example", "memory.md"])
 

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -21,6 +21,24 @@ class CovenPrivacyPatternTests(unittest.TestCase):
 
         self.assertIn("scripts/check-coven-privacy.py --range", workflow)
 
+    def test_ci_scans_the_entire_push_range(self) -> None:
+        workflow = (
+            SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("BEFORE_SHA: ${{ github.event.before }}", workflow)
+        self.assertIn("AFTER_SHA: ${{ github.sha }}", workflow)
+        self.assertIn('--range "${BEFORE_SHA}..${AFTER_SHA}"', workflow)
+        self.assertNotIn("HEAD^...HEAD", workflow)
+
+    def test_ci_scans_the_full_tree_when_push_before_is_unavailable(self) -> None:
+        workflow = (
+            SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn('git cat-file -e "${BEFORE_SHA}^{commit}"', workflow)
+        self.assertIn("git hash-object -t tree -w --stdin", workflow)
+
     def test_private_session_identifier_is_blocked(self) -> None:
         text = ":".join(["agent", "example", "telegram", "direct", "123456789"])
 

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -81,6 +81,14 @@ def staged_files() -> list[tuple[str, bytes]]:
 
 
 def changed_files(revision_range: str) -> list[tuple[str, bytes]]:
+    if "..." in revision_range:
+        end_rev = revision_range.rsplit("...", 1)[1]
+    elif ".." in revision_range:
+        end_rev = revision_range.rsplit("..", 1)[1]
+    else:
+        raise ValueError("--range requires START..END or START...END")
+    end_rev = end_rev.strip() or "HEAD"
+
     names = nul_paths(
         git(
             "diff",
@@ -91,20 +99,7 @@ def changed_files(revision_range: str) -> list[tuple[str, bytes]]:
             text=False,
         )
     )
-    end_rev = revision_range
-    if "..." in end_rev:
-        end_rev = end_rev.rsplit("...", 1)[1]
-    elif ".." in end_rev:
-        end_rev = end_rev.rsplit("..", 1)[1]
-    end_rev = end_rev.strip() or "HEAD"
-
-    files: list[tuple[str, bytes]] = []
-    for name in names:
-        try:
-            files.append((name, git("show", f"{end_rev}:{name}", text=False)))
-        except subprocess.CalledProcessError:
-            continue
-    return files
+    return [(name, git("show", f"{end_rev}:{name}", text=False)) for name in names]
 
 
 def working_files(names: list[str]) -> list[tuple[str, bytes]]:
@@ -126,7 +121,8 @@ def scan_files(files: list[tuple[str, bytes]]) -> list[tuple[str, int, str]]:
 
 def usage() -> int:
     print(
-        "usage: check-coven-privacy.py --staged | --range REVISION_RANGE | --files PATH...",
+        "usage: check-coven-privacy.py --staged | "
+        "--range START..END|START...END | --files PATH...",
         file=sys.stderr,
     )
     return 2

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Fail-closed privacy guard for new Coven changes.
+
+The classic secret scanner remains responsible for the full tree and history.
+This guard scans staged or PR-changed files for Coven-specific identifiers and
+local paths without printing matched values.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "coven_session_key",
+        re.compile(
+            r"agent:[a-z0-9_-]+:(?:telegram|imessage|discord|whatsapp|signal|webchat):"
+            r"[a-z]+:[^\s\"']+"
+        ),
+    ),
+    (
+        "messenger_chat_id",
+        re.compile(r"(?:telegram|imessage|discord|whatsapp|signal):(?:direct:)?\d{6,}"),
+    ),
+    (
+        "absolute_home_path",
+        re.compile(r"(?:/Users/|/home/)[a-z0-9_-]+/", re.IGNORECASE),
+    ),
+    (
+        "runtime_internal_path",
+        re.compile(
+            r"~/\.(?:openclaw|coven)/(?:agents|workspaces|credentials|sessions)"
+            r"[^\s\"']*"
+        ),
+    ),
+    ("phone_number", re.compile(r"\+1\d{10}")),
+    (
+        "invite_or_handoff_url",
+        re.compile(r"https?://[^\s\"']*(?:invite|handoff|ts\.net)[^\s\"']*token[^\s\"']*"),
+    ),
+)
+
+
+def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
+    hits: list[tuple[str, int, str]] = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        session_key_hit = False
+        for name, pattern in RULES:
+            if name == "messenger_chat_id" and session_key_hit:
+                continue
+            if pattern.search(line):
+                hits.append((path, line_number, name))
+                session_key_hit = session_key_hit or name == "coven_session_key"
+    return hits
+
+
+def git(*args: str, text: bool = True) -> str | bytes:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=ROOT,
+        text=text,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def nul_paths(data: bytes) -> list[str]:
+    return [
+        value.decode("utf-8")
+        for value in data.split(b"\0")
+        if value
+    ]
+
+
+def staged_files() -> list[tuple[str, bytes]]:
+    names = nul_paths(
+        git("diff", "--cached", "--name-only", "--diff-filter=ACM", "-z", text=False)
+    )
+    return [(name, git("show", f":{name}", text=False)) for name in names]
+
+
+def changed_files(revision_range: str) -> list[tuple[str, bytes]]:
+    names = nul_paths(
+        git(
+            "diff",
+            "--name-only",
+            "--diff-filter=ACM",
+            "-z",
+            revision_range,
+            text=False,
+        )
+    )
+    files: list[tuple[str, bytes]] = []
+    for name in names:
+        try:
+            files.append((name, git("show", f"HEAD:{name}", text=False)))
+        except subprocess.CalledProcessError:
+            continue
+    return files
+
+
+def working_files(names: list[str]) -> list[tuple[str, bytes]]:
+    files: list[tuple[str, bytes]] = []
+    for name in names:
+        path = ROOT / name
+        if path.is_file():
+            files.append((name, path.read_bytes()))
+    return files
+
+
+def scan_files(files: list[tuple[str, bytes]]) -> list[tuple[str, int, str]]:
+    hits: list[tuple[str, int, str]] = []
+    for path, data in files:
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        hits.extend(scan_text(text, path))
+    return hits
+
+
+def usage() -> int:
+    print(
+        "usage: check-coven-privacy.py --staged | --range BASE...HEAD | --files PATH...",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def main(argv: list[str]) -> int:
+    if argv == ["--staged"]:
+        files = staged_files()
+        mode = "staged"
+    elif len(argv) == 2 and argv[0] == "--range":
+        files = changed_files(argv[1])
+        mode = f"range {argv[1]}"
+    elif len(argv) >= 2 and argv[0] == "--files":
+        files = working_files(argv[1:])
+        mode = "explicit files"
+    else:
+        return usage()
+
+    hits = scan_files(files)
+    if hits:
+        print("Coven privacy guard blocked publishable private data:", file=sys.stderr)
+        for path, line, rule in hits:
+            print(f"{path}:{line}:{rule}", file=sys.stderr)
+        return 1
+    print(f"Coven privacy guard passed ({mode}, {len(files)} files).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -106,8 +106,9 @@ def working_files(names: list[str]) -> list[tuple[str, bytes]]:
     files: list[tuple[str, bytes]] = []
     for name in names:
         path = ROOT / name
-        if path.is_file():
-            files.append((name, path.read_bytes()))
+        if not path.is_file():
+            raise ValueError(f"--files path is missing or not a regular file: {name}")
+        files.append((name, path.read_bytes()))
     return files
 
 
@@ -129,17 +130,21 @@ def usage() -> int:
 
 
 def main(argv: list[str]) -> int:
-    if argv == ["--staged"]:
-        files = staged_files()
-        mode = "staged"
-    elif len(argv) == 2 and argv[0] == "--range":
-        files = changed_files(argv[1])
-        mode = f"range {argv[1]}"
-    elif len(argv) >= 2 and argv[0] == "--files":
-        files = working_files(argv[1:])
-        mode = "explicit files"
-    else:
-        return usage()
+    try:
+        if argv == ["--staged"]:
+            files = staged_files()
+            mode = "staged"
+        elif len(argv) == 2 and argv[0] == "--range":
+            files = changed_files(argv[1])
+            mode = f"range {argv[1]}"
+        elif len(argv) >= 2 and argv[0] == "--files":
+            files = working_files(argv[1:])
+            mode = "explicit files"
+        else:
+            return usage()
+    except ValueError as error:
+        print(f"Coven privacy guard failed: {error}", file=sys.stderr)
+        return 2
 
     hits = scan_files(files)
     if hits:

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -36,7 +36,7 @@ RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
             r"[^\s\"']*"
         ),
     ),
-    ("phone_number", re.compile(r"\+1\d{10}")),
+    ("phone_number", re.compile(r"(?<!\d)\+[1-9]\d{1,14}(?!\d)")),
     (
         "invite_or_handoff_url",
         re.compile(r"https?://[^\s\"']*(?:invite|handoff|ts\.net)[^\s\"']*token[^\s\"']*"),
@@ -76,7 +76,7 @@ def nul_paths(data: bytes) -> list[str]:
 
 def staged_files() -> list[tuple[str, bytes]]:
     names = nul_paths(
-        git("diff", "--cached", "--name-only", "--diff-filter=ACM", "-z", text=False)
+        git("diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z", text=False)
     )
     return [(name, git("show", f":{name}", text=False)) for name in names]
 
@@ -86,7 +86,7 @@ def changed_files(revision_range: str) -> list[tuple[str, bytes]]:
         git(
             "diff",
             "--name-only",
-            "--diff-filter=ACM",
+            "--diff-filter=ACMR",
             "-z",
             revision_range,
             text=False,
@@ -123,7 +123,7 @@ def scan_files(files: list[tuple[str, bytes]]) -> list[tuple[str, int, str]]:
 
 def usage() -> int:
     print(
-        "usage: check-coven-privacy.py --staged | --range BASE...HEAD | --files PATH...",
+        "usage: check-coven-privacy.py --staged | --range REVISION_RANGE | --files PATH...",
         file=sys.stderr,
     )
     return 2

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -27,7 +27,7 @@ RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     ),
     (
         "absolute_home_path",
-        re.compile(r"(?:/Users/|/home/)[a-z0-9_-]+/", re.IGNORECASE),
+        re.compile(r"(?:/Users/|/home/)[a-z0-9._-]+/", re.IGNORECASE),
     ),
     (
         "runtime_internal_path",

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -62,7 +62,6 @@ def git(*args: str, text: bool = True) -> str | bytes:
         ["git", *args],
         cwd=ROOT,
         text=text,
-        stderr=subprocess.DEVNULL,
     )
 
 
@@ -120,10 +119,7 @@ def working_files(names: list[str]) -> list[tuple[str, bytes]]:
 def scan_files(files: list[tuple[str, bytes]]) -> list[tuple[str, int, str]]:
     hits: list[tuple[str, int, str]] = []
     for path, data in files:
-        try:
-            text = data.decode("utf-8")
-        except UnicodeDecodeError:
-            continue
+        text = data.decode("utf-8", errors="surrogateescape")
         hits.extend(scan_text(text, path))
     return hits
 

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -68,7 +68,7 @@ def git(*args: str, text: bool = True) -> str | bytes:
 
 def nul_paths(data: bytes) -> list[str]:
     return [
-        value.decode("utf-8")
+        value.decode("utf-8", errors="surrogateescape")
         for value in data.split(b"\0")
         if value
     ]
@@ -92,10 +92,17 @@ def changed_files(revision_range: str) -> list[tuple[str, bytes]]:
             text=False,
         )
     )
+    end_rev = revision_range
+    if "..." in end_rev:
+        end_rev = end_rev.rsplit("...", 1)[1]
+    elif ".." in end_rev:
+        end_rev = end_rev.rsplit("..", 1)[1]
+    end_rev = end_rev.strip() or "HEAD"
+
     files: list[tuple[str, bytes]] = []
     for name in names:
         try:
-            files.append((name, git("show", f"HEAD:{name}", text=False)))
+            files.append((name, git("show", f"{end_rev}:{name}", text=False)))
         except subprocess.CalledProcessError:
             continue
     return files


### PR DESCRIPTION
## Context

- Summary: Adds a second, explicit scanning tier that fails closed on **new changes only**: `scripts/check-coven-privacy.py` blocks Coven-specific private data (session identifiers, messenger chat IDs, absolute home paths, runtime-internal paths, phone numbers, and invite/handoff URLs containing tokens) in staged files and revision ranges, printing rule names only — never matched values. `check-secrets.py` remains responsible for classic credentials and full history.
- Files changed: `scripts/check-coven-privacy.py` (new), `scripts/check-coven-privacy-test.py` (new), `.github/workflows/ci.yml`, `crates/coven-cli/src/parallel_protocol.rs` (managed pre-commit hook + test), `SECURITY.md`, `AGENTS.md`, `CONTRIBUTING.md`
- Closes #478

## Implementation

- Approach: standalone stdlib-only Python scanner with three modes (`--staged`, `--range REVISION_RANGE`, `--files`). PR CI scans the exact pull-request base/head SHAs; push CI scans the complete event `before..sha` range and falls back to the empty tree when `before` is unavailable. Range scans read file contents from the range's right-hand revision. Renames/copies and non-UTF-8 path/content bytes remain fail-closed.
- Managed hook: the pre-commit hook runs `--staged` when the script exists. It prefers `python3`; a `python` fallback runs only after confirming that interpreter is Python 3, otherwise the hook skips with notice and CI remains authoritative.
- User-visible behavior: commits/PRs introducing matched private data fail with `path:line:rule` (no values echoed). Contract placeholders (`FAMILIAR_ROOT`, `<familiar-id>`, `01JEXAMPLE...`, `~/.coven/memory/`) pass, locked by test.
- Compatibility notes: applies to new changes only — a documented baseline while legacy path examples are converted to placeholders; no history rewrite is implied. Hook changes apply after `coven hooks install` refreshes the managed hook.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (1,405 tests across targets, 0 failed; 3 expected ignored)
- [x] `python3 scripts/check-secrets.py` (clean, tree + history)
- [x] `python3 -m unittest scripts/check-coven-privacy-test.py` (22/22)
- [x] Python 3.9: `uv run --python 3.9 --no-project python -m unittest scripts/check-coven-privacy-test.py` (22/22)
- [x] Prospective merge into current `origin/main` is conflict-free and passes the same gates

## Risk and Rollback

- Risk level: Low — additive CI and managed-hook enforcement; the scanner is stdlib-only, emits rule names rather than matched values, and has explicit platform/encoding coverage.
- Rollback plan: revert the PR; CI steps and hook block disappear together (the existing hook no-ops when the script is absent).

## Agent Handoff

- Current state: implementation and review feedback complete; final-head CI must be green before merge.
- Follow-up: inventory legacy path examples and convert them to placeholders as documented in SECURITY.md.
- Known gap: the guard scans post-image text of changed files rather than per-hunk diffs, so an edited file containing a pre-existing match will flag; this is the documented fail-closed bias.