### PR TITLE
docs: add CLI core workflow guides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -3933,15 +3933,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -481,6 +481,9 @@ comux is a standalone terminal cockpit that proved the tmux-cockpit model for pa
 
 | Document                                                | What it covers                                                        |
 | ------------------------------------------------------- | --------------------------------------------------------------------- |
+| [CLI core functionality for developers](docs/development/cli-core-functionality.md) | Command ownership, core-access contract, source map, and maintainer verification loop |
+| [Workflow guides](docs/guides/index.md)                | Runnable examples for core access, session operations, JSON automation, worktrees, and troubleshooting |
+| [Top-level `coven` command](docs/reference/cli-coven.md) | Interactive entry point, free-text task routing, global flags, and command discovery |
 | [Getting started](docs/GETTING-STARTED.md)              | Full install → first session walkthrough                              |
 | [Concepts](docs/CONCEPTS.md)                            | Definitions: harness, session, project, ritual, daemon, store, client |
 | [Glossary](docs/GLOSSARY.md)                            | Term definitions for the full OpenCoven ecosystem                     |

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -37,7 +37,7 @@ portable-pty = "0.9"
 rand = "0.9"
 regex = "1"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
-rustls-pemfile = "2"
+rustls-pki-types = "1"
 rcgen = { version = "0.14", features = ["crypto", "pem", "ring"] }
 p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }
 qrcode = { version = "0.14", default-features = false }

--- a/crates/coven-cli/src/mobile_memory/identity.rs
+++ b/crates/coven-cli/src/mobile_memory/identity.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::io::{self, BufReader};
+use std::io;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
@@ -8,6 +8,7 @@ use base64::Engine;
 use p256::elliptic_curve::sec1::ToEncodedPoint;
 use p256::pkcs8::DecodePrivateKey;
 use rcgen::{CertificateParams, DistinguishedName, DnType, KeyPair};
+use rustls_pki_types::{pem::PemObject, CertificateDer};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
@@ -186,8 +187,7 @@ fn load_stored_certificate(
         bail!("mobile host identity does not match the private key");
     }
 
