### PR TITLE
fix: scope default claim identity to worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ PRs that a session then has to close. Before you touch code:
    worktree-scoped, so enter the worktree before acquiring the claim:
    ```sh
    git fetch origin main
-   git worktree add -b <branch> /tmp/coven-<branch> origin/main
-   cd /tmp/coven-<branch>
+   git worktree add -b <branch> /tmp/coven-<branch-slug> origin/main
+   cd /tmp/coven-<branch-slug>
    ```
 
 3. **Claim it with a shared, issue-keyed token** — not your working branch name,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Coven is a small, boring **Rust authority layer** with TypeScript integration
 packages around it. The development loop must keep that boundary clear: core
 logic stays in Rust; the npm packages are thin integration surface.
 
-## Claim your work first — parallel sessions duplicate otherwise
+## Check, enter a worktree, then claim it
 
 Multiple agent sessions (Codex, Claude Code, familiars) frequently run against
 **the same checkout at once**, each in its own worktree. Worktrees keep git
@@ -34,7 +34,15 @@ PRs that a session then has to close. Before you touch code:
    ```
    If the issue is claimed or already has a PR, pick different work or coordinate.
 
-2. **Claim it with a shared, issue-keyed token** — not your working branch name,
+2. **Create or enter the task worktree.** The automatic fallback identity is
+   worktree-scoped, so enter the worktree before acquiring the claim:
+   ```sh
+   git fetch origin main
+   git worktree add -b <branch> /tmp/coven-<branch> origin/main
+   cd /tmp/coven-<branch>
+   ```
+
+3. **Claim it with a shared, issue-keyed token** — not your working branch name,
    which no other session can predict:
    ```sh
    coven claim acquire issue-<N>     # e.g. issue-311; a TTL-bounded lock
@@ -43,22 +51,22 @@ PRs that a session then has to close. Before you touch code:
    worktree and session sees them. For long tasks, extend the TTL with
    `coven claim heartbeat issue-<N>`.
 
-3. **Release when your PR merges or you stop:** `coven claim release issue-<N>`.
+4. **Release from the same worktree when your PR merges or you stop:**
+   `coven claim release issue-<N>`.
 
 This step is cheap and it is the single thing that prevents duplicate-PR churn.
+Without an explicit `COVEN_AGENT_ID`, Coven identifies the owner as
+`$USER@<worktree-slug>`. Set distinct explicit IDs only when multiple agents
+must share one worktree.
 
 ## Branch & PR workflow (all agents)
 
-- **Claim the issue first** (see above) — `coven claim status` + `gh pr list`
-  before starting, then `coven claim acquire issue-<N>`.
+- **Coordinate before editing** (see above) — check `coven claim status` and
+  `gh pr list`, enter a fresh worktree, then acquire `issue-<N>` from inside it.
 - **Never push to `main`.** Every change lands via a PR with green CI. Branch
   from current `origin/main`.
