### PR TITLE
fix: recover partial npm publication

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -52,14 +52,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      release_mode: ${{ steps.release-context.outputs.release_mode }}
+      release_tag: ${{ steps.release-context.outputs.release_tag }}
+      npm_version: ${{ steps.release-context.outputs.npm_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6.0.0
         with:
           fetch-depth: 0
+      - name: Derive stable or recovery release context
+        id: release-context
+        run: node scripts/release-npm-context.mjs "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
       - name: Confirm tag is annotated, signer-authorized, and points to main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_RELEASE_ALLOWED_SIGNERS: ${{ vars.NPM_RELEASE_ALLOWED_SIGNERS }}
+          RELEASE_MODE: ${{ steps.release-context.outputs.release_mode }}
+          RELEASE_TAG: ${{ steps.release-context.outputs.release_tag }}
         run: |
           set -euo pipefail
           TAG_NAME="${GITHUB_REF#refs/tags/}"
@@ -111,6 +120,51 @@ jobs:
             echo "::error::Refusing release: tagged commit $TAGGED_COMMIT_SHA is not contained in origin/main."
             exit 1
           fi
+          if [ "$RELEASE_MODE" != "recovery" ]; then
+            exit 0
+          fi
+          if ! BASE_TAG_OBJECT_SHA=$(git rev-parse "$RELEASE_TAG^{tag}" 2>/dev/null); then
+            echo "::error::Base release tag $RELEASE_TAG is missing or is not annotated."
+            exit 1
+          fi
+          BASE_TAG_PAYLOAD=$(gh api "/repos/$GITHUB_REPOSITORY/git/tags/$BASE_TAG_OBJECT_SHA")
+          BASE_VERIFIED=$(jq -r '.verification.verified' <<<"$BASE_TAG_PAYLOAD")
+          BASE_REASON=$(jq -r '.verification.reason' <<<"$BASE_TAG_PAYLOAD")
+          BASE_OBJECT_TYPE=$(jq -r '.object.type // ""' <<<"$BASE_TAG_PAYLOAD")
+          BASE_COMMIT_SHA=$(jq -r '.object.sha // ""' <<<"$BASE_TAG_PAYLOAD")
+          if [ "$BASE_VERIFIED" != "true" ]; then
+            echo "::error::Base release tag $RELEASE_TAG is not GitHub-verified (reason=$BASE_REASON)."
+            exit 1
+          fi
+          if [ "$BASE_OBJECT_TYPE" != "commit" ] || [ -z "$BASE_COMMIT_SHA" ]; then
+            echo "::error::Base release tag $RELEASE_TAG does not target a commit."
+            exit 1
+          fi
+          if ! base_verify_output=$(git verify-tag "$RELEASE_TAG" 2>&1); then
+            printf '%s\n' "$base_verify_output"
+            echo "::error::Base release tag $RELEASE_TAG is not signed by a key in NPM_RELEASE_ALLOWED_SIGNERS."
+            exit 1
+          fi
+          printf '%s\n' "$base_verify_output"
+          if ! git merge-base --is-ancestor "$BASE_COMMIT_SHA" "$TAGGED_COMMIT_SHA"; then
+            echo "::error::Recovery tag $TAG_NAME does not descend from $RELEASE_TAG."
+            exit 1
+          fi
+          while IFS= read -r changed_path; do
+            case "$changed_path" in
+              .github/workflows/release-npm.yml|\
+              scripts/release-npm-context.mjs|\
+              scripts/publish-npm-test.mjs|\
+              docs/reference/releasing.md|\
+              docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md|\
+              docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md)
+                ;;
+              *)
+                echo "::error::Refusing recovery: changed path $changed_path is not release-only."
+                exit 1
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_COMMIT_SHA..$TAGGED_COMMIT_SHA")
 
   build-platform:
     name: Build ${{ matrix.npm-target }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -206,7 +206,7 @@ jobs:
   npm-dry-run:
     name: npm publish dry-run
     runs-on: ubuntu-latest
-    needs: build-platform
+    needs: [build-platform, verify-tag]
     permissions:
       contents: read
     steps:
@@ -230,18 +230,18 @@ jobs:
           path: target/x86_64-pc-windows-msvc/release
       - run: node scripts/publish-npm.mjs --target=macos --skip-build --dry-run
         env:
-          COVEN_NPM_VERSION: ${{ github.ref_name }}
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper
         env:
-          COVEN_NPM_VERSION: ${{ github.ref_name }}
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=windows --skip-build --dry-run --skip-wrapper
         env:
-          COVEN_NPM_VERSION: ${{ github.ref_name }}
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
 
   npm-publish:
     name: npm publish
     runs-on: ubuntu-latest
-    needs: [build-platform, npm-dry-run]
+    needs: [build-platform, npm-dry-run, verify-tag]
     # OIDC trusted publishing: id-token:write lets the job mint a short-lived OIDC token
     # that `npm publish --provenance` exchanges with the npm registry for a one-shot
     # publish credential. No NPM_TOKEN secret is read or written.
@@ -269,19 +269,54 @@ jobs:
           name: coven-windows
           path: target/x86_64-pc-windows-msvc/release
       - name: Refuse placeholder version
+        env:
+          NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME}"
-          if [ "$TAG" = "v0.0.0" ]; then
-            echo "::error::Refusing to publish placeholder version $TAG"
+          if [ "$NPM_VERSION" = "0.0.0" ]; then
+            echo "::error::Refusing to publish placeholder version $NPM_VERSION"
             exit 1
           fi
