### PR TITLE
fix(ci): scope secret scan exceptions

### DIFF
--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -69,6 +69,13 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
 
+    def test_markdown_environment_secret_references_do_not_trigger(self) -> None:
+        text = "and the header `X-API-Key: $TINYFISH_API_KEY`."
+
+        hits = check_secrets.scan_text(text, "skills/tinyfish-agent-run/SKILL.md")
+
+        self.assertEqual(hits, [])
+
     def test_literal_secret_assignments_still_trigger_generic_assignment(self) -> None:
         key_name = "api" + "_key"
         secret_value = "S" * 24
@@ -89,6 +96,20 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
 
+    def test_fake_private_key_fixture_does_not_hide_another_header(self) -> None:
+        begin = "-----BEGIN " + "PRIVATE KEY-----"
+        end = "-----END " + "PRIVATE KEY-----"
+        other_begin = "-----BEGIN OPENSSH " + "PRIVATE KEY-----"
+        fixture = f'"{begin}\\nfakefakefakefakefakefakefake\\n{end}"'
+        text = f"{fixture} {other_begin}"
+
+        hits = check_secrets.scan_text(text, "crates/coven-cli/src/privacy.rs")
+
+        self.assertEqual(
+            hits,
+            [("crates/coven-cli/src/privacy.rs", 1, "private_key")],
+        )
+
     def test_real_private_key_header_still_triggers(self) -> None:
         text = "-----BEGIN PRIVATE KEY-----\nnot-a-placeholder\n-----END PRIVATE KEY-----"
 
@@ -108,7 +129,7 @@ class SecretGuardLockfileTests(unittest.TestCase):
         self.assertEqual(hits, [])
 
     def test_opencoven_local_worktree_paths_do_not_trigger_high_entropy(self) -> None:
-        text = "/Users/buns/Documents/GitHub/OpenCoven/coven/.worktrees/feat-tui-chat-module"
+        text = "/tmp/OpenCoven/coven/.worktrees/feat-tui-chat-module"
 
         hits = check_secrets.scan_text(text, "docs/superpowers/plans/example.md")
 
@@ -119,8 +140,8 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
     def test_local_worktree_paths_do_not_trigger_high_entropy(self) -> None:
         text = (
-            "cd /Users/buns/Documents/GitHub/OpenCoven/coven/.worktrees/feat-tui-chat-module\n"
-            "Expected: /Users/buns/Documents/GitHub/OpenCoven/coven/.worktrees/feat-tui-chat-module"
+            "cd /tmp/OpenCoven/coven/.worktrees/feat-tui-chat-module\n"
+            "Expected: /tmp/OpenCoven/coven/.worktrees/feat-tui-chat-module"
         )
 
         hits = check_secrets.scan_text(text, "docs/superpowers/plans/example.md")
@@ -319,7 +340,7 @@ class SecretGuardLockfileTests(unittest.TestCase):
             [
                 "`~/Library/LaunchAgents/dev.opencoven.hub.plist`:",
                 'launchctl bootstrap "gui/$(id -u)" ~/Library/LaunchAgents/dev.opencoven.hub.plist',
-                "sudo cp hub.plist /Users/coven/Library/LaunchAgents/dev.opencoven.hub.plist",
+                "sudo cp hub.plist Library/LaunchAgents/dev.opencoven.hub.plist",
             ]
         )
 
@@ -392,6 +413,223 @@ class SecretGuardLockfileTests(unittest.TestCase):
                 "actions/checkout@m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aBEuIqOwPz9RkT"
             )
         )
+
+
+class SecretGuardExceptionScopeTests(unittest.TestCase):
+    def test_angle_brackets_do_not_suppress_structural_secret_rules(self) -> None:
+        cases = {
+            "aws_access_key": "AKIA" + "A1" * 8,
+            "github_token": "ghp_" + "A1" * 12,
+            "openai_key": "sk-" + "A1" * 16,
+            "anthropic_key": "sk-ant-" + "A1" * 10,
+            "slack_token": "xoxb-" + "A1-" * 7,
+        }
+
+        for expected_rule, value in cases.items():
+            with self.subTest(rule=expected_rule):
+                hits = check_secrets.scan_text(
+                    f"<span>{value}</span>", "docs/example.html"
+                )
+
+                self.assertEqual(
+                    hits, [("docs/example.html", 1, expected_rule)]
+                )
+
+    def test_safe_line_context_does_not_suppress_high_entropy_tokens(self) -> None:
+        token = (
+            "m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aB/"
+            "EuIqOwPz9RkTlVxCyNmS3HdG7fA"
+        )
+        contexts = [
+            "<span>rendered value</span>",
+            "example value",
+            "api_key=<secret-value>",
+            "https://github.com/OpenCoven/coven/blob/main/DESIGN.md",
+            "/tmp/OpenCoven/coven/.worktrees/demo",
+        ]
+
+        for context in contexts:
+            with self.subTest(context=context):
+                hits = check_secrets.scan_text(
+                    f"{context} {token}", "docs/example.md"
+                )
+
+                self.assertEqual(
+                    hits, [("docs/example.md", 1, "high_entropy")]
+                )
+
+    def test_angle_placeholder_is_scoped_to_the_assignment_value(self) -> None:
+        placeholder_hits = check_secrets.scan_text(
+            "api_key=<secret-value>", "docs/example.env"
+        )
+        literal_hits = check_secrets.scan_text(
+            "api_key=hunter2hunter2hunter2 <span>example</span>",
+            "docs/example.env",
+        )
+
+        self.assertEqual(placeholder_hits, [])
+        self.assertEqual(
+            literal_hits,
+            [("docs/example.env", 1, "generic_assignment")],
+        )
+
+    def test_lockfile_exception_is_scoped_to_the_integrity_token(self) -> None:
+        digest = (
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        )
+        token = (
+            "m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aB/"
+            "EuIqOwPz9RkTlVxCyNmS3HdG7fA"
+        )
+        text = f"resolution: {{integrity: sha512-{digest}}} observed: {token}"
+
+        hits = check_secrets.scan_text(
+            text, "packages/openclaw-coven/pnpm-lock.yaml"
+        )
+
+        self.assertEqual(
+            hits,
+            [
+                (
+                    "packages/openclaw-coven/pnpm-lock.yaml",
+                    1,
+                    "high_entropy",
+                )
+            ],
+        )
+
+    def test_known_public_discord_article_url_is_not_high_entropy(self) -> None:
+        text = (
+            "https://support-dev.discord.com/hc/en-us/articles/"
+            "6207308062871-What-are-Privileged-Intents"
+        )
+
+        hits = check_secrets.scan_text(text, "docs/channels/discord-setup.md")
+
+        self.assertEqual(hits, [])
+
+    def test_other_discord_article_slugs_still_trigger_high_entropy(self) -> None:
+        token = (
+            "m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aB"
+            "EuIqOwPz9RkTlVxCyNmS3HdG7fA"
+        )
+        text = (
+            "https://support-dev.discord.com/hc/en-us/articles/1-"
+            f"{token}"
+        )
+
+        hits = check_secrets.scan_text(text, "docs/channels/discord-setup.md")
+
+        self.assertEqual(
+            hits,
+            [("docs/channels/discord-setup.md", 1, "high_entropy")],
+        )
+
+    def test_ordered_alphabet_fixtures_are_not_high_entropy(self) -> None:
+        fixtures = [
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
+        ]
+
+        for fixture in fixtures:
+            with self.subTest(fixture_length=len(fixture)):
+                hits = check_secrets.scan_text(fixture, "src/lib.rs")
+
+                self.assertEqual(hits, [])
+
+    def test_reserved_example_url_assignment_is_not_a_secret(self) -> None:
+        text = (
+            'let url = "https://private-gateway.example.test/'
+            'session?token=fakegatewaytoken123";'
+        )
+
+        hits = check_secrets.scan_text(text, "crates/coven-cli/src/privacy.rs")
+
+        self.assertEqual(hits, [])
+
+    def test_safe_generic_values_allow_only_syntax_suffixes(self) -> None:
+        cases = [
+            "api_key=<secret-value>;",
+            "<code>api_key=<secret-value></code>",
+            "const token = process.env.REALLY_LONG_SECRET_NAME;",
+            "const token = process.env.REALLY_LONG_SECRET_NAME.trim();",
+            "const token = process.env.REALLY_LONG_SECRET_NAME?.trim();",
+            "const token = process.env.REALLY_LONG_SECRET_NAME!;",
+            'const token = process.env.REALLY_LONG_SECRET_NAME ?? "";',
+            'const token = process.env.REALLY_LONG_SECRET_NAME || "";',
+            'api_key=os.environ.get("API_KEY", "")',
+            'api_key=os.environ.get("API_KEY", None)',
+            'api_key=os.environ.get("API_KEY", "").strip()',
+            'api_key=os.environ.get("API_KEY") or None',
+            'let token = std::env::var("TOKEN").unwrap_or_default();',
+            "api_key=your_api_key_here",
+            "api_key=placeholder_value",
+            "api_key=op://Development/Service/api_key",
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "docs/example.md")
+
+                self.assertEqual(hits, [])
+
+    def test_environment_reference_with_appended_value_is_not_safe(self) -> None:
+        text = "api_key=${API_KEY}hunter2hunter2hunter2"
+
+        hits = check_secrets.scan_text(text, "src/config.env")
+
+        self.assertEqual(
+            hits,
+            [("src/config.env", 1, "generic_assignment")],
+        )
+
+    def test_environment_read_with_literal_fallback_is_not_safe(self) -> None:
+        text = 'api_key=os.environ.get("API_KEY","hunter2hunter2hunter2")'
+
+        hits = check_secrets.scan_text(text, "src/config.py")
+
+        self.assertEqual(
+            hits,
+            [("src/config.py", 1, "generic_assignment")],
+        )
+
+    def test_shell_environment_reference_with_literal_default_is_not_safe(
+        self,
+    ) -> None:
+        text = "api_key=${API_KEY:-hunter2hunter2hunter2}"
+
+        hits = check_secrets.scan_text(text, "src/config.env")
+
+        self.assertEqual(
+            hits,
+            [("src/config.env", 1, "generic_assignment")],
+        )
+
+    def test_quoted_and_call_safe_values_reject_appended_payloads(self) -> None:
+        cases = [
+            'api_key="<secret-value>"hunter2hunter2hunter2',
+            'api_key="${API_KEY}"hunter2hunter2hunter2',
+            'api_key=os.environ.get("API_KEY")+hunter2hunter2hunter2',
+            'api_key=std::env::var("API_KEY")+hunter2hunter2hunter2',
+            'api_key="<secret-value>" + hunter2hunter2hunter2',
+            'api_key="${API_KEY}" + hunter2hunter2hunter2',
+            'api_key=os.environ.get("API_KEY") + hunter2hunter2hunter2',
+            "api_key=process.env.API_KEY + hunter2hunter2hunter2",
+            'api_key=process.env.API_KEY || "hunter2hunter2hunter2"',
+            'api_key=process.env.API_KEY ?? "hunter2hunter2hunter2"',
+            'api_key=os.environ.get("API_KEY") or "hunter2hunter2hunter2"',
+            'api_key=os.environ.get("API_KEY", "").strip()hunter2hunter2hunter2',
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "src/config.example")
+
+                self.assertEqual(
+                    hits,
+                    [("src/config.example", 1, "generic_assignment")],
+                )
 
 
 class SecretGuardRustLetBindingTests(unittest.TestCase):

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -631,6 +631,49 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
                     [("src/config.example", 1, "generic_assignment")],
                 )
 