-- **Fresh branch per task.** If multiple sessions may touch this repo, work in a
-  git worktree so operations don't race:
-  ```sh
-  git fetch origin main
-  git worktree add -b <branch> /tmp/coven-<branch> origin/main
-  ```
+- **Fresh branch per task.** If multiple sessions may touch this repo, use the
+  task worktree created before claim acquisition so operations don't race.
 - Keep the diff **scoped to one concern**; no drive-by refactors in a feature PR.
 - Conventional-commit subjects: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`.
 - For larger changes, **start from an issue** and include the readiness packet

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -86,7 +86,7 @@ pub(crate) fn run_wt_command(
 
 pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
-    let agent_id = agent_id();
+    let agent_id = agent_id(&repo);
 
     // Creating the claim file is the only step that decides the race, so it
     // has to be the same step that tests for a free slot: a separate
@@ -164,7 +164,7 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
 
 pub(crate) fn claim_release(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
-    let agent_id = agent_id();
+    let agent_id = agent_id(&repo);
     match read_claim(&repo, branch)? {
         ClaimFileState::Parsed(existing) => {
             if existing.is_active(unix_now()) && existing.agent_id != agent_id {
@@ -193,7 +193,7 @@ pub(crate) fn claim_release(branch: &str) -> Result<()> {
 
 pub(crate) fn claim_heartbeat(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
-    let agent_id = agent_id();
+    let agent_id = agent_id(&repo);
     let now = unix_now();
     let mut claim = match read_claim(&repo, branch)? {
         ClaimFileState::Parsed(claim) => claim,
@@ -1078,12 +1078,25 @@ fn primary_branch() -> String {
     std::env::var("COVEN_PRIMARY_BRANCH").unwrap_or_else(|_| DEFAULT_PRIMARY_BRANCH.to_string())
 }
 
-fn agent_id() -> String {
-    std::env::var("COVEN_AGENT_ID")
+fn agent_id(repo: &Repo) -> String {
+    if let Some(agent_id) = std::env::var("COVEN_AGENT_ID")
         .ok()
         .filter(|value| !value.trim().is_empty())
-        .or_else(|| std::env::var("USER").ok())
-        .unwrap_or_else(|| "unknown-agent".to_string())
+    {
+        return agent_id;
+    }
+
+    let user = std::env::var("USER")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown-agent".to_string());
+    let worktree = repo
+        .root
+        .file_name()
+        .map(|name| branch_slug(&name.to_string_lossy()))
+        .filter(|slug| !slug.is_empty())
+        .unwrap_or_else(|| "worktree".to_string());
+    format!("{user}@{worktree}")
 }
 
 fn claim_ttl_seconds() -> u64 {
@@ -1117,7 +1130,22 @@ claim_value() {
 
 branch="$(git symbolic-ref --quiet --short HEAD || true)"
 primary="${COVEN_PRIMARY_BRANCH:-main}"
-agent="${COVEN_AGENT_ID:-${USER:-unknown-agent}}"
+repo_root="$(git rev-parse --show-toplevel)"
+worktree_name="${repo_root##*/}"
+worktree_slug="$(slug_branch "$worktree_name")"
+[ -n "$worktree_slug" ] || worktree_slug="worktree"
+nonblank() {
+  [ -n "$(printf '%s' "$1" | tr -d '[:space:]')" ]
+}
+base_user="${USER:-}"
+if ! nonblank "$base_user"; then
+  base_user="unknown-agent"
+fi
+fallback_agent="${base_user}@${worktree_slug}"
+agent="${COVEN_AGENT_ID:-}"
+if ! nonblank "$agent"; then
+  agent="$fallback_agent"
+fi
 common_dir="$(git rev-parse --git-common-dir)"
 
 if [ "$branch" = "$primary" ] && [ "${COVEN_ALLOW_PRIMARY_COMMIT:-}" != "1" ]; then
@@ -1152,7 +1180,6 @@ if [ -f "$canary" ] && [ -n "$branch" ]; then
   fi
 fi
 
-repo_root="$(git rev-parse --show-toplevel)"
 privacy_guard="$repo_root/scripts/check-coven-privacy.py"
 if [ -f "$privacy_guard" ]; then
   if command -v python3 >/dev/null 2>&1; then

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -67,6 +67,105 @@ fn claim_acquire_blocks_other_agent_until_release() -> anyhow::Result<()> {
 }
 
 #[test]
+fn default_claim_identity_blocks_same_user_in_another_worktree() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let first_worktree = repo.add_worktree("first-session", "feature/first-session")?;
+    let second_worktree = repo.add_worktree("second-session", "feature/second-session")?;
+
+    let acquired = repo.coven_in_with_env(
+        &first_worktree,
+        ["claim", "acquire", "issue-demo"],
+        [("USER", "val")],
+    )?;
+    assert_success("claim acquire from first worktree", &acquired);
+
+    let blocked = repo.coven_in_with_env(
+        &second_worktree,
+        ["claim", "acquire", "issue-demo"],
+        [("USER", "val")],
+    )?;
+    assert_failure("claim acquire from second worktree", &blocked);
+    assert_stderr_contains(
+        "claim acquire from second worktree",
+        &blocked,
+        "already claimed by val@first-session",
+    );
+    assert_eq!(
+        repo.claim_field("issue-demo", "agent_id")?,
+        "val@first-session"
+    );
+    Ok(())
+}
+
+#[test]
+fn default_claim_identity_supports_same_worktree_lifecycle() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let worktree = repo.add_worktree("one-session", "feature/one-session")?;
+    let env = [("USER", "val")];
+
+    let acquired = repo.coven_in_with_env(&worktree, ["claim", "acquire", "issue-demo"], env)?;
+    assert_success("claim acquire with fallback identity", &acquired);
+    assert_eq!(
+        repo.claim_field("issue-demo", "agent_id")?,
+        "val@one-session"
+    );
+
+    let heartbeat = repo.coven_in_with_env(&worktree, ["claim", "heartbeat", "issue-demo"], env)?;
+    assert_success("claim heartbeat with fallback identity", &heartbeat);
+
+    let released = repo.coven_in_with_env(&worktree, ["claim", "release", "issue-demo"], env)?;
+    assert_success("claim release with fallback identity", &released);
+    assert!(
+        !repo.claim_path("issue-demo")?.exists(),
+        "release should remove the claim"
+    );
+    Ok(())
+}
+
+#[test]
+fn default_claim_identity_handles_blank_user() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let worktree = repo.add_worktree("one-session", "feature/one-session")?;
+    let env = [("USER", "   "), ("COVEN_AGENT_ID", "   ")];
+
+    let acquired = repo.coven_in_with_env(&worktree, ["claim", "acquire", "issue-demo"], env)?;
+    assert_success("claim acquire with blank user", &acquired);
+    assert_eq!(
+        repo.claim_field("issue-demo", "agent_id")?,
+        "unknown-agent@one-session"
+    );
+
+    let heartbeat = repo.coven_in_with_env(&worktree, ["claim", "heartbeat", "issue-demo"], env)?;
+    assert_success("claim heartbeat with blank user", &heartbeat);
+
+    let released = repo.coven_in_with_env(&worktree, ["claim", "release", "issue-demo"], env)?;
+    assert_success("claim release with blank user", &released);
+    assert!(
+        !repo.claim_path("issue-demo")?.exists(),
+        "release should remove the claim"
+    );
+    Ok(())
+}
+
+#[test]
+fn explicit_agent_identity_remains_authoritative_across_worktrees() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let first_worktree = repo.add_worktree("first-session", "feature/first-session")?;
+    let second_worktree = repo.add_worktree("second-session", "feature/second-session")?;
+    let env = [("COVEN_AGENT_ID", "cody")];
+
+    let acquired =
+        repo.coven_in_with_env(&first_worktree, ["claim", "acquire", "issue-demo"], env)?;
+    assert_success("claim acquire with explicit identity", &acquired);
+
+    let refreshed =
+        repo.coven_in_with_env(&second_worktree, ["claim", "acquire", "issue-demo"], env)?;
+    assert_success("claim refresh with explicit identity", &refreshed);
+    assert_eq!(repo.claim_field("issue-demo", "agent_id")?, "cody");
+    Ok(())
+}
+
+#[test]
 fn concurrent_claim_acquire_yields_exactly_one_winner() -> anyhow::Result<()> {
     let repo = TestRepo::new()?;
 
@@ -391,6 +490,61 @@ fn installed_hooks_block_primary_commits_and_claim_conflicts() -> anyhow::Result
 }
 
 #[test]
+fn managed_hook_uses_worktree_scoped_default_identity() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let install = repo.coven(["hooks", "install"])?;
+    assert_success("hooks install", &install);
+
+    repo.git(["checkout", "-b", "feature/demo"])?;
+    let owner_env = [("USER", "val")];
+    let claim = repo.coven_with_env(["claim", "acquire", "feature/demo"], owner_env)?;
+    assert_success("claim feature/demo with fallback identity", &claim);
+    assert_eq!(repo.claim_field("feature/demo", "agent_id")?, "val@project");
+
+    fs::write(repo.path.join("main.txt"), "allowed\n")?;
+    let allowed = repo.git_output(["commit", "-am", "allowed by fallback owner"], owner_env)?;
+    assert_success("commit with fallback owning identity", &allowed);
+
+    let released = repo.coven_with_env(["claim", "release", "feature/demo"], owner_env)?;
+    assert_success("release fallback-owned claim", &released);
+    let other_worktree = repo.add_worktree("other-session", "feature/other-session")?;
+    let other_claim = repo.coven_in_with_env(
+        &other_worktree,
+        ["claim", "acquire", "feature/demo"],
+        owner_env,
+    )?;
+    assert_success("claim from another worktree", &other_claim);
+
+    fs::write(repo.path.join("main.txt"), "blocked\n")?;
+    let blocked = repo.git_output(["commit", "-am", "blocked by other worktree"], owner_env)?;
+    assert_failure("commit against another worktree's claim", &blocked);
+    assert_stderr_contains(
+        "commit against another worktree's claim",
+        &blocked,
+        "claimed by val@other-session",
+    );
+    Ok(())
+}
+
+#[test]
+fn managed_hook_treats_blank_explicit_agent_id_as_unset() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let install = repo.coven(["hooks", "install"])?;
+    assert_success("hooks install", &install);
+
+    repo.git(["checkout", "-b", "feature/demo"])?;
+    let env = [("USER", "val"), ("COVEN_AGENT_ID", "   ")];
+    let claim = repo.coven_with_env(["claim", "acquire", "feature/demo"], env)?;
+    assert_success("claim with blank explicit identity", &claim);
+    assert_eq!(repo.claim_field("feature/demo", "agent_id")?, "val@project");
+
+    fs::write(repo.path.join("main.txt"), "allowed\n")?;
+    let allowed = repo.git_output(["commit", "-am", "allowed by fallback owner"], env)?;
+    assert_success("commit with blank explicit identity", &allowed);
+    Ok(())
+}
+
+#[test]
 fn installed_pre_push_requires_merge_intent_for_primary_and_consumes_it() -> anyhow::Result<()> {
     let repo = TestRepo::new()?;
     let remote_dir = tempfile::tempdir()?;
@@ -450,10 +604,19 @@ impl TestRepo {
         args: [&str; N],
         env: [(&str, &str); M],
     ) -> anyhow::Result<Output> {
+        self.coven_in_with_env(&self.path, args, env)
+    }
+
+    fn coven_in_with_env<const N: usize, const M: usize>(
+        &self,
+        cwd: &Path,
+        args: [&str; N],
+        env: [(&str, &str); M],
+    ) -> anyhow::Result<Output> {
         let mut command = Command::new(coven_bin());
         command
             .args(args)
-            .current_dir(&self.path)
+            .current_dir(cwd)
             .env("COVEN_HOME", self.path.join(".coven-home"))
             .env_remove("COVEN_AGENT_ID")
             .env_remove("COVEN_ALLOW_PRIMARY_COMMIT");
@@ -461,6 +624,13 @@ impl TestRepo {
             command.env(key, value);
         }
         command.output().map_err(Into::into)
+    }
+
+    fn add_worktree(&self, name: &str, branch: &str) -> anyhow::Result<PathBuf> {
+        let path = self._temp.path().join(name);
+        let output = self.git_os(["worktree", "add", "-b", branch], [&path])?;
+        assert_success("git worktree add", &output);
+        Ok(path)
     }
 
     fn git<const N: usize>(&self, args: [&str; N]) -> anyhow::Result<String> {
@@ -504,7 +674,7 @@ impl TestRepo {
         Ok(self.git_common_dir()?.join("agent-claims"))
     }
 
-    fn claim_field(&self, branch: &str, key: &str) -> anyhow::Result<String> {
+    fn claim_path(&self, branch: &str) -> anyhow::Result<PathBuf> {
         let slug: String = branch
             .chars()
             .map(|ch| {
@@ -515,7 +685,11 @@ impl TestRepo {
                 }
             })
             .collect();
-        let path = self.claims_dir()?.join(slug.trim_matches('-'));
+        Ok(self.claims_dir()?.join(slug.trim_matches('-')))
+    }
+
+    fn claim_field(&self, branch: &str, key: &str) -> anyhow::Result<String> {
+        let path = self.claim_path(branch)?;
         let contents = fs::read_to_string(&path)
             .map_err(|err| anyhow::anyhow!("reading {}: {err}", path.display()))?;
         contents

--- a/docs/MERGE-GUIDE.md
+++ b/docs/MERGE-GUIDE.md
@@ -19,26 +19,28 @@ familiars alike.
 
 ```mermaid
 flowchart LR
