### PR TITLE
fix: make claim acquire atomic so racing agents can't both win

### DIFF
--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -99,6 +99,13 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
         // Someone holds the slot. Re-read to decide whether it is ours to
         // refresh, someone else's to respect, or expired and up for grabs.
         match read_claim(&repo, branch)? {
+            None => {
+                // `create_new` publishes the directory entry before the
+                // winner finishes writing the claim body. An empty or partial
+                // file is therefore contended, not abandoned: retrying gives
+                // the writer time to finish without letting a loser steal it.
+                std::thread::sleep(Duration::from_millis(20));
+            }
             Some(existing) if existing.is_active(now) && existing.agent_id != agent_id => {
                 anyhow::bail!(
                     "{} is already claimed by {} until {}",
@@ -115,12 +122,11 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
                 println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
                 return Ok(());
             }
-            // Expired, or too corrupt to identify an owner. Contend for the
-            // takeover under a lock: unlike a free slot, this transition
-            // cannot be arbitrated by `create_new` (the file already exists),
-            // and it must never leave the slot empty or a concurrent
-            // `create_new` would slip into the gap and mint a second winner.
-            _ => {
+            // An expired claim is eligible for takeover. Contend under a
+            // lock: unlike a free slot, this transition cannot be arbitrated
+            // by `create_new` (the file already exists), and it must never
+            // leave the slot empty or a concurrent creator could slip in.
+            Some(_) => {
                 if try_takeover(&repo, branch, &claim)? {
                     println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
                     return Ok(());
@@ -200,8 +206,13 @@ pub(crate) fn claim_status(json: bool) -> Result<()> {
     let mut claims = if claims_dir.exists() {
         fs::read_dir(&claims_dir)?
             .filter_map(|entry| entry.ok())
-            .filter(|entry| !is_temp_claim_file(&entry.path()))
-            .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
+            .filter_map(|entry| {
+                let path = entry.path();
+                read_claim_file(&path)
+                    .ok()
+                    .flatten()
+                    .filter(|claim| claim_path(&repo, &claim.branch) == path)
+            })
             .collect::<Vec<_>>()
     } else {
         Vec::new()
@@ -614,6 +625,22 @@ fn create_claim_exclusive(repo: &Repo, claim: &Claim) -> Result<bool> {
     let claims_dir = repo.common_dir.join("agent-claims");
     fs::create_dir_all(&claims_dir)?;
     let path = claim_path(repo, &claim.branch);
+    let takeover_lock = takeover_lock_path(&path);
+    if takeover_lock.try_exists().with_context(|| {
+        format!(
+            "failed to inspect takeover lock {}",
+            takeover_lock.display()
+        )
+    })? {
+        if lock_is_stale(&takeover_lock) {
+            let _ = fs::remove_file(&takeover_lock);
+        } else {
+            // A releaser can remove an expired claim while its winner holds
+            // the takeover lock. Do not let that temporary empty slot admit
+            // a second winner before the takeover publishes its replacement.
+            return Ok(false);
+        }
+    }
     match fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -640,9 +667,8 @@ fn replace_claim(repo: &Repo, claim: &Claim) -> Result<()> {
     fs::write(&staging, render_claim(claim))
         .with_context(|| format!("failed to stage claim {}", staging.display()))?;
     replace_claim_file(&staging, &path)
-        .map_err(|err| {
+        .inspect_err(|_| {
             let _ = fs::remove_file(&staging);
-            err
         })
         .with_context(|| format!("failed to publish claim {}", path.display()))?;
     Ok(())
@@ -691,15 +717,16 @@ fn replace_claim_file(staging: &Path, path: &Path) -> std::io::Result<()> {
 }
 
 /// Sibling path for staged and cleared claim files. Kept in the same directory
-/// so the rename stays within one filesystem, and dot-prefixed so
-/// `claim status` skips it if a crash leaves one behind.
+/// so the rename stays within one filesystem. The `@` prefix is reserved for
+/// protocol internals because `branch_slug` never preserves `@`, so no valid
+/// claim filename can collide with staging or lock state.
 fn temp_claim_path(path: &Path, kind: &str) -> PathBuf {
     let name = path
         .file_name()
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| "claim".to_string());
     let unique = format!(
-        ".{name}.{kind}.{}.{}",
+        "@{name}.{kind}.{}.{}",
         std::process::id(),
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -730,10 +757,15 @@ fn try_takeover(repo: &Repo, branch: &str, claim: &Claim) -> Result<bool> {
         Some(existing) if existing.is_active(now) && existing.agent_id != claim.agent_id => {
             Ok(false)
         }
-        _ => {
+        Some(_) => {
             replace_claim(repo, claim)?;
             Ok(true)
         }
+        // A concurrent release may remove the expired claim after we decide
+        // to take it over. With no file left to replace, drop the lock and let
+        // the next free-slot acquisition use `create_new`; recreating it here
+        // would race that path and could report two winners.
+        None => Ok(false),
     }
 }
 
@@ -790,41 +822,7 @@ fn takeover_lock_path(path: &Path) -> PathBuf {
         .file_name()
         .map(|name| name.to_string_lossy().to_string())
         .unwrap_or_else(|| "claim".to_string());
-    path.with_file_name(format!(".{name}.takeover"))
-}
-
-fn is_temp_claim_file(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    is_staged_claim_file(name) || is_takeover_lock_file(path, name)
-}
-
-fn is_staged_claim_file(name: &str) -> bool {
-    let Some(rest) = name.strip_prefix('.') else {
-        return false;
-    };
-    let Some((prefix, nanos)) = rest.rsplit_once('.') else {
-        return false;
-    };
-    let Some((prefix, pid)) = prefix.rsplit_once('.') else {
-        return false;
-    };
-    prefix.ends_with(".write")
-        && !pid.is_empty()
-        && pid.bytes().all(|byte| byte.is_ascii_digit())
-        && !nanos.is_empty()
-        && nanos.bytes().all(|byte| byte.is_ascii_digit())
-}
-
-fn is_takeover_lock_file(path: &Path, name: &str) -> bool {
-    let Some(rest) = name.strip_prefix('.') else {
-        return false;
-    };
-    let Some(claim_name) = rest.strip_suffix(".takeover") else {
-        return false;
-    };
-    !claim_name.is_empty() && path.with_file_name(claim_name).exists()
+    path.with_file_name(format!("@{name}.takeover"))
 }
 
 fn write_claim(repo: &Repo, claim: &Claim) -> Result<()> {
@@ -1228,18 +1226,54 @@ mod tests {
     }
 
     #[test]
-    fn temp_claim_file_detection_is_specific() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let claim = temp.path().join(".foo");
-        let staged = temp.path().join(".foo.write.123.456");
-        let lock = temp.path().join(".foo.takeover");
+    fn replace_claim_overwrites_existing_claim() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let repo = Repo {
+            root: temp.path().to_path_buf(),
+            common_dir: temp.path().to_path_buf(),
+        };
+        let original = sample_claim();
+        assert!(create_claim_exclusive(&repo, &original).expect("create original claim"));
 
-        assert!(!is_temp_claim_file(&claim));
-        assert!(is_temp_claim_file(&staged));
-        assert!(!is_temp_claim_file(&lock));
+        let replacement = Claim {
+            agent_id: "agent-b".to_string(),
+            expires_at: original.expires_at + 3600,
+            ..original.clone()
+        };
+        replace_claim(&repo, &replacement).expect("replace existing claim");
 
-        fs::write(temp.path().join("foo"), "").expect("seed claim");
-        assert!(is_temp_claim_file(&lock));
+        let stored = read_claim(&repo, &replacement.branch)
+            .expect("read replacement")
+            .expect("claim exists");
+        assert_eq!(stored.agent_id, replacement.agent_id);
+        assert_eq!(stored.expires_at, replacement.expires_at);
+    }
+
+    #[test]
+    fn takeover_does_not_recreate_a_released_claim() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let repo = Repo {
+            root: temp.path().to_path_buf(),
+            common_dir: temp.path().to_path_buf(),
+        };
+        fs::create_dir_all(repo.common_dir.join("agent-claims")).expect("claims dir");
+        let claim = sample_claim();
+
+        assert!(!try_takeover(&repo, &claim.branch, &claim).expect("try takeover"));
+        assert!(!claim_path(&repo, &claim.branch).exists());
+    }
+
+    #[test]
+    fn internal_claim_paths_use_unrepresentable_prefix() {
+        let claim = PathBuf::from("feature-demo");
+        let staged = temp_claim_path(&claim, "write");
+        let lock = takeover_lock_path(&claim);
+
+        for internal in [staged, lock] {
+            let name = internal.file_name().unwrap().to_string_lossy();
+            assert!(name.starts_with('@'));
+            assert_ne!(branch_slug(&name), name);
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -639,11 +639,55 @@ fn replace_claim(repo: &Repo, claim: &Claim) -> Result<()> {
     let staging = temp_claim_path(&path, "write");
     fs::write(&staging, render_claim(claim))
         .with_context(|| format!("failed to stage claim {}", staging.display()))?;
-    fs::rename(&staging, &path).with_context(|| {
-        let _ = fs::remove_file(&staging);
-        format!("failed to publish claim {}", path.display())
-    })?;
+    replace_claim_file(&staging, &path)
+        .map_err(|err| {
+            let _ = fs::remove_file(&staging);
+            err
+        })
+        .with_context(|| format!("failed to publish claim {}", path.display()))?;
     Ok(())
+}
+
+#[cfg(not(windows))]
+fn replace_claim_file(staging: &Path, path: &Path) -> std::io::Result<()> {
+    fs::rename(staging, path)
+}
+
+#[cfg(windows)]
+fn replace_claim_file(staging: &Path, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+
+    #[link(name = "Kernel32")]
+    extern "system" {
+        #[link_name = "MoveFileExW"]
+        fn move_file_ex_w(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+
+    let existing: Vec<u16> = staging
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let new: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let ok = unsafe {
+        move_file_ex_w(
+            existing.as_ptr(),
+            new.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    };
+    if ok == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 /// Sibling path for staged and cleared claim files. Kept in the same directory
@@ -750,9 +794,37 @@ fn takeover_lock_path(path: &Path) -> PathBuf {
 }
 
 fn is_temp_claim_file(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.starts_with('.'))
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    is_staged_claim_file(name) || is_takeover_lock_file(path, name)
+}
+
+fn is_staged_claim_file(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix('.') else {
+        return false;
+    };
+    let Some((prefix, nanos)) = rest.rsplit_once('.') else {
+        return false;
+    };
+    let Some((prefix, pid)) = prefix.rsplit_once('.') else {
+        return false;
+    };
+    prefix.ends_with(".write")
+        && !pid.is_empty()
+        && pid.bytes().all(|byte| byte.is_ascii_digit())
+        && !nanos.is_empty()
+        && nanos.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn is_takeover_lock_file(path: &Path, name: &str) -> bool {
+    let Some(rest) = name.strip_prefix('.') else {
+        return false;
+    };
+    let Some(claim_name) = rest.strip_suffix(".takeover") else {
+        return false;
+    };
+    !claim_name.is_empty() && path.with_file_name(claim_name).exists()
 }
 
 fn write_claim(repo: &Repo, claim: &Claim) -> Result<()> {
@@ -1153,6 +1225,21 @@ mod tests {
         let value: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
 
         assert_eq!(value["claims"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn temp_claim_file_detection_is_specific() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let claim = temp.path().join(".foo");
+        let staged = temp.path().join(".foo.write.123.456");
+        let lock = temp.path().join(".foo.takeover");
+
+        assert!(!is_temp_claim_file(&claim));
+        assert!(is_temp_claim_file(&staged));
+        assert!(!is_temp_claim_file(&lock));
+
+        fs::write(temp.path().join("foo"), "").expect("seed claim");
+        assert!(is_temp_claim_file(&lock));
     }
 
     #[test]

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -14,6 +14,10 @@ const CLAIM_ACQUIRE_ATTEMPTS: usize = 8;
 /// A takeover holds its lock for two syscalls, so anything older than this was
 /// abandoned by a process that died mid-takeover.
 const TAKEOVER_LOCK_STALE: Duration = Duration::from_secs(30);
+/// Initial claim writes normally finish within one syscall-sized critical
+/// window. An incomplete file older than this was abandoned by a process that
+/// died after `create_new` published the directory entry.
+const INCOMPLETE_CLAIM_STALE: Duration = Duration::from_secs(30);
 const DEFAULT_PRIMARY_BRANCH: &str = "main";
 const MANAGED_HOOK_MARKER: &str = "Coven Parallel Work Protocol managed hook";
 
@@ -30,6 +34,13 @@ struct Claim {
     acquired_at: u64,
     expires_at: u64,
     head: Option<String>,
+}
+
+#[derive(Debug)]
+enum ClaimFileState {
+    Missing,
+    Incomplete,
+    Parsed(Claim),
 }
 
 #[derive(Debug)]
@@ -99,14 +110,26 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
         // Someone holds the slot. Re-read to decide whether it is ours to
         // refresh, someone else's to respect, or expired and up for grabs.
         match read_claim(&repo, branch)? {
-            None => {
-                // `create_new` publishes the directory entry before the
-                // winner finishes writing the claim body. An empty or partial
-                // file is therefore contended, not abandoned: retrying gives
-                // the writer time to finish without letting a loser steal it.
+            ClaimFileState::Missing => {
+                // A takeover lock may temporarily protect a missing slot, or
+                // the owner may change between the failed create and this
+                // read. Retry without treating either state as free.
                 std::thread::sleep(Duration::from_millis(20));
             }
-            Some(existing) if existing.is_active(now) && existing.agent_id != agent_id => {
+            ClaimFileState::Incomplete => {
+                // A fresh partial file belongs to a writer still publishing
+                // its exclusive-create win. Once stale, recover it under the
+                // same lock used for expired-claim takeover.
+                if incomplete_claim_is_stale(&repo, branch) && try_takeover(&repo, branch, &claim)?
+                {
+                    println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
+                    return Ok(());
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            ClaimFileState::Parsed(existing)
+                if existing.is_active(now) && existing.agent_id != agent_id =>
+            {
                 anyhow::bail!(
                     "{} is already claimed by {} until {}",
                     branch,
@@ -114,7 +137,7 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
                     existing.expires_at
                 );
             }
-            Some(existing) if existing.is_active(now) => {
+            ClaimFileState::Parsed(existing) if existing.is_active(now) => {
                 // Our own live claim: extend it in place rather than
                 // reporting a conflict against ourselves.
                 debug_assert_eq!(existing.agent_id, agent_id);
@@ -126,7 +149,7 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
             // lock: unlike a free slot, this transition cannot be arbitrated
             // by `create_new` (the file already exists), and it must never
             // leave the slot empty or a concurrent creator could slip in.
-            Some(_) => {
+            ClaimFileState::Parsed(_) => {
                 if try_takeover(&repo, branch, &claim)? {
                     println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
                     return Ok(());
@@ -142,20 +165,28 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
 pub(crate) fn claim_release(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
     let agent_id = agent_id();
-    if let Some(existing) = read_claim(&repo, branch)? {
-        if existing.is_active(unix_now()) && existing.agent_id != agent_id {
+    match read_claim(&repo, branch)? {
+        ClaimFileState::Parsed(existing) => {
+            if existing.is_active(unix_now()) && existing.agent_id != agent_id {
+                anyhow::bail!(
+                    "{} is claimed by {}; {} cannot release it",
+                    branch,
+                    existing.agent_id,
+                    agent_id
+                );
+            }
+            fs::remove_file(claim_path(&repo, branch))
+                .with_context(|| format!("failed to release claim for {branch}"))?;
+            println!("released {branch}");
+        }
+        ClaimFileState::Incomplete => {
             anyhow::bail!(
-                "{} is claimed by {}; {} cannot release it",
-                branch,
-                existing.agent_id,
-                agent_id
+                "claim file for {branch} is incomplete; refusing to release ambiguous ownership"
             );
         }
-        fs::remove_file(claim_path(&repo, branch))
-            .with_context(|| format!("failed to release claim for {branch}"))?;
-        println!("released {branch}");
-    } else {
-        println!("no claim for {branch}");
+        ClaimFileState::Missing => {
+            println!("no claim for {branch}");
+        }
     }
     Ok(())
 }
@@ -164,13 +195,21 @@ pub(crate) fn claim_heartbeat(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
     let agent_id = agent_id();
     let now = unix_now();
-    let mut claim = read_claim(&repo, branch)?.unwrap_or_else(|| Claim {
-        branch: branch.to_string(),
-        agent_id: agent_id.clone(),
-        acquired_at: now,
-        expires_at: now,
-        head: current_head().ok(),
-    });
+    let mut claim = match read_claim(&repo, branch)? {
+        ClaimFileState::Parsed(claim) => claim,
+        ClaimFileState::Missing => Claim {
+            branch: branch.to_string(),
+            agent_id: agent_id.clone(),
+            acquired_at: now,
+            expires_at: now,
+            head: current_head().ok(),
+        },
+        ClaimFileState::Incomplete => {
+            anyhow::bail!(
+                "claim file for {branch} is incomplete; refusing to heartbeat ambiguous ownership"
+            );
+        }
+    };
     if claim.is_active(now) && claim.agent_id != agent_id {
         anyhow::bail!(
             "{} is claimed by {}; {} cannot heartbeat it",
@@ -210,7 +249,7 @@ pub(crate) fn claim_status(json: bool) -> Result<()> {
                 let path = entry.path();
                 read_claim_file(&path)
                     .ok()
-                    .flatten()
+                    .and_then(ClaimFileState::into_parsed)
                     .filter(|claim| claim_path(&repo, &claim.branch) == path)
             })
             .collect::<Vec<_>>()
@@ -334,7 +373,8 @@ fn wt_list(repo: &Repo, json: bool) -> Result<()> {
         let claimed_by = worktree
             .branch
             .as_deref()
-            .and_then(|branch| read_claim(repo, branch).ok().flatten())
+            .and_then(|branch| read_claim(repo, branch).ok())
+            .and_then(ClaimFileState::into_parsed)
             .filter(|claim| claim.is_active(now))
             .map(|claim| claim.agent_id);
         rows.push(WorktreeRow {
@@ -632,7 +672,7 @@ fn create_claim_exclusive(repo: &Repo, claim: &Claim) -> Result<bool> {
             takeover_lock.display()
         )
     })? {
-        if lock_is_stale(&takeover_lock) {
+        if path_is_stale(&takeover_lock, TAKEOVER_LOCK_STALE) {
             let _ = fs::remove_file(&takeover_lock);
         } else {
             // A releaser can remove an expired claim while its winner holds
@@ -754,10 +794,16 @@ fn try_takeover(repo: &Repo, branch: &str, claim: &Claim) -> Result<bool> {
     // changed while we were contending for it.
     let now = unix_now();
     match read_claim(repo, branch)? {
-        Some(existing) if existing.is_active(now) && existing.agent_id != claim.agent_id => {
+        ClaimFileState::Parsed(existing)
+            if existing.is_active(now) && existing.agent_id != claim.agent_id =>
+        {
             Ok(false)
         }
-        Some(_) => {
+        ClaimFileState::Parsed(_) => {
+            replace_claim(repo, claim)?;
+            Ok(true)
+        }
+        ClaimFileState::Incomplete if incomplete_claim_is_stale(repo, branch) => {
             replace_claim(repo, claim)?;
             Ok(true)
         }
@@ -765,7 +811,7 @@ fn try_takeover(repo: &Repo, branch: &str, claim: &Claim) -> Result<bool> {
         // to take it over. With no file left to replace, drop the lock and let
         // the next free-slot acquisition use `create_new`; recreating it here
         // would race that path and could report two winners.
-        None => Ok(false),
+        ClaimFileState::Missing | ClaimFileState::Incomplete => Ok(false),
     }
 }
 
@@ -787,7 +833,7 @@ impl TakeoverLock {
                 // The critical section is two syscalls long, so a lock this
                 // old belongs to a process that died holding it. Breaking it
                 // only returns us to contending for the same lock.
-                if lock_is_stale(&path) {
+                if path_is_stale(&path, TAKEOVER_LOCK_STALE) {
                     let _ = fs::remove_file(&path);
                 }
                 Ok(None)
@@ -805,7 +851,7 @@ impl Drop for TakeoverLock {
     }
 }
 
-fn lock_is_stale(path: &Path) -> bool {
+fn path_is_stale(path: &Path, stale_after: Duration) -> bool {
     let Ok(modified) = fs::metadata(path).and_then(|meta| meta.modified()) else {
         return false;
     };
@@ -813,7 +859,7 @@ fn lock_is_stale(path: &Path) -> bool {
     // is the safe direction: we wait instead of breaking someone's lock.
     SystemTime::now()
         .duration_since(modified)
-        .map(|age| age > TAKEOVER_LOCK_STALE)
+        .map(|age| age > stale_after)
         .unwrap_or(false)
 }
 
@@ -829,16 +875,24 @@ fn write_claim(repo: &Repo, claim: &Claim) -> Result<()> {
     replace_claim(repo, claim)
 }
 
-fn read_claim(repo: &Repo, branch: &str) -> Result<Option<Claim>> {
+fn incomplete_claim_is_stale(repo: &Repo, branch: &str) -> bool {
+    path_is_stale(&claim_path(repo, branch), INCOMPLETE_CLAIM_STALE)
+}
+
+fn read_claim(repo: &Repo, branch: &str) -> Result<ClaimFileState> {
     read_claim_file(&claim_path(repo, branch))
 }
 
-fn read_claim_file(path: &Path) -> Result<Option<Claim>> {
-    if !path.exists() {
-        return Ok(None);
-    }
-    let contents = fs::read_to_string(path)
-        .with_context(|| format!("failed to read claim {}", path.display()))?;
+fn read_claim_file(path: &Path) -> Result<ClaimFileState> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(ClaimFileState::Missing);
+        }
+        Err(err) => {
+            return Err(err).with_context(|| format!("failed to read claim {}", path.display()));
+        }
+    };
     let value = |key: &str| -> Option<String> {
         contents.lines().find_map(|line| {
             line.split_once('=')
@@ -846,21 +900,19 @@ fn read_claim_file(path: &Path) -> Result<Option<Claim>> {
                 .map(|(_, value)| value.to_string())
         })
     };
-    let branch = value("branch").unwrap_or_else(|| {
-        path.file_name()
-            .map(|name| name.to_string_lossy().to_string())
-            .unwrap_or_else(|| "unknown".to_string())
-    });
-    let Some(agent_id) = value("agent_id") else {
-        return Ok(None);
+    let Some(branch) = value("branch").filter(|value| !value.trim().is_empty()) else {
+        return Ok(ClaimFileState::Incomplete);
     };
-    let acquired_at = value("acquired_at")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0);
-    let expires_at = value("expires_at")
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(0);
-    Ok(Some(Claim {
+    let Some(agent_id) = value("agent_id").filter(|value| !value.trim().is_empty()) else {
+        return Ok(ClaimFileState::Incomplete);
+    };
+    let Some(acquired_at) = value("acquired_at").and_then(|value| value.parse().ok()) else {
+        return Ok(ClaimFileState::Incomplete);
+    };
+    let Some(expires_at) = value("expires_at").and_then(|value| value.parse().ok()) else {
+        return Ok(ClaimFileState::Incomplete);
+    };
+    Ok(ClaimFileState::Parsed(Claim {
         branch,
         agent_id,
         acquired_at,
@@ -878,6 +930,15 @@ fn claim_path(repo: &Repo, branch: &str) -> PathBuf {
 impl Claim {
     fn is_active(&self, now: u64) -> bool {
         self.expires_at > now
+    }
+}
+
+impl ClaimFileState {
+    fn into_parsed(self) -> Option<Claim> {
+        match self {
+            Self::Parsed(claim) => Some(claim),
+            Self::Missing | Self::Incomplete => None,
+        }
     }
 }
 
@@ -1244,6 +1305,7 @@ mod tests {
 
         let stored = read_claim(&repo, &replacement.branch)
             .expect("read replacement")
+            .into_parsed()
             .expect("claim exists");
         assert_eq!(stored.agent_id, replacement.agent_id);
         assert_eq!(stored.expires_at, replacement.expires_at);

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -7,6 +7,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, SecondsFormat};
 const CLAIM_TTL_SECONDS: u64 = 60 * 60;
+/// Passes allowed through the acquire loop. Each pass either settles the claim
+/// or loses a race to another agent, and a loser only re-runs after the winner
+/// has published its claim, so a couple of passes is plenty.
+const CLAIM_ACQUIRE_ATTEMPTS: usize = 8;
+/// A takeover holds its lock for two syscalls, so anything older than this was
+/// abandoned by a process that died mid-takeover.
+const TAKEOVER_LOCK_STALE: Duration = Duration::from_secs(30);
 const DEFAULT_PRIMARY_BRANCH: &str = "main";
 const MANAGED_HOOK_MARKER: &str = "Coven Parallel Work Protocol managed hook";
 
@@ -69,28 +76,61 @@ pub(crate) fn run_wt_command(
 pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
     let agent_id = agent_id();
-    let now = unix_now();
-    if let Some(existing) = read_claim(&repo, branch)? {
-        if existing.is_active(now) && existing.agent_id != agent_id {
-            anyhow::bail!(
-                "{} is already claimed by {} until {}",
-                branch,
-                existing.agent_id,
-                existing.expires_at
-            );
+
+    // Creating the claim file is the only step that decides the race, so it
+    // has to be the same step that tests for a free slot: a separate
+    // read-then-write lets two agents both observe "free" and both write,
+    // which is how one issue ends up with two agents and two PRs.
+    for _ in 0..CLAIM_ACQUIRE_ATTEMPTS {
+        let now = unix_now();
+        let claim = Claim {
+            branch: branch.to_string(),
+            agent_id: agent_id.clone(),
+            acquired_at: now,
+            expires_at: now + claim_ttl_seconds(),
+            head: current_head().ok(),
+        };
+
+        if create_claim_exclusive(&repo, &claim)? {
+            println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
+            return Ok(());
+        }
+
+        // Someone holds the slot. Re-read to decide whether it is ours to
+        // refresh, someone else's to respect, or expired and up for grabs.
+        match read_claim(&repo, branch)? {
+            Some(existing) if existing.is_active(now) && existing.agent_id != agent_id => {
+                anyhow::bail!(
+                    "{} is already claimed by {} until {}",
+                    branch,
+                    existing.agent_id,
+                    existing.expires_at
+                );
+            }
+            Some(existing) if existing.is_active(now) => {
+                // Our own live claim: extend it in place rather than
+                // reporting a conflict against ourselves.
+                debug_assert_eq!(existing.agent_id, agent_id);
+                replace_claim(&repo, &claim)?;
+                println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
+                return Ok(());
+            }
+            // Expired, or too corrupt to identify an owner. Contend for the
+            // takeover under a lock: unlike a free slot, this transition
+            // cannot be arbitrated by `create_new` (the file already exists),
+            // and it must never leave the slot empty or a concurrent
+            // `create_new` would slip into the gap and mint a second winner.
+            _ => {
+                if try_takeover(&repo, branch, &claim)? {
+                    println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
+                    return Ok(());
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
         }
     }
 
-    let claim = Claim {
-        branch: branch.to_string(),
-        agent_id: agent_id.clone(),
-        acquired_at: now,
-        expires_at: now + claim_ttl_seconds(),
-        head: current_head().ok(),
-    };
-    write_claim(&repo, &claim)?;
-    println!("claimed {branch} for {agent_id} until {}", claim.expires_at);
-    Ok(())
+    anyhow::bail!("could not acquire claim for {branch}: contended by other agents, retry")
 }
 
 pub(crate) fn claim_release(branch: &str) -> Result<()> {
@@ -160,6 +200,7 @@ pub(crate) fn claim_status(json: bool) -> Result<()> {
     let mut claims = if claims_dir.exists() {
         fs::read_dir(&claims_dir)?
             .filter_map(|entry| entry.ok())
+            .filter(|entry| !is_temp_claim_file(&entry.path()))
             .filter_map(|entry| read_claim_file(&entry.path()).ok().flatten())
             .collect::<Vec<_>>()
     } else {
@@ -552,20 +593,170 @@ fn worktree_path(repo: &Repo, branch: &str) -> Result<PathBuf> {
     Ok(worktree_root(repo)?.join(branch_slug(branch)))
 }
 
-fn write_claim(repo: &Repo, claim: &Claim) -> Result<()> {
+fn render_claim(claim: &Claim) -> String {
+    let mut rendered = String::new();
+    rendered.push_str(&format!("branch={}\n", claim.branch));
+    rendered.push_str(&format!("agent_id={}\n", claim.agent_id));
+    rendered.push_str(&format!("acquired_at={}\n", claim.acquired_at));
+    rendered.push_str(&format!("expires_at={}\n", claim.expires_at));
+    if let Some(head) = &claim.head {
+        rendered.push_str(&format!("head={head}\n"));
+    }
+    rendered
+}
+
+/// Create the claim file, failing rather than overwriting when one exists.
+///
+/// `create_new` is the whole guarantee: the kernel resolves the O_CREAT|O_EXCL
+/// open, so exactly one of any number of racing agents is told it created the
+/// file. Returns `false` when the slot was already taken.
+fn create_claim_exclusive(repo: &Repo, claim: &Claim) -> Result<bool> {
     let claims_dir = repo.common_dir.join("agent-claims");
     fs::create_dir_all(&claims_dir)?;
     let path = claim_path(repo, &claim.branch);
-    let mut file = fs::File::create(&path)
-        .with_context(|| format!("failed to create claim {}", path.display()))?;
-    writeln!(file, "branch={}", claim.branch)?;
-    writeln!(file, "agent_id={}", claim.agent_id)?;
-    writeln!(file, "acquired_at={}", claim.acquired_at)?;
-    writeln!(file, "expires_at={}", claim.expires_at)?;
-    if let Some(head) = &claim.head {
-        writeln!(file, "head={head}")?;
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&path)
+    {
+        Ok(mut file) => {
+            file.write_all(render_claim(claim).as_bytes())
+                .with_context(|| format!("failed to write claim {}", path.display()))?;
+            Ok(true)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+        Err(err) => Err(err).with_context(|| format!("failed to create claim {}", path.display())),
     }
+}
+
+/// Overwrite an existing claim through a temp file plus rename, so a reader
+/// never observes a half-written claim and two concurrent writers cannot
+/// interleave their lines into one file.
+fn replace_claim(repo: &Repo, claim: &Claim) -> Result<()> {
+    let claims_dir = repo.common_dir.join("agent-claims");
+    fs::create_dir_all(&claims_dir)?;
+    let path = claim_path(repo, &claim.branch);
+    let staging = temp_claim_path(&path, "write");
+    fs::write(&staging, render_claim(claim))
+        .with_context(|| format!("failed to stage claim {}", staging.display()))?;
+    fs::rename(&staging, &path).with_context(|| {
+        let _ = fs::remove_file(&staging);
+        format!("failed to publish claim {}", path.display())
+    })?;
     Ok(())
+}
+
+/// Sibling path for staged and cleared claim files. Kept in the same directory
+/// so the rename stays within one filesystem, and dot-prefixed so
+/// `claim status` skips it if a crash leaves one behind.
+fn temp_claim_path(path: &Path, kind: &str) -> PathBuf {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "claim".to_string());
+    let unique = format!(
+        ".{name}.{kind}.{}.{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|value| value.as_nanos())
+            .unwrap_or_default()
+    );
+    path.with_file_name(unique)
+}
+
+/// Take over an expired claim, serialised so exactly one agent can do it.
+///
+/// Replacing an existing claim cannot be arbitrated by `create_new`, so this
+/// is the one transition that needs a lock. The replacement is published with
+/// an atomic rename rather than a delete-then-create, so the slot is never
+/// observed empty: agents that are not holding the lock keep failing their own
+/// `create_new`, re-read, and see the new owner.
+///
+/// Returns `true` when `claim` was published.
+fn try_takeover(repo: &Repo, branch: &str, claim: &Claim) -> Result<bool> {
+    let Some(_lock) = TakeoverLock::try_acquire(repo, branch)? else {
+        return Ok(false);
+    };
+
+    // Re-read under the lock: the state that justified the takeover may have
+    // changed while we were contending for it.
+    let now = unix_now();
+    match read_claim(repo, branch)? {
+        Some(existing) if existing.is_active(now) && existing.agent_id != claim.agent_id => {
+            Ok(false)
+        }
+        _ => {
+            replace_claim(repo, claim)?;
+            Ok(true)
+        }
+    }
+}
+
+/// Exclusive lock guarding the expired-claim takeover, released on drop.
+struct TakeoverLock {
+    path: PathBuf,
+}
+
+impl TakeoverLock {
+    fn try_acquire(repo: &Repo, branch: &str) -> Result<Option<Self>> {
+        let path = takeover_lock_path(&claim_path(repo, branch));
+        match fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+        {
+            Ok(_) => Ok(Some(Self { path })),
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+                // The critical section is two syscalls long, so a lock this
+                // old belongs to a process that died holding it. Breaking it
+                // only returns us to contending for the same lock.
+                if lock_is_stale(&path) {
+                    let _ = fs::remove_file(&path);
+                }
+                Ok(None)
+            }
+            Err(err) => {
+                Err(err).with_context(|| format!("failed to lock takeover {}", path.display()))
+            }
+        }
+    }
+}
+
+impl Drop for TakeoverLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn lock_is_stale(path: &Path) -> bool {
+    let Ok(modified) = fs::metadata(path).and_then(|meta| meta.modified()) else {
+        return false;
+    };
+    // A clock skew that puts the lock in the future reads as not-stale, which
+    // is the safe direction: we wait instead of breaking someone's lock.
+    SystemTime::now()
+        .duration_since(modified)
+        .map(|age| age > TAKEOVER_LOCK_STALE)
+        .unwrap_or(false)
+}
+
+fn takeover_lock_path(path: &Path) -> PathBuf {
+    let name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "claim".to_string());
+    path.with_file_name(format!(".{name}.takeover"))
+}
+
+fn is_temp_claim_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+}
+
+fn write_claim(repo: &Repo, claim: &Claim) -> Result<()> {
+    replace_claim(repo, claim)
 }
 
 fn read_claim(repo: &Repo, branch: &str) -> Result<Option<Claim>> {

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -66,6 +66,137 @@ fn claim_acquire_blocks_other_agent_until_release() -> anyhow::Result<()> {
 }
 
 #[test]
+fn concurrent_claim_acquire_yields_exactly_one_winner() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+
+    // A read-then-write acquire lets every racer observe a free slot and
+    // then overwrite the others, so each one is told it holds the claim.
+    let results = repo.race_acquire("feature/demo", &["cody", "sage", "nova", "kitty"], [])?;
+
+    let winners: Vec<&str> = results
+        .iter()
+        .filter(|(_, output)| output.status.success())
+        .map(|(agent, _)| *agent)
+        .collect();
+    assert_eq!(
+        winners.len(),
+        1,
+        "expected exactly one winner, got {winners:?}"
+    );
+
+    // The agent that was told it won must be the one recorded on disk.
+    assert_eq!(repo.claim_field("feature/demo", "agent_id")?, winners[0]);
+
+    for (agent, output) in results.iter().filter(|(agent, _)| *agent != winners[0]) {
+        assert_failure(&format!("claim acquire by {agent}"), output);
+        assert_stderr_contains(
+            &format!("claim acquire by {agent}"),
+            output,
+            "already claimed by",
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn concurrent_takeover_of_expired_claim_yields_exactly_one_winner() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+
+    // Seed a claim that is already expired, so every racer is entitled to
+    // take it over. Replacing an existing file cannot be arbitrated by an
+    // exclusive create, which makes this the path most likely to double-win.
+    let seeded = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [
+            ("COVEN_AGENT_ID", "ghost"),
+            ("COVEN_CLAIM_TTL_SECONDS", "1"),
+        ],
+    )?;
+    assert_success("claim acquire by ghost", &seeded);
+    std::thread::sleep(std::time::Duration::from_millis(1_200));
+
+    let results = repo.race_acquire("feature/demo", &["cody", "sage", "nova", "kitty"], [])?;
+
+    let winners: Vec<&str> = results
+        .iter()
+        .filter(|(_, output)| output.status.success())
+        .map(|(agent, _)| *agent)
+        .collect();
+    assert_eq!(
+        winners.len(),
+        1,
+        "expected exactly one winner taking over the expired claim, got {winners:?}"
+    );
+    assert_eq!(repo.claim_field("feature/demo", "agent_id")?, winners[0]);
+    Ok(())
+}
+
+#[test]
+fn claim_acquire_by_the_same_agent_extends_its_own_claim() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+
+    let first = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [
+            ("COVEN_AGENT_ID", "cody"),
+            ("COVEN_CLAIM_TTL_SECONDS", "60"),
+        ],
+    )?;
+    assert_success("first claim acquire by cody", &first);
+    let first_expiry: u64 = repo.claim_field("feature/demo", "expires_at")?.parse()?;
+
+    let again = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [
+            ("COVEN_AGENT_ID", "cody"),
+            ("COVEN_CLAIM_TTL_SECONDS", "6000"),
+        ],
+    )?;
+    assert_success("re-acquire by the same agent", &again);
+
+    let second_expiry: u64 = repo.claim_field("feature/demo", "expires_at")?.parse()?;
+    assert!(
+        second_expiry > first_expiry,
+        "re-acquiring should extend the owner's claim: {first_expiry} -> {second_expiry}"
+    );
+    assert_eq!(repo.claim_field("feature/demo", "agent_id")?, "cody");
+    Ok(())
+}
+
+#[test]
+fn claim_status_ignores_leftover_internal_files() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let acquired = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_success("claim acquire by cody", &acquired);
+
+    // Staging and lock files are dot-prefixed siblings of the claim; a crash
+    // mid-takeover can leave one behind and it must not read as a claim.
+    let claims_dir = repo.claims_dir()?;
+    fs::write(claims_dir.join(".feature-demo.takeover"), "")?;
+    fs::write(
+        claims_dir.join(".feature-demo.write.1.2"),
+        "branch=feature/demo\nagent_id=stale\nacquired_at=0\nexpires_at=0\n",
+    )?;
+
+    let status = repo.coven(["claim", "status"])?;
+    assert_success("claim status", &status);
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(
+        !stdout.contains("stale"),
+        "claim status must ignore internal files, got:\n{stdout}"
+    );
+    assert_eq!(
+        stdout.lines().filter(|line| line.contains("cody")).count(),
+        1,
+        "expected exactly one claim row, got:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn installed_hooks_block_primary_commits_and_claim_conflicts() -> anyhow::Result<()> {
     let repo = TestRepo::new()?;
 
@@ -222,6 +353,66 @@ impl TestRepo {
             command.env(key, value);
         }
         command.output().map_err(Into::into)
+    }
+
+    fn claims_dir(&self) -> anyhow::Result<PathBuf> {
+        Ok(self.git_common_dir()?.join("agent-claims"))
+    }
+
+    fn claim_field(&self, branch: &str, key: &str) -> anyhow::Result<String> {
+        let slug: String = branch
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                    ch
+                } else {
+                    '-'
+                }
+            })
+            .collect();
+        let path = self.claims_dir()?.join(slug.trim_matches('-'));
+        let contents = fs::read_to_string(&path)
+            .map_err(|err| anyhow::anyhow!("reading {}: {err}", path.display()))?;
+        contents
+            .lines()
+            .find_map(|line| line.strip_prefix(&format!("{key}=")))
+            .map(str::to_string)
+            .ok_or_else(|| anyhow::anyhow!("no {key} in {}:\n{contents}", path.display()))
+    }
+
+    /// Launch one `claim acquire` per agent as concurrently as processes
+    /// allow, so the acquire path is exercised as a real race rather than a
+    /// sequence. Every child is spawned before any of them is waited on.
+    fn race_acquire<'a, const M: usize>(
+        &self,
+        branch: &str,
+        agents: &[&'a str],
+        env: [(&str, &str); M],
+    ) -> anyhow::Result<Vec<(&'a str, Output)>> {
+        let children = agents
+            .iter()
+            .map(|agent| {
+                let mut command = Command::new(coven_bin());
+                command
+                    .args(["claim", "acquire", branch])
+                    .current_dir(&self.path)
+                    .env("COVEN_HOME", self.path.join(".coven-home"))
+                    .env("COVEN_AGENT_ID", agent)
+                    .env_remove("COVEN_ALLOW_PRIMARY_COMMIT")
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped());
+                for (key, value) in env {
+                    command.env(key, value);
+                }
+                command.spawn().map(|child| (*agent, child))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        children
+            .into_iter()
+            .map(|(agent, child)| child.wait_with_output().map(|output| (agent, output)))
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     fn git_common_dir(&self) -> anyhow::Result<PathBuf> {

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -3,6 +3,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
+use std::time::SystemTime;
 
 #[test]
 fn wt_creates_sibling_worktree_and_lists_protocol_state() -> anyhow::Result<()> {
@@ -182,6 +183,72 @@ fn claim_acquire_does_not_steal_an_incomplete_claim() -> anyhow::Result<()> {
         "contended",
     );
     assert_eq!(fs::read(&claim_path)?, b"");
+    Ok(())
+}
+
+#[test]
+fn claim_acquire_recovers_an_abandoned_incomplete_claim() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let claims_dir = repo.claims_dir()?;
+    fs::create_dir_all(&claims_dir)?;
+    let claim_path = claims_dir.join("feature-demo");
+    fs::write(&claim_path, "")?;
+    fs::File::options()
+        .write(true)
+        .open(&claim_path)?
+        .set_times(
+            fs::FileTimes::new()
+                .set_accessed(SystemTime::UNIX_EPOCH)
+                .set_modified(SystemTime::UNIX_EPOCH),
+        )?;
+
+    let acquire = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_success("claim acquire after abandoned initial write", &acquire);
+    assert_eq!(repo.claim_field("feature/demo", "agent_id")?, "sage");
+    Ok(())
+}
+
+#[test]
+fn claim_release_rejects_an_incomplete_claim() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    fs::create_dir_all(repo.claims_dir()?)?;
+    fs::write(repo.claims_dir()?.join("feature-demo"), "")?;
+
+    let release = repo.coven_with_env(
+        ["claim", "release", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_failure("claim release while initial write is incomplete", &release);
+    assert_stderr_contains(
+        "claim release while initial write is incomplete",
+        &release,
+        "incomplete",
+    );
+    Ok(())
+}
+
+#[test]
+fn claim_heartbeat_rejects_an_incomplete_claim() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    fs::create_dir_all(repo.claims_dir()?)?;
+    fs::write(repo.claims_dir()?.join("feature-demo"), "")?;
+
+    let heartbeat = repo.coven_with_env(
+        ["claim", "heartbeat", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_failure(
+        "claim heartbeat while initial write is incomplete",
+        &heartbeat,
+    );
+    assert_stderr_contains(
+        "claim heartbeat while initial write is incomplete",
+        &heartbeat,
+        "incomplete",
+    );
     Ok(())
 }
 

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -197,6 +197,29 @@ fn claim_status_ignores_leftover_internal_files() -> anyhow::Result<()> {
 }
 
 #[test]
+fn claim_status_lists_real_dot_prefixed_claims() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    fs::create_dir_all(repo.claims_dir()?)?;
+    fs::write(
+        repo.claims_dir()?.join(".foo"),
+        "branch=.foo\nagent_id=dotty\nacquired_at=0\nexpires_at=9999999999\n",
+    )?;
+
+    let status = repo.coven(["claim", "status"])?;
+    assert_success("claim status", &status);
+    let stdout = String::from_utf8_lossy(&status.stdout);
+    assert!(
+        stdout.contains(".foo"),
+        "claim status should list real dot-prefixed claims, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("dotty"),
+        "claim status should show the dot-prefixed claim owner, got:\n{stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn installed_hooks_block_primary_commits_and_claim_conflicts() -> anyhow::Result<()> {
     let repo = TestRepo::new()?;
 

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -164,6 +164,45 @@ fn claim_acquire_by_the_same_agent_extends_its_own_claim() -> anyhow::Result<()>
 }
 
 #[test]
+fn claim_acquire_does_not_steal_an_incomplete_claim() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let claims_dir = repo.claims_dir()?;
+    fs::create_dir_all(&claims_dir)?;
+    let claim_path = claims_dir.join("feature-demo");
+    fs::write(&claim_path, "")?;
+
+    let acquire = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_failure("claim acquire while initial write is incomplete", &acquire);
+    assert_stderr_contains(
+        "claim acquire while initial write is incomplete",
+        &acquire,
+        "contended",
+    );
+    assert_eq!(fs::read(&claim_path)?, b"");
+    Ok(())
+}
+
+#[test]
+fn claim_acquire_respects_live_takeover_lock_when_claim_is_missing() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let claims_dir = repo.claims_dir()?;
+    fs::create_dir_all(&claims_dir)?;
+    fs::write(claims_dir.join("@feature-demo.takeover"), "")?;
+
+    let acquire = repo.coven_with_env(
+        ["claim", "acquire", "feature/demo"],
+        [("COVEN_AGENT_ID", "sage")],
+    )?;
+    assert_failure("claim acquire during takeover", &acquire);
+    assert_stderr_contains("claim acquire during takeover", &acquire, "contended");
+    assert!(!claims_dir.join("feature-demo").exists());
+    Ok(())
+}
+
+#[test]
 fn claim_status_ignores_leftover_internal_files() -> anyhow::Result<()> {
     let repo = TestRepo::new()?;
     let acquired = repo.coven_with_env(
@@ -172,12 +211,12 @@ fn claim_status_ignores_leftover_internal_files() -> anyhow::Result<()> {
     )?;
     assert_success("claim acquire by cody", &acquired);
 
-    // Staging and lock files are dot-prefixed siblings of the claim; a crash
+    // Staging and lock files use the reserved `@`-prefixed namespace; a crash
     // mid-takeover can leave one behind and it must not read as a claim.
     let claims_dir = repo.claims_dir()?;
-    fs::write(claims_dir.join(".feature-demo.takeover"), "")?;
+    fs::write(claims_dir.join("@feature-demo.takeover"), "")?;
     fs::write(
-        claims_dir.join(".feature-demo.write.1.2"),
+        claims_dir.join("@feature-demo.write.1.2"),
         "branch=feature/demo\nagent_id=stale\nacquired_at=0\nexpires_at=0\n",
     )?;
 
@@ -216,6 +255,22 @@ fn claim_status_lists_real_dot_prefixed_claims() -> anyhow::Result<()> {
         stdout.contains("dotty"),
         "claim status should show the dot-prefixed claim owner, got:\n{stdout}"
     );
+    Ok(())
+}
+
+#[test]
+fn claim_status_lists_real_claim_matching_staging_filename_shape() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let acquired = repo.coven_with_env(
+        ["claim", "acquire", ".feature.write.123.456"],
+        [("COVEN_AGENT_ID", "dotty")],
+    )?;
+    assert_success("claim acquire by dotty", &acquired);
+
+    let status = repo.coven(["claim", "status"])?;
+    assert_success("claim status", &status);
+    assert_stdout_contains("claim status", &status, ".feature.write.123.456");
+    assert_stdout_contains("claim status", &status, "dotty");
     Ok(())
 }
 

--- a/docs/reference/cli-claim.md
+++ b/docs/reference/cli-claim.md
@@ -31,9 +31,12 @@ default; override with `COVEN_CLAIM_TTL_SECONDS`.
 
 - `acquire` fails while another agent's claim is active. The claim file is
   created exclusively, so when several sessions race for the same free or
-  expired token, exactly one of them is told it succeeded.
+  expired token, exactly one of them is told it succeeded. A partial claim
+  abandoned during creation remains contended for 30 seconds, then becomes
+  eligible for the same locked takeover path as an expired claim.
 - `release` refuses to remove another agent's active claim.
 - `heartbeat` re-acquires or extends your own claim for another TTL window.
+  Both `release` and `heartbeat` fail closed on a fresh incomplete claim.
 - `canary <branch>` records the current HEAD in `<git-common-dir>/AGENT_HEAD_AT_START`
   so the managed pre-commit hook can detect history rewrites.
 

--- a/docs/reference/cli-claim.md
+++ b/docs/reference/cli-claim.md
@@ -29,7 +29,9 @@ the repository sees the same registry. The claiming identity comes from
 `COVEN_AGENT_ID` (falling back to `USER`). A claim expires after one hour by
 default; override with `COVEN_CLAIM_TTL_SECONDS`.
 
-- `acquire` fails while another agent's claim is active.
+- `acquire` fails while another agent's claim is active. The claim file is
+  created exclusively, so when several sessions race for the same free or
+  expired token, exactly one of them is told it succeeded.
 - `release` refuses to remove another agent's active claim.
 - `heartbeat` re-acquires or extends your own claim for another TTL window.
 - `canary <branch>` records the current HEAD in `<git-common-dir>/AGENT_HEAD_AT_START`


### PR DESCRIPTION
Fixes the atomicity half of #491.

## Problem

`claim_acquire` read the claim file, decided the slot was free, then wrote it. Nothing held the gap between the check and the write, and `write_claim` used `fs::File::create` (`O_CREAT|O_TRUNC`), which silently clobbers an existing claim. Two agents could both pass the check and both write — and both were told they succeeded.

Reproduced against `main`:

```console
$ ( COVEN_AGENT_ID=alice coven claim acquire issue-42; echo "alice exit=$?" ) &
  ( COVEN_AGENT_ID=bob   coven claim acquire issue-42; echo "bob   exit=$?" ) &
  wait

alice exit=0    claimed issue-42 for alice until 1785062933
bob   exit=0    claimed issue-42 for bob   until 1785062933

$ cat "$(git rev-parse --git-common-dir)"/agent-claims/issue-42
agent_id=bob        # alice's claim was silently overwritten
```

`alice` then proceeds believing she holds the claim. That is the mechanism behind the duplicate-PR churn `AGENTS.md` describes as having "happened repeatedly".

## Approach

**Free slot — let the kernel arbitrate.** The claim file is created with `create_new` (`O_CREAT|O_EXCL`), so the test for a free slot and the act of taking it are one operation and exactly one racer is told it created the file. This is the hot path and it stays lock-free.

**Expired claim — serialise the takeover.** Replacing an existing file cannot be arbitrated by `create_new`, so this one transition runs under a lock file. It publishes with a temp-file rename rather than a delete-then-create, which matters more than it looks: my first attempt cleared the slot and re-created it, and that left a window where a concurrent `create_new` slipped into the gap and produced a second winner (reproduced at ~1 round in 20). Replacing in place means the slot is never observed empty, so agents that are not holding the lock keep failing their own `create_new`, re-read, and see the new owner. A lock older than 30s is treated as abandoned by a process that died mid-takeover; the critical section is two syscalls.

`write_claim` now routes through the same atomic rename, so a `heartbeat` can no longer interleave its lines into a half-written claim.

## Verification

New tests fail deterministically against the old implementation and pass against this one:

```
concurrent_claim_acquire_yields_exactly_one_winner ......... FAILED  (old: got ["cody","sage","nova","kitty"])
concurrent_takeover_of_expired_claim_yields_exactly_one_winner  FAILED  (old: got ["cody","sage","nova","kitty"])
```

They assert both halves of the contract: exactly one agent is told it won, **and** the claim file records that same agent.

Beyond the suite, 40 rounds x 4 concurrent acquirers on a fresh token and another 40 on an expired token: one winner every round, file always matches the winner, no leftover lock or staging files.

Gates, all clean locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked` (1307 + 8 in this suite), `python scripts/check-secrets.py`.

## Deliberately out of scope

`agent_id()` falls back to `$USER`, so same-user sessions still share one identity and the ownership guards cannot tell them apart — after this PR the second racer is treated as *the owner re-acquiring* and still proceeds. That default is documented in five places, so changing it is a contract change rather than a bug fix and needs its own PR. Written up separately; linked in a comment on #491.

`branch_slug` collisions (`feature/demo` and `feature-demo` share one claim file) are noted in #491 and also left alone here.
