### PR TITLE
perf: move store initialization off request paths

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2187,6 +2187,10 @@ fn acquire_serve_lock(coven_home: &Path) -> Result<std::fs::File> {
     Ok(file)
 }
 
+fn initialize_daemon_store(coven_home: &Path) -> Result<()> {
+    crate::store::initialize_store(&coven_home.join("coven.sqlite3"))
+}
+
 #[cfg(unix)]
 pub fn serve_forever(
     coven_home: &Path,
@@ -2206,6 +2210,7 @@ pub fn serve_forever(
     // catching the wedged-but-alive incumbent the socket guard can't, and the
     // direct `daemon serve` path that bypasses ensure_background_server.
     let _serve_lock = acquire_serve_lock(coven_home)?;
+    initialize_daemon_store(coven_home)?;
     let status = DaemonStatus {
         pid: std::process::id(),
         started_at: started_at.clone(),
@@ -2752,6 +2757,7 @@ pub fn serve_forever(
     // Claim the pipe before mutating shared daemon/session state. A duplicate
     // daemon must fail at bind without replacing the incumbent's daemon.json
     // or marking sessions owned by that live daemon orphaned.
+    initialize_daemon_store(coven_home)?;
     write_status(coven_home, &status)?;
     recover_orphaned_sessions(coven_home, &started_at)?;
 
@@ -2829,6 +2835,15 @@ pub fn serve_forever(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn daemon_store_initialization_prepares_request_connections() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        initialize_daemon_store(temp_dir.path())?;
+        let conn = crate::store::open_initialized_store(&temp_dir.path().join("coven.sqlite3"))?;
+        assert!(crate::store::list_sessions(&conn)?.is_empty());
+        Ok(())
+    }
 
     #[test]
     fn is_client_disconnect_detects_wrapped_broken_pipe() {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1,9 +1,16 @@
-use std::path::Path;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::{OnceLock, RwLock},
+};
+
+#[cfg(test)]
+use std::{collections::HashMap, sync::Mutex};
 
 use anyhow::{Context, Result};
 use base64::Engine;
 use chrono::{Duration, SecondsFormat, Utc};
-use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
+use rusqlite::{params, Connection, ErrorCode, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -329,7 +336,63 @@ fn ensure_ward_audit_schema(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn initialized_store_paths() -> &'static RwLock<HashSet<PathBuf>> {
+    static PATHS: OnceLock<RwLock<HashSet<PathBuf>>> = OnceLock::new();
+    PATHS.get_or_init(|| RwLock::new(HashSet::new()))
+}
+
+fn store_was_initialized(path: &Path) -> bool {
+    initialized_store_paths()
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .contains(path)
+}
+
+fn remember_initialized_store(path: &Path) {
+    initialized_store_paths()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(path.to_path_buf());
+    #[cfg(test)]
+    {
+        let mut counts = initialization_counts()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *counts.entry(path.to_path_buf()).or_default() += 1;
+    }
+}
+
+#[cfg(test)]
+fn initialization_counts() -> &'static Mutex<HashMap<PathBuf, usize>> {
+    static COUNTS: OnceLock<Mutex<HashMap<PathBuf, usize>>> = OnceLock::new();
+    COUNTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+fn initialization_count(path: &Path) -> usize {
+    initialization_counts()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(path)
+        .copied()
+        .unwrap_or_default()
+}
+
+/// Opens a writable store for a standalone CLI caller. The first open for a
+/// path in this process initializes or upgrades it; later opens only configure
+/// the connection. Daemon startup calls [`initialize_store`] explicitly before
+/// it starts accepting requests, so its request paths always take the latter.
 pub fn open_store(path: &Path) -> Result<Connection> {
+    if !store_was_initialized(path) {
+        initialize_store(path)?;
+    }
+    open_initialized_store(path)
+}
+
+/// Performs the idempotent, write-capable store initialization and migration
+/// sequence. Call this before serving requests; ordinary request connections
+/// should use [`open_initialized_store`] after this succeeds.
+pub fn initialize_store(path: &Path) -> Result<()> {
     if let Some(parent) = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -340,7 +403,39 @@ pub fn open_store(path: &Path) -> Result<Connection> {
 
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
-    configure_writable_connection(&conn)?;
+    configure_initializing_connection(&conn)?;
+    // The Ward audit migrator owns its own transaction because a legacy table
+    // rebuild must be atomic. Run it before our transaction for the remaining
+    // idempotent store schema work; nesting these transactions is invalid in
+    // SQLite. Its transaction also serializes concurrent Ward upgrades.
+    ensure_ward_audit_schema(&conn)?;
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .context("failed to acquire SQLite initialization transaction")?;
+    let result = initialize_store_schema(&conn);
+    match result {
+        Ok(()) => conn
+            .execute_batch("COMMIT")
+            .context("failed to commit SQLite initialization transaction")?,
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            return Err(error);
+        }
+    }
+    remember_initialized_store(path);
+    Ok(())
+}
+
+/// Opens a writable connection after [`initialize_store`] has completed. This
+/// deliberately omits schema DDL, compatibility checks, FTS backfill, and WAL
+/// changes so it is safe for per-request use on the daemon hot path.
+pub fn open_initialized_store(path: &Path) -> Result<Connection> {
+    let conn = Connection::open(path)
+        .with_context(|| format!("failed to open Coven store at {}", path.display()))?;
+    configure_runtime_writable_connection(&conn)?;
+    Ok(conn)
+}
+
+fn initialize_store_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS sessions (
             id TEXT PRIMARY KEY NOT NULL,
@@ -567,35 +662,68 @@ pub fn open_store(path: &Path) -> Result<Connection> {
         ",
     )
     .context("failed to initialize Coven store schema")?;
-    // The coven-threads gate layer's daemon-owned tables: the append-only
-    // ward.audit ledger (single audit store — PHASE-0-DESIGN §3.4, RFC-0001
-    // §5.6) and the per-familiar surface baseline manifest. Both idempotent.
-    ensure_ward_audit_schema(&conn)?;
+    // The per-familiar surface baseline manifest is idempotent. The Ward audit
+    // ledger ran before this transaction because legacy migration SQL owns its
+    // own transaction.
     conn.execute_batch(crate::threads_gate::WARD_MANIFEST_SCHEMA_SQL)
         .context("failed to initialize ward_manifest schema")?;
-    ensure_exit_code_column(&conn)?;
-    ensure_archived_at_column(&conn)?;
-    ensure_conversation_id_column(&conn)?;
-    ensure_event_privacy_columns(&conn)?;
-    ensure_sensitive_artifacts_table(&conn)?;
-    ensure_labels_column(&conn)?;
-    ensure_visibility_column(&conn)?;
-    ensure_familiar_id_column(&conn)?;
-    ensure_node_registry_dispatch_columns(&conn)?;
-    ensure_session_external_columns(&conn)?;
+    ensure_exit_code_column(conn)?;
+    ensure_archived_at_column(conn)?;
+    ensure_conversation_id_column(conn)?;
+    ensure_event_privacy_columns(conn)?;
+    ensure_sensitive_artifacts_table(conn)?;
+    ensure_labels_column(conn)?;
+    ensure_visibility_column(conn)?;
+    ensure_familiar_id_column(conn)?;
+    ensure_node_registry_dispatch_columns(conn)?;
+    ensure_session_external_columns(conn)?;
 
-    backfill_events_fts_if_needed(&conn)?;
+    backfill_events_fts_if_needed(conn)?;
 
-    Ok(conn)
+    Ok(())
 }
 
-fn configure_writable_connection(conn: &Connection) -> Result<()> {
+fn configure_initializing_connection(conn: &Connection) -> Result<()> {
     // WAL mode allows concurrent readers alongside a single writer and avoids
     // "database is locked" errors under typical daemon + API concurrency.
     // busy_timeout gives writers up to 5 s to retry before returning SQLITE_BUSY.
     conn.execute_batch(
-        "PRAGMA journal_mode = WAL;
-         PRAGMA busy_timeout = 5000;
+        "PRAGMA busy_timeout = 5000;
+         PRAGMA foreign_keys = ON;",
+    )
+    .context("failed to configure writable Coven store connection")?;
+    enable_wal_with_retry(conn)?;
+    Ok(())
+}
+
+fn enable_wal_with_retry(conn: &Connection) -> Result<()> {
+    const ATTEMPTS: usize = 50;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
+
+    for attempt in 0..ATTEMPTS {
+        match conn.query_row("PRAGMA journal_mode = WAL", [], |row| {
+            row.get::<_, String>(0)
+        }) {
+            Ok(mode) if mode.eq_ignore_ascii_case("wal") => return Ok(()),
+            Ok(mode) => anyhow::bail!("SQLite refused WAL mode and reported `{mode}`"),
+            Err(error)
+                if matches!(
+                    error.sqlite_error_code(),
+                    Some(ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked)
+                ) && attempt + 1 < ATTEMPTS =>
+            {
+                std::thread::sleep(RETRY_DELAY);
+            }
+            Err(error) => return Err(error).context("failed to enable WAL mode for Coven store"),
+        }
+    }
+
+    unreachable!("WAL retry loop either succeeds or returns its final error")
+}
+
+fn configure_runtime_writable_connection(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "PRAGMA busy_timeout = 5000;
          PRAGMA foreign_keys = ON;",
     )
     .context("failed to configure writable Coven store connection")?;
@@ -3133,7 +3261,8 @@ mod tests {
         )?;
         drop(conn);
 
-        let conn = open_store(&path)?;
+        initialize_store(&path)?;
+        let conn = open_initialized_store(&path)?;
 
         assert_eq!(
             ward_audit_component_version(&conn)?,
@@ -3366,6 +3495,61 @@ mod tests {
         let conn = open_existing_store_read_only(&store_path)?.expect("store should exist");
 
         assert!(!repositories_table_exists(&conn)?);
+        Ok(())
+    }
+
+    #[test]
+    fn store_initialization_boundary_creates_schema_once_before_lightweight_opens() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+
+        let unopened = open_initialized_store(&path)?;
+        assert!(list_sessions(&unopened).is_err());
+        drop(unopened);
+
+        initialize_store(&path)?;
+        let conn = open_initialized_store(&path)?;
+        assert!(list_sessions(&conn)?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn open_store_only_initializes_an_unseen_path_once_per_process() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+
+        drop(open_store(&path)?);
+        assert_eq!(initialization_count(&path), 1);
+        drop(open_store(&path)?);
+        assert_eq!(initialization_count(&path), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn concurrent_store_initialization_serializes_migrations() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+        let handles = (0..2)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    initialize_store(&path)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().expect("initializer thread panicked")?;
+        }
+        let conn = open_initialized_store(&path)?;
+        assert!(list_sessions(&conn)?.is_empty());
+        assert_eq!(
+            ward_audit_component_version(&conn)?,
+            coven_threads_core::WARD_AUDIT_SCHEMA_VERSION
+        );
         Ok(())
     }
 

--- a/docs/superpowers/plans/2026-07-29-store-initialization-boundary.md
+++ b/docs/superpowers/plans/2026-07-29-store-initialization-boundary.md
@@ -1,0 +1,136 @@
+# Store Initialization Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move SQLite schema and migration work out of daemon request opens while preserving fresh-install, upgrade, and concurrent-start guarantees.
+
+**Architecture:** Split `store::open_store` into a lightweight connection open and an explicit idempotent `store::initialize_store` boundary. Daemon startup runs the initializer while holding its existing serve lock; a process-local initialized-path cache keeps legacy CLI callers safe without repeating schema work for request connections. Initialization takes a SQLite immediate transaction so independently-started callers serialize migrations.
+
+**Tech Stack:** Rust, rusqlite, SQLite WAL/transactions, existing daemon serve lock, Node benchmark harness.
+
+---
+
+### Task 1: Define and test the initialization boundary
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs:332-604`
+- Test: `crates/coven-cli/src/store.rs:3070-3475`
+
+- [ ] **Step 1: Write failing boundary tests**
+
+Add tests proving `open_initialized_store` does not create schema, `initialize_store` creates a usable fresh database, and repeated initialization preserves a session record.
+
+```rust
+assert!(open_initialized_store(&path)?.execute("SELECT 1 FROM sessions", []).is_err());
+initialize_store(&path)?;
+let conn = open_initialized_store(&path)?;
+assert_eq!(list_sessions(&conn)?.len(), 0);
+```
+
+- [ ] **Step 2: Run the new test before implementation**
+
+Run: `cargo test -p coven-cli store_initialization_boundary -- --nocapture`
+
+Expected: FAIL because `open_initialized_store` and `initialize_store` do not exist.
+
+- [ ] **Step 3: Implement explicit initialization and lightweight opens**
+
+Extract the existing parent creation, WAL configuration, schema DDL, compatibility columns, Ward schemas, and FTS backfill into `initialize_store`. Wrap that sequence in `BEGIN IMMEDIATE` / `COMMIT`, rolling back if any required migration fails. Keep `open_initialized_store` limited to `Connection::open`, `busy_timeout`, and `foreign_keys`; it must not execute schema DDL or `journal_mode`.
+
+- [ ] **Step 4: Keep CLI callers backward-compatible without request-path work**
+
+Make `open_store` initialize an unseen path once per process, then delegate to `open_initialized_store`. Record only successful initialization in a synchronized path cache, so standalone CLI commands still initialize fresh or upgraded stores and repeated daemon request opens only take the lightweight branch.
+
+- [ ] **Step 5: Run focused store tests**
+
+Run: `cargo test -p coven-cli store::tests -- --nocapture`
+
+Expected: PASS, including legacy Ward schema and FTS migration tests.
+
+### Task 2: Establish daemon startup as the authoritative initialization point
+
+**Files:**
+- Modify: `crates/coven-cli/src/daemon.rs:2191-2235`
+- Test: `crates/coven-cli/src/daemon.rs` daemon serve tests
+
+- [ ] **Step 1: Write a failing daemon-startup regression**
+
+Add a helper-level test that calls the daemon initialization seam for a temporary Coven home, then verifies a subsequent request-style store open can read the sessions table.
+
+```rust
+initialize_daemon_store(temp.path())?;
+let conn = store::open_initialized_store(&temp.path().join("coven.sqlite3"))?;
+assert!(store::list_sessions(&conn)?.is_empty());
+```
+
+- [ ] **Step 2: Run the regression before implementation**
+
+Run: `cargo test -p coven-cli daemon_store_initialization -- --nocapture`
+
+Expected: FAIL because the startup seam is absent.
+
+- [ ] **Step 3: Initialize after the serve lock and before socket acceptance**
+
+Call the new store initializer in `serve_forever` immediately after `acquire_serve_lock` and before `bind_api_socket`. Keep the recovery sweep, scheduler startup, API listeners, WAL, and status-file ordering otherwise unchanged.
+
+- [ ] **Step 4: Run daemon and API focused regressions**
+
+Run: `cargo test -p coven-cli 'daemon::tests|api::tests::sessions_endpoint' -- --nocapture`
+
+Expected: PASS.
+
+### Task 3: Verify concurrency and measurable request-path behavior
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs` tests and test-only telemetry
+
+- [ ] **Step 1: Add concurrent initialization coverage**
+
+Spawn two threads that call `initialize_store` on the same fresh path, join both successfully, then open the resulting store and verify the current Ward component version and sessions table are present.
+
+```rust
+let handles = (0..2).map(|_| std::thread::spawn(move || initialize_store(&path))).collect::<Vec<_>>();
+for handle in handles { handle.join().expect("thread panicked")?; }
+```
+
+- [ ] **Step 2: Add request-open telemetry regression**
+
+Expose test-only initialization-count helpers. Initialize once, perform multiple `open_store` calls, and assert the count remains one; this proves request-path opens do not replay DDL/migrations.
+
+- [ ] **Step 3: Run the existing repeated bounded sessions-read benchmark**
+
+Measure repeated `/api/v1/sessions?limit=100` requests against a daemon that has already completed startup initialization. The existing benchmark already has this scenario and status-code assertion, so record its result without changing the harness.
+
+- [ ] **Step 4: Run focused tests and the benchmark**
+
+Run: `cargo test -p coven-cli store_initialization -- --nocapture` and the existing benchmark command.
+
+Expected: PASS.
+
+### Task 4: Validate, commit, and deliver
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs`
+- Modify: `crates/coven-cli/src/daemon.rs`
+
+- [ ] **Step 1: Run full repository gates**
+
+Run: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --locked && python scripts/check-secrets.py`
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Run staged privacy validation**
+
+Run: `python3 scripts/check-coven-privacy.py --staged`
+
+Expected: `Coven privacy guard passed`.
+
+- [ ] **Step 3: Commit and open the issue-linked PR**
+
+Run: `git commit -m "perf: move store initialization off request paths"` followed by `git push -u origin perf/527-store-initialization` and `gh pr create --fill --body "Closes #527"`.
+
+Expected: a PR exists with green required checks.
+
+- [ ] **Step 4: Resolve review feedback and merge**
+
+Reply to each verified Copilot thread, resolve only addressed threads, re-run required gates after every code change, then squash merge only with a clean merge state and green checks. Release `issue-527` after verifying the issue is closed.


### PR DESCRIPTION
Closes #527

## Summary
- initialize and migrate the SQLite store before the daemon accepts requests
- keep daemon request connections to connection-local busy/FK pragmas only
- preserve standalone CLI behavior with a successful-initialization cache and serialize concurrent upgrades

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- 10k-session daemon `/api/v1/sessions?limit=100` benchmark: 7.982 ms (single sample; previous baseline 16.545 ms)