-    let mut reader = BufReader::new(stored.certificate_pem.as_bytes());
-    let certificates = rustls_pemfile::certs(&mut reader)
+    let certificates = CertificateDer::pem_slice_iter(stored.certificate_pem.as_bytes())
         .collect::<std::result::Result<Vec<_>, _>>()
         .context("mobile host certificate PEM is invalid")?;
     if certificates.len() != 1 {

--- a/docs/development/cli-core-functionality.md
+++ b/docs/development/cli-core-functionality.md
@@ -1,0 +1,112 @@
+---
+title: "Coven CLI core functionality for developers"
+summary: "The command ownership map, access contract, and verification loop for maintaining Coven's core CLI and daemon surfaces."
+read_when:
+  - Changing a core coven command or flag
+  - Debugging whether a local Coven installation can reach its core runtime
+  - Updating CLI, daemon, or workflow documentation
+description: "Developer guide to Coven CLI command ownership, local runtime access, safe verification, and documentation maintenance."
+---
+
+# Coven CLI core functionality for developers
+
+This is the maintainer map for the CLI paths that make Coven useful: discover a ready environment, reach the local daemon, launch a project-scoped harness session, and inspect or manage the resulting session. It complements the user-facing [CLI reference](/reference/cli), not replaces it.
+
+## Core access contract
+
+Core functionality is reachable when all of these are true:
+
+1. `coven doctor` can inspect a writable `COVEN_HOME` and reports at least one usable harness.
+2. `coven daemon status --json` can reach the same-user local socket. A stopped daemon is an expected first-run state; a stale daemon is not.
+3. A command runs from an explicit project root, and any `--cwd` remains inside that root after canonicalization.
+4. The selected harness is available in the same shell environment as Coven. Provider authentication stays with that harness; Coven does not own provider credentials.
+5. The session ledger can persist metadata and events beneath `COVEN_HOME`.
+
+Do not call the CLI healthy merely because `--help` renders. A healthy core path proves readiness, daemon reachability, and a read of the session ledger. A harness launch is a separate, intentional operation because it may cause model work.
+
+## Command ownership
+
+| User outcome | CLI entry point | Primary Rust owner | Contract to preserve |
+| --- | --- | --- | --- |
+| Discover commands and route free-text input | `coven`, `coven chat`, `coven tui`, `coven help` | `crates/coven-cli/src/main.rs`, `tui/`, `engine.rs` | Bare Coven opens the interactive route; free-text work remains confirmable and recorded. |
+| Check local readiness | `coven doctor [--json]` | `main.rs`, `harness.rs`, `paths.rs`, `daemon.rs` | Human output gives repair hints; JSON stays a single machine-readable document. |
+| Control the daemon | `coven daemon start/status/restart/stop` | `daemon.rs`, `api.rs`, `paths.rs` | One same-user local daemon owns the socket and state directory. |
+| Launch work | `coven run <harness> <prompt>` | `session_launch.rs`, `harness.rs`, `pty_runner.rs`, `store.rs` | Validate project root and cwd in Rust, construct argv safely, then record session/events. |
+| Inspect and manage history | `coven sessions`, `attach`, `archive`, `summon`, `sacrifice`, `kill` | `store.rs`, `daemon.rs`, `tui/` | Archive is reversible; sacrifice and other destructive actions keep explicit confirmation. |
+| Read runtime state | `status`, `familiars`, `skills`, `memory`, `research`, `calls`, `hub`, `scheduler`, `travel` | `observe.rs`, `hub.rs`, `control_plane.rs` | Read surfaces do not silently become write paths. |
+| Coordinate parallel work | `wt`, `claim`, `hooks` | `parallel_protocol.rs` | Claims are shared through git's common directory and remain TTL-bounded. |
+| Repair or diagnose a machine | `patch`, `pc`, `logs`, `vacuum` | `patch.rs`, `pc.rs`, `store.rs` | Keep inspection separate from explicit write/repair confirmation. |
+
+`main.rs` is the authoritative parser and dispatch map. When a command changes, start there and follow its delegated module before changing documentation.
+
+## Access paths developers should exercise
+
+Run these from a clean, representative project directory. They are ordered from read-only inspection to daemon activation; the final launch is intentionally opt-in.
+
+```sh
+# Parser and command inventory: no daemon or harness execution.
+coven --help
+
+# Readiness envelope: succeeds only when a usable local path exists.
+coven doctor --json | jq -e '.ok'
+
+# Daemon reachability and socket identity.
+coven daemon status --json
+
+# Session ledger read without opening the interactive browser.
+coven sessions --json
+```
+
+If the daemon is stopped, start it deliberately and repeat the status check:
+
+```sh
+coven daemon start
+coven daemon status --json
+```
+
+Only after those checks should a developer launch a harness session:
+
+```sh
+coven run codex "explain this repository in five bullets" --permission read-only
+```
+
+Use the harness selected by `doctor`; `codex` is an example, not a requirement. The [core access guide](/guides/core-access) gives the equivalent operator walkthrough.
+
+## Failure classification
+
+| Symptom | Boundary to inspect | First safe action |
+| --- | --- | --- |
+| `doctor` reports no usable harness | Shell PATH and harness-owned login | Run the printed harness install/login hint, then rerun `coven doctor`. |
+| `daemon status` is stale or cannot connect | `COVEN_HOME`, socket, daemon lifecycle | Read `coven daemon status`; then follow [daemon troubleshooting](/help/daemon-wont-start). |
+| Launch rejects a cwd | Project-root and canonical-path guard | Run from the intended project root; ensure `--cwd` resolves inside it. |
+| Sessions cannot be listed | Daemon/store reachability | Check `coven doctor --json`, then `coven daemon status --json`. |
+| JSON consumer breaks | Command-specific serialization contract | Verify the exact command's `--json` reference before changing stdout or stderr. |
+
+Never document a maintainer's absolute path, real session id, token, or provider environment dump. Use `/path/to/project`, `session-1`, and synthetic output in examples.
+
+## Documentation change checklist
+
+When a CLI behavior changes, update the matching layer in the same change:
+
+1. `docs/reference/cli.md` for the command inventory and flags.
+2. The focused `docs/reference/cli-*.md` page for semantics and examples.
+3. A `docs/guides/` workflow when the change affects an end-to-end task rather than one flag.
+4. `README.md` when it changes the first path a developer should discover.
+5. `docs/API-CONTRACT.md` for a socket/API compatibility change.
+6. `scripts/onboarding-docs-test.mjs` when a discovery link or core workflow must not regress.
+
+For docs-only work, run:
+
+```sh
+node scripts/onboarding-docs-test.mjs
+python scripts/check-secrets.py
+git diff --check
+```
+
+## Related
+
+- [CLI reference](/reference/cli)
+- [Core access guide](/guides/core-access)
+- [Automation and JSON guide](/guides/automation-json)
+- [Runtime architecture](/ARCHITECTURE)
+- [Documentation maintenance](/DOCS-MAINTENANCE)

--- a/docs/development/cli-core-functionality.md
+++ b/docs/development/cli-core-functionality.md
@@ -32,10 +32,10 @@ Do not call the CLI healthy merely because `--help` renders. A healthy core path
 | Check local readiness | `coven doctor [--json]` | `main.rs`, `harness.rs`, `paths.rs`, `daemon.rs` | Human output gives repair hints; JSON stays a single machine-readable document. |
 | Control the daemon | `coven daemon start/status/restart/stop` | `daemon.rs`, `api.rs`, `paths.rs` | One same-user local daemon owns the socket and state directory. |
 | Launch work | `coven run <harness> <prompt>` | `session_launch.rs`, `harness.rs`, `pty_runner.rs`, `store.rs` | Validate project root and cwd in Rust, construct argv safely, then record session/events. |
-| Inspect and manage history | `coven sessions`, `attach`, `archive`, `summon`, `sacrifice`, `kill` | `store.rs`, `daemon.rs`, `tui/` | Archive is reversible; sacrifice and other destructive actions keep explicit confirmation. |
-| Read runtime state | `status`, `familiars`, `skills`, `memory`, `research`, `calls`, `hub`, `scheduler`, `travel` | `observe.rs`, `hub.rs`, `control_plane.rs` | Read surfaces do not silently become write paths. |
-| Coordinate parallel work | `wt`, `claim`, `hooks` | `parallel_protocol.rs` | Claims are shared through git's common directory and remain TTL-bounded. |
-| Repair or diagnose a machine | `patch`, `pc`, `logs`, `vacuum` | `patch.rs`, `pc.rs`, `store.rs` | Keep inspection separate from explicit write/repair confirmation. |
+| Inspect and manage history | `coven sessions`, `coven attach`, `coven archive`, `coven summon`, `coven sacrifice`, `coven kill` | `store.rs`, `daemon.rs`, `tui/` | Archive is reversible; sacrifice and other destructive actions keep explicit confirmation. |
+| Read runtime state | `coven status`, `coven familiars`, `coven skills`, `coven memory`, `coven research`, `coven calls`, `coven hub`, `coven scheduler`, `coven travel` | `observe.rs`, `hub.rs`, `control_plane.rs` | Read surfaces do not silently become write paths. |
+| Coordinate parallel work | `coven wt`, `coven claim`, `coven hooks` | `parallel_protocol.rs` | Claims are shared through git's common directory and remain TTL-bounded. |
+| Repair or diagnose a machine | `coven patch`, `coven pc`, `coven logs`, `coven vacuum` | `patch.rs`, `pc.rs`, `store.rs` | Keep inspection separate from explicit write/repair confirmation. |
 
 `main.rs` is the authoritative parser and dispatch map. When a command changes, start there and follow its delegated module before changing documentation.
 

--- a/docs/guides/automation-json.md
+++ b/docs/guides/automation-json.md
@@ -1,0 +1,66 @@
+---
+title: "Automate Coven with JSON output"
+summary: "Use Coven's documented JSON commands safely in shell automation and local integrations."
+read_when:
+  - Writing a shell script around Coven
+  - Building a local client or status check
+description: "Examples for Coven doctor, daemon, and session JSON output, plus the local API boundary."
+---
+
+# Automate Coven with JSON output
+
+Use documented `--json` modes for automation. Do not parse the human terminal UI or infer state from decorative output. Each command owns its JSON schema; inspect the matching reference page before depending on optional fields.
+
+## Gate environment readiness
+
+```sh
+if coven doctor --json | jq -e '.ok' >/dev/null; then
+  echo "Coven is ready"
+else
+  echo "Coven needs local setup" >&2
+  exit 1
+fi
+```
+
+The `doctor` envelope reports `ok`, `blocking`, checks, and next steps. A warning can be non-blocking; gate on `ok` rather than assuming that every warning is failure.
+
+## Check daemon reachability
+
+```sh
+coven daemon status --json | jq -e '.ok and .status == "running"'
+```
+
+If a workflow may start the daemon, do so as a separate, explicit action:
+
+```sh
+coven daemon start
+coven daemon status --json
+```
+
+## Read sessions without a terminal UI
+
+```sh
+coven sessions --json | jq '.sessions[] | { id, harness, status, title }'
+```
+
+Use `coven sessions --all --json` only when archived history is relevant. Treat ids as opaque strings and do not record session titles or event content in public logs without a privacy review.
+
+## Pick the right integration boundary
+
+- Use the CLI JSON commands for local shell automation and maintainer checks.
+- Use the versioned local socket API when building a persistent client. Begin with the compatibility handshake described in the [API contract](/API-CONTRACT).
+- Keep the daemon local and same-user. It is not a remote HTTP service and does not provide a provider-credential API.
+
+## Output rules
+
+- With `--json`, stdout is for the JSON document. Send your own diagnostics to stderr.
+- Avoid `--json` modes that the focused command does not document.
+- Preserve unknown fields when relaying a document; consumers should read only fields they own.
+- Never paste real session output, paths, tokens, or provider environment data into fixtures or public issue reports.
+
+## Related
+
+- [Core access](/guides/core-access)
+- [Developer core-functionality guide](/development/cli-core-functionality)
+- [CLI reference](/reference/cli)
+- [API contract](/API-CONTRACT)

--- a/docs/guides/core-access.md
+++ b/docs/guides/core-access.md
@@ -1,0 +1,87 @@
+---
+title: "Reach Coven core functionality"
+summary: "Verify your local CLI, daemon, harness, and session ledger before launching project-scoped agent work."
+read_when:
+  - Setting up Coven on a development machine
+  - Checking whether the CLI can reach its core local runtime
+description: "A runnable workflow for doctor, daemon, harness, and session access in Coven."
+---
+
+# Reach Coven core functionality
+
+This guide proves the useful local path before you start agent work: the CLI is present, a harness is usable, the daemon/socket is reachable, and session history is readable.
+
+## 1. Inspect the command surface
+
+```sh
+coven --help
+```
+
+You should see `doctor`, `daemon`, `run`, and `sessions`. Help rendering proves the binary can parse commands, but not that it can reach local state.
+
+## 2. Check readiness
+
+```sh
+coven doctor
+```
+
+For scripts, gate on the JSON envelope instead of scraping prose:
+
+```sh
+coven doctor --json | jq -e '.ok'
+```
+
+`doctor` checks the active `COVEN_HOME`, harness visibility in this shell, and daemon condition. You need at least one usable harness. Follow the per-harness hint it prints; provider authentication happens in the harness's own CLI, not in Coven.
+
+## 3. Start or verify the local daemon
+
+```sh
+coven daemon status --json
+```
+
+If the daemon is stopped, start it and verify again:
+
+```sh
+coven daemon start
+coven daemon status --json
+```
+
+The daemon is a same-user local service. Do not expose its socket over a network. See [daemon configuration](/daemon/configuration) before changing `COVEN_HOME` or service supervision.
+
+## 4. Confirm session-ledger access
+
+```sh
+coven sessions --json
+```
+
+This reads recorded sessions without opening the interactive browser. For a human-readable table, use:
+
+```sh
+coven sessions --plain
+```
+
+## 5. Launch one deliberate project-scoped session
+
+Change into the project you want Coven to supervise. The project root is an authority boundary, so do not use a parent directory just for convenience.
+
+```sh
+cd /path/to/project
+coven run codex "summarize this repository in five bullets" --permission read-only
+```
+
+Replace `codex` with a harness that `coven doctor` reports as ready. `--permission read-only` is a useful first-run posture when your selected harness supports it. After the run starts, inspect it with:
+
+```sh
+coven sessions
+```
+
+## What success means
+
+You have core access when `doctor --json` reports `ok: true`, `daemon status --json` reports a reachable state, `sessions --json` returns a document, and a selected harness can create a project-scoped session. A missing optional adapter does not prevent core use when another supported harness is ready.
+
+## Related
+
+- [Session operations](/guides/session-operations)
+- [Troubleshooting core access](/guides/troubleshooting-core-access)
+- [Doctor reference](/reference/cli-doctor)
+- [Daemon reference](/reference/cli-daemon)

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,0 +1,33 @@
+---
+title: "Coven workflow guides"
+summary: "Task-oriented guides for reaching and using Coven's local CLI, daemon, sessions, automation output, and parallel-work protocol."
+read_when:
+  - Looking for a runnable Coven workflow
+  - Choosing between the command reference and an end-to-end example
+description: "Runnable, task-oriented Coven guides for core access, session operations, automation, parallel work, and troubleshooting."
+---
+
+# Coven workflow guides
+
+Use these guides when you want a verified task flow rather than a list of flags. The [CLI reference](/reference/cli) remains the complete command and option surface; each guide links back to the precise reference page for edge cases.
+
+| Guide | Use it for | Starts with |
+| --- | --- | --- |
+| [Core access](/guides/core-access) | Installing or validating a usable local Coven path | `coven doctor` |
+| [Session operations](/guides/session-operations) | Listing, replaying, archiving, restoring, or deleting sessions | `coven sessions --plain` |
+| [Automation and JSON](/guides/automation-json) | Shell scripts and local clients that need stable machine-readable output | `coven doctor --json` |
+| [Multi-agent worktrees](/guides/multi-agent-worktrees) | Isolated branches, shared claims, and managed hooks | `coven wt` |
+| [Troubleshooting core access](/guides/troubleshooting-core-access) | Missing harnesses, daemon/socket state, and project-boundary failures | `coven doctor` |
+
+## Choose the right document
+
+- Need every accepted flag or subcommand? Read the [CLI reference](/reference/cli).
+- Need the implementation and ownership boundary? Read the [developer core-functionality guide](/development/cli-core-functionality).
+- Need to build a local client? Start with [the API contract](/API-CONTRACT) after the [automation and JSON guide](/guides/automation-json).
+- Need a supported harness? Use [the harness setup guides](/harnesses).
+
+## Related
+
+- [Getting started](/GETTING-STARTED)
+- [CLI reference](/reference/cli)
+- [Developer core-functionality guide](/development/cli-core-functionality)

--- a/docs/guides/multi-agent-worktrees.md
+++ b/docs/guides/multi-agent-worktrees.md
@@ -1,0 +1,59 @@
+---
+title: "Coordinate parallel work with Coven"
+summary: "Use managed worktrees, TTL-bounded claims, and hooks to keep concurrent agent work from colliding."
+read_when:
+  - Starting a parallel change in a Coven-enabled repository
+  - Checking whether another agent already owns work
+description: "A practical workflow for coven wt, coven claim, and coven hooks."
+---
+
+# Coordinate parallel work with Coven
+
+The parallel-work commands prevent duplicate work; they do not replace normal review or pull-request discipline. Run them from the repository you intend to change.
+
+## 1. Check existing work
+
+```sh
+coven claim status
+git worktree list
+```
+
+Look for an active claim that matches the issue or task before creating a branch. Claims are shared through git's common directory, so sibling worktrees see the same ownership state.
+
+## 2. Create or enter an isolated worktree
+
+```sh
+coven wt docs/cli-core-guides
+cd "$(coven wt docs/cli-core-guides)"
+```
+
+The printed path is designed for command substitution. Use a task-specific branch name; do not share an active worktree with another agent unless you have explicitly coordinated that work.
+
+## 3. Acquire and maintain ownership
+
+```sh
+coven claim acquire docs-cli-core-guides
+coven claim heartbeat docs-cli-core-guides
+```
+
+Claims are TTL-bounded. Heartbeat a long-running task before the claim expires. Release it from the same worktree after the pull request merges or when you stop:
+
+```sh
+coven claim release docs-cli-core-guides
+```
+
+## 4. Install managed hooks when the repository uses them
+
+```sh
+coven hooks install
+coven wt --doctor
+```
+
+Managed hooks preserve existing hooks through a `.local` chain when appropriate. Do not replace a repository's tracked hook configuration by hand.
+
+## Related
+
+- [Worktree reference](/reference/cli-wt)
+- [Claim reference](/reference/cli-claim)
+- [Developer core-functionality guide](/development/cli-core-functionality)
+- [Merge guide](/MERGE-GUIDE)

--- a/docs/guides/multi-agent-worktrees.md
+++ b/docs/guides/multi-agent-worktrees.md
@@ -32,14 +32,14 @@ The printed path is designed for command substitution. Use a task-specific branc
 ## 3. Acquire and maintain ownership
 
 ```sh
-coven claim acquire docs-cli-core-guides
-coven claim heartbeat docs-cli-core-guides
+coven claim acquire issue-<N>
+coven claim heartbeat issue-<N>
 ```
 
 Claims are TTL-bounded. Heartbeat a long-running task before the claim expires. Release it from the same worktree after the pull request merges or when you stop:
 
 ```sh
-coven claim release docs-cli-core-guides
+coven claim release issue-<N>
 ```
 
 ## 4. Install managed hooks when the repository uses them

--- a/docs/guides/session-operations.md
+++ b/docs/guides/session-operations.md
@@ -1,0 +1,79 @@
+---
+title: "Operate Coven sessions"
+summary: "List, inspect, replay, archive, restore, and deliberately delete project-scoped Coven sessions."
+read_when:
+  - Managing a recorded harness session
+  - Recovering or cleaning up completed work
+description: "Examples for Coven session listing, logs, attach, archive, summon, kill, and sacrifice."
+---
+
+# Operate Coven sessions
+
+Sessions are the durable record of a harness run. Use the interactive browser for discovery; use explicit commands when scripting or when you already have an id.
+
+## List and identify a session
+
+```sh
+coven sessions --plain
+coven sessions --all --plain
+coven sessions --json
+```
+
+The default list omits archived sessions. `--all` includes them. Session-id arguments accept a unique prefix, but prefer the full id in scripts.
+
+Search recorded events or inspect one record:
+
+```sh
+coven sessions search "authentication"
+coven sessions show session-1
+coven sessions events session-1
+coven sessions log session-1
+```
+
+## Replay or rejoin live work
+
+```sh
+coven attach session-1
+```
+
+`attach` replays recorded output and follows a live Coven-managed session. It is not a new harness launch. Use the session browser (`coven sessions`) when you want to choose Rejoin or View Log without copying an id.
+
+## Archive and restore finished work
+
+Archive hides a completed session from the default list without deleting its events:
+
+```sh
+coven archive session-1
+coven sessions --all --plain
+```
+
+Restore it with `summon`:
+
+```sh
+coven summon session-1
+```
+
+`summon` clears the archive state and can replay or follow the selected session. Archive is the reversible cleanup action.
+
+## Stop or delete deliberately
+
+For a running session, preserve the event log while ending the managed process:
+
+```sh
+coven kill session-1
+```
+
+For a non-running session you no longer need, permanently delete the record and event history only with explicit confirmation:
+
+```sh
+coven sacrifice session-1 --yes
+```
+
+There is no undo for sacrifice. Archive first when you only want to remove work from the active list.
+
+## Related
+
+- [Core access](/guides/core-access)
+- [Sessions reference](/reference/cli-sessions)
+- [Attach reference](/reference/cli-attach)
+- [Session lifecycle](/sessions/lifecycle)

--- a/docs/guides/troubleshooting-core-access.md
+++ b/docs/guides/troubleshooting-core-access.md
@@ -1,0 +1,79 @@
+---
+title: "Troubleshoot Coven core access"
+summary: "Recover from missing harnesses, daemon/socket failures, state-directory issues, and project-boundary rejections."
+read_when:
+  - Coven cannot launch or list sessions
+  - A harness is not detected in the current shell
+description: "A diagnosis-first guide for Coven doctor, daemon status, COVEN_HOME, and project-root access failures."
+---
+
+# Troubleshoot Coven core access
+
+Start with the smallest read-only check that can locate the failed boundary. Do not delete `COVEN_HOME`, session data, or sockets as a first response.
+
+## No usable harness
+
+```sh
+coven doctor
+```
+
+Run the install or login command that `doctor` prints, in the same shell environment where you run Coven. Then repeat:
+
+```sh
+coven doctor --json | jq -e '.ok'
+```
+
+One ready supported harness is enough for core access. An unavailable optional adapter is not necessarily a blocker.
+
+## Daemon is stopped, stale, or unreachable
+
+```sh
+coven daemon status
+coven daemon status --json
+```
+
+For an expected stopped state:
+
+```sh
+coven daemon start
+coven daemon status
+```
+
+For a stale or failing state, use the specific recovery sequence in [Daemon will not start](/help/daemon-wont-start). Do not expose the local socket to a network as a workaround.
+
+## Unexpected state directory
+
+```sh
+printf '%s\n' "${COVEN_HOME:-$HOME/.coven}"
+coven doctor
+```
+
+`COVEN_HOME` contains local daemon state, including the session store and socket. Confirm the variable is intentional before changing it. Use [Coven home](/daemon/coven-home) for supported layout and migration guidance.
+
+## Project or cwd rejected
+
+Run from the intended repository root, then narrow the request:
+
+```sh
+cd /path/to/project
+coven run codex "describe this repository" --permission read-only
+```
+
+If you use `--cwd`, it must resolve inside that project root. This restriction is enforced by the Rust authority layer and should not be bypassed with symlinks or a parent directory.
+
+## Session list or attach fails
+
+```sh
+coven doctor --json
+coven daemon status --json
+coven sessions --json
+```
+
+These commands distinguish environment readiness, daemon reachability, and ledger access. For a session that is no longer live, use its log or archive state rather than repeatedly trying to attach.
+
+## Related
+
+- [Core access](/guides/core-access)
+- [Daemon troubleshooting](/help/daemon-wont-start)
+- [Harness not found](/help/harness-not-found)
+- [Paths and COVEN_HOME](/help/paths)

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,9 @@ description: "Coven powers CastCodes with local-first project-scoped harness ses
   <Card title="CLI reference" href="/reference/cli" icon="terminal">
     Core verbs — doctor, daemon, run, sessions, attach — plus the archive, summon, and sacrifice rituals and the rest of the command surface.
   </Card>
+  <Card title="Workflow guides" href="/guides" icon="book-open">
+    Runnable paths for core access, session operations, JSON automation, parallel work, and diagnostics.
+  </Card>
 </Columns>
 
 ## What is Coven?

--- a/docs/reference/cli-coven.md
+++ b/docs/reference/cli-coven.md
@@ -6,4 +6,62 @@ title: "coven"
 description: "Reference for the top-level coven command: subcommands, global flags, and the interactive menu that opens when you run coven with no arguments."
 ---
 
-Stub — fill in.
+# `coven`
+
+`coven` is the interactive entry point for the local Coven runtime. With no
+arguments it opens the interactive Coven UI; with a free-text task it prepares
+that task for a recorded, project-scoped session. Use an explicit subcommand
+when you need a scriptable or repeatable operation.
+
+## Usage
+
+```sh
+# Open the interactive Coven UI.
+coven
+coven chat
+coven tui
+
+# Describe work in plain language; Coven presents a plan before running it.
+coven "summarize this repository in five bullets"
+
+# Discover the full command inventory and command-specific help.
+coven --help
+coven run --help
+```
+
+`chat` and `tui` are explicit aliases for the no-argument interactive route.
+The UI is powered by the managed Coven engine. The engine is installed or
+updated through `coven engine` rather than by treating it as a library inside
+the Rust CLI.
+
+## Global option
+
+```sh
+coven --color never doctor
+```
+
+`--color auto` is the default and honors `NO_COLOR` and `CLICOLOR_FORCE`.
+Choose `always` or `never` only when a terminal or a captured output path needs
+an explicit ANSI-color policy.
+
+## Choose a path
+
+| Goal | Start with |
+| --- | --- |
+| Check whether the local runtime is usable | `coven doctor` |
+| Control the local daemon | `coven daemon status` |
+| Launch an explicit harness task | `coven run <harness> "<prompt>"` |
+| Browse or manage history | `coven sessions` |
+| Automate a readiness or status check | `coven doctor --json` |
+| Find an end-to-end example | [Workflow guides](/guides) |
+
+The top-level command is not a shortcut around project or permission policy.
+Launches still validate project roots and working directories in the Rust
+authority layer, and harness credentials remain owned by the selected harness.
+
+## Related
+
+- [CLI reference](/reference/cli)
+- [Core access guide](/guides/core-access)
+- [Coven TUI](/start/coven-tui)
+- [Engine contract](/ENGINE-CONTRACT)

--- a/docs/reference/cli-run.md
+++ b/docs/reference/cli-run.md
@@ -20,6 +20,7 @@ coven run <harness> <prompt> [flags]
 |---|---|
 | `--cwd <path>` | Launch from a directory inside the resolved project root. |
 | `--add-dir <path>` | Grant the harness access to an additional directory beyond its cwd; repeat the flag for multiple directories. Maps to each harness's native trust flag (`--add-dir` for codex, claude, copilot, and coven-code). Harnesses with no add-dir mechanism warn and continue. |
+| `--permission <full\|read-only>` | Set the harness sandbox policy. `full` is the default; `read-only` maps to the harness's native sandbox or permission-mode flag. Harnesses without a declared sandbox mechanism warn and continue. |
 | `--title <text>` | Store a readable session title. |
 | `--model <id>` | Forward a model override through the adapter's declared transform. `strip_provider` (the legacy default) removes the first non-empty provider segment when the remainder is non-empty and does not start with `/`; degenerate ids such as `openai//gpt` remain unchanged. `preserve` forwards the provider-qualified id unchanged. Values that are unsafe for process argv after transformation are rejected before launch. |
 | `--think` | Request deeper reasoning. Claude, Coven Code, and Copilot map this to `--effort high`; unsupported harnesses warn and continue. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -214,6 +214,8 @@ Current builds return `0` for success and a non-zero error for failed CLI execut
 ## Related
 
 - [Getting started](/GETTING-STARTED)
+- [Workflow guides](/guides)
+- [Developer core-functionality guide](/development/cli-core-functionality)
 - [Coven TUI](/start/coven-tui)
 - [Session lifecycle](/SESSION-LIFECYCLE)
 - [Harness adapter guide](/HARNESS-ADAPTERS)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -126,7 +126,7 @@ flowchart TB
 
 | Command | Flags |
 |---|---|
-| `coven run` | `--cwd <path>`, `--title <text>`, `--detach`, `--model <id>`, `--think`, `--speed fast\|balanced\|thorough` |
+| `coven run` | `--cwd <path>`, `--title <text>`, `--detach`, `--model <id>`, `--permission <full\|read-only>`, `--think`, `--speed fast\|balanced\|thorough` |
 | `coven doctor` | `--json` |
 | `coven daemon status` | `--json` |
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |

--- a/scripts/cli-docs-test.mjs
+++ b/scripts/cli-docs-test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const coreGuideDocs = [
+  {
+    path: 'docs/development/cli-core-functionality.md',
+    required: ['Command ownership', 'Access contract', 'coven doctor --json', 'coven daemon status --json']
+  },
+  {
+    path: 'docs/guides/index.md',
+    required: ['/guides/core-access', '/guides/session-operations', '/guides/automation-json', '/guides/multi-agent-worktrees', '/guides/troubleshooting-core-access']
+  },
+  {
+    path: 'docs/guides/core-access.md',
+    required: ['coven doctor', 'coven daemon start', 'coven run codex', 'coven sessions']
+  },
+  {
+    path: 'docs/guides/session-operations.md',
+    required: ['coven sessions --plain', 'coven attach', 'coven archive', 'coven sacrifice']
+  },
+  {
+    path: 'docs/guides/automation-json.md',
+    required: ['coven doctor --json', 'coven daemon status --json', 'coven sessions --json']
+  },
+  {
+    path: 'docs/guides/multi-agent-worktrees.md',
+    required: ['coven wt', 'coven claim acquire', 'coven hooks install']
+  },
+  {
+    path: 'docs/guides/troubleshooting-core-access.md',
+    required: ['COVEN_HOME', 'coven daemon status', 'coven doctor']
+  }
+];
+
+function readRepoFile(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+function escaped(phrase) {
+  return phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+test('prepublish smoke runs the CLI docs discovery guard', () => {
+  const prepublish = readRepoFile('scripts/test-cli-prepublish.mjs');
+  assert.match(prepublish, /scripts\/cli-docs-test\.mjs/);
+});
+
+test('core CLI docs are discoverable from the README and guide index', () => {
+  const readme = readRepoFile('README.md');
+  assert.match(readme, /docs\/development\/cli-core-functionality\.md/);
+  assert.match(readme, /docs\/guides\/index\.md/);
+  assert.match(readme, /docs\/reference\/cli-coven\.md/);
+
+  const topLevelCli = readRepoFile('docs/reference/cli-coven.md');
+  assert.doesNotMatch(topLevelCli, /^Stub -- fill in\.?$/m);
+  assert.match(topLevelCli, /## Usage/);
+  assert.match(topLevelCli, /## Related/);
+  assert.match(topLevelCli, /coven chat/);
+
+  for (const { path, required } of coreGuideDocs) {
+    const text = readRepoFile(path);
+    assert.doesNotMatch(text, /^Stub -- fill in\.?$/m, `${path} must not be a stub`);
+    assert.match(text, /## Related/, `${path} must link next steps`);
+    for (const phrase of required) {
+      assert.match(text, new RegExp(escaped(phrase), 'i'), `${path} must mention ${phrase}`);
+    }
+  }
+});

--- a/scripts/cli-docs-test.mjs
+++ b/scripts/cli-docs-test.mjs
@@ -41,6 +41,62 @@ function escaped(phrase) {
   return phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+function assertNotStub(text, path) {
+  assert.doesNotMatch(text, /^Stub\s+(?:--|—)\s+fill in\b/im, `${path} must not be a stub`);
+}
+
+test('CLI docs guard rejects ASCII and em-dash stub markers', () => {
+  for (const stub of ['Stub -- fill in.', 'Stub — fill in. Add the command details here.']) {
+    assert.throws(() => assertNotStub(stub, 'fixture'), /fixture must not be a stub/);
+  }
+});
+
+test('run permission policy is listed in both CLI references', () => {
+  const commandReference = readRepoFile('docs/reference/cli.md');
+  const runReference = readRepoFile('docs/reference/cli-run.md');
+
+  assert.match(commandReference, /--permission <full\\\|read-only>/);
+  assert.match(runReference, /--permission <full\\\|read-only>/);
+});
+
+test('command ownership uses fully-qualified Coven commands', () => {
+  const developerGuide = readRepoFile('docs/development/cli-core-functionality.md');
+
+  for (const command of [
+    'coven attach',
+    'coven archive',
+    'coven summon',
+    'coven sacrifice',
+    'coven kill',
+    'coven status',
+    'coven familiars',
+    'coven skills',
+    'coven memory',
+    'coven research',
+    'coven calls',
+    'coven hub',
+    'coven scheduler',
+    'coven travel',
+    'coven wt',
+    'coven claim',
+    'coven hooks',
+    'coven patch',
+    'coven pc',
+    'coven logs',
+    'coven vacuum'
+  ]) {
+    assert.match(developerGuide, new RegExp(escaped(command)), `command ownership must include ${command}`);
+  }
+});
+
+test('parallel-work guide uses issue-keyed claim tokens', () => {
+  const guide = readRepoFile('docs/guides/multi-agent-worktrees.md');
+
+  for (const action of ['acquire', 'heartbeat', 'release']) {
+    assert.match(guide, new RegExp(`coven claim ${action} issue-<N>`));
+  }
+});
+
 test('prepublish smoke runs the CLI docs discovery guard', () => {
   const prepublish = readRepoFile('scripts/test-cli-prepublish.mjs');
   assert.match(prepublish, /scripts\/cli-docs-test\.mjs/);
@@ -53,14 +109,14 @@ test('core CLI docs are discoverable from the README and guide index', () => {
   assert.match(readme, /docs\/reference\/cli-coven\.md/);
 
   const topLevelCli = readRepoFile('docs/reference/cli-coven.md');
-  assert.doesNotMatch(topLevelCli, /^Stub -- fill in\.?$/m);
+  assertNotStub(topLevelCli, 'docs/reference/cli-coven.md');
   assert.match(topLevelCli, /## Usage/);
   assert.match(topLevelCli, /## Related/);
   assert.match(topLevelCli, /coven chat/);
 
   for (const { path, required } of coreGuideDocs) {
     const text = readRepoFile(path);
-    assert.doesNotMatch(text, /^Stub -- fill in\.?$/m, `${path} must not be a stub`);
+    assertNotStub(text, path);
     assert.match(text, /## Related/, `${path} must link next steps`);
     for (const phrase of required) {
       assert.match(text, new RegExp(escaped(phrase), 'i'), `${path} must mention ${phrase}`);

--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -76,6 +76,37 @@ const platformDocs = [
   }
 ];
 
+const coreGuideDocs = [
+  {
+    path: 'docs/development/cli-core-functionality.md',
+    required: ['Command ownership', 'Access contract', 'coven doctor --json', 'coven daemon status --json']
+  },
+  {
+    path: 'docs/guides/index.md',
+    required: ['/guides/core-access', '/guides/session-operations', '/guides/automation-json', '/guides/multi-agent-worktrees', '/guides/troubleshooting-core-access']
+  },
+  {
+    path: 'docs/guides/core-access.md',
+    required: ['coven doctor', 'coven daemon start', 'coven run codex', 'coven sessions']
+  },
+  {
+    path: 'docs/guides/session-operations.md',
+    required: ['coven sessions --plain', 'coven attach', 'coven archive', 'coven sacrifice']
+  },
+  {
+    path: 'docs/guides/automation-json.md',
+    required: ['coven doctor --json', 'coven daemon status --json', 'coven sessions --json']
+  },
+  {
+    path: 'docs/guides/multi-agent-worktrees.md',
+    required: ['coven wt', 'coven claim acquire', 'coven hooks install']
+  },
+  {
+    path: 'docs/guides/troubleshooting-core-access.md',
+    required: ['COVEN_HOME', 'coven daemon status', 'coven doctor']
+  }
+];
+
 function readRepoFile(path) {
   return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 }
@@ -113,6 +144,28 @@ test('session command reference docs are actionable after onboarding', () => {
     assert.match(text, /## Usage/, `${path} must include usage`);
     assert.match(text, /## Related/, `${path} must link next steps`);
     assert.ok(text.length > 900, `${path} must include practical command guidance`);
+    for (const phrase of required) {
+      assert.match(text, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `${path} must mention ${phrase}`);
+    }
+  }
+});
+
+test('core CLI docs are discoverable from the README and guide index', () => {
+  const readme = readRepoFile('README.md');
+  assert.match(readme, /docs\/development\/cli-core-functionality\.md/);
+  assert.match(readme, /docs\/guides\/index\.md/);
+  assert.match(readme, /docs\/reference\/cli-coven\.md/);
+
+  const topLevelCli = readRepoFile('docs/reference/cli-coven.md');
+  assert.doesNotMatch(topLevelCli, /^Stub -- fill in\.?$/m);
+  assert.match(topLevelCli, /## Usage/);
+  assert.match(topLevelCli, /## Related/);
+  assert.match(topLevelCli, /coven chat/);
+
+  for (const { path, required } of coreGuideDocs) {
+    const text = readRepoFile(path);
+    assert.doesNotMatch(text, /^Stub -- fill in\.?$/m, `${path} must not be a stub`);
+    assert.match(text, /## Related/, `${path} must link next steps`);
     for (const phrase of required) {
       assert.match(text, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `${path} must mention ${phrase}`);
     }

--- a/scripts/onboarding-docs-test.mjs
+++ b/scripts/onboarding-docs-test.mjs
@@ -76,37 +76,6 @@ const platformDocs = [
   }
 ];
 
-const coreGuideDocs = [
-  {
-    path: 'docs/development/cli-core-functionality.md',
-    required: ['Command ownership', 'Access contract', 'coven doctor --json', 'coven daemon status --json']
-  },
-  {
-    path: 'docs/guides/index.md',
-    required: ['/guides/core-access', '/guides/session-operations', '/guides/automation-json', '/guides/multi-agent-worktrees', '/guides/troubleshooting-core-access']
-  },
-  {
-    path: 'docs/guides/core-access.md',
-    required: ['coven doctor', 'coven daemon start', 'coven run codex', 'coven sessions']
-  },
-  {
-    path: 'docs/guides/session-operations.md',
-    required: ['coven sessions --plain', 'coven attach', 'coven archive', 'coven sacrifice']
-  },
-  {
-    path: 'docs/guides/automation-json.md',
-    required: ['coven doctor --json', 'coven daemon status --json', 'coven sessions --json']
-  },
-  {
-    path: 'docs/guides/multi-agent-worktrees.md',
-    required: ['coven wt', 'coven claim acquire', 'coven hooks install']
-  },
-  {
-    path: 'docs/guides/troubleshooting-core-access.md',
-    required: ['COVEN_HOME', 'coven daemon status', 'coven doctor']
-  }
-];
-
 function readRepoFile(path) {
   return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 }
@@ -144,28 +113,6 @@ test('session command reference docs are actionable after onboarding', () => {
     assert.match(text, /## Usage/, `${path} must include usage`);
     assert.match(text, /## Related/, `${path} must link next steps`);
     assert.ok(text.length > 900, `${path} must include practical command guidance`);
-    for (const phrase of required) {
-      assert.match(text, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `${path} must mention ${phrase}`);
-    }
-  }
-});
-
-test('core CLI docs are discoverable from the README and guide index', () => {
-  const readme = readRepoFile('README.md');
-  assert.match(readme, /docs\/development\/cli-core-functionality\.md/);
-  assert.match(readme, /docs\/guides\/index\.md/);
-  assert.match(readme, /docs\/reference\/cli-coven\.md/);
-
-  const topLevelCli = readRepoFile('docs/reference/cli-coven.md');
-  assert.doesNotMatch(topLevelCli, /^Stub -- fill in\.?$/m);
-  assert.match(topLevelCli, /## Usage/);
-  assert.match(topLevelCli, /## Related/);
-  assert.match(topLevelCli, /coven chat/);
-
-  for (const { path, required } of coreGuideDocs) {
-    const text = readRepoFile(path);
-    assert.doesNotMatch(text, /^Stub -- fill in\.?$/m, `${path} must not be a stub`);
-    assert.match(text, /## Related/, `${path} must link next steps`);
     for (const phrase of required) {
       assert.match(text, new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'), `${path} must mention ${phrase}`);
     }

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -115,6 +115,7 @@ step('onboarding, PR readiness, and publish guardrails', () => {
   run('node', [
     '--test',
     'scripts/onboarding-docs-test.mjs',
+    'scripts/cli-docs-test.mjs',
     'scripts/pr-readiness-test.mjs',
     'scripts/publish-npm-test.mjs'
   ]);


### PR DESCRIPTION
## Context

- Summary: Add a developer-owned map of CLI core functionality and task-oriented workflow guides; replace the top-level CLI reference stub and make the full path discoverable from the README and docs home.
- Files changed: README and docs discovery links; a developer CLI guide; five workflow guides; top-level CLI reference; dedicated CLI documentation guard and prepublish wiring; the CLI PEM parser dependency migration required by CI audit.
- Closes #: Not applicable (docs-only improvement).

## Implementation

- Approach: Keep `docs/reference/cli.md` as the canonical flag inventory, add `docs/development/` for source ownership and verification expectations, and add `docs/guides/` for runnable task flows.
- User-visible behavior: Developers can discover the documented core-access, session, JSON automation, parallel-work, and troubleshooting workflows from the README and docs home.
- Compatibility notes: No CLI, daemon, API, package, or runtime behavior changes.
- Security maintenance: Replace archived `rustls-pemfile` with `rustls-pki-types` while preserving the existing one-certificate PEM validation path.

## Verification

- [x] `node --test scripts/onboarding-docs-test.mjs scripts/cli-docs-test.mjs scripts/pr-readiness-test.mjs scripts/publish-npm-test.mjs` (77 passing)
- [x] `python3 scripts/check-coven-privacy.py --range origin/main...HEAD`
- [x] `python scripts/check-secrets.py`
- [x] `git diff --check`
- [x] `node scripts/test-cli-prepublish.mjs --target=macos --skip-build --skip-secrets-scan` (isolated packaged CLI smoke)
- [x] `cargo fmt --check`
- [x] `cargo clippy -p coven-cli --all-targets -- -D warnings`
- [x] `cargo test -p coven-cli --locked` (1,545 unit + 56 integration tests passed; 2 expected ignores)
- [x] `cargo deny check advisories licenses bans sources`

## Risk and Rollback

- Risk level: Low; documentation, structural documentation guard, and a direct dependency migration with preserved parsing behavior.
- Rollback plan: Revert `ca28f7d`, `ae46e33`, `359bf9b`, and `c3f369e`.

## Agent Handoff

- Current state: Draft PR; branch is based on current `origin/main` and all three commits are DCO-signed.
- Follow-ups: Review guide wording and docs-site navigation behavior if the docs-site sync has a separate release path.
- Known gaps: This repository does not contain a standalone docs-site build command; the guide routes follow its existing Markdown route conventions.
