### PR TITLE
fix: preserve npm wrapper signal exits

### DIFF
--- a/docs/superpowers/plans/2026-07-26-npm-wrapper-signal-exit.md
+++ b/docs/superpowers/plans/2026-07-26-npm-wrapper-signal-exit.md
@@ -1,0 +1,124 @@
+# npm Wrapper Signal Exit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve SIGINT/SIGTERM failure semantics through the npm wrapper instead of reporting interrupted runs as successful.
+
+**Architecture:** Keep the existing signal-forwarding handlers. When the child reports signal termination, POSIX removes the matching handler and re-raises; Windows computes the conventional numeric exit code.
+
+**Tech Stack:** Node.js ESM, `node:test`, child processes, npm packaging smoke tests.
+
+---
+
+### Task 1: Add a behavioral regression test
+
+**Files:**
+- Modify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Build an isolated fake native package**
+
+Import `spawn`, `once`, and the required temporary-filesystem helpers. Add a
+helper that copies the wrapper into a temporary ESM package, creates the
+current platform's optional dependency, and symlinks its `bin/coven` to
+`process.execPath`.
+
+- [ ] **Step 2: Exercise both forwarded signals**
+
+For POSIX, launch:
+
+```js
+spawn(process.execPath, [
+  wrapperPath,
+  '-e',
+  'console.log("ready"); setInterval(() => {}, 1_000);'
+]);
+```
+
+Wait for `ready`, send SIGINT or SIGTERM to the wrapper, await its exit, and
+assert `code === null` and `exitSignal === signal`. Clean the fixture and kill
+any surviving child in `finally`.
+
+- [ ] **Step 3: Run the test and verify RED**
+
+Run:
+
+```sh
+node --test --test-name-pattern='preserves child signal termination' scripts/publish-npm-test.mjs
+```
+
+Expected: the current wrapper exits with code 0 and no terminating signal.
+
+### Task 2: Fix termination propagation
+
+**Files:**
+- Modify: `npm/coven/bin/coven.js`
+- Modify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Add the platform-aware exit path**
+
+Import Node OS constants and replace the signal branch with:
+
+```js
+if (signal) {
+  if (process.platform === 'win32') {
+    const signalNumber = osConstants.signals[signal];
+    process.exit(signalNumber === undefined ? 1 : 128 + signalNumber);
+  }
+  process.removeAllListeners(signal);
+  process.kill(process.pid, signal);
+  return;
+}
+```
+
+- [ ] **Step 2: Guard the packaged Windows fallback**
+
+Add assertions that the wrapper contains the Windows platform branch,
+`osConstants.signals[signal]`, and `128 + signalNumber`.
+
+- [ ] **Step 3: Run the focused tests and verify GREEN**
+
+```sh
+node --test --test-name-pattern='preserves child signal termination|Windows signal fallback' scripts/publish-npm-test.mjs
+```
+
+Expected: both tests pass.
+
+### Task 3: Run npm and repository verification
+
+**Files:**
+- Verify: `npm/coven/bin/coven.js`
+- Verify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Run npm guardrails**
+
+```sh
+node --test scripts/onboarding-docs-test.mjs scripts/pr-readiness-test.mjs scripts/publish-npm-test.mjs
+node scripts/test-cli-prepublish.mjs --target=macos --skip-build --skip-secrets-scan
+```
+
+Expected: all tests and the packaged-wrapper smoke pass.
+
+- [ ] **Step 2: Run repository gates**
+
+```sh
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Commit and push**
+
+```sh
+git add npm/coven/bin/coven.js scripts/publish-npm-test.mjs docs/superpowers
+git commit -m "fix: preserve npm wrapper signal exits"
+git push -u origin fix/495-npm-signal-exit
+```
+
+- [ ] **Step 4: Open the PR**
+
+Create a PR with `Closes #495`, the observed pre-fix exit-0 evidence, and the
+post-fix SIGINT/SIGTERM results. Resolve review conversations only after their
+concerns are addressed.

