### PR TITLE
fix(doctor): separate provider auth from discovery

### DIFF
--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -68,7 +68,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 interprocess = "2"
 widestring = "1"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_SystemInformation"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -2804,41 +2804,94 @@ fn engine_source_label(source: &engine::EngineSource) -> &'static str {
 /// not proof that a provider turn succeeds.
 fn engine_auth_summary(binary: &Path) -> Option<bool> {
     use std::io::Read;
-    use std::process::Stdio;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc::{self, TryRecvError};
     use std::time::{Duration, Instant};
 
-    let mut child = std::process::Command::new(binary)
+    const TIMEOUT: Duration = Duration::from_secs(5);
+    const OUTPUT_LIMIT: usize = 1024 * 1024;
+
+    let mut command = Command::new(binary);
+    command
         .args(["auth", "status", "--json"])
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
+        .stderr(Stdio::null());
+    pty_runner::configure_child_process_tree_command(&mut command);
+    let mut child = command.spawn().ok()?;
+    let mut process_tree = pty_runner::ChildProcessTree::attach(&child);
+    if !process_tree.is_strictly_contained() {
+        // Doctor cannot promise a bounded local-only probe without ownership
+        // of descendants, so fail closed instead of running uncontained.
+        let _ = child.kill();
+        let _ = child.wait();
+        return None;
+    }
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            process_tree.terminate(&mut child);
+            let _ = child.wait();
+            return None;
+        }
+    };
+    let (sender, receiver) = mpsc::channel::<std::io::Result<Vec<u8>>>();
+    std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let result = stdout
+            .take((OUTPUT_LIMIT + 1) as u64)
+            .read_to_end(&mut bytes)
+            .map(|_| bytes);
+        let _ = sender.send(result);
+    });
+
+    let deadline = Instant::now() + TIMEOUT;
+    let mut status = None;
+    let mut output = None;
+    loop {
+        if output.is_none() {
+            match receiver.try_recv() {
+                Ok(Ok(bytes)) if bytes.len() <= OUTPUT_LIMIT => output = Some(bytes),
+                Ok(Ok(_)) | Ok(Err(_)) | Err(TryRecvError::Disconnected) => {
+                    process_tree.terminate(&mut child);
                     let _ = child.wait();
                     return None;
                 }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-            Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                return None;
+                Err(TryRecvError::Empty) => {}
             }
         }
-    };
 
-    // `auth status --json` output is a few hundred bytes — far under the pipe
-    // buffer — so reading after exit cannot deadlock.
-    let mut buf = String::new();
-    child.stdout.take()?.read_to_string(&mut buf).ok()?;
-    parse_engine_auth_summary(status.code(), &buf)
+        if status.is_none() {
+            match child.try_wait() {
+                Ok(Some(exit_status)) => {
+                    status = Some(exit_status);
+                    // The direct engine has exited. Terminate anything it left
+                    // behind before waiting for pipe EOF; a descendant that
+                    // inherited stdout must not extend Doctor's deadline.
+                    process_tree.terminate(&mut child);
+                    let _ = child.wait();
+                }
+                Ok(None) => {}
+                Err(_) => {
+                    process_tree.terminate(&mut child);
+                    let _ = child.wait();
+                    return None;
+                }
+            }
+        }
+
+        if let (Some(status), Some(bytes)) = (status.as_ref(), output.as_ref()) {
+            let stdout = std::str::from_utf8(bytes).ok()?;
+            return parse_engine_auth_summary(status.code(), stdout);
+        }
+
+        if Instant::now() >= deadline {
+            process_tree.terminate(&mut child);
+            let _ = child.wait();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
 }
 
 /// Parse only the engine's boolean auth summary and reject contradictory

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1794,19 +1794,21 @@ fn print_doctor_prose(report: &DoctorReport) {
 
     println!("\nHarnesses:");
     for harness in &report.harnesses {
-        let status = if harness.available {
-            "ready"
-        } else {
-            "missing"
-        };
         let marker = if harness.available { "OK" } else { "!!" };
-        println!(
-            "  [{marker}] {:<18} `{}` is {status} ({})",
-            harness.label,
-            harness.executable,
-            adapter_source_label(&harness.source)
-        );
-        if !harness.available {
+        if harness.available {
+            println!(
+                "  [{marker}] {:<18} `{}` executable is available ({})",
+                harness.label,
+                harness.executable,
+                adapter_source_label(&harness.source)
+            );
+        } else {
+            println!(
+                "  [{marker}] {:<18} `{}` is missing ({})",
+                harness.label,
+                harness.executable,
+                adapter_source_label(&harness.source)
+            );
             println!("       {}", harness.install_hint);
         }
     }
@@ -1960,7 +1962,10 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
         checks.push(if harness.available {
             DoctorCheck::pass(
                 format!("harness:{}", harness.id),
-                format!("`{}` is ready ({})", harness.executable, harness.source),
+                format!(
+                    "`{}` executable is available ({})",
+                    harness.executable, harness.source
+                ),
             )
         } else {
             DoctorCheck::warn(
@@ -1979,7 +1984,7 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
         DoctorCheck::pass(
             "harnesses",
             format!(
-                "{available} of {} configured harnesses available",
+                "{available} of {} configured harness executables available",
                 report.harnesses.len()
             ),
         )
@@ -2045,16 +2050,47 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
 
     if let Some(auth) = report.engine_auth {
         checks.push(match auth {
-            Some(true) => DoctorCheck::pass("credentials:engine", "logged in"),
+            Some(true) => DoctorCheck::warn(
+                "credentials:engine",
+                "authentication configured; provider turn not verified",
+                Some("run an explicitly authorized test turn to verify provider access".to_string()),
+            ),
             Some(false) => DoctorCheck::warn(
                 "credentials:engine",
-                "not logged in",
+                "authentication not configured",
                 Some(
                     "set ANTHROPIC_API_KEY, authenticate Claude Code, or configure OAuth then run: coven auth login"
                         .to_string(),
                 ),
             ),
-            None => DoctorCheck::warn("credentials:engine", "auth check skipped", None),
+            None => DoctorCheck::warn(
+                "credentials:engine",
+                "authentication status unavailable; provider turn not verified",
+                None,
+            ),
+        });
+    }
+
+    for harness in report
+        .harnesses
+        .iter()
+        .filter(|harness| harness.id != engine::ENGINE_HARNESS_ID)
+    {
+        checks.push(if harness.available {
+            DoctorCheck::warn(
+                format!("credentials:{}", harness.id),
+                "executable available; authentication not verified",
+                Some(format!(
+                    "verify with: {}",
+                    login_hint_for_harness(&harness.id)
+                )),
+            )
+        } else {
+            DoctorCheck::warn(
+                format!("credentials:{}", harness.id),
+                "authentication not checked because the executable is missing",
+                Some(harness.install_hint.trim().to_string()),
+            )
         });
     }
 
@@ -2756,10 +2792,11 @@ fn engine_source_label(source: &engine::EngineSource) -> &'static str {
     }
 }
 
-/// Query the engine's auth state via `auth status --json`, bounded to ~5s so a
-/// hung engine never hangs `coven doctor`. Returns `Some(logged_in)` on a clean
-/// parse, or `None` if the check couldn't be completed (spawn/timeout/parse
-/// failure) — the caller treats `None` as a skipped, non-blocking check.
+/// Query the engine's local auth state via `auth status --json`, bounded to ~5s
+/// so a hung engine never hangs `coven doctor`. Returns `Some(configured)` only
+/// when the JSON value agrees with the engine contract's exit status (0 for
+/// configured, 1 for not configured). This is local configuration evidence,
+/// not proof that a provider turn succeeds.
 fn engine_auth_summary(binary: &Path) -> Option<bool> {
     use std::io::Read;
     use std::process::Stdio;
@@ -2773,9 +2810,9 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
         .ok()?;
 
     let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
+    let status = loop {
         match child.try_wait() {
-            Ok(Some(_)) => break,
+            Ok(Some(status)) => break status,
             Ok(None) => {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
@@ -2786,23 +2823,34 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
             }
             Err(_) => return None,
         }
-    }
+    };
 
     // `auth status --json` output is a few hundred bytes — far under the pipe
     // buffer — so reading after exit cannot deadlock.
     let mut buf = String::new();
     child.stdout.take()?.read_to_string(&mut buf).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&buf).ok()?;
-    json.get("loggedIn")?.as_bool()
+    parse_engine_auth_summary(status.code(), &buf)
+}
+
+/// Parse only the engine's boolean auth summary and reject contradictory
+/// status/output pairs. Additional fields are deliberately ignored so Doctor
+/// never forwards provider metadata or credential material.
+fn parse_engine_auth_summary(exit_code: Option<i32>, stdout: &str) -> Option<bool> {
+    let json: serde_json::Value = serde_json::from_str(stdout).ok()?;
+    let configured = json.get("loggedIn")?.as_bool()?;
+    match (exit_code, configured) {
+        (Some(0), true) | (Some(1), false) => Some(configured),
+        _ => None,
+    }
 }
 
 /// Pure formatter for the "Credentials:" section of `coven doctor`.
 ///
 /// `engine_auth` is:
 /// - `None`          — engine binary is missing; skip engine auth row entirely
-/// - `Some(None)`    — engine present but auth probe returned no result (skipped)
-/// - `Some(Some(true))`  — engine present and logged in
-/// - `Some(Some(false))` — engine present but not logged in
+/// - `Some(None)`    — engine present but local auth status is unavailable
+/// - `Some(Some(true))`  — engine reports local authentication configured
+/// - `Some(Some(false))` — engine reports local authentication not configured
 ///
 /// Harnesses with `id == "coven-code"` are skipped (that is the engine, shown above).
 ///
@@ -2820,15 +2868,21 @@ fn credentials_lines(
                 .push("  [!!] Coven Code (engine) — missing; see Engine section above".to_string());
         }
         Some(Some(true)) => {
-            lines.push("  [OK] Coven Code (engine) — logged in".to_string());
+            lines.push(
+                "  [--] Coven Code (engine) — authentication configured; provider turn not verified"
+                    .to_string(),
+            );
         }
         Some(Some(false)) => {
             lines.push(
-                "  [!!] Coven Code (engine) — not logged in; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
+                "  [!!] Coven Code (engine) — authentication not configured; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
             );
         }
         Some(None) => {
-            lines.push("  [--] Coven Code (engine) — auth check skipped".to_string());
+            lines.push(
+                "  [--] Coven Code (engine) — authentication status unavailable; provider turn not verified"
+                    .to_string(),
+            );
         }
     }
 
