### PR TITLE
feat: persist Ward Gate 4 apply records into the ward_audit ledger

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -3080,6 +3080,20 @@ fn familiar_audit_response(
     )
 }
 
+pub(crate) const WARD_AUDIT_EVENT_TAGS: &[&str] = &[
+    "proposal_submitted",
+    "proposal_window_opened",
+    "proposal_approved",
+    "proposal_rejected",
+    "proposal_vetoed",
+    "ward_updated",
+    "memory_entry_admitted",
+    "principal_authorized_write",
+    "validation_verdict",
+    "compaction_ledger",
+    "apply_audit",
+];
+
 pub(crate) fn validate_ward_audit_event_tag(event: &str) -> Result<()> {
     anyhow::ensure!(
         !event.is_empty()
@@ -3089,11 +3103,8 @@ pub(crate) fn validate_ward_audit_event_tag(event: &str) -> Result<()> {
         "Query parameter `event` must be a lowercase ASCII event tag containing only lowercase letters, digits, and `_`."
     );
     anyhow::ensure!(
-        matches!(
-            event,
-            "apply_audit" | "proposal_submitted" | "validation_verdict"
-        ),
-        "Query parameter `event` must be one of `apply_audit`, `proposal_submitted`, or `validation_verdict`."
+        WARD_AUDIT_EVENT_TAGS.contains(&event),
+        "Query parameter `event` must be a known ward_audit event tag."
     );
     Ok(())
 }
@@ -9021,6 +9032,32 @@ tier = 1
             assert_eq!(response.status, 400, "path {path} got {}", response.body);
             let body: Value = serde_json::from_str(&response.body)?;
             assert_eq!(body["error"]["code"], "invalid_request");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_audit_event_filter_accepts_every_ledger_event_type() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        for event in [
+            "proposal_submitted",
+            "proposal_window_opened",
+            "proposal_approved",
+            "proposal_rejected",
+            "proposal_vetoed",
+            "ward_updated",
+            "memory_entry_admitted",
+            "principal_authorized_write",
+            "validation_verdict",
+            "compaction_ledger",
+            "apply_audit",
+        ] {
+            let path = format!("/api/v1/familiars/sage/audit?event={event}");
+            let response = handle_request("GET", &path, home, None)?;
+            assert_eq!(response.status, 200, "event {event} got {}", response.body);
         }
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2800,10 +2800,10 @@ fn apply_familiar_edits(
             }),
         );
     }
-    advance_applied_protected_baselines(coven_home, familiar_id, &workspace, &report.changes)?;
     // Gate 4 persistence (#414): the audit records returned to the client
     // also land in the append-only ward_audit ledger, so applied writes stay
-    // observable across daemon restarts.
+    // observable across daemon restarts. Persist before advancing protected
+    // baselines so a post-write failure is less likely to leave an audit gap.
     {
         let mut conn = store::open_store(&store_path(coven_home))?;
         crate::threads_gate::persist_apply_audit_records(
@@ -2814,6 +2814,7 @@ fn apply_familiar_edits(
             &report,
         )?;
     }
+    advance_applied_protected_baselines(coven_home, familiar_id, &workspace, &report.changes)?;
     json_response(
         200,
         &json!({
@@ -2958,7 +2959,21 @@ fn familiar_audit_response(
             }
         },
     };
-    let event = query.and_then(|q| query_param(q, "event"));
+    let event = match query.and_then(|q| query_param(q, "event")) {
+        Some(event) => {
+            if let Err(message) = validate_ward_audit_event_tag(event) {
+                let message = message.to_string();
+                return api_error(
+                    400,
+                    "invalid_request",
+                    &message,
+                    Some(json!({ "event": event })),
+                );
+            }
+            Some(event)
+        }
+        None => None,
+    };
 
     let conn = store::open_store(&store_path(coven_home))?;
     let mut sql = String::from(
@@ -2981,26 +2996,53 @@ fn familiar_audit_response(
             .ok()
             .filter(Value::is_array)
             .unwrap_or_else(|| json!([]));
-        Ok(json!({
-            "id": row.get::<_, i64>(0)?,
-            "eventType": row.get::<_, String>(1)?,
-            "proposalId": row.get::<_, Option<String>>(2)?,
-            "wardVersion": row.get::<_, Option<String>>(3)?,
-            "wardHash": hex_string(&ward_hash),
-            "tier": row.get::<_, Option<String>>(5)?,
-            "decision": row.get::<_, String>(6)?,
-            "approver": row.get::<_, Option<String>>(7)?,
-            "diffSha256": diff_hash.as_deref().map(hex_string),
-            "detail": detail
-                .as_deref()
-                .map(|raw| serde_json::from_str(raw).unwrap_or(Value::Null)),
-            "filesTouched": files_touched,
-            "channel": row.get::<_, Option<String>>(11)?,
-            "threadId": row.get::<_, Option<String>>(12)?,
-            "submittedAt": row.get::<_, String>(13)?,
-            "decidedAt": row.get::<_, String>(14)?,
-            "recordedAt": row.get::<_, String>(15)?,
-        }))
+        let (detail, detail_raw) = match detail {
+            Some(raw) => match serde_json::from_str::<Value>(&raw) {
+                Ok(parsed) => (parsed, None),
+                Err(_) => (Value::Null, Some(raw)),
+            },
+            None => (Value::Null, None),
+        };
+        let mut record = serde_json::Map::from_iter([
+            ("id".to_string(), json!(row.get::<_, i64>(0)?)),
+            ("eventType".to_string(), json!(row.get::<_, String>(1)?)),
+            (
+                "proposalId".to_string(),
+                json!(row.get::<_, Option<String>>(2)?),
+            ),
+            (
+                "wardVersion".to_string(),
+                json!(row.get::<_, Option<String>>(3)?),
+            ),
+            ("wardHash".to_string(), json!(hex_string(&ward_hash))),
+            ("tier".to_string(), json!(row.get::<_, Option<String>>(5)?)),
+            ("decision".to_string(), json!(row.get::<_, String>(6)?)),
+            (
+                "approver".to_string(),
+                json!(row.get::<_, Option<String>>(7)?),
+            ),
+            (
+                "diffSha256".to_string(),
+                json!(diff_hash.as_deref().map(hex_string)),
+            ),
+            ("detail".to_string(), detail),
+            ("filesTouched".to_string(), files_touched),
+            (
+                "channel".to_string(),
+                json!(row.get::<_, Option<String>>(11)?),
+            ),
+            (
+                "threadId".to_string(),
+                json!(row.get::<_, Option<String>>(12)?),
+            ),
+            ("submittedAt".to_string(), json!(row.get::<_, String>(13)?)),
+            ("decidedAt".to_string(), json!(row.get::<_, String>(14)?)),
+            ("recordedAt".to_string(), json!(row.get::<_, String>(15)?)),
+        ]);
+        if let Some(raw) = detail_raw {
+            record.insert("detailRaw".to_string(), Value::String(raw));
+        }
+        Ok(Value::Object(record))
     };
     let records: Vec<Value> = match event {
         Some(event) => statement
@@ -3018,6 +3060,17 @@ fn familiar_audit_response(
             "records": records,
         }),
     )
+}
+
+pub(crate) fn validate_ward_audit_event_tag(event: &str) -> Result<()> {
+    anyhow::ensure!(
+        !event.is_empty()
+            && event
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+        "Query parameter `event` must be a lowercase ASCII event tag containing only lowercase letters, digits, and `_`."
+    );
+    Ok(())
 }
 
 /// Lowercase hex of raw hash bytes for API payloads.
@@ -8894,6 +8947,32 @@ tier = 1
     }
 
     #[test]