-  A["Claim the work"] --> B["Branch in a worktree"]
-  B --> C["Make the change"]
-  C --> D["Run local gates"]
-  D --> E["Open a scoped PR"]
-  E --> F["Review + green CI"]
-  F --> G["Squash merge"]
-  G --> H["Clean up"]
+  A["Check existing work"] --> B["Branch in a worktree"]
+  B --> C["Claim the issue"]
+  C --> D["Make the change"]
+  D --> E["Run local gates"]
+  E --> F["Open a scoped PR"]
+  F --> G["Review + green CI"]
+  G --> H["Squash merge"]
+  H --> I["Clean up"]
 ```
 
 In prose, the same contract:
 
-1. **Claim** the issue so parallel sessions do not duplicate it.
+1. **Check** claims and PRs so parallel sessions do not duplicate work.
 2. **Branch** from current `origin/main` in an isolated worktree.
-3. **Change** one concern; no drive-by refactors.
-4. **Gate** locally: format, lint, test, secret scan.
-5. **PR** with a conventional-commit subject and a DCO sign-off.
-6. **Merge** only with green CI, preserving contributor attribution.
-7. **Clean up**: delete the branch, prune the worktree, release the claim.
+3. **Claim** the issue from inside that worktree before editing.
+4. **Change** one concern; no drive-by refactors.
+5. **Gate** locally: format, lint, test, secret scan.
+6. **PR** with a conventional-commit subject and a DCO sign-off.
+7. **Merge** only with green CI, preserving contributor attribution.
+8. **Clean up**: delete the branch, prune the worktree, release the claim.
 
-## Step 1 — Claim the work
+## Step 1 — Check for existing work
 
 Multiple sessions (Codex, Claude Code, familiars) often run against the same
 repository at once. Worktrees stop git operations from racing, but they do not
@@ -56,26 +58,7 @@ Branch names alone will not reveal duplication — one issue can spawn
 three different sessions. Check the claim registry and the open PR list, not
 just branches.
 
-If the work is free, claim it with a **shared, issue-keyed token** — not your
-working branch name, which no other session can predict:
-
-```sh
-coven claim acquire issue-311
-```
-
-Claims are TTL-bounded (default one hour) and live under git's common
-directory in `agent-claims/`, so every worktree and session sees them. For
-long tasks, extend the claim:
-
-```sh
-coven claim heartbeat issue-311
-```
-
-Set `COVEN_AGENT_ID` to a stable agent name so claim ownership is meaningful
-across sessions. See [Parallel specialist lanes](familiars/parallel-lanes.md)
-for the full protocol, including hooks and environment variables.
-
-## Step 2 — Branch in a worktree
+## Step 2 — Branch in a worktree and claim
 
 Branch from current `origin/main`, one fresh branch per task. If more than one
 session can touch the repository, work in a worktree so operations do not race:
@@ -90,6 +73,28 @@ This creates or enters `<repo>.wt/<branch-slug>/`. The plain-git equivalent:
 git fetch origin main
 git worktree add -b fix/311-output-polish /path/to/coven.wt/fix-311-output-polish origin/main
 ```
