### PR TITLE
feat(ward): add proposal decision commands

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -51,6 +51,7 @@ mod ward_probes;
 // coherence approval all compose through the Ward primitives in ward.rs.
 #[allow(dead_code)]
 mod ward;
+mod ward_decision;
 mod ward_migrate;
 // The coven-threads validator call site: typed authority-state gating of
 // protected-surface mutations (OpenCoven/coven-threads Phase 2). Runs before
@@ -144,7 +145,7 @@ enum Command {
         #[command(subcommand)]
         command: DaemonCommand,
     },
-    #[command(about = "Inspect and migrate Ward configuration")]
+    #[command(about = "Inspect and decide Ward proposals or migrate configuration")]
     Ward {
         #[command(subcommand)]
         command: WardCommand,
@@ -696,6 +697,28 @@ enum WardCommand {
         #[arg(help = "Proposal id: show one staged proposal instead of the list")]
         id: Option<String>,
         #[arg(long, help = "Print proposals as JSON (machine-readable)")]
+        json: bool,
+    },
+    #[command(about = "Approve and apply a pending Ward proposal")]
+    Approve {
+        #[arg(help = "Proposal id")]
+        id: String,
+        #[arg(
+            long,
+            value_name = "TEXT",
+            help = "Principal rationale (required by some approval paths)"
+        )]
+        note: Option<String>,
+        #[arg(long, help = "Print the API decision report as JSON")]
+        json: bool,
+    },
+    #[command(about = "Reject a pending Ward proposal without applying it")]
+    Reject {
+        #[arg(help = "Proposal id")]
+        id: String,
+        #[arg(long, value_name = "TEXT", help = "Principal rejection rationale")]
+        note: Option<String>,
+        #[arg(long, help = "Print the API decision report as JSON")]
         json: bool,
     },
     #[command(about = "Show the append-only ward_audit ledger for one familiar")]
