### PR TITLE
docs: design the authenticated remote daemon listener (companion clients)

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -118,7 +118,11 @@ The current auth solution is not:
 - a cloud account boundary; or
 - permission to expose the socket API on localhost TCP, a remote network, or a browser page.
 
-If a future dashboard, mobile app, remote bridge, or browser-exposed service needs to talk to Coven, it needs an explicit additional auth and pairing design. Do not tunnel or proxy the raw daemon socket into a network service and call that authenticated. That design is drafted in [Authenticated remote listener](/design/remote-listener-auth) (#463); until it ships, the tunnel patterns in [Remote access](/daemon/remote-access) are the only supported remote paths.
+If a future dashboard, mobile app, remote bridge, or browser-exposed service needs to talk to Coven,
+it needs an explicit additional auth and pairing design. Do not tunnel or proxy the raw daemon socket
+into a network service and call that authenticated. That design is drafted in
+[Authenticated remote listener](/design/remote-listener-auth) (#463); until it ships, the tunnel
+patterns in [Remote access](/daemon/remote-access) are the only supported remote paths.
 
 ## Current hardening gap
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -118,7 +118,7 @@ The current auth solution is not:
 - a cloud account boundary; or
 - permission to expose the socket API on localhost TCP, a remote network, or a browser page.
 
-If a future dashboard, mobile app, remote bridge, or browser-exposed service needs to talk to Coven, it needs an explicit additional auth and pairing design. Do not tunnel or proxy the raw daemon socket into a network service and call that authenticated. That design is drafted in [Authenticated remote listener](design/remote-listener-auth.md) (#463); until it ships, the tunnel patterns in [Remote access](daemon/remote-access.md) are the only supported remote paths.
+If a future dashboard, mobile app, remote bridge, or browser-exposed service needs to talk to Coven, it needs an explicit additional auth and pairing design. Do not tunnel or proxy the raw daemon socket into a network service and call that authenticated. That design is drafted in [Authenticated remote listener](/design/remote-listener-auth) (#463); until it ships, the tunnel patterns in [Remote access](/daemon/remote-access) are the only supported remote paths.
 
 ## Current hardening gap
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -118,7 +118,7 @@ The current auth solution is not:
 - a cloud account boundary; or
 - permission to expose the socket API on localhost TCP, a remote network, or a browser page.
 
-If a future dashboard, mobile app, remote bridge, or browser-exposed service needs to talk to Coven, it needs an explicit additional auth and pairing design. Do not tunnel or proxy the raw daemon socket into a network service and call that authenticated.
+If a future dashboard, mobile app, remote bridge, or browser-exposed service needs to talk to Coven, it needs an explicit additional auth and pairing design. Do not tunnel or proxy the raw daemon socket into a network service and call that authenticated. That design is drafted in [Authenticated remote listener](design/remote-listener-auth.md) (#463); until it ships, the tunnel patterns in [Remote access](daemon/remote-access.md) are the only supported remote paths.
 
 ## Current hardening gap
 

--- a/docs/daemon/remote-access.md
+++ b/docs/daemon/remote-access.md
@@ -35,6 +35,9 @@ Two patterns, both keeping the API on loopback:
   stays on loopback; Tailscale remains the boundary.
 
 Never bind `--tcp` to a non-loopback or public address to achieve remote access
-— the API is unauthenticated. Let SSH or Tailscale be the boundary.
+— the API is unauthenticated. Let SSH or Tailscale be the boundary. A
+first-class authenticated remote listener (paired devices, TLS, scoped tokens)
+is designed in
+[Authenticated remote listener](/design/remote-listener-auth) (#463).
 
 See [Daemon overview](/daemon/index) and [Safety model](/daemon/safety-model).

--- a/docs/design/remote-listener-auth.md
+++ b/docs/design/remote-listener-auth.md
@@ -1,0 +1,211 @@
+---
+title: "Authenticated remote listener for the daemon"
+description: "Design for an opt-in, TLS-wrapped, device-paired remote listener so companion clients (Coven Pocket) can reach the daemon without a hand-managed SSH or Tailscale tunnel."
+---
+
+# Authenticated Remote Listener — Design
+
+Status: Proposed — needs maintainer ratification of the open questions
+Date: 2026-07-26
+Scope: `crates/coven-cli` (`daemon.rs`, `api.rs`, `main.rs`, store) plus
+`docs/AUTH.md` / `docs/daemon/*` updates when implemented. Companion client:
+OpenCoven/coven-pocket (tracked there as coven-pocket#6). Tracking: #463.
+
+## Summary
+
+Today the daemon's only trust boundary is same-user filesystem access to the
+Unix socket; the optional TCP listener is loopback-only and unauthenticated,
+and remote reachability is delegated to SSH or Tailscale
+([Remote access](/daemon/remote-access)). That is the deliberate MVP posture —
+[AUTH.md](../AUTH.md) explicitly forbids tunneling the raw socket into a
+network service and calling it authenticated.
+
+This design adds the "separate auth design" AUTH.md calls for: an **opt-in
+remote listener** (`coven daemon serve --remote <bind>`) that is TLS-wrapped,
+accepts only **paired devices** holding per-device bearer tokens (hashed at
+rest), scopes each device to *observe* or *control*, downgrades
+unauthenticated connections to a redacted `/health`, and supports immediate
+revocation. Loopback-only remains the default; nothing changes for existing
+local clients or for the tunnel-based patterns, which stay documented and
+supported.
+
+## Non-goals
+
+- **Internet-facing relay or broker infrastructure.** The listener assumes
+  direct reachability (LAN, Tailscale/WireGuard overlay, or port-forward the
+  operator owns). No hosted rendezvous service.
+- **Multi-user daemons.** The trust boundary stays "one user's devices". A
+  paired phone is the *same* principal as the desktop user, possibly with a
+  narrower scope — never a second user with separate data visibility.
+- **Replacing the local socket model.** The Unix socket (and Windows named
+  pipe) remain the primary transport and keep their existing
+  filesystem-permission trust anchor.
+- **OAuth / OIDC / hosted accounts.** Pairing is device-to-daemon, offline,
+  operator-initiated. No third-party identity provider enters the loop.
+
+## Current state (verified on main @ 3d2e54b)
+
+What already exists — the remote listener composes with all of it:
+
+- **Loopback-only TCP transport** (`daemon.rs`): `bind_tcp_listener` resolves
+  the bind address and `ensure_loopback_addrs` refuses any non-loopback
+  socket address outright. `--allow-host` widens only the *Host/Origin*
+  guard (`HostGuard::Loopback`), never the bind.
+- **Browser-attack defenses on TCP**: exact-match Host allowlist plus Origin
+  check defend against CSRF and DNS rebinding; `TCP_IO_TIMEOUT` (30 s
+  read/write) and `MAX_TCP_BODY_BYTES` (1 MiB) cap slowloris and allocation
+  abuse. The remote listener inherits all of these.
+- **Fail-closed local trust anchor**: `ensure_private_coven_home` refuses a
+  `COVEN_HOME` not owned by the current uid (`check_owned_by_current_user`)
+  before binding the socket. The remote listener's key material lives under
+  the same directory and inherits the same posture.
+- **Versioned protocol handshake**: clients probe `GET /health`, which
+  returns `apiVersion: "coven.daemon.v1"`, the coven version, a capabilities
+  block, `DaemonStatus` (including **pid** and socket path), and a hub
+  summary. `X-Coven-Api-Version` negotiation and structured error envelopes
+  already exist ([API contract](/reference/api-contract)).
+- **Pocket MVP** (coven-pocket#6): the phone reaches a loopback daemon over
+  Tailscale or `ssh -L`, probing `/health`. It authenticates at the network
+  layer only.
+
+## Design
+
+### 1. Opt-in listener
+
+```sh
+coven daemon serve --remote 0.0.0.0:7443        # explicit flag, or
+# settings.json: { "daemon": { "remote": { "bind": "0.0.0.0:7443" } } }
+```
+
+- A **separate listener** from `--tcp`; the loopback listener and its
+  `--allow-host` guard are untouched. `--remote` without at least one paired
+  device logs a warning and still serves (pairing happens over it — §3).
+- The remote listener **refuses to start without TLS material** (§2) — there
+  is no plaintext-remote mode. Operators who want to terminate security at
+  Tailscale/WireGuard instead keep using the existing loopback +
+  `--allow-host` pattern, which stays documented as the tunnel alternative.
+- `HostGuard` is `Disabled` on this listener (Host pinning is meaningless for
+  a non-loopback bind); the browser threat model is instead closed by TLS +
+  token auth, and `Origin`-bearing requests are rejected outright — companion
+  clients are native apps, not browsers.
+
+### 2. Transport security: TLS with pairing-time pinning
+
+- First `--remote` start generates a self-signed server certificate
+  (`rcgen`), stored at `<covenHome>/tls/remote-{cert,key}.pem` with `0600`
+  permissions, covered by the existing `ensure_private_coven_home` check.
+- The certificate's SHA-256 fingerprint is embedded in the pairing payload
+  (§3). Clients **pin the fingerprint at pairing time** and refuse any other
+  presented certificate thereafter — trust-on-first-pair, not
+  trust-on-first-use: the fingerprint travels out-of-band in the QR code, so
+  an active MITM during pairing is excluded rather than merely unlikely.
+- v1 uses `rustls` server-side only. **Path to mTLS (v2)**: pairing mints a
+  per-device client certificate alongside the token; the listener then
+  requires client certs and tokens become a secondary check. The pairing
+  payload format (§3) reserves a field for this so v1 QR codes stay valid.
+
+### 3. Pairing and per-device tokens
+
+```sh
+coven daemon pair                 # opens a 120-second pairing window
+```
+
+- Prints a QR code (and the equivalent URL) embedding:
+  `coven-pair://<host>:<port>?fp=<cert-sha256>&pin=<8-digit-code>&v=1`.
+  The phone connects over TLS (pinning `fp`), presents the short-lived
+  `pin` to `POST /pair`, and receives its **device token** in the response:
+  `cvnd_<device-id>_<32-byte-secret>`. The pin is single-use and expires
+  with the window; `POST /pair` is the only route (besides redacted
+  `/health`) an unauthenticated connection can reach, and only while a
+  window is open.
+- The daemon stores `{ device_id, name, token_sha256, scope, created_at,
+  last_seen_at }` in a new `paired_devices` store table. **Only the SHA-256
+  of the secret is persisted**; comparison is constant-time. The plaintext
+  token exists once, in the pairing response.
+- Requests authenticate with `Authorization: Bearer cvnd_…`. The device id
+  prefix selects the row; the hash comparison verifies the secret. Failures
+  return the structured `401 unauthorized` envelope and are rate-limited
+  per source address (token brute-force is already hopeless at 32 random
+  bytes, but the limiter keeps the log signal clean).
+
+### 4. Handshake gating and /health redaction
+
+- Unauthenticated connections on the remote listener get exactly two
+  routes: `GET /health` and `POST /pair` (window-gated). Everything else is
+  `401` before any handler runs.
+- Remote `/health` is **redacted**: `{ ok, apiVersion }` only — no pid, no
+  socket path, no coven version, no capabilities, no hub summary. That is
+  enough for Pocket's reachability probe and version handshake while
+  keeping process details off an unauthenticated network surface. The
+  full body returns once the bearer token is presented.
+- Authenticated requests then follow the normal `coven.daemon.v1`
+  handshake: same `X-Coven-Api-Version` negotiation, same structured
+  errors, same routes — the remote listener adds authentication, not a
+  second protocol.
+
+### 5. Scoped authorization
+
+Each paired device carries a scope, chosen at pairing (`coven daemon pair
+--scope observe|control`, default `observe`):
+
+- **observe** — read-only: `GET` sessions/events/health/capabilities and
+  SSE attach in read-only mode.
+- **control** — everything observe grants plus launch (`POST /sessions`),
+  input forwarding, approvals, and kill.
+
+Enforcement is an **explicit allowlist of observe-safe routes** in the
+router, checked after authentication and before dispatch. Anything not on
+the allowlist requires `control` — new routes are therefore
+control-scoped (fail closed) until someone deliberately classifies them.
+Scope violations return the structured `403 forbidden` envelope with the
+required scope named.
+
+### 6. Revocation and inspection
+
+```sh
+coven daemon devices list            # id, name, scope, created, last seen
+coven daemon devices revoke <id>     # immediate
+```
+
+Revocation deletes the row; because every request re-checks the token
+hash against the store, a revoked device loses access on its next
+request — no token expiry machinery needed in v1 (tokens are
+long-lived-until-revoked, which matches the "one user's devices" trust
+model). `pair` re-runs replace a device's token (re-pair after a lost
+phone plus revoke covers rotation).
+
+## Rollout
+
+1. **v1**: TLS listener + pairing + hashed bearer tokens + scopes +
+   revocation + redacted health. Pocket switches its companion mode probe
+   to the paired transport; tunnel patterns remain documented for users
+   who prefer them.
+2. **v2**: mTLS client certificates minted at pairing (payload field
+   reserved), tightening the transport story from "pinned server cert +
+   bearer" to mutual certificate auth.
+
+## Open questions (need maintainer decisions)
+
+1. **Dependency budget**: `rustls` + `rcgen` are new dependencies for the
+   CLI crate. Acceptable, or should the TLS layer live behind a feature
+   flag so the default build stays dependency-lean?
+2. **Pairing pin transport**: is the 8-digit single-use pin inside the QR
+   enough, or should pairing also require confirming a match code shown on
+   both screens (SAS-style) before the token is released?
+3. **Store vs sidecar file** for `paired_devices`: the store table gets
+   transactions and the existing backup story; a sidecar
+   `devices.json` would keep auth material out of the SQLite file that
+   other tooling opens. Leaning store table.
+4. **Scope granularity**: is observe/control enough for v1, or does
+   Pocket's approval flow need approvals split out of `control` (a device
+   that may approve but not launch)?
+
+## Prior art referenced
+
+- `crates/coven-cli/src/daemon.rs` — TCP transport, loopback guard,
+  Host/Origin guard, timeouts, body caps, fail-closed uid checks.
+- [`docs/AUTH.md`](../AUTH.md) — current same-user posture and the explicit
+  requirement that remote surfaces get a separate auth + pairing design.
+- [Remote access](/daemon/remote-access) — the tunnel patterns this design
+  complements (and does not replace).
+- OpenCoven/coven-pocket#6 — the companion-mode MVP this unblocks.

--- a/docs/design/remote-listener-auth.md
+++ b/docs/design/remote-listener-auth.md
@@ -21,10 +21,10 @@ and remote reachability is delegated to SSH or Tailscale
 network service and calling it authenticated.
 
 This design adds the "separate auth design" AUTH.md calls for: an **opt-in
-remote listener** (`coven daemon serve --remote <bind>`) that is TLS-wrapped,
-accepts only **paired devices** holding per-device bearer tokens (hashed at
-rest), scopes each device to *observe* or *control*, downgrades
-unauthenticated connections to a redacted `/health`, and supports immediate
+remote listener** (configured via `coven daemon start --remote <bind>` or
+settings) that is TLS-wrapped, accepts only **paired devices** holding
+per-device bearer tokens (hashed at rest), scopes each device to *observe*
+or *control*, downgrades unauthenticated connections to a redacted `/health`, and supports immediate
 revocation. Loopback-only remains the default; nothing changes for existing
 local clients or for the tunnel-based patterns, which stay documented and
 supported.

--- a/docs/design/remote-listener-auth.md
+++ b/docs/design/remote-listener-auth.md
@@ -17,7 +17,7 @@ Today the daemon's only trust boundary is same-user filesystem access to the
 Unix socket; the optional TCP listener is loopback-only and unauthenticated,
 and remote reachability is delegated to SSH or Tailscale
 ([Remote access](/daemon/remote-access)). That is the deliberate MVP posture —
-[AUTH.md](../AUTH.md) explicitly forbids tunneling the raw socket into a
+[AUTH.md](/AUTH) explicitly forbids tunneling the raw socket into a
 network service and calling it authenticated.
 
 This design adds the "separate auth design" AUTH.md calls for: an **opt-in
@@ -204,7 +204,7 @@ phone plus revoke covers rotation).
 
 - `crates/coven-cli/src/daemon.rs` — TCP transport, loopback guard,
   Host/Origin guard, timeouts, body caps, fail-closed uid checks.
-- [`docs/AUTH.md`](../AUTH.md) — current same-user posture and the explicit
+- [`docs/AUTH.md`](/AUTH) — current same-user posture and the explicit
   requirement that remote surfaces get a separate auth + pairing design.
 - [Remote access](/daemon/remote-access) — the tunnel patterns this design
   complements (and does not replace).

--- a/docs/design/remote-listener-auth.md
+++ b/docs/design/remote-listener-auth.md
@@ -73,7 +73,7 @@ What already exists — the remote listener composes with all of it:
 ### 1. Opt-in listener
 
 ```sh
-coven daemon serve --remote 0.0.0.0:7443        # explicit flag, or
+coven daemon start --remote 0.0.0.0:7443        # explicit flag, or
 # settings.json: { "daemon": { "remote": { "bind": "0.0.0.0:7443" } } }
 ```
 


### PR DESCRIPTION
## Context

- Summary: Writes the design #463 asked for: a first-class **authenticated remote listener** so companion clients (Coven Pocket, coven-pocket#6) can reach the daemon without a hand-managed SSH/Tailscale tunnel. The design covers every requirement bullet in the issue — opt-in listener, mutual authentication with a pairing flow, transport security, protocol-handshake gating, scoped authorization, and revocation — and keeps the issue's non-goals (relay infrastructure, multi-user daemons) explicitly out of scope.
- Files changed: `docs/design/remote-listener-auth.md` (new), `docs/AUTH.md` (one cross-link), `docs/daemon/remote-access.md` (one cross-link)
- Closes #463

## Implementation

- Approach: Follows the house design-doc format (`docs/design/ward-gate3-coherence.md`): frontmatter, Status/Scope/Tracking header, Summary, Non-goals, **Current state verified on main @ 3d2e54b**, design sections, rollout, and open questions flagged for maintainer ratification. Key design points:
  - **Opt-in listener** — `coven daemon serve --remote <bind>` (or settings), a separate listener from `--tcp`; loopback-only stays the default and the existing `--allow-host` tunnel pattern is untouched.
  - **Pairing + tokens** — `coven daemon pair` opens a 120 s window and prints a QR (`coven-pair://host?fp=<cert-sha256>&pin=…`); the device receives a `cvnd_<id>_<secret>` bearer token whose **SHA-256 only** is persisted in a `paired_devices` store table, compared constant-time.
  - **Transport security** — rustls + rcgen self-signed cert under `<covenHome>/tls/`, fingerprint **pinned at pairing time** (travels out-of-band in the QR, excluding pairing-time MITM); refuses to start without TLS; reserved payload field gives a compatible path to mTLS in v2.
  - **Handshake gating** — unauthenticated connections get exactly redacted `GET /health` (`ok` + `apiVersion` only — no pid/socket/version/hub, addressing the issue's redaction note) and window-gated `POST /pair`; everything else 401s before dispatch.
  - **Scoped authorization** — per-device `observe` vs `control` scope enforced by an explicit allowlist of observe-safe routes, so unclassified new routes fail closed to control-scope.
  - **Revocation** — `coven daemon devices list|revoke <id>`, effective on the next request since every request re-checks the token hash.
  - Grounded in the verified existing transport code: `ensure_loopback_addrs`, `HostGuard`, `TCP_IO_TIMEOUT`/`MAX_TCP_BODY_BYTES`, and the fail-closed `ensure_private_coven_home` uid check the key material inherits.
- User-visible behavior: None — documentation only. The two cross-links point AUTH.md's "needs a separate design" paragraph and remote-access.md's tunnel guidance at the new design.
- Compatibility notes: No code, schema, or protocol changes. Four open questions (dependency budget for rustls/rcgen, pairing pin strength, store-table vs sidecar file, scope granularity for Pocket approvals) are called out for maintainers before any implementation issue is cut.

## Verification

- [x] `python3 scripts/check-secrets.py` — clean
- [x] Additional manual checks: docs-only diff (no Rust/npm surface); `scripts/onboarding-docs-test.mjs` assertions unaffected (additive edits to non-covered files); design-doc format matches `docs/design/ward-gate3-coherence.md`; all cited code facts re-verified against `daemon.rs`/`api.rs` on main @ 3d2e54b.
- Cargo gates not run: no Rust changes (CI still runs them on the PR).

## Risk and Rollback

- Risk level: Low — documentation only; proposes (does not implement) daemon changes, with explicit "Status: Proposed" and maintainer-decision gates.
- Rollback plan: Revert the single commit.

## Agent Handoff

- Current state: Design complete and cross-linked; no implementation started (deliberately — the issue is a design task and the open questions need ratification first).
- Follow-ups: Once the open questions are decided, cut implementation issues per rollout phase (v1: TLS + pairing + scopes + revocation; v2: mTLS) and update `docs/AUTH.md` / `docs/daemon/auth-posture.md` when the listener ships.
- Known gaps: The `docs/daemon/auth-posture.md` stub remains a stub; filling it is independent of this design.