+
+From inside the new worktree, claim the issue with a **shared, issue-keyed
+token** — not your working branch name, which no other session can predict:
+
+```sh
+cd /path/to/coven.wt/fix-311-output-polish
+coven claim acquire issue-311
+```
+
+Claims are TTL-bounded (default one hour) and live under git's common
+`agent-claims/` directory, so every worktree sees them. Without an explicit
+`COVEN_AGENT_ID`, the owner defaults to `$USER@<worktree-slug>`; multiple
+agents intentionally sharing one worktree must set distinct explicit IDs.
+Heartbeat and release the claim from the same worktree:
+
+```sh
+coven claim heartbeat issue-311
+coven claim release issue-311
+```
+
+See [Parallel specialist lanes](familiars/parallel-lanes.md) for the full
+protocol, including hooks and environment variables.
 
 Optionally install the local guard hooks; they block accidental
 primary-branch commits, cross-agent claim conflicts, and protected pushes

--- a/docs/familiars/parallel-lanes.md
+++ b/docs/familiars/parallel-lanes.md
@@ -82,7 +82,7 @@ to modify it automatically and prints integration options.
 | `COVEN_PRIMARY_BRANCH` | `main` | Primary branch protected by pre-commit and pre-push. |
 | `COVEN_PROTECTED_REGEX` | `^(release\|hotfix)/` | Additional protected branch names for pre-push. |
 | `COVEN_MERGE_PHRASE` | `Enchant merge to main.` | Required exact text in `.git/MERGE_INTENT` before protected pushes. |