+    def test_grep_extended_regex_pattern_assignment_terms_are_safe(self) -> None:
+        cases = [
+            "grep -cE '(token=|key=|secret=|password=)' history",
+            "grep -c -E '(token=|key=|secret=|password=)' history",
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "scripts/audit.sh")
+
+                self.assertEqual(hits, [])
+
+    def test_grep_exception_is_scoped_to_its_pattern_argument(self) -> None:
+        key_name = "api" + "_key"
+        value = "hunter2" * 3
+        cases = [
+            f'echo "{key_name}={value}" # unrelated grep -E "safe"',
+            f'grep "{key_name}={value}" file # use -E later',
+            f'grep -E "safe" "{key_name}={value}"',
+            f'grep safe; echo -E "{key_name}={value}"',
+            f'grep -E safe "{key_name}={value}"',
+            f'grep -E -f "{key_name}={value}" data',
+            f'echo grep -E "{key_name}={value}"',
+            f'x=$(grep -E safe) echo "{key_name}={value}"',
+            (
+                "grep -E '(token=|key=|secret=|password=''"
+                + value
+                + ")' history"
+            ),
+            f'pattern = "(token=|key=|secret=|password=" + "{value})"',
+            f"grep -E 'token=|bearer [api_key={value}]' history",
+            f"grep -E '(token=|bearer [password={value}])' history",
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "scripts/audit.sh")
+
+                self.assertEqual(
+                    hits,
+                    [("scripts/audit.sh", 1, "generic_assignment")],
+                )
+
 
 class SecretGuardRustLetBindingTests(unittest.TestCase):
     def test_rust_let_call_bindings_do_not_trigger_generic_assignment(self) -> None:

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -473,6 +473,67 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
             [("docs/example.env", 1, "generic_assignment")],
         )
 
+    def test_angle_placeholder_rejects_literal_payload(self) -> None:
+        hits = check_secrets.scan_text(
+            "api_key=<hunter2hunter2hunter2>", "docs/example.env"
+        )
+
+        self.assertEqual(
+            hits, [("docs/example.env", 1, "generic_assignment")]
+        )
+
+    def test_common_angle_placeholder_is_safe(self) -> None:
+        cases = [
+            "api_key=<YOUR_API_KEY>",
+            "api_key=<YOUR_API_KEY_HERE>",
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "docs/example.env")
+
+                self.assertEqual(hits, [])
+
+    def test_safe_value_rejects_unquoted_passphrase_continuation(self) -> None:
+        cases = [
+            "api_key=<secret-value> correct horse battery staple",
+            "api_key=<secret-value> correct horse battery",
+            "api_key=<secret-value> hunter2 hunter2 hunter2",
+            "api_key=<secret-value> correct horse battery.",
+            "api_key=<secret-value> correct horse battery;",
+            "api_key=<secret-value> correct horse battery!",
+            "api_key=<secret-value> correct horse battery # note",
+            "api_key=<YOUR_API_KEY> correct horse battery.",
+            "api_key=<secret-value> correct, horse, battery",
+            "api_key=<secret-value> correct: horse: battery",
+            "api_key=<secret-value> correct / horse / battery",
+            "api_key=<secret-value> (correct horse battery)",
+            "api_key=<secret-value> correct horse (battery)",
+            "api_key=<secret-value> [correct horse battery]",
+            "api_key=<secret-value> correct horse battery <b>",
+            "api_key=<secret-value> correct horse and battery",
+            (
+                "api_key=<secret-value> "
+                "# note AbCdEfGhIjKlMnOpQrStUvWx"
+            ),
+            (
+                "api_key=<secret-value> "
+                "[note AbCdEfGhIjKlMnOpQrStUvWx](README.md)"
+            ),
+            (
+                "api_key=<secret-value> "
+                "# replace correct horse battery with actual value"
+            ),
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "docs/example.env")
+
+                self.assertEqual(
+                    hits, [("docs/example.env", 1, "generic_assignment")]
+                )
+
     def test_lockfile_exception_is_scoped_to_the_integrity_token(self) -> None:
         digest = (
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
@@ -804,6 +865,7 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
             ),
             "api_key=<secret-value> # configuration placeholder",
             "api_key=<secret-value> # configuration placeholder.",
+            "api_key=<secret-value> # replace with your actual value",
             (
                 "api_key=<secret-value> "
                 "# don't commit the placeholder"
@@ -845,10 +907,93 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
                     hits, [("docs/example.md", 1, expected_rule)]
                 )
 
+    def test_safe_path_context_rejects_credential_like_segments(self) -> None:
+        token = "".join(
+            ("m9R3tQv7WzK2pL5", "nX8cF1gJ4sD6hY0", "aBEuIqOwPz")
+        )
+        cases = [
+            (f"/tmp/a/b/{token}", "high_entropy"),
+            (
+                "https://github.com/OpenCoven/coven/blob/main/"
+                f"{token}",
+                "high_entropy",
+            ),
+            (
+                "https://github.com/OpenCoven/coven/"
+                f"releases/download/v1/{token}",
+                "high_entropy",
+            ),
+            (f"Library/LaunchAgents/{token}", "high_entropy"),
+            ("/tmp/a/b/hunter2hunter2hunter2", "generic_assignment"),
+            ("/tmp/a/b/abcdefghijklmnopqrst", "generic_assignment"),
+            ("/tmp/a/b/correcthorsebattery", "generic_assignment"),
+            ("/tmp/a/b/hunterhunterhunter", "generic_assignment"),
+            ("/tmp/a/b/CorrectHorseBattery", "generic_assignment"),
+            ("/tmp/a/b/correct/horse/battery", "generic_assignment"),
+            (
+                "https://github.com/OpenCoven/coven/blob/main/"
+                "correcthorsebattery",
+                "generic_assignment",
+            ),
+        ]
+
+        for value, expected_rule in cases:
+            with self.subTest(value=value):
+                hits = check_secrets.scan_text(
+                    f"api_key=<secret-value> {value}",
+                    "docs/example.md",
+                )
+
+                self.assertEqual(
+                    hits, [("docs/example.md", 1, expected_rule)]
+                )
+
+    def test_structured_reference_rejects_credential_like_segments(self) -> None:
+        token = "".join(
+            ("m9R3tQv7WzK2pL5", "nX8cF1gJ4sD6hY0", "aBEuIqOwPz")
+        )
+        sha = "deadbeef" * 5
+        cases = [
+            (
+                f"https://github.com/{token}/repo/commit/{sha}",
+                "high_entropy",
+            ),
+            (
+                f"https://github.com/OpenCoven/{token}/commit/{sha}",
+                "high_entropy",
+            ),
+            (f"actions/{token}@{sha}", "high_entropy"),
+            (
+                f"https://www.apple.com/DTDs/{token}.dtd",
+                "high_entropy",
+            ),
+            (
+                "https://github.com/OpenCoven/coven"
+                "#correcthorsebattery",
+                "generic_assignment",
+            ),
+        ]
+
+        for value, expected_rule in cases:
+            with self.subTest(value=value):
+                hits = check_secrets.scan_text(
+                    f"api_key=<secret-value> {value}",
+                    "docs/example.md",
+                )
+
+                self.assertEqual(
+                    hits, [("docs/example.md", 1, expected_rule)]
+                )
+
     def test_grep_extended_regex_pattern_assignment_terms_are_safe(self) -> None:
         cases = [
             "grep -cE '(token=|key=|secret=|password=)' history",
             "grep -c -E '(token=|key=|secret=|password=)' history",
+            (
+                "COUNT=$(grep -cE "
+                "'(token=|key=|secret=|password=|Bearer [A-Za-z0-9])' "
+                '"$HIST_FILE" 2>/dev/null || true)'
+            ),
         ]
 
         for text in cases:
@@ -890,12 +1035,18 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
 
 
 class SecretGuardRustLetBindingTests(unittest.TestCase):
