### PR TITLE
feat(ward): add deterministic coherence probes (Gate 3 PR 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,6 +675,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
  "sha2 0.11.0",
  "sysinfo",
  "tempfile",
@@ -3851,6 +3852,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4779,6 +4793,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "time",
  "toml",
  "toml_edit",
+ "unicode-normalization",
  "unicode-width",
  "uuid",
  "widestring",
@@ -4405,6 +4406,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4733,6 +4749,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -37,6 +37,7 @@ regex = "1"
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml_ng = "0.10"
 sha2 = "0.11"
 toml = "1.1"
 toml_edit = { version = "0.25", features = ["serde"] }

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -41,6 +41,7 @@ serde_yaml_ng = "0.10"
 sha2 = "0.11"
 toml = "1.1"
 toml_edit = { version = "0.25", features = ["serde"] }
+unicode-normalization = "0.1"
 uuid = { version = "1", features = ["v4", "v5"] }
 sysinfo = "0.39"
 dirs-next = "2"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2725,6 +2725,22 @@ fn apply_familiar_edits(
             Some(json!({ "changes": changes })),
         );
     }
+    let mut resolved_targets = HashSet::with_capacity(adjudication.decisions.len());
+    if let Some(duplicate) = adjudication
+        .decisions
+        .iter()
+        .find(|decision| !resolved_targets.insert(decision.resolved.as_str()))
+    {
+        return api_error(
+            400,
+            "invalid_request",
+            "Each edit must resolve to a unique familiar surface.",
+            Some(json!({
+                "resolved": duplicate.resolved.as_str(),
+                "target": duplicate.target.as_str(),
+            })),
+        );
+    }
     let gated_targets: Vec<String> = adjudication
         .decisions
         .iter()
@@ -2968,6 +2984,7 @@ fn familiar_ward_response(coven_home: &Path, familiar_id: &str) -> Result<ApiRes
                 "defaultTier": config.default_tier,
                 "surface": config.surface,
                 "protectedSurface": config.protected_surface,
+                "probes": config.probe,
             },
         }),
     )
@@ -3218,6 +3235,17 @@ fn threads_proposals_response(coven_home: &Path, id: Option<&str>) -> Result<Api
             }));
             continue;
         };
+        let (mut probes, mut probe_evidence_degraded) = match raw_value.get("probes") {
+            Some(value) => {
+                match serde_json::from_value::<Vec<crate::ward_probes::SurfaceProbeReport>>(
+                    value.clone(),
+                ) {
+                    Ok(probes) => (Some(probes), None),
+                    Err(_) => (None, Some("proposal-probes-unparseable")),
+                }
+            }
+            None => (None, None),
+        };
         let mut proposal_value = raw_value.clone();
         if let Some(object) = proposal_value.as_object_mut() {
             object.remove("decisionRequest");
@@ -3268,11 +3296,35 @@ fn threads_proposals_response(coven_home: &Path, id: Option<&str>) -> Result<Api
             }));
             continue;
         };
+        if let Some(reports) = probes.as_deref() {
+            let workspace = crate::cockpit_sources::familiar_workspace(coven_home, &familiar_id);
+            let validation = match ward::WardConfig::load(&workspace) {
+                Ok(Some(config)) => crate::ward_probes::validate_staged_reports(
+                    &workspace, &config, proposal, reports,
+                ),
+                Ok(None) | Err(_) => crate::ward_probes::ProbeEvidenceValidation::Inconsistent,
+            };
+            match validation {
+                crate::ward_probes::ProbeEvidenceValidation::Valid => {}
+                crate::ward_probes::ProbeEvidenceValidation::Stale => {
+                    probes = None;
+                    probe_evidence_degraded = Some("proposal-probes-stale");
+                }
+                crate::ward_probes::ProbeEvidenceValidation::Inconsistent => {
+                    probes = None;
+                    probe_evidence_degraded = Some("proposal-probes-inconsistent");
+                }
+            }
+        }
         let targets: Vec<String> = proposal
             .edits
             .iter()
             .map(|edit| edit.surface.as_str().to_string())
             .collect();
+        let probe_summary = probes
+            .as_deref()
+            .map(crate::ward_probes::ProbeSummary::from_reports)
+            .unwrap_or_else(|| crate::ward_probes::ProbeSummary::unscored_targets(targets.len()));
         let format = time::format_description::well_known::Rfc3339;
         let mut view = json!({
             "proposalId": proposal.id.0.to_string(),
@@ -3282,7 +3334,21 @@ fn threads_proposals_response(coven_home: &Path, id: Option<&str>) -> Result<Api
             "stagedAt": proposal.staged_at.format(&format).ok(),
             "targets": targets,
             "proposalRevision": proposal_revision(&proposal_value)?,
+            "probeSummary": probe_summary,
         });
+        if let Some(reason) = probe_evidence_degraded {
+            view.as_object_mut()
+                .expect("proposal view is always a JSON object")
+                .insert(
+                    "probeEvidenceDegraded".to_string(),
+                    json!({ "reason": reason }),
+                );
+        }
+        if id.is_some() {
+            view.as_object_mut()
+                .expect("proposal view is always a JSON object")
+                .insert("probes".to_string(), json!(probes.unwrap_or_default()));
+        }
         if let Some(scheduled) = &scheduled {
             let approval_path = coven_threads_core::ApprovalPathWireEnvelope::from_classification(
                 scheduled.classification(),
@@ -8791,6 +8857,10 @@ tier = 0
 [[surface]]
 path = "memory/"
 tier = 2
+
+[[probe]]
+surface = "memory/**"
+id = "size-delta"
 "#,
         )?;
 
@@ -8809,6 +8879,8 @@ tier = 2
         assert_eq!(body["ward"]["surface"][1]["path"], "memory/");
         assert_eq!(body["ward"]["surface"][1]["tier"], 2);
         assert_eq!(body["ward"]["protectedSurface"][0], "SOUL.md");
+        assert_eq!(body["ward"]["probes"][0]["surface"], "memory/**");
+        assert_eq!(body["ward"]["probes"][0]["id"], "size-delta");
         Ok(())
     }
 
@@ -8868,6 +8940,15 @@ tier = 2
         assert_eq!(listed["familiarId"], "sage");
         assert_eq!(listed["reviewKind"], "coherence");
         assert_eq!(listed["targets"][0], "reviewed/skill.md");
+        assert_eq!(listed["probeSummary"]["status"], "passed");
+        assert_eq!(listed["probeSummary"]["passed"], 2);
+        assert_eq!(listed["probeSummary"]["failed"], 0);
+        assert_eq!(listed["probeSummary"]["unscored"], 0);
+        assert_eq!(listed["probeSummary"]["targets"], 1);
+        assert!(
+            listed.get("probes").is_none(),
+            "the list route must expose only the compact summary"
+        );
 
         // Detail returns the same record; unknown and malformed ids fail
         // closed with the structured shapes.
@@ -8880,6 +8961,17 @@ tier = 2
         assert_eq!(response.status, 200);
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
         assert_eq!(body["proposal"]["reviewKind"], "coherence");
+        assert_eq!(body["proposal"]["probeSummary"]["status"], "passed");
+        assert_eq!(body["proposal"]["probes"][0]["target"], "reviewed/skill.md");
+        assert_eq!(body["proposal"]["probes"][0]["status"], "passed");
+        assert_eq!(
+            body["proposal"]["probes"][0]["results"][0]["id"],
+            "size-delta"
+        );
+        assert_eq!(
+            body["proposal"]["probes"][0]["results"][1]["id"],
+            "pattern-lint"
+        );
 
         let response = handle_request(
             "GET",
@@ -8976,7 +9068,166 @@ tier = 2
         assert_eq!(listed["lifecycle"], "veto_window_open");
         assert_eq!(listed["earliestClose"], "2023-11-14T22:14:20Z");
         assert_eq!(listed["affectedRegions"][0], "tool_defaults");
+        assert_eq!(listed["probeSummary"]["status"], "unscored");
+        assert_eq!(listed["probeSummary"]["unscored"], 1);
         assert!(listed.get("reviewKind").is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn threads_proposals_degrades_malformed_probe_evidence() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+        let staged = post_edits(
+            home,
+            r#"{"edits":[{"target":"reviewed/skill.md","contents":"tweak"}]}"#,
+        )?;
+        let body: serde_json::Value = serde_json::from_str(&staged.body)?;
+        let pending_path = PathBuf::from(body["pendingPath"].as_str().context("pending path")?);
+        let mut value: serde_json::Value = serde_json::from_slice(&std::fs::read(&pending_path)?)?;
+        value["probes"] = serde_json::json!({"not": "an array"});
+        std::fs::write(&pending_path, serde_json::to_vec_pretty(&value)?)?;
+
+        let response = handle_request("GET", "/api/v1/threads/proposals", home, None)?;
+
+        assert_eq!(response.status, 200, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(
+            body["proposals"][0]["probeEvidenceDegraded"]["reason"],
+            "proposal-probes-unparseable"
+        );
+        assert_eq!(body["proposals"][0]["probeSummary"]["status"], "unscored");
+        assert_eq!(body["proposals"][0]["probeSummary"]["targets"], 1);
+        assert_eq!(body["proposals"][0]["probeSummary"]["unscored"], 1);
+        Ok(())
+    }
+
+    #[test]
+    fn threads_proposals_demotes_inconsistent_probe_evidence_to_unscored() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let workspace = seed_warded_familiar(home)?;
+        let staged = post_edits(
+            home,
+            r#"{"edits":[{"target":"reviewed/skill.md","contents":"tweak"}]}"#,
+        )?;
+        let body: serde_json::Value = serde_json::from_str(&staged.body)?;
+        let proposal_id = body["proposalId"].as_str().context("proposal id")?;
+        let pending_path = PathBuf::from(body["pendingPath"].as_str().context("pending path")?);
+        let original: serde_json::Value = serde_json::from_slice(&std::fs::read(&pending_path)?)?;
+        let mut wrong_target = original.clone();
+        wrong_target["probes"][0]["target"] = serde_json::json!("reviewed/other.md");
+        let mut wrong_surface = original.clone();
+        wrong_surface["probes"][0]["surface"] = serde_json::json!("reviewed/other.md");
+        let mut wrong_hash = original.clone();
+        wrong_hash["probes"][0]["proposedSha256"] = serde_json::json!("0".repeat(64));
+        let mut wrong_baseline = original.clone();
+        wrong_baseline["probes"][0]["baselineSha256"] = serde_json::json!("0".repeat(64));
+        let mut contradictory_status = original.clone();
+        contradictory_status["probes"][0]["status"] = serde_json::json!("failed");
+        let mut inner_result_tamper = original.clone();
+        inner_result_tamper["probes"][0]["results"][1]["status"] = serde_json::json!("failed");
+        inner_result_tamper["probes"][0]["results"][1]["summary"] =
+            serde_json::json!("Tampered result.");
+        inner_result_tamper["probes"][0]["status"] = serde_json::json!("failed");
+        let cases = [
+            ("empty coverage", {
+                let mut value = original.clone();
+                value["probes"] = serde_json::json!([]);
+                (value, "proposal-probes-inconsistent")
+            }),
+            (
+                "wrong target",
+                (wrong_target, "proposal-probes-inconsistent"),
+            ),
+            (
+                "wrong surface",
+                (wrong_surface, "proposal-probes-inconsistent"),
+            ),
+            (
+                "wrong proposed hash",
+                (wrong_hash, "proposal-probes-inconsistent"),
+            ),
+            (
+                "wrong baseline hash",
+                (wrong_baseline, "proposal-probes-stale"),
+            ),
+            (
+                "contradictory aggregate status",
+                (contradictory_status, "proposal-probes-inconsistent"),
+            ),
+            (
+                "coordinated inner-result tamper",
+                (inner_result_tamper, "proposal-probes-inconsistent"),
+            ),
+        ];
+
+        for (case, (value, expected_reason)) in cases {
+            std::fs::write(&pending_path, serde_json::to_vec_pretty(&value)?)?;
+            let response = handle_request(
+                "GET",
+                &format!("/api/v1/threads/proposals/{proposal_id}"),
+                home,
+                None,
+            )?;
+
+            assert_eq!(response.status, 200, "{case}: got {}", response.body);
+            let body: serde_json::Value = serde_json::from_str(&response.body)?;
+            assert_eq!(
+                body["proposal"]["probeSummary"]["status"], "unscored",
+                "{case}"
+            );
+            assert_eq!(body["proposal"]["probeSummary"]["targets"], 1, "{case}");
+            assert_eq!(body["proposal"]["probeSummary"]["unscored"], 1, "{case}");
+            assert_eq!(
+                body["proposal"]["probeEvidenceDegraded"]["reason"], expected_reason,
+                "{case}"
+            );
+            assert_eq!(body["proposal"]["probes"], serde_json::json!([]), "{case}");
+        }
+
+        std::fs::create_dir_all(workspace.join("reviewed"))?;
+        std::fs::write(workspace.join("reviewed/skill.md"), "drifted baseline")?;
+        std::fs::write(&pending_path, serde_json::to_vec_pretty(&original)?)?;
+        let response = handle_request(
+            "GET",
+            &format!("/api/v1/threads/proposals/{proposal_id}"),
+            home,
+            None,
+        )?;
+        assert_eq!(
+            response.status, 200,
+            "baseline drift: got {}",
+            response.body
+        );
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["proposal"]["probeSummary"]["status"], "unscored");
+        assert_eq!(
+            body["proposal"]["probeEvidenceDegraded"]["reason"],
+            "proposal-probes-stale"
+        );
+
+        std::fs::write(&pending_path, serde_json::to_vec_pretty(&original)?)?;
+        let ward_path = workspace.join("ward.toml");
+        let ward_toml = std::fs::read_to_string(&ward_path)?;
+        let changed_ward_toml =
+            ward_toml.replace("(?i)ignore previous", "(?i)different forbidden pattern");
+        assert_ne!(changed_ward_toml, ward_toml);
+        std::fs::write(&ward_path, changed_ward_toml)?;
+        let response = handle_request(
+            "GET",
+            &format!("/api/v1/threads/proposals/{proposal_id}"),
+            home,
+            None,
+        )?;
+        assert_eq!(response.status, 200, "config drift: got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["proposal"]["probeSummary"]["status"], "unscored");
+        assert_eq!(
+            body["proposal"]["probeEvidenceDegraded"]["reason"],
+            "proposal-probes-inconsistent"
+        );
         Ok(())
     }
 
@@ -9139,6 +9390,15 @@ tier = 0
 [[surface]]
 path = "reviewed/"
 tier = 1
+
+[[probe]]
+surface = "reviewed/**"
+id = "size-delta"
+
+[[probe]]
+surface = "reviewed/**"
+id = "pattern-lint"
+forbidden = ["(?i)ignore previous"]
 "#,
         )?;
         Ok(workspace)