-| `COVEN_AGENT_ID` | `$USER` | Stable agent identity for claim ownership. |
+| `COVEN_AGENT_ID` | `$USER@<worktree-slug>` | Stable agent identity for claim ownership. |
 | `COVEN_CLAIM_TTL_SECONDS` | `3600` | Claim lifetime before another agent may acquire it. |
 | `COVEN_ALLOW_PRIMARY_COMMIT` | unset | Set to `1` only for explicit human-approved primary commits. |
 
@@ -100,3 +100,7 @@ share the same protocol state:
 
 Claim files use simple `key=value` fields so shell hooks can read them without a
 runtime dependency.
+
+The fallback identity is scoped to the current worktree. Run `claim acquire`,
+`heartbeat`, and `release` from that worktree. If multiple agents intentionally
+share one worktree, give each a distinct explicit `COVEN_AGENT_ID`.

--- a/docs/reference/cli-claim.md
+++ b/docs/reference/cli-claim.md
@@ -14,7 +14,7 @@ the same issue.
 
 ```sh
 coven claim status              # what is already taken?
-coven claim acquire issue-42    # claim before touching code
+coven claim acquire issue-42    # run inside the task worktree before editing
 coven claim heartbeat issue-42  # extend the TTL on long tasks
 coven claim release issue-42    # release when the PR merges or you stop
 ```
@@ -26,8 +26,12 @@ over working-branch names, which other sessions cannot predict.
 
 Claims are files under `<git-common-dir>/agent-claims/`, so every worktree of
 the repository sees the same registry. The claiming identity comes from
-`COVEN_AGENT_ID` (falling back to `USER`). A claim expires after one hour by
-default; override with `COVEN_CLAIM_TTL_SECONDS`.
+an explicit `COVEN_AGENT_ID`, or defaults to
+`$USER@<worktree-slug>` when that variable is unset. Enter the task worktree
+before acquiring, then heartbeat and release from the same worktree. If `USER`
+is also blank or unset, its component becomes `unknown-agent`. Multiple agents
+sharing one worktree must set distinct explicit IDs. A claim expires after one
+hour by default; override with `COVEN_CLAIM_TTL_SECONDS`.
 
 - `acquire` fails while another agent's claim is active. The claim file is
   created exclusively, so when several sessions race for the same free or