+      - name: Confirm expected partial npm state
+        if: needs.verify-tag.outputs.release_mode == 'recovery'
+        env:
+          NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+        run: |
+          set -euo pipefail
+          expect_published() {
+            local package_name="$1"
+            local actual
+            actual=$(npm view "$package_name@$NPM_VERSION" version --json | jq -r '.')
+            if [ "$actual" != "$NPM_VERSION" ]; then
+              echo "::error::Expected $package_name@$NPM_VERSION to be published; found ${actual:-missing}."
+              exit 1
+            fi
+          }
+          expect_missing() {
+            local package_name="$1"
+            local output
+            if output=$(npm view "$package_name@$NPM_VERSION" version 2>&1); then
+              echo "::error::Expected $package_name@$NPM_VERSION to be absent before recovery."
+              exit 1
+            fi
+            if ! grep -q 'E404' <<<"$output"; then
+              printf '%s\n' "$output"
+              echo "::error::Could not prove $package_name@$NPM_VERSION is absent."
+              exit 1
+            fi
+          }
+          expect_published @opencoven/cli-linux-x64
+          expect_published @opencoven/cli-windows
+          expect_missing @opencoven/cli-macos
+          expect_missing @opencoven/cli
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper
+        if: needs.verify-tag.outputs.release_mode == 'normal'
         env:
-          COVEN_NPM_VERSION: ${{ github.ref_name }}
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=windows --skip-build --publish --skip-wrapper
+        if: needs.verify-tag.outputs.release_mode == 'normal'
         env:
-          COVEN_NPM_VERSION: ${{ github.ref_name }}
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=macos --skip-build --publish
         env:
-          COVEN_NPM_VERSION: ${{ github.ref_name }}
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -14,7 +14,18 @@ Source package versions stay `0.0.0` in the repo. The published version comes fr
 
 ## One-time setup (per package, per fresh npm publisher)
 
-Before the first OIDC release, configure trusted publishing for every package on npmjs.com. This is a manual web-only step — there is no npm CLI for it today.
+Before the first OIDC release, configure trusted publishing for every package. With npm 11.16 or newer, an authenticated publisher can configure it from the CLI:
+
+```sh
+npm trust github @opencoven/cli --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
+npm trust github @opencoven/cli-macos --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
+npm trust github @opencoven/cli-linux-x64 --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
+npm trust github @opencoven/cli-windows --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
+```
+
+Leave the environment unset. Verify the result with `npm trust list <package>`.
+
+The npm website exposes the same configuration:
 
 For each of `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-linux-x64`, `@opencoven/cli-windows`:
 
@@ -93,7 +104,28 @@ Create or update the matching GitHub Release from the successful workflow artifa
 
 The release body should include the npm install command, published package list, action run URL, tagged commit, and compare link. This GitHub Release is the public binary/checksum surface; npm provenance remains the package-integrity surface.
 
-If any package did not publish, do not re-tag with the same version (npm forbids overwrite). Inspect the failed job, fix the underlying cause, then push a new patch-bumped signed tag.
+If publishing stopped after Linux and Windows succeeded but before macOS and the wrapper published, use the narrowly-scoped recovery procedure below. For every other partial state, inspect the failure, fix the cause, and push a new patch-bumped signed tag.
+
+### Recover a partial npm publication
+
+The recovery path exists for one exact registry state:
+
+- `@opencoven/cli-linux-x64@X.Y.Z` and `@opencoven/cli-windows@X.Y.Z` already exist.
+- `@opencoven/cli-macos@X.Y.Z` and `@opencoven/cli@X.Y.Z` do not exist.
+
+Fix the trusted-publisher configuration and land the release-only workflow repair on `main`. Then create a **new signed recovery tag** whose commit descends from the original release. The workflow requires that the original release tag is an ancestor and that every intervening changed path is on its release-only allowlist.
+
+```sh
+git fetch origin main --tags
+git checkout main
+git pull --ff-only origin main
+git tag -s vX.Y.Z-recovery.N -m "Recover partial vX.Y.Z npm publication"
+git push origin vX.Y.Z-recovery.N
+```
+
+Never move or reuse the original release tag or a recovery tag. Increment `N` if a later, separately-reviewed recovery attempt is required.
+
+Before publishing, the recovery workflow verifies both signed tags, ancestry, the changed-path allowlist, and the exact npm registry state above. It then skips the already-published Linux and Windows packages and publishes macOS followed by the wrapper through OIDC with provenance.
 
 ## Recovering from a refused release
 