@@ -9181,6 +9441,28 @@ tier = 1
             std::fs::read_to_string(workspace.join("notes/today.md"))?,
             "hello ward"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn post_familiar_edits_rejects_duplicate_resolved_targets() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        seed_warded_familiar(home)?;
+
+        let response = post_edits(
+            home,
+            r#"{"edits":[
+                {"target":"reviewed/skill.md","contents":"first"},
+                {"target":"reviewed/../reviewed/skill.md","contents":"second"}
+            ]}"#,
+        )?;
+
+        assert_eq!(response.status, 400, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "invalid_request");
+        assert_eq!(body["error"]["details"]["resolved"], "reviewed/skill.md");
+        assert!(!home.join("pending").exists());
         Ok(())
     }
 
@@ -11351,6 +11633,9 @@ tier = 0
         let raw = std::fs::read_to_string(&pending_path)?;
         let staged: serde_json::Value = serde_json::from_str(&raw)?;
         assert_eq!(staged["reviewKind"], "coherence");
+        assert_eq!(staged["probes"][0]["surface"], "reviewed/skill.md");
+        assert_eq!(staged["probes"][0]["status"], "passed");
+        assert_eq!(staged["probes"][0]["results"].as_array().unwrap().len(), 2);
         let parsed: coven_threads_core::PendingProposal = serde_json::from_str(&raw)?;
         assert_eq!(parsed.id.0.to_string(), body["proposalId"]);
         assert_eq!(parsed.edits.len(), 1);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2729,7 +2729,7 @@ fn apply_familiar_edits(
     if let Some(duplicate) = adjudication
         .decisions
         .iter()
-        .find(|decision| !resolved_targets.insert(decision.resolved.as_str()))
+        .find(|decision| !resolved_targets.insert(ward::portable_surface_key(&decision.resolved)))
     {
         return api_error(
             400,
@@ -9462,6 +9462,37 @@ forbidden = ["(?i)ignore previous"]
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
         assert_eq!(body["error"]["code"], "invalid_request");
         assert_eq!(body["error"]["details"]["resolved"], "reviewed/skill.md");
+        assert!(!home.join("pending").exists());
+
+        let response = post_edits(
+            home,
+            r#"{"edits":[
+                {"target":"reviewed/skill.md","contents":"first"},
+                {"target":"reviewed/SKILL.md","contents":"second"}
+            ]}"#,
+        )?;
+
+        assert_eq!(response.status, 400, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "invalid_request");
+        assert_eq!(body["error"]["details"]["resolved"], "reviewed/SKILL.md");
+        assert!(!home.join("pending").exists());
+
+        let response = post_edits(
+            home,
+            r#"{"edits":[
+                {"target":"reviewed/caf\u00e9.md","contents":"first"},
+                {"target":"reviewed/cafe\u0301.md","contents":"second"}
+            ]}"#,
+        )?;
+
+        assert_eq!(response.status, 400, "got {}", response.body);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "invalid_request");
+        assert_eq!(
+            body["error"]["details"]["resolved"],
+            "reviewed/cafe\u{301}.md"
+        );
         assert!(!home.join("pending").exists());
         Ok(())
     }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -45,9 +45,10 @@ mod stream_json;
 mod theme;
 mod tui;
 mod verification;
-// Ward identity-layer enforcement (Gates 1-2). Not yet wired into the API
+mod ward_probes;
 // Wired into the daemon router via `POST /familiars/{id}/edits` (api.rs);
-// Gate 3 (coherence review) remains a follow-up — see ward.rs.
+// Gate 3 staging, read surfaces, and deterministic probes are present;
+// coherence approval remains a follow-up — see ward.rs.
 #[allow(dead_code)]
 mod ward;
 mod ward_migrate;
@@ -4562,10 +4563,10 @@ mod tests {
         assert!(frame.contains("/start"));
         assert!(frame.contains("/help"));
         assert!(frame.contains("/run"));
-        // Selection arrow uses the thin guillemet (U+203A), not ASCII `>`.
+        // Selection arrow uses the thin guillemet (Unicode 203A), not ASCII `>`.
         assert!(
             frame.contains('›'),
-            "selected row should render with U+203A"
+            "selected row should render with Unicode 203A"
         );
     }
 
