### PR TITLE
fix: avoid privacy false positives in pnpm lockfiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: '3.x'
+      - run: python scripts/check-coven-privacy-test.py
       - run: python scripts/check-secrets.py
       - name: Coven privacy guard (pull request changes)
         if: github.event_name == 'pull_request'

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -17,6 +17,17 @@ assert spec.loader is not None
 spec.loader.exec_module(check_coven_privacy)
 
 
+def phone_like_sha512_digest() -> str:
+    return (
+        "sha512-"
+        + ("a" * 40)
+        + "+"
+        + "576"
+        + ("b" * 42)
+        + "=="
+    )
+
+
 class CovenPrivacyPatternTests(unittest.TestCase):
     def test_scanner_sources_do_not_match_their_own_rules(self) -> None:
         sources = [
@@ -38,6 +49,16 @@ class CovenPrivacyPatternTests(unittest.TestCase):
         )
         self.assertNotIn(
             '${{ github.event.pull_request.base.sha }}...HEAD',
+            workflow,
+        )
+
+    def test_ci_runs_privacy_guard_unit_tests(self) -> None:
+        workflow = (
+            SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "python scripts/check-coven-privacy-test.py",
             workflow,
         )
 
@@ -220,6 +241,64 @@ class CovenPrivacyPatternTests(unittest.TestCase):
 
     def test_short_e164_phone_number_is_blocked(self) -> None:
         text = "+" + "683" + "1234"
+
+        hits = check_coven_privacy.scan_text(text, "docs/example.md")
+
+        self.assertEqual(hits, [("docs/example.md", 1, "phone_number")])
+
+    def test_pnpm_integrity_digest_phone_like_substring_is_allowed(self) -> None:
+        digest = phone_like_sha512_digest()
+        text = f"resolution: {{integrity: {digest}}}"
+
+        hits = check_coven_privacy.scan_text(
+            text, "packages/example/pnpm-lock.yaml"
+        )
+
+        self.assertEqual(hits, [])
+
+    def test_phone_number_outside_pnpm_integrity_digest_is_blocked(self) -> None:
+        digest = phone_like_sha512_digest()
+        phone = "+" + "1" + "312" + "555" + "0100"
+        text = f"resolution: {{integrity: {digest}}} phone: {phone}"
+
+        hits = check_coven_privacy.scan_text(
+            text, "packages/example/pnpm-lock.yaml"
+        )
+
+        self.assertEqual(
+            hits,
+            [("packages/example/pnpm-lock.yaml", 1, "phone_number")],
+        )
+
+    def test_invalid_pnpm_integrity_digest_remains_scannable(self) -> None:
+        phone = "+" + "1" + "312" + "555" + "0100"
+        text = f"integrity: sha512-{phone}"
+
+        hits = check_coven_privacy.scan_text(
+            text, "packages/example/pnpm-lock.yaml"
+        )
+
+        self.assertEqual(
+            hits,
+            [("packages/example/pnpm-lock.yaml", 1, "phone_number")],
+        )
+
+    def test_pnpm_non_field_integrity_text_remains_scannable(self) -> None:
+        digest = phone_like_sha512_digest()
+        text = f"note: integrity={digest}"
+
+        hits = check_coven_privacy.scan_text(
+            text, "packages/example/pnpm-lock.yaml"
+        )
+
+        self.assertEqual(
+            hits,
+            [("packages/example/pnpm-lock.yaml", 1, "phone_number")],
+        )
+
+    def test_integrity_digest_in_regular_file_remains_scannable(self) -> None:
+        digest = phone_like_sha512_digest()
+        text = f"integrity: {digest}"
 
         hits = check_coven_privacy.scan_text(text, "docs/example.md")
 

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -13,6 +13,11 @@ import subprocess
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+PNPM_SHA512_INTEGRITY_DIGEST = re.compile(
+    r"(?P<prefix>(?:^\s*|[{,]\s*)integrity:\s*)"
+    r"sha512-[A-Za-z0-9+/]{86}=="
+    r"(?=$|[\s},#])"
+)
 RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "coven_session_key",
@@ -44,9 +49,19 @@ RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 
+def scannable_line(line: str, path: str) -> str:
+    if pathlib.PurePath(path).name != "pnpm-lock.yaml":
+        return line
+    return PNPM_SHA512_INTEGRITY_DIGEST.sub(
+        r"\g<prefix><integrity-digest>",
+        line,
+    )
+
+
 def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
     hits: list[tuple[str, int, str]] = []
     for line_number, line in enumerate(text.splitlines(), 1):
+        line = scannable_line(line, path)
         session_key_hit = False
         for name, pattern in RULES:
             if name == "messenger_chat_id" and session_key_hit:

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -49,8 +49,8 @@ RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 
-def scannable_line(line: str, path: str) -> str:
-    if pathlib.PurePath(path).name != "pnpm-lock.yaml":
+def scannable_line(line: str, is_pnpm_lock: bool) -> str:
+    if not is_pnpm_lock:
         return line
     return PNPM_SHA512_INTEGRITY_DIGEST.sub(
         r"\g<prefix><integrity-digest>",
@@ -60,8 +60,9 @@ def scannable_line(line: str, path: str) -> str:
 
 def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
     hits: list[tuple[str, int, str]] = []
+    is_pnpm_lock = pathlib.PurePath(path).name == "pnpm-lock.yaml"
     for line_number, line in enumerate(text.splitlines(), 1):
-        line = scannable_line(line, path)
+        line = scannable_line(line, is_pnpm_lock)
         session_key_hit = False
         for name, pattern in RULES:
             if name == "messenger_chat_id" and session_key_hit:


### PR DESCRIPTION
## Context

- Summary: Fix the Coven privacy guard false positive caused by phone-like digits inside a generated pnpm SHA-512 integrity digest.
- Files changed: privacy scanner, focused regression tests, and CI test wiring.
- Tracking: `coven-hq8`

## Implementation

- Approach: Mask only exact-length SHA-512 SRI values on actual `integrity:` fields in files named `pnpm-lock.yaml` before applying private-data rules.
- User-visible behavior: Generated integrity hashes no longer fail the phone-number guard.
- Compatibility notes: Invalid or short digests, `integrity=` text, ordinary files, and real phone numbers elsewhere remain blocked.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy-test.py` (31 passed)
- [x] Exact failing range `29d471a..63515c7` now passes
- [x] Independent review: no Critical, Important, or Minor findings

## Risk and Rollback

- Risk level: Low; exemption is limited by filename, YAML field shape, algorithm, digest length, and termination.
- Rollback plan: Revert this commit to restore prior fail-closed behavior.

## Agent Handoff

- Current state: Verified and ready for CI.
- Follow-ups: None for this fix.
- Known gaps: None.