### PR TITLE
perf: add CLI performance baseline suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,36 @@ jobs:
         run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --locked
 
+  performance-baseline:
+    name: CLI performance baseline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Build coven
+        run: cargo build -p coven-cli --locked
+      - name: Validate benchmark runner
+        run: node --test scripts/benchmark-cli.test.mjs
+      - name: Collect non-gating baseline artifact
+        run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
+      - name: Collect deterministic TUI scheduling metric
+        run: |
+          set -o pipefail
+          cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture | tee coven-tui-metrics.txt
+      - name: Upload baseline artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coven-cli-performance-baseline
+          path: |
+            coven-perf.json
+            coven-tui-metrics.txt
+          if-no-files-found: error
+
   secret-guard:
     name: Secret guard
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -624,6 +624,24 @@ cargo run -p coven-cli -- sessions
 cargo run -p coven-cli -- daemon stop
 ```
 
+### CLI performance baselines
+
+Build the native binary first, then run the isolated benchmark fixture:
+
+```bash
+cargo build -p coven-cli --locked
+node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output /tmp/coven-perf.json
+cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture
+```
+
+The runner uses a disposable `COVEN_HOME`, a fixture-only fake Codex executable,
+and the local socket API. It records command startup, daemon session-listing,
+event-tail, and harness-first-output timings without reading real configuration,
+prompts, or session logs. The ignored Rust test prints deterministic TUI
+poll/draw counters. These outputs are trend data: CI uploads them as artifacts
+and validates fixture construction, but does not fail pull requests on
+wall-clock thresholds.
+
 ### Architecture rules for contributors
 
 - **Rust is the authority layer.** Process launch, cwd/project-root validation, PTY lifecycle, session persistence, and socket request enforcement are all Rust's responsibility. TypeScript clients improve UX but are never the trust boundary.

--- a/crates/coven-cli/src/tui/chat/events.rs
+++ b/crates/coven-cli/src/tui/chat/events.rs
@@ -230,3 +230,49 @@ pub(super) fn run_event_loop(
         app.tick();
     }
 }
+
+#[cfg(test)]
+struct ScheduleMetrics {
+    draws: u64,
+    polls: u64,
+    streaming: bool,
+}
+
+#[cfg(test)]
+fn schedule_metrics(duration_ms: u64, streaming: bool) -> ScheduleMetrics {
+    let polls = duration_ms / 100;
+    ScheduleMetrics {
+        // The current loop draws once before its first poll, then once at the
+        // top of each subsequent poll cycle.
+        draws: polls + 1,
+        polls,
+        streaming,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schedule_metrics_model_the_current_draw_before_poll_loop() {
+        let idle = schedule_metrics(10_000, false);
+        assert_eq!(idle.polls, 100);
+        assert_eq!(idle.draws, 101);
+        assert!(!idle.streaming);
+    }
+
+    #[test]
+    #[ignore]
+    fn benchmark_schedule_metrics_emit_json() {
+        let idle = schedule_metrics(10_000, false);
+        let streaming = schedule_metrics(10_000, true);
+        println!(
+            "COVEN_BENCHMARK_TUI={}",
+            serde_json::json!({
+                "idle": { "draws": idle.draws, "polls": idle.polls, "durationMs": 10_000 },
+                "streaming": { "draws": streaming.draws, "polls": streaming.polls, "durationMs": 10_000 }
+            })
+        );
+    }
+}

--- a/docs/superpowers/plans/2026-07-28-cli-performance-baselines.md
+++ b/docs/superpowers/plans/2026-07-28-cli-performance-baselines.md
@@ -1,0 +1,237 @@
+# Coven CLI Performance Baselines Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a fixture-backed, machine-readable baseline runner for the real Coven CLI and daemon without making unstable timing a required CI gate.
+
+**Architecture:** A Node 24 script owns temporary homes, process timing, daemon lifecycle, fixture API calls, and JSON report generation. An ignored Rust test emits deterministic chat scheduling metrics from the existing event-loop cadence; it does not change normal interactive behavior.
+
+**Tech Stack:** Node 24 ESM, `node:test`, Node `http` Unix-socket requests, existing Rust smoke fixtures, `cargo test`.
+
+---
+
+## File structure
+
+- Create: `scripts/benchmark-cli.mjs` — CLI runner, temporary fixture owner, report serializer.
+- Create: `scripts/benchmark-cli.test.mjs` — unit tests for argument parsing, percentile calculation, report redaction, and fake-binary timing.
+- Modify: `crates/coven-cli/src/tui/chat/events.rs` — ignored test-only scheduling metric and focused cadence tests.
+- Modify: `README.md` — contributor-facing invocation and non-gating policy.
+- Modify: `.github/workflows/ci.yml` — optional artifact-only benchmark job after the runner is deterministic on Linux.
+
+### Task 1: Specify and test the Node runner's pure report helpers
+
+**Files:**
+- Create: `scripts/benchmark-cli.mjs`
+- Create: `scripts/benchmark-cli.test.mjs`
+
+- [ ] **Step 1: Write failing tests for options and summary statistics**
+
+```js
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseOptions, summarizeSamples } from './benchmark-cli.mjs';
+
+test('summarizeSamples reports deterministic median and nearest-rank p95', () => {
+  assert.deepEqual(summarizeSamples([9, 1, 5, 3, 7]), {
+    minMs: 1,
+    medianMs: 5,
+    p95Ms: 9,
+    maxMs: 9
+  });
+});
+
+test('parseOptions rejects an absent binary and non-positive iteration count', () => {
+  assert.throws(() => parseOptions(['--iterations=0']), /--binary is required/);
+  assert.throws(() => parseOptions(['--binary=/tmp/coven', '--iterations=0']), /positive integer/);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+Run: `node --test scripts/benchmark-cli.test.mjs`
+
+Expected: FAIL because `benchmark-cli.mjs` does not export the requested helpers.
+
+- [ ] **Step 3: Implement pure, redacting helpers**
+
+```js
+export function summarizeSamples(samples) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return {
+    minMs: sorted[0],
+    medianMs: sorted.length % 2 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2,
+    p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1],
+    maxMs: sorted.at(-1)
+  };
+}
+```
+
+Implement `parseOptions` with `--binary`, `--iterations`, `--output`, and
+`--session-counts`, rejecting unknown flags and non-positive values. Implement
+`reportEnvironment` without serializing `HOME`, `COVEN_HOME`, or temporary paths.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `node --test scripts/benchmark-cli.test.mjs`
+
+Expected: PASS.
+
+### Task 2: Add isolated process timing and report writing
+
+**Files:**
+- Modify: `scripts/benchmark-cli.mjs`
+- Modify: `scripts/benchmark-cli.test.mjs`
+
+- [ ] **Step 1: Write a failing fake-binary test**
+
+```js
+test('runScenario preserves only timing and exit metadata', async () => {
+  const report = await runScenario({ command: fakeBinary, args: ['--help'], iterations: 2 });
+  assert.equal(report.samplesMs.length, 2);
+  assert.deepEqual(Object.keys(report).sort(), ['exitCodes', 'samplesMs', 'summary']);
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+Run: `node --test scripts/benchmark-cli.test.mjs`
+
+Expected: FAIL because `runScenario` is absent.
+
+- [ ] **Step 3: Implement process timing and atomic report output**
+
+Use `spawnSync` with explicit `cwd`, a temporary `COVEN_HOME`, a controlled
+`HOME`/`USERPROFILE`, and a command timeout. Measure with `process.hrtime.bigint()`;
+record milliseconds rounded to three decimal places. Write JSON through a sibling
+temporary file followed by rename. Fail if a scenario exits outside its declared
+allowed exit codes.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `node --test scripts/benchmark-cli.test.mjs`
+
+Expected: PASS.
+
+### Task 3: Add daemon fixture population through the public socket API
+
+**Files:**
+- Modify: `scripts/benchmark-cli.mjs`
+- Modify: `scripts/benchmark-cli.test.mjs`
+
+- [ ] **Step 1: Write a failing request-shape test**
+
+```js
+test('external session fixture request uses the versioned sessions endpoint', () => {
+  assert.deepEqual(externalSessionRequest('s-1').path, '/api/v1/sessions/external');
+  assert.equal(externalSessionRequest('s-1').method, 'POST');
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+Run: `node --test scripts/benchmark-cli.test.mjs`
+
+Expected: FAIL because the request factory is absent.
+
+- [ ] **Step 3: Implement lifecycle and fixtures**
+
+Start `coven daemon start`, wait for health through its local socket, and stop it
+in `finally`. Implement HTTP-over-Unix-socket requests with Node `http.request`.
+Register deterministic external sessions through `/api/v1/sessions/external` for
+the 100, 1,000, and 10,000 session-list fixtures. For event-tail fixtures,
+launch a controlled live `codex` shim through `POST /sessions`, seed safe input
+events through `POST /sessions/:id/input`, advance to the final bounded page via
+the documented events cursor, and measure that read. Kill the live fixture before
+stopping its daemon. Do not write SQLite files directly and do not add a
+fixture-only daemon endpoint.
+
+- [ ] **Step 4: Run the runner against a prebuilt binary**
+
+Run: `cargo build -p coven-cli --locked && node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output /tmp/coven-perf.json`
+
+Expected: exit 0 and a JSON report with command, daemon, list, event-tail, and launch scenarios.
+
+### Task 4: Add deterministic chat scheduling metrics without changing the event loop
+
+**Files:**
+- Modify: `crates/coven-cli/src/tui/chat/events.rs`
+
+- [ ] **Step 1: Write a failing ignored metric test**
+
+```rust
+#[test]
+#[ignore]
+fn benchmark_schedule_metrics_emit_json() {
+    println!("COVEN_BENCHMARK_TUI={}", serde_json::json!({
+        "idle": { "draws": 100, "polls": 100, "durationMs": 10_000 },
+        "streaming": { "draws": 100, "polls": 100, "durationMs": 10_000 }
+    }));
+}
+```
+
+- [ ] **Step 2: Run the focused Rust test and verify failure**
+
+Run: `cargo test -p coven-cli tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture`
+
+Expected: FAIL because the metric test is absent.
+
+- [ ] **Step 3: Implement a test-only cadence model**
+
+Inside the existing `events.rs` test module, add a pure helper that models the
+current 100 ms poll and draw-before-poll loop for a supplied duration and active
+state. The ignored test must print one `COVEN_BENCHMARK_TUI=` JSON line. Keep
+`run_event_loop` byte-for-byte behaviorally unchanged; #529 owns its eventual
+dirty-frame scheduling replacement.
+
+- [ ] **Step 4: Run focused and existing chat tests**
+
+Run: `cargo test -p coven-cli tui::chat --locked && cargo test -p coven-cli tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture`
+
+Expected: PASS, including the deterministic metric line.
+
+### Task 5: Document and wire artifact-only CI execution
+
+**Files:**
+- Modify: `README.md`
+- Modify: `.github/workflows/ci.yml`
+- Modify: `scripts/benchmark-cli.test.mjs`
+
+- [ ] **Step 1: Write a failing documentation-contract test**
+
+```js
+test('README documents the non-gating benchmark invocation', () => {
+  assert.match(readFileSync('README.md', 'utf8'), /benchmark-cli\.mjs/);
+  assert.match(readFileSync('README.md', 'utf8'), /trend data/i);
+});
+```
+
+- [ ] **Step 2: Run the test and verify failure**
+
+Run: `node --test scripts/benchmark-cli.test.mjs`
+
+Expected: FAIL because README has no benchmark guidance.
+
+- [ ] **Step 3: Add non-gating guidance and CI artifact upload**
+
+Document the local command, prebuilt-binary prerequisite, isolated-fixture
+contract, and that timings are trend data. Add a Linux CI job that builds the
+binary, runs three iterations, and uploads the JSON artifact. The job must fail
+on runner/fixture/report-shape errors but must contain no wall-clock threshold.
+
+- [ ] **Step 4: Run the complete verification bundle**
+
+Run:
+
+```bash
+node --test scripts/benchmark-cli.test.mjs
+cargo test -p coven-cli tui::chat --locked
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --staged
+git diff --check
+```
+
+Expected: every command exits 0.

--- a/docs/superpowers/specs/2026-07-28-cli-performance-baselines-design.md
+++ b/docs/superpowers/specs/2026-07-28-cli-performance-baselines-design.md
@@ -1,0 +1,70 @@
+# Coven CLI performance baselines
+
+## Purpose
+
+Establish a reproducible, end-to-end measurement harness before changing the
+Coven CLI's session, store, capability, or TUI implementations. The harness
+must distinguish a stable regression signal from host-specific timing noise.
+
+## Chosen approach
+
+Use a Node 24 runner at `scripts/benchmark-cli.mjs`, following the repository's
+existing npm smoke conventions. It receives a prebuilt native binary, builds
+isolated `COVEN_HOME` fixtures, invokes the real CLI and daemon socket API, and
+writes one JSON report. It does not include build time in any measurement.
+
+This is preferred over Criterion-only benchmarks because the priority paths
+include process startup, daemon socket work, and shell shims. It is preferred
+over a hard dependency on an external timing program because the runner must
+work in the existing GitHub Actions matrix with no global installation.
+
+## Measured scenarios
+
+1. `coven --help` and `coven --version` cold command execution.
+2. `coven doctor` against an isolated, intentionally unconfigured home.
+3. Daemon-backed session listing and event-tail reads with 100, 1,000, and
+   10,000 fixture records.
+4. Daemon-launched non-interactive fake-harness session to the first meaningful
+   output event.
+5. Chat scheduling-model metrics: idle draw/poll wakeups and active-stream
+   update cadence, expressed as deterministic counters rather than host CPU
+   utilization.
+
+## Fixture and report contract
+
+The runner creates all state below a temporary directory, starts and stops its
+own daemon, and never reads a user's real Coven or harness configuration. A
+small API fixture client registers synthetic external sessions for session-list
+measurements. Event-tail fixtures launch a controlled live fake harness, seed
+safe input events through the documented session-input API, advance to the final
+bounded event page through cursor reads, then measure that page. The runner must
+not write SQLite files directly or add a fixture-only daemon route.
+
+The JSON report includes schema version, commit identifier when available,
+platform, runner options, per-scenario sample durations in milliseconds, and
+summary values (`min`, `median`, `p95`, `max`). The report may be retained as a
+CI artifact or compared locally. It must not contain environment paths, prompt
+text, or harness output that could contain private user data.
+
+## CI policy
+
+The runner first validates fixture construction and report shape in CI. CI also
+captures the ignored deterministic TUI metric alongside the JSON report. These
+publish trend data but do not fail a pull request on wall-clock duration until
+repeated per-platform runs establish a stable threshold. Functional, privacy,
+secret, and packaging gates remain unchanged.
+
+## Boundaries
+
+The baseline slice adds no production optimization and does not change the
+public daemon API. It may add an ignored, test-only chat scheduling metric that
+prints deterministic frame/poll counts; it does not alter the event loop.
+Pagination, store initialization, capability caching, and idle rendering remain
+in their separate dependent issues (#526 through #529).
+
+## Verification
+
+- `node --test scripts/benchmark-cli.test.mjs`
+- a focused Rust test for the chat scheduling counters
+- `node scripts/benchmark-cli.mjs --binary <prebuilt-coven> --iterations 3`
+- existing Rust and JavaScript repository gates before a PR

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -378,11 +378,17 @@ export function collectCoreScenarios({ binary, iterations, env, run = runScenari
 
 export function isolatedEnvironment(covenHome, environment = process.env) {
   const userHome = join(covenHome, 'user-home');
+  const xdgConfigHome = join(userHome, '.config');
+  const xdgCacheHome = join(userHome, '.cache');
+  const xdgStateHome = join(userHome, '.local', 'state');
   return {
     ...environment,
     COVEN_HOME: covenHome,
     HOME: userHome,
-    USERPROFILE: userHome
+    USERPROFILE: userHome,
+    XDG_CONFIG_HOME: xdgConfigHome,
+    XDG_CACHE_HOME: xdgCacheHome,
+    XDG_STATE_HOME: xdgStateHome
   };
 }
 

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -48,6 +48,9 @@ export function parseOptions(args) {
       }
     } else if (arg === '--session-counts' || arg.startsWith('--session-counts=')) {
       const raw = valueFor('--session-counts');
+      if (!raw) {
+        throw new Error('--session-counts requires a value');
+      }
       if (raw === 'none') {
         sessionCounts = [];
       } else {
@@ -224,16 +227,25 @@ export async function waitForOutputEvent(
   { attempts, delayMs, request = socketRequest }
 ) {
   let lastError;
-  const path = `/api/v1/sessions/${sessionId}/events?limit=1`;
+  let afterSeq;
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     try {
+      const cursor = afterSeq === undefined ? '' : `afterSeq=${afterSeq}&`;
+      const path = `/api/v1/sessions/${sessionId}/events?${cursor}limit=1`;
       const response = await request(socketPath, { method: 'GET', path });
-      const body = JSON.parse(response.body);
-      if (response.statusCode === 200 && body.events?.some((event) => event.kind === 'output')) {
-        return;
+      if (response.statusCode !== 200) {
+        lastError = new Error(`events returned ${response.statusCode}`);
+      } else {
+        const body = JSON.parse(response.body);
+        if (body.events?.some((event) => event.kind === 'output')) {
+          return;
+        }
+        if (Number.isInteger(body.nextCursor?.afterSeq)) {
+          afterSeq = body.nextCursor.afterSeq;
+        }
+        lastError = new Error('no output event yet');
       }
-      lastError = new Error(`events returned ${response.statusCode}`);
     } catch (error) {
       lastError = error;
     }

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -70,7 +70,7 @@ export function runScenario({ command, args, iterations, allowedExitCodes = [0],
 
   for (let iteration = 0; iteration < iterations; iteration += 1) {
     const startedAt = process.hrtime.bigint();
-    const result = spawnSync(command, args, { encoding: 'utf8', env });
+    const result = spawnSync(command, args, { encoding: 'utf8', env, timeout: 120_000, killSignal: 'SIGKILL' });
     const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
 
     if (result.error) {

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -156,7 +156,12 @@ export function sessionInputRequest(sessionId, index) {
   };
 }
 
-export function socketRequest(socketPath, { method, path, body = '' }) {
+export function socketRequest(socketPath, {
+  method,
+  path,
+  body = '',
+  timeoutMs = COMMAND_TIMEOUT_MS
+}) {
   return new Promise((resolve, reject) => {
     const request = requestHttp(
       {
@@ -181,6 +186,9 @@ export function socketRequest(socketPath, { method, path, body = '' }) {
     );
 
     request.once('error', reject);
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(new Error(`socket request timed out after ${timeoutMs}ms`));
+    });
     request.end(body);
   });
 }

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -41,6 +41,9 @@ export function parseOptions(args) {
       iterations = value;
     } else if (arg === '--output' || arg.startsWith('--output=')) {
       output = valueFor('--output');
+      if (!output) {
+        throw new Error('--output requires a path');
+      }
     } else if (arg === '--session-counts' || arg.startsWith('--session-counts=')) {
       const raw = valueFor('--session-counts');
       if (raw === 'none') {

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -1,0 +1,655 @@
+import { spawnSync } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { request as requestHttp } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+export function summarizeSamples(samples) {
+  const sorted = [...samples].sort((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+
+  return {
+    minMs: sorted[0],
+    medianMs:
+      sorted.length % 2 === 1
+        ? sorted[middle]
+        : (sorted[middle - 1] + sorted[middle]) / 2,
+    p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1],
+    maxMs: sorted.at(-1)
+  };
+}
+
+export function parseOptions(args) {
+  let binary;
+  let iterations = 5;
+  let output;
+  let sessionCounts;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const valueFor = (option) =>
+      arg === option ? args[++index] : arg.slice(`${option}=`.length);
+
+    if (arg === '--binary' || arg.startsWith('--binary=')) {
+      binary = valueFor('--binary');
+    } else if (arg === '--iterations' || arg.startsWith('--iterations=')) {
+      const value = Number.parseInt(valueFor('--iterations'), 10);
+      if (!Number.isSafeInteger(value) || value <= 0) {
+        throw new Error('--iterations must be a positive integer');
+      }
+      iterations = value;
+    } else if (arg === '--output' || arg.startsWith('--output=')) {
+      output = valueFor('--output');
+    } else if (arg === '--session-counts' || arg.startsWith('--session-counts=')) {
+      const raw = valueFor('--session-counts');
+      if (raw === 'none') {
+        sessionCounts = [];
+      } else {
+        const values = raw.split(',').map((value) => Number.parseInt(value, 10));
+        if (values.some((value) => !Number.isSafeInteger(value) || value <= 0)) {
+          throw new Error('--session-counts must contain positive integers');
+        }
+        sessionCounts = values;
+      }
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  if (!binary) {
+    throw new Error('--binary is required');
+  }
+
+  return { binary, iterations, output, sessionCounts };
+}
+
+export function runScenario({ command, args, iterations, allowedExitCodes = [0], env }) {
+  const samplesMs = [];
+  const exitCodes = [];
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const startedAt = process.hrtime.bigint();
+    const result = spawnSync(command, args, { encoding: 'utf8', env });
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+
+    if (result.error) {
+      throw result.error;
+    }
+    if (!Number.isInteger(result.status) || !allowedExitCodes.includes(result.status)) {
+      throw new Error(`scenario exited with ${result.status}`);
+    }
+
+    samplesMs.push(Number(elapsedMs.toFixed(3)));
+    exitCodes.push(result.status);
+  }
+
+  return { samplesMs, exitCodes, summary: summarizeSamples(samplesMs) };
+}
+
+export function runCommand({ command, args, allowedExitCodes = [0], env }) {
+  const result = spawnSync(command, args, { encoding: 'utf8', env });
+  if (result.error) {
+    throw result.error;
+  }
+  if (!Number.isInteger(result.status) || !allowedExitCodes.includes(result.status)) {
+    const stderr = result.stderr.trim();
+    throw new Error(`command exited with ${result.status}${stderr ? `: ${stderr}` : ''}`);
+  }
+  return { status: result.status };
+}
+
+export function externalSessionRequest({ id, projectRoot }) {
+  return {
+    method: 'POST',
+    path: '/api/v1/sessions/external',
+    body: JSON.stringify({
+      id,
+      projectRoot,
+      harness: 'benchmark-fixture',
+      title: 'Benchmark fixture session'
+    })
+  };
+}
+
+export function harnessSessionRequest({ projectRoot }) {
+  return {
+    method: 'POST',
+    path: '/api/v1/sessions',
+    body: JSON.stringify({
+      projectRoot,
+      cwd: projectRoot,
+      harness: 'codex',
+      launchMode: 'nonInteractive',
+      prompt: 'Benchmark fixture prompt',
+      title: 'Benchmark harness fixture'
+    })
+  };
+}
+
+export function sessionInputRequest(sessionId, index) {
+  return {
+    method: 'POST',
+    path: `/api/v1/sessions/${sessionId}/input`,
+    body: JSON.stringify({ data: `Benchmark event ${String(index).padStart(6, '0')}\n` })
+  };
+}
+
+export function socketRequest(socketPath, { method, path, body = '' }) {
+  return new Promise((resolve, reject) => {
+    const request = requestHttp(
+      {
+        socketPath,
+        method,
+        path,
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body)
+        }
+      },
+      (response) => {
+        let responseBody = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        response.on('end', () => {
+          resolve({ statusCode: response.statusCode, body: responseBody });
+        });
+      }
+    );
+
+    request.once('error', reject);
+    request.end(body);
+  });
+}
+
+export async function waitForHealth(socketPath, { attempts, delayMs }) {
+  let lastError;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await socketRequest(socketPath, {
+        method: 'GET',
+        path: '/api/v1/health'
+      });
+      if (response.statusCode === 200 && JSON.parse(response.body).ok === true) {
+        return;
+      }
+      lastError = new Error(`health returned ${response.statusCode}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt + 1 < attempts && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw new Error(`daemon health did not become ready: ${lastError?.message ?? 'unknown error'}`);
+}
+
+export async function waitForOutputEvent(
+  socketPath,
+  sessionId,
+  { attempts, delayMs, request = socketRequest }
+) {
+  let lastError;
+  const path = `/api/v1/sessions/${sessionId}/events?limit=1`;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      const response = await request(socketPath, { method: 'GET', path });
+      const body = JSON.parse(response.body);
+      if (response.statusCode === 200 && body.events?.some((event) => event.kind === 'output')) {
+        return;
+      }
+      lastError = new Error(`events returned ${response.statusCode}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt + 1 < attempts && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw new Error(`harness output event did not arrive: ${lastError?.message ?? 'unknown error'}`);
+}
+
+export async function registerInputEvents({
+  socketPath,
+  sessionId,
+  count,
+  request = socketRequest
+}) {
+  for (let index = 1; index <= count; index += 1) {
+    const response = await request(socketPath, sessionInputRequest(sessionId, index));
+    if (response.statusCode !== 202) {
+      throw new Error(`input event fixture returned ${response.statusCode}`);
+    }
+  }
+}
+
+export async function launchHarnessSession({
+  socketPath,
+  projectRoot,
+  request = socketRequest
+}) {
+  const response = await request(socketPath, harnessSessionRequest({ projectRoot }));
+  if (response.statusCode !== 201) {
+    throw new Error(`harness fixture returned ${response.statusCode}`);
+  }
+  const { id } = JSON.parse(response.body);
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('harness fixture response has no session id');
+  }
+  return id;
+}
+
+export async function stopLiveSession({
+  socketPath,
+  sessionId,
+  request = socketRequest
+}) {
+  const response = await request(socketPath, {
+    method: 'POST',
+    path: `/api/v1/sessions/${sessionId}/kill`
+  });
+  if (response.statusCode !== 202) {
+    throw new Error(`live fixture stop returned ${response.statusCode}`);
+  }
+}
+
+export async function prepareEventTail({
+  socketPath,
+  sessionId,
+  count,
+  request = socketRequest
+}) {
+  const maxEvents = 1000;
+  const tailSize = Math.min(count, maxEvents);
+  let remainingBeforeTail = count - tailSize;
+  let afterSeq;
+
+  while (remainingBeforeTail > 0) {
+    const limit = Math.min(maxEvents, remainingBeforeTail);
+    const cursor = afterSeq === undefined ? '' : `afterSeq=${afterSeq}&`;
+    const path = `/api/v1/sessions/${sessionId}/events?${cursor}limit=${limit}`;
+    const response = await request(socketPath, { method: 'GET', path });
+    if (response.statusCode !== 200) {
+      throw new Error(`event-tail setup returned ${response.statusCode}`);
+    }
+    const body = JSON.parse(response.body);
+    if (body.events?.length !== limit || !Number.isInteger(body.nextCursor?.afterSeq)) {
+      throw new Error('event-tail setup did not return the requested cursor page');
+    }
+    afterSeq = body.nextCursor.afterSeq;
+    remainingBeforeTail -= limit;
+  }
+
+  const cursor = afterSeq === undefined ? '' : `afterSeq=${afterSeq}&`;
+  return `/api/v1/sessions/${sessionId}/events?${cursor}limit=${tailSize}`;
+}
+
+export async function runHarnessOutputScenario({
+  socketPath,
+  projectRoot,
+  iterations,
+  request = socketRequest,
+  wait = waitForOutputEvent
+}) {
+  const samplesMs = [];
+  const statusCodes = [];
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const startedAt = process.hrtime.bigint();
+    const response = await request(socketPath, harnessSessionRequest({ projectRoot }));
+    if (response.statusCode !== 201) {
+      throw new Error(`harness fixture returned ${response.statusCode}`);
+    }
+    const { id } = JSON.parse(response.body);
+    if (typeof id !== 'string' || id.length === 0) {
+      throw new Error('harness fixture response has no session id');
+    }
+    await wait(socketPath, id, { attempts: 100, delayMs: 25, request });
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    samplesMs.push(Number(elapsedMs.toFixed(3)));
+    statusCodes.push(response.statusCode);
+  }
+
+  return { samplesMs, statusCodes, summary: summarizeSamples(samplesMs) };
+}
+
+export async function createHarnessFixture(fixtureRoot, environment = process.env) {
+  const binDir = join(fixtureRoot, 'bin');
+  await mkdir(binDir, { recursive: true });
+  const executable = join(binDir, 'codex');
+  await writeFile(executable, '#!/bin/sh\nprintf "benchmark output\\n"\n', { mode: 0o700 });
+  await chmod(executable, 0o700);
+  return { ...environment, PATH: `${binDir}:${environment.PATH ?? ''}` };
+}
+
+export async function createInputHarnessFixture(fixtureRoot, environment = process.env) {
+  const binDir = join(fixtureRoot, 'event-bin');
+  await mkdir(binDir, { recursive: true });
+  const executable = join(binDir, 'codex');
+  await writeFile(executable, '#!/bin/sh\nwhile IFS= read -r line; do :; done\n', { mode: 0o700 });
+  await chmod(executable, 0o700);
+  return { ...environment, PATH: `${binDir}:${environment.PATH ?? ''}` };
+}
+
+export function buildReport({ iterations, sessionCounts, scenarios, environment = process.env }) {
+  const report = {
+    schemaVersion: 1,
+    platform: {
+      os: process.platform,
+      arch: process.arch,
+      node: process.version
+    },
+    options: { iterations, sessionCounts },
+    scenarios
+  };
+  if (environment.GITHUB_SHA) {
+    report.commit = environment.GITHUB_SHA;
+  }
+  return report;
+}
+
+export function coreScenarioDefinitions(binary) {
+  return [
+    { id: 'help', command: binary, args: ['--help'], allowedExitCodes: [0] },
+    { id: 'version', command: binary, args: ['--version'], allowedExitCodes: [0] },
+    { id: 'doctor', command: binary, args: ['doctor'], allowedExitCodes: [0, 1] }
+  ];
+}
+
+export function collectCoreScenarios({ binary, iterations, env, run = runScenario }) {
+  return Object.fromEntries(
+    coreScenarioDefinitions(binary).map(({ id, ...definition }) => [
+      id,
+      run({ ...definition, iterations, env })
+    ])
+  );
+}
+
+export function isolatedEnvironment(covenHome, environment = process.env) {
+  const userHome = join(covenHome, 'user-home');
+  return {
+    ...environment,
+    COVEN_HOME: covenHome,
+    HOME: userHome,
+    USERPROFILE: userHome
+  };
+}
+
+export async function daemonSocketPath(covenHome) {
+  const status = JSON.parse(await readFile(join(covenHome, 'daemon.json'), 'utf8'));
+  if (typeof status.socket !== 'string' || status.socket.trim() === '') {
+    throw new Error('daemon metadata has no socket path');
+  }
+  return status.socket;
+}
+
+export async function startDaemon({
+  binary,
+  covenHome,
+  env,
+  run = runCommand,
+  readSocket = daemonSocketPath,
+  wait = waitForHealth
+}) {
+  run({ command: binary, args: ['daemon', 'start'], allowedExitCodes: [0], env });
+  const socketPath = await readSocket(covenHome);
+  await wait(socketPath, { attempts: 100, delayMs: 25 });
+  return socketPath;
+}
+
+export function stopDaemon({ binary, env, run = runCommand }) {
+  run({ command: binary, args: ['daemon', 'stop'], allowedExitCodes: [0], env });
+}
+
+export async function registerExternalSessions({
+  socketPath,
+  count,
+  concurrency = 1,
+  projectRoot,
+  request = socketRequest
+}) {
+  let nextIndex = 1;
+  const workerCount = Math.min(count, concurrency);
+
+  const worker = async () => {
+    while (nextIndex <= count) {
+      const index = nextIndex;
+      nextIndex += 1;
+      const id = `benchmark-session-${String(index).padStart(6, '0')}`;
+      const response = await request(socketPath, externalSessionRequest({ id, projectRoot }));
+      if (response.statusCode !== 200 && response.statusCode !== 201) {
+        throw new Error(`external session fixture returned ${response.statusCode}`);
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, worker));
+}
+
+export async function runSocketScenario({
+  socketPath,
+  path,
+  iterations,
+  allowedStatusCodes = [200],
+  request = socketRequest
+}) {
+  const samplesMs = [];
+  const statusCodes = [];
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const startedAt = process.hrtime.bigint();
+    const response = await request(socketPath, { method: 'GET', path });
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+    if (!allowedStatusCodes.includes(response.statusCode)) {
+      throw new Error(`socket scenario returned ${response.statusCode}`);
+    }
+    samplesMs.push(Number(elapsedMs.toFixed(3)));
+    statusCodes.push(response.statusCode);
+  }
+
+  return { samplesMs, statusCodes, summary: summarizeSamples(samplesMs) };
+}
+
+export async function measureSessionLists({
+  binary,
+  fixtureRoot,
+  sessionCounts,
+  environment,
+  fixtureConcurrency = 8,
+  iterations = 1,
+  makeDirectory = (path) => mkdir(path, { recursive: true }),
+  start = startDaemon,
+  seed = registerExternalSessions,
+  measure = runSocketScenario,
+  stop = stopDaemon
+}) {
+  const reports = {};
+
+  for (const count of sessionCounts) {
+    const covenHome = join(fixtureRoot, `s-${count}`);
+    const env = isolatedEnvironment(covenHome, environment);
+    await makeDirectory(join(covenHome, 'user-home'));
+    const socketPath = await start({ binary, covenHome, env });
+
+    try {
+      await seed({
+        socketPath,
+        count,
+        concurrency: fixtureConcurrency,
+        projectRoot: fixtureRoot
+      });
+      reports[`sessions_${count}`] = await measure({
+        socketPath,
+        path: '/api/v1/sessions',
+        iterations
+      });
+    } finally {
+      stop({ binary, covenHome, env });
+    }
+  }
+
+  return reports;
+}
+
+export async function measureHarnessOutput({
+  binary,
+  fixtureRoot,
+  environment,
+  iterations,
+  makeDirectory = (path) => mkdir(path, { recursive: true }),
+  createFixture = createHarnessFixture,
+  start = startDaemon,
+  measure = runHarnessOutputScenario,
+  stop = stopDaemon
+}) {
+  const covenHome = join(fixtureRoot, 'h');
+  const baseEnvironment = isolatedEnvironment(covenHome, environment);
+  await makeDirectory(join(covenHome, 'user-home'));
+  const env = await createFixture(fixtureRoot, baseEnvironment);
+  const socketPath = await start({ binary, covenHome, env });
+
+  try {
+    return await measure({ socketPath, projectRoot: fixtureRoot, iterations });
+  } finally {
+    stop({ binary, covenHome, env });
+  }
+}
+
+export async function measureEventTails({
+  binary,
+  fixtureRoot,
+  eventCounts,
+  environment,
+  iterations = 1,
+  makeDirectory = (path) => mkdir(path, { recursive: true }),
+  createFixture = createInputHarnessFixture,
+  start = startDaemon,
+  launch = launchHarnessSession,
+  seed = registerInputEvents,
+  prepare = prepareEventTail,
+  measure = runSocketScenario,
+  finish = stopLiveSession,
+  stop = stopDaemon
+}) {
+  const reports = {};
+
+  for (const count of eventCounts) {
+    const covenHome = join(fixtureRoot, `e-${count}`);
+    const baseEnvironment = isolatedEnvironment(covenHome, environment);
+    await makeDirectory(join(covenHome, 'user-home'));
+    const env = await createFixture(fixtureRoot, baseEnvironment);
+    const socketPath = await start({ binary, covenHome, env });
+    let sessionId;
+
+    try {
+      sessionId = await launch({ socketPath, projectRoot: fixtureRoot });
+      await seed({ socketPath, sessionId, count });
+      const path = await prepare({ socketPath, sessionId, count });
+      reports[`event_tail_${count}`] = await measure({ socketPath, path, iterations });
+    } finally {
+      if (sessionId) {
+        await finish({ socketPath, sessionId });
+      }
+      stop({ binary, covenHome, env });
+    }
+  }
+
+  return reports;
+}
+
+export async function collectBenchmarkScenarios({
+  options,
+  fixtureRoot,
+  environment,
+  makeDirectory = (path) => mkdir(path, { recursive: true }),
+  collectCore = collectCoreScenarios,
+  measureHarness = measureHarnessOutput,
+  measureEvents = measureEventTails,
+  measureLists = measureSessionLists
+}) {
+  const coreHome = join(fixtureRoot, 'c');
+  const coreEnv = isolatedEnvironment(coreHome, environment);
+  await makeDirectory(join(coreHome, 'user-home'));
+  const scenarios = collectCore({
+    binary: options.binary,
+    iterations: options.iterations,
+    env: coreEnv
+  });
+
+  if (options.sessionCounts.length > 0) {
+    scenarios.harness_first_output = await measureHarness({
+      binary: options.binary,
+      fixtureRoot,
+      environment,
+      iterations: options.iterations
+    });
+    Object.assign(
+      scenarios,
+      await measureEvents({
+        binary: options.binary,
+        fixtureRoot,
+        eventCounts: options.sessionCounts,
+        environment,
+        iterations: options.iterations
+      })
+    );
+    Object.assign(
+      scenarios,
+      await measureLists({
+        binary: options.binary,
+        fixtureRoot,
+        sessionCounts: options.sessionCounts,
+        environment,
+        iterations: options.iterations
+      })
+    );
+  }
+
+  return scenarios;
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const options = parseOptions(args);
+  const sessionCounts = options.sessionCounts ?? [100, 1000, 10000];
+  const fixtureRoot = await mkdtemp(join(tmpdir(), 'coven-benchmark-'));
+
+  try {
+    const report = buildReport({
+      iterations: options.iterations,
+      sessionCounts,
+      environment: process.env,
+      scenarios: await collectBenchmarkScenarios({
+        options: { ...options, sessionCounts },
+        fixtureRoot,
+        environment: process.env
+      })
+    });
+
+    const serialized = `${JSON.stringify(report)}\n`;
+    if (options.output) {
+      const temporaryOutput = `${options.output}.${process.pid}.tmp`;
+      await writeFile(temporaryOutput, serialized, { encoding: 'utf8', mode: 0o600 });
+      await rename(temporaryOutput, options.output);
+    } else {
+      process.stdout.write(serialized);
+    }
+    return report;
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`benchmark-cli: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+const COMMAND_TIMEOUT_MS = 120_000;
+
 export function summarizeSamples(samples) {
   const sorted = [...samples].sort((left, right) => left - right);
   const middle = Math.floor(sorted.length / 2);
@@ -73,7 +75,12 @@ export function runScenario({ command, args, iterations, allowedExitCodes = [0],
 
   for (let iteration = 0; iteration < iterations; iteration += 1) {
     const startedAt = process.hrtime.bigint();
-    const result = spawnSync(command, args, { encoding: 'utf8', env, timeout: 120_000, killSignal: 'SIGKILL' });
+    const result = spawnSync(command, args, {
+      encoding: 'utf8',
+      env,
+      timeout: COMMAND_TIMEOUT_MS,
+      killSignal: 'SIGKILL'
+    });
     const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
 
     if (result.error) {
@@ -90,8 +97,19 @@ export function runScenario({ command, args, iterations, allowedExitCodes = [0],
   return { samplesMs, exitCodes, summary: summarizeSamples(samplesMs) };
 }
 
-export function runCommand({ command, args, allowedExitCodes = [0], env }) {
-  const result = spawnSync(command, args, { encoding: 'utf8', env });
+export function runCommand({
+  command,
+  args,
+  allowedExitCodes = [0],
+  env,
+  timeoutMs = COMMAND_TIMEOUT_MS
+}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    env,
+    timeout: timeoutMs,
+    killSignal: 'SIGKILL'
+  });
   if (result.error) {
     throw result.error;
   }

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -80,6 +80,17 @@ test('parseOptions accepts an output path and explicit session fixture sizes', (
   );
 });
 
+test('parseOptions rejects a missing output path', () => {
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--output']),
+    /--output requires a path/
+  );
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--output=']),
+    /--output requires a path/
+  );
+});
+
 test('parseOptions accepts space-separated option values', () => {
   assert.deepEqual(
     parseOptions([
@@ -178,7 +189,10 @@ test('isolatedEnvironment replaces Coven and user-home paths', () => {
     PATH: '/fixture/bin',
     COVEN_HOME: '/fixture/coven-home',
     HOME: '/fixture/coven-home/user-home',
-    USERPROFILE: '/fixture/coven-home/user-home'
+    USERPROFILE: '/fixture/coven-home/user-home',
+    XDG_CONFIG_HOME: '/fixture/coven-home/user-home/.config',
+    XDG_CACHE_HOME: '/fixture/coven-home/user-home/.cache',
+    XDG_STATE_HOME: '/fixture/coven-home/user-home/.local/state'
   });
 });
 
@@ -310,6 +324,18 @@ test('runCommand includes captured stderr when a lifecycle command fails', () =>
       env: process.env
     }),
     /command exited with 7: fixture command failed/
+  );
+});
+
+test('runCommand times out hung lifecycle commands', () => {
+  assert.throws(
+    () => runCommand({
+      command: process.execPath,
+      args: ['--eval', 'setTimeout(() => {}, 10_000)'],
+      env: process.env,
+      timeoutMs: 25
+    }),
+    /ETIMEDOUT/
   );
 });
 

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -769,6 +769,23 @@ test('socketRequest sends an external-session fixture over a local socket', asyn
   assert.deepEqual(response, { statusCode: 201, body: '{"ok":true}' });
 });
 
+test('socketRequest rejects when a local daemon request stalls', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-timeout-'));
+  const socketPath = join(directory, 'daemon.sock');
+  const server = createServer(() => {});
+
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  await assert.rejects(
+    socketRequest(socketPath, { method: 'GET', path: '/api/v1/health', timeoutMs: 25 }),
+    /socket request timed out after 25ms/
+  );
+});
+
 test('waitForHealth resolves after the local daemon health response', async (t) => {
   const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-health-'));
   const socketPath = join(directory, 'daemon.sock');

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -119,6 +119,17 @@ test('parseOptions accepts none as a core-only session fixture mode', () => {
   );
 });
 
+test('parseOptions rejects a missing session fixture size', () => {
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--session-counts']),
+    /--session-counts requires a value/
+  );
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--session-counts=']),
+    /--session-counts requires a value/
+  );
+});
+
 test('buildReport omits the local binary path and fixture home', () => {
   const report = buildReport({
     binary: '/private/tmp/coven',
@@ -701,7 +712,8 @@ test('waitForOutputEvent resolves only after an output event is recorded', async
       return {
         statusCode: 200,
         body: JSON.stringify({
-          events: reads === 2 ? [{ kind: 'output' }] : [{ kind: 'exit' }]
+          events: reads === 2 ? [{ kind: 'output' }] : [{ kind: 'exit' }],
+          nextCursor: { afterSeq: reads * 10 }
         })
       };
     }
@@ -709,7 +721,7 @@ test('waitForOutputEvent resolves only after an output event is recorded', async
 
   assert.deepEqual(paths, [
     '/api/v1/sessions/session-1/events?limit=1',
-    '/api/v1/sessions/session-1/events?limit=1'
+    '/api/v1/sessions/session-1/events?afterSeq=10&limit=1'
   ]);
 });
 

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -1,0 +1,763 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+import {
+  buildReport,
+  collectBenchmarkScenarios,
+  collectCoreScenarios,
+  coreScenarioDefinitions,
+  daemonSocketPath,
+  externalSessionRequest,
+  harnessSessionRequest,
+  isolatedEnvironment,
+  launchHarnessSession,
+  prepareEventTail,
+  measureEventTails,
+  measureSessionLists,
+  registerInputEvents,
+  registerExternalSessions,
+  runCommand,
+  runHarnessOutputScenario,
+  parseOptions,
+  runScenario,
+  runSocketScenario,
+  sessionInputRequest,
+  stopLiveSession,
+  socketRequest,
+  startDaemon,
+  stopDaemon,
+  summarizeSamples,
+  waitForOutputEvent,
+  waitForHealth
+} from './benchmark-cli.mjs';
+
+test('summarizeSamples reports deterministic median and nearest-rank p95', () => {
+  assert.deepEqual(summarizeSamples([9, 1, 5, 3, 7]), {
+    minMs: 1,
+    medianMs: 5,
+    p95Ms: 9,
+    maxMs: 9
+  });
+});
+
+test('parseOptions requires a binary path', () => {
+  assert.throws(() => parseOptions(['--iterations=3']), /--binary is required/);
+});
+
+test('parseOptions rejects a non-positive iteration count', () => {
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--iterations=0']),
+    /--iterations must be a positive integer/
+  );
+});
+
+test('parseOptions rejects unknown flags', () => {
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--interations=3']),
+    /unknown option: --interations=3/
+  );
+});
+
+test('parseOptions accepts an output path and explicit session fixture sizes', () => {
+  assert.deepEqual(
+    parseOptions([
+      '--binary=/tmp/coven',
+      '--iterations=3',
+      '--output=/tmp/report.json',
+      '--session-counts=100,1000,10000'
+    ]),
+    {
+      binary: '/tmp/coven',
+      iterations: 3,
+      output: '/tmp/report.json',
+      sessionCounts: [100, 1000, 10000]
+    }
+  );
+});
+
+test('parseOptions accepts space-separated option values', () => {
+  assert.deepEqual(
+    parseOptions([
+      '--binary',
+      '/tmp/coven',
+      '--iterations',
+      '3',
+      '--output',
+      '/tmp/report.json',
+      '--session-counts',
+      '100,1000'
+    ]),
+    {
+      binary: '/tmp/coven',
+      iterations: 3,
+      output: '/tmp/report.json',
+      sessionCounts: [100, 1000]
+    }
+  );
+});
+
+test('parseOptions accepts none as a core-only session fixture mode', () => {
+  assert.deepEqual(
+    parseOptions(['--binary=/tmp/coven', '--session-counts=none']).sessionCounts,
+    []
+  );
+});
+
+test('buildReport omits the local binary path and fixture home', () => {
+  const report = buildReport({
+    binary: '/private/tmp/coven',
+    fixtureHome: '/private/tmp/coven-home',
+    iterations: 3,
+    sessionCounts: [100],
+    scenarios: { help: { samplesMs: [1], exitCodes: [0], summary: { minMs: 1 } }
+    }
+  });
+
+  const serialized = JSON.stringify(report);
+  assert.equal(report.schemaVersion, 1);
+  assert.equal(report.options.iterations, 3);
+  assert.deepEqual(report.options.sessionCounts, [100]);
+  assert.doesNotMatch(serialized, /private\/tmp/);
+});
+
+test('buildReport includes a CI commit identifier when provided', () => {
+  const report = buildReport({
+    iterations: 1,
+    sessionCounts: [],
+    scenarios: {},
+    environment: { GITHUB_SHA: 'abc123' }
+  });
+
+  assert.equal(report.commit, 'abc123');
+});
+
+test('coreScenarioDefinitions includes command startup and doctor scenarios', () => {
+  assert.deepEqual(coreScenarioDefinitions('/tmp/coven'), [
+    { id: 'help', command: '/tmp/coven', args: ['--help'], allowedExitCodes: [0] },
+    { id: 'version', command: '/tmp/coven', args: ['--version'], allowedExitCodes: [0] },
+    { id: 'doctor', command: '/tmp/coven', args: ['doctor'], allowedExitCodes: [0, 1] }
+  ]);
+});
+
+test('collectCoreScenarios runs every core scenario with the requested iterations', () => {
+  const calls = [];
+  const scenarios = collectCoreScenarios({
+    binary: '/tmp/coven',
+    iterations: 2,
+    env: { COVEN_HOME: '/fixture/home' },
+    run: (definition) => {
+      calls.push(definition);
+      return { samplesMs: [1, 2], exitCodes: [0, 0], summary: { minMs: 1 } };
+    }
+  });
+
+  assert.deepEqual(Object.keys(scenarios), ['help', 'version', 'doctor']);
+  assert.equal(calls.length, 3);
+  assert.deepEqual(calls.map((call) => call.iterations), [2, 2, 2]);
+  assert.deepEqual(calls.map((call) => call.env), [
+    { COVEN_HOME: '/fixture/home' },
+    { COVEN_HOME: '/fixture/home' },
+    { COVEN_HOME: '/fixture/home' }
+  ]);
+});
+
+test('isolatedEnvironment replaces Coven and user-home paths', () => {
+  const env = isolatedEnvironment('/fixture/coven-home', {
+    PATH: '/fixture/bin',
+    COVEN_HOME: '/real/coven-home',
+    HOME: '/real/home',
+    USERPROFILE: '/real/profile'
+  });
+
+  assert.deepEqual(env, {
+    PATH: '/fixture/bin',
+    COVEN_HOME: '/fixture/coven-home',
+    HOME: '/fixture/coven-home/user-home',
+    USERPROFILE: '/fixture/coven-home/user-home'
+  });
+});
+
+test('daemonSocketPath reads the daemon socket from isolated metadata', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-status-'));
+  await writeFile(
+    join(directory, 'daemon.json'),
+    JSON.stringify({ pid: 42, socket: '/fixture/coven.sock' })
+  );
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  assert.equal(await daemonSocketPath(directory), '/fixture/coven.sock');
+});
+
+test('benchmark CLI emits a machine-readable core-scenario report', () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      'scripts/benchmark-cli.mjs',
+      `--binary=${process.execPath}`,
+      '--iterations=1',
+      '--session-counts=none'
+    ],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.schemaVersion, 1);
+  assert.deepEqual(Object.keys(report.scenarios), ['help', 'version', 'doctor']);
+});
+
+test('benchmark CLI writes its report to the requested output path', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-output-'));
+  const output = join(directory, 'report.json');
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      'scripts/benchmark-cli.mjs',
+      `--binary=${process.execPath}`,
+      '--iterations=1',
+      '--session-counts=none',
+      `--output=${output}`
+    ],
+    { encoding: 'utf8' }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '');
+  const report = JSON.parse(await readFile(output, 'utf8'));
+  assert.equal(report.schemaVersion, 1);
+});
+
+test('benchmark CLI isolates the child Coven environment', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-isolation-'));
+  const binary = join(directory, 'fake-coven.mjs');
+  await writeFile(
+    binary,
+    '#!/usr/bin/env node\nprocess.exit(process.env.COVEN_HOME === "/operator-state" ? 9 : 0);\n'
+  );
+  await chmod(binary, 0o755);
+  t.after(() => rm(directory, { recursive: true, force: true }));
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      'scripts/benchmark-cli.mjs',
+      '--binary',
+      binary,
+      '--iterations',
+      '1',
+      '--session-counts=none'
+    ],
+    { encoding: 'utf8', env: { ...process.env, COVEN_HOME: '/operator-state' } }
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const report = JSON.parse(result.stdout);
+  assert.deepEqual(report.scenarios.help.exitCodes, [0]);
+});
+
+test('README documents the non-gating benchmark invocation', async () => {
+  const readme = await readFile('README.md', 'utf8');
+  assert.match(readme, /benchmark-cli\.mjs/);
+  assert.match(readme, /trend data/i);
+});
+
+test('runScenario preserves only timing and exit metadata', () => {
+  const report = runScenario({
+    command: process.execPath,
+    args: ['--eval', 'process.exit(0)'],
+    iterations: 2
+  });
+
+  assert.equal(report.samplesMs.length, 2);
+  assert.deepEqual(Object.keys(report).sort(), ['exitCodes', 'samplesMs', 'summary']);
+  assert.deepEqual(report.exitCodes, [0, 0]);
+});
+
+test('runScenario uses the supplied isolated environment', () => {
+  const report = runScenario({
+    command: process.execPath,
+    args: ['--eval', "process.exit(process.env.COVEN_HOME === '/fixture/home' ? 0 : 7)"],
+    iterations: 1,
+    env: { ...process.env, COVEN_HOME: '/fixture/home' }
+  });
+
+  assert.deepEqual(report.exitCodes, [0]);
+});
+
+test('runCommand accepts an expected nonzero exit and preserves environment isolation', () => {
+  const result = runCommand({
+    command: process.execPath,
+    args: ['--eval', "process.exit(process.env.COVEN_HOME === '/fixture/home' ? 1 : 7)"],
+    allowedExitCodes: [1],
+    env: { ...process.env, COVEN_HOME: '/fixture/home' }
+  });
+
+  assert.equal(result.status, 1);
+});
+
+test('runCommand includes captured stderr when a lifecycle command fails', () => {
+  assert.throws(
+    () => runCommand({
+      command: process.execPath,
+      args: ['--eval', "process.stderr.write('fixture command failed\\n'); process.exit(7)"],
+      env: process.env
+    }),
+    /command exited with 7: fixture command failed/
+  );
+});
+
+test('startDaemon starts, resolves metadata, then waits for health', async () => {
+  const calls = [];
+  const socket = await startDaemon({
+    binary: '/tmp/coven',
+    covenHome: '/fixture/coven-home',
+    env: { COVEN_HOME: '/fixture/coven-home' },
+    run: (command) => calls.push(['run', command]),
+    readSocket: async (home) => {
+      calls.push(['readSocket', home]);
+      return '/fixture/coven.sock';
+    },
+    wait: async (path, options) => calls.push(['wait', path, options])
+  });
+
+  assert.equal(socket, '/fixture/coven.sock');
+  assert.deepEqual(calls, [
+    [
+      'run',
+      {
+        command: '/tmp/coven',
+        args: ['daemon', 'start'],
+        allowedExitCodes: [0],
+        env: { COVEN_HOME: '/fixture/coven-home' }
+      }
+    ],
+    ['readSocket', '/fixture/coven-home'],
+    ['wait', '/fixture/coven.sock', { attempts: 100, delayMs: 25 }]
+  ]);
+});
+
+test('stopDaemon shuts down through the same isolated command boundary', () => {
+  const calls = [];
+  stopDaemon({
+    binary: '/tmp/coven',
+    env: { COVEN_HOME: '/fixture/coven-home' },
+    run: (command) => calls.push(command)
+  });
+
+  assert.deepEqual(calls, [
+    {
+      command: '/tmp/coven',
+      args: ['daemon', 'stop'],
+      allowedExitCodes: [0],
+      env: { COVEN_HOME: '/fixture/coven-home' }
+    }
+  ]);
+});
+
+test('registerExternalSessions seeds deterministic rows through the socket API', async () => {
+  const calls = [];
+  await registerExternalSessions({
+    socketPath: '/fixture/coven.sock',
+    count: 3,
+    projectRoot: '/fixture/project',
+    request: async (socketPath, request) => {
+      calls.push([socketPath, request]);
+      return { statusCode: 201, body: '{}' };
+    }
+  });
+
+  assert.deepEqual(calls.map(([socketPath, request]) => [socketPath, request.path]), [
+    ['/fixture/coven.sock', '/api/v1/sessions/external'],
+    ['/fixture/coven.sock', '/api/v1/sessions/external'],
+    ['/fixture/coven.sock', '/api/v1/sessions/external']
+  ]);
+  assert.deepEqual(
+    calls.map(([, request]) => JSON.parse(request.body).id),
+    ['benchmark-session-000001', 'benchmark-session-000002', 'benchmark-session-000003']
+  );
+});
+
+test('registerExternalSessions limits concurrent fixture registration', async () => {
+  let active = 0;
+  let maximumActive = 0;
+  let registered = 0;
+
+  await registerExternalSessions({
+    socketPath: '/fixture/coven.sock',
+    count: 6,
+    concurrency: 2,
+    projectRoot: '/fixture/project',
+    request: async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      registered += 1;
+      return { statusCode: 201, body: '{}' };
+    }
+  });
+
+  assert.equal(registered, 6);
+  assert.equal(maximumActive, 2);
+});
+
+test('runSocketScenario records only response timing and status metadata', async () => {
+  const report = await runSocketScenario({
+    socketPath: '/fixture/coven.sock',
+    request: async () => ({ statusCode: 200, body: '[{"id":"fixture"}]' }),
+    path: '/api/v1/sessions',
+    iterations: 2
+  });
+
+  assert.equal(report.samplesMs.length, 2);
+  assert.deepEqual(report.statusCodes, [200, 200]);
+  assert.deepEqual(Object.keys(report).sort(), ['samplesMs', 'statusCodes', 'summary']);
+});
+
+test('measureSessionLists isolates every requested fixture size', async () => {
+  const calls = [];
+  const reports = await measureSessionLists({
+    binary: '/tmp/coven',
+    fixtureRoot: '/fixture/root',
+    sessionCounts: [2, 3],
+    fixtureConcurrency: 2,
+    environment: { PATH: '/fixture/bin' },
+    makeDirectory: async (path) => calls.push(['mkdir', path]),
+    start: async ({ covenHome, env }) => {
+      calls.push(['start', covenHome, env.COVEN_HOME]);
+      return `${covenHome}/coven.sock`;
+    },
+    seed: async ({ count, socketPath, concurrency }) =>
+      calls.push(['seed', count, socketPath, concurrency]),
+    measure: async ({ socketPath }) => ({
+      samplesMs: [1],
+      statusCodes: [200],
+      summary: { minMs: 1 },
+      socketPath
+    }),
+    stop: ({ covenHome }) => calls.push(['stop', covenHome])
+  });
+
+  assert.deepEqual(Object.keys(reports), ['sessions_2', 'sessions_3']);
+  assert.deepEqual(calls, [
+    ['mkdir', '/fixture/root/s-2/user-home'],
+    ['start', '/fixture/root/s-2', '/fixture/root/s-2'],
+    ['seed', 2, '/fixture/root/s-2/coven.sock', 2],
+    ['stop', '/fixture/root/s-2'],
+    ['mkdir', '/fixture/root/s-3/user-home'],
+    ['start', '/fixture/root/s-3', '/fixture/root/s-3'],
+    ['seed', 3, '/fixture/root/s-3/coven.sock', 2],
+    ['stop', '/fixture/root/s-3']
+  ]);
+});
+
+test('collectBenchmarkScenarios merges core and daemon fixture reports', async () => {
+  const calls = [];
+  const scenarios = await collectBenchmarkScenarios({
+    options: { binary: '/tmp/coven', iterations: 2, sessionCounts: [2] },
+    fixtureRoot: '/fixture/root',
+    environment: { PATH: '/fixture/bin' },
+    makeDirectory: async (path) => calls.push(['mkdir', path]),
+    collectCore: ({ env }) => {
+      calls.push(['core', env.COVEN_HOME]);
+      return { help: { samplesMs: [1], exitCodes: [0], summary: { minMs: 1 } } };
+    },
+    measureHarness: async (input) => {
+      calls.push(['harness', input.fixtureRoot, input.iterations]);
+      return { samplesMs: [3], statusCodes: [201], summary: { minMs: 3 } };
+    },
+    measureEvents: async (input) => {
+      calls.push(['events', input.fixtureRoot, input.eventCounts]);
+      return { event_tail_2: { samplesMs: [4], statusCodes: [200], summary: { minMs: 4 } } };
+    },
+    measureLists: async (input) => {
+      calls.push(['lists', input.fixtureRoot, input.sessionCounts]);
+      return { sessions_2: { samplesMs: [2], statusCodes: [200], summary: { minMs: 2 } } };
+    }
+  });
+
+  assert.deepEqual(Object.keys(scenarios), [
+    'help',
+    'harness_first_output',
+    'event_tail_2',
+    'sessions_2'
+  ]);
+  assert.deepEqual(calls, [
+    ['mkdir', '/fixture/root/c/user-home'],
+    ['core', '/fixture/root/c'],
+    ['harness', '/fixture/root', 2],
+    ['events', '/fixture/root', [2]],
+    ['lists', '/fixture/root', [2]]
+  ]);
+});
+
+test('external session fixture request uses the versioned sessions endpoint', () => {
+  const request = externalSessionRequest({
+    id: 'fixture-session-1',
+    projectRoot: '/fixture/project'
+  });
+
+  assert.equal(request.path, '/api/v1/sessions/external');
+  assert.equal(request.method, 'POST');
+  assert.deepEqual(JSON.parse(request.body), {
+    id: 'fixture-session-1',
+    projectRoot: '/fixture/project',
+    harness: 'benchmark-fixture',
+    title: 'Benchmark fixture session'
+  });
+});
+
+test('harness session fixture request uses the public launch endpoint', () => {
+  const request = harnessSessionRequest({ projectRoot: '/fixture/project' });
+
+  assert.equal(request.path, '/api/v1/sessions');
+  assert.equal(request.method, 'POST');
+  assert.deepEqual(JSON.parse(request.body), {
+    projectRoot: '/fixture/project',
+    cwd: '/fixture/project',
+    harness: 'codex',
+    launchMode: 'nonInteractive',
+    prompt: 'Benchmark fixture prompt',
+    title: 'Benchmark harness fixture'
+  });
+});
+
+test('session input fixture request records safe input through the public API', () => {
+  const request = sessionInputRequest('session-1', 7);
+
+  assert.equal(request.method, 'POST');
+  assert.equal(request.path, '/api/v1/sessions/session-1/input');
+  assert.deepEqual(JSON.parse(request.body), { data: 'Benchmark event 000007\n' });
+});
+
+test('registerInputEvents seeds deterministic session events through the input API', async () => {
+  const calls = [];
+  await registerInputEvents({
+    socketPath: '/fixture/coven.sock',
+    sessionId: 'session-1',
+    count: 3,
+    request: async (socketPath, request) => {
+      calls.push([socketPath, request]);
+      return { statusCode: 202, body: '{"accepted":true}' };
+    }
+  });
+
+  assert.deepEqual(calls.map(([socketPath, request]) => [socketPath, request.path]), [
+    ['/fixture/coven.sock', '/api/v1/sessions/session-1/input'],
+    ['/fixture/coven.sock', '/api/v1/sessions/session-1/input'],
+    ['/fixture/coven.sock', '/api/v1/sessions/session-1/input']
+  ]);
+  assert.deepEqual(
+    calls.map(([, request]) => JSON.parse(request.body).data),
+    ['Benchmark event 000001\n', 'Benchmark event 000002\n', 'Benchmark event 000003\n']
+  );
+});
+
+test('prepareEventTail advances a large fixture to its final bounded page', async () => {
+  const paths = [];
+  const path = await prepareEventTail({
+    socketPath: '/fixture/coven.sock',
+    sessionId: 'session-1',
+    count: 2_500,
+    request: async (_socketPath, request) => {
+      paths.push(request.path);
+      if (paths.length === 1) {
+        return {
+          statusCode: 200,
+          body: JSON.stringify({ events: Array(1000).fill({ kind: 'input' }), nextCursor: { afterSeq: 1000 } })
+        };
+      }
+      return {
+        statusCode: 200,
+        body: JSON.stringify({ events: Array(500).fill({ kind: 'input' }), nextCursor: { afterSeq: 1500 } })
+      };
+    }
+  });
+
+  assert.deepEqual(paths, [
+    '/api/v1/sessions/session-1/events?limit=1000',
+    '/api/v1/sessions/session-1/events?afterSeq=1000&limit=500'
+  ]);
+  assert.equal(path, '/api/v1/sessions/session-1/events?afterSeq=1500&limit=1000');
+});
+
+test('launchHarnessSession returns the daemon-assigned session id', async () => {
+  const id = await launchHarnessSession({
+    socketPath: '/fixture/coven.sock',
+    projectRoot: '/fixture/project',
+    request: async (_socketPath, request) => {
+      assert.equal(request.path, '/api/v1/sessions');
+      return { statusCode: 201, body: JSON.stringify({ id: 'event-session-1' }) };
+    }
+  });
+
+  assert.equal(id, 'event-session-1');
+});
+
+test('measureEventTails isolates each event scale and cleans up its live session', async () => {
+  const calls = [];
+  const reports = await measureEventTails({
+    binary: '/tmp/coven',
+    fixtureRoot: '/fixture/root',
+    eventCounts: [2, 3],
+    environment: { PATH: '/fixture/bin' },
+    makeDirectory: async (path) => calls.push(['mkdir', path]),
+    createFixture: async (_root, environment) => ({ ...environment, PATH: '/fixture/event-bin' }),
+    start: async ({ covenHome, env }) => {
+      calls.push(['start', covenHome, env.PATH]);
+      return `${covenHome}/coven.sock`;
+    },
+    launch: async ({ socketPath }) => {
+      calls.push(['launch', socketPath]);
+      return `session-${calls.filter(([kind]) => kind === 'launch').length}`;
+    },
+    seed: async ({ sessionId, count }) => calls.push(['seed', sessionId, count]),
+    prepare: async ({ sessionId, count }) => {
+      calls.push(['prepare', sessionId, count]);
+      return `/api/v1/sessions/${sessionId}/events?limit=${count}`;
+    },
+    measure: async ({ path }) => {
+      calls.push(['measure', path]);
+      return { samplesMs: [1], statusCodes: [200], summary: { minMs: 1 } };
+    },
+    finish: async ({ socketPath, sessionId }) => calls.push(['finish', socketPath, sessionId]),
+    stop: ({ covenHome }) => calls.push(['stop', covenHome])
+  });
+
+  assert.deepEqual(Object.keys(reports), ['event_tail_2', 'event_tail_3']);
+  assert.deepEqual(calls, [
+    ['mkdir', '/fixture/root/e-2/user-home'],
+    ['start', '/fixture/root/e-2', '/fixture/event-bin'],
+    ['launch', '/fixture/root/e-2/coven.sock'],
+    ['seed', 'session-1', 2],
+    ['prepare', 'session-1', 2],
+    ['measure', '/api/v1/sessions/session-1/events?limit=2'],
+    ['finish', '/fixture/root/e-2/coven.sock', 'session-1'],
+    ['stop', '/fixture/root/e-2'],
+    ['mkdir', '/fixture/root/e-3/user-home'],
+    ['start', '/fixture/root/e-3', '/fixture/event-bin'],
+    ['launch', '/fixture/root/e-3/coven.sock'],
+    ['seed', 'session-2', 3],
+    ['prepare', 'session-2', 3],
+    ['measure', '/api/v1/sessions/session-2/events?limit=3'],
+    ['finish', '/fixture/root/e-3/coven.sock', 'session-2'],
+    ['stop', '/fixture/root/e-3']
+  ]);
+});
+
+test('stopLiveSession sends the public kill request', async () => {
+  await stopLiveSession({
+    socketPath: '/fixture/coven.sock',
+    sessionId: 'session-1',
+    request: async (_socketPath, request) => {
+      assert.deepEqual(request, { method: 'POST', path: '/api/v1/sessions/session-1/kill' });
+      return { statusCode: 202, body: '{"accepted":true}' };
+    }
+  });
+});
+
+test('waitForOutputEvent resolves only after an output event is recorded', async () => {
+  const paths = [];
+  let reads = 0;
+  await waitForOutputEvent('/fixture/coven.sock', 'session-1', {
+    attempts: 3,
+    delayMs: 0,
+    request: async (_socketPath, request) => {
+      paths.push(request.path);
+      reads += 1;
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          events: reads === 2 ? [{ kind: 'output' }] : [{ kind: 'exit' }]
+        })
+      };
+    }
+  });
+
+  assert.deepEqual(paths, [
+    '/api/v1/sessions/session-1/events?limit=1',
+    '/api/v1/sessions/session-1/events?limit=1'
+  ]);
+});
+
+test('runHarnessOutputScenario measures launch through first output event', async () => {
+  const calls = [];
+  const report = await runHarnessOutputScenario({
+    socketPath: '/fixture/coven.sock',
+    projectRoot: '/fixture/project',
+    iterations: 2,
+    request: async (_socketPath, request) => {
+      calls.push(request);
+      return { statusCode: 201, body: JSON.stringify({ id: `session-${calls.length}` }) };
+    },
+    wait: async (socketPath, sessionId, options) => {
+      calls.push({ socketPath, sessionId, options });
+    }
+  });
+
+  assert.deepEqual(report.statusCodes, [201, 201]);
+  assert.equal(report.samplesMs.length, 2);
+  assert.equal(calls[0].path, '/api/v1/sessions');
+  assert.equal(calls[1].socketPath, '/fixture/coven.sock');
+  assert.equal(calls[1].sessionId, 'session-1');
+  assert.equal(calls[1].options.attempts, 100);
+  assert.equal(calls[1].options.delayMs, 25);
+});
+
+test('socketRequest sends an external-session fixture over a local socket', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-test-'));
+  const socketPath = join(directory, 'daemon.sock');
+  const server = createServer((request, response) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', (chunk) => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/api/v1/sessions/external');
+      assert.equal(JSON.parse(body).id, 'fixture-session-1');
+      response.writeHead(201, { 'content-type': 'application/json' });
+      response.end('{"ok":true}');
+    });
+  });
+
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  const response = await socketRequest(socketPath, externalSessionRequest({
+    id: 'fixture-session-1',
+    projectRoot: '/fixture/project'
+  }));
+
+  assert.deepEqual(response, { statusCode: 201, body: '{"ok":true}' });
+});
+
+test('waitForHealth resolves after the local daemon health response', async (t) => {
+  const directory = await mkdtemp(join(tmpdir(), 'coven-benchmark-health-'));
+  const socketPath = join(directory, 'daemon.sock');
+  const server = createServer((request, response) => {
+    assert.equal(request.method, 'GET');
+    assert.equal(request.url, '/api/v1/health');
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end('{"ok":true}');
+  });
+
+  await new Promise((resolve) => server.listen(socketPath, resolve));
+  t.after(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  await waitForHealth(socketPath, { attempts: 1, delayMs: 0 });
+});


### PR DESCRIPTION
## Summary
- add an isolated CLI and daemon baseline runner with 100, 1k, and 10k session and event-tail fixtures
- add deterministic chat scheduling metrics and artifact-only CI trend capture
- document the local baseline workflow and macOS-safe compact fixture homes

Closes #525

## Verification
- node --test scripts/benchmark-cli.test.mjs
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- python scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --staged
- 3-iteration local runner at 100, 1k, and 10k fixtures