@@ -51,7 +55,7 @@ coven claim status --json
   "claims": [
     {
       "branch": "issue-42",
-      "agent_id": "buns",
+      "agent_id": "buns@fix-42",
       "state": "active",
       "acquired_at": 1784078000,
       "acquired_at_rfc3339": "2026-07-15T01:53:20Z",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -199,7 +199,8 @@ Coven Parallel Work Protocol for multi-agent repositories.
 
 - `coven wt <branch>` creates or enters `<repo>.wt/<branch-slug>/`.
 - `coven claim acquire <branch>` writes a TTL-bounded branch claim under git's
-  common directory. Set `COVEN_AGENT_ID` to a stable agent name.
+  common directory. Run it inside the task worktree; the owner defaults to
+  `$USER@<worktree-slug>`, while an explicit `COVEN_AGENT_ID` overrides it.
 - `coven hooks install` installs `pre-commit` and `pre-push` hooks. Existing
   hooks are chained through `<hook>.local`; tracked `core.hooksPath`
   directories are left untouched.

--- a/docs/superpowers/plans/2026-07-26-claim-worktree-identity.md
+++ b/docs/superpowers/plans/2026-07-26-claim-worktree-identity.md
@@ -1,0 +1,197 @@
+# Worktree-Scoped Claim Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make default claim ownership distinguish same-user sessions in different Git worktrees while preserving explicit agent IDs.
+
+**Architecture:** The Rust CLI derives a fallback owner from the OS user and current worktree root basename. The managed and reference pre-commit hooks reproduce that algorithm, and documentation moves claim acquisition inside the task worktree.
+
+**Tech Stack:** Rust, Git worktrees, POSIX shell, Rust integration tests, Markdown.
+
+---
+
+### Task 1: Prove the broken default and lifecycle contract
+
+**Files:**
+- Modify: `crates/coven-cli/tests/parallel_protocol.rs`
+
+- [ ] **Step 1: Add worktree-aware test helpers and failing tests**
+
+Add helpers that run the built `coven` binary from a supplied working
+directory while removing `COVEN_AGENT_ID`. Add tests covering:
+
+```rust
+#[test]
+fn default_claim_identity_blocks_same_user_in_another_worktree() -> anyhow::Result<()> {
+    // Create two linked worktrees, acquire from the first with USER=val,
+    // and assert the second USER=val acquire fails as already claimed.
+}
+
+#[test]
+fn default_claim_identity_supports_same_worktree_lifecycle() -> anyhow::Result<()> {
+    // Acquire, heartbeat, and release from one worktree with USER=val.
+}
+
+#[test]
+fn explicit_agent_identity_remains_authoritative_across_worktrees() -> anyhow::Result<()> {
+    // Use the same explicit COVEN_AGENT_ID from two worktrees and assert the
+    // second invocation refreshes the same owner's claim.
+}
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```sh
+cargo test -p coven-cli --test parallel_protocol default_claim_identity -- --nocapture
+```
+
+Expected: the cross-worktree test fails because both owners are `val`.
+
+### Task 2: Derive one canonical fallback identity
+
+**Files:**
+- Modify: `crates/coven-cli/src/parallel_protocol.rs`
+
+- [ ] **Step 1: Pass repository context into identity resolution**
+
+Change claim acquire, release, and heartbeat to call `agent_id(&repo)`.
+Implement:
+
+```rust
+fn agent_id(repo: &Repo) -> String {
+    if let Some(explicit) = std::env::var("COVEN_AGENT_ID")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    {
+        return explicit;
+    }
+
+    let user = std::env::var("USER")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| "unknown-agent".to_string());
+    let worktree = repo
+        .root
+        .file_name()
+        .map(|name| branch_slug(&name.to_string_lossy()))
+        .filter(|slug| !slug.is_empty())
+        .unwrap_or_else(|| "worktree".to_string());
+    format!("{user}@{worktree}")
+}
+```
+
+- [ ] **Step 2: Run the focused lifecycle tests and verify GREEN**
+
+Run:
+
+```sh
+cargo test -p coven-cli --test parallel_protocol default_claim_identity -- --nocapture
+cargo test -p coven-cli --test parallel_protocol explicit_agent_identity -- --nocapture
+```
+
+Expected: all new identity tests pass.
+
+### Task 3: Keep hooks behaviorally identical
+
+**Files:**
+- Modify: `crates/coven-cli/src/parallel_protocol.rs`
+- Modify: `skills/coven-parallel-work/hooks/pre-commit`
+- Modify: `crates/coven-cli/tests/parallel_protocol.rs`
+
+- [ ] **Step 1: Add a failing managed-hook parity test**
+
+Install the managed hook, acquire a branch claim with only `USER` set, and
+commit from the same worktree with the same environment. Assert the commit is
+accepted; then seed a different worktree-scoped owner and assert rejection.
+
+- [ ] **Step 2: Verify the parity test fails**
+
+Run:
+
+```sh
+cargo test -p coven-cli --test parallel_protocol managed_hook_uses_worktree_scoped_default_identity -- --nocapture
+```
+
+Expected: the current `$USER`-only hook disagrees with the new claim owner.
+
+- [ ] **Step 3: Implement the shared shell derivation**
+
+In both hook implementations, derive:
+
+```sh
+repo_root="$(git rev-parse --show-toplevel)"
+worktree_name="${repo_root##*/}"
+worktree_slug="$(slug_branch "$worktree_name")"
+[ -n "$worktree_slug" ] || worktree_slug="worktree"
+fallback_agent="${USER:-unknown-agent}@${worktree_slug}"
+agent="${COVEN_AGENT_ID:-$fallback_agent}"
+```
+
+- [ ] **Step 4: Verify hook parity**
+
+Run the focused parity test and the full `parallel_protocol` integration test.
+Expected: all tests pass.
+
+### Task 4: Update the public workflow contract
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/MERGE-GUIDE.md`
+- Modify: `docs/familiars/parallel-lanes.md`
+- Modify: `docs/reference/cli-claim.md`
+- Modify: `docs/reference/cli.md`
+- Modify: `skills/coven-parallel-work/PROTOCOL.md`
+- Modify: `skills/coven-parallel-work/SKILL.md`
+
+- [ ] **Step 1: Replace the `$USER` default**
+
+Document `$USER@<worktree-slug>` everywhere the default is described, state
+that explicit `COVEN_AGENT_ID` wins, and disclose that shared-worktree agents
+still need explicit IDs.
+
+- [ ] **Step 2: Put worktree entry before acquisition**
+
+Update contributor/agent steps so sessions check status, enter a worktree,
+then acquire the shared issue token before editing.
+
+- [ ] **Step 3: Verify documentation consistency**
+
+Run:
+
+```sh
+rg -n 'falling back to USER|Defaults? to `?\\$USER|\\| `COVEN_AGENT_ID` \\| `\\$USER`' AGENTS.md docs skills/coven-parallel-work
+```
+
+Expected: no stale claim-identity contract remains.
+
+### Task 5: Verify and publish
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Run repository gates**
+
+```sh
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Commit and push**
+
+```sh
+git add AGENTS.md crates/coven-cli/src/parallel_protocol.rs crates/coven-cli/tests/parallel_protocol.rs docs skills/coven-parallel-work
+git commit -m "fix: scope default claim identity to worktrees"
+git push -u origin fix/499-claim-worktree-identity
+```
+
+- [ ] **Step 3: Open the PR**
+
+Create a PR with `Closes #499`, exact test evidence, and the documented
+contract change. Resolve review conversations only after their concerns are
+addressed.

--- a/docs/superpowers/specs/2026-07-26-claim-worktree-identity-design.md
+++ b/docs/superpowers/specs/2026-07-26-claim-worktree-identity-design.md
@@ -1,0 +1,69 @@
+# Worktree-Scoped Claim Identity Design
+
+## Problem
+
+When `COVEN_AGENT_ID` is unset, the claim CLI and managed pre-commit hook use
+`USER` as the owner identity. Two agent sessions running as the same OS user
+therefore look like one owner, even when they occupy different worktrees. A
+second session can re-acquire, heartbeat, release, or commit against the first
+session's claim.
+
+## Identity contract
+
+An explicit, non-blank `COVEN_AGENT_ID` remains authoritative and unchanged.
+Without it, Coven derives:
+
+```text
+<USER-or-unknown-agent>@<worktree-slug>
+```
+
+`worktree-slug` is the sanitized basename of `git rev-parse --show-toplevel`,
+using the claim filename sanitizer. This is stable across commands in one
+worktree, distinct for the repository's normal sibling worktrees, readable in
+`claim status`, and implementable identically in Rust and POSIX shell. If the
+basename sanitizes to an empty string, Coven uses `worktree`.
+
+Two agents sharing one worktree still share the fallback identity. Harnesses
+that need finer separation must set distinct `COVEN_AGENT_ID` values.
+
+## Workflow contract
+
+Because the fallback identity is worktree-scoped, sessions must enter or create
+their task worktree before acquiring an issue-keyed claim. Repository agent
+guidance and merge documentation will use this order:
+
+1. Check the shared claim registry and open PRs.
+2. Create or enter the task worktree.
+3. Acquire `issue-<N>` from inside that worktree before editing code.
+4. Heartbeat and release from the same worktree.
+
+## Surfaces
+
+- `crates/coven-cli/src/parallel_protocol.rs`: derive the fallback identity
+  from `Repo::root` and use the same shell algorithm in the managed hook.
+- `crates/coven-cli/tests/parallel_protocol.rs`: prove cross-worktree
+  exclusion, same-worktree lifecycle behavior, explicit-ID compatibility, and
+  managed-hook parity.
+- `skills/coven-parallel-work/hooks/pre-commit`: keep the reference hook
+  aligned with the canonical managed hook.
+- `AGENTS.md`, `docs/MERGE-GUIDE.md`,
+  `docs/familiars/parallel-lanes.md`, `docs/reference/cli-claim.md`,
+  `docs/reference/cli.md`, `skills/coven-parallel-work/PROTOCOL.md`, and
+  `skills/coven-parallel-work/SKILL.md`: document the new default and command
+  ordering.
+
+## Error handling
+
+Explicit blank IDs fall back instead of creating an empty owner. A missing or
+blank `USER` uses `unknown-agent`. Identity derivation never prevents claim
+operations solely because a worktree basename is unusual.
+
+## Acceptance evidence
+
+- Same `USER`, different worktrees, no explicit ID: the first acquire succeeds
+  and the second is refused.
+- One worktree, no explicit ID: acquire, heartbeat, and release all succeed.
+- One explicit ID across worktrees retains the existing explicit-owner
+  behavior.
+- A managed pre-commit hook computes the same fallback owner as the CLI.
+- All claim-protocol tests and repository CI gates pass.

--- a/skills/coven-parallel-work/PROTOCOL.md
+++ b/skills/coven-parallel-work/PROTOCOL.md
@@ -45,8 +45,8 @@ on the same FS path. Mitigations layered on top of git can.
    `core.hooksPath` set, secret-scanning hooks, husky, etc. must keep
    working. The protocol chains, never silently replaces.
 6. **Identifiable.** Each participant has a stable, opaque identity
-   (`COVEN_AGENT_ID`). Defaults to `$USER` if unset, so the protocol
-   degrades gracefully on machines with one human and one AI.
+   (`COVEN_AGENT_ID`). Without an explicit value, identity defaults to
+   `$USER@<worktree-slug>` so same-user sibling worktrees remain distinct.
 
 ## 3. Concepts
 
@@ -80,10 +80,14 @@ absolute path elsewhere) are non-conforming for protocol purposes.
 
 `$COVEN_AGENT_ID` — short, stable, opaque string that identifies the
 agent occupying a shell. Examples: `nova`, `codex-a`, `claude-code`,
