### PR TITLE
refactor: consolidate session-launch plumbing (coven run vs POST /sessions)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -21,7 +21,7 @@ use crate::{
     daemon::DaemonStatus,
     encrypted_artifacts::SensitiveArtifactStore,
     harness::{ConversationHint, HarnessLaunchMode},
-    privacy, project, store, ward,
+    privacy, session_launch, store, ward,
 };
 
 const MAX_EVENTS_LIMIT: i64 = 1_000;
@@ -1630,12 +1630,10 @@ fn launch_session(
             return api_error(400, "invalid_request", &error.to_string(), None);
         }
     };
-    let familiar_ctx = match launch.familiar_id.as_deref() {
-        Some(familiar_id) => match crate::familiar_identity::resolve(coven_home, familiar_id) {
-            Ok(Some(familiar_ctx)) => Some(familiar_ctx),
-            Ok(None) => {
-                let error =
-                    crate::familiar_identity::unknown_familiar_error(coven_home, familiar_id);
+    let familiar_ctx =
+        match session_launch::resolve_familiar(coven_home, launch.familiar_id.as_deref()) {
+            Ok(familiar_ctx) => familiar_ctx,
+            Err(session_launch::FamiliarError::Unknown { familiar_id, error }) => {
                 return api_error(
                     400,
                     "unknown_familiar",
@@ -1643,32 +1641,25 @@ fn launch_session(
                     Some(json!({ "familiarId": familiar_id })),
                 );
             }
-            Err(error) => {
+            Err(session_launch::FamiliarError::LookupFailed(error)) => {
                 return api_error(500, "familiar_lookup_failed", &error.to_string(), None);
             }
-        },
-        None => None,
-    };
+        };
     launch.familiar_id = familiar_ctx.as_ref().map(|familiar| familiar.id.clone());
     let conn = store::open_store(&store_path(coven_home))?;
     let now = current_timestamp();
-    let record = store::SessionRecord {
+    let record = session_launch::new_session_record(session_launch::NewSessionParams {
         id: launch.id.clone(),
         project_root: launch.project_root.clone(),
         harness: launch.harness.clone(),
         title: launch.title.clone(),
         status: "running".to_string(),
-        exit_code: None,
-        archived_at: None,
-        created_at: now.clone(),
-        updated_at: now,
+        now,
         conversation_id: launch.conversation_id.clone(),
         familiar_id: familiar_ctx.as_ref().map(|familiar| familiar.id.clone()),
         labels: Vec::new(),
-        visibility: "private".to_string(),
-        external: false,
-        transcript_path: None,
-    };
+        visibility: None,
+    });
     store::insert_session(&conn, &record)?;
     if let Err(error) = runtime.launch_session(&launch) {
         // Don't propagate to the accept loop — that crashes the daemon.
@@ -1815,25 +1806,21 @@ fn complete_external_session(
 fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
     let project_root = required_string(&payload, "projectRoot")?;
     let cwd = payload.get("cwd").and_then(Value::as_str);
-    let canonical_project_root = project::canonical_project_root(Path::new(&project_root))
-        .context("failed to resolve projectRoot")?;
-    let canonical_cwd = project::resolve_inside_root(&canonical_project_root, cwd.map(Path::new))?;
+    let paths = session_launch::resolve_launch_paths(Path::new(&project_root), cwd.map(Path::new))
+        .map_err(|error| match error {
+            session_launch::LaunchPathError::ProjectRoot(error) => {
+                error.context("failed to resolve projectRoot")
+            }
+            session_launch::LaunchPathError::Cwd(error) => error,
+        })?;
     let harness = required_string(&payload, "harness")?;
     // Validate against the supported harness set up-front (client error)
     // instead of letting the runtime's arg builder surface it later as a
     // 500. Bonus: rejecting here means we never insert a session row for
-    // a launch that can't possibly succeed.
-    let supported_specs = crate::harness::configured_harness_specs()?;
-    let supported: Vec<&str> = supported_specs
-        .iter()
-        .map(|spec| spec.id.as_str())
-        .collect();
-    if !supported.contains(&harness.as_str()) {
-        anyhow::bail!(
-            "{}",
-            crate::harness::unsupported_harness_message(&harness, &supported)
-        );
-    }
+    // a launch that can't possibly succeed. Availability is deliberately
+    // not required (HarnessCheck::Configured): a configured-but-missing
+    // binary is surfaced by the runtime as a structured launch failure.
+    session_launch::validate_harness(&harness, session_launch::HarnessCheck::Configured)?;
     let launch_mode = launch_mode_from_payload(&payload)?;
     let model = payload
         .get("model")
@@ -1871,8 +1858,8 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
 
     Ok(SessionLaunch {
         id: Uuid::new_v4().to_string(),
-        project_root: canonical_project_root.to_string_lossy().into_owned(),
-        cwd: canonical_cwd.to_string_lossy().into_owned(),
+        project_root: paths.project_root.to_string_lossy().into_owned(),
+        cwd: paths.cwd.to_string_lossy().into_owned(),
         harness,
         model,
         launch_mode,
@@ -5178,6 +5165,7 @@ pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiRe
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::project;
 
     #[test]
     fn builds_health_response() {

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -1799,7 +1799,7 @@ fn executable_exists(executable: &str) -> bool {
 /// Availability check for a harness: most harnesses rely on PATH only, but
 /// `coven-code` is also available when the managed engine resolver finds it
 /// (e.g. `~/.coven/engine/<ver>/coven-code` not on PATH).
-fn harness_available(executable: &str) -> bool {
+pub(crate) fn harness_available(executable: &str) -> bool {
     harness_available_with(executable, || crate::engine::resolve().is_some())
 }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3059,9 +3059,7 @@ fn run_session(
     // preamble to the prompt here so the integration layer remains harness-agnostic.
     let familiar_ctx = session_launch::resolve_familiar(&coven_home, familiar_id)
         .map_err(session_launch::FamiliarError::into_error)?;
-    let spec = harness::configured_harness_specs()?
-        .into_iter()
-        .find(|s| s.id == selected_harness.id);
+    let spec = Some(selected_harness.clone());
 
     // Resolve the requested model. Cave sends a namespaced id; the harness arg
     // builders strip the provider/ prefix and forward the bare id to the native

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3059,7 +3059,7 @@ fn run_session(
     // preamble to the prompt here so the integration layer remains harness-agnostic.
     let familiar_ctx = session_launch::resolve_familiar(&coven_home, familiar_id)
         .map_err(session_launch::FamiliarError::into_error)?;
-    let spec = Some(selected_harness.clone());
+    let spec = Some(&selected_harness);
 
     // Resolve the requested model. Cave sends a namespaced id; the harness arg
     // builders strip the provider/ prefix and forward the bare id to the native

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -38,6 +38,7 @@ mod prompt_refs;
 mod proposal_scheduler;
 mod pty_runner;
 mod repos_config;
+mod session_launch;
 mod settings;
 mod store;
 mod stream_json;
@@ -2393,29 +2394,27 @@ fn default_harness_id() -> Option<String> {
 }
 
 fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
-    let selected_harness = selected_available_harness(request.harness_id.as_str())?;
+    let selected_harness = session_launch::validate_harness(
+        request.harness_id.as_str(),
+        session_launch::HarnessCheck::Available,
+    )?;
     let coven_home = coven_home_dir()?;
     let store_path = coven_home.join(STORE_FILE_NAME);
     let conn = store::open_store(&store_path)?;
     let now = current_timestamp();
     let brief = patch::build_repair_brief(request);
-    let record = store::SessionRecord {
+    let record = session_launch::new_session_record(session_launch::NewSessionParams {
         id: Uuid::new_v4().to_string(),
         project_root: request.repo.root.to_string_lossy().into_owned(),
         harness: selected_harness.id.to_string(),
         title: session_title(Some(&format!("Patch {}", request.repo.repo_name)), &brief),
         status: DEFAULT_SESSION_STATUS.to_string(),
-        exit_code: None,
-        archived_at: None,
-        created_at: now.clone(),
-        updated_at: now.clone(),
+        now: now.clone(),
         conversation_id: None,
         familiar_id: None,
         labels: Vec::new(),
-        visibility: "private".to_string(),
-        external: false,
-        transcript_path: None,
-    };
+        visibility: None,
+    });
     store::insert_session(&conn, &record)?;
     let metadata = serde_json::json!({
         "patchTarget": request.repo.repo_name,
@@ -3028,15 +3027,17 @@ fn run_session(
         anyhow::bail!("nothing to do; pass a prompt, or use --continue [ID] to resume a session");
     }
 
-    let selected_harness = selected_available_harness(harness_id)?;
+    let selected_harness =
+        session_launch::validate_harness(harness_id, session_launch::HarnessCheck::Available)?;
     let current_dir = std::env::current_dir().context("failed to read current directory")?;
-    let project_root = project::canonical_project_root(&current_dir).with_context(|| {
-        format!(
-            "failed to resolve project root from {}",
-            current_dir.display()
-        )
-    })?;
-    let cwd = project::resolve_inside_root(&project_root, cwd).context("failed to resolve cwd")?;
+    let session_launch::LaunchPaths { project_root, cwd } =
+        session_launch::resolve_launch_paths(&current_dir, cwd).map_err(|error| match error {
+            session_launch::LaunchPathError::ProjectRoot(error) => error.context(format!(
+                "failed to resolve project root from {}",
+                current_dir.display()
+            )),
+            session_launch::LaunchPathError::Cwd(error) => error.context("failed to resolve cwd"),
+        })?;
     let coven_home = coven_home_dir()?;
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;
@@ -3056,7 +3057,8 @@ fn run_session(
     // via that flag in build_harness_command_with_conversation; the prompt stays
     // clean. For harnesses without one (Codex), we prepend a bracketed identity
     // preamble to the prompt here so the integration layer remains harness-agnostic.
-    let familiar_ctx = familiar_identity::resolve_optional(&coven_home, familiar_id)?;
+    let familiar_ctx = session_launch::resolve_familiar(&coven_home, familiar_id)
+        .map_err(session_launch::FamiliarError::into_error)?;
     let spec = harness::configured_harness_specs()?
         .into_iter()
         .find(|s| s.id == selected_harness.id);
@@ -3184,23 +3186,18 @@ fn run_session(
             ),
         }
     } else {
-        let r = store::SessionRecord {
+        let r = session_launch::new_session_record(session_launch::NewSessionParams {
             id: Uuid::new_v4().to_string(),
             project_root: project_root.to_string_lossy().into_owned(),
             harness: selected_harness.id.to_string(),
             title: session_title(title, &prompt),
             status: DEFAULT_SESSION_STATUS.to_string(),
-            exit_code: None,
-            archived_at: None,
-            created_at: now.clone(),
-            updated_at: now,
+            now,
             conversation_id: None,
             familiar_id: familiar_ctx.as_ref().map(|f| f.id.clone()),
             labels,
-            visibility: visibility.unwrap_or("private").to_string(),
-            external: false,
-            transcript_path: None,
-        };
+            visibility: visibility.map(str::to_string),
+        });
         (r, false)
     };
 
@@ -3954,31 +3951,6 @@ fn parse_http_status(response: &str) -> Result<u16> {
         .and_then(|line| line.split_whitespace().nth(1))
         .and_then(|status| status.parse::<u16>().ok())
         .context("invalid Coven daemon response")
-}
-
-fn selected_available_harness(harness_id: &str) -> Result<harness::HarnessSummary> {
-    let harnesses = harness::configured_harnesses()?;
-    let configured_ids = harnesses
-        .iter()
-        .map(|harness| harness.id.as_str())
-        .collect::<Vec<_>>();
-    let selected = harnesses
-        .iter()
-        .find(|harness| harness.id == harness_id)
-        .cloned();
-
-    match selected {
-        Some(harness) if harness.available => Ok(harness),
-        Some(harness) => Err(anyhow!(
-            "harness `{}` is not available. {}",
-            harness.id,
-            harness.install_hint
-        )),
-        None => Err(anyhow!(
-            "{}",
-            harness::unsupported_harness_message(harness_id, &configured_ids)
-        )),
-    }
 }
 
 fn joined_prompt(prompt_args: &[String]) -> Result<String> {

--- a/crates/coven-cli/src/session_launch.rs
+++ b/crates/coven-cli/src/session_launch.rs
@@ -67,11 +67,27 @@ pub enum HarnessCheck {
 }
 
 /// Validate the requested harness against the configured adapter set and
-/// return its summary. Both the CLI and the API validate through this
+/// return its command spec. Both the CLI and the API validate through this
 /// function, so the supported-harness id set and the unsupported-harness
 /// message cannot drift between the two surfaces.
-pub fn validate_harness(harness_id: &str, check: HarnessCheck) -> Result<harness::HarnessSummary> {
-    let harnesses = harness::configured_harnesses()?;
+pub fn validate_harness(
+    harness_id: &str,
+    check: HarnessCheck,
+) -> Result<harness::HarnessCommandSpec> {
+    validate_harness_specs(
+        harness_id,
+        check,
+        harness::configured_harness_specs()?,
+        harness::harness_available,
+    )
+}
+
+fn validate_harness_specs(
+    harness_id: &str,
+    check: HarnessCheck,
+    harnesses: Vec<harness::HarnessCommandSpec>,
+    is_available: impl Fn(&str) -> bool,
+) -> Result<harness::HarnessCommandSpec> {
     let configured_ids = harnesses
         .iter()
         .map(|harness| harness.id.as_str())
@@ -82,7 +98,9 @@ pub fn validate_harness(harness_id: &str, check: HarnessCheck) -> Result<harness
         .cloned();
 
     match selected {
-        Some(harness) if check == HarnessCheck::Configured || harness.available => Ok(harness),
+        Some(harness) if check == HarnessCheck::Configured || is_available(&harness.executable) => {
+            Ok(harness)
+        }
         Some(harness) => Err(anyhow::anyhow!(
             "harness `{}` is not available. {}",
             harness.id,
@@ -229,6 +247,19 @@ mod tests {
             matches!(error, Err(LaunchPathError::ProjectRoot(_))),
             "a missing root must be a ProjectRoot error"
         );
+    }
+
+    #[test]
+    fn configured_harness_validation_does_not_probe_executables() -> Result<()> {
+        let selected = validate_harness_specs(
+            "codex",
+            HarnessCheck::Configured,
+            harness::configured_harness_specs()?,
+            |_| panic!("configured-only validation must not probe executable availability"),
+        )?;
+
+        assert_eq!(selected.id, "codex");
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/session_launch.rs
+++ b/crates/coven-cli/src/session_launch.rs
@@ -1,0 +1,295 @@
+//! Shared session-launch preparation core (#401).
+//!
+//! `coven run` (main.rs), `coven patch` repair sessions (main.rs), and the
+//! daemon's `POST /sessions` (api.rs::launch_session) all perform the same
+//! launch steps: resolve the project root and cwd, validate the requested
+//! harness, resolve the familiar, and build the `SessionRecord`. Before this
+//! module each side carried its own copy and they had already drifted — the
+//! CLI and API validated harnesses through different helpers and built
+//! record literals independently.
+//!
+//! This module is the single implementation of those steps. Errors are typed
+//! so each edge keeps its own presentation: the CLI attaches its human
+//! contexts and exits non-zero; the API maps the same variants onto its
+//! structured HTTP error envelope (`400 invalid_request`/`unknown_familiar`,
+//! `500 familiar_lookup_failed`) without changing either contract.
+//! Caller-specific UX — prompt expansion, TTY detection, stream-json,
+//! detach, payload parsing — stays at the edges by design.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use crate::{familiar_identity, harness, project, store};
+
+/// The canonical filesystem coordinates of a launch: the project root and a
+/// cwd guaranteed to live inside it.
+pub struct LaunchPaths {
+    pub project_root: PathBuf,
+    pub cwd: PathBuf,
+}
+
+/// Which launch-path step failed, so callers can keep their own error
+/// presentation for each step (CLI human contexts vs API 400 bodies).
+pub enum LaunchPathError {
+    /// Canonicalizing the project root failed.
+    ProjectRoot(anyhow::Error),
+    /// The cwd could not be resolved, or escapes the project root.
+    Cwd(anyhow::Error),
+}
+
+/// Resolve the launch coordinates: canonicalize `project_root_hint` and
+/// resolve `cwd` inside it (rejecting escapes). One semantics for every
+/// launch path — the CLI resolves from the process cwd, the API from the
+/// request's `projectRoot` field, through this same function.
+pub fn resolve_launch_paths(
+    project_root_hint: &Path,
+    cwd: Option<&Path>,
+) -> Result<LaunchPaths, LaunchPathError> {
+    let project_root =
+        project::canonical_project_root(project_root_hint).map_err(LaunchPathError::ProjectRoot)?;
+    let cwd = project::resolve_inside_root(&project_root, cwd).map_err(LaunchPathError::Cwd)?;
+    Ok(LaunchPaths { project_root, cwd })
+}
+
+/// How strictly to validate the requested harness.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HarnessCheck {
+    /// The harness must be configured (a known adapter). Used by the daemon
+    /// API: rejecting unknown harnesses up-front avoids inserting a session
+    /// row for a launch that cannot possibly succeed, while a configured but
+    /// uninstalled binary is still surfaced by the runtime as a structured
+    /// launch failure.
+    Configured,
+    /// The harness must be configured *and* its executable available. Used
+    /// by CLI foreground paths that are about to spawn the binary directly.
+    Available,
+}
+
+/// Validate the requested harness against the configured adapter set and
+/// return its summary. Both the CLI and the API validate through this
+/// function, so the supported-harness id set and the unsupported-harness
+/// message cannot drift between the two surfaces.
+pub fn validate_harness(harness_id: &str, check: HarnessCheck) -> Result<harness::HarnessSummary> {
+    let harnesses = harness::configured_harnesses()?;
+    let configured_ids = harnesses
+        .iter()
+        .map(|harness| harness.id.as_str())
+        .collect::<Vec<_>>();
+    let selected = harnesses
+        .iter()
+        .find(|harness| harness.id == harness_id)
+        .cloned();
+
+    match selected {
+        Some(harness) if check == HarnessCheck::Configured || harness.available => Ok(harness),
+        Some(harness) => Err(anyhow::anyhow!(
+            "harness `{}` is not available. {}",
+            harness.id,
+            harness.install_hint
+        )),
+        None => Err(anyhow::anyhow!(
+            "{}",
+            harness::unsupported_harness_message(harness_id, &configured_ids)
+        )),
+    }
+}
+
+/// Why a familiar could not be resolved, so the API can distinguish the
+/// client error (unknown id → 400) from the server error (roster unreadable
+/// → 500) while the CLI folds both into its usual anyhow presentation.
+pub enum FamiliarError {
+    /// The id is not declared in familiars.toml. Carries the same guidance
+    /// error `familiar_identity::unknown_familiar_error` always produced.
+    Unknown {
+        familiar_id: String,
+        error: anyhow::Error,
+    },
+    /// Reading the roster itself failed.
+    LookupFailed(anyhow::Error),
+}
+
+impl FamiliarError {
+    /// Collapse into the underlying error (the CLI presentation).
+    pub fn into_error(self) -> anyhow::Error {
+        match self {
+            FamiliarError::Unknown { error, .. } => error,
+            FamiliarError::LookupFailed(error) => error,
+        }
+    }
+}
+
+/// Resolve an optional familiar id against the roster. `None`, empty, and
+/// whitespace-only ids mean "no familiar" — the same normalization both
+/// launch surfaces already applied.
+pub fn resolve_familiar(
+    coven_home: &Path,
+    familiar_id: Option<&str>,
+) -> Result<Option<harness::FamiliarContext>, FamiliarError> {
+    let Some(familiar_id) = familiar_id
+        .map(str::trim)
+        .filter(|familiar_id| !familiar_id.is_empty())
+    else {
+        return Ok(None);
+    };
+    match familiar_identity::resolve(coven_home, familiar_id) {
+        Ok(Some(context)) => Ok(Some(context)),
+        Ok(None) => Err(FamiliarError::Unknown {
+            familiar_id: familiar_id.to_string(),
+            error: familiar_identity::unknown_familiar_error(coven_home, familiar_id),
+        }),
+        Err(error) => Err(FamiliarError::LookupFailed(error)),
+    }
+}
+
+/// The caller-specific fields of a new session row. Everything not listed
+/// here (exit code, archive state, external flag, transcript path) is a
+/// fixed invariant of a fresh launch and set by [`new_session_record`].
+pub struct NewSessionParams {
+    pub id: String,
+    pub project_root: String,
+    pub harness: String,
+    pub title: String,
+    /// `created` on CLI foreground paths (the run loop advances it),
+    /// `running` on the daemon path (the runtime launch already happened by
+    /// the time the row is read back).
+    pub status: String,
+    /// Row creation time; also used as `updated_at`.
+    pub now: String,
+    pub conversation_id: Option<String>,
+    pub familiar_id: Option<String>,
+    pub labels: Vec<String>,
+    /// `None` means the default (`private`).
+    pub visibility: Option<String>,
+}
+
+/// Build the session row for a fresh (non-resume) launch. The single place
+/// the launch-time record shape lives: a future `SessionRecord` field gets a
+/// launch default here once, for every launch surface.
+pub fn new_session_record(params: NewSessionParams) -> store::SessionRecord {
+    store::SessionRecord {
+        id: params.id,
+        project_root: params.project_root,
+        harness: params.harness,
+        title: params.title,
+        status: params.status,
+        exit_code: None,
+        archived_at: None,
+        created_at: params.now.clone(),
+        updated_at: params.now,
+        conversation_id: params.conversation_id,
+        familiar_id: params.familiar_id,
+        labels: params.labels,
+        visibility: params.visibility.unwrap_or_else(|| "private".to_string()),
+        external: false,
+        transcript_path: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_launch_paths_canonicalizes_and_rejects_escapes() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = temp.path().join("repo");
+        std::fs::create_dir_all(root.join("child"))?;
+
+        let paths = match resolve_launch_paths(&root, Some(Path::new("child"))) {
+            Ok(paths) => paths,
+            Err(LaunchPathError::ProjectRoot(error) | LaunchPathError::Cwd(error)) => {
+                return Err(error);
+            }
+        };
+        assert_eq!(paths.cwd, paths.project_root.join("child"));
+
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&outside)?;
+        let error = resolve_launch_paths(&root, Some(&outside));
+        match error {
+            Err(LaunchPathError::Cwd(error)) => {
+                assert!(
+                    error.to_string().contains("outside the Coven project root"),
+                    "unexpected error: {error}"
+                );
+            }
+            Err(LaunchPathError::ProjectRoot(error)) => {
+                panic!("escape must be a Cwd error, got ProjectRoot: {error}")
+            }
+            Ok(_) => panic!("cwd outside the root must be rejected"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn resolve_launch_paths_distinguishes_missing_root() {
+        let error = resolve_launch_paths(Path::new("/nonexistent/coven-launch-test"), None);
+        assert!(
+            matches!(error, Err(LaunchPathError::ProjectRoot(_))),
+            "a missing root must be a ProjectRoot error"
+        );
+    }
+
+    #[test]
+    fn resolve_familiar_normalizes_blank_ids_to_none() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        for id in [None, Some(""), Some("   ")] {
+            let resolved = resolve_familiar(temp.path(), id);
+            assert!(
+                matches!(resolved, Ok(None)),
+                "blank familiar ids must resolve to None"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_familiar_distinguishes_unknown_from_lookup_failure() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        std::fs::write(
+            temp.path().join("familiars.toml"),
+            "[[familiar]]\nid = \"sage\"\ndisplay_name = \"Sage\"\nrole = \"Research\"\ndescription = \"Reads.\"\n",
+        )?;
+
+        let resolved =
+            resolve_familiar(temp.path(), Some("sage")).map_err(FamiliarError::into_error)?;
+        assert_eq!(resolved.expect("known familiar").id, "sage");
+
+        match resolve_familiar(temp.path(), Some("ghost")) {
+            Err(FamiliarError::Unknown { familiar_id, error }) => {
+                assert_eq!(familiar_id, "ghost");
+                assert!(error.to_string().contains("unknown familiar `ghost`"));
+                assert!(error.to_string().contains("sage"));
+            }
+            Err(FamiliarError::LookupFailed(error)) => {
+                panic!("unknown id must not be a lookup failure: {error}")
+            }
+            Ok(_) => panic!("unknown familiar must not resolve"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn new_session_record_sets_launch_invariants() {
+        let record = new_session_record(NewSessionParams {
+            id: "session-1".into(),
+            project_root: "/repo".into(),
+            harness: "codex".into(),
+            title: "Fix tests".into(),
+            status: "created".into(),
+            now: "2026-01-01T00:00:00Z".into(),
+            conversation_id: None,
+            familiar_id: Some("sage".into()),
+            labels: vec!["ci".into()],
+            visibility: None,
+        });
+        assert_eq!(record.visibility, "private");
+        assert_eq!(record.created_at, record.updated_at);
+        assert_eq!(record.exit_code, None);
+        assert_eq!(record.archived_at, None);
+        assert!(!record.external);
+        assert_eq!(record.transcript_path, None);
+        assert_eq!(record.familiar_id.as_deref(), Some("sage"));
+        assert_eq!(record.labels, vec!["ci".to_string()]);
+    }
+}

--- a/crates/coven-cli/src/session_launch.rs
+++ b/crates/coven-cli/src/session_launch.rs
@@ -250,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn configured_harness_validation_does_not_probe_executables() -> Result<()> {
+    fn configured_harness_validation_returns_spec_without_probing_executables() -> Result<()> {
         let selected = validate_harness_specs(
             "codex",
             HarnessCheck::Configured,
@@ -259,6 +259,8 @@ mod tests {
         )?;
 
         assert_eq!(selected.id, "codex");
+        assert_eq!(selected.executable, "codex");
+        assert!(selected.supports_model());
         Ok(())
     }
 


### PR DESCRIPTION
## Context

- Summary: Extracts the shared launch-preparation core proposed in #401 into a new `crates/coven-cli/src/session_launch.rs`, consumed by all three launch surfaces: CLI `coven run` (`main.rs::run_session`), the patch repair path (`main.rs::launch_patch_session`), and the daemon `POST /sessions` (`api.rs::launch_session` / `session_launch_from_payload`). The four duplicated steps from the workstream-3 survey now have exactly one implementation each: project-root/cwd resolution (`resolve_launch_paths`), harness validation (`validate_harness`), familiar resolution (`resolve_familiar`), and session-record construction (`new_session_record`).
- Files changed: `crates/coven-cli/src/session_launch.rs` (new), `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/api.rs`
- Closes #401

## Implementation

- Approach: The core exposes typed seams so each edge keeps its own presentation:
  - `resolve_launch_paths` returns `LaunchPathError::{ProjectRoot,Cwd}`, letting the CLI attach its human contexts (`failed to resolve project root from …` / `failed to resolve cwd`) and the API attach `failed to resolve projectRoot` — byte-identical messages to before.
  - `validate_harness(id, HarnessCheck::{Configured,Available})` replaces both `main.rs::selected_available_harness` (deleted) and the API's hand-rolled `configured_harness_specs` membership check. The two surfaces can no longer drift on the supported-harness id set or the unsupported-harness message.
  - `resolve_familiar` returns `FamiliarError::{Unknown,LookupFailed}` so the API maps them to 400 `unknown_familiar` / 500 `familiar_lookup_failed` while the CLI collapses both into its usual anyhow presentation (`into_error`).
  - `new_session_record(NewSessionParams)` centralizes the fresh-launch row invariants (no exit code, not archived, not external, `created_at == updated_at`, default `private` visibility); caller-specific fields (status, title, labels) stay parameters.
  - Two deliberate asymmetries are preserved and now documented in the types instead of hidden in duplicated code: the API requires *configured* only (a configured-but-missing binary still becomes a structured 500 `launch_failed` after the row insert), and launch status is `created` on CLI paths vs `running` on the daemon path.
  - Caller-specific UX stays at the edges per the issue's proposal: prompt expansion, harness option warnings, `--continue`/detach/stream-json on the CLI; payload parsing, validation order (projectRoot → cwd → harness → launchMode → …), and HTTP error mapping on the API.
- User-visible behavior: None. Error messages, HTTP statuses, response shapes, and session-row contents are unchanged on every path; `docs/API-CONTRACT.md` needed no edits.
- Compatibility notes: All 15 pinned `api.rs::launch_request_*` tests pass unchanged, including `launch_request_with_unknown_harness_returns_400_upfront_no_session_row`, `launch_request_rejects_cwd_outside_project_root`, `launch_request_rejects_unknown_familiar_id_without_inserting_session`, and `launch_request_runtime_failure_returns_500_and_marks_session_failed`.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — 1299 passed
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: 5 new unit tests in `session_launch::tests` pin the core directly (canonicalization + escape rejection, `ProjectRoot` vs `Cwd` attribution, blank-familiar normalization, `Unknown` vs `LookupFailed` distinction, `new_session_record` launch invariants). Net **−40 lines** despite module docs and tests.

## Risk and Rollback

- Risk level: Medium — touches the daemon launch contract and CLI foreground path, but the refactor is behavior-preserving by construction (typed error passthrough, identical message strings) and pinned by the existing `launch_request_*` suite plus the new unit tests.
- Rollback plan: Revert the single commit; no schema, config, or protocol changes to unwind.

## Agent Handoff

- Current state: All three launch surfaces consume `session_launch`; `selected_available_harness` is gone; local CI gates green.
- Follow-ups: The remaining survey row (event/delegation emission) stays edge-specific by design — CLI event plumbing and `coven_calls::emit_running` serve different products; consolidating them was out of scope per the issue.
- Known gaps: None known.
