### PR TITLE
fix: skip published packages in recovery dry-run

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -232,9 +232,11 @@ jobs:
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper
+        if: needs.verify-tag.outputs.release_mode == 'normal'
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=windows --skip-build --dry-run --skip-wrapper
+        if: needs.verify-tag.outputs.release_mode == 'normal'
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
 

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -713,6 +713,10 @@ test('release workflow publishes only missing packages during recovery', () => {
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
+  const dryRun = workflow.slice(
+    workflow.indexOf('  npm-dry-run:'),
+    workflow.indexOf('  npm-publish:')
+  );
   const publish = workflow.slice(workflow.indexOf('  npm-publish:'));
 
   assert.match(workflow, /npm-dry-run:[\s\S]*?needs: \[build-platform, verify-tag\]/);
@@ -730,6 +734,21 @@ test('release workflow publishes only missing packages during recovery', () => {
     publish,
     /Could not prove \$package_name@\$NPM_VERSION is absent/,
     'registry errors other than E404 must fail closed'
+  );
+  assert.match(
+    dryRun,
+    /--target=linux-x64 --skip-build --dry-run --skip-wrapper\s*\n\s*if: needs\.verify-tag\.outputs\.release_mode == 'normal'/,
+    'Linux dry-run must skip an already-published version during recovery'
+  );
+  assert.match(
+    dryRun,
+    /--target=windows --skip-build --dry-run --skip-wrapper\s*\n\s*if: needs\.verify-tag\.outputs\.release_mode == 'normal'/,
+    'Windows dry-run must skip an already-published version during recovery'
+  );
+  assert.match(
+    dryRun,
+    /--target=macos --skip-build --dry-run\s*\n\s*env:/,
+    'macOS plus wrapper dry-run must run in normal and recovery modes'
   );
   assert.match(
     publish,

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -713,11 +713,13 @@ test('release workflow publishes only missing packages during recovery', () => {
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
-  const dryRun = workflow.slice(
-    workflow.indexOf('  npm-dry-run:'),
-    workflow.indexOf('  npm-publish:')
-  );
-  const publish = workflow.slice(workflow.indexOf('  npm-publish:'));
+  const dryRunStart = workflow.indexOf('  npm-dry-run:');
+  const publishStart = workflow.indexOf('  npm-publish:');
+  assert.ok(dryRunStart !== -1, 'npm-dry-run job must exist in release workflow');
+  assert.ok(publishStart !== -1, 'npm-publish job must exist in release workflow');
+  assert.ok(dryRunStart < publishStart, 'npm-dry-run must appear before npm-publish in release workflow');
+  const dryRun = workflow.slice(dryRunStart, publishStart);
+  const publish = workflow.slice(publishStart);
 
   assert.match(workflow, /npm-dry-run:[\s\S]*?needs: \[build-platform, verify-tag\]/);
   assert.match(


### PR DESCRIPTION
## Context

- Summary: make recovery dry-run skip the same already-published Linux/Windows versions that real recovery publish skips.
- Evidence: recovery attempt [30689020272](https://github.com/OpenCoven/coven/actions/runs/30689020272) stopped safely before publishing because Linux `npm publish --dry-run` rejected existing `0.2.3`.
- Files changed: `.github/workflows/release-npm.yml`, `scripts/publish-npm-test.mjs`.

## Implementation

- Add the existing `release_mode == 'normal'` condition to Linux and Windows dry-run steps.
- Keep macOS plus wrapper dry-run active in both normal and recovery modes.
- Add a focused contract test for all three routes.

## Verification

- [x] Focused test observed RED before the workflow change, then GREEN.
- [x] `node --test scripts/publish-npm-test.mjs` (57 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `node scripts/test-cli-prepublish.mjs` (all 5 checks passed)
- [x] `git diff --check`

## Risk and Rollback

- Risk level: low; two recovery-only conditions plus contract coverage.
- Rollback: revert this commit. No npm package was published by the failed attempt.

## Agent Handoff

- Current state: locally verified; recovery registry state remains unchanged.
- Follow-up: after green merge, create new signed `v0.2.3-recovery.2` and verify the complete release.
- Known gaps: none.