@@ -2873,6 +2896,22 @@ fn run_ward_command(command: WardCommand) -> Result<()> {
     match command {
         WardCommand::Pending { id, json } => {
             return observe::run_ward_pending(id.as_deref(), json);
+        }
+        WardCommand::Approve { id, note, json } => {
+            return ward_decision::run(
+                &id,
+                ward_decision::WardDecision::Approve,
+                note.as_deref(),
+                json,
+            );
+        }
+        WardCommand::Reject { id, note, json } => {
+            return ward_decision::run(
+                &id,
+                ward_decision::WardDecision::Reject,
+                note.as_deref(),
+                json,
+            );
         }
         WardCommand::Audit {
             familiar,
@@ -5104,6 +5143,75 @@ mod tests {
                 assert!(apply);
             }
             other => panic!("expected ward migrate command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_ward_approve_options() {
+        let cli = Cli::parse_from([
+            "coven",
+            "ward",
+            "approve",
+            "018f6e9d-4d20-7e42-b9f1-6bdb1bb35165",
+            "--note",
+            "reviewed identity change",
+            "--json",
+        ]);
+
+        match cli.command {
+            Some(Command::Ward {
+                command: WardCommand::Approve { id, note, json },
+            }) => {
+                assert_eq!(id, "018f6e9d-4d20-7e42-b9f1-6bdb1bb35165");
+                assert_eq!(note.as_deref(), Some("reviewed identity change"));
+                assert!(json);
+            }
+            other => panic!("expected ward approve command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_bare_ward_approve() {
+        let cli = Cli::parse_from([
+            "coven",
+            "ward",
+            "approve",
+            "018f6e9d-4d20-7e42-b9f1-6bdb1bb35165",
+        ]);
+
+        match cli.command {
+            Some(Command::Ward {
+                command: WardCommand::Approve { id, note, json },
+            }) => {
+                assert_eq!(id, "018f6e9d-4d20-7e42-b9f1-6bdb1bb35165");
+                assert!(note.is_none());
+                assert!(!json);
+            }
+            other => panic!("expected bare ward approve command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_parses_ward_reject_options() {
+        let cli = Cli::parse_from([
+            "coven",
+            "ward",
+            "reject",
+            "018f6e9d-4d20-7e42-b9f1-6bdb1bb35165",
+            "--note",
+            "needs revision",
+            "--json",
+        ]);
+
+        match cli.command {
+            Some(Command::Ward {
+                command: WardCommand::Reject { id, note, json },
+            }) => {
+                assert_eq!(id, "018f6e9d-4d20-7e42-b9f1-6bdb1bb35165");
+                assert_eq!(note.as_deref(), Some("needs revision"));
+                assert!(json);
+            }
+            other => panic!("expected ward reject command, got {other:?}"),
         }
     }
 

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -563,7 +563,10 @@ fn render_ward_pending(body: &Value) -> String {
                 .unwrap_or_default(),
         ));
     }
-    out.push_str("\nDecide: coven ward approve <id> · coven ward reject <id> --note \"reason\"\n");
+    out.push_str(
+        "\nDecide: coven ward approve <id> [--note \"rationale\"] · \
+         coven ward reject <id> [--note \"reason\"]\n",
+    );
     out
 }
 
@@ -1560,6 +1563,14 @@ mod tests {
         assert!(rendered.contains("failed"), "{rendered}");
         assert!(rendered.contains("coven ward approve <id>"), "{rendered}");
         assert!(rendered.contains("coven ward reject <id>"), "{rendered}");
+        assert!(
+            rendered.contains("approve <id> [--note \"rationale\"]"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("reject <id> [--note \"reason\"]"),
+            "{rendered}"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/observe.rs
+++ b/crates/coven-cli/src/observe.rs
@@ -563,9 +563,7 @@ fn render_ward_pending(body: &Value) -> String {
                 .unwrap_or_default(),
         ));
     }
-    out.push_str(
-        "\nDecide with the daemon API: POST /api/v1/threads/proposals/<id>/approve|reject\n",
-    );
+    out.push_str("\nDecide: coven ward approve <id> · coven ward reject <id> --note \"reason\"\n");
     out
 }
 
@@ -1560,6 +1558,8 @@ mod tests {
 
         assert!(rendered.contains("probes"), "{rendered}");
         assert!(rendered.contains("failed"), "{rendered}");
+        assert!(rendered.contains("coven ward approve <id>"), "{rendered}");
+        assert!(rendered.contains("coven ward reject <id>"), "{rendered}");
     }
 
     #[test]

--- a/crates/coven-cli/src/ward_decision.rs
+++ b/crates/coven-cli/src/ward_decision.rs
@@ -60,9 +60,9 @@ fn decide_at(
     } else if detail_response.status == 404
         && detail.pointer("/error/code").and_then(Value::as_str) == Some("proposal_not_found")
     {
-        // A completed proposal no longer has a pending detail document. Still
-        // call the decision route so its terminal audit can make retries
-        // idempotent (or report an opposite prior decision).
+        // A proposal absent from pending may already be complete. Still call
+        // the decision route so its terminal audit can make completed retries
+        // idempotent; an unknown id remains a not-found error.
         None
     } else {
         return api_failure(&detail_path, detail_response.status, &detail);

--- a/crates/coven-cli/src/ward_decision.rs
+++ b/crates/coven-cli/src/ward_decision.rs
@@ -1,0 +1,320 @@
+// ward_decision.rs — principal-facing Ward proposal decision commands.
+
+use std::path::Path;
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+use crate::{api, coven_home_dir};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WardDecision {
+    Approve,
+    Reject,
+}
+
+impl WardDecision {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Approve => "approve",
+            Self::Reject => "reject",
+        }
+    }
+}
+
+pub(crate) fn run(
+    proposal_id: &str,
+    decision: WardDecision,
+    note: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let body = decide_at(&coven_home_dir()?, proposal_id, decision, note)?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&body)
+                .context("failed to serialize Ward decision response as JSON")?
+        );
+    } else {
+        print!("{}", render_decision(&body));
+    }
+    Ok(())
+}
+
+fn decide_at(
+    coven_home: &Path,
+    proposal_id: &str,
+    decision: WardDecision,
+    note: Option<&str>,
+) -> Result<Value> {
+    let detail_path = format!("/api/v1/threads/proposals/{proposal_id}");
+    let detail_response = api::handle_request("GET", &detail_path, coven_home, None)?;
+    let detail: Value = parse_body(&detail_path, &detail_response.body)?;
+    let expected_revision = if detail_response.status < 400 {
+        Some(
+            detail
+                .pointer("/proposal/proposalRevision")
+                .and_then(Value::as_str)
+                .context("Ward proposal detail is missing proposalRevision")?,
+        )
+    } else if detail_response.status == 404
+        && detail.pointer("/error/code").and_then(Value::as_str) == Some("proposal_not_found")
+    {
+        // A completed proposal no longer has a pending detail document. Still
+        // call the decision route so its terminal audit can make retries
+        // idempotent (or report an opposite prior decision).
+        None
+    } else {
+        return api_failure(&detail_path, detail_response.status, &detail);
+    };
+
+    let mut payload = serde_json::Map::new();
+    if let Some(revision) = expected_revision {
+        payload.insert(
+            "expectedRevision".to_string(),
+            Value::String(revision.to_string()),
+        );
+    }
+    if let Some(note) = note {
+        payload.insert("note".to_string(), Value::String(note.to_string()));
+    }
+    let payload = Value::Object(payload).to_string();
+    let decision_path = format!(
+        "/api/v1/threads/proposals/{proposal_id}/{}",
+        decision.as_str()
+    );
+    let response =
+        api::handle_request_with_body("POST", &decision_path, coven_home, None, Some(&payload))?;
+    let body = parse_body(&decision_path, &response.body)?;
+    if response.status >= 400 {
+        return api_failure(&decision_path, response.status, &body);
+    }
+    Ok(body)
+}
+
+fn parse_body(path: &str, body: &str) -> Result<Value> {
+    serde_json::from_str(body).with_context(|| format!("failed to parse API response for {path}"))
+}
+
+fn api_failure(path: &str, status: u16, body: &Value) -> Result<Value> {
+    if let Some(why) = body.get("why").and_then(Value::as_str) {
+        bail!("Ward decision blocked: {why} (HTTP {status})");
+    }
+    let code = body
+        .pointer("/error/code")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown_error");
+    let message = body
+        .pointer("/error/message")
+        .and_then(Value::as_str)
+        .unwrap_or("Request failed.");
+    bail!("{message} ({code}; HTTP {status}; {path})");
+}
+
+fn render_decision(body: &Value) -> String {
+    let proposal_id = body
+        .get("proposalId")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let decision = body
+        .get("decision")
+        .and_then(Value::as_str)
+        .unwrap_or("decided");
+    let retry = if body.get("idempotent").and_then(Value::as_bool) == Some(true) {
+        " (already recorded)"
+    } else {
+        ""
+    };
+    let mut out = format!("Ward proposal {proposal_id}: {decision}{retry}\n");
+    let files = body
+        .get("filesTouched")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    if !files.is_empty() {
+        out.push_str(&format!("Targets: {}\n", files.join(", ")));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{Context, Result};
+    use serde_json::Value;
+
+    use super::*;
+
+    fn stage_reviewed_edit(home: &Path, after: &str) -> Result<(String, std::path::PathBuf)> {
+        std::fs::write(
+            home.join("familiars.toml"),
+            r#"[[familiar]]
+id = "sage"
+display_name = "Sage"
+role = "Research"
+description = "Reads and synthesizes."
+"#,
+        )?;
+        let workspace = home.join("familiars").join("sage");
+        std::fs::create_dir_all(workspace.join("reviewed"))?;
+        std::fs::write(workspace.join("reviewed").join("skill.md"), "before")?;
+        std::fs::write(
+            workspace.join("ward.toml"),
+            r#"principal_key_fingerprint = "fpr-val"
+
+[[surface]]
+path = "reviewed/"
+tier = 1
+
+[[probe]]
+surface = "reviewed/**"
+id = "size-delta"
+"#,
+        )?;
+        let response = crate::api::handle_request_with_body(
+            "POST",
+            "/api/v1/familiars/sage/edits",
+            home,
+            None,
+            Some(
+                &serde_json::json!({
+                    "edits": [{
+                        "target": "reviewed/skill.md",
+                        "contents": after,
+                    }],
+                })
+                .to_string(),
+            ),
+        )?;
+        anyhow::ensure!(response.status == 202, "staging failed: {}", response.body);
+        let body: Value = serde_json::from_str(&response.body)?;
+        let proposal_id = body["proposalId"]
+            .as_str()
+            .context("staged response carries proposalId")?
+            .to_string();
+        let pending_path = body["pendingPath"]
+            .as_str()
+            .context("staged response carries pendingPath")?
+            .into();
+        Ok((proposal_id, pending_path))
+    }
+
+    #[test]
+    fn approve_reads_revision_then_applies_through_api() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (proposal_id, pending_path) = stage_reviewed_edit(temp.path(), "after")?;
+
+        let body = decide_at(
+            temp.path(),
+            &proposal_id,
+            WardDecision::Approve,
+            Some("reviewed coherence evidence"),
+        )?;
+
+        assert_eq!(body["decision"], "approved");
+        assert_eq!(body["proposalId"], proposal_id);
+        assert_eq!(
+            std::fs::read_to_string(
+                temp.path()
+                    .join("familiars")
+                    .join("sage")
+                    .join("reviewed")
+                    .join("skill.md"),
+            )?,
+            "after"
+        );
+        assert!(!pending_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn reject_passes_note_and_leaves_staged_bytes_unapplied() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (proposal_id, pending_path) = stage_reviewed_edit(temp.path(), "rejected bytes")?;
+
+        let body = decide_at(
+            temp.path(),
+            &proposal_id,
+            WardDecision::Reject,
+            Some("needs revision"),
+        )?;
+
+        assert_eq!(body["decision"], "rejected");
+        assert_eq!(body["note"], "needs revision");
+        assert_eq!(
+            std::fs::read_to_string(
+                temp.path()
+                    .join("familiars")
+                    .join("sage")
+                    .join("reviewed")
+                    .join("skill.md"),
+            )?,
+            "before"
+        );
+        assert!(!pending_path.exists());
+        Ok(())
+    }
+
+    #[test]
+    fn completed_decision_retries_through_terminal_audit() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (proposal_id, _) = stage_reviewed_edit(temp.path(), "after")?;
+
+        decide_at(
+            temp.path(),
+            &proposal_id,
+            WardDecision::Approve,
+            Some("reviewed"),
+        )?;
+        let retry = decide_at(
+            temp.path(),
+            &proposal_id,
+            WardDecision::Approve,
+            Some("reviewed"),
+        )?;
+
+        assert_eq!(retry["decision"], "approved");
+        assert_eq!(retry["idempotent"], true);
+        Ok(())
+    }
+
+    #[test]
+    fn opposite_completed_decision_reports_terminal_conflict() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let (proposal_id, _) = stage_reviewed_edit(temp.path(), "after")?;
+
+        decide_at(
+            temp.path(),
+            &proposal_id,
+            WardDecision::Approve,
+            Some("reviewed"),
+        )?;
+        let error = decide_at(
+            temp.path(),
+            &proposal_id,
+            WardDecision::Reject,
+            Some("changed my mind"),
+        )
+        .expect_err("opposite terminal decision must fail");
+
+        assert!(
+            error.to_string().contains("proposal-already-decided"),
+            "{error:#}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn decision_renderer_marks_idempotent_terminal_result() {
+        let rendered = render_decision(&serde_json::json!({
+            "decision": "approved",
+            "proposalId": "proposal-1",
+            "filesTouched": ["reviewed/skill.md"],
+            "idempotent": true,
+        }));
+
+        assert!(rendered.contains("proposal-1: approved (already recorded)"));
+        assert!(rendered.contains("Targets: reviewed/skill.md"));
+    }
+}

