### PR TITLE
fix(cli): redact doctor JSON paths

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1911,23 +1911,94 @@ impl DoctorCheck {
     }
 }
 
+/// Replace paths in the machine-readable doctor report with stable role
+/// tokens. Doctor JSON is commonly attached to CI logs and bug reports; raw
+/// absolute paths make otherwise identical reports host-specific and can leak
+/// account or project directory names. The prose report intentionally keeps
+/// the concrete paths for local troubleshooting.
+struct DoctorJsonPathRedactor {
+    replacements: Vec<(String, String)>,
+}
+
+impl DoctorJsonPathRedactor {
+    fn new(report: &DoctorReport) -> Self {
+        let mut replacements = Vec::new();
+        let mut add_path = |path: &Path, token: String| {
+            // Only redact rooted paths with a component below the root. A
+            // one-character relative path or filesystem root would otherwise
+            // act like an unsafe global substring replacement.
+            if path.has_root() && path.components().count() > 1 {
+                replacements.push((path.display().to_string(), token));
+            }
+        };
+
+        add_path(
+            &report.familiars_manifest,
+            "<familiars-manifest>".to_string(),
+        );
+        add_path(&report.repos_config_path, "<repos-config>".to_string());
+        if let Some(engine) = &report.engine {
+            add_path(&engine.path, "<engine>".to_string());
+        }
+        for repo in &report.repos {
+            add_path(&repo.path, format!("<repo:{}>", repo.name));
+        }
+        if let Some(project_root) = &report.project_root {
+            add_path(project_root, "<project>".to_string());
+        }
+        add_path(&report.home, "<coven-home>".to_string());
+
+        if let Some(status) = report.daemon.as_ref().map(|state| match state {
+            daemon::DaemonStatusState::Running(status)
+            | daemon::DaemonStatusState::Stale(status) => status,
+        }) {
+            let socket = Path::new(&status.socket);
+            add_path(socket, "<daemon-socket>".to_string());
+        }
+
+        // Replace children before parents, for example the manifest before
+        // COVEN_HOME. `sort_by` is stable, so equally long exact paths retain
+        // the role-specific insertion order above.
+        replacements.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
+        Self { replacements }
+    }
+
+    fn text(&self, value: impl AsRef<str>) -> String {
+        self.replacements
+            .iter()
+            .fold(value.as_ref().to_string(), |redacted, (path, token)| {
+                redacted.replace(path, token)
+            })
+    }
+
+    fn path(&self, value: &Path) -> String {
+        self.text(value.display().to_string())
+    }
+}
+
 /// Derive the machine-readable check list from a gathered report. Statuses
 /// mirror the prose markers: `fail` is exactly the set of conditions that
 /// flip [`DoctorReport::healthy`], so `ok`/exit-code semantics stay identical
 /// across both output modes.
 fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
     let mut checks = Vec::new();
