### PR TITLE
Remove rectangle from opencoven-black.svg

### DIFF
--- a/brand/logo/opencoven-black.svg
+++ b/brand/logo/opencoven-black.svg
@@ -11,13 +11,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"><defs
      id="defs1955" /><g
      id="layer1"
-     transform="translate(18.769485,30.834001)"><rect
-       style="fill:#ffffff;stroke:#000000;stroke-width:0.256248;stroke-miterlimit:1"
-       id="rect729"
-       width="299.87756"
-       height="299.87756"
-       x="-18.641361"
-       y="-30.705877" /><path
+     transform="translate(18.769485,30.834001)"><path
        style="display:none;fill:none;stroke:#000000;stroke-width:0.5;stroke-miterlimit:1;stroke-dasharray:none;stroke-opacity:1"
        d="M 131.36431,-70.700205 V 299.2998"
        id="path2371" /><path


### PR DESCRIPTION
Removed a rectangle element from the SVG file.

## Context

I was using old svg, Luigi gave me link to this one, noticed there was a black rectangle around it (bad)

- Summary: 
<img width="910" height="912" alt="image" src="https://github.com/user-attachments/assets/336b00a7-3750-47e8-91a5-7c9ec9af2afa" />
- Files changed: brand/logo/opencoven-black.svg