@@ -4690,12 +4691,12 @@ mod tests {
             let allowed = ch == '\n'
                 || ch == '\r'
                 || ch.is_ascii()
-                || ch == '─'   // U+2500 thin horizontal rule
-                || ch == '›'   // U+203A selected-row marker
-                || ch == '·'   // U+00B7 separator
+                || ch == '─'   // Unicode 2500 thin horizontal rule
+                || ch == '›'   // Unicode 203A selected-row marker
+                || ch == '·'   // Unicode 00B7 separator
                 || ch == '↑'
                 || ch == '↓'
-                || ch == '…'; // U+2026 truncation marker from fit_chars
+                || ch == '…'; // Unicode 2026 truncation marker from fit_chars
             assert!(
                 allowed,
                 "unexpected glyph in launcher frame: {ch:?} (U+{code:04X})"

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -530,8 +530,8 @@ fn render_ward_pending(body: &Value) -> String {
     }
     let mut out = String::new();
     out.push_str(&format!(
-        "{:<38} {:<12} {:<10} {:<22} targets\n",
-        "proposal", "familiar", "review", "staged"
+        "{:<38} {:<12} {:<10} {:<10} {:<22} targets\n",
+        "proposal", "familiar", "review", "probes", "staged"
     ));
     for proposal in &proposals {
         if let Some(degraded) = proposal.get("degraded") {
@@ -543,10 +543,14 @@ fn render_ward_pending(body: &Value) -> String {
             continue;
         }
         out.push_str(&format!(
-            "{:<38} {:<12} {:<10} {:<22} {}\n",
+            "{:<38} {:<12} {:<10} {:<10} {:<22} {}\n",
             str_cell(proposal, "proposalId"),
             str_cell(proposal, "familiarId"),
             str_cell(proposal, "reviewKind"),
+            proposal
+                .get("probeSummary")
+                .map(|summary| str_cell(summary, "status"))
+                .unwrap_or_else(|| "unscored".to_string()),
             str_cell(proposal, "stagedAt"),
             proposal
                 .get("targets")
@@ -588,6 +592,66 @@ fn render_ward_proposal(proposal: &Value) -> String {
     if let Some(targets) = proposal.get("targets").and_then(Value::as_array) {
         for target in targets.iter().filter_map(Value::as_str) {
             out.push_str(&format!("    {target}\n"));
+        }
+    }
+    out.push_str(&format!(
+        "  probe set  {}\n",
+        proposal
+            .get("probeSummary")
+            .map(|summary| str_cell(summary, "status"))
+            .unwrap_or_else(|| "unscored".to_string())
+    ));
+    if let Some(reason) = proposal
+        .get("probeEvidenceDegraded")
+        .and_then(|degraded| degraded.get("reason"))
+        .and_then(Value::as_str)
+    {
+        out.push_str(&format!("  probe evidence degraded: {reason}\n"));
+    }
+    out.push_str("  probes\n");
+    let probes = proposal
+        .get("probes")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if probes.is_empty() {
+        out.push_str("    unscored (no staged probe evidence)\n");
+    }
+    for report in &probes {
+        out.push_str(&format!(
+            "    {} [{}]\n",
+            str_cell(report, "surface"),
+            str_cell(report, "status")
+        ));
+        out.push_str(&format!(
+            "      baseline {}\n",
+            report
+                .get("baselineSha256")
+                .and_then(Value::as_str)
+                .unwrap_or("(absent)")
+        ));
+        out.push_str(&format!(
+            "      proposed {}\n",
+            str_cell(report, "proposedSha256")
+        ));
+        if let Some(error) = report.get("error").and_then(Value::as_str) {
+            out.push_str(&format!("      error    {error}\n"));
+        }
+        for result in report
+            .get("results")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+        {
+            out.push_str(&format!(
+                "      {} [{}] — {}\n",
+                str_cell(result, "id"),
+                str_cell(result, "status"),
+                str_cell(result, "summary")
+            ));
+            if let Some(detail) = result.get("detail").filter(|detail| !detail.is_null()) {
+                out.push_str(&format!("        {}\n", detail));
+            }
         }
     }
     out
@@ -1474,6 +1538,97 @@ mod tests {
     use serde_json::json;
 
     #[test]
+    fn ward_pending_renderer_surfaces_probe_summary() {
+        let body = json!({
+            "proposals": [{
+                "proposalId": "proposal-1",
+                "familiarId": "sage",
+                "reviewKind": "coherence",
+                "stagedAt": "2026-07-27T00:00:00Z",
+                "targets": ["reviewed/SKILL.md"],
+                "probeSummary": {
+                    "status": "failed",
+                    "passed": 2,
+                    "failed": 1,
+                    "unscored": 0,
+                    "targets": 1
+                }
+            }]
+        });
+
+        let rendered = render_ward_pending(&body);
+
+        assert!(rendered.contains("probes"), "{rendered}");
+        assert!(rendered.contains("failed"), "{rendered}");
+    }
+
+    #[test]
+    fn ward_proposal_renderer_surfaces_full_probe_evidence() {
+        let proposal = json!({
+            "proposalId": "proposal-1",
+            "familiarId": "sage",
+            "reviewKind": "coherence",
+            "writer": "client:unsigned",
+            "stagedAt": "2026-07-27T00:00:00Z",
+            "targets": ["reviewed/SKILL.md"],
+            "probeSummary": {
+                "status": "passed",
+                "passed": 1,
+                "failed": 0,
+                "unscored": 0,
+                "targets": 1
+            },
+            "probes": [{
+                "surface": "reviewed/SKILL.md",
+                "baselineSha256": null,
+                "proposedSha256": "abc123",
+                "status": "passed",
+                "results": [{
+                    "id": "size-delta",
+                    "configuredSurface": "reviewed/**",
+                    "status": "passed",
+                    "summary": "Size delta calculated.",
+                    "detail": {"beforeBytes": 0, "afterBytes": 12}
+                }]
+            }]
+        });
+
+        let rendered = render_ward_proposal(&proposal);
+
+        assert!(
+            rendered.contains("reviewed/SKILL.md [passed]"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("size-delta [passed]"), "{rendered}");
+        assert!(rendered.contains("beforeBytes"), "{rendered}");
+    }
+
+    #[test]
+    fn ward_proposal_renderer_surfaces_degraded_probe_evidence() {
+        let proposal = json!({
+            "proposalId": "proposal-1",
+            "probeSummary": {
+                "status": "unscored",
+                "passed": 0,
+                "failed": 0,
+                "unscored": 1,
+                "targets": 1
+            },
+            "probeEvidenceDegraded": {
+                "reason": "proposal-probes-inconsistent"
+            },
+            "probes": []
+        });
+
+        let rendered = render_ward_proposal(&proposal);
+
+        assert!(
+            rendered.contains("probe evidence degraded: proposal-probes-inconsistent"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
     fn ward_audit_path_rejects_ambiguous_event_query_values() {
         for event in [
             "apply_audit&limit=1",
@@ -1645,7 +1800,7 @@ mod tests {
         let body = json!({
             "ok": true,
             "familiarId": "sage",
-            "workspace": "/home/x/.coven/familiars/sage",
+            "workspace": "/var/tmp/coven-test/familiars/sage",
             "ward": {
                 "principalKeyFingerprint": "SHA256:principal-key",
                 "defaultTier": 2,
@@ -1660,7 +1815,7 @@ mod tests {
         let text = render_familiar_ward(&body);
 
         assert!(text.contains("Familiar sage — Ward surface"));
-        assert!(text.contains("/home/x/.coven/familiars/sage"));
+        assert!(text.contains("/var/tmp/coven-test/familiars/sage"));
         assert!(text.contains("SHA256:principal-key"));
         assert!(text.contains("tier 2 (logged)"));
         assert!(text.contains("protected"));

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -431,12 +431,9 @@ pub(crate) fn read_surface_if_exists(workspace: &Path, surface: &str) -> Result<
     // component, so canonicalize the deepest *existing* ancestor and require
     // it to stay inside the canonical workspace (second review pass finding —
     // `linkdir/secret` with `linkdir` pointing outside must refuse).
-    let canonical_workspace = workspace.canonicalize().with_context(|| {
-        format!(
-            "familiar workspace `{}` is not resolvable",
-            workspace.display()
-        )
-    })?;
+    let canonical_workspace = workspace
+        .canonicalize()
+        .with_context(|| format!("familiar workspace for surface `{surface}` is not resolvable"))?;
     let mut ancestor = path.parent();
     let deepest_existing = loop {
         match ancestor {
@@ -855,9 +852,9 @@ fn stage_pending_proposal(
         .with_context(|| format!("creating {}", pending_dir.display()))?;
     let path = pending_dir.join(proposal.file_name());
     let body = {
-        /// On-disk pending-proposal shape: the core type plus the optional
-        /// lane marker (absent ⇒ authority, so existing files and the core
-        /// deserializer keep working unchanged).
+        /// On-disk pending-proposal shape: the core type plus additive lane
+        /// and probe-evidence sidecars. An absent lane still means authority;
+        /// existing files and the core deserializer keep working unchanged.
         #[derive(serde::Serialize)]
         struct StagedProposalFile<'a> {
             #[serde(flatten)]
@@ -1342,6 +1339,20 @@ tier = 0
     #[test]
     fn surface_read_errors_name_only_the_logical_surface() {
         let f = fixture();
+        let missing_workspace = f.workspace.join("missing-workspace");
+        let missing_error = read_surface_if_exists(&missing_workspace, "reviewed/file.md")
+            .expect_err("a missing workspace must refuse");
+        let missing_rendered = format!("{missing_error:#}");
+
+        assert!(
+            missing_rendered.contains("reviewed/file.md"),
+            "{missing_rendered}"
+        );
+        assert!(
+            !missing_rendered.contains(&missing_workspace.display().to_string()),
+            "{missing_rendered}"
+        );
+
         std::os::unix::fs::symlink("loop", f.workspace.join("loop")).unwrap();
 
         let error = read_surface_if_exists(&f.workspace, "loop/file.md")

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -224,6 +224,11 @@ pub fn gate_protected_edits(conn: &Connection, req: &GateRequest<'_>) -> Result<
             },
             edits,
             now,
+            StagingProbeContext {
+                workspace,
+                config,
+                authorization,
+            },
         )?;
         GateOutcome::Staged {
             pending_path,
@@ -396,6 +401,16 @@ pub(crate) fn familiar_weave_id(familiar_id: &str) -> threads::FamiliarId {
 /// directories included), and the read is capped so a pathological
 /// declaration cannot balloon memory.
 pub(crate) fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
+    Ok(read_surface_if_exists(workspace, surface)?.unwrap_or_default())
+}
+
+/// The confined surface read with file absence preserved.
+///
+/// Probe evidence needs to distinguish an absent baseline from an existing
+/// empty file so a later approval can detect either state changing. The
+/// authority weave keeps its historical absent-as-empty convention through
+/// [`read_surface`].
+pub(crate) fn read_surface_if_exists(workspace: &Path, surface: &str) -> Result<Option<Vec<u8>>> {
     const MAX_SURFACE_BYTES: u64 = 16 * 1024 * 1024;
 
     if surface.starts_with('/') || surface.starts_with('\\') {
@@ -451,7 +466,7 @@ pub(crate) fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
         Ok(metadata) => metadata,
         // An absent protected file baselines as empty: creating it later is
         // drift like any other content change.
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(err) => {
             return Err(err).with_context(|| format!("inspecting surface {}", path.display()))
         }
@@ -466,7 +481,9 @@ pub(crate) fn read_surface(workspace: &Path, surface: &str) -> Result<Vec<u8>> {
             "protected surface `{surface}` exceeds the {MAX_SURFACE_BYTES}-byte baseline cap"
         );
     }
-    std::fs::read(&path).with_context(|| format!("reading surface {}", path.display()))
+    std::fs::read(&path)
+        .map(Some)
+        .with_context(|| format!("reading surface {}", path.display()))
 }
 
 fn load_or_create_manifest_id(conn: &Connection, familiar_id: &str) -> Result<threads::ManifestId> {
@@ -748,6 +765,11 @@ pub fn stage_coherence_proposal(
         },
         edits,
         now,
+        StagingProbeContext {
+            workspace,
+            config,
+            authorization,
+        },
     )?;
 
     let files_touched = serde_json::to_string(
@@ -792,6 +814,12 @@ struct StagingLane {
     review_kind: Option<&'static str>,
 }
 
+struct StagingProbeContext<'a> {
+    workspace: &'a Path,
+    config: &'a ward::WardConfig,
+    authorization: &'a ward::Authorization,
+}
+
 fn stage_pending_proposal(
     coven_home: &Path,
     familiar_uuid: &threads::FamiliarId,
@@ -799,6 +827,7 @@ fn stage_pending_proposal(
     lane: StagingLane,
     edits: &[ward::FileEdit],
     now: time::OffsetDateTime,
+    probe_context: StagingProbeContext<'_>,
 ) -> Result<(PathBuf, String)> {
     let proposal = threads::PendingProposal {
         id: threads::ProposalId::new(),
@@ -816,6 +845,13 @@ fn stage_pending_proposal(
             .collect(),
         staged_at: now,
     };
+    let probes = crate::ward_probes::run_at_staging(
+        probe_context.workspace,
+        probe_context.config,
+        edits,
+        probe_context.authorization,
+    )
+    .context("running deterministic Ward probes")?;
 
     let pending_dir = coven_home.join("pending");
     std::fs::create_dir_all(&pending_dir)
@@ -831,10 +867,12 @@ fn stage_pending_proposal(
             proposal: &'a threads::PendingProposal,
             #[serde(rename = "reviewKind", skip_serializing_if = "Option::is_none")]
             review_kind: Option<&'static str>,
+            probes: &'a [crate::ward_probes::SurfaceProbeReport],
         }
         serde_json::to_vec_pretty(&StagedProposalFile {
             proposal: &proposal,
             review_kind: lane.review_kind,
+            probes: &probes,
         })
         .context("serializing pending proposal")?
     };
@@ -1080,8 +1118,17 @@ tier = 2
             panic!("expected Staged, got {report:?}");
         };
         assert!(pending_path.exists(), "pending file must exist");
-        let staged: threads::PendingProposal =
-            serde_json::from_slice(&std::fs::read(pending_path).unwrap()).unwrap();
+        let raw = std::fs::read(pending_path).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&raw).unwrap();
+        assert_eq!(value["probes"][0]["target"], "SOUL.md");
+        assert_eq!(value["probes"][0]["surface"], "SOUL.md");
+        assert_eq!(value["probes"][0]["status"], "unscored");
+        assert_eq!(value["probes"][0]["results"], serde_json::json!([]));
+        assert_eq!(
+            value["probes"][0]["baselineSha256"].as_str().map(str::len),
+            Some(64)
+        );
+        let staged: threads::PendingProposal = serde_json::from_slice(&raw).unwrap();
         assert_eq!(staged.edits.len(), 1);
         assert!(matches!(
             staged.fray,

--- a/crates/coven-cli/src/threads_gate.rs
+++ b/crates/coven-cli/src/threads_gate.rs
@@ -446,9 +446,8 @@ pub(crate) fn read_surface_if_exists(workspace: &Path, surface: &str) -> Result<
                     ancestor = candidate.parent();
                 }
                 Err(err) => {
-                    return Err(err).with_context(|| {
-                        format!("resolving ancestor of surface {}", path.display())
-                    })
+                    return Err(err)
+                        .with_context(|| format!("resolving ancestor of surface `{surface}`"))
                 }
             },
             None => break None,
@@ -467,9 +466,7 @@ pub(crate) fn read_surface_if_exists(workspace: &Path, surface: &str) -> Result<
         // An absent protected file baselines as empty: creating it later is
         // drift like any other content change.
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(err) => {
-            return Err(err).with_context(|| format!("inspecting surface {}", path.display()))
-        }
+        Err(err) => return Err(err).with_context(|| format!("inspecting surface `{surface}`")),
     };
     // Only regular files are hashable surfaces; a symlinked or special-file
     // surface is refused rather than followed out of the workspace.
@@ -483,7 +480,7 @@ pub(crate) fn read_surface_if_exists(workspace: &Path, surface: &str) -> Result<
     }
     std::fs::read(&path)
         .map(Some)
-        .with_context(|| format!("reading surface {}", path.display()))
+        .with_context(|| format!("reading surface `{surface}`"))
 }
 
 fn load_or_create_manifest_id(conn: &Connection, familiar_id: &str) -> Result<threads::ManifestId> {
@@ -1339,6 +1336,23 @@ tier = 0
         )
         .expect_err("symlinked surface must refuse");
         assert!(format!("{err:#}").contains("not a regular file"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn surface_read_errors_name_only_the_logical_surface() {
+        let f = fixture();
+        std::os::unix::fs::symlink("loop", f.workspace.join("loop")).unwrap();
+
+        let error = read_surface_if_exists(&f.workspace, "loop/file.md")
+            .expect_err("a symlink loop must refuse");
+        let rendered = format!("{error:#}");
+
+        assert!(rendered.contains("loop/file.md"), "{rendered}");
+        assert!(
+            !rendered.contains(&f.workspace.display().to_string()),
+            "{rendered}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/coven-cli/src/ward.rs
+++ b/crates/coven-cli/src/ward.rs
@@ -170,10 +170,8 @@ pub struct ProbeConfig {
 }
 
 impl ProbeConfig {
-    pub(crate) fn matches_surface(&self, surface: &str) -> Result<bool> {
-        Ok(compile_glob(&self.surface, false)?
-            .compile_matcher()
-            .is_match(surface))
+    pub(crate) fn surface_matcher(&self) -> Result<globset::GlobMatcher> {
+        Ok(compile_glob(&self.surface, false)?.compile_matcher())
     }
 }
 
@@ -1941,10 +1939,9 @@ required = ["(?m)^name:"]
         );
         assert_eq!(config.probe[1].id, ProbeId::PatternLint);
         assert_eq!(config.probe[1].forbidden, vec!["(?i)ignore previous"]);
-        assert!(config.probe[1]
-            .matches_surface("reviewed/SKILL.md")
-            .unwrap());
-        assert!(!config.probe[1].matches_surface("notes/SKILL.md").unwrap());
+        let matcher = config.probe[1].surface_matcher().unwrap();
+        assert!(matcher.is_match("reviewed/SKILL.md"));
+        assert!(!matcher.is_match("notes/SKILL.md"));
     }
 
     #[test]

--- a/crates/coven-cli/src/ward.rs
+++ b/crates/coven-cli/src/ward.rs
@@ -89,6 +89,7 @@ use std::path::{Component, Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use globset::{Glob, GlobBuilder, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
+use unicode_normalization::UnicodeNormalization;
 
 /// Trust tier of a path within a familiar's surface.
 ///
@@ -1733,6 +1734,16 @@ fn to_forward_slashes(path: &Path) -> String {
         })
         .collect::<Vec<_>>()
         .join("/")
+}
+
+/// Portable uniqueness key for a Gate-2-resolved surface.
+///
+/// Familiar proposals must not contain case-only aliases: they name one file
+/// on default macOS and Windows filesystems even when they remain distinct on
+/// a case-sensitive checkout. Rejecting them everywhere keeps staged evidence
+/// portable and follows the Ward's existing case-insensitive collision posture.
+pub(crate) fn portable_surface_key(surface: &str) -> String {
+    surface.chars().flat_map(char::to_lowercase).nfc().collect()
 }
 
 #[cfg(test)]

--- a/crates/coven-cli/src/ward.rs
+++ b/crates/coven-cli/src/ward.rs
@@ -16,12 +16,13 @@
 //!    hardlink, or case collision) to a protected path is caught here and
 //!    classified by its *real* target.
 //! 3. **Identity coherence validation** — Tier 0/1 modifications must pass the
-//!    familiar's probe set. *(Requires model/regression infrastructure; not
-//!    implemented in this module — see [`Verdict::RequiresCoherenceReview`].)*
+//!    familiar's deterministic probe set before an explicit principal decision.
+//!    Probe execution lives in the sibling `ward_probes` module; this module
+//!    continues to represent the hold as [`Verdict::RequiresCoherenceReview`].
 //! 4. **Audit logging** — modifications are recorded to an append-only log.
 //!    [`Ward::apply`] emits a tamper-evident [`AuditRecord`] (before/after
-//!    SHA-256 content hashes) for every Tier 2 write; persisting those records
-//!    to the daemon's store is a follow-up.
+//!    SHA-256 content hashes) for every Tier 2 write, and the daemon persists
+//!    apply records to its audit ledger.
 //!
 //! This module implements the two **deterministic** gates — 1 and 2 — which are
 //! the load-bearing structural checks. It has no dependency on the language
@@ -29,8 +30,9 @@
 //! surface and the proposal. [`Ward::apply`] is the **fail-closed enforcement
 //! boundary**: it routes every write through Gates 1–2, refuses or holds the
 //! whole proposal as a unit if any target is blocked or needs coherence review,
-//! and only then writes — emitting Gate 4 audit records. Gate 3 (coherence)
-//! remains deferred: a change that needs it is *held*, never written.
+//! and only then writes — emitting Gate 4 audit records. Tier 0/1 changes stay
+//! held here; the daemon's staged proposal flow attaches probe evidence for a
+//! separate explicit coherence decision.
 //!
 //! ## Fail-closed posture
 //!
@@ -143,6 +145,56 @@ pub struct SurfaceEntry {
     pub tier: Tier,
 }
 
+/// One deterministic, offline Gate-3 probe declared in `ward.toml`.
+///
+/// The probe matches Gate-2-resolved surface paths. Parameters are deliberately
+/// small and typed: `parse` uses `format`, while `pattern-lint` uses
+/// `forbidden` and `required`. The other v1 probes have no parameters.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProbeConfig {
+    /// Glob over familiar-home-relative, forward-slashed surface paths.
+    pub surface: String,
+    /// Deterministic probe implementation to run.
+    pub id: ProbeId,
+    /// Declared parser for the `parse` probe.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<ProbeFormat>,
+    /// Regexes that must not match for `pattern-lint`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub forbidden: Vec<String>,
+    /// Regexes that must match for `pattern-lint`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+}
+
+impl ProbeConfig {
+    pub(crate) fn matches_surface(&self, surface: &str) -> Result<bool> {
+        Ok(compile_glob(&self.surface, false)?
+            .compile_matcher()
+            .is_match(surface))
+    }
+}
+
+/// The four deterministic Gate-3 probes in the v1 contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProbeId {
+    Parse,
+    SizeDelta,
+    ProtectedRegion,
+    PatternLint,
+}
+
+/// Supported declared formats for the deterministic `parse` probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProbeFormat {
+    Toml,
+    Json,
+    MarkdownFrontMatter,
+}
+
 /// A familiar's Ward configuration — the declared surface plus the principal
 /// binding that authorizes Tier 0 changes.
 ///
@@ -167,6 +219,10 @@ pub struct WardConfig {
     /// stays large while unknown edits are still recorded — not frozen.
     #[serde(default = "default_unmatched_tier")]
     pub default_tier: Tier,
+    /// Deterministic, advisory Gate-3 probes. The singular field name maps to
+    /// TOML's repeated `[[probe]]` tables.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub probe: Vec<ProbeConfig>,
 }
 
 fn default_unmatched_tier() -> Tier {
@@ -229,6 +285,50 @@ impl WardConfig {
                  missing from protected_surface: {missing:?}; \
                  not declared tier-0: {extra:?}"
             );
+        }
+
+        for (index, probe) in self.probe.iter().enumerate() {
+            if probe.surface.trim().is_empty() {
+                bail!("probe[{index}] has an empty surface glob");
+            }
+            if probe.surface.starts_with(['/', '\\'])
+                || probe.surface.contains('\\')
+                || probe.surface.contains(':')
+                || probe
+                    .surface
+                    .split('/')
+                    .any(|segment| segment == "." || segment == "..")
+            {
+                bail!(
+                    "probe[{index}] surface `{}` must stay relative to the familiar home",
+                    probe.surface
+                );
+            }
+            compile_glob(&probe.surface, false)
+                .with_context(|| format!("invalid probe[{index}] surface glob"))?;
+
+            let has_patterns = !probe.forbidden.is_empty() || !probe.required.is_empty();
+            match probe.id {
+                ProbeId::Parse if has_patterns => {
+                    bail!("probe[{index}] `parse` does not accept regex parameters")
+                }
+                ProbeId::PatternLint if probe.format.is_some() => {
+                    bail!("probe[{index}] `pattern-lint` does not accept `format`")
+                }
+                ProbeId::SizeDelta | ProbeId::ProtectedRegion
+                    if probe.format.is_some() || has_patterns =>
+                {
+                    bail!(
+                        "probe[{index}] `{}` does not accept parameters",
+                        match probe.id {
+                            ProbeId::SizeDelta => "size-delta",
+                            ProbeId::ProtectedRegion => "protected-region",
+                            _ => unreachable!("guard restricts this branch"),
+                        }
+                    )
+                }
+                _ => {}
+            }
         }
 
         Ok(())
@@ -654,9 +754,9 @@ impl Ward {
     /// - If any target is **Blocked** (Gate 1/2), the proposal is *refused* as a
     ///   unit and nothing is written.
     /// - If any target needs **Gate 3 coherence review** — Tier 1, or a Tier 0
-    ///   change authorized by Gate 1 (Gate 3 is not yet implemented, so an
-    ///   authorized protected change cannot be cleared here) — the proposal is
-    ///   *held* as a unit and nothing is written.
+    ///   change authorized by Gate 1 — the direct apply path *holds* the
+    ///   proposal as a unit. Probe evidence and the principal's decision are
+    ///   handled by the daemon's staged proposal flow.
     /// - Otherwise every edit is Tier 2/3: each is written atomically (staged
     ///   as a randomized `create_new` sibling in the target's re-verified
     ///   directory, then renamed into place) and every Tier 2 write emits a
@@ -777,9 +877,9 @@ impl Ward {
 
 /// Whether a verdict needs Gate 3 coherence review before it can be applied.
 ///
-/// This includes Gate-1 authorized Tier 0 changes: Gate 3 is not yet
-/// implemented, so an authorized protected change cannot be cleared for apply
-/// here. Fail-closed — hold rather than write.
+/// This includes Gate-1 authorized Tier 0 changes. The direct apply path cannot
+/// represent the staged probe evidence and principal decision, so it fails
+/// closed — hold rather than write.
 fn requires_coherence(verdict: &Verdict) -> bool {
     matches!(
         verdict,
@@ -1674,6 +1774,7 @@ mod tests {
             ],
             protected_surface: vec!["SOUL.md".into(), "IDENTITY.md".into(), "USER.md".into()],
             default_tier: Tier::Logged,
+            probe: Vec::new(),
         }
     }
 
@@ -1794,6 +1895,88 @@ tier = 2
         assert_eq!(config.surface.len(), 2);
         assert_eq!(config.surface[0].tier, Tier::Protected);
         assert_eq!(config.default_tier, Tier::Logged);
+        assert!(config.probe.is_empty());
+    }
+
+    #[test]
+    fn parses_deterministic_probe_declarations() {
+        let toml = r#"
+principal_key_fingerprint = "SHA256:abc"
+protected_surface = []
+
+[[surface]]
+path = "reviewed/"
+tier = 1
+
+[[probe]]
+surface = "reviewed/**"
+id = "parse"
+format = "markdown-front-matter"
+
+[[probe]]
+surface = "reviewed/**"
+id = "pattern-lint"
+forbidden = ["(?i)ignore previous"]
+required = ["(?m)^name:"]
+"#;
+
+        let config = WardConfig::from_toml_str(toml).expect("probe config parses");
+
+        assert_eq!(config.probe.len(), 2);
+        assert_eq!(config.probe[0].id, ProbeId::Parse);
+        assert_eq!(
+            config.probe[0].format,
+            Some(ProbeFormat::MarkdownFrontMatter)
+        );
+        assert_eq!(config.probe[1].id, ProbeId::PatternLint);
+        assert_eq!(config.probe[1].forbidden, vec!["(?i)ignore previous"]);
+        assert!(config.probe[1]
+            .matches_surface("reviewed/SKILL.md")
+            .unwrap());
+        assert!(!config.probe[1].matches_surface("notes/SKILL.md").unwrap());
+    }
+
+    #[test]
+    fn validation_rejects_escaping_or_mistyped_probe_parameters() {
+        let escaping = r#"
+principal_key_fingerprint = "SHA256:abc"
+protected_surface = []
+
+[[probe]]
+surface = "../SOUL.md"
+id = "size-delta"
+"#;
+        assert!(WardConfig::from_toml_str(escaping)
+            .unwrap_err()
+            .to_string()
+            .contains("must stay relative"));
+
+        let mistyped = r#"
+principal_key_fingerprint = "SHA256:abc"
+protected_surface = []
+
+[[probe]]
+surface = "reviewed/**"
+id = "size-delta"
+format = "json"
+"#;
+        assert!(WardConfig::from_toml_str(mistyped)
+            .unwrap_err()
+            .to_string()
+            .contains("does not accept parameters"));
+
+        let unknown_parameter = r#"
+principal_key_fingerprint = "SHA256:abc"
+protected_surface = []
+
+[[probe]]
+surface = "reviewed/**"
+id = "parse"
+format = "json"
+formatter = "lenient"
+"#;
+        let error = WardConfig::from_toml_str(unknown_parameter).unwrap_err();
+        assert!(format!("{error:#}").contains("unknown field"));
     }
 
     #[test]

--- a/crates/coven-cli/src/ward_migrate.rs
+++ b/crates/coven-cli/src/ward_migrate.rs
@@ -313,6 +313,7 @@ fn migrate_one(
             )
             .collect(),
         default_tier: Tier::Logged,
+        probe: Vec::new(),
     };
     let generated_toml = render_phase2_toml(&config)?;
     if let Err(error) = WardConfig::from_toml_str(&generated_toml) {

--- a/crates/coven-cli/src/ward_probes.rs
+++ b/crates/coven-cli/src/ward_probes.rs
@@ -19,6 +19,7 @@ use crate::ward::{
 
 const PROTECTED_START: &str = "<!-- ward:protected -->";
 const PROTECTED_END: &str = "<!-- /ward:protected -->";
+type CompiledProbeMatcher<'a> = (&'a ProbeConfig, globset::GlobMatcher);
 
 /// One surface's immutable staging-time probe evidence.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -138,6 +139,7 @@ pub(crate) fn run_at_staging(
     if outcome.decisions.len() != edits.len() {
         bail!("Ward returned an incomplete probe adjudication");
     }
+    let compiled_probes = compile_probe_matchers(config)?;
     let mut targets = std::collections::BTreeSet::new();
     let mut surfaces = std::collections::BTreeSet::new();
     for (edit, decision) in edits.iter().zip(&outcome.decisions) {
@@ -161,7 +163,7 @@ pub(crate) fn run_at_staging(
         .map(|(edit, decision)| {
             run_surface(
                 workspace,
-                config,
+                &compiled_probes,
                 &edit.target,
                 &decision.resolved,
                 &edit.new_contents,
@@ -170,22 +172,30 @@ pub(crate) fn run_at_staging(
         .collect()
 }
 
+fn compile_probe_matchers(config: &WardConfig) -> Result<Vec<CompiledProbeMatcher<'_>>> {
+    config
+        .probe
+        .iter()
+        .map(|probe| {
+            probe
+                .surface_matcher()
+                .with_context(|| format!("invalid probe surface glob `{}`", probe.surface))
+                .map(|matcher| (probe, matcher))
+        })
+        .collect()
+}
+
 fn run_surface(
     workspace: &Path,
-    config: &WardConfig,
+    compiled_probes: &[CompiledProbeMatcher<'_>],
     target: &str,
     surface: &str,
     proposed: &[u8],
 ) -> Result<SurfaceProbeReport> {
-    let matching = config
-        .probe
+    let matching = compiled_probes
         .iter()
-        .filter_map(|probe| match probe.matches_surface(surface) {
-            Ok(true) => Some(Ok(probe)),
-            Ok(false) => None,
-            Err(error) => Some(Err(error)),
-        })
-        .collect::<Result<Vec<_>>>()?;
+        .filter_map(|(probe, matcher)| matcher.is_match(surface).then_some(*probe))
+        .collect::<Vec<_>>();
     let proposed_sha256 = sha256_hex(proposed);
     let baseline = match threads_gate::read_surface_if_exists(workspace, surface) {
         Ok(baseline) => baseline,
@@ -662,6 +672,32 @@ required = ["(?m)^name: sage$"]
 "#,
         )
         .expect("probe config parses")
+    }
+
+    #[test]
+    fn probe_matchers_compile_in_declaration_order_for_reuse() {
+        let config = config_with_all_probes();
+
+        let compiled = compile_probe_matchers(&config).unwrap();
+
+        assert_eq!(compiled.len(), config.probe.len());
+        assert!(compiled
+            .iter()
+            .all(|(_, matcher)| matcher.is_match("reviewed/SKILL.md")));
+        assert!(compiled
+            .iter()
+            .all(|(_, matcher)| !matcher.is_match("notes/SKILL.md")));
+        assert_eq!(
+            compiled
+                .iter()
+                .map(|(probe, _)| probe.id)
+                .collect::<Vec<_>>(),
+            config
+                .probe
+                .iter()
+                .map(|probe| probe.id)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/ward_probes.rs
+++ b/crates/coven-cli/src/ward_probes.rs
@@ -150,7 +150,7 @@ pub(crate) fn run_at_staging(
         if !targets.insert(edit.target.as_str()) {
             bail!("probe staging requires unique edit targets");
         }
-        if !surfaces.insert(decision.resolved.as_str()) {
+        if !surfaces.insert(crate::ward::portable_surface_key(&decision.resolved)) {
             bail!("probe staging requires unique resolved surfaces");
         }
     }
@@ -916,6 +916,34 @@ required = ["(?m)^name:"]
         assert_eq!(result.status, ProbeStatus::Failed);
         assert_eq!(result.detail["forbiddenMatches"], json!([0]));
         assert_eq!(result.detail["missingRequired"], json!([0]));
+    }
+
+    #[test]
+    fn staging_refuses_nonportable_resolved_surface_aliases() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(temp.path().join("reviewed")).unwrap();
+        for (left, right) in [
+            ("reviewed/skill.md", "reviewed/SKILL.md"),
+            ("reviewed/caf\u{e9}.md", "reviewed/cafe\u{301}.md"),
+        ] {
+            let edits = vec![
+                FileEdit::new(left, "---\nname: sage\n---\n"),
+                FileEdit::new(right, "---\nname: sage\n---\n"),
+            ];
+
+            let error = run_at_staging(
+                temp.path(),
+                &config_with_all_probes(),
+                &edits,
+                &Authorization::unsigned(),
+            )
+            .expect_err("nonportable aliases must not produce conflicting probe reports");
+
+            assert!(
+                error.to_string().contains("unique resolved surfaces"),
+                "{error:#}"
+            );
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/ward_probes.rs
+++ b/crates/coven-cli/src/ward_probes.rs
@@ -1,0 +1,976 @@
+//! Deterministic, offline evidence for Ward Gate-3 review.
+//!
+//! Probes are advisory: their status is serialized beside a staged proposal,
+//! but no result applies or approves a write. Runtime/configuration failures
+//! become `unscored` evidence rather than an implicit pass.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::threads_gate;
+use crate::ward::{
+    Authorization, FileEdit, ProbeConfig, ProbeFormat, ProbeId, Proposal, Verdict, Ward, WardConfig,
+};
+
+const PROTECTED_START: &str = "<!-- ward:protected -->";
+const PROTECTED_END: &str = "<!-- /ward:protected -->";
+
+/// One surface's immutable staging-time probe evidence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SurfaceProbeReport {
+    /// Target exactly as stored in the pending proposal.
+    pub target: String,
+    /// Gate-2-resolved familiar-home-relative surface.
+    pub surface: String,
+    /// SHA-256 of the current file, or `null` when the file does not exist.
+    pub baseline_sha256: Option<String>,
+    /// SHA-256 of the full proposed end state.
+    pub proposed_sha256: String,
+    /// Aggregate status for this surface.
+    pub status: ProbeStatus,
+    /// A baseline read error. Individual matching probes are also unscored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Results in `ward.toml` declaration order.
+    pub results: Vec<ProbeResult>,
+}
+
+/// One configured deterministic check.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProbeResult {
+    pub id: ProbeId,
+    pub configured_surface: String,
+    /// SHA-256 of the full typed `[[probe]]` declaration used for this result.
+    pub configuration_sha256: String,
+    pub status: ProbeStatus,
+    pub summary: String,
+    #[serde(default, skip_serializing_if = "Value::is_null")]
+    pub detail: Value,
+}
+
+/// A probe's deterministic outcome. No variant carries approval authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ProbeStatus {
+    Passed,
+    Failed,
+    Unscored,
+}
+
+/// Compact evidence shown by pending-proposal list surfaces.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ProbeSummary {
+    pub status: ProbeStatus,
+    pub passed: usize,
+    pub failed: usize,
+    pub unscored: usize,
+    pub targets: usize,
+}
+
+impl ProbeSummary {
+    pub(crate) fn unscored_targets(targets: usize) -> Self {
+        Self {
+            status: ProbeStatus::Unscored,
+            passed: 0,
+            failed: 0,
+            unscored: targets,
+            targets,
+        }
+    }
+
+    pub(crate) fn from_reports(reports: &[SurfaceProbeReport]) -> Self {
+        let mut passed = 0;
+        let mut failed = 0;
+        let mut unscored = 0;
+        for report in reports {
+            if report.results.is_empty() {
+                unscored += 1;
+                continue;
+            }
+            for result in &report.results {
+                match result.status {
+                    ProbeStatus::Passed => passed += 1,
+                    ProbeStatus::Failed => failed += 1,
+                    ProbeStatus::Unscored => unscored += 1,
+                }
+            }
+        }
+        let status = if failed > 0 {
+            ProbeStatus::Failed
+        } else if unscored > 0 || passed == 0 {
+            ProbeStatus::Unscored
+        } else {
+            ProbeStatus::Passed
+        };
+        Self {
+            status,
+            passed,
+            failed,
+            unscored,
+            targets: reports.len(),
+        }
+    }
+}
+
+/// Run the configured probe set against the exact end-state edits being
+/// staged. Gate 1-2 are re-evaluated here solely to obtain confined, resolved
+/// surface paths; a newly blocked target aborts staging rather than recording
+/// evidence for an unsafe path.
+pub(crate) fn run_at_staging(
+    workspace: &Path,
+    config: &WardConfig,
+    edits: &[FileEdit],
+    authorization: &Authorization,
+) -> Result<Vec<SurfaceProbeReport>> {
+    let ward = Ward::new(workspace, config.clone())?;
+    let outcome = ward.evaluate(&Proposal {
+        targets: edits.iter().map(|edit| edit.target.clone()).collect(),
+        authorization: authorization.clone(),
+    });
+    if outcome.decisions.len() != edits.len() {
+        bail!("Ward returned an incomplete probe adjudication");
+    }
+    let mut targets = std::collections::BTreeSet::new();
+    let mut surfaces = std::collections::BTreeSet::new();
+    for (edit, decision) in edits.iter().zip(&outcome.decisions) {
+        if matches!(decision.verdict, Verdict::Blocked { .. }) {
+            bail!(
+                "probe target `{}` became blocked during staging",
+                edit.target
+            );
+        }
+        if !targets.insert(edit.target.as_str()) {
+            bail!("probe staging requires unique edit targets");
+        }
+        if !surfaces.insert(decision.resolved.as_str()) {
+            bail!("probe staging requires unique resolved surfaces");
+        }
+    }
+
+    edits
+        .iter()
+        .zip(outcome.decisions)
+        .map(|(edit, decision)| {
+            run_surface(
+                workspace,
+                config,
+                &edit.target,
+                &decision.resolved,
+                &edit.new_contents,
+            )
+        })
+        .collect()
+}
+
+fn run_surface(
+    workspace: &Path,
+    config: &WardConfig,
+    target: &str,
+    surface: &str,
+    proposed: &[u8],
+) -> Result<SurfaceProbeReport> {
+    let matching = config
+        .probe
+        .iter()
+        .filter_map(|probe| match probe.matches_surface(surface) {
+            Ok(true) => Some(Ok(probe)),
+            Ok(false) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let proposed_sha256 = sha256_hex(proposed);
+    let baseline = match threads_gate::read_surface_if_exists(workspace, surface) {
+        Ok(baseline) => baseline,
+        Err(error) => {
+            let message = format!("current surface could not be read: {error:#}");
+            let results = matching
+                .iter()
+                .map(|probe| ProbeResult {
+                    id: probe.id,
+                    configured_surface: probe.surface.clone(),
+                    configuration_sha256: probe_config_sha256(probe),
+                    status: ProbeStatus::Unscored,
+                    summary: "Baseline unavailable; probe was not scored.".to_string(),
+                    detail: json!({ "error": "baseline-unavailable" }),
+                })
+                .collect();
+            return Ok(SurfaceProbeReport {
+                target: target.to_string(),
+                surface: surface.to_string(),
+                baseline_sha256: None,
+                proposed_sha256,
+                status: ProbeStatus::Unscored,
+                error: Some(message),
+                results,
+            });
+        }
+    };
+    let baseline_bytes = baseline.as_deref().unwrap_or_default();
+    let results: Vec<ProbeResult> = matching
+        .into_iter()
+        .map(|probe| run_probe(probe, baseline_bytes, proposed))
+        .collect();
+    let status = aggregate_results(&results);
+    Ok(SurfaceProbeReport {
+        target: target.to_string(),
+        surface: surface.to_string(),
+        baseline_sha256: baseline.as_deref().map(sha256_hex),
+        proposed_sha256,
+        status,
+        error: None,
+        results,
+    })
+}
+
+/// Result of reconciling persisted evidence with current deterministic output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ProbeEvidenceValidation {
+    Valid,
+    Stale,
+    Inconsistent,
+}
+
+/// Recompute a persisted sidecar from the staged contents and current baseline.
+/// Callers must summarize only `Valid` evidence; stale or inconsistent evidence
+/// is explicitly unscored.
+pub(crate) fn validate_staged_reports(
+    workspace: &Path,
+    config: &WardConfig,
+    proposal: &coven_threads_core::PendingProposal,
+    reports: &[SurfaceProbeReport],
+) -> ProbeEvidenceValidation {
+    if reports.len() != proposal.edits.len() {
+        return ProbeEvidenceValidation::Inconsistent;
+    }
+
+    let Some(edits) = proposal
+        .edits
+        .iter()
+        .map(|edit| {
+            edit.contents
+                .to_bytes()
+                .ok()
+                .map(|contents| FileEdit::new(edit.surface.as_str(), contents))
+        })
+        .collect::<Option<Vec<_>>>()
+    else {
+        return ProbeEvidenceValidation::Inconsistent;
+    };
+    let authorization = proposal
+        .writer
+        .as_str()
+        .strip_prefix("principal:")
+        .map(|fingerprint| Authorization::signed_by(fingerprint.to_string()))
+        .unwrap_or_else(Authorization::unsigned);
+    let Ok(expected) = run_at_staging(workspace, config, &edits, &authorization) else {
+        return ProbeEvidenceValidation::Inconsistent;
+    };
+    if reports == expected {
+        return ProbeEvidenceValidation::Valid;
+    }
+
+    let same_binding = reports.len() == expected.len()
+        && reports
+            .iter()
+            .zip(&expected)
+            .all(|(stored, current)| same_evidence_binding(stored, current));
+    let baseline_changed = reports.iter().zip(&expected).any(|(stored, current)| {
+        stored.baseline_sha256 != current.baseline_sha256 || stored.error != current.error
+    });
+    if same_binding && baseline_changed {
+        ProbeEvidenceValidation::Stale
+    } else {
+        ProbeEvidenceValidation::Inconsistent
+    }
+}
+
+fn same_evidence_binding(stored: &SurfaceProbeReport, current: &SurfaceProbeReport) -> bool {
+    stored.target == current.target
+        && stored.surface == current.surface
+        && stored.proposed_sha256 == current.proposed_sha256
+        && stored.results.len() == current.results.len()
+        && stored
+            .results
+            .iter()
+            .zip(&current.results)
+            .all(|(stored, current)| {
+                stored.id == current.id
+                    && stored.configured_surface == current.configured_surface
+                    && stored.configuration_sha256 == current.configuration_sha256
+            })
+}
+
+fn aggregate_results(results: &[ProbeResult]) -> ProbeStatus {
+    if results
+        .iter()
+        .any(|result| result.status == ProbeStatus::Failed)
+    {
+        ProbeStatus::Failed
+    } else if results.is_empty()
+        || results
+            .iter()
+            .any(|result| result.status == ProbeStatus::Unscored)
+    {
+        ProbeStatus::Unscored
+    } else {
+        ProbeStatus::Passed
+    }
+}
+
+fn run_probe(probe: &ProbeConfig, baseline: &[u8], proposed: &[u8]) -> ProbeResult {
+    let (status, summary, detail) = match probe.id {
+        ProbeId::Parse => run_parse(probe.format, proposed),
+        ProbeId::SizeDelta => run_size_delta(baseline, proposed),
+        ProbeId::ProtectedRegion => run_protected_region(baseline, proposed),
+        ProbeId::PatternLint => run_pattern_lint(&probe.forbidden, &probe.required, proposed),
+    };
+    ProbeResult {
+        id: probe.id,
+        configured_surface: probe.surface.clone(),
+        configuration_sha256: probe_config_sha256(probe),
+        status,
+        summary,
+        detail,
+    }
+}
+
+fn run_parse(format: Option<ProbeFormat>, proposed: &[u8]) -> (ProbeStatus, String, Value) {
+    let Some(format) = format else {
+        return (
+            ProbeStatus::Unscored,
+            "No format was declared; parse probe was not scored.".to_string(),
+            json!({ "error": "format-not-declared" }),
+        );
+    };
+    let result = match format {
+        ProbeFormat::Toml => std::str::from_utf8(proposed)
+            .context("TOML is not UTF-8")
+            .and_then(|text| {
+                toml::from_str::<toml::Value>(text)
+                    .context("invalid TOML")
+                    .map(|_| ())
+            }),
+        ProbeFormat::Json => serde_json::from_slice::<Value>(proposed)
+            .context("invalid JSON")
+            .map(|_| ()),
+        ProbeFormat::MarkdownFrontMatter => parse_markdown_front_matter(proposed),
+    };
+    let format_value = serde_json::to_value(format).unwrap_or(Value::Null);
+    match result {
+        Ok(()) => (
+            ProbeStatus::Passed,
+            "Proposed contents parse as the declared format.".to_string(),
+            json!({ "format": format_value }),
+        ),
+        Err(error) => (
+            ProbeStatus::Failed,
+            "Proposed contents do not parse as the declared format.".to_string(),
+            json!({ "format": format_value, "error": error.to_string() }),
+        ),
+    }
+}
+
+fn parse_markdown_front_matter(proposed: &[u8]) -> Result<()> {
+    let text = std::str::from_utf8(proposed).context("Markdown is not UTF-8")?;
+    let Some(after_open) = text
+        .strip_prefix("---\n")
+        .or_else(|| text.strip_prefix("---\r\n"))
+    else {
+        bail!("Markdown front matter must start with a `---` fence");
+    };
+    let mut offset = 0;
+    for line in after_open.split_inclusive('\n') {
+        let candidate = line.strip_suffix('\n').unwrap_or(line);
+        let candidate = candidate.strip_suffix('\r').unwrap_or(candidate);
+        if candidate == "---" {
+            let metadata = &after_open[..offset];
+            serde_yaml_ng::from_str::<serde_yaml_ng::Value>(metadata)
+                .context("invalid YAML front matter")?;
+            return Ok(());
+        }
+        offset += line.len();
+    }
+    bail!("Markdown front matter has no closing `---` fence")
+}
+
+fn run_size_delta(baseline: &[u8], proposed: &[u8]) -> (ProbeStatus, String, Value) {
+    let before_bytes = baseline.len() as i64;
+    let after_bytes = proposed.len() as i64;
+    let before_lines = logical_line_count(baseline) as i64;
+    let after_lines = logical_line_count(proposed) as i64;
+    (
+        ProbeStatus::Passed,
+        "Size delta calculated.".to_string(),
+        json!({
+            "beforeBytes": before_bytes,
+            "afterBytes": after_bytes,
+            "bytesDelta": after_bytes - before_bytes,
+            "beforeLines": before_lines,
+            "afterLines": after_lines,
+            "linesDelta": after_lines - before_lines,
+        }),
+    )
+}
+
+fn logical_line_count(bytes: &[u8]) -> usize {
+    if bytes.is_empty() {
+        return 0;
+    }
+    bytes.iter().filter(|byte| **byte == b'\n').count() + usize::from(bytes.last() != Some(&b'\n'))
+}
+
+fn run_protected_region(baseline: &[u8], proposed: &[u8]) -> (ProbeStatus, String, Value) {
+    let baseline_regions = match protected_regions(baseline) {
+        Ok(regions) => regions,
+        Err(error) => {
+            return (
+                ProbeStatus::Unscored,
+                "Current protected regions could not be parsed.".to_string(),
+                json!({ "error": error.to_string() }),
+            )
+        }
+    };
+    let proposed_regions = match protected_regions(proposed) {
+        Ok(regions) => regions,
+        Err(error) => {
+            return (
+                ProbeStatus::Failed,
+                "Proposed protected-region fences are malformed.".to_string(),
+                json!({ "error": error.to_string() }),
+            )
+        }
+    };
+    let region_count = baseline_regions.len();
+    if baseline_regions == proposed_regions {
+        (
+            ProbeStatus::Passed,
+            if region_count == 0 {
+                "No protected regions are present.".to_string()
+            } else {
+                "Protected regions are unchanged.".to_string()
+            },
+            json!({ "regions": region_count }),
+        )
+    } else {
+        (
+            ProbeStatus::Failed,
+            "A protected region was added, removed, relocated, reordered, or changed.".to_string(),
+            json!({
+                "baselineRegions": region_count,
+                "proposedRegions": proposed_regions.len(),
+            }),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ProtectedRegion {
+    start_line: usize,
+    bytes: String,
+}
+
+fn protected_regions(bytes: &[u8]) -> Result<Vec<ProtectedRegion>> {
+    let text = std::str::from_utf8(bytes).context("protected-region surface is not UTF-8")?;
+    let mut regions = Vec::new();
+    let mut cursor = 0;
+    while cursor < text.len() {
+        let remaining = &text[cursor..];
+        let next_start = remaining.find(PROTECTED_START);
+        let next_end = remaining.find(PROTECTED_END);
+        match (next_start, next_end) {
+            (None, None) => break,
+            (None, Some(_)) => bail!("closing protected marker has no opening marker"),
+            (Some(start), Some(end)) if end < start => {
+                bail!("closing protected marker appears before its opening marker")
+            }
+            (Some(start), _) => {
+                let start = cursor + start;
+                let content_start = start + PROTECTED_START.len();
+                let tail = &text[content_start..];
+                let Some(end_offset) = tail.find(PROTECTED_END) else {
+                    bail!("opening protected marker has no closing marker");
+                };
+                if tail[..end_offset].contains(PROTECTED_START) {
+                    bail!("nested protected regions are not supported");
+                }
+                let end = content_start + end_offset + PROTECTED_END.len();
+                let line_start = text[..start]
+                    .rfind('\n')
+                    .map(|index| index + 1)
+                    .unwrap_or(0);
+                regions.push(ProtectedRegion {
+                    start_line: text[..line_start]
+                        .bytes()
+                        .filter(|byte| *byte == b'\n')
+                        .count(),
+                    bytes: text[line_start..end].to_string(),
+                });
+                cursor = end;
+            }
+        }
+    }
+    Ok(regions)
+}
+
+fn run_pattern_lint(
+    forbidden: &[String],
+    required: &[String],
+    proposed: &[u8],
+) -> (ProbeStatus, String, Value) {
+    if forbidden.is_empty() && required.is_empty() {
+        return (
+            ProbeStatus::Unscored,
+            "No forbidden or required patterns were configured.".to_string(),
+            json!({ "error": "patterns-not-declared" }),
+        );
+    }
+    let text = match std::str::from_utf8(proposed) {
+        Ok(text) => text,
+        Err(_) => {
+            return (
+                ProbeStatus::Unscored,
+                "Pattern lint requires UTF-8 proposed contents.".to_string(),
+                json!({ "error": "proposed-contents-not-utf8" }),
+            )
+        }
+    };
+    let forbidden = match compile_patterns("forbidden", forbidden) {
+        Ok(patterns) => patterns,
+        Err(detail) => {
+            return (
+                ProbeStatus::Unscored,
+                "A forbidden regex is invalid; pattern lint was not scored.".to_string(),
+                detail,
+            )
+        }
+    };
+    let required = match compile_patterns("required", required) {
+        Ok(patterns) => patterns,
+        Err(detail) => {
+            return (
+                ProbeStatus::Unscored,
+                "A required regex is invalid; pattern lint was not scored.".to_string(),
+                detail,
+            )
+        }
+    };
+    let forbidden_matches: Vec<usize> = forbidden
+        .iter()
+        .enumerate()
+        .filter_map(|(index, pattern)| pattern.is_match(text).then_some(index))
+        .collect();
+    let missing_required: Vec<usize> = required
+        .iter()
+        .enumerate()
+        .filter_map(|(index, pattern)| (!pattern.is_match(text)).then_some(index))
+        .collect();
+    let detail = json!({
+        "forbiddenPatterns": forbidden.len(),
+        "requiredPatterns": required.len(),
+        "forbiddenMatches": forbidden_matches,
+        "missingRequired": missing_required,
+    });
+    if detail["forbiddenMatches"]
+        .as_array()
+        .is_some_and(|matches| !matches.is_empty())
+        || detail["missingRequired"]
+            .as_array()
+            .is_some_and(|missing| !missing.is_empty())
+    {
+        (
+            ProbeStatus::Failed,
+            "Pattern lint found forbidden or missing required content.".to_string(),
+            detail,
+        )
+    } else {
+        (
+            ProbeStatus::Passed,
+            "Pattern lint passed.".to_string(),
+            detail,
+        )
+    }
+}
+
+fn compile_patterns(kind: &str, patterns: &[String]) -> std::result::Result<Vec<Regex>, Value> {
+    patterns
+        .iter()
+        .enumerate()
+        .map(|(index, pattern)| {
+            Regex::new(pattern)
+                .map_err(|error| json!({ "error": "invalid-regex", "kind": kind, "index": index, "detail": error.to_string() }))
+        })
+        .collect()
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn probe_config_sha256(probe: &ProbeConfig) -> String {
+    let serialized =
+        serde_json::to_vec(probe).expect("typed Ward probe configuration always serializes");
+    sha256_hex(&serialized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ward::{Authorization, FileEdit, WardConfig};
+
+    fn config_with_all_probes() -> WardConfig {
+        WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "reviewed/**"
+tier = 1
+
+[[probe]]
+surface = "reviewed/**"
+id = "parse"
+format = "markdown-front-matter"
+
+[[probe]]
+surface = "reviewed/**"
+id = "size-delta"
+
+[[probe]]
+surface = "reviewed/**"
+id = "protected-region"
+
+[[probe]]
+surface = "reviewed/**"
+id = "pattern-lint"
+forbidden = ["(?i)ignore previous"]
+required = ["(?m)^name: sage$"]
+"#,
+        )
+        .expect("probe config parses")
+    }
+
+    #[test]
+    fn all_four_deterministic_probes_pass_and_capture_snapshot_hashes() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        std::fs::create_dir_all(workspace.join("reviewed")).unwrap();
+        std::fs::write(
+            workspace.join("reviewed/SKILL.md"),
+            "---\nname: sage\n---\nBefore\n<!-- ward:protected -->\nfixed\n<!-- /ward:protected -->\n",
+        )
+        .unwrap();
+        let edits = vec![FileEdit::new(
+            "reviewed/SKILL.md",
+            "---\nname: sage\n---\nAfter\n<!-- ward:protected -->\nfixed\n<!-- /ward:protected -->\n",
+        )];
+
+        let reports = run_at_staging(
+            workspace,
+            &config_with_all_probes(),
+            &edits,
+            &Authorization::unsigned(),
+        )
+        .unwrap();
+
+        assert_eq!(reports.len(), 1);
+        let report = &reports[0];
+        assert_eq!(report.surface, "reviewed/SKILL.md");
+        assert_eq!(report.status, ProbeStatus::Passed);
+        assert_eq!(report.baseline_sha256.as_deref().map(str::len), Some(64));
+        assert_eq!(report.proposed_sha256.len(), 64);
+        assert_eq!(report.results.len(), 4);
+        assert!(report
+            .results
+            .iter()
+            .all(|result| result.status == ProbeStatus::Passed));
+        assert_eq!(ProbeSummary::from_reports(&reports).passed, 4);
+    }
+
+    #[test]
+    fn deterministic_failures_and_probe_errors_remain_advisory_evidence() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path();
+        std::fs::write(
+            workspace.join("reviewed.json"),
+            "<!-- ward:protected -->\nfixed\n<!-- /ward:protected -->\n",
+        )
+        .unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "reviewed.json"
+tier = 1
+
+[[probe]]
+surface = "reviewed.json"
+id = "parse"
+format = "json"
+
+[[probe]]
+surface = "reviewed.json"
+id = "protected-region"
+
+[[probe]]
+surface = "reviewed.json"
+id = "pattern-lint"
+forbidden = ["["]
+"#,
+        )
+        .unwrap();
+        let edits = vec![FileEdit::new(
+            "reviewed.json",
+            b"{not json}\n<!-- ward:protected -->\nchanged\n<!-- /ward:protected -->\n".to_vec(),
+        )];
+
+        let reports =
+            run_at_staging(workspace, &config, &edits, &Authorization::unsigned()).unwrap();
+        let results = &reports[0].results;
+
+        assert_eq!(reports[0].status, ProbeStatus::Failed);
+        assert_eq!(results[0].status, ProbeStatus::Failed);
+        assert_eq!(results[1].status, ProbeStatus::Failed);
+        assert_eq!(results[2].status, ProbeStatus::Unscored);
+        let summary = ProbeSummary::from_reports(&reports);
+        assert_eq!(summary.failed, 2);
+        assert_eq!(summary.unscored, 1);
+        assert_eq!(summary.status, ProbeStatus::Failed);
+    }
+
+    #[test]
+    fn parse_probe_accepts_each_declared_v1_format() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "*.toml"
+tier = 1
+
+[[surface]]
+path = "*.json"
+tier = 1
+
+[[surface]]
+path = "*.md"
+tier = 1
+
+[[probe]]
+surface = "*.toml"
+id = "parse"
+format = "toml"
+
+[[probe]]
+surface = "*.json"
+id = "parse"
+format = "json"
+
+[[probe]]
+surface = "*.md"
+id = "parse"
+format = "markdown-front-matter"
+"#,
+        )
+        .unwrap();
+        let edits = vec![
+            FileEdit::new("identity.toml", "name = \"sage\"\n"),
+            FileEdit::new("identity.json", r#"{"name":"sage"}"#),
+            FileEdit::new("identity.md", "---\nname: sage\n---\n# Sage\n"),
+        ];
+
+        let reports =
+            run_at_staging(temp.path(), &config, &edits, &Authorization::unsigned()).unwrap();
+
+        assert_eq!(reports.len(), 3);
+        assert!(reports
+            .iter()
+            .all(|report| report.status == ProbeStatus::Passed));
+    }
+
+    #[test]
+    fn markdown_front_matter_requires_opening_and_closing_fences() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "*.md"
+tier = 1
+
+[[probe]]
+surface = "*.md"
+id = "parse"
+format = "markdown-front-matter"
+"#,
+        )
+        .unwrap();
+        let edits = vec![
+            FileEdit::new("missing-open.md", "name: sage\n---\n# Sage\n"),
+            FileEdit::new("missing-close.md", "---\nname: sage\n# Sage\n"),
+        ];
+
+        let reports =
+            run_at_staging(temp.path(), &config, &edits, &Authorization::unsigned()).unwrap();
+
+        assert_eq!(reports.len(), 2);
+        assert!(reports
+            .iter()
+            .all(|report| report.status == ProbeStatus::Failed));
+    }
+
+    #[test]
+    fn markdown_front_matter_rejects_invalid_yaml_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "*.md"
+tier = 1
+
+[[probe]]
+surface = "*.md"
+id = "parse"
+format = "markdown-front-matter"
+"#,
+        )
+        .unwrap();
+        let edits = vec![FileEdit::new(
+            "invalid-front-matter.md",
+            "---\nname: [\n---\n# Sage\n",
+        )];
+
+        let reports =
+            run_at_staging(temp.path(), &config, &edits, &Authorization::unsigned()).unwrap();
+
+        assert_eq!(reports[0].status, ProbeStatus::Failed);
+        assert_eq!(reports[0].results[0].status, ProbeStatus::Failed);
+    }
+
+    #[test]
+    fn protected_region_rejects_relocation_or_marker_reindentation() {
+        let baseline = b"intro\n<!-- ward:protected -->\nfixed\n<!-- /ward:protected -->\noutro\n";
+        let relocated = b"intro\noutro\n<!-- ward:protected -->\nfixed\n<!-- /ward:protected -->\n";
+        let reindented =
+            b"intro\n  <!-- ward:protected -->\nfixed\n<!-- /ward:protected -->\noutro\n";
+
+        assert_eq!(
+            run_protected_region(baseline, relocated).0,
+            ProbeStatus::Failed
+        );
+        assert_eq!(
+            run_protected_region(baseline, reindented).0,
+            ProbeStatus::Failed
+        );
+    }
+
+    #[test]
+    fn pattern_lint_reports_forbidden_matches_and_missing_requirements() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "MEMORY.md"
+tier = 1
+
+[[probe]]
+surface = "MEMORY.md"
+id = "pattern-lint"
+forbidden = ["(?i)secret"]
+required = ["(?m)^name:"]
+"#,
+        )
+        .unwrap();
+        let edits = vec![FileEdit::new("MEMORY.md", "contains a SECRET")];
+
+        let reports =
+            run_at_staging(temp.path(), &config, &edits, &Authorization::unsigned()).unwrap();
+        let result = &reports[0].results[0];
+
+        assert_eq!(result.status, ProbeStatus::Failed);
+        assert_eq!(result.detail["forbiddenMatches"], json!([0]));
+        assert_eq!(result.detail["missingRequired"], json!([0]));
+    }
+
+    #[test]
+    fn absent_probe_config_is_explicitly_unscored() {
+        let temp = tempfile::tempdir().unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "reviewed/**"
+tier = 1
+"#,
+        )
+        .unwrap();
+        let edits = vec![FileEdit::new("reviewed/new.md", "new")];
+
+        let reports =
+            run_at_staging(temp.path(), &config, &edits, &Authorization::unsigned()).unwrap();
+
+        assert_eq!(reports[0].status, ProbeStatus::Unscored);
+        assert!(reports[0].results.is_empty());
+        assert_eq!(reports[0].baseline_sha256, None);
+        let summary = ProbeSummary::from_reports(&reports);
+        assert_eq!(summary.unscored, 1);
+        assert_eq!(summary.status, ProbeStatus::Unscored);
+    }
+
+    #[test]
+    fn unreadable_baseline_demotes_matching_probes_to_unscored() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(temp.path().join("reviewed")).unwrap();
+        let config = WardConfig::from_toml_str(
+            r#"
+principal_key_fingerprint = "fp-val"
+protected_surface = []
+
+[[surface]]
+path = "reviewed"
+tier = 1
+
+[[probe]]
+surface = "reviewed"
+id = "size-delta"
+"#,
+        )
+        .unwrap();
+        let edits = vec![FileEdit::new("reviewed", "replacement")];
+
+        let reports =
+            run_at_staging(temp.path(), &config, &edits, &Authorization::unsigned()).unwrap();
+
+        assert_eq!(reports[0].status, ProbeStatus::Unscored);
+        assert_eq!(reports[0].results[0].status, ProbeStatus::Unscored);
+        assert!(reports[0].error.is_some());
+    }
+}

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -97,7 +97,7 @@ or public state.
 |---|---|---|---|---|
 | POST | `/api/v1/cast` | Submit a cast line (status/delegation shorthand) to the cockpit session. | `202 { accepted, cast_id, echo }` | `400 invalid_request` |
 | PUT | `/api/v1/familiars/:id/icon` | Update a familiar's icon glyph. | updated familiar | `400`, `404` |
-| POST | `/api/v1/familiars/:id/edits` | Ward-adjudicated writes into a familiar home (Gates 1–2, fail-closed, audited). Applied writes append `apply_audit` rows to the `ward_audit` ledger (Gate 4 persistence). | edit report | `400`, `403` (ward denial), `404` |
+| POST | `/api/v1/familiars/:id/edits` | Ward-adjudicated writes into a familiar home (Gates 1–2, fail-closed, audited). Held writes stage with deterministic Gate-3 probe evidence; applied writes append `apply_audit` rows to the `ward_audit` ledger. | edit report | `400`, `403` (ward denial), `404` |
 
 ## Ward proposals (threads)
 
@@ -109,10 +109,19 @@ Tier-0 authority degradations and Tier-1 coherence holds, distinguished by
 | Method | Path | Purpose | Success | Errors |
 |---|---|---|---|---|
 | GET | `/api/v1/threads/weaves` | Per-familiar weave/authority state (degraded configs reported inline). | weave entries | — |
-| GET | `/api/v1/threads/proposals` | Pending proposals (unparseable files reported as `degraded` entries, newest first). | `{ proposals }` | — |
-| GET | `/api/v1/threads/proposals/:id` | One pending proposal. | `{ proposal }` | `400 invalid_request` / `404 proposal_not_found` |
+| GET | `/api/v1/threads/proposals` | Pending proposals with compact `probeSummary` evidence (unparseable files reported as `degraded` entries, newest first). | `{ proposals }` | — |
+| GET | `/api/v1/threads/proposals/:id` | One pending proposal with `probeSummary` and full per-surface `probes`. | `{ proposal }` | `400 invalid_request` / `404 proposal_not_found` |
 | POST | `/api/v1/threads/proposals/:id/approve` | Re-validate and apply a staged authority proposal (coherence approval lands with Gate 3 PR 4). | decision report | `400`, `404`, `409` |
 | POST | `/api/v1/threads/proposals/:id/reject` | Reject and remove a staged proposal (audited). | decision report | `400`, `404`, `409` |
+
+Probe evidence is additive sidecar data, so the underlying
+`coven_threads_core::PendingProposal` remains backward-readable. A missing
+probe sidecar (older pending files), no matching `[[probe]]`, or a probe
+runtime error is reported as `unscored`; it is never treated as a pass.
+Stale, malformed, or internally inconsistent sidecars are likewise demoted to
+`unscored` with `probeEvidenceDegraded`, after deterministic recomputation
+against staged targets and contents, the current baseline and Gate-2
+resolution, and the declared probe set.
 
 ## Skills: eval-loop
 

--- a/docs/reference/cli-ward.md
+++ b/docs/reference/cli-ward.md
@@ -35,6 +35,54 @@ the [observe contract](cli-observe.md). Unparseable pending files appear as
 `degraded` entries instead of aborting the read. Unknown ids fail with
 `proposal_not_found`.
 
+Every newly staged proposal carries deterministic, offline probe evidence.
+The list prints its aggregate `passed`, `failed`, or `unscored` status;
+`coven ward pending <id>` prints each surface, its staging-time baseline and
+proposed SHA-256, and every probe result. `--json` exposes the same data as
+`probeSummary` (list and detail) plus `probes` (detail only).
+
+Declare probes per surface in the familiar's `ward.toml`:
+
+```toml
+[[probe]]
+surface = "reviewed/**"
+id = "parse"
+format = "markdown-front-matter" # also: toml, json
+
+[[probe]]
+surface = "reviewed/**"
+id = "size-delta"
+
+[[probe]]
+surface = "reviewed/**"
+id = "protected-region"
+
+[[probe]]
+surface = "reviewed/**"
+id = "pattern-lint"
+forbidden = ["(?i)ignore previous"]
+required = ["(?m)^name:"]
+```
+
+- `parse` checks TOML, JSON, or a UTF-8 Markdown document whose opening and
+  closing `---` fences contain valid YAML front matter.
+- `size-delta` reports byte and logical-line deltas; v1 has no threshold.
+- `protected-region` requires every block fenced by
+  `<!-- ward:protected -->` and `<!-- /ward:protected -->` to stay
+  byte-for-byte unchanged at the same logical line position.
+- `pattern-lint` runs Rust regular expressions against the proposed UTF-8
+  contents. Forbidden patterns must not match; every required pattern must.
+
+No matching `[[probe]]` declaration is explicitly `unscored`, never a pass.
+Invalid regexes, unreadable baselines, and other probe errors are also
+`unscored`. Failed and unscored results are advisory evidence: neither result
+applies, rejects, or auto-approves a proposal.
+
+The daemon recomputes persisted evidence against the staged edits, current
+baseline, Gate-2 path resolution, and declared probe set. Stale, malformed, or
+inconsistent sidecars are demoted to `unscored` and carry
+`probeEvidenceDegraded`; they are never summarized as a pass.
+
 Decisions are daemon-API verbs today
 (`POST /api/v1/threads/proposals/<id>/approve|reject` — see
 [api](api.md)); approving a `coherence` proposal stays fail-closed until


### PR DESCRIPTION
## Context

- Summary: Add the deterministic, offline probe engine and persisted/readable evidence for Ward Gate 3.
- Files changed: Ward config/probe execution, pending sidecars, proposal API/CLI rendering, migration defaults, Cargo lockfile, and reference docs.
- Refs #335

## Implementation

- Approach: Parse typed `[[probe]]` declarations and run `parse`, `size-delta`, `protected-region`, and `pattern-lint` checks against Gate-2-resolved staged surfaces.
- User-visible behavior: Newly staged authority/coherence proposals carry per-surface evidence; pending list/detail surfaces expose aggregate and detailed results. Missing, malformed, stale, or inconsistent evidence is explicitly `unscored`.
- Compatibility notes: Probe evidence is an additive sidecar, so existing `coven_threads_core::PendingProposal` readers and older pending files remain supported. Probes are advisory and cannot approve, reject, or apply edits.
- Integrity: Read paths deterministically recompute evidence against staged contents, current baselines, Gate-2 resolution, and full typed probe configuration. Duplicate resolved edit targets fail closed before staging using lowercase, NFC-normalized portable surface keys. Probe globs compile once per staging or evidence-revalidation pass and are reused across resolved surfaces.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` (1,426 unit tests passed; integration suites passed; expected ignored tests only)
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Independent review: READY after two fail-closed hardening passes

## Risk and Rollback

- Risk level: Medium; this adds evidence generation/read surfaces but no new authority to apply writes.
- Rollback plan: Revert the feature commit. Additive sidecars remain backward-readable if already staged.

## Agent Handoff

- Current state: Gate 3 PR 2 implementation is complete and locally verified.
- Follow-ups: Gate 3 coherence resolution/apply path, then explicit CLI approve/reject verbs and final docs.
- Known gaps: Coherence proposals remain held; this PR intentionally does not grant approval authority.