--- a/docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md
@@ -1,0 +1,451 @@
+# Signed-Tag Partial npm Release Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover a partially published npm release through the existing OIDC-trusted workflow without overwriting published versions, weakening signed-tag gates, or losing provenance.
+
+**Architecture:** Add one small release-context parser for stable and recovery tags, then make `.github/workflows/release-npm.yml` consume its outputs. Recovery tags re-verify both the recovery tag and base release tag, allow only operational release-file changes, assert the expected partial npm state, and publish only macOS plus the wrapper.
+
+**Tech Stack:** Node.js 24, `node:test`, GitHub Actions YAML, Bash, npm trusted publishing over GitHub OIDC.
+
+---
+
+## File Map
+
+- Create `scripts/release-npm-context.mjs`: parse stable/recovery tags and emit injection-safe GitHub Actions outputs.
+- Modify `scripts/publish-npm-test.mjs`: unit-test tag parsing and lock the workflow's recovery security contract.
+- Modify `.github/workflows/release-npm.yml`: verify recovery lineage/path safety, assert registry state, and conditionally publish missing packages.
+- Modify `docs/reference/releasing.md`: document when and how a signed recovery tag may be used.
+
+### Task 1: Lock the release-tag context contract
+
+**Files:**
+- Create: `scripts/release-npm-context.mjs`
+- Modify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Add failing parser tests**
+
+Import `parseReleaseTag` from the new module and add these tests to `scripts/publish-npm-test.mjs`:
+
+```js
+test('parseReleaseTag preserves stable releases', () => {
+  assert.deepEqual(parseReleaseTag('v0.2.3'), {
+    releaseMode: 'normal',
+    releaseTag: 'v0.2.3',
+    npmVersion: '0.2.3',
+    recoveryAttempt: null
+  });
+});
+
+test('parseReleaseTag derives the base version from signed recovery tags', () => {
+  assert.deepEqual(parseReleaseTag('v0.2.3-recovery.1'), {
+    releaseMode: 'recovery',
+    releaseTag: 'v0.2.3',
+    npmVersion: '0.2.3',
+    recoveryAttempt: 1
+  });
+});
+
+test('parseReleaseTag rejects malformed and unrelated prerelease tags', () => {
+  for (const tag of ['v0.2', 'v0.2.3-rc.1', 'v0.2.3-recovery.0', 'v01.2.3', 'recovery-v0.2.3']) {
+    assert.throws(() => parseReleaseTag(tag), /stable vX.Y.Z tag or vX.Y.Z-recovery.N/);
+  }
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm RED**
+
+Run:
+
+```bash
+node --test scripts/publish-npm-test.mjs
+```
+
+Expected: FAIL because `scripts/release-npm-context.mjs` or `parseReleaseTag` does not exist.
+
+- [ ] **Step 3: Implement the minimal parser and CLI output**
+
+Create `scripts/release-npm-context.mjs` with:
+
+```js
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+const VERSION = '(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)';
+const STABLE_TAG = new RegExp(`^v(${VERSION})$`);
+const RECOVERY_TAG = new RegExp(`^v(${VERSION})-recovery\\.([1-9]\\d*)$`);
+
+export function parseReleaseTag(tag) {
+  const stable = STABLE_TAG.exec(tag);
+  if (stable) {
+    return {
+      releaseMode: 'normal',
+      releaseTag: tag,
+      npmVersion: stable[1],
+      recoveryAttempt: null
+    };
+  }
+
+  const recovery = RECOVERY_TAG.exec(tag);
+  if (recovery) {
+    return {
+      releaseMode: 'recovery',
+      releaseTag: `v${recovery[1]}`,
+      npmVersion: recovery[1],
+      recoveryAttempt: Number.parseInt(recovery[5], 10)
+    };
+  }
+
+  throw new Error(`Release tag ${JSON.stringify(tag)} must be a stable vX.Y.Z tag or vX.Y.Z-recovery.N tag.`);
+}
+
+function isMainModule(argv1 = process.argv[1], moduleUrl = import.meta.url) {
+  return Boolean(argv1) && moduleUrl === pathToFileURL(argv1).href;
+}
+
+if (isMainModule()) {
+  const context = parseReleaseTag(process.argv[2] ?? '');
+  process.stdout.write([
+    `release_mode=${context.releaseMode}`,
+    `release_tag=${context.releaseTag}`,
+    `npm_version=${context.npmVersion}`,
+    `recovery_attempt=${context.recoveryAttempt ?? ''}`,
+    ''
+  ].join('\n'));
+}
+```
+
+- [ ] **Step 4: Run focused tests and confirm GREEN**
+
+Run:
+
+```bash
+node --test scripts/publish-npm-test.mjs
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the parser contract**
+
+```bash
+git add scripts/release-npm-context.mjs scripts/publish-npm-test.mjs
+git commit -s -m "test: define npm recovery tag context"
+```
+
+### Task 2: Verify recovery tags and inert recovery changes
+
+**Files:**
+- Modify: `.github/workflows/release-npm.yml`
+- Modify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Add failing workflow-contract assertions**
+
+Add a test that requires:
+
+```js
+test('release workflow fail-closes signed recovery tags', () => {
+  const workflow = readFileSync(
+    new URL(['..', '.github', 'workflows', 'release-npm.yml'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(workflow, /node scripts\/release-npm-context\.mjs "\$GITHUB_REF_NAME"/);
+  assert.match(workflow, /outputs:[\s\S]*release_mode:[\s\S]*release_tag:[\s\S]*npm_version:/);
+  assert.match(workflow, /git verify-tag "\$RELEASE_TAG"/);
+  assert.match(workflow, /git merge-base --is-ancestor "\$BASE_COMMIT_SHA" "\$TAGGED_COMMIT_SHA"/);
+  assert.match(workflow, /git diff --name-only "\$BASE_COMMIT_SHA\.\.\$TAGGED_COMMIT_SHA"/);
+  assert.match(workflow, /Refusing recovery: changed path/);
+});
+```
+
+- [ ] **Step 2: Run the focused tests and confirm RED**
+
+Run `node --test scripts/publish-npm-test.mjs`.
+
+Expected: FAIL because the workflow does not expose release context or recovery validation.
+
+- [ ] **Step 3: Add release-context outputs and dual tag verification**
+
+In `verify-tag`, add job outputs sourced from a `release-context` step:
+
+```yaml
+outputs:
+  release_mode: ${{ steps.release-context.outputs.release_mode }}
+  release_tag: ${{ steps.release-context.outputs.release_tag }}
+  npm_version: ${{ steps.release-context.outputs.npm_version }}
+```
+
+The `release-context` step runs:
+
+```yaml
+- name: Derive stable or recovery release context
+  id: release-context
+  run: node scripts/release-npm-context.mjs "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+```
+
+Refactor the existing signed-tag shell block so it verifies the pushed tag exactly as today. When `release_mode` is `recovery`, also:
+
+```bash
+git verify-tag "$RELEASE_TAG"
+BASE_TAG_OBJECT_SHA=$(git rev-parse "$RELEASE_TAG^{tag}")
+BASE_TAG_PAYLOAD=$(gh api "/repos/$GITHUB_REPOSITORY/git/tags/$BASE_TAG_OBJECT_SHA")
+BASE_VERIFIED=$(jq -r '.verification.verified' <<<"$BASE_TAG_PAYLOAD")
+BASE_OBJECT_TYPE=$(jq -r '.object.type // ""' <<<"$BASE_TAG_PAYLOAD")
+BASE_COMMIT_SHA=$(jq -r '.object.sha // ""' <<<"$BASE_TAG_PAYLOAD")
+if [ "$BASE_VERIFIED" != "true" ]; then
+  echo "::error::Base release tag $RELEASE_TAG is not GitHub-verified."
+  exit 1
+fi
+if [ "$BASE_OBJECT_TYPE" != "commit" ] || [ -z "$BASE_COMMIT_SHA" ]; then
+  echo "::error::Base release tag $RELEASE_TAG does not target a commit."
+  exit 1
+fi
+if ! git merge-base --is-ancestor "$BASE_COMMIT_SHA" "$TAGGED_COMMIT_SHA"; then
+  echo "::error::Recovery tag $TAG_NAME does not descend from $RELEASE_TAG."
+  exit 1
+fi
+```
+
+Allow only these changed paths after the base tag:
+
+```bash
+while IFS= read -r changed_path; do
+  case "$changed_path" in
+    .github/workflows/release-npm.yml|\
+    scripts/release-npm-context.mjs|\
+    scripts/publish-npm-test.mjs|\
+    docs/reference/releasing.md|\
+    docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md|\
+    docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md)
+      ;;
+    *)
+      echo "::error::Refusing recovery: changed path $changed_path is not release-only."
+      exit 1
+      ;;
+  esac
+done < <(git diff --name-only "$BASE_COMMIT_SHA..$TAGGED_COMMIT_SHA")
+```
+
+- [ ] **Step 4: Run focused tests and confirm GREEN**
+
+Run `node --test scripts/publish-npm-test.mjs`.
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit signed recovery verification**
+
+```bash
+git add .github/workflows/release-npm.yml scripts/publish-npm-test.mjs
+git commit -s -m "feat: verify signed npm recovery tags"
+```
+
+### Task 3: Publish only the missing packages
+
+**Files:**
+- Modify: `.github/workflows/release-npm.yml`
+- Modify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Add failing publication-routing tests**
+
+Add assertions requiring `npm-dry-run` and `npm-publish` to depend on `verify-tag`, use `needs.verify-tag.outputs.npm_version`, verify the four-package partial state in recovery mode, and gate Linux/Windows publish steps with:
+
+```yaml
+if: needs.verify-tag.outputs.release_mode == 'normal'
+```
+
+Require the macOS publish step to remain ungated so it runs in both modes.
+
+- [ ] **Step 2: Run focused tests and confirm RED**
+
+Run `node --test scripts/publish-npm-test.mjs`.
+
+Expected: FAIL because publication still uses `github.ref_name` and always attempts Linux/Windows.
+
+- [ ] **Step 3: Thread verified context into publish jobs**
+
+Change job dependencies to:
+
+```yaml
+npm-dry-run:
+  needs: [build-platform, verify-tag]
+
+npm-publish:
+  needs: [build-platform, npm-dry-run, verify-tag]
+```
+
+Set every `COVEN_NPM_VERSION` to `${{ needs.verify-tag.outputs.npm_version }}`.
+
+Before publishing, add this recovery-only registry check:
+
+```yaml
+- name: Confirm expected partial npm state
+  if: needs.verify-tag.outputs.release_mode == 'recovery'
+  env:
+    NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+  run: |
+    set -euo pipefail
+    expect_published() {
+      local package_name="$1"
+      local actual
+      actual=$(npm view "$package_name@$NPM_VERSION" version --json | jq -r '.')
+      if [ "$actual" != "$NPM_VERSION" ]; then
+        echo "::error::Expected $package_name@$NPM_VERSION to be published; found ${actual:-missing}."
+        exit 1
+      fi
+    }
+    expect_missing() {
+      local package_name="$1"
+      local output
+      if output=$(npm view "$package_name@$NPM_VERSION" version 2>&1); then
+        echo "::error::Expected $package_name@$NPM_VERSION to be absent before recovery."
+        exit 1
+      fi
+      if ! grep -q 'E404' <<<"$output"; then
+        printf '%s\n' "$output"
+        echo "::error::Could not prove $package_name@$NPM_VERSION is absent."
+        exit 1
+      fi
+    }
+    expect_published @opencoven/cli-linux-x64
+    expect_published @opencoven/cli-windows
+    expect_missing @opencoven/cli-macos
+    expect_missing @opencoven/cli
+```
+
+Gate the Linux and Windows real-publish steps to normal mode. Leave the macOS command unchanged except for the verified version output; it publishes macOS and then the wrapper.
+
+- [ ] **Step 4: Run focused tests and confirm GREEN**
+
+Run `node --test scripts/publish-npm-test.mjs`.
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit recovery publication routing**
+
+```bash
+git add .github/workflows/release-npm.yml scripts/publish-npm-test.mjs
+git commit -s -m "fix: recover partial npm publication"
+```
+
+### Task 4: Document the operator path
+
+**Files:**
+- Modify: `docs/reference/releasing.md`
+- Modify: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Add a failing docs contract**
+
+Require the releasing guide to include `vX.Y.Z-recovery.N`, state that the recovery tag must be newly signed and descend from the original tag, forbid moving tags, and require an already-partial Linux/Windows-present plus macOS/wrapper-missing registry state.
+
+- [ ] **Step 2: Run focused tests and confirm RED**
+
+Run `node --test scripts/publish-npm-test.mjs`.
+
+Expected: FAIL because the recovery runbook is absent.
+
+- [ ] **Step 3: Add the concise recovery runbook**
+
+Document this exact operator sequence:
+
+```bash
+git fetch origin main --tags
+git switch main
+git pull --ff-only origin main
+git config gpg.format ssh
+git tag -s vX.Y.Z-recovery.N -m "Recover partial vX.Y.Z npm publication"
+git push origin vX.Y.Z-recovery.N
+```
+
+State that this is permitted only when the original signed release is partial in the exact supported package pattern and that the workflow rejects product-code drift or an unexpected registry state.
+
+- [ ] **Step 4: Run docs and release tests**
+
+Run:
+
+```bash
+node --test scripts/publish-npm-test.mjs
+node --test scripts/onboarding-docs-test.mjs
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit the runbook**
+
+```bash
+git add docs/reference/releasing.md scripts/publish-npm-test.mjs
+git commit -s -m "docs: add partial npm recovery runbook"
+```
+
+### Task 5: Verify and deliver the patch
+
+**Files:**
+- Verify all files changed by Tasks 1-4.
+
+- [ ] **Step 1: Run release-facing tests**
+
+```bash
+node --test scripts/publish-npm-test.mjs
+node --test scripts/onboarding-docs-test.mjs
+node scripts/test-cli-prepublish.mjs
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Run repository-required gates**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --staged
+git diff --check
+```
+
+Expected: all pass with zero warnings or findings.
+
+- [ ] **Step 3: Review branch scope**
+
+```bash
+git status --short --branch
+git diff --stat origin/main...HEAD
+git log --show-signature --oneline origin/main..HEAD
+```
+
+Expected: only the design, plan, release workflow, helper, focused test, and releasing guide are changed; every commit is signed off.
+
+- [ ] **Step 4: Push and open the PR**
+
+Push `fix/release-partial-publish-recovery`, open a scoped PR with the verification matrix and rollback notes, and wait for all required checks and review threads.
+
+- [ ] **Step 5: Merge only after fresh green proof**
+
+Squash-merge with an explicit conventional subject and signed-off body. Verify `origin/main` contains the merge and the PR is `MERGED`.
+
+### Task 6: Execute and prove the recovery release
+
+**Files:**
+- Use staged assets under `/private/tmp/coven-v0.2.3-release.uGaJJ2/out/`.
+
+- [ ] **Step 1: Recheck the exact npm partial state**
+
+Verify Linux/Windows are `0.2.3` and wrapper/macOS are still absent at `0.2.3`.
+
+- [ ] **Step 2: Create the immutable signed recovery tag**
+
+From fresh `origin/main`, create and locally verify `v0.2.3-recovery.1`, then push it once. Never move or reuse it.
+
+- [ ] **Step 3: Wait for the complete release workflow**
+
+Watch the new `Release npm packages` run to terminal success. Verify the publish job skipped Linux/Windows, passed the partial-state gate, and published macOS plus wrapper with provenance.
+
+- [ ] **Step 4: Verify the public npm surface**
+
+Confirm `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-linux-x64`, and `@opencoven/cli-windows` all report version/dist-tag `0.2.3`, and inspect provenance for the two recovered packages.
+
+- [ ] **Step 5: Create and verify the GitHub Release**
+
+Create `Coven v0.2.3` at the original `v0.2.3` tag with the three native archives and `SHA256SUMS`. Include both the original failed workflow and successful recovery workflow as evidence, then verify asset names, sizes, digests, and public URLs.
+
+- [ ] **Step 6: Release coordination state and clean up**
+
+Release `release-v0.2.3`, remove the task worktree/branch after merge, and verify the canonical checkout remains clean and synchronized.

--- a/docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md
@@ -1,0 +1,74 @@
+# Signed-Tag Partial npm Release Recovery
+
+## Context
+
+The signed `v0.2.3` release passed every source, test, tag, and native build gate, then partially published. npm accepted `@opencoven/cli-linux-x64@0.2.3` and `@opencoven/cli-windows@0.2.3`, but rejected `@opencoven/cli-macos@0.2.3` because that package's trusted publisher was incorrectly constrained to a nonexistent environment. The wrapper `@opencoven/cli@0.2.3` was never attempted because the macOS publish failed first.
+
+The trusted-publisher configuration is now corrected. Re-running the original job is still unsafe: `scripts/publish-npm.mjs` deliberately refuses to overwrite an existing package version, so the job would stop on Linux before reaching the missing packages. Publishing locally would complete the registry versions without GitHub OIDC provenance and would violate the repository's release contract.
+
+## Decision
+
+Extend the existing `.github/workflows/release-npm.yml` with a signed-tag-only recovery mode. A tag named `v<version>-recovery.<attempt>` runs through the same trusted workflow filename and publishes the base `<version>`, but only after proving that the recovery commit is an operational descendant of the original signed release tag.
+
+For this incident, the recovery tag will be `v0.2.3-recovery.1` and the npm target version will remain `0.2.3`.
+
+No `workflow_dispatch`, repository secret, long-lived npm token, version overwrite, or unsigned entry point is introduced.
+
+## Safety Contract
+
+The workflow must fail closed unless all of these conditions hold:
+
+1. The pushed tag is either a normal stable release tag (`vX.Y.Z`) or a recovery tag (`vX.Y.Z-recovery.N`).
+2. The pushed tag is annotated, GitHub-verified, locally verifiable against `NPM_RELEASE_ALLOWED_SIGNERS`, and points to a commit contained in `origin/main`.
+3. For recovery mode, the base `vX.Y.Z` tag exists and independently passes the same annotated/signature/authorized-signer checks.
+4. The base tagged commit is an ancestor of the recovery commit.
+5. Every path changed after the base tag is operationally inert for the produced package: the release workflow, its focused tests, and this design/implementation documentation. Rust sources, npm package templates, lockfiles, build configuration, and dependencies are forbidden.
+6. The expected partial registry state is present before publishing: Linux x64 and Windows already have the base version, while macOS and the wrapper do not.
+7. Recovery mode skips Linux and Windows publication and invokes the existing macOS target once. That target publishes the macOS package first and the wrapper second.
+8. If either missing package appears before the recovery publish begins, the existing publish script refuses to continue rather than trusting an unknown artifact.
+
+## Workflow Shape
+
+A preflight step derives these values from `GITHUB_REF_NAME`:
+
+- `release_mode`: `normal` or `recovery`
+- `release_tag`: the stable base tag, such as `v0.2.3`
+- `npm_version`: the base version, such as `0.2.3`
+
+The values are emitted as job outputs and consumed by dry-run and publish jobs instead of using `github.ref_name` directly.
+
+Normal mode preserves the current sequence: Linux x64, Windows, then macOS plus wrapper. Recovery mode runs the same release and tag gates, builds the platform artifacts, checks the expected partial npm state, and runs only macOS plus wrapper with `COVEN_NPM_VERSION` set to the base release tag.
+
+The recovery commit is intentionally the provenance source. It contains no product-code changes relative to the base tag, and the workflow records both the original release tag and recovery tag in its evidence.
+
+## Failure Handling
+
+- Malformed recovery tags fail before builds or registry access.
+- Missing, lightweight, unverified, unauthorized, unrelated, or non-main tags fail before publication.
+- A changed path outside the recovery allowlist fails with the exact offending path.
+- Unexpected npm state fails before `npm publish`.
+- Existing package versions continue to fail closed inside `scripts/publish-npm.mjs`.
+- A failed recovery requires a new incremented signed recovery tag; recovery tags are never moved or reused.
+
+## Verification
+
+Focused tests must cover:
+
+- normal stable-tag parsing and unchanged normal publish ordering;
+- recovery-tag parsing and base-version derivation;
+- rejection of malformed or prerelease-like tags that are not recovery tags;
+- signed base-tag and ancestry checks represented in the workflow contract;
+- recovery path allowlisting;
+- exact expected npm-state checks;
+- recovery mode skipping Linux and Windows while publishing macOS plus wrapper;
+- continued absence of `workflow_dispatch` and long-lived npm credentials.
+
+Before the PR is opened, run the repository release-facing tests plus all required Rust, secret, privacy, and diff gates. After merge, create and verify the signed recovery tag, wait for the complete GitHub Actions run, verify all four npm packages report `0.2.3` with provenance, then create the `v0.2.3` GitHub Release with the already-built native archives and `SHA256SUMS`.
+
+## Non-Goals
+
+- General retry of arbitrary release steps.
+- Overwriting, unpublishing, or trusting pre-existing npm versions.
+- Adding manual or token-authenticated publication.
+- Changing runtime, CLI, npm wrapper, or native binary behavior.
+- Retargeting either the original release tag or a recovery tag.

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -801,6 +801,21 @@ test('release workflow concurrency keeps overlapping releases from interleaving'
   assert.match(workflow, /cancel-in-progress:\s*false/);
 });
 
+test('releasing guide documents signed partial-publish recovery', () => {
+  const guide = readFileSync(
+    new URL(['..', 'docs', 'reference', 'releasing.md'].join('/'), import.meta.url),
+    'utf8'
+  );
+
+  assert.match(guide, /vX\.Y\.Z-recovery\.N/);
+  assert.match(guide, /new signed recovery tag/i);
+  assert.match(guide, /original release tag is an ancestor/i);
+  assert.match(guide, /never move or reuse/i);
+  assert.match(guide, /@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows/);
+  assert.match(guide, /@opencoven\/cli-macos[\s\S]*@opencoven\/cli/);
+  assert.match(guide, /npm trust github/);
+});
+
 test('secret guard unit tests run in local and tag-driven release gates', () => {
   const prepublish = readFileSync(
     new URL('test-cli-prepublish.mjs', import.meta.url),

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -707,6 +707,56 @@ test('release workflow fail-closes signed recovery tags', () => {
   );
 });
 
+test('release workflow publishes only missing packages during recovery', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const publish = workflow.slice(workflow.indexOf('  npm-publish:'));
+
+  assert.match(workflow, /npm-dry-run:[\s\S]*?needs: \[build-platform, verify-tag\]/);
+  assert.match(
+    publish,
+    /needs: \[build-platform, npm-dry-run, verify-tag\]/,
+    'publish job must consume verified release context'
+  );
+  assert.match(
+    publish,
+    /name: Confirm expected partial npm state[\s\S]*@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows[\s\S]*@opencoven\/cli-macos[\s\S]*@opencoven\/cli/,
+    'recovery must prove the exact two-published, two-missing package state'
+  );
+  assert.match(
+    publish,
+    /Could not prove \$package_name@\$NPM_VERSION is absent/,
+    'registry errors other than E404 must fail closed'
+  );
+  assert.match(
+    publish,
+    /--target=linux-x64 --skip-build --publish --skip-wrapper\s*\n\s*if: needs\.verify-tag\.outputs\.release_mode == 'normal'/,
+    'Linux publication must run only for normal releases'
+  );
+  assert.match(
+    publish,
+    /--target=windows --skip-build --publish --skip-wrapper\s*\n\s*if: needs\.verify-tag\.outputs\.release_mode == 'normal'/,
+    'Windows publication must run only for normal releases'
+  );
+  assert.match(
+    publish,
+    /--target=macos --skip-build --publish\s*\n\s*env:/,
+    'macOS plus wrapper publication must run in normal and recovery modes'
+  );
+  assert.doesNotMatch(
+    workflow,
+    /COVEN_NPM_VERSION: \$\{\{ github\.ref_name \}\}/,
+    'publication must use the base npm version derived from verified tag context'
+  );
+  assert.match(
+    workflow,
+    /COVEN_NPM_VERSION: \$\{\{ needs\.verify-tag\.outputs\.npm_version \}\}/
+  );
+});
+
 test('release workflow triggers only on signed v* tag pushes (no workflow_dispatch fallback)', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -18,11 +18,45 @@ import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { defaultTargetName, isMainModule, isOidcContext, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
+import { parseReleaseTag } from './release-npm-context.mjs';
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
   ACTIONS_ID_TOKEN_REQUEST_URL: 'https://token.actions.githubusercontent.com/'
 };
+
+test('parseReleaseTag preserves stable releases', () => {
+  assert.deepEqual(parseReleaseTag('v0.2.3'), {
+    releaseMode: 'normal',
+    releaseTag: 'v0.2.3',
+    npmVersion: '0.2.3',
+    recoveryAttempt: null
+  });
+});
+
+test('parseReleaseTag derives the base version from signed recovery tags', () => {
+  assert.deepEqual(parseReleaseTag('v0.2.3-recovery.1'), {
+    releaseMode: 'recovery',
+    releaseTag: 'v0.2.3',
+    npmVersion: '0.2.3',
+    recoveryAttempt: 1
+  });
+});
+
+test('parseReleaseTag rejects malformed and unrelated prerelease tags', () => {
+  for (const tag of [
+    'v0.2',
+    'v0.2.3-rc.1',
+    'v0.2.3-recovery.0',
+    'v01.2.3',
+    'recovery-v0.2.3'
+  ]) {
+    assert.throws(
+      () => parseReleaseTag(tag),
+      /stable vX.Y.Z tag or vX.Y.Z-recovery.N/
+    );
+  }
+});
 
 const SIGNAL_TEST_PACKAGES = {
   'darwin-arm64': ['@opencoven/cli-macos', 'coven'],

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -658,6 +658,55 @@ test('release workflow verifies the signed release tag before building or publis
   );
 });
 
+test('release workflow fail-closes signed recovery tags', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+
+  assert.match(
+    workflow,
+    /node scripts\/release-npm-context\.mjs "\$GITHUB_REF_NAME"/,
+    'workflow must derive stable release context from the pushed signed tag'
+  );
+  assert.match(
+    workflow,
+    /outputs:[\s\S]*release_mode:[\s\S]*release_tag:[\s\S]*npm_version:/,
+    'verify-tag must expose validated release context to downstream jobs'
+  );
+  assert.match(
+    workflow,
+    /git verify-tag "\$RELEASE_TAG"/,
+    'recovery must locally verify the original stable release tag'
+  );
+  assert.match(
+    workflow,
+    /BASE_TAG_PAYLOAD=.*gh api/,
+    'recovery must query GitHub verification for the original release tag'
+  );
+  assert.match(
+    workflow,
+    /BASE_OBJECT_TYPE.*commit/s,
+    'recovery must reject a base tag that does not target a commit'
+  );
+  assert.match(
+    workflow,
+    /git merge-base --is-ancestor "\$BASE_COMMIT_SHA" "\$TAGGED_COMMIT_SHA"/,
+    'recovery tag must descend from the stable release tag'
+  );
+  assert.match(
+    workflow,
+    /git diff --name-only "\$BASE_COMMIT_SHA\.\.\$TAGGED_COMMIT_SHA"/,
+    'recovery must inspect every changed path after the stable release'
+  );
+  assert.match(
+    workflow,
+    /Refusing recovery: changed path/,
+    'recovery must fail closed on product or package drift'
+  );
+});
+
 test('release workflow triggers only on signed v* tag pushes (no workflow_dispatch fallback)', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),

--- a/scripts/release-npm-context.mjs
+++ b/scripts/release-npm-context.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const VERSION = '(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)';
+const STABLE_TAG = new RegExp(`^v(${VERSION})$`);
+const RECOVERY_TAG = new RegExp(`^v(${VERSION})-recovery\\.([1-9]\\d*)$`);
+
+export function parseReleaseTag(tag) {
+  const stable = STABLE_TAG.exec(tag);
+  if (stable) {
+    return {
+      releaseMode: 'normal',
+      releaseTag: tag,
+      npmVersion: stable[1],
+      recoveryAttempt: null
+    };
+  }
+
+  const recovery = RECOVERY_TAG.exec(tag);
+  if (recovery) {
+    return {
+      releaseMode: 'recovery',
+      releaseTag: `v${recovery[1]}`,
+      npmVersion: recovery[1],
+      recoveryAttempt: Number.parseInt(recovery[5], 10)
+    };
+  }
+
+  throw new Error(
+    `Release tag ${JSON.stringify(tag)} must be a stable vX.Y.Z tag or vX.Y.Z-recovery.N tag.`
+  );
+}
+
+function isMainModule(argv1 = process.argv[1], moduleUrl = import.meta.url) {
+  return Boolean(argv1) && moduleUrl === pathToFileURL(argv1).href;
+}
+
+if (isMainModule()) {
+  const context = parseReleaseTag(process.argv[2] ?? '');
+  process.stdout.write(
+    [
+      `release_mode=${context.releaseMode}`,
+      `release_tag=${context.releaseTag}`,
+      `npm_version=${context.npmVersion}`,
+      `recovery_attempt=${context.recoveryAttempt ?? ''}`,
+      ''
+    ].join('\n')
+  );
+}


### PR DESCRIPTION
## Context

- Summary: add a signed-tag-only recovery path for the partially published npm 0.2.3 release.
- Files changed: release workflow, release-tag parser, focused contracts, operator runbook, approved design and implementation plan.
- Closes: none; release incident recovery.

## Implementation

- Approach: accept only `vX.Y.Z-recovery.N` tags, independently verify the recovery and base tags, require main ancestry and a release-only path allowlist, then prove the exact registry state before publishing.
- User-visible behavior: normal releases are unchanged; the supported recovery skips existing Linux/Windows packages and publishes missing macOS/wrapper packages through the existing OIDC workflow with provenance.
- Compatibility notes: no product, package-template, lockfile, dependency, token, or manual-dispatch changes.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node --test scripts/publish-npm-test.mjs` (57 passed)
- [x] `node --test scripts/onboarding-docs-test.mjs` (13 passed)
- [x] `node scripts/test-cli-prepublish.mjs` (all 5 checks passed, including pack/install/daemon lifecycle)
- [x] `git diff --check`

## Risk and Rollback

- Risk level: medium; release-control code, fail-closed and limited to one proven partial state.
- Rollback plan: revert this PR before any recovery tag is created. After a recovery tag publishes immutable npm versions, preserve the tag and revert only the reusable recovery path if desired.

## Agent Handoff

- Current state: locally verified and ready for CI/review.
- Follow-ups: after merge, verify npm trusted publishers for macOS and wrapper, create signed `v0.2.3-recovery.1`, wait for the workflow, verify all four packages at 0.2.3 with provenance, then publish the GitHub Release assets.
- Known gaps: no open product-code gaps; the first local prepublish attempt exceeded its 120s child timeout on a cold 208.77s release build, and the unchanged warm rerun passed.
