### PR TITLE
Launch the local memory dashboard from Coven

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The Rust daemon is the authority boundary. All clients — including the CLI its
 | **Rust stable toolchain**    | Required only when building from source                                     |
 | **Git**                      | Required                                                                    |
 | **macOS, Linux, or Windows x64** | Native npm packages are published for all three platforms                  |
-| **Node.js 18+**              | Required only for npm wrapper or package/plugin development                 |
+| **Node.js 18+**              | Required for the npm wrapper; `coven memory open` requires Node.js 24+      |
 | **At least one harness CLI** | Codex, Claude Code, and/or GitHub Copilot CLI (see below)                    |
 
 ### Installing harness CLIs
@@ -151,7 +151,12 @@ Install globally:
 ```bash
 npm install -g @opencoven/cli
 coven doctor
+coven memory open
 ```
+
+The core npm wrapper supports Node.js 18 or newer. The optional memory
+dashboard requires Node.js 24 or newer; on an older runtime, only
+`coven memory open` is blocked and prints an upgrade instruction.
 
 **Available npm packages:**
 
@@ -161,6 +166,7 @@ coven doctor
 | `@opencoven/cli-macos`     | macOS Apple Silicon                            |
 | `@opencoven/cli-linux-x64` | Linux x64                                      |
 | `@opencoven/cli-windows`   | Windows x64                                    |
+| `@opencoven/coven-memory-dashboard` | Optional loopback memory dashboard companion |
 
 ### Build from source (recommended for contributors)
 
@@ -243,7 +249,8 @@ The full command surface — every subcommand, flag, and JSON output shape — l
 | `coven attach <id>` | Replay/follow session output and forward input | [`cli-attach.md`](docs/reference/cli-attach.md) |
 | `coven archive` / `summon` / `sacrifice` / `kill` | Session rituals (see below) | [`cli-archive.md`](docs/reference/cli-archive.md), [`cli-summon.md`](docs/reference/cli-summon.md), [`cli-sacrifice.md`](docs/reference/cli-sacrifice.md), [`cli-kill.md`](docs/reference/cli-kill.md) |
 | `coven adapter list/doctor/install` | Inspect harness adapters; opt into trusted adapter recipes (e.g. `coven adapter install grok`) | [`docs/HARNESS-ADAPTERS.md`](docs/HARNESS-ADAPTERS.md) |
-| `coven status` / `familiars` / `skills` / `memory` / `research` / `calls` / `hub` | Read-only observability with `--json`, mirroring the daemon API routes | [`cli-observe.md`](docs/reference/cli-observe.md) |
+| `coven status` / `familiars` / `skills` / `research` / `calls` / `hub` | Read-only observability with `--json`, mirroring the daemon API routes | [`cli-observe.md`](docs/reference/cli-observe.md) |
+| `coven memory` / `coven memory --json` / `coven memory open` | Preserve the memory list output or launch the private loopback dashboard | [`cli-observe.md`](docs/reference/cli-observe.md) |
 | `coven wt` / `claim` / `hooks` | Parallel work protocol: worktrees, TTL-bounded claims, git hooks | [`cli-wt.md`](docs/reference/cli-wt.md), [`cli-claim.md`](docs/reference/cli-claim.md) |
 | `coven pc` | macOS-first system diagnostics; write operations require `--confirm` | [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) |
 | `coven patch openclaw` / `logs prune` / `vacuum` | OpenClaw rescue loop, log-retention pruning, store repair | [`cli-patch.md`](docs/reference/cli-patch.md), [`cli-logs.md`](docs/reference/cli-logs.md), [`cli-vacuum.md`](docs/reference/cli-vacuum.md) |
@@ -292,6 +299,14 @@ Local dashboards use `GET /api/v1/memory`, `GET /api/v1/memory/overview`,
 and `GET /api/v1/memory/:id`. The daemon resolves and validates memory files;
 clients must not open the archival database, vector index, manifest, or memory
 paths directly.
+
+`coven memory open` delegates to the local
+`@opencoven/coven-memory-dashboard` executable. The npm wrapper supplies only
+the installed Node executable and dashboard entrypoint; memory data and daemon
+transport proofs are never passed through the environment. Direct native
+binary installs can place `coven-memory-dashboard` on `PATH` or install the
+package globally. The dashboard requires Node.js 24 or newer; the rest of the
+npm-wrapped CLI remains available on Node.js 18 or newer.
 
 Treat the socket API as the product contract. Clients may validate for better UX, but the Rust daemon remains the authority boundary.
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::{SecondsFormat, Utc};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 use uuid::Uuid;
 
 mod api;