+    fn familiar_audit_route_preserves_malformed_detail_as_detail_raw() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO ward_audit (
+                event_type, familiar_id, ward_hash, decision, detail, files_touched,
+                submitted_at, decided_at
+             ) VALUES ('apply_audit', 'sage', ?1, 'applied', ?2, '[]', ?3, ?3)",
+            rusqlite::params![
+                vec![0x11_u8; 32],
+                "{malformed detail",
+                "2026-07-26T00:00:00Z"
+            ],
+        )?;
+
+        let response = handle_request("GET", "/api/v1/familiars/sage/audit", home, None)?;
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert!(body["records"][0]["detail"].is_null());
+        assert_eq!(body["records"][0]["detailRaw"], "{malformed detail");
+        Ok(())
+    }
+
+    #[test]
     fn familiar_audit_route_fails_closed_on_unknown_and_bad_limit() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let home = temp.path();
@@ -8908,6 +8987,9 @@ tier = 1
             "/api/v1/familiars/sage/audit?limit=0",
             "/api/v1/familiars/sage/audit?limit=1001",
             "/api/v1/familiars/sage/audit?limit=abc",
+            "/api/v1/familiars/sage/audit?event=",
+            "/api/v1/familiars/sage/audit?event=ApplyAudit",
+            "/api/v1/familiars/sage/audit?event=apply%20audit",
         ] {
             let response = handle_request("GET", path, home, None)?;
             assert_eq!(response.status, 400, "path {path} got {}", response.body);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2931,6 +2931,15 @@ fn familiar_ward_response(coven_home: &Path, familiar_id: &str) -> Result<ApiRes
 
 const DEGRADED_WARD_CONFIG_UNPARSEABLE: &str = "ward-config-unparseable";
 
+fn normalize_ward_audit_tier(tier: Option<String>) -> Option<String> {
+    tier.map(|value| {
+        value
+            .parse::<u8>()
+            .map(|number| format!("tier_{number}"))
+            .unwrap_or(value)
+    })
+}
+
 /// `GET /familiars/{id}/audit` — the append-only `ward_audit` ledger for one
 /// familiar, newest first (#414; RFC-0001 §5.6).
 ///
@@ -2995,7 +3004,8 @@ fn familiar_audit_response(
 
     let conn = store::open_store(&store_path(coven_home))?;
     let mut sql = String::from(
-        "SELECT id, event_type, proposal_id, ward_version, ward_hash, tier,
+        "SELECT id, event_type, proposal_id, ward_version, ward_hash,
+                CAST(tier AS TEXT),
                 decision, approver, diff_hash, detail, files_touched, channel,
                 thread_id, submitted_at, decided_at, recorded_at
          FROM ward_audit WHERE familiar_id = ?1",
@@ -3007,6 +3017,7 @@ fn familiar_audit_response(
     let mut statement = conn.prepare(&sql)?;
     let map_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<Value> {
         let ward_hash: Vec<u8> = row.get(4)?;
+        let tier = normalize_ward_audit_tier(row.get(5)?);
         let diff_hash: Option<Vec<u8>> = row.get(8)?;
         let detail: Option<String> = row.get(9)?;
         let files_touched: String = row.get(10)?;
@@ -3033,7 +3044,7 @@ fn familiar_audit_response(
                 json!(row.get::<_, Option<String>>(3)?),
             ),
             ("wardHash".to_string(), json!(hex_string(&ward_hash))),
-            ("tier".to_string(), json!(row.get::<_, Option<String>>(5)?)),
+            ("tier".to_string(), json!(tier)),
             ("decision".to_string(), json!(row.get::<_, String>(6)?)),
             (
                 "approver".to_string(),
@@ -9005,6 +9016,28 @@ tier = 1
         let body: Value = serde_json::from_str(&response.body)?;
         assert!(body["records"][0]["detail"].is_null());
         assert_eq!(body["records"][0]["detailRaw"], "{malformed detail");
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_audit_route_normalizes_numeric_legacy_tier() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO ward_audit (
+                event_type, familiar_id, ward_hash, tier, decision, files_touched,
+                submitted_at, decided_at
+             ) VALUES ('proposal_submitted', 'sage', ?1, ?2, 'staged:coherence',
+                       '[]', ?3, ?3)",
+            rusqlite::params![vec![0x11_u8; 32], 1_i64, "2026-07-26T00:00:00Z"],
+        )?;
+
+        let response = handle_request("GET", "/api/v1/familiars/sage/audit", home, None)?;
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["records"][0]["tier"], "tier_1");
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -3070,6 +3070,13 @@ pub(crate) fn validate_ward_audit_event_tag(event: &str) -> Result<()> {
                 .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
         "Query parameter `event` must be a lowercase ASCII event tag containing only lowercase letters, digits, and `_`."
     );
+    anyhow::ensure!(
+        matches!(
+            event,
+            "apply_audit" | "proposal_submitted" | "validation_verdict"
+        ),
+        "Query parameter `event` must be one of `apply_audit`, `proposal_submitted`, or `validation_verdict`."
+    );
     Ok(())
 }
 
@@ -8990,6 +8997,7 @@ tier = 1
             "/api/v1/familiars/sage/audit?event=",
             "/api/v1/familiars/sage/audit?event=ApplyAudit",
             "/api/v1/familiars/sage/audit?event=apply%20audit",
+            "/api/v1/familiars/sage/audit?event=unknown_tag",
         ] {
             let response = handle_request("GET", path, home, None)?;
             assert_eq!(response.status, 400, "path {path} got {}", response.body);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -352,6 +352,14 @@ pub fn handle_request_with_runtime(
                 .trim_end_matches("/edits");
             apply_familiar_edits(coven_home, id, body)
         }
+        // The append-only ward_audit ledger for one familiar — where the
+        // /edits write path persists its Gate 4 apply records (#414).
+        ("GET", path) if path.starts_with("/familiars/") && path.ends_with("/audit") => {
+            let id = path
+                .trim_start_matches("/familiars/")
+                .trim_end_matches("/audit");
+            familiar_audit_response(coven_home, id, query)
+        }
         ("GET", "/threads/weaves") => threads_weaves_response(coven_home),
         ("GET", "/threads/proposals") => threads_proposals_response(coven_home, None),
         ("GET", path) if path.starts_with("/threads/proposals/") => {
@@ -2793,6 +2801,19 @@ fn apply_familiar_edits(
         );
     }
     advance_applied_protected_baselines(coven_home, familiar_id, &workspace, &report.changes)?;
+    // Gate 4 persistence (#414): the audit records returned to the client
+    // also land in the append-only ward_audit ledger, so applied writes stay
+    // observable across daemon restarts.
+    {
+        let conn = store::open_store(&store_path(coven_home))?;
+        crate::threads_gate::persist_apply_audit_records(
+            &conn,
+            familiar_id,
+            &workspace,
+            &config,
+            &report,
+        )?;
+    }
     json_response(
         200,
         &json!({
@@ -2890,6 +2911,116 @@ fn familiar_ward_response(coven_home: &Path, familiar_id: &str) -> Result<ApiRes
 }
 
 const DEGRADED_WARD_CONFIG_UNPARSEABLE: &str = "ward-config-unparseable";
+
+/// `GET /familiars/{id}/audit` — the append-only `ward_audit` ledger for one
+/// familiar, newest first (#414; RFC-0001 §5.6).
+///
+/// Read-side twin of the `/edits` write path's Gate 4 persistence: rows come
+/// straight from the store the write path appends to — no separate source of
+/// truth. Unlike `/ward` this endpoint does not require a live `ward.toml`:
+/// the ledger is append-only history and stays observable even after a
+/// familiar's Ward config is removed. Unknown familiars are structured 404s.
+///
+/// Query parameters: `limit` (rows, default 100, max 1000) and `event`
+/// (exact `event_type` filter, e.g. `apply_audit`).
+fn familiar_audit_response(
+    coven_home: &Path,
+    familiar_id: &str,
+    query: Option<&str>,
+) -> Result<ApiResponse> {
+    if familiar_id.is_empty() || familiar_id.contains('/') {
+        return api_error(
+            400,
+            "invalid_request",
+            "Familiar id is required and must not contain '/'.",
+            None,
+        );
+    }
+    if crate::familiar_identity::resolve(coven_home, familiar_id)?.is_none() {
+        return api_error(
+            404,
+            "familiar_not_found",
+            "No familiar with that id is declared in familiars.toml.",
+            Some(json!({ "id": familiar_id })),
+        );
+    }
+    let limit = match query.and_then(|q| query_param(q, "limit")) {
+        None => 100_i64,
+        Some(raw) => match raw.parse::<i64>() {
+            Ok(n) if (1..=1000).contains(&n) => n,
+            _ => {
+                return api_error(
+                    400,
+                    "invalid_request",
+                    "Query parameter `limit` must be an integer between 1 and 1000.",
+                    Some(json!({ "limit": raw })),
+                );
+            }
+        },
+    };
+    let event = query.and_then(|q| query_param(q, "event"));
+
+    let conn = store::open_store(&store_path(coven_home))?;
+    let mut sql = String::from(
+        "SELECT id, event_type, proposal_id, ward_version, ward_hash, tier,
+                decision, approver, diff_hash, detail, files_touched, channel,
+                thread_id, submitted_at, decided_at, recorded_at
+         FROM ward_audit WHERE familiar_id = ?1",
+    );
+    if event.is_some() {
+        sql.push_str(" AND event_type = ?3");
+    }
+    sql.push_str(" ORDER BY id DESC LIMIT ?2");
+    let mut statement = conn.prepare(&sql)?;
+    let map_row = |row: &rusqlite::Row<'_>| -> rusqlite::Result<Value> {
+        let ward_hash: Vec<u8> = row.get(4)?;
+        let diff_hash: Option<Vec<u8>> = row.get(8)?;
+        let detail: Option<String> = row.get(9)?;
+        let files_touched: String = row.get(10)?;
+        Ok(json!({
+            "id": row.get::<_, i64>(0)?,
+            "eventType": row.get::<_, String>(1)?,
+            "proposalId": row.get::<_, Option<String>>(2)?,
+            "wardVersion": row.get::<_, Option<String>>(3)?,
+            "wardHash": hex_string(&ward_hash),
+            "tier": row.get::<_, Option<String>>(5)?,
+            "decision": row.get::<_, String>(6)?,
+            "approver": row.get::<_, Option<String>>(7)?,
+            "diffSha256": diff_hash.as_deref().map(hex_string),
+            "detail": detail
+                .as_deref()
+                .map(|raw| serde_json::from_str(raw).unwrap_or(Value::Null)),
+            "filesTouched": serde_json::from_str::<Value>(&files_touched)
+                .unwrap_or(Value::Null),
+            "channel": row.get::<_, Option<String>>(11)?,
+            "threadId": row.get::<_, Option<String>>(12)?,
+            "submittedAt": row.get::<_, String>(13)?,
+            "decidedAt": row.get::<_, String>(14)?,
+            "recordedAt": row.get::<_, String>(15)?,
+        }))
+    };
+    let records: Vec<Value> = match event {
+        Some(event) => statement
+            .query_map(rusqlite::params![familiar_id, limit, event], map_row)?
+            .collect::<rusqlite::Result<_>>()?,
+        None => statement
+            .query_map(rusqlite::params![familiar_id, limit], map_row)?
+            .collect::<rusqlite::Result<_>>()?,
+    };
+    json_response(
+        200,
+        &json!({
+            "ok": true,
+            "familiarId": familiar_id,
+            "records": records,
+        }),
+    )
+}
+
+/// Lowercase hex of raw hash bytes for API payloads.
+fn hex_string(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
 
 /// `GET /api/v1/threads/proposals[/:id]` — the pending-proposal read surface
 /// (Gate 3 PR 3, `docs/design/ward-gate3-coherence.md` G3.3).
@@ -8601,6 +8732,164 @@ tier = 1
     }
 
     #[test]
+    fn post_familiar_edits_persists_apply_audit_rows_across_reopen() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        let first = post_edits(
+            home,
+            r#"{"edits":[{"target":"notes/today.md","contents":"hello ward"}]}"#,
+        )?;
+        assert_eq!(first.status, 200, "got {}", first.body);
+        let first_body: Value = serde_json::from_str(&first.body)?;
+        let first_next = first_body["changes"][0]["audit"]["nextSha256"]
+            .as_str()
+            .expect("apply response carries nextSha256")
+            .to_string();
+
+        // A fresh store connection stands in for a daemon restart: the rows
+        // must come from disk, not the in-memory ApplyReport.
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        let (tier, decision, diff_hash, detail, files_touched): (
+            String,
+            String,
+            Vec<u8>,
+            String,
+            String,
+        ) = conn.query_row(
+            "SELECT tier, decision, diff_hash, detail, files_touched
+             FROM ward_audit WHERE event_type = 'apply_audit' AND familiar_id = 'sage'",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )?;
+        assert_eq!(tier, "tier_2");
+        assert_eq!(decision, "applied");
+        assert_eq!(hex_string(&diff_hash), first_next);
+        let detail: Value = serde_json::from_str(&detail)?;
+        assert!(detail["prev_sha256"].is_null(), "created file has no prev");
+        assert_eq!(detail["bytes_written"], "hello ward".len() as u64);
+        assert_eq!(
+            serde_json::from_str::<Value>(&files_touched)?,
+            serde_json::json!(["notes/today.md"])
+        );
+
+        // Overwrite: the second row's prev must chain to the first's next.
+        let second = post_edits(
+            home,
+            r#"{"edits":[{"target":"notes/today.md","contents":"hello again"}]}"#,
+        )?;
+        assert_eq!(second.status, 200, "got {}", second.body);
+        let second_detail: String = conn.query_row(
+            "SELECT detail FROM ward_audit
+             WHERE event_type = 'apply_audit' ORDER BY id DESC LIMIT 1",
+            [],
+            |row| row.get(0),
+        )?;
+        let second_detail: Value = serde_json::from_str(&second_detail)?;
+        assert_eq!(second_detail["prev_sha256"], Value::String(first_next));
+
+        // The ledger stays append-only under the new event type.
+        let tampered = conn.execute(
+            "UPDATE ward_audit SET decision = 'forged' WHERE event_type = 'apply_audit'",
+            [],
+        );
+        assert!(
+            tampered.is_err(),
+            "append-only trigger must abort UPDATEs on apply_audit rows"
+        );
+        Ok(())
+    }
+
+    // ---- GET /api/v1/familiars/{id}/audit (ward_audit read surface) -------
+
+    #[test]
+    fn familiar_audit_route_serves_ledger_rows_newest_first() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        let response = handle_request("GET", "/api/v1/familiars/sage/audit", home, None)?;
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["records"], serde_json::json!([]));
+
+        post_edits(
+            home,
+            r#"{"edits":[{"target":"notes/a.md","contents":"one"}]}"#,
+        )?;
+        post_edits(
+            home,
+            r#"{"edits":[{"target":"notes/b.md","contents":"two"}]}"#,
+        )?;
+
+        let response = handle_request(
+            "GET",
+            "/api/v1/familiars/sage/audit?event=apply_audit",
+            home,
+            None,
+        )?;
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        let records = body["records"].as_array().expect("records array");
+        assert_eq!(records.len(), 2);
+        // Newest first: the second write leads.
+        assert_eq!(
+            records[0]["filesTouched"],
+            serde_json::json!(["notes/b.md"])
+        );
+        assert_eq!(records[0]["eventType"], "apply_audit");
+        assert_eq!(records[0]["tier"], "tier_2");
+        assert_eq!(records[0]["decision"], "applied");
+        assert_eq!(records[0]["channel"], "mutation");
+        assert!(records[0]["diffSha256"].is_string());
+        assert_eq!(records[0]["detail"]["bytes_written"], 3);
+
+        let limited = handle_request(
+            "GET",
+            "/api/v1/familiars/sage/audit?event=apply_audit&limit=1",
+            home,
+            None,
+        )?;
+        let body: Value = serde_json::from_str(&limited.body)?;
+        assert_eq!(body["records"].as_array().map(Vec::len), Some(1));
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_audit_route_fails_closed_on_unknown_and_bad_limit() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        let response = handle_request("GET", "/api/v1/familiars/ghost/audit", home, None)?;
+        assert_eq!(response.status, 404, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "familiar_not_found");
+
+        for path in [
+            "/api/v1/familiars/sage/audit?limit=0",
+            "/api/v1/familiars/sage/audit?limit=1001",
+            "/api/v1/familiars/sage/audit?limit=abc",
+        ] {
+            let response = handle_request("GET", path, home, None)?;
+            assert_eq!(response.status, 400, "path {path} got {}", response.body);
+            let body: Value = serde_json::from_str(&response.body)?;
+            assert_eq!(body["error"]["code"], "invalid_request");
+        }
+        Ok(())
+    }
+
+    #[test]
     fn post_familiar_edits_refuses_traversal_and_writes_nothing() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let home = temp.path();
@@ -8789,7 +9078,8 @@ tier = 1
     #[test]
     fn post_familiar_edits_editable_tier_bypasses_the_weave() -> Result<()> {
         // Editable-tier writes are the Ward tiers' lane: the weave reports no
-        // verdicts and appends nothing to ward_audit.
+        // verdicts and appends no validation rows to ward_audit. Gate 4
+        // persistence (#414) still appends the applied write's audit record.
         let temp = tempfile::tempdir()?;
         let home = temp.path();
         seed_warded_familiar(home)?;
@@ -8804,8 +9094,18 @@ tier = 1
             Some(0)
         );
         let conn = store::open_store(&home.join("coven.sqlite3"))?;
-        let count: i64 = conn.query_row("SELECT COUNT(*) FROM ward_audit", [], |row| row.get(0))?;
-        assert_eq!(count, 0);
+        let verdict_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM ward_audit WHERE event_type = 'validation_verdict'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(verdict_count, 0, "weave must not adjudicate editable tiers");
+        let apply_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM ward_audit WHERE event_type = 'apply_audit'",
+            [],
+            |row| row.get(0),
+        )?;
+        assert_eq!(apply_count, 1, "applied tier-2 write must persist Gate 4");
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2804,15 +2804,33 @@ fn apply_familiar_edits(
     // also land in the append-only ward_audit ledger, so applied writes stay
     // observable across daemon restarts. Persist before advancing protected
     // baselines so a post-write failure is less likely to leave an audit gap.
+    // On persistence failure, return a structured 500 that includes the applied
+    // changes so clients can distinguish "write applied, audit failed" from a
+    // full failure and avoid blind retries that would produce duplicate writes.
     {
         let mut conn = store::open_store(&store_path(coven_home))?;
-        crate::threads_gate::persist_apply_audit_records(
+        if let Err(err) = crate::threads_gate::persist_apply_audit_records(
             &mut conn,
             familiar_id,
             &workspace,
             &config,
             &report,
-        )?;
+        ) {
+            return json_response(
+                500,
+                &json!({
+                    "error": {
+                        "code": "audit_persist_failed",
+                        "message": format!(
+                            "The file write was applied but the audit ledger \
+                             could not be updated: {err:#}"
+                        ),
+                        "details": { "writeApplied": true },
+                    },
+                    "changes": changes,
+                }),
+            );
+        }
     }
     advance_applied_protected_baselines(coven_home, familiar_id, &workspace, &report.changes)?;
     json_response(

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2805,9 +2805,9 @@ fn apply_familiar_edits(
     // also land in the append-only ward_audit ledger, so applied writes stay
     // observable across daemon restarts.
     {
-        let conn = store::open_store(&store_path(coven_home))?;
+        let mut conn = store::open_store(&store_path(coven_home))?;
         crate::threads_gate::persist_apply_audit_records(
-            &conn,
+            &mut conn,
             familiar_id,
             &workspace,
             &config,
@@ -2977,6 +2977,10 @@ fn familiar_audit_response(
         let diff_hash: Option<Vec<u8>> = row.get(8)?;
         let detail: Option<String> = row.get(9)?;
         let files_touched: String = row.get(10)?;
+        let files_touched = serde_json::from_str::<Value>(&files_touched)
+            .ok()
+            .filter(Value::is_array)
+            .unwrap_or_else(|| json!([]));
         Ok(json!({
             "id": row.get::<_, i64>(0)?,
             "eventType": row.get::<_, String>(1)?,
@@ -2990,8 +2994,7 @@ fn familiar_audit_response(
             "detail": detail
                 .as_deref()
                 .map(|raw| serde_json::from_str(raw).unwrap_or(Value::Null)),
-            "filesTouched": serde_json::from_str::<Value>(&files_touched)
-                .unwrap_or(Value::Null),
+            "filesTouched": files_touched,
             "channel": row.get::<_, Option<String>>(11)?,
             "threadId": row.get::<_, Option<String>>(12)?,
             "submittedAt": row.get::<_, String>(13)?,
@@ -8862,6 +8865,31 @@ tier = 1
         )?;
         let body: Value = serde_json::from_str(&limited.body)?;
         assert_eq!(body["records"].as_array().map(Vec::len), Some(1));
+        Ok(())
+    }
+
+    #[test]
+    fn familiar_audit_route_keeps_files_touched_an_array_for_malformed_legacy_json() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+        let conn = store::open_store(&home.join("coven.sqlite3"))?;
+        conn.execute(
+            "INSERT INTO ward_audit (
+                event_type, familiar_id, ward_hash, decision, files_touched,
+                submitted_at, decided_at
+             ) VALUES ('apply_audit', 'sage', ?1, 'applied', ?2, ?3, ?3)",
+            rusqlite::params![
+                vec![0x11_u8; 32],
+                "{malformed legacy json",
+                "2026-07-26T00:00:00Z"
+            ],
+        )?;
+
+        let response = handle_request("GET", "/api/v1/familiars/sage/audit", home, None)?;
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["records"][0]["filesTouched"], serde_json::json!([]));
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -711,7 +711,7 @@ enum WardCommand {
         #[arg(
             long,
             value_name = "TYPE",
-            help = "Only rows with this event type (e.g. apply_audit, validation_verdict)"
+            help = "Only rows with this event type (apply_audit, proposal_submitted, validation_verdict)"
         )]
         event: Option<String>,
         #[arg(long, help = "Print the ledger as JSON (machine-readable)")]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -711,7 +711,7 @@ enum WardCommand {
         #[arg(
             long,
             value_name = "TYPE",
-            help = "Only rows with this event type (apply_audit, proposal_submitted, validation_verdict)"
+            help = "Only rows with this event type (proposal_submitted, proposal_window_opened, proposal_approved, proposal_rejected, proposal_vetoed, ward_updated, memory_entry_admitted, principal_authorized_write, validation_verdict, compaction_ledger, apply_audit)"
         )]
         event: Option<String>,
         #[arg(long, help = "Print the ledger as JSON (machine-readable)")]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -698,6 +698,25 @@ enum WardCommand {
         #[arg(long, help = "Print proposals as JSON (machine-readable)")]
         json: bool,
     },
+    #[command(about = "Show the append-only ward_audit ledger for one familiar")]
+    Audit {
+        #[arg(help = "Familiar id (familiars.toml key)")]
+        familiar: String,
+        #[arg(
+            long,
+            value_name = "N",
+            help = "Maximum rows to show, newest first (default 100, max 1000)"
+        )]
+        limit: Option<u32>,
+        #[arg(
+            long,
+            value_name = "TYPE",
+            help = "Only rows with this event type (e.g. apply_audit, validation_verdict)"
+        )]
+        event: Option<String>,
+        #[arg(long, help = "Print the ledger as JSON (machine-readable)")]
+        json: bool,
+    },
     #[command(about = "Migrate Ward v0.1 ward.toml files to Phase-2 WardConfig")]
     Migrate {
         #[arg(long, value_name = "ID", help = "Only migrate the named familiar")]
@@ -2856,6 +2875,14 @@ fn run_ward_command(command: WardCommand) -> Result<()> {
     match command {
         WardCommand::Pending { id, json } => {
             return observe::run_ward_pending(id.as_deref(), json);
+        }
+        WardCommand::Audit {
+            familiar,
+            limit,
+            event,
+            json,
+        } => {
+            return observe::run_ward_audit(&familiar, limit, event.as_deref(), json);
         }
         WardCommand::Migrate {
             familiar,

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -618,13 +618,8 @@ fn ward_audit_path(familiar_id: &str, limit: Option<u32>, event: Option<&str>) -
         params.push(format!("limit={limit}"));
     }
     if let Some(event) = event {
-        anyhow::ensure!(
-            !event.is_empty()
-                && event
-                    .bytes()
-                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
-            "--event must be a lowercase ASCII event tag containing only letters, digits, and `_`"
-        );
+        crate::api::validate_ward_audit_event_tag(event)
+            .map_err(|_| anyhow::anyhow!("--event must be a lowercase ASCII event tag containing only lowercase letters, digits, and `_`"))?;
         params.push(format!("event={event}"));
     }
     if !params.is_empty() {

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -602,24 +602,36 @@ pub(crate) fn run_ward_audit(
     json: bool,
 ) -> Result<()> {
     let coven_home = coven_home_dir()?;
-    let mut path = format!("/api/v1/familiars/{familiar_id}/audit");
-    let mut params = Vec::new();
-    if let Some(limit) = limit {
-        params.push(format!("limit={limit}"));
-    }
-    if let Some(event) = event {
-        params.push(format!("event={event}"));
-    }
-    if !params.is_empty() {
-        path.push('?');
-        path.push_str(&params.join("&"));
-    }
+    let path = ward_audit_path(familiar_id, limit, event)?;
     let body = api_get(&coven_home, &path)?;
     if json {
         return print_json(&body);
     }
     print!("{}", render_ward_audit(&body));
     Ok(())
+}
+
+fn ward_audit_path(familiar_id: &str, limit: Option<u32>, event: Option<&str>) -> Result<String> {
+    let mut path = format!("/api/v1/familiars/{familiar_id}/audit");
+    let mut params = Vec::new();
+    if let Some(limit) = limit {
+        params.push(format!("limit={limit}"));
+    }
+    if let Some(event) = event {
+        anyhow::ensure!(
+            !event.is_empty()
+                && event
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_'),
+            "--event must be a lowercase ASCII event tag containing only letters, digits, and `_`"
+        );
+        params.push(format!("event={event}"));
+    }
+    if !params.is_empty() {
+        path.push('?');
+        path.push_str(&params.join("&"));
+    }
+    Ok(path)
 }
 
 fn render_ward_audit(body: &Value) -> String {
@@ -1454,6 +1466,20 @@ fn resolve_full_session_id(reference: &str) -> Result<String> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn ward_audit_path_rejects_ambiguous_event_query_values() {
+        for event in [
+            "apply_audit&limit=1",
+            "apply_audit=1",
+            "apply audit",
+            "äpply",
+        ] {
+            let error = ward_audit_path("sage", Some(10), Some(event))
+                .expect_err("unsafe event query value must be rejected");
+            assert!(error.to_string().contains("--event"), "{event}: {error:#}");
+        }
+    }
 
     #[test]
     fn render_table_pads_columns_and_trims_trailing_space() {

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -619,9 +619,7 @@ fn ward_audit_path(familiar_id: &str, limit: Option<u32>, event: Option<&str>) -
     }
     if let Some(event) = event {
         crate::api::validate_ward_audit_event_tag(event)
-            .with_context(|| {
-                "--event must be a known lowercase ASCII event tag (`apply_audit`, `proposal_submitted`, or `validation_verdict`)"
-            })?;
+            .with_context(|| "--event must be a known lowercase ASCII ward_audit event tag")?;
         params.push(format!("event={event}"));
     }
     if !params.is_empty() {
@@ -639,7 +637,7 @@ fn render_ward_audit(body: &Value) -> String {
         .unwrap_or_default();
     if records.is_empty() {
         return concat!(
-            "No ward_audit rows for this familiar.\n",
+            "No matching ward_audit rows.\n",
             "Applied Tier-2 writes, gate verdicts, and proposal events land here\n",
             "(append-only, RFC-0001 §5.6).\n"
         )
@@ -1477,6 +1475,13 @@ mod tests {
                 .expect_err("unsafe event query value must be rejected");
             assert!(error.to_string().contains("--event"), "{event}: {error:#}");
         }
+    }
+
+    #[test]
+    fn render_ward_audit_empty_output_is_filter_safe() {
+        let output = render_ward_audit(&json!({ "records": [] }));
+
+        assert!(output.starts_with("No matching ward_audit rows.\n"));
     }
 
     #[test]

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -593,6 +593,85 @@ fn render_ward_proposal(proposal: &Value) -> String {
     out
 }
 
+// ── coven ward audit ─────────────────────────────────────────────────────────
+
+pub(crate) fn run_ward_audit(
+    familiar_id: &str,
+    limit: Option<u32>,
+    event: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let coven_home = coven_home_dir()?;
+    let mut path = format!("/api/v1/familiars/{familiar_id}/audit");
+    let mut params = Vec::new();
+    if let Some(limit) = limit {
+        params.push(format!("limit={limit}"));
+    }
+    if let Some(event) = event {
+        params.push(format!("event={event}"));
+    }
+    if !params.is_empty() {
+        path.push('?');
+        path.push_str(&params.join("&"));
+    }
+    let body = api_get(&coven_home, &path)?;
+    if json {
+        return print_json(&body);
+    }
+    print!("{}", render_ward_audit(&body));
+    Ok(())
+}
+
+fn render_ward_audit(body: &Value) -> String {
+    let records = body
+        .get("records")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if records.is_empty() {
+        return concat!(
+            "No ward_audit rows for this familiar.\n",
+            "Applied Tier-2 writes, gate verdicts, and proposal events land here\n",
+            "(append-only, RFC-0001 §5.6).\n"
+        )
+        .to_string();
+    }
+    let rows: Vec<Vec<String>> = records
+        .iter()
+        .map(|record| {
+            let surfaces = record
+                .get("filesTouched")
+                .and_then(Value::as_array)
+                .map(|files| {
+                    files
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .unwrap_or_default();
+            vec![
+                record
+                    .get("id")
+                    .and_then(Value::as_i64)
+                    .map(|id| id.to_string())
+                    .unwrap_or_else(|| "—".to_string()),
+                str_cell(record, "eventType"),
+                str_cell(record, "tier"),
+                str_cell(record, "decision"),
+                theme::fit_chars(&surfaces, TEXT_CELL_LIMIT),
+                str_cell(record, "decidedAt"),
+            ]
+        })
+        .collect();
+    let mut out = render_table(
+        &["ID", "EVENT", "TIER", "DECISION", "SURFACES", "DECIDED"],
+        &rows,
+    );
+    out.push_str(&format!("\n{} audit row(s), newest first\n", records.len()));
+    out
+}
+
 // ── coven calls ──────────────────────────────────────────────────────────────
 
 pub(crate) fn run_calls(id: Option<&str>, json: bool) -> Result<()> {

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -612,6 +612,17 @@ pub(crate) fn run_ward_audit(
 }
 
 fn ward_audit_path(familiar_id: &str, limit: Option<u32>, event: Option<&str>) -> Result<String> {
+    if familiar_id.is_empty()
+        || familiar_id.bytes().any(|byte| {
+            byte.is_ascii_whitespace()
+                || byte.is_ascii_control()
+                || matches!(byte, b'/' | b'\\' | b'?' | b'#' | b'%')
+        })
+    {
+        bail!(
+            "familiar id must be a non-empty URL path segment without delimiters, whitespace, or control characters"
+        );
+    }
     let mut path = format!("/api/v1/familiars/{familiar_id}/audit");
     let mut params = Vec::new();
     if let Some(limit) = limit {
@@ -1474,6 +1485,25 @@ mod tests {
             let error = ward_audit_path("sage", Some(10), Some(event))
                 .expect_err("unsafe event query value must be rejected");
             assert!(error.to_string().contains("--event"), "{event}: {error:#}");
+        }
+    }
+
+    #[test]
+    fn ward_audit_path_rejects_ambiguous_familiar_path_segments() {
+        for familiar_id in [
+            "",
+            "sa/ge",
+            "sage?limit=1",
+            "sage#fragment",
+            "sage%2Faudit",
+            "sage name",
+        ] {
+            let error = ward_audit_path(familiar_id, None, None)
+                .expect_err("unsafe familiar path segment must be rejected");
+            assert!(
+                error.to_string().contains("familiar id"),
+                "{familiar_id}: {error:#}"
+            );
         }
     }
 

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -619,7 +619,9 @@ fn ward_audit_path(familiar_id: &str, limit: Option<u32>, event: Option<&str>) -
     }
     if let Some(event) = event {
         crate::api::validate_ward_audit_event_tag(event)
-            .map_err(|_| anyhow::anyhow!("--event must be a lowercase ASCII event tag containing only lowercase letters, digits, and `_`"))?;
+            .with_context(|| {
+                "--event must be a known lowercase ASCII event tag (`apply_audit`, `proposal_submitted`, or `validation_verdict`)"
+            })?;
         params.push(format!("event={event}"));
     }
     if !params.is_empty() {
@@ -1469,6 +1471,7 @@ mod tests {
             "apply_audit=1",
             "apply audit",
             "äpply",
+            "unknown_tag",
         ] {
             let error = ward_audit_path("sage", Some(10), Some(event))
                 .expect_err("unsafe event query value must be rejected");

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -616,7 +616,7 @@ pub(crate) fn append_audit_row(
 /// (`{"prev_sha256":…,"bytes_written":…}`). The weave view is read-only:
 /// persisting audit rows must not bootstrap baselines.
 pub fn persist_apply_audit_records(
-    conn: &Connection,
+    conn: &mut Connection,
     familiar_id: &str,
     workspace: &Path,
     config: &ward::WardConfig,
@@ -630,62 +630,74 @@ pub fn persist_apply_audit_records(
     let now = time::OffsetDateTime::now_utc();
     let format = time::format_description::well_known::Rfc3339;
     let now_text = now.format(&format)?;
-    for audit in records {
-        let prev = audit
-            .prev_sha256
-            .as_deref()
-            .map(hex_to_bytes)
-            .transpose()
-            .context("decoding apply-audit prev_sha256")?;
-        let next = hex_to_bytes(&audit.next_sha256).context("decoding apply-audit next_sha256")?;
-        let record = threads::WardAuditRecord::for_apply(
-            state.familiar_uuid,
-            state.weave.weave_hash(),
-            threads::SurfaceId::new(audit.resolved.clone()),
-            &format!("tier_{}", u8::from(audit.tier)),
-            prev.as_deref(),
-            Some(&next),
-            audit.bytes_written as u64,
-            Some(threads::Channel::Mutation),
-            now,
-            now,
-        );
-        let files_touched = serde_json::to_string(
-            &record
-                .files_touched
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<_>>(),
-        )?;
-        conn.execute(
+    let transaction = conn
+        .transaction()
+        .context("starting apply-audit batch transaction")?;
+    {
+        let mut statement = transaction.prepare(
             "INSERT INTO ward_audit (
                 event_type, proposal_id, familiar_id, ward_version, ward_hash,
                 tier, decision, approver, diff_hash, detail, files_touched,
                 channel, submitted_at, decided_at
             ) VALUES (?1, NULL, ?2, NULL, ?3, ?4, ?5, NULL, ?6, ?7, ?8, ?9, ?10, ?10)",
-            params![
-                record.event_type.tag(),
-                // Human-readable familiar id in the store; the uuid rides in
-                // the JSON record shape for cross-system correlation.
-                familiar_id,
-                record.ward_hash,
-                record.tier,
-                record.decision,
-                record.diff_hash,
-                record.detail,
-                files_touched,
-                record.channel.map(|c| format!("{c:?}").to_lowercase()),
-                now_text,
-            ],
-        )
-        .context("appending apply_audit row")?;
+        )?;
+        for audit in records {
+            let prev = audit
+                .prev_sha256
+                .as_deref()
+                .map(hex_to_bytes)
+                .transpose()
+                .context("decoding apply-audit prev_sha256")?;
+            let next =
+                hex_to_bytes(&audit.next_sha256).context("decoding apply-audit next_sha256")?;
+            let record = threads::WardAuditRecord::for_apply(
+                state.familiar_uuid,
+                state.weave.weave_hash(),
+                threads::SurfaceId::new(audit.resolved.clone()),
+                &format!("tier_{}", u8::from(audit.tier)),
+                prev.as_deref(),
+                Some(&next),
+                audit.bytes_written as u64,
+                Some(threads::Channel::Mutation),
+                now,
+                now,
+            );
+            let files_touched = serde_json::to_string(
+                &record
+                    .files_touched
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>(),
+            )?;
+            statement
+                .execute(params![
+                    record.event_type.tag(),
+                    // Human-readable familiar id in the store; the uuid rides in
+                    // the JSON record shape for cross-system correlation.
+                    familiar_id,
+                    record.ward_hash,
+                    record.tier,
+                    record.decision,
+                    record.diff_hash,
+                    record.detail,
+                    files_touched,
+                    record.channel.map(|c| format!("{c:?}").to_lowercase()),
+                    now_text,
+                ])
+                .context("appending apply_audit row")?;
+        }
     }
-    Ok(())
+    transaction
+        .commit()
+        .context("committing apply-audit batch transaction")
 }
 
 /// Decode a hex digest into raw bytes. The Ward emits SHA-256 hex strings;
 /// the `ward_audit` ledger stores raw bytes (`diff_hash BLOB`).
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
+    if !hex.is_ascii() {
+        anyhow::bail!("non-ASCII hex digest `{hex}`");
+    }
     if !hex.len().is_multiple_of(2) {
         anyhow::bail!("odd-length hex digest `{hex}`");
     }
@@ -891,6 +903,53 @@ tier = 2
 
     fn signed() -> ward::Authorization {
         ward::Authorization::signed_by("fp-val-1")
+    }
+
+    #[test]
+    fn hex_to_bytes_rejects_non_ascii_without_panicking() {
+        let error = hex_to_bytes("0éx").expect_err("non-ASCII hex must be rejected");
+        assert!(error.to_string().contains("non-ASCII"), "{error:#}");
+    }
+
+    #[test]
+    fn persist_apply_audit_records_rolls_back_the_batch_on_insert_failure() {
+        let mut f = fixture();
+        let config = ward_config();
+        let ward = ward::Ward::new(f.workspace.clone(), config.clone()).unwrap();
+        let report = ward
+            .apply(
+                &[
+                    ward::FileEdit::new("notes/a.md", "one"),
+                    ward::FileEdit::new("notes/b.md", "two"),
+                ],
+                &ward::Authorization::unsigned(),
+            )
+            .unwrap();
+        f.conn
+            .execute_batch(
+                r#"
+                CREATE TRIGGER fail_second_apply_audit
+                BEFORE INSERT ON ward_audit
+                WHEN NEW.files_touched = '["notes/b.md"]'
+                BEGIN
+                    SELECT RAISE(ABORT, 'injected second-row failure');
+                END;
+                "#,
+            )
+            .unwrap();
+
+        let result =
+            persist_apply_audit_records(&mut f.conn, "sage", &f.workspace, &config, &report);
+        assert!(result.is_err(), "injected insert failure must surface");
+        let count: i64 = f
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM ward_audit WHERE event_type = 'apply_audit'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0, "the failed batch must leave no partial rows");
     }
 
     fn soul_edit() -> Vec<ward::FileEdit> {

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -698,8 +698,8 @@ fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
     if !hex.is_ascii() {
         anyhow::bail!("non-ASCII hex digest `{hex}`");
     }
-    if !hex.len().is_multiple_of(2) {
-        anyhow::bail!("odd-length hex digest `{hex}`");
+    if hex.len() != 64 {
+        anyhow::bail!("expected 64-character SHA-256 hex digest, got `{hex}`");
     }
     (0..hex.len())
         .step_by(2)
@@ -909,6 +909,12 @@ tier = 2
     fn hex_to_bytes_rejects_non_ascii_without_panicking() {
         let error = hex_to_bytes("0éx").expect_err("non-ASCII hex must be rejected");
         assert!(error.to_string().contains("non-ASCII"), "{error:#}");
+    }
+
+    #[test]
+    fn hex_to_bytes_rejects_non_sha256_lengths() {
+        let error = hex_to_bytes("abcd").expect_err("non-SHA-256 digest must be rejected");
+        assert!(error.to_string().contains("64-character"), "{error:#}");
     }
 
     #[test]

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -606,6 +606,98 @@ pub(crate) fn append_audit_row(
     Ok(())
 }
 
+/// Persist the Ward's Gate-4 apply records into the append-only `ward_audit`
+/// ledger (#414; RFC-0001 §5.6, coven-threads#5).
+///
+/// One `apply_audit` row per written change that carries an
+/// [`ward::AuditRecord`] (Tier-2 logged writes). Following the upstream
+/// `WardAuditRecord::for_apply` contract, `diff_hash` carries the post-write
+/// SHA-256 and the pre-write hash plus byte count ride in the `detail` JSON
+/// (`{"prev_sha256":…,"bytes_written":…}`). The weave view is read-only:
+/// persisting audit rows must not bootstrap baselines.
+pub fn persist_apply_audit_records(
+    conn: &Connection,
+    familiar_id: &str,
+    workspace: &Path,
+    config: &ward::WardConfig,
+    report: &ward::ApplyReport,
+) -> Result<()> {
+    let mut records = report.audit_records().peekable();
+    if records.peek().is_none() {
+        return Ok(());
+    }
+    let state = build_weave_state(conn, familiar_id, workspace, config, &[], false)?;
+    let now = time::OffsetDateTime::now_utc();
+    let format = time::format_description::well_known::Rfc3339;
+    let now_text = now.format(&format)?;
+    for audit in records {
+        let prev = audit
+            .prev_sha256
+            .as_deref()
+            .map(hex_to_bytes)
+            .transpose()
+            .context("decoding apply-audit prev_sha256")?;
+        let next = hex_to_bytes(&audit.next_sha256).context("decoding apply-audit next_sha256")?;
+        let record = threads::WardAuditRecord::for_apply(
+            state.familiar_uuid,
+            state.weave.weave_hash(),
+            threads::SurfaceId::new(audit.resolved.clone()),
+            &format!("tier_{}", u8::from(audit.tier)),
+            prev.as_deref(),
+            Some(&next),
+            audit.bytes_written as u64,
+            Some(threads::Channel::Mutation),
+            now,
+            now,
+        );
+        let files_touched = serde_json::to_string(
+            &record
+                .files_touched
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+        )?;
+        conn.execute(
+            "INSERT INTO ward_audit (
+                event_type, proposal_id, familiar_id, ward_version, ward_hash,
+                tier, decision, approver, diff_hash, detail, files_touched,
+                channel, submitted_at, decided_at
+            ) VALUES (?1, NULL, ?2, NULL, ?3, ?4, ?5, NULL, ?6, ?7, ?8, ?9, ?10, ?10)",
+            params![
+                record.event_type.tag(),
+                // Human-readable familiar id in the store; the uuid rides in
+                // the JSON record shape for cross-system correlation.
+                familiar_id,
+                record.ward_hash,
+                record.tier,
+                record.decision,
+                record.diff_hash,
+                record.detail,
+                files_touched,
+                record.channel.map(|c| format!("{c:?}").to_lowercase()),
+                now_text,
+            ],
+        )
+        .context("appending apply_audit row")?;
+    }
+    Ok(())
+}
+
+/// Decode a hex digest into raw bytes. The Ward emits SHA-256 hex strings;
+/// the `ward_audit` ledger stores raw bytes (`diff_hash BLOB`).
+fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
+    if !hex.len().is_multiple_of(2) {
+        anyhow::bail!("odd-length hex digest `{hex}`");
+    }
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| {
+            u8::from_str_radix(&hex[i..i + 2], 16)
+                .with_context(|| format!("invalid hex digest `{hex}`"))
+        })
+        .collect()
+}
+
 /// Stage a proposal held **solely** for Gate-3 coherence review (Tier-1
 /// targets) as a pending proposal beside the Tier-0 authority lane
 /// (`docs/design/ward-gate3-coherence.md` G3.1).

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -696,17 +696,14 @@ pub fn persist_apply_audit_records(
 /// the `ward_audit` ledger stores raw bytes (`diff_hash BLOB`).
 fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
     if !hex.is_ascii() {
-        anyhow::bail!("non-ASCII hex digest `{hex}`");
+        anyhow::bail!("non-ASCII hex digest");
     }
     if hex.len() != 64 {
-        anyhow::bail!("expected 64-character SHA-256 hex digest, got `{hex}`");
+        anyhow::bail!("expected 64-character SHA-256 hex digest");
     }
     (0..hex.len())
         .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&hex[i..i + 2], 16)
-                .with_context(|| format!("invalid hex digest `{hex}`"))
-        })
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).context("invalid hex digest"))
         .collect()
 }
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,7 @@ These power `coven status`, `coven familiars`, `coven skills`, `coven memory`, `
 | GET | `/api/v1/overview` | Dashboard aggregate: open sessions, roster/skill/research counts. | overview object |
 | GET | `/api/v1/familiars` | Familiar roster from `familiars.toml`. | `FamiliarDto[]` |
 | GET | `/api/v1/familiars/:id/ward` | One familiar's declared Ward surface (tiers, protected paths, principal binding) — the read twin of `/familiars/:id/edits`. | `{ ok, familiarId, workspace, ward }` · `400 invalid_request` / `404 familiar_not_found` / `404 ward_not_configured` / `500 ward_config_invalid` |
+| GET | `/api/v1/familiars/:id/audit` | The append-only `ward_audit` ledger for one familiar, newest first — where `/edits` persists its Gate 4 apply records. `?limit=N` (default 100, max 1000), `?event=TYPE` (e.g. `apply_audit`). | `{ ok, familiarId, records }` · `400 invalid_request` / `404 familiar_not_found` |
 | GET | `/api/v1/skills` | Installed skills from `~/.coven/skills/`. | `SkillDto[]` |
 | GET | `/api/v1/memory` | Familiar memory files from `~/.coven/memory/`. | memory list |
 | GET | `/api/v1/research` | Research loop log rows. | research list |
@@ -75,7 +76,7 @@ These power `coven status`, `coven familiars`, `coven skills`, `coven memory`, `
 |---|---|---|---|---|
 | POST | `/api/v1/cast` | Submit a cast line (status/delegation shorthand) to the cockpit session. | `202 { accepted, cast_id, echo }` | `400 invalid_request` |
 | PUT | `/api/v1/familiars/:id/icon` | Update a familiar's icon glyph. | updated familiar | `400`, `404` |
-| POST | `/api/v1/familiars/:id/edits` | Ward-adjudicated writes into a familiar home (Gates 1–2, fail-closed, audited). | edit report | `400`, `403` (ward denial), `404` |
+| POST | `/api/v1/familiars/:id/edits` | Ward-adjudicated writes into a familiar home (Gates 1–2, fail-closed, audited). Applied writes append `apply_audit` rows to the `ward_audit` ledger (Gate 4 persistence). | edit report | `400`, `403` (ward denial), `404` |
 
 ## Ward proposals (threads)
 

--- a/docs/reference/cli-ward.md
+++ b/docs/reference/cli-ward.md
@@ -1,10 +1,11 @@
 ---
-summary: "Inspect and manage the Ward proposal lifecycle: pending reads and config migration."
+summary: "Inspect and manage the Ward proposal lifecycle: pending reads, the audit ledger, and config migration."
 read_when:
   - Looking up ward
   - Reviewing staged (held) Ward proposals
+  - Auditing applied Ward writes
 title: "coven ward"
-description: "Reference for coven ward: list and inspect pending Ward proposals staged for the principal, and migrate v0.1 ward.toml files to the Phase-2 WardConfig dialect."
+description: "Reference for coven ward: list and inspect pending Ward proposals staged for the principal, read the append-only ward_audit ledger, and migrate v0.1 ward.toml files to the Phase-2 WardConfig dialect."
 ---
 
 `coven ward` groups the Ward's principal-facing lifecycle verbs. Held writes
@@ -16,6 +17,7 @@ is the supported way to see what is waiting.
 coven ward pending             # table of staged proposals, newest first
 coven ward pending <id>        # one proposal in full
 coven ward pending --json      # exact daemon body (GET /api/v1/threads/proposals)
+coven ward audit <familiar>    # append-only ward_audit ledger, newest first
 coven ward migrate --apply     # migrate v0.1 ward.toml files to Phase-2
 ```
 
@@ -38,6 +40,32 @@ Decisions are daemon-API verbs today
 [api](api.md)); approving a `coherence` proposal stays fail-closed until
 Gate 3's resolution stage lands. Nothing ever auto-approves — the principal
 is the sole approver (design Non-goals).
+
+## Audit ledger
+
+`coven ward audit <familiar>` reads the append-only `ward_audit` ledger for
+one familiar, newest first — the Gate 4 record of what the Ward actually did
+(RFC-0001 §5.6). Every applied write through `POST /familiars/{id}/edits`
+persists one `apply_audit` row per logged change: `diffSha256` is the
+post-write content hash, and `detail` carries `prev_sha256` (null on file
+creation) and `bytes_written`, so consecutive writes to the same surface form
+a tamper-evident hash chain. Gate verdicts (`validation_verdict`), proposal
+lifecycle events, and compaction ledger entries land in the same table.
+
+```sh
+coven ward audit sage                      # full ledger, newest first
+coven ward audit sage --event apply_audit  # only applied-write records
+coven ward audit sage --limit 10           # at most 10 rows
+coven ward audit sage --json               # exact daemon body
+```
+
+`--json` output carries exactly the daemon body
+(`GET /api/v1/familiars/{id}/audit`) per the
+[observe contract](cli-observe.md). The ledger is enforced append-only by
+schema triggers — rows survive daemon restarts and cannot be updated or
+deleted. Reading does not require a live `ward.toml`: history stays
+observable even after a familiar's Ward config is removed. Unknown familiars
+fail with `familiar_not_found`.
 
 ## Migration
 


### PR DESCRIPTION
## Context

- Summary: Ward Gate 4 apply records (`AuditRecord`: before/after SHA-256, bytes) were emitted in-memory only — returned in the `POST /familiars/{id}/edits` response and then lost. This persists them into the append-only `ward_audit` ledger and surfaces the ledger for reads. The upstream blocker (`AuditEventType::ApplyAudit` + schema CHECK tag + `WardAuditRecord::for_apply` + migration, OpenCoven/coven-threads#5) already landed in the pinned rev `7da030d`; the store-side migration (`detail` column, `apply_audit` tag) was already wired in `store::open_store`.
- Files changed: `crates/coven-cli/src/{threads_gate.rs,api.rs,main.rs,observe.rs}`, `docs/reference/{api.md,cli-ward.md}`
- Closes #414

## Implementation

- Approach:
  - `threads_gate::persist_apply_audit_records` — called after `Ward::apply` reports an applied disposition and before `advance_applied_protected_baselines`, reducing the chance that a post-write failure leaves an audit gap. This direct apply path currently writes only Tier 2/3 surfaces, while baseline advancement filters for applied Tier 0 surfaces, so the advancement call is a no-op whenever apply-audit records exist. Each `apply_audit` row follows the upstream `WardAuditRecord::for_apply` contract: `diff_hash` ← `next_sha256`; `prev_sha256` (null on creation) + `bytes_written` in the `detail` JSON, so consecutive writes to one surface form a tamper-evident hash chain. The weave view is read-only (no baseline bootstrap), matching `stage_coherence_proposal`.
  - `GET /api/v1/familiars/{id}/audit` — ledger read surface, newest first, `?limit=N` (default 100, max 1000) and `?event=TYPE` filters. Fail-closed 404 on unknown familiars; deliberately does **not** require a live `ward.toml` — append-only history stays observable after config removal.
  - `coven ward audit <familiar> [--limit N] [--event TYPE] [--json]` — observe-contract verb (in-process router; `--json` is the exact daemon body).
- User-visible behavior: applied Tier-2 writes now survive daemon restarts in `ward_audit`; new read endpoint + CLI verb; docs updated.
- Compatibility notes: additive — no changes to existing routes' success shapes. Audit-persistence failure returns a structured `audit_persist_failed` response with `writeApplied: true` and the applied changes so clients can avoid blind retries. Existing stores migrate via the already-landed `ward_audit_schema_action` path. One test updated: `post_familiar_edits_editable_tier_bypasses_the_weave` pinned the pre-#414 "no rows" behavior; it now pins "no verdict rows, exactly one apply_audit row".

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py` (clean, incl. history)
- [x] Additional manual checks: new tests cover persistence across a fresh store connection (restart stand-in), prev→next hash chaining across overwrites, the append-only UPDATE trigger aborting on `apply_audit` rows, read-route shapes, fail-closed filter validation, and every ledger event tag.

## Risk and Rollback

- Risk level: Low–medium. The persistence point sits on the daemon's only arbitrary-file write path into familiar homes, but is additive and runs after the file write, before a baseline-advance call that is currently a no-op for this Tier-2-only audit path. A ledger-append failure surfaces as a structured 500 with the applied changes.
- Rollback plan: revert the commit; the `ward_audit` schema is unchanged (rows of the new event type simply stop being appended — append-only history remains valid).

## Agent Handoff

- Current state: implementation complete; CI must be green at the final head before merge.
- Follow-ups: #335 items 1 (Gate 3 coherence resolution stage) and 3 (control-plane wiring) remain open; a retention/pruning story for `ward_audit` growth is future work.
- Known gaps: the audit read surface lists rows per familiar only (no cross-familiar fleet view yet).