### PR TITLE
fix: batch secret history scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           python-version: '3.x'
       - run: python scripts/check-coven-privacy-test.py
+      - run: python scripts/check-secrets-test.py
       - run: python scripts/check-secrets.py
       - name: Coven privacy guard (pull request changes)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -44,6 +44,7 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --locked
+      - run: python3 scripts/check-secrets-test.py
       - run: python3 scripts/check-secrets.py
 
   verify-tag:

--- a/scripts/check-coven-privacy-test.py
+++ b/scripts/check-coven-privacy-test.py
@@ -62,6 +62,16 @@ class CovenPrivacyPatternTests(unittest.TestCase):
             workflow,
         )
 
+    def test_ci_runs_secret_guard_unit_tests(self) -> None:
+        workflow = (
+            SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn(
+            "python scripts/check-secrets-test.py",
+            workflow,
+        )
+
     def test_ci_scans_the_entire_push_range(self) -> None:
         workflow = (
             SCRIPT.parents[1] / ".github" / "workflows" / "ci.yml"

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import io
 import importlib.util
 import pathlib
+import subprocess
+import tempfile
 import unittest
 from unittest import mock
 
@@ -223,6 +226,176 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
         self.assertEqual(calls, [("git", "rev-list", "--objects", "origin/main")])
+
+    def test_batch_reader_rejects_malformed_headers(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "malformed object header"):
+            check_secrets.read_batch_object(io.BytesIO(b"malformed\n"), "a" * 40)
+
+    def test_batch_reader_rejects_out_of_order_objects(self) -> None:
+        stream = io.BytesIO(f"{'b' * 40} blob 0\n\n".encode())
+
+        with self.assertRaisesRegex(RuntimeError, "objects out of order"):
+            check_secrets.read_batch_object(stream, "a" * 40)
+
+    def test_batch_reader_rejects_unknown_object_types(self) -> None:
+        stream = io.BytesIO(f"{'a' * 40} future-object 0\n\n".encode())
+
+        with self.assertRaisesRegex(RuntimeError, "unknown object type"):
+            check_secrets.read_batch_object(stream, "a" * 40)
+
+    def test_batch_reader_rejects_invalid_object_sizes(self) -> None:
+        sha = "a" * 40
+        invalid_sizes = (
+            b"not-a-number",
+            b"-1",
+            str(check_secrets.MAX_BATCH_OBJECT_BYTES + 1).encode(),
+        )
+
+        for size in invalid_sizes:
+            with self.subTest(size=size):
+                stream = io.BytesIO(sha.encode() + b" blob " + size + b"\n")
+                with self.assertRaisesRegex(RuntimeError, "malformed object size"):
+                    check_secrets.read_batch_object(stream, sha)
+
+    def test_batch_reader_rejects_truncated_objects_and_missing_trailers(self) -> None:
+        sha = "a" * 40
+        streams = (
+            io.BytesIO(f"{sha} blob 4\n".encode() + b"abc"),
+            io.BytesIO(f"{sha} blob 3\n".encode() + b"abcX"),
+        )
+
+        for stream in streams:
+            with self.subTest(data=stream.getvalue()):
+                with self.assertRaisesRegex(RuntimeError, "truncated object"):
+                    check_secrets.read_batch_object(stream, sha)
+
+    def test_history_scan_rejects_nonzero_batch_exit(self) -> None:
+        sha = "a" * 40
+
+        class FailedBatch:
+            stdout = io.BytesIO(f"{sha} blob 0\n\n".encode())
+
+            def __enter__(self) -> FailedBatch:
+                return self
+
+            def __exit__(self, *_: object) -> None:
+                return None
+
+            def wait(self) -> int:
+                return 1
+
+        with (
+            mock.patch.object(
+                check_secrets,
+                "sh",
+                return_value=f"{sha} docs/example.md\n",
+            ),
+            mock.patch.object(subprocess, "Popen", return_value=FailedBatch()),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "cat-file --batch failed"):
+                check_secrets.history_blob_hits()
+
+    def test_history_scan_rejects_unexpected_batch_output(self) -> None:
+        sha = "a" * 40
+
+        class ExtraOutputBatch:
+            stdout = io.BytesIO(f"{sha} blob 0\n\nunexpected".encode())
+
+            def __enter__(self) -> ExtraOutputBatch:
+                return self
+
+            def __exit__(self, *_: object) -> None:
+                return None
+
+            def wait(self) -> int:
+                return 0
+
+        with (
+            mock.patch.object(
+                check_secrets,
+                "sh",
+                return_value=f"{sha} docs/example.md\n",
+            ),
+            mock.patch.object(
+                subprocess,
+                "Popen",
+                return_value=ExtraOutputBatch(),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "unexpected trailing output"):
+                check_secrets.history_blob_hits()
+
+    def test_history_scan_uses_bounded_git_processes_without_skipping_deleted_secrets(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo = pathlib.Path(temp_dir)
+
+            def git(*args: str) -> None:
+                subprocess.run(
+                    ["git", *args],
+                    cwd=repo,
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+
+            git("init", "-q")
+            git("config", "user.name", "Secret Guard Test")
+            git("config", "user.email", "secret-guard@example.invalid")
+            secret_file = repo / "secret.txt"
+            secret_file.write_text(
+                "token=" + "ghp_" + ("A1" * 12) + "\n",
+                encoding="utf-8",
+            )
+            git("add", "secret.txt")
+            git("commit", "-q", "-m", "add historical fixture")
+            secret_file.unlink()
+            git("add", "-u")
+            git("commit", "-q", "-m", "remove historical fixture")
+
+            original_popen = subprocess.Popen
+            spawned: list[tuple[object, dict[str, object]]] = []
+
+            def counting_popen(*args: object, **kwargs: object) -> subprocess.Popen[bytes]:
+                spawned.append((args[0], kwargs))
+                return original_popen(*args, **kwargs)
+
+            with (
+                mock.patch.object(check_secrets, "ROOT", repo),
+                mock.patch.object(
+                    subprocess,
+                    "Popen",
+                    side_effect=counting_popen,
+                ),
+            ):
+                hits = check_secrets.history_blob_hits()
+
+        self.assertIn(
+            ("secret.txt", 1, "github_token"),
+            [(path, line, rule) for _, path, line, rule in hits],
+        )
+        self.assertLessEqual(
+            len(spawned),
+            3,
+            f"history scan spawned one or more Git processes per object: {spawned}",
+        )
+        batch_calls = [
+            kwargs
+            for command, kwargs in spawned
+            if command == ["git", "cat-file", "--batch"]
+        ]
+        self.assertEqual(len(batch_calls), 1)
+        self.assertIsNot(
+            batch_calls[0].get("stdin"),
+            subprocess.PIPE,
+            "batch stdin must be finite so malformed output cannot wait for another request",
+        )
+        self.assertEqual(
+            batch_calls[0].get("stderr"),
+            subprocess.DEVNULL,
+            "batch stderr must not be an undrained pipe",
+        )
 
     def test_base64_like_values_still_trigger_high_entropy(self) -> None:
         token = "m9R3tQv7WzK2pL5nX8cF1gJ4sD6hY0aB/EuIqOwPz9RkTlVxCyNmS3HdG7fA"

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -12,8 +12,14 @@ import pathlib
 import re
 import subprocess
 import sys
+import tempfile
+from typing import BinaryIO
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
+GIT_OBJECT_TYPES = {b"blob", b"commit", b"tag", b"tree"}
+# Fail closed instead of allowing a malformed batch header to request an
+# unbounded allocation. The largest object in this repository is under 6 MiB.
+MAX_BATCH_OBJECT_BYTES = 64 * 1024 * 1024
 EXCLUDED_PARTS = {".git", "target", "node_modules", ".coven", ".comux", ".comux-hooks"}
 EXCLUDED_PATHS = {"scripts/check-secrets.py", "scripts/check-secrets-test.py"}
 LOCKFILE_NAMES = ("pnpm-lock.yaml", "package-lock.json", "yarn.lock")
@@ -951,10 +957,36 @@ def tracked_file_hits() -> list[tuple[str, int, str]]:
     return hits
 
 
+def read_batch_object(
+    stream: BinaryIO, expected_sha: str
+) -> tuple[bytes, bytes]:
+    header = stream.readline().rstrip(b"\n").split()
+    if len(header) != 3:
+        raise RuntimeError("git cat-file --batch returned a malformed object header")
+    object_sha, object_type, size_bytes = header
+    if object_sha != expected_sha.encode("ascii"):
+        raise RuntimeError("git cat-file --batch returned objects out of order")
+    if object_type not in GIT_OBJECT_TYPES:
+        raise RuntimeError("git cat-file --batch returned an unknown object type")
+    try:
+        size = int(size_bytes)
+    except ValueError as error:
+        raise RuntimeError(
+            "git cat-file --batch returned a malformed object size"
+        ) from error
+    if not 0 <= size <= MAX_BATCH_OBJECT_BYTES:
+        raise RuntimeError("git cat-file --batch returned a malformed object size")
+    data = stream.read(size)
+    if len(data) != size or stream.read(1) != b"\n":
+        raise RuntimeError("git cat-file --batch returned a truncated object")
+    return object_type, data
+
+
 def history_blob_hits(ref: str = "HEAD") -> list[tuple[str, str, int, str]]:
     rows = sh("git", "rev-list", "--objects", ref).splitlines()
     hits: list[tuple[str, str, int, str]] = []
     seen: set[str] = set()
+    objects: list[tuple[str, str]] = []
     for row in rows:
         parts = row.split(" ", 1)
         sha = parts[0]
@@ -966,11 +998,40 @@ def history_blob_hits(ref: str = "HEAD") -> list[tuple[str, str, int, str]]:
         seen.add(sha)
         if any(part in EXCLUDED_PARTS for part in pathlib.PurePosixPath(rel).parts):
             continue
-        if sh("git", "cat-file", "-t", sha).strip() != "blob":
-            continue
-        data = subprocess.check_output(["git", "cat-file", "-p", sha], cwd=ROOT)
-        for path, line, rule in scan_bytes(data, rel):
-            hits.append((sha[:12], path, line, rule))
+        objects.append((sha, rel))
+
+    if not objects:
+        return hits
+
+    # A finite file gives cat-file every request up front. If its output is
+    # malformed or truncated, it cannot deadlock waiting for another request.
+    with tempfile.TemporaryFile() as requests:
+        for sha, _ in objects:
+            requests.write(f"{sha}\n".encode())
+        requests.seek(0)
+
+        with subprocess.Popen(
+            ["git", "cat-file", "--batch"],
+            cwd=ROOT,
+            stdin=requests,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        ) as batch:
+            assert batch.stdout is not None
+            for sha, rel in objects:
+                object_type, data = read_batch_object(batch.stdout, sha)
+                if object_type != b"blob":
+                    continue
+                for path, line, rule in scan_bytes(data, rel):
+                    hits.append((sha[:12], path, line, rule))
+
+            if batch.stdout.read(1):
+                raise RuntimeError(
+                    "git cat-file --batch returned unexpected trailing output"
+                )
+            return_code = batch.wait()
+            if return_code != 0:
+                raise RuntimeError("git cat-file --batch failed")
     return hits
 
 

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -668,6 +668,31 @@ test('release workflow concurrency keeps overlapping releases from interleaving'
   assert.match(workflow, /cancel-in-progress:\s*false/);
 });
 
+test('secret guard unit tests run in local and tag-driven release gates', () => {
+  const prepublish = readFileSync(
+    new URL('test-cli-prepublish.mjs', import.meta.url),
+    'utf8'
+  );
+  const workflow = readFileSync(
+    new URL(
+      ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+      import.meta.url
+    ),
+    'utf8'
+  );
+
+  assert.match(
+    prepublish,
+    /run\('python3', \['scripts\/check-secrets-test\.py'\]\)/,
+    'local prepublish must prove the scanner regression suite before scanning'
+  );
+  assert.match(
+    workflow,
+    /python3 scripts\/check-secrets-test\.py/,
+    'tag-driven release gates must prove the scanner regression suite before publishing'
+  );
+});
+
 test('prepublish smoke has explicit dry-run version override and registry failure message', () => {
   const scriptPath = new URL('test-cli-prepublish.mjs', import.meta.url);
   const script = readFileSync(scriptPath, 'utf8');

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -24,8 +24,8 @@
 //   --with-cargo-gates    Also run `cargo fmt --check`, `cargo clippy`, and
 //                         `cargo test --workspace --locked` (the CI verify
 //                         gates). Off by default to keep local runs fast.
-//   --skip-secrets-scan   Skip `python3 scripts/check-secrets.py` for local
-//                         iteration; CI still runs it.
+//   --skip-secrets-scan   Skip the secret-guard unit tests and full scan for
+//                         local iteration; CI still runs both.
 //   --keep-tempdir        Leave the temp install dir on disk for inspection.
 //   COVEN_NPM_DRY_RUN_VERSION=vX.Y.Z
 //                         Override the synthesized dry-run version when the
@@ -106,6 +106,7 @@ step('prerequisites', () => {
 
 if (!skipSecretsScan) {
   step('secrets scan', () => {
+    run('python3', ['scripts/check-secrets-test.py']);
     run('python3', ['scripts/check-secrets.py']);
   });
 }


### PR DESCRIPTION
## Context

- Summary: Keep the complete current-tree and reachable-history secret scan while replacing per-object Git subprocesses with one fail-closed batched reader. The documented prepublish command previously exceeded its 120 s command timeout; the scan now completes in about 15 s.
- Files changed: secret scanner and regression suite, CI/release wiring, local prepublish wiring, and cross-control tests.
- Tracker: `cave-ud7nz.1`

## Implementation

- Approach: Feed all reachable object IDs to one `git cat-file --batch` process through a finite temporary request file, validate SHA/type/size/trailer/order, cap object allocation at 64 MiB, and reject malformed, truncated, extra, or failed output.
- User-visible behavior: `node scripts/test-cli-prepublish.mjs` completes instead of timing out during the secret scan.
- Compatibility notes: Uses standard Python temporary files and Git batch protocol on supported macOS/Linux/Windows environments. Scanner findings remain value-redacted.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py` — passed in 15.18 s
- [x] `python3 scripts/check-secrets-test.py` — 77 passed
- [x] `python3 scripts/check-coven-privacy-test.py` — 33 passed
- [x] `node --test scripts/onboarding-docs-test.mjs scripts/pr-readiness-test.mjs scripts/publish-npm-test.mjs` — 71 passed
- [x] `node scripts/test-cli-prepublish.mjs` — all 5 checks passed, including package install and daemon lifecycle
- [x] Fresh-context review — no remaining findings

## Risk and Rollback

- Risk level: Medium; this changes a release-blocking security control. Adversarial tests cover malformed headers, wrong order, unknown types, invalid sizes, truncated payloads, missing trailers, unexpected output, nonzero exit, bounded process count, and deleted historical-secret detection.
- Rollback plan: Revert this commit to restore the prior per-object scanner, acknowledging the prepublish timeout will return.

## Agent Handoff

- Current state: Verified and ready for maintainer review.
- Follow-ups: Merge before creating the next signed Coven release tag.
- Known gaps: None.