@@ -26,6 +26,7 @@ mod executor_node;
 mod familiar_identity;
 mod harness;
 mod hub;
+mod memory_dashboard;
 mod observe;
 mod openclaw_repo;
 mod parallel_protocol;
@@ -98,6 +99,28 @@ struct Cli {
         help = "Free-text task to cast when no subcommand is given: Coven plans it, asks you to confirm, then runs it in a session"
     )]
     prompt: Vec<String>,
+}
+
+impl Cli {
+    fn validate(self) -> std::result::Result<Self, clap::Error> {
+        if matches!(
+            self.command,
+            Some(Command::Memory {
+                command: Some(MemoryCommand::Open),
+                json: true,
+            })
+        ) {
+            let mut command = Cli::command();
+            let memory = command
+                .find_subcommand_mut("memory")
+                .expect("derived CLI must contain the memory command");
+            return Err(memory.error(
+                clap::error::ErrorKind::ArgumentConflict,
+                "the argument '--json' cannot be used with 'open'",
+            ));
+        }
+        Ok(self)
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -415,8 +438,10 @@ enum Command {
         #[arg(long, help = "Print skills as JSON (machine-readable)")]
         json: bool,
     },
-    #[command(about = "List familiar memory files from ~/.coven/memory/")]
+    #[command(about = "List familiar memory or open its private local dashboard")]
     Memory {
+        #[command(subcommand)]
+        command: Option<MemoryCommand>,
         #[arg(long, help = "Print memory files as JSON (machine-readable)")]
         json: bool,
     },
@@ -477,6 +502,12 @@ enum Command {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
         args: Vec<OsString>,
     },
+}
+
+#[derive(Subcommand, Debug)]
+enum MemoryCommand {
+    #[command(about = "Open the private local memory dashboard")]
+    Open,
 }
 
 #[derive(Subcommand, Debug)]
@@ -858,7 +889,7 @@ fn main() -> Result<()> {
         });
     settings::init_cached(loaded);
 