--- a/docs/design/ward-gate3-coherence.md
+++ b/docs/design/ward-gate3-coherence.md
@@ -5,11 +5,12 @@ description: "Design for resolving held Ward proposals: stage Tier-1 holds besid
 
 # Ward Gate 3 — Coherence Review Design
 
-Status: Implemented through G3.4; CLI decision verbs remain in PR 5
+Status: Implemented
 Date: 2026-07-26
-Scope: `crates/coven-cli` (`ward.rs`, `threads_gate.rs`, `api.rs`, `observe.rs`) plus
-reference docs. Composes with — never duplicates — the coven-threads §5 staging
-machinery that already exists. Tracking: #415 (sub-issue of #335).
+Scope: `crates/coven-cli` (`ward.rs`, `threads_gate.rs`, `api.rs`, `observe.rs`,
+`ward_decision.rs`) plus reference docs. Composes with — never duplicates —
+the coven-threads §5 staging machinery that already exists. Tracking: #415
+(sub-issue of #335).
 
 ## Summary
 
@@ -136,7 +137,8 @@ with evidence:
 - CLI: `coven ward pending [--json]` and `coven ward pending <id> [--json]`
   via the observe.rs pattern (`--json` = exact daemon body). Reference page
   `docs/reference/cli-ward.md` documents the lifecycle; `api.md` carries the
-  route rows. The `approve` / `reject` CLI wrappers are the final PR 5 slice.
+  route rows. `coven ward approve|reject` reuses those decision routes and
+  carries the proposal's exact revision into every pending decision.
 
 ### G3.4 — Resolution for coherence proposals
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -111,8 +111,8 @@ Tier-0 authority degradations and Tier-1 coherence holds, distinguished by
 | GET | `/api/v1/threads/weaves` | Per-familiar weave/authority state (degraded configs reported inline). | weave entries | — |
 | GET | `/api/v1/threads/proposals` | Pending proposals with compact `probeSummary` evidence (unparseable files reported as `degraded` entries, newest first). | `{ proposals }` | — |
 | GET | `/api/v1/threads/proposals/:id` | One pending proposal with `probeSummary` and full per-surface `probes`. | `{ proposal }` | `400 invalid_request` / `404 proposal_not_found` |
-| POST | `/api/v1/threads/proposals/:id/approve` | Re-validate and atomically apply a staged authority or coherence proposal. | decision report | `400`, `404`, `409` |
-| POST | `/api/v1/threads/proposals/:id/reject` | Reject and remove a staged proposal (audited). | decision report | `400`, `404`, `409` |
+| POST | `/api/v1/threads/proposals/:id/approve` | Re-validate and atomically apply a staged authority or coherence proposal. Pending decisions require `{ expectedRevision, note? }`; take the exact revision from the GET detail response. | decision report | `400`, `404`, `409` |
+| POST | `/api/v1/threads/proposals/:id/reject` | Reject and remove a staged proposal (audited). Pending decisions require `{ expectedRevision, note? }`; take the exact revision from the GET detail response. | decision report | `400`, `404`, `409` |
 
 Probe evidence is additive sidecar data, so the underlying
 `coven_threads_core::PendingProposal` remains backward-readable. A missing

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -111,7 +111,7 @@ Tier-0 authority degradations and Tier-1 coherence holds, distinguished by
 | GET | `/api/v1/threads/weaves` | Per-familiar weave/authority state (degraded configs reported inline). | weave entries | — |
 | GET | `/api/v1/threads/proposals` | Pending proposals with compact `probeSummary` evidence (unparseable files reported as `degraded` entries, newest first). | `{ proposals }` | — |
 | GET | `/api/v1/threads/proposals/:id` | One pending proposal with `probeSummary` and full per-surface `probes`. | `{ proposal }` | `400 invalid_request` / `404 proposal_not_found` |
-| POST | `/api/v1/threads/proposals/:id/approve` | Re-validate and atomically apply a staged authority or coherence proposal. Pending decisions require `{ expectedRevision, note? }`; take the exact revision from the GET detail response. | decision report | `400`, `404`, `409` |
+| POST | `/api/v1/threads/proposals/:id/approve` | Re-validate and atomically apply a staged authority or coherence proposal. Pending decisions require `{ expectedRevision, note? }`; take the exact revision from the GET detail response. `HumanApprovalWithRationale` paths require a non-empty `note`. | decision report | `400`, `404`, `409` |
 | POST | `/api/v1/threads/proposals/:id/reject` | Reject and remove a staged proposal (audited). Pending decisions require `{ expectedRevision, note? }`; take the exact revision from the GET detail response. | decision report | `400`, `404`, `409` |
 
 Probe evidence is additive sidecar data, so the underlying

--- a/docs/reference/cli-ward.md
+++ b/docs/reference/cli-ward.md
@@ -19,7 +19,7 @@ coven ward pending             # table of staged proposals, newest first
 coven ward pending <id>        # one proposal in full
 coven ward pending --json      # exact daemon body (GET /api/v1/threads/proposals)
 coven ward approve <id>        # re-validate and atomically apply
-coven ward reject <id> --note "reason" # reject without applying
+coven ward reject <id> [--note "reason"] # reject without applying
 coven ward audit <familiar>    # append-only ward_audit ledger, newest first
 coven ward migrate --apply     # migrate v0.1 ward.toml files to Phase-2
 ```

--- a/docs/reference/cli-ward.md
+++ b/docs/reference/cli-ward.md
@@ -1,11 +1,12 @@
 ---
-summary: "Inspect and manage the Ward proposal lifecycle: pending reads, the audit ledger, and config migration."
+summary: "Inspect and manage the Ward proposal lifecycle: pending reads, principal decisions, the audit ledger, and config migration."
 read_when:
   - Looking up ward
   - Reviewing staged (held) Ward proposals
+  - Approving or rejecting a Ward proposal
   - Auditing applied Ward writes
 title: "coven ward"
-description: "Reference for coven ward: list and inspect pending Ward proposals staged for the principal, read the append-only ward_audit ledger, and migrate v0.1 ward.toml files to the Phase-2 WardConfig dialect."
+description: "Reference for coven ward: inspect, approve, or reject pending Ward proposals, read the append-only ward_audit ledger, and migrate v0.1 ward.toml files to the Phase-2 WardConfig dialect."
 ---
 
 `coven ward` groups the Ward's principal-facing lifecycle verbs. Held writes
@@ -17,6 +18,8 @@ is the supported way to see what is waiting.
 coven ward pending             # table of staged proposals, newest first
 coven ward pending <id>        # one proposal in full
 coven ward pending --json      # exact daemon body (GET /api/v1/threads/proposals)
+coven ward approve <id>        # re-validate and atomically apply
+coven ward reject <id> --note "reason" # reject without applying
 coven ward audit <familiar>    # append-only ward_audit ledger, newest first
 coven ward migrate --apply     # migrate v0.1 ward.toml files to Phase-2
 ```
@@ -83,20 +86,36 @@ baseline, Gate-2 path resolution, and declared probe set. Stale, malformed, or
 inconsistent sidecars are demoted to `unscored` and carry
 `probeEvidenceDegraded`; they are never summarized as a pass.
 
-Decisions are daemon-API verbs today
-(`POST /api/v1/threads/proposals/<id>/approve|reject` — see
-[api](api.md)); the CLI wrappers land in the final Gate-3 slice. Coherence
-approval re-runs Gates 1–2 and the probes, skips the threads validator, and
-atomically applies only while the write's before-image matches the re-probed
-baseline. Missing, malformed, stale, or inconsistent evidence returns `409`
-and leaves the proposal pending. A valid `failed` or `unscored` result remains
-advisory and may be explicitly approved. Nothing ever auto-approves — the
-principal is the sole approver (design Non-goals). A first apply also requires
-the exact before-image even when concurrent bytes equal the proposal; only a
-durable recovery intent may accept already-applied bytes, and recovery
-revalidates the persisted Gate-2-resolved surface at the Ward's final
-adjudication. Clean failures clear recovery state; only a write that may have
-committed remains eligible for idempotent replay.
+## Principal decisions
+
+`coven ward approve <id>` and `coven ward reject <id>` are local CLI wrappers
+over the existing daemon API decision routes. Both first read the pending
+proposal and submit its exact `proposalRevision`, so a concurrent change fails
+closed instead of deciding stale bytes. `--note <TEXT>` is available on both
+verbs and is required when an approval's declared path calls for a principal
+rationale. `--json` prints the API decision report.
+
+```sh
+coven ward approve <id> --note "reviewed identity change"
+coven ward reject <id> --note "needs revision"
+coven ward approve <id> --json
+```
+
+Approval re-runs Gates 1–2 and the probes, skips the threads validator for
+coherence proposals, and atomically applies only while the write's before-image
+matches the re-probed baseline. Rejection audits and removes the proposal
+without applying it. Missing, malformed, stale, or inconsistent evidence
+returns `409` and leaves the proposal pending. A valid `failed` or `unscored`
+result remains advisory and may be explicitly approved. Nothing ever
+auto-approves — the principal is the sole approver (design Non-goals).
+
+A first apply also requires the exact before-image even when concurrent bytes
+equal the proposal; only a durable recovery intent may accept already-applied
+bytes, and recovery revalidates the persisted Gate-2-resolved surface at the
+Ward's final adjudication. Clean failures clear recovery state; only a write
+that may have committed remains eligible for idempotent replay. Retrying the
+same CLI decision after a terminal audit is idempotent; attempting the opposite
+decision fails with `proposal-already-decided`.
 
 ## Audit ledger
 

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -12,7 +12,7 @@ title: "Coven changelog and release notes"
 
 - **Ward proposals can be decided from the CLI.** `coven ward approve <id>`
   re-validates and atomically applies a pending proposal, while
-  `coven ward reject <id> --note "reason"` audits and removes it without
+  `coven ward reject <id> [--note "reason"]` audits and removes it without
   applying. Both wrappers read and submit the proposal's exact revision before
   deciding; `--note` also supports rationale-required approvals, and `--json`
   returns the API decision report. See [Ward commands](/reference/cli-ward) and

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -10,6 +10,13 @@ title: "Coven changelog and release notes"
 
 ### New features
 
+- **Ward proposals can be decided from the CLI.** `coven ward approve <id>`
+  re-validates and atomically applies a pending proposal, while
+  `coven ward reject <id> --note "reason"` audits and removes it without
+  applying. Both wrappers read and submit the proposal's exact revision before
+  deciding; `--note` also supports rationale-required approvals, and `--json`
+  returns the API decision report. See [Ward commands](/reference/cli-ward) and
+  [issue #335](https://github.com/OpenCoven/coven/issues/335).
 - **Safe memory reads for local dashboards.** `GET /api/v1/memory` now returns
   stable opaque ids and machine-readable timestamps while preserving its
   existing summary fields. `GET /api/v1/memory/overview` reports counts and


### PR DESCRIPTION
## Context

- Summary: Complete the final Ward Gate 3 slice with principal-facing approve/reject CLI commands.
- Files changed: Ward CLI parsing/orchestration, a revision-safe decision wrapper, pending-list guidance, Gate 3/API/CLI references, and release notes.
- Closes #335

## Implementation

- Approach: `coven ward approve|reject <id>` reads the proposal detail, carries its exact `proposalRevision` into the existing decision POST route, and delegates all authority, revalidation, audit, and apply behavior to that route.
- User-visible behavior: both verbs accept `--note`; `--json` emits the API decision report; terminal retries remain idempotent and opposite retries surface the existing conflict.
- Compatibility notes: no API shape or Ward authority boundary changes. Existing pending/audit/migrate commands are unchanged.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Focused approve/reject, terminal retry/conflict, renderer, parser, and CLI help checks
- [x] npm/TypeScript gates not applicable; no npm/TypeScript package changed

## Risk and Rollback

- Risk level: Medium — approval is intentionally state-mutating, but the CLI adds no new authority and preserves optimistic concurrency through `expectedRevision`.
- Rollback plan: Revert this commit to remove the CLI wrappers and documentation; the existing API decision routes remain intact.

## Agent Handoff

- Current state: Verified locally; draft PR opened for CI and maintainer review.
- Follow-ups: Mark ready after CI/review, then squash-merge and close the #335 umbrella.
- Known gaps: None.