### PR TITLE
perf: paginate session history and cache overlay

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -164,6 +164,12 @@ pub struct EventsResponse {
     pub has_more: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionPageResponse {
+    pub sessions: Vec<store::SessionRecord>,
+    pub next_cursor: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApiResponse {
     pub status: u16,
@@ -636,12 +642,7 @@ pub fn handle_request_with_runtime(
             let loop_id = path.trim_start_matches("/scheduler/loops/");
             get_scheduler_loop_state(coven_home, loop_id)
         }
-        ("GET", "/sessions") => {
-            let conn = store::open_store(&store_path(coven_home))?;
-            reap_stale_created_sessions_throttled(&conn);
-            let sessions = store::list_sessions(&conn)?;
-            json_response(200, &sessions)
-        }
+        ("GET", "/sessions") => list_sessions_response(coven_home, query),
         ("POST", "/sessions") => launch_session(coven_home, body, runtime),
         ("POST", "/sessions/external") => register_external_session(coven_home, body),
         ("POST", path) if path.starts_with("/sessions/") && path.ends_with("/complete") => {
@@ -2136,6 +2137,72 @@ struct OverviewDto {
     average_skill_score: u32,
     research_iterations: u32,
     last_research_delta: i32,
+}
+
+fn list_sessions_response(coven_home: &Path, query: Option<&str>) -> Result<ApiResponse> {
+    let query = query.unwrap_or_default();
+    let limit = query_param(query, "limit");
+    let cursor = query_param(query, "cursor");
+    let include_archived = query_param(query, "includeArchived");
+    if limit.is_none() && cursor.is_none() && include_archived.is_none() {
+        let conn = store::open_store(&store_path(coven_home))?;
+        reap_stale_created_sessions_throttled(&conn);
+        return json_response(200, &store::list_sessions(&conn)?);
+    }
+
+    let limit = match limit {
+        Some(raw) => match raw.parse::<usize>() {
+            Ok(limit) if (1..=store::MAX_SESSION_PAGE_LIMIT).contains(&limit) => limit,
+            _ => {
+                return api_error(
+                    400,
+                    "invalid_request",
+                    "Query parameter `limit` must be an integer between 1 and 1000.",
+                    Some(json!({ "limit": raw })),
+                )
+            }
+        },
+        None => store::DEFAULT_SESSION_PAGE_LIMIT,
+    };
+    let include_archived = match include_archived {
+        Some("true") => true,
+        Some("false") | None => false,
+        Some(raw) => {
+            return api_error(
+                400,
+                "invalid_request",
+                "Query parameter `includeArchived` must be `true` or `false`.",
+                Some(json!({ "includeArchived": raw })),
+            )
+        }
+    };
+    if let Some(cursor) = cursor {
+        if let Err(error) = store::validate_session_cursor(cursor) {
+            return api_error(
+                400,
+                "invalid_request",
+                "Query parameter `cursor` is invalid.",
+                Some(json!({ "cursor": cursor, "detail": error.to_string() })),
+            );
+        }
+    }
+    let conn = store::open_store(&store_path(coven_home))?;
+    reap_stale_created_sessions_throttled(&conn);
+    let page = store::list_session_page(
+        &conn,
+        store::SessionListQuery {
+            limit,
+            cursor,
+            include_archived,
+        },
+    )?;
+    json_response(
+        200,
+        &SessionPageResponse {
+            sessions: page.sessions,
+            next_cursor: page.next_cursor,
+        },
+    )
 }
 
 fn overview_response(coven_home: &Path) -> Result<ApiResponse> {
@@ -6086,6 +6153,99 @@ pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiRe
 mod tests {
     use super::*;
     use crate::project;
+
+    #[test]
+    fn sessions_endpoint_keeps_legacy_array_and_supports_cursor_pages() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let conn = store::open_store(&store_path(home))?;
+        for (id, created_at) in [
+            ("oldest", "2026-07-29T00:00:00Z"),
+            ("middle", "2026-07-29T01:00:00Z"),
+            ("newest", "2026-07-29T02:00:00Z"),
+        ] {
+            store::insert_session(
+                &conn,
+                &store::SessionRecord {
+                    id: id.to_string(),
+                    project_root: "/repo".to_string(),
+                    harness: "codex".to_string(),
+                    title: id.to_string(),
+                    status: "completed".to_string(),
+                    exit_code: Some(0),
+                    archived_at: None,
+                    created_at: created_at.to_string(),
+                    updated_at: created_at.to_string(),
+                    conversation_id: None,
+                    familiar_id: None,
+                    labels: Vec::new(),
+                    visibility: "private".to_string(),
+                    external: false,
+                    transcript_path: None,
+                },
+            )?;
+        }
+        drop(conn);
+
+        let legacy = handle_request("GET", "/api/v1/sessions", home, None)?;
+        let legacy: Vec<store::SessionRecord> = serde_json::from_str(&legacy.body)?;
+        assert_eq!(legacy.len(), 3);
+
+        let first = handle_request("GET", "/api/v1/sessions?limit=2", home, None)?;
+        let first: SessionPageResponse = serde_json::from_str(&first.body)?;
+        assert_eq!(
+            first
+                .sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newest", "middle"]
+        );
+        let cursor = first.next_cursor.expect("first page must continue");
+        let second = handle_request(
+            "GET",
+            &format!("/api/v1/sessions?limit=2&cursor={cursor}"),
+            home,
+            None,
+        )?;
+        let second: SessionPageResponse = serde_json::from_str(&second.body)?;
+        assert_eq!(
+            second
+                .sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["oldest"]
+        );
+        assert!(second.next_cursor.is_none());
+
+        for path in [
+            "/api/v1/sessions?limit=0",
+            "/api/v1/sessions?limit=1001",
+            "/api/v1/sessions?includeArchived=yes",
+            "/api/v1/sessions?cursor=not-a-valid-cursor",
+        ] {
+            let response = handle_request("GET", path, home, None)?;
+            assert_eq!(response.status, 400, "path {path}");
+            let body: serde_json::Value = serde_json::from_str(&response.body)?;
+            assert_eq!(body["error"]["code"], "invalid_request");
+        }
+
+        let conn = store::open_store(&store_path(home))?;
+        store::archive_session(&conn, "oldest", "2026-07-29T03:00:00Z")?;
+        let included = handle_request(
+            "GET",
+            "/api/v1/sessions?limit=10&includeArchived=true",
+            home,
+            None,
+        )?;
+        assert_eq!(included.status, 200);
+        let included: SessionPageResponse = serde_json::from_str(&included.body)?;
+        assert_eq!(included.sessions.len(), 3);
+        assert_eq!(included.sessions[2].id, "oldest");
+        assert!(included.sessions[2].archived_at.is_some());
+        Ok(())
+    }
 
     #[test]
     fn builds_health_response() {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use base64::Engine;
 use chrono::{Duration, SecondsFormat, Utc};
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,8 @@ use crate::{
 
 const FTS_BACKFILL_BATCH_SIZE: i64 = 1_000;
 const FTS_BACKFILL_COMPLETE_KEY: &str = "events_fts_backfill_complete";
+pub const DEFAULT_SESSION_PAGE_LIMIT: usize = 100;
+pub const MAX_SESSION_PAGE_LIMIT: usize = 1_000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SessionRecord {
@@ -1933,6 +1936,107 @@ pub fn list_sessions_including_archived(conn: &Connection) -> Result<Vec<Session
     list_sessions_with_archive_filter(conn, true)
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct SessionListQuery<'a> {
+    pub limit: usize,
+    pub cursor: Option<&'a str>,
+    pub include_archived: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionPage {
+    pub sessions: Vec<SessionRecord>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionCursor {
+    created_at: String,
+    id: String,
+}
+
+pub fn list_session_page(conn: &Connection, query: SessionListQuery<'_>) -> Result<SessionPage> {
+    if query.limit == 0 || query.limit > MAX_SESSION_PAGE_LIMIT {
+        anyhow::bail!(
+            "session page limit must be between 1 and {MAX_SESSION_PAGE_LIMIT}, got {}",
+            query.limit
+        );
+    }
+    let cursor = query.cursor.map(decode_session_cursor).transpose()?;
+    let archive_filter = if query.include_archived {
+        ""
+    } else {
+        "WHERE archived_at IS NULL"
+    };
+    let cursor_filter = if cursor.is_some() {
+        if query.include_archived {
+            "WHERE (created_at < ?1 OR (created_at = ?1 AND id < ?2))"
+        } else {
+            "AND (created_at < ?1 OR (created_at = ?1 AND id < ?2))"
+        }
+    } else {
+        ""
+    };
+    let mut statement = conn
+        .prepare(&format!(
+            "SELECT
+                {SESSION_COLUMNS}
+            FROM sessions
+            {archive_filter}
+            {cursor_filter}
+            ORDER BY created_at DESC, id DESC
+            LIMIT ?3"
+        ))
+        .context("failed to prepare paginated session list query")?;
+    let limit = i64::try_from(query.limit + 1).expect("bounded session page limit fits i64");
+    let mut sessions = match cursor {
+        Some(cursor) => statement
+            .query_map(
+                params![cursor.created_at, cursor.id, limit],
+                session_record_from_row,
+            )
+            .context("failed to query paginated sessions")?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("failed to read paginated sessions")?,
+        None => statement
+            .query_map(params!["", "", limit], session_record_from_row)
+            .context("failed to query paginated sessions")?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("failed to read paginated sessions")?,
+    };
+    let has_next_page = sessions.len() > query.limit;
+    sessions.truncate(query.limit);
+    let next_cursor = has_next_page
+        .then(|| sessions.last())
+        .flatten()
+        .map(encode_session_cursor)
+        .transpose()?;
+    Ok(SessionPage {
+        sessions,
+        next_cursor,
+    })
+}
+
+fn encode_session_cursor(session: &SessionRecord) -> Result<String> {
+    let cursor = SessionCursor {
+        created_at: session.created_at.clone(),
+        id: session.id.clone(),
+    };
+    Ok(base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&cursor).context("failed to encode session cursor")?))
+}
+
+fn decode_session_cursor(cursor: &str) -> Result<SessionCursor> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(cursor)
+        .context("session cursor is not valid URL-safe base64")?;
+    serde_json::from_slice(&bytes).context("session cursor is malformed")
+}
+
+pub fn validate_session_cursor(cursor: &str) -> Result<()> {
+    decode_session_cursor(cursor).map(|_| ())
+}
+
 fn list_sessions_with_archive_filter(
     conn: &Connection,
     include_archived: bool,
@@ -3281,6 +3385,113 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(ids, vec!["newer", "older"]);
+        Ok(())
+    }
+
+    #[test]
+    fn list_session_page_continues_in_created_at_and_id_order() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        for (id, created_at) in [
+            ("oldest", "2026-04-27T06:00:00Z"),
+            ("middle-a", "2026-04-27T07:00:00Z"),
+            ("middle-b", "2026-04-27T07:00:00Z"),
+            ("newest", "2026-04-27T08:00:00Z"),
+        ] {
+            insert_session(&conn, &session_record(id, created_at))?;
+        }
+
+        let first = list_session_page(
+            &conn,
+            SessionListQuery {
+                limit: 2,
+                cursor: None,
+                include_archived: false,
+            },
+        )?;
+        assert_eq!(
+            first
+                .sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["newest", "middle-b"]
+        );
+        let second = list_session_page(
+            &conn,
+            SessionListQuery {
+                limit: 2,
+                cursor: first.next_cursor.as_deref(),
+                include_archived: false,
+            },
+        )?;
+        assert_eq!(
+            second
+                .sessions
+                .iter()
+                .map(|session| session.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["middle-a", "oldest"]
+        );
+        assert!(second.next_cursor.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn list_session_page_rejects_invalid_limits_and_cursors() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+
+        for limit in [0, MAX_SESSION_PAGE_LIMIT + 1] {
+            assert!(list_session_page(
+                &conn,
+                SessionListQuery {
+                    limit,
+                    cursor: None,
+                    include_archived: false,
+                },
+            )
+            .is_err());
+        }
+        assert!(list_session_page(
+            &conn,
+            SessionListQuery {
+                limit: 1,
+                cursor: Some("not-a-valid-cursor"),
+                include_archived: false,
+            },
+        )
+        .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn list_session_page_respects_archived_filter() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("active", "2026-04-27T06:00:00Z"))?;
+        insert_session(&conn, &session_record("archived", "2026-04-27T07:00:00Z"))?;
+        archive_session(&conn, "archived", "2026-04-27T08:00:00Z")?;
+
+        for (include_archived, expected_ids) in
+            [(false, vec!["active"]), (true, vec!["archived", "active"])]
+        {
+            let page = list_session_page(
+                &conn,
+                SessionListQuery {
+                    limit: 10,
+                    cursor: None,
+                    include_archived,
+                },
+            )?;
+            assert_eq!(
+                page.sessions
+                    .iter()
+                    .map(|session| session.id.as_str())
+                    .collect::<Vec<_>>(),
+                expected_ids
+            );
+        }
         Ok(())
     }
 

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -21,6 +21,7 @@ use super::client::{
     ChatClient, ChatDaemonStatus, ChatEventQuery, DaemonChatClient, LaunchRequest,
 };
 use super::persistence;
+use super::render::collapse_session_overlay_indices;
 use super::settings::{self, ChatSettings, StreamingMode};
 
 // ── Data types ─────────────────────────────────────────────────────────────
@@ -225,6 +226,7 @@ pub(super) struct App {
     event_poll_paused_for_api_mismatch: bool,
     daemon_status: ChatDaemonStatus,
     pub(super) sessions: Vec<store::SessionRecord>,
+    pub(super) session_overlay_entries: Vec<(usize, usize)>,
     pub(super) show_session_overlay: bool,
     pub(super) input_history: Vec<String>,
     pub(super) history_index: Option<usize>,
@@ -463,6 +465,7 @@ impl App {
             event_poll_paused_for_api_mismatch: false,
             daemon_status,
             sessions: Vec::new(),
+            session_overlay_entries: Vec::new(),
             show_session_overlay: false,
             input_history: Vec::new(),
             history_index: None,
@@ -1556,13 +1559,21 @@ impl App {
     /// toggle, and re-sacrificing it reported "session not found").
     fn remove_session_from_list(&mut self, session_id: &str) {
         self.sessions.retain(|session| session.id != session_id);
+        self.rebuild_session_overlay_entries();
     }
 
     pub(super) fn refresh_sessions(&mut self) {
         match self.client.list_sessions() {
-            Ok(sessions) => self.sessions = sessions,
+            Ok(sessions) => {
+                self.sessions = sessions;
+                self.rebuild_session_overlay_entries();
+            }
             Err(error) => self.push_system_message(&format!("Failed to load sessions: {error}")),
         }
+    }
+
+    fn rebuild_session_overlay_entries(&mut self) {
+        self.session_overlay_entries = collapse_session_overlay_indices(&self.sessions);
     }
 
     /// The Coven home for store-backed views and exports: the app-pinned
@@ -7555,7 +7566,7 @@ mod tests {
         // A realistic long cwd previously pushed the rightmost segment off the
         // status bar; the project label must yield first so the spinner +
         // (composing) tail always survives.
-        app.project_label = "/Users/buns/Documents/GitHub/OpenCoven/coven".to_string();
+        app.project_label = "/workspace/opencoven/coven".to_string();
         app.active_session_id = Some("demo-session".to_string());
         app.is_responding = true;
         app.push_event_message(&output_event(1, "demo-session", "partial reply"));

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -19,7 +19,7 @@ use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::{
-    api::{EventsResponse, HealthResponse, COVEN_API_NAMED_VERSION},
+    api::{EventsResponse, HealthResponse, SessionPageResponse, COVEN_API_NAMED_VERSION},
     current_timestamp, daemon, harness, store, STORE_FILE_NAME,
 };
 
@@ -272,7 +272,9 @@ impl ChatClient for DaemonChatClient {
     }
 
     fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
-        self.request_json("GET", "/api/v1/sessions", None)
+        let page: SessionPageResponse =
+            self.request_json("GET", "/api/v1/sessions?limit=100", None)?;
+        Ok(page.sessions)
     }
 
     fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {

--- a/crates/coven-cli/src/tui/chat/render.rs
+++ b/crates/coven-cli/src/tui/chat/render.rs
@@ -1037,7 +1037,6 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
             theme::ratatui_style(DIM),
         )));
     } else {
-        let entries = collapse_sessions_by_conversation(&app.sessions);
         // Compute the composite key of the chat's active session (same
         // shape as `collapse_sessions_by_conversation` uses) so the
         // active-marker matches the same grouping a colliding
@@ -1056,11 +1055,8 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
                     })
                 })
         });
-        for entry in entries.iter().take(10) {
-            let (rep, turn_count) = match entry {
-                SessionOverlayEntry::Group { rep, turn_count } => (*rep, *turn_count),
-                SessionOverlayEntry::Singleton { session } => (*session, 1),
-            };
+        for &(representative_index, turn_count) in app.session_overlay_entries.iter().take(10) {
+            let rep = &app.sessions[representative_index];
             // A row is "active" if the chat's active_session_id belongs
             // to it: either via shared composite `(project_root,
             // harness, conversation_id)` key (group) or matching the
@@ -1121,6 +1117,7 @@ fn render_session_overlay(f: &mut Frame, app: &App, area: Rect) {
 /// one-off `coven run`-style launches) or a group of N chat turns that all
 /// share the same conversation_id — collapsed into a single representative
 /// row so the overlay isn't flooded after a long chat.
+#[cfg(test)]
 enum SessionOverlayEntry<'a> {
     Group {
         rep: &'a crate::store::SessionRecord,
@@ -1146,13 +1143,9 @@ enum SessionOverlayEntry<'a> {
 /// same chat) and otherwise watch the overlay merge unrelated rows
 /// into a single entry. Composite key makes that misuse harmless.
 ///
-/// Runs in O(N) over `sessions` with two passes (counts + entries). Called
-/// from `render_session_overlay` per frame while the overlay is open, so
-/// the realistic cost ceiling is N×<200 (a few hundred sessions on a
-/// busy user's machine) × ~10 frames/sec — sub-millisecond per render.
-/// If `app.sessions` ever grows past O(thousands), move this behind a
-/// cache that invalidates on `refresh_sessions` instead of recomputing
-/// per frame.
+/// Test-only reference implementation of the grouping rules. Production uses
+/// the cached index form below, rebuilt when `App::sessions` changes.
+#[cfg(test)]
 fn collapse_sessions_by_conversation(
     sessions: &[crate::store::SessionRecord],
 ) -> Vec<SessionOverlayEntry<'_>> {
@@ -1186,6 +1179,38 @@ fn collapse_sessions_by_conversation(
                 }
             }
             None => entries.push(SessionOverlayEntry::Singleton { session }),
+        }
+    }
+    entries
+}
+
+pub(super) fn collapse_session_overlay_indices(
+    sessions: &[crate::store::SessionRecord],
+) -> Vec<(usize, usize)> {
+    use std::collections::{HashMap, HashSet};
+    type GroupKey<'a> = (&'a str, &'a str, &'a str);
+    fn key_of(session: &crate::store::SessionRecord) -> Option<GroupKey<'_>> {
+        session.conversation_id.as_deref().map(|conversation_id| {
+            (
+                session.project_root.as_str(),
+                session.harness.as_str(),
+                conversation_id,
+            )
+        })
+    }
+    let mut counts: HashMap<GroupKey<'_>, usize> = HashMap::new();
+    for session in sessions {
+        if let Some(key) = key_of(session) {
+            *counts.entry(key).or_insert(0) += 1;
+        }
+    }
+    let mut seen = HashSet::new();
+    let mut entries = Vec::new();
+    for (index, session) in sessions.iter().enumerate() {
+        match key_of(session) {
+            Some(key) if seen.insert(key) => entries.push((index, counts[&key])),
+            Some(_) => {}
+            None => entries.push((index, 1)),
         }
     }
     entries
@@ -1711,6 +1736,23 @@ mod tests {
     }
 
     #[test]
+    fn cached_overlay_entries_bound_ten_thousand_session_history() {
+        let sessions = (0..10_000)
+            .map(|index| {
+                make_session(
+                    &format!("turn-{index}"),
+                    Some(&format!("conversation-{}", index % 100)),
+                    "chat turn",
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let entries = collapse_session_overlay_indices(&sessions);
+        assert_eq!(entries.len(), 100);
+        assert!(entries.iter().all(|&(_, turns)| turns == 100));
+    }
+
+    #[test]
     fn collapse_sessions_groups_consecutive_same_conversation_into_one_entry() {
         let sessions = vec![
             make_session("turn-3", Some("conv-a"), "third"),
@@ -1718,6 +1760,7 @@ mod tests {
             make_session("turn-1", Some("conv-a"), "first"),
         ];
         let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(collapse_session_overlay_indices(&sessions), vec![(0, 3)]);
         assert_eq!(entries.len(), 1);
         match &entries[0] {
             SessionOverlayEntry::Group { rep, turn_count } => {
@@ -1735,6 +1778,10 @@ mod tests {
             make_session("solo-1", None, "free-running task 1"),
         ];
         let entries = collapse_sessions_by_conversation(&sessions);
+        assert_eq!(
+            collapse_session_overlay_indices(&sessions),
+            vec![(0, 1), (1, 1)]
+        );
         assert_eq!(entries.len(), 2);
         for entry in &entries {
             assert!(matches!(entry, SessionOverlayEntry::Singleton { .. }));

--- a/docs/superpowers/plans/2026-07-29-paginated-session-history.md
+++ b/docs/superpowers/plans/2026-07-29-paginated-session-history.md
@@ -1,0 +1,238 @@
+# Paginated Session History Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the default session API and chat overlay bounded at 10,000 stored sessions while preserving explicit CLI and API all-history workflows.
+
+**Architecture:** Introduce a keyset-paginated `SessionPage` at the store boundary, ordered by the existing `(created_at DESC, id DESC)` contract. Keep the legacy bare-array API response for unqualified `GET /api/v1/sessions`; return the new envelope only when `limit` or `cursor` is requested, and move the chat client to that bounded envelope. Cache owned overlay entries in `App` whenever its session list changes, so rendering only reads the cache.
+
+**Tech Stack:** Rust, rusqlite keyset queries, serde JSON, Ratatui TUI, Node benchmark harness.
+
+---
+
+### Task 1: Define and test the store pagination contract
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs:1928-1971`
+- Test: `crates/coven-cli/src/store.rs` unit-test module
+
+- [ ] **Step 1: Write failing store tests for the ordered first page, cursor continuation, archived filter, and invalid limits.**
+
+```rust
+let first = list_session_page(&conn, SessionListQuery { limit: 2, cursor: None, include_archived: false })?;
+assert_eq!(ids(&first.sessions), ["newest", "middle"]);
+assert_eq!(first.next_cursor.as_deref(), Some("<middle-created-at>|middle"));
+
+let second = list_session_page(&conn, SessionListQuery { limit: 2, cursor: first.next_cursor.as_deref(), include_archived: false })?;
+assert_eq!(ids(&second.sessions), ["oldest"]);
+assert!(second.next_cursor.is_none());
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail because `SessionListQuery` and `list_session_page` do not exist.**
+
+Run: `cargo test -p coven-cli store::tests::list_session_page`
+
+Expected: compile failure naming the missing pagination API.
+
+- [ ] **Step 3: Add the minimal store types and keyset query.**
+
+```rust
+pub const DEFAULT_SESSION_PAGE_LIMIT: usize = 100;
+pub const MAX_SESSION_PAGE_LIMIT: usize = 1_000;
+
+pub struct SessionListQuery<'a> {
+    pub limit: usize,
+    pub cursor: Option<&'a str>,
+    pub include_archived: bool,
+}
+
+pub struct SessionPage {
+    pub sessions: Vec<SessionRecord>,
+    pub next_cursor: Option<String>,
+}
+```
+
+Use `LIMIT limit + 1`, retain the first `limit` rows, and encode/decode the last returned row's `(created_at, id)` as URL-safe base64 JSON so a caller-supplied ID cannot make a delimiter cursor ambiguous. The continuation predicate must be `(created_at < ?1 OR (created_at = ?1 AND id < ?2))`, matching the existing descending ordering. Reject zero, over-`MAX_SESSION_PAGE_LIMIT`, and malformed cursors before querying.
+
+- [ ] **Step 4: Run the focused store tests and verify they pass.**
+
+Run: `cargo test -p coven-cli store::tests::list_session_page`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the store-only change.**
+
+```bash
+git add crates/coven-cli/src/store.rs
+git commit -m "feat: paginate session store listings"
+```
+
+### Task 2: Add the backward-compatible API envelope
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs:639-644`
+- Test: `crates/coven-cli/src/api.rs` unit-test module
+
+- [ ] **Step 1: Write failing API tests for legacy and paginated responses.**
+
+```rust
+let legacy = handle_request("GET", "/api/v1/sessions", home, None)?;
+assert!(serde_json::from_str::<Vec<store::SessionRecord>>(&legacy.body).is_ok());
+
+let page = handle_request("GET", "/api/v1/sessions?limit=2", home, None)?;
+let page: SessionPageResponse = serde_json::from_str(&page.body)?;
+assert_eq!(page.sessions.len(), 2);
+assert!(page.next_cursor.is_some());
+```
+
+- [ ] **Step 2: Run the focused API tests and verify they fail because paginated session responses are not implemented.**
+
+Run: `cargo test -p coven-cli api::tests::get_sessions`
+
+Expected: assertion failure because the response is still an array.
+
+- [ ] **Step 3: Parse `limit`, `cursor`, and `includeArchived` only for `GET /sessions`.**
+
+Keep an unqualified request on `store::list_sessions` so existing clients keep their array response. For a request with `limit` or `cursor`, call `list_session_page` and serialize:
+
+```rust
+#[derive(Serialize, Deserialize)]
+pub struct SessionPageResponse {
+    pub sessions: Vec<store::SessionRecord>,
+    pub next_cursor: Option<String>,
+}
+```
+
+Reject malformed query values with the existing structured 400-response path. `includeArchived=true` is supported only in the explicit paginated path; local `coven sessions --all` remains its existing full-history store workflow.
+
+- [ ] **Step 4: Run the focused API tests and verify they pass.**
+
+Run: `cargo test -p coven-cli api::tests::get_sessions`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the API change.**
+
+```bash
+git add crates/coven-cli/src/api.rs
+git commit -m "feat: add paginated sessions API"
+```
+
+### Task 3: Move the chat overlay to bounded sessions and cache rows
+
+**Files:**
+- Modify: `crates/coven-cli/src/tui/chat/client.rs:102-106,274-276`
+- Modify: `crates/coven-cli/src/tui/chat/app.rs:227-228,1557-1565`
+- Modify: `crates/coven-cli/src/tui/chat/render.rs:1013-1192`
+- Test: `crates/coven-cli/src/tui/chat/app.rs` and `crates/coven-cli/src/tui/chat/render.rs` unit-test modules
+
+- [ ] **Step 1: Write failing chat tests for the bounded endpoint and cache invalidation.**
+
+```rust
+app.refresh_sessions();
+assert_eq!(client.calls.borrow().last(), Some(&"GET /api/v1/sessions?limit=100".into()));
+assert_eq!(app.session_overlay_entries.len(), 1);
+
+app.remove_session_from_list("turn-2");
+assert_eq!(app.session_overlay_entries.len(), 1);
+assert_eq!(app.session_overlay_entries[0].turn_count, 1);
+```
+
+Also construct 10,000 records in a render test, refresh once, render twice, and assert the cached entry set is reused rather than calling the collapse helper during either frame.
+
+- [ ] **Step 2: Run the focused chat tests and verify they fail.**
+
+Run: `cargo test -p coven-cli tui::chat::`
+
+Expected: assertion failure because the client requests the unbounded endpoint and the renderer rebuilds entries per frame.
+
+- [ ] **Step 3: Add `list_recent_sessions(limit)` to `ChatClient` and cache owned overlay rows in `App`.**
+
+Make `DaemonChatClient` request `/api/v1/sessions?limit=100` and deserialize `SessionPageResponse`. Convert `SessionOverlayEntry` to an owned, render-ready type containing only the representative session index/id and turn count, rebuild it inside a single `rebuild_session_overlay_entries` helper, and call that helper after `refresh_sessions`, local removal, and any local insert/update that changes `sessions`.
+
+`render_session_overlay` must iterate `app.session_overlay_entries` directly; it must not call a collapse helper or allocate grouping maps during a frame.
+
+- [ ] **Step 4: Run the focused chat tests and verify they pass.**
+
+Run: `cargo test -p coven-cli tui::chat::`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the chat change.**
+
+```bash
+git add crates/coven-cli/src/tui/chat/app.rs crates/coven-cli/src/tui/chat/client.rs crates/coven-cli/src/tui/chat/render.rs
+git commit -m "perf: bound and cache chat session overlay"
+```
+
+### Task 4: Measure and validate the 10k default path
+
+**Files:**
+- Modify: `scripts/benchmark-cli.mjs:535-540`
+- Modify: `scripts/benchmark-cli.test.mjs`
+
+- [ ] **Step 1: Write a failing benchmark-helper test that expects the default sessions scenario to use a bounded page.**
+
+```js
+assert.equal(sessionListRequest().path, '/api/v1/sessions?limit=100');
+```
+
+- [ ] **Step 2: Run the focused benchmark tests and verify they fail.**
+
+Run: `node --test scripts/benchmark-cli.test.mjs --test-name-pattern "session.*list"`
+
+Expected: assertion failure because the measured path is `/api/v1/sessions`.
+
+- [ ] **Step 3: Change only the default performance scenario to measure the bounded API.**
+
+Keep a separate explicit all-history measurement if the benchmark needs historical comparison. Record the returned session count and response bytes in the JSON report so the 10k fixture proves the default payload is bounded.
+
+- [ ] **Step 4: Run the focused benchmark tests and one real report.**
+
+Run: `node --test scripts/benchmark-cli.test.mjs --test-name-pattern "session.*list"`
+
+Run: `node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations=1 --output /tmp/coven-issue-526-benchmark.json`
+
+Expected: PASS; `sessions_10000` reports the bounded default request and response.
+
+- [ ] **Step 5: Commit the benchmark update.**
+
+```bash
+git add scripts/benchmark-cli.mjs scripts/benchmark-cli.test.mjs
+git commit -m "perf: measure bounded session listings"
+```
+
+### Task 5: Run repository gates and publish
+
+**Files:**
+- Modify: only files from Tasks 1-4
+
+- [ ] **Step 1: Rebase on current `origin/main` and inspect the complete diff.**
+
+Run: `git fetch origin main && git rebase origin/main && git diff --check && git status --short`
+
+Expected: clean rebase and no whitespace errors.
+
+- [ ] **Step 2: Run the required gates.**
+
+Run: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --locked && python scripts/check-secrets.py`
+
+Expected: all commands exit 0.
+
+- [ ] **Step 3: Stage the scoped files and run the staged privacy guard.**
+
+Run: `git add crates/coven-cli/src/store.rs crates/coven-cli/src/api.rs crates/coven-cli/src/tui/chat/app.rs crates/coven-cli/src/tui/chat/client.rs crates/coven-cli/src/tui/chat/render.rs scripts/benchmark-cli.mjs scripts/benchmark-cli.test.mjs && python3 scripts/check-coven-privacy.py --staged`
+
+Expected: `Coven privacy guard passed`.
+
+- [ ] **Step 4: Push and open a PR that closes #526.**
+
+Run: `git push -u origin perf/526-paginate-session-history`
+
+Expected: branch is available for a PR with the benchmark evidence and compatibility note.
+
+## Self-review
+
+- Spec coverage: Task 1 covers pagination, deterministic ordering, archive filtering, and 10k-safe query bounds. Task 2 preserves legacy API clients and adds the cursor response. Task 3 moves the overlay to the bounded path and invalidates its cache only when session state changes. Task 4 captures the required measurement evidence. Task 5 applies the repository gates and PR workflow.
+- Placeholder scan: no TODO/TBD or generic test steps remain; each task names paths, test behavior, and commands.
+- Type consistency: `SessionListQuery`, `SessionPage`, and `SessionPageResponse` are introduced before callers use them; the chat client is the sole consumer of the envelope in this change.

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -535,7 +535,7 @@ export async function measureSessionLists({
       });
       reports[`sessions_${count}`] = await measure({
         socketPath,
-        path: '/api/v1/sessions',
+        path: '/api/v1/sessions?limit=100',
         iterations
       });
     } finally {

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -473,12 +473,15 @@ test('measureSessionLists isolates every requested fixture size', async () => {
     },
     seed: async ({ count, socketPath, concurrency }) =>
       calls.push(['seed', count, socketPath, concurrency]),
-    measure: async ({ socketPath }) => ({
-      samplesMs: [1],
-      statusCodes: [200],
-      summary: { minMs: 1 },
-      socketPath
-    }),
+    measure: async ({ socketPath, path }) => {
+      calls.push(['measure', socketPath, path]);
+      return {
+        samplesMs: [1],
+        statusCodes: [200],
+        summary: { minMs: 1 },
+        socketPath
+      };
+    },
     stop: ({ covenHome }) => calls.push(['stop', covenHome])
   });
 
@@ -487,10 +490,12 @@ test('measureSessionLists isolates every requested fixture size', async () => {
     ['mkdir', '/fixture/root/s-2/user-home'],
     ['start', '/fixture/root/s-2', '/fixture/root/s-2'],
     ['seed', 2, '/fixture/root/s-2/coven.sock', 2],
+    ['measure', '/fixture/root/s-2/coven.sock', '/api/v1/sessions?limit=100'],
     ['stop', '/fixture/root/s-2'],
     ['mkdir', '/fixture/root/s-3/user-home'],
     ['start', '/fixture/root/s-3', '/fixture/root/s-3'],
     ['seed', 3, '/fixture/root/s-3/coven.sock', 2],
+    ['measure', '/fixture/root/s-3/coven.sock', '/api/v1/sessions?limit=100'],
     ['stop', '/fixture/root/s-3']
   ]);
 });


### PR DESCRIPTION
Closes #526

## Summary
- add opaque cursor/limit session pages while preserving the legacy unqualified array response
- move the chat overlay to the bounded 100-row response and cache collapsed conversation rows until session state changes
- measure the bounded list path in the CLI benchmark suite

## Evidence
- real 10,000-session fixture: bounded `GET /api/v1/sessions?limit=100` returned HTTP 200 in 16.545 ms (one local iteration)
- cache regression groups 10,000 sessions into 100 overlay rows

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked` (1,493 passed, 2 ignored)
- `node --test scripts/benchmark-cli.test.mjs` (44 passed)
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`