### PR TITLE
fix(doctor): distinguish advisory prose states

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1653,7 +1653,6 @@ struct DoctorReport {
     home: PathBuf,
     project_root: Option<PathBuf>,
     daemon: Option<daemon::DaemonStatusState>,
-    repos_config_path: PathBuf,
     repos: Vec<DoctorRepoReport>,
     harnesses: Vec<harness::HarnessSummary>,
     engine: Option<DoctorEngineReport>,
@@ -1667,6 +1666,7 @@ struct DoctorReport {
 struct DoctorRepoReport {
     name: String,
     path: PathBuf,
+    config_path: PathBuf,
     ok: bool,
 }
 
@@ -1694,20 +1694,42 @@ impl DoctorReport {
     }
 }
 
+fn doctor_repo_config_path(
+    name: &str,
+    legacy_path: &Path,
+    settings_path: Option<&Path>,
+    loaded_settings: Option<&settings::Settings>,
+) -> PathBuf {
+    if loaded_settings.is_some_and(|value| value.coven_cli.repos.contains_key(name)) {
+        settings_path.unwrap_or(legacy_path).to_path_buf()
+    } else {
+        legacy_path.to_path_buf()
+    }
+}
+
 fn gather_doctor_report() -> Result<DoctorReport> {
     let home = coven_home_dir()?;
     let project_root = std::env::current_dir()
         .ok()
         .and_then(|cwd| project::canonical_project_root(&cwd).ok());
     let daemon = daemon::background_server_status(&home)?;
+    let legacy_repos_config_path = repos_config::config_path(&home);
+    let settings_config_path = settings::user_settings_path();
     let repos_config = repos_config::load_with_settings(&home, settings::cached())?;
     let repos = repos_config
         .entries()
         .map(|(name, path)| {
             let ok = path.is_dir() && path.join(".git").exists();
+            let config_path = doctor_repo_config_path(
+                name,
+                &legacy_repos_config_path,
+                settings_config_path.as_deref(),
+                settings::cached(),
+            );
             DoctorRepoReport {
                 name: name.to_string(),
                 path,
+                config_path,
                 ok,
             }
         })
@@ -1730,7 +1752,6 @@ fn gather_doctor_report() -> Result<DoctorReport> {
     let familiars = cockpit_sources::read_familiars(&home).map_err(|err| format!("{err:#}"));
     Ok(DoctorReport {
         familiars_manifest: home.join("familiars.toml"),
-        repos_config_path: repos_config::config_path(&home),
         home,
         project_root,
         daemon,
@@ -1789,15 +1810,12 @@ fn print_doctor_prose(report: &DoctorReport) {
     }
 
     if !report.repos.is_empty() {
-        println!("\nRepos ({}):", report.repos_config_path.display());
+        println!("\nRepos:");
         for repo in &report.repos {
             let marker = if repo.ok { "OK" } else { "!!" };
             println!("  [{marker}] {:<16} {}", repo.name, repo.path.display());
             if !repo.ok {
-                println!(
-                    "       fix the path in {}",
-                    report.repos_config_path.display()
-                );
+                println!("       fix the path in {}", repo.config_path.display());
             }
         }
     }
@@ -1963,10 +1981,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             DoctorCheck::fail(
                 format!("repo:{}", repo.name),
                 format!("{} is missing or not a git repository", repo.path.display()),
-                Some(format!(
-                    "fix the path in {}",
-                    report.repos_config_path.display()
-                )),
+                Some(format!("fix the path in {}", repo.config_path.display())),
             )
         });
     }
@@ -2049,7 +2064,10 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
                 "could not read {}: {error}",
                 report.familiars_manifest.display()
             ),
-            None,
+            Some(format!(
+                "fix access to or contents of {}, then rerun coven doctor",
+                report.familiars_manifest.display()
+            )),
         ),
         Ok(familiars) if familiars.is_empty() => DoctorCheck::pass(
             "familiars",
@@ -2119,7 +2137,11 @@ fn print_familiars_section(
         Ok(familiars) => familiars,
         Err(err) => {
             println!("\nFamiliars:");
-            println!("  !! could not read {}: {err}", manifest.display());
+            println!("  [--] could not read {}: {err}", manifest.display());
+            println!(
+                "       fix access to or contents of {}, then rerun coven doctor",
+                manifest.display()
+            );
             return;
         }
     };
@@ -6240,7 +6262,6 @@ mod tests {
                 started_at: "2026-01-01T00:00:00Z".to_string(),
                 socket: "/tmp/coven-home/coven.sock".to_string(),
             })),