@@ -2840,7 +2894,7 @@ fn credentials_lines(
         if h.available {
             let login_hint = login_hint_for_harness(&h.id);
             lines.push(format!(
-                "  [OK] {} — available; authenticate with `{}`",
+                "  [--] {} — executable available; authentication not verified; verify with `{}`",
                 h.label, login_hint
             ));
         } else {
@@ -6130,18 +6184,32 @@ mod tests {
     }
 
     #[test]
-    fn credentials_lines_engine_logged_in() {
+    fn credentials_lines_engine_configured_does_not_claim_a_provider_turn() {
         let lines = credentials_lines(Some(Some(true)), &[]);
         assert_eq!(lines.len(), 1);
-        assert!(lines[0].contains("logged in"), "got: {}", lines[0]);
-        assert!(lines[0].contains("[OK]"), "got: {}", lines[0]);
+        assert!(
+            lines[0].contains("authentication configured"),
+            "got: {}",
+            lines[0]
+        );
+        assert!(
+            lines[0].contains("provider turn not verified"),
+            "got: {}",
+            lines[0]
+        );
+        assert!(lines[0].contains("[--]"), "got: {}", lines[0]);
+        assert!(!lines[0].contains("logged in"), "got: {}", lines[0]);
     }
 
     #[test]
-    fn credentials_lines_engine_not_logged_in() {
+    fn credentials_lines_engine_not_configured() {
         let lines = credentials_lines(Some(Some(false)), &[]);
         assert_eq!(lines.len(), 1);
-        assert!(lines[0].contains("not logged in"), "got: {}", lines[0]);
+        assert!(
+            lines[0].contains("authentication not configured"),
+            "got: {}",
+            lines[0]
+        );
         assert!(lines[0].contains("ANTHROPIC_API_KEY"), "got: {}", lines[0]);
         assert!(lines[0].contains("Claude Code"), "got: {}", lines[0]);
         assert!(lines[0].contains("[!!]"), "got: {}", lines[0]);
@@ -6194,11 +6262,47 @@ mod tests {
     }
 
     #[test]
-    fn credentials_lines_engine_auth_skipped() {
+    fn credentials_lines_engine_auth_unavailable() {
         let lines = credentials_lines(Some(None), &[]);
         assert_eq!(lines.len(), 1);
-        assert!(lines[0].contains("skipped"), "got: {}", lines[0]);
+        assert!(lines[0].contains("status unavailable"), "got: {}", lines[0]);
+        assert!(
+            lines[0].contains("provider turn not verified"),
+            "got: {}",
+            lines[0]
+        );
         assert!(lines[0].contains("[--]"), "got: {}", lines[0]);
+    }
+
+    #[test]
+    fn engine_auth_summary_requires_consistent_contract_output() {
+        let configured =
+            parse_engine_auth_summary(Some(0), r#"{"loggedIn":true,"account":"private-sentinel"}"#);
+        assert_eq!(configured, Some(true));
+        assert!(
+            credentials_lines(Some(configured), &[])
+                .iter()
+                .all(|line| !line.contains("private-sentinel")),
+            "Doctor must reduce engine output to the boolean boundary"
+        );
+        assert_eq!(
+            parse_engine_auth_summary(Some(1), r#"{"loggedIn":false}"#),
+            Some(false)
+        );
+        assert_eq!(
+            parse_engine_auth_summary(Some(1), r#"{"loggedIn":true}"#),
+            None,
+            "a contradictory exit status must not be presented as authenticated"
+        );
+        assert_eq!(
+            parse_engine_auth_summary(Some(0), r#"{"loggedIn":"yes"}"#),
+            None
+        );
+        assert_eq!(parse_engine_auth_summary(Some(0), "not-json"), None);
+        assert_eq!(
+            parse_engine_auth_summary(None, r#"{"loggedIn":true}"#),
+            None
+        );
     }
 
     #[test]
@@ -6335,7 +6439,7 @@ mod tests {
     }
 
     #[test]
-    fn doctor_passing_report_keeps_daemon_and_credentials_checks() {
+    fn doctor_passing_report_keeps_authentication_checks_non_blocking_and_unverified() {
         let body = doctor_json_body(&make_doctor_report());
         assert_eq!(body["ok"], serde_json::json!(true));
         assert_eq!(body["blocking"], serde_json::json!(false));
@@ -6356,7 +6460,20 @@ mod tests {
             .iter()
             .find(|check| check["id"] == "credentials:engine")
             .expect("credentials:engine check");
-        assert_eq!(credentials["status"], "pass");
+        assert_eq!(credentials["status"], "warn");
+        assert_eq!(
+            credentials["message"],
+            "authentication configured; provider turn not verified"
+        );
+        let codex_credentials = checks
+            .iter()
+            .find(|check| check["id"] == "credentials:codex")
+            .expect("credentials:codex check");
+        assert_eq!(codex_credentials["status"], "warn");
+        assert_eq!(
+            codex_credentials["message"],
+            "executable available; authentication not verified"
+        );
         assert!(
             checks.iter().all(|check| check["status"] != "fail"),
             "healthy report must not contain fail checks"
@@ -6381,10 +6498,18 @@ mod tests {
         // engine row + 2 harness rows
         assert_eq!(lines.len(), 3);
         let codex_line = &lines[1];
-        assert!(codex_line.contains("[OK]"), "got: {codex_line}");
+        assert!(codex_line.contains("[--]"), "got: {codex_line}");
+        assert!(
+            codex_line.contains("authentication not verified"),
+            "got: {codex_line}"
+        );
         assert!(codex_line.contains("codex login"), "got: {codex_line}");
         let claude_line = &lines[2];
-        assert!(claude_line.contains("[OK]"), "got: {claude_line}");
+        assert!(claude_line.contains("[--]"), "got: {claude_line}");
+        assert!(
+            claude_line.contains("authentication not verified"),
+            "got: {claude_line}"
+        );
         assert!(claude_line.contains("claude doctor"), "got: {claude_line}");
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1644,9 +1644,9 @@ fn interactive_shell_route(
 
 /// Exits 1 when a blocking problem is found (stale daemon, broken registered
 /// repo, no harness available, missing coven-code) so scripts can gate on
-/// `coven doctor && …`. Individual missing harnesses print `[!!]` but don't
-/// fail the check while another harness is available — one working harness
-/// makes coven usable.
+/// `coven doctor && …`. Individual missing harnesses print advisory `[--]`
+/// rows; when none is available, one aggregate `[!!]` row marks the blocking
+/// failure. One working harness makes coven usable.
 /// Everything `coven doctor` inspects, gathered before rendering so the
 /// prose and `--json` surfaces read the same probe results and cannot drift.
 struct DoctorReport {
@@ -1794,7 +1794,9 @@ fn print_doctor_prose(report: &DoctorReport) {
 
     println!("\nHarnesses:");
     for harness in &report.harnesses {
-        let marker = if harness.available { "OK" } else { "!!" };
+        // Individual missing harnesses are advisory. The aggregate condition
+        // below is the blocking failure when every supported harness is absent.
+        let marker = if harness.available { "OK" } else { "--" };
         if harness.available {
             println!(
                 "  [{marker}] {:<18} `{}` executable is available ({})",
@@ -1811,6 +1813,9 @@ fn print_doctor_prose(report: &DoctorReport) {
             );
             println!("       {}", harness.install_hint);
         }
+    }
+    if !report.harnesses.iter().any(|harness| harness.available) {
+        println!("  [!!] No supported harness is available");
     }
 
     println!("\nEngine:");
@@ -2081,8 +2086,8 @@ fn doctor_checks(report: &DoctorReport) -> Vec<DoctorCheck> {
                 format!("credentials:{}", harness.id),
                 "executable available; authentication not verified",
                 Some(format!(
-                    "verify with: {}",
-                    login_hint_for_harness(&harness.id)
+                    "authenticate or inspect local setup with: {}; verify provider access with an explicitly authorized test turn",
+                    auth_setup_hint_for_harness(&harness.id)
                 )),
             )
         } else {
@@ -2821,7 +2826,11 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
-            Err(_) => return None,
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
         }
     };
 
@@ -2875,7 +2884,7 @@ fn credentials_lines(
         }
         Some(Some(false)) => {
             lines.push(
-                "  [!!] Coven Code (engine) — authentication not configured; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
+                "  [--] Coven Code (engine) — authentication not configured; set ANTHROPIC_API_KEY, use Claude Code, or configure OAuth".to_string(),
             );
         }
         Some(None) => {
@@ -2892,10 +2901,10 @@ fn credentials_lines(
             continue;
         }
         if h.available {
-            let login_hint = login_hint_for_harness(&h.id);
+            let setup_hint = auth_setup_hint_for_harness(&h.id);
             lines.push(format!(
-                "  [--] {} — executable available; authentication not verified; verify with `{}`",
-                h.label, login_hint
+                "  [--] {} — executable available; authentication not verified; authenticate or inspect local setup with `{}`; verify provider access with an explicitly authorized test turn",
+                h.label, setup_hint
             ));
         } else {
             lines.push(format!(
@@ -2909,8 +2918,9 @@ fn credentials_lines(
     lines
 }
 
-/// Return the canonical "how to log in" command for a harness by id.
-fn login_hint_for_harness(harness_id: &str) -> &'static str {
+/// Return the canonical authentication or local-status command for a harness.
+/// Running this command is not proof that a provider turn will succeed.
+fn auth_setup_hint_for_harness(harness_id: &str) -> &'static str {
     match harness_id {
         "codex" => "codex login",
         "claude" => "claude doctor",
@@ -6212,7 +6222,12 @@ mod tests {
         );
         assert!(lines[0].contains("ANTHROPIC_API_KEY"), "got: {}", lines[0]);
         assert!(lines[0].contains("Claude Code"), "got: {}", lines[0]);
-        assert!(lines[0].contains("[!!]"), "got: {}", lines[0]);
+        assert!(lines[0].contains("[--]"), "got: {}", lines[0]);
+        assert!(
+            !lines[0].contains("[!!]"),
+            "non-blocking auth guidance must not look blocking: {}",
+            lines[0]
+        );
     }
 
     #[test]
@@ -6300,9 +6315,25 @@ mod tests {
         );
         assert_eq!(parse_engine_auth_summary(Some(0), "not-json"), None);
         assert_eq!(
+            parse_engine_auth_summary(Some(2), r#"{"loggedIn":false}"#),
+            None,
+            "non-contract exit codes must report auth status as unavailable"
+        );
+        assert_eq!(
             parse_engine_auth_summary(None, r#"{"loggedIn":true}"#),
             None
         );
+    }
+
+    #[test]
+    fn engine_auth_summary_returns_unavailable_when_spawn_fails() {
+        let temp_dir = tempfile::tempdir().expect("temporary directory");
+        let missing = temp_dir.path().join(if cfg!(windows) {
+            "missing-coven-code.exe"
+        } else {
+            "missing-coven-code"
+        });
+        assert_eq!(engine_auth_summary(&missing), None);
     }
 
     #[test]
@@ -6489,7 +6520,7 @@ mod tests {
     }
 
     #[test]
-    fn credentials_lines_available_harness_shows_login_hint() {
+    fn credentials_lines_available_harness_separates_setup_from_turn_verification() {
         let harnesses = vec![
             make_harness_with_hint("codex", true, "npm install -g @openai/codex"),
             make_harness_with_hint("claude", true, "npm install -g @anthropic-ai/claude-code"),
@@ -6504,6 +6535,10 @@ mod tests {
             "got: {codex_line}"
         );
         assert!(codex_line.contains("codex login"), "got: {codex_line}");
+        assert!(
+            codex_line.contains("explicitly authorized test turn"),
+            "got: {codex_line}"
+        );
         let claude_line = &lines[2];
         assert!(claude_line.contains("[--]"), "got: {claude_line}");
         assert!(
@@ -6511,6 +6546,10 @@ mod tests {
             "got: {claude_line}"
         );
         assert!(claude_line.contains("claude doctor"), "got: {claude_line}");
+        assert!(
+            claude_line.contains("explicitly authorized test turn"),
+            "got: {claude_line}"
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -2809,29 +2809,38 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
     use std::time::{Duration, Instant};
 
     const TIMEOUT: Duration = Duration::from_secs(5);
+    const CLEANUP_BUDGET: Duration = Duration::from_millis(500);
     const OUTPUT_LIMIT: usize = 1024 * 1024;
+    let total_deadline = Instant::now() + TIMEOUT;
+    let probe_deadline = total_deadline - CLEANUP_BUDGET;
 
     let mut command = Command::new(binary);
     command
         .args(["auth", "status", "--json"])
         .stdout(Stdio::piped())
         .stderr(Stdio::null());
-    pty_runner::configure_child_process_tree_command(&mut command);
-    let mut child = command.spawn().ok()?;
-    let mut process_tree = pty_runner::ChildProcessTree::attach(&child);
-    if !process_tree.is_strictly_contained() {
-        // Doctor cannot promise a bounded local-only probe without ownership
-        // of descendants, so fail closed instead of running uncontained.
-        let _ = child.kill();
-        let _ = child.wait();
-        return None;
-    }
+    let (mut child, mut process_tree) =
+        pty_runner::spawn_strict_child_process_tree(&mut command).ok()?;
+    let terminate_and_reap = |process_tree: &mut pty_runner::StrictChildProcessTree,
+                              child: &mut std::process::Child| {
+        process_tree.terminate(child);
+        loop {
+            match child.try_wait() {
+                Ok(Some(_)) | Err(_) => break,
+                Ok(None) => {}
+            }
+            let remaining = total_deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10).min(remaining));
+        }
+    };
 
     let stdout = match child.stdout.take() {
         Some(stdout) => stdout,
         None => {
-            process_tree.terminate(&mut child);
-            let _ = child.wait();
+            terminate_and_reap(&mut process_tree, &mut child);
             return None;
         }
     };
@@ -2845,7 +2854,6 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
         let _ = sender.send(result);
     });
 
-    let deadline = Instant::now() + TIMEOUT;
     let mut status = None;
     let mut output = None;
     loop {
@@ -2853,8 +2861,7 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
             match receiver.try_recv() {
                 Ok(Ok(bytes)) if bytes.len() <= OUTPUT_LIMIT => output = Some(bytes),
                 Ok(Ok(_)) | Ok(Err(_)) | Err(TryRecvError::Disconnected) => {
-                    process_tree.terminate(&mut child);
-                    let _ = child.wait();
+                    terminate_and_reap(&mut process_tree, &mut child);
                     return None;
                 }
                 Err(TryRecvError::Empty) => {}
@@ -2868,13 +2875,11 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
                     // The direct engine has exited. Terminate anything it left
                     // behind before waiting for pipe EOF; a descendant that
                     // inherited stdout must not extend Doctor's deadline.
-                    process_tree.terminate(&mut child);
-                    let _ = child.wait();
+                    terminate_and_reap(&mut process_tree, &mut child);
                 }
                 Ok(None) => {}
                 Err(_) => {
-                    process_tree.terminate(&mut child);
-                    let _ = child.wait();
+                    terminate_and_reap(&mut process_tree, &mut child);
                     return None;
                 }
             }
@@ -2885,9 +2890,8 @@ fn engine_auth_summary(binary: &Path) -> Option<bool> {
             return parse_engine_auth_summary(status.code(), stdout);
         }
 
-        if Instant::now() >= deadline {
-            process_tree.terminate(&mut child);
-            let _ = child.wait();
+        if Instant::now() >= probe_deadline {
+            terminate_and_reap(&mut process_tree, &mut child);
             return None;
         }
         std::thread::sleep(Duration::from_millis(10));

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -805,7 +805,7 @@ fn child_job_object_for_process(
 fn resume_suspended_child(child: &std::process::Child) -> bool {
     use std::mem::size_of;
     use windows_sys::Win32::{
-        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        Foundation::{CloseHandle, GetLastError, ERROR_NO_MORE_FILES, INVALID_HANDLE_VALUE},
         System::{
             Diagnostics::ToolHelp::{
                 CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD,
@@ -826,14 +826,21 @@ fn resume_suspended_child(child: &std::process::Child) -> bool {
     };
     let mut thread_ids = Vec::new();
     let mut has_entry = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+    let mut enumeration_complete = false;
     while has_entry {
         if entry.th32OwnerProcessID == child.id() {
             thread_ids.push(entry.th32ThreadID);
         }
         has_entry = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+        if !has_entry {
+            enumeration_complete = unsafe { GetLastError() } == ERROR_NO_MORE_FILES;
+        }
     }
     unsafe { CloseHandle(snapshot) };
 
+    if !enumeration_complete {
+        return false;
+    }
     // CREATE_SUSPENDED creates exactly one primary thread. Anything else is
     // inconsistent with the promised before-first-instruction boundary.
     let [thread_id] = thread_ids.as_slice() else {

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -889,6 +889,9 @@ pub(crate) fn spawn_strict_child_process_tree(
         command.creation_flags(CREATE_SUSPENDED);
     }
 
+    let mut child = command.spawn()?;
+    match StrictChildProcessTree::attach(&child) {
+        Some(tree) => Ok((child, tree)),
         None => {
             let _ = child.kill();
             let _ = child.wait();

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -620,22 +620,11 @@ impl ChildProcessTree {
         }
     }
 
-    pub(crate) fn is_strictly_contained(&self) -> bool {
-        #[cfg(unix)]
-        {
-            true
-        }
-        #[cfg(windows)]
-        {
-            self.job_handle.is_some()
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            false
-        }
+    pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
+        self.terminate_impl(child, true);
     }
 
-    pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
+    fn terminate_impl(&mut self, child: &mut std::process::Child, _allow_taskkill_fallback: bool) {
         if self.terminated {
             return;
         }
@@ -657,7 +646,7 @@ impl ChildProcessTree {
                     succeeded
                 })
                 .unwrap_or(false);
-            if !terminated_by_job {
+            if !terminated_by_job && _allow_taskkill_fallback {
                 // A Job Object can be unavailable when a parent policy forbids
                 // assignment. Fall back to Windows' documented tree kill for
                 // npm's cmd.exe -> node.exe -> codex.exe chain.
@@ -673,6 +662,44 @@ impl ChildProcessTree {
             }
         }
         let _ = child.kill();
+    }
+}
+
+/// A process tree whose descendants were contained before its first
+/// instruction ran. Its termination path deliberately cannot select the
+/// legacy `taskkill` fallback used by the Codex runner.
+pub(crate) struct StrictChildProcessTree(ChildProcessTree);
+
+impl StrictChildProcessTree {
+    fn attach(child: &std::process::Child) -> Option<Self> {
+        #[cfg(unix)]
+        {
+            Some(Self(ChildProcessTree::attach(child)))
+        }
+        #[cfg(windows)]
+        {
+            let job_handle = child_job_object_for_process(child)?;
+            if !resume_suspended_child(child) {
+                // KILL_ON_JOB_CLOSE ensures a partially resumed child cannot
+                // escape when thread enumeration/resume fails.
+                unsafe { windows_sys::Win32::Foundation::CloseHandle(job_handle) };
+                return None;
+            }
+            Some(Self(ChildProcessTree {
+                pid: child.id(),
+                terminated: false,
+                job_handle: Some(job_handle),
+            }))
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = child;
+            None
+        }
+    }
+
+    pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
+        self.0.terminate_impl(child, false);
     }
 }
 
@@ -774,7 +801,54 @@ fn child_job_object_for_process(
     }
 }
 
-pub(crate) fn configure_child_process_tree_command(_command: &mut std::process::Command) {
+#[cfg(windows)]
+fn resume_suspended_child(child: &std::process::Child) -> bool {
+    use std::mem::size_of;
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        System::{
+            Diagnostics::ToolHelp::{
+                CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD,
+                THREADENTRY32,
+            },
+            Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME},
+        },
+    };
+
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return false;
+    }
+
+    let mut entry = THREADENTRY32 {
+        dwSize: size_of::<THREADENTRY32>() as u32,
+        ..Default::default()
+    };
+    let mut thread_ids = Vec::new();
+    let mut has_entry = unsafe { Thread32First(snapshot, &mut entry) } != 0;
+    while has_entry {
+        if entry.th32OwnerProcessID == child.id() {
+            thread_ids.push(entry.th32ThreadID);
+        }
+        has_entry = unsafe { Thread32Next(snapshot, &mut entry) } != 0;
+    }
+    unsafe { CloseHandle(snapshot) };
+
+    // CREATE_SUSPENDED creates exactly one primary thread. Anything else is
+    // inconsistent with the promised before-first-instruction boundary.
+    let [thread_id] = thread_ids.as_slice() else {
+        return false;
+    };
+    let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, *thread_id) };
+    if thread.is_null() {
+        return false;
+    }
+    let previous_suspend_count = unsafe { ResumeThread(thread) };
+    unsafe { CloseHandle(thread) };
+    previous_suspend_count == 1
+}
+
+fn configure_child_process_tree_command(_command: &mut std::process::Command) {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -787,6 +861,35 @@ pub(crate) fn configure_child_process_tree_command(_command: &mut std::process::
                 }
                 Ok(())
             });
+        }
+    }
+}
+
+/// Spawn a process tree that cannot execute before Coven owns its descendants.
+/// Unix uses a fresh session created in the child before exec. Windows creates
+/// the process suspended, assigns it to a kill-on-close Job Object, and only
+/// then resumes its initial thread.
+pub(crate) fn spawn_strict_child_process_tree(
+    command: &mut std::process::Command,
+) -> std::io::Result<(std::process::Child, StrictChildProcessTree)> {
+    #[cfg(unix)]
+    configure_child_process_tree_command(command);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
+
+        command.creation_flags(CREATE_SUSPENDED);
+    }
+
+    let mut child = command.spawn()?;
+    match StrictChildProcessTree::attach(&child) {
+        Some(tree) => Ok((child, tree)),
+        None => {
+            let _ = child.kill();
+            Err(std::io::Error::other(
+                "failed to establish strict child-process containment",
+            ))
         }
     }
 }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -889,11 +889,9 @@ pub(crate) fn spawn_strict_child_process_tree(
         command.creation_flags(CREATE_SUSPENDED);
     }
 
-    let mut child = command.spawn()?;
-    match StrictChildProcessTree::attach(&child) {
-        Some(tree) => Ok((child, tree)),
         None => {
             let _ = child.kill();
+            let _ = child.wait();
             Err(std::io::Error::other(
                 "failed to establish strict child-process containment",
             ))

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -597,21 +597,21 @@ struct CodexJsonState {
     emitted_assistant: bool,
 }
 
-/// Owns the direct Codex child and all of its descendants while a one-shot
-/// JSON turn is running. A Node/npm wrapper can outlive or outspawn the direct
-/// launcher, so a plain `Child::kill()` is not enough to guarantee pipe EOF.
-struct CodexProcessTree {
+/// Own a one-shot child process tree. A wrapper can outlive or outspawn the
+/// direct launcher, so a plain `Child::kill()` is not enough to guarantee pipe
+/// EOF or descendant cleanup.
+pub(crate) struct ChildProcessTree {
     pid: u32,
     terminated: bool,
     #[cfg(windows)]
     job_handle: Option<windows_sys::Win32::Foundation::HANDLE>,
 }
 
-impl CodexProcessTree {
-    fn attach(child: &std::process::Child) -> Self {
+impl ChildProcessTree {
+    pub(crate) fn attach(child: &std::process::Child) -> Self {
         let pid = child.id();
         #[cfg(windows)]
-        let job_handle = codex_job_object_for_process(child);
+        let job_handle = child_job_object_for_process(child);
         Self {
             pid,
             terminated: false,
@@ -620,14 +620,29 @@ impl CodexProcessTree {
         }
     }
 
-    fn terminate(&mut self, child: &mut std::process::Child) {
+    pub(crate) fn is_strictly_contained(&self) -> bool {
+        #[cfg(unix)]
+        {
+            true
+        }
+        #[cfg(windows)]
+        {
+            self.job_handle.is_some()
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            false
+        }
+    }
+
+    pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
         if self.terminated {
             return;
         }
         self.terminated = true;
         #[cfg(unix)]
         {
-            terminate_codex_unix_process_group(self.pid);
+            terminate_unix_process_group(self.pid);
         }
         #[cfg(windows)]
         {
@@ -662,26 +677,26 @@ impl CodexProcessTree {
 }
 
 #[cfg(unix)]
-fn terminate_codex_unix_process_group(pid: u32) {
+fn terminate_unix_process_group(pid: u32) {
     // The launch config puts the child at the head of a new session, so the
     // negative pid reaches its wrapper and every descendant.
     let _ = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
 }
 
 #[cfg(unix)]
-impl Drop for CodexProcessTree {
+impl Drop for ChildProcessTree {
     fn drop(&mut self) {
         if !self.terminated {
             // A wrapper can exit after detaching a descendant that has already
             // closed stdout/stderr. There is then no pipe timeout to trigger
             // terminate(), but this one-shot runner still owns that group.
-            terminate_codex_unix_process_group(self.pid);
+            terminate_unix_process_group(self.pid);
         }
     }
 }
 
 #[cfg(windows)]
-impl Drop for CodexProcessTree {
+impl Drop for ChildProcessTree {
     fn drop(&mut self) {
         if let Some(job) = self.job_handle.take() {
             // The job is configured with KILL_ON_JOB_CLOSE, so an abrupt
@@ -720,7 +735,7 @@ fn trusted_windows_taskkill_path() -> Option<PathBuf> {
 }
 
 #[cfg(windows)]
-fn codex_job_object_for_process(
+fn child_job_object_for_process(
     child: &std::process::Child,
 ) -> Option<windows_sys::Win32::Foundation::HANDLE> {
     use std::mem::size_of;
@@ -759,7 +774,7 @@ fn codex_job_object_for_process(
     }
 }
 
-fn configure_codex_json_command(_command: &mut std::process::Command) {
+pub(crate) fn configure_child_process_tree_command(_command: &mut std::process::Command) {
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
@@ -848,7 +863,7 @@ where
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    configure_codex_json_command(&mut child_command);
+    configure_child_process_tree_command(&mut child_command);
     let cancellation = CodexCancellationGuard::install()?;
     if let Some(error) = codex_cancellation_error(&cancellation) {
         anyhow::bail!(error);
@@ -859,7 +874,7 @@ where
             command.program()
         )
     })?;
-    let mut process_tree = CodexProcessTree::attach(&child);
+    let mut process_tree = ChildProcessTree::attach(&child);
     cancellation.arm(process_tree.pid);
 
     let stdout = match child.stdout.take() {

--- a/crates/coven-cli/tests/doctor_auth_boundary.rs
+++ b/crates/coven-cli/tests/doctor_auth_boundary.rs
@@ -261,7 +261,7 @@ fn assert_only_local_engine_probes(invocations: &[Invocation]) {
     );
 }
 
-fn parse_json<'a>(label: &str, output: &'a Output) -> Result<Value> {
+fn parse_json(label: &str, output: &Output) -> Result<Value> {
     serde_json::from_slice(&output.stdout).with_context(|| {
         format!(
             "{label} did not emit one JSON document\nstdout:\n{}\nstderr:\n{}",

--- a/crates/coven-cli/tests/doctor_auth_boundary.rs
+++ b/crates/coven-cli/tests/doctor_auth_boundary.rs
@@ -64,6 +64,7 @@ impl ProbeFixture {
         let home = self.root.join(format!("home-{label}"));
         let config = self.root.join(format!("config-{label}"));
         let log = self.root.join(format!("invocations-{label}.log"));
+        let descendant_pid_file = self.root.join(format!("descendant-{label}.pid"));
         fs::create_dir_all(&home)?;
         fs::create_dir_all(&config)?;
 
@@ -74,6 +75,7 @@ impl ProbeFixture {
             .env("COVEN_ENGINE_BIN", &self.engine)
             .env("COVEN_DOCTOR_PROBE_LOG", &log)
             .env("COVEN_DOCTOR_PROBE_MODE", mode)
+            .env("COVEN_DOCTOR_DESCENDANT_PID_FILE", &descendant_pid_file)
             .env("PATH", path_containing_only(&self.bin_dir)?)
             .env("HOME", &home)
             .env("USERPROFILE", &home)
@@ -93,10 +95,14 @@ impl ProbeFixture {
             .context("run coven doctor with auth probe")?;
         let elapsed = started.elapsed();
         let invocations = read_invocations(&log)?;
+        let descendant_pid = fs::read_to_string(&descendant_pid_file)
+            .ok()
+            .and_then(|value| value.trim().parse().ok());
         Ok(ProbeRun {
             output,
             elapsed,
             invocations,
+            descendant_pid,
         })
     }
 }
@@ -105,6 +111,7 @@ struct ProbeRun {
     output: Output,
     elapsed: Duration,
     invocations: Vec<Invocation>,
+    descendant_pid: Option<u32>,
 }
 
 #[test]
@@ -176,10 +183,29 @@ fn doctor_auth_boundary_is_offline_hermetic_and_failure_bounded() -> Result<()> 
         .find(|invocation| invocation.args == ["auth", "status", "--json"])
         .expect("timed-out auth invocation")
         .pid;
-    assert!(
-        !process_is_running(timeout_pid),
-        "Doctor returned without killing and reaping timed-out auth probe pid {timeout_pid}"
+    assert_process_stopped(timeout_pid, "timed-out auth probe");
+
+    let descendant = fixture.run("descendant", "descendant", true)?;
+    assert_success("stdout-holding descendant", &descendant.output);
+    anyhow::ensure!(
+        descendant.elapsed < Duration::from_secs(12),
+        "a descendant-held stdout pipe escaped Doctor's bound: {:?}",
+        descendant.elapsed
     );
+    let descendant_json = parse_json("stdout-holding descendant", &descendant.output)?;
+    assert_eq!(credential_status(&descendant_json, "engine"), "warn");
+    assert_only_local_engine_probes(&descendant.invocations);
+    let descendant_parent_pid = descendant
+        .invocations
+        .iter()
+        .find(|invocation| invocation.args == ["auth", "status", "--json"])
+        .expect("descendant-mode auth invocation")
+        .pid;
+    let descendant_pid = descendant
+        .descendant_pid
+        .context("probe did not record stdout-holding descendant pid")?;
+    assert_process_stopped(descendant_parent_pid, "descendant-mode engine parent");
+    assert_process_stopped(descendant_pid, "stdout-holding engine descendant");
 
     Ok(())
 }
@@ -319,4 +345,15 @@ fn process_is_running(pid: u32) -> bool {
     let mut system = System::new();
     system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
     system.process(pid).is_some()
+}
+
+fn assert_process_stopped(pid: u32, label: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while process_is_running(pid) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(
+        !process_is_running(pid),
+        "Doctor returned without stopping {label} pid {pid}"
+    );
 }

--- a/crates/coven-cli/tests/doctor_auth_boundary.rs
+++ b/crates/coven-cli/tests/doctor_auth_boundary.rs
@@ -1,0 +1,322 @@
+use std::ffi::OsString;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use sysinfo::{Pid, ProcessesToUpdate, System};
+
+#[derive(Debug)]
+struct Invocation {
+    executable: String,
+    pid: u32,
+    args: Vec<String>,
+}
+
+struct ProbeFixture {
+    _temp_dir: tempfile::TempDir,
+    root: PathBuf,
+    bin_dir: PathBuf,
+    engine: PathBuf,
+}
+
+impl ProbeFixture {
+    fn new() -> Result<Self> {
+        let temp_dir = tempfile::tempdir()?;
+        let root = temp_dir.path().to_path_buf();
+        let bin_dir = root.join("bin");
+        fs::create_dir_all(&bin_dir)?;
+
+        let compiled = root.join(platform_executable_name("doctor-auth-probe"));
+        let source =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/doctor_auth_probe.rs");
+        let rustc = std::env::var_os("RUSTC")
+            .unwrap_or_else(|| OsString::from(if cfg!(windows) { "rustc.exe" } else { "rustc" }));
+        let compile = Command::new(rustc)
+            .arg("--edition=2021")
+            .arg("-o")
+            .arg(&compiled)
+            .arg(&source)
+            .output()
+            .context("failed to compile Doctor auth probe")?;
+        anyhow::ensure!(
+            compile.status.success(),
+            "Doctor auth probe failed to compile:\n{}",
+            String::from_utf8_lossy(&compile.stderr)
+        );
+
+        let engine = install_probe_as(&compiled, &bin_dir, "coven-code")?;
+        for harness in ["codex", "claude", "copilot"] {
+            install_probe_as(&compiled, &bin_dir, harness)?;
+        }
+
+        Ok(Self {
+            _temp_dir: temp_dir,
+            root,
+            bin_dir,
+            engine,
+        })
+    }
+
+    fn run(&self, label: &str, mode: &str, json: bool) -> Result<ProbeRun> {
+        let home = self.root.join(format!("home-{label}"));
+        let config = self.root.join(format!("config-{label}"));
+        let log = self.root.join(format!("invocations-{label}.log"));
+        fs::create_dir_all(&home)?;
+        fs::create_dir_all(&config)?;
+
+        let mut command = Command::new(env!("CARGO_BIN_EXE_coven"));
+        command
+            .arg("doctor")
+            .env("COVEN_HOME", &home)
+            .env("COVEN_ENGINE_BIN", &self.engine)
+            .env("COVEN_DOCTOR_PROBE_LOG", &log)
+            .env("COVEN_DOCTOR_PROBE_MODE", mode)
+            .env("PATH", path_containing_only(&self.bin_dir)?)
+            .env("HOME", &home)
+            .env("USERPROFILE", &home)
+            .env("XDG_CONFIG_HOME", &config)
+            .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST")
+            .env_remove("COVEN_HARNESS_ADAPTER_DIRS");
+        if cfg!(windows) {
+            command.env("PATHEXT", ".EXE");
+        }
+        if json {
+            command.arg("--json");
+        }
+
+        let started = Instant::now();
+        let output = command
+            .output()
+            .context("run coven doctor with auth probe")?;
+        let elapsed = started.elapsed();
+        let invocations = read_invocations(&log)?;
+        Ok(ProbeRun {
+            output,
+            elapsed,
+            invocations,
+        })
+    }
+}
+
+struct ProbeRun {
+    output: Output,
+    elapsed: Duration,
+    invocations: Vec<Invocation>,
+}
+
+#[test]
+fn doctor_auth_boundary_is_offline_hermetic_and_failure_bounded() -> Result<()> {
+    let fixture = ProbeFixture::new()?;
+
+    let configured = fixture.run("configured", "configured", true)?;
+    assert_success("configured auth", &configured.output);
+    let configured_json = parse_json("configured auth", &configured.output)?;
+    assert_eq!(credential_status(&configured_json, "engine"), "warn");
+    assert_eq!(
+        credential_message(&configured_json, "engine"),
+        "authentication configured; provider turn not verified"
+    );
+    for harness in ["codex", "claude", "copilot"] {
+        assert_eq!(harness_status(&configured_json, harness), "pass");
+        assert_eq!(credential_status(&configured_json, harness), "warn");
+    }
+    assert_eq!(
+        credential_hint(&configured_json, "codex"),
+        "authenticate or inspect local setup with: codex login; verify provider access with an explicitly authorized test turn"
+    );
+    assert_only_local_engine_probes(&configured.invocations);
+
+    let unconfigured = fixture.run("unconfigured", "unconfigured", false)?;
+    assert_success("unconfigured auth", &unconfigured.output);
+    let prose = String::from_utf8_lossy(&unconfigured.output.stdout);
+    assert!(
+        prose.contains("[--] Coven Code (engine) — authentication not configured"),
+        "unconfigured engine auth must be advisory:\n{prose}"
+    );
+    assert!(
+        !prose.contains("[!!] Coven Code (engine)"),
+        "unconfigured engine auth must not look blocking:\n{prose}"
+    );
+    assert!(
+        prose.contains("verify provider access with an explicitly authorized test turn"),
+        "setup commands must not be presented as provider verification:\n{prose}"
+    );
+    assert_only_local_engine_probes(&unconfigured.invocations);
+
+    let exit_two = fixture.run("exit-two", "exit2", true)?;
+    assert_success("non-contract auth exit", &exit_two.output);
+    let exit_two_json = parse_json("non-contract auth exit", &exit_two.output)?;
+    assert_eq!(credential_status(&exit_two_json, "engine"), "warn");
+    assert_eq!(
+        credential_message(&exit_two_json, "engine"),
+        "authentication status unavailable; provider turn not verified"
+    );
+    assert_only_local_engine_probes(&exit_two.invocations);
+
+    let timed_out = fixture.run("timeout", "timeout", true)?;
+    assert_success("timed-out auth probe", &timed_out.output);
+    anyhow::ensure!(
+        timed_out.elapsed < Duration::from_secs(12),
+        "Doctor did not enforce its five-second auth timeout: {:?}",
+        timed_out.elapsed
+    );
+    let timeout_json = parse_json("timed-out auth probe", &timed_out.output)?;
+    assert_eq!(credential_status(&timeout_json, "engine"), "warn");
+    assert_eq!(
+        credential_message(&timeout_json, "engine"),
+        "authentication status unavailable; provider turn not verified"
+    );
+    assert_only_local_engine_probes(&timed_out.invocations);
+    let timeout_pid = timed_out
+        .invocations
+        .iter()
+        .find(|invocation| invocation.args == ["auth", "status", "--json"])
+        .expect("timed-out auth invocation")
+        .pid;
+    assert!(
+        !process_is_running(timeout_pid),
+        "Doctor returned without killing and reaping timed-out auth probe pid {timeout_pid}"
+    );
+
+    Ok(())
+}
+
+fn platform_executable_name(stem: &str) -> String {
+    if cfg!(windows) {
+        format!("{stem}.exe")
+    } else {
+        stem.to_string()
+    }
+}
+
+fn install_probe_as(compiled: &Path, bin_dir: &Path, name: &str) -> Result<PathBuf> {
+    let destination = bin_dir.join(platform_executable_name(name));
+    fs::copy(compiled, &destination)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&destination, fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(destination)
+}
+
+fn path_containing_only(bin_dir: &Path) -> Result<OsString> {
+    std::env::join_paths([bin_dir]).context("construct isolated probe PATH")
+}
+
+fn read_invocations(path: &Path) -> Result<Vec<Invocation>> {
+    let text = fs::read_to_string(path)
+        .with_context(|| format!("read invocation log {}", path.display()))?;
+    text.lines()
+        .map(|line| {
+            let mut fields = line.splitn(3, '\t');
+            let executable = fields.next().unwrap_or_default().to_string();
+            let pid = fields
+                .next()
+                .context("invocation log missing pid")?
+                .parse::<u32>()
+                .context("invocation log pid is not numeric")?;
+            let args = fields
+                .next()
+                .unwrap_or_default()
+                .split('\u{1f}')
+                .filter(|arg| !arg.is_empty())
+                .map(str::to_string)
+                .collect();
+            Ok(Invocation {
+                executable,
+                pid,
+                args,
+            })
+        })
+        .collect()
+}
+
+fn assert_only_local_engine_probes(invocations: &[Invocation]) {
+    assert_eq!(
+        invocations.len(),
+        2,
+        "Doctor must run exactly the two local engine probes: {invocations:#?}"
+    );
+    assert!(
+        invocations
+            .iter()
+            .all(|invocation| invocation.executable == "coven-code"),
+        "Doctor must not launch a provider harness: {invocations:#?}"
+    );
+    assert!(
+        invocations
+            .iter()
+            .any(|invocation| invocation.args == ["--version"]),
+        "missing engine version probe: {invocations:#?}"
+    );
+    assert!(
+        invocations
+            .iter()
+            .any(|invocation| invocation.args == ["auth", "status", "--json"]),
+        "missing local engine auth probe: {invocations:#?}"
+    );
+}
+
+fn parse_json<'a>(label: &str, output: &'a Output) -> Result<Value> {
+    serde_json::from_slice(&output.stdout).with_context(|| {
+        format!(
+            "{label} did not emit one JSON document\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    })
+}
+
+fn check<'a>(document: &'a Value, id: &str) -> &'a Value {
+    document["checks"]
+        .as_array()
+        .expect("Doctor checks array")
+        .iter()
+        .find(|check| check["id"] == id)
+        .unwrap_or_else(|| panic!("missing Doctor check {id}: {document}"))
+}
+
+fn harness_status<'a>(document: &'a Value, harness: &str) -> &'a str {
+    check(document, &format!("harness:{harness}"))["status"]
+        .as_str()
+        .expect("harness status string")
+}
+
+fn credential_status<'a>(document: &'a Value, harness: &str) -> &'a str {
+    check(document, &format!("credentials:{harness}"))["status"]
+        .as_str()
+        .expect("credential status string")
+}
+
+fn credential_message<'a>(document: &'a Value, harness: &str) -> &'a str {
+    check(document, &format!("credentials:{harness}"))["message"]
+        .as_str()
+        .expect("credential message string")
+}
+
+fn credential_hint<'a>(document: &'a Value, harness: &str) -> &'a str {
+    check(document, &format!("credentials:{harness}"))["hint"]
+        .as_str()
+        .expect("credential hint string")
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn process_is_running(pid: u32) -> bool {
+    let pid = Pid::from_u32(pid);
+    let mut system = System::new();
+    system.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
+    system.process(pid).is_some()
+}

--- a/crates/coven-cli/tests/doctor_auth_boundary.rs
+++ b/crates/coven-cli/tests/doctor_auth_boundary.rs
@@ -185,27 +185,39 @@ fn doctor_auth_boundary_is_offline_hermetic_and_failure_bounded() -> Result<()> 
         .pid;
     assert_process_stopped(timeout_pid, "timed-out auth probe");
 
-    let descendant = fixture.run("descendant", "descendant", true)?;
-    assert_success("stdout-holding descendant", &descendant.output);
-    anyhow::ensure!(
-        descendant.elapsed < Duration::from_secs(12),
-        "a descendant-held stdout pipe escaped Doctor's bound: {:?}",
-        descendant.elapsed
-    );
-    let descendant_json = parse_json("stdout-holding descendant", &descendant.output)?;
-    assert_eq!(credential_status(&descendant_json, "engine"), "warn");
-    assert_only_local_engine_probes(&descendant.invocations);
-    let descendant_parent_pid = descendant
-        .invocations
-        .iter()
-        .find(|invocation| invocation.args == ["auth", "status", "--json"])
-        .expect("descendant-mode auth invocation")
-        .pid;
-    let descendant_pid = descendant
-        .descendant_pid
-        .context("probe did not record stdout-holding descendant pid")?;
-    assert_process_stopped(descendant_parent_pid, "descendant-mode engine parent");
-    assert_process_stopped(descendant_pid, "stdout-holding engine descendant");
+    let assert_descendant = |label: &str| -> Result<()> {
+        let descendant = fixture.run(label, "descendant", true)?;
+        assert_success("stdout-holding descendant", &descendant.output);
+        anyhow::ensure!(
+            descendant.elapsed < Duration::from_secs(12),
+            "a descendant-held stdout pipe escaped Doctor's bound: {:?}",
+            descendant.elapsed
+        );
+        let descendant_json = parse_json("stdout-holding descendant", &descendant.output)?;
+        assert_eq!(credential_status(&descendant_json, "engine"), "warn");
+        assert_eq!(
+            credential_message(&descendant_json, "engine"),
+            "authentication configured; provider turn not verified"
+        );
+        assert_only_local_engine_probes(&descendant.invocations);
+        let descendant_parent_pid = descendant
+            .invocations
+            .iter()
+            .find(|invocation| invocation.args == ["auth", "status", "--json"])
+            .expect("descendant-mode auth invocation")
+            .pid;
+        let descendant_pid = descendant
+            .descendant_pid
+            .context("probe did not record stdout-holding descendant pid")?;
+        assert_process_stopped(descendant_parent_pid, "descendant-mode engine parent");
+        assert_process_stopped(descendant_pid, "stdout-holding engine descendant");
+        Ok(())
+    };
+    assert_descendant("descendant")?;
+    #[cfg(windows)]
+    for attempt in 0..3 {
+        assert_descendant(&format!("descendant-stress-{attempt}"))?;
+    }
 
     Ok(())
 }

--- a/crates/coven-cli/tests/doctor_json_contract.rs
+++ b/crates/coven-cli/tests/doctor_json_contract.rs
@@ -121,6 +121,9 @@ fn doctor_json_is_stable_redacted_and_stdout_pure() -> anyhow::Result<()> {
             "harnesses",
             "engine",
             "familiars",
+            "credentials:codex",
+            "credentials:claude",
+            "credentials:copilot",
         ],
         "Doctor check ordering is part of the JSON compatibility contract"
     );

--- a/crates/coven-cli/tests/fixtures/doctor_auth_probe.rs
+++ b/crates/coven-cli/tests/fixtures/doctor_auth_probe.rs
@@ -1,6 +1,6 @@
 use std::fs::OpenOptions;
 use std::io::Write;
-use std::process;
+use std::process::{self, Command};
 use std::thread;
 use std::time::Duration;
 
@@ -12,6 +12,10 @@ fn main() {
         .expect("probe executable name")
         .to_ascii_lowercase();
     let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args == ["--hold-stdout"] {
+        thread::sleep(Duration::from_secs(60));
+        return;
+    }
     record_invocation(&invoked_as, &args);
 
     if invoked_as != "coven-code" {
@@ -42,10 +46,24 @@ fn main() {
                 record_timeout_completion();
                 println!(r#"{{"loggedIn":true}}"#);
             }
+            "descendant" => {
+                let descendant = Command::new(&executable)
+                    .arg("--hold-stdout")
+                    .spawn()
+                    .expect("spawn stdout-holding descendant");
+                record_descendant_pid(descendant.id());
+                println!(r#"{{"loggedIn":true}}"#);
+            }
             other => panic!("unknown probe mode: {other}"),
         },
         _ => process::exit(92),
     }
+}
+
+fn record_descendant_pid(pid: u32) {
+    let path = std::env::var_os("COVEN_DOCTOR_DESCENDANT_PID_FILE")
+        .expect("descendant pid file path");
+    std::fs::write(path, pid.to_string()).expect("record descendant pid");
 }
 
 fn record_invocation(invoked_as: &str, args: &[String]) {

--- a/crates/coven-cli/tests/fixtures/doctor_auth_probe.rs
+++ b/crates/coven-cli/tests/fixtures/doctor_auth_probe.rs
@@ -1,0 +1,76 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::process;
+use std::thread;
+use std::time::Duration;
+
+fn main() {
+    let executable = std::env::current_exe().expect("resolve probe executable");
+    let invoked_as = executable
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .expect("probe executable name")
+        .to_ascii_lowercase();
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    record_invocation(&invoked_as, &args);
+
+    if invoked_as != "coven-code" {
+        // Provider executables exist so Doctor can discover them, but Doctor
+        // must never launch one. A launch is recorded above before failing.
+        process::exit(91);
+    }
+
+    match args.iter().map(String::as_str).collect::<Vec<_>>().as_slice() {
+        ["--version"] => {
+            println!("coven-code 0.6.1");
+        }
+        ["auth", "status", "--json"] => match std::env::var("COVEN_DOCTOR_PROBE_MODE")
+            .as_deref()
+            .unwrap_or("configured")
+        {
+            "configured" => println!(r#"{{"loggedIn":true}}"#),
+            "unconfigured" => {
+                println!(r#"{{"loggedIn":false}}"#);
+                process::exit(1);
+            }
+            "exit2" => {
+                println!(r#"{{"loggedIn":false}}"#);
+                process::exit(2);
+            }
+            "timeout" => {
+                thread::sleep(Duration::from_secs(60));
+                record_timeout_completion();
+                println!(r#"{{"loggedIn":true}}"#);
+            }
+            other => panic!("unknown probe mode: {other}"),
+        },
+        _ => process::exit(92),
+    }
+}
+
+fn record_invocation(invoked_as: &str, args: &[String]) {
+    let log_path = std::env::var_os("COVEN_DOCTOR_PROBE_LOG").expect("probe log path");
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .expect("open probe log");
+    writeln!(
+        log,
+        "{invoked_as}\t{}\t{}",
+        process::id(),
+        args.join("\u{1f}")
+    )
+    .expect("record probe invocation");
+}
+
+fn record_timeout_completion() {
+    let log_path = std::env::var_os("COVEN_DOCTOR_PROBE_LOG").expect("probe log path");
+    let mut log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .expect("open probe log");
+    writeln!(log, "timeout-completed\t{}\t", process::id())
+        .expect("record unexpected timeout completion");
+}

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -488,6 +488,34 @@ fn doctor_json_passes_with_fake_harness_and_engine() -> anyhow::Result<()> {
         .find(|check| check["id"] == "harness:codex")
         .expect("doctor JSON should report harness:codex");
     assert_eq!(codex["status"], "pass");
+    assert!(
+        codex["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("executable is available")),
+        "harness discovery must describe executable availability only: {codex}"
+    );
+    let codex_auth = checks
+        .iter()
+        .find(|check| check["id"] == "credentials:codex")
+        .expect("doctor JSON should report the unverified Codex auth boundary");
+    assert_eq!(codex_auth["status"], "warn");
+    assert_eq!(
+        codex_auth["message"],
+        "executable available; authentication not verified"
+    );
+    let engine_auth = checks
+        .iter()
+        .find(|check| check["id"] == "credentials:engine")
+        .expect("doctor JSON should report the engine's local auth state");
+    assert_eq!(engine_auth["status"], "warn");
+    assert_eq!(
+        engine_auth["message"],
+        "authentication configured; provider turn not verified"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("logged in"),
+        "doctor must not turn local configuration evidence into a live-auth claim"
+    );
     Ok(())
 }
 
@@ -595,6 +623,25 @@ fn doctor_reports_no_familiars_when_manifest_absent() -> anyhow::Result<()> {
     assert_success("doctor without familiars", &output);
     assert_stdout_contains("doctor without familiars", &output, "none configured");
     assert_stdout_contains("doctor without familiars", &output, "familiars.toml");
+    assert_stdout_contains(
+        "doctor without familiars",
+        &output,
+        "`codex` executable is available",
+    );
+    assert_stdout_contains(
+        "doctor without familiars",
+        &output,
+        "authentication not verified",
+    );
+    assert_stdout_contains(
+        "doctor without familiars",
+        &output,
+        "provider turn not verified",
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stdout).contains("logged in"),
+        "doctor must not turn local configuration evidence into a live-auth claim"
+    );
     Ok(())
 }
 
@@ -1394,7 +1441,17 @@ printf 'fake grok reply\n'
 /// healthy environment plant a fake alongside the fake harness.
 fn write_fake_coven_code(fake_bin: &Path) -> anyhow::Result<()> {
     let coven_code = fake_bin.join("coven-code");
-    fs::write(&coven_code, "#!/bin/sh\nexit 0\n")?;
+    fs::write(
+        &coven_code,
+        r#"#!/bin/sh
+if [ "$1" = "--version" ]; then
+  printf 'coven-code 0.6.1\n'
+elif [ "$1" = "auth" ] && [ "$2" = "status" ] && [ "$3" = "--json" ]; then
+  printf '{"loggedIn":true}\n'
+fi
+exit 0
+"#,
+    )?;
     let mut permissions = fs::metadata(&coven_code)?.permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&coven_code, permissions)?;

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -427,6 +427,7 @@ fn doctor_json_reports_blocking_failure_when_no_harness_is_available() -> anyhow
     let output = Command::new(&coven)
         .args(["doctor", "--json"])
         .env("COVEN_HOME", &coven_home)
+        .env_remove("COVEN_ENGINE_BIN")
         .env("PATH", &empty_path)
         .env("HOME", &fake_home)
         .output()?;
@@ -470,7 +471,13 @@ fn doctor_json_passes_with_fake_harness_and_engine() -> anyhow::Result<()> {
     let path = prepend_path(&fake_bin);
     let coven = coven_bin();
 
-    let output = run_coven(&coven, &coven_home, &path, &["doctor", "--json"])?;
+    let output = run_coven_with_engine(
+        &coven,
+        &coven_home,
+        &path,
+        &fake_bin.join("coven-code"),
+        &["doctor", "--json"],
+    )?;
 
     assert_success("doctor --json with fakes", &output);
     let value = parse_stdout_json("doctor --json with fakes", &output)?;
@@ -593,7 +600,13 @@ description = "Keeps the coven sociable."
     let path = prepend_path(&fake_bin);
     let coven = coven_bin();
 
-    let output = run_coven(&coven, &coven_home, &path, &["doctor"])?;
+    let output = run_coven_with_engine(
+        &coven,
+        &coven_home,
+        &path,
+        &fake_bin.join("coven-code"),
+        &["doctor"],
+    )?;
 
     assert_success("doctor with familiars", &output);
     assert_stdout_contains("doctor with familiars", &output, "Familiars (");
@@ -618,7 +631,13 @@ fn doctor_reports_no_familiars_when_manifest_absent() -> anyhow::Result<()> {
     let path = prepend_path(&fake_bin);
     let coven = coven_bin();
 
-    let output = run_coven(&coven, &coven_home, &path, &["doctor"])?;
+    let output = run_coven_with_engine(
+        &coven,
+        &coven_home,
+        &path,
+        &fake_bin.join("coven-code"),
+        &["doctor"],
+    )?;
 
     assert_success("doctor without familiars", &output);
     assert_stdout_contains("doctor without familiars", &output, "none configured");
@@ -661,6 +680,7 @@ fn doctor_missing_harness_prints_cross_platform_setup_loop() -> anyhow::Result<(
     let output = Command::new(&coven)
         .args(["doctor"])
         .env("COVEN_HOME", &coven_home)
+        .env_remove("COVEN_ENGINE_BIN")
         .env("PATH", &empty_path)
         .env("HOME", &fake_home)
         .output()?;
@@ -720,7 +740,13 @@ fn doctor_reports_live_daemon_socket_status() -> anyhow::Result<()> {
     assert_success("daemon start", &start);
     wait_for_daemon_health(&coven_home)?;
 
-    let output = run_coven(&coven, &coven_home, &path, &["doctor"])?;
+    let output = run_coven_with_engine(
+        &coven,
+        &coven_home,
+        &path,
+        &fake_bin.join("coven-code"),
+        &["doctor"],
+    )?;
 
     assert_success("doctor with live daemon", &output);
     assert_stdout_contains("doctor with live daemon", &output, "Daemon:");
@@ -1276,6 +1302,22 @@ fn run_coven(
     Command::new(coven)
         .args(args)
         .env("COVEN_HOME", coven_home)
+        .env("PATH", path)
+        .output()
+        .map_err(Into::into)
+}
+
+fn run_coven_with_engine(
+    coven: &Path,
+    coven_home: &Path,
+    path: &OsString,
+    engine: &Path,
+    args: &[&str],
+) -> anyhow::Result<Output> {
+    Command::new(coven)
+        .args(args)
+        .env("COVEN_HOME", coven_home)
+        .env("COVEN_ENGINE_BIN", engine)
         .env("PATH", path)
         .output()
         .map_err(Into::into)

--- a/docs/ENGINE-CONTRACT.md
+++ b/docs/ENGINE-CONTRACT.md
@@ -41,9 +41,14 @@ version.
    validation
 8. `coven-code --permission-mode {default|accept-edits|bypass-permissions|plan}` —
    accepted and honored; coven passes the value through unvalidated
-9. `coven-code auth status --json` — machine-readable auth state; coven reads only
-   the `loggedIn` boolean; additional fields may be present and are ignored;
-   exit 0 = logged in, 1 = not
+9. `coven-code auth status --json` — machine-readable, local auth-configuration
+   state. This command MUST be an offline read of engine-owned local state: it
+   MUST NOT contact a provider or other network service, refresh credentials,
+   launch an external harness, or start a provider turn. Coven reads only the
+   `loggedIn` boolean; additional fields may be present and are ignored. Exit
+   0 with `loggedIn: true` means authentication is locally configured; exit 1
+   with `loggedIn: false` means it is not. Any other exit/output combination is
+   unavailable advisory evidence, never proof of provider access.
 
    Minimal example:
    ```json

--- a/docs/guides/core-access.md
+++ b/docs/guides/core-access.md
@@ -31,7 +31,7 @@ For scripts, gate on the JSON envelope instead of scraping prose:
 coven doctor --json | jq -e '.ok'
 ```
 
-`doctor` checks the active `COVEN_HOME`, harness executable visibility in this shell, and daemon condition. You need at least one visible harness executable. Follow the per-harness hint it prints; provider authentication happens in the harness's own CLI, and Doctor reports it as unverified until you run a deliberate provider turn.
+`doctor` checks the active `COVEN_HOME`, harness executable visibility in this shell, and daemon condition. You need at least one visible harness executable. A per-harness login/status hint configures or inspects local authentication; it does not verify provider access. Doctor reports provider access as unverified until you run an explicitly authorized provider turn.
 
 ## 3. Start or verify the local daemon
 

--- a/docs/guides/core-access.md
+++ b/docs/guides/core-access.md
@@ -31,7 +31,7 @@ For scripts, gate on the JSON envelope instead of scraping prose:
 coven doctor --json | jq -e '.ok'
 ```
 
-`doctor` checks the active `COVEN_HOME`, harness visibility in this shell, and daemon condition. You need at least one usable harness. Follow the per-harness hint it prints; provider authentication happens in the harness's own CLI, not in Coven.
+`doctor` checks the active `COVEN_HOME`, harness executable visibility in this shell, and daemon condition. You need at least one visible harness executable. Follow the per-harness hint it prints; provider authentication happens in the harness's own CLI, and Doctor reports it as unverified until you run a deliberate provider turn.
 
 ## 3. Start or verify the local daemon
 
@@ -69,7 +69,7 @@ cd /path/to/project
 coven run codex "summarize this repository in five bullets" --permission read-only
 ```
 
-Replace `codex` with a harness that `coven doctor` reports as ready. `--permission read-only` is a useful first-run posture when your selected harness supports it. After the run starts, inspect it with:
+Replace `codex` with a harness whose executable `coven doctor` reports as available. `--permission read-only` is a useful first-run posture when your selected harness supports it. After the run starts, inspect it with:
 
 ```sh
 coven sessions
@@ -77,7 +77,7 @@ coven sessions
 
 ## What success means
 
-You have core access when `doctor --json` reports `ok: true`, `daemon status --json` reports a reachable state, `sessions --json` returns a document, and a selected harness can create a project-scoped session. A missing optional adapter does not prevent core use when another supported harness is ready.
+You have core access when `doctor --json` reports `ok: true`, `daemon status --json` reports a reachable state, `sessions --json` returns a document, and a selected harness completes a project-scoped provider turn. A missing optional adapter does not prevent core use when another supported harness executable is available.
 
 ## Related
 

--- a/docs/harnesses/provider-auth.md
+++ b/docs/harnesses/provider-auth.md
@@ -14,8 +14,8 @@ Coven supervises harness PTYs. It never reads, proxies, persists, or mints provi
 
 - Provider tokens live wherever the harness already puts them — typically `~/.codex/`, `~/.config/anthropic/`, `~/.copilot/`, or a system keychain managed by that CLI.
 - The Coven daemon never reads them, never stores them in SQLite, never forwards them over the socket API, and never logs them into the event ledger.
-- `coven doctor` reports the Coven Code engine's local auth configuration as unverified, but only checks whether each external harness binary exists; it does **not** run a provider turn or test provider credentials for any harness. Each harness already ships its own `login` / `doctor` for that.
-- Treat Coven as having **zero** knowledge of provider auth state. The boundary is intentional.
+- `coven doctor` reports the Coven Code engine's local auth configuration as advisory evidence, but only checks whether each external harness binary exists. The engine status command is contractually local and offline; Doctor does **not** launch an external harness, contact a provider, run a provider turn, or test provider credentials.
+- Treat Coven as having **zero** knowledge of external-harness provider auth state and no proof that any provider is reachable. The engine's boolean is local configuration evidence only. The boundary is intentional.
 
 ## Why Coven refuses to own credentials
 
@@ -64,7 +64,9 @@ Without that OAuth configuration, use one of the supported alternatives:
 
 `coven doctor` reports the engine's local auth configuration, explicitly notes
 that no provider turn was verified, and points to these alternatives instead of
-suggesting an OAuth login that cannot succeed.
+suggesting an OAuth login that cannot succeed. Its engine probe is the
+contractually offline `coven-code auth status --json`; Doctor does not contact
+Anthropic, OpenAI, or another provider while gathering this report.
 
 ### Daemon API
 

--- a/docs/harnesses/provider-auth.md
+++ b/docs/harnesses/provider-auth.md
@@ -14,7 +14,7 @@ Coven supervises harness PTYs. It never reads, proxies, persists, or mints provi
 
 - Provider tokens live wherever the harness already puts them — typically `~/.codex/`, `~/.config/anthropic/`, `~/.copilot/`, or a system keychain managed by that CLI.
 - The Coven daemon never reads them, never stores them in SQLite, never forwards them over the socket API, and never logs them into the event ledger.
-- `coven doctor` reports the Coven Code engine's login state, but only checks whether each external harness binary exists; it does **not** test provider credentials for those harnesses. Each harness already ships its own `login` / `doctor` for that.
+- `coven doctor` reports the Coven Code engine's local auth configuration as unverified, but only checks whether each external harness binary exists; it does **not** run a provider turn or test provider credentials for any harness. Each harness already ships its own `login` / `doctor` for that.
 - Treat Coven as having **zero** knowledge of provider auth state. The boundary is intentional.
 
 ## Why Coven refuses to own credentials
@@ -62,8 +62,9 @@ Without that OAuth configuration, use one of the supported alternatives:
 - Authenticate the official Claude Code CLI and use `coven run claude <prompt>`.
 - Run `coven code codex login` for ChatGPT/Codex authentication.
 
-`coven doctor` reports the engine's login state and points to these alternatives
-instead of suggesting an OAuth login that cannot succeed.
+`coven doctor` reports the engine's local auth configuration, explicitly notes
+that no provider turn was verified, and points to these alternatives instead of
+suggesting an OAuth login that cannot succeed.
 
 ### Daemon API
 

--- a/docs/help/harness-not-found.md
+++ b/docs/help/harness-not-found.md
@@ -95,19 +95,23 @@ coven doctor
 
 If `coven doctor` says the harness executable is available but `coven run` exits
 immediately, the binary is visible but the provider CLI may not be authenticated.
-Run the provider setup command directly:
+Run the provider setup or local-status command directly:
 
 ```sh
 codex login
 claude doctor
 ```
 
-Then verify again:
+Then, when a provider call is explicitly authorized, verify access with a test
+turn:
 
 ```sh
-coven doctor
 coven run codex "say hello"
 ```
+
+Running `coven doctor` again can confirm executable discovery and local engine
+state, but it deliberately does not call a provider or prove the external
+harness is authenticated.
 
 ## Still failing
 

--- a/docs/help/harness-not-found.md
+++ b/docs/help/harness-not-found.md
@@ -16,9 +16,10 @@ Start with:
 coven doctor
 ```
 
-In the `Harnesses` section, `ready` means Coven can find the executable. `missing`
-means the binary is not visible from this shell, even if another terminal or app
-can run it.
+In the `Harnesses` section, `executable is available` means Coven can find the
+binary. It does not mean provider authentication was verified. `missing` means
+the binary is not visible from this shell, even if another terminal or app can
+run it.
 
 ## Install a supported harness
 
@@ -92,9 +93,9 @@ coven doctor
 
 ## Authentication failures
 
-If `coven doctor` says the harness is ready but `coven run` exits immediately,
-the binary is visible but the provider CLI is not authenticated. Run the provider
-setup command directly:
+If `coven doctor` says the harness executable is available but `coven run` exits
+immediately, the binary is visible but the provider CLI may not be authenticated.
+Run the provider setup command directly:
 
 ```sh
 codex login

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -33,7 +33,7 @@ found):
     { "id": "harness:codex", "status": "pass", "message": "`codex` executable is available (built-in)" },
     { "id": "harnesses", "status": "pass", "message": "1 of 3 configured harness executables available" },
     { "id": "engine", "status": "pass", "message": "/path/to/coven-home/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" },
-    { "id": "credentials:codex", "status": "warn", "message": "executable available; authentication not verified", "hint": "verify with: codex login" }
+    { "id": "credentials:codex", "status": "warn", "message": "executable available; authentication not verified", "hint": "authenticate or inspect local setup with: codex login; verify provider access with an explicitly authorized test turn" }
   ],
   "nextSteps": ["coven run codex \"explain this repo in 5 bullets\"", "coven sessions"]
 }
@@ -60,7 +60,7 @@ availability, where any missing adapter is a `fail`.
 | `Daemon` | Whether the background daemon is stopped, running, or stale. |
 | `Repos` | Configured repositories from Coven repo settings, if present. |
 | `Harnesses` | Supported harness executables that are visible on this shell's `PATH`. |
-| `Credentials` | Local engine auth configuration and explicit `authentication not verified` rows for external harnesses. Doctor never starts a provider turn or reads harness credentials. |
+| `Credentials` | Advisory local engine auth configuration and explicit `authentication not verified` rows for external harnesses. Doctor calls only the engine's contractually offline `auth status --json`; it never launches a provider harness, starts a provider turn, contacts a provider, or reads harness credentials. |
 | `Familiars` | Configured familiar identities from `familiars.toml`, if present. |
 | `Next steps` | The safest next command based on the detected state. |
 
@@ -140,10 +140,12 @@ blocking problem:
 - a registered repo entry points at a missing or non-git path
 - `coven-code` is missing
 
-A missing harness prints a `[!!]` line with an install hint but does not fail
-the check while another harness executable is available. Executable discovery
-does not prove provider authentication; verify that separately with the
-harness's own login/status command or an explicitly authorized test turn.
+Each missing harness prints an advisory `[--]` line with an install hint. When
+none is available, Doctor adds a blocking `[!!] No supported harness is
+available` line and exits 1; one working harness keeps the aggregate usable.
+Executable discovery does not prove provider authentication. A harness's own
+login/status command can configure or inspect local authentication, while only
+an explicitly authorized test turn verifies provider access.
 
 `coven adapter doctor` is stricter about its own subject: it exits `1` if any
 listed adapter is unavailable. `coven wt --doctor` exits `1` when managed hooks

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -131,9 +131,10 @@ coven daemon start
 
 ## Exit behavior
 
-`coven doctor` exits `0` when the environment can run Coven end to end, so
-scripts can gate on it (`coven doctor && …`). It exits `1` when it finds a
-blocking problem:
+`coven doctor` exits `0` when local structural prerequisites are ready, so
+scripts can gate on them (`coven doctor && …`). Provider access is deliberately
+outside that claim and still requires an explicitly authorized test turn. The
+command exits `1` when it finds a blocking local problem:
 
 - no supported harness is available on `PATH`
 - the daemon is stale (`running` and `stopped` are both healthy states)

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -26,13 +26,14 @@ found):
 {
   "ok": true,
   "blocking": false,
-  "store": "/home/alex/.coven",
-  "project": "/home/alex/src/app",
+  "store": "/path/to/coven-home",
+  "project": "/path/to/project",
   "checks": [
-    { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket /home/alex/.coven/coven.sock)" },
-    { "id": "harness:codex", "status": "pass", "message": "`codex` is ready (built-in)" },
-    { "id": "harnesses", "status": "pass", "message": "1 of 3 configured harnesses available" },
-    { "id": "engine", "status": "pass", "message": "/home/alex/.coven/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" }
+    { "id": "daemon", "status": "pass", "message": "running (pid 12345, socket /path/to/coven-home/coven.sock)" },
+    { "id": "harness:codex", "status": "pass", "message": "`codex` executable is available (built-in)" },
+    { "id": "harnesses", "status": "pass", "message": "1 of 3 configured harness executables available" },
+    { "id": "engine", "status": "pass", "message": "/path/to/coven-home/engine/bin/coven-code (managed install), version 0.6.1 (pin 0.6.1)" },
+    { "id": "credentials:codex", "status": "warn", "message": "executable available; authentication not verified", "hint": "verify with: codex login" }
   ],
   "nextSteps": ["coven run codex \"explain this repo in 5 bullets\"", "coven sessions"]
 }
@@ -59,6 +60,7 @@ availability, where any missing adapter is a `fail`.
 | `Daemon` | Whether the background daemon is stopped, running, or stale. |
 | `Repos` | Configured repositories from Coven repo settings, if present. |
 | `Harnesses` | Supported harness executables that are visible on this shell's `PATH`. |
+| `Credentials` | Local engine auth configuration and explicit `authentication not verified` rows for external harnesses. Doctor never starts a provider turn or reads harness credentials. |
 | `Familiars` | Configured familiar identities from `familiars.toml`, if present. |
 | `Next steps` | The safest next command based on the detected state. |
 
@@ -110,7 +112,7 @@ coven daemon status --json
 Typical human output from `coven daemon status`:
 
 ```text
-Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
+Coven daemon: running (pid 12345, socket /path/to/coven-home/coven.sock)
 ```
 
 `not running` means no background daemon is running yet. Start it with:
@@ -139,8 +141,9 @@ blocking problem:
 - `coven-code` is missing
 
 A missing harness prints a `[!!]` line with an install hint but does not fail
-the check while another harness is available — one working harness makes Coven
-usable.
+the check while another harness executable is available. Executable discovery
+does not prove provider authentication; verify that separately with the
+harness's own login/status command or an explicitly authorized test turn.
 
 `coven adapter doctor` is stricter about its own subject: it exits `1` if any
 listed adapter is unavailable. `coven wt --doctor` exits `1` when managed hooks


### PR DESCRIPTION
## Context

- Summary: Separates executable discovery, local engine auth configuration, and verified provider turns in `coven doctor` so Doctor never claims authentication it did not prove.
- Closes #554
- Certification tracking: OpenCoven/coven-dev-tools#313 (`coven-live-xwl`)

## Implementation

- Renames readiness prose to executable availability and adds explicit non-blocking `credentials:<harness>` checks.
- Reduces engine auth output to a contract-validated boolean; malformed, contradictory, failed, signaled, oversized, or timed-out probes become unavailable evidence.
- Keeps unconfigured engine auth and individual unavailable harnesses advisory; only the no-supported-harness aggregate remains blocking.
- Defines `coven-code auth status --json` as a local/offline read that cannot refresh credentials, contact a provider, or start a turn.
- Bounds the local probe and inherited stdout under one five-second budget with a 1 MiB output cap and reserved cleanup time.
- Uses a Unix session/process group or a Doctor-only Windows strict process tree. Windows starts the probe suspended, assigns a kill-on-close Job Object, verifies and resumes its sole primary thread, then permits execution.
- Doctor's strict cleanup can only use owned process/job handles; it cannot invoke the legacy Codex `taskkill` fallback or perform an unbounded wait.
- Qualifies Doctor exit 0 as local structural readiness, not end-to-end provider verification.

## Verification

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — WSL/Linux initial implementation
- [x] `cargo test --workspace --locked` — WSL/Linux initial implementation: 1,620 passed, 4 ignored
- [x] `cargo test -p coven-cli --test doctor_auth_boundary --locked` — Windows and WSL/Linux
- [x] Immediate stdout-holding descendant coverage verifies configured output and parent/descendant cleanup; Windows repeats the race-sensitive case three additional times
- [x] `cargo test -p coven-cli engine_auth_summary --locked` — 2 passed
- [x] `cargo test -p coven-cli credentials_lines --locked` — 7 passed
- [x] Existing Codex JSON timeout/pipe-holding/closed-pipe process-tree regressions — 6 passed on WSL/Linux after the shared guard refactor
- [x] Targeted Clippy with `-D warnings` — Windows and WSL/Linux
- [x] `python scripts/check-coven-privacy.py --staged` — strict-containment correction and final 1-file fail-closed delta
- [x] `git diff --check`
- [x] Prior-head GitHub CI passed across Ubuntu/Windows Rust, performance, secret, packaging, onboarding, engine-contract, and dependency-audit jobs
- [x] GitHub CI on head `74903cd` — all required jobs passed
- [x] Final independent review of head `74903cd` — two reviewers found no remaining P0/P1/P2 issues

## Risk and Rollback

- Risk level: Medium. Diagnostic claims become more conservative and Doctor's local engine probe now has explicit process-containment behavior; the blocking decision is unchanged.
- Safety guarantees: Doctor remains read-only and provider-offline. The local engine probe is time-, output-, and process-tree-bounded.
- Rollback plan: revert the six signed-off commits; there are no migrations, credentials, or persisted-state changes.

## Agent Handoff

- Current state: Ready for review; final CI is green and two independent reviews found no remaining P0/P1/P2 issues.
- Known gap by design: provider access remains unverified until a separately authorized real turn is performed.