### PR TITLE
feat(memory): expose authoritative summary source

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -8385,6 +8385,54 @@ description = "digs deep"
     }
 
     #[test]
+    fn memory_list_route_serializes_authoritative_source_without_absolute_path() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let sage = home.join("memory").join("sage");
+        std::fs::create_dir_all(&sage)?;
+        std::fs::write(sage.join("notes.md"), "Durable fact.")?;
+
+        let response = handle_request("GET", "/api/v1/memory", home, None)?;
+
+        assert_eq!(response.status, 200);
+        let entries: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(
+            entries[0]["source"],
+            serde_json::json!({
+                "kind": "coven-origin",
+                "label": "Coven origin"
+            })
+        );
+        assert!(!response.body.contains(home.to_string_lossy().as_ref()));
+        Ok(())
+    }
+
+    #[test]
+    fn memory_list_and_detail_routes_share_exact_source_metadata() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let sage = home.join("memory").join("sage");
+        std::fs::create_dir_all(&sage)?;
+        std::fs::write(sage.join("notes.md"), "Durable fact.")?;
+
+        let list_response = handle_request("GET", "/api/v1/memory", home, None)?;
+        let entries: serde_json::Value = serde_json::from_str(&list_response.body)?;
+        let id = entries[0]["id"].as_str().expect("opaque id");
+        let list_source = entries[0]["source"].clone();
+
+        let detail_response = handle_request("GET", &format!("/api/v1/memory/{id}"), home, None)?;
+        let detail: serde_json::Value = serde_json::from_str(&detail_response.body)?;
+
+        assert_eq!(detail_response.status, 200);
+        assert_eq!(detail["source"], list_source);
+        assert!(detail.get("path").is_none());
+        assert!(!detail_response
+            .body
+            .contains(home.to_string_lossy().as_ref()));
+        Ok(())
+    }
+
+    #[test]
     fn memory_detail_route_returns_content_and_rejects_invalid_ids() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let home = temp.path();

--- a/crates/coven-cli/src/cockpit_sources.rs
+++ b/crates/coven-cli/src/cockpit_sources.rs
@@ -338,6 +338,7 @@ pub struct MemoryFileDto {
     pub updated_at: String,
     pub updated_at_iso: String,
     pub excerpt: String,
+    pub source: MemorySourceDto,
     pub privacy_classification: Option<String>,
     pub reveal_required: Option<bool>,
     pub verification_state: String,
@@ -352,6 +353,7 @@ struct MemoryRecord {
     relative_path: String,
     updated_at: String,
     updated_at_iso: String,
+    source: MemorySourceDto,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -639,6 +641,10 @@ impl MemoryRoot {
                     relative_path,
                     updated_at,
                     updated_at_iso,
+                    source: MemorySourceDto {
+                        kind: "coven-origin".to_string(),
+                        label: "Coven origin".to_string(),
+                    },
                 });
             }
         }
@@ -781,6 +787,7 @@ pub fn scan_memory(coven_home: &Path) -> Result<Vec<MemoryFileDto>> {
             updated_at: record.updated_at,
             updated_at_iso: record.updated_at_iso,
             excerpt,
+            source: record.source,
             privacy_classification: None,
             reveal_required: None,
             verification_state: "unknown".to_string(),
@@ -809,10 +816,7 @@ pub fn read_memory_detail(coven_home: &Path, id: &str) -> Result<Option<MemoryDe
         familiar_id: record.familiar_id,
         title: record.title,
         updated_at: record.updated_at_iso,
-        source: MemorySourceDto {
-            kind: "coven-origin".to_string(),
-            label: "Coven origin".to_string(),
-        },
+        source: record.source,
         content,
         content_format: "markdown".to_string(),
         privacy: MemoryPrivacyDto {

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -230,7 +230,8 @@ The memory read surface is additive to the existing observability list:
 - `GET /api/v1/memory/:id` returns one validated detail row.
 
 The list preserves its original `familiar_id`, `title`, `path`, `updated_at`,
-and `excerpt` fields. `path` is relative to the memory root and exists for CLI
+and `excerpt` fields, and adds the same authoritative `source` object returned
+by detail. `path` is relative to the memory root and exists for CLI
 compatibility; it is never absolute. The opaque UUID `id` is stable while the
 relative file identity is stable. Browser-facing adapters should omit `path`
 from their DTOs.
@@ -257,6 +258,10 @@ with an empty `excerpt`; other valid rows are still returned.
     "updated_at": "4m ago",
     "updated_at_iso": "2026-07-26T09:56:00Z",
     "excerpt": "Durable fact.",
+    "source": {
+      "kind": "coven-origin",
+      "label": "Coven origin"
+    },
     "privacy_classification": null,
     "reveal_required": null,
     "verification_state": "unknown"


### PR DESCRIPTION
## Summary
- add authoritative source metadata to memory list summaries
- create source once on the hardened MemoryRecord and use that exact value for both list and detail DTOs
- preserve opaque IDs, relative-only CLI paths, exact-handle reads, and bounded content behavior
- document the additive list contract

## Compatibility
The first-party dashboard was deployed first at OpenCoven/coven-memory main a1e15ed. Its strict list schema accepts source as optional, so older daemons remain compatible while this daemon field becomes available.

## Verification
- TDD RED: list source was null and list/detail differed
- 44 cockpit source tests
- 10 memory API tests plus post-commit list tests
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked (1455 passed, 3 ignored)
- cargo test -p coven-cli --test smoke -- --nocapture (25 passed)
- cargo deny check
- python3 scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --range origin/main...HEAD
- git diff --check
- independent review: no findings