-            repos_config_path: PathBuf::from("/tmp/coven-home/repos.toml"),
             repos: vec![],
             harnesses: vec![make_harness_with_hint("codex", true, "npm i -g codex")],
             engine: Some(DoctorEngineReport {
@@ -6273,6 +6294,7 @@ mod tests {
         bad_repo.repos.push(DoctorRepoReport {
             name: "openclaw".to_string(),
             path: PathBuf::from("/does/not/exist"),
+            config_path: PathBuf::from("/tmp/settings.json"),
             ok: false,
         });
 
@@ -6306,6 +6328,49 @@ mod tests {
                 "{label}: check statuses disagree with healthy()"
             );
         }
+    }
+
+    #[test]
+    fn doctor_bad_repo_hint_names_the_entrys_actual_config_source() {
+        let mut report = make_doctor_report();
+        report.repos.push(DoctorRepoReport {
+            name: "openclaw".to_string(),
+            path: PathBuf::from("/does/not/exist"),
+            config_path: PathBuf::from("/tmp/settings.json"),
+            ok: false,
+        });
+
+        let check = doctor_checks(&report)
+            .into_iter()
+            .find(|check| check.id == "repo:openclaw")
+            .expect("repo check");
+        assert_eq!(check.status, "fail");
+        assert_eq!(
+            check.hint.as_deref(),
+            Some("fix the path in /tmp/settings.json")
+        );
+    }
+
+    #[test]
+    fn doctor_repo_config_path_tracks_settings_overrides() {
+        let legacy = Path::new("/tmp/repos.toml");
+        let settings_path = Path::new("/tmp/settings.json");
+        let mut loaded = settings::Settings::default();
+        loaded.coven_cli.repos.insert(
+            "settings-repo".to_string(),
+            settings::RepoSettings {
+                path: PathBuf::from("/tmp/repo"),
+            },
+        );
+
+        assert_eq!(
+            doctor_repo_config_path("settings-repo", legacy, Some(settings_path), Some(&loaded)),
+            settings_path
+        );
+        assert_eq!(
+            doctor_repo_config_path("legacy-repo", legacy, Some(settings_path), Some(&loaded)),
+            legacy
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1644,9 +1644,8 @@ fn interactive_shell_route(
 
 /// Exits 1 when a blocking problem is found (stale daemon, broken registered
 /// repo, no harness available, missing coven-code) so scripts can gate on
-/// `coven doctor && …`. Individual missing harnesses print `[!!]` but don't
-/// fail the check while another harness is available — one working harness
-/// makes coven usable.
+/// `coven doctor && …`. Individual missing harnesses print advisory `[--]`
+/// rows; the aggregate `[!!]` row blocks only when none is available.
 /// Everything `coven doctor` inspects, gathered before rendering so the
 /// prose and `--json` surfaces read the same probe results and cannot drift.
 struct DoctorReport {
@@ -1784,27 +1783,49 @@ fn run_doctor(json: bool) -> Result<()> {
     Ok(())
 }
 
+/// Keep Doctor's line-oriented prose safe even when a user-controlled config
+/// value contains terminal controls. Static line breaks are emitted by
+/// `println!`; embedded control characters are rendered visibly instead of
+/// being passed through to the terminal.
+fn doctor_prose_line(value: impl AsRef<str>) -> String {
+    let mut output = String::with_capacity(value.as_ref().len());
+    for character in value.as_ref().chars() {
+        if character.is_control() {
+            use std::fmt::Write as _;
+            write!(&mut output, "\\u{{{:x}}}", character as u32)
+                .expect("writing to a String cannot fail");
+        } else {
+            output.push(character);
+        }
+    }
+    output
+}
+
+fn print_doctor_line(value: impl AsRef<str>) {
+    println!("{}", doctor_prose_line(value));
+}
+
 fn print_doctor_prose(report: &DoctorReport) {
     println!("Coven doctor");
-    println!("Store: {}", report.home.display());
+    print_doctor_line(format!("Store: {}", report.home.display()));
     match &report.project_root {
-        Some(root) => println!("Project: {}", root.display()),
+        Some(root) => print_doctor_line(format!("Project: {}", root.display())),
         None => println!("Project: not inside a git/project root yet"),
     }
 
     println!("\nDaemon:");
     match &report.daemon {
         Some(daemon::DaemonStatusState::Running(status)) => {
-            println!(
+            print_doctor_line(format!(
                 "  [OK] Running (pid {}, socket {})",
                 status.pid, status.socket
-            );
+            ));
         }
         Some(daemon::DaemonStatusState::Stale(status)) => {
-            println!(
+            print_doctor_line(format!(
                 "  [!!] Stale (pid {}, socket {}) — run: coven daemon restart",
                 status.pid, status.socket
-            );
+            ));
         }
         None => println!("  [--] Not running — run: coven daemon start"),
     }
@@ -1813,9 +1834,16 @@ fn print_doctor_prose(report: &DoctorReport) {
         println!("\nRepos:");
         for repo in &report.repos {
             let marker = if repo.ok { "OK" } else { "!!" };
-            println!("  [{marker}] {:<16} {}", repo.name, repo.path.display());
+            print_doctor_line(format!(
+                "  [{marker}] {:<16} {}",
+                repo.name,
+                repo.path.display()
+            ));
             if !repo.ok {
-                println!("       fix the path in {}", repo.config_path.display());
+                print_doctor_line(format!(
+                    "       fix the path in {}",
+                    repo.config_path.display()
+                ));
             }
         }
     }
@@ -1830,14 +1858,14 @@ fn print_doctor_prose(report: &DoctorReport) {
         // A single missing harness is advisory while another harness is
         // available. The aggregate row below is the blocking condition.
         let marker = if harness.available { "OK" } else { "--" };
-        println!(
+        print_doctor_line(format!(
             "  [{marker}] {:<18} `{}` is {status} ({})",
             harness.label,
             harness.executable,
             adapter_source_label(&harness.source)
-        );
+        ));
         if !harness.available {
-            println!("       {}", harness.install_hint);
+            print_doctor_line(format!("       {}", harness.install_hint));
         }
     }
     if !report.harnesses.iter().any(|harness| harness.available) {
@@ -1847,7 +1875,11 @@ fn print_doctor_prose(report: &DoctorReport) {
     println!("\nEngine:");
     match &report.engine {
         Some(engine) => {
-            println!("  [OK] {} ({})", engine.path.display(), engine.source_label);
+            print_doctor_line(format!(
+                "  [OK] {} ({})",
+                engine.path.display(),
+                engine.source_label
+            ));
             match engine.version {
                 Some(version) => {
                     let (a, b, c) = version;
@@ -1876,12 +1908,12 @@ fn print_doctor_prose(report: &DoctorReport) {
 
     println!("\nCredentials:");
     for line in credentials_lines(report.engine_auth, &report.harnesses) {
-        println!("{line}");
+        print_doctor_line(line);
     }
 
     println!("\nNext steps:");
     for line in doctor_next_steps(report.default_harness.as_deref()) {
-        println!("  {line}");
+        print_doctor_line(format!("  {line}"));
     }
 }
 
@@ -2137,18 +2169,21 @@ fn print_familiars_section(
         Ok(familiars) => familiars,
         Err(err) => {
             println!("\nFamiliars:");
-            println!("  [--] could not read {}: {err}", manifest.display());
-            println!(
+            print_doctor_line(format!(
+                "  [--] could not read {}: {err}",
+                manifest.display()
+            ));
+            print_doctor_line(format!(
                 "       fix access to or contents of {}, then rerun coven doctor",
                 manifest.display()
-            );
+            ));
             return;
         }
     };
 
     if familiars.is_empty() {
         println!("\nFamiliars:");
-        println!("  none configured ({})", manifest.display());
+        print_doctor_line(format!("  none configured ({})", manifest.display()));
         println!(
             "  Declare [[familiar]] entries there, then run with \
              `coven run <harness> --familiar <id> \"...\"`."
@@ -2156,7 +2191,8 @@ fn print_familiars_section(
         return;
     }
 
-    println!("\nFamiliars ({}):", manifest.display());
+    println!();
+    print_doctor_line(format!("Familiars ({}):", manifest.display()));
     let id_width = familiars
         .iter()
         .map(|familiar| familiar.id.len())
@@ -2168,10 +2204,10 @@ fn print_familiars_section(
         } else {
             format!(" — {}", familiar.role)
         };
-        println!(
+        print_doctor_line(format!(
             "  {:<id_width$} {}{}  (memory: {})",
             familiar.id, familiar.display_name, role, familiar.memory_freshness
-        );
+        ));
     }
 }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -6289,6 +6289,14 @@ mod tests {
 
     // --- doctor report/check unit tests ---
 
+    #[test]
+    fn doctor_prose_line_escapes_controls_and_preserves_printable_unicode() {
+        assert_eq!(
+            doctor_prose_line("safe\t\n\r\u{1b}\u{009b} —"),
+            r"safe\u{9}\u{a}\u{d}\u{1b}\u{9b} —"
+        );
+    }
+
     fn make_doctor_report() -> DoctorReport {
         DoctorReport {
             home: PathBuf::from("/tmp/coven-home"),

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1774,14 +1774,18 @@ fn print_doctor_prose(report: &DoctorReport) {
     println!("\nDaemon:");
     match &report.daemon {
         Some(daemon::DaemonStatusState::Running(status)) => {
-            // `ok` is always true for a live daemon, so the prose "Running"
-            // already conveys it; the `--json` path keeps the field.
-            println!("  Running (pid {}, socket {})", status.pid, status.socket);
+            println!(
+                "  [OK] Running (pid {}, socket {})",
+                status.pid, status.socket
+            );
         }
         Some(daemon::DaemonStatusState::Stale(status)) => {
-            println!("  Stale (pid {}, socket {})", status.pid, status.socket);
+            println!(
+                "  [!!] Stale (pid {}, socket {}) — run: coven daemon restart",
+                status.pid, status.socket
+            );
         }
-        None => println!("  Not running"),
+        None => println!("  [--] Not running — run: coven daemon start"),
     }
 
     if !report.repos.is_empty() {
@@ -1789,6 +1793,12 @@ fn print_doctor_prose(report: &DoctorReport) {
         for repo in &report.repos {
             let marker = if repo.ok { "OK" } else { "!!" };
             println!("  [{marker}] {:<16} {}", repo.name, repo.path.display());
+            if !repo.ok {
+                println!(
+                    "       fix the path in {}",
+                    report.repos_config_path.display()
+                );
+            }
         }
     }
 
@@ -1799,7 +1809,9 @@ fn print_doctor_prose(report: &DoctorReport) {
         } else {
             "missing"
         };
-        let marker = if harness.available { "OK" } else { "!!" };
+        // A single missing harness is advisory while another harness is
+        // available. The aggregate row below is the blocking condition.
+        let marker = if harness.available { "OK" } else { "--" };
         println!(
             "  [{marker}] {:<18} `{}` is {status} ({})",
             harness.label,
@@ -1809,6 +1821,9 @@ fn print_doctor_prose(report: &DoctorReport) {
         if !harness.available {
             println!("       {}", harness.install_hint);
         }
+    }
+    if !report.harnesses.iter().any(|harness| harness.available) {
+        println!("  [!!] No supported harness is available");
     }
 
     println!("\nEngine:");
@@ -1827,7 +1842,7 @@ fn print_doctor_prose(report: &DoctorReport) {
                         );
                     }
                 }
-                None => println!("       version: unknown (could not run the engine)"),
+                None => println!("  [--] version: unknown (could not run the engine)"),
             }
             println!("       pin: {}", engine::pinned_version());
         }
@@ -2824,7 +2839,7 @@ fn credentials_lines(
         }
         Some(Some(false)) => {
             lines.push(
-                "  [!!] Coven Code (engine) — not logged in; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
+                "  [--] Coven Code (engine) — not logged in; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
             );
         }
         Some(None) => {
@@ -6144,7 +6159,12 @@ mod tests {
         assert!(lines[0].contains("not logged in"), "got: {}", lines[0]);
         assert!(lines[0].contains("ANTHROPIC_API_KEY"), "got: {}", lines[0]);
         assert!(lines[0].contains("Claude Code"), "got: {}", lines[0]);
-        assert!(lines[0].contains("[!!]"), "got: {}", lines[0]);
+        assert!(lines[0].contains("[--]"), "got: {}", lines[0]);
+        assert!(
+            !lines[0].contains("[!!]"),
+            "non-blocking auth guidance must not look like a blocking failure: {}",
+            lines[0]
+        );
     }
 
     #[test]

--- a/crates/coven-cli/tests/doctor_prose_contract.rs
+++ b/crates/coven-cli/tests/doctor_prose_contract.rs
@@ -101,3 +101,37 @@ fn doctor_prose_markers_match_json_severity_and_are_ansi_free() -> anyhow::Resul
     assert_eq!(repeated.stdout, prose_text.as_bytes());
     Ok(())
 }
+
+#[test]
+fn doctor_prose_escapes_terminal_controls_from_familiar_config() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let project = temp.path().join("project");
+    let coven_home = temp.path().join("coven-home");
+    fs::create_dir_all(project.join(".git"))?;
+    fs::create_dir_all(&coven_home)?;
+    fs::create_dir_all(temp.path().join("user-home"))?;
+    fs::write(
+        coven_home.join("familiars.toml"),
+        r#"[[familiar]]
+id = "wren"
+display_name = "Wr\u001ben"
+role = "Research\u009ber"
+description = "Exercises terminal-control escaping."
+"#,
+    )?;
+
+    let output = isolated_doctor_command(
+        temp.path(),
+        &project,
+        &coven_home,
+        &["--color=always", "doctor"],
+    )
+    .output()?;
+    assert_blocking_exit(&output);
+    let prose = String::from_utf8(output.stdout)?;
+    assert!(!prose.contains('\u{1b}'));
+    assert!(!prose.contains('\u{009b}'));
+    assert!(prose.contains(r"Wr\u{1b}en"), "{prose:?}");
+    assert!(prose.contains(r"Research\u{9b}er"), "{prose:?}");
+    Ok(())
+}

--- a/crates/coven-cli/tests/doctor_prose_contract.rs
+++ b/crates/coven-cli/tests/doctor_prose_contract.rs
@@ -1,0 +1,103 @@
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+fn isolated_doctor_command(
+    root: &Path,
+    project: &Path,
+    coven_home: &Path,
+    args: &[&str],
+) -> Command {
+    let fake_home = root.join("user-home");
+    let mut command = Command::new(coven_bin());
+    command
+        .args(args)
+        .current_dir(project)
+        .env("COVEN_HOME", coven_home)
+        .env("HOME", &fake_home)
+        .env("USERPROFILE", &fake_home)
+        .env("XDG_CONFIG_HOME", fake_home.join("config"))
+        .env("PATH", OsString::new())
+        .env("COVEN_ENGINE_BIN", root.join("missing-engine"))
+        .env_remove("COVEN_HARNESS_ADAPTER_DIRS")
+        .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST")
+        .env_remove("COVEN_SETTINGS_PATH");
+    command
+}
+
+fn check_status<'a>(json: &'a Value, id: &str) -> Option<&'a str> {
+    json["checks"]
+        .as_array()?
+        .iter()
+        .find(|check| check["id"] == id)?["status"]
+        .as_str()
+}
+
+fn assert_blocking_exit(output: &Output) {
+    assert_eq!(output.status.code(), Some(1));
+    assert!(
+        output.stderr.is_empty(),
+        "Doctor should keep diagnostics on stdout: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn doctor_prose_markers_match_json_severity_and_are_ansi_free() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let project = temp.path().join("project");
+    let coven_home = temp.path().join("coven-home");
+    fs::create_dir_all(project.join(".git"))?;
+    fs::create_dir_all(&coven_home)?;
+    fs::create_dir_all(temp.path().join("user-home"))?;
+    fs::write(coven_home.join("familiars.toml"), "[[familiar]\n")?;
+
+    let prose = isolated_doctor_command(
+        temp.path(),
+        &project,
+        &coven_home,
+        &["--color=always", "doctor"],
+    )
+    .output()?;
+    assert_blocking_exit(&prose);
+    let prose_text = String::from_utf8(prose.stdout)?;
+    assert!(prose_text.contains("[--] Not running — run: coven daemon start"));
+    assert!(prose_text.contains("[--] Codex"));
+    assert!(prose_text.contains("[!!] No supported harness is available"));
+    assert!(prose_text.contains("[!!] the Coven engine is missing"));
+    assert!(prose_text.contains("[--] could not read"));
+    assert!(prose_text.contains("fix access to or contents of"));
+    assert!(
+        !prose_text.contains('\u{1b}'),
+        "Doctor prose must remain ANSI-free even when color is forced"
+    );
+
+    let json_output =
+        isolated_doctor_command(temp.path(), &project, &coven_home, &["doctor", "--json"])
+            .output()?;
+    assert_blocking_exit(&json_output);
+    let json: Value = serde_json::from_slice(&json_output.stdout)?;
+    assert_eq!(check_status(&json, "daemon"), Some("warn"));
+    assert_eq!(check_status(&json, "harness:codex"), Some("warn"));
+    assert_eq!(check_status(&json, "harnesses"), Some("fail"));
+    assert_eq!(check_status(&json, "engine"), Some("fail"));
+    assert_eq!(check_status(&json, "familiars"), Some("warn"));
+
+    let repeated = isolated_doctor_command(
+        temp.path(),
+        &project,
+        &coven_home,
+        &["--color=always", "doctor"],
+    )
+    .output()?;
+    assert_blocking_exit(&repeated);
+    assert_eq!(repeated.stdout, prose_text.as_bytes());
+    Ok(())
+}

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -492,6 +492,43 @@ fn doctor_json_passes_with_fake_harness_and_engine() -> anyhow::Result<()> {
 }
 
 #[test]
+fn doctor_prose_distinguishes_warnings_from_blocking_failures() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home)?;
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin)?;
+    write_fake_codex(&fake_bin)?;
+    write_fake_coven_code(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
+    let coven = coven_bin();
+
+    let output = run_coven(&coven, &coven_home, &path, &["--color=always", "doctor"])?;
+
+    assert_success("doctor prose with advisory checks", &output);
+    assert_stdout_contains(
+        "doctor prose with advisory checks",
+        &output,
+        "[--] Not running — run: coven daemon start",
+    );
+    assert_stdout_contains(
+        "doctor prose with advisory checks",
+        &output,
+        "[--] Claude Code",
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("\u{1b}["),
+        "doctor's line-oriented report must remain ANSI-free even when color is forced: {stdout:?}"
+    );
+    assert!(
+        !stdout.contains("[!!]"),
+        "a healthy report must not label advisory checks as blocking failures: {stdout}"
+    );
+    Ok(())
+}
+
+#[test]
 fn adapter_doctor_json_reports_each_adapter() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -492,43 +492,6 @@ fn doctor_json_passes_with_fake_harness_and_engine() -> anyhow::Result<()> {
 }
 
 #[test]
-fn doctor_prose_distinguishes_warnings_from_blocking_failures() -> anyhow::Result<()> {
-    let temp_dir = tempfile::tempdir()?;
-    let coven_home = temp_dir.path().join("coven-home");
-    fs::create_dir_all(&coven_home)?;
-    let fake_bin = temp_dir.path().join("bin");
-    fs::create_dir_all(&fake_bin)?;
-    write_fake_codex(&fake_bin)?;
-    write_fake_coven_code(&fake_bin)?;
-    let path = prepend_path(&fake_bin);
-    let coven = coven_bin();
-
-    let output = run_coven(&coven, &coven_home, &path, &["--color=always", "doctor"])?;
-
-    assert_success("doctor prose with advisory checks", &output);
-    assert_stdout_contains(
-        "doctor prose with advisory checks",
-        &output,
-        "[--] Not running — run: coven daemon start",
-    );
-    assert_stdout_contains(
-        "doctor prose with advisory checks",
-        &output,
-        "[--] Claude Code",
-    );
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("\u{1b}["),
-        "doctor's line-oriented report must remain ANSI-free even when color is forced: {stdout:?}"
-    );
-    assert!(
-        !stdout.contains("[!!]"),
-        "a healthy report must not label advisory checks as blocking failures: {stdout}"
-    );
-    Ok(())
-}
-
-#[test]
 fn adapter_doctor_json_reports_each_adapter() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -666,6 +629,12 @@ fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<(
     assert_stdout_contains("doctor without harnesses", &output, "Harnesses:");
     assert_stdout_contains("doctor without harnesses", &output, "`codex` is missing");
     assert_stdout_contains("doctor without harnesses", &output, "`claude` is missing");
+    assert_stdout_contains("doctor without harnesses", &output, "[--] Codex");
+    assert_stdout_contains(
+        "doctor without harnesses",
+        &output,
+        "[!!] No supported harness is available",
+    );
     assert_stdout_contains(
         "doctor without harnesses",
         &output,

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -142,9 +142,9 @@ blocking problem:
 - a registered repo entry points at a missing or non-git path
 - `coven-code` is missing
 
-A missing harness prints a `[!!]` line with an install hint but does not fail
-the check while another harness is available — one working harness makes Coven
-usable.
+Each missing harness prints an advisory `[--]` line with an install hint. When
+none is available, Doctor adds a blocking `[!!] No supported harness is
+available` line and exits 1; one working harness keeps the aggregate usable.
 
 `coven adapter doctor` is stricter about its own subject: it exits `1` if any
 listed adapter is unavailable. `coven wt --doctor` exits `1` when managed hooks

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -16,6 +16,10 @@ coven doctor
 The command is read-only. It prints local setup state and a next step without
 starting a session.
 
+The prose report uses `[OK]` for passing checks, `[--]` for advisory warnings,
+and `[!!]` only for blocking failures. It is line-oriented plain text and does
+not emit ANSI escape sequences, including when global color is forced.
+
 ## Machine-readable output
 
 `coven doctor --json` emits one JSON document for scripts and CI gates, with
@@ -26,13 +30,13 @@ found):
 {
   "ok": true,
   "blocking": false,
-  "store": "/home/alex/.coven",
-  "project": "/home/alex/src/app",
+  "store": "<COVEN_HOME>",
+  "project": "/path/to/project",
   "checks": [
-    { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket /home/alex/.coven/coven.sock)" },
+    { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket <COVEN_HOME>/coven.sock)" },
     { "id": "harness:codex", "status": "pass", "message": "`codex` is ready (built-in)" },
     { "id": "harnesses", "status": "pass", "message": "1 of 3 configured harnesses available" },
-    { "id": "engine", "status": "pass", "message": "/home/alex/.coven/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" }
+    { "id": "engine", "status": "pass", "message": "<COVEN_HOME>/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" }
   ],
   "nextSteps": ["coven run codex \"explain this repo in 5 bullets\"", "coven sessions"]
 }
@@ -110,7 +114,7 @@ coven daemon status --json
 Typical human output from `coven daemon status`:
 
 ```text
-Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
+Coven daemon: running (pid 12345, socket <COVEN_HOME>/coven.sock)
 ```
 
 `not running` means no background daemon is running yet. Start it with:

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -18,7 +18,8 @@ starting a session.
 
 The prose report uses `[OK]` for passing checks, `[--]` for advisory warnings,
 and `[!!]` only for blocking failures. It is line-oriented plain text and does
-not emit ANSI escape sequences, including when global color is forced.
+not emit or pass through ANSI escape sequences, including when global color is
+forced or configuration text contains terminal controls.
 
 ## Machine-readable output
 
@@ -35,7 +36,7 @@ found):
   "checks": [
     { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket <COVEN_HOME>/coven.sock)" },
     { "id": "harness:codex", "status": "pass", "message": "`codex` is ready (built-in)" },
-    { "id": "harnesses", "status": "pass", "message": "1 of 3 configured harnesses available" },
+    { "id": "harnesses", "status": "pass", "message": "2 of 4 configured harnesses available" },
     { "id": "engine", "status": "pass", "message": "<COVEN_HOME>/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" }
   ],
   "nextSteps": ["coven run codex \"explain this repo in 5 bullets\"", "coven sessions"]
@@ -63,7 +64,9 @@ availability, where any missing adapter is a `fail`.
 | `Daemon` | Whether the background daemon is stopped, running, or stale. |
 | `Repos` | Configured repositories from Coven repo settings, if present. |
 | `Harnesses` | Supported harness executables that are visible on this shell's `PATH`. |
+| `Engine` | Whether the Coven engine is installed and meets the minimum supported version. |
 | `Familiars` | Configured familiar identities from `familiars.toml`, if present. |
+| `Credentials` | Local engine authentication state and setup hints; external harness provider turns are not performed. |
 | `Next steps` | The safest next command based on the detected state. |
 
 ## Expected first-run loop
@@ -141,6 +144,7 @@ blocking problem:
 - the daemon is stale (`running` and `stopped` are both healthy states)
 - a registered repo entry points at a missing or non-git path
 - `coven-code` is missing
+- the installed `coven-code` version is older than the supported minimum
 
 Each missing harness prints an advisory `[--]` line with an install hint. When
 none is available, Doctor adds a blocking `[!!] No supported harness is


### PR DESCRIPTION
## Context

- Summary: Makes human-readable `coven doctor` status markers agree with its warning/failure exit contract, adds precise remediation, and keeps prose safe for terminals.
- Files changed: `crates/coven-cli/src/main.rs`, `crates/coven-cli/tests/doctor_prose_contract.rs`, `crates/coven-cli/tests/smoke.rs`, `docs/reference/cli-doctor.md`
- Closes #552
- Certification tracking: OpenCoven/coven-dev-tools#229 (`coven-live-dgq`)

## Implementation

- Approach: Keeps the fixed section order while reserving `[!!]` for blocking checks and using `[--]` for advisory states.
- User-visible behavior: stopped daemon, individual unavailable harnesses, malformed familiar inventory, unknown engine version, and unverified engine auth are advisory; stale daemon, invalid repos, no available harness, and missing/old engine remain visibly blocking.
- Remediation: malformed familiar inventory includes a repair/rerun hint; invalid repository entries point to the actual source that defined that entry, including settings overrides.
- Terminal safety: Doctor adds no ANSI styling and renders embedded control characters from user-controlled paths/configuration as visible Unicode escapes instead of passing them to the terminal.
- Compatibility notes: exit codes and the JSON schema are unchanged. Prose gains explicit severity markers/remediation and one no-harness aggregate failure line.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo test -p coven-cli doctor --locked` — 17 Doctor-focused tests across unit/integration targets on Windows
- [x] `cargo test -p coven-cli --test doctor_prose_contract --locked` — 2/2 hermetic cross-platform tests covering marker/JSON parity, determinism, forced color, and malicious ESC/C1 config values
- [x] `python scripts/check-coven-privacy.py --staged`
- [x] `git diff --check`
- [x] Independent review: no P0/P1; all reported P2 documentation and terminal-control findings corrected
- [x] GitHub CI passed on the preceding corrected head across Ubuntu/Windows Rust, performance, secret, packaging, engine-contract, dependency-audit, and Linux/macOS onboarding jobs
- [x] GitHub CI passed on final head `47c1bdf`

## Risk and Rollback

- Risk level: Low. The change is limited to Doctor diagnostics and its tests/reference page.
- Safety guarantees: Doctor remains read-only; no new provider or credential access is introduced; dynamic diagnostic text cannot inject terminal controls.
- Rollback plan: revert the three signed-off commits; there are no migrations or persisted-state changes.

## Agent Handoff

- Current state: Ready for maintainer review; final-head CI and independent review are green.
- Follow-ups: maintainers may review and merge; run the linked live certification procedure separately.
- Known gaps: none in the scoped implementation; the linked live certification issue remains unrun until its evidence procedure is executed.