-`hermes`. If unset, identity falls back to `$USER`.
+`hermes`. If unset, identity falls back to `$USER@<worktree-slug>`, where the
+slug is the sanitized basename of the current worktree root. A blank or unset
+`USER` becomes `unknown-agent`.
 
 Agents SHOULD set this once at session start (in their familiar's startup
-file, harness config, or shell rc).
+file, harness config, or shell rc) when multiple agents share one worktree.
+Otherwise, they SHOULD enter the task worktree before acquiring and run later
+heartbeat/release commands there.
 
 ### 3.3 Branch claims
 
@@ -98,7 +102,7 @@ the repo's git common dir:
 Claim file format (key=value lines):
 
 ```
-agent=<COVEN_AGENT_ID>
+agent=<effective-agent-id>
 branch=<branch>
 acquired=<unix-seconds>
 ttl_until=<unix-seconds>
@@ -155,7 +159,8 @@ A conforming pre-commit hook MUST refuse the commit if any of:
 1. **Primary-branch guard.** Current branch equals the primary branch
    AND `$COVEN_ALLOW_PRIMARY_COMMIT` is not `1`.
 2. **Claim conflict.** A claim file exists for the current branch, the
-   claim is unexpired, and `agent=` differs from `$COVEN_AGENT_ID`.
+   claim is unexpired, and `agent=` differs from the effective agent identity
+   (explicit `COVEN_AGENT_ID`, otherwise `$USER@<worktree-slug>`).
 3. **HEAD canary.** Canary file exists, the recorded HEAD differs from
    current HEAD, and recorded HEAD is not an ancestor of current HEAD.
 
@@ -214,7 +219,7 @@ than refusing.
 | `COVEN_PRIMARY_BRANCH` | `main` | repo or session | Protected primary branch name |
 | `COVEN_PROTECTED_REGEX` | `^(release\|hotfix)/` | repo or session | Other protected branch pattern (POSIX ERE) |
 | `COVEN_MERGE_PHRASE` | `Enchant merge to main.` | repo or session | Canonical user intent phrase, exact match |
-| `COVEN_AGENT_ID` | `$USER` | session | Stable agent identity |
+| `COVEN_AGENT_ID` | `$USER@<worktree-slug>` | session | Stable agent identity; set explicitly for multiple agents in one worktree |
 | `COVEN_REPO_ROOT` | autodetect | session | Override primary repo root |
 | `COVEN_ALLOW_PRIMARY_COMMIT` | unset | session | Allow commits on primary (rare) |
 

--- a/skills/coven-parallel-work/SKILL.md
+++ b/skills/coven-parallel-work/SKILL.md
@@ -90,9 +90,9 @@ cv-claim canary  feat/my-thing      # snapshots HEAD for the canary check
 
 Set `COVEN_AGENT_ID` per familiar (e.g. `nova`, `cody`, `kitty`,
 `charm`, `astra`, `echo`). For OpenClaw familiars, this should be in
-your familiar's config or shell rc. If unset, identity falls back to
-`$USER`, which is fine on a single-human-one-AI machine but fails the
-moment you have multiple AIs.
+your familiar's config or shell rc when multiple familiars share one
+worktree. If unset, identity falls back to `$USER@<worktree-slug>`, so enter
+the worktree before acquiring and run heartbeat/release commands there.
 
 ### During long sessions
 

--- a/skills/coven-parallel-work/hooks/pre-commit
+++ b/skills/coven-parallel-work/hooks/pre-commit
@@ -14,11 +14,29 @@
 
 set -euo pipefail
 
+slug_worktree() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '-' | sed -e 's/^-*//' -e 's/-*$//'
+}
+
 repo_root=$(git rev-parse --show-toplevel)
 git_common=$(git rev-parse --git-common-dir)
 primary=${COVEN_PRIMARY_BRANCH:-main}
 branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo HEAD)
-agent=${COVEN_AGENT_ID:-${USER:-unknown}}
+worktree_name=${repo_root##*/}
+worktree_slug=$(slug_worktree "$worktree_name")
+[ -n "$worktree_slug" ] || worktree_slug=worktree
+nonblank() {
+  [ -n "$(printf '%s' "$1" | tr -d '[:space:]')" ]
+}
+base_user=${USER:-}
+if ! nonblank "$base_user"; then
+  base_user=unknown-agent
+fi
+fallback_agent=${base_user}@${worktree_slug}
+agent=${COVEN_AGENT_ID:-}
+if ! nonblank "$agent"; then
+  agent=$fallback_agent
+fi
 
 red()    { printf '\033[31m%s\033[0m\n' "$*" >&2; }
 yellow() { printf '\033[33m%s\033[0m\n' "$*" >&2; }


### PR DESCRIPTION
## Context

- Summary: Default claim ownership collapsed every same-user agent to `$USER`, so sibling worktrees could acquire, heartbeat, or release one another's claims.
- Files changed: Rust claim identity and managed-hook logic, integration tests, parallel-work reference hook, and all documented default/worktree sequencing surfaces.
- Closes #499

## Implementation

- Approach: Preserve a nonblank explicit `COVEN_AGENT_ID`; otherwise derive `$USER@<worktree-slug>` from the sanitized worktree-root basename, with `unknown-agent` for a blank user. The binary and both hook implementations use the same rule.
- User-visible behavior: Same-user sessions in sibling worktrees now conflict by default. Acquire/heartbeat/release continue to match inside one worktree. Agents intentionally sharing a worktree can still use explicit IDs.
- Compatibility notes: The default identity contract changes from `$USER` to a worktree-scoped value. Docs now require entering the task worktree before claim acquisition.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: `cargo test -p coven-cli --test parallel_protocol` (21/21); managed-hook same-owner/conflict and blank-ID regressions; `bash -n skills/coven-parallel-work/hooks/pre-commit`; staged privacy guard; docs/default consistency search.

## Risk and Rollback

- Risk level: Low to moderate; ownership strings change only when no explicit agent ID is configured.
- Rollback plan: Revert this PR to restore the prior `$USER` fallback and documentation.

## Agent Handoff

- Current state: Ready for review; all required local gates pass on `b02b5bb`.
- Follow-ups: None.
- Known gaps: None.