-    def test_rust_let_call_bindings_do_not_trigger_generic_assignment(self) -> None:
+    def test_known_rust_runtime_bindings_do_not_trigger_generic_assignment(
+        self,
+    ) -> None:
         text = "\n".join(
             [
                 "    let token = text.split_whitespace().last()?;",
                 "    let token = token.strip_prefix('v').unwrap_or(token);",
                 "    let mut secret = std::env::args().nth(1).unwrap_or_default();",
+                (
+                    "    let token = text.split_whitespace().last()?; "
+                    "// parse runtime token"
+                ),
                 "    let password: String = prompt_hidden(\"Password: \")?;",
                 "    let api_key = format!(\"{prefix}-{suffix}\");",
             ]
@@ -912,6 +1063,76 @@ class SecretGuardRustLetBindingTests(unittest.TestCase):
 
         self.assertEqual(
             hits, [("crates/coven-cli/src/engine.rs", 1, "generic_assignment")]
+        )
+
+    def test_rust_let_call_with_appended_value_still_triggers_generic_assignment(
+        self,
+    ) -> None:
+        cases = [
+            'let token = compute_token() + "hunter2hunter2hunter2";',
+            'let token = compute_token().trim() + "hunter2hunter2hunter2";',
+            "let token = compute_token() || hunter2hunter2hunter2;",
+            'let token = compute_token().unwrap_or("hunter2hunter2hunter2");',
+            "let token = compute_token(hunter2hunter2hunter2);",
+            'let token = compute_token(r#"hunter2hunter2hunter2"#);',
+            'let token = compute_token("hunterhunter");',
+            'let password = prompt_hidden("correct horse battery staple");',
+            'let token = compute_token("abcdefghijklmnop-qrst");',
+            'let token = compute_token("correct horse battery");',
+            'let token = compute_token("Correct Horse Battery Staple");',
+            (
+                "let token = compute_token("
+                '/* ); // */ "hunter2hunter2hunter2");'
+            ),
+            (
+                'let token = compute_token(concat!("hunter2", '
+                '"hunter2", "hunter2"));'
+            ),
+            (
+                'let token = compute_token(format!("{}{}{}", '
+                '"hunter2", "hunter2", "hunter2"));'
+            ),
+            (
+                'let token = compute_token(["hunter2", "hunter2", '
+                '"hunter2"].concat());'
+            ),
+            "let token = compute_token(12345678901234567890.into());",
+            "let token = compute_token(&12345678901234567890);",
+            "let token = compute_token::<12345678901234567890>();",
+            (
+                "let token = text.split_whitespace().last()?; "
+                "// correct horse battery staple"
+            ),
+            (
+                "let token = text.split_whitespace().last()?; "
+                "// note AbCdEfGhIjKlMnOpQrStUvWx"
+            ),
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(
+                    text, "crates/coven-cli/src/engine.rs"
+                )
+
+                self.assertEqual(
+                    hits,
+                    [
+                        (
+                            "crates/coven-cli/src/engine.rs",
+                            1,
+                            "generic_assignment",
+                        )
+                    ],
+                )
+
+    def test_rust_let_call_exception_is_scoped_to_rust_files(self) -> None:
+        hits = check_secrets.scan_text(
+            "let token = text.split_whitespace().last()?;", "docs/example.txt"
+        )
+
+        self.assertEqual(
+            hits, [("docs/example.txt", 1, "generic_assignment")]
         )
 
     def test_rust_let_with_bare_blob_still_triggers_generic_assignment(self) -> None:

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -539,14 +539,46 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
                 self.assertEqual(hits, [])
 
     def test_reserved_example_url_assignment_is_not_a_secret(self) -> None:
+        cases = [
+            (
+                'let url = "https://private-gateway.example.test/'
+                'session?token=fakegatewaytoken123";'
+            ),
+            (
+                '"https://private-gateway.example.test/'
+                'session?token=fakegatewaytoken123".to_string()'
+            ),
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(
+                    text, "crates/coven-cli/src/privacy.rs"
+                )
+
+                self.assertEqual(hits, [])
+
+    def test_reserved_example_url_rejects_operator_payload(self) -> None:
+        value = "hunter2" * 3
         text = (
-            'let url = "https://private-gateway.example.test/'
-            'session?token=fakegatewaytoken123";'
+            '"https://private-gateway.example.test/'
+            f'session?token=fakegatewaytoken123" + "{value}"'
         )
 
-        hits = check_secrets.scan_text(text, "crates/coven-cli/src/privacy.rs")
+        hits = check_secrets.scan_text(
+            text, "crates/coven-cli/src/privacy.rs"
+        )
 
-        self.assertEqual(hits, [])
+        self.assertEqual(
+            hits,
+            [
+                (
+                    "crates/coven-cli/src/privacy.rs",
+                    1,
+                    "generic_assignment",
+                )
+            ],
+        )
 
     def test_safe_generic_values_allow_only_syntax_suffixes(self) -> None:
         cases = [

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -558,27 +558,35 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
 
                 self.assertEqual(hits, [])
 
-    def test_reserved_example_url_rejects_operator_payload(self) -> None:
+    def test_reserved_example_url_rejects_literal_payload(self) -> None:
         value = "hunter2" * 3
-        text = (
-            '"https://private-gateway.example.test/'
-            f'session?token=fakegatewaytoken123" + "{value}"'
-        )
+        cases = [
+            (
+                '"https://private-gateway.example.test/'
+                f'session?token=fakegatewaytoken123" + "{value}"'
+            ),
+            (
+                '"https://private-gateway.example.test/'
+                f'session?token=fakegatewaytoken123" {value}'
+            ),
+        ]
 
-        hits = check_secrets.scan_text(
-            text, "crates/coven-cli/src/privacy.rs"
-        )
-
-        self.assertEqual(
-            hits,
-            [
-                (
-                    "crates/coven-cli/src/privacy.rs",
-                    1,
-                    "generic_assignment",
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(
+                    text, "crates/coven-cli/src/privacy.rs"
                 )
-            ],
-        )
+
+                self.assertEqual(
+                    hits,
+                    [
+                        (
+                            "crates/coven-cli/src/privacy.rs",
+                            1,
+                            "generic_assignment",
+                        )
+                    ],
+                )
 
     def test_safe_generic_values_allow_only_syntax_suffixes(self) -> None:
         cases = [
@@ -639,10 +647,80 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
         )
 
     def test_quoted_and_call_safe_values_reject_appended_payloads(self) -> None:
+        short_mixed = "AbCdEfGh" + "IjKlMnOp" + "QrStUvWx"
+        hex_value = "deadbeef" * 4
+        punctuated = ":".join(["hunter2"] * 3)
+        password = "P@ssw0rd!" * 2
+        segmented = [
+            separator.join(["hunter2"] * 3)
+            for separator in ("_", ".", "/", "-")
+        ]
         cases = [
             'api_key="<secret-value>"hunter2hunter2hunter2',
+            'api_key="<secret-value>" hunter2hunter2hunter2',
+            f'api_key="<secret-value>" {short_mixed}',
+            f'api_key="<secret-value>" {hex_value}',
+            f'api_key="<secret-value>" {punctuated}',
+            f'api_key="<secret-value>" {password}',
+            'api_key="<secret-value>" "hunter2 hunter2 hunter2"',
+            (
+                'api_key="<secret-value>" '
+                '"correct horse battery staple"'
+            ),
+            (
+                'api_key="<secret-value>" '
+                '"hunter2" "hunter2" "hunter2"'
+            ),
+            'api_key="<secret-value>" "hunter2 hunter2 hunter2',
+            (
+                "api_key=\"<secret-value>\" "
+                "'correct horse battery staple"
+            ),
+            'api_key="<secret-value>" a"hunter2 hunter2"b',
+            (
+                'api_key="<secret-value>" '
+                "[hunter2hunter2hunter2]"
+                "(https://github.com/OpenCoven/coven)"
+            ),
+            (
+                'api_key="<secret-value>" '
+                "[P@ssw0rd!P@ssw0rd!]"
+                "(https://github.com/OpenCoven/coven)"
+            ),
+            (
+                'api_key="<secret-value>" '
+                "[correcthorsebatterystaple]"
+                "(https://github.com/OpenCoven/coven)"
+            ),
+            (
+                'api_key="<secret-value>" '
+                "[correct-horse-battery-staple]"
+                "(https://github.com/OpenCoven/coven)"
+            ),
+            (
+                'api_key="<secret-value>" '
+                "# correct horse battery staple"
+            ),
+            f'api_key="<secret-value>" # {short_mixed}',
+            (
+                f'api_key="<secret-value>" [{short_mixed}]'
+                "(https://github.com/OpenCoven/coven)"
+            ),
+            'api_key="<secret-value>" hunter2\\ hunter2\\ hunter2',
+            'api_key="<secret-value>" hunter2/hunter2',
+            (
+                'api_key="<secret-value>" '
+                "https://github.com/OpenCoven/coven/"
+                "hunter2hunter2hunter2"
+            ),
+            *[
+                f'api_key="<secret-value>" {value}'
+                for value in segmented
+            ],
             'api_key="${API_KEY}"hunter2hunter2hunter2',
+            'api_key="${API_KEY}" hunter2hunter2hunter2',
             'api_key=os.environ.get("API_KEY")+hunter2hunter2hunter2',
+            'api_key=os.environ.get("API_KEY") hunter2hunter2hunter2',
             'api_key=std::env::var("API_KEY")+hunter2hunter2hunter2',
             'api_key="<secret-value>" + hunter2hunter2hunter2',
             'api_key="${API_KEY}" + hunter2hunter2hunter2',
@@ -661,6 +739,110 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
                 self.assertEqual(
                     hits,
                     [("src/config.example", 1, "generic_assignment")],
+                )
+
+    def test_safe_values_allow_known_nonsecret_trailing_context(self) -> None:
+        cases = [
+            "api_key=<secret-value> docs/reference/api.md",
+            (
+                "api_key=<secret-value> "
+                "https://docs.example.com/configuration"
+            ),
+            "api_key=<secret-value> CONFIG_VALUE_REFERENCE",
+            "api_key=<secret-value> CONFIGURATION_VALUE",
+            "api_key=<secret-value> CONFIGURATION_VALUE:",
+            (
+                "api_key=<secret-value> "
+                "https://github.com/OpenCoven/coven"
+            ),
+            (
+                "api_key=<secret-value> "
+                "(https://github.com/OpenCoven/coven)."
+            ),
+            "api_key=<secret-value> /etc/configuration",
+            "api_key=<secret-value> docs/reference/api.md:",
+            (
+                "api_key=<secret-value> "
+                "https://github.com/advisories/GHSA-rhfx-m35p-ff5j"
+            ),
+            (
+                "api_key=<secret-value> "
+                "https://github.com/OpenCoven/coven/commit/"
+                + ("deadbeef" * 5)
+            ),
+            (
+                "api_key=<secret-value> "
+                "https://www.apple.com/DTDs/PropertyList-1.0.dtd"
+            ),
+            (
+                "api_key=<secret-value> "
+                "https://support-dev.discord.com/hc/en-us/articles/"
+                "6207308062871-What-are-Privileged-Intents"
+            ),
+            'api_key=<secret-value> "$CONFIGURATION_FILE"',
+            'api_key=<secret-value> "${CONFIGURATION_FILE}"',
+            (
+                "api_key=<secret-value> "
+                "[reference](https://github.com/OpenCoven/coven)"
+            ),
+            (
+                "api_key=<secret-value> "
+                "https://github.com/OpenCoven/coven#readme"
+            ),
+            (
+                "api_key=<secret-value> "
+                "[configuration](docs/reference/api.md)"
+            ),
+            (
+                'api_key=<secret-value> '
+                '"$HOME/.config/opencoven/config.toml"'
+            ),
+            (
+                "api_key=<secret-value> "
+                "https://github.com/OpenCoven/coven/"
+                "blob/main/README.md#L10"
+            ),
+            "api_key=<secret-value> # configuration placeholder",
+            "api_key=<secret-value> # configuration placeholder.",
+            (
+                "api_key=<secret-value> "
+                "# don't commit the placeholder"
+            ),
+            "api_key=<secret-value> [Read more](README.md)",
+            (
+                "api_key=<secret-value> "
+                "[configuration](#configuration)"
+            ),
+            (
+                "api_key=<secret-value> "
+                "[configuration]"
+                "(docs/reference/api.md#configuration)"
+            ),
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(text, "docs/example.md")
+
+                self.assertEqual(hits, [])
+
+    def test_broad_safe_context_shapes_reject_payloads(self) -> None:
+        password = "P@ssw0rd!" * 2
+        cases = [
+            (
+                f"github.com/advisories/GHSA-{password}",
+                "high_entropy",
+            ),
+            (f"/tmp/a/b/{password}", "generic_assignment"),
+        ]
+
+        for value, expected_rule in cases:
+            with self.subTest(value=value):
+                text = f'api_key="<secret-value>" {value}'
+                hits = check_secrets.scan_text(text, "docs/example.md")
+
+                self.assertEqual(
+                    hits, [("docs/example.md", 1, expected_rule)]
                 )
 
     def test_grep_extended_regex_pattern_assignment_terms_are_safe(self) -> None:

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -39,7 +39,14 @@ SECRET_RULES: list[tuple[str, re.Pattern[str]]] = [
 GENERIC_ASSIGNMENT_SAFE_VALUE = re.compile(
     r'''(?ix)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*["']?'''
     r"(?:"
-    r"<[-A-Za-z0-9_ .]{1,40}>"
+    r"<(?:"
+    r"(?:your|example|placeholder)[-_ ]"
+    r"(?:api[-_ ]?key|private[-_ ]?key|secret|token|password|credential|value)"
+    r"(?:[-_ ](?:value|placeholder|example|here))?"
+    r"|(?:api[-_ ]?key|private[-_ ]?key|secret|token|password|credential)"
+    r"(?:[-_ ](?:value|placeholder|example|here))?"
+    r"|value|placeholder|example"
+    r")>"
     r"|your_[A-Za-z0-9_.-]{1,64}"
     r"|(?:placeholder|example|secret_value)(?:[-_][A-Za-z0-9_.-]{1,64})?"
     r"|op://[A-Za-z0-9_.@/%+-]{1,200}"
@@ -68,14 +75,20 @@ ENV_SECRET_REFERENCE = re.compile(
     r"(?i)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*[\"']?"
     r"(?:\$[A-Z0-9_]+|\$\{[A-Z0-9_]+(?:(?::?\?)[^}\"']*)?\})"
 )
-# A Rust `let` binding whose right-hand side begins with a call expression
-# (identifier chain followed by `(`, e.g. `let token = text.split_whitespace()`).
-# The secret-sounding name binds the RESULT of code that runs later; the line
-# cannot contain a credential literal. A quoted or bare-blob RHS does not match
-# this shape and still trips `generic_assignment`.
-RUST_LET_CALL_BINDING = re.compile(
-    r"^\s*let\s+(?:mut\s+)?[A-Za-z_][A-Za-z0-9_]*\s*(?::[^=]{1,64})?=\s*"
-    r"[A-Za-z_][A-Za-z0-9_]*(?:(?:::|\.)[A-Za-z_][A-Za-z0-9_]*)*!?\("
+# History scanning cannot be repaired by renaming these locals at HEAD. Keep
+# the exception to the three proven runtime-derived bindings instead of
+# attempting to recognize arbitrary Rust call expressions.
+RUST_KNOWN_SAFE_RUNTIME_BINDING = re.compile(
+    r"""(?x)
+    ^\s*
+    (?:
+        let\s+token\s*=\s*text\.split_whitespace\(\)\.last\(\)\?;
+        |let\s+token\s*=\s*token\.strip_prefix\('v'\)\.unwrap_or\(token\);
+        |let\s+mut\s+secret\s*=\s*std::env::args\(\)\.nth\(1\)
+            \.unwrap_or_default\(\);
+    )
+    \s*$
+    """
 )
 QUOTED_TEXT = re.compile(r"'[^']*'|\"[^\"]*\"")
 SAFE_SECRET_FIELD_REGEX_PATTERN = re.compile(
@@ -134,6 +147,16 @@ ASSIGNMENT_CONTEXT_MARKDOWN_LINK = re.compile(
 ASSIGNMENT_CONTEXT_PROSE = re.compile(
     r"[A-Za-z][A-Za-z ,.:;()'/-]{0,160}"
 )
+ASSIGNMENT_CONTEXT_GUIDANCE = re.compile(
+    r"""(?ix)
+    (?:
+        replace\s+with\s+(?:your\s+)?actual\s+value
+        |(?:parse|read|load|derive|use)\s+(?:the\s+)?runtime\s+
+            (?:value|token|input|argument)
+    )
+    [.:;]?
+    """
+)
 ASSIGNMENT_CONTEXT_DOC_PATH = re.compile(
     r"(?:[A-Za-z0-9_.-]{1,64}/)*"
     r"[A-Za-z0-9_.-]{1,64}\."
@@ -158,6 +181,44 @@ ORDERED_ALPHABET_FIXTURES = {
 }
 KNOWN_PUBLIC_DOCUMENTATION_TOKENS = {
     "support-dev.discord.com/hc/en-us/articles/6207308062871-What-are-Privileged-Intents",
+}
+KNOWN_SAFE_LONG_PATH_ATOMS = {
+    "ARCHITECTURE",
+    "CONTRIBUTING",
+    "LaunchAgents",
+    "LaunchDaemons",
+    "PropertyList",
+    "TROUBLESHOOTING",
+    "accessibility",
+    "announcements",
+    "architecture",
+    "capabilities",
+    "configuration",
+    "orchestration",
+    "troubleshooting",
+    "verification",
+}
+PATH_CONTEXT_BOUNDARIES = {
+    ".worktrees",
+    "Library",
+    "LaunchAgents",
+    "LaunchDaemons",
+    "OpenCoven",
+    "assets",
+    "blob",
+    "brand",
+    "crates",
+    "docs",
+    "download",
+    "main",
+    "packages",
+    "releases",
+    "scripts",
+    "skills",
+    "specs",
+    "src",
+    "tree",
+    "worktrees",
 }
 KNOWN_FAKE_PRIVATE_KEY_FIXTURE = re.compile(
     r"-----BEGIN PRIVATE KEY-----\\n(?:fake){3,}\\n-----END PRIVATE KEY-----"
@@ -205,7 +266,11 @@ def assignment_is_covered_by_safe_match(
 
 
 def safe_assignment_continuation_is_syntax(
-    path: str, line: str, safe_match: re.Match[str]
+    path: str,
+    line: str,
+    safe_match: re.Match[str],
+    *,
+    reject_unmarked_passphrase: bool = True,
 ) -> bool:
     tail = line[safe_match.end() :]
     immediate_suffix = re.match(r"\S*", tail)
@@ -218,6 +283,13 @@ def safe_assignment_continuation_is_syntax(
         operator, fallback = continuation.groups()
         return operator != "+" and bool(SAFE_FALLBACK_VALUE.fullmatch(fallback))
     trailing_start = safe_match.end() + immediate_suffix.end()
+    trailing_context = line[trailing_start:].strip()
+    if (
+        reject_unmarked_passphrase
+        and not trailing_context.startswith(("#", "//"))
+        and is_likely_unmarked_passphrase(trailing_context)
+    ):
+        return False
     return all(
         assignment_trailing_chunk_is_accounted_for(path, line, chunk_match)
         for chunk_match in ASSIGNMENT_TRAILING_CHUNK.finditer(
@@ -248,8 +320,29 @@ def is_safe_secret_field_regex_assignment(
                 quoted.group(0)[1:-1]
             )
         )
-        and safe_assignment_continuation_is_syntax(path, line, quoted)
+        and safe_assignment_continuation_is_syntax(
+            path,
+            line,
+            quoted,
+            reject_unmarked_passphrase=False,
+        )
         for quoted in QUOTED_TEXT.finditer(line)
+    )
+
+
+def is_known_safe_rust_runtime_binding(
+    path: str, line: str, assignment: re.Match[str]
+) -> bool:
+    code, comment_marker, comment = line.partition("//")
+    if comment_marker and not is_known_safe_assignment_context_prose(
+        comment, allow_empty=True
+    ):
+        return False
+    binding = RUST_KNOWN_SAFE_RUNTIME_BINDING.fullmatch(code)
+    return bool(
+        path.replace("\\", "/").endswith(".rs")
+        and binding
+        and match_is_within(assignment, binding)
     )
 
 
@@ -275,10 +368,7 @@ def is_known_safe_generic_assignment(
     ):
         return True
 
-    rust_binding = RUST_LET_CALL_BINDING.match(line)
-    if rust_binding and match_is_within(
-        assignment, rust_binding, require_end=False
-    ):
+    if is_known_safe_rust_runtime_binding(path, line, assignment):
         return True
 
     if is_safe_secret_field_regex_assignment(path, line, assignment):
@@ -308,16 +398,84 @@ def is_known_safe_lockfile_token(
     )
 
 
-def is_local_path_like_token(token: str) -> bool:
+def is_safe_path_segment(segment: str, *, strict: bool = False) -> bool:
+    if (
+        not segment
+        or len(segment) > 64
+        or not re.fullmatch(r"[A-Za-z0-9_.-]+", segment)
+    ):
+        return False
+    for atom in (part for part in re.split(r"[._-]", segment) if part):
+        if (
+            strict
+            and len(atom) >= 12
+            and atom not in KNOWN_SAFE_LONG_PATH_ATOMS
+        ):
+            return False
+        if len(atom) > 24:
+            return False
+        if len(atom) < 12:
+            continue
+        letters = "".join(char for char in atom if char.isalpha())
+        if any(char.isdigit() for char in atom):
+            return False
+        if (
+            letters
+            and not (letters.islower() or letters.isupper())
+            and not re.fullmatch(r"(?:[A-Z][a-z]+){2,}", letters)
+        ):
+            return False
+    return True
+
+
+def path_segments_are_safe(
+    segments: list[str], *, strict: bool = False
+) -> bool:
+    if any(
+        not is_safe_path_segment(segment, strict=strict)
+        for segment in segments
+    ):
+        return False
+    if not strict:
+        return True
+
+    passphrase_run = 0
+    for segment in segments:
+        if segment in PATH_CONTEXT_BOUNDARIES:
+            passphrase_run = 0
+            continue
+        stem = segment.rsplit(".", 1)[0]
+        if re.fullmatch(r"[A-Za-z0-9]{4,}", stem):
+            passphrase_run += 1
+            if passphrase_run >= 3:
+                return False
+        else:
+            passphrase_run = 0
+    return True
+
+
+def is_known_safe_assignment_context_path(path: str) -> bool:
+    if not (
+        ASSIGNMENT_CONTEXT_PATH.fullmatch(path)
+        or ASSIGNMENT_CONTEXT_DOC_PATH.fullmatch(path)
+    ):
+        return False
+    return path_segments_are_safe(
+        [
+            part
+            for part in path.replace("\\", "/").split("/")
+            if part not in {"", ".", ".."}
+        ],
+        strict=True,
+    )
+
+
+def is_local_path_like_token(token: str, *, strict: bool = False) -> bool:
     normalized = token.strip("/")
     parts = normalized.split("/")
     if len(parts) < 4:
         return False
-    if any(
-        len(part) > 64
-        or not re.fullmatch(r"[A-Za-z0-9_.-]+", part)
-        for part in parts
-    ):
+    if not path_segments_are_safe(parts, strict=strict):
         return False
     if parts[0] in {"Users", "home", "private", "var", "tmp", "Volumes"}:
         return True
@@ -326,7 +484,9 @@ def is_local_path_like_token(token: str) -> bool:
     return ".worktrees" in parts or "worktrees" in parts
 
 
-def is_public_repo_url_like_token(token: str) -> bool:
+def is_public_repo_url_like_token(
+    token: str, *, strict: bool = False
+) -> bool:
     normalized = token.strip("/")
     if not re.fullmatch(
         r"github\.com/OpenCoven/[A-Za-z0-9_.-]+/"
@@ -334,33 +494,32 @@ def is_public_repo_url_like_token(token: str) -> bool:
         normalized,
     ):
         return False
-    if any(len(part) > 64 for part in normalized.split("/")):
+    if not path_segments_are_safe(
+        normalized.split("/"), strict=strict
+    ):
         return False
     if "/blob/" in normalized or "/tree/" in normalized:
         return True
-    # Release-artifact URLs (…/releases/download/<tag>/<artifact>): tags and
-    # artifact filenames are short path segments; cap each so a token-like
-    # blob smuggled into a fake artifact name still trips the entropy rule.
+    # Release-artifact URLs (…/releases/download/<tag>/<artifact>) use the
+    # same segment validation so credential-like artifact names fail closed.
     if "/releases/download/" in normalized:
-        return all(len(part) <= 64 for part in normalized.split("/"))
+        return True
     return False
 
 
-def is_opencoven_repo_relative_path_token(token: str) -> bool:
+def is_opencoven_repo_relative_path_token(
+    token: str, *, strict: bool = False
+) -> bool:
     normalized = token.strip("/")
     if not normalized.startswith("OpenCoven/coven/"):
         return False
-    # Keep this allowlist tight: only permit path-ish characters (no `+`/`@`) and
-    # reject mixed-case-within-a-segment / extremely long segments that look token-like.
+    # Keep this allowlist tight: only permit path-ish characters (no `+`/`@`)
+    # and reject credential-like path segments.
     if not re.fullmatch(r"OpenCoven/coven/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+){1,}", normalized):
         return False
-    for part in normalized.split("/")[2:]:
-        if len(part) > 64:
-            return False
-        letters = "".join(ch for ch in part if ch.isalpha())
-        if letters and not (letters.islower() or letters.isupper()):
-            return False
-    return True
+    return path_segments_are_safe(
+        normalized.split("/")[2:], strict=strict
+    )
 
 
 def is_github_advisory_url_like_token(token: str) -> bool:
@@ -376,24 +535,47 @@ def is_github_advisory_url_like_token(token: str) -> bool:
     )
 
 
-def is_github_commit_url_like_token(token: str) -> bool:
+def is_github_commit_url_like_token(
+    token: str, *, strict: bool = False
+) -> bool:
     normalized = token.strip("/")
-    return bool(re.fullmatch(r"github\.com/[^/\s]+/[^/\s]+/commit/[0-9a-f]{32,64}", normalized))
+    match = re.fullmatch(
+        r"github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)"
+        r"/commit/[0-9a-f]{32,64}",
+        normalized,
+    )
+    return bool(
+        match
+        and path_segments_are_safe(
+            [match.group("owner"), match.group("repo")],
+            strict=strict,
+        )
+    )
 
 
 _GITHUB_ACTION_SHA_REF = re.compile(
-    r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+@[0-9a-f]{40}$"
+    r"^(?P<owner>[A-Za-z0-9._-]+)/(?P<repo>[A-Za-z0-9._-]+)"
+    r"@[0-9a-f]{40}$"
 )
 
 
-def is_github_action_sha_ref_token(token: str) -> bool:
+def is_github_action_sha_ref_token(
+    token: str, *, strict: bool = False
+) -> bool:
     """Whether `token` is a GitHub Actions `uses:` reference pinned to a 40-char
     commit SHA, e.g. ``actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd``.
     SHA-pinned refs are an OpenSSF best practice (they prevent action authors
     from silently moving a version tag onto a malicious commit) but the trailing
     40-hex SHA otherwise pushes the workflow line over the entropy threshold.
     """
-    return bool(_GITHUB_ACTION_SHA_REF.match(token))
+    match = _GITHUB_ACTION_SHA_REF.fullmatch(token)
+    return bool(
+        match
+        and path_segments_are_safe(
+            [match.group("owner"), match.group("repo")],
+            strict=strict,
+        )
+    )
 
 
 _MACOS_LIBRARY_PATH_TOKEN = re.compile(
@@ -403,7 +585,9 @@ _MACOS_LIBRARY_PATH_TOKEN = re.compile(
 )
 
 
-def is_macos_library_path_token(token: str) -> bool:
+def is_macos_library_path_token(
+    token: str, *, strict: bool = False
+) -> bool:
     """Whether `token` is a macOS `Library/...` well-known path such as
     ``Library/LaunchAgents/dev.opencoven.hub.plist``. These show up in
     launchd/service documentation and are never credentials, but reverse-DNS
@@ -413,19 +597,31 @@ def is_macos_library_path_token(token: str) -> bool:
     """
     if not _MACOS_LIBRARY_PATH_TOKEN.fullmatch(token):
         return False
-    return all(len(part) <= 64 for part in token.split("/"))
+    return path_segments_are_safe(
+        token.split("/"), strict=strict
+    )
 
 
-_APPLE_DTD_URL_TOKEN = re.compile(r"www\.apple\.com/DTDs/[A-Za-z0-9_.-]{1,64}\.dtd")
+_APPLE_DTD_URL_TOKEN = re.compile(
+    r"www\.apple\.com/DTDs/(?P<name>[A-Za-z0-9_.-]{1,64})\.dtd"
+)
 
 
-def is_apple_dtd_url_token(token: str) -> bool:
+def is_apple_dtd_url_token(
+    token: str, *, strict: bool = False
+) -> bool:
     """Whether `token` is the Apple property-list DTD system identifier
     (``www.apple.com/DTDs/PropertyList-1.0.dtd``) that appears in every plist
     XML doctype. It is public boilerplate, not a secret, but the mixed-case
     host/path combination exceeds the entropy threshold.
     """
-    return bool(_APPLE_DTD_URL_TOKEN.fullmatch(token))
+    match = _APPLE_DTD_URL_TOKEN.fullmatch(token)
+    return bool(
+        match
+        and is_safe_path_segment(
+            match.group("name"), strict=strict
+        )
+    )
 
 
 def is_ordered_alphabet_fixture_token(token: str) -> bool:
@@ -490,17 +686,30 @@ def is_assignment_context_identifier(chunk: str) -> bool:
     return True
 
 
+def is_safe_url_fragment(fragment: str, *, strict: bool = False) -> bool:
+    if not SAFE_URL_FRAGMENT.fullmatch(fragment):
+        return False
+    anchor = fragment[1:]
+    if re.fullmatch(r"L[0-9]{1,7}(?:-L[0-9]{1,7})?", anchor):
+        return True
+    return is_safe_path_segment(anchor, strict=strict)
+
+
 def is_known_safe_assignment_context_url(url: str) -> bool:
     fragment = SAFE_URL_FRAGMENT.search(url)
+    if fragment and not is_safe_url_fragment(
+        fragment.group(0), strict=True
+    ):
+        return False
     base_url = url[: fragment.start()] if fragment else url
     without_scheme = re.sub(r"(?i)^https?://", "", base_url)
     return bool(
         RESERVED_EXAMPLE_URL.fullmatch(base_url)
         or OPEN_COVEN_REPO_ROOT_URL.fullmatch(base_url)
-        or is_public_repo_url_like_token(without_scheme)
+        or is_public_repo_url_like_token(without_scheme, strict=True)
         or is_github_advisory_url_like_token(without_scheme)
-        or is_github_commit_url_like_token(without_scheme)
-        or is_apple_dtd_url_token(without_scheme)
+        or is_github_commit_url_like_token(without_scheme, strict=True)
+        or is_apple_dtd_url_token(without_scheme, strict=True)
         or is_discord_support_article_token(without_scheme)
     )
 
@@ -509,22 +718,59 @@ def is_known_safe_markdown_target(target: str) -> bool:
     if is_known_safe_assignment_context_url(target):
         return True
     if SAFE_URL_FRAGMENT.fullmatch(target):
-        return True
+        return is_safe_url_fragment(target, strict=True)
     fragment = SAFE_URL_FRAGMENT.search(target)
+    if fragment and not is_safe_url_fragment(
+        fragment.group(0), strict=True
+    ):
+        return False
     base_target = target[: fragment.start()] if fragment else target
-    return bool(
-        ASSIGNMENT_CONTEXT_PATH.fullmatch(base_target)
-        or ASSIGNMENT_CONTEXT_DOC_PATH.fullmatch(base_target)
-    )
+    return is_known_safe_assignment_context_path(base_target)
 
 
 def is_likely_passphrase_prose(text: str) -> bool:
     words = re.findall(r"[A-Za-z]+", text)
-    if len(words) == 1:
-        return len(words[0]) >= 20
-    return len(words) >= 4 and all(
+    if any(len(word) >= 20 for word in words):
+        return True
+    return len(words) >= 3 and all(
         len(word) >= 4 and word.islower() for word in words
     )
+
+
+def is_likely_unmarked_passphrase(text: str) -> bool:
+    candidate = re.split(r"\s+(?:#|//)", text, maxsplit=1)[0]
+    candidate = normalize_assignment_context_chunk(candidate.strip())
+    markdown_link = ASSIGNMENT_CONTEXT_MARKDOWN_LINK.fullmatch(candidate)
+    if markdown_link:
+        label, target = markdown_link.groups()
+        if (
+            is_known_safe_assignment_context_prose(label)
+            and is_known_safe_markdown_target(target)
+        ):
+            return False
+    if (
+        is_known_safe_assignment_context_url(candidate)
+        or is_known_safe_assignment_context_path(candidate)
+        or is_assignment_context_identifier(candidate)
+        or ASSIGNMENT_CONTEXT_ENV_REFERENCE.fullmatch(candidate)
+        or ASSIGNMENT_CONTEXT_ENV_PATH.fullmatch(candidate)
+        or is_local_path_like_token(candidate, strict=True)
+        or is_opencoven_repo_relative_path_token(candidate, strict=True)
+        or is_github_action_sha_ref_token(candidate, strict=True)
+        or is_macos_library_path_token(candidate, strict=True)
+        or is_ordered_alphabet_fixture_token(candidate)
+    ):
+        return False
+    if any(
+        name != "generic_assignment" and pattern.search(candidate)
+        for name, pattern in SECRET_RULES
+    ) or any(
+        entropy(token_match.group(0)) >= 4.3
+        for token_match in ENTROPY_TOKEN.finditer(candidate)
+    ):
+        return False
+    words = re.findall(r"[A-Za-z0-9]+", candidate)
+    return sum(len(word) >= 4 for word in words) >= 3
 
 
 def is_known_safe_assignment_context_prose(
@@ -535,7 +781,10 @@ def is_known_safe_assignment_context_prose(
         return allow_empty
     return bool(
         ASSIGNMENT_CONTEXT_PROSE.fullmatch(normalized)
-        and not is_likely_passphrase_prose(normalized)
+        and (
+            ASSIGNMENT_CONTEXT_GUIDANCE.fullmatch(normalized)
+            or not is_likely_passphrase_prose(normalized)
+        )
     )
 
 
@@ -582,14 +831,14 @@ def is_known_safe_assignment_context_chunk(chunk: str) -> bool:
         return True
     if (
         is_known_safe_assignment_context_url(core)
-        or ASSIGNMENT_CONTEXT_PATH.fullmatch(core)
+        or is_known_safe_assignment_context_path(core)
         or is_assignment_context_identifier(core)
         or ASSIGNMENT_CONTEXT_ENV_REFERENCE.fullmatch(core)
         or ASSIGNMENT_CONTEXT_ENV_PATH.fullmatch(core)
-        or is_local_path_like_token(core)
-        or is_opencoven_repo_relative_path_token(core)
-        or is_github_action_sha_ref_token(core)
-        or is_macos_library_path_token(core)
+        or is_local_path_like_token(core, strict=True)
+        or is_opencoven_repo_relative_path_token(core, strict=True)
+        or is_github_action_sha_ref_token(core, strict=True)
+        or is_macos_library_path_token(core, strict=True)
         or is_ordered_alphabet_fixture_token(core)
     ):
         return True

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -78,6 +78,26 @@ RUST_LET_CALL_BINDING = re.compile(
     r"[A-Za-z_][A-Za-z0-9_]*(?:(?:::|\.)[A-Za-z_][A-Za-z0-9_]*)*!?\("
 )
 QUOTED_TEXT = re.compile(r"'[^']*'|\"[^\"]*\"")
+SAFE_SECRET_FIELD_REGEX_PATTERN = re.compile(
+    r"""(?ix)
+    ^(?P<paren>\()?
+    (?:
+        (?:api[_-]?key|apikey|key|secret|token|password|private[_-]?key|authorization)
+        (?:\s*[:=]|\[=:\])?
+        |bearer(?:\s+\[A-Za-z0-9\])?\s*
+    )
+    (?:
+        \|
+        (?:
+            (?:api[_-]?key|apikey|key|secret|token|password|private[_-]?key|authorization)
+            (?:\s*[:=]|\[=:\])?
+            |bearer(?:\s+\[A-Za-z0-9\])?\s*
+        )
+    )+
+    (?(paren)\)|)
+    $
+    """
+)
 SAFE_ASSIGNMENT_SUFFIX = re.compile(
     r'''(?x)
     (?:
@@ -174,6 +194,21 @@ def has_unsafe_safe_assignment_continuation(line: str) -> bool:
     )
 
 
+def is_safe_secret_field_regex_assignment(
+    line: str, assignment: re.Match[str]
+) -> bool:
+    return any(
+        match_is_within(assignment, quoted)
+        and bool(
+            SAFE_SECRET_FIELD_REGEX_PATTERN.fullmatch(
+                quoted.group(0)[1:-1]
+            )
+        )
+        and safe_assignment_continuation_is_syntax(line, quoted)
+        for quoted in QUOTED_TEXT.finditer(line)
+    )
+
+
 def is_known_safe_generic_assignment(
     line: str, assignment: re.Match[str]
 ) -> bool:
@@ -201,12 +236,8 @@ def is_known_safe_generic_assignment(
     ):
         return True
 
-    if "grep" in line and re.search(r"-[A-Za-z]*E\b", line):
-        if any(
-            match_is_within(assignment, quoted)
-            for quoted in QUOTED_TEXT.finditer(line)
-        ):
-            return True
+    if is_safe_secret_field_regex_assignment(line, assignment):
+        return True
 
     return False
 

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -113,6 +113,45 @@ SAFE_FALLBACK_VALUE = re.compile(
 ASSIGNMENT_CONTINUATION_OPERATOR = re.compile(
     r"(?is)\s*(\+|\|\||\?\?|or\b)\s*(.*)"
 )
+ASSIGNMENT_TRAILING_CHUNK = re.compile(
+    r'''\[[^\]\r\n]{1,80}\]\([^()\s]+\)'''
+    r'''|(?:\#|//)[^\r\n]*'''
+    r'''|"[^"]*"|'[^']*'|`[^`]*`|(?:\\.|[^\s])+'''
+)
+ASSIGNMENT_CONTEXT_IDENTIFIER = re.compile(
+    r"[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+"
+)
+ASSIGNMENT_CONTEXT_ENV_REFERENCE = re.compile(
+    r"\$(?:[A-Z][A-Z0-9_]*|\{[A-Z][A-Z0-9_]*\})"
+)
+ASSIGNMENT_CONTEXT_ENV_PATH = re.compile(
+    r"(?:~|\$[A-Z][A-Z0-9_]*|\$\{[A-Z][A-Z0-9_]*\})"
+    r"(?:/[A-Za-z0-9_.-]{1,64})+"
+)
+ASSIGNMENT_CONTEXT_MARKDOWN_LINK = re.compile(
+    r"\[([^\]\r\n]{1,80})\]\(([^()\s]+)\)"
+)
+ASSIGNMENT_CONTEXT_PROSE = re.compile(
+    r"[A-Za-z][A-Za-z ,.:;()'/-]{0,160}"
+)
+ASSIGNMENT_CONTEXT_DOC_PATH = re.compile(
+    r"(?:[A-Za-z0-9_.-]{1,64}/)*"
+    r"[A-Za-z0-9_.-]{1,64}\."
+    r"(?:md|txt|rst|adoc|html?)"
+)
+ASSIGNMENT_CONTEXT_PATH = re.compile(
+    r"(?:(?:/(?:etc|usr|opt|var|tmp|home|Users))"
+    r"|(?:(?:\./|\.\./)?(?:docs|src|scripts|crates|packages|skills)))"
+    r"(?:/[A-Za-z0-9_.-]{1,64})+"
+)
+OPEN_COVEN_REPO_ROOT_URL = re.compile(
+    r"https?://github\.com/OpenCoven/coven/?"
+)
+SAFE_URL_FRAGMENT = re.compile(
+    r"#(?:L[0-9]{1,7}(?:-L[0-9]{1,7})?"
+    r"|[A-Za-z][A-Za-z0-9_.-]{0,63})$"
+)
+ENTROPY_TOKEN = re.compile(r"\b[A-Za-z0-9_+/@.-]{32,}\b")
 ORDERED_ALPHABET_FIXTURES = {
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
@@ -166,7 +205,7 @@ def assignment_is_covered_by_safe_match(
 
 
 def safe_assignment_continuation_is_syntax(
-    line: str, safe_match: re.Match[str]
+    path: str, line: str, safe_match: re.Match[str]
 ) -> bool:
     tail = line[safe_match.end() :]
     immediate_suffix = re.match(r"\S*", tail)
@@ -175,15 +214,21 @@ def safe_assignment_continuation_is_syntax(
         return False
     remainder = tail[immediate_suffix.end() :]
     continuation = ASSIGNMENT_CONTINUATION_OPERATOR.fullmatch(remainder)
-    if continuation is None:
-        return True
-    operator, fallback = continuation.groups()
-    return operator != "+" and bool(SAFE_FALLBACK_VALUE.fullmatch(fallback))
+    if continuation is not None:
+        operator, fallback = continuation.groups()
+        return operator != "+" and bool(SAFE_FALLBACK_VALUE.fullmatch(fallback))
+    trailing_start = safe_match.end() + immediate_suffix.end()
+    return all(
+        assignment_trailing_chunk_is_accounted_for(path, line, chunk_match)
+        for chunk_match in ASSIGNMENT_TRAILING_CHUNK.finditer(
+            line, trailing_start
+        )
+    )
 
 
-def has_unsafe_safe_assignment_continuation(line: str) -> bool:
+def has_unsafe_safe_assignment_continuation(path: str, line: str) -> bool:
     return any(
-        not safe_assignment_continuation_is_syntax(line, safe_match)
+        not safe_assignment_continuation_is_syntax(path, line, safe_match)
         for pattern in (
             GENERIC_ASSIGNMENT_SAFE_VALUE,
             ENV_SECRET_READ,
@@ -194,7 +239,7 @@ def has_unsafe_safe_assignment_continuation(line: str) -> bool:
 
 
 def is_safe_secret_field_regex_assignment(
-    line: str, assignment: re.Match[str]
+    path: str, line: str, assignment: re.Match[str]
 ) -> bool:
     return any(
         match_is_within(assignment, quoted)
@@ -203,13 +248,13 @@ def is_safe_secret_field_regex_assignment(
                 quoted.group(0)[1:-1]
             )
         )
-        and safe_assignment_continuation_is_syntax(line, quoted)
+        and safe_assignment_continuation_is_syntax(path, line, quoted)
         for quoted in QUOTED_TEXT.finditer(line)
     )
 
 
 def is_known_safe_generic_assignment(
-    line: str, assignment: re.Match[str]
+    path: str, line: str, assignment: re.Match[str]
 ) -> bool:
     for pattern in (
         GENERIC_ASSIGNMENT_SAFE_VALUE,
@@ -218,14 +263,14 @@ def is_known_safe_generic_assignment(
     ):
         if any(
             assignment_is_covered_by_safe_match(assignment, match)
-            and safe_assignment_continuation_is_syntax(line, match)
+            and safe_assignment_continuation_is_syntax(path, line, match)
             for match in pattern.finditer(line)
         ):
             return True
 
     if any(
         assignment_is_covered_by_safe_match(assignment, match)
-        and safe_assignment_continuation_is_syntax(line, match)
+        and safe_assignment_continuation_is_syntax(path, line, match)
         for match in RESERVED_EXAMPLE_URL.finditer(line)
     ):
         return True
@@ -236,7 +281,7 @@ def is_known_safe_generic_assignment(
     ):
         return True
 
-    if is_safe_secret_field_regex_assignment(line, assignment):
+    if is_safe_secret_field_regex_assignment(path, line, assignment):
         return True
 
     return False
@@ -268,6 +313,12 @@ def is_local_path_like_token(token: str) -> bool:
     parts = normalized.split("/")
     if len(parts) < 4:
         return False
+    if any(
+        len(part) > 64
+        or not re.fullmatch(r"[A-Za-z0-9_.-]+", part)
+        for part in parts
+    ):
+        return False
     if parts[0] in {"Users", "home", "private", "var", "tmp", "Volumes"}:
         return True
     if parts[0:2] == ["Documents", "GitHub"]:
@@ -277,7 +328,13 @@ def is_local_path_like_token(token: str) -> bool:
 
 def is_public_repo_url_like_token(token: str) -> bool:
     normalized = token.strip("/")
-    if not re.match(r"github\.com/OpenCoven/[A-Za-z0-9_.-]+/", normalized):
+    if not re.fullmatch(
+        r"github\.com/OpenCoven/[A-Za-z0-9_.-]+/"
+        r"[A-Za-z0-9_+/@.,~%:-]+",
+        normalized,
+    ):
+        return False
+    if any(len(part) > 64 for part in normalized.split("/")):
         return False
     if "/blob/" in normalized or "/tree/" in normalized:
         return True
@@ -308,7 +365,15 @@ def is_opencoven_repo_relative_path_token(token: str) -> bool:
 
 def is_github_advisory_url_like_token(token: str) -> bool:
     normalized = token.strip("/")
-    return normalized.startswith("github.com/advisories/GHSA-")
+    return bool(
+        re.fullmatch(
+            r"(?i)github\.com/advisories/"
+            r"GHSA-[23456789cfghjmpqrvwx]{4}"
+            r"-[23456789cfghjmpqrvwx]{4}"
+            r"-[23456789cfghjmpqrvwx]{4}",
+            normalized,
+        )
+    )
 
 
 def is_github_commit_url_like_token(token: str) -> bool:
@@ -416,6 +481,170 @@ def is_programming_identifier_token(token: str) -> bool:
     return has_letter_segment
 
 
+def is_assignment_context_identifier(chunk: str) -> bool:
+    if not ASSIGNMENT_CONTEXT_IDENTIFIER.fullmatch(chunk):
+        return False
+    for part in chunk.split("_"):
+        if len(part) > 32:
+            return False
+    return True
+
+
+def is_known_safe_assignment_context_url(url: str) -> bool:
+    fragment = SAFE_URL_FRAGMENT.search(url)
+    base_url = url[: fragment.start()] if fragment else url
+    without_scheme = re.sub(r"(?i)^https?://", "", base_url)
+    return bool(
+        RESERVED_EXAMPLE_URL.fullmatch(base_url)
+        or OPEN_COVEN_REPO_ROOT_URL.fullmatch(base_url)
+        or is_public_repo_url_like_token(without_scheme)
+        or is_github_advisory_url_like_token(without_scheme)
+        or is_github_commit_url_like_token(without_scheme)
+        or is_apple_dtd_url_token(without_scheme)
+        or is_discord_support_article_token(without_scheme)
+    )
+
+
+def is_known_safe_markdown_target(target: str) -> bool:
+    if is_known_safe_assignment_context_url(target):
+        return True
+    if SAFE_URL_FRAGMENT.fullmatch(target):
+        return True
+    fragment = SAFE_URL_FRAGMENT.search(target)
+    base_target = target[: fragment.start()] if fragment else target
+    return bool(
+        ASSIGNMENT_CONTEXT_PATH.fullmatch(base_target)
+        or ASSIGNMENT_CONTEXT_DOC_PATH.fullmatch(base_target)
+    )
+
+
+def is_likely_passphrase_prose(text: str) -> bool:
+    words = re.findall(r"[A-Za-z]+", text)
+    if len(words) == 1:
+        return len(words[0]) >= 20
+    return len(words) >= 4 and all(
+        len(word) >= 4 and word.islower() for word in words
+    )
+
+
+def is_known_safe_assignment_context_prose(
+    text: str, *, allow_empty: bool = False
+) -> bool:
+    normalized = text.strip()
+    if not normalized:
+        return allow_empty
+    return bool(
+        ASSIGNMENT_CONTEXT_PROSE.fullmatch(normalized)
+        and not is_likely_passphrase_prose(normalized)
+    )
+
+
+def normalize_assignment_context_chunk(chunk: str) -> str:
+    core = chunk.rstrip(".,;:")
+    wrapper_pairs = (
+        ('"', '"'),
+        ("'", "'"),
+        ("`", "`"),
+        ("(", ")"),
+        ("[", "]"),
+        ("{", "}"),
+        ("<", ">"),
+    )
+    while len(core) >= 2:
+        for opener, closer in wrapper_pairs:
+            if core.startswith(opener) and core.endswith(closer):
+                core = core[1:-1].strip().rstrip(".,;:")
+                break
+        else:
+            return core
+    return core
+
+
+def is_known_safe_assignment_context_chunk(chunk: str) -> bool:
+    markdown_link = ASSIGNMENT_CONTEXT_MARKDOWN_LINK.fullmatch(chunk)
+    if markdown_link:
+        label, target = markdown_link.groups()
+        if is_known_safe_assignment_context_prose(
+            label
+        ) and is_known_safe_markdown_target(target):
+            return True
+    if chunk.startswith("#"):
+        return is_known_safe_assignment_context_prose(
+            chunk[1:], allow_empty=True
+        )
+    if chunk.startswith("//"):
+        return is_known_safe_assignment_context_prose(
+            chunk[2:], allow_empty=True
+        )
+    contains_quote = any(quote in chunk for quote in "\"'`")
+    core = normalize_assignment_context_chunk(chunk)
+    if not core:
+        return True
+    if (
+        is_known_safe_assignment_context_url(core)
+        or ASSIGNMENT_CONTEXT_PATH.fullmatch(core)
+        or is_assignment_context_identifier(core)
+        or ASSIGNMENT_CONTEXT_ENV_REFERENCE.fullmatch(core)
+        or ASSIGNMENT_CONTEXT_ENV_PATH.fullmatch(core)
+        or is_local_path_like_token(core)
+        or is_opencoven_repo_relative_path_token(core)
+        or is_github_action_sha_ref_token(core)
+        or is_macos_library_path_token(core)
+        or is_ordered_alphabet_fixture_token(core)
+    ):
+        return True
+    return not contains_quote and len(core) < 12
+
+
+def is_known_safe_entropy_token(
+    path: str, line: str, token_match: re.Match[str]
+) -> bool:
+    token = token_match.group(0)
+    return bool(
+        re.fullmatch(r"[0-9a-f]{32,64}", token)
+        or is_known_safe_lockfile_token(path, line, token_match)
+        or is_local_path_like_token(token)
+        or is_public_repo_url_like_token(token)
+        or is_opencoven_repo_relative_path_token(token)
+        or is_github_advisory_url_like_token(token)
+        or is_github_commit_url_like_token(token)
+        or is_github_action_sha_ref_token(token)
+        or is_macos_library_path_token(token)
+        or is_apple_dtd_url_token(token)
+        or is_ordered_alphabet_fixture_token(token)
+        or is_discord_support_article_token(token)
+        or is_programming_identifier_token(token)
+    )
+
+
+def is_high_entropy_finding(
+    path: str, line: str, token_match: re.Match[str]
+) -> bool:
+    token = token_match.group(0)
+    return not is_known_safe_entropy_token(
+        path, line, token_match
+    ) and entropy(token) >= 4.3
+
+
+def assignment_trailing_chunk_is_accounted_for(
+    path: str, line: str, chunk_match: re.Match[str]
+) -> bool:
+    chunk = chunk_match.group(0)
+    if is_known_safe_assignment_context_chunk(chunk):
+        return True
+    if any(
+        name != "generic_assignment" and pattern.search(chunk)
+        for name, pattern in SECRET_RULES
+    ):
+        return True
+    return any(
+        is_high_entropy_finding(path, line, token_match)
+        for token_match in ENTROPY_TOKEN.finditer(
+            line, chunk_match.start(), chunk_match.end()
+        )
+    )
+
+
 def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
     hits: list[tuple[str, int, str]] = []
     for line_number, line in enumerate(text.splitlines(), 1):
@@ -428,13 +657,15 @@ def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
                     if not is_known_fake_private_key_match(line, match)
                 ]
             if name == "generic_assignment":
-                unsafe_continuation = has_unsafe_safe_assignment_continuation(line)
+                unsafe_continuation = has_unsafe_safe_assignment_continuation(
+                    path, line
+                )
                 if not matches:
                     if unsafe_continuation:
                         hits.append((path, line_number, name))
                     continue
                 if not unsafe_continuation and all(
-                    is_known_safe_generic_assignment(line, match)
+                    is_known_safe_generic_assignment(path, line, match)
                     for match in matches
                 ):
                     continue
@@ -443,26 +674,8 @@ def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
             if not matches:
                 continue
             hits.append((path, line_number, name))
-        for match in re.finditer(r"\b[A-Za-z0-9_+/@.-]{32,}\b", line):
-            token = match.group(0)
-            if re.fullmatch(r"[0-9a-f]{32,64}", token):
-                continue
-            if (
-                is_known_safe_lockfile_token(path, line, match)
-                or is_local_path_like_token(token)
-                or is_public_repo_url_like_token(token)
-                or is_opencoven_repo_relative_path_token(token)
-                or is_github_advisory_url_like_token(token)
-                or is_github_commit_url_like_token(token)
-                or is_github_action_sha_ref_token(token)
-                or is_macos_library_path_token(token)
-                or is_apple_dtd_url_token(token)
-                or is_ordered_alphabet_fixture_token(token)
-                or is_discord_support_article_token(token)
-                or is_programming_identifier_token(token)
-            ):
-                continue
-            if entropy(token) >= 4.3:
+        for match in ENTROPY_TOKEN.finditer(line):
+            if is_high_entropy_finding(path, line, match):
                 hits.append((path, line_number, "high_entropy"))
     return hits
 

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -22,10 +22,6 @@ LOCKFILE_NODE_MODULE_KEY = re.compile(r'''^\s*["']?node_modules/(?:@?[A-Za-z0-9_
 LOCKFILE_PACKAGE_VERSION_ENTRY = re.compile(r"^\s*['\"]?@?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?['\"]?\s*:\s*\d+\.\d+\.\d+(?:[-+][A-Za-z0-9_.-]+)?\s*$")
 LOCKFILE_INTEGRITY_LINE = re.compile(r'''["']?\bintegrity\b["']?\s*:\s*["']?(?:sha256|sha384|sha512)-[A-Za-z0-9+/=]+["']?''')
 LOCKFILE_RESOLVED_LINE = re.compile(r'''["']?\bresolved\b["']?\s*:\s*["']?https://registry\.npmjs\.org/[A-Za-z0-9_+/@.,~%:-]+\.tgz["']?''')
-OPENCOVEN_GITHUB_URL = re.compile(r"https://github\.com/OpenCoven/coven/(?:blob|tree)/[A-Za-z0-9_./@%+-]+")
-OPENCOVEN_LOCAL_WORKTREE = re.compile(
-    r"/Users/[A-Za-z0-9_.-]+/Documents/GitHub/OpenCoven/coven/\.worktrees/[A-Za-z0-9_.-]+"
-)
 SECRET_RULES: list[tuple[str, re.Pattern[str]]] = [
     ("private_key", re.compile(r"-----BEGIN (?:RSA |DSA |EC |OPENSSH |PGP )?PRIVATE KEY-----")),
     ("aws_access_key", re.compile(r"AKIA[0-9A-Z]{16}")),
@@ -40,16 +36,37 @@ SECRET_RULES: list[tuple[str, re.Pattern[str]]] = [
         ),
     ),
 ]
-ALLOW_LINE = re.compile(
-    r"(?i)(example|placeholder|secret_value|your_|<.*>|op://|secret scanning|secret guard|missing|expected|description|readme|docs/|abcdefghijklmnopqrstuvwxyz|custom-coven-home)"
+GENERIC_ASSIGNMENT_SAFE_VALUE = re.compile(
+    r'''(?ix)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*["']?'''
+    r"(?:"
+    r"<[-A-Za-z0-9_ .]{1,40}>"
+    r"|your_[A-Za-z0-9_.-]{1,64}"
+    r"|(?:placeholder|example|secret_value)(?:[-_][A-Za-z0-9_.-]{1,64})?"
+    r"|op://[A-Za-z0-9_.@/%+-]{1,200}"
+    r")"
+    r'''["']?'''
+)
+RESERVED_EXAMPLE_URL = re.compile(
+    r"(?i)https?://(?:[A-Za-z0-9-]+\.)*"
+    r"(?:example\.(?:com|net|org)|[A-Za-z0-9-]+\.(?:example|invalid|localhost|test))"
+    r"(?::[0-9]{1,5})?(?:/[^\s\"'<>]*)?"
 )
 ENV_SECRET_READ = re.compile(
-    r"(?i)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*"
-    r"(?:os\.environ(?:\.get)?\(|std::env::var\(|env::var\(|process\.env\.)"
+    r'''(?ix)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*
+    (?:
+        os\.environ\.get\(
+            \s*["'][A-Z0-9_]+["']
+            (?:\s*,\s*(?:""|''|None))?
+            \s*
+        \)
+        |std::env::var\(\s*["'][A-Z0-9_]+["']\s*\)
+        |env::var\(\s*["'][A-Z0-9_]+["']\s*\)
+        |process\.env\.[A-Z0-9_]+(?:\.trim\(\)|\?\.trim\(\)|!)?
+    )'''
 )
 ENV_SECRET_REFERENCE = re.compile(
     r"(?i)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*[\"']?"
-    r"\$\{?[A-Z0-9_]+(?:[:?][^\"']*)?\}?"
+    r"(?:\$[A-Z0-9_]+|\$\{[A-Z0-9_]+(?:(?::?\?)[^}\"']*)?\})"
 )
 # A Rust `let` binding whose right-hand side begins with a call expression
 # (identifier chain followed by `(`, e.g. `let token = text.split_whitespace()`).
@@ -59,6 +76,33 @@ ENV_SECRET_REFERENCE = re.compile(
 RUST_LET_CALL_BINDING = re.compile(
     r"^\s*let\s+(?:mut\s+)?[A-Za-z_][A-Za-z0-9_]*\s*(?::[^=]{1,64})?=\s*"
     r"[A-Za-z_][A-Za-z0-9_]*(?:(?:::|\.)[A-Za-z_][A-Za-z0-9_]*)*!?\("
+)
+QUOTED_TEXT = re.compile(r"'[^']*'|\"[^\"]*\"")
+SAFE_ASSIGNMENT_SUFFIX = re.compile(
+    r'''(?x)
+    (?:
+        ["';,.:?)}\]`]+
+        |</[A-Za-z][A-Za-z0-9-]*>
+        |\.(?:strip|trim|unwrap_or_default)\(\)
+    )*
+    '''
+)
+SAFE_FALLBACK_VALUE = re.compile(
+    r'''(?ix)(?:""|''|none|null|undefined)[;,.)}\]]*(?:\s*(?:\#|//).*)?'''
+)
+ASSIGNMENT_CONTINUATION_OPERATOR = re.compile(
+    r"(?is)\s*(\+|\|\||\?\?|or\b)\s*(.*)"
+)
+ORDERED_ALPHABET_FIXTURES = {
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
+}
+KNOWN_PUBLIC_DOCUMENTATION_TOKENS = {
+    "support-dev.discord.com/hc/en-us/articles/"
+    "6207308062871-What-are-Privileged-Intents",
+}
+KNOWN_FAKE_PRIVATE_KEY_FIXTURE = re.compile(
+    r"-----BEGIN PRIVATE KEY-----\\n(?:fake){3,}\\n-----END PRIVATE KEY-----"
 )
 
 
@@ -83,16 +127,108 @@ def is_excluded_path(path: str) -> bool:
     return normalized in EXCLUDED_PATHS
 
 
-def is_known_safe_lockfile_line(path: str, line: str) -> bool:
+def match_is_within(
+    inner: re.Match[str], outer: re.Match[str], *, require_end: bool = True
+) -> bool:
+    if require_end:
+        return outer.start() <= inner.start() and inner.end() <= outer.end()
+    return outer.start() <= inner.start() < outer.end()
+
+
+def assignment_is_covered_by_safe_match(
+    assignment: re.Match[str], safe_match: re.Match[str]
+) -> bool:
+    if assignment.start() < safe_match.start() or assignment.start() >= safe_match.end():
+        return False
+    if assignment.end() <= safe_match.end():
+        return True
+    suffix = assignment.string[safe_match.end() : assignment.end()]
+    return bool(SAFE_ASSIGNMENT_SUFFIX.fullmatch(suffix))
+
+
+def safe_assignment_continuation_is_syntax(
+    line: str, safe_match: re.Match[str]
+) -> bool:
+    tail = line[safe_match.end() :]
+    immediate_suffix = re.match(r"\S*", tail)
+    assert immediate_suffix is not None
+    if not SAFE_ASSIGNMENT_SUFFIX.fullmatch(immediate_suffix.group(0)):
+        return False
+    remainder = tail[immediate_suffix.end() :]
+    continuation = ASSIGNMENT_CONTINUATION_OPERATOR.fullmatch(remainder)
+    if continuation is None:
+        return True
+    operator, fallback = continuation.groups()
+    return operator != "+" and bool(SAFE_FALLBACK_VALUE.fullmatch(fallback))
+
+
+def has_unsafe_safe_assignment_continuation(line: str) -> bool:
+    return any(
+        not safe_assignment_continuation_is_syntax(line, safe_match)
+        for pattern in (
+            GENERIC_ASSIGNMENT_SAFE_VALUE,
+            ENV_SECRET_READ,
+            ENV_SECRET_REFERENCE,
+        )
+        for safe_match in pattern.finditer(line)
+    )
+
+
+def is_known_safe_generic_assignment(
+    line: str, assignment: re.Match[str]
+) -> bool:
+    for pattern in (
+        GENERIC_ASSIGNMENT_SAFE_VALUE,
+        ENV_SECRET_READ,
+        ENV_SECRET_REFERENCE,
+    ):
+        if any(
+            assignment_is_covered_by_safe_match(assignment, match)
+            and safe_assignment_continuation_is_syntax(line, match)
+            for match in pattern.finditer(line)
+        ):
+            return True
+
+    if any(
+        assignment_is_covered_by_safe_match(assignment, match)
+        for match in RESERVED_EXAMPLE_URL.finditer(line)
+    ):
+        return True
+
+    rust_binding = RUST_LET_CALL_BINDING.match(line)
+    if rust_binding and match_is_within(
+        assignment, rust_binding, require_end=False
+    ):
+        return True
+
+    if "grep" in line and re.search(r"-[A-Za-z]*E\b", line):
+        if any(
+            match_is_within(assignment, quoted)
+            for quoted in QUOTED_TEXT.finditer(line)
+        ):
+            return True
+
+    return False
+
+
+def is_known_safe_lockfile_token(
+    path: str, line: str, token_match: re.Match[str]
+) -> bool:
     if not is_lockfile_path(path):
         return False
+
+    for pattern in (LOCKFILE_INTEGRITY_LINE, LOCKFILE_RESOLVED_LINE):
+        if any(
+            match_is_within(token_match, safe_match)
+            for safe_match in pattern.finditer(line)
+        ):
+            return True
+
     stripped = line.strip()
     return bool(
-        LOCKFILE_INTEGRITY_LINE.search(stripped)
-        or LOCKFILE_RESOLVED_LINE.search(stripped)
-        or LOCKFILE_NODE_MODULE_KEY.match(stripped)
-        or LOCKFILE_PACKAGE_KEY.match(stripped)
-        or LOCKFILE_PACKAGE_VERSION_ENTRY.match(stripped)
+        LOCKFILE_NODE_MODULE_KEY.fullmatch(stripped)
+        or LOCKFILE_PACKAGE_KEY.fullmatch(stripped)
+        or LOCKFILE_PACKAGE_VERSION_ENTRY.fullmatch(stripped)
     )
 
 
@@ -196,11 +332,20 @@ def is_apple_dtd_url_token(token: str) -> bool:
     return bool(_APPLE_DTD_URL_TOKEN.fullmatch(token))
 
 
-def is_known_fake_private_key_fixture(line: str) -> bool:
-    return (
-        "-----BEGIN PRIVATE KEY-----" in line
-        and "\\nfakefakefake" in line
-        and "\\n-----END PRIVATE KEY-----" in line
+def is_ordered_alphabet_fixture_token(token: str) -> bool:
+    return token in ORDERED_ALPHABET_FIXTURES
+
+
+def is_discord_support_article_token(token: str) -> bool:
+    return token in KNOWN_PUBLIC_DOCUMENTATION_TOKENS
+
+
+def is_known_fake_private_key_match(
+    line: str, private_key_match: re.Match[str]
+) -> bool:
+    return any(
+        match_is_within(private_key_match, fixture_match)
+        for fixture_match in KNOWN_FAKE_PRIVATE_KEY_FIXTURE.finditer(line)
     )
 
 
@@ -243,35 +388,37 @@ def is_programming_identifier_token(token: str) -> bool:
 def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
     hits: list[tuple[str, int, str]] = []
     for line_number, line in enumerate(text.splitlines(), 1):
-        allow = bool(ALLOW_LINE.search(line))
         for name, pattern in SECRET_RULES:
-            if name == "private_key" and is_known_fake_private_key_fixture(line):
-                continue
-            if name == "generic_assignment" and ENV_SECRET_READ.search(line):
-                continue
-            if name == "generic_assignment" and ENV_SECRET_REFERENCE.search(line):
-                continue
-            if name == "generic_assignment" and RUST_LET_CALL_BINDING.match(line):
-                continue
-            if name == "generic_assignment" and "grep" in line and re.search(r"-[A-Za-z]*E\b", line):
-                continue
-            if pattern.search(line) and not (allow and name != "private_key"):
+            matches = list(pattern.finditer(line))
+            if name == "private_key":
+                matches = [
+                    match
+                    for match in matches
+                    if not is_known_fake_private_key_match(line, match)
+                ]
+            if name == "generic_assignment":
+                unsafe_continuation = has_unsafe_safe_assignment_continuation(line)
+                if not matches:
+                    if unsafe_continuation:
+                        hits.append((path, line_number, name))
+                    continue
+                if not unsafe_continuation and all(
+                    is_known_safe_generic_assignment(line, match)
+                    for match in matches
+                ):
+                    continue
                 hits.append((path, line_number, name))
-        if allow:
-            continue
-        if (
-            OPENCOVEN_GITHUB_URL.search(line)
-            or OPENCOVEN_LOCAL_WORKTREE.search(line)
-        ):
-            continue
-        if is_known_safe_lockfile_line(path, line):
-            continue
+                continue
+            if not matches:
+                continue
+            hits.append((path, line_number, name))
         for match in re.finditer(r"\b[A-Za-z0-9_+/@.-]{32,}\b", line):
             token = match.group(0)
             if re.fullmatch(r"[0-9a-f]{32,64}", token):
                 continue
             if (
-                is_local_path_like_token(token)
+                is_known_safe_lockfile_token(path, line, match)
+                or is_local_path_like_token(token)
                 or is_public_repo_url_like_token(token)
                 or is_opencoven_repo_relative_path_token(token)
                 or is_github_advisory_url_like_token(token)
@@ -279,6 +426,8 @@ def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
                 or is_github_action_sha_ref_token(token)
                 or is_macos_library_path_token(token)
                 or is_apple_dtd_url_token(token)
+                or is_ordered_alphabet_fixture_token(token)
+                or is_discord_support_article_token(token)
                 or is_programming_identifier_token(token)
             ):
                 continue

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -103,7 +103,7 @@ SAFE_ASSIGNMENT_SUFFIX = re.compile(
     (?:
         ["';,.:?)}\]`]+
         |</[A-Za-z][A-Za-z0-9-]*>
-        |\.(?:strip|trim|unwrap_or_default)\(\)
+        |\.(?:strip|to_string|trim|unwrap_or_default)\(\)
     )*
     '''
 )
@@ -118,8 +118,7 @@ ORDERED_ALPHABET_FIXTURES = {
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV",
 }
 KNOWN_PUBLIC_DOCUMENTATION_TOKENS = {
-    "support-dev.discord.com/hc/en-us/articles/"
-    "6207308062871-What-are-Privileged-Intents",
+    "support-dev.discord.com/hc/en-us/articles/6207308062871-What-are-Privileged-Intents",
 }
 KNOWN_FAKE_PRIVATE_KEY_FIXTURE = re.compile(
     r"-----BEGIN PRIVATE KEY-----\\n(?:fake){3,}\\n-----END PRIVATE KEY-----"
@@ -226,6 +225,7 @@ def is_known_safe_generic_assignment(
 
     if any(
         assignment_is_covered_by_safe_match(assignment, match)
+        and safe_assignment_continuation_is_syntax(line, match)
         for match in RESERVED_EXAMPLE_URL.finditer(line)
     ):
         return True


### PR DESCRIPTION
## Context

- Summary: harden the repository secret guard so safe examples exempt only their own match or token, never the rest of the line.
- Files changed: `scripts/check-secrets.py`, `scripts/check-secrets-test.py`
- Closes #494

## Implementation

- Approach: remove the broad line-level allow switch and replace it with match-scoped generic-assignment exceptions plus token-scoped entropy exceptions. Structural secret rules now always run.
- User-visible behavior: credentials and high-entropy payloads are reported even when the same line contains HTML, placeholders, documentation URLs, worktree paths, lockfile metadata, or other safe context.
- Compatibility notes: exact placeholders, environment references/reads, reserved and public documentation URLs, known fixtures, lockfile fields, repository paths, bounded empty/none fallbacks, and exact known runtime-derived Rust bindings remain accepted. Adjacent, operator-based, whitespace-separated, quoted, shell-escaped, punctuation-separated, path/URL/reference-smuggled, and passphrase-shaped literal payloads fail closed.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] Additional checks:
  - `python3 scripts/check-secrets-test.py` (69/69)
  - `python3 -m py_compile scripts/check-secrets.py scripts/check-secrets-test.py`
  - `python3 scripts/check-coven-privacy.py --staged`
  - `gitleaks protect --staged --no-banner --redact`
  - independent adversarial review: final verdict READY, no Critical or Important findings
- [x] GitHub CI run 30233425671: all 9 jobs passed
- [x] Copilot new-head review: no new comments

## Risk and Rollback

- Risk level: medium; this changes CI scanner exception matching and could expose previously masked false positives.
- Rollback plan: revert the PR's squash commit to restore the prior scanner behavior.

## Agent Handoff

- Current state: final reviewed head `3146981` is pushed, locally verified, and green on GitHub.
- Follow-ups: maintainer review and squash-merge.
- Known gaps: none.