### PR TITLE
Potential fix for code scanning alert no. 11: Hard-coded cryptographic value

### DIFF
--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -7,10 +7,6 @@ use base64::Engine;
 use chrono::{DateTime, Utc};
 use qrcode::render::unicode::Dense1x2;
 use qrcode::QrCode;
-#[cfg(test)]
-use rand::rngs::OsRng;
-#[cfg(test)]
-use rand::TryRngCore;
 use sha2::{Digest, Sha256};
 use url::Url;
 use uuid::Uuid;
@@ -464,8 +460,7 @@ mod tests {
         }
 
         fn enroll_after_expiry(&self) -> Result<EnrolledPairing, PairingError> {
-            let mut nonce = [0u8; 32];
-            OsRng.try_fill_bytes(&mut nonce).expect("OS RNG failed");
+            let nonce = random::<[u8; 32]>();
             self.manager.enroll(
                 self.pairing_id,
                 nonce,

--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -10,7 +10,7 @@ use qrcode::QrCode;
 #[cfg(test)]
 use rand::rngs::OsRng;
 #[cfg(test)]
-use rand::RngCore;
+use rand::TryRngCore;
 use sha2::{Digest, Sha256};
 use url::Url;
 use uuid::Uuid;
@@ -465,7 +465,7 @@ mod tests {
 
         fn enroll_after_expiry(&self) -> Result<EnrolledPairing, PairingError> {
             let mut nonce = [0u8; 32];
-            OsRng.fill_bytes(&mut nonce);
+            OsRng.try_fill_bytes(&mut nonce).expect("OS RNG failed");
             self.manager.enroll(
                 self.pairing_id,
                 nonce,

--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -7,7 +7,9 @@ use base64::Engine;
 use chrono::{DateTime, Utc};
 use qrcode::render::unicode::Dense1x2;
 use qrcode::QrCode;
+#[cfg(test)]
 use rand::rngs::OsRng;
+#[cfg(test)]
 use rand::RngCore;
 use sha2::{Digest, Sha256};
 use url::Url;

--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -7,6 +7,8 @@ use base64::Engine;
 use chrono::{DateTime, Utc};
 use qrcode::render::unicode::Dense1x2;
 use qrcode::QrCode;
+use rand::rngs::OsRng;
+use rand::RngCore;
 use sha2::{Digest, Sha256};
 use url::Url;
 use uuid::Uuid;
@@ -456,9 +458,11 @@ mod tests {
         }
 
         fn enroll_after_expiry(&self) -> Result<EnrolledPairing, PairingError> {
+            let mut nonce = [0u8; 32];
+            OsRng.fill_bytes(&mut nonce);
             self.manager.enroll(
                 self.pairing_id,
-                [7; 32],
+                nonce,
                 self.request.clone(),
                 [3; 32],
                 self.now + Duration::minutes(6),


### PR DESCRIPTION
Potential fix for [https://github.com/OpenCoven/coven/security/code-scanning/11](https://github.com/OpenCoven/coven/security/code-scanning/11)

Use non-hardcoded nonce bytes for the specific flagged call on line 461.  
Best fix: replace `[7; 32]` in `enroll_after_expiry` with a generated/random nonce value, consistent with the recommendation to avoid hard-coded cryptographic material.

In `crates/coven-cli/src/mobile_memory/pairing.rs`, within `impl PairingHarness::enroll_after_expiry`, introduce a local nonce generated via a CSPRNG and pass it to `self.manager.enroll(...)`. Since this file snippet does not currently include RNG imports, add `use rand::rngs::OsRng;` and `use rand::RngCore;` near existing imports, then fill a `[u8; 32]` buffer via `OsRng.fill_bytes(&mut nonce)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