+    let paths = DoctorJsonPathRedactor::new(report);
 
     checks.push(match &report.daemon {
         Some(daemon::DaemonStatusState::Running(status)) => DoctorCheck::pass(
             "daemon",
-            format!("running (pid {}, socket {})", status.pid, status.socket),
+            format!(
+                "running (pid {}, socket {})",
+                status.pid,
+                paths.text(&status.socket)
+            ),
         ),
         Some(daemon::DaemonStatusState::Stale(status)) => DoctorCheck::fail(
             "daemon",
             format!(
                 "stale daemon record (pid {}, socket {})",
-                status.pid, status.socket
+                status.pid,
+                paths.text(&status.socket)
             ),
             Some("run: coven daemon restart".to_string()),
         ),
@@ -1940,17 +2011,17 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
 
     for repo in &report.repos {
         checks.push(if repo.ok {
-            DoctorCheck::pass(
-                format!("repo:{}", repo.name),
-                repo.path.display().to_string(),
-            )
+            DoctorCheck::pass(format!("repo:{}", repo.name), paths.path(&repo.path))
         } else {
             DoctorCheck::fail(
                 format!("repo:{}", repo.name),
-                format!("{} is missing or not a git repository", repo.path.display()),
+                format!(
+                    "{} is missing or not a git repository",
+                    paths.path(&repo.path)
+                ),
                 Some(format!(
                     "fix the path in {}",
-                    report.repos_config_path.display()
+                    paths.path(&report.repos_config_path)
                 )),
             )
         });
@@ -1998,7 +2069,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             Some("run: coven engine install".to_string()),
         ),
         Some(engine) => {
-            let located = format!("{} ({})", engine.path.display(), engine.source_label);
+            let located = format!("{} ({})", paths.path(&engine.path), engine.source_label);
             match engine.version {
                 None => DoctorCheck::warn(
                     "engine",
@@ -2032,13 +2103,17 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             "familiars",
             format!(
                 "could not read {}: {error}",
-                report.familiars_manifest.display()
+                paths.path(&report.familiars_manifest),
+                error = paths.text(error)
             ),
             None,
         ),
         Ok(familiars) if familiars.is_empty() => DoctorCheck::pass(
             "familiars",
-            format!("none configured ({})", report.familiars_manifest.display()),
+            format!(
+                "none configured ({})",
+                paths.path(&report.familiars_manifest)
+            ),
         ),
         Ok(familiars) => DoctorCheck::pass("familiars", format!("{} configured", familiars.len())),
     });
@@ -2072,11 +2147,8 @@ fn doctor_json_body(report: &DoctorReport) -> serde_json::Value {
     serde_json::json!({
         "ok": ok,
         "blocking": !ok,
-        "store": report.home.display().to_string(),
-        "project": report
-            .project_root
-            .as_ref()
-            .map(|root| root.display().to_string()),
+        "store": "<coven-home>",
+        "project": report.project_root.as_ref().map(|_| "<project>"),
         "checks": checks,
         "nextSteps": doctor_next_steps(report.default_harness.as_deref()),
     })
@@ -6299,8 +6371,8 @@ mod tests {
         let body = doctor_json_body(&report);
         assert_eq!(body["ok"], serde_json::json!(false));
         assert_eq!(body["blocking"], serde_json::json!(true));
-        assert_eq!(body["store"], serde_json::json!("/tmp/coven-home"));
-        assert_eq!(body["project"], serde_json::json!("/tmp/project"));
+        assert_eq!(body["store"], serde_json::json!("<coven-home>"));
+        assert_eq!(body["project"], serde_json::json!("<project>"));
         let checks = body["checks"].as_array().expect("checks array");
         let harness_check = checks
             .iter()
@@ -6319,6 +6391,18 @@ mod tests {
             .expect("engine check");
         assert_eq!(engine["status"], "fail");
         assert_eq!(engine["hint"], "run: coven engine install");
+        let familiars = checks
+            .iter()
+            .find(|check| check["id"] == "familiars")
+            .expect("familiars check");
+        assert_eq!(
+            familiars["message"],
+            "none configured (<familiars-manifest>)"
+        );
+        assert!(
+            !body.to_string().contains("/tmp/"),
+            "doctor JSON must not expose host-specific fixture paths: {body}"
+        );
         assert!(
             checks
                 .iter()
@@ -6349,8 +6433,18 @@ mod tests {
             daemon["message"]
                 .as_str()
                 .unwrap_or_default()
-                .contains("pid 42"),
+                .contains("pid 42, socket <daemon-socket>"),
             "daemon message should carry the pid: {daemon}"
+        );
+        let engine = checks
+            .iter()
+            .find(|check| check["id"] == "engine")
+            .expect("engine check");
+        assert!(
+            engine["message"]
+                .as_str()
+                .is_some_and(|message| message.starts_with("<engine>")),
+            "engine path should be role-redacted: {engine}"
         );
         let credentials = checks
             .iter()

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1917,13 +1917,18 @@ impl DoctorCheck {
 /// account or project directory names. The prose report intentionally keeps
 /// the concrete paths for local troubleshooting.
 struct DoctorJsonPathRedactor {
+    role_replacements: Vec<(String, String)>,
     replacements: Vec<(String, String)>,
 }
 
 impl DoctorJsonPathRedactor {
     fn new(report: &DoctorReport) -> Self {
+        let mut role_replacements = Vec::new();
         let mut replacements = Vec::new();
         let mut add_path = |path: &Path, token: String| {
+            let rendered = path.display().to_string();
+            role_replacements.push((rendered.clone(), token.clone()));
+
             // Only redact rooted paths with a normal component below the root.
             // Checking components rather than their count rejects Unix `/`,
             // Windows drive roots, and UNC share roots; prefix/root components
@@ -1935,7 +1940,7 @@ impl DoctorJsonPathRedactor {
                     .components()
                     .any(|component| matches!(component, std::path::Component::Normal(_)))
             {
-                replacements.push((path.display().to_string(), token));
+                replacements.push((rendered, token));
             }
         };
 
@@ -1970,7 +1975,10 @@ impl DoctorJsonPathRedactor {
         // COVEN_HOME. `sort_by` is stable, so equally long exact paths retain
         // the role-specific insertion order above.
         replacements.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
-        Self { replacements }
+        Self {
+            role_replacements,
+            replacements,
+        }
     }
 
     fn text(&self, value: impl AsRef<str>) -> String {
@@ -1981,15 +1989,18 @@ impl DoctorJsonPathRedactor {
             })
     }
 
-    /// Render a value that is itself a known path role. Exact absolute roles
-    /// can always become their semantic token, including filesystem roots;
-    /// unlike `text`, this never performs a broad root substring replacement.
+    /// Render a value that is itself a known path role. Exact roles can always
+    /// become their semantic token, including relative paths and filesystem
+    /// roots; unlike `text`, this never performs a broad substring replacement
+    /// with those otherwise unsafe values.
     fn role_path(&self, value: &Path, token: &str) -> String {
-        if value.is_absolute() {
-            token.to_string()
-        } else {
-            self.text(value.display().to_string())
-        }
+        let rendered = value.display().to_string();
+        self.role_replacements
+            .iter()
+            .find(|(path, registered_token)| {
+                path == &rendered && registered_token.as_str() == token
+            })
+            .map_or_else(|| self.text(rendered), |(_, token)| token.clone())
     }
 }
 
@@ -6383,6 +6394,40 @@ mod tests {
             .find(|check| check.id == "repo:unc-root")
             .expect("UNC-root repository check");
         assert_eq!(unc_check.message, "<repo>");
+    }
+
+    #[test]
+    fn doctor_json_redacts_relative_daemon_socket_without_broad_replacement() {
+        let mut report = make_doctor_report();
+        let private_hash = "0123456789abcdef0123456789abcdef";
+        let socket = format!("coven-daemon-{private_hash}.sock");
+        report.daemon = Some(daemon::DaemonStatusState::Running(daemon::DaemonStatus {
+            pid: 42,
+            started_at: "2026-01-01T00:00:00Z".to_string(),
+            socket: socket.clone(),
+        }));
+
+        let redactor = DoctorJsonPathRedactor::new(&report);
+        assert_eq!(
+            redactor.text(format!("socket={socket}")),
+            format!("socket={socket}"),
+            "relative paths must not become broad substring replacements"
+        );
+
+        let body = doctor_json_body(&report);
+        let daemon = body["checks"]
+            .as_array()
+            .expect("checks array")
+            .iter()
+            .find(|check| check["id"] == "daemon")
+            .expect("daemon check");
+        assert_eq!(
+            daemon["message"],
+            "running (pid 42, socket <daemon-socket>)"
+        );
+        let serialized = body.to_string();
+        assert!(!serialized.contains(private_hash));
+        assert!(!serialized.contains(&socket));
     }
 
     fn make_doctor_report() -> DoctorReport {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1981,8 +1981,15 @@ impl DoctorJsonPathRedactor {
             })
     }
 
-    fn path(&self, value: &Path) -> String {
-        self.text(value.display().to_string())
+    /// Render a value that is itself a known path role. Exact absolute roles
+    /// can always become their semantic token, including filesystem roots;
+    /// unlike `text`, this never performs a broad root substring replacement.
+    fn role_path(&self, value: &Path, token: &str) -> String {
+        if value.is_absolute() {
+            token.to_string()
+        } else {
+            self.text(value.display().to_string())
+        }
     }
 }
 
@@ -2000,7 +2007,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             format!(
                 "running (pid {}, socket {})",
                 status.pid,
-                paths.text(&status.socket)
+                paths.role_path(Path::new(&status.socket), "<daemon-socket>")
             ),
         ),
         Some(daemon::DaemonStatusState::Stale(status)) => DoctorCheck::fail(
@@ -2008,7 +2015,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             format!(
                 "stale daemon record (pid {}, socket {})",
                 status.pid,
-                paths.text(&status.socket)
+                paths.role_path(Path::new(&status.socket), "<daemon-socket>")
             ),
             Some("run: coven daemon restart".to_string()),
         ),
@@ -2021,17 +2028,20 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
 
     for repo in &report.repos {
         checks.push(if repo.ok {
-            DoctorCheck::pass(format!("repo:{}", repo.name), paths.path(&repo.path))
+            DoctorCheck::pass(
+                format!("repo:{}", repo.name),
+                paths.role_path(&repo.path, "<repo>"),
+            )
         } else {
             DoctorCheck::fail(
                 format!("repo:{}", repo.name),
                 format!(
                     "{} is missing or not a git repository",
-                    paths.path(&repo.path)
+                    paths.role_path(&repo.path, "<repo>")
                 ),
                 Some(format!(
                     "fix the path in {}",
-                    paths.path(&report.repos_config_path)
+                    paths.role_path(&report.repos_config_path, "<repos-config>")
                 )),
             )
         });
@@ -2079,7 +2089,11 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             Some("run: coven engine install".to_string()),
         ),
         Some(engine) => {
-            let located = format!("{} ({})", paths.path(&engine.path), engine.source_label);
+            let located = format!(
+                "{} ({})",
+                paths.role_path(&engine.path, "<engine>"),
+                engine.source_label
+            );
             match engine.version {
                 None => DoctorCheck::warn(
                     "engine",
@@ -2113,7 +2127,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             "familiars",
             format!(
                 "could not read {}: {error}",
-                paths.path(&report.familiars_manifest),
+                paths.role_path(&report.familiars_manifest, "<familiars-manifest>"),
                 error = paths.text(error)
             ),
             None,
@@ -2122,7 +2136,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
             "familiars",
             format!(
                 "none configured ({})",
-                paths.path(&report.familiars_manifest)
+                paths.role_path(&report.familiars_manifest, "<familiars-manifest>")
             ),
         ),
         Ok(familiars) => DoctorCheck::pass("familiars", format!("{} configured", familiars.len())),
@@ -6298,6 +6312,11 @@ mod tests {
     fn doctor_json_redactor_rejects_unix_root_replacements() {
         let mut report = make_doctor_report();
         report.home = PathBuf::from("/");
+        report.repos.push(DoctorRepoReport {
+            name: "root".to_string(),
+            path: PathBuf::from("/"),
+            ok: true,
+        });
 
         let redactor = DoctorJsonPathRedactor::new(&report);
         assert!(
@@ -6305,6 +6324,11 @@ mod tests {
             "the Unix filesystem root must never become a global replacement"
         );
         assert_eq!(redactor.text("/var/lib/coven"), "/var/lib/coven");
+        let root_check = doctor_checks(&report)
+            .into_iter()
+            .find(|check| check.id == "repo:root")
+            .expect("root repository check");
+        assert_eq!(root_check.message, "<repo>");
     }
 
     #[cfg(windows)]
@@ -6312,6 +6336,11 @@ mod tests {
     fn doctor_json_redactor_rejects_windows_drive_and_unc_roots() {
         let mut drive_report = make_doctor_report();
         drive_report.home = PathBuf::from(r"C:\");
+        drive_report.repos.push(DoctorRepoReport {
+            name: "drive-root".to_string(),
+            path: PathBuf::from(r"C:\"),
+            ok: true,
+        });
         let drive_redactor = DoctorJsonPathRedactor::new(&drive_report);
         assert!(
             drive_redactor
@@ -6324,9 +6353,19 @@ mod tests {
             drive_redactor.text(r"C:\Users\example\project"),
             r"C:\Users\example\project"
         );
+        let drive_check = doctor_checks(&drive_report)
+            .into_iter()
+            .find(|check| check.id == "repo:drive-root")
+            .expect("drive-root repository check");
+        assert_eq!(drive_check.message, "<repo>");
 
         let mut unc_report = make_doctor_report();
         unc_report.home = PathBuf::from(r"\\server\share\");
+        unc_report.repos.push(DoctorRepoReport {
+            name: "unc-root".to_string(),
+            path: PathBuf::from(r"\\server\share\"),
+            ok: true,
+        });
         let unc_redactor = DoctorJsonPathRedactor::new(&unc_report);
         assert!(
             unc_redactor
@@ -6339,6 +6378,11 @@ mod tests {
             unc_redactor.text(r"\\server\share\project"),
             r"\\server\share\project"
         );
+        let unc_check = doctor_checks(&unc_report)
+            .into_iter()
+            .find(|check| check.id == "repo:unc-root")
+            .expect("UNC-root repository check");
+        assert_eq!(unc_check.message, "<repo>");
     }
 
     fn make_doctor_report() -> DoctorReport {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1924,10 +1924,17 @@ impl DoctorJsonPathRedactor {
     fn new(report: &DoctorReport) -> Self {
         let mut replacements = Vec::new();
         let mut add_path = |path: &Path, token: String| {
-            // Only redact rooted paths with a component below the root. A
-            // one-character relative path or filesystem root would otherwise
-            // act like an unsafe global substring replacement.
-            if path.has_root() && path.components().count() > 1 {
+            // Only redact rooted paths with a normal component below the root.
+            // Checking components rather than their count rejects Unix `/`,
+            // Windows drive roots, and UNC share roots; prefix/root components
+            // alone would otherwise create an unsafe broad substring
+            // replacement. Root-relative Windows paths are still safe because
+            // the normal component keeps the replacement narrow.
+            if path.has_root()
+                && path
+                    .components()
+                    .any(|component| matches!(component, std::path::Component::Normal(_)))
+            {
                 replacements.push((path.display().to_string(), token));
             }
         };
@@ -1941,7 +1948,10 @@ impl DoctorJsonPathRedactor {
             add_path(&engine.path, "<engine>".to_string());
         }
         for repo in &report.repos {
-            add_path(&repo.path, format!("<repo:{}>", repo.name));
+            // A path may be registered under multiple aliases. Keep the token
+            // path-scoped and neutral so insertion order cannot assign one
+            // alias's identity to another alias's check.
+            add_path(&repo.path, "<repo>".to_string());
         }
         if let Some(project_root) = &report.project_root {
             add_path(project_root, "<project>".to_string());
@@ -6282,6 +6292,54 @@ mod tests {
     }
 
     // --- doctor report/check unit tests ---
+
+    #[cfg(unix)]
+    #[test]
+    fn doctor_json_redactor_rejects_unix_root_replacements() {
+        let mut report = make_doctor_report();
+        report.home = PathBuf::from("/");
+
+        let redactor = DoctorJsonPathRedactor::new(&report);
+        assert!(
+            redactor.replacements.iter().all(|(path, _)| path != "/"),
+            "the Unix filesystem root must never become a global replacement"
+        );
+        assert_eq!(redactor.text("/var/lib/coven"), "/var/lib/coven");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn doctor_json_redactor_rejects_windows_drive_and_unc_roots() {
+        let mut drive_report = make_doctor_report();
+        drive_report.home = PathBuf::from(r"C:\");
+        let drive_redactor = DoctorJsonPathRedactor::new(&drive_report);
+        assert!(
+            drive_redactor
+                .replacements
+                .iter()
+                .all(|(path, _)| path != r"C:\"),
+            "a Windows drive root must never become a global replacement"
+        );
+        assert_eq!(
+            drive_redactor.text(r"C:\Users\example\project"),
+            r"C:\Users\example\project"
+        );
+
+        let mut unc_report = make_doctor_report();
+        unc_report.home = PathBuf::from(r"\\server\share\");
+        let unc_redactor = DoctorJsonPathRedactor::new(&unc_report);
+        assert!(
+            unc_redactor
+                .replacements
+                .iter()
+                .all(|(path, _)| path != r"\\server\share\"),
+            "a UNC share root must never become a global replacement"
+        );
+        assert_eq!(
+            unc_redactor.text(r"\\server\share\project"),
+            r"\\server\share\project"
+        );
+    }
 
     fn make_doctor_report() -> DoctorReport {
         DoctorReport {

--- a/crates/coven-cli/tests/doctor_json_contract.rs
+++ b/crates/coven-cli/tests/doctor_json_contract.rs
@@ -1,0 +1,134 @@
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+fn isolated_doctor_command(
+    root: &Path,
+    project: &Path,
+    coven_home: &Path,
+    args: &[&str],
+) -> Command {
+    let fake_home = root.join("user-home");
+    let mut command = Command::new(coven_bin());
+    command
+        .args(args)
+        .current_dir(project)
+        .env("COVEN_HOME", coven_home)
+        .env("HOME", &fake_home)
+        .env("USERPROFILE", &fake_home)
+        .env("PATH", OsString::new())
+        .env("COVEN_ENGINE_BIN", root.join("missing-engine"))
+        .env_remove("COVEN_HARNESS_ADAPTER_DIRS")
+        .env_remove("COVEN_SETTINGS_PATH");
+    command
+}
+
+fn assert_single_json_document(output: &Output) -> anyhow::Result<Value> {
+    let stdout = std::str::from_utf8(&output.stdout)?;
+    anyhow::ensure!(
+        output.stderr.is_empty(),
+        "doctor --json must keep stderr empty; got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_str(stdout).map_err(Into::into)
+}
+
+#[test]
+fn doctor_json_is_stable_redacted_and_stdout_pure() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let project = temp.path().join("private-project-name");
+    let coven_home = temp.path().join("private-coven-home");
+    fs::create_dir_all(project.join(".git"))?;
+    fs::create_dir_all(&coven_home)?;
+    fs::create_dir_all(temp.path().join("user-home"))?;
+
+    let first = isolated_doctor_command(
+        temp.path(),
+        &project,
+        &coven_home,
+        &["--color", "always", "doctor", "--json"],
+    )
+    .output()?;
+    assert_eq!(first.status.code(), Some(1));
+    let first_json = assert_single_json_document(&first)?;
+
+    let keys: BTreeSet<_> = first_json
+        .as_object()
+        .expect("doctor output must be an object")
+        .keys()
+        .map(String::as_str)
+        .collect();
+    assert_eq!(
+        keys,
+        BTreeSet::from(["blocking", "checks", "nextSteps", "ok", "project", "store"])
+    );
+    assert_eq!(first_json["ok"], false);
+    assert_eq!(first_json["blocking"], true);
+    assert_eq!(first_json["store"], "<coven-home>");
+    assert_eq!(first_json["project"], "<project>");
+
+    let checks = first_json["checks"].as_array().expect("checks array");
+    assert!(!checks.is_empty());
+    for check in checks {
+        let check = check.as_object().expect("check object");
+        assert!(check.get("id").is_some_and(Value::is_string));
+        assert!(check.get("message").is_some_and(Value::is_string));
+        assert!(check
+            .get("status")
+            .and_then(Value::as_str)
+            .is_some_and(|status| matches!(status, "pass" | "warn" | "fail")));
+        assert!(check.get("hint").is_none_or(Value::is_string));
+    }
+    assert!(first_json["nextSteps"]
+        .as_array()
+        .is_some_and(|steps| !steps.is_empty() && steps.iter().all(Value::is_string)));
+
+    let stdout = String::from_utf8(first.stdout)?;
+    assert!(
+        !stdout.contains('\u{1b}'),
+        "JSON must never contain ANSI escapes"
+    );
+    assert!(!stdout.contains(&temp.path().display().to_string()));
+    assert!(!stdout.contains("private-project-name"));
+    assert!(!stdout.contains("private-coven-home"));
+
+    let second = isolated_doctor_command(temp.path(), &project, &coven_home, &["doctor", "--json"])
+        .output()?;
+    assert_eq!(second.status.code(), Some(1));
+    assert_eq!(assert_single_json_document(&second)?, first_json);
+    Ok(())
+}
+
+#[test]
+fn doctor_json_rejects_trailing_arguments_without_stdout() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let project = temp.path().join("project");
+    let coven_home = temp.path().join("coven-home");
+    fs::create_dir_all(project.join(".git"))?;
+    fs::create_dir_all(&coven_home)?;
+    fs::create_dir_all(temp.path().join("user-home"))?;
+
+    let output = isolated_doctor_command(
+        temp.path(),
+        &project,
+        &coven_home,
+        &["doctor", "--json", "unexpected"],
+    )
+    .output()?;
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unexpected argument"),
+        "clap should explain the invalid argument: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}

--- a/crates/coven-cli/tests/doctor_json_contract.rs
+++ b/crates/coven-cli/tests/doctor_json_contract.rs
@@ -26,9 +26,19 @@ fn isolated_doctor_command(
         .env("USERPROFILE", &fake_home)
         .env("PATH", OsString::new())
         .env("COVEN_ENGINE_BIN", root.join("missing-engine"))
+        .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST")
         .env_remove("COVEN_HARNESS_ADAPTER_DIRS")
         .env_remove("COVEN_SETTINGS_PATH");
     command
+}
+
+fn toml_path(path: &Path) -> String {
+    format!(
+        "\"{}\"",
+        path.to_string_lossy()
+            .replace('\\', "\\\\")
+            .replace('\"', "\\\"")
+    )
 }
 
 fn assert_single_json_document(output: &Output) -> anyhow::Result<Value> {
@@ -49,6 +59,20 @@ fn doctor_json_is_stable_redacted_and_stdout_pure() -> anyhow::Result<()> {
     fs::create_dir_all(project.join(".git"))?;
     fs::create_dir_all(&coven_home)?;
     fs::create_dir_all(temp.path().join("user-home"))?;
+    let shared_repo = temp.path().join("private-shared-repo");
+    let missing_repo = temp.path().join("private-missing-repo");
+    fs::create_dir_all(shared_repo.join(".git"))?;
+    fs::write(
+        coven_home.join("repos.toml"),
+        format!(
+            "[repos.alias_a]\npath = {}\n\
+             [repos.alias_b]\npath = {}\n\
+             [repos.missing]\npath = {}\n",
+            toml_path(&shared_repo),
+            toml_path(&shared_repo),
+            toml_path(&missing_repo),
+        ),
+    )?;
 
     let first = isolated_doctor_command(
         temp.path(),
@@ -77,6 +101,27 @@ fn doctor_json_is_stable_redacted_and_stdout_pure() -> anyhow::Result<()> {
 
     let checks = first_json["checks"].as_array().expect("checks array");
     assert!(!checks.is_empty());
+    let check_ids: Vec<_> = checks
+        .iter()
+        .map(|check| check["id"].as_str().expect("check id"))
+        .collect();
+    assert_eq!(
+        check_ids,
+        vec![
+            "daemon",
+            "repo:alias_a",
+            "repo:alias_b",
+            "repo:missing",
+            "harness:codex",
+            "harness:claude",
+            "harness:coven-code",
+            "harness:copilot",
+            "harnesses",
+            "engine",
+            "familiars",
+        ],
+        "Doctor check ordering is part of the JSON compatibility contract"
+    );
     for check in checks {
         let check = check.as_object().expect("check object");
         assert!(check.get("id").is_some_and(Value::is_string));
@@ -87,6 +132,24 @@ fn doctor_json_is_stable_redacted_and_stdout_pure() -> anyhow::Result<()> {
             .is_some_and(|status| matches!(status, "pass" | "warn" | "fail")));
         assert!(check.get("hint").is_none_or(Value::is_string));
     }
+    for id in ["repo:alias_a", "repo:alias_b"] {
+        let check = checks
+            .iter()
+            .find(|check| check["id"] == id)
+            .expect("aliased repository check");
+        assert_eq!(check["status"], "pass");
+        assert_eq!(check["message"], "<repo>");
+    }
+    let missing = checks
+        .iter()
+        .find(|check| check["id"] == "repo:missing")
+        .expect("missing repository check");
+    assert_eq!(missing["status"], "fail");
+    assert_eq!(
+        missing["message"],
+        "<repo> is missing or not a git repository"
+    );
+    assert_eq!(missing["hint"], "fix the path in <repos-config>");
     assert!(first_json["nextSteps"]
         .as_array()
         .is_some_and(|steps| !steps.is_empty() && steps.iter().all(Value::is_string)));

--- a/crates/coven-cli/tests/doctor_json_contract.rs
+++ b/crates/coven-cli/tests/doctor_json_contract.rs
@@ -24,6 +24,7 @@ fn isolated_doctor_command(
         .env("COVEN_HOME", coven_home)
         .env("HOME", &fake_home)
         .env("USERPROFILE", &fake_home)
+        .env("XDG_CONFIG_HOME", root.join("xdg-config"))
         .env("PATH", OsString::new())
         .env("COVEN_ENGINE_BIN", root.join("missing-engine"))
         .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST")
@@ -59,6 +60,7 @@ fn doctor_json_is_stable_redacted_and_stdout_pure() -> anyhow::Result<()> {
     fs::create_dir_all(project.join(".git"))?;
     fs::create_dir_all(&coven_home)?;
     fs::create_dir_all(temp.path().join("user-home"))?;
+    fs::create_dir_all(temp.path().join("xdg-config"))?;
     let shared_repo = temp.path().join("private-shared-repo");
     let missing_repo = temp.path().join("private-missing-repo");
     fs::create_dir_all(shared_repo.join(".git"))?;

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -118,7 +118,7 @@ coven daemon status --json
 Typical human output from `coven daemon status`:
 
 ```text
-Coven daemon: running (pid 12345, socket <coven-home>/coven.sock)
+Coven daemon: running (pid 12345, socket /path/to/coven-home/coven.sock)
 ```
 
 `not running` means no background daemon is running yet. Start it with:

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -26,17 +26,23 @@ found):
 {
   "ok": true,
   "blocking": false,
-  "store": "/home/alex/.coven",
-  "project": "/home/alex/src/app",
+  "store": "<coven-home>",
+  "project": "<project>",
   "checks": [
-    { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket /home/alex/.coven/coven.sock)" },
+    { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket <daemon-socket>)" },
     { "id": "harness:codex", "status": "pass", "message": "`codex` is ready (built-in)" },
     { "id": "harnesses", "status": "pass", "message": "1 of 3 configured harnesses available" },
-    { "id": "engine", "status": "pass", "message": "/home/alex/.coven/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" }
+    { "id": "engine", "status": "pass", "message": "<engine> (managed install), version 0.6.1 (pin 0.6.1)" }
   ],
   "nextSteps": ["coven run codex \"explain this repo in 5 bullets\"", "coven sessions"]
 }
 ```
+
+Absolute paths are replaced with stable role tokens such as `<coven-home>`,
+`<project>`, `<engine>`, and `<daemon-socket>`. This keeps repeated output
+comparable across machines and safer to attach to CI logs or bug reports. Run
+the prose form locally when you need the concrete paths. `project` is `null`
+when the command runs outside a project root.
 
 Check `status` is `pass`, `warn`, or `fail`. Every `fail` is blocking — `ok`
 is false and the command exits 1 — while `warn` needs attention but does not
@@ -110,7 +116,7 @@ coven daemon status --json
 Typical human output from `coven daemon status`:
 
 ```text
-Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
+Coven daemon: running (pid 12345, socket <coven-home>/coven.sock)
 ```
 
 `not running` means no background daemon is running yet. Start it with:

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -38,11 +38,13 @@ found):
 }
 ```
 
-Absolute paths are replaced with stable role tokens such as `<coven-home>`,
-`<project>`, `<engine>`, and `<daemon-socket>`. This keeps repeated output
-comparable across machines and safer to attach to CI logs or bug reports. Run
-the prose form locally when you need the concrete paths. `project` is `null`
-when the command runs outside a project root.
+Known Doctor-owned absolute path roles are replaced with stable tokens such as
+`<coven-home>`, `<project>`, `<engine>`, `<daemon-socket>`, `<repo>`, and
+`<repos-config>`. This keeps repeated output comparable across machines and
+safer to attach to CI logs or bug reports without implying that arbitrary
+user-authored hint text is sanitized. Run the prose form locally when you need
+the concrete paths. `project` is `null` when the command runs outside a project
+root.
 
 Check `status` is `pass`, `warn`, or `fail`. Every `fail` is blocking — `ok`
 is false and the command exits 1 — while `warn` needs attention but does not


### PR DESCRIPTION
## Context

- Summary: Redacts host-specific paths from `coven doctor --json` with stable semantic role tokens while preserving concrete paths in the local prose report.
- Closes #553
- Certification tracking: OpenCoven/coven-dev-tools#157 (`coven-live-07v`)

## Implementation

- Builds a report-scoped redactor from known Doctor-owned path roles and applies longest-path-first replacement only to machine-readable Doctor fields and check text.
- Redacts top-level store/project paths and nested daemon-socket, engine, repository-config, familiars-manifest, and repository roles.
- Exact semantic roles redact even when represented by a relative path or filesystem root. This covers the production Windows `coven-daemon-<hash>.sock` value.
- Broad nested-text replacement remains limited to rooted paths with normal components, preventing unsafe replacement of Unix root, Windows drive root, or UNC share root.
- Uses a neutral `<repo>` token for duplicate aliases so output does not depend on insertion order or disclose alias identity.
- Preserves JSON field names, types, check ordering, severity, and exit-code semantics. The prose report intentionally retains local concrete paths.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p coven-cli --locked`
- [x] `cargo test -p coven-cli doctor_json --locked` — focused unit and integration tests
- [x] `cargo test -p coven-cli --test doctor_json_contract --locked` — 2/2 on Windows and WSL/Linux
- [x] Native redactor regressions for Unix root, Windows drive/UNC roots, duplicate aliases, exact check order, and relative daemon sockets
- [x] Targeted Clippy for the Doctor JSON integration target
- [x] `python scripts/check-coven-privacy.py --staged`
- [x] `git diff --check`
- [x] Prior-head GitHub CI passed across Ubuntu/Windows Rust, performance, secret, packaging, onboarding, engine-contract, and dependency-audit jobs
- [x] GitHub CI on head `aa2c1b6` — all required jobs passed
- [x] Final independent review of head `aa2c1b6` — no P0/P1/P2 findings

## Risk and Rollback

- Risk level: Medium. Diagnostic path values intentionally change to privacy-safe tokens.
- Safety guarantees: Doctor remains read-only; no broad environment scrubber or root-wide substring replacement is introduced.
- Rollback plan: revert the four signed-off commits; there are no migrations or persisted-state changes.

## Agent Handoff

- Current state: Ready for review; final CI is green and independent review found no P0/P1/P2 issues.
- Known scope boundary: redaction is limited to known Doctor-owned path roles. The prose report remains the local concrete-path troubleshooting surface.