--- a/docs/superpowers/specs/2026-07-26-npm-wrapper-signal-exit-design.md
+++ b/docs/superpowers/specs/2026-07-26-npm-wrapper-signal-exit-design.md
@@ -1,0 +1,38 @@
+# npm Wrapper Signal Exit Design
+
+## Problem
+
+The npm launcher installs SIGINT and SIGTERM forwarding handlers. When the
+native child exits because of one of those signals, the launcher re-sends the
+signal to itself without removing its handler. The handler consumes the signal,
+and the launcher falls off the event loop with exit code 0.
+
+## Termination contract
+
+- Continue forwarding SIGINT and SIGTERM from the wrapper to the native child.
+- On POSIX, remove the wrapper's handler for the child's terminating signal
+  before re-raising it. Shells and supervisors then observe the wrapper as
+  terminated by the same signal.
+- On Windows, where POSIX re-raising is not portable, exit with
+  `128 + os.constants.signals[signal]`. Use exit code 1 only if Node reports an
+  unknown signal name.
+- Preserve ordinary child exit codes and launch-error behavior unchanged.
+
+## Test design
+
+`scripts/publish-npm-test.mjs` will construct a temporary wrapper installation
+whose platform-native binary is a symlink to the current Node executable. The
+fake child prints a readiness marker and waits. The test sends SIGINT and
+SIGTERM to the wrapper only after readiness, then asserts that POSIX reports
+the same terminating signal rather than exit code 0. A source-level Windows
+guard asserts that the numeric fallback remains packaged.
+
+The fixture is isolated under the OS temporary directory and removed in a
+`finally` block.
+
+## Acceptance evidence
+
+- The new behavioral test fails against the current wrapper with exit code 0.
+- SIGINT and SIGTERM both terminate the fixed POSIX wrapper by the same signal.
+- Windows fallback code maps known signals to `128 + signum`.
+- Existing npm publish/onboarding smoke tests and all repository CI gates pass.

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
+import { constants as osConstants } from 'node:os';
 
 const require = createRequire(import.meta.url);
 