-    let cli = Cli::parse();
+    let cli = Cli::parse().validate().unwrap_or_else(|error| error.exit());
     // Resolve --color before anything renders: theme::mode() caches on
     // first use, so the override must be recorded ahead of any output.
     theme::set_color_choice(match cli.color.as_str() {
@@ -984,7 +1015,10 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Status { json }) => observe::run_status(json),
         Some(Command::Familiars { id, json }) => observe::run_familiars(id.as_deref(), json),
         Some(Command::Skills { json }) => observe::run_skills(json),
-        Some(Command::Memory { json }) => observe::run_memory(json),
+        Some(Command::Memory { command, json }) => match command {
+            Some(MemoryCommand::Open) => memory_dashboard::run_open(),
+            None => observe::run_memory(json),
+        },
         Some(Command::Research { json }) => observe::run_research(json),
         Some(Command::Calls { id, json }) => observe::run_calls(id.as_deref(), json),
         Some(Command::Hub { command }) => match command {
@@ -4147,7 +4181,24 @@ mod tests {
         ));
         assert!(matches!(
             Cli::parse_from(["coven", "memory"]).command,
-            Some(Command::Memory { json: false })
+            Some(Command::Memory {
+                command: None,
+                json: false
+            })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "memory", "--json"]).command,
+            Some(Command::Memory {
+                command: None,
+                json: true
+            })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "memory", "open"]).command,
+            Some(Command::Memory {
+                command: Some(MemoryCommand::Open),
+                json: false
+            })
         ));
         assert!(matches!(
             Cli::parse_from(["coven", "research"]).command,
@@ -4168,6 +4219,35 @@ mod tests {
             Cli::parse_from(["coven", "doctor", "--json"]).command,
             Some(Command::Doctor { json: true })
         ));
+    }
+
+    #[test]
+    fn memory_open_rejects_list_flags_but_keeps_global_color_placements() {
+        let error = Cli::try_parse_from(["coven", "memory", "--json", "open"])
+            .and_then(Cli::validate)
+            .expect_err("memory open must reject parent list-only --json");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+
+        let error = Cli::try_parse_from(["coven", "memory", "open", "--json"])
+            .expect_err("memory open must reject trailing list-only --json");
+        assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
+
+        for args in [
+            vec!["coven", "--color=never", "memory", "open"],
+            vec!["coven", "memory", "--color=never", "open"],
+            vec!["coven", "memory", "open", "--color=never"],
+        ] {
+            assert!(matches!(
+                Cli::try_parse_from(args)
+                    .and_then(Cli::validate)
+                    .expect("global --color remains valid around memory open")
+                    .command,
+                Some(Command::Memory {
+                    command: Some(MemoryCommand::Open),
+                    json: false
+                })
+            ));
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/memory_dashboard.rs
+++ b/crates/coven-cli/src/memory_dashboard.rs
@@ -1,0 +1,149 @@
+use anyhow::{anyhow, bail, Context, Result};
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+const ENTRY_ENV: &str = "COVEN_MEMORY_DASHBOARD_ENTRY";
+const NODE_ENV: &str = "COVEN_MEMORY_DASHBOARD_NODE";
+const BIN_ENV: &str = "COVEN_MEMORY_DASHBOARD_BIN";
+
+#[derive(Debug, PartialEq, Eq)]
+struct LaunchCommand {
+    program: PathBuf,
+    args: Vec<OsString>,
+}
+
+fn executable(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+fn resolve_from(
+    node: Option<&OsStr>,
+    entry: Option<&OsStr>,
+    override_bin: Option<&OsStr>,
+    path_var: Option<&OsStr>,
+) -> Option<LaunchCommand> {
+    if let (Some(node), Some(entry)) = (node, entry) {
+        let node = PathBuf::from(node);
+        let entry = PathBuf::from(entry);
+        if executable(&node) && entry.is_file() {
+            return Some(LaunchCommand {
+                program: node,
+                args: vec![entry.into_os_string()],
+            });
+        }
+    }
+
+    if let Some(override_bin) = override_bin {
+        let path = PathBuf::from(override_bin);
+        if executable(&path) {
+            return Some(LaunchCommand {
+                program: path,
+                args: Vec::new(),
+            });
+        }
+    }
+
+    let path_var = path_var?;
+    for directory in std::env::split_paths(path_var) {
+        #[cfg(windows)]
+        let names = [
+            "coven-memory-dashboard.exe",
+            "coven-memory-dashboard.cmd",
+            "coven-memory-dashboard.bat",
+        ];
+        #[cfg(not(windows))]
+        let names = ["coven-memory-dashboard"];
+
+        for name in names {
+            let candidate = directory.join(name);
+            if executable(&candidate) {
+                return Some(LaunchCommand {
+                    program: candidate,
+                    args: Vec::new(),
+                });
+            }
+        }
+    }
+    None
+}
+
+fn resolve() -> Option<LaunchCommand> {
+    resolve_from(
+        std::env::var_os(NODE_ENV).as_deref(),
+        std::env::var_os(ENTRY_ENV).as_deref(),
+        std::env::var_os(BIN_ENV).as_deref(),
+        std::env::var_os("PATH").as_deref(),
+    )
+}
+
+pub fn run_open() -> Result<()> {
+    let launch = resolve().ok_or_else(|| {
+        anyhow!(
+            "The Coven Memory dashboard is not installed.\n\n  \
+             npm install -g @opencoven/coven-memory-dashboard\n\n\
+             Then rerun: coven memory open"
+        )
+    })?;
+    let status = Command::new(&launch.program)
+        .args(&launch.args)
+        .status()
+        .with_context(|| {
+            format!(
+                "failed to launch Coven Memory with {}",
+                launch.program.display()
+            )
+        })?;
+    if !status.success() {
+        bail!("Coven Memory exited with {status}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn resolves_wrapper_supplied_node_entrypoint_first() {
+        let temp = tempfile::tempdir().unwrap();
+        let node = temp.path().join("node");
+        let entry = temp.path().join("dashboard.mjs");
+        fs::write(&node, "").unwrap();
+        fs::write(&entry, "").unwrap();
+        #[cfg(unix)]
+        fs::set_permissions(&node, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let resolved =
+            resolve_from(Some(node.as_os_str()), Some(entry.as_os_str()), None, None).unwrap();
+
+        assert_eq!(resolved.program, node);
+        assert_eq!(resolved.args, vec![entry.into_os_string()]);
+    }
+
+    #[test]
+    fn rejects_an_incomplete_wrapper_contract() {
+        let temp = tempfile::tempdir().unwrap();
+        let entry = temp.path().join("dashboard.mjs");
+        fs::write(&entry, "").unwrap();
+
+        assert!(resolve_from(None, Some(entry.as_os_str()), None, None).is_none());
+    }
+}

--- a/docs/install/npm.md
+++ b/docs/install/npm.md
@@ -18,6 +18,23 @@ coven doctor
 
 The wrapper exposes the `coven` command and selects the native package for the current platform.
 
+The wrapper also declares `@opencoven/coven-memory-dashboard` as an optional
+companion on its own release train. With optional dependencies enabled, launch
+the packaged loopback-only dashboard with:
+
+```sh
+coven memory open
+```
+
+The wrapper passes only the resolved dashboard entrypoint and the current Node
+executable to the native CLI. It does not put memory content, daemon transport
+proofs, or credentials in the environment.
+
+The core npm wrapper supports Node.js 18 or newer. The optional dashboard
+requires Node.js 24 or newer. On Node.js 18–23, `coven memory open` prints an
+upgrade instruction; list output and every other Coven command remain
+available.
+
 ## Supported npm targets
 
 | Platform | Native package |
@@ -35,6 +52,14 @@ coven doctor
 ```
 
 On Linux, use a glibc-based distribution for the prebuilt package. For Alpine or another musl-based environment, use [Install from source](/install/from-source).
+
+If Coven was installed as a direct native binary, install the dashboard
+executable separately and keep it on `PATH`:
+
+```sh
+npm install -g @opencoven/coven-memory-dashboard
+coven memory open
+```
 
 ## Install harness CLIs
 

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -10,10 +10,11 @@ description: "Reference for coven status, familiars, skills, memory, research, c
 # Observability commands
 
 Everything the CovenCave dashboard reads is also visible from the terminal.
-These commands are **read-only**, work **without a running daemon** (they read
-the same `~/.coven` files and SQLite store the daemon serves), and each takes
-`--json` for machine-readable output that carries the same body as the
-corresponding daemon API route.
+The commands in the table below are **read-only**, work **without a running
+daemon** (they read the same `~/.coven` files and SQLite store the daemon
+serves), and each takes `--json` for machine-readable output that carries the
+same body as the corresponding daemon API route. `coven memory open` is a
+separate local-dashboard launcher described after the table.
 
 | Command | Human view | `--json` body |
 |---|---|---|
@@ -31,6 +32,15 @@ corresponding daemon API route.
 | `coven sessions events <id>` | Recorded events (redacted) | `GET /api/v1/sessions/:id/events` |
 | `coven sessions log <id>` | Log lines | `GET /api/v1/sessions/:id/log` |
 
+## coven memory open
+
+`coven memory open` launches the optional
+`@opencoven/coven-memory-dashboard` companion on a validated loopback address.
+It does not accept `--json`; `coven memory` and `coven memory --json` retain the
+read-only list behavior above. The npm wrapper requires Node.js 24 or newer for
+the dashboard only, while other wrapped Coven commands continue to support
+Node.js 18 or newer.
+
 ## coven status
 
 The "what is my coven doing" front door. Complements `coven doctor`
@@ -39,7 +49,7 @@ The "what is my coven doing" front door. Complements `coven doctor`
 ```text
 Coven status
 
-  daemon     running (pid 63321, socket /Users/alice/.coven/coven.sock)
+  daemon     running (pid 63321, socket /path/to/coven.sock)
   version    0.1.7
   sessions   3 open
   familiars  1 active / 2 total
@@ -80,7 +90,7 @@ one source of truth for what a familiar's principal has protected:
 ```text
 Familiar sage — Ward surface
 
-  workspace  /home/x/.coven/familiars/sage
+  workspace  /path/to/familiar-workspace
   principal  SHA256:principal-key
   unmatched  tier 2 (logged)
 
@@ -176,4 +186,3 @@ bare words (`status`, `familiars`, `roster`, …). Every card shows the
 scriptable `coven <view>` spelling so the terminal form stays discoverable.
 `status` in a composer means this ecosystem overview; setup checks stay on
 `doctor`/`health`.
-

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -14,6 +14,16 @@ npx @opencoven/cli doctor
 
 The wrapper installs platform-specific native packages through `optionalDependencies` and runs the matching `coven` binary for your OS and CPU. No Rust toolchain is required for end users after a supported package is published.
 
+It also installs `@opencoven/coven-memory-dashboard` as an optional companion.
+`coven memory open` passes only that package's installed entrypoint and the
+current Node executable to the native CLI, which launches the private
+loopback-only dashboard. Existing `coven memory` and `coven memory --json`
+continue to print the memory list.
+
+The wrapper and native CLI support Node.js 18 or newer. The optional dashboard
+requires Node.js 24 or newer; on Node.js 18–23, `coven memory open` prints an
+upgrade instruction while other Coven commands continue to work.
+
 ## v0 platform scope
 
 Current early-adopter packages target:

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -14,6 +14,7 @@ const PLATFORM_PACKAGES = {
 const binaryName = process.platform === 'win32' ? 'coven.exe' : 'coven';
 const platformKey = `${process.platform}-${process.arch}`;
 const packageName = PLATFORM_PACKAGES[platformKey];
+const MEMORY_DASHBOARD_MIN_NODE_MAJOR = 24;
 
 function resolveBinary() {
   if (!packageName) {
@@ -31,6 +32,33 @@ function resolveBinary() {
   }
 }
 
+function isMemoryOpenInvocation(args) {
+  if (args.includes('--json')) {
+    return false;
+  }
+  const commandPath = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--color') {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--color=')) {
+      continue;
+    }
+    commandPath.push(arg);
+    if (commandPath.length === 2) {
+      break;
+    }
+  }
+  return commandPath[0] === 'memory' && commandPath[1] === 'open';
+}
+
+function supportsMemoryDashboard(nodeVersion) {
+  const major = Number.parseInt(nodeVersion.split('.')[0], 10);
+  return Number.isInteger(major) && major >= MEMORY_DASHBOARD_MIN_NODE_MAJOR;
+}
+
 let binary;
 try {
   binary = resolveBinary();
@@ -44,10 +72,34 @@ try {
 // line. (The wrapper previously short-circuited --version to its own
 // package.json version, which shadowed that output for npm installs.)
 const args = process.argv.slice(2);
+const childEnv = { ...process.env };
+const opensMemoryDashboard = isMemoryOpenInvocation(args);
+const requestsHelp = args.some((arg) => arg === '--help' || arg === '-h');
+if (
+  opensMemoryDashboard &&
+  !requestsHelp &&
+  !supportsMemoryDashboard(process.versions.node)
+) {
+  console.error(
+    `coven memory open requires Node.js ${MEMORY_DASHBOARD_MIN_NODE_MAJOR} or newer; current Node.js is ${process.versions.node}. Upgrade Node.js and reinstall @opencoven/cli. Other Coven CLI commands continue to support Node.js 18 or newer.`
+  );
+  process.exit(1);
+}
+if (opensMemoryDashboard) {
+  try {
+    childEnv['COVEN_MEMORY_DASHBOARD_ENTRY'] = require.resolve(
+      '@opencoven/coven-memory-dashboard/bin/coven-memory-dashboard.mjs'
+    );
+    childEnv['COVEN_MEMORY_DASHBOARD_NODE'] = process.execPath;
+  } catch {
+    // The native binary emits the single actionable installation error.
+  }
+}
 
 const child = spawn(binary, args, {
   stdio: 'inherit',
-  windowsHide: false
+  windowsHide: false,
+  env: childEnv
 });
 
 for (const signal of ['SIGINT', 'SIGTERM']) {

--- a/npm/coven/package.json
+++ b/npm/coven/package.json
@@ -17,6 +17,7 @@
     "url": "git+https://github.com/OpenCoven/coven.git"
   },
   "optionalDependencies": {
+    "@opencoven/coven-memory-dashboard": "^0.1.0",
     "@opencoven/cli-macos": "0.0.0",
     "@opencoven/cli-linux-x64": "0.0.0",
     "@opencoven/cli-windows": "0.0.0"

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { once } from 'node:events';
 import {
+  chmodSync,
   copyFileSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync
@@ -183,6 +185,188 @@ test('wrapper declares linux x64 native package as an optional dependency', () =
   const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
   assert.equal(packageJson.optionalDependencies['@opencoven/cli-linux-x64'], '0.0.0');
 });
+
+test('wrapper keeps the dashboard companion on its independent version', () => {
+  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  assert.equal(
+    packageJson.optionalDependencies['@opencoven/coven-memory-dashboard'],
+    '^0.1.0'
+  );
+});
+
+test('wrapper declares the installed dashboard entrypoint handoff', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const bin = readFileSync(binPath, 'utf8');
+  assert.match(bin, /COVEN_MEMORY_DASHBOARD_ENTRY/);
+  assert.match(bin, /COVEN_MEMORY_DASHBOARD_NODE/);
+});
+
+test(
+  'wrapper passes the dashboard handoff for every valid memory open option placement only',
+  {
+    skip:
+      process.platform === 'win32' ||
+      !SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`]
+  },
+  () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'coven-wrapper-dashboard-'));
+    try {
+      const wrapperDir = path.join(fixture, 'wrapper');
+      const wrapperBinDir = path.join(wrapperDir, 'bin');
+      const wrapperPath = path.join(wrapperBinDir, 'coven.js');
+      mkdirSync(wrapperBinDir, { recursive: true });
+      writeFileSync(
+        path.join(wrapperDir, 'package.json'),
+        JSON.stringify({ name: '@opencoven/cli-test', type: 'module' })
+      );
+      copyFileSync(
+        fileURLToPath(new URL('../npm/coven/bin/coven.js', import.meta.url)),
+        wrapperPath
+      );
+
+      const [packageName, binaryName] =
+        SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`];
+      const nativeDir = path.join(wrapperDir, 'node_modules', ...packageName.split('/'));
+      const nativeBinDir = path.join(nativeDir, 'bin');
+      const nativePath = path.join(nativeBinDir, binaryName);
+      mkdirSync(nativeBinDir, { recursive: true });
+      writeFileSync(
+        path.join(nativeDir, 'package.json'),
+        JSON.stringify({ name: packageName, version: '0.0.0' })
+      );
+      writeFileSync(
+        nativePath,
+        [
+          '#!/bin/sh',
+          'printf "%s\\n%s\\n" "$COVEN_MEMORY_DASHBOARD_ENTRY" "$COVEN_MEMORY_DASHBOARD_NODE"',
+          ''
+        ].join('\n')
+      );
+      chmodSync(nativePath, 0o755);
+
+      const dashboardDir = path.join(
+        wrapperDir,
+        'node_modules',
+        '@opencoven',
+        'coven-memory-dashboard'
+      );
+      const dashboardBinDir = path.join(dashboardDir, 'bin');
+      const dashboardEntry = path.join(
+        dashboardBinDir,
+        'coven-memory-dashboard.mjs'
+      );
+      mkdirSync(dashboardBinDir, { recursive: true });
+      writeFileSync(
+        path.join(dashboardDir, 'package.json'),
+        JSON.stringify({
+          name: '@opencoven/coven-memory-dashboard',
+          version: '0.0.0',
+          type: 'module'
+        })
+      );
+      writeFileSync(dashboardEntry, '');
+
+      const versionRunner = path.join(fixture, 'run-wrapper-with-node-version.mjs');
+      writeFileSync(
+        versionRunner,
+        [
+          "Object.defineProperty(process.versions, 'node', {",
+          "  value: process.env.TEST_NODE_VERSION",
+          '});',
+          `process.argv = [process.execPath, ${JSON.stringify(wrapperPath)}, ...JSON.parse(process.env.TEST_WRAPPER_ARGS)];`,
+          `await import(${JSON.stringify(pathToFileURL(wrapperPath).href)});`,
+          ''
+        ].join('\n')
+      );
+
+      for (const args of [
+        ['memory', 'open'],
+        ['--color=never', 'memory', 'open'],
+        ['--color', 'never', 'memory', 'open'],
+        ['memory', '--color=never', 'open'],
+        ['memory', '--color', 'never', 'open'],
+        ['memory', 'open', '--color=never'],
+        ['memory', 'open', '--color', 'never']
+      ]) {
+        const result = spawnSync(process.execPath, [wrapperPath, ...args], {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            COVEN_MEMORY_DASHBOARD_ENTRY: '',
+            COVEN_MEMORY_DASHBOARD_NODE: ''
+          }
+        });
+
+        assert.equal(result.status, 0, `${args.join(' ')}: ${result.stderr}`);
+        assert.deepEqual(
+          result.stdout.trim().split('\n'),
+          [realpathSync(dashboardEntry), process.execPath],
+          args.join(' ')
+        );
+      }
+
+      for (const args of [
+        ['memory'],
+        ['memory', '--json'],
+        ['memory', '--json', 'open'],
+        ['memory', 'open', '--json'],
+        ['--color=never', 'memory', '--json'],
+        ['memory', '--color', 'never', '--json']
+      ]) {
+        const result = spawnSync(process.execPath, [wrapperPath, ...args], {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            COVEN_MEMORY_DASHBOARD_ENTRY: '',
+            COVEN_MEMORY_DASHBOARD_NODE: ''
+          }
+        });
+
+        assert.equal(result.status, 0, `${args.join(' ')}: ${result.stderr}`);
+        assert.equal(result.stdout, '\n\n', args.join(' '));
+      }
+
+      const unsupportedNode = spawnSync(process.execPath, [versionRunner], {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          COVEN_MEMORY_DASHBOARD_ENTRY: '',
+          COVEN_MEMORY_DASHBOARD_NODE: '',
+          TEST_NODE_VERSION: '23.11.0',
+          TEST_WRAPPER_ARGS: JSON.stringify(['memory', 'open'])
+        }
+      });
+      assert.equal(unsupportedNode.status, 1);
+      assert.equal(unsupportedNode.stdout, '');
+      assert.match(
+        unsupportedNode.stderr,
+        /coven memory open requires Node\.js 24 or newer/
+      );
+
+      for (const args of [
+        ['memory', 'open', '--help'],
+        ['memory', '--json'],
+        ['memory', '--json', 'open'],
+        ['memory', 'open', '--json']
+      ]) {
+        const result = spawnSync(process.execPath, [versionRunner], {
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            COVEN_MEMORY_DASHBOARD_ENTRY: '',
+            COVEN_MEMORY_DASHBOARD_NODE: '',
+            TEST_NODE_VERSION: '23.11.0',
+            TEST_WRAPPER_ARGS: JSON.stringify(args)
+          }
+        });
+        assert.equal(result.status, 0, `${args.join(' ')}: ${result.stderr}`);
+      }
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  }
+);
 
 test('release publishes only the canonical @opencoven/cli wrapper package', () => {
   assert.deepEqual(wrapperPackageNameList(), ['@opencoven/cli']);
@@ -490,6 +674,33 @@ test('prepublish smoke has explicit dry-run version override and registry failur
 
   assert.match(script, /COVEN_NPM_DRY_RUN_VERSION/);
   assert.match(script, /Could not read current \$\{packageName\} version/);
+});
+
+test('prepublish smoke rejects a missing dashboard tarball before running gates', () => {
+  const fixture = mkdtempSync(path.join(tmpdir(), 'coven-dashboard-tarball-'));
+  try {
+    const scriptPath = fileURLToPath(new URL('test-cli-prepublish.mjs', import.meta.url));
+    const missing = path.join(fixture, 'missing-dashboard.tgz');
+    const childEnv = { ...process.env };
+    delete childEnv.NODE_TEST_CONTEXT;
+    const result = spawnSync(
+      process.execPath,
+      [
+        scriptPath,
+        '--target=unsupported-test-target',
+        `--dashboard-tarball=${missing}`
+      ],
+      { encoding: 'utf8', env: childEnv }
+    );
+
+    assert.notEqual(result.status, 0);
+    assert.match(
+      `${result.stdout}\n${result.stderr}`,
+      /dashboard tarball not found/
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
 });
 
 test('publish-npm entrypoint detection works with filesystem paths', () => {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -148,7 +148,9 @@ function writeWrapperPackage(version, packageName = primaryWrapperPackageName) {
   packageJson.name = packageName;
   packageJson.version = version;
   for (const optionalName of Object.keys(packageJson.optionalDependencies)) {
-    packageJson.optionalDependencies[optionalName] = version;
+    if (optionalName.startsWith('@opencoven/cli-')) {
+      packageJson.optionalDependencies[optionalName] = version;
+    }
   }
   writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
   rewriteWrapperText(path.join(outDir, 'README.md'), packageName);

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -15,6 +15,9 @@
 // Flags:
 //   --target=<name>       Override the npm target (macos, linux-x64, windows).
 //                         Defaults to the local platform.
+//   --dashboard-tarball=<path>
+//                         Install a locally packed dashboard companion and
+//                         verify `coven memory open --help` through the wrapper.
 //   --skip-build          Reuse an existing release binary at
 //                         target/<rust-target>/release/coven instead of
 //                         re-running `cargo build --release --target ...`.
@@ -31,7 +34,7 @@
 // Exit code is non-zero on the first failing step.
 
 import { spawnSync } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -62,6 +65,20 @@ const skipBuild = flag('--skip-build');
 const withCargoGates = flag('--with-cargo-gates');
 const skipSecretsScan = flag('--skip-secrets-scan');
 const keepTempdir = flag('--keep-tempdir');
+const dashboardTarballOption = opt('--dashboard-tarball');
+const dashboardTarball =
+  dashboardTarballOption === undefined
+    ? undefined
+    : path.resolve(dashboardTarballOption);
+
+if (
+  dashboardTarballOption !== undefined &&
+  (!dashboardTarballOption ||
+    !existsSync(dashboardTarball) ||
+    !statSync(dashboardTarball).isFile())
+) {
+  fail(`dashboard tarball not found or is not a file: ${dashboardTarballOption || '(empty)'}`);
+}
 
 const target = PLATFORM_TARGETS[targetName];
 if (!target) {
@@ -162,7 +179,11 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
 
   // --omit=optional avoids npm trying to fetch the optional native package by
   // version from the public registry; we install the local tarball directly.
-  run('npm', ['install', '--no-package-lock', '--omit=optional', platformTgz, wrapperTgz], {
+  const installArgs = ['install', '--no-package-lock', '--omit=optional', platformTgz, wrapperTgz];
+  if (dashboardTarball) {
+    installArgs.push(dashboardTarball);
+  }
+  run('npm', installArgs, {
     cwd: tempDir
   });
 
@@ -176,11 +197,20 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
     fail(`wrapper bin not present at ${wrapperBin} after install`);
   }
 
+  const isolatedUserHome = path.join(tempDir, 'user-home');
+  mkdirSync(isolatedUserHome, { recursive: true });
   const smokeEnv = {
     ...process.env,
     COVEN_HOME: path.join(tempDir, 'coven-home'),
-    PATH: firstRunSmokePath(wrapperBin, tempDir)
+    HOME: isolatedUserHome,
+    PATH: firstRunSmokePath(wrapperBin, tempDir),
+    USERPROFILE: isolatedUserHome
   };
+  if (process.platform === 'win32') {
+    const homeRoot = path.parse(isolatedUserHome).root;
+    smokeEnv.HOMEDRIVE = homeRoot.replace(/[\\/]$/, '');
+    smokeEnv.HOMEPATH = isolatedUserHome.slice(homeRoot.length - 1);
+  }
   mkdirSync(smokeEnv.COVEN_HOME, { recursive: true });
 
   const versionOutput = runCapture(wrapperBin, ['--version'], { env: smokeEnv });
@@ -224,6 +254,28 @@ step(`install wrapper + native package in a temp project (${targetName})`, () =>
   }
   if (!helpOutput.stdout.toLowerCase().includes('usage')) {
     fail(`\`coven --help\` missing usage section.\nstdout:\n${helpOutput.stdout}`);
+  }
+
+  if (dashboardTarball) {
+    const dashboardEntry = path.join(
+      tempDir,
+      'node_modules',
+      '@opencoven',
+      'coven-memory-dashboard',
+      'bin',
+      'coven-memory-dashboard.mjs'
+    );
+    if (!existsSync(dashboardEntry)) {
+      fail(`dashboard entry not present after install: ${dashboardEntry}`);
+    }
+    const memoryHelp = runCapture(wrapperBin, ['memory', 'open', '--help'], {
+      env: smokeEnv
+    });
+    if (!memoryHelp.stdout.includes('private local memory dashboard')) {
+      fail(
+        `\`coven memory open --help\` did not describe the private local dashboard.\nstdout:\n${memoryHelp.stdout}\nstderr:\n${memoryHelp.stderr}`
+      );
+    }
   }
 
   let daemonStarted = false;


### PR DESCRIPTION
## Summary

- add `coven memory open` while preserving list and JSON output
- pass the installed dashboard entrypoint and Node executable through the npm wrapper
- retain core Node 18 support with an actionable Node 24 dashboard gate

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `node --test scripts/publish-npm-test.mjs` (50 passed)
- `python3 scripts/check-secrets.py`
- cross-repository canonical-memory smoke (`blocker_count=0`, `smoke_status=ok`)