### PR TITLE
fix: make Copilot stats trailer filtering fail open

### DIFF
--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -2201,8 +2201,8 @@ impl App {
     /// A session's exit finalizes its held fragment: EOF ends the line, so
     /// classify it as a complete line and surface it if it's assistant
     /// prose — a reply whose final line lacks a trailing newline must not
-    /// be eaten (#471). Kill paths drop the buffer instead (a cancelled
-    /// turn's half-line is noise), mirroring `stream_json_buffers`.
+    /// be eaten (#471). Kill paths surface any complete candidate rows but
+    /// still drop the cancelled turn's unfinished raw line.
     fn flush_pty_line_buffer(&mut self, session_id: &str) {
         let Some(mut state) = self.pty_line_buffers.remove(session_id) else {
             return;
@@ -2228,6 +2228,15 @@ impl App {
         self.flush_pty_visible(&mut visible, false);
     }
 
+    fn flush_pty_candidate_on_kill(&mut self, session_id: &str) {
+        let Some(mut state) = self.pty_line_buffers.remove(session_id) else {
+            return;
+        };
+        if !state.copilot_stats.is_empty() {
+            self.emit_agent_text(&state.copilot_stats.take_visible());
+        }
+    }
+
     fn push_event_message(&mut self, event: &store::EventRecord) {
         // Drop events from sessions we've decided to hide (today: failed
         // sessions whose stale-id we already auto-recovered from). Clear
@@ -2236,9 +2245,9 @@ impl App {
         if self.suppressed_session_ids.contains(&event.session_id) {
             if matches!(event.kind.as_str(), "exit" | "kill") {
                 self.suppressed_session_ids.remove(&event.session_id);
-                // The suppressed session may have buffered a partial line
-                // before it was hidden; its terminal event is the last
-                // chance to reclaim that memory (#471).
+                // The suppressed session may have buffered PTY state before
+                // it was hidden; its terminal event is the last chance to
+                // reclaim that memory (#471).
                 self.pty_line_buffers.remove(&event.session_id);
             }
             return;
@@ -2330,10 +2339,10 @@ impl App {
                 self.push_system_message(&format!("Session {status}."));
             }
             "kill" => {
-                // A cancelled turn's half-line is noise: drop the held
-                // fragment instead of flushing it (#471), mirroring the
-                // stream-JSON buffer teardown below.
-                self.pty_line_buffers.remove(&event.session_id);
+                // A cancelled turn's incomplete raw line is noise, but a
+                // bounded Copilot candidate contains complete cleaned lines
+                // and must fail open instead of disappearing.
+                self.flush_pty_candidate_on_kill(&event.session_id);
                 self.flush_pending_agent_buffer();
                 // Delegation call was cancelled by a kill event.
                 if let (Some(call_id), Some(home)) =
@@ -5396,6 +5405,70 @@ mod tests {
     }
 
     #[test]
+    fn kill_flushes_copilot_candidate_but_drops_the_unfinished_tail() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+        let candidate = concat!("Changes    +1 -1\n", "Requests   1 Premium (8s)\n",);
+
+        app.push_event_message(&output_event(
+            1,
+            "session-1",
+            &format!("{candidate}unfinished"),
+        ));
+        assert!(agent_text(&app).is_empty());
+
+        app.push_event_message(&terminal_event(2, "session-1", "kill"));
+
+        assert_eq!(agent_text(&app), candidate);
+        assert!(!agent_text(&app).contains("unfinished"));
+    }
+
+    #[test]
+    fn batched_kill_flushes_copilot_candidate_through_the_pending_sink() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.handle_slash_command("/stream off");
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+        app.is_responding = true;
+        let candidate = concat!("Changes    +1 -1\n", "Requests   1 Premium (8s)\n",);
+
+        app.push_event_message(&output_event(
+            1,
+            "session-1",
+            &format!("{candidate}unfinished"),
+        ));
+        assert!(agent_text(&app).is_empty());
+
+        app.push_event_message(&terminal_event(2, "session-1", "kill"));
+
+        assert_eq!(agent_text(&app), candidate);
+        assert!(!agent_text(&app).contains("unfinished"));
+    }
+
+    #[test]
+    fn batched_copilot_stats_shaped_prose_fails_open() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.handle_slash_command("/stream off");
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+        app.is_responding = true;
+        let reply = concat!(
+            "Changes    +1 -1\n",
+            "Requests   1 Premium (8s)\n",
+            "This table is part of the answer.\n",
+        );
+
+        app.push_event_message(&output_event(1, "session-1", reply));
+        app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+        assert_eq!(agent_text(&app), reply);
+    }
+
+    #[test]
     fn stats_shaped_prose_is_visible_for_non_copilot_harnesses() {
         for harness in ["codex", "claude", "grok", "custom"] {
             let client = RecordingChatClient::default();
@@ -5646,38 +5719,30 @@ mod tests {
         );
     }
 
-    /// Regression for #471: a copilot stats line split across two chunks
-    /// must still be recognized and hidden once complete; classifying the
-    /// halves as two complete lines leaked both fragments as prose.
+    /// A genuine terminal Copilot trailer stays hidden even when arbitrary
+    /// PTY read boundaries split its labels and values.
     #[test]
-    fn copilot_stats_line_split_across_chunks_is_still_hidden() {
-        let client = RecordingChatClient::with_session(test_session(
-            "session-1",
-            "copilot",
-            "Existing",
-            "running",
-        ));
-        client.events.borrow_mut().extend([
-            output_event(1, "session-1", "Done.\r\nChanges  "),
-            output_event(2, "session-1", "  +1 -1\r\nRequests   1 Premium (8s)\r\n"),
-        ]);
+    fn copilot_terminal_stats_trailer_is_hidden_across_pty_chunks() {
+        let client = RecordingChatClient::default();
         let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
 
-        app.handle_slash_command("/attach session-1");
+        for (seq, chunk) in [
+            "Answer.\nCha",
+            "nges    +1 -1\nRequests ",
+            "  1 Premium (8s)\nTokens     ↑ 28.0k",
+            " (20.4k cached) • ↓ 32\nRes",
+            "ume     copilot --resume=cb845dd4\n",
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            app.push_event_message(&output_event(seq as i64 + 1, "session-1", chunk));
+        }
+        app.push_event_message(&terminal_event(6, "session-1", "exit"));
 
-        let agent_text = app
-            .messages
-            .iter()
-            .filter(|message| matches!(message.role, MessageRole::Agent))
-            .map(|message| message.content.as_str())
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(agent_text.contains("Done."));
-        assert!(
-            !agent_text.contains("+1 -1"),
-            "a chunk-split stats line must still hide once complete: {agent_text}"
-        );
-        assert!(!agent_text.contains("Premium"));
+        assert_eq!(agent_text(&app), "Answer.\n");
     }
 
     /// Regression for #471: a held trailing fragment is finalized by the
@@ -5735,9 +5800,8 @@ mod tests {
         );
     }
 
-    /// Regression for #489: `/clear` wipes the transcript, so a PTY line
-    /// fragment held from before the clear must not resurface when the
-    /// session later exits and flushes it.
+    /// Regression for #489: `/clear` wipes the transcript, so buffered PTY
+    /// state from before the clear must not resurface on a later exit.
     #[test]
     fn clear_transcript_drops_held_pty_line_fragments() {
         let client = RecordingChatClient::with_session(test_session(
@@ -5749,35 +5813,28 @@ mod tests {
         client
             .events
             .borrow_mut()
-            .push(output_event(1, "session-1", "All done.\r\nResume"));
+            .push(output_event(1, "session-1", "Changes    +1 -1\r\n"));
         let (mut app, _) = app_with_client(client);
 
         app.handle_slash_command("/attach session-1");
         assert!(
             app.pty_line_buffers.contains_key("session-1"),
-            "the stats-shaped fragment must be held before the clear"
+            "the trailer candidate must be held before the clear"
         );
 
         app.clear_transcript();
         assert!(
             !app.pty_line_buffers.contains_key("session-1"),
-            "/clear must drop held PTY line fragments, as it drops stream JSON buffers"
+            "/clear must drop held PTY state, as it drops stream JSON buffers"
         );
 
-        app.push_event_message(&EventRecord {
-            seq: 2,
-            id: "event-exit".to_string(),
-            session_id: "session-1".to_string(),
-            kind: "exit".to_string(),
-            payload_json: serde_json::json!({ "status": "completed" }).to_string(),
-            created_at: "2026-05-19T00:00:00Z".to_string(),
-        });
+        app.push_event_message(&terminal_event(2, "session-1", "exit"));
 
         assert!(
             !app.messages
                 .iter()
-                .any(|message| message.content.contains("Resume")),
-            "a pre-clear fragment must not land in the cleared transcript: {:?}",
+                .any(|message| message.content.contains("Changes    +1 -1")),
+            "a pre-clear candidate must not land in the cleared transcript: {:?}",
             app.messages
                 .iter()
                 .map(|message| message.content.as_str())
@@ -5786,9 +5843,8 @@ mod tests {
     }
 
     /// `/new` keeps the transcript visible on purpose, and it does not kill
-    /// PTY sessions — so a held fragment there belongs to an in-flight line
-    /// that is still streaming into that same visible transcript. Dropping
-    /// it would lose the head of a line, so `/new` must keep it (#489).
+    /// PTY sessions — so buffered output still belongs to that same visible
+    /// transcript and `/new` must keep it (#489).
     #[test]
     fn start_new_conversation_keeps_held_pty_line_fragments() {
         let client = RecordingChatClient::with_session(test_session(
@@ -5800,7 +5856,7 @@ mod tests {
         client
             .events
             .borrow_mut()
-            .push(output_event(1, "session-1", "All done.\r\nResume"));
+            .push(output_event(1, "session-1", "Changes    +1 -1\r\n"));
         let (mut app, _) = app_with_client(client);
 
         app.handle_slash_command("/attach session-1");
@@ -5808,8 +5864,47 @@ mod tests {
 
         assert!(
             app.pty_line_buffers.contains_key("session-1"),
-            "/new keeps the transcript, so an in-flight line's head must survive"
+            "/new keeps the transcript, so the active candidate must survive"
         );
+    }
+
+    #[test]
+    fn suppressed_terminal_event_drops_copilot_candidate_without_displaying_it() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+
+        app.push_event_message(&output_event(1, "session-1", "Changes    +1 -1\n"));
+        assert!(app.pty_line_buffers.contains_key("session-1"));
+        app.suppressed_session_ids.insert("session-1".to_string());
+
+        app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+        assert!(!app.pty_line_buffers.contains_key("session-1"));
+        assert!(!app.suppressed_session_ids.contains("session-1"));
+        assert!(agent_text(&app).is_empty());
+    }
+
+    #[test]
+    fn copilot_stats_candidate_storage_stays_bounded() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+
+        app.push_event_message(&output_event(
+            1,
+            "session-1",
+            &format!("{COPILOT_STATS_TRAILER}\n\n\n"),
+        ));
+
+        let state = app
+            .pty_line_buffers
+            .get("session-1")
+            .expect("complete trailer candidate");
+        assert_eq!(state.copilot_stats.lines.len(), 4);
+        assert!(state.copilot_stats.trailing_blank);
     }
 
     /// Regression for #471 × #469: a CR-overwrite sequence split across

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -43,6 +43,96 @@ enum AgentOutputMode {
     Hidden,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CopilotStatsLine {
+    Changes,
+    Requests,
+    Tokens,
+    Resume,
+}
+
+#[derive(Debug, Default)]
+struct CopilotStatsCandidate {
+    /// Exact cleaned lines, including their newlines. Candidate advancement
+    /// bounds this to the four recognized trailer rows.
+    lines: Vec<String>,
+    /// Copilot may print cosmetic blank spacing after its terminal table.
+    trailing_blank: bool,
+}
+
+impl CopilotStatsCandidate {
+    fn expected(&self) -> Option<CopilotStatsLine> {
+        match self.lines.len() {
+            0 => Some(CopilotStatsLine::Changes),
+            1 => Some(CopilotStatsLine::Requests),
+            2 => Some(CopilotStatsLine::Tokens),
+            3 => Some(CopilotStatsLine::Resume),
+            _ => None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+
+    fn is_complete(&self) -> bool {
+        self.lines.len() == 4
+    }
+
+    fn clear(&mut self) {
+        self.lines.clear();
+        self.trailing_blank = false;
+    }
+
+    fn take_visible(&mut self) -> String {
+        let mut visible = std::mem::take(&mut self.lines).concat();
+        if std::mem::take(&mut self.trailing_blank) {
+            visible.push('\n');
+        }
+        visible
+    }
+
+    fn push_line(&mut self, raw_line: &str, visible: &mut String) {
+        let marker = raw_line.trim_end_matches('\n').trim();
+        if self.is_complete() && marker.is_empty() {
+            self.trailing_blank = true;
+            return;
+        }
+
+        let kind = copilot_stats_line_kind(marker);
+        if self
+            .expected()
+            .is_some_and(|expected| kind == Some(expected))
+        {
+            self.lines.push(raw_line.to_string());
+            debug_assert!(self.lines.len() <= 4);
+            return;
+        }
+
+        if !self.is_empty() {
+            visible.push_str(&self.take_visible());
+        }
+        if kind == Some(CopilotStatsLine::Changes) {
+            self.lines.push(raw_line.to_string());
+        } else {
+            visible.push_str(raw_line);
+        }
+    }
+
+    /// Normal EOF confirms a complete candidate as the terminal trailer.
+    /// Every incomplete candidate fails open.
+    fn finish_at_exit(&mut self) -> Option<String> {
+        if self.is_empty() {
+            return None;
+        }
+        if self.is_complete() {
+            self.clear();
+            return None;
+        }
+        Some(self.take_visible())
+    }
+}
+
 /// Per-PTY-session state for the trailing partial line of the transcript
 /// filter (#471). See the `pty_line_buffers` field.
 #[derive(Debug, Default)]
@@ -54,6 +144,14 @@ struct PtyLineBuffer {
     /// Number of cleaned chars from `tail` already appended to the current
     /// agent bubble. Continuations re-clean `tail` and reconcile this prefix.
     emitted_len: usize,
+    /// Bounded Copilot-only candidate for a terminal usage-stats trailer.
+    copilot_stats: CopilotStatsCandidate,
+}
+
+impl PtyLineBuffer {
+    fn has_pending(&self) -> bool {
+        !self.tail.is_empty() || self.emitted_len > 0 || !self.copilot_stats.is_empty()
+    }
 }
 
 /// Whether an appended chunk of agent output starts a new assistant
@@ -1942,6 +2040,12 @@ impl App {
         matches!(self.active_session_harness.as_deref(), None | Some("codex"))
     }
 
+    /// Copilot is the only supported PTY harness with this terminal stats
+    /// trailer. Unknown and other harnesses fail open.
+    fn active_session_emits_copilot_stats(&self) -> bool {
+        self.active_session_harness.as_deref() == Some("copilot")
+    }
+
     /// Route visible PTY text through the live/batched display split.
     /// PTY chunks split at arbitrary byte boundaries and already carry
     /// their own newlines, so they never start a new segment (#470).
@@ -2011,6 +2115,7 @@ impl App {
     /// held otherwise until its newline or the session's exit.
     fn dispatch_pty_output(&mut self, session_id: &str, data: &str) {
         let codex_markers = self.active_session_emits_codex_markers();
+        let copilot_stats = self.active_session_emits_copilot_stats();
         let mut state = self.pty_line_buffers.remove(session_id).unwrap_or_default();
         let mut visible = String::new();
         let mut force_emit_visible = false;
@@ -2056,11 +2161,13 @@ impl App {
         };
         let complete = std::mem::replace(&mut state.tail, fragment);
         if !complete.is_empty() {
-            let classified = if codex_markers {
-                human_facing_agent_output(&complete, &mut self.agent_output_mode)
-            } else {
-                human_facing_plain_output(&complete, &mut self.agent_output_mode)
-            };
+            let classified = human_facing_pty_output(
+                &complete,
+                &mut self.agent_output_mode,
+                codex_markers,
+                copilot_stats,
+                &mut state.copilot_stats,
+            );
             if let Some(text) = classified {
                 visible.push_str(&text);
             }
@@ -2073,16 +2180,18 @@ impl App {
         if !state.tail.is_empty()
             && self.agent_output_mode != AgentOutputMode::Hidden
             && state.emitted_len == 0
+            && state.copilot_stats.is_empty()
         {
-            let displayable = clean_terminal_output(&state.tail)
-                .filter(|text| !partial_line_may_become_marker(text.trim(), codex_markers));
+            let displayable = clean_terminal_output(&state.tail).filter(|text| {
+                !partial_line_may_become_marker(text.trim(), codex_markers, copilot_stats)
+            });
             if let Some(text) = displayable {
                 visible.push_str(&text);
                 state.emitted_len = text.chars().count();
             }
         }
 
-        if !state.tail.is_empty() || state.emitted_len > 0 {
+        if state.has_pending() {
             self.pty_line_buffers.insert(session_id.to_string(), state);
         }
 
@@ -2095,23 +2204,28 @@ impl App {
     /// be eaten (#471). Kill paths drop the buffer instead (a cancelled
     /// turn's half-line is noise), mirroring `stream_json_buffers`.
     fn flush_pty_line_buffer(&mut self, session_id: &str) {
-        let Some(state) = self.pty_line_buffers.remove(session_id) else {
+        let Some(mut state) = self.pty_line_buffers.remove(session_id) else {
             return;
         };
-        if state.tail.is_empty() {
-            return;
+        let codex_markers = self.active_session_emits_codex_markers();
+        let copilot_stats = self.active_session_emits_copilot_stats();
+        let mut visible = String::new();
+
+        if !state.tail.is_empty() && state.emitted_len == 0 {
+            if let Some(text) = human_facing_pty_output(
+                &state.tail,
+                &mut self.agent_output_mode,
+                codex_markers,
+                copilot_stats,
+                &mut state.copilot_stats,
+            ) {
+                visible.push_str(&text);
+            }
         }
-        if state.emitted_len > 0 {
-            return;
+        if let Some(text) = state.copilot_stats.finish_at_exit() {
+            visible.push_str(&text);
         }
-        let classified = if self.active_session_emits_codex_markers() {
-            human_facing_agent_output(&state.tail, &mut self.agent_output_mode)
-        } else {
-            human_facing_plain_output(&state.tail, &mut self.agent_output_mode)
-        };
-        if let Some(text) = classified {
-            self.emit_agent_text(&text);
-        }
+        self.flush_pty_visible(&mut visible, false);
     }
 
     fn push_event_message(&mut self, event: &store::EventRecord) {
@@ -2914,10 +3028,7 @@ fn human_facing_agent_output(data: &str, mode: &mut AgentOutputMode) -> Option<S
             *mode = AgentOutputMode::Assistant;
             continue;
         }
-        if is_hidden_transcript_marker(marker)
-            || is_codex_metadata_line(marker)
-            || is_copilot_stats_line(marker)
-        {
+        if is_hidden_transcript_marker(marker) || is_codex_metadata_line(marker) {
             *mode = AgentOutputMode::Hidden;
             continue;
         }
@@ -2932,32 +3043,41 @@ fn human_facing_agent_output(data: &str, mode: &mut AgentOutputMode) -> Option<S
     has_structure.then_some(visible)
 }
 
-/// Like `human_facing_agent_output`, but for harnesses that never emit
-/// codex's interleaved role markers (copilot, grok, claude PTY fallback).
-/// Only the copilot stats-block shapes hide; a bare `bash` list item or a
-/// closing `Completed` line is ordinary prose there, and honoring the
-/// codex markers would flip the filter to Hidden with no assistant marker
-/// ever arriving to flip it back (#471).
-fn human_facing_plain_output(data: &str, mode: &mut AgentOutputMode) -> Option<String> {
+/// Harnesses without Codex transcript markers or Copilot's known terminal
+/// trailer are plain terminal prose.
+fn human_facing_plain_output(data: &str) -> Option<String> {
+    clean_terminal_output(data)
+}
+
+fn human_facing_copilot_output(
+    data: &str,
+    candidate: &mut CopilotStatsCandidate,
+) -> Option<String> {
     let cleaned = clean_terminal_output(data)?;
     let mut visible = String::new();
 
     for raw_line in cleaned.split_inclusive('\n') {
-        let marker = raw_line.trim_end_matches('\n').trim();
-
-        if is_copilot_stats_line(marker) {
-            *mode = AgentOutputMode::Hidden;
-            continue;
-        }
-
-        match mode {
-            AgentOutputMode::Assistant | AgentOutputMode::Unknown => visible.push_str(raw_line),
-            AgentOutputMode::Hidden => {}
-        }
+        candidate.push_line(raw_line, &mut visible);
     }
 
     let has_structure = visible.chars().any(|ch| ch == '\n' || !ch.is_whitespace());
     has_structure.then_some(visible)
+}
+
+fn human_facing_pty_output(
+    data: &str,
+    mode: &mut AgentOutputMode,
+    codex_markers: bool,
+    copilot_stats: bool,
+    candidate: &mut CopilotStatsCandidate,
+) -> Option<String> {
+    if codex_markers {
+        human_facing_agent_output(data, mode)
+    } else if copilot_stats {
+        human_facing_copilot_output(data, candidate)
+    } else {
+        human_facing_plain_output(data)
+    }
 }
 
 /// True when `fragment` — the cleaned, trimmed text of a line that hasn't
@@ -2966,7 +3086,11 @@ fn human_facing_plain_output(data: &str, mode: &mut AgentOutputMode) -> Option<S
 /// shown or classified early: judging them as complete lines is exactly
 /// the misread #471 fixes (prose split right after `user` flipped the
 /// filter to Hidden; a `codex` marker split as `cod`/`ex` was missed).
-fn partial_line_may_become_marker(fragment: &str, codex_markers: bool) -> bool {
+fn partial_line_may_become_marker(
+    fragment: &str,
+    codex_markers: bool,
+    copilot_stats: bool,
+) -> bool {
     // A fragment can still come to *start with* `pattern` while it's a
     // prefix of the pattern or already carries the pattern as its head.
     fn may_match_prefix_pattern(fragment: &str, pattern: &str) -> bool {
@@ -2977,21 +3101,22 @@ fn partial_line_may_become_marker(fragment: &str, codex_markers: bool) -> bool {
         }
     }
 
-    // Copilot stats shapes hide for every harness. Hold a label head until
-    // enough of the line is present to rule out the 3+-space gutter that
-    // `is_copilot_stats_line` requires next.
-    const STATS_LABELS: [&str; 4] = ["Changes", "Requests", "Tokens", "Resume"];
-    let stats_open = STATS_LABELS.iter().any(|label| {
-        if fragment.len() < label.len() {
-            label.starts_with(fragment)
-        } else {
-            fragment
-                .strip_prefix(label)
-                .is_some_and(|rest| rest.chars().take(3).all(|c| c == ' '))
+    if copilot_stats {
+        // Hold a Copilot label head until enough of the line is present to
+        // rule out the 3+-space stats gutter.
+        const STATS_LABELS: [&str; 4] = ["Changes", "Requests", "Tokens", "Resume"];
+        let stats_open = STATS_LABELS.iter().any(|label| {
+            if fragment.len() < label.len() {
+                label.starts_with(fragment)
+            } else {
+                fragment
+                    .strip_prefix(label)
+                    .is_some_and(|rest| rest.chars().take(3).all(|c| c == ' '))
+            }
+        });
+        if stats_open {
+            return true;
         }
-    });
-    if stats_open {
-        return true;
     }
     if !codex_markers {
         return false;
@@ -3062,32 +3187,30 @@ fn is_codex_metadata_line(line: &str) -> bool {
         || line.starts_with("session id:")
 }
 
-/// One-shot `copilot --prompt` runs close with a columnar stats block on
-/// stderr (`Changes    +0 -0`, `Requests   1 Premium (8s)`,
-/// `Tokens     ↑ 28.0k … • ↓ 43 …`, `Resume     copilot --resume=<id>`),
-/// which the PTY merges into the transcript. Recognize those exact column
-/// shapes — label, a 3+-space gutter, then a value with a distinctive lead —
-/// so chat stays prose-only. Anything looser risks hiding assistant text
-/// that merely starts with the same word.
-fn is_copilot_stats_line(line: &str) -> bool {
+/// Classify the strict column shape of one row in Copilot's four-line
+/// terminal stats trailer.
+fn copilot_stats_line_kind(line: &str) -> Option<CopilotStatsLine> {
     fn column<'a>(line: &'a str, label: &str) -> Option<&'a str> {
         line.strip_prefix(label)?
             .strip_prefix("   ")
             .map(str::trim_start)
     }
-    if let Some(value) = column(line, "Changes") {
-        return value.starts_with('+');
+
+    if column(line, "Changes").is_some_and(|value| value.starts_with('+')) {
+        return Some(CopilotStatsLine::Changes);
     }
-    if let Some(value) = column(line, "Requests") {
-        return value.chars().next().is_some_and(|c| c.is_ascii_digit());
+    if column(line, "Requests")
+        .is_some_and(|value| value.chars().next().is_some_and(|c| c.is_ascii_digit()))
+    {
+        return Some(CopilotStatsLine::Requests);
     }
-    if let Some(value) = column(line, "Tokens") {
-        return value.starts_with('↑');
+    if column(line, "Tokens").is_some_and(|value| value.starts_with('↑')) {
+        return Some(CopilotStatsLine::Tokens);
     }
-    if let Some(value) = column(line, "Resume") {
-        return value.starts_with("copilot --resume=");
+    if column(line, "Resume").is_some_and(|value| value.starts_with("copilot --resume=")) {
+        return Some(CopilotStatsLine::Resume);
     }
-    false
+    None
 }
 
 fn skip_escape_sequence<I>(chars: &mut std::iter::Peekable<I>)
@@ -3353,6 +3476,20 @@ mod tests {
             kind: "output".to_string(),
             payload_json: serde_json::json!({ "data": data }).to_string(),
             created_at: "2026-05-19T00:00:00Z".to_string(),
+        }
+    }
+
+    fn terminal_event(seq: i64, session_id: &str, kind: &str) -> EventRecord {
+        EventRecord {
+            seq,
+            id: format!("event-{seq}"),
+            session_id: session_id.to_string(),
+            kind: kind.to_string(),
+            payload_json: serde_json::json!({
+                "status": if kind == "exit" { "completed" } else { "killed" }
+            })
+            .to_string(),
+            created_at: "2026-07-26T00:00:00Z".to_string(),
         }
     }
 
@@ -5127,58 +5264,224 @@ mod tests {
         assert!(!harness_supports_chat_resume("hermes"));
     }
 
+    const COPILOT_STATS_TRAILER: &str = concat!(
+        "Changes    +1 -1\n",
+        "Requests   1 Premium (8s)\n",
+        "Tokens     ↑ 28.0k (20.4k cached) • ↓ 32\n",
+        "Resume     copilot --resume=cb845dd4-234f-46a0-8e6a-7f15ce8170be\n",
+    );
+
     #[test]
-    fn copilot_stats_lines_hide_from_chat_transcript() {
-        assert!(is_copilot_stats_line("Changes    +0 -0"));
-        assert!(is_copilot_stats_line("Requests   1 Premium (11s)"));
-        assert!(is_copilot_stats_line(
-            "Tokens     ↑ 28.0k (28.0k written) • ↓ 43 (28 reasoning)"
+    fn copilot_resume_shaped_prose_and_following_reply_stay_visible() {
+        let client = RecordingChatClient::with_session(test_session(
+            "session-1",
+            "copilot",
+            "Existing",
+            "running",
         ));
-        assert!(is_copilot_stats_line(
-            "Resume     copilot --resume=0ded81e6-36cc-4b36-bc11-42ef4a254c10"
+        client.events.borrow_mut().push(output_event(
+            1,
+            "session-1",
+            concat!(
+                "Use the saved command below.\n",
+                "Resume     copilot --resume=example\n",
+                "Then verify the result.\n",
+            ),
         ));
-        // Assistant prose that merely leads with a stats label must stay
-        // visible: no column gutter, or the wrong value shape.
-        assert!(!is_copilot_stats_line(
-            "Changes to the API are listed below"
-        ));
-        assert!(!is_copilot_stats_line(
-            "Requests should be retried with backoff"
-        ));
-        assert!(!is_copilot_stats_line("Tokens are stored in the keychain"));
-        assert!(!is_copilot_stats_line(
-            "Resume     the deployment afterwards"
-        ));
-        assert!(!is_copilot_stats_line("Resume work on the parser"));
+        let (mut app, _) = app_with_client(client);
+
+        app.handle_slash_command("/attach session-1");
+
+        assert_eq!(
+            agent_text(&app),
+            concat!(
+                "Use the saved command below.\n",
+                "Resume     copilot --resume=example\n",
+                "Then verify the result.\n",
+            )
+        );
+        assert_eq!(app.agent_output_mode, AgentOutputMode::Unknown);
     }
 
     #[test]
-    fn copilot_transcript_keeps_prose_and_drops_stats_block() {
-        let mut mode = AgentOutputMode::Unknown;
+    fn copilot_complete_stats_shape_followed_by_prose_is_visible_verbatim() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+
+        app.push_event_message(&output_event(
+            1,
+            "session-1",
+            &format!("{COPILOT_STATS_TRAILER}Explanation continues.\n"),
+        ));
+
+        assert_eq!(
+            agent_text(&app),
+            format!("{COPILOT_STATS_TRAILER}Explanation continues.\n")
+        );
+    }
+
+    #[test]
+    fn copilot_false_positive_split_across_chunks_stays_visible() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+
+        app.push_event_message(&output_event(1, "session-1", "Res"));
+        app.push_event_message(&output_event(
+            2,
+            "session-1",
+            "ume     copilot --resume=example\nLater prose.\n",
+        ));
+
+        assert_eq!(
+            agent_text(&app),
+            "Resume     copilot --resume=example\nLater prose.\n"
+        );
+    }
+
+    #[test]
+    fn copilot_out_of_order_candidate_flushes_verbatim() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+        let out_of_order = concat!(
+            "Changes    +1 -1\n",
+            "Tokens     ↑ 28.0k (20.4k cached) • ↓ 32\n",
+        );
+
+        app.push_event_message(&output_event(1, "session-1", out_of_order));
+
+        assert_eq!(agent_text(&app), out_of_order);
+    }
+
+    #[test]
+    fn copilot_partial_stats_candidate_flushes_on_exit() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+
+        let partial = concat!("Changes    +1 -1\n", "Requests   1 Premium (8s)\n",);
+        app.push_event_message(&output_event(1, "session-1", partial));
+        assert!(agent_text(&app).is_empty());
+
+        app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+        assert_eq!(agent_text(&app), partial);
+    }
+
+    #[test]
+    fn copilot_complete_terminal_stats_trailer_is_hidden_on_exit() {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        app.active_session_harness = Some("copilot".to_string());
+
+        app.push_event_message(&output_event(
+            1,
+            "session-1",
+            &format!("Answer.\n{COPILOT_STATS_TRAILER}"),
+        ));
+        assert_eq!(agent_text(&app), "Answer.\n");
+        assert!(app.pty_line_buffers.contains_key("session-1"));
+
+        app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+        assert_eq!(agent_text(&app), "Answer.\n");
+        assert!(!app.pty_line_buffers.contains_key("session-1"));
+    }
+
+    #[test]
+    fn stats_shaped_prose_is_visible_for_non_copilot_harnesses() {
+        for harness in ["codex", "claude", "grok", "custom"] {
+            let client = RecordingChatClient::default();
+            let (mut app, _) = app_with_client(client);
+            app.active_session_id = Some(format!("{harness}-session"));
+            app.active_session_harness = Some(harness.to_string());
+            let session_id = app.active_session_id.clone().expect("active session");
+            let transcript =
+                format!("assistant\n{COPILOT_STATS_TRAILER}This belongs to {harness}.\n");
+
+            app.push_event_message(&output_event(1, &session_id, &transcript));
+            app.push_event_message(&terminal_event(2, &session_id, "exit"));
+
+            let visible = agent_text(&app);
+            assert!(
+                visible.contains("Resume     copilot --resume="),
+                "{harness} must not run the Copilot trailer recognizer: {visible:?}"
+            );
+            assert!(
+                visible.contains(&format!("This belongs to {harness}.")),
+                "{harness} prose after stats-shaped text must stay visible: {visible:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn copilot_stats_classifier_requires_strict_row_shapes() {
+        assert_eq!(
+            copilot_stats_line_kind("Changes    +0 -0"),
+            Some(CopilotStatsLine::Changes)
+        );
+        assert_eq!(
+            copilot_stats_line_kind("Requests   1 Premium (11s)"),
+            Some(CopilotStatsLine::Requests)
+        );
+        assert_eq!(
+            copilot_stats_line_kind("Tokens     ↑ 28.0k (28.0k written) • ↓ 43 (28 reasoning)"),
+            Some(CopilotStatsLine::Tokens)
+        );
+        assert_eq!(
+            copilot_stats_line_kind(
+                "Resume     copilot --resume=0ded81e6-36cc-4b36-bc11-42ef4a254c10"
+            ),
+            Some(CopilotStatsLine::Resume)
+        );
+        // Assistant prose that merely leads with a stats label must stay
+        // visible: no column gutter, or the wrong value shape.
+        assert_eq!(
+            copilot_stats_line_kind("Changes to the API are listed below"),
+            None
+        );
+        assert_eq!(
+            copilot_stats_line_kind("Requests should be retried with backoff"),
+            None
+        );
+        assert_eq!(
+            copilot_stats_line_kind("Tokens are stored in the keychain"),
+            None
+        );
+        assert_eq!(
+            copilot_stats_line_kind("Resume     the deployment afterwards"),
+            None
+        );
+        assert_eq!(copilot_stats_line_kind("Resume work on the parser"), None);
+    }
+
+    #[test]
+    fn copilot_output_holds_a_complete_stats_candidate() {
+        let mut candidate = CopilotStatsCandidate::default();
         let transcript = "The fix is in `parser.rs`.\n\nChanges    +1 -1\nRequests   1 Premium (8s)\nTokens     ↑ 28.0k (20.4k cached) • ↓ 32\nResume     copilot --resume=cb845dd4-234f-46a0-8e6a-7f15ce8170be\n";
-        let visible =
-            human_facing_agent_output(transcript, &mut mode).expect("prose must stay visible");
+        let visible = human_facing_copilot_output(transcript, &mut candidate)
+            .expect("prose must stay visible");
         assert!(visible.contains("The fix is in `parser.rs`."));
         assert!(!visible.contains("Premium"));
         assert!(!visible.contains("--resume="));
         assert!(!visible.contains("↑"));
+        assert!(candidate.is_complete());
+        assert_eq!(candidate.finish_at_exit(), None);
     }
 
-    /// Plain-output filter (#471): non-codex harnesses keep marker-shaped
-    /// prose visible but still hide the copilot stats block.
+    /// Plain non-Codex/non-Copilot output has no role or trailer syntax.
     #[test]
-    fn plain_output_keeps_marker_like_prose_and_still_drops_stats_block() {
-        let mut mode = AgentOutputMode::Unknown;
+    fn plain_output_keeps_marker_and_stats_shaped_prose() {
         let transcript = "Run these:\nbash\nCompleted\nuser\nAll good.\nChanges    +1 -1\nRequests   1 Premium (8s)\n";
-        let visible =
-            human_facing_plain_output(transcript, &mut mode).expect("prose must stay visible");
-        assert!(visible.contains("Run these:"));
-        assert!(visible.contains("bash"));
-        assert!(visible.contains("Completed"));
-        assert!(visible.contains("user"));
-        assert!(visible.contains("All good."));
-        assert!(!visible.contains("+1 -1"));
-        assert!(!visible.contains("Premium"));
+        let visible = human_facing_plain_output(transcript).expect("prose must stay visible");
+        assert_eq!(visible, transcript);
     }
 
     /// Hold rules for chunk-split fragments (#471): a fragment is held only
@@ -5187,27 +5490,44 @@ mod tests {
     #[test]
     fn partial_line_hold_rules_cover_markers_stats_and_prose() {
         // Prefixes of codex markers (exact and starts_with shapes) hold.
-        assert!(partial_line_may_become_marker("cod", true));
-        assert!(partial_line_may_become_marker("codex", true));
-        assert!(partial_line_may_become_marker("user", true));
-        assert!(partial_line_may_become_marker("Comp", true));
-        assert!(partial_line_may_become_marker("succeeded in 0", true));
-        assert!(partial_line_may_become_marker("hook", true));
-        assert!(partial_line_may_become_marker("", true));
+        assert!(partial_line_may_become_marker("cod", true, false));
+        assert!(partial_line_may_become_marker("codex", true, false));
+        assert!(partial_line_may_become_marker("user", true, false));
+        assert!(partial_line_may_become_marker("Comp", true, false));
+        assert!(partial_line_may_become_marker(
+            "succeeded in 0",
+            true,
+            false
+        ));
+        assert!(partial_line_may_become_marker("hook", true, false));
+        assert!(partial_line_may_become_marker("", true, false));
         // Once the fragment can no longer match, it is shown immediately.
-        assert!(!partial_line_may_become_marker("codexy", true));
-        assert!(!partial_line_may_become_marker("user data", true));
-        assert!(!partial_line_may_become_marker("hello from daemon", true));
-        assert!(!partial_line_may_become_marker("successfully parsed", true));
-        // Stats labels hold for every harness until the gutter is ruled out.
-        assert!(partial_line_may_become_marker("Resume", false));
-        assert!(partial_line_may_become_marker("Changes   ", false));
-        assert!(partial_line_may_become_marker("Tokens    ↑ 2", false));
-        assert!(!partial_line_may_become_marker("Resume work", false));
-        assert!(!partial_line_may_become_marker("Tokens are stored", false));
-        // Codex markers do not hold for non-codex harnesses.
-        assert!(!partial_line_may_become_marker("cod", false));
-        assert!(!partial_line_may_become_marker("user", false));
+        assert!(!partial_line_may_become_marker("codexy", true, false));
+        assert!(!partial_line_may_become_marker("user data", true, false));
+        assert!(!partial_line_may_become_marker(
+            "hello from daemon",
+            true,
+            false
+        ));
+        assert!(!partial_line_may_become_marker(
+            "successfully parsed",
+            true,
+            false
+        ));
+        // Stats labels hold only for Copilot until the gutter is ruled out.
+        assert!(partial_line_may_become_marker("Resume", false, true));
+        assert!(partial_line_may_become_marker("Changes   ", false, true));
+        assert!(partial_line_may_become_marker("Tokens    ↑ 2", false, true));
+        assert!(!partial_line_may_become_marker("Resume work", false, true));
+        assert!(!partial_line_may_become_marker(
+            "Tokens are stored",
+            false,
+            true
+        ));
+        // Neither syntax holds for an unrelated harness.
+        assert!(!partial_line_may_become_marker("cod", false, false));
+        assert!(!partial_line_may_become_marker("user", false, false));
+        assert!(!partial_line_may_become_marker("Resume", false, false));
     }
 
     /// Regression for #471: copilot's PTY never emits codex-style role

--- a/docs/superpowers/plans/2026-07-26-copilot-stats-trailer.md
+++ b/docs/superpowers/plans/2026-07-26-copilot-stats-trailer.md
@@ -1,0 +1,748 @@
+# Copilot Stats Trailer Formatting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep genuine terminal Copilot usage trailers out of `coven chat` while ensuring stats-shaped assistant prose, incomplete trailers, and every later reply remain visible.
+
+**Architecture:** Replace the current per-line, mode-mutating Copilot filter with a small bounded candidate state inside each `PtyLineBuffer`. Only an exact ordered `Changes → Requests → Tokens → Resume` candidate from a known Copilot session may be discarded, and only when a normal `exit` confirms that it is the terminal suffix. All mismatches fail open by replaying the candidate verbatim through the existing live/batched output sink.
+
+**Tech Stack:** Rust, the existing `coven-cli` TUI state machine, `cargo test`, and the repository CI commands.
+
+---
+
+## Task 1: Encode the fail-open contract as regressions
+
+**Files:**
+
+- Modify: `crates/coven-cli/src/tui/chat/app.rs` (test module near the existing Copilot and PTY tests)
+
+- [ ] Add one test constant and one terminal-event helper beside the existing `output_event`/`agent_text` test helpers:
+
+```rust
+const COPILOT_STATS_TRAILER: &str = concat!(
+    "Changes    +1 -1\n",
+    "Requests   1 Premium (8s)\n",
+    "Tokens     ↑ 28.0k (20.4k cached) • ↓ 32\n",
+    "Resume     copilot --resume=cb845dd4-234f-46a0-8e6a-7f15ce8170be\n",
+);
+
+fn terminal_event(seq: i64, session_id: &str, kind: &str) -> EventRecord {
+    EventRecord {
+        seq,
+        id: format!("event-{seq}"),
+        session_id: session_id.to_string(),
+        kind: kind.to_string(),
+        payload_json: serde_json::json!({
+            "status": if kind == "exit" { "completed" } else { "killed" }
+        })
+        .to_string(),
+        created_at: "2026-07-26T00:00:00Z".to_string(),
+    }
+}
+```
+
+- [ ] Replace the old line-oriented expectations in
+  `copilot_stats_lines_hide_from_chat_transcript`,
+  `copilot_transcript_keeps_prose_and_drops_stats_block`, and
+  `plain_output_keeps_marker_like_prose_and_still_drops_stats_block` with
+  end-to-end tests for the approved trailer contract:
+
+```rust
+#[test]
+fn copilot_resume_shaped_prose_and_following_reply_stay_visible() {
+    let client = RecordingChatClient::with_session(test_session(
+        "session-1",
+        "copilot",
+        "Existing",
+        "running",
+    ));
+    client.events.borrow_mut().push(output_event(
+        1,
+        "session-1",
+        concat!(
+            "Use the saved command below.\n",
+            "Resume     copilot --resume=example\n",
+            "Then verify the result.\n",
+        ),
+    ));
+    let (mut app, _) = app_with_client(client);
+
+    app.handle_slash_command("/attach session-1");
+
+    assert_eq!(
+        agent_text(&app),
+        concat!(
+            "Use the saved command below.\n",
+            "Resume     copilot --resume=example\n",
+            "Then verify the result.\n",
+        )
+    );
+    assert_eq!(app.agent_output_mode, AgentOutputMode::Unknown);
+}
+
+#[test]
+fn copilot_complete_stats_shape_followed_by_prose_is_visible_verbatim() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+
+    app.push_event_message(&output_event(
+        1,
+        "session-1",
+        &format!("{COPILOT_STATS_TRAILER}Explanation continues.\n"),
+    ));
+
+    assert_eq!(
+        agent_text(&app),
+        format!("{COPILOT_STATS_TRAILER}Explanation continues.\n")
+    );
+}
+
+#[test]
+fn copilot_false_positive_split_across_chunks_stays_visible() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+
+    app.push_event_message(&output_event(1, "session-1", "Res"));
+    app.push_event_message(&output_event(
+        2,
+        "session-1",
+        "ume     copilot --resume=example\nLater prose.\n",
+    ));
+
+    assert_eq!(
+        agent_text(&app),
+        "Resume     copilot --resume=example\nLater prose.\n"
+    );
+}
+
+#[test]
+fn copilot_out_of_order_candidate_flushes_verbatim() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+    let out_of_order = concat!(
+        "Changes    +1 -1\n",
+        "Tokens     ↑ 28.0k (20.4k cached) • ↓ 32\n",
+    );
+
+    app.push_event_message(&output_event(1, "session-1", out_of_order));
+
+    assert_eq!(agent_text(&app), out_of_order);
+}
+
+#[test]
+fn copilot_partial_stats_candidate_flushes_on_exit() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+
+    let partial = concat!(
+        "Changes    +1 -1\n",
+        "Requests   1 Premium (8s)\n",
+    );
+    app.push_event_message(&output_event(1, "session-1", partial));
+    assert!(agent_text(&app).is_empty());
+
+    app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+    assert_eq!(agent_text(&app), partial);
+}
+
+#[test]
+fn copilot_complete_terminal_stats_trailer_is_hidden_on_exit() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+
+    app.push_event_message(&output_event(
+        1,
+        "session-1",
+        &format!("Answer.\n{COPILOT_STATS_TRAILER}"),
+    ));
+    assert_eq!(agent_text(&app), "Answer.\n");
+    assert!(app.pty_line_buffers.contains_key("session-1"));
+
+    app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+    assert_eq!(agent_text(&app), "Answer.\n");
+    assert!(!app.pty_line_buffers.contains_key("session-1"));
+}
+
+#[test]
+fn stats_shaped_prose_is_visible_for_non_copilot_harnesses() {
+    for harness in ["codex", "claude", "grok", "custom"] {
+        let client = RecordingChatClient::default();
+        let (mut app, _) = app_with_client(client);
+        app.active_session_id = Some(format!("{harness}-session"));
+        app.active_session_harness = Some(harness.to_string());
+        let session_id = app.active_session_id.clone().expect("active session");
+        let transcript = format!(
+            "assistant\n{COPILOT_STATS_TRAILER}This belongs to {harness}.\n"
+        );
+
+        app.push_event_message(&output_event(1, &session_id, &transcript));
+        app.push_event_message(&terminal_event(2, &session_id, "exit"));
+
+        let visible = agent_text(&app);
+        assert!(
+            visible.contains("Resume     copilot --resume="),
+            "{harness} must not run the Copilot trailer recognizer: {visible:?}"
+        );
+        assert!(
+            visible.contains(&format!("This belongs to {harness}.")),
+            "{harness} prose after stats-shaped text must stay visible: {visible:?}"
+        );
+    }
+}
+```
+
+- [ ] Run the regressions against the old implementation and confirm RED:
+
+```sh
+cargo test -p coven-cli tui::chat::app::tests::copilot_resume_shaped_prose_and_following_reply_stay_visible -- --exact --nocapture
+cargo test -p coven-cli tui::chat::app::tests::copilot_false_positive_split_across_chunks_stays_visible -- --exact --nocapture
+cargo test -p coven-cli tui::chat::app::tests::copilot_partial_stats_candidate_flushes_on_exit -- --exact --nocapture
+cargo test -p coven-cli tui::chat::app::tests::stats_shaped_prose_is_visible_for_non_copilot_harnesses -- --exact --nocapture
+```
+
+Expected: assertion failures showing the `Resume` line and later prose are absent, the partial candidate is lost at exit, and non-Copilot output is filtered. Do not accept a compile error as the RED result.
+
+## Task 2: Implement the bounded Copilot trailer candidate
+
+**Files:**
+
+- Modify: `crates/coven-cli/src/tui/chat/app.rs:35-60`
+- Modify: `crates/coven-cli/src/tui/chat/app.rs` around `active_session_emits_codex_markers`
+- Modify: `crates/coven-cli/src/tui/chat/app.rs` around `dispatch_pty_output` and `flush_pty_line_buffer`
+- Modify: `crates/coven-cli/src/tui/chat/app.rs` around the output-classification helpers
+
+- [ ] Add typed, bounded candidate state before `PtyLineBuffer`:
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CopilotStatsLine {
+    Changes,
+    Requests,
+    Tokens,
+    Resume,
+}
+
+#[derive(Debug, Default)]
+struct CopilotStatsCandidate {
+    /// Exact cleaned lines, including their original newlines. Logic below
+    /// bounds this to the four recognized trailer rows.
+    lines: Vec<String>,
+    /// Copilot may print one cosmetic blank after its terminal table.
+    trailing_blank: bool,
+}
+
+impl CopilotStatsCandidate {
+    fn expected(&self) -> Option<CopilotStatsLine> {
+        match self.lines.len() {
+            0 => Some(CopilotStatsLine::Changes),
+            1 => Some(CopilotStatsLine::Requests),
+            2 => Some(CopilotStatsLine::Tokens),
+            3 => Some(CopilotStatsLine::Resume),
+            _ => None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.lines.is_empty()
+    }
+
+    fn is_complete(&self) -> bool {
+        self.lines.len() == 4
+    }
+
+    fn clear(&mut self) {
+        self.lines.clear();
+        self.trailing_blank = false;
+    }
+
+    fn take_visible(&mut self) -> String {
+        let mut visible = std::mem::take(&mut self.lines).concat();
+        if std::mem::take(&mut self.trailing_blank) {
+            visible.push('\n');
+        }
+        visible
+    }
+
+    fn push_line(&mut self, raw_line: &str, visible: &mut String) {
+        let marker = raw_line.trim_end_matches('\n').trim();
+        if self.is_complete() && marker.is_empty() {
+            self.trailing_blank = true;
+            return;
+        }
+
+        let kind = copilot_stats_line_kind(marker);
+        if kind == self.expected() {
+            self.lines.push(raw_line.to_string());
+            debug_assert!(self.lines.len() <= 4);
+            return;
+        }
+
+        if !self.is_empty() {
+            visible.push_str(&self.take_visible());
+        }
+        if kind == Some(CopilotStatsLine::Changes) {
+            self.lines.push(raw_line.to_string());
+        } else {
+            visible.push_str(raw_line);
+        }
+    }
+
+    /// Normal EOF confirms a complete candidate as the terminal trailer.
+    /// Every incomplete candidate fails open.
+    fn finish_at_exit(&mut self) -> Option<String> {
+        if self.is_empty() {
+            return None;
+        }
+        if self.is_complete() {
+            self.clear();
+            return None;
+        }
+        Some(self.take_visible())
+    }
+}
+```
+
+- [ ] Extend `PtyLineBuffer` and centralize its retention predicate:
+
+```rust
+#[derive(Debug, Default)]
+struct PtyLineBuffer {
+    tail: String,
+    emitted_len: usize,
+    copilot_stats: CopilotStatsCandidate,
+}
+
+impl PtyLineBuffer {
+    fn has_pending(&self) -> bool {
+        !self.tail.is_empty() || self.emitted_len > 0 || !self.copilot_stats.is_empty()
+    }
+}
+```
+
+- [ ] Replace `is_copilot_stats_line` with a typed classifier. Keep the existing strict column/value recognition:
+
+```rust
+fn copilot_stats_line_kind(line: &str) -> Option<CopilotStatsLine> {
+    fn column<'a>(line: &'a str, label: &str) -> Option<&'a str> {
+        line.strip_prefix(label)?
+            .strip_prefix("   ")
+            .map(str::trim_start)
+    }
+
+    if column(line, "Changes").is_some_and(|value| value.starts_with('+')) {
+        return Some(CopilotStatsLine::Changes);
+    }
+    if column(line, "Requests").is_some_and(|value| {
+        value.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+    }) {
+        return Some(CopilotStatsLine::Requests);
+    }
+    if column(line, "Tokens").is_some_and(|value| value.starts_with('↑')) {
+        return Some(CopilotStatsLine::Tokens);
+    }
+    if column(line, "Resume").is_some_and(|value| value.starts_with("copilot --resume=")) {
+        return Some(CopilotStatsLine::Resume);
+    }
+    None
+}
+```
+
+- [ ] Remove the Copilot predicate from `human_facing_agent_output`; stats text must never mutate `AgentOutputMode`.
+
+- [ ] Replace `human_facing_plain_output` with harness-neutral passthrough and add the candidate-aware dispatcher:
+
+```rust
+fn human_facing_plain_output(data: &str) -> Option<String> {
+    clean_terminal_output(data)
+}
+
+fn human_facing_copilot_output(
+    data: &str,
+    candidate: &mut CopilotStatsCandidate,
+) -> Option<String> {
+    let cleaned = clean_terminal_output(data)?;
+    let mut visible = String::new();
+    for raw_line in cleaned.split_inclusive('\n') {
+        candidate.push_line(raw_line, &mut visible);
+    }
+    let has_structure = visible.chars().any(|ch| ch == '\n' || !ch.is_whitespace());
+    has_structure.then_some(visible)
+}
+
+fn human_facing_pty_output(
+    data: &str,
+    mode: &mut AgentOutputMode,
+    codex_markers: bool,
+    copilot_stats: bool,
+    candidate: &mut CopilotStatsCandidate,
+) -> Option<String> {
+    if codex_markers {
+        human_facing_agent_output(data, mode)
+    } else if copilot_stats {
+        human_facing_copilot_output(data, candidate)
+    } else {
+        human_facing_plain_output(data)
+    }
+}
+```
+
+- [ ] Add a separate exact harness gate beside `active_session_emits_codex_markers`:
+
+```rust
+fn active_session_emits_copilot_stats(&self) -> bool {
+    self.active_session_harness.as_deref() == Some("copilot")
+}
+```
+
+- [ ] Change `partial_line_may_become_marker` to accept
+  `(fragment, codex_markers, copilot_stats)`. Run the stats-prefix logic only
+  when `copilot_stats` is true; preserve the Codex marker logic exactly.
+  Update every existing test call to pass both booleans.
+
+- [ ] In `dispatch_pty_output`, capture both harness gates, route complete
+  lines through `human_facing_pty_output`, and retain state when
+  `state.has_pending()`:
+
+```rust
+let codex_markers = self.active_session_emits_codex_markers();
+let copilot_stats = self.active_session_emits_copilot_stats();
+// ...
+let classified = human_facing_pty_output(
+    &complete,
+    &mut self.agent_output_mode,
+    codex_markers,
+    copilot_stats,
+    &mut state.copilot_stats,
+);
+// ...
+if state.has_pending() {
+    self.pty_line_buffers.insert(session_id.to_string(), state);
+}
+```
+
+- [ ] Tighten the trailing-fragment pre-emission condition so prose after a
+  candidate cannot leapfrog the held candidate:
+
+```rust
+if !state.tail.is_empty()
+    && self.agent_output_mode != AgentOutputMode::Hidden
+    && state.emitted_len == 0
+    && state.copilot_stats.is_empty()
+{
+    let displayable = clean_terminal_output(&state.tail).filter(|text| {
+        !partial_line_may_become_marker(text.trim(), codex_markers, copilot_stats)
+    });
+    // existing emission body
+}
+```
+
+- [ ] Rewrite `flush_pty_line_buffer` so it handles an empty raw tail with a
+  pending candidate, classifies an un-emitted EOF tail through the same
+  harness-aware helper, and finally calls `finish_at_exit`:
+
+```rust
+fn flush_pty_line_buffer(&mut self, session_id: &str) {
+    let Some(mut state) = self.pty_line_buffers.remove(session_id) else {
+        return;
+    };
+    let codex_markers = self.active_session_emits_codex_markers();
+    let copilot_stats = self.active_session_emits_copilot_stats();
+    let mut visible = String::new();
+
+    if !state.tail.is_empty() && state.emitted_len == 0 {
+        if let Some(text) = human_facing_pty_output(
+            &state.tail,
+            &mut self.agent_output_mode,
+            codex_markers,
+            copilot_stats,
+            &mut state.copilot_stats,
+        ) {
+            visible.push_str(&text);
+        }
+    }
+    if let Some(text) = state.copilot_stats.finish_at_exit() {
+        visible.push_str(&text);
+    }
+    self.flush_pty_visible(&mut visible, false);
+}
+```
+
+- [ ] Run the new contract tests and the complete chat-app test module:
+
+```sh
+cargo test -p coven-cli tui::chat::app::tests::copilot_ -- --nocapture
+cargo test -p coven-cli tui::chat::app::tests -- --nocapture
+```
+
+Expected: all pass. Specifically confirm that existing Codex marker,
+CR/backspace/ANSI, whitespace, attach/replay, and batched-output regressions
+remain green.
+
+- [ ] Format, inspect, and commit the core fix:
+
+```sh
+cargo fmt --check
+git diff --check
+git diff -- crates/coven-cli/src/tui/chat/app.rs
+git status --short
+git add crates/coven-cli/src/tui/chat/app.rs
+git commit -s -m "fix: make Copilot stats filtering fail open"
+```
+
+## Task 3: Cover teardown and state-lifecycle semantics
+
+**Files:**
+
+- Modify: `crates/coven-cli/src/tui/chat/app.rs` (kill handling and tests)
+
+- [ ] Add the kill-path regression first:
+
+```rust
+#[test]
+fn kill_flushes_copilot_candidate_but_drops_the_unfinished_tail() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+    let candidate = concat!(
+        "Changes    +1 -1\n",
+        "Requests   1 Premium (8s)\n",
+    );
+
+    app.push_event_message(&output_event(
+        1,
+        "session-1",
+        &format!("{candidate}unfinished"),
+    ));
+    assert!(agent_text(&app).is_empty());
+
+    app.push_event_message(&terminal_event(2, "session-1", "kill"));
+
+    assert_eq!(agent_text(&app), candidate);
+    assert!(!agent_text(&app).contains("unfinished"));
+}
+```
+
+- [ ] Run it and confirm RED:
+
+```sh
+cargo test -p coven-cli tui::chat::app::tests::kill_flushes_copilot_candidate_but_drops_the_unfinished_tail -- --exact --nocapture
+```
+
+Expected: the old kill branch drops the candidate, leaving an empty agent transcript.
+
+- [ ] Add a narrowly scoped kill helper and call it before flushing the pending batched sink:
+
+```rust
+fn flush_pty_candidate_on_kill(&mut self, session_id: &str) {
+    let Some(mut state) = self.pty_line_buffers.remove(session_id) else {
+        return;
+    };
+    if !state.copilot_stats.is_empty() {
+        self.emit_agent_text(&state.copilot_stats.take_visible());
+    }
+}
+```
+
+Replace the kill branch's direct `pty_line_buffers.remove` with:
+
+```rust
+self.flush_pty_candidate_on_kill(&event.session_id);
+self.flush_pending_agent_buffer();
+```
+
+- [ ] Extend the existing `/clear`, `/new`, and suppressed-session tests so
+  they seed a real `Changes` candidate, not only a partial `Resume` line:
+
+```rust
+app.push_event_message(&output_event(
+    1,
+    "session-1",
+    "Changes    +1 -1\n",
+));
+```
+
+Assert:
+
+- `/clear` removes the candidate and it never resurfaces.
+- `/new` preserves the candidate because it preserves the visible transcript
+  and live PTY session.
+- a suppressed terminal event removes the candidate without displaying it.
+- a complete candidate plus repeated blank output never stores more than four
+  candidate lines (`lines.len() == 4`); the blank-state flag remains boolean.
+
+- [ ] Run the lifecycle tests in both live and batched mode:
+
+```sh
+cargo test -p coven-cli tui::chat::app::tests::kill_flushes_copilot_candidate_but_drops_the_unfinished_tail -- --exact --nocapture
+cargo test -p coven-cli tui::chat::app::tests::clear_transcript_drops_held_pty_line_fragments -- --exact --nocapture
+cargo test -p coven-cli tui::chat::app::tests::start_new_conversation_keeps_held_pty_line_fragments -- --exact --nocapture
+cargo test -p coven-cli tui::chat::app::tests::batched_ -- --nocapture
+```
+
+Expected: all pass, and the recovered kill candidate reaches the same sink in
+both streaming modes.
+
+- [ ] Format, inspect, and commit:
+
+```sh
+cargo fmt --check
+git diff --check
+git diff -- crates/coven-cli/src/tui/chat/app.rs
+git add crates/coven-cli/src/tui/chat/app.rs
+git commit -s -m "fix: preserve Copilot candidates on cancellation"
+```
+
+## Task 4: Verify chunk boundaries and output-mode parity
+
+**Files:**
+
+- Modify: `crates/coven-cli/src/tui/chat/app.rs` (tests only unless a regression exposes a defect)
+
+- [ ] Replace `copilot_stats_line_split_across_chunks_is_still_hidden` with a
+  full ordered trailer split at hostile boundaries, then terminate normally:
+
+```rust
+#[test]
+fn copilot_terminal_stats_trailer_is_hidden_across_pty_chunks() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+
+    for (seq, chunk) in [
+        "Answer.\nCha",
+        "nges    +1 -1\nRequests ",
+        "  1 Premium (8s)\nTokens     ↑ 28.0k",
+        " (20.4k cached) • ↓ 32\nRes",
+        "ume     copilot --resume=cb845dd4\n",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        app.push_event_message(&output_event(seq as i64 + 1, "session-1", chunk));
+    }
+    app.push_event_message(&terminal_event(6, "session-1", "exit"));
+
+    assert_eq!(agent_text(&app), "Answer.\n");
+}
+```
+
+- [ ] Add a batched-mode mirror of the issue #493 false-positive regression:
+
+```rust
+#[test]
+fn batched_copilot_stats_shaped_prose_fails_open() {
+    let client = RecordingChatClient::default();
+    let (mut app, _) = app_with_client(client);
+    app.handle_slash_command("/stream off");
+    app.active_session_id = Some("session-1".to_string());
+    app.active_session_harness = Some("copilot".to_string());
+    app.is_responding = true;
+    let reply = concat!(
+        "Changes    +1 -1\n",
+        "Requests   1 Premium (8s)\n",
+        "This table is part of the answer.\n",
+    );
+
+    app.push_event_message(&output_event(1, "session-1", reply));
+    app.push_event_message(&terminal_event(2, "session-1", "exit"));
+
+    assert_eq!(agent_text(&app), reply);
+}
+```
+
+- [ ] Run the entire affected test module again:
+
+```sh
+cargo test -p coven-cli tui::chat::app::tests -- --nocapture
+```
+
+Expected: all tests pass. If any CR/backspace/ANSI fidelity test fails, fix the
+shared PTY buffering logic rather than weakening that test.
+
+- [ ] Commit the regression coverage:
+
+```sh
+cargo fmt --check
+git diff --check
+git add crates/coven-cli/src/tui/chat/app.rs
+git commit -s -m "test: cover Copilot trailer formatting boundaries"
+```
+
+## Task 5: Run repository gates and prepare the issue-scoped PR
+
+**Files:**
+
+- Verify: `docs/superpowers/specs/2026-07-26-copilot-stats-trailer-design.md`
+- Verify: `docs/superpowers/plans/2026-07-26-copilot-stats-trailer.md`
+- Verify: `crates/coven-cli/src/tui/chat/app.rs`
+
+- [ ] Refresh the shared claim before the slower gates:
+
+```sh
+coven claim heartbeat issue-493
+```
+
+- [ ] Run every required Rust and repository gate from the worktree root:
+
+```sh
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+git diff --check origin/main...HEAD
+```
+
+Expected:
+
+- formatting clean;
+- clippy exits zero with no warnings;
+- workspace tests report zero failures;
+- secret guard reports no current-tree or history findings;
+- diff check prints nothing.
+
+- [ ] Audit the final scope and history:
+
+```sh
+git status --short --branch
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD -- crates/coven-cli/src/tui/chat/app.rs
+git log --oneline --decorate origin/main..HEAD
+gh pr list --state open --search "493 in:body,head"
+```
+
+Expected: only the approved design, this implementation plan, and the
+issue-493 `app.rs` change are present; no duplicate PR exists.
+
+- [ ] Push the issue branch and open one PR:
+
+```sh
+git push -u origin fix/493-copilot-stats-trailer
+gh pr create \
+  --title "fix: make Copilot stats trailer filtering fail open" \
+  --body $'Closes #493\n\n## Summary\n- treat Copilot usage stats as a bounded, ordered terminal trailer instead of mode-changing lines\n- fail open for partial, out-of-order, followed-by-prose, cancelled, and non-Copilot output\n- preserve PTY chunk fidelity and live/batched output parity\n\n## Verification\n- cargo fmt --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --locked\n- python scripts/check-secrets.py\n- git diff --check origin/main...HEAD'
+```
+
+- [ ] Inspect the created PR and its initial checks:
+
+```sh
+gh pr view --json number,url,title,body,headRefName,baseRefName
+gh pr checks
+gh pr checks --watch --interval 10
+```
+
+Expected: all required checks finish green. Do not merge. Keep `issue-493`
+claimed until the PR is merged or the work is explicitly stopped.

--- a/docs/superpowers/specs/2026-07-26-copilot-stats-trailer-design.md
+++ b/docs/superpowers/specs/2026-07-26-copilot-stats-trailer-design.md
@@ -2,7 +2,7 @@
 
 - **Date:** 2026-07-26
 - **Issue:** [#493](https://github.com/OpenCoven/coven/issues/493)
-- **Status:** design approved; written-spec review pending
+- **Status:** approved for implementation
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-26-copilot-stats-trailer-design.md
+++ b/docs/superpowers/specs/2026-07-26-copilot-stats-trailer-design.md
@@ -1,0 +1,212 @@
+# Copilot stats trailer filtering — design
+
+- **Date:** 2026-07-26
+- **Issue:** [#493](https://github.com/OpenCoven/coven/issues/493)
+- **Status:** design approved; written-spec review pending
+
+## Problem
+
+`coven chat` cleans PTY output and removes harness-owned transcript metadata
+before displaying assistant prose. Copilot's one-shot prompt mode ends with a
+four-line statistics trailer:
+
+```text
+Changes    +1 -1
+Requests   1 Premium (8s)
+Tokens     ↑ 28.0k (20.4k cached) • ↓ 32
+Resume     copilot --resume=<session-id>
+```
+
+The current filter recognizes each of those line shapes independently and
+sets the shared `AgentOutputMode` to `Hidden`. That mode persists across PTY
+chunks and is reset only by a later assistant marker or turn teardown. Copilot
+does not emit Codex's `assistant`/`codex` markers, so one stats-shaped line in
+ordinary prose can hide every later line in the turn. A realistic example is
+an assistant explaining a resume command:
+
+```text
+Resume     copilot --resume=<session-id>
+```
+
+This is not only a formatting defect. It is silent assistant-output loss.
+
+## Evidence and root cause
+
+The data path is:
+
+1. daemon `output` events deliver arbitrary PTY chunks;
+2. `dispatch_pty_output` retains incomplete raw lines and cleans terminal
+   control sequences;
+3. complete lines enter `human_facing_plain_output`;
+4. `is_copilot_stats_line` classifies a single line;
+5. the classifier mutates the role-visibility mode to `Hidden`;
+6. later Copilot prose is discarded because no marker can restore visibility.
+
+Recent fixes already establish the adjacent invariants:
+
+- classification happens only on complete PTY lines;
+- Codex role markers are harness-gated;
+- raw line state survives chunk boundaries for CR, backspace, ANSI, and
+  whitespace fidelity;
+- live and batched modes share the same visible-text sink.
+
+The remaining architectural mistake is treating a Copilot terminal trailer as
+a role transition. Trailer recognition needs its own bounded, fail-open state.
+
+## Goals
+
+1. Never let one marker-shaped assistant line hide later prose.
+2. Preserve the prose-only chat transcript by removing a genuine Copilot
+   statistics trailer.
+3. Apply Copilot trailer rules only to Copilot PTY sessions.
+4. Preserve exact visible text when a trailer candidate is incomplete,
+   out-of-order, followed by prose, or interrupted.
+5. Keep behavior identical in live and batched streaming modes.
+6. Bound all new per-session state and clean it up with the existing PTY
+   lifecycle.
+7. Preserve Codex transcript filtering and terminal-control handling.
+
+## Non-goals
+
+- Do not change daemon event formats, session persistence, or harness launch.
+- Do not change stream-JSON rendering; the defect is in merged PTY output.
+- Do not expose Copilot statistics as a new transcript message or status UI.
+- Do not broaden or loosen Codex role-marker recognition.
+- Do not refactor the rest of the large chat app while fixing this seam.
+- Do not audit unrelated human-facing CLI commands in this PR.
+
+## Design
+
+### D1 — Separate role filtering from trailer filtering
+
+`AgentOutputMode` remains the Codex transcript role state. Copilot statistics
+must never mutate it.
+
+- Codex sessions continue through `human_facing_agent_output`, without
+  Copilot stats classification.
+- Copilot PTY sessions pass complete cleaned lines through a dedicated trailer
+  recognizer.
+- Claude fallback, Grok, and other non-Codex PTY harnesses treat
+  Copilot-shaped lines as ordinary prose.
+- An unknown harness does not apply the Copilot recognizer. Fail-open output is
+  safer than deleting content based on an unproven wire format.
+
+### D2 — Recognize one exact ordered terminal suffix
+
+The recognizer accepts only this ordered sequence:
+
+1. `Changes` with the existing `+…` value shape;
+2. `Requests` with the existing leading-digit value shape;
+3. `Tokens` with the existing `↑…` value shape;
+4. `Resume` with the existing `copilot --resume=…` value shape.
+
+A candidate starts only on `Changes`. A lone `Requests`, `Tokens`, or `Resume`
+line is emitted immediately as prose.
+
+Candidate lines are held until the session reaches its normal `exit` event.
+At that point:
+
+- an exact completed sequence at the end of output is discarded as Copilot's
+  statistics trailer;
+- an incomplete sequence is emitted verbatim;
+- a candidate followed by any non-trailer prose is emitted verbatim before
+  that prose;
+- an out-of-order line flushes the candidate, then is reprocessed so a new
+  `Changes` line can start a fresh candidate.
+
+Optional blank lines after a complete candidate may remain held until exit.
+The state records at most four trailer lines plus whether trailing blank
+spacing occurred; it never accumulates arbitrary output.
+
+### D3 — Keep state with the PTY line buffer
+
+The existing per-session `PtyLineBuffer` is the ownership boundary for:
+
+- the raw incomplete line;
+- the number of already-rendered cleaned characters;
+- the bounded Copilot trailer candidate.
+
+Keeping these together makes line assembly happen before trailer
+classification and reuses the established session cleanup paths. The map entry
+remains alive while any of those three states is non-empty.
+
+Pure helpers classify a complete line by trailer field and advance or flush
+the candidate. They return visible text to the existing `emit_agent_text`
+sink; they do not mutate transcript messages directly.
+
+### D4 — Fail-open lifecycle behavior
+
+Normal session completion finalizes a candidate:
+
+- complete terminal trailer → discard;
+- partial candidate → emit.
+
+Other lifecycle paths preserve existing transcript semantics:
+
+- **kill/cancel:** emit complete candidate lines before dropping an unfinished
+  raw line;
+- **`/clear`:** drop all buffered state because the transcript was explicitly
+  erased; nothing may resurface later;
+- **`/new`:** preserve state for a still-running session, matching the current
+  PTY-fragment behavior;
+- **suppressed stale-session retry:** drop state with the suppressed session,
+  because that session's output is intentionally replaced by recovery copy;
+- **attach/replay:** start from empty state and reconstruct deterministically
+  from recorded events.
+
+No lifecycle path may carry a candidate into a different session.
+
+### D5 — Formatting and ordering
+
+When a false candidate is flushed, its raw cleaned lines retain their original
+newlines and ordering. The current live/batched sink remains authoritative:
+
+- live mode appends recovered prose immediately;
+- batched mode appends it to the pending buffer;
+- neither path injects stream-JSON paragraph separators into PTY data.
+
+Terminal cleanup still runs before classification, so split ANSI sequences,
+carriage-return frames, backspaces, whitespace-only continuations, and UTF-8
+retractions retain the behavior covered by the existing tests.
+
+## Testing
+
+Implementation proceeds test-first and covers:
+
+1. a lone `Resume     copilot --resume=…` line and all following prose remain
+   visible;
+2. false-positive lines split across PTY chunks remain visible after their
+   newline arrives;
+3. a complete ordered Copilot trailer is hidden only when it is the terminal
+   suffix;
+4. the complete trailer remains hidden when its lines and labels span
+   arbitrary PTY chunks;
+5. partial and out-of-order candidates flush verbatim at EOF;
+6. a complete candidate followed by prose flushes the candidate and prose in
+   order;
+7. stats-shaped lines stay visible for Codex, Claude fallback, Grok, and an
+   unknown harness unless their own established filter says otherwise;
+8. live and batched modes produce equivalent assistant text;
+9. kill flushes complete candidate lines, `/clear` prevents resurfacing,
+   `/new` preserves the active session candidate, and suppressed-session
+   cleanup drops it;
+10. candidate storage remains bounded;
+11. existing Codex role-marker, chunk-split, CR/backspace, ANSI, whitespace,
+    UTF-8, and stream-JSON tests remain green.
+
+Required verification:
+
+```sh
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+```
+
+## Rollout
+
+One issue-scoped PR from `fix/493-copilot-stats-trailer`. No migration,
+configuration change, API change, or user documentation update is required.
+The PR should close #493 and describe the fail-open invariant explicitly:
+cosmetic trailer filtering may show extra harness metadata, but it must never
+silently remove assistant prose.


### PR DESCRIPTION
Closes #493

## Summary
- treat Copilot usage stats as a bounded, ordered terminal trailer instead of mode-changing lines
- fail open for partial, out-of-order, followed-by-prose, cancelled, and non-Copilot output
- preserve PTY chunk fidelity and live/batched output parity

## Verification
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- python scripts/check-secrets.py
- git diff --check origin/main...HEAD