@@ -64,6 +65,11 @@ child.on('error', (error) => {
 
 child.on('exit', (code, signal) => {
   if (signal) {
+    if (process.platform === 'win32') {
+      const signalNumber = osConstants.signals[signal];
+      process.exit(signalNumber === undefined ? 1 : 128 + signalNumber);
+    }
+    process.removeAllListeners(signal);
     process.kill(process.pid, signal);
     return;
   }

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -55,13 +55,14 @@ async function assertWrapperPreservesSignal(signal) {
     );
     symlinkSync(process.execPath, path.join(nativeBinDir, binaryName));
 
+    let stdout = '';
     let stderr = '';
     wrapperProcess = spawn(
       process.execPath,
       [
         wrapperPath,
         '-e',
-        'process.stdout.write("ready\\n"); setTimeout(() => process.exit(2), 20_000);'
+        'process.stdout.write("rea"); setTimeout(() => process.stdout.write("dy\\n"), 10); setTimeout(() => process.exit(2), 20_000);'
       ],
       { stdio: ['ignore', 'pipe', 'pipe'] }
     );
@@ -72,12 +73,18 @@ async function assertWrapperPreservesSignal(signal) {
 
     await new Promise((resolve, reject) => {
       const timeout = setTimeout(
-        () => reject(new Error(`timed out waiting for fake native child; stderr:\n${stderr}`)),
+        () =>
+          reject(
+            new Error(
+              `timed out waiting for fake native child; stdout:\n${stdout}\nstderr:\n${stderr}`
+            )
+          ),
         10_000
       );
       wrapperProcess.stdout.setEncoding('utf8');
       wrapperProcess.stdout.on('data', (chunk) => {
-        if (chunk.includes('ready')) {
+        stdout += chunk;
+        if (stdout.includes('ready')) {
           clearTimeout(timeout);
           resolve();
         }
@@ -90,7 +97,7 @@ async function assertWrapperPreservesSignal(signal) {
         clearTimeout(timeout);
         reject(
           new Error(
-            `wrapper exited before readiness: code=${code} signal=${exitSignal}; stderr:\n${stderr}`
+            `wrapper exited before readiness: code=${code} signal=${exitSignal}; stdout:\n${stdout}\nstderr:\n${stderr}`
           )
         );
       });

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -61,7 +61,7 @@ async function assertWrapperPreservesSignal(signal) {
       [
         wrapperPath,
         '-e',
-        'process.stdout.write("ready\\n"); setTimeout(() => process.exit(2), 30_000);'
+        'process.stdout.write("ready\\n"); setTimeout(() => process.exit(2), 20_000);'
       ],
       { stdio: ['ignore', 'pipe', 'pipe'] }
     );

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1,5 +1,17 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -9,6 +21,112 @@ const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
   ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/'
 };
+
+const SIGNAL_TEST_PACKAGES = {
+  'darwin-arm64': ['@opencoven/cli-macos', 'coven'],
+  'linux-x64': ['@opencoven/cli-linux-x64', 'coven']
+};
+
+async function assertWrapperPreservesSignal(signal) {
+  const fixture = mkdtempSync(path.join(tmpdir(), 'coven-wrapper-signal-'));
+  let wrapperProcess;
+  try {
+    const wrapperDir = path.join(fixture, 'wrapper');
+    const wrapperBinDir = path.join(wrapperDir, 'bin');
+    const wrapperPath = path.join(wrapperBinDir, 'coven.js');
+    mkdirSync(wrapperBinDir, { recursive: true });
+    writeFileSync(
+      path.join(wrapperDir, 'package.json'),
+      JSON.stringify({ name: '@opencoven/cli-test', type: 'module' })
+    );
+    copyFileSync(
+      fileURLToPath(new URL('../npm/coven/bin/coven.js', import.meta.url)),
+      wrapperPath
+    );
+
+    const [packageName, binaryName] =
+      SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`];
+    const nativeDir = path.join(wrapperDir, 'node_modules', ...packageName.split('/'));
+    const nativeBinDir = path.join(nativeDir, 'bin');
+    mkdirSync(nativeBinDir, { recursive: true });
+    writeFileSync(
+      path.join(nativeDir, 'package.json'),
+      JSON.stringify({ name: packageName, version: '0.0.0' })
+    );
+    symlinkSync(process.execPath, path.join(nativeBinDir, binaryName));
+
+    let stderr = '';
+    wrapperProcess = spawn(
+      process.execPath,
+      [
+        wrapperPath,
+        '-e',
+        'process.stdout.write("ready\\n"); setTimeout(() => process.exit(2), 30_000);'
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    wrapperProcess.stderr.setEncoding('utf8');
+    wrapperProcess.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    await new Promise((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`timed out waiting for fake native child; stderr:\n${stderr}`)),
+        10_000
+      );
+      wrapperProcess.stdout.setEncoding('utf8');
+      wrapperProcess.stdout.on('data', (chunk) => {
+        if (chunk.includes('ready')) {
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+      wrapperProcess.once('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      wrapperProcess.once('exit', (code, exitSignal) => {
+        clearTimeout(timeout);
+        reject(
+          new Error(
+            `wrapper exited before readiness: code=${code} signal=${exitSignal}; stderr:\n${stderr}`
+          )
+        );
+      });
+    });
+
+    const exit = once(wrapperProcess, 'exit');
+    assert.equal(wrapperProcess.kill(signal), true);
+    const [code, exitSignal] = await exit;
+    assert.equal(code, null, `wrapper should not convert ${signal} into exit code ${code}`);
+    assert.equal(exitSignal, signal, `wrapper should terminate with ${signal}`);
+  } finally {
+    if (
+      wrapperProcess &&
+      wrapperProcess.exitCode === null &&
+      wrapperProcess.signalCode === null
+    ) {
+      wrapperProcess.kill('SIGKILL');
+    }
+    rmSync(fixture, { recursive: true, force: true });
+  }
+}
+
+test(
+  'npm wrapper preserves child signal termination',
+  {
+    skip:
+      process.platform === 'win32' ||
+      !SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`],
+    timeout: 30_000
+  },
+  async () => {
+    for (const signal of ['SIGINT', 'SIGTERM']) {
+      await assertWrapperPreservesSignal(signal);
+    }
+  }
+);
 
 test('releaseVersion prefers explicit COVEN_NPM_VERSION and strips a leading v', () => {
   assert.equal(
@@ -88,6 +206,15 @@ test('wrapper binary maps windows x64 to windows native package and exe binary',
   const bin = readFileSync(binPath, 'utf8');
   assert.match(bin, /'win32-x64': '@opencoven\/cli-windows'/);
   assert.match(bin, /process\.platform === 'win32' \? 'coven\.exe' : 'coven'/);
+});
+
+test('wrapper includes conventional Windows signal fallback', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const bin = readFileSync(binPath, 'utf8');
+  assert.match(bin, /constants as osConstants/);
+  assert.match(bin, /process\.platform === 'win32'/);
+  assert.match(bin, /osConstants\.signals\[signal\]/);
+  assert.match(bin, /128 \+ signalNumber/);
 });
 
 test('install docs do not claim macOS x64 support unless the wrapper maps darwin x64', () => {


### PR DESCRIPTION
## Context

- Summary: The npm launcher re-raised SIGINT/SIGTERM while its own listener was still installed, swallowing the re-raise and reporting an interrupted CLI run as success.
- Files changed: npm wrapper signal-exit handling, behavioral regression fixture, and implementation design/plan docs.
- Closes #495

## Implementation

- Approach: On POSIX, remove the installed listener before re-raising the child's signal so the default disposition terminates the wrapper. On Windows, exit with `128 + os.constants.signals[signal]`, falling back to 1 for an unknown signal.
- User-visible behavior: Ctrl-C and SIGTERM from an npm-installed `coven` now remain signal terminations instead of exit code 0.
- Compatibility notes: Normal numeric child exit codes are unchanged.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: 66/66 onboarding/readiness/npm tests; real fake-native SIGINT and SIGTERM propagation; `node --check` for wrapper and test; staged privacy guard; Apple Silicon release build; npm dry-run publish, pack, local install, and installed wrapper `--version` execution.

## Risk and Rollback

- Risk level: Low; the changed branch runs only when the native child exited due to a signal.
- Rollback plan: Revert this PR to restore the previous wrapper exit behavior.

## Agent Handoff

- Current state: Ready for review; required local gates pass on `c5cfe58`.
- Follow-ups: None.
- Known gaps: The final local prepublish `doctor` assertion expects a bare machine and returned 0 because this host has a managed `~/.coven/engine/0.7.0/coven-code`. Build, publish dry-run, pack, install, and wrapper execution all passed before that environment-only assertion; clean-runner CI remains the authoritative package smoke.