### PR TITLE
fix: avoid privacy false positives in package-lock integrity fields

### DIFF
--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -256,6 +256,16 @@ class CovenPrivacyPatternTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
 
+    def test_package_lock_integrity_digest_phone_like_substring_is_allowed(self) -> None:
+        digest = phone_like_sha512_digest()
+        text = f'"integrity": "{digest}",'
+
+        hits = check_coven_privacy.scan_text(
+            text, "packages/example/package-lock.json"
+        )
+
+        self.assertEqual(hits, [])
+
     def test_phone_number_outside_pnpm_integrity_digest_is_blocked(self) -> None:
         digest = phone_like_sha512_digest()
         phone = "+" + "1" + "312" + "555" + "0100"

--- a/scripts/check-coven-privacy.py
+++ b/scripts/check-coven-privacy.py
@@ -18,6 +18,11 @@ PNPM_SHA512_INTEGRITY_DIGEST = re.compile(
     r"sha512-[A-Za-z0-9+/]{86}=="
     r"(?=$|[\s},#])"
 )
+PACKAGE_LOCK_SHA512_INTEGRITY_DIGEST = re.compile(
+    r'(?P<prefix>(?:^\s*|[{,]\s*)"integrity"\s*:\s*")'
+    r"sha512-[A-Za-z0-9+/]{86}=="
+    r'(?="(?:\s*[,}])?$)'
+)
 RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "coven_session_key",
@@ -49,20 +54,25 @@ RULES: tuple[tuple[str, re.Pattern[str]], ...] = (
 )
 
 
-def scannable_line(line: str, is_pnpm_lock: bool) -> str:
-    if not is_pnpm_lock:
-        return line
-    return PNPM_SHA512_INTEGRITY_DIGEST.sub(
-        r"\g<prefix><integrity-digest>",
-        line,
-    )
+def scannable_line(line: str, lockfile_name: str) -> str:
+    if lockfile_name == "pnpm-lock.yaml":
+        return PNPM_SHA512_INTEGRITY_DIGEST.sub(
+            r"\g<prefix><integrity-digest>",
+            line,
+        )
+    if lockfile_name == "package-lock.json":
+        return PACKAGE_LOCK_SHA512_INTEGRITY_DIGEST.sub(
+            r"\g<prefix><integrity-digest>",
+            line,
+        )
+    return line
 
 
 def scan_text(text: str, path: str) -> list[tuple[str, int, str]]:
     hits: list[tuple[str, int, str]] = []
-    is_pnpm_lock = pathlib.PurePath(path).name == "pnpm-lock.yaml"
+    lockfile_name = pathlib.PurePath(path).name
     for line_number, line in enumerate(text.splitlines(), 1):
-        line = scannable_line(line, is_pnpm_lock)
+        line = scannable_line(line, lockfile_name)
         session_key_hit = False
         for name, pattern in RULES:
             if name == "messenger_chat_id" and session_key_hit:


### PR DESCRIPTION
## Summary

Recognize complete SHA-512 SRI values only in JSON `integrity` fields of `package-lock.json`, matching the existing pnpm lockfile handling.

## Root cause

Dependabot PR #518 contains a valid upstream SRI digest whose base64 text includes a phone-like substring. The privacy guard scanned it as publishable private data.

## Validation

- `python scripts/check-coven-privacy-test.py` (32 tests)
- `python scripts/check-coven-privacy.py --range origin/main...origin/pr-518`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `git diff --check`