### PR TITLE
perf: cache capability discovery snapshots

### DIFF
--- a/crates/coven-cli/src/capabilities.rs
+++ b/crates/coven-cli/src/capabilities.rs
@@ -136,6 +136,7 @@ fn get_or_refresh(
     // concurrent refreshes may duplicate work, but readers retain access to a
     // complete prior snapshot throughout either scan.
     let response = build();
+    let built_at = Instant::now();
     cache()
         .write()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -143,7 +144,7 @@ fn get_or_refresh(
             key,
             CapabilitySnapshot {
                 response: response.clone(),
-                built_at: Instant::now(),
+                built_at,
             },
         );
     response
@@ -987,6 +988,32 @@ mod tests {
         release_tx.send(()).unwrap();
         reader.join().unwrap();
         assert_eq!(refresh.join().unwrap().scanned_at, "refreshed");
+    }
+
+    #[test]
+    fn snapshot_ttl_starts_when_discovery_finishes() {
+        let _serial = cache_test_lock().lock().unwrap();
+        clear_cache_for_tests();
+        let key = CacheKey::new(PathBuf::from("/coven"), PathBuf::from("/harness"));
+
+        let write_guard = cache().write().unwrap();
+        let (built_tx, built_rx) = mpsc::channel();
+        let refresh_key = key.clone();
+        let refresh = std::thread::spawn(move || {
+            get_or_refresh(refresh_key, true, || {
+                built_tx.send(()).unwrap();
+                fixture_response("refreshed")
+            })
+        });
+        built_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+        std::thread::sleep(Duration::from_millis(50));
+
+        let lock_released_at = Instant::now();
+        drop(write_guard);
+        refresh.join().unwrap();
+
+        let snapshot = cache().read().unwrap().get(&key).cloned().unwrap();
+        assert!(snapshot.built_at <= lock_released_at);
     }
 
     #[test]

--- a/crates/coven-cli/src/capabilities.rs
+++ b/crates/coven-cli/src/capabilities.rs
@@ -13,7 +13,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
@@ -88,15 +88,73 @@ pub struct CapabilitiesResponse {
 
 const CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
-struct CapabilityCache {
-    manifests: HashMap<String, HarnessCapabilityManifest>,
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    coven_home: PathBuf,
+    harness_home: PathBuf,
+}
+
+impl CacheKey {
+    fn new(coven_home: PathBuf, harness_home: PathBuf) -> Self {
+        Self {
+            coven_home,
+            harness_home,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct CapabilitySnapshot {
+    response: CapabilitiesResponse,
     built_at: Instant,
 }
 
-static CACHE: OnceLock<Mutex<Option<CapabilityCache>>> = OnceLock::new();
+static CACHE: OnceLock<RwLock<HashMap<CacheKey, CapabilitySnapshot>>> = OnceLock::new();
 
-fn cache() -> &'static Mutex<Option<CapabilityCache>> {
-    CACHE.get_or_init(|| Mutex::new(None))
+fn cache() -> &'static RwLock<HashMap<CacheKey, CapabilitySnapshot>> {
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn get_or_refresh(
+    key: CacheKey,
+    refresh: bool,
+    build: impl FnOnce() -> CapabilitiesResponse,
+) -> CapabilitiesResponse {
+    if !refresh {
+        let guard = cache()
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(snapshot) = guard
+            .get(&key)
+            .filter(|snapshot| snapshot.built_at.elapsed() < CACHE_TTL)
+        {
+            return snapshot.response.clone();
+        }
+    }
+
+    // Filesystem discovery must happen outside the shared cache lock. Two
+    // concurrent refreshes may duplicate work, but readers retain access to a
+    // complete prior snapshot throughout either scan.
+    let response = build();
+    cache()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(
+            key,
+            CapabilitySnapshot {
+                response: response.clone(),
+                built_at: Instant::now(),
+            },
+        );
+    response
+}
+
+#[cfg(test)]
+fn clear_cache_for_tests() {
+    cache()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
 }
 
 fn utc_now_iso() -> String {
@@ -130,56 +188,27 @@ fn utc_now_iso() -> String {
 /// Returns all harness manifests, using the cache when fresh.
 /// Pass `refresh = true` to force a re-scan.
 pub fn get_all(coven_home: &Path, refresh: bool) -> CapabilitiesResponse {
-    let home = dirs_home();
-    {
-        let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
-        if !refresh {
-            if let Some(ref c) = *guard {
-                if c.built_at.elapsed() < CACHE_TTL {
-                    let manifests: Vec<_> = c.manifests.values().cloned().collect();
-                    let coven_skills =
-                        crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
-                    return CapabilitiesResponse {
-                        coven_skills,
-                        harness_capabilities: manifests,
-                        scanned_at: utc_now_iso(),
-                    };
-                }
-            }
-        }
-        // Re-scan.
-        let codex = scan_codex_capabilities(&home);
-        let claude = scan_claude_capabilities(&home);
-        let cursor = scan_cursor_capabilities(&home);
-        let gemini = scan_gemini_capabilities(&home);
-        let opencode = scan_opencode_capabilities(&home);
-        let coven_code = scan_coven_code_capabilities(&home);
-        let copilot = scan_copilot_capabilities(&home);
-        let mut manifests = HashMap::new();
-        manifests.insert("codex".to_string(), codex);
-        manifests.insert("claude".to_string(), claude);
-        manifests.insert("cursor".to_string(), cursor);
-        manifests.insert("gemini".to_string(), gemini);
-        manifests.insert("opencode".to_string(), opencode);
-        manifests.insert("coven-code".to_string(), coven_code);
-        manifests.insert("copilot".to_string(), copilot);
-        *guard = Some(CapabilityCache {
-            manifests,
-            built_at: Instant::now(),
-        });
-    }
-    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
-    let manifests: Vec<_> = guard
-        .as_ref()
-        .unwrap()
-        .manifests
-        .values()
-        .cloned()
-        .collect();
-    let coven_skills = crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default();
+    let harness_home = dirs_home();
+    get_all_for_home(coven_home, &harness_home, refresh)
+}
+
+fn get_all_for_home(coven_home: &Path, harness_home: &Path, refresh: bool) -> CapabilitiesResponse {
+    let key = CacheKey::new(coven_home.to_path_buf(), harness_home.to_path_buf());
+    get_or_refresh(key, refresh, || build_response(coven_home, harness_home))
+}
+
+fn build_response(coven_home: &Path, harness_home: &Path) -> CapabilitiesResponse {
     CapabilitiesResponse {
-        coven_skills,
-        harness_capabilities: manifests,
+        coven_skills: crate::cockpit_sources::scan_skills(coven_home).unwrap_or_default(),
+        harness_capabilities: vec![
+            scan_codex_capabilities(harness_home),
+            scan_claude_capabilities(harness_home),
+            scan_cursor_capabilities(harness_home),
+            scan_gemini_capabilities(harness_home),
+            scan_opencode_capabilities(harness_home),
+            scan_coven_code_capabilities(harness_home),
+            scan_copilot_capabilities(harness_home),
+        ],
         scanned_at: utc_now_iso(),
     }
 }
@@ -190,17 +219,29 @@ pub fn get_one(
     harness_id: &str,
     refresh: bool,
 ) -> Option<HarnessCapabilityManifest> {
-    // Ensure the cache is warm first.
-    get_all(coven_home, refresh);
-    let guard = cache().lock().unwrap_or_else(|e| e.into_inner());
-    guard.as_ref()?.manifests.get(harness_id).cloned()
+    let harness_home = dirs_home();
+    get_one_for_home(coven_home, &harness_home, harness_id, refresh)
+}
+
+fn get_one_for_home(
+    coven_home: &Path,
+    harness_home: &Path,
+    harness_id: &str,
+    refresh: bool,
+) -> Option<HarnessCapabilityManifest> {
+    get_all_for_home(coven_home, harness_home, refresh)
+        .harness_capabilities
+        .into_iter()
+        .find(|manifest| manifest.harness_id == harness_id)
 }
 
 /// Invalidate the cache (e.g. on SIGHUP).
 #[allow(dead_code)]
 pub fn invalidate() {
-    let mut guard = cache().lock().unwrap_or_else(|e| e.into_inner());
-    *guard = None;
+    cache()
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clear();
 }
 
 // ── Scanners ──────────────────────────────────────────────────────────────────
@@ -848,11 +889,135 @@ fn parse_automation_toml(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::{
+        fs,
+        sync::{mpsc, Mutex},
+        time::Duration,
+    };
     use tempfile::TempDir;
 
     fn tmp() -> TempDir {
         tempfile::tempdir().expect("tempdir")
+    }
+
+    fn cache_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn fixture_response(label: &str) -> CapabilitiesResponse {
+        CapabilitiesResponse {
+            coven_skills: vec![crate::cockpit_sources::SkillDto {
+                id: label.to_string(),
+                name: label.to_string(),
+                owner: "test".to_string(),
+                category: "test".to_string(),
+                tags: vec![],
+                score: 0.0,
+                effective_rate: 0.0,
+                applied_rate: 0.0,
+                completion_rate: 0.0,
+                fallback_rate: 0.0,
+                version: "1.0.0".to_string(),
+                description: "test fixture".to_string(),
+            }],
+            harness_capabilities: vec![HarnessCapabilityManifest {
+                harness_id: "codex".to_string(),
+                scanned_at: label.to_string(),
+                global_instructions: GlobalInstructions {
+                    present: false,
+                    path: None,
+                    byte_count: None,
+                },
+                skills: vec![],
+                plugins: vec![],
+                warnings: vec![],
+            }],
+            scanned_at: label.to_string(),
+        }
+    }
+
+    #[test]
+    fn fresh_cache_hit_returns_the_complete_snapshot_without_building() {
+        let _serial = cache_test_lock().lock().unwrap();
+        clear_cache_for_tests();
+        let key = CacheKey::new(PathBuf::from("/coven"), PathBuf::from("/harness"));
+        let initial = fixture_response("initial");
+
+        let first = get_or_refresh(key.clone(), false, || initial.clone());
+        let hit = get_or_refresh(key, false, || panic!("fresh cache must not build"));
+
+        assert_eq!(first.scanned_at, "initial");
+        assert_eq!(hit.scanned_at, "initial");
+        assert_eq!(hit.coven_skills[0].id, "initial");
+        assert_eq!(hit.harness_capabilities[0].scanned_at, "initial");
+    }
+
+    #[test]
+    fn refresh_does_not_block_fresh_reader() {
+        let _serial = cache_test_lock().lock().unwrap();
+        clear_cache_for_tests();
+        let key = CacheKey::new(PathBuf::from("/coven"), PathBuf::from("/harness"));
+        let cached = fixture_response("cached");
+        get_or_refresh(key.clone(), false, || cached);
+
+        let (started_tx, started_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let refresh_key = key.clone();
+        let refresh = std::thread::spawn(move || {
+            get_or_refresh(refresh_key, true, || {
+                started_tx.send(()).unwrap();
+                release_rx.recv().unwrap();
+                fixture_response("refreshed")
+            })
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let (reader_tx, reader_rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            reader_tx
+                .send(get_or_refresh(key, false, || {
+                    panic!("fresh cache must not build")
+                }))
+                .unwrap();
+        });
+        let response = reader_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(response.scanned_at, "cached");
+
+        release_tx.send(()).unwrap();
+        reader.join().unwrap();
+        assert_eq!(refresh.join().unwrap().scanned_at, "refreshed");
+    }
+
+    #[test]
+    fn get_one_reads_the_published_response_snapshot() {
+        let _serial = cache_test_lock().lock().unwrap();
+        clear_cache_for_tests();
+        let coven_home = PathBuf::from("/coven");
+        let harness_home = PathBuf::from("/harness");
+        get_or_refresh(
+            CacheKey::new(coven_home.clone(), harness_home.clone()),
+            false,
+            || fixture_response("published"),
+        );
+
+        let manifest = get_one_for_home(&coven_home, &harness_home, "codex", false)
+            .expect("published codex manifest");
+        assert_eq!(manifest.scanned_at, "published");
+    }
+
+    #[test]
+    fn snapshots_are_scoped_to_coven_and_harness_homes() {
+        let _serial = cache_test_lock().lock().unwrap();
+        clear_cache_for_tests();
+        let first = CacheKey::new(PathBuf::from("/coven-one"), PathBuf::from("/harness"));
+        let second = CacheKey::new(PathBuf::from("/coven-two"), PathBuf::from("/harness"));
+
+        get_or_refresh(first.clone(), false, || fixture_response("first"));
+        get_or_refresh(second, false, || fixture_response("second"));
+
+        let first_hit = get_or_refresh(first, false, || panic!("first cache must remain scoped"));
+        assert_eq!(first_hit.scanned_at, "first");
     }
 
     // ── Codex ──────────────────────────────────────────────────────────────

--- a/crates/coven-cli/src/capabilities.rs
+++ b/crates/coven-cli/src/capabilities.rs
@@ -971,7 +971,7 @@ mod tests {
                 fixture_response("refreshed")
             })
         });
-        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        started_rx.recv_timeout(Duration::from_secs(5)).unwrap();
 
         let (reader_tx, reader_rx) = mpsc::channel();
         let reader = std::thread::spawn(move || {
@@ -981,7 +981,7 @@ mod tests {
                 }))
                 .unwrap();
         });
-        let response = reader_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let response = reader_rx.recv_timeout(Duration::from_secs(5)).unwrap();
         assert_eq!(response.scanned_at, "cached");
 
         release_tx.send(()).unwrap();

--- a/docs/superpowers/plans/2026-07-29-capability-cache.md
+++ b/docs/superpowers/plans/2026-07-29-capability-cache.md
@@ -1,0 +1,270 @@
+# Capability Discovery Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make capability discovery return a complete cached response on hot reads without holding a lock during filesystem scans.
+
+**Architecture:** Key immutable complete response snapshots by both the Coven home and harness home. A `RwLock<HashMap<CacheKey, CapabilitySnapshot>>` serves valid snapshots under a shared lock. Expired, missing, or forced refreshes build the whole response outside all cache locks, then atomically replace one key's snapshot under a short write lock.
+
+**Tech Stack:** Rust, `std::sync::RwLock`, `HashMap`, existing capability scanners, Node benchmark harness.
+
+---
+
+### Task 1: Define a complete, path-scoped cache snapshot
+
+**Files:**
+- Modify: `crates/coven-cli/src/capabilities.rs:13-205`
+- Test: `crates/coven-cli/src/capabilities.rs` test module
+
+- [x] **Step 1: Write failing cache-boundary tests**
+
+Add fixture helpers and tests that exercise a closure-based refresh seam without changing process `HOME`:
+
+```rust
+#[test]
+fn fresh_cache_hit_returns_the_complete_snapshot_without_building() {
+    let _serial = cache_test_lock().lock().unwrap();
+    let key = CacheKey::new(PathBuf::from("/coven"), PathBuf::from("/harness"));
+    clear_cache_for_tests();
+    let expected = fixture_response("first", "2026-07-29T00:00:00Z");
+
+    assert_eq!(get_or_refresh(key.clone(), false, || expected.clone()).scanned_at, expected.scanned_at);
+    let hit = get_or_refresh(key, false, || panic!("fresh cache must not build"));
+    assert_eq!(hit.coven_skills[0].id, expected.coven_skills[0].id);
+    assert_eq!(
+        hit.harness_capabilities[0].harness_id,
+        expected.harness_capabilities[0].harness_id
+    );
+}
+```
+
+Add a second test which starts `get_or_refresh(key, true, ...)` in a thread whose builder waits on a channel; while it waits, call `get_or_refresh(key, false, || panic!(...))` and assert it returns the old snapshot before releasing the refresh thread. Add a third test that refreshes a fixture response, then checks `get_one_for_home` returns the manifest from that same replacement response.
+
+- [x] **Step 2: Run the new tests to verify they fail**
+
+Run: `cargo test -p coven-cli 'capabilities::tests::fresh_cache_hit_returns_the_complete_snapshot_without_building|capabilities::tests::refresh_does_not_block_fresh_reader|capabilities::tests::get_one_reads_the_published_response_snapshot' -- --nocapture`
+
+Expected: FAIL because `CacheKey`, `get_or_refresh`, and the test helpers do not exist.
+
+- [x] **Step 3: Replace the manifest-only mutex cache**
+
+Replace `CapabilityCache`, `Mutex`, and `cache()` with these types and helpers:
+
+```rust
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    coven_home: PathBuf,
+    harness_home: PathBuf,
+}
+
+#[derive(Clone)]
+struct CapabilitySnapshot {
+    response: CapabilitiesResponse,
+    built_at: Instant,
+}
+
+static CACHE: OnceLock<RwLock<HashMap<CacheKey, CapabilitySnapshot>>> = OnceLock::new();
+
+fn get_or_refresh(
+    key: CacheKey,
+    refresh: bool,
+    build: impl FnOnce() -> CapabilitiesResponse,
+) -> CapabilitiesResponse {
+    if !refresh {
+        let guard = cache().read().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(snapshot) = guard.get(&key).filter(|snapshot| snapshot.built_at.elapsed() < CACHE_TTL) {
+            return snapshot.response.clone();
+        }
+    }
+
+    let response = build();
+    cache().write().unwrap_or_else(|poisoned| poisoned.into_inner()).insert(
+        key,
+        CapabilitySnapshot { response: response.clone(), built_at: Instant::now() },
+    );
+    response
+}
+```
+
+Keep the builder invocation outside both lock scopes. Do not introduce a refresh mutex: duplicate concurrent scans are acceptable and keep readers non-blocking.
+
+- [x] **Step 4: Run the cache-boundary tests**
+
+Run: `cargo test -p coven-cli capabilities::tests -- --nocapture`
+
+Expected: PASS, including the new hot-hit, atomic replacement, and blocked-refresh reader tests.
+
+- [x] **Step 5: Commit the cache boundary**
+
+```bash
+git add crates/coven-cli/src/capabilities.rs
+git commit -m "perf: cache complete capability discovery snapshots"
+```
+
+### Task 2: Route all capability reads through the immutable response
+
+**Files:**
+- Modify: `crates/coven-cli/src/capabilities.rs:130-205`
+- Test: `crates/coven-cli/src/capabilities.rs` test module
+- Test: `crates/coven-cli/src/api.rs:7170-7235`
+
+- [x] **Step 1: Write failing route-semantics tests**
+
+Add a test that supplies distinct fixture responses to `get_all_for_home` and verifies a warm response preserves both `coven_skills` and `scanned_at`. Add an API test that requests `/api/v1/capabilities/harnesses?refresh=1` after a warm request and verifies the response remains a complete aggregate.
+
+```rust
+let response = get_all_for_home(coven_home, harness_home, false);
+assert_eq!(response.scanned_at, "2026-07-29T00:00:00Z");
+assert_eq!(response.coven_skills, vec![fixture_skill("cached")]);
+assert_eq!(response.harness_capabilities[0].harness_id, "codex");
+```
+
+- [x] **Step 2: Run the focused route tests to verify the missing behavior**
+
+Run: `cargo test -p coven-cli 'capabilities::tests::warm_response_keeps_skills_and_scan_time|api::tests::harness_capability_aggregate_accepts_refresh_query' -- --nocapture`
+
+Expected: FAIL because hot responses still call `scan_skills` and regenerate `scanned_at`.
+
+- [x] **Step 3: Build and publish a complete response**
+
+Factor scanner collection into `build_response(coven_home, harness_home) -> CapabilitiesResponse`. It must call every existing harness scanner, collect `scan_skills(coven_home).unwrap_or_default()`, and assign `utc_now_iso()` once. Implement:
+
+```rust
+pub fn get_all(coven_home: &Path, refresh: bool) -> CapabilitiesResponse {
+    let harness_home = dirs_home();
+    get_all_for_home(coven_home, &harness_home, refresh)
+}
+
+fn get_one_for_home(
+    coven_home: &Path,
+    harness_home: &Path,
+    harness_id: &str,
+    refresh: bool,
+) -> Option<HarnessCapabilityManifest> {
+    get_all_for_home(coven_home, harness_home, refresh)
+        .harness_capabilities
+        .into_iter()
+        .find(|manifest| manifest.harness_id == harness_id)
+}
+```
+
+Make `get_one` call this helper rather than take a second cache lock. Update `invalidate` to clear all keyed snapshots. Preserve the existing missing-harness `None` behavior and scanner warning/error treatment.
+
+- [x] **Step 4: Run route and capability tests**
+
+Run: `cargo test -p coven-cli 'capabilities::tests|api::tests::routes_harness_capability_aggregate_to_json|api::tests::harness_capability_aggregate_accepts_refresh_query|api::tests::routes_single_harness_capability_manifest' -- --nocapture`
+
+Expected: PASS.
+
+- [x] **Step 5: Commit the response integration**
+
+```bash
+git add crates/coven-cli/src/capabilities.rs crates/coven-cli/src/api.rs
+git commit -m "perf: serve hot capability responses from snapshots"
+```
+
+### Task 3: Add a benchmarked hot capability route
+
+**Files:**
+- Modify: `scripts/benchmark-cli.mjs:508-663`
+- Test: `scripts/benchmark-cli.test.mjs:430-530`
+
+- [x] **Step 1: Write the failing benchmark-harness test**
+
+Extend `collectBenchmarkScenarios`'s dependency injection with `measureCapabilities` and assert the aggregate report contains a `capabilities_hot` response after startup:
+
+```js
+assert.deepEqual(Object.keys(scenarios), [
+  'help', 'harness_first_output', 'event_tail_2', 'sessions_2', 'capabilities_hot'
+]);
+assert.deepEqual(calls.at(-1), ['capabilities', '/fixture/root', 2]);
+```
+
+- [x] **Step 2: Run the Node test to verify it fails**
+
+Run: `node --test scripts/benchmark-cli.test.mjs --test-name-pattern='collectBenchmarkScenarios merges core and daemon fixture reports'`
+
+Expected: FAIL because no capability measurement is injected or reported.
+
+- [x] **Step 3: Add the warmed capability measurement**
+
+Add `measureCapabilityReads` that starts an isolated daemon, makes one unmeasured `GET /api/v1/capabilities/harnesses` warm-up call, then calls `runSocketScenario` on the same path for the requested iterations. Wire its report into `collectBenchmarkScenarios` as `capabilities_hot` when session fixtures are enabled. Always stop the daemon in `finally`.
+
+```js
+await measure({ socketPath, path: '/api/v1/capabilities/harnesses', iterations: 1 });
+return measure({ socketPath, path: '/api/v1/capabilities/harnesses', iterations });
+```
+
+- [x] **Step 4: Run benchmark unit tests and a local report**
+
+Run:
+
+```bash
+node --test scripts/benchmark-cli.test.mjs
+CARGO_TARGET_DIR=/tmp/coven-issue-528-check cargo build -p coven-cli --locked
+node scripts/benchmark-cli.mjs --binary /tmp/coven-issue-528-check/debug/coven --iterations=3 --session-counts=100 --output /tmp/coven-issue-528-benchmark.json
+jq '.scenarios.capabilities_hot' /tmp/coven-issue-528-benchmark.json
+```
+
+Expected: tests pass and the report contains only timing, status-code, and summary data for `capabilities_hot`.
+
+- [x] **Step 5: Commit the performance evidence**
+
+```bash
+git add scripts/benchmark-cli.mjs scripts/benchmark-cli.test.mjs
+git commit -m "perf: benchmark hot capability discovery"
+```
+
+### Task 4: Validate and deliver issue #528
+
+**Files:**
+- Modify: `crates/coven-cli/src/capabilities.rs`
+- Modify: `scripts/benchmark-cli.mjs`
+- Modify: `scripts/benchmark-cli.test.mjs`
+
+- [x] **Step 1: Run all repository gates**
+
+Run:
+
+```bash
+CARGO_TARGET_DIR=/tmp/coven-issue-528-check cargo fmt --check
+CARGO_TARGET_DIR=/tmp/coven-issue-528-check cargo clippy --workspace --all-targets -- -D warnings
+CARGO_TARGET_DIR=/tmp/coven-issue-528-check cargo test --workspace --locked
+node --test scripts/benchmark-cli.test.mjs
+python scripts/check-secrets.py
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 2: Stage and validate privacy**
+
+Run:
+
+```bash
+git add crates/coven-cli/src/capabilities.rs scripts/benchmark-cli.mjs scripts/benchmark-cli.test.mjs docs/superpowers/specs/2026-07-29-capability-cache-design.md docs/superpowers/plans/2026-07-29-capability-cache.md
+git diff --cached --check
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: no whitespace errors and `Coven privacy guard passed`.
+
+- [ ] **Step 3: Open the issue-linked PR**
+
+Run:
+
+```bash
+git push -u origin perf/528-capability-cache
+gh pr create --repo OpenCoven/coven --base main --title "perf: cache capability discovery snapshots" --body "Closes #528"
+```
+
+Expected: a single-purpose PR exists and links issue #528.
+
+- [ ] **Step 4: Resolve review feedback and merge**
+
+For each actionable Copilot or maintainer review thread: make the smallest verified fix, reply with the commit and test evidence, resolve the thread only after the fix is pushed, and wait for all required checks. Then verify `mergeStateStatus` is `CLEAN` and squash merge the PR:
+
+```bash
+gh pr merge <number> --repo OpenCoven/coven --squash --subject "perf: cache capability discovery snapshots" --body "Closes #528."
+```
+
+Expected: the PR is merged, #528 is closed, and `COVEN_AGENT_ID=buns coven claim release issue-528` succeeds.

--- a/docs/superpowers/specs/2026-07-29-capability-cache-design.md
+++ b/docs/superpowers/specs/2026-07-29-capability-cache-design.md
@@ -1,0 +1,58 @@
+# Capability Discovery Cache Design
+
+## Goal
+
+Make fresh capability reads entirely memory-backed and ensure filesystem
+discovery never holds the shared cache lock.
+
+## Scope
+
+The affected API routes are `GET /capabilities/harnesses` and
+`GET /capabilities/:harness_id`. Their existing `refresh=1` and five-minute
+TTL behavior remain unchanged. Coven continues to read harness and skill
+directories only; this change introduces no writes to those directories.
+
+## Design
+
+Replace the mutable manifest-only cache with an immutable, complete response
+snapshot containing harness manifests, Coven skills, and the discovery time.
+Store that snapshot behind an `RwLock`.
+
+1. A non-refresh request first takes a shared lock. If the snapshot is within
+   the TTL, it clones the snapshot and returns without a harness or skill
+   directory scan.
+2. A refresh request, or an expired/missing snapshot, collects every harness
+   manifest and the Coven skill list outside the lock.
+3. After collection succeeds, it takes the write lock only long enough to
+   atomically replace the complete snapshot, then returns the same immutable
+   result.
+4. `get_one` reads from that same snapshot, so it cannot race a second cache
+   lookup after `get_all` has warmed it.
+
+Concurrent cold or forced refreshes may perform duplicate scans. This is
+intentional: readers never wait for filesystem I/O and no partial state is
+published. A successful later refresh simply replaces the prior complete
+snapshot.
+
+## Failure behavior
+
+Harness scanners preserve their existing warning-bearing manifests. A skill
+scan failure remains represented as an empty skill list, matching the current
+route behavior. Publishing occurs only after the complete replacement snapshot
+has been built, so an already-valid cached response stays intact until a new
+one is ready.
+
+## Verification
+
+Add focused tests proving that:
+
+- a warm cache returns the original complete snapshot without rescanning
+  harnesses or Coven skills;
+- a refresh builds outside the shared read lock, allowing unrelated readers to
+  return the last complete snapshot while the refresh is blocked in discovery;
+- an explicit refresh atomically replaces the entire response and `get_one`
+  sees the matching manifest;
+- the capability benchmark covers concurrent reads and reports the hot-path
+  result.
+
+Run the existing Rust, JavaScript, secret, privacy, and CI gates before merge.

--- a/docs/superpowers/specs/2026-07-29-capability-cache-design.md
+++ b/docs/superpowers/specs/2026-07-29-capability-cache-design.md
@@ -7,8 +7,8 @@ discovery never holds the shared cache lock.
 
 ## Scope
 
-The affected API routes are `GET /capabilities/harnesses` and
-`GET /capabilities/:harness_id`. Their existing `refresh=1` and five-minute
+The affected API routes are `GET /api/v1/capabilities/harnesses` and
+`GET /api/v1/capabilities/:harnessId`. Their existing `refresh=1` and five-minute
 TTL behavior remain unchanged. Coven continues to read harness and skill
 directories only; this change introduces no writes to those directories.
 

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -546,6 +546,40 @@ export async function measureSessionLists({
   return reports;
 }
 
+export async function measureCapabilityReads({
+  binary,
+  fixtureRoot,
+  environment,
+  iterations,
+  makeDirectory = (path) => mkdir(path, { recursive: true }),
+  start = startDaemon,
+  measure = runSocketScenario,
+  stop = stopDaemon
+}) {
+  // Unix-domain socket paths have a small platform limit (104 bytes on macOS).
+  // Keep this fixture name shorter than the session fixtures so a default
+  // macOS temporary directory still leaves enough room for `coven.sock`.
+  const covenHome = join(fixtureRoot, 'k');
+  const env = isolatedEnvironment(covenHome, environment);
+  await makeDirectory(join(covenHome, 'user-home'));
+  const socketPath = await start({ binary, covenHome, env });
+
+  try {
+    await measure({
+      socketPath,
+      path: '/api/v1/capabilities/harnesses',
+      iterations: 1
+    });
+    return await measure({
+      socketPath,
+      path: '/api/v1/capabilities/harnesses',
+      iterations
+    });
+  } finally {
+    stop({ binary, covenHome, env });
+  }
+}
+
 export async function measureHarnessOutput({
   binary,
   fixtureRoot,
@@ -620,7 +654,8 @@ export async function collectBenchmarkScenarios({
   collectCore = collectCoreScenarios,
   measureHarness = measureHarnessOutput,
   measureEvents = measureEventTails,
-  measureLists = measureSessionLists
+  measureLists = measureSessionLists,
+  measureCapabilities = measureCapabilityReads
 }) {
   const coreHome = join(fixtureRoot, 'c');
   const coreEnv = isolatedEnvironment(coreHome, environment);
@@ -658,6 +693,12 @@ export async function collectBenchmarkScenarios({
         iterations: options.iterations
       })
     );
+    scenarios.capabilities_hot = await measureCapabilities({
+      binary: options.binary,
+      fixtureRoot,
+      environment,
+      iterations: options.iterations
+    });
   }
 
   return scenarios;

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -18,6 +18,7 @@ import {
   launchHarnessSession,
   prepareEventTail,
   measureEventTails,
+  measureCapabilityReads,
   measureSessionLists,
   registerInputEvents,
   registerExternalSessions,
@@ -500,6 +501,51 @@ test('measureSessionLists isolates every requested fixture size', async () => {
   ]);
 });
 
+test('measureCapabilityReads uses a short socket-safe fixture home', async () => {
+  const calls = [];
+  let releaseHotRead;
+  let hotReadStarted;
+  const hotReadStartedPromise = new Promise((resolve) => {
+    hotReadStarted = resolve;
+  });
+  const reportPromise = measureCapabilityReads({
+    binary: '/tmp/coven',
+    fixtureRoot: '/fixture/root',
+    environment: { PATH: '/fixture/bin' },
+    iterations: 2,
+    makeDirectory: async (path) => calls.push(['mkdir', path]),
+    start: async ({ covenHome, env }) => {
+      calls.push(['start', covenHome, env.COVEN_HOME]);
+      return `${covenHome}/coven.sock`;
+    },
+    measure: async ({ socketPath, path, iterations }) => {
+      calls.push(['measure', socketPath, path, iterations]);
+      if (iterations === 2) {
+        hotReadStarted();
+        await new Promise((resolve) => {
+          releaseHotRead = resolve;
+        });
+      }
+      return { samplesMs: [1], statusCodes: [200], summary: { minMs: 1 } };
+    },
+    stop: ({ covenHome }) => calls.push(['stop', covenHome])
+  });
+
+  await hotReadStartedPromise;
+  assert.equal(calls.some(([name]) => name === 'stop'), false);
+  releaseHotRead();
+  const report = await reportPromise;
+
+  assert.deepEqual(report, { samplesMs: [1], statusCodes: [200], summary: { minMs: 1 } });
+  assert.deepEqual(calls, [
+    ['mkdir', '/fixture/root/k/user-home'],
+    ['start', '/fixture/root/k', '/fixture/root/k'],
+    ['measure', '/fixture/root/k/coven.sock', '/api/v1/capabilities/harnesses', 1],
+    ['measure', '/fixture/root/k/coven.sock', '/api/v1/capabilities/harnesses', 2],
+    ['stop', '/fixture/root/k']
+  ]);
+});
+
 test('collectBenchmarkScenarios merges core and daemon fixture reports', async () => {
   const calls = [];
   const scenarios = await collectBenchmarkScenarios({
@@ -522,6 +568,10 @@ test('collectBenchmarkScenarios merges core and daemon fixture reports', async (
     measureLists: async (input) => {
       calls.push(['lists', input.fixtureRoot, input.sessionCounts]);
       return { sessions_2: { samplesMs: [2], statusCodes: [200], summary: { minMs: 2 } } };
+    },
+    measureCapabilities: async (input) => {
+      calls.push(['capabilities', input.fixtureRoot, input.iterations]);
+      return { samplesMs: [5], statusCodes: [200], summary: { minMs: 5 } };
     }
   });
 
@@ -529,15 +579,42 @@ test('collectBenchmarkScenarios merges core and daemon fixture reports', async (
     'help',
     'harness_first_output',
     'event_tail_2',
-    'sessions_2'
+    'sessions_2',
+    'capabilities_hot'
   ]);
   assert.deepEqual(calls, [
     ['mkdir', '/fixture/root/c/user-home'],
     ['core', '/fixture/root/c'],
     ['harness', '/fixture/root', 2],
     ['events', '/fixture/root', [2]],
-    ['lists', '/fixture/root', [2]]
+    ['lists', '/fixture/root', [2]],
+    ['capabilities', '/fixture/root', 2]
   ]);
+});
+
+test('collectBenchmarkScenarios records warmed capability reads', async () => {
+  const calls = [];
+  const scenarios = await collectBenchmarkScenarios({
+    options: { binary: '/tmp/coven', iterations: 2, sessionCounts: [2] },
+    fixtureRoot: '/fixture/root',
+    environment: { PATH: '/fixture/bin' },
+    makeDirectory: async () => {},
+    collectCore: () => ({ help: { samplesMs: [1], exitCodes: [0], summary: { minMs: 1 } } }),
+    measureHarness: async () => ({ samplesMs: [3], statusCodes: [201], summary: { minMs: 3 } }),
+    measureEvents: async () => ({ event_tail_2: { samplesMs: [4], statusCodes: [200], summary: { minMs: 4 } } }),
+    measureLists: async () => ({ sessions_2: { samplesMs: [2], statusCodes: [200], summary: { minMs: 2 } } }),
+    measureCapabilities: async (input) => {
+      calls.push([input.fixtureRoot, input.iterations]);
+      return { samplesMs: [5], statusCodes: [200], summary: { minMs: 5 } };
+    }
+  });
+
+  assert.deepEqual(scenarios.capabilities_hot, {
+    samplesMs: [5],
+    statusCodes: [200],
+    summary: { minMs: 5 }
+  });
+  assert.deepEqual(calls, [['/fixture/root', 2]]);
 });
 
 test('external session fixture request uses the versioned sessions endpoint', () => {


### PR DESCRIPTION
Closes #528.

## Summary
- publish complete capability snapshots keyed by Coven and harness homes
- keep filesystem discovery outside cache locks so fresh readers stay non-blocking
- benchmark warmed capability reads and protect the fixture lifecycle

## Verification
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- node --test scripts/benchmark-cli.test.mjs
- python scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --staged
- local benchmark: capabilities_hot median 0.333 ms (3/3 HTTP 200)