### PR TITLE
docs: make incomplete work recovery plan Bash 3.2-safe

### DIFF
--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -930,18 +930,64 @@ esac
 ISSUE_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search.json"
 ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
 ISSUE_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-blocker.txt"
-test -s "$ALL_ISSUES_EVIDENCE"
+ISSUE_LEDGER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issues.json"
+if ! gh api --paginate --slurp \
+  "repos/OpenCoven/coven/issues?state=all&per_page=100" \
+  > "$ALL_ISSUES_EVIDENCE"
+then
+  {
+    printf 'Blocked %s: could not refresh the paginated issue ledger before reuse/create.\n' \
+      "$WORKSTREAM_ID"
+    printf 'Latest shared issue ledger: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue ledger refresh failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: could not refresh live issue evidence before exact-title reuse/create."
+  exit 0
+fi
+if ! cp "$ALL_ISSUES_EVIDENCE" "$ISSUE_LEDGER_EVIDENCE"; then
+  {
+    printf 'Blocked %s: could not persist the refreshed issue ledger copy.\n' \
+      "$WORKSTREAM_ID"
+    printf 'Latest shared issue ledger: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue ledger persistence failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: could not persist live issue evidence before exact-title reuse/create."
+  exit 0
+fi
+if ! test -s "$ALL_ISSUES_EVIDENCE" || ! test -s "$ISSUE_LEDGER_EVIDENCE"; then
+  {
+    printf 'Blocked %s: refreshed issue ledger evidence is empty.\n' \
+      "$WORKSTREAM_ID"
+    printf 'Latest shared issue ledger: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue ledger evidence was empty; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: live issue evidence was empty before exact-title reuse/create."
+  exit 0
+fi
 jq --arg title "$ISSUE_TITLE" \
   '[.[] | .[] | select(.pull_request? | not) | select(.title == $title and .state == "open") | {number, title, url, state}]' \
-  "$ALL_ISSUES_EVIDENCE" > "$ISSUE_SEARCH_EVIDENCE"
+  "$ISSUE_LEDGER_EVIDENCE" > "$ISSUE_SEARCH_EVIDENCE"
 ISSUE_COUNT="$(jq 'length' "$ISSUE_SEARCH_EVIDENCE")"
 ```
 
-Task 4's paginated `issues.json` is the authoritative reuse source. Each
-workstream's `viable/$WORKSTREAM_ID-issue-search.json` stores only the filtered
-non-PR exact-title `open` matches from that full ledger, so default-limited
-`gh issue list` output never drives reuse. A sole unrelated or closed result in
-`issues.json` leaves `ISSUE_COUNT=0` and must not be reused.
+Immediately before every exact-title reuse/create decision, refresh the fully
+paginated shared `issue-541/issues.json` ledger with `gh api --paginate
+--slurp`, then persist that row's exact live capture to
+`viable/$WORKSTREAM_ID-issues.json`. Only after that refresh may the plan
+filter and count exact-title non-PR `open` matches. Each workstream's
+`viable/$WORKSTREAM_ID-issue-search.json` stores only the filtered matches from
+that persisted live ledger, so default-limited `gh issue list` output never
+drives reuse. A sole unrelated or closed result in the refreshed ledger leaves
+`ISSUE_COUNT=0` and must not be reused.
 
 If exactly one exact-title open issue already exists, reuse it without creating
 a duplicate:
@@ -960,12 +1006,13 @@ case "$ISSUE_COUNT" in
         printf 'Blocked %s: issue #%s did not verify as exact-title OPEN.\n' \
           "$WORKSTREAM_ID" "$ISSUE_NUMBER"
         printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Persisted live issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
         printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
         printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
       } > "$ISSUE_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "Issue verification mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Issue verification mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
         "Blocked: candidate issue failed exact-title OPEN verification."
       exit 0
     fi
@@ -1018,12 +1065,13 @@ EOF
         printf 'Blocked %s: created issue #%s did not verify as exact-title OPEN.\n' \
           "$WORKSTREAM_ID" "$ISSUE_NUMBER"
         printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Persisted live issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
         printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
         printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
       } > "$ISSUE_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "Created issue verification mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Created issue verification mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
         "Blocked: created issue did not verify as exact-title OPEN."
       exit 0
     fi
@@ -1035,11 +1083,12 @@ EOF
       printf 'Blocked %s: expected 0 or 1 exact-title open issues for %s, found %s.\n' \
         "$WORKSTREAM_ID" "$ISSUE_TITLE" "$ISSUE_COUNT"
       printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+      printf 'Persisted live issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
       printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
     } > "$ISSUE_BLOCKER_EVIDENCE"
     update_classification_row \
       "blocked" \
-      "Issue ambiguity; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+      "Issue ambiguity; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
       "Blocked: multiple open issues exactly match $ISSUE_TITLE."
     exit 0
     ;;
@@ -1048,7 +1097,7 @@ ISSUE_NUMBER="$(jq -r '.number' "$ISSUE_VIEW_EVIDENCE")"
 ISSUE_URL="$(jq -r '.url' "$ISSUE_VIEW_EVIDENCE")"
 update_classification_row \
   "viable" \
-  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-view.json." \
+  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-view.json." \
   "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL)."
 ```
 
@@ -1101,8 +1150,9 @@ continuing an adopted exact-head PR.
 - [ ] **Step 5: Recover and publish each viable concern sequentially**
 
 Skip this step for any row whose Task 5 Step 1 action is `continue existing PR`.
-For each remaining viable row, set `ISSUE_NUMBER` to its created or reused
-issue number and set `BRANCH_SLUG` from this fixed mapping:
+For each remaining viable row, set `WORKSTREAM_ID` to its exact workstream ID,
+set `ISSUE_NUMBER` to its created or reused issue number, and set
+`BRANCH_SLUG` from this fixed mapping:
 
 ```text
 mobile-memory-gateway -> mobile-pairing-recovery
@@ -1119,6 +1169,35 @@ Then run:
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
+CLAIM_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-claim-blocker.txt"
+mkdir -p "$RECOVERY"
+update_classification_row() {
+  python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+workstream, classification, evidence, action = sys.argv[2:6]
+needle = f"| {workstream} |"
+lines = path.read_text().splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith(needle):
+        parts = [part.strip() for part in line.strip().strip("|").split("|")]
+        if len(parts) != 5:
+            raise SystemExit(f"Unexpected classification row: {line}")
+        parts[1] = classification
+        parts[2] = evidence
+        parts[4] = action
+        lines[idx] = "| " + " | ".join(parts) + " |"
+        path.write_text("\n".join(lines) + "\n")
+        break
+else:
+    raise SystemExit(f"Missing classification row for {workstream}")
+PY
+}
+RECOVERY_BRANCH="issue-$ISSUE_NUMBER-$BRANCH_SLUG"
 RECOVERY_WORKTREE="$REPO/.worktrees/coven-recovery-541-$ISSUE_NUMBER-$BRANCH_SLUG"
 if test -e "$RECOVERY_WORKTREE"; then
   printf 'Recovery worktree path already exists: %s\n' "$RECOVERY_WORKTREE" >&2
@@ -1131,13 +1210,48 @@ if git -C "$REPO" worktree list --porcelain | awk -v path="$RECOVERY_WORKTREE" '
   printf 'Recovery worktree is already registered by Git: %s\n' "$RECOVERY_WORKTREE" >&2
   exit 1
 fi
-git -C "$REPO" fetch origin main
-git -C "$REPO" worktree add \
+if ! git -C "$REPO" fetch origin main; then
+  printf 'Failed to fetch origin/main before creating %s.\n' "$RECOVERY_BRANCH" >&2
+  exit 1
+fi
+if ! git -C "$REPO" worktree add \
   -b "issue-$ISSUE_NUMBER-$BRANCH_SLUG" \
   "$RECOVERY_WORKTREE" \
   origin/main
+then
+  printf 'Failed to create recovery worktree %s.\n' "$RECOVERY_WORKTREE" >&2
+  exit 1
+fi
 cd "$RECOVERY_WORKTREE"
-coven claim acquire "issue-$ISSUE_NUMBER"
+if ! coven claim acquire "issue-$ISSUE_NUMBER"; then
+  {
+    printf 'Blocked %s: coven claim acquire issue-%s failed.\n' \
+      "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+    printf 'Recovery worktree: %s\n' "$RECOVERY_WORKTREE"
+    printf 'Recovery branch: %s\n' "$RECOVERY_BRANCH"
+  } > "$CLAIM_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Claim acquisition failed; see viable/$WORKSTREAM_ID-claim-blocker.txt." \
+    "Blocked: child claim issue-$ISSUE_NUMBER could not be acquired."
+  if [ -n "$(git -C "$RECOVERY_WORKTREE" status --porcelain --untracked-files=all)" ]; then
+    printf 'Cleanup blocked: child worktree is no longer clean; leave it in place for inspection.\n' \
+      >> "$CLAIM_BLOCKER_EVIDENCE"
+    exit 1
+  fi
+  cd "$REPO"
+  if ! git -C "$REPO" worktree remove "$RECOVERY_WORKTREE"; then
+    printf 'Cleanup blocked: could not remove clean child worktree %s without force.\n' \
+      "$RECOVERY_WORKTREE" >> "$CLAIM_BLOCKER_EVIDENCE"
+    exit 1
+  fi
+  if ! git -C "$REPO" branch -d "$RECOVERY_BRANCH"; then
+    printf 'Cleanup blocked: could not delete clean child branch %s without force.\n' \
+      "$RECOVERY_BRANCH" >> "$CLAIM_BLOCKER_EVIDENCE"
+    exit 1
+  fi
+  exit 0
+fi
 ```
 
 For long child recovery sessions, keep the child claim alive from that child
@@ -1156,6 +1270,14 @@ when that pull request merges or the owning recovery session stops:
 cd "$RECOVERY_WORKTREE"
 coven claim release "issue-$ISSUE_NUMBER"
 ```
+
+Continue into the child recovery plan only after `coven claim acquire`
+succeeds. If acquisition fails, persist
+`viable/$WORKSTREAM_ID-claim-blocker.txt`, rewrite the classification row to
+`blocked`, remove the newly created still-clean child worktree and its exact
+local branch without force, and stop that row. If either cleanup command
+fails, leave the residue in place, keep the row blocked, and treat that as an
+operator-visible blocker.
 
 Execute that issue's plan, run its full gates, commit each child change with
 the Task 5 Step 4 trailer pattern, add human contributor co-author trailers
@@ -1428,11 +1550,90 @@ done
 If a row is `viable`, confirm its classification row cites either the adopted
 exact-head PR URL or the open replacement PR URL before removal. Otherwise
 confirm the row already records its `already-shipped`, `superseded`, or
-`blocked` evidence. Then remove only the four original dirty source worktrees:
+`blocked` evidence. Before any `--force` removal, recompute live proof files
+under the private recovery archive and compare them byte-for-byte with the
+preserved snapshot. Any mismatch or missing file blocks removal and requires a
+fresh snapshot plus reclassification for that row. Only unchanged rows may use
+the exact-path force-removal exception:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+RETIRE_PROOF_ROOT="$RECOVERY/private-retire-proof"
+mkdir -p "$RETIRE_PROOF_ROOT"
+for id in \
+  docs-psyche-specs \
+  memory-promote \
+  mobile-memory-gateway \
+  pr-476-review
+do
+  SNAPSHOT="$RECOVERY/dirty/$id"
+  PROOF_DIR="$RETIRE_PROOF_ROOT/$id"
+  BLOCKER="$RECOVERY/$id-retire-blocker.txt"
+  mkdir -p "$PROOF_DIR"
+  case "$id" in
+    docs-psyche-specs)
+      SOURCE="$REPO/.worktrees/docs-psyche-specs"
+      ;;
+    memory-promote)
+      SOURCE="$REPO/.worktrees/feat-cmem-1ev-memory-promote"
+      ;;
+    mobile-memory-gateway)
+      SOURCE="$REPO/.worktrees/mobile-memory-gateway"
+      ;;
+    pr-476-review)
+      SOURCE="$REPO/.worktrees/pr-476-review"
+      ;;
+  esac
+  if ! test -d "$SOURCE"; then
+    printf 'Blocked %s: source worktree is missing before retirement proof; take a fresh snapshot and reclassify.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  git -C "$SOURCE" rev-parse HEAD > "$PROOF_DIR/live-head.txt"
+  if ! cmp -s "$PROOF_DIR/live-head.txt" "$SNAPSHOT/head.txt"; then
+    printf 'Blocked %s: HEAD drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  git -C "$SOURCE" diff --binary > "$PROOF_DIR/live-worktree.patch"
+  if ! cmp -s "$PROOF_DIR/live-worktree.patch" "$SNAPSHOT/worktree.patch"; then
+    printf 'Blocked %s: unstaged tracked changes drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  git -C "$SOURCE" diff --cached --binary > "$PROOF_DIR/live-index.patch"
+  if ! cmp -s "$PROOF_DIR/live-index.patch" "$SNAPSHOT/index.patch"; then
+    printf 'Blocked %s: staged changes drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  git -C "$SOURCE" ls-files --others --exclude-standard > "$PROOF_DIR/live-untracked-files.txt"
+  if ! cmp -s "$PROOF_DIR/live-untracked-files.txt" "$SNAPSHOT/untracked-files.txt"; then
+    printf 'Blocked %s: untracked path inventory drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  while IFS= read -r path; do
+    test -n "$path" || continue
+    if ! test -e "$SOURCE/$path"; then
+      printf 'Blocked %s: live untracked file is missing: %s. Take a fresh snapshot and reclassify before removal.\n' \
+        "$id" "$path" > "$BLOCKER"
+      exit 1
+    fi
+    if ! test -e "$SNAPSHOT/untracked/$path"; then
+      printf 'Blocked %s: snapshotted untracked file copy is missing: %s. Take a fresh snapshot and reclassify before removal.\n' \
+        "$id" "$path" > "$BLOCKER"
+      exit 1
+    fi
+    if ! cmp -s "$SOURCE/$path" "$SNAPSHOT/untracked/$path"; then
+      printf 'Blocked %s: untracked file content drifted for %s; take a fresh snapshot and reclassify before removal.\n' \
+        "$id" "$path" > "$BLOCKER"
+      exit 1
+    fi
+  done < "$SNAPSHOT/untracked-files.txt"
+done
 for path in \
   "$REPO/.worktrees/docs-psyche-specs" \
   "$REPO/.worktrees/feat-cmem-1ev-memory-promote" \
@@ -1445,10 +1646,12 @@ done
 
 Expected: only those four exact dirty source paths are force-removed, because
 their committed history, dirty state, and recovery disposition have already
-been proven elsewhere in the archive. Empty worktree, index, and untracked
-snapshot classes are still acceptable, but the retirement proof now requires
-non-empty evidence files populated either with captured change summaries or
-deterministic sentinel lines.
+been proven elsewhere in the archive and reconfirmed as unchanged against the
+preserved snapshot immediately before removal. Empty worktree, index, and
+untracked snapshot classes are still acceptable, but the retirement proof now
+requires non-empty evidence files populated either with captured change
+summaries or deterministic sentinel lines, plus matching live proof files under
+`private-retire-proof/`.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 
@@ -1649,7 +1852,10 @@ if [ -n "$STATUS" ]; then
   block_restore \
     "Blocked: primary checkout has tracked or untracked changes; leave it untouched."
 fi
-git fetch origin main
+if ! git fetch origin main; then
+  block_restore \
+    "Blocked: could not fetch origin/main for the primary checkout; leave it untouched."
+fi
 if ! git show-ref --verify --quiet refs/heads/main; then
   block_restore "Blocked: local main branch is missing; leave the checkout untouched."
 fi
@@ -1658,7 +1864,10 @@ if ! git merge-base --is-ancestor main origin/main; then
     "Blocked: local main cannot be fast-forwarded safely to origin/main; leave the checkout untouched."
 fi
 if [ "$CURRENT_BRANCH" = "main" ]; then
-  git merge --ff-only origin/main
+  if ! git merge --ff-only origin/main; then
+    block_restore \
+      "Blocked: primary checkout could not fast-forward main to origin/main; leave it untouched."
+  fi
 elif printf '%s\n%s\n' "$CURRENT_BRANCH" "$UPSTREAM_REF" | grep -Eq '(^|[-/])issue-541($|[-/])|(^|[-/])541($|[-/])'; then
   if [ -z "$UPSTREAM_REMOTE" ] || [ -z "$UPSTREAM_MERGE_REF" ]; then
     block_restore \
@@ -1681,11 +1890,27 @@ elif printf '%s\n%s\n' "$CURRENT_BRANCH" "$UPSTREAM_REF" | grep -Eq '(^|[-/])iss
     block_restore \
       "Blocked: recovery-owned branch HEAD is not fully pushed to its freshly fetched configured upstream; leave it untouched."
   fi
-  git switch main
-  git merge --ff-only origin/main
+  if ! git switch main; then
+    block_restore \
+      "Blocked: could not switch the primary checkout to main; leave it untouched."
+  fi
+  if ! git merge --ff-only origin/main; then
+    block_restore \
+      "Blocked: primary checkout could not fast-forward main to origin/main after switching; leave it untouched."
+  fi
 else
   block_restore \
     "Blocked: primary checkout is on an unrelated branch; leave it untouched."
+fi
+FINAL_BRANCH="$(git branch --show-current)"
+FINAL_STATUS="$(git status --porcelain --untracked-files=all)"
+if [ "$FINAL_BRANCH" != "main" ]; then
+  block_restore \
+    "Blocked: final primary checkout branch is not main after restore; leave it untouched."
+fi
+if [ -n "$FINAL_STATUS" ]; then
+  block_restore \
+    "Blocked: primary checkout is not clean after restore; leave it untouched."
 fi
 {
   printf 'Primary checkout restored for final audit.\n'

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -1951,6 +1951,22 @@ directly into each row. Use `Preserved source` values such as
 private snapshot artifacts. A row is not complete until another engineer can
 reproduce its classification from the cited source.
 
+For viable rows, keep the column contract strict and deterministic:
+
+- `Main/PR evidence` may contain narrative non-terminal evidence only until a
+  pull request is actually adopted or opened. Once Task 5 adopts an existing
+  PR or opens a new recovery PR, rewrite `Main/PR evidence` to the raw
+  canonical PR URL only, for example
+  `https://github.com/OpenCoven/coven/pull/542`.
+- `Recovery action` must use semicolon-delimited `key=value` fields rather
+  than prose so retirement can parse it exactly. Use these modes only:
+  - `mode=continue-existing-pr; pr_kind=adopted; issue_url=...; archive_id=...; expected_branch=...; preserved_head=...`
+  - `mode=awaiting-recovery-pr; pr_kind=recovered; issue_url=...; archive_id=...; expected_branch=...`
+  - `mode=recovery-pr-open; pr_kind=recovered; issue_url=...; archive_id=...; expected_branch=...`
+- A viable row that has only reached issue reuse/creation remains explicitly
+  non-terminal with `mode=awaiting-recovery-pr`; it must not look retired or
+  PR-complete until the later PR-writing step rewrites both columns.
+
 - [ ] **Step 4: Apply the classification rules**
 
 Use these deterministic rules:
@@ -1977,12 +1993,21 @@ blocked:
 Expected: Task 4 Step 4 replaces every `pending` row with exactly one terminal
 classification (`already-shipped`, `superseded`, `viable`, or `blocked`) and
 one next action before Task 4 Step 5 and Task 9 Step 1 verification. A viable
-row may later keep that classification while Task 5 updates its action to
-`continue existing PR` only after a fully paginated same-repo open-PR capture
-returns one exact-source-branch candidate and that single candidate passes the
-fetched-tip, preserved-head ancestry, and empty-dirty-snapshot checks. Rows
-with zero same-repo exact-head candidates keep the normal issue-reuse-or-create
-flow.
+row may later keep that classification while Task 5 first records
+`mode=awaiting-recovery-pr` after verified issue reuse/create, then rewrites
+the row to a terminal PR-backed state only after one of these outcomes:
+
+- `mode=continue-existing-pr` after a fully paginated same-repo open-PR
+  capture returns one exact-source-branch candidate and that single candidate
+  passes the fetched-tip, preserved-head ancestry, and empty-dirty-snapshot
+  checks; or
+- `mode=recovery-pr-open` after the zero-candidate issue flow creates and
+  verifies a new OPEN recovery PR from the expected recovery branch.
+
+Rows with zero same-repo exact-head candidates keep the normal
+issue-reuse-or-create flow, and any `mode=awaiting-recovery-pr` row remains
+non-terminal until the later PR update rewrites `Main/PR evidence` to the raw
+canonical PR URL.
 
 - [ ] **Step 5: Review the ledger against the manifest**
 
@@ -2209,42 +2234,49 @@ case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
     SOURCE_BRANCH="feat/mobile-memory-gateway"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway/head.txt"
+    ARCHIVE_ID="dirty/mobile-memory-gateway"
     DIRTY_SNAPSHOT_ID="dirty/mobile-memory-gateway"
     DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   feat-npm-macos-x64)
     SOURCE_BRANCH="feat/npm-macos-x64"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/feat-npm-macos-x64/head.txt"
+    ARCHIVE_ID="branches/feat-npm-macos-x64.bundle"
     DIRTY_SNAPSHOT_ID=""
     DIRTY_SNAPSHOT_ROOT=""
     ;;
   fix-521-ward-surface-confinement)
     SOURCE_BRANCH="fix/521-ward-surface-confinement"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/head.txt"
+    ARCHIVE_ID="branches/fix-521-ward-surface-confinement.bundle"
     DIRTY_SNAPSHOT_ID=""
     DIRTY_SNAPSHOT_ROOT=""
     ;;
   memory-promote)
     SOURCE_BRANCH="feat/cmem-1ev-memory-promote"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote/head.txt"
+    ARCHIVE_ID="dirty/memory-promote"
     DIRTY_SNAPSHOT_ID="dirty/memory-promote"
     DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   docs-psyche-specs)
     SOURCE_BRANCH="docs/psyche-specs"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs/head.txt"
+    ARCHIVE_ID="dirty/docs-psyche-specs"
     DIRTY_SNAPSHOT_ID="dirty/docs-psyche-specs"
     DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   docs-universal-runtime-capability-design)
     SOURCE_BRANCH="docs/universal-runtime-capability-design"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/head.txt"
+    ARCHIVE_ID="branches/docs-universal-runtime-capability-design.bundle"
     DIRTY_SNAPSHOT_ID=""
     DIRTY_SNAPSHOT_ROOT=""
     ;;
   pr-476-review)
     SOURCE_BRANCH="fix/476-review-threads"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review/head.txt"
+    ARCHIVE_ID="dirty/pr-476-review"
     DIRTY_SNAPSHOT_ID="dirty/pr-476-review"
     DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
@@ -2258,6 +2290,7 @@ OPEN_PR_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-open-prs.json"
 PR_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-view.json"
 PR_ADOPTION_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-adoption.txt"
 PR_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-blocker.txt"
+SOURCE_ISSUE_URL="https://github.com/OpenCoven/coven/issues/541"
 test -s "$SOURCE_HEAD_FILE"
 EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
 {
@@ -2463,8 +2496,8 @@ case "$PR_COUNT" in
     fi
     update_classification_row \
       "viable" \
-      "Preserved head $EXPECTED_HEAD is ancestor of PR head $ACTUAL_HEAD, which matches fetched origin/$SOURCE_BRANCH tip $FRESH_BRANCH_TIP; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-adoption.txt." \
-      "continue existing PR #$PR_NUMBER ($PR_URL)"
+      "$PR_URL" \
+      "mode=continue-existing-pr; pr_kind=adopted; issue_url=$SOURCE_ISSUE_URL; archive_id=$ARCHIVE_ID; expected_branch=$SOURCE_BRANCH; preserved_head=$EXPECTED_HEAD"
     exit 0
     ;;
   0)
@@ -2514,9 +2547,11 @@ untouched while blocked. Record the preserved local head, fresh branch tip, PR
 head, ancestry result, PR URL, and any dirty-class byte counts in
 `viable/$WORKSTREAM_ID-pr-adoption.txt`, and also note there when the
 preserved ignored inventory is non-empty so later cleanup knows forced removal
-is prohibited. Record `continue existing PR` only after all of those checks
-pass. If `PR_COUNT>1`, block immediately with open-PR evidence because the
-same-repo exact-head query is already ambiguous.
+is prohibited. Only after all of those checks pass may the row rewrite
+`Main/PR evidence` to the raw canonical PR URL and set `Recovery action` to
+`mode=continue-existing-pr; pr_kind=adopted; issue_url=https://github.com/OpenCoven/coven/issues/541; archive_id=<preserved-source>; expected_branch=<source-branch>; preserved_head=<preserved-head>`.
+If `PR_COUNT>1`, block immediately with open-PR evidence because the same-repo
+exact-head query is already ambiguous.
 If `gh pr view` fails because the candidate disappears or cannot be read after
 the paginated REST capture, if the single-candidate branch fetch fails, if the
 GitHub capture itself fails, or if any other identity, ancestry, or dirty
@@ -2540,10 +2575,10 @@ from branch `docs/psyche-specs` at execution time, its `headRefOid` matches
 the freshly fetched `origin/docs/psyche-specs` tip, the preserved local
 `head.txt` is equal to or an ancestor of that PR head, and the preserved
 `worktree.patch`, `index.patch`, and `.untracked.zlist` are all empty, this
-step adopts the exact-source-branch PR that GitHub returns at that moment
-rather than hardcoding a PR number. If any of those three preserved dirty
-classes are non-empty, the row blocks with resume instructions instead of being
-treated as fully covered by the existing PR.
+step rewrites `Main/PR evidence` to that exact canonical PR URL and records a
+deterministic adopted-PR action instead of hardcoding a PR number. If any of
+those three preserved dirty classes are non-empty, the row blocks with resume
+instructions instead of being treated as fully covered by the existing PR.
 
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
@@ -2663,24 +2698,38 @@ PY
 case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
     ISSUE_TITLE="Recover mobile pairing workstream"
+    BRANCH_SLUG="mobile-pairing-recovery"
+    ARCHIVE_ID="dirty/mobile-memory-gateway"
     ;;
   feat-npm-macos-x64)
     ISSUE_TITLE="Recover or block Intel macOS npm packaging workstream"
+    BRANCH_SLUG="npm-macos-x64-recovery"
+    ARCHIVE_ID="branches/feat-npm-macos-x64.bundle"
     ;;
   fix-521-ward-surface-confinement)
     ISSUE_TITLE="Recover Ward surface confinement workstream"
+    BRANCH_SLUG="ward-surface-confinement-recovery"
+    ARCHIVE_ID="branches/fix-521-ward-surface-confinement.bundle"
     ;;
   memory-promote)
     ISSUE_TITLE="Recover memory promotion workstream"
+    BRANCH_SLUG="memory-promotion-recovery"
+    ARCHIVE_ID="dirty/memory-promote"
     ;;
   docs-psyche-specs)
     ISSUE_TITLE="Recover Psyche specification workstream"
+    BRANCH_SLUG="psyche-spec-recovery"
+    ARCHIVE_ID="dirty/docs-psyche-specs"
     ;;
   docs-universal-runtime-capability-design)
     ISSUE_TITLE="Recover universal runtime capability design workstream"
+    BRANCH_SLUG="universal-runtime-capability-recovery"
+    ARCHIVE_ID="branches/docs-universal-runtime-capability-design.bundle"
     ;;
   pr-476-review)
     ISSUE_TITLE="Recover runtime model parity plan workstream"
+    BRANCH_SLUG="runtime-parity-plan-recovery"
+    ARCHIVE_ID="dirty/pr-476-review"
     ;;
   *)
     printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
@@ -2894,6 +2943,7 @@ EOF
 esac
 ISSUE_NUMBER="$(jq -r '.number' "$ISSUE_VIEW_EVIDENCE")"
 ISSUE_URL="$(jq -r '.url' "$ISSUE_VIEW_EVIDENCE")"
+RECOVERY_BRANCH="issue-$ISSUE_NUMBER-$BRANCH_SLUG"
 rm -f "$ISSUE_POSTCONDITION_STAGE"
 if ! gh api --paginate --slurp \
   "repos/OpenCoven/coven/issues?state=all&per_page=100" \
@@ -3011,8 +3061,8 @@ fi
 jq '.[0]' "$ISSUE_POSTCONDITION_SEARCH_EVIDENCE" > "$ISSUE_POSTCONDITION_VIEW_EVIDENCE"
 update_classification_row \
   "viable" \
-  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, and viable/$WORKSTREAM_ID-issue-postcondition-view.json." \
-  "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL)."
+  "Awaiting recovery PR; issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, and viable/$WORKSTREAM_ID-issue-postcondition-view.json." \
+  "mode=awaiting-recovery-pr; pr_kind=recovered; issue_url=$ISSUE_URL; archive_id=$ARCHIVE_ID; expected_branch=$RECOVERY_BRANCH"
 ```
 
 When `ISSUE_COUNT=0`, the self-contained block above creates and verifies an
@@ -3038,8 +3088,12 @@ the row to `blocked`, and stop that row rather than choosing one arbitrarily.
 
 Expected: every viable row without an adopted PR has exactly one verified issue
 number, and every reuse, create, or block decision cites the saved paginated
-issue ledger, per-workstream filtered search evidence, and verification files. If
-the postcondition detects a race after this run created a duplicate issue, close
+issue ledger, per-workstream filtered search evidence, and verification files.
+After this step, those rows remain explicitly non-terminal: `Main/PR evidence`
+still says the row is awaiting a recovery PR, while `Recovery action` is the
+deterministic `mode=awaiting-recovery-pr; ... expected_branch=issue-<n>-<slug>`
+payload that Task 5 Step 5 must later rewrite after a PR exists. If the
+postcondition detects a race after this run created a duplicate issue, close
 that newly created issue as superseded with an explicit `--repo OpenCoven/coven`
 comment, verify it is `CLOSED`, leave any reused pre-existing issue untouched,
 and keep the row blocked until a rerun revalidates uniqueness.
@@ -3115,7 +3169,8 @@ continuing an adopted exact-source-branch PR.
 
 - [ ] **Step 5: Recover and publish each viable concern sequentially**
 
-Skip this step for any row whose Task 5 Step 1 action is `continue existing PR`.
+Skip this step for any row whose Task 5 Step 1 action is
+`mode=continue-existing-pr`.
 For each remaining viable row, set `WORKSTREAM_ID` to its exact workstream ID,
 set `ISSUE_NUMBER` to its created or reused issue number, and set
 `BRANCH_SLUG` from this fixed mapping:
@@ -3438,6 +3493,33 @@ ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
 PR_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-view.json"
 PR_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-blocker.txt"
 RECOVERY_BRANCH="issue-$ISSUE_NUMBER-$BRANCH_SLUG"
+case "$WORKSTREAM_ID" in
+  mobile-memory-gateway)
+    ARCHIVE_ID="dirty/mobile-memory-gateway"
+    ;;
+  feat-npm-macos-x64)
+    ARCHIVE_ID="branches/feat-npm-macos-x64.bundle"
+    ;;
+  fix-521-ward-surface-confinement)
+    ARCHIVE_ID="branches/fix-521-ward-surface-confinement.bundle"
+    ;;
+  memory-promote)
+    ARCHIVE_ID="dirty/memory-promote"
+    ;;
+  docs-psyche-specs)
+    ARCHIVE_ID="dirty/docs-psyche-specs"
+    ;;
+  docs-universal-runtime-capability-design)
+    ARCHIVE_ID="branches/docs-universal-runtime-capability-design.bundle"
+    ;;
+  pr-476-review)
+    ARCHIVE_ID="dirty/pr-476-review"
+    ;;
+  *)
+    printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
+    exit 1
+    ;;
+esac
 mkdir -p "$RECOVERY"
 update_classification_row() {
   python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
@@ -3528,15 +3610,16 @@ if [ "$ACTUAL_STATE" != "OPEN" ] || \
 fi
 update_classification_row \
   "viable" \
-  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-view.json; recovery PR verified via viable/$WORKSTREAM_ID-pr-view.json." \
-  "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL) with open PR #$RECOVERY_PR_NUMBER ($ACTUAL_PR_URL)."
+  "$ACTUAL_PR_URL" \
+  "mode=recovery-pr-open; pr_kind=recovered; issue_url=$ISSUE_URL; archive_id=$ARCHIVE_ID; expected_branch=$RECOVERY_BRANCH"
 ```
 
 Expected: every viable row either continues one adopted same-repo
 exact-source-branch open pull request after the single-candidate verification
 and empty-dirty-snapshot flow, or rewrites its ledger row to stay `viable`
-with one verified OPEN recovery PR URL from the expected current-main recovery
-branch after the zero-candidate normal flow, before Task 7 cleanup or Task 9
+with the raw canonical recovery PR URL in `Main/PR evidence` plus a
+deterministic `mode=recovery-pr-open; ... expected_branch=issue-<n>-<slug>`
+action after the zero-candidate normal flow, before Task 7 cleanup or Task 9
 audit begins.
 
 ### Task 6: Record Non-Viable Outcomes
@@ -4218,6 +4301,48 @@ else:
     raise SystemExit(f"Missing classification row for {workstream}")
 PY
 }
+parse_recovery_action() {
+  python3 - "$1" <<'PY'
+import sys
+
+action = sys.argv[1].strip()
+fields = {}
+for raw_part in action.split(";"):
+    part = raw_part.strip()
+    if not part:
+        continue
+    if "=" not in part:
+        raise SystemExit(f"Recovery action segment is not key=value: {part}")
+    key, value = part.split("=", 1)
+    key = key.strip()
+    value = value.strip()
+    if not key or not value:
+        raise SystemExit(f"Recovery action segment has an empty key or value: {part}")
+    if key in fields:
+        raise SystemExit(f"Recovery action repeats key {key}")
+    fields[key] = value
+
+mode = fields.get("mode")
+required = ["mode", "pr_kind", "issue_url", "archive_id", "expected_branch"]
+if mode == "continue-existing-pr":
+    required.append("preserved_head")
+elif mode in {"awaiting-recovery-pr", "recovery-pr-open"}:
+    pass
+else:
+    raise SystemExit(f"Unsupported recovery action mode: {mode}")
+
+for key in required:
+    if key not in fields:
+        raise SystemExit(f"Recovery action is missing {key}")
+
+print(fields["mode"])
+print(fields["pr_kind"])
+print(fields["issue_url"])
+print(fields["archive_id"])
+print(fields["expected_branch"])
+print(fields.get("preserved_head", ""))
+PY
+}
 block_retirement() {
   local id="$1"
   local blocker="$2"
@@ -4307,10 +4432,67 @@ do
           continue
           ;;
       esac
+      if ! RECOVERY_ACTION_FIELDS="$(parse_recovery_action "$RECOVERY_ACTION")"; then
+        block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+          "viable rows must encode a deterministic recovery action payload"
+        continue
+      fi
+      mapfile -t ACTION_ROW <<<"$RECOVERY_ACTION_FIELDS"
+      if test "${#ACTION_ROW[@]}" -ne 6; then
+        block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+          "recovery action parsing returned an unexpected field count"
+        continue
+      fi
+      ACTION_MODE="${ACTION_ROW[0]}"
+      ACTION_PR_KIND="${ACTION_ROW[1]}"
+      ACTION_ISSUE_URL="${ACTION_ROW[2]}"
+      ACTION_ARCHIVE_ID="${ACTION_ROW[3]}"
+      ACTION_EXPECTED_BRANCH="${ACTION_ROW[4]}"
+      ACTION_PRESERVED_HEAD="${ACTION_ROW[5]}"
+      case "$ACTION_ISSUE_URL" in
+        https://github.com/OpenCoven/coven/issues/*)
+          ;;
+        *)
+          block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+            "recovery action must record a GitHub issue URL for OpenCoven/coven"
+          continue
+          ;;
+      esac
+      if [ "$ACTION_ARCHIVE_ID" != "$PRESERVED_SOURCE" ]; then
+        block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+          "recovery action archive_id must match the preserved source column"
+        continue
+      fi
+      case "$ACTION_MODE" in
+        continue-existing-pr)
+          if [ "$ACTION_PR_KIND" != "adopted" ]; then
+            block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+              "continue-existing-pr rows must declare pr_kind=adopted"
+            continue
+          fi
+          ;;
+        recovery-pr-open)
+          if [ "$ACTION_PR_KIND" != "recovered" ]; then
+            block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+              "recovery-pr-open rows must declare pr_kind=recovered"
+            continue
+          fi
+          ;;
+        awaiting-recovery-pr)
+          block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+            "rows that are still awaiting a recovery PR are never eligible for forced retirement"
+          continue
+          ;;
+        *)
+          block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+            "recovery action mode is not eligible for forced retirement"
+          continue
+          ;;
+      esac
       PR_VIEW_EVIDENCE="$PROOF_DIR/live-pr-view.json"
       PR_BLOCKER_EVIDENCE="$PROOF_DIR/live-pr-view.err"
       if ! gh pr view --repo OpenCoven/coven "$PR_URL" \
-        --json number,title,url,state,headRepositoryOwner,isCrossRepository,baseRefName \
+        --json number,title,url,state,headRefOid,headRefName,headRepositoryOwner,isCrossRepository,baseRefName \
         > "$PR_VIEW_EVIDENCE" 2> "$PR_BLOCKER_EVIDENCE"; then
         block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
           "recorded viable PR could not be freshly verified against OpenCoven/coven"
@@ -4319,6 +4501,8 @@ do
       fi
       ACTUAL_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
       ACTUAL_STATE="$(jq -r '.state' "$PR_VIEW_EVIDENCE")"
+      ACTUAL_HEAD="$(jq -r '.headRefOid' "$PR_VIEW_EVIDENCE")"
+      ACTUAL_BRANCH="$(jq -r '.headRefName' "$PR_VIEW_EVIDENCE")"
       ACTUAL_OWNER="$(jq -r '.headRepositoryOwner.login' "$PR_VIEW_EVIDENCE")"
       ACTUAL_CROSS="$(jq -r '.isCrossRepository' "$PR_VIEW_EVIDENCE")"
       ACTUAL_BASE="$(jq -r '.baseRefName' "$PR_VIEW_EVIDENCE")"
@@ -4331,6 +4515,37 @@ do
           "viable PR did not freshly verify as OPEN on base main in OpenCoven/coven"
         continue
       fi
+      case "$ACTION_MODE" in
+        continue-existing-pr)
+          SNAPSHOT_HEAD="$(tr -d '\n' < "$SNAPSHOT/head.txt")"
+          if [ "$ACTION_EXPECTED_BRANCH" != "$ACTUAL_BRANCH" ] || \
+             [ "$ACTION_PRESERVED_HEAD" != "$SNAPSHOT_HEAD" ] || \
+             ! git -C "$REPO" merge-base --is-ancestor "$ACTION_PRESERVED_HEAD" "$ACTUAL_HEAD"; then
+            block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+              "adopted PR no longer matches the expected source branch and preserved-head ancestry"
+            {
+              printf 'Expected branch from recovery action: %s\n' "$ACTION_EXPECTED_BRANCH"
+              printf 'Actual branch from PR: %s\n' "$ACTUAL_BRANCH"
+              printf 'Preserved head from recovery action: %s\n' "$ACTION_PRESERVED_HEAD"
+              printf 'Preserved head from snapshot: %s\n' "$SNAPSHOT_HEAD"
+              printf 'Current PR head: %s\n' "$ACTUAL_HEAD"
+            } >> "$BLOCKER"
+            continue
+          fi
+          ;;
+        recovery-pr-open)
+          if [ "$ACTION_EXPECTED_BRANCH" != "$ACTUAL_BRANCH" ]; then
+            block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+              "recovery PR no longer matches the expected recovery branch"
+            {
+              printf 'Expected recovery branch: %s\n' "$ACTION_EXPECTED_BRANCH"
+              printf 'Actual PR branch: %s\n' "$ACTUAL_BRANCH"
+              printf 'Current PR head: %s\n' "$ACTUAL_HEAD"
+            } >> "$BLOCKER"
+            continue
+          fi
+          ;;
+      esac
       ;;
     pending|blocked)
       block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
@@ -4423,12 +4638,20 @@ done
 
 Expected: a row may retire only when its exact classification row says
 `already-shipped` with concrete merged/main evidence, `superseded` with concrete
-superseding evidence, or `viable` with a recorded GitHub PR URL that freshly
-verifies `OPEN`, `baseRefName=main`, and `OpenCoven/coven`. `pending` and
-`blocked` rows never retire. Any unverifiable viable PR writes cleanup blocker
-evidence and leaves the original source worktree and branch untouched. After
-that gate, the existing snapshot, live-drift, and ignored-content comparisons
-still run before removal.
+superseding evidence, or `viable` with `Main/PR evidence` set to a recorded
+GitHub PR URL and `Recovery action` set to a deterministic terminal PR mode.
+`pending`, `blocked`, and `mode=awaiting-recovery-pr` rows never retire. At
+retirement, every viable PR still has to freshly verify `OPEN`,
+`baseRefName=main`, and `OpenCoven/coven`. Adopted rows additionally require
+their parsed expected source branch to equal the current `headRefName`, and
+their parsed preserved head to remain equal to or an ancestor of the current
+`headRefOid`; a force-push or divergence blocks retirement with evidence.
+Newly recovered rows require the parsed expected recovery branch to equal the
+current `headRefName`, but do not require ancestry to the old preserved local
+snapshot head because that work may have been rebuilt on current `main`. Any
+unverifiable viable PR writes cleanup blocker evidence and leaves the original
+source worktree and branch untouched. After that gate, the existing snapshot,
+live-drift, and ignored-content comparisons still run before removal.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 
@@ -5256,7 +5479,8 @@ Expected: all seven workstreams match exactly one terminal classification.
 
 - [ ] **Step 2: Verify all viable rows have open pull requests**
 
-For every `viable` row, set `PR_URL` to the recorded pull-request URL and run:
+For every `viable` row, set `PR_URL` to the raw canonical pull-request URL
+recorded in `Main/PR evidence` and run:
 
 ```bash
 set -euo pipefail

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Preserve and classify every discovered local workstream, recover each viable concern through its own issue and implementation plan, and safely remove only proven stale residue.
 
-**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive. Run a preservation and classification phase before any cleanup, then hand each viable subsystem to an isolated issue/spec/plan/PR flow based on current `origin/main`.
+**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive with a fixed current-run root at `agent-recovery/issue-541` and immutable private rerun archives for older runs. Run a preservation and classification phase before any cleanup, then hand each viable subsystem to an isolated issue/spec/plan/PR flow based on current `origin/main`.
 
 **Tech Stack:** Git worktrees and bundles, GitHub CLI, Coven claims, Markdown recovery ledger, Rust/Cargo, npm, repository secret and privacy guards.
 
@@ -31,7 +31,9 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
   - `.git/agent-recovery/issue-541/private/issue-ledger-refresh/<workstream-id>-issues.stage.json`
   - Authoritative source-branch fetch evidence, open-PR evidence, verified
-    PR-view evidence, preserved-head adoption ancestry evidence,
+    same-repository candidate evidence, verified PR-view evidence,
+    preserved-head adoption ancestry evidence plus dirty-snapshot emptiness
+    evidence when applicable,
     per-workstream exact-title open issue-match evidence derived from paginated
     `issues.json`, blocker evidence for each viable workstream, and the
     private staged ledger used to atomically refresh `issues.json`.
@@ -41,6 +43,12 @@
   - Private branch-ref recheck evidence for each recovered source branch,
     including missing-ref outcomes and drift blockers recorded immediately
     before each deletion command.
+- Create only when Task 2 Step 1 reruns after a prior current root exists:
+  - `.git/agent-recovery/private/reruns/<rerun-id>/issue-541/`
+  - `.git/agent-recovery/private/reruns/<rerun-id>/archive-record.txt`
+  - Immutable archive of the former current `issue-541` run, including its
+    prior fixed location and archival timestamp, so reruns create a fresh
+    current root without truncating earlier manifests or snapshots.
 - Create only when Task 9 runs:
   - `.git/agent-recovery/issue-541/final-audit-primary-checkout.txt`
   - Primary-checkout restore and blocker evidence for the final audit.
@@ -203,18 +211,38 @@ without auto-closing it.
 Run:
 
 ```bash
+set -euo pipefail
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 git -C "$REPO" fetch origin main
-RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
-mkdir -p "$RECOVERY/dirty" "$RECOVERY/branches"
+RECOVERY_PARENT="$COMMON_DIR/agent-recovery"
+RECOVERY="$RECOVERY_PARENT/issue-541"
+RERUN_ARCHIVE_ROOT="$RECOVERY_PARENT/private/reruns"
+if test -e "$RECOVERY"; then
+  mkdir -p "$RERUN_ARCHIVE_ROOT"
+  RERUN_ARCHIVE_DIR="$(mktemp -d "$RERUN_ARCHIVE_ROOT/issue-541-rerun-XXXXXX")"
+  ARCHIVED_RECOVERY="$RERUN_ARCHIVE_DIR/issue-541"
+  mv "$RECOVERY" "$ARCHIVED_RECOVERY"
+  printf 'Former current root: %s\nArchived root: %s\nArchived at (UTC): %s\n' \
+    "$RECOVERY" \
+    "$ARCHIVED_RECOVERY" \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$RERUN_ARCHIVE_DIR/archive-record.txt"
+fi
+mkdir -p "$RECOVERY/dirty" "$RECOVERY/branches" "$RECOVERY/private"
 printf 'id\ttype\tsource\thead\tmerge_base\tsnapshot\n' > "$RECOVERY/manifest.tsv"
 ```
 
 Expected: the recovery root exists under
 `$COMMON_DIR/agent-recovery/issue-541`, and that fetched `origin/main`
-becomes the baseline for every Task 2 and Task 3 `merge_base` record. Task 4
-may fetch `origin/main` again before classification.
+becomes the baseline for every Task 2 and Task 3 `merge_base` record. If a
+prior current root already existed, it is first moved atomically into a unique
+private rerun archive created with `mktemp -d` under
+`$COMMON_DIR/agent-recovery/private/reruns`, its former fixed location and
+archival time are recorded in `archive-record.txt`, and the rerun then creates
+a fresh current root at the same fixed path so downstream `issue-541/...`
+paths stay valid. If the archival move or fresh-root creation fails, stop
+before writing any new manifest or snapshot. Task 4 may fetch `origin/main`
+again before classification.
 
 - [ ] **Step 2: Snapshot `docs-psyche-specs`**
 
@@ -661,10 +689,11 @@ Expected: Task 4 Step 4 replaces every `pending` row with exactly one terminal
 classification (`already-shipped`, `superseded`, `viable`, or `blocked`) and
 one next action before Task 4 Step 5 and Task 9 Step 1 verification. A viable
 row may later keep that classification while Task 5 updates its action to
-`continue existing PR` only after an exact-head query returns one open PR from
-the source branch and that single candidate passes the fetched-tip and
-preserved-head ancestry checks. Rows with zero exact-head candidates keep the
-normal issue-reuse-or-create flow.
+`continue existing PR` only after a fully paginated same-repo open-PR capture
+returns one exact-source-branch candidate and that single candidate passes the
+fetched-tip, preserved-head ancestry, and empty-dirty-snapshot checks. Rows
+with zero same-repo exact-head candidates keep the normal issue-reuse-or-create
+flow.
 
 - [ ] **Step 5: Review the ledger against the manifest**
 
@@ -701,6 +730,7 @@ Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then map it to its
 current source branch:
 
 ```bash
+set -euo pipefail
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
@@ -734,30 +764,44 @@ case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
     SOURCE_BRANCH="feat/mobile-memory-gateway"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway/head.txt"
+    DIRTY_SNAPSHOT_ID="dirty/mobile-memory-gateway"
+    DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   feat-npm-macos-x64)
     SOURCE_BRANCH="feat/npm-macos-x64"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/feat-npm-macos-x64/head.txt"
+    DIRTY_SNAPSHOT_ID=""
+    DIRTY_SNAPSHOT_ROOT=""
     ;;
   fix-521-ward-surface-confinement)
     SOURCE_BRANCH="fix/521-ward-surface-confinement"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/head.txt"
+    DIRTY_SNAPSHOT_ID=""
+    DIRTY_SNAPSHOT_ROOT=""
     ;;
   memory-promote)
     SOURCE_BRANCH="feat/cmem-1ev-memory-promote"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote/head.txt"
+    DIRTY_SNAPSHOT_ID="dirty/memory-promote"
+    DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   docs-psyche-specs)
     SOURCE_BRANCH="docs/psyche-specs"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs/head.txt"
+    DIRTY_SNAPSHOT_ID="dirty/docs-psyche-specs"
+    DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   docs-universal-runtime-capability-design)
     SOURCE_BRANCH="docs/universal-runtime-capability-design"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/head.txt"
+    DIRTY_SNAPSHOT_ID=""
+    DIRTY_SNAPSHOT_ROOT=""
     ;;
   pr-476-review)
     SOURCE_BRANCH="fix/476-review-threads"
     SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review/head.txt"
+    DIRTY_SNAPSHOT_ID="dirty/pr-476-review"
+    DIRTY_SNAPSHOT_ROOT="$COMMON_DIR/agent-recovery/issue-541/$DIRTY_SNAPSHOT_ID"
     ;;
   *)
     printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
@@ -774,13 +818,44 @@ EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
 {
   printf 'Source branch: %s\n' "$SOURCE_BRANCH"
   printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
-  printf 'Exact-head PR query runs before any source-branch fetch.\n'
+  printf 'Candidate discovery: capture every open PR for OpenCoven/coven via paginated REST API, then filter with jq only when head.ref matches the source branch and head.repo.full_name equals OpenCoven/coven.\n'
+  printf 'Same-named fork PRs do not count as same-repository candidates.\n'
+  printf 'Candidate discovery runs before any source-branch fetch.\n'
 } > "$BRANCH_FETCH_EVIDENCE"
-gh pr list \
-  --repo OpenCoven/coven \
-  --state open \
-  --head "$SOURCE_BRANCH" \
-  --json number,title,url,headRefName > "$OPEN_PR_EVIDENCE"
+if ! {
+  gh api --paginate --slurp \
+    "repos/OpenCoven/coven/pulls?state=open&per_page=100" | \
+  jq --arg SOURCE_BRANCH "$SOURCE_BRANCH" '
+    [ .[] | .[]
+      | select(.head.ref == $SOURCE_BRANCH)
+      | select(.head.repo != null and .head.repo.full_name == "OpenCoven/coven")
+      | {
+          number,
+          title,
+          url: .html_url,
+          state,
+          headRefName: .head.ref,
+          headRefOid: .head.sha,
+          headRepoFullName: .head.repo.full_name,
+          baseRefName: .base.ref
+        }
+    ]
+  ' > "$OPEN_PR_EVIDENCE"
+} 2> "$PR_BLOCKER_EVIDENCE"; then
+  API_ERROR="$(cat "$PR_BLOCKER_EVIDENCE")"
+  {
+    printf 'Blocked %s: open-PR candidate capture failed before source-branch verification.\n' "$WORKSTREAM_ID"
+    printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
+    printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+    printf 'Candidate discovery uses repos/OpenCoven/coven/pulls?state=open with --paginate --slurp and jq same-repo filtering.\n'
+    printf 'Failure follows:\n%s\n' "$API_ERROR"
+  } > "$PR_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Open PR candidate capture failed for preserved head $EXPECTED_HEAD before any source-branch verification; see viable/$WORKSTREAM_ID-branch-fetch.txt and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+    "Blocked: could not capture same-repo open PR candidates from GitHub."
+  exit 0
+fi
 PR_COUNT="$(jq 'length' "$OPEN_PR_EVIDENCE")"
 ```
 
@@ -789,7 +864,7 @@ Then branch on the exact-source-branch result:
 ```bash
 case "$PR_COUNT" in
   1)
-    printf 'Exact-head open PR count: 1\n' >> "$BRANCH_FETCH_EVIDENCE"
+    printf 'Same-repo exact-head open PR count: 1\n' >> "$BRANCH_FETCH_EVIDENCE"
     printf 'Fetching origin/%s for candidate identity verification.\n' \
       "$SOURCE_BRANCH" >> "$BRANCH_FETCH_EVIDENCE"
     if ! git -C "$REPO" fetch --no-tags origin \
@@ -797,7 +872,7 @@ case "$PR_COUNT" in
       >> "$BRANCH_FETCH_EVIDENCE" 2>&1; then
       FETCH_OUTPUT="$(cat "$BRANCH_FETCH_EVIDENCE")"
       {
-        printf 'Blocked %s: exact-head candidate exists, but origin/%s could not be fetched for identity verification.\n' \
+        printf 'Blocked %s: same-repo exact-head candidate exists, but origin/%s could not be fetched for identity verification.\n' \
           "$WORKSTREAM_ID" "$SOURCE_BRANCH"
         printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
         printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
@@ -805,7 +880,7 @@ case "$PR_COUNT" in
       } > "$PR_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "Single PR candidate could not be verified because origin/$SOURCE_BRANCH fetch failed for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+        "Single same-repo PR candidate could not be verified because origin/$SOURCE_BRANCH fetch failed for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
         "Blocked: candidate PR source branch could not be fetched from origin."
       exit 0
     fi
@@ -818,7 +893,7 @@ case "$PR_COUNT" in
       > "$PR_VIEW_EVIDENCE" 2> "$PR_BLOCKER_EVIDENCE"; then
       PR_VIEW_ERROR="$(cat "$PR_BLOCKER_EVIDENCE")"
       {
-        printf 'Blocked %s: candidate PR #%s disappeared or could not be read between gh pr list and gh pr view.\n' \
+        printf 'Blocked %s: candidate PR #%s disappeared or could not be read between paginated gh api capture and gh pr view.\n' \
           "$WORKSTREAM_ID" "$PR_NUMBER"
         printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
         printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
@@ -890,6 +965,50 @@ case "$PR_COUNT" in
       exit 0
     fi
     PR_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
+    printf 'Existing PR URL: %s\n' "$PR_URL" >> "$PR_ADOPTION_EVIDENCE"
+    if test -n "$DIRTY_SNAPSHOT_ROOT"; then
+      test -f "$DIRTY_SNAPSHOT_ROOT/worktree.patch"
+      test -f "$DIRTY_SNAPSHOT_ROOT/index.patch"
+      test -f "$DIRTY_SNAPSHOT_ROOT/untracked-files.txt"
+      WORKTREE_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/worktree.patch" | tr -d ' ')"
+      INDEX_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/index.patch" | tr -d ' ')"
+      UNTRACKED_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/untracked-files.txt" | tr -d ' ')"
+      DIRTY_CLASS_LIST=""
+      if [ "$WORKTREE_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="worktree.patch"; fi
+      if [ "$INDEX_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="${DIRTY_CLASS_LIST:+$DIRTY_CLASS_LIST, }index.patch"; fi
+      if [ "$UNTRACKED_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="${DIRTY_CLASS_LIST:+$DIRTY_CLASS_LIST, }untracked-files.txt"; fi
+      {
+        printf 'Preserved dirty snapshot: %s\n' "$DIRTY_SNAPSHOT_ID"
+        printf 'worktree.patch bytes: %s\n' "$WORKTREE_BYTES"
+        printf 'index.patch bytes: %s\n' "$INDEX_BYTES"
+        printf 'untracked-files.txt bytes: %s\n' "$UNTRACKED_BYTES"
+      } >> "$PR_ADOPTION_EVIDENCE"
+      if [ -n "$DIRTY_CLASS_LIST" ]; then
+        {
+          printf 'Blocked %s: existing PR #%s passed identity checks, but preserved dirty delta remains.\n' \
+            "$WORKSTREAM_ID" "$PR_NUMBER"
+          printf 'Existing PR URL: %s\n' "$PR_URL"
+          printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+          printf 'Preserved snapshot archive IDs: %s/worktree.patch, %s/index.patch, %s/untracked-files.txt\n' \
+            "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID"
+          printf 'Non-empty preserved dirty classes: %s\n' "$DIRTY_CLASS_LIST"
+          printf 'Resume condition: land or reconcile PR #%s, then recover the preserved delta from current main in a separate scoped track.\n' "$PR_NUMBER"
+          printf 'Do not force-remove or delete the original source worktree or branch while this blocker remains.\n'
+          printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
+          printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
+          printf 'PR view evidence: viable/%s-pr-view.json\n' "$WORKSTREAM_ID"
+          printf 'PR adoption evidence: viable/%s-pr-adoption.txt\n' "$WORKSTREAM_ID"
+        } > "$PR_BLOCKER_EVIDENCE"
+        update_classification_row \
+          "blocked" \
+          "Existing PR #$PR_NUMBER ($PR_URL) matches preserved head $EXPECTED_HEAD, but preserved dirty snapshot $DIRTY_SNAPSHOT_ID still has non-empty classes ($DIRTY_CLASS_LIST); see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, viable/$WORKSTREAM_ID-pr-adoption.txt, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+          "Blocked: land or reconcile PR #$PR_NUMBER, then recover preserved delta from current main in a separate scoped track. Leave source worktree and branch untouched."
+        exit 0
+      fi
+      printf 'Dirty snapshot check: all preserved dirty classes are empty, so existing-PR adoption may continue.\n' >> "$PR_ADOPTION_EVIDENCE"
+    else
+      printf 'Dirty snapshot check: not applicable for branch-only preserved source.\n' >> "$PR_ADOPTION_EVIDENCE"
+    fi
     update_classification_row \
       "viable" \
       "Preserved head $EXPECTED_HEAD is ancestor of PR head $ACTUAL_HEAD, which matches fetched origin/$SOURCE_BRANCH tip $FRESH_BRANCH_TIP; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-adoption.txt." \
@@ -897,64 +1016,78 @@ case "$PR_COUNT" in
     exit 0
     ;;
   0)
-    printf 'Exact-head open PR count: 0\n' >> "$BRANCH_FETCH_EVIDENCE"
-    printf 'No exact-head open PR candidate; skipping source-branch fetch and continuing to issue reuse/create.\n' >> "$BRANCH_FETCH_EVIDENCE"
+    printf 'Same-repo exact-head open PR count: 0\n' >> "$BRANCH_FETCH_EVIDENCE"
+    printf 'No same-repo exact-head open PR candidate; skipping source-branch fetch and continuing to issue reuse/create.\n' >> "$BRANCH_FETCH_EVIDENCE"
     ;;
   *)
     {
-      printf 'Blocked %s: expected 0 or 1 open PRs for source branch %s, found %s before identity verification.\n' \
+      printf 'Blocked %s: expected 0 or 1 same-repo open PRs for source branch %s, found %s before identity verification.\n' \
         "$WORKSTREAM_ID" "$SOURCE_BRANCH" "$PR_COUNT"
       printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
-      printf 'No source-branch fetch was attempted because the exact-head query was already ambiguous.\n'
+      printf 'No source-branch fetch was attempted because the same-repo exact-head query was already ambiguous.\n'
       printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
       printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
     } > "$PR_BLOCKER_EVIDENCE"
     update_classification_row \
       "blocked" \
       "Open PR ambiguity for preserved head $EXPECTED_HEAD before any source-branch verification; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
-      "Blocked: multiple open PRs claim $SOURCE_BRANCH."
+      "Blocked: multiple same-repo open PRs claim $SOURCE_BRANCH."
     exit 0
     ;;
 esac
 ```
 
 If `PR_COUNT=0`, do not fetch the source branch; record in
-`viable/$WORKSTREAM_ID-branch-fetch.txt` that the exact-head query found no
-candidate and continue directly to Step 2's issue reuse or creation flow. If
-`PR_COUNT=1`, verify the candidate PR before adopting it: fetch the exact
-expected source branch from `origin`, record the freshly fetched tip in
+`viable/$WORKSTREAM_ID-branch-fetch.txt` that the same-repo exact-head query
+found no candidate and continue directly to Step 2's issue reuse or creation
+flow. If `PR_COUNT=1`, verify the candidate PR before adopting it: fetch the
+exact expected source branch from `origin`, record the freshly fetched tip in
 `viable/$WORKSTREAM_ID-branch-fetch.txt`, then require `.state=OPEN`,
 `headRefName=$SOURCE_BRANCH`, `headRepositoryOwner.login=OpenCoven`,
 `isCrossRepository=false`, `baseRefName=main`, and `headRefOid` equal to that
 freshly fetched branch tip. Only after the PR head matches the authoritative
 fetched tip may the plan compare the preserved local `head.txt` to the PR head
 with `git merge-base --is-ancestor`; equality or ancestry is acceptable, but a
-diverged local head blocks adoption. Record the preserved local head, fresh
-branch tip, PR head, and ancestry result in
+diverged local head blocks adoption. For dirty-worktree sources, identity and
+ancestry success is still insufficient: inspect the preserved
+`worktree.patch`, `index.patch`, and `untracked-files.txt`, and adopt the PR
+only when all three classes are empty. If any preserved dirty class is
+non-empty, write `viable/$WORKSTREAM_ID-pr-blocker.txt` with the existing PR
+URL, the snapshot archive IDs, and the safe resume condition to land or
+reconcile that PR first and then recover the preserved delta from current
+`main` in a separate scoped track; the original source worktree and branch stay
+untouched while blocked. Record the preserved local head, fresh branch tip, PR
+head, ancestry result, PR URL, and any dirty-class byte counts in
 `viable/$WORKSTREAM_ID-pr-adoption.txt`, and record `continue existing PR`
 only after all of those checks pass. If `PR_COUNT>1`, block immediately with
-open-PR evidence because the exact-head query is already ambiguous. If
-`gh pr view` fails because the candidate disappears or cannot be read after
-`gh pr list`, if the single-candidate branch fetch fails, or if any other
-identity or ancestry check fails, write
-`viable/$WORKSTREAM_ID-pr-blocker.txt`, update the classification row to
-`blocked`, and stop that row only after the blocker evidence is persisted.
-This deterministically avoids duplicating possibly delivered work while still
-allowing a clean local worktree to adopt its open PR after that PR has advanced
-beyond the preserved local snapshot. A later rerun must reclassify against
-current main and GitHub history before deciding whether any replacement issue
-or PR is still needed. Continue to Step 2 only when `PR_COUNT=0`.
+open-PR evidence because the same-repo exact-head query is already ambiguous.
+If `gh pr view` fails because the candidate disappears or cannot be read after
+the paginated REST capture, if the single-candidate branch fetch fails, if the
+GitHub capture itself fails, or if any other identity, ancestry, or dirty
+snapshot check fails, update the classification row to `blocked` and stop that
+row only after the blocker evidence is persisted. This deterministically avoids
+duplicating possibly delivered work while still allowing a clean local worktree
+to adopt its open PR after that PR has advanced beyond the preserved local
+snapshot. A later rerun must reclassify against current main and GitHub history
+before deciding whether any replacement issue or PR is still needed. Continue
+to Step 2 only when `PR_COUNT=0`.
 
-Expected: every viable row records the exact-head open-PR query before any
-issue reuse or creation begins. Rows with one candidate add an evidence-backed
-authoritative-source-branch fetch and a `main`-targeting PR decision; rows
-with zero candidates skip fetch and continue normally; rows with multiple
-candidates block before branch verification. If `docs/psyche-specs` still has
-exactly one open PR from branch `docs/psyche-specs` at execution time, its
-`headRefOid` matches the freshly fetched `origin/docs/psyche-specs` tip, and
-the preserved local `head.txt` is equal to or an ancestor of that PR head,
-this step adopts the exact-source-branch PR that GitHub returns at that moment
-rather than hardcoding a PR number.
+Expected: every viable row records a paginated same-repo open-PR capture before
+any issue reuse or creation begins, and `viable/$WORKSTREAM_ID-open-prs.json`
+contains only same-repository candidates whose `head.ref` exactly matches
+`$SOURCE_BRANCH`. Same-named fork PRs remain excluded from the candidate count.
+Rows with one candidate add an evidence-backed authoritative-source-branch
+fetch and a `main`-targeting PR decision; rows with zero candidates skip fetch
+and continue normally; rows with multiple candidates block before branch
+verification. If `docs/psyche-specs` still has exactly one same-repo open PR
+from branch `docs/psyche-specs` at execution time, its `headRefOid` matches
+the freshly fetched `origin/docs/psyche-specs` tip, the preserved local
+`head.txt` is equal to or an ancestor of that PR head, and the preserved
+`worktree.patch`, `index.patch`, and `untracked-files.txt` are all empty, this
+step adopts the exact-source-branch PR that GitHub returns at that moment
+rather than hardcoding a PR number. If any of those three preserved dirty
+classes are non-empty, the row blocks with resume instructions instead of being
+treated as fully covered by the existing PR.
 
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
@@ -1511,11 +1644,12 @@ update_classification_row \
   "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL) with open PR #$RECOVERY_PR_NUMBER ($ACTUAL_PR_URL)."
 ```
 
-Expected: every viable row either continues one adopted exact-source-branch
-open pull request after the single-candidate verification flow, or rewrites
-its ledger row to stay `viable` with one verified OPEN recovery PR URL from
-the expected current-main recovery branch after the zero-candidate normal
-flow, before Task 7 cleanup or Task 9 audit begins.
+Expected: every viable row either continues one adopted same-repo
+exact-source-branch open pull request after the single-candidate verification
+and empty-dirty-snapshot flow, or rewrites its ledger row to stay `viable`
+with one verified OPEN recovery PR URL from the expected current-main recovery
+branch after the zero-candidate normal flow, before Task 7 cleanup or Task 9
+audit begins.
 
 ### Task 6: Record Non-Viable Outcomes
 
@@ -1558,7 +1692,9 @@ For each `blocked` row, add:
 ```
 
 Expected: no non-viable row relies on branch age or lack of a PR as its sole
-reason.
+reason. Rows blocked because an active PR leaves preserved dirty delta behind
+must cite that PR URL, the preserved snapshot archive IDs, and the explicit
+resume condition to recover the delta later from current `main`.
 
 ### Task 7: Clean Verified Git Residue
 
@@ -1648,8 +1784,11 @@ step, only for these four exact paths, and only after the worktree and index
 patch evidence, verified branch bundle, untracked inventory, terminal ledger
 classification, and either an adopted exact-source-branch open PR, an open
 replacement PR, or recorded non-viable/blocker evidence are all present.
-Unrelated or
-unsnapshotted worktrees must never use force.
+Rows blocked because an existing PR already covers the preserved head while
+`worktree.patch`, `index.patch`, or `untracked-files.txt` remains non-empty are
+explicitly excluded from forced source cleanup and leave their original
+worktree and branch untouched. Unrelated or unsnapshotted worktrees must never
+use force.
 
 Run:
 
@@ -1686,6 +1825,7 @@ COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 RETIRE_PROOF_ROOT="$RECOVERY/private-retire-proof"
+CLASSIFICATION="$RECOVERY/classification.md"
 mkdir -p "$RETIRE_PROOF_ROOT"
 for id in \
   docs-psyche-specs \
@@ -1711,6 +1851,13 @@ do
       SOURCE="$REPO/.worktrees/pr-476-review"
       ;;
   esac
+  if grep -F "| $id | blocked |" "$CLASSIFICATION" | \
+    grep -Fq 'Leave source worktree and branch untouched.'
+  then
+    printf 'Skip forced retirement for %s: classification is blocked because preserved dirty delta remains behind an existing PR. Leave the original source worktree and branch untouched.\n' \
+      "$id" > "$BLOCKER"
+    continue
+  fi
   if ! test -d "$SOURCE"; then
     printf 'Blocked %s: source worktree is missing before retirement proof; take a fresh snapshot and reclassify.\n' \
       "$id" > "$BLOCKER"
@@ -1758,14 +1905,7 @@ do
       exit 1
     fi
   done < "$SNAPSHOT/untracked-files.txt"
-done
-for path in \
-  "$REPO/.worktrees/docs-psyche-specs" \
-  "$REPO/.worktrees/feat-cmem-1ev-memory-promote" \
-  "$REPO/.worktrees/mobile-memory-gateway" \
-  "$REPO/.worktrees/pr-476-review"
-do
-  git -C "$REPO" worktree remove --force "$path"
+  git -C "$REPO" worktree remove --force "$SOURCE"
 done
 ```
 
@@ -1776,18 +1916,23 @@ preserved snapshot immediately before removal. Empty worktree, index, and
 untracked snapshot classes are still acceptable, but the retirement proof now
 requires non-empty evidence files populated either with captured change
 summaries or deterministic sentinel lines, plus matching live proof files under
-`private-retire-proof/`.
+`private-retire-proof/`. Any row blocked because preserved dirty delta remains
+behind an active PR writes a skip blocker and leaves its original source
+worktree in place.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 
 For each branch in the ledger with merged or superseded evidence, or each of
 the four dirty source branches once Step 4 has removed its worktree and proven
 either the verified bundle or a pushed replacement recovery ref, set
-`BRANCH_TO_DELETE` to its exact local branch name. Recheck that exact branch
-ref immediately before every deletion command against the preserved head source
-for that branch; do not rely only on the earlier worktree-retirement proof.
-Task 3 Step 3 already creates the explicit orphan-branch `head.txt` files used
-below. Use this exact mapping for all seven recovered source branches:
+`BRANCH_TO_DELETE` to its exact local branch name. Do not run this step for any
+dirty-source branch whose classification action says `Leave source worktree and
+branch untouched.` because preserved dirty delta remains behind an active PR.
+Recheck that exact branch ref immediately before every deletion command against
+the preserved head source for that branch; do not rely only on the earlier
+worktree-retirement proof. Task 3 Step 3 already creates the explicit
+orphan-branch `head.txt` files used below. Use this exact mapping for all seven
+recovered source branches:
 
 - `docs/psyche-specs` -> `dirty/docs-psyche-specs/head.txt`
 - `docs/universal-runtime-capability-design` -> `branches/docs-universal-runtime-capability-design/head.txt`

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -27,9 +27,17 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-blocker.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
+  - `.git/agent-recovery/issue-541/private/issue-ledger-refresh/<workstream-id>-issues.stage.json`
   - Exact-head open-PR evidence, verified replacement-PR view evidence,
     per-workstream exact-title open issue-match evidence derived from paginated
-    `issues.json`, and blocker evidence for each viable workstream.
+    `issues.json`, blocker evidence for each viable workstream, and the
+    private staged ledger used to atomically refresh `issues.json`.
+- Create only when Task 8 Step 5 runs:
+  - `.git/agent-recovery/issue-541/private/branch-delete-proof/<branch-proof-id>-pre-delete-d.txt`
+  - `.git/agent-recovery/issue-541/private/branch-delete-proof/<branch-proof-id>-pre-delete-D.txt`
+  - Private branch-ref recheck evidence for each recovered source branch,
+    including missing-ref outcomes and drift blockers recorded immediately
+    before each deletion command.
 - Create only when Task 9 runs:
   - `.git/agent-recovery/issue-541/final-audit-primary-checkout.txt`
   - Primary-checkout restore and blocker evidence for the final audit.
@@ -873,9 +881,10 @@ matching exact issue title:
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+PRIVATE_RECOVERY="$COMMON_DIR/agent-recovery/issue-541/private"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
 ALL_ISSUES_EVIDENCE="$COMMON_DIR/agent-recovery/issue-541/issues.json"
-mkdir -p "$RECOVERY"
+mkdir -p "$RECOVERY" "$PRIVATE_RECOVERY/issue-ledger-refresh"
 update_classification_row() {
   python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
 from pathlib import Path
@@ -931,46 +940,71 @@ ISSUE_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search.json"
 ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
 ISSUE_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-blocker.txt"
 ISSUE_LEDGER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issues.json"
+ISSUE_LEDGER_STAGE="$PRIVATE_RECOVERY/issue-ledger-refresh/$WORKSTREAM_ID-issues.stage.json"
+rm -f "$ISSUE_LEDGER_STAGE"
 if ! gh api --paginate --slurp \
   "repos/OpenCoven/coven/issues?state=all&per_page=100" \
-  > "$ALL_ISSUES_EVIDENCE"
+  > "$ISSUE_LEDGER_STAGE"
 then
+  rm -f "$ISSUE_LEDGER_STAGE"
   {
     printf 'Blocked %s: could not refresh the paginated issue ledger before reuse/create.\n' \
       "$WORKSTREAM_ID"
-    printf 'Latest shared issue ledger: issue-541/issues.json\n'
-    printf 'Per-workstream issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+    printf 'Preserved shared issue ledger: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger target: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+    printf 'Staging file removed after gh api failure: private/issue-ledger-refresh/%s-issues.stage.json\n' "$WORKSTREAM_ID"
   } > "$ISSUE_BLOCKER_EVIDENCE"
   update_classification_row \
     "blocked" \
-    "Issue ledger refresh failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Issue ledger refresh failed without replacing issue-541/issues.json; see viable/$WORKSTREAM_ID-issue-blocker.txt." \
     "Blocked: could not refresh live issue evidence before exact-title reuse/create."
   exit 0
 fi
-if ! cp "$ALL_ISSUES_EVIDENCE" "$ISSUE_LEDGER_EVIDENCE"; then
+if ! test -s "$ISSUE_LEDGER_STAGE" || \
+   ! jq -e 'type == "array" and length > 0 and all(.[]; type == "array")' "$ISSUE_LEDGER_STAGE" > /dev/null
+then
+  rm -f "$ISSUE_LEDGER_STAGE"
   {
-    printf 'Blocked %s: could not persist the refreshed issue ledger copy.\n' \
+    printf 'Blocked %s: staged issue ledger was empty or not a valid paginated slurped array.\n' \
       "$WORKSTREAM_ID"
-    printf 'Latest shared issue ledger: issue-541/issues.json\n'
-    printf 'Per-workstream issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+    printf 'Preserved shared issue ledger: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger target: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+    printf 'Expected staging shape: JSON array whose elements are page arrays.\n'
   } > "$ISSUE_BLOCKER_EVIDENCE"
   update_classification_row \
     "blocked" \
-    "Issue ledger persistence failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
-    "Blocked: could not persist live issue evidence before exact-title reuse/create."
+    "Issue ledger staging validation failed without replacing issue-541/issues.json; see viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: live issue evidence failed validation before exact-title reuse/create."
   exit 0
 fi
-if ! test -s "$ALL_ISSUES_EVIDENCE" || ! test -s "$ISSUE_LEDGER_EVIDENCE"; then
+if ! mv "$ISSUE_LEDGER_STAGE" "$ALL_ISSUES_EVIDENCE"; then
+  rm -f "$ISSUE_LEDGER_STAGE"
   {
-    printf 'Blocked %s: refreshed issue ledger evidence is empty.\n' \
+    printf 'Blocked %s: could not atomically replace the shared issue ledger.\n' \
       "$WORKSTREAM_ID"
-    printf 'Latest shared issue ledger: issue-541/issues.json\n'
-    printf 'Per-workstream issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+    printf 'Shared issue ledger path: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger target: viable/%s-issues.json\n' "$WORKSTREAM_ID"
   } > "$ISSUE_BLOCKER_EVIDENCE"
   update_classification_row \
     "blocked" \
-    "Issue ledger evidence was empty; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
-    "Blocked: live issue evidence was empty before exact-title reuse/create."
+    "Issue ledger replacement failed; see issue-541/issues.json and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: could not atomically replace shared live issue evidence before exact-title reuse/create."
+  exit 0
+fi
+if ! cp "$ALL_ISSUES_EVIDENCE" "$ISSUE_LEDGER_EVIDENCE" || \
+   ! cmp -s "$ALL_ISSUES_EVIDENCE" "$ISSUE_LEDGER_EVIDENCE"
+then
+  rm -f "$ISSUE_LEDGER_EVIDENCE"
+  {
+    printf 'Blocked %s: could not persist an exact per-workstream copy of the verified issue ledger.\n' \
+      "$WORKSTREAM_ID"
+    printf 'Verified shared issue ledger: issue-541/issues.json\n'
+    printf 'Per-workstream issue ledger target: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue ledger persistence failed after shared refresh; see issue-541/issues.json and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: could not persist verified live issue evidence before exact-title reuse/create."
   exit 0
 fi
 jq --arg title "$ISSUE_TITLE" \
@@ -980,14 +1014,20 @@ ISSUE_COUNT="$(jq 'length' "$ISSUE_SEARCH_EVIDENCE")"
 ```
 
 Immediately before every exact-title reuse/create decision, refresh the fully
-paginated shared `issue-541/issues.json` ledger with `gh api --paginate
---slurp`, then persist that row's exact live capture to
-`viable/$WORKSTREAM_ID-issues.json`. Only after that refresh may the plan
-filter and count exact-title non-PR `open` matches. Each workstream's
-`viable/$WORKSTREAM_ID-issue-search.json` stores only the filtered matches from
-that persisted live ledger, so default-limited `gh issue list` output never
-drives reuse. A sole unrelated or closed result in the refreshed ledger leaves
-`ISSUE_COUNT=0` and must not be reused.
+paginated shared `issue-541/issues.json` ledger into
+`private/issue-ledger-refresh/$WORKSTREAM_ID-issues.stage.json`. If `gh api`
+fails, preserve the existing `issue-541/issues.json`, remove the staging file,
+persist blocker evidence, and stop that row. Only a non-empty JSON value that
+passes `jq -e 'type == "array" and length > 0 and all(.[]; type == "array")'` may replace the
+shared ledger, and that replacement must happen atomically with `mv`. Only
+after the verified shared ledger is in place may the plan copy it to
+`viable/$WORKSTREAM_ID-issues.json`, filter exact-title non-PR `open` matches,
+and count them. Each workstream's `viable/$WORKSTREAM_ID-issue-search.json`
+stores only the filtered matches from that verified persisted ledger, so
+default-limited `gh issue list` output never drives reuse, and a refresh
+failure never truncates the last known-good shared ledger. A sole unrelated or
+closed result in the refreshed ledger leaves `ISSUE_COUNT=0` and must not be
+reused.
 
 If exactly one exact-title open issue already exists, reuse it without creating
 a duplicate:
@@ -1658,22 +1698,195 @@ summaries or deterministic sentinel lines, plus matching live proof files under
 For each branch in the ledger with merged or superseded evidence, or each of
 the four dirty source branches once Step 4 has removed its worktree and proven
 either the verified bundle or a pushed replacement recovery ref, set
-`BRANCH_TO_DELETE` to its exact local branch name and run:
+`BRANCH_TO_DELETE` to its exact local branch name. Recheck that exact branch
+ref immediately before every deletion command against the preserved head source
+for that branch; do not rely only on the earlier worktree-retirement proof.
+Task 3 Step 3 already creates the explicit orphan-branch `head.txt` files used
+below. Use this exact mapping for all seven recovered source branches:
+
+- `docs/psyche-specs` -> `dirty/docs-psyche-specs/head.txt`
+- `docs/universal-runtime-capability-design` -> `branches/docs-universal-runtime-capability-design/head.txt`
+- `feat/cmem-1ev-memory-promote` -> `dirty/memory-promote/head.txt`
+- `feat/mobile-memory-gateway` -> `dirty/mobile-memory-gateway/head.txt`
+- `feat/npm-macos-x64` -> `branches/feat-npm-macos-x64/head.txt`
+- `fix/476-review-threads` -> `dirty/pr-476-review/head.txt`
+- `fix/521-ward-surface-confinement` -> `branches/fix-521-ward-surface-confinement/head.txt`
+
+Run this immediately before `branch -d`:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
+BRANCH_DELETE_PROOF_ROOT="$COMMON_DIR/agent-recovery/issue-541/private/branch-delete-proof"
+mkdir -p "$BRANCH_DELETE_PROOF_ROOT"
+recheck_branch_ref_tip() {
+  MODE="$1"
+  BRANCH_PROOF_ID="$(printf '%s' "$BRANCH_TO_DELETE" | tr '/' '_')"
+  case "$BRANCH_TO_DELETE" in
+    docs/psyche-specs)
+      PRESERVED_HEAD_SOURCE="dirty/docs-psyche-specs/head.txt"
+      ;;
+    docs/universal-runtime-capability-design)
+      PRESERVED_HEAD_SOURCE="branches/docs-universal-runtime-capability-design/head.txt"
+      ;;
+    feat/cmem-1ev-memory-promote)
+      PRESERVED_HEAD_SOURCE="dirty/memory-promote/head.txt"
+      ;;
+    feat/mobile-memory-gateway)
+      PRESERVED_HEAD_SOURCE="dirty/mobile-memory-gateway/head.txt"
+      ;;
+    feat/npm-macos-x64)
+      PRESERVED_HEAD_SOURCE="branches/feat-npm-macos-x64/head.txt"
+      ;;
+    fix/476-review-threads)
+      PRESERVED_HEAD_SOURCE="dirty/pr-476-review/head.txt"
+      ;;
+    fix/521-ward-surface-confinement)
+      PRESERVED_HEAD_SOURCE="branches/fix-521-ward-surface-confinement/head.txt"
+      ;;
+    *)
+      printf 'Blocked: unknown recovered source branch %s.\n' "$BRANCH_TO_DELETE" \
+        > "$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE.txt"
+      return 1
+      ;;
+  esac
+  PRESERVED_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/$PRESERVED_HEAD_SOURCE"
+  PROOF_FILE="$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE.txt"
+  LIVE_HEAD_FILE="$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE-live-head.txt"
+  LIVE_ERR_FILE="$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE-live-head.err"
+  if ! test -s "$PRESERVED_HEAD_FILE"; then
+    printf 'Blocked %s: preserved head file is missing: %s\n' \
+      "$BRANCH_TO_DELETE" "$PRESERVED_HEAD_SOURCE" > "$PROOF_FILE"
+    return 1
+  fi
+  if ! git -C "$REPO" rev-parse --verify "refs/heads/$BRANCH_TO_DELETE" \
+    > "$LIVE_HEAD_FILE" 2> "$LIVE_ERR_FILE"
+  then
+    {
+      printf 'Branch: %s\n' "$BRANCH_TO_DELETE"
+      printf 'Preserved head source: %s\n' "$PRESERVED_HEAD_SOURCE"
+      printf 'Outcome: local branch ref is already missing immediately before %s; no deletion command ran.\n' "$MODE"
+    } > "$PROOF_FILE"
+    rm -f "$LIVE_HEAD_FILE" "$LIVE_ERR_FILE"
+    return 2
+  fi
+  PRESERVED_HEAD="$(tr -d '\n' < "$PRESERVED_HEAD_FILE")"
+  LIVE_HEAD="$(tr -d '\n' < "$LIVE_HEAD_FILE")"
+  {
+    printf 'Branch: %s\n' "$BRANCH_TO_DELETE"
+    printf 'Preserved head source: %s\n' "$PRESERVED_HEAD_SOURCE"
+    printf 'Preserved head: %s\n' "$PRESERVED_HEAD"
+    printf 'Live branch ref tip: %s\n' "$LIVE_HEAD"
+  } > "$PROOF_FILE"
+  if [ "$LIVE_HEAD" != "$PRESERVED_HEAD" ]; then
+    printf 'Blocked: live branch ref tip differs from the preserved head; newer commits are unpreserved.\n' \
+      >> "$PROOF_FILE"
+    return 1
+  fi
+  return 0
+}
+recheck_branch_ref_tip pre-delete-d
+CHECK_STATUS=$?
+if [ "$CHECK_STATUS" -eq 2 ]; then
+  exit 0
+fi
+if [ "$CHECK_STATUS" -ne 0 ]; then
+  exit "$CHECK_STATUS"
+fi
 git -C "$REPO" branch -d "$BRANCH_TO_DELETE"
 ```
 
-If squash history makes `-d` refuse, recheck the ledger evidence and use:
+If squash history makes `-d` refuse, recheck the ledger evidence, reconfirm
+its source worktree is already removed and its verified snapshot bundle or
+pushed replacement branch still proves the committed history, then rerun the
+same branch-ref proof immediately before `branch -D`:
 
 ```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+BRANCH_DELETE_PROOF_ROOT="$COMMON_DIR/agent-recovery/issue-541/private/branch-delete-proof"
+mkdir -p "$BRANCH_DELETE_PROOF_ROOT"
+recheck_branch_ref_tip() {
+  MODE="$1"
+  BRANCH_PROOF_ID="$(printf '%s' "$BRANCH_TO_DELETE" | tr '/' '_')"
+  case "$BRANCH_TO_DELETE" in
+    docs/psyche-specs)
+      PRESERVED_HEAD_SOURCE="dirty/docs-psyche-specs/head.txt"
+      ;;
+    docs/universal-runtime-capability-design)
+      PRESERVED_HEAD_SOURCE="branches/docs-universal-runtime-capability-design/head.txt"
+      ;;
+    feat/cmem-1ev-memory-promote)
+      PRESERVED_HEAD_SOURCE="dirty/memory-promote/head.txt"
+      ;;
+    feat/mobile-memory-gateway)
+      PRESERVED_HEAD_SOURCE="dirty/mobile-memory-gateway/head.txt"
+      ;;
+    feat/npm-macos-x64)
+      PRESERVED_HEAD_SOURCE="branches/feat-npm-macos-x64/head.txt"
+      ;;
+    fix/476-review-threads)
+      PRESERVED_HEAD_SOURCE="dirty/pr-476-review/head.txt"
+      ;;
+    fix/521-ward-surface-confinement)
+      PRESERVED_HEAD_SOURCE="branches/fix-521-ward-surface-confinement/head.txt"
+      ;;
+    *)
+      printf 'Blocked: unknown recovered source branch %s.\n' "$BRANCH_TO_DELETE" \
+        > "$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE.txt"
+      return 1
+      ;;
+  esac
+  PRESERVED_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/$PRESERVED_HEAD_SOURCE"
+  PROOF_FILE="$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE.txt"
+  LIVE_HEAD_FILE="$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE-live-head.txt"
+  LIVE_ERR_FILE="$BRANCH_DELETE_PROOF_ROOT/$BRANCH_PROOF_ID-$MODE-live-head.err"
+  if ! test -s "$PRESERVED_HEAD_FILE"; then
+    printf 'Blocked %s: preserved head file is missing: %s\n' \
+      "$BRANCH_TO_DELETE" "$PRESERVED_HEAD_SOURCE" > "$PROOF_FILE"
+    return 1
+  fi
+  if ! git -C "$REPO" rev-parse --verify "refs/heads/$BRANCH_TO_DELETE" \
+    > "$LIVE_HEAD_FILE" 2> "$LIVE_ERR_FILE"
+  then
+    {
+      printf 'Branch: %s\n' "$BRANCH_TO_DELETE"
+      printf 'Preserved head source: %s\n' "$PRESERVED_HEAD_SOURCE"
+      printf 'Outcome: local branch ref is already missing immediately before %s; no deletion command ran.\n' "$MODE"
+    } > "$PROOF_FILE"
+    rm -f "$LIVE_HEAD_FILE" "$LIVE_ERR_FILE"
+    return 2
+  fi
+  PRESERVED_HEAD="$(tr -d '\n' < "$PRESERVED_HEAD_FILE")"
+  LIVE_HEAD="$(tr -d '\n' < "$LIVE_HEAD_FILE")"
+  {
+    printf 'Branch: %s\n' "$BRANCH_TO_DELETE"
+    printf 'Preserved head source: %s\n' "$PRESERVED_HEAD_SOURCE"
+    printf 'Preserved head: %s\n' "$PRESERVED_HEAD"
+    printf 'Live branch ref tip: %s\n' "$LIVE_HEAD"
+  } > "$PROOF_FILE"
+  if [ "$LIVE_HEAD" != "$PRESERVED_HEAD" ]; then
+    printf 'Blocked: live branch ref tip differs from the preserved head; newer commits are unpreserved.\n' \
+      >> "$PROOF_FILE"
+    return 1
+  fi
+  return 0
+}
+recheck_branch_ref_tip pre-delete-D
+CHECK_STATUS=$?
+if [ "$CHECK_STATUS" -eq 2 ]; then
+  exit 0
+fi
+if [ "$CHECK_STATUS" -ne 0 ]; then
+  exit "$CHECK_STATUS"
+fi
 git -C "$REPO" branch -D "$BRANCH_TO_DELETE"
 ```
 
-only after confirming its source worktree is already removed and its verified
-snapshot bundle or pushed replacement branch still proves the committed history.
+If the local branch ref is already missing, record that outcome in the private
+proof file and succeed without failing the step. If the live branch ref tip
+exists but differs from the preserved head, stop and do not use `-D`; newer
+commits are unpreserved until a fresh archive captures them.
 
 - [ ] **Step 6: Release only merged or stopped recovery claims**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -661,9 +661,10 @@ Expected: Task 4 Step 4 replaces every `pending` row with exactly one terminal
 classification (`already-shipped`, `superseded`, `viable`, or `blocked`) and
 one next action before Task 4 Step 5 and Task 9 Step 1 verification. A viable
 row may later keep that classification while Task 5 updates its action to
-`continue existing PR` after verifying one open PR from the exact source
-branch whose head matches the freshly fetched `origin/<branch>` tip and still
-descends from the preserved local `head.txt` snapshot.
+`continue existing PR` only after an exact-head query returns one open PR from
+the source branch and that single candidate passes the fetched-tip and
+preserved-head ancestry checks. Rows with zero exact-head candidates keep the
+normal issue-reuse-or-create flow.
 
 - [ ] **Step 5: Review the ledger against the manifest**
 
@@ -773,27 +774,8 @@ EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
 {
   printf 'Source branch: %s\n' "$SOURCE_BRANCH"
   printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+  printf 'Exact-head PR query runs before any source-branch fetch.\n'
 } > "$BRANCH_FETCH_EVIDENCE"
-if ! git -C "$REPO" fetch --no-tags origin \
-  "refs/heads/$SOURCE_BRANCH:refs/remotes/origin/$SOURCE_BRANCH" \
-  >> "$BRANCH_FETCH_EVIDENCE" 2>&1; then
-  FETCH_OUTPUT="$(cat "$BRANCH_FETCH_EVIDENCE")"
-  {
-    printf 'Blocked %s: could not fetch origin/%s before PR adoption.\n' \
-      "$WORKSTREAM_ID" "$SOURCE_BRANCH"
-    printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
-    printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
-    printf 'Fetch output follows:\n%s\n' "$FETCH_OUTPUT"
-  } > "$PR_BLOCKER_EVIDENCE"
-  update_classification_row \
-    "blocked" \
-    "Source-branch fetch failed for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt and viable/$WORKSTREAM_ID-pr-blocker.txt." \
-    "Blocked: candidate PR source branch could not be fetched from origin."
-  exit 0
-fi
-FRESH_BRANCH_TIP="$(git -C "$REPO" rev-parse "refs/remotes/origin/$SOURCE_BRANCH")"
-printf 'Fresh fetched origin/%s tip: %s\n' \
-  "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP" >> "$BRANCH_FETCH_EVIDENCE"
 gh pr list \
   --repo OpenCoven/coven \
   --state open \
@@ -807,6 +789,29 @@ Then branch on the exact-source-branch result:
 ```bash
 case "$PR_COUNT" in
   1)
+    printf 'Exact-head open PR count: 1\n' >> "$BRANCH_FETCH_EVIDENCE"
+    printf 'Fetching origin/%s for candidate identity verification.\n' \
+      "$SOURCE_BRANCH" >> "$BRANCH_FETCH_EVIDENCE"
+    if ! git -C "$REPO" fetch --no-tags origin \
+      "refs/heads/$SOURCE_BRANCH:refs/remotes/origin/$SOURCE_BRANCH" \
+      >> "$BRANCH_FETCH_EVIDENCE" 2>&1; then
+      FETCH_OUTPUT="$(cat "$BRANCH_FETCH_EVIDENCE")"
+      {
+        printf 'Blocked %s: exact-head candidate exists, but origin/%s could not be fetched for identity verification.\n' \
+          "$WORKSTREAM_ID" "$SOURCE_BRANCH"
+        printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+        printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
+        printf 'Fetch output follows:\n%s\n' "$FETCH_OUTPUT"
+      } > "$PR_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Single PR candidate could not be verified because origin/$SOURCE_BRANCH fetch failed for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+        "Blocked: candidate PR source branch could not be fetched from origin."
+      exit 0
+    fi
+    FRESH_BRANCH_TIP="$(git -C "$REPO" rev-parse "refs/remotes/origin/$SOURCE_BRANCH")"
+    printf 'Fresh fetched origin/%s tip: %s\n' \
+      "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP" >> "$BRANCH_FETCH_EVIDENCE"
     PR_NUMBER="$(jq -r '.[0].number' "$OPEN_PR_EVIDENCE")"
     if ! gh pr view --repo OpenCoven/coven "$PR_NUMBER" \
       --json number,title,url,state,headRefOid,headRefName,headRepositoryOwner,isCrossRepository,baseRefName \
@@ -892,28 +897,33 @@ case "$PR_COUNT" in
     exit 0
     ;;
   0)
+    printf 'Exact-head open PR count: 0\n' >> "$BRANCH_FETCH_EVIDENCE"
+    printf 'No exact-head open PR candidate; skipping source-branch fetch and continuing to issue reuse/create.\n' >> "$BRANCH_FETCH_EVIDENCE"
     ;;
   *)
     {
-      printf 'Blocked %s: expected 0 or 1 open PRs for source branch %s, found %s.\n' \
+      printf 'Blocked %s: expected 0 or 1 open PRs for source branch %s, found %s before identity verification.\n' \
         "$WORKSTREAM_ID" "$SOURCE_BRANCH" "$PR_COUNT"
       printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
-      printf 'Fresh fetched origin/%s tip: %s\n' "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP"
+      printf 'No source-branch fetch was attempted because the exact-head query was already ambiguous.\n'
       printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
       printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
     } > "$PR_BLOCKER_EVIDENCE"
     update_classification_row \
       "blocked" \
-      "Open PR ambiguity after fetching origin/$SOURCE_BRANCH tip $FRESH_BRANCH_TIP for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+      "Open PR ambiguity for preserved head $EXPECTED_HEAD before any source-branch verification; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
       "Blocked: multiple open PRs claim $SOURCE_BRANCH."
     exit 0
     ;;
 esac
 ```
 
-If `PR_COUNT=1`, verify the candidate PR before adopting it: first fetch the
-exact expected source branch from `origin` and record the freshly fetched tip
-in `viable/$WORKSTREAM_ID-branch-fetch.txt`. Then require `.state=OPEN`,
+If `PR_COUNT=0`, do not fetch the source branch; record in
+`viable/$WORKSTREAM_ID-branch-fetch.txt` that the exact-head query found no
+candidate and continue directly to Step 2's issue reuse or creation flow. If
+`PR_COUNT=1`, verify the candidate PR before adopting it: fetch the exact
+expected source branch from `origin`, record the freshly fetched tip in
+`viable/$WORKSTREAM_ID-branch-fetch.txt`, then require `.state=OPEN`,
 `headRefName=$SOURCE_BRANCH`, `headRepositoryOwner.login=OpenCoven`,
 `isCrossRepository=false`, `baseRefName=main`, and `headRefOid` equal to that
 freshly fetched branch tip. Only after the PR head matches the authoritative
@@ -922,9 +932,11 @@ with `git merge-base --is-ancestor`; equality or ancestry is acceptable, but a
 diverged local head blocks adoption. Record the preserved local head, fresh
 branch tip, PR head, and ancestry result in
 `viable/$WORKSTREAM_ID-pr-adoption.txt`, and record `continue existing PR`
-only after all of those checks pass. If `gh pr view` fails because the
-candidate disappears or cannot be read after `gh pr list`, if the branch fetch
-fails, or if any other identity or ancestry check fails, write
+only after all of those checks pass. If `PR_COUNT>1`, block immediately with
+open-PR evidence because the exact-head query is already ambiguous. If
+`gh pr view` fails because the candidate disappears or cannot be read after
+`gh pr list`, if the single-candidate branch fetch fails, or if any other
+identity or ancestry check fails, write
 `viable/$WORKSTREAM_ID-pr-blocker.txt`, update the classification row to
 `blocked`, and stop that row only after the blocker evidence is persisted.
 This deterministically avoids duplicating possibly delivered work while still
@@ -933,14 +945,16 @@ beyond the preserved local snapshot. A later rerun must reclassify against
 current main and GitHub history before deciding whether any replacement issue
 or PR is still needed. Continue to Step 2 only when `PR_COUNT=0`.
 
-Expected: every viable row has an evidence-backed authoritative-source-branch
-fetch and a `main`-targeting PR decision before issue reuse or creation
-begins. If `docs/psyche-specs` still has exactly one open PR from branch
-`docs/psyche-specs` at execution time, its `headRefOid` matches the freshly
-fetched `origin/docs/psyche-specs` tip, and the preserved local `head.txt` is
-equal to or an ancestor of that PR head, this step adopts the
-exact-source-branch PR that GitHub returns at that moment rather than
-hardcoding a PR number.
+Expected: every viable row records the exact-head open-PR query before any
+issue reuse or creation begins. Rows with one candidate add an evidence-backed
+authoritative-source-branch fetch and a `main`-targeting PR decision; rows
+with zero candidates skip fetch and continue normally; rows with multiple
+candidates block before branch verification. If `docs/psyche-specs` still has
+exactly one open PR from branch `docs/psyche-specs` at execution time, its
+`headRefOid` matches the freshly fetched `origin/docs/psyche-specs` tip, and
+the preserved local `head.txt` is equal to or an ancestor of that PR head,
+this step adopts the exact-source-branch PR that GitHub returns at that moment
+rather than hardcoding a PR number.
 
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
@@ -1498,9 +1512,10 @@ update_classification_row \
 ```
 
 Expected: every viable row either continues one adopted exact-source-branch
-open pull request or rewrites its ledger row to stay `viable` with one
-verified OPEN recovery PR URL from the expected current-main recovery branch
-before Task 7 cleanup or Task 9 audit begins.
+open pull request after the single-candidate verification flow, or rewrites
+its ledger row to stay `viable` with one verified OPEN recovery PR URL from
+the expected current-main recovery branch after the zero-candidate normal
+flow, before Task 7 cleanup or Task 9 audit begins.
 
 ### Task 6: Record Non-Viable Outcomes
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -24,12 +24,12 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-open-prs.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search.json`
-  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search-exact-open.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-blocker.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
-  - Exact-head open-PR evidence, exact-open issue-match evidence, and blocker
-    evidence for each viable workstream.
+  - Exact-head open-PR evidence, per-workstream exact-title open issue-match
+    evidence derived from paginated `issues.json`, and blocker evidence for
+    each viable workstream.
 - Create only when Task 9 runs:
   - `.git/agent-recovery/issue-541/final-audit-primary-checkout.txt`
   - Primary-checkout restore and blocker evidence for the final audit.
@@ -519,7 +519,8 @@ Expected: all five evidence files exist and are non-empty, and both
 `pulls.json` and `issues.json` are valid paginated GitHub API JSON captures.
 Because the issues API returns both issues and pull requests, PR-specific
 classification must use `pulls.json` as the dedicated pull-request evidence
-source and treat `issues.json` as the broader issue-history ledger.
+source and treat `issues.json` as the broader issue-history ledger and the
+authoritative fully paginated source for later exact-title issue-reuse filters.
 
 - [ ] **Step 2: Compare each source with current main**
 
@@ -769,12 +770,14 @@ case "$PR_COUNT" in
       --json number,title,url,state,headRefOid,headRefName,headRepositoryOwner,isCrossRepository,baseRefName \
       > "$PR_VIEW_EVIDENCE"
     EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
+    ACTUAL_STATE="$(jq -r '.state' "$PR_VIEW_EVIDENCE")"
     ACTUAL_HEAD="$(jq -r '.headRefOid' "$PR_VIEW_EVIDENCE")"
     ACTUAL_BRANCH="$(jq -r '.headRefName' "$PR_VIEW_EVIDENCE")"
     ACTUAL_OWNER="$(jq -r '.headRepositoryOwner.login' "$PR_VIEW_EVIDENCE")"
     ACTUAL_CROSS="$(jq -r '.isCrossRepository' "$PR_VIEW_EVIDENCE")"
     ACTUAL_BASE="$(jq -r '.baseRefName' "$PR_VIEW_EVIDENCE")"
-    if [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] || \
+    if [ "$ACTUAL_STATE" != "OPEN" ] || \
+       [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] || \
        [ "$ACTUAL_BRANCH" != "$SOURCE_BRANCH" ] || \
        [ "$ACTUAL_OWNER" != "OpenCoven" ] || \
        [ "$ACTUAL_CROSS" != "false" ] || \
@@ -782,10 +785,12 @@ case "$PR_COUNT" in
       {
         printf 'Blocked %s: candidate PR #%s failed identity checks.\n' \
           "$WORKSTREAM_ID" "$PR_NUMBER"
+        printf 'Expected state: OPEN\n'
         printf 'Expected source head: %s\n' "$EXPECTED_HEAD"
         printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
         printf 'Expected owner/cross-repo: OpenCoven / false\n'
         printf 'Expected base branch: main\n'
+        printf 'Actual state: %s\n' "$ACTUAL_STATE"
         printf 'Actual head: %s\n' "$ACTUAL_HEAD"
         printf 'Actual branch: %s\n' "$ACTUAL_BRANCH"
         printf 'Actual owner: %s\n' "$ACTUAL_OWNER"
@@ -797,7 +802,7 @@ case "$PR_COUNT" in
       update_classification_row \
         "blocked" \
         "PR identity mismatch; see viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
-        "Blocked: candidate PR failed exact-head SHA/branch/owner/non-cross-repo/base validation."
+        "Blocked: candidate PR failed OPEN-state/SHA/branch/owner/non-cross-repo/base validation."
       exit 0
     fi
     PR_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
@@ -824,15 +829,19 @@ case "$PR_COUNT" in
 esac
 ```
 
-If `PR_COUNT=1`, verify the candidate PR before adopting it: `headRefOid` must
-equal the snapshotted source `head.txt`, `headRefName` must equal
-`$SOURCE_BRANCH`, `headRepositoryOwner.login` must equal `OpenCoven`, and
-`isCrossRepository` must be `false`, and `baseRefName` must equal `main`.
-Record `continue existing PR` only after those checks pass. If `PR_COUNT>1`,
-or if the single candidate fails any
-identity check, write `viable/$WORKSTREAM_ID-pr-blocker.txt`, update the
-classification row to `blocked`, and stop that row without creating or
-adopting anything. Continue to Step 2 only when `PR_COUNT=0`.
+If `PR_COUNT=1`, verify the candidate PR before adopting it: `.state` must be
+`OPEN`, `headRefOid` must equal the snapshotted source `head.txt`,
+`headRefName` must equal `$SOURCE_BRANCH`,
+`headRepositoryOwner.login` must equal `OpenCoven`, `isCrossRepository` must
+be `false`, and `baseRefName` must equal `main`. Record `continue existing PR`
+only after all of those checks pass. If the PR closes or merges between
+`gh pr list` and `gh pr view`, or if any other identity check fails, write
+`viable/$WORKSTREAM_ID-pr-blocker.txt`, update the classification row to
+`blocked`, and stop that row without creating or adopting anything. This
+deterministically avoids duplicating possibly delivered work; a later rerun
+must reclassify against current main and GitHub history before deciding whether
+any replacement issue or PR is still needed. Continue to Step 2 only when
+`PR_COUNT=0`.
 
 Expected: every viable row has an evidence-backed exact-head, `main`-targeting
 PR decision before issue reuse or creation begins. If `docs/psyche-specs`
@@ -843,12 +852,13 @@ GitHub returns then rather than hardcoding a PR number.
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
 Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
-matching exact issue title and search query:
+matching exact issue title:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
+ALL_ISSUES_EVIDENCE="$COMMON_DIR/agent-recovery/issue-541/issues.json"
 mkdir -p "$RECOVERY"
 update_classification_row() {
   python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
@@ -877,31 +887,24 @@ PY
 case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
     ISSUE_TITLE="Recover mobile pairing workstream"
-    ISSUE_SEARCH='"mobile pairing"'
     ;;
   feat-npm-macos-x64)
     ISSUE_TITLE="Recover Intel macOS npm packaging workstream"
-    ISSUE_SEARCH='"Intel macOS" npm'
     ;;
   fix-521-ward-surface-confinement)
     ISSUE_TITLE="Recover Ward surface confinement workstream"
-    ISSUE_SEARCH='"Ward surface confinement"'
     ;;
   memory-promote)
     ISSUE_TITLE="Recover memory promotion workstream"
-    ISSUE_SEARCH='"memory promotion"'
     ;;
   docs-psyche-specs)
     ISSUE_TITLE="Recover Psyche specification workstream"
-    ISSUE_SEARCH='"Psyche" specs'
     ;;
   docs-universal-runtime-capability-design)
     ISSUE_TITLE="Recover universal runtime capability design workstream"
-    ISSUE_SEARCH='"universal runtime" capability'
     ;;
   pr-476-review)
     ISSUE_TITLE="Recover runtime model parity plan workstream"
-    ISSUE_SEARCH='"runtime model parity"'
     ;;
   *)
     printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
@@ -909,31 +912,28 @@ case "$WORKSTREAM_ID" in
     ;;
 esac
 ISSUE_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search.json"
-EXACT_OPEN_ISSUE_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search-exact-open.json"
 ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
 ISSUE_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-blocker.txt"
-gh issue list \
-  --repo OpenCoven/coven \
-  --state all \
-  --search "$ISSUE_SEARCH" \
-  --json number,title,url,state > "$ISSUE_SEARCH_EVIDENCE"
+test -s "$ALL_ISSUES_EVIDENCE"
 jq --arg title "$ISSUE_TITLE" \
-  '[.[] | select(.title == $title and .state == "OPEN")]' \
-  "$ISSUE_SEARCH_EVIDENCE" > "$EXACT_OPEN_ISSUE_EVIDENCE"
-ISSUE_COUNT="$(jq 'length' "$EXACT_OPEN_ISSUE_EVIDENCE")"
+  '[.[] | .[] | select(.pull_request? | not) | select(.title == $title and .state == "open") | {number, title, url, state}]' \
+  "$ALL_ISSUES_EVIDENCE" > "$ISSUE_SEARCH_EVIDENCE"
+ISSUE_COUNT="$(jq 'length' "$ISSUE_SEARCH_EVIDENCE")"
 ```
 
-Broad search results are preserved for evidence, but only exact-title OPEN
-matches are reusable. A sole unrelated or closed search hit leaves
-`ISSUE_COUNT=0` and must not be reused.
+Task 4's paginated `issues.json` is the authoritative reuse source. Each
+workstream's `viable/$WORKSTREAM_ID-issue-search.json` stores only the filtered
+non-PR exact-title `open` matches from that full ledger, so default-limited
+`gh issue list` output never drives reuse. A sole unrelated or closed result in
+`issues.json` leaves `ISSUE_COUNT=0` and must not be reused.
 
-If exactly one exact-title OPEN issue already exists, reuse it without creating
+If exactly one exact-title open issue already exists, reuse it without creating
 a duplicate:
 
 ```bash
 case "$ISSUE_COUNT" in
   1)
-    ISSUE_NUMBER="$(jq -r '.[0].number' "$EXACT_OPEN_ISSUE_EVIDENCE")"
+    ISSUE_NUMBER="$(jq -r '.[0].number' "$ISSUE_SEARCH_EVIDENCE")"
     gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
       --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
     if ! jq -e --arg title "$ISSUE_TITLE" \
@@ -943,13 +943,13 @@ case "$ISSUE_COUNT" in
       {
         printf 'Blocked %s: issue #%s did not verify as exact-title OPEN.\n' \
           "$WORKSTREAM_ID" "$ISSUE_NUMBER"
-        printf 'Broad issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
-        printf 'Exact-open issue evidence: viable/%s-issue-search-exact-open.json\n' "$WORKSTREAM_ID"
+        printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
         printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
       } > "$ISSUE_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "Issue verification mismatch; see viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Issue verification mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
         "Blocked: candidate issue failed exact-title OPEN verification."
       exit 0
     fi
@@ -1001,13 +1001,13 @@ EOF
       {
         printf 'Blocked %s: created issue #%s did not verify as exact-title OPEN.\n' \
           "$WORKSTREAM_ID" "$ISSUE_NUMBER"
-        printf 'Broad issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
-        printf 'Exact-open issue evidence: viable/%s-issue-search-exact-open.json\n' "$WORKSTREAM_ID"
+        printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
         printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
       } > "$ISSUE_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "Created issue verification mismatch; see viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Created issue verification mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
         "Blocked: created issue did not verify as exact-title OPEN."
       exit 0
     fi
@@ -1016,15 +1016,15 @@ EOF
     ;;
   *)
     {
-      printf 'Blocked %s: expected 0 or 1 exact-title OPEN issues for %s, found %s.\n' \
+      printf 'Blocked %s: expected 0 or 1 exact-title open issues for %s, found %s.\n' \
         "$WORKSTREAM_ID" "$ISSUE_TITLE" "$ISSUE_COUNT"
-      printf 'Broad issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
-      printf 'Exact-open issue evidence: viable/%s-issue-search-exact-open.json\n' "$WORKSTREAM_ID"
+      printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+      printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
     } > "$ISSUE_BLOCKER_EVIDENCE"
     update_classification_row \
       "blocked" \
-      "Issue ambiguity; see viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
-      "Blocked: multiple OPEN issues exactly match $ISSUE_TITLE."
+      "Issue ambiguity; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+      "Blocked: multiple open issues exactly match $ISSUE_TITLE."
     exit 0
     ;;
 esac
@@ -1032,7 +1032,7 @@ ISSUE_NUMBER="$(jq -r '.number' "$ISSUE_VIEW_EVIDENCE")"
 ISSUE_URL="$(jq -r '.url' "$ISSUE_VIEW_EVIDENCE")"
 update_classification_row \
   "viable" \
-  "Issue verified via viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, and viable/$WORKSTREAM_ID-issue-view.json." \
+  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-view.json." \
   "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL)."
 ```
 
@@ -1040,8 +1040,8 @@ If `ISSUE_COUNT>1`, write `viable/$WORKSTREAM_ID-issue-blocker.txt`, update
 the row to `blocked`, and stop that row rather than choosing one arbitrarily.
 
 Expected: every viable row without an adopted PR has exactly one verified issue
-number, and every reuse, create, or block decision cites saved broad-search,
-exact-open-filter, and verification evidence files.
+number, and every reuse, create, or block decision cites the saved paginated
+issue ledger, per-workstream filtered search evidence, and verification files.
 
 - [ ] **Step 3: Create one approved design per viable issue**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Preserve and classify every discovered local workstream, recover each viable concern through its own issue and implementation plan, and safely remove only proven stale residue.
 
-**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive with a fixed current-run root at `agent-recovery/issue-541` and immutable private rerun archives for older runs. Discover or create the controller worktree for `docs/541-incomplete-work-recovery-design` through repo-local worktree conventions rather than a fixed machine path, then run a preservation and classification phase before any cleanup and hand each viable subsystem to an isolated issue/spec/plan/PR flow based on current `origin/main`.
+**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive with a fixed current-run root at `agent-recovery/issue-541` and immutable private rerun archives for older runs. Resolve the controller worktree for `docs/541-incomplete-work-recovery-design` through a resilient repo-local helper that treats registered-but-missing paths as stale, recreates `.worktrees/issue-541-recovery` only for the exact existing branch, and uses `git worktree add --force` only when that missing registration is proven stale and the branch is not live anywhere else. Classification evidence compares current `origin/main` against immutable preserved snapshot-head SHAs rather than mutable live branch names before any cleanup or child PR work begins.
 
 **Tech Stack:** Git worktrees and bundles, GitHub CLI, Coven claims, Markdown recovery ledger, Rust/Cargo, npm, repository secret and privacy guards.
 
@@ -55,11 +55,15 @@
   - Byte-for-byte pre-removal proof artifacts regenerated from the live source
     worktree before any forced removal.
 - Create only when Task 4 Step 2 runs:
+  - `.git/agent-recovery/issue-541/<workstream-id>-commits.txt`
+  - `.git/agent-recovery/issue-541/<workstream-id>-stat.txt`
+  - `.git/agent-recovery/issue-541/<workstream-id>-cherry.txt`
   - `.git/agent-recovery/issue-541/<workstream-id>-worktree-evidence.txt`
   - `.git/agent-recovery/issue-541/<workstream-id>-index-evidence.txt`
   - `.git/agent-recovery/issue-541/<workstream-id>-untracked-evidence.json`
   - `.git/agent-recovery/issue-541/<workstream-id>-ignored-evidence.json`
-  - Readable tracked-change summaries plus JSON-escaped untracked and ignored
+  - Immutable preserved-head commit lists, diff stats, and cherry evidence plus
+    readable tracked-change summaries and JSON-escaped untracked and ignored
     inventory evidence copied from the preserved snapshots for later
     classification and cleanup checks.
 - Create only when Task 2 Step 1 reruns after a prior current root exists:
@@ -138,49 +142,87 @@ Run:
 
 ```bash
 set -euo pipefail
-CONTROL_BRANCH="docs/541-incomplete-work-recovery-design"
 START_COMMON_DIR="$(git rev-parse --git-common-dir)"
 REPO="$(cd "$START_COMMON_DIR/.." && pwd)"
 coven claim status
 gh pr list --repo OpenCoven/coven --state open --limit 100
-CONTROL_WORKTREE="$(
-  git -C "$REPO" worktree list --porcelain | awk -v branch="refs/heads/$CONTROL_BRANCH" '
-    $1 == "worktree" { path = substr($0, 10) }
-    $1 == "branch" && $2 == branch { print path; exit }
-  '
-)"
-if test -z "$CONTROL_WORKTREE"; then
-  if ! git -C "$REPO" check-ignore -q .worktrees/; then
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
+    exit 1
+  fi
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
     printf 'Repository-local .worktrees/ is not ignored.\n' >&2
     exit 1
   fi
-  if ! git -C "$REPO" check-ignore -q .worktrees/issue-541-recovery; then
-    printf 'Repository-local control worktree path is not ignored: %s\n' \
-      '.worktrees/issue-541-recovery' >&2
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
     exit 1
   fi
-  mkdir -p "$REPO/.worktrees"
-  CONTROL_WORKTREE="$REPO/.worktrees/issue-541-recovery"
-  if test -e "$CONTROL_WORKTREE"; then
-    printf 'Control worktree path already exists without a branch registration: %s\n' \
-      "$CONTROL_WORKTREE" >&2
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
     exit 1
   fi
-  if ! git -C "$REPO" show-ref --verify --quiet "refs/heads/$CONTROL_BRANCH"; then
-    git -C "$REPO" fetch origin "$CONTROL_BRANCH:$CONTROL_BRANCH"
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
   fi
-  git -C "$REPO" worktree add "$CONTROL_WORKTREE" "$CONTROL_BRANCH"
-fi
-if ! test -d "$CONTROL_WORKTREE"; then
-  printf 'Control worktree path is not present: %s\n' "$CONTROL_WORKTREE" >&2
-  exit 1
-fi
-ACTUAL_BRANCH="$(git -C "$CONTROL_WORKTREE" branch --show-current)"
-if test "$ACTUAL_BRANCH" != "$CONTROL_BRANCH"; then
-  printf 'Control worktree branch mismatch: expected %s, got %s\n' \
-    "$CONTROL_BRANCH" "$ACTUAL_BRANCH" >&2
-  exit 1
-fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 (
   cd "$CONTROL_WORKTREE"
@@ -189,16 +231,20 @@ COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 git -C "$CONTROL_WORKTREE" status --short --branch
 printf 'CONTROL_WORKTREE=%s\nCOMMON_DIR=%s\nREPO=%s\n' \
   "$CONTROL_WORKTREE" "$COMMON_DIR" "$REPO"
+
 ```
 
 Expected: from any `OpenCoven/coven` worktree, the shared claim registry and
 open PR set are reviewed first; `git worktree list --porcelain` discovers an
-existing linked controller for branch `docs/541-incomplete-work-recovery-design`
-or, if none exists, the operator verifies `.worktrees/` is ignored and creates
-a deterministic repo-local controller worktree at
-`.worktrees/issue-541-recovery` from the existing or freshly fetched branch
-without creating a duplicate branch. `CONTROL_WORKTREE`, `COMMON_DIR`, and
-`REPO` are printed explicitly, `CONTROL_WORKTREE` is verified to be on
+existing linked controller for branch
+`docs/541-incomplete-work-recovery-design`; if the discovered registration
+points at a missing directory, the helper treats it as stale/absent instead of
+failing immediately. The deterministic repo-local controller
+`.worktrees/issue-541-recovery` is recreated only for the exact existing branch
+and only with the minimal `git worktree add --force` exception when that stale
+registration is proven missing and no live worktree still has the branch;
+otherwise the step blocks. `CONTROL_WORKTREE`, `COMMON_DIR`, and `REPO` are
+printed explicitly, the resolved or recreated controller path is verified on
 `docs/541-incomplete-work-recovery-design`, `issue-541` is acquired from that
 controller worktree, and `git status --short --branch` there shows only the
 plan file untracked before it is staged.
@@ -210,21 +256,79 @@ instead of assuming shell variables persist:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -245,21 +349,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -281,21 +443,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -322,21 +542,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -353,21 +631,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -402,21 +738,79 @@ Run:
 set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -458,21 +852,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -536,21 +988,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -613,21 +1123,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -689,21 +1257,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -764,21 +1390,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -891,21 +1575,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -935,21 +1677,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -969,149 +1769,104 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
-for entry in \
-  'docs-universal-runtime-capability-design|docs/universal-runtime-capability-design' \
-  'feat-npm-macos-x64|feat/npm-macos-x64' \
-  'fix-521-ward-surface-confinement|fix/521-ward-surface-confinement'
-do
-  id=${entry%%|*}
-  branch=${entry#*|}
-  mkdir -p "$RECOVERY/branches/$id"
-  printf '%s\n' "$branch" > "$RECOVERY/branches/$id/branch.txt"
-  git -C "$REPO" rev-parse "$branch" > "$RECOVERY/branches/$id/head.txt"
-  git -C "$REPO" merge-base "$branch" origin/main \
-    > "$RECOVERY/branches/$id/merge-base.txt"
-  printf '%s\torphan-branch\t%s\t%s\t%s\t%s\n' \
-    "$id" \
-    "$branch" \
-    "$(cat "$RECOVERY/branches/$id/head.txt")" \
-    "$(cat "$RECOVERY/branches/$id/merge-base.txt")" \
-    "$RECOVERY/branches/$id.bundle" >> "$RECOVERY/manifest.tsv"
-done
-```
-
-Expected: `manifest.tsv` has seven data rows plus its header, and each orphan
-branch now has immutable `branch.txt`, `head.txt`, and `merge-base.txt`
-metadata beside its bundle.
-Every Task 3 `merge_base` value still uses the `origin/main` fetched in Task 2
-Step 1.
-
-### Task 4: Build the Classification Ledger
-
-**Artifacts:**
-- Create: `.git/agent-recovery/issue-541/classification.md`
-
-- [ ] **Step 1: Capture branch and GitHub evidence**
-
-Run:
-
-```bash
-resolve_control_worktree() {
-  local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
-  start_common_dir="$(git rev-parse --git-common-dir)"
-  repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
-    exit 1
-  fi
-  printf '%s\n' "$control_worktree"
-}
-CONTROL_WORKTREE="$(resolve_control_worktree)"
-COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
-REPO="$(cd "$COMMON_DIR/.." && pwd)"
-RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
-git -C "$REPO" fetch origin main
-git -C "$REPO" --no-pager branch -vv > "$RECOVERY/branches.txt"
-git -C "$REPO" worktree list --porcelain > "$RECOVERY/worktrees.txt"
-cd "$REPO"
-coven claim status > "$RECOVERY/claims.txt"
-gh api --paginate --slurp \
-  "repos/OpenCoven/coven/pulls?state=all&per_page=100" \
-  > "$RECOVERY/pulls.json"
-gh api --paginate --slurp \
-  "repos/OpenCoven/coven/issues?state=all&per_page=100" \
-  > "$RECOVERY/issues.json"
-```
-
-Expected: all five evidence files exist and are non-empty, and both
-`pulls.json` and `issues.json` are valid paginated GitHub API JSON captures.
-Because the issues API returns both issues and pull requests, PR-specific
-classification must use `pulls.json` as the dedicated pull-request evidence
-source and treat `issues.json` as the broader issue-history ledger and the
-authoritative fully paginated source for later exact-title issue-reuse filters.
-
-- [ ] **Step 2: Compare each source with current main**
-
-Run:
-
-```bash
-resolve_control_worktree() {
-  local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
-  start_common_dir="$(git rev-parse --git-common-dir)"
-  repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
-    exit 1
-  fi
-  printf '%s\n' "$control_worktree"
-}
-CONTROL_WORKTREE="$(resolve_control_worktree)"
-COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
-REPO="$(cd "$COMMON_DIR/.." && pwd)"
-RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
-for branch in \
-  docs/psyche-specs \
-  docs/universal-runtime-capability-design \
-  feat/cmem-1ev-memory-promote \
-  feat/mobile-memory-gateway \
-  feat/npm-macos-x64 \
-  fix/476-review-threads \
-  fix/521-ward-surface-confinement
-do
-  id=$(printf '%s' "$branch" | tr '/' '-')
-  git -C "$REPO" --no-pager log --oneline --reverse \
-    "origin/main..$branch" > "$RECOVERY/$id-commits.txt"
-  git -C "$REPO" --no-pager diff --stat \
-    "origin/main...$branch" > "$RECOVERY/$id-stat.txt"
-  git -C "$REPO" cherry -v origin/main "$branch" \
-    > "$RECOVERY/$id-cherry.txt"
-done
+while IFS='|' read -r id branch preserved_head_source bundle_source; do
+  preserved_head_file="$RECOVERY/$preserved_head_source"
+  bundle_file="$RECOVERY/$bundle_source"
+  test -s "$preserved_head_file"
+  test -s "$bundle_file"
+  source_head="$(cat "$preserved_head_file")"
+  git -C "$REPO" cat-file -e "$source_head^{commit}"
+  git -C "$REPO" bundle verify "$bundle_file" > /dev/null
+  git -C "$REPO" --no-pager log --oneline --reverse "origin/main..$source_head" > "$RECOVERY/$id-commits.txt"
+  git -C "$REPO" --no-pager diff --stat "origin/main...$source_head" > "$RECOVERY/$id-stat.txt"
+  git -C "$REPO" cherry -v origin/main "$source_head" > "$RECOVERY/$id-cherry.txt"
+done <<'EOF'
+docs-psyche-specs|docs/psyche-specs|dirty/docs-psyche-specs/head.txt|dirty/docs-psyche-specs/branch.bundle
+docs-universal-runtime-capability-design|docs/universal-runtime-capability-design|branches/docs-universal-runtime-capability-design/head.txt|branches/docs-universal-runtime-capability-design.bundle
+memory-promote|feat/cmem-1ev-memory-promote|dirty/memory-promote/head.txt|dirty/memory-promote/branch.bundle
+mobile-memory-gateway|feat/mobile-memory-gateway|dirty/mobile-memory-gateway/head.txt|dirty/mobile-memory-gateway/branch.bundle
+feat-npm-macos-x64|feat/npm-macos-x64|branches/feat-npm-macos-x64/head.txt|branches/feat-npm-macos-x64.bundle
+pr-476-review|fix/476-review-threads|dirty/pr-476-review/head.txt|dirty/pr-476-review/branch.bundle
+fix-521-ward-surface-confinement|fix/521-ward-surface-confinement|branches/fix-521-ward-surface-confinement/head.txt|branches/fix-521-ward-surface-confinement.bundle
+EOF
 for id in \
   docs-psyche-specs \
   memory-promote \
@@ -1144,14 +1899,17 @@ do
 done
 ```
 
-Expected: the seven historical branch comparisons still provide complementary
-commit, stat, and cherry evidence, and the four dirty snapshots now each have
-reviewable worktree, index, untracked, and ignored evidence files, so branch
-evidence covers all seven branch-backed workstreams and dirty evidence
-complements the four dirty rows. Empty worktree and index snapshot classes
-remain valid because they emit deterministic sentinel lines, while empty
-untracked or ignored inventories remain valid because their copied JSON
-evidence files still contain readable `[]`.
+Expected: every preserved-head file in the seven-row map verifies as a commit,
+every paired bundle still verifies, and each `<workstream-id>-commits.txt`,
+`<workstream-id>-stat.txt`, and `<workstream-id>-cherry.txt` file is generated
+from that immutable preserved snapshot head SHA rather than from a mutable live
+branch name. The four dirty snapshots still produce reviewable worktree, index,
+untracked, and ignored evidence files, so branch evidence covers all seven
+branch-backed workstreams and dirty evidence complements the four dirty rows.
+Empty worktree and index snapshot classes remain valid because they emit
+deterministic sentinel lines, while empty untracked or ignored inventories
+remain valid because their copied JSON evidence files still contain readable
+`[]`.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 
@@ -1223,21 +1981,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -1274,21 +2090,79 @@ current source branch:
 set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -1673,21 +2547,79 @@ matching exact issue title:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -1978,11 +2910,34 @@ an approved and committed design document.
 
 Use the writing-plans workflow separately for each approved design that reached
 Step 3 without being blocked. Each plan must include exact paths, failing
-tests, targeted commands, full repository gates, commit boundaries, explicit
-`git commit -s` usage, the session-required Copilot co-author trailer on child
-commits, push, and PR creation. Human contributor `Co-authored-by:` trailers
-remain conditional under `AGENTS.md` and are separate from the required
-Copilot trailer.
+tests, targeted commands, the applicable repository-native npm/package commands
+below instead of root-level placeholders, full repository gates, commit
+boundaries, explicit `git commit -s` usage, the session-required Copilot
+co-author trailer on child commits, push, and PR creation. Human contributor
+`Co-authored-by:` trailers remain conditional under `AGENTS.md` and are
+separate from the required Copilot trailer.
+
+When a child recovery plan touches npm or Node-delivered surfaces, its gate
+section must use these repository-native commands:
+
+- `packages/channels`: `npm ci`, `npm run build`, and `npm test` in
+  `packages/channels` (or the exact `npm --prefix packages/channels ...`
+  equivalents).
+- npm CLI wrapper or platform packaging (`packages/cli`, `npm/coven`, platform
+  package manifests, or the publish/prepublish scripts): run the supported
+  `node scripts/test-cli-prepublish.mjs` smoke for the affected target and pair
+  it with the matching release build plus the repository cargo gates. The
+  supported matrix is `macos`/`aarch64-apple-darwin`,
+  `linux-x64`/`x86_64-unknown-linux-gnu`, and
+  `windows`/`x86_64-pc-windows-msvc`. For the Intel macOS recovery row, keep
+  using `--target=macos` unless the child design intentionally introduces a new
+  target contract.
+- `packages/openclaw-coven`: `npm install` and `npm exec vitest run` in
+  `packages/openclaw-coven`; do not claim nonexistent package-local build or
+  test scripts there.
+- `packages/cli` and `npm/coven` have no package-local `npm run build` or
+  `npm test` scripts; validate them through the prepublish smoke and the
+  relevant Node tests that it already executes.
 
 Every child plan must reuse this exact child-commit pattern, replacing only
 the commit message and adding any conditional human contributor trailers as
@@ -2021,21 +2976,79 @@ Then run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2159,21 +3172,79 @@ verify that PR before Task 7 cleanup or Task 9 audit continues:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2341,21 +3412,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2374,21 +3503,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2414,21 +3601,79 @@ Check each known linked worktree:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2452,21 +3697,79 @@ and remove the five clean worktrees:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2507,21 +3810,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2561,21 +3922,79 @@ exact-path force-removal exception:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2732,21 +4151,79 @@ Run this immediately before `branch -d`:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2838,21 +4315,79 @@ same branch-ref proof immediately before `branch -D`:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -2965,21 +4500,79 @@ stops or the full issue #541 recovery effort is complete:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3003,21 +4596,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3067,21 +4718,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3107,21 +4816,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3150,21 +4917,79 @@ For every `viable` row, set `PR_URL` to the recorded pull-request URL and run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3184,21 +5009,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3321,21 +5204,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3363,21 +5304,79 @@ Run:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3410,21 +5409,79 @@ links, non-viable evidence, and remaining human blockers. Do not post
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
@@ -3445,21 +5502,79 @@ been safely preserved or cleaned:
 ```bash
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
-  local start_common_dir repo control_worktree
+  local start_common_dir repo target_path path branch_ref live_path stale_path
+  local target_registration_branch actual_branch
   start_common_dir="$(git rev-parse --git-common-dir)"
   repo="$(cd "$start_common_dir/.." && pwd)"
-  control_worktree="$(
-    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = substr($0, 10) }
-      $1 == "branch" && $2 == branch { print path; exit }
-    '
-  )"
-  if test -z "$control_worktree"; then
-    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
-      "$control_branch" >&2
+  target_path="$repo/.worktrees/issue-541-recovery"
+  while IFS="$(printf "\t")" read -r path branch_ref; do
+    test -n "$path" || continue
+    if test "$path" = "$target_path"; then
+      target_registration_branch="$branch_ref"
+    fi
+    if test "$branch_ref" != "refs/heads/$control_branch"; then
+      continue
+    fi
+    if test -d "$path"; then
+      live_path="$path"
+    else
+      stale_path="$path"
+    fi
+  done <<EOF
+$(git -C "$repo" worktree list --porcelain | awk '
+  $1 == "worktree" { if (path != "") print path "\t" branch; path = substr($0, 10); branch = ""; next }
+  $1 == "branch" { branch = $2; next }
+  END { if (path != "") print path "\t" branch }
+')
+EOF
+  if test -n "$target_registration_branch" && test "$target_registration_branch" != "refs/heads/$control_branch"; then
+    printf 'Blocked: %s is registered to %s, not %s.\n' "$target_path" "$target_registration_branch" "$control_branch" >&2
     exit 1
   fi
-  printf '%s\n' "$control_worktree"
+  if test -n "$live_path"; then
+    if test -n "$stale_path" && test "$live_path" != "$target_path"; then
+      printf 'Blocked: %s has a stale controller registration and a different live worktree (%s); do not override it.\n' "$control_branch" "$live_path" >&2
+      exit 1
+    fi
+    actual_branch="$(git -C "$live_path" branch --show-current)"
+    if test "$actual_branch" != "$control_branch"; then
+      printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+      exit 1
+    fi
+    printf '%s\n' "$live_path"
+    return 0
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$repo" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$repo/.worktrees"
+  if test -e "$target_path"; then
+    printf 'Control worktree path already exists without a matching live registration: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  if ! git -C "$repo" show-ref --verify --quiet "refs/heads/$control_branch"; then
+    git -C "$repo" fetch origin "$control_branch:$control_branch"
+  fi
+  if test -n "$stale_path"; then
+    git -C "$repo" worktree add --force "$target_path" "$control_branch"
+  else
+    git -C "$repo" worktree add "$target_path" "$control_branch"
+  fi
+  if ! test -d "$target_path"; then
+    printf 'Control worktree path is not present after resolution: %s\n' "$target_path" >&2
+    exit 1
+  fi
+  actual_branch="$(git -C "$target_path" branch --show-current)"
+  if test "$actual_branch" != "$control_branch"; then
+    printf 'Control worktree branch mismatch: expected %s, got %s\n' "$control_branch" "$actual_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$target_path"
 }
 CONTROL_WORKTREE="$(resolve_control_worktree)"
 COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -21,14 +21,17 @@
     `superseded`, `viable`, or `blocked`. GitHub-visible `Preserved source`
     values use archive IDs only, never local absolute paths.
 - Create only when a row reaches Task 5:
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-branch-fetch.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-open-prs.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-view.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-adoption.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-blocker.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
   - `.git/agent-recovery/issue-541/private/issue-ledger-refresh/<workstream-id>-issues.stage.json`
-  - Exact-head open-PR evidence, verified replacement-PR view evidence,
+  - Authoritative source-branch fetch evidence, open-PR evidence, verified
+    PR-view evidence, preserved-head adoption ancestry evidence,
     per-workstream exact-title open issue-match evidence derived from paginated
     `issues.json`, blocker evidence for each viable workstream, and the
     private staged ledger used to atomically refresh `issues.json`.
@@ -62,8 +65,9 @@
 - Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/`
   - Ref-preserving archive for each orphan branch.
   - Exact `branch.txt`, `head.txt`, and `merge-base.txt` snapshots for each
-    orphan branch so later PR identity checks use the preserved source head
-    rather than a mutable local ref.
+    orphan branch so later PR adoption checks use the preserved local source
+    head plus a freshly fetched authoritative branch tip rather than a mutable
+    local ref.
 - Modify: `.copilot/goals.md`
   - Reconcile active goals after all classification and delivery outcomes are
     known. Keep this as a local untracked file.
@@ -657,7 +661,9 @@ Expected: Task 4 Step 4 replaces every `pending` row with exactly one terminal
 classification (`already-shipped`, `superseded`, `viable`, or `blocked`) and
 one next action before Task 4 Step 5 and Task 9 Step 1 verification. A viable
 row may later keep that classification while Task 5 updates its action to
-`continue existing PR` after verifying one exact-head open PR.
+`continue existing PR` after verifying one open PR from the exact source
+branch whose head matches the freshly fetched `origin/<branch>` tip and still
+descends from the preserved local `head.txt` snapshot.
 
 - [ ] **Step 5: Review the ledger against the manifest**
 
@@ -688,13 +694,14 @@ Expected: every workstream appears in both files.
 - Create only for rows classified `viable`:
   - The exact design and plan paths listed in the File and Artifact Map.
 
-- [ ] **Step 1: Check for an exact-head open pull request before creating anything**
+- [ ] **Step 1: Check for an adoptable exact-source-branch open pull request before creating anything**
 
 Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then map it to its
 current source branch:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
 mkdir -p "$RECOVERY"
@@ -756,10 +763,37 @@ case "$WORKSTREAM_ID" in
     exit 1
     ;;
 esac
+BRANCH_FETCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-branch-fetch.txt"
 OPEN_PR_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-open-prs.json"
 PR_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-view.json"
+PR_ADOPTION_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-adoption.txt"
 PR_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-blocker.txt"
 test -s "$SOURCE_HEAD_FILE"
+EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
+{
+  printf 'Source branch: %s\n' "$SOURCE_BRANCH"
+  printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+} > "$BRANCH_FETCH_EVIDENCE"
+if ! git -C "$REPO" fetch --no-tags origin \
+  "refs/heads/$SOURCE_BRANCH:refs/remotes/origin/$SOURCE_BRANCH" \
+  >> "$BRANCH_FETCH_EVIDENCE" 2>&1; then
+  FETCH_OUTPUT="$(cat "$BRANCH_FETCH_EVIDENCE")"
+  {
+    printf 'Blocked %s: could not fetch origin/%s before PR adoption.\n' \
+      "$WORKSTREAM_ID" "$SOURCE_BRANCH"
+    printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+    printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
+    printf 'Fetch output follows:\n%s\n' "$FETCH_OUTPUT"
+  } > "$PR_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Source-branch fetch failed for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+    "Blocked: candidate PR source branch could not be fetched from origin."
+  exit 0
+fi
+FRESH_BRANCH_TIP="$(git -C "$REPO" rev-parse "refs/remotes/origin/$SOURCE_BRANCH")"
+printf 'Fresh fetched origin/%s tip: %s\n' \
+  "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP" >> "$BRANCH_FETCH_EVIDENCE"
 gh pr list \
   --repo OpenCoven/coven \
   --state open \
@@ -768,7 +802,7 @@ gh pr list \
 PR_COUNT="$(jq 'length' "$OPEN_PR_EVIDENCE")"
 ```
 
-Then branch on the exact-head result:
+Then branch on the exact-source-branch result:
 
 ```bash
 case "$PR_COUNT" in
@@ -782,56 +816,78 @@ case "$PR_COUNT" in
         printf 'Blocked %s: candidate PR #%s disappeared or could not be read between gh pr list and gh pr view.\n' \
           "$WORKSTREAM_ID" "$PR_NUMBER"
         printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
-        printf 'Expected source head: %s\n' "$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
+        printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+        printf 'Fresh fetched origin/%s tip: %s\n' "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP"
+        printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
         printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
         printf 'gh pr view failure follows:\n%s\n' "$PR_VIEW_ERROR"
       } > "$PR_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "PR view failed after candidate discovery; see viable/$WORKSTREAM_ID-open-prs.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+        "PR view failed after fetching origin/$SOURCE_BRANCH tip $FRESH_BRANCH_TIP for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
         "Blocked: candidate PR disappeared or could not be read before identity verification."
       exit 0
     fi
-    EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
     ACTUAL_STATE="$(jq -r '.state' "$PR_VIEW_EVIDENCE")"
     ACTUAL_HEAD="$(jq -r '.headRefOid' "$PR_VIEW_EVIDENCE")"
     ACTUAL_BRANCH="$(jq -r '.headRefName' "$PR_VIEW_EVIDENCE")"
     ACTUAL_OWNER="$(jq -r '.headRepositoryOwner.login' "$PR_VIEW_EVIDENCE")"
     ACTUAL_CROSS="$(jq -r '.isCrossRepository' "$PR_VIEW_EVIDENCE")"
     ACTUAL_BASE="$(jq -r '.baseRefName' "$PR_VIEW_EVIDENCE")"
+    if [ "$ACTUAL_HEAD" = "$FRESH_BRANCH_TIP" ] && \
+       git -C "$REPO" merge-base --is-ancestor "$EXPECTED_HEAD" "$ACTUAL_HEAD"; then
+      SNAPSHOT_ANCESTRY="ancestor-or-equal"
+    elif [ "$ACTUAL_HEAD" = "$FRESH_BRANCH_TIP" ]; then
+      SNAPSHOT_ANCESTRY="not-ancestor"
+    else
+      SNAPSHOT_ANCESTRY="not-checked-authoritative-tip-mismatch"
+    fi
+    {
+      printf 'Source branch: %s\n' "$SOURCE_BRANCH"
+      printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+      printf 'Fresh fetched origin/%s tip: %s\n' "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP"
+      printf 'PR head: %s\n' "$ACTUAL_HEAD"
+      printf 'Preserved head ancestry to PR head: %s\n' "$SNAPSHOT_ANCESTRY"
+    } > "$PR_ADOPTION_EVIDENCE"
     if [ "$ACTUAL_STATE" != "OPEN" ] || \
-       [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] || \
+       [ "$ACTUAL_HEAD" != "$FRESH_BRANCH_TIP" ] || \
        [ "$ACTUAL_BRANCH" != "$SOURCE_BRANCH" ] || \
        [ "$ACTUAL_OWNER" != "OpenCoven" ] || \
        [ "$ACTUAL_CROSS" != "false" ] || \
-       [ "$ACTUAL_BASE" != "main" ]; then
+       [ "$ACTUAL_BASE" != "main" ] || \
+       [ "$SNAPSHOT_ANCESTRY" != "ancestor-or-equal" ]; then
       {
         printf 'Blocked %s: candidate PR #%s failed identity checks.\n' \
           "$WORKSTREAM_ID" "$PR_NUMBER"
         printf 'Expected state: OPEN\n'
-        printf 'Expected source head: %s\n' "$EXPECTED_HEAD"
+        printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+        printf 'Expected fresh fetched origin/%s tip: %s\n' \
+          "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP"
         printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
         printf 'Expected owner/cross-repo: OpenCoven / false\n'
         printf 'Expected base branch: main\n'
         printf 'Actual state: %s\n' "$ACTUAL_STATE"
-        printf 'Actual head: %s\n' "$ACTUAL_HEAD"
+        printf 'PR head: %s\n' "$ACTUAL_HEAD"
         printf 'Actual branch: %s\n' "$ACTUAL_BRANCH"
         printf 'Actual owner: %s\n' "$ACTUAL_OWNER"
         printf 'Actual cross-repo: %s\n' "$ACTUAL_CROSS"
         printf 'Actual base branch: %s\n' "$ACTUAL_BASE"
+        printf 'Preserved head ancestry to PR head: %s\n' "$SNAPSHOT_ANCESTRY"
+        printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
         printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
         printf 'PR view evidence: viable/%s-pr-view.json\n' "$WORKSTREAM_ID"
+        printf 'PR adoption evidence: viable/%s-pr-adoption.txt\n' "$WORKSTREAM_ID"
       } > "$PR_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
-        "PR identity mismatch; see viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
-        "Blocked: candidate PR failed OPEN-state/SHA/branch/owner/non-cross-repo/base validation."
+        "PR identity mismatch (preserved head $EXPECTED_HEAD, fetched tip $FRESH_BRANCH_TIP, PR head $ACTUAL_HEAD, ancestry $SNAPSHOT_ANCESTRY); see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, viable/$WORKSTREAM_ID-pr-adoption.txt, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+        "Blocked: candidate PR failed OPEN-state/fresh-tip/branch/owner/non-cross-repo/base/ancestry validation."
       exit 0
     fi
     PR_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
     update_classification_row \
       "viable" \
-      "Exact-head PR verified via viable/$WORKSTREAM_ID-open-prs.json and viable/$WORKSTREAM_ID-pr-view.json." \
+      "Preserved head $EXPECTED_HEAD is ancestor of PR head $ACTUAL_HEAD, which matches fetched origin/$SOURCE_BRANCH tip $FRESH_BRANCH_TIP; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-adoption.txt." \
       "continue existing PR #$PR_NUMBER ($PR_URL)"
     exit 0
     ;;
@@ -839,39 +895,52 @@ case "$PR_COUNT" in
     ;;
   *)
     {
-      printf 'Blocked %s: expected 0 or 1 open PRs for head %s, found %s.\n' \
+      printf 'Blocked %s: expected 0 or 1 open PRs for source branch %s, found %s.\n' \
         "$WORKSTREAM_ID" "$SOURCE_BRANCH" "$PR_COUNT"
+      printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
+      printf 'Fresh fetched origin/%s tip: %s\n' "$SOURCE_BRANCH" "$FRESH_BRANCH_TIP"
+      printf 'Branch fetch evidence: viable/%s-branch-fetch.txt\n' "$WORKSTREAM_ID"
       printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
     } > "$PR_BLOCKER_EVIDENCE"
     update_classification_row \
       "blocked" \
-      "Open PR ambiguity; see viable/$WORKSTREAM_ID-open-prs.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+      "Open PR ambiguity after fetching origin/$SOURCE_BRANCH tip $FRESH_BRANCH_TIP for preserved head $EXPECTED_HEAD; see viable/$WORKSTREAM_ID-branch-fetch.txt, viable/$WORKSTREAM_ID-open-prs.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
       "Blocked: multiple open PRs claim $SOURCE_BRANCH."
     exit 0
     ;;
 esac
 ```
 
-If `PR_COUNT=1`, verify the candidate PR before adopting it: `.state` must be
-`OPEN`, `headRefOid` must equal the snapshotted source `head.txt`,
-`headRefName` must equal `$SOURCE_BRANCH`,
-`headRepositoryOwner.login` must equal `OpenCoven`, `isCrossRepository` must
-be `false`, and `baseRefName` must equal `main`. Record `continue existing PR`
+If `PR_COUNT=1`, verify the candidate PR before adopting it: first fetch the
+exact expected source branch from `origin` and record the freshly fetched tip
+in `viable/$WORKSTREAM_ID-branch-fetch.txt`. Then require `.state=OPEN`,
+`headRefName=$SOURCE_BRANCH`, `headRepositoryOwner.login=OpenCoven`,
+`isCrossRepository=false`, `baseRefName=main`, and `headRefOid` equal to that
+freshly fetched branch tip. Only after the PR head matches the authoritative
+fetched tip may the plan compare the preserved local `head.txt` to the PR head
+with `git merge-base --is-ancestor`; equality or ancestry is acceptable, but a
+diverged local head blocks adoption. Record the preserved local head, fresh
+branch tip, PR head, and ancestry result in
+`viable/$WORKSTREAM_ID-pr-adoption.txt`, and record `continue existing PR`
 only after all of those checks pass. If `gh pr view` fails because the
-candidate disappears or cannot be read after `gh pr list`, or if any other
-identity check fails, write `viable/$WORKSTREAM_ID-pr-blocker.txt`, update the
-classification row to `blocked`, and stop that row only after the blocker
-evidence is persisted. This
-deterministically avoids duplicating possibly delivered work; a later rerun
-must reclassify against current main and GitHub history before deciding whether
-any replacement issue or PR is still needed. Continue to Step 2 only when
-`PR_COUNT=0`.
+candidate disappears or cannot be read after `gh pr list`, if the branch fetch
+fails, or if any other identity or ancestry check fails, write
+`viable/$WORKSTREAM_ID-pr-blocker.txt`, update the classification row to
+`blocked`, and stop that row only after the blocker evidence is persisted.
+This deterministically avoids duplicating possibly delivered work while still
+allowing a clean local worktree to adopt its open PR after that PR has advanced
+beyond the preserved local snapshot. A later rerun must reclassify against
+current main and GitHub history before deciding whether any replacement issue
+or PR is still needed. Continue to Step 2 only when `PR_COUNT=0`.
 
-Expected: every viable row has an evidence-backed exact-head, `main`-targeting
-PR decision before issue reuse or creation begins. If `docs/psyche-specs`
-still has exactly one open PR from head `docs/psyche-specs` at execution time
-and its identity checks pass, this step adopts whichever exact-source PR
-GitHub returns then rather than hardcoding a PR number.
+Expected: every viable row has an evidence-backed authoritative-source-branch
+fetch and a `main`-targeting PR decision before issue reuse or creation
+begins. If `docs/psyche-specs` still has exactly one open PR from branch
+`docs/psyche-specs` at execution time, its `headRefOid` matches the freshly
+fetched `origin/docs/psyche-specs` tip, and the preserved local `head.txt` is
+equal to or an ancestor of that PR head, this step adopts the
+exact-source-branch PR that GitHub returns at that moment rather than
+hardcoding a PR number.
 
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
@@ -1185,7 +1254,7 @@ git commit -s --trailer "$COPILOT_TRAILER" -m "<child commit message>"
 ```
 
 Expected: independent plans exist only for viable rows that are not already
-continuing an adopted exact-head PR.
+continuing an adopted exact-source-branch PR.
 
 - [ ] **Step 5: Recover and publish each viable concern sequentially**
 
@@ -1428,10 +1497,10 @@ update_classification_row \
   "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL) with open PR #$RECOVERY_PR_NUMBER ($ACTUAL_PR_URL)."
 ```
 
-Expected: every viable row either continues one adopted exact-head open pull
-request or rewrites its ledger row to stay `viable` with one verified OPEN
-recovery PR URL from the expected current-main recovery branch before Task 7
-cleanup or Task 9 audit begins.
+Expected: every viable row either continues one adopted exact-source-branch
+open pull request or rewrites its ledger row to stay `viable` with one
+verified OPEN recovery PR URL from the expected current-main recovery branch
+before Task 7 cleanup or Task 9 audit begins.
 
 ### Task 6: Record Non-Viable Outcomes
 
@@ -1562,8 +1631,9 @@ formerly dirty tree may now be clean because its changes were committed to an
 accurate active PR. `git worktree remove --force` is allowed only in this
 step, only for these four exact paths, and only after the worktree and index
 patch evidence, verified branch bundle, untracked inventory, terminal ledger
-classification, and either an adopted exact-head open PR, an open replacement
-PR, or recorded non-viable/blocker evidence are all present. Unrelated or
+classification, and either an adopted exact-source-branch open PR, an open
+replacement PR, or recorded non-viable/blocker evidence are all present.
+Unrelated or
 unsnapshotted worktrees must never use force.
 
 Run:
@@ -1588,9 +1658,9 @@ done
 ```
 
 If a row is `viable`, confirm its classification row cites either the adopted
-exact-head PR URL or the open replacement PR URL before removal. Otherwise
-confirm the row already records its `already-shipped`, `superseded`, or
-`blocked` evidence. Before any `--force` removal, recompute live proof files
+exact-source-branch PR URL or the open replacement PR URL before removal.
+Otherwise confirm the row already records its `already-shipped`, `superseded`,
+or `blocked` evidence. Before any `--force` removal, recompute live proof files
 under the private recovery archive and compare them byte-for-byte with the
 preserved snapshot. Any mismatch or missing file blocks removal and requires a
 fresh snapshot plus reclassification for that row. Only unchanged rows may use

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -2658,7 +2658,7 @@ case "$WORKSTREAM_ID" in
     ISSUE_TITLE="Recover mobile pairing workstream"
     ;;
   feat-npm-macos-x64)
-    ISSUE_TITLE="Recover Intel macOS npm packaging workstream"
+    ISSUE_TITLE="Recover or block Intel macOS npm packaging workstream"
     ;;
   fix-521-ward-surface-confinement)
     ISSUE_TITLE="Recover Ward surface confinement workstream"
@@ -2929,9 +2929,15 @@ section must use these repository-native commands:
   it with the matching release build plus the repository cargo gates. The
   supported matrix is `macos`/`aarch64-apple-darwin`,
   `linux-x64`/`x86_64-unknown-linux-gnu`, and
-  `windows`/`x86_64-pc-windows-msvc`. For the Intel macOS recovery row, keep
-  using `--target=macos` unless the child design intentionally introduces a new
-  target contract.
+  `windows`/`x86_64-pc-windows-msvc`. Current main cannot validate Intel x64,
+  and `--target=macos` must never be used as a proxy for Intel recovery. If the
+  child design/plan has not first restored the concrete
+  `macos-x64`/`@opencoven/cli-macos-x64` contract in current code with tests
+  proving default darwin x64 mapping and package metadata, classify the
+  Intel workstream as blocked. Once that contract exists, the exact Intel
+  validation command is
+  `node scripts/test-cli-prepublish.mjs --target=macos-x64 --with-cargo-gates`,
+  plus any targeted Node tests documented by the child plan.
 - `packages/openclaw-coven`: `npm install` and `npm exec vitest run` in
   `packages/openclaw-coven`; do not claim nonexistent package-local build or
   test scripts there.

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -35,7 +35,7 @@
   - Ref-preserving archive for each orphan branch.
 - Modify: `.copilot/goals.md`
   - Reconcile active goals after all classification and delivery outcomes are
-    known. This file is intentionally git-excluded.
+    known. Keep this as a local untracked file.
 - Create only when the matching workstream is viable:
   - `docs/superpowers/specs/2026-08-01-mobile-pairing-recovery-design.md`
   - `docs/superpowers/plans/2026-08-01-mobile-pairing-recovery.md`
@@ -93,11 +93,10 @@ Run:
 
 ```bash
 cd /tmp/coven-issue-541
-git commit -m "docs: plan incomplete work recovery"
+git commit -s -m "docs: plan incomplete work recovery"
 ```
 
-Expected: a commit containing only the implementation plan and the
-session-required Copilot co-author trailer.
+Expected: a commit containing only the implementation plan.
 
 - [ ] **Step 4: Push the design branch**
 
@@ -143,6 +142,7 @@ Run:
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
+git -C "$REPO" fetch origin main
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 mkdir -p "$RECOVERY/dirty" "$RECOVERY/branches"
 printf 'id\ttype\tsource\thead\tmerge_base\tsnapshot\n' > "$RECOVERY/manifest.tsv"

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -27,16 +27,22 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-adoption.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-postcondition.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-postcondition-search.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-postcondition-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-blocker.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
   - `.git/agent-recovery/issue-541/private/issue-ledger-refresh/<workstream-id>-issues.stage.json`
+  - `.git/agent-recovery/issue-541/private/issue-ledger-refresh/<workstream-id>-issue-postcondition.stage.json`
   - Authoritative source-branch fetch evidence, open-PR evidence, verified
     same-repository candidate evidence, verified PR-view evidence,
     preserved-head adoption ancestry evidence plus dirty-snapshot emptiness
     evidence when applicable,
     per-workstream exact-title open issue-match evidence derived from paginated
-    `issues.json`, blocker evidence for each viable workstream, and the
-    private staged ledger used to atomically refresh `issues.json`.
+    `issues.json`, blocker evidence for each viable workstream, the
+    postcondition revalidation evidence saved after selecting or creating
+    `ISSUE_NUMBER`, and the private staged ledgers used to atomically refresh
+    `issues.json` before and after the exact-title decision.
 - Create only when Task 8 Step 5 runs:
   - `.git/agent-recovery/issue-541/private/branch-delete-proof/<branch-proof-id>-pre-delete-d.txt`
   - `.git/agent-recovery/issue-541/private/branch-delete-proof/<branch-proof-id>-pre-delete-D.txt`
@@ -2682,9 +2688,13 @@ case "$WORKSTREAM_ID" in
 esac
 ISSUE_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search.json"
 ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
+ISSUE_POSTCONDITION_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-postcondition.json"
+ISSUE_POSTCONDITION_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-postcondition-search.json"
+ISSUE_POSTCONDITION_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-postcondition-view.json"
 ISSUE_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-blocker.txt"
 ISSUE_LEDGER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issues.json"
 ISSUE_LEDGER_STAGE="$PRIVATE_RECOVERY/issue-ledger-refresh/$WORKSTREAM_ID-issues.stage.json"
+ISSUE_POSTCONDITION_STAGE="$PRIVATE_RECOVERY/issue-ledger-refresh/$WORKSTREAM_ID-issue-postcondition.stage.json"
 rm -f "$ISSUE_LEDGER_STAGE"
 if ! gh api --paginate --slurp \
   "repos/OpenCoven/coven/issues?state=all&per_page=100" \
@@ -2879,9 +2889,77 @@ EOF
 esac
 ISSUE_NUMBER="$(jq -r '.number' "$ISSUE_VIEW_EVIDENCE")"
 ISSUE_URL="$(jq -r '.url' "$ISSUE_VIEW_EVIDENCE")"
+rm -f "$ISSUE_POSTCONDITION_STAGE"
+if ! gh api --paginate --slurp \
+  "repos/OpenCoven/coven/issues?state=all&per_page=100" \
+  > "$ISSUE_POSTCONDITION_STAGE"
+then
+  rm -f "$ISSUE_POSTCONDITION_STAGE"
+  {
+    printf 'Blocked %s: could not refresh the postcondition paginated issue ledger after selecting issue #%s.\n' \
+      "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+    printf 'Verified precondition issue ledger: issue-541/issues.json\n'
+    printf 'Postcondition staging target: private/issue-ledger-refresh/%s-issue-postcondition.stage.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue postcondition refresh failed without replacing viable/$WORKSTREAM_ID-issue-postcondition-search.json; see viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: could not refresh live issue evidence after exact-title reuse/create."
+  exit 0
+fi
+if ! test -s "$ISSUE_POSTCONDITION_STAGE" || \
+   ! jq -e 'type == "array" and length > 0 and all(.[]; type == "array")' "$ISSUE_POSTCONDITION_STAGE" > /dev/null
+then
+  rm -f "$ISSUE_POSTCONDITION_STAGE"
+  {
+    printf 'Blocked %s: staged postcondition issue ledger was empty or not a valid paginated slurped array.\n' \
+      "$WORKSTREAM_ID"
+    printf 'Verified precondition issue ledger: issue-541/issues.json\n'
+    printf 'Postcondition staging target: private/issue-ledger-refresh/%s-issue-postcondition.stage.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue postcondition staging validation failed without replacing viable/$WORKSTREAM_ID-issue-postcondition-search.json; see viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: live issue evidence failed validation after exact-title reuse/create."
+  exit 0
+fi
+if ! mv "$ISSUE_POSTCONDITION_STAGE" "$ISSUE_POSTCONDITION_EVIDENCE"; then
+  rm -f "$ISSUE_POSTCONDITION_STAGE"
+  {
+    printf 'Blocked %s: could not atomically replace the postcondition issue ledger.\n' \
+      "$WORKSTREAM_ID"
+    printf 'Postcondition staging target: private/issue-ledger-refresh/%s-issue-postcondition.stage.json\n' "$WORKSTREAM_ID"
+    printf 'Postcondition ledger path: viable/%s-issue-postcondition.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue postcondition replacement failed; see viable/$WORKSTREAM_ID-issue-blocker.txt." \
+    "Blocked: could not atomically replace postcondition live issue evidence after exact-title reuse/create."
+  exit 0
+fi
+jq --arg title "$ISSUE_TITLE" \
+  '[.[] | .[] | select(.pull_request? | not) | select(.title == $title and .state == "open") | {number, title, url, state}]' \
+  "$ISSUE_POSTCONDITION_EVIDENCE" > "$ISSUE_POSTCONDITION_SEARCH_EVIDENCE"
+if ! jq -e 'length == 1' "$ISSUE_POSTCONDITION_SEARCH_EVIDENCE" > /dev/null || \
+   ! jq -e --argjson issue_number "$ISSUE_NUMBER" '.[0].number == $issue_number' "$ISSUE_POSTCONDITION_SEARCH_EVIDENCE" > /dev/null
+then
+  {
+    printf 'Blocked %s: postcondition issue evidence did not resolve to exactly one exact-title OPEN non-PR issue matching #%s.\n' \
+      "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+    printf 'Postcondition paginated issue evidence: viable/%s-issue-postcondition.json\n' "$WORKSTREAM_ID"
+    printf 'Postcondition filtered issue evidence: viable/%s-issue-postcondition-search.json\n' "$WORKSTREAM_ID"
+    printf 'Postcondition issue view evidence: viable/%s-issue-postcondition-view.json\n' "$WORKSTREAM_ID"
+  } > "$ISSUE_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Issue postcondition mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-blocker.txt, and the postcondition ledger." \
+    "Blocked: postcondition exact-title issue verification failed after reuse/create."
+  exit 0
+fi
+jq '.[0]' "$ISSUE_POSTCONDITION_SEARCH_EVIDENCE" > "$ISSUE_POSTCONDITION_VIEW_EVIDENCE"
 update_classification_row \
   "viable" \
-  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-view.json." \
+  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, and viable/$WORKSTREAM_ID-issue-postcondition-view.json." \
   "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL)."
 ```
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -43,6 +43,25 @@
   - Private branch-ref recheck evidence for each recovered source branch,
     including missing-ref outcomes and drift blockers recorded immediately
     before each deletion command.
+- Create only when Task 8 Step 4 runs:
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-head.txt`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-worktree.patch`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-index.patch`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-untracked.zlist`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-untracked.json`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-untracked.tar`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-ignored.zlist`
+  - `.git/agent-recovery/issue-541/private-retire-proof/<workstream-id>/live-ignored.json`
+  - Byte-for-byte pre-removal proof artifacts regenerated from the live source
+    worktree before any forced removal.
+- Create only when Task 4 Step 2 runs:
+  - `.git/agent-recovery/issue-541/<workstream-id>-worktree-evidence.txt`
+  - `.git/agent-recovery/issue-541/<workstream-id>-index-evidence.txt`
+  - `.git/agent-recovery/issue-541/<workstream-id>-untracked-evidence.json`
+  - `.git/agent-recovery/issue-541/<workstream-id>-ignored-evidence.json`
+  - Readable tracked-change summaries plus JSON-escaped untracked and ignored
+    inventory evidence copied from the preserved snapshots for later
+    classification and cleanup checks.
 - Create only when Task 2 Step 1 reruns after a prior current root exists:
   - `.git/agent-recovery/private/reruns/<rerun-id>/issue-541/`
   - `.git/agent-recovery/private/reruns/<rerun-id>/archive-record.txt`
@@ -60,11 +79,20 @@
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/branch.bundle`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/branch.bundle`
 - Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/<workstream-id>/.untracked.zlist`
+- Create: `.git/agent-recovery/issue-541/dirty/<workstream-id>/untracked.json`
+- Create: `.git/agent-recovery/issue-541/dirty/<workstream-id>/untracked.tar`
+- Create: `.git/agent-recovery/issue-541/dirty/<workstream-id>/.ignored.zlist`
+- Create: `.git/agent-recovery/issue-541/dirty/<workstream-id>/ignored.json`
   - Status, commit identifiers, exact branch-name marker, verified
-    `branch.bundle`, binary patches, and copied untracked files for each source
-    worktree, so committed branch history is preserved before any later source
-    branch deletion. Empty patches remain valid evidence when a formerly dirty
-    worktree is now clean because its changes were committed to an active PR.
+    `branch.bundle`, binary patches, private NUL-delimited untracked and
+    ignored inventories, JSON-escaped readable inventories, and a lossless
+    uncompressed untracked tar archive for each source worktree, so committed
+    branch history plus untracked-path content and metadata are preserved
+    before any later source branch deletion. Ignored content is inventoried but
+    never archived. Empty patches and empty inventories remain valid evidence
+    when a formerly dirty worktree is now clean because its changes were
+    committed to an active PR.
 - Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
@@ -254,7 +282,7 @@ REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/docs-psyche-specs"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs"
 BRANCH="$(git -C "$SOURCE" branch --show-current)"
-mkdir -p "$DEST/untracked"
+mkdir -p "$DEST"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
 printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
@@ -263,12 +291,27 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
-while IFS= read -r path; do
-  test -n "$path" || continue
-  mkdir -p "$DEST/untracked/$(dirname "$path")"
-  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-done < "$DEST/untracked-files.txt"
+git -C "$SOURCE" ls-files --others --exclude-standard -z > "$DEST/.untracked.zlist"
+python3 - "$DEST/.untracked.zlist" > "$DEST/untracked.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
+tar -C "$SOURCE" --null -T "$DEST/.untracked.zlist" -cf "$DEST/untracked.tar"
+git -C "$SOURCE" ls-files --others --ignored --exclude-standard -z > "$DEST/.ignored.zlist"
+python3 - "$DEST/.ignored.zlist" > "$DEST/ignored.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
 printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$SOURCE" \
   "$(cat "$DEST/head.txt")" \
@@ -277,12 +320,16 @@ printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
 ```
 
 Expected: `branch.bundle` verifies against `docs/psyche-specs`, preserving its
-committed history before any later branch deletion; both patch files exist; and
-any copied untracked files match only the paths listed in
-`untracked-files.txt`. If the worktree is still dirty, the patch files capture
-those changes. If the worktree is now clean because the source branch already
-backs an active PR, the patch files may be empty and `status.txt` becomes the
-evidence of that clean post-commit state.
+committed history before any later branch deletion; both patch files exist; the
+private `.untracked.zlist` and `.ignored.zlist` inventories are NUL-delimited;
+`untracked.json` and `ignored.json` are JSON-escaped readable renderings of
+those inventories; and `untracked.tar` preserves exactly the listed untracked
+entries from the source worktree without rewriting newline pathnames or symlink
+metadata. Ignored content is inventoried only and is never archived. If the
+worktree is still dirty, the patch files capture those changes. If the worktree
+is now clean because the source branch already backs an active PR, the patch
+files may be empty and `status.txt` becomes the evidence of that clean
+post-commit state.
 
 - [ ] **Step 3: Snapshot `feat-cmem-1ev-memory-promote`**
 
@@ -294,7 +341,7 @@ REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/feat-cmem-1ev-memory-promote"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote"
 BRANCH="$(git -C "$SOURCE" branch --show-current)"
-mkdir -p "$DEST/untracked"
+mkdir -p "$DEST"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
 printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
@@ -303,12 +350,27 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
-while IFS= read -r path; do
-  test -n "$path" || continue
-  mkdir -p "$DEST/untracked/$(dirname "$path")"
-  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-done < "$DEST/untracked-files.txt"
+git -C "$SOURCE" ls-files --others --exclude-standard -z > "$DEST/.untracked.zlist"
+python3 - "$DEST/.untracked.zlist" > "$DEST/untracked.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
+tar -C "$SOURCE" --null -T "$DEST/.untracked.zlist" -cf "$DEST/untracked.tar"
+git -C "$SOURCE" ls-files --others --ignored --exclude-standard -z > "$DEST/.ignored.zlist"
+python3 - "$DEST/.ignored.zlist" > "$DEST/ignored.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
 ```
 
 ```bash
@@ -321,9 +383,11 @@ printf 'memory-promote\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
 
 Expected: `branch.bundle` verifies against
 `feat/cmem-1ev-memory-promote`, preserving committed branch history before any
-later branch deletion, and the untracked tree includes
-`crates/coven-memory/src/promotion.rs`, `scripts/check-coven-privacy.py`, and
-`scripts/check-coven-privacy-test.py`.
+later branch deletion, and the untracked inventory plus `untracked.tar`
+preserve `crates/coven-memory/src/promotion.rs`,
+`scripts/check-coven-privacy.py`, and
+`scripts/check-coven-privacy-test.py` losslessly. Any ignored paths are
+captured only in `.ignored.zlist` and `ignored.json`.
 
 - [ ] **Step 4: Snapshot `feat/mobile-memory-gateway`**
 
@@ -335,7 +399,7 @@ REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/mobile-memory-gateway"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway"
 BRANCH="$(git -C "$SOURCE" branch --show-current)"
-mkdir -p "$DEST/untracked"
+mkdir -p "$DEST"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
 printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
@@ -344,12 +408,27 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
-while IFS= read -r path; do
-  test -n "$path" || continue
-  mkdir -p "$DEST/untracked/$(dirname "$path")"
-  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-done < "$DEST/untracked-files.txt"
+git -C "$SOURCE" ls-files --others --exclude-standard -z > "$DEST/.untracked.zlist"
+python3 - "$DEST/.untracked.zlist" > "$DEST/untracked.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
+tar -C "$SOURCE" --null -T "$DEST/.untracked.zlist" -cf "$DEST/untracked.tar"
+git -C "$SOURCE" ls-files --others --ignored --exclude-standard -z > "$DEST/.ignored.zlist"
+python3 - "$DEST/.ignored.zlist" > "$DEST/ignored.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
 ```
 
 ```bash
@@ -363,7 +442,9 @@ printf 'mobile-memory-gateway\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
 Expected: `branch.bundle` verifies against `feat/mobile-memory-gateway`,
 preserving committed branch history before any later branch deletion, and
 `worktree.patch` contains the changes to
-`crates/coven-cli/src/mobile_memory/pairing.rs`.
+`crates/coven-cli/src/mobile_memory/pairing.rs`. Any untracked additions are
+captured through `.untracked.zlist`, `untracked.json`, and `untracked.tar`,
+while ignored paths remain inventory-only.
 
 - [ ] **Step 5: Snapshot `fix/476-review-threads`**
 
@@ -375,7 +456,7 @@ REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/pr-476-review"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review"
 BRANCH="$(git -C "$SOURCE" branch --show-current)"
-mkdir -p "$DEST/untracked"
+mkdir -p "$DEST"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
 printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
@@ -384,12 +465,27 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
-while IFS= read -r path; do
-  test -n "$path" || continue
-  mkdir -p "$DEST/untracked/$(dirname "$path")"
-  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-done < "$DEST/untracked-files.txt"
+git -C "$SOURCE" ls-files --others --exclude-standard -z > "$DEST/.untracked.zlist"
+python3 - "$DEST/.untracked.zlist" > "$DEST/untracked.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
+tar -C "$SOURCE" --null -T "$DEST/.untracked.zlist" -cf "$DEST/untracked.tar"
+git -C "$SOURCE" ls-files --others --ignored --exclude-standard -z > "$DEST/.ignored.zlist"
+python3 - "$DEST/.ignored.zlist" > "$DEST/ignored.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
 ```
 
 ```bash
@@ -402,7 +498,9 @@ printf 'pr-476-review\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
 
 Expected: `branch.bundle` verifies against `fix/476-review-threads`,
 preserving committed branch history before any later branch deletion, and the
-untracked tree contains all three runtime parity plan files.
+untracked inventory plus `untracked.tar` contain all three runtime parity plan
+files without flattening special pathnames or symlink metadata. Any ignored
+paths remain captured only in `.ignored.zlist` and `ignored.json`.
 
 - [ ] **Step 6: Verify snapshot completeness**
 
@@ -415,6 +513,20 @@ RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 test "$(wc -l < "$RECOVERY/manifest.tsv" | tr -d ' ')" = 5
 for id in docs-psyche-specs memory-promote mobile-memory-gateway pr-476-review; do
   SNAPSHOT="$RECOVERY/dirty/$id"
+  case "$id" in
+    docs-psyche-specs)
+      SOURCE="$REPO/.worktrees/docs-psyche-specs"
+      ;;
+    memory-promote)
+      SOURCE="$REPO/.worktrees/feat-cmem-1ev-memory-promote"
+      ;;
+    mobile-memory-gateway)
+      SOURCE="$REPO/.worktrees/mobile-memory-gateway"
+      ;;
+    pr-476-review)
+      SOURCE="$REPO/.worktrees/pr-476-review"
+      ;;
+  esac
   test -s "$SNAPSHOT/status.txt"
   test -s "$SNAPSHOT/branch.txt"
   test -s "$SNAPSHOT/head.txt"
@@ -422,21 +534,65 @@ for id in docs-psyche-specs memory-promote mobile-memory-gateway pr-476-review; 
   test -s "$SNAPSHOT/branch.bundle"
   test -f "$SNAPSHOT/worktree.patch"
   test -f "$SNAPSHOT/index.patch"
-  test -f "$SNAPSHOT/untracked-files.txt"
-  while IFS= read -r path; do
-    test -n "$path" || continue
-    test -e "$SNAPSHOT/untracked/$path"
-  done < "$SNAPSHOT/untracked-files.txt"
+  test -f "$SNAPSHOT/.untracked.zlist"
+  test -s "$SNAPSHOT/untracked.json"
+  test -f "$SNAPSHOT/untracked.tar"
+  test -f "$SNAPSHOT/.ignored.zlist"
+  test -s "$SNAPSHOT/ignored.json"
+  python3 - "$SNAPSHOT" "$SOURCE" <<'PY'
+import json
+import os
+import stat
+import sys
+import tarfile
+from pathlib import Path
+
+snapshot = Path(sys.argv[1])
+source = Path(sys.argv[2])
+
+def read_zlist(path: Path) -> list[str]:
+    raw = path.read_bytes()
+    if not raw:
+        return []
+    return [entry.decode("utf-8", "surrogateescape") for entry in raw.rstrip(b"\0").split(b"\0")]
+
+untracked = read_zlist(snapshot / ".untracked.zlist")
+if json.loads((snapshot / "untracked.json").read_text()) != untracked:
+    raise SystemExit("untracked.json does not match .untracked.zlist")
+
+with tarfile.open(snapshot / "untracked.tar") as tf:
+    members = tf.getmembers()
+    if [member.name for member in members] != untracked:
+        raise SystemExit("untracked.tar members do not match .untracked.zlist")
+    for member in members:
+        path = source / member.name
+        st = os.lstat(path)
+        if member.issym() != stat.S_ISLNK(st.st_mode):
+            raise SystemExit(f"type mismatch for {member.name}")
+        if stat.S_IMODE(st.st_mode) != stat.S_IMODE(member.mode):
+            raise SystemExit(f"mode mismatch for {member.name}")
+        if member.isfile() and st.st_size != member.size:
+            raise SystemExit(f"size mismatch for {member.name}")
+        if member.issym() and os.readlink(path) != member.linkname:
+            raise SystemExit(f"symlink target mismatch for {member.name}")
+
+ignored = read_zlist(snapshot / ".ignored.zlist")
+if json.loads((snapshot / "ignored.json").read_text()) != ignored:
+    raise SystemExit("ignored.json does not match .ignored.zlist")
+PY
   git -C "$REPO" bundle verify "$SNAPSHOT/branch.bundle" > /dev/null
 done
 ```
 
 Expected: every dirty snapshot includes status, branch, head, merge-base, both
-patches, an explicit untracked inventory, and a verified `branch.bundle`, so
-committed branch history is preserved before any later branch deletion. Empty
-worktree, index, and untracked artifact classes are valid and appear as
-existing zero-byte files; non-empty untracked inventories still verify every
-copied path, and an empty inventory passes.
+patches, private NUL-delimited untracked and ignored inventories, JSON-escaped
+readable inventory files, an uncompressed `untracked.tar`, and a verified
+`branch.bundle`, so committed branch history plus lossless untracked content
+and metadata are preserved before any later branch deletion. Empty worktree and
+index patches remain valid zero-byte files, and empty untracked or ignored
+inventories remain valid when `.untracked.zlist` or `.ignored.zlist` is empty,
+their JSON companions are `[]`, and `untracked.tar` is a readable empty
+archive.
 
 ### Task 3: Archive Every Orphan Branch
 
@@ -612,25 +768,21 @@ do
   fi
   test -f "$RECOVERY/$id-index-evidence.txt"
   test -s "$RECOVERY/$id-index-evidence.txt"
-  if test -s "$SNAPSHOT/untracked-files.txt"; then
-    cp "$SNAPSHOT/untracked-files.txt" "$RECOVERY/$id-untracked-evidence.txt"
-  else
-    printf 'No untracked files in snapshot.\n' \
-      > "$RECOVERY/$id-untracked-evidence.txt"
-  fi
-  test -f "$RECOVERY/$id-untracked-evidence.txt"
-  test -s "$RECOVERY/$id-untracked-evidence.txt"
+  cp "$SNAPSHOT/untracked.json" "$RECOVERY/$id-untracked-evidence.json"
+  test -s "$RECOVERY/$id-untracked-evidence.json"
+  cp "$SNAPSHOT/ignored.json" "$RECOVERY/$id-ignored-evidence.json"
+  test -s "$RECOVERY/$id-ignored-evidence.json"
 done
 ```
 
 Expected: the seven historical branch comparisons still provide complementary
 commit, stat, and cherry evidence, and the four dirty snapshots now each have
-reviewable worktree, index, and inventory-backed untracked evidence files, so
-branch evidence covers all seven branch-backed workstreams and dirty evidence
-complements the four dirty rows. Empty worktree, index, and untracked snapshot
-classes remain valid, but each generated evidence file is still non-empty
-because it contains either `git apply --stat --summary` output or a
-deterministic sentinel line documenting that the snapshot class was empty.
+reviewable worktree, index, untracked, and ignored evidence files, so branch
+evidence covers all seven branch-backed workstreams and dirty evidence
+complements the four dirty rows. Empty worktree and index snapshot classes
+remain valid because they emit deterministic sentinel lines, while empty
+untracked or ignored inventories remain valid because their copied JSON
+evidence files still contain readable `[]`.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 
@@ -969,28 +1121,40 @@ case "$PR_COUNT" in
     if test -n "$DIRTY_SNAPSHOT_ROOT"; then
       test -f "$DIRTY_SNAPSHOT_ROOT/worktree.patch"
       test -f "$DIRTY_SNAPSHOT_ROOT/index.patch"
-      test -f "$DIRTY_SNAPSHOT_ROOT/untracked-files.txt"
+      test -f "$DIRTY_SNAPSHOT_ROOT/.untracked.zlist"
+      test -s "$DIRTY_SNAPSHOT_ROOT/untracked.json"
+      test -f "$DIRTY_SNAPSHOT_ROOT/untracked.tar"
+      test -f "$DIRTY_SNAPSHOT_ROOT/.ignored.zlist"
+      test -s "$DIRTY_SNAPSHOT_ROOT/ignored.json"
       WORKTREE_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/worktree.patch" | tr -d ' ')"
       INDEX_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/index.patch" | tr -d ' ')"
-      UNTRACKED_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/untracked-files.txt" | tr -d ' ')"
+      UNTRACKED_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/.untracked.zlist" | tr -d ' ')"
+      IGNORED_BYTES="$(wc -c < "$DIRTY_SNAPSHOT_ROOT/.ignored.zlist" | tr -d ' ')"
       DIRTY_CLASS_LIST=""
       if [ "$WORKTREE_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="worktree.patch"; fi
       if [ "$INDEX_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="${DIRTY_CLASS_LIST:+$DIRTY_CLASS_LIST, }index.patch"; fi
-      if [ "$UNTRACKED_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="${DIRTY_CLASS_LIST:+$DIRTY_CLASS_LIST, }untracked-files.txt"; fi
+      if [ "$UNTRACKED_BYTES" -gt 0 ]; then DIRTY_CLASS_LIST="${DIRTY_CLASS_LIST:+$DIRTY_CLASS_LIST, }.untracked.zlist"; fi
       {
         printf 'Preserved dirty snapshot: %s\n' "$DIRTY_SNAPSHOT_ID"
         printf 'worktree.patch bytes: %s\n' "$WORKTREE_BYTES"
         printf 'index.patch bytes: %s\n' "$INDEX_BYTES"
-        printf 'untracked-files.txt bytes: %s\n' "$UNTRACKED_BYTES"
+        printf '.untracked.zlist bytes: %s\n' "$UNTRACKED_BYTES"
+        printf 'untracked.json: %s/untracked.json\n' "$DIRTY_SNAPSHOT_ID"
+        printf 'untracked.tar: %s/untracked.tar\n' "$DIRTY_SNAPSHOT_ID"
+        printf '.ignored.zlist bytes: %s\n' "$IGNORED_BYTES"
+        printf 'ignored.json: %s/ignored.json\n' "$DIRTY_SNAPSHOT_ID"
       } >> "$PR_ADOPTION_EVIDENCE"
+      if [ "$IGNORED_BYTES" -gt 0 ]; then
+        printf 'Cleanup note: preserved ignored inventory is non-empty; Task 8 force-removal is prohibited for this source worktree.\n' >> "$PR_ADOPTION_EVIDENCE"
+      fi
       if [ -n "$DIRTY_CLASS_LIST" ]; then
         {
           printf 'Blocked %s: existing PR #%s passed identity checks, but preserved dirty delta remains.\n' \
             "$WORKSTREAM_ID" "$PR_NUMBER"
           printf 'Existing PR URL: %s\n' "$PR_URL"
           printf 'Preserved local head: %s\n' "$EXPECTED_HEAD"
-          printf 'Preserved snapshot archive IDs: %s/worktree.patch, %s/index.patch, %s/untracked-files.txt\n' \
-            "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID"
+          printf 'Preserved snapshot archive IDs: %s/worktree.patch, %s/index.patch, %s/.untracked.zlist, %s/untracked.json, %s/untracked.tar\n' \
+            "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID" "$DIRTY_SNAPSHOT_ID"
           printf 'Non-empty preserved dirty classes: %s\n' "$DIRTY_CLASS_LIST"
           printf 'Resume condition: land or reconcile PR #%s, then recover the preserved delta from current main in a separate scoped track.\n' "$PR_NUMBER"
           printf 'Do not force-remove or delete the original source worktree or branch while this blocker remains.\n'
@@ -1050,17 +1214,21 @@ fetched tip may the plan compare the preserved local `head.txt` to the PR head
 with `git merge-base --is-ancestor`; equality or ancestry is acceptable, but a
 diverged local head blocks adoption. For dirty-worktree sources, identity and
 ancestry success is still insufficient: inspect the preserved
-`worktree.patch`, `index.patch`, and `untracked-files.txt`, and adopt the PR
-only when all three classes are empty. If any preserved dirty class is
+`worktree.patch`, `index.patch`, and `.untracked.zlist`, and adopt the PR only
+when all three classes are empty. The same preserved snapshot must also carry
+`untracked.json`, `untracked.tar`, `.ignored.zlist`, and `ignored.json` so the
+dirty-state evidence is readable and lossless. If any preserved dirty class is
 non-empty, write `viable/$WORKSTREAM_ID-pr-blocker.txt` with the existing PR
 URL, the snapshot archive IDs, and the safe resume condition to land or
 reconcile that PR first and then recover the preserved delta from current
 `main` in a separate scoped track; the original source worktree and branch stay
 untouched while blocked. Record the preserved local head, fresh branch tip, PR
 head, ancestry result, PR URL, and any dirty-class byte counts in
-`viable/$WORKSTREAM_ID-pr-adoption.txt`, and record `continue existing PR`
-only after all of those checks pass. If `PR_COUNT>1`, block immediately with
-open-PR evidence because the same-repo exact-head query is already ambiguous.
+`viable/$WORKSTREAM_ID-pr-adoption.txt`, and also note there when the
+preserved ignored inventory is non-empty so later cleanup knows forced removal
+is prohibited. Record `continue existing PR` only after all of those checks
+pass. If `PR_COUNT>1`, block immediately with open-PR evidence because the
+same-repo exact-head query is already ambiguous.
 If `gh pr view` fails because the candidate disappears or cannot be read after
 the paginated REST capture, if the single-candidate branch fetch fails, if the
 GitHub capture itself fails, or if any other identity, ancestry, or dirty
@@ -1083,7 +1251,7 @@ verification. If `docs/psyche-specs` still has exactly one same-repo open PR
 from branch `docs/psyche-specs` at execution time, its `headRefOid` matches
 the freshly fetched `origin/docs/psyche-specs` tip, the preserved local
 `head.txt` is equal to or an ancestor of that PR head, and the preserved
-`worktree.patch`, `index.patch`, and `untracked-files.txt` are all empty, this
+`worktree.patch`, `index.patch`, and `.untracked.zlist` are all empty, this
 step adopts the exact-source-branch PR that GitHub returns at that moment
 rather than hardcoding a PR number. If any of those three preserved dirty
 classes are non-empty, the row blocks with resume instructions instead of being
@@ -1781,14 +1949,16 @@ complete. Their runtime dirtiness may change after snapshotting—for example, a
 formerly dirty tree may now be clean because its changes were committed to an
 accurate active PR. `git worktree remove --force` is allowed only in this
 step, only for these four exact paths, and only after the worktree and index
-patch evidence, verified branch bundle, untracked inventory, terminal ledger
-classification, and either an adopted exact-source-branch open PR, an open
-replacement PR, or recorded non-viable/blocker evidence are all present.
+patch evidence, verified branch bundle, lossless untracked inventory plus tar
+evidence, ignored-path inventory evidence, terminal ledger classification, and
+either an adopted exact-source-branch open PR, an open replacement PR, or
+recorded non-viable/blocker evidence are all present.
 Rows blocked because an existing PR already covers the preserved head while
-`worktree.patch`, `index.patch`, or `untracked-files.txt` remains non-empty are
+`worktree.patch`, `index.patch`, or `.untracked.zlist` remains non-empty are
 explicitly excluded from forced source cleanup and leave their original
-worktree and branch untouched. Unrelated or unsnapshotted worktrees must never
-use force.
+worktree and branch untouched. Any non-empty preserved `.ignored.zlist` also
+prohibits forced source cleanup and must instead emit blocker evidence with a
+resume condition. Unrelated or unsnapshotted worktrees must never use force.
 
 Run:
 
@@ -1804,7 +1974,11 @@ for id in \
 do
   test -s "$RECOVERY/$id-worktree-evidence.txt"
   test -s "$RECOVERY/$id-index-evidence.txt"
-  test -s "$RECOVERY/$id-untracked-evidence.txt"
+  test -s "$RECOVERY/$id-untracked-evidence.json"
+  test -s "$RECOVERY/$id-ignored-evidence.json"
+  test -f "$RECOVERY/dirty/$id/.untracked.zlist"
+  test -f "$RECOVERY/dirty/$id/untracked.tar"
+  test -f "$RECOVERY/dirty/$id/.ignored.zlist"
   git -C "$REPO" bundle verify "$RECOVERY/dirty/$id/branch.bundle" > /dev/null
   grep -E "^\| $id \| (already-shipped|superseded|viable|blocked) \|" \
     "$RECOVERY/classification.md"
@@ -1816,9 +1990,12 @@ exact-source-branch PR URL or the open replacement PR URL before removal.
 Otherwise confirm the row already records its `already-shipped`, `superseded`,
 or `blocked` evidence. Before any `--force` removal, recompute live proof files
 under the private recovery archive and compare them byte-for-byte with the
-preserved snapshot. Any mismatch or missing file blocks removal and requires a
-fresh snapshot plus reclassification for that row. Only unchanged rows may use
-the exact-path force-removal exception:
+preserved snapshot. This proof must regenerate the live `.untracked.zlist`,
+`untracked.json`, `untracked.tar`, `.ignored.zlist`, and `ignored.json` with
+the same lossless method used at snapshot time. Any mismatch or missing file
+blocks removal and requires a fresh snapshot plus reclassification for that
+row. Only unchanged rows with an empty preserved ignored inventory may use the
+exact-path force-removal exception:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
@@ -1881,30 +2058,57 @@ do
       "$id" > "$BLOCKER"
     exit 1
   fi
-  git -C "$SOURCE" ls-files --others --exclude-standard > "$PROOF_DIR/live-untracked-files.txt"
-  if ! cmp -s "$PROOF_DIR/live-untracked-files.txt" "$SNAPSHOT/untracked-files.txt"; then
+  git -C "$SOURCE" ls-files --others --exclude-standard -z > "$PROOF_DIR/live-untracked.zlist"
+  python3 - "$PROOF_DIR/live-untracked.zlist" > "$PROOF_DIR/live-untracked.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
+  tar -C "$SOURCE" --null -T "$PROOF_DIR/live-untracked.zlist" -cf "$PROOF_DIR/live-untracked.tar"
+  if ! cmp -s "$PROOF_DIR/live-untracked.zlist" "$SNAPSHOT/.untracked.zlist"; then
     printf 'Blocked %s: untracked path inventory drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
       "$id" > "$BLOCKER"
     exit 1
   fi
-  while IFS= read -r path; do
-    test -n "$path" || continue
-    if ! test -e "$SOURCE/$path"; then
-      printf 'Blocked %s: live untracked file is missing: %s. Take a fresh snapshot and reclassify before removal.\n' \
-        "$id" "$path" > "$BLOCKER"
-      exit 1
-    fi
-    if ! test -e "$SNAPSHOT/untracked/$path"; then
-      printf 'Blocked %s: snapshotted untracked file copy is missing: %s. Take a fresh snapshot and reclassify before removal.\n' \
-        "$id" "$path" > "$BLOCKER"
-      exit 1
-    fi
-    if ! cmp -s "$SOURCE/$path" "$SNAPSHOT/untracked/$path"; then
-      printf 'Blocked %s: untracked file content drifted for %s; take a fresh snapshot and reclassify before removal.\n' \
-        "$id" "$path" > "$BLOCKER"
-      exit 1
-    fi
-  done < "$SNAPSHOT/untracked-files.txt"
+  if ! cmp -s "$PROOF_DIR/live-untracked.json" "$SNAPSHOT/untracked.json"; then
+    printf 'Blocked %s: readable untracked inventory evidence drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  if ! cmp -s "$PROOF_DIR/live-untracked.tar" "$SNAPSHOT/untracked.tar"; then
+    printf 'Blocked %s: untracked tar archive drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    exit 1
+  fi
+  git -C "$SOURCE" ls-files --others --ignored --exclude-standard -z > "$PROOF_DIR/live-ignored.zlist"
+  python3 - "$PROOF_DIR/live-ignored.zlist" > "$PROOF_DIR/live-ignored.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+raw = Path(sys.argv[1]).read_bytes()
+entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
+print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
+PY
+  if ! cmp -s "$PROOF_DIR/live-ignored.zlist" "$SNAPSHOT/.ignored.zlist"; then
+    printf 'Blocked %s: ignored path inventory drifted since snapshot; leave the source worktree untouched, take a fresh snapshot, and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    continue
+  fi
+  if ! cmp -s "$PROOF_DIR/live-ignored.json" "$SNAPSHOT/ignored.json"; then
+    printf 'Blocked %s: readable ignored inventory evidence drifted since snapshot; leave the source worktree untouched, take a fresh snapshot, and reclassify before removal.\n' \
+      "$id" > "$BLOCKER"
+    continue
+  fi
+  if test -s "$SNAPSHOT/.ignored.zlist"; then
+    printf 'Blocked %s: preserved ignored-path inventory is non-empty, so forced source-worktree removal is prohibited. Resume only after that ignored content is intentionally handled outside this recovery, a fresh snapshot records an empty ignored inventory, and the row is reclassified.\n' \
+      "$id" > "$BLOCKER"
+    continue
+  fi
   git -C "$REPO" worktree remove --force "$SOURCE"
 done
 ```
@@ -1912,13 +2116,14 @@ done
 Expected: only those four exact dirty source paths are force-removed, because
 their committed history, dirty state, and recovery disposition have already
 been proven elsewhere in the archive and reconfirmed as unchanged against the
-preserved snapshot immediately before removal. Empty worktree, index, and
-untracked snapshot classes are still acceptable, but the retirement proof now
-requires non-empty evidence files populated either with captured change
-summaries or deterministic sentinel lines, plus matching live proof files under
-`private-retire-proof/`. Any row blocked because preserved dirty delta remains
-behind an active PR writes a skip blocker and leaves its original source
-worktree in place.
+preserved snapshot immediately before removal. Empty worktree and index patches
+are still acceptable, and empty untracked or ignored inventories remain valid
+when the regenerated `.zlist`, JSON, and tar artifacts match byte-for-byte.
+Rows with non-empty preserved or live ignored inventories never use force:
+they write blocker evidence plus a resume condition and leave the original
+source worktree in place. Any row blocked because preserved dirty delta remains
+behind an active PR likewise writes a skip blocker and leaves its original
+source worktree untouched.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -576,12 +576,24 @@ Then run:
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY_WORKTREE="$REPO/.worktrees/coven-recovery-541-$ISSUE_NUMBER-$BRANCH_SLUG"
+if test -e "$RECOVERY_WORKTREE"; then
+  printf 'Recovery worktree path already exists: %s\n' "$RECOVERY_WORKTREE" >&2
+  exit 1
+fi
+if git -C "$REPO" worktree list --porcelain | awk -v path="$RECOVERY_WORKTREE" '
+    $1 == "worktree" && $2 == path { found = 1 }
+    END { exit found ? 0 : 1 }
+  '; then
+  printf 'Recovery worktree is already registered by Git: %s\n' "$RECOVERY_WORKTREE" >&2
+  exit 1
+fi
 git -C "$REPO" fetch origin main
 git -C "$REPO" worktree add \
   -b "issue-$ISSUE_NUMBER-$BRANCH_SLUG" \
-  "/tmp/coven-issue-$ISSUE_NUMBER" \
+  "$RECOVERY_WORKTREE" \
   origin/main
-cd "/tmp/coven-issue-$ISSUE_NUMBER"
+cd "$RECOVERY_WORKTREE"
 coven claim acquire "issue-$ISSUE_NUMBER"
 ```
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -27,9 +27,9 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-blocker.txt`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
-  - Exact-head open-PR evidence, per-workstream exact-title open issue-match
-    evidence derived from paginated `issues.json`, and blocker evidence for
-    each viable workstream.
+  - Exact-head open-PR evidence, verified replacement-PR view evidence,
+    per-workstream exact-title open issue-match evidence derived from paginated
+    `issues.json`, and blocker evidence for each viable workstream.
 - Create only when Task 9 runs:
   - `.git/agent-recovery/issue-541/final-audit-primary-checkout.txt`
   - Primary-checkout restore and blocker evidence for the final audit.
@@ -766,9 +766,24 @@ Then branch on the exact-head result:
 case "$PR_COUNT" in
   1)
     PR_NUMBER="$(jq -r '.[0].number' "$OPEN_PR_EVIDENCE")"
-    gh pr view --repo OpenCoven/coven "$PR_NUMBER" \
+    if ! gh pr view --repo OpenCoven/coven "$PR_NUMBER" \
       --json number,title,url,state,headRefOid,headRefName,headRepositoryOwner,isCrossRepository,baseRefName \
-      > "$PR_VIEW_EVIDENCE"
+      > "$PR_VIEW_EVIDENCE" 2> "$PR_BLOCKER_EVIDENCE"; then
+      PR_VIEW_ERROR="$(cat "$PR_BLOCKER_EVIDENCE")"
+      {
+        printf 'Blocked %s: candidate PR #%s disappeared or could not be read between gh pr list and gh pr view.\n' \
+          "$WORKSTREAM_ID" "$PR_NUMBER"
+        printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
+        printf 'Expected source head: %s\n' "$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
+        printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
+        printf 'gh pr view failure follows:\n%s\n' "$PR_VIEW_ERROR"
+      } > "$PR_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "PR view failed after candidate discovery; see viable/$WORKSTREAM_ID-open-prs.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+        "Blocked: candidate PR disappeared or could not be read before identity verification."
+      exit 0
+    fi
     EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
     ACTUAL_STATE="$(jq -r '.state' "$PR_VIEW_EVIDENCE")"
     ACTUAL_HEAD="$(jq -r '.headRefOid' "$PR_VIEW_EVIDENCE")"
@@ -834,10 +849,11 @@ If `PR_COUNT=1`, verify the candidate PR before adopting it: `.state` must be
 `headRefName` must equal `$SOURCE_BRANCH`,
 `headRepositoryOwner.login` must equal `OpenCoven`, `isCrossRepository` must
 be `false`, and `baseRefName` must equal `main`. Record `continue existing PR`
-only after all of those checks pass. If the PR closes or merges between
-`gh pr list` and `gh pr view`, or if any other identity check fails, write
-`viable/$WORKSTREAM_ID-pr-blocker.txt`, update the classification row to
-`blocked`, and stop that row without creating or adopting anything. This
+only after all of those checks pass. If `gh pr view` fails because the
+candidate disappears or cannot be read after `gh pr list`, or if any other
+identity check fails, write `viable/$WORKSTREAM_ID-pr-blocker.txt`, update the
+classification row to `blocked`, and stop that row only after the blocker
+evidence is persisted. This
 deterministically avoids duplicating possibly delivered work; a later rerun
 must reclassify against current main and GitHub history before deciding whether
 any replacement issue or PR is still needed. Continue to Step 2 only when
@@ -1144,9 +1160,116 @@ coven claim release "issue-$ISSUE_NUMBER"
 Execute that issue's plan, run its full gates, commit each child change with
 the Task 5 Step 4 trailer pattern, add human contributor co-author trailers
 only when `AGENTS.md` requires them, push, and open its scoped pull request.
+Immediately after any non-adopted recovery branch opens its PR, capture and
+verify that PR before Task 7 cleanup or Task 9 audit continues:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
+ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
+PR_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-view.json"
+PR_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-blocker.txt"
+RECOVERY_BRANCH="issue-$ISSUE_NUMBER-$BRANCH_SLUG"
+mkdir -p "$RECOVERY"
+update_classification_row() {
+  python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+workstream, classification, evidence, action = sys.argv[2:6]
+needle = f"| {workstream} |"
+lines = path.read_text().splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith(needle):
+        parts = [part.strip() for part in line.strip().strip("|").split("|")]
+        if len(parts) != 5:
+            raise SystemExit(f"Unexpected classification row: {line}")
+        parts[1] = classification
+        parts[2] = evidence
+        parts[4] = action
+        lines[idx] = "| " + " | ".join(parts) + " |"
+        path.write_text("\n".join(lines) + "\n")
+        break
+else:
+    raise SystemExit(f"Missing classification row for {workstream}")
+PY
+}
+test -s "$ISSUE_VIEW_EVIDENCE"
+ISSUE_URL="$(jq -r '.url' "$ISSUE_VIEW_EVIDENCE")"
+if [ -z "${RECOVERY_PR_URL:-}" ]; then
+  if ! RECOVERY_PR_URL="$(gh pr view --repo OpenCoven/coven "$RECOVERY_BRANCH" \
+    --json url --jq '.url' 2> "$PR_BLOCKER_EVIDENCE")"; then
+    PR_VIEW_ERROR="$(cat "$PR_BLOCKER_EVIDENCE")"
+    {
+      printf 'Blocked %s: no recovery PR URL was captured from gh pr create, and gh pr view could not recover it.\n' \
+        "$WORKSTREAM_ID"
+      printf 'Expected recovery branch: %s\n' "$RECOVERY_BRANCH"
+      printf 'Issue evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
+      printf 'gh pr view failure follows:\n%s\n' "$PR_VIEW_ERROR"
+    } > "$PR_BLOCKER_EVIDENCE"
+    update_classification_row \
+      "blocked" \
+      "Recovery PR URL capture failed; see viable/$WORKSTREAM_ID-issue-view.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+      "Blocked: recovery PR URL could not be recovered for $RECOVERY_BRANCH."
+    exit 0
+  fi
+fi
+if ! gh pr view "$RECOVERY_PR_URL" --repo OpenCoven/coven \
+  --json number,url,state,headRefName,baseRefName \
+  > "$PR_VIEW_EVIDENCE" 2> "$PR_BLOCKER_EVIDENCE"; then
+  PR_VIEW_ERROR="$(cat "$PR_BLOCKER_EVIDENCE")"
+  {
+    printf 'Blocked %s: recovery PR URL %s could not be verified.\n' \
+      "$WORKSTREAM_ID" "$RECOVERY_PR_URL"
+    printf 'Expected recovery branch: %s\n' "$RECOVERY_BRANCH"
+    printf 'Issue evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
+    printf 'gh pr view failure follows:\n%s\n' "$PR_VIEW_ERROR"
+  } > "$PR_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Recovery PR verification failed; see viable/$WORKSTREAM_ID-pr-view.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+    "Blocked: recovery PR URL could not be verified for $RECOVERY_BRANCH."
+  exit 0
+fi
+RECOVERY_PR_NUMBER="$(jq -r '.number' "$PR_VIEW_EVIDENCE")"
+ACTUAL_PR_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
+ACTUAL_STATE="$(jq -r '.state' "$PR_VIEW_EVIDENCE")"
+ACTUAL_BRANCH="$(jq -r '.headRefName' "$PR_VIEW_EVIDENCE")"
+ACTUAL_BASE="$(jq -r '.baseRefName' "$PR_VIEW_EVIDENCE")"
+if [ "$ACTUAL_STATE" != "OPEN" ] || \
+   [ "$ACTUAL_BRANCH" != "$RECOVERY_BRANCH" ] || \
+   [ "$ACTUAL_BASE" != "main" ]; then
+  {
+    printf 'Blocked %s: recovery PR verification failed.\n' "$WORKSTREAM_ID"
+    printf 'Expected PR URL: %s\n' "$RECOVERY_PR_URL"
+    printf 'Expected recovery branch: %s\n' "$RECOVERY_BRANCH"
+    printf 'Expected base branch: main\n'
+    printf 'Expected state: OPEN\n'
+    printf 'Actual PR URL: %s\n' "$ACTUAL_PR_URL"
+    printf 'Actual state: %s\n' "$ACTUAL_STATE"
+    printf 'Actual branch: %s\n' "$ACTUAL_BRANCH"
+    printf 'Actual base branch: %s\n' "$ACTUAL_BASE"
+    printf 'PR view evidence: viable/%s-pr-view.json\n' "$WORKSTREAM_ID"
+  } > "$PR_BLOCKER_EVIDENCE"
+  update_classification_row \
+    "blocked" \
+    "Recovery PR verification mismatch; see viable/$WORKSTREAM_ID-pr-view.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+    "Blocked: recovery PR was not OPEN on $RECOVERY_BRANCH targeting main."
+  exit 0
+fi
+update_classification_row \
+  "viable" \
+  "Issue verified via issue-541/issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-view.json; recovery PR verified via viable/$WORKSTREAM_ID-pr-view.json." \
+  "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL) with open PR #$RECOVERY_PR_NUMBER ($ACTUAL_PR_URL)."
+```
 
 Expected: every viable row either continues one adopted exact-head open pull
-request or links to one open pull request from a current-main recovery branch.
+request or rewrites its ledger row to stay `viable` with one verified OPEN
+recovery PR URL from the expected current-main recovery branch before Task 7
+cleanup or Task 9 audit begins.
 
 ### Task 6: Record Non-Viable Outcomes
 
@@ -1498,13 +1621,20 @@ AUDIT_EVIDENCE="$COMMON_DIR/agent-recovery/issue-541/final-audit-primary-checkou
 cd "$REPO"
 CURRENT_BRANCH="$(git branch --show-current)"
 UPSTREAM_REF="$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)"
+UPSTREAM_REMOTE="$(git config --get "branch.$CURRENT_BRANCH.remote" 2>/dev/null || true)"
+UPSTREAM_MERGE_REF="$(git config --get "branch.$CURRENT_BRANCH.merge" 2>/dev/null || true)"
 STATUS="$(git status --porcelain=v1 --untracked-files=all)"
 record_state() {
-  local current_branch current_upstream
+  local current_branch current_upstream current_remote current_merge
   current_branch="$(git branch --show-current)"
   current_upstream="$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)"
+  current_remote="$(git config --get "branch.$current_branch.remote" 2>/dev/null || true)"
+  current_merge="$(git config --get "branch.$current_branch.merge" 2>/dev/null || true)"
   printf 'Current branch: %s\n' "$current_branch"
+  printf 'Current HEAD: %s\n' "$(git rev-parse HEAD)"
   printf 'Configured upstream: %s\n' "${current_upstream:-<none>}"
+  printf 'Configured upstream remote: %s\n' "${current_remote:-<none>}"
+  printf 'Configured upstream merge ref: %s\n' "${current_merge:-<none>}"
   git status --short --branch --untracked-files=all
 }
 block_restore() {
@@ -1530,13 +1660,26 @@ fi
 if [ "$CURRENT_BRANCH" = "main" ]; then
   git merge --ff-only origin/main
 elif printf '%s\n%s\n' "$CURRENT_BRANCH" "$UPSTREAM_REF" | grep -Eq '(^|[-/])issue-541($|[-/])|(^|[-/])541($|[-/])'; then
-  if [ -z "$UPSTREAM_REF" ]; then
+  if [ -z "$UPSTREAM_REMOTE" ] || [ -z "$UPSTREAM_MERGE_REF" ]; then
     block_restore \
-      "Blocked: recovery-owned branch has no configured upstream; leave it untouched."
+      "Blocked: recovery-owned branch has no configured upstream remote/branch; leave it untouched."
   fi
-  if ! git merge-base --is-ancestor HEAD "$UPSTREAM_REF"; then
+  if ! git remote get-url "$UPSTREAM_REMOTE" > /dev/null 2>&1; then
     block_restore \
-      "Blocked: recovery-owned branch HEAD is not fully pushed to its configured upstream; leave it untouched."
+      "Blocked: recovery-owned branch upstream remote cannot be resolved; leave it untouched."
+  fi
+  if ! git fetch "$UPSTREAM_REMOTE" "$UPSTREAM_MERGE_REF"; then
+    block_restore \
+      "Blocked: recovery-owned branch upstream could not be fetched; leave it untouched."
+  fi
+  FETCHED_UPSTREAM="$(git rev-parse --verify FETCH_HEAD^{commit} 2>/dev/null || true)"
+  if [ -z "$FETCHED_UPSTREAM" ]; then
+    block_restore \
+      "Blocked: recovery-owned branch upstream fetch produced no commit tip; leave it untouched."
+  fi
+  if ! git merge-base --is-ancestor HEAD "$FETCHED_UPSTREAM"; then
+    block_restore \
+      "Blocked: recovery-owned branch HEAD is not fully pushed to its freshly fetched configured upstream; leave it untouched."
   fi
   git switch main
   git merge --ff-only origin/main
@@ -1554,7 +1697,10 @@ cat "$AUDIT_EVIDENCE"
 This step is mandatory before any final-audit branch-sensitive command. It
 must stay non-interactive: do not use `git reset`, `git checkout --force`, or
 any other destructive switch. If this step exits non-zero, stop Task 9 and
-leave the primary checkout exactly as it was.
+leave the primary checkout exactly as it was. For recovery-owned branches, the
+safety check must parse `branch.<name>.remote` and `branch.<name>.merge`,
+fetch that exact upstream into `FETCH_HEAD`, and compare `HEAD` with the fresh
+upstream tip rather than relying on a stale remote-tracking ref.
 
 Expected: the primary checkout either remains untouched with blocker evidence
 in `final-audit-primary-checkout.txt`, or it is restored cleanly to `main` by

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -81,14 +81,14 @@ Run:
 
 ```bash
 cd /tmp/coven-issue-541
-git diff --check
-python scripts/check-secrets.py
 git add docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+git diff --cached --check
+python scripts/check-secrets.py
 python3 scripts/check-coven-privacy.py --staged
 ```
 
-Expected: every command exits zero and the privacy guard reports one staged
-plan file.
+Expected: every command exits zero, the staged diff check inspects the new plan
+file, and the privacy guard reports one staged plan file.
 
 - [ ] **Step 3: Commit the implementation plan**
 
@@ -96,13 +96,19 @@ Run:
 
 ```bash
 cd /tmp/coven-issue-541
-git commit -s -m "docs: plan incomplete work recovery"
+COPILOT_GH_ID=223556219
+COPILOT_GH_USER=Copilot
+COPILOT_NOREPLY_DOMAIN=users.noreply.github.com
+COPILOT_TRAILER="Co-authored-by: $COPILOT_GH_USER <${COPILOT_GH_ID}+${COPILOT_GH_USER}@${COPILOT_NOREPLY_DOMAIN}>"
+git commit -s --trailer "$COPILOT_TRAILER" \
+  -m "docs: plan incomplete work recovery"
 ```
 
 Expected: a commit containing only the implementation plan and the
 repository-required DCO sign-off plus the session-required Copilot co-author
 trailer. Human contributor co-author trailers remain conditional under
-`AGENTS.md` and are separate from the required Copilot trailer.
+`AGENTS.md` and, when required, are added separately with additional
+`--trailer` arguments rather than replacing the required Copilot trailer.
 
 - [ ] **Step 4: Push the design branch**
 
@@ -438,6 +444,7 @@ RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 git -C "$REPO" fetch origin main
 git -C "$REPO" --no-pager branch -vv > "$RECOVERY/branches.txt"
 git -C "$REPO" worktree list --porcelain > "$RECOVERY/worktrees.txt"
+cd "$REPO"
 coven claim status > "$RECOVERY/claims.txt"
 gh api --paginate --slurp \
   "repos/OpenCoven/coven/pulls?state=all&per_page=100" \
@@ -661,6 +668,18 @@ Copilot co-author trailer on child commits, push, and PR creation. Human
 contributor `Co-authored-by:` trailers remain conditional under `AGENTS.md`
 and are separate from the required Copilot trailer.
 
+Every child plan must reuse this exact child-commit pattern, replacing only
+the commit message and adding any conditional human contributor trailers as
+separate extra `--trailer` arguments:
+
+```bash
+COPILOT_GH_ID=223556219
+COPILOT_GH_USER=Copilot
+COPILOT_NOREPLY_DOMAIN=users.noreply.github.com
+COPILOT_TRAILER="Co-authored-by: $COPILOT_GH_USER <${COPILOT_GH_ID}+${COPILOT_GH_USER}@${COPILOT_NOREPLY_DOMAIN}>"
+git commit -s --trailer "$COPILOT_TRAILER" -m "<child commit message>"
+```
+
 Expected: independent plans exist for mobile pairing, Intel macOS packaging,
 Ward confinement, memory promotion, Psyche specifications, universal runtime
 design, or runtime parity only when their ledger row is `viable`.
@@ -706,10 +725,9 @@ cd "$RECOVERY_WORKTREE"
 coven claim acquire "issue-$ISSUE_NUMBER"
 ```
 
-Execute that issue's plan, run its full gates, commit with `git commit -s`,
-include the session-required Copilot co-author trailer on each child commit,
-add human contributor co-author trailers only when `AGENTS.md` requires them,
-push, and open its scoped pull request.
+Execute that issue's plan, run its full gates, commit each child change with
+the Task 5 Step 3 trailer pattern, add human contributor co-author trailers
+only when `AGENTS.md` requires them, push, and open its scoped pull request.
 
 Expected: every viable row links to one open pull request from a current-main
 branch.
@@ -1027,7 +1045,11 @@ Expected: all seven workstreams match exactly one terminal classification.
 For every `viable` row, set `PR_URL` to the recorded pull-request URL and run:
 
 ```bash
-gh pr view "$PR_URL" --json state,isDraft,mergeStateStatus,url
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+gh pr view "$PR_URL" --repo OpenCoven/coven \
+  --json state,isDraft,mergeStateStatus,url
 ```
 
 Expected: state is `OPEN`; draft status may reflect repository readiness, and
@@ -1044,7 +1066,7 @@ cd "$REPO"
 git status --short --branch
 git worktree list
 coven claim status
-gh pr list --state open --limit 100
+gh pr list --repo OpenCoven/coven --state open --limit 100
 ```
 
 Document every remaining recovery-owned worktree, claim, and open PR from these
@@ -1090,7 +1112,9 @@ links, non-viable evidence, and remaining human blockers. Do not post
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
-gh issue comment 541 --body-file \
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+gh issue comment 541 --repo OpenCoven/coven --body-file \
   "$COMMON_DIR/agent-recovery/issue-541/classification.md"
 ```
 
@@ -1103,7 +1127,10 @@ Close only after every viable concern has an open PR and all local residue has
 been safely preserved or cleaned:
 
 ```bash
-gh issue close 541 --comment \
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+gh issue close 541 --repo OpenCoven/coven --comment \
   "Recovery inventory is complete. Every viable concern has a scoped open PR; non-viable work has evidence and durable snapshots; local goals and Git hygiene are reconciled."
 ```
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -24,8 +24,12 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-open-prs.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-view.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search-exact-open.json`
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
-  - Exact-head open-PR and issue-search evidence for each viable workstream.
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-blocker.txt`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
+  - Exact-head open-PR evidence, exact-open issue-match evidence, and blocker
+    evidence for each viable workstream.
 - Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
@@ -42,7 +46,13 @@
 - Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
+- Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/`
+- Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64/`
+- Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/`
   - Ref-preserving archive for each orphan branch.
+  - Exact `branch.txt`, `head.txt`, and `merge-base.txt` snapshots for each
+    orphan branch so later PR identity checks use the preserved source head
+    rather than a mutable local ref.
 - Modify: `.copilot/goals.md`
   - Reconcile active goals after all classification and delivery outcomes are
     known. Keep this as a local untracked file.
@@ -391,6 +401,15 @@ copied path, and an empty inventory passes.
 - Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
+- Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/branch.txt`
+- Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/head.txt`
+- Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/merge-base.txt`
+- Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64/branch.txt`
+- Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64/head.txt`
+- Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64/merge-base.txt`
+- Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/branch.txt`
+- Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/head.txt`
+- Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/merge-base.txt`
 
 - [ ] **Step 1: Create ref-preserving bundles**
 
@@ -400,6 +419,10 @@ Run:
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+mkdir -p \
+  "$RECOVERY/branches/docs-universal-runtime-capability-design" \
+  "$RECOVERY/branches/feat-npm-macos-x64" \
+  "$RECOVERY/branches/fix-521-ward-surface-confinement"
 git -C "$REPO" bundle create \
   "$RECOVERY/branches/docs-universal-runtime-capability-design.bundle" \
   docs/universal-runtime-capability-design
@@ -411,7 +434,7 @@ git -C "$REPO" bundle create \
   fix/521-ward-surface-confinement
 ```
 
-Expected: three bundle files are created.
+Expected: three bundle files and three metadata directories are created.
 
 - [ ] **Step 2: Verify each bundle**
 
@@ -428,7 +451,7 @@ git -C "$REPO" bundle verify "$RECOVERY/branches/fix-521-ward-surface-confinemen
 
 Expected: Git reports each bundle is okay and lists its branch ref.
 
-- [ ] **Step 3: Record the archived branches**
+- [ ] **Step 3: Record the archived branches and snapshot their exact heads**
 
 Run:
 
@@ -443,16 +466,23 @@ for entry in \
 do
   id=${entry%%|*}
   branch=${entry#*|}
+  mkdir -p "$RECOVERY/branches/$id"
+  printf '%s\n' "$branch" > "$RECOVERY/branches/$id/branch.txt"
+  git -C "$REPO" rev-parse "$branch" > "$RECOVERY/branches/$id/head.txt"
+  git -C "$REPO" merge-base "$branch" origin/main \
+    > "$RECOVERY/branches/$id/merge-base.txt"
   printf '%s\torphan-branch\t%s\t%s\t%s\t%s\n' \
     "$id" \
     "$branch" \
-    "$(git -C "$REPO" rev-parse "$branch")" \
-    "$(git -C "$REPO" merge-base "$branch" origin/main)" \
+    "$(cat "$RECOVERY/branches/$id/head.txt")" \
+    "$(cat "$RECOVERY/branches/$id/merge-base.txt")" \
     "$RECOVERY/branches/$id.bundle" >> "$RECOVERY/manifest.tsv"
 done
 ```
 
-Expected: `manifest.tsv` has seven data rows plus its header.
+Expected: `manifest.tsv` has seven data rows plus its header, and each orphan
+branch now has immutable `branch.txt`, `head.txt`, and `merge-base.txt`
+metadata beside its bundle.
 Every Task 3 `merge_base` value still uses the `origin/main` fetched in Task 2
 Step 1.
 
@@ -652,38 +682,72 @@ Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then map it to its
 current source branch:
 
 ```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
+mkdir -p "$RECOVERY"
+update_classification_row() {
+  python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+workstream, classification, evidence, action = sys.argv[2:6]
+needle = f"| {workstream} |"
+lines = path.read_text().splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith(needle):
+        parts = [part.strip() for part in line.strip().strip("|").split("|")]
+        if len(parts) != 5:
+            raise SystemExit(f"Unexpected classification row: {line}")
+        parts[1] = classification
+        parts[2] = evidence
+        parts[4] = action
+        lines[idx] = "| " + " | ".join(parts) + " |"
+        path.write_text("\n".join(lines) + "\n")
+        break
+else:
+    raise SystemExit(f"Missing classification row for {workstream}")
+PY
+}
 case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
     SOURCE_BRANCH="feat/mobile-memory-gateway"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway/head.txt"
     ;;
   feat-npm-macos-x64)
     SOURCE_BRANCH="feat/npm-macos-x64"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/feat-npm-macos-x64/head.txt"
     ;;
   fix-521-ward-surface-confinement)
     SOURCE_BRANCH="fix/521-ward-surface-confinement"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement/head.txt"
     ;;
   memory-promote)
     SOURCE_BRANCH="feat/cmem-1ev-memory-promote"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote/head.txt"
     ;;
   docs-psyche-specs)
     SOURCE_BRANCH="docs/psyche-specs"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs/head.txt"
     ;;
   docs-universal-runtime-capability-design)
     SOURCE_BRANCH="docs/universal-runtime-capability-design"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design/head.txt"
     ;;
   pr-476-review)
     SOURCE_BRANCH="fix/476-review-threads"
+    SOURCE_HEAD_FILE="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review/head.txt"
     ;;
   *)
     printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
     exit 1
     ;;
 esac
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
-RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
-mkdir -p "$RECOVERY"
 OPEN_PR_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-open-prs.json"
 PR_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-view.json"
+PR_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-blocker.txt"
+test -s "$SOURCE_HEAD_FILE"
 gh pr list \
   --repo OpenCoven/coven \
   --state open \
@@ -699,30 +763,74 @@ case "$PR_COUNT" in
   1)
     PR_NUMBER="$(jq -r '.[0].number' "$OPEN_PR_EVIDENCE")"
     gh pr view --repo OpenCoven/coven "$PR_NUMBER" \
-      --json number,title,url,state,headRefName,baseRefName > "$PR_VIEW_EVIDENCE"
+      --json number,title,url,state,headRefOid,headRefName,headRepositoryOwner,isCrossRepository,baseRefName \
+      > "$PR_VIEW_EVIDENCE"
+    EXPECTED_HEAD="$(tr -d '\n' < "$SOURCE_HEAD_FILE")"
+    ACTUAL_HEAD="$(jq -r '.headRefOid' "$PR_VIEW_EVIDENCE")"
+    ACTUAL_BRANCH="$(jq -r '.headRefName' "$PR_VIEW_EVIDENCE")"
+    ACTUAL_OWNER="$(jq -r '.headRepositoryOwner.login' "$PR_VIEW_EVIDENCE")"
+    ACTUAL_CROSS="$(jq -r '.isCrossRepository' "$PR_VIEW_EVIDENCE")"
+    if [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] || \
+       [ "$ACTUAL_BRANCH" != "$SOURCE_BRANCH" ] || \
+       [ "$ACTUAL_OWNER" != "OpenCoven" ] || \
+       [ "$ACTUAL_CROSS" != "false" ]; then
+      {
+        printf 'Blocked %s: candidate PR #%s failed identity checks.\n' \
+          "$WORKSTREAM_ID" "$PR_NUMBER"
+        printf 'Expected source head: %s\n' "$EXPECTED_HEAD"
+        printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
+        printf 'Expected owner/cross-repo: OpenCoven / false\n'
+        printf 'Actual head: %s\n' "$ACTUAL_HEAD"
+        printf 'Actual branch: %s\n' "$ACTUAL_BRANCH"
+        printf 'Actual owner: %s\n' "$ACTUAL_OWNER"
+        printf 'Actual cross-repo: %s\n' "$ACTUAL_CROSS"
+        printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
+        printf 'PR view evidence: viable/%s-pr-view.json\n' "$WORKSTREAM_ID"
+      } > "$PR_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "PR identity mismatch; see viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+        "Blocked: candidate PR failed exact-head SHA/branch/owner/repository validation."
+      exit 0
+    fi
+    PR_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
+    update_classification_row \
+      "viable" \
+      "Exact-head PR verified via viable/$WORKSTREAM_ID-open-prs.json and viable/$WORKSTREAM_ID-pr-view.json." \
+      "continue existing PR #$PR_NUMBER ($PR_URL)"
+    exit 0
     ;;
   0)
     ;;
   *)
-    printf 'Blocked %s: expected 0 or 1 open PRs for head %s, found %s. Evidence: %s\n' \
-      "$WORKSTREAM_ID" "$SOURCE_BRANCH" "$PR_COUNT" "$OPEN_PR_EVIDENCE" >&2
-    exit 1
+    {
+      printf 'Blocked %s: expected 0 or 1 open PRs for head %s, found %s.\n' \
+        "$WORKSTREAM_ID" "$SOURCE_BRANCH" "$PR_COUNT"
+      printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
+    } > "$PR_BLOCKER_EVIDENCE"
+    update_classification_row \
+      "blocked" \
+      "Open PR ambiguity; see viable/$WORKSTREAM_ID-open-prs.json and viable/$WORKSTREAM_ID-pr-blocker.txt." \
+      "Blocked: multiple open PRs claim $SOURCE_BRANCH."
+    exit 0
     ;;
 esac
 ```
 
-If `PR_COUNT=1`, verify the PR accurately owns the workstream, record its
-number and URL in the classification row's `Recovery action` as
-`continue existing PR`, and skip child issue, branch, worktree, claim, and PR
-creation for that row. If `PR_COUNT>1`, change that row to `blocked`, cite
-`$OPEN_PR_EVIDENCE`, and stop rather than guessing. If `PR_COUNT=0`, continue
-to Step 2.
+If `PR_COUNT=1`, verify the candidate PR before adopting it: `headRefOid` must
+equal the snapshotted source `head.txt`, `headRefName` must equal
+`$SOURCE_BRANCH`, `headRepositoryOwner.login` must equal `OpenCoven`, and
+`isCrossRepository` must be `false`. Record `continue existing PR` only after
+those checks pass. If `PR_COUNT>1`, or if the single candidate fails any
+identity check, write `viable/$WORKSTREAM_ID-pr-blocker.txt`, update the
+classification row to `blocked`, and stop that row without creating or
+adopting anything. Continue to Step 2 only when `PR_COUNT=0`.
 
 Expected: every viable row has an evidence-backed exact-head PR decision before
 issue reuse or creation begins. If `docs/psyche-specs` still has exactly one
-open PR from head `docs/psyche-specs` at execution time, this step adopts that
-live PR (currently #546) dynamically via the query result rather than
-hardcoding the number.
+open PR from head `docs/psyche-specs` at execution time and its identity checks
+pass, this step adopts whichever exact-source PR GitHub returns then rather
+than hardcoding a PR number.
 
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
@@ -730,6 +838,34 @@ Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
 matching exact issue title and search query:
 
 ```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
+mkdir -p "$RECOVERY"
+update_classification_row() {
+  python3 - "$CLASSIFICATION" "$WORKSTREAM_ID" "$1" "$2" "$3" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+workstream, classification, evidence, action = sys.argv[2:6]
+needle = f"| {workstream} |"
+lines = path.read_text().splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith(needle):
+        parts = [part.strip() for part in line.strip().strip("|").split("|")]
+        if len(parts) != 5:
+            raise SystemExit(f"Unexpected classification row: {line}")
+        parts[1] = classification
+        parts[2] = evidence
+        parts[4] = action
+        lines[idx] = "| " + " | ".join(parts) + " |"
+        path.write_text("\n".join(lines) + "\n")
+        break
+else:
+    raise SystemExit(f"Missing classification row for {workstream}")
+PY
+}
 case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
     ISSUE_TITLE="Recover mobile pairing workstream"
@@ -764,28 +900,51 @@ case "$WORKSTREAM_ID" in
     exit 1
     ;;
 esac
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
-RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
-mkdir -p "$RECOVERY"
 ISSUE_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search.json"
+EXACT_OPEN_ISSUE_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search-exact-open.json"
 ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
+ISSUE_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-blocker.txt"
 gh issue list \
   --repo OpenCoven/coven \
   --state all \
   --search "$ISSUE_SEARCH" \
   --json number,title,url,state > "$ISSUE_SEARCH_EVIDENCE"
-ISSUE_COUNT="$(jq 'length' "$ISSUE_SEARCH_EVIDENCE")"
+jq --arg title "$ISSUE_TITLE" \
+  '[.[] | select(.title == $title and .state == "OPEN")]' \
+  "$ISSUE_SEARCH_EVIDENCE" > "$EXACT_OPEN_ISSUE_EVIDENCE"
+ISSUE_COUNT="$(jq 'length' "$EXACT_OPEN_ISSUE_EVIDENCE")"
 ```
 
-If exactly one accurate issue already exists, reuse it without creating a
-duplicate:
+Broad search results are preserved for evidence, but only exact-title OPEN
+matches are reusable. A sole unrelated or closed search hit leaves
+`ISSUE_COUNT=0` and must not be reused.
+
+If exactly one exact-title OPEN issue already exists, reuse it without creating
+a duplicate:
 
 ```bash
 case "$ISSUE_COUNT" in
   1)
-    ISSUE_NUMBER="$(jq -r '.[0].number' "$ISSUE_SEARCH_EVIDENCE")"
+    ISSUE_NUMBER="$(jq -r '.[0].number' "$EXACT_OPEN_ISSUE_EVIDENCE")"
     gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
       --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
+    if ! jq -e --arg title "$ISSUE_TITLE" \
+      '.title == $title and .state == "OPEN"' \
+      "$ISSUE_VIEW_EVIDENCE" > /dev/null
+    then
+      {
+        printf 'Blocked %s: issue #%s did not verify as exact-title OPEN.\n' \
+          "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+        printf 'Broad issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
+        printf 'Exact-open issue evidence: viable/%s-issue-search-exact-open.json\n' "$WORKSTREAM_ID"
+        printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
+      } > "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Issue verification mismatch; see viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: candidate issue failed exact-title OPEN verification."
+      exit 0
+    fi
     ;;
 esac
 ```
@@ -827,15 +986,54 @@ EOF
     ISSUE_NUMBER="${ISSUE_URL##*/}"
     gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
       --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
+    if ! jq -e --arg title "$ISSUE_TITLE" \
+      '.title == $title and .state == "OPEN"' \
+      "$ISSUE_VIEW_EVIDENCE" > /dev/null
+    then
+      {
+        printf 'Blocked %s: created issue #%s did not verify as exact-title OPEN.\n' \
+          "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+        printf 'Broad issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
+        printf 'Exact-open issue evidence: viable/%s-issue-search-exact-open.json\n' "$WORKSTREAM_ID"
+        printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
+      } > "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Created issue verification mismatch; see viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: created issue did not verify as exact-title OPEN."
+      exit 0
+    fi
+    ;;
+  1)
+    ;;
+  *)
+    {
+      printf 'Blocked %s: expected 0 or 1 exact-title OPEN issues for %s, found %s.\n' \
+        "$WORKSTREAM_ID" "$ISSUE_TITLE" "$ISSUE_COUNT"
+      printf 'Broad issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
+      printf 'Exact-open issue evidence: viable/%s-issue-search-exact-open.json\n' "$WORKSTREAM_ID"
+    } > "$ISSUE_BLOCKER_EVIDENCE"
+    update_classification_row \
+      "blocked" \
+      "Issue ambiguity; see viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+      "Blocked: multiple OPEN issues exactly match $ISSUE_TITLE."
+    exit 0
     ;;
 esac
+ISSUE_NUMBER="$(jq -r '.number' "$ISSUE_VIEW_EVIDENCE")"
+ISSUE_URL="$(jq -r '.url' "$ISSUE_VIEW_EVIDENCE")"
+update_classification_row \
+  "viable" \
+  "Issue verified via viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-search-exact-open.json, and viable/$WORKSTREAM_ID-issue-view.json." \
+  "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL)."
 ```
 
-If more than one issue matches, change that row to `blocked`, cite
-`$ISSUE_SEARCH_EVIDENCE`, and stop rather than choosing one arbitrarily.
+If `ISSUE_COUNT>1`, write `viable/$WORKSTREAM_ID-issue-blocker.txt`, update
+the row to `blocked`, and stop that row rather than choosing one arbitrarily.
 
 Expected: every viable row without an adopted PR has exactly one verified issue
-number, and every reuse or block decision cites a saved JSON evidence file.
+number, and every reuse, create, or block decision cites saved broad-search,
+exact-open-filter, and verification evidence files.
 
 - [ ] **Step 3: Create one approved design per viable issue**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -1,0 +1,880 @@
+# Incomplete Work Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve and classify every discovered local workstream, recover each viable concern through its own issue and implementation plan, and safely remove only proven stale residue.
+
+**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive. Run a preservation and classification phase before any cleanup, then hand each viable subsystem to an isolated issue/spec/plan/PR flow based on current `origin/main`.
+
+**Tech Stack:** Git worktrees and bundles, GitHub CLI, Coven claims, Markdown recovery ledger, Rust/Cargo, npm, repository secret and privacy guards.
+
+---
+
+## File and Artifact Map
+
+- Create: `.git/agent-recovery/issue-541/manifest.tsv`
+  - Immutable inventory of source worktrees, branches, heads, bases, and snapshot paths.
+- Create: `.git/agent-recovery/issue-541/classification.md`
+  - Evidence ledger assigning each workstream `already-shipped`, `superseded`,
+    `viable`, or `blocked`.
+- Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
+- Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
+- Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
+- Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/`
+  - Status, commit identifiers, binary patches, and copied untracked files for
+    each dirty worktree.
+- Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
+- Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
+- Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
+  - Ref-preserving archive for each orphan branch.
+- Modify: `.copilot/goals.md`
+  - Reconcile active goals after all classification and delivery outcomes are
+    known. This file is intentionally git-excluded.
+- Create only when the matching workstream is viable:
+  - `docs/superpowers/specs/2026-08-01-mobile-pairing-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-mobile-pairing-recovery.md`
+  - `docs/superpowers/specs/2026-08-01-npm-macos-x64-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-npm-macos-x64-recovery.md`
+  - `docs/superpowers/specs/2026-08-01-ward-surface-confinement-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-ward-surface-confinement-recovery.md`
+  - `docs/superpowers/specs/2026-08-01-memory-promotion-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-memory-promotion-recovery.md`
+  - `docs/superpowers/specs/2026-08-01-psyche-spec-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-psyche-spec-recovery.md`
+  - `docs/superpowers/specs/2026-08-01-universal-runtime-capability-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-universal-runtime-capability-recovery.md`
+  - `docs/superpowers/specs/2026-08-01-runtime-parity-plan-recovery-design.md`
+  - `docs/superpowers/plans/2026-08-01-runtime-parity-plan-recovery.md`
+  - One issue-keyed branch, claim, commit series, and pull request.
+
+No production file is modified during preservation or classification.
+
+### Task 1: Publish the Approved Recovery Design and Plan
+
+**Files:**
+- Existing: `docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md`
+- Create: `docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md`
+
+- [ ] **Step 1: Confirm the design worktree is clean except for the plan**
+
+Run:
+
+```bash
+git -C /tmp/coven-issue-541 status --short --branch
+```
+
+Expected: branch `docs/541-incomplete-work-recovery-design`, with only the plan
+file untracked before it is staged.
+
+- [ ] **Step 2: Run document safety checks**
+
+Run:
+
+```bash
+cd /tmp/coven-issue-541
+git diff --check
+python scripts/check-secrets.py
+git add docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: every command exits zero and the privacy guard reports one staged
+plan file.
+
+- [ ] **Step 3: Commit the implementation plan**
+
+Run:
+
+```bash
+cd /tmp/coven-issue-541
+git commit -m "docs: plan incomplete work recovery"
+```
+
+Expected: a commit containing only the implementation plan and the
+session-required Copilot co-author trailer.
+
+- [ ] **Step 4: Push the design branch**
+
+Run:
+
+```bash
+git -C /tmp/coven-issue-541 push -u origin docs/541-incomplete-work-recovery-design
+```
+
+Expected: the remote branch is created successfully.
+
+- [ ] **Step 5: Open the design pull request**
+
+Run:
+
+```bash
+cd /tmp/coven-issue-541
+gh pr create \
+  --title "docs: design incomplete work recovery" \
+  --body $'Closes #541\n\nDefines a preservation-first process for recovering dirty worktrees and orphan branches without losing data or duplicating shipped work.\n\nThe implementation is deliberately split into one issue/spec/plan/PR per viable subsystem after snapshot and classification.'
+```
+
+Expected: GitHub returns the URL of one open pull request linked to issue #541.
+
+### Task 2: Snapshot Every Dirty Worktree
+
+**Artifacts:**
+- Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
+- Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
+- Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
+- Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/`
+- Create: `.git/agent-recovery/issue-541/manifest.tsv`
+
+- [ ] **Step 1: Create the recovery archive root**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+mkdir -p "$RECOVERY/dirty" "$RECOVERY/branches"
+printf 'id\ttype\tsource\thead\tmerge_base\tsnapshot\n' > "$RECOVERY/manifest.tsv"
+```
+
+Expected: the recovery root exists under
+`$COMMON_DIR/agent-recovery/issue-541`.
+
+- [ ] **Step 2: Snapshot `docs-psyche-specs`**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+SOURCE="$REPO/.worktrees/docs-psyche-specs"
+DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs"
+mkdir -p "$DEST/untracked"
+git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
+git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
+git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
+git -C "$SOURCE" ls-files --others --exclude-standard -z |
+  while IFS= read -r -d '' path; do
+    mkdir -p "$DEST/untracked/$(dirname "$path")"
+    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+  done
+printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
+  "$SOURCE" \
+  "$(cat "$DEST/head.txt")" \
+  "$(cat "$DEST/merge-base.txt")" \
+  "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
+```
+
+Expected: both patch files exist and the copied untracked tree contains
+`specs/psyche/COVEN_PREREQUISITES.md`, `specs/psyche/PLAN.md`, and the Psyche
+reconciliation plan.
+
+- [ ] **Step 3: Snapshot `feat-cmem-1ev-memory-promote`**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+SOURCE="$REPO/.worktrees/feat-cmem-1ev-memory-promote"
+DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote"
+mkdir -p "$DEST/untracked"
+git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
+git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
+git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
+git -C "$SOURCE" ls-files --others --exclude-standard -z |
+  while IFS= read -r -d '' path; do
+    mkdir -p "$DEST/untracked/$(dirname "$path")"
+    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+  done
+```
+
+```bash
+printf 'memory-promote\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
+  "$SOURCE" \
+  "$(cat "$DEST/head.txt")" \
+  "$(cat "$DEST/merge-base.txt")" \
+  "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
+```
+
+Expected: the untracked tree includes `crates/coven-memory/src/promotion.rs`,
+`scripts/check-coven-privacy.py`, and `scripts/check-coven-privacy-test.py`.
+
+- [ ] **Step 4: Snapshot `feat/mobile-memory-gateway`**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+SOURCE="$REPO/.worktrees/mobile-memory-gateway"
+DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway"
+mkdir -p "$DEST/untracked"
+git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
+git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
+git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
+git -C "$SOURCE" ls-files --others --exclude-standard -z |
+  while IFS= read -r -d '' path; do
+    mkdir -p "$DEST/untracked/$(dirname "$path")"
+    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+  done
+```
+
+```bash
+printf 'mobile-memory-gateway\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
+  "$SOURCE" \
+  "$(cat "$DEST/head.txt")" \
+  "$(cat "$DEST/merge-base.txt")" \
+  "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
+```
+
+Expected: `worktree.patch` contains the changes to
+`crates/coven-cli/src/mobile_memory/pairing.rs`.
+
+- [ ] **Step 5: Snapshot `fix/476-review-threads`**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+SOURCE="$REPO/.worktrees/pr-476-review"
+DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review"
+mkdir -p "$DEST/untracked"
+git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
+git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
+git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
+git -C "$SOURCE" ls-files --others --exclude-standard -z |
+  while IFS= read -r -d '' path; do
+    mkdir -p "$DEST/untracked/$(dirname "$path")"
+    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+  done
+```
+
+```bash
+printf 'pr-476-review\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
+  "$SOURCE" \
+  "$(cat "$DEST/head.txt")" \
+  "$(cat "$DEST/merge-base.txt")" \
+  "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
+```
+
+Expected: the untracked tree contains all three runtime parity plan files.
+
+- [ ] **Step 6: Verify snapshot completeness**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+test "$(wc -l < "$RECOVERY/manifest.tsv" | tr -d ' ')" = 5
+for id in docs-psyche-specs memory-promote mobile-memory-gateway pr-476-review; do
+  test -s "$RECOVERY/dirty/$id/status.txt"
+  test -s "$RECOVERY/dirty/$id/head.txt"
+  test -s "$RECOVERY/dirty/$id/merge-base.txt"
+  test -f "$RECOVERY/dirty/$id/worktree.patch"
+  test -f "$RECOVERY/dirty/$id/index.patch"
+done
+```
+
+Expected: every assertion exits zero.
+
+### Task 3: Archive Every Orphan Branch
+
+**Artifacts:**
+- Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
+- Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
+- Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
+
+- [ ] **Step 1: Create ref-preserving bundles**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+git -C "$REPO" bundle create \
+  "$RECOVERY/branches/docs-universal-runtime-capability-design.bundle" \
+  docs/universal-runtime-capability-design
+git -C "$REPO" bundle create \
+  "$RECOVERY/branches/feat-npm-macos-x64.bundle" \
+  feat/npm-macos-x64
+git -C "$REPO" bundle create \
+  "$RECOVERY/branches/fix-521-ward-surface-confinement.bundle" \
+  fix/521-ward-surface-confinement
+```
+
+Expected: three bundle files are created.
+
+- [ ] **Step 2: Verify each bundle**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+git bundle verify "$RECOVERY/branches/docs-universal-runtime-capability-design.bundle"
+git bundle verify "$RECOVERY/branches/feat-npm-macos-x64.bundle"
+git bundle verify "$RECOVERY/branches/fix-521-ward-surface-confinement.bundle"
+```
+
+Expected: Git reports each bundle is okay and lists its branch ref.
+
+- [ ] **Step 3: Record the archived branches**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+for entry in \
+  'docs-universal-runtime-capability-design|docs/universal-runtime-capability-design' \
+  'feat-npm-macos-x64|feat/npm-macos-x64' \
+  'fix-521-ward-surface-confinement|fix/521-ward-surface-confinement'
+do
+  id=${entry%%|*}
+  branch=${entry#*|}
+  printf '%s\torphan-branch\t%s\t%s\t%s\t%s\n' \
+    "$id" \
+    "$branch" \
+    "$(git -C "$REPO" rev-parse "$branch")" \
+    "$(git -C "$REPO" merge-base "$branch" origin/main)" \
+    "$RECOVERY/branches/$id.bundle" >> "$RECOVERY/manifest.tsv"
+done
+```
+
+Expected: `manifest.tsv` has seven data rows plus its header.
+
+### Task 4: Build the Classification Ledger
+
+**Artifacts:**
+- Create: `.git/agent-recovery/issue-541/classification.md`
+
+- [ ] **Step 1: Capture branch and GitHub evidence**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+git -C "$REPO" fetch origin main
+git -C "$REPO" --no-pager branch -vv > "$RECOVERY/branches.txt"
+git -C "$REPO" worktree list --porcelain > "$RECOVERY/worktrees.txt"
+coven claim status > "$RECOVERY/claims.txt"
+gh pr list --repo OpenCoven/coven --state all --limit 200 \
+  --json number,state,title,headRefName,baseRefName,mergedAt,url \
+  > "$RECOVERY/pulls.json"
+gh issue list --repo OpenCoven/coven --state all --limit 200 \
+  --json number,state,title,closedAt,url \
+  > "$RECOVERY/issues.json"
+```
+
+Expected: all five evidence files exist and are non-empty.
+
+- [ ] **Step 2: Compare each source with current main**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+for branch in \
+  docs/psyche-specs \
+  docs/universal-runtime-capability-design \
+  feat/npm-macos-x64 \
+  fix/476-review-threads \
+  fix/521-ward-surface-confinement
+do
+  id=$(printf '%s' "$branch" | tr '/' '-')
+  git -C "$REPO" --no-pager log --oneline --reverse \
+    "origin/main..$branch" > "$RECOVERY/$id-commits.txt"
+  git -C "$REPO" --no-pager diff --stat \
+    "origin/main...$branch" > "$RECOVERY/$id-stat.txt"
+  git -C "$REPO" cherry -v origin/main "$branch" \
+    > "$RECOVERY/$id-cherry.txt"
+done
+```
+
+Expected: each branch has commit, stat, and patch-equivalence evidence.
+
+- [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
+
+Create `.git/agent-recovery/issue-541/classification.md` with a five-column
+table headed `Workstream`, `Classification`, `Main/PR evidence`,
+`Preserved source`, and `Recovery action`. Include exactly these seven rows:
+
+```markdown
+# Issue 541 Recovery Classification
+
+docs-psyche-specs
+memory-promote
+mobile-memory-gateway
+pr-476-review
+docs-universal-runtime-capability-design
+feat-npm-macos-x64
+fix-521-ward-surface-confinement
+```
+
+Write the selected classification, concrete commit/PR/issue/path evidence,
+preserved source path, and deterministic recovery action directly into each
+row. A row is not complete until another engineer can reproduce its
+classification from the cited source.
+
+- [ ] **Step 4: Apply the classification rules**
+
+Use these deterministic rules:
+
+```text
+already-shipped:
+  Current main contains equivalent behavior or documentation, with a merged PR
+  or direct file/commit evidence.
+
+superseded:
+  A later merged change intentionally replaces the same contract, and applying
+  the old work would regress or duplicate it.
+
+viable:
+  The work's user-visible or authority-preserving intent is absent from current
+  main, remains consistent with current policy, and has a testable acceptance
+  boundary.
+
+blocked:
+  The work requires a maintainer decision, external authority, missing source,
+  or an unresolved contract choice that cannot be inferred safely.
+```
+
+Expected: every row has exactly one classification and one next action.
+
+- [ ] **Step 5: Review the ledger against the manifest**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+for id in \
+  docs-psyche-specs \
+  memory-promote \
+  mobile-memory-gateway \
+  pr-476-review \
+  docs-universal-runtime-capability-design \
+  feat-npm-macos-x64 \
+  fix-521-ward-surface-confinement
+do
+  grep -F "| $id |" "$RECOVERY/classification.md"
+  grep -F "$id" "$RECOVERY/manifest.tsv"
+done
+```
+
+Expected: every workstream appears in both files.
+
+### Task 5: Create One Recovery Track per Viable Workstream
+
+**Files:**
+- Create only for rows classified `viable`:
+  - The exact design and plan paths listed in the File and Artifact Map.
+
+- [ ] **Step 1: Create or identify one issue per viable row**
+
+Use the matching exact query for each viable row:
+
+```bash
+gh issue list --repo OpenCoven/coven --state all --search '"mobile pairing"' --limit 20
+gh issue list --repo OpenCoven/coven --state all --search '"Intel macOS" npm' --limit 20
+gh issue list --repo OpenCoven/coven --state all --search '"Ward surface confinement"' --limit 20
+gh issue list --repo OpenCoven/coven --state all --search '"memory promotion"' --limit 20
+gh issue list --repo OpenCoven/coven --state all --search '"Psyche" specs' --limit 20
+gh issue list --repo OpenCoven/coven --state all --search '"universal runtime" capability' --limit 20
+gh issue list --repo OpenCoven/coven --state all --search '"runtime model parity"' --limit 20
+```
+
+If no issue accurately owns the concern, create one whose body includes:
+
+```markdown
+## Recovered source
+
+Issue #541 recovery archive and classification ledger.
+
+## Acceptance criteria
+
+- Preserve the still-valid intent identified in the classification evidence.
+- Rebuild against current `origin/main`; do not blindly replay obsolete code.
+- Add or retain regression coverage for the recovered behavior.
+- Pass all repository-required gates.
+```
+
+Expected: every viable row has exactly one issue number.
+
+- [ ] **Step 2: Create one approved design per viable issue**
+
+Use the brainstorming workflow separately for each issue. The design must name:
+
+- the current-main files and contracts involved;
+- the exact portion of the preserved source that remains valid;
+- intentionally omitted obsolete portions;
+- test and migration behavior;
+- one-concern pull-request boundaries.
+
+Expected: each viable concern has an approved and committed design document.
+
+- [ ] **Step 3: Create one implementation plan per approved design**
+
+Use the writing-plans workflow separately for each approved design. Each plan
+must include exact paths, failing tests, targeted commands, full repository
+gates, commit boundaries, push, and PR creation.
+
+Expected: independent plans exist for mobile pairing, Intel macOS packaging,
+Ward confinement, memory promotion, Psyche specifications, universal runtime
+design, or runtime parity only when their ledger row is `viable`.
+
+- [ ] **Step 4: Recover and publish each viable concern sequentially**
+
+For each viable row, set `ISSUE_NUMBER` to its created or reused issue number
+and set `BRANCH_SLUG` from this fixed mapping:
+
+```text
+mobile-memory-gateway -> mobile-pairing-recovery
+feat-npm-macos-x64 -> npm-macos-x64-recovery
+fix-521-ward-surface-confinement -> ward-surface-confinement-recovery
+memory-promote -> memory-promotion-recovery
+docs-psyche-specs -> psyche-spec-recovery
+docs-universal-runtime-capability-design -> universal-runtime-capability-recovery
+pr-476-review -> runtime-parity-plan-recovery
+```
+
+Then run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+git -C "$REPO" fetch origin main
+git -C "$REPO" worktree add \
+  -b "issue-$ISSUE_NUMBER-$BRANCH_SLUG" \
+  "/tmp/coven-issue-$ISSUE_NUMBER" \
+  origin/main
+cd "/tmp/coven-issue-$ISSUE_NUMBER"
+coven claim acquire "issue-$ISSUE_NUMBER"
+```
+
+Execute that issue's plan, run its full gates, commit with the required Copilot
+co-author trailer, push, and open its scoped pull request.
+
+Expected: every viable row links to one open pull request from a current-main
+branch.
+
+### Task 6: Record Non-Viable Outcomes
+
+**Artifacts:**
+- Modify: `.git/agent-recovery/issue-541/classification.md`
+
+- [ ] **Step 1: Record already-shipped evidence**
+
+For each `already-shipped` row, add:
+
+```markdown
+- Equivalent current file or behavior:
+- Merged pull request or commit:
+- Why replay would duplicate rather than extend main:
+```
+
+Fill every field with a path and commit or pull-request URL.
+
+- [ ] **Step 2: Record supersession evidence**
+
+For each `superseded` row, add:
+
+```markdown
+- Superseding contract:
+- Superseding pull request or commit:
+- Regression or duplication caused by replay:
+```
+
+Fill every field with concrete evidence.
+
+- [ ] **Step 3: Record blockers**
+
+For each `blocked` row, add:
+
+```markdown
+- Missing authority or decision:
+- Evidence that the agent cannot infer it:
+- Preserved snapshot:
+- Safe resume condition:
+```
+
+Expected: no non-viable row relies on branch age or lack of a PR as its sole
+reason.
+
+### Task 7: Clean Verified Git Residue
+
+**Files:** None. This task changes only local Git worktree and branch metadata.
+
+- [ ] **Step 1: Recheck claims and open pull requests**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+coven claim status
+gh pr list --state open --limit 100
+```
+
+Expected: every active recovery claim and open PR is understood before cleanup.
+
+- [ ] **Step 2: Remove prunable registrations only after snapshot verification**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+git worktree prune --dry-run --verbose
+```
+
+Verify every listed `/private/tmp` path either has a bundle/snapshot in the
+issue-541 archive or corresponds to a merged/detached review with no unique
+work. Then run:
+
+```bash
+git worktree prune --verbose
+```
+
+Expected: only registrations whose directories no longer exist are removed.
+
+- [ ] **Step 3: Remove clean merged worktrees**
+
+Check each known linked worktree:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+for path in \
+  "$REPO/.worktrees/docs-cli-core-guides" \
+  "$REPO/.worktrees/memory-summary-source" \
+  "$REPO/.worktrees/memory-open" \
+  "$REPO/.worktrees/fix-coven-hq8-privacy-lockfile" \
+  "$REPO/.worktrees/memory-api-review"
+do
+  git -C "$path" status --porcelain
+done
+```
+
+Expected: empty output.
+
+Then prove each branch's PR merged or its tip is represented by current main,
+and remove the five clean worktrees:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+for path in \
+  "$REPO/.worktrees/docs-cli-core-guides" \
+  "$REPO/.worktrees/memory-summary-source" \
+  "$REPO/.worktrees/memory-open" \
+  "$REPO/.worktrees/fix-coven-hq8-privacy-lockfile" \
+  "$REPO/.worktrees/memory-api-review"
+do
+  git -C "$REPO" worktree remove "$path"
+done
+```
+
+Do not use `--force`. Any non-empty status blocks removal.
+
+- [ ] **Step 4: Delete only proven local branch residue**
+
+For each branch in the ledger with merged or superseded evidence, set
+`BRANCH_TO_DELETE` to its exact local branch name and run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+git -C "$REPO" branch -d "$BRANCH_TO_DELETE"
+```
+
+If squash history makes `-d` refuse, recheck the ledger evidence and use:
+
+```bash
+git -C "$REPO" branch -D "$BRANCH_TO_DELETE"
+```
+
+only after confirming its snapshot or pushed replacement branch exists.
+
+- [ ] **Step 5: Release stopped recovery claims**
+
+After each child pull request is opened, release its claim from that worktree:
+
+```bash
+coven claim release "issue-$ISSUE_NUMBER"
+```
+
+Release the design claim when issue #541 work stops:
+
+```bash
+cd /tmp/coven-issue-541
+coven claim release issue-541
+```
+
+Expected: `coven claim status` has no abandoned active claim.
+
+### Task 8: Reconcile Repository Goals
+
+**Files:**
+- Modify: `.copilot/goals.md`
+
+- [ ] **Step 1: Re-read goals and live issue state**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+sed -n '1,260p' .copilot/goals.md
+for issue in 401 414 521 541; do
+  gh issue view "$issue" --json number,state,title,closedAt,url
+done
+```
+
+Expected: #401, #414, and #521 are closed; #541 reflects the recovery PR state.
+
+- [ ] **Step 2: Close stale active goal content**
+
+Move `usability-core-consolidation` to `done` because its named high-risk
+follow-up #401 is closed. Set:
+
+```markdown
+- completed: 2026-08-01
+- outcome: |
+    The five top gaps and the session-launch consolidation tracked by #401 are
+    closed. Remaining translation drift is not part of this completed
+    consolidation goal and requires a separately claimed issue if resumed.
+```
+
+Remove obsolete `next` text that presents #401 as future work.
+
+- [ ] **Step 3: Reconcile contribution stewardship**
+
+Keep `contribution-stewardship` active because it is an ongoing maintenance
+objective. Append a 2026-08-01 checkpoint that records:
+
+- #414 and #521 are closed;
+- there were no open PRs at recovery start;
+- issue #541 owns local recovery;
+- viable workstream PR URLs from the classification ledger;
+- already-shipped, superseded, and blocked outcomes.
+
+Set its single `next` action to review the open recovery PRs and perform the
+next external-PR sweep. Remove the duplicated stale `next` line.
+
+- [ ] **Step 4: Verify goals structure**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+grep -n '^## active\|^## paused\|^## done\|^### goal:\|^- next:' \
+  .copilot/goals.md
+```
+
+Expected: each active goal has one `next` field, completed goals are under
+`## done`, and no active `next` references closed issues as future work.
+
+### Task 9: Final Recovery Audit
+
+**Artifacts:**
+- Modify: `.git/agent-recovery/issue-541/classification.md`
+
+- [ ] **Step 1: Verify every manifest row has a terminal recovery state**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+for id in \
+  docs-psyche-specs \
+  memory-promote \
+  mobile-memory-gateway \
+  pr-476-review \
+  docs-universal-runtime-capability-design \
+  feat-npm-macos-x64 \
+  fix-521-ward-surface-confinement
+do
+  grep -E "^\| $id \| (already-shipped|superseded|viable|blocked) \|" \
+    "$RECOVERY/classification.md"
+done
+```
+
+Expected: all seven workstreams match exactly one terminal classification.
+
+- [ ] **Step 2: Verify all viable rows have open pull requests**
+
+For every `viable` row, set `PR_URL` to the recorded pull-request URL and run:
+
+```bash
+gh pr view "$PR_URL" --json state,isDraft,mergeStateStatus,url
+```
+
+Expected: state is `OPEN`; draft status may reflect repository readiness, and
+the URL matches the ledger.
+
+- [ ] **Step 3: Verify the primary checkout**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$REPO"
+git status --short --branch
+git worktree list
+coven claim status
+gh pr list --state open --limit 100
+```
+
+Expected: the primary checkout is clean on `main`; all remaining worktrees,
+claims, and open PRs correspond to documented active recovery work.
+
+- [ ] **Step 4: Update issue #541**
+
+Post a comment containing the classification table, recovery PR links,
+non-viable evidence, and remaining human blockers:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+gh issue comment 541 --body-file \
+  "$COMMON_DIR/agent-recovery/issue-541/classification.md"
+```
+
+Expected: issue #541 contains the durable GitHub-visible recovery ledger.
+
+- [ ] **Step 5: Close issue #541 when all machine work is delivered**
+
+Close only after every viable concern has an open PR and all local residue has
+been safely preserved or cleaned:
+
+```bash
+gh issue close 541 --comment \
+  "Recovery inventory is complete. Every viable concern has a scoped open PR; non-viable work has evidence and durable snapshots; local goals and Git hygiene are reconciled."
+```
+
+Expected: #541 is closed while child implementation PRs continue through normal
+review and merge.

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -21,8 +21,14 @@
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
 - Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/`
-  - Status, commit identifiers, binary patches, and copied untracked files for
-    each dirty worktree.
+- Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/memory-promote/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/branch.bundle`
+  - Status, commit identifiers, exact branch-name marker, verified
+    `branch.bundle`, binary patches, and copied untracked files for each dirty
+    worktree, so committed branch history is preserved before any later source
+    branch deletion.
 - Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
@@ -124,6 +130,10 @@ without auto-closing it.
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
 - Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/`
+- Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/memory-promote/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/branch.bundle`
+- Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/branch.bundle`
 - Create: `.git/agent-recovery/issue-541/manifest.tsv`
 
 - [ ] **Step 1: Create the recovery archive root**
@@ -150,10 +160,14 @@ COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/docs-psyche-specs"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs"
+BRANCH="$(git -C "$SOURCE" branch --show-current)"
 mkdir -p "$DEST/untracked"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
 git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
+git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
 git -C "$SOURCE" ls-files --others --exclude-standard -z |
@@ -168,9 +182,10 @@ printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
 ```
 
-Expected: both patch files exist and the copied untracked tree contains
-`specs/psyche/COVEN_PREREQUISITES.md`, `specs/psyche/PLAN.md`, and the Psyche
-reconciliation plan.
+Expected: `branch.bundle` verifies against `docs/psyche-specs`, preserving its
+committed history before any later branch deletion; both patch files exist; and
+the copied untracked tree contains `specs/psyche/COVEN_PREREQUISITES.md`,
+`specs/psyche/PLAN.md`, and the Psyche reconciliation plan.
 
 - [ ] **Step 3: Snapshot `feat-cmem-1ev-memory-promote`**
 
@@ -181,10 +196,14 @@ COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/feat-cmem-1ev-memory-promote"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote"
+BRANCH="$(git -C "$SOURCE" branch --show-current)"
 mkdir -p "$DEST/untracked"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
 git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
+git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
 git -C "$SOURCE" ls-files --others --exclude-standard -z |
@@ -202,8 +221,11 @@ printf 'memory-promote\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
 ```
 
-Expected: the untracked tree includes `crates/coven-memory/src/promotion.rs`,
-`scripts/check-coven-privacy.py`, and `scripts/check-coven-privacy-test.py`.
+Expected: `branch.bundle` verifies against
+`feat/cmem-1ev-memory-promote`, preserving committed branch history before any
+later branch deletion, and the untracked tree includes
+`crates/coven-memory/src/promotion.rs`, `scripts/check-coven-privacy.py`, and
+`scripts/check-coven-privacy-test.py`.
 
 - [ ] **Step 4: Snapshot `feat/mobile-memory-gateway`**
 
@@ -214,10 +236,14 @@ COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/mobile-memory-gateway"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway"
+BRANCH="$(git -C "$SOURCE" branch --show-current)"
 mkdir -p "$DEST/untracked"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
 git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
+git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
 git -C "$SOURCE" ls-files --others --exclude-standard -z |
@@ -235,7 +261,9 @@ printf 'mobile-memory-gateway\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
 ```
 
-Expected: `worktree.patch` contains the changes to
+Expected: `branch.bundle` verifies against `feat/mobile-memory-gateway`,
+preserving committed branch history before any later branch deletion, and
+`worktree.patch` contains the changes to
 `crates/coven-cli/src/mobile_memory/pairing.rs`.
 
 - [ ] **Step 5: Snapshot `fix/476-review-threads`**
@@ -247,10 +275,14 @@ COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/pr-476-review"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review"
+BRANCH="$(git -C "$SOURCE" branch --show-current)"
 mkdir -p "$DEST/untracked"
 git -C "$SOURCE" status --short --branch > "$DEST/status.txt"
+printf '%s\n' "$BRANCH" > "$DEST/branch.txt"
 git -C "$SOURCE" rev-parse HEAD > "$DEST/head.txt"
 git -C "$SOURCE" merge-base HEAD origin/main > "$DEST/merge-base.txt"
+git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
+git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
 git -C "$SOURCE" ls-files --others --exclude-standard -z |
@@ -268,7 +300,9 @@ printf 'pr-476-review\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$DEST" >> "$COMMON_DIR/agent-recovery/issue-541/manifest.tsv"
 ```
 
-Expected: the untracked tree contains all three runtime parity plan files.
+Expected: `branch.bundle` verifies against `fix/476-review-threads`,
+preserving committed branch history before any later branch deletion, and the
+untracked tree contains all three runtime parity plan files.
 
 - [ ] **Step 6: Verify snapshot completeness**
 
@@ -276,18 +310,24 @@ Run:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 test "$(wc -l < "$RECOVERY/manifest.tsv" | tr -d ' ')" = 5
 for id in docs-psyche-specs memory-promote mobile-memory-gateway pr-476-review; do
   test -s "$RECOVERY/dirty/$id/status.txt"
+  test -s "$RECOVERY/dirty/$id/branch.txt"
   test -s "$RECOVERY/dirty/$id/head.txt"
   test -s "$RECOVERY/dirty/$id/merge-base.txt"
-  test -f "$RECOVERY/dirty/$id/worktree.patch"
-  test -f "$RECOVERY/dirty/$id/index.patch"
+  test -s "$RECOVERY/dirty/$id/branch.bundle"
+  test -s "$RECOVERY/dirty/$id/worktree.patch"
+  test -s "$RECOVERY/dirty/$id/index.patch"
+  git -C "$REPO" bundle verify "$RECOVERY/dirty/$id/branch.bundle" > /dev/null
 done
 ```
 
-Expected: every assertion exits zero.
+Expected: every dirty snapshot includes status, branch, head, merge-base, both
+patches, and a verified `branch.bundle`, so committed branch history is
+preserved before any later branch deletion.
 
 ### Task 3: Archive Every Orphan Branch
 
@@ -407,24 +447,34 @@ do
   git -C "$REPO" cherry -v origin/main "$branch" \
     > "$RECOVERY/$id-cherry.txt"
 done
-for id in memory-promote mobile-memory-gateway
+for id in \
+  docs-psyche-specs \
+  memory-promote \
+  mobile-memory-gateway \
+  pr-476-review
 do
   SNAPSHOT="$RECOVERY/dirty/$id"
   git apply --stat --summary "$SNAPSHOT/worktree.patch" \
     > "$RECOVERY/$id-worktree-evidence.txt"
+  test -s "$RECOVERY/$id-worktree-evidence.txt" || \
+    printf '<no unstaged diff>\n' > "$RECOVERY/$id-worktree-evidence.txt"
   git apply --stat --summary "$SNAPSHOT/index.patch" \
     > "$RECOVERY/$id-index-evidence.txt"
+  test -s "$RECOVERY/$id-index-evidence.txt" || \
+    printf '<no staged diff>\n' > "$RECOVERY/$id-index-evidence.txt"
   (
     cd "$SNAPSHOT/untracked" &&
     find . -type f | sed 's#^\./##' | LC_ALL=C sort
   ) > "$RECOVERY/$id-untracked-evidence.txt"
+  test -s "$RECOVERY/$id-untracked-evidence.txt" || \
+    printf '<no untracked files>\n' > "$RECOVERY/$id-untracked-evidence.txt"
 done
 ```
 
-Expected: each branch-backed source has commit, stat, and patch-equivalence
-evidence, and `memory-promote` plus `mobile-memory-gateway` each have
+Expected: the five historical branch comparisons still provide complementary
+commit, stat, and cherry evidence, and all four dirty snapshots now each have
 reviewable worktree, index, and untracked evidence files, so evidence exists
-for all seven rows.
+for all seven workstreams.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 
@@ -724,9 +774,63 @@ done
 
 Do not use `--force`. Any non-empty status blocks removal.
 
-- [ ] **Step 4: Delete only proven local branch residue**
+- [ ] **Step 4: Retire the original dirty source worktrees only after proof checks**
 
-For each branch in the ledger with merged or superseded evidence, set
+These four source worktrees remain intentionally dirty until their proof is
+complete. `git worktree remove --force` is allowed only in this step, only for
+these four exact paths, and only after the worktree and index patch evidence,
+verified branch bundle, untracked inventory, terminal ledger classification,
+and either an open replacement PR or recorded non-viable/blocker evidence are
+all present. Unrelated or unsnapshotted worktrees must never use force.
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
+for id in \
+  docs-psyche-specs \
+  memory-promote \
+  mobile-memory-gateway \
+  pr-476-review
+do
+  test -s "$RECOVERY/$id-worktree-evidence.txt"
+  test -s "$RECOVERY/$id-index-evidence.txt"
+  test -s "$RECOVERY/$id-untracked-evidence.txt"
+  git -C "$REPO" bundle verify "$RECOVERY/dirty/$id/branch.bundle" > /dev/null
+  grep -E "^\| $id \| (already-shipped|superseded|viable|blocked) \|" \
+    "$RECOVERY/classification.md"
+done
+```
+
+If a row is `viable`, confirm its classification row cites the open replacement
+PR URL before removal. Otherwise confirm the row already records its
+`already-shipped`, `superseded`, or `blocked` evidence. Then remove only the
+four original dirty source worktrees:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+for path in \
+  "$REPO/.worktrees/docs-psyche-specs" \
+  "$REPO/.worktrees/feat-cmem-1ev-memory-promote" \
+  "$REPO/.worktrees/mobile-memory-gateway" \
+  "$REPO/.worktrees/pr-476-review"
+do
+  git -C "$REPO" worktree remove --force "$path"
+done
+```
+
+Expected: only those four exact dirty source paths are force-removed, because
+their committed history, dirty state, and recovery disposition have already
+been proven elsewhere in the archive.
+
+- [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
+
+For each branch in the ledger with merged or superseded evidence, or each of
+the four dirty source branches once Step 4 has removed its worktree and proven
+either the verified bundle or a pushed replacement recovery ref, set
 `BRANCH_TO_DELETE` to its exact local branch name and run:
 
 ```bash
@@ -741,9 +845,10 @@ If squash history makes `-d` refuse, recheck the ledger evidence and use:
 git -C "$REPO" branch -D "$BRANCH_TO_DELETE"
 ```
 
-only after confirming its snapshot or pushed replacement branch exists.
+only after confirming its source worktree is already removed and its verified
+snapshot bundle or pushed replacement branch still proves the committed history.
 
-- [ ] **Step 5: Release stopped recovery claims**
+- [ ] **Step 6: Release stopped recovery claims**
 
 After each child pull request is opened, release its claim from that worktree:
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -4193,6 +4193,47 @@ RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 RETIRE_PROOF_ROOT="$RECOVERY/private-retire-proof"
 CLASSIFICATION="$RECOVERY/classification.md"
 mkdir -p "$RETIRE_PROOF_ROOT"
+parse_classification_row() {
+  python3 - "$CLASSIFICATION" "$1" <<'PY'
+import sys
+from pathlib import Path
+
+classification_path = Path(sys.argv[1])
+workstream = sys.argv[2]
+for raw in classification_path.read_text(encoding="utf-8").splitlines():
+    line = raw.strip()
+    if not line.startswith("|") or not line.endswith("|"):
+        continue
+    cells = [cell.strip() for cell in line.strip("|").split("|")]
+    if len(cells) != 5 or cells[0] == "Workstream":
+        continue
+    if cells[0] != workstream:
+        continue
+    print(cells[1])
+    print(cells[2])
+    print(cells[3])
+    print(cells[4])
+    break
+else:
+    raise SystemExit(f"Missing classification row for {workstream}")
+PY
+}
+block_retirement() {
+  local id="$1"
+  local blocker="$2"
+  local classification="$3"
+  local evidence="$4"
+  local preserved_source="$5"
+  local recovery_action="$6"
+  local reason="$7"
+  {
+    printf 'Blocked %s: %s\n' "$id" "$reason"
+    printf 'Classification: %s\n' "$classification"
+    printf 'Main/PR evidence: %s\n' "$evidence"
+    printf 'Preserved source: %s\n' "$preserved_source"
+    printf 'Recovery action: %s\n' "$recovery_action"
+  } > "$blocker"
+}
 for id in \
   docs-psyche-specs \
   memory-promote \
@@ -4217,35 +4258,113 @@ do
       SOURCE="$REPO/.worktrees/pr-476-review"
       ;;
   esac
-  if grep -F "| $id | blocked |" "$CLASSIFICATION" | \
-    grep -Fq 'Leave source worktree and branch untouched.'
-  then
-    printf 'Skip forced retirement for %s: classification is blocked because preserved dirty delta remains behind an existing PR. Leave the original source worktree and branch untouched.\n' \
-      "$id" > "$BLOCKER"
+  if ! CLASSIFICATION_FIELDS="$(parse_classification_row "$id")"; then
+    block_retirement "$id" "$BLOCKER" "unparsed" "missing exact row" "$SOURCE" "unparsed" \
+      "classification row could not be parsed safely before any live-state checks"
     continue
   fi
+  mapfile -t CLASSIFICATION_ROW <<<"$CLASSIFICATION_FIELDS"
+  if test "${#CLASSIFICATION_ROW[@]}" -ne 4; then
+    block_retirement "$id" "$BLOCKER" "unparsed" "unexpected column count" "$SOURCE" "unparsed" \
+      "classification row could not be parsed safely before any live-state checks"
+    continue
+  fi
+  CLASSIFICATION_LABEL="${CLASSIFICATION_ROW[0]}"
+  MAIN_PR_EVIDENCE="${CLASSIFICATION_ROW[1]}"
+  PRESERVED_SOURCE="${CLASSIFICATION_ROW[2]}"
+  RECOVERY_ACTION="${CLASSIFICATION_ROW[3]}"
+  case "$CLASSIFICATION_LABEL" in
+    already-shipped)
+      case "$MAIN_PR_EVIDENCE" in
+        *merged*main*|*main*merged*|*merged into main*)
+          ;;
+        *)
+          block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+            "already-shipped rows require concrete merged/main evidence"
+          continue
+          ;;
+      esac
+      ;;
+    superseded)
+      case "$MAIN_PR_EVIDENCE" in
+        *supersed*|*replac*)
+          ;;
+        *)
+          block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+            "superseded rows require concrete superseding evidence"
+          continue
+          ;;
+      esac
+      ;;
+    viable)
+      PR_URL="$MAIN_PR_EVIDENCE"
+      case "$PR_URL" in
+        https://github.com/OpenCoven/coven/pull/*)
+          ;;
+        *)
+          block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+            "viable rows must record a GitHub PR URL for OpenCoven/coven"
+          continue
+          ;;
+      esac
+      PR_VIEW_EVIDENCE="$PROOF_DIR/live-pr-view.json"
+      PR_BLOCKER_EVIDENCE="$PROOF_DIR/live-pr-view.err"
+      if ! gh pr view --repo OpenCoven/coven "$PR_URL" \
+        --json number,title,url,state,headRepositoryOwner,isCrossRepository,baseRefName \
+        > "$PR_VIEW_EVIDENCE" 2> "$PR_BLOCKER_EVIDENCE"; then
+        block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+          "recorded viable PR could not be freshly verified against OpenCoven/coven"
+        cat "$PR_BLOCKER_EVIDENCE" >> "$BLOCKER"
+        continue
+      fi
+      ACTUAL_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
+      ACTUAL_STATE="$(jq -r '.state' "$PR_VIEW_EVIDENCE")"
+      ACTUAL_OWNER="$(jq -r '.headRepositoryOwner.login' "$PR_VIEW_EVIDENCE")"
+      ACTUAL_CROSS="$(jq -r '.isCrossRepository' "$PR_VIEW_EVIDENCE")"
+      ACTUAL_BASE="$(jq -r '.baseRefName' "$PR_VIEW_EVIDENCE")"
+      if [ "$ACTUAL_URL" != "$PR_URL" ] || \
+         [ "$ACTUAL_STATE" != "OPEN" ] || \
+         [ "$ACTUAL_OWNER" != "OpenCoven" ] || \
+         [ "$ACTUAL_CROSS" != "false" ] || \
+         [ "$ACTUAL_BASE" != "main" ]; then
+        block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+          "viable PR did not freshly verify as OPEN on base main in OpenCoven/coven"
+        continue
+      fi
+      ;;
+    pending|blocked)
+      block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+        "pending and blocked rows are never eligible for forced retirement"
+      continue
+      ;;
+    *)
+      block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+        "classification is not eligible for forced retirement"
+      continue
+      ;;
+  esac
   if ! test -d "$SOURCE"; then
-    printf 'Blocked %s: source worktree is missing before retirement proof; take a fresh snapshot and reclassify.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "source worktree is missing before retirement proof; take a fresh snapshot and reclassify"
+    continue
   fi
   git -C "$SOURCE" rev-parse HEAD > "$PROOF_DIR/live-head.txt"
   if ! cmp -s "$PROOF_DIR/live-head.txt" "$SNAPSHOT/head.txt"; then
-    printf 'Blocked %s: HEAD drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "HEAD drifted since snapshot; take a fresh snapshot and reclassify before removal"
+    continue
   fi
   git -C "$SOURCE" diff --binary > "$PROOF_DIR/live-worktree.patch"
   if ! cmp -s "$PROOF_DIR/live-worktree.patch" "$SNAPSHOT/worktree.patch"; then
-    printf 'Blocked %s: unstaged tracked changes drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "unstaged tracked changes drifted since snapshot; take a fresh snapshot and reclassify before removal"
+    continue
   fi
   git -C "$SOURCE" diff --cached --binary > "$PROOF_DIR/live-index.patch"
   if ! cmp -s "$PROOF_DIR/live-index.patch" "$SNAPSHOT/index.patch"; then
-    printf 'Blocked %s: staged changes drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "staged changes drifted since snapshot; take a fresh snapshot and reclassify before removal"
+    continue
   fi
   git -C "$SOURCE" ls-files --others --exclude-standard -z > "$PROOF_DIR/live-untracked.zlist"
   python3 - "$PROOF_DIR/live-untracked.zlist" > "$PROOF_DIR/live-untracked.json" <<'PY'
@@ -4259,19 +4378,19 @@ print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries]
 PY
   tar -C "$SOURCE" --null -T "$PROOF_DIR/live-untracked.zlist" -cf "$PROOF_DIR/live-untracked.tar"
   if ! cmp -s "$PROOF_DIR/live-untracked.zlist" "$SNAPSHOT/.untracked.zlist"; then
-    printf 'Blocked %s: untracked path inventory drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "untracked path inventory drifted since snapshot; take a fresh snapshot and reclassify before removal"
+    continue
   fi
   if ! cmp -s "$PROOF_DIR/live-untracked.json" "$SNAPSHOT/untracked.json"; then
-    printf 'Blocked %s: readable untracked inventory evidence drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "readable untracked inventory evidence drifted since snapshot; take a fresh snapshot and reclassify before removal"
+    continue
   fi
   if ! cmp -s "$PROOF_DIR/live-untracked.tar" "$SNAPSHOT/untracked.tar"; then
-    printf 'Blocked %s: untracked tar archive drifted since snapshot; take a fresh snapshot and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
-    exit 1
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "untracked tar archive drifted since snapshot; take a fresh snapshot and reclassify before removal"
+    continue
   fi
   git -C "$SOURCE" ls-files --others --ignored --exclude-standard -z > "$PROOF_DIR/live-ignored.zlist"
   python3 - "$PROOF_DIR/live-ignored.zlist" > "$PROOF_DIR/live-ignored.json" <<'PY'
@@ -4284,35 +4403,32 @@ entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
 print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
 PY
   if ! cmp -s "$PROOF_DIR/live-ignored.zlist" "$SNAPSHOT/.ignored.zlist"; then
-    printf 'Blocked %s: ignored path inventory drifted since snapshot; leave the source worktree untouched, take a fresh snapshot, and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "ignored path inventory drifted since snapshot; leave the source worktree untouched, take a fresh snapshot, and reclassify before removal"
     continue
   fi
   if ! cmp -s "$PROOF_DIR/live-ignored.json" "$SNAPSHOT/ignored.json"; then
-    printf 'Blocked %s: readable ignored inventory evidence drifted since snapshot; leave the source worktree untouched, take a fresh snapshot, and reclassify before removal.\n' \
-      "$id" > "$BLOCKER"
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "readable ignored inventory evidence drifted since snapshot; leave the source worktree untouched, take a fresh snapshot, and reclassify before removal"
     continue
   fi
   if test -s "$SNAPSHOT/.ignored.zlist"; then
-    printf 'Blocked %s: preserved ignored-path inventory is non-empty, so forced source-worktree removal is prohibited. Resume only after that ignored content is intentionally handled outside this recovery, a fresh snapshot records an empty ignored inventory, and the row is reclassified.\n' \
-      "$id" > "$BLOCKER"
+    block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
+      "preserved ignored-path inventory is non-empty, so forced source-worktree removal is prohibited"
     continue
   fi
   git -C "$REPO" worktree remove --force "$SOURCE"
 done
 ```
 
-Expected: only those four exact dirty source paths are force-removed, because
-their committed history, dirty state, and recovery disposition have already
-been proven elsewhere in the archive and reconfirmed as unchanged against the
-preserved snapshot immediately before removal. Empty worktree and index patches
-are still acceptable, and empty untracked or ignored inventories remain valid
-when the regenerated `.zlist`, JSON, and tar artifacts match byte-for-byte.
-Rows with non-empty preserved or live ignored inventories never use force:
-they write blocker evidence plus a resume condition and leave the original
-source worktree in place. Any row blocked because preserved dirty delta remains
-behind an active PR likewise writes a skip blocker and leaves its original
-source worktree untouched.
+Expected: a row may retire only when its exact classification row says
+`already-shipped` with concrete merged/main evidence, `superseded` with concrete
+superseding evidence, or `viable` with a recorded GitHub PR URL that freshly
+verifies `OPEN`, `baseRefName=main`, and `OpenCoven/coven`. `pending` and
+`blocked` rows never retire. Any unverifiable viable PR writes cleanup blocker
+evidence and leaves the original source worktree and branch untouched. After
+that gate, the existing snapshot, live-drift, and ignored-content comparisons
+still run before removal.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -30,6 +30,9 @@
   - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-blocker.txt`
   - Exact-head open-PR evidence, exact-open issue-match evidence, and blocker
     evidence for each viable workstream.
+- Create only when Task 9 runs:
+  - `.git/agent-recovery/issue-541/final-audit-primary-checkout.txt`
+  - Primary-checkout restore and blocker evidence for the final audit.
 - Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
@@ -770,27 +773,31 @@ case "$PR_COUNT" in
     ACTUAL_BRANCH="$(jq -r '.headRefName' "$PR_VIEW_EVIDENCE")"
     ACTUAL_OWNER="$(jq -r '.headRepositoryOwner.login' "$PR_VIEW_EVIDENCE")"
     ACTUAL_CROSS="$(jq -r '.isCrossRepository' "$PR_VIEW_EVIDENCE")"
+    ACTUAL_BASE="$(jq -r '.baseRefName' "$PR_VIEW_EVIDENCE")"
     if [ "$ACTUAL_HEAD" != "$EXPECTED_HEAD" ] || \
        [ "$ACTUAL_BRANCH" != "$SOURCE_BRANCH" ] || \
        [ "$ACTUAL_OWNER" != "OpenCoven" ] || \
-       [ "$ACTUAL_CROSS" != "false" ]; then
+       [ "$ACTUAL_CROSS" != "false" ] || \
+       [ "$ACTUAL_BASE" != "main" ]; then
       {
         printf 'Blocked %s: candidate PR #%s failed identity checks.\n' \
           "$WORKSTREAM_ID" "$PR_NUMBER"
         printf 'Expected source head: %s\n' "$EXPECTED_HEAD"
         printf 'Expected source branch: %s\n' "$SOURCE_BRANCH"
         printf 'Expected owner/cross-repo: OpenCoven / false\n'
+        printf 'Expected base branch: main\n'
         printf 'Actual head: %s\n' "$ACTUAL_HEAD"
         printf 'Actual branch: %s\n' "$ACTUAL_BRANCH"
         printf 'Actual owner: %s\n' "$ACTUAL_OWNER"
         printf 'Actual cross-repo: %s\n' "$ACTUAL_CROSS"
+        printf 'Actual base branch: %s\n' "$ACTUAL_BASE"
         printf 'Open PR evidence: viable/%s-open-prs.json\n' "$WORKSTREAM_ID"
         printf 'PR view evidence: viable/%s-pr-view.json\n' "$WORKSTREAM_ID"
       } > "$PR_BLOCKER_EVIDENCE"
       update_classification_row \
         "blocked" \
         "PR identity mismatch; see viable/$WORKSTREAM_ID-open-prs.json, viable/$WORKSTREAM_ID-pr-view.json, and viable/$WORKSTREAM_ID-pr-blocker.txt." \
-        "Blocked: candidate PR failed exact-head SHA/branch/owner/repository validation."
+        "Blocked: candidate PR failed exact-head SHA/branch/owner/non-cross-repo/base validation."
       exit 0
     fi
     PR_URL="$(jq -r '.url' "$PR_VIEW_EVIDENCE")"
@@ -820,17 +827,18 @@ esac
 If `PR_COUNT=1`, verify the candidate PR before adopting it: `headRefOid` must
 equal the snapshotted source `head.txt`, `headRefName` must equal
 `$SOURCE_BRANCH`, `headRepositoryOwner.login` must equal `OpenCoven`, and
-`isCrossRepository` must be `false`. Record `continue existing PR` only after
-those checks pass. If `PR_COUNT>1`, or if the single candidate fails any
+`isCrossRepository` must be `false`, and `baseRefName` must equal `main`.
+Record `continue existing PR` only after those checks pass. If `PR_COUNT>1`,
+or if the single candidate fails any
 identity check, write `viable/$WORKSTREAM_ID-pr-blocker.txt`, update the
 classification row to `blocked`, and stop that row without creating or
 adopting anything. Continue to Step 2 only when `PR_COUNT=0`.
 
-Expected: every viable row has an evidence-backed exact-head PR decision before
-issue reuse or creation begins. If `docs/psyche-specs` still has exactly one
-open PR from head `docs/psyche-specs` at execution time and its identity checks
-pass, this step adopts whichever exact-source PR GitHub returns then rather
-than hardcoding a PR number.
+Expected: every viable row has an evidence-backed exact-head, `main`-targeting
+PR decision before issue reuse or creation begins. If `docs/psyche-specs`
+still has exactly one open PR from head `docs/psyche-specs` at execution time
+and its identity checks pass, this step adopts whichever exact-source PR
+GitHub returns then rather than hardcoding a PR number.
 
 - [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
 
@@ -1438,6 +1446,7 @@ Expected: each active goal has one `next` field, completed goals are under
 ### Task 9: Final Recovery Audit
 
 **Artifacts:**
+- Create or modify: `.git/agent-recovery/issue-541/final-audit-primary-checkout.txt`
 - Modify: `.git/agent-recovery/issue-541/classification.md`
 
 - [ ] **Step 1: Verify every manifest row has a terminal recovery state**
@@ -1478,7 +1487,80 @@ gh pr view "$PR_URL" --repo OpenCoven/coven \
 Expected: state is `OPEN`; draft status may reflect repository readiness, and
 the URL matches the ledger.
 
-- [ ] **Step 3: Verify the primary checkout**
+- [ ] **Step 3: Restore the primary checkout before the final audit**
+
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+AUDIT_EVIDENCE="$COMMON_DIR/agent-recovery/issue-541/final-audit-primary-checkout.txt"
+cd "$REPO"
+CURRENT_BRANCH="$(git branch --show-current)"
+UPSTREAM_REF="$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)"
+STATUS="$(git status --porcelain=v1 --untracked-files=all)"
+record_state() {
+  local current_branch current_upstream
+  current_branch="$(git branch --show-current)"
+  current_upstream="$(git rev-parse --abbrev-ref --symbolic-full-name @{upstream} 2>/dev/null || true)"
+  printf 'Current branch: %s\n' "$current_branch"
+  printf 'Configured upstream: %s\n' "${current_upstream:-<none>}"
+  git status --short --branch --untracked-files=all
+}
+block_restore() {
+  {
+    printf '%s\n' "$1"
+    record_state
+  } > "$AUDIT_EVIDENCE"
+  cat "$AUDIT_EVIDENCE"
+  exit 1
+}
+if [ -n "$STATUS" ]; then
+  block_restore \
+    "Blocked: primary checkout has tracked or untracked changes; leave it untouched."
+fi
+git fetch origin main
+if ! git show-ref --verify --quiet refs/heads/main; then
+  block_restore "Blocked: local main branch is missing; leave the checkout untouched."
+fi
+if ! git merge-base --is-ancestor main origin/main; then
+  block_restore \
+    "Blocked: local main cannot be fast-forwarded safely to origin/main; leave the checkout untouched."
+fi
+if [ "$CURRENT_BRANCH" = "main" ]; then
+  git merge --ff-only origin/main
+elif printf '%s\n%s\n' "$CURRENT_BRANCH" "$UPSTREAM_REF" | grep -Eq '(^|[-/])issue-541($|[-/])|(^|[-/])541($|[-/])'; then
+  if [ -z "$UPSTREAM_REF" ]; then
+    block_restore \
+      "Blocked: recovery-owned branch has no configured upstream; leave it untouched."
+  fi
+  if ! git merge-base --is-ancestor HEAD "$UPSTREAM_REF"; then
+    block_restore \
+      "Blocked: recovery-owned branch HEAD is not fully pushed to its configured upstream; leave it untouched."
+  fi
+  git switch main
+  git merge --ff-only origin/main
+else
+  block_restore \
+    "Blocked: primary checkout is on an unrelated branch; leave it untouched."
+fi
+{
+  printf 'Primary checkout restored for final audit.\n'
+  record_state
+} > "$AUDIT_EVIDENCE"
+cat "$AUDIT_EVIDENCE"
+```
+
+This step is mandatory before any final-audit branch-sensitive command. It
+must stay non-interactive: do not use `git reset`, `git checkout --force`, or
+any other destructive switch. If this step exits non-zero, stop Task 9 and
+leave the primary checkout exactly as it was.
+
+Expected: the primary checkout either remains untouched with blocker evidence
+in `final-audit-primary-checkout.txt`, or it is restored cleanly to `main` by
+a safe fast-forward-only path.
+
+- [ ] **Step 4: Verify the primary checkout**
 
 Run:
 
@@ -1501,7 +1583,7 @@ recovery-owned worktree, claim, and open PR is documented; and unrelated active
 worktrees, claims, and PRs remain allowed when they are explicitly marked
 out-of-scope rather than removed or treated as audit failures.
 
-- [ ] **Step 4: Reject unsanitized local paths before posting the ledger**
+- [ ] **Step 5: Reject unsanitized local paths before posting the ledger**
 
 Run:
 
@@ -1527,7 +1609,7 @@ PY
 Expected: the command exits zero only when `classification.md` contains
 sanitized archive IDs and no local absolute path prefixes.
 
-- [ ] **Step 5: Update issue #541**
+- [ ] **Step 6: Update issue #541**
 
 Post a comment containing the sanitized classification table, recovery PR
 links, non-viable evidence, and remaining human blockers. Do not post
@@ -1544,7 +1626,7 @@ gh issue comment 541 --repo OpenCoven/coven --body-file \
 Expected: issue #541 contains the durable GitHub-visible recovery ledger sourced
 from the sanitized `classification.md`.
 
-- [ ] **Step 6: Close issue #541 when all machine work is delivered**
+- [ ] **Step 7: Close issue #541 when all machine work is delivered**
 
 Close only after every viable concern has an open PR and all local residue has
 been safely preserved or cleaned:

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -324,8 +324,8 @@ for id in docs-psyche-specs memory-promote mobile-memory-gateway pr-476-review; 
   test -s "$SNAPSHOT/head.txt"
   test -s "$SNAPSHOT/merge-base.txt"
   test -s "$SNAPSHOT/branch.bundle"
-  test -s "$SNAPSHOT/worktree.patch"
-  test -s "$SNAPSHOT/index.patch"
+  test -f "$SNAPSHOT/worktree.patch"
+  test -f "$SNAPSHOT/index.patch"
   test -f "$SNAPSHOT/untracked-files.txt"
   while IFS= read -r path; do
     test -n "$path" || continue
@@ -337,7 +337,10 @@ done
 
 Expected: every dirty snapshot includes status, branch, head, merge-base, both
 patches, an explicit untracked inventory, and a verified `branch.bundle`, so
-committed branch history is preserved before any later branch deletion.
+committed branch history is preserved before any later branch deletion. Empty
+worktree, index, and untracked artifact classes are valid and appear as
+existing zero-byte files; non-empty untracked inventories still verify every
+copied path, and an empty inventory passes.
 
 ### Task 3: Archive Every Orphan Branch
 
@@ -468,13 +471,12 @@ do
   SNAPSHOT="$RECOVERY/dirty/$id"
   git apply --stat --summary "$SNAPSHOT/worktree.patch" \
     > "$RECOVERY/$id-worktree-evidence.txt"
-  test -s "$RECOVERY/$id-worktree-evidence.txt" || \
-    printf '<no unstaged diff>\n' > "$RECOVERY/$id-worktree-evidence.txt"
+  test -f "$RECOVERY/$id-worktree-evidence.txt"
   git apply --stat --summary "$SNAPSHOT/index.patch" \
     > "$RECOVERY/$id-index-evidence.txt"
-  test -s "$RECOVERY/$id-index-evidence.txt" || \
-    printf '<no staged diff>\n' > "$RECOVERY/$id-index-evidence.txt"
+  test -f "$RECOVERY/$id-index-evidence.txt"
   cp "$SNAPSHOT/untracked-files.txt" "$RECOVERY/$id-untracked-evidence.txt"
+  test -f "$RECOVERY/$id-untracked-evidence.txt"
 done
 ```
 
@@ -482,7 +484,8 @@ Expected: the seven historical branch comparisons still provide complementary
 commit, stat, and cherry evidence, and the four dirty snapshots now each have
 reviewable worktree, index, and inventory-backed untracked evidence files, so
 branch evidence covers all seven branch-backed workstreams and dirty evidence
-complements the four dirty rows.
+complements the four dirty rows. Empty worktree, index, and untracked evidence
+classes are valid and remain as existing zero-byte files.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 
@@ -803,9 +806,9 @@ for id in \
   mobile-memory-gateway \
   pr-476-review
 do
-  test -s "$RECOVERY/$id-worktree-evidence.txt"
-  test -s "$RECOVERY/$id-index-evidence.txt"
-  test -s "$RECOVERY/$id-untracked-evidence.txt"
+  test -f "$RECOVERY/$id-worktree-evidence.txt"
+  test -f "$RECOVERY/$id-index-evidence.txt"
+  test -f "$RECOVERY/$id-untracked-evidence.txt"
   git -C "$REPO" bundle verify "$RECOVERY/dirty/$id/branch.bundle" > /dev/null
   grep -E "^\| $id \| (already-shipped|superseded|viable|blocked) \|" \
     "$RECOVERY/classification.md"
@@ -832,7 +835,9 @@ done
 
 Expected: only those four exact dirty source paths are force-removed, because
 their committed history, dirty state, and recovery disposition have already
-been proven elsewhere in the archive.
+been proven elsewhere in the archive. Empty worktree, index, and untracked
+evidence classes are valid and remain as existing zero-byte files, and these
+proof checks use the same file-existence semantics as Task 2.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -170,11 +170,12 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard -z |
-  while IFS= read -r -d '' path; do
-    mkdir -p "$DEST/untracked/$(dirname "$path")"
-    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-  done
+git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
+while IFS= read -r path; do
+  test -n "$path" || continue
+  mkdir -p "$DEST/untracked/$(dirname "$path")"
+  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+done < "$DEST/untracked-files.txt"
 printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$SOURCE" \
   "$(cat "$DEST/head.txt")" \
@@ -206,11 +207,12 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard -z |
-  while IFS= read -r -d '' path; do
-    mkdir -p "$DEST/untracked/$(dirname "$path")"
-    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-  done
+git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
+while IFS= read -r path; do
+  test -n "$path" || continue
+  mkdir -p "$DEST/untracked/$(dirname "$path")"
+  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+done < "$DEST/untracked-files.txt"
 ```
 
 ```bash
@@ -246,11 +248,12 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard -z |
-  while IFS= read -r -d '' path; do
-    mkdir -p "$DEST/untracked/$(dirname "$path")"
-    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-  done
+git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
+while IFS= read -r path; do
+  test -n "$path" || continue
+  mkdir -p "$DEST/untracked/$(dirname "$path")"
+  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+done < "$DEST/untracked-files.txt"
 ```
 
 ```bash
@@ -285,11 +288,12 @@ git -C "$REPO" bundle create "$DEST/branch.bundle" "$BRANCH"
 git -C "$REPO" bundle verify "$DEST/branch.bundle"
 git -C "$SOURCE" diff --binary > "$DEST/worktree.patch"
 git -C "$SOURCE" diff --cached --binary > "$DEST/index.patch"
-git -C "$SOURCE" ls-files --others --exclude-standard -z |
-  while IFS= read -r -d '' path; do
-    mkdir -p "$DEST/untracked/$(dirname "$path")"
-    cp -p "$SOURCE/$path" "$DEST/untracked/$path"
-  done
+git -C "$SOURCE" ls-files --others --exclude-standard > "$DEST/untracked-files.txt"
+while IFS= read -r path; do
+  test -n "$path" || continue
+  mkdir -p "$DEST/untracked/$(dirname "$path")"
+  cp -p "$SOURCE/$path" "$DEST/untracked/$path"
+done < "$DEST/untracked-files.txt"
 ```
 
 ```bash
@@ -314,20 +318,26 @@ REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 test "$(wc -l < "$RECOVERY/manifest.tsv" | tr -d ' ')" = 5
 for id in docs-psyche-specs memory-promote mobile-memory-gateway pr-476-review; do
-  test -s "$RECOVERY/dirty/$id/status.txt"
-  test -s "$RECOVERY/dirty/$id/branch.txt"
-  test -s "$RECOVERY/dirty/$id/head.txt"
-  test -s "$RECOVERY/dirty/$id/merge-base.txt"
-  test -s "$RECOVERY/dirty/$id/branch.bundle"
-  test -s "$RECOVERY/dirty/$id/worktree.patch"
-  test -s "$RECOVERY/dirty/$id/index.patch"
-  git -C "$REPO" bundle verify "$RECOVERY/dirty/$id/branch.bundle" > /dev/null
+  SNAPSHOT="$RECOVERY/dirty/$id"
+  test -s "$SNAPSHOT/status.txt"
+  test -s "$SNAPSHOT/branch.txt"
+  test -s "$SNAPSHOT/head.txt"
+  test -s "$SNAPSHOT/merge-base.txt"
+  test -s "$SNAPSHOT/branch.bundle"
+  test -s "$SNAPSHOT/worktree.patch"
+  test -s "$SNAPSHOT/index.patch"
+  test -f "$SNAPSHOT/untracked-files.txt"
+  while IFS= read -r path; do
+    test -n "$path" || continue
+    test -e "$SNAPSHOT/untracked/$path"
+  done < "$SNAPSHOT/untracked-files.txt"
+  git -C "$REPO" bundle verify "$SNAPSHOT/branch.bundle" > /dev/null
 done
 ```
 
 Expected: every dirty snapshot includes status, branch, head, merge-base, both
-patches, and a verified `branch.bundle`, so committed branch history is
-preserved before any later branch deletion.
+patches, an explicit untracked inventory, and a verified `branch.bundle`, so
+committed branch history is preserved before any later branch deletion.
 
 ### Task 3: Archive Every Orphan Branch
 
@@ -435,6 +445,8 @@ RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 for branch in \
   docs/psyche-specs \
   docs/universal-runtime-capability-design \
+  feat/cmem-1ev-memory-promote \
+  feat/mobile-memory-gateway \
   feat/npm-macos-x64 \
   fix/476-review-threads \
   fix/521-ward-surface-confinement
@@ -462,19 +474,15 @@ do
     > "$RECOVERY/$id-index-evidence.txt"
   test -s "$RECOVERY/$id-index-evidence.txt" || \
     printf '<no staged diff>\n' > "$RECOVERY/$id-index-evidence.txt"
-  (
-    cd "$SNAPSHOT/untracked" &&
-    find . -type f | sed 's#^\./##' | LC_ALL=C sort
-  ) > "$RECOVERY/$id-untracked-evidence.txt"
-  test -s "$RECOVERY/$id-untracked-evidence.txt" || \
-    printf '<no untracked files>\n' > "$RECOVERY/$id-untracked-evidence.txt"
+  cp "$SNAPSHOT/untracked-files.txt" "$RECOVERY/$id-untracked-evidence.txt"
 done
 ```
 
-Expected: the five historical branch comparisons still provide complementary
-commit, stat, and cherry evidence, and all four dirty snapshots now each have
-reviewable worktree, index, and untracked evidence files, so evidence exists
-for all seven workstreams.
+Expected: the seven historical branch comparisons still provide complementary
+commit, stat, and cherry evidence, and the four dirty snapshots now each have
+reviewable worktree, index, and inventory-backed untracked evidence files, so
+branch evidence covers all seven branch-backed workstreams and dirty evidence
+complements the four dirty rows.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -439,15 +439,19 @@ git -C "$REPO" fetch origin main
 git -C "$REPO" --no-pager branch -vv > "$RECOVERY/branches.txt"
 git -C "$REPO" worktree list --porcelain > "$RECOVERY/worktrees.txt"
 coven claim status > "$RECOVERY/claims.txt"
-gh pr list --repo OpenCoven/coven --state all --limit 200 \
-  --json number,state,title,headRefName,baseRefName,mergedAt,url \
+gh api --paginate --slurp \
+  "repos/OpenCoven/coven/pulls?state=all&per_page=100" \
   > "$RECOVERY/pulls.json"
-gh issue list --repo OpenCoven/coven --state all --limit 200 \
-  --json number,state,title,closedAt,url \
+gh api --paginate --slurp \
+  "repos/OpenCoven/coven/issues?state=all&per_page=100" \
   > "$RECOVERY/issues.json"
 ```
 
-Expected: all five evidence files exist and are non-empty.
+Expected: all five evidence files exist and are non-empty, and both
+`pulls.json` and `issues.json` are valid paginated GitHub API JSON captures.
+Because the issues API returns both issues and pull requests, PR-specific
+classification must use `pulls.json` as the dedicated pull-request evidence
+source and treat `issues.json` as the broader issue-history ledger.
 
 - [ ] **Step 2: Compare each source with current main**
 
@@ -481,14 +485,32 @@ for id in \
   pr-476-review
 do
   SNAPSHOT="$RECOVERY/dirty/$id"
-  git apply --stat --summary "$SNAPSHOT/worktree.patch" \
-    > "$RECOVERY/$id-worktree-evidence.txt"
+  if test -s "$SNAPSHOT/worktree.patch"; then
+    git apply --stat --summary "$SNAPSHOT/worktree.patch" \
+      > "$RECOVERY/$id-worktree-evidence.txt"
+  else
+    printf 'No unstaged tracked changes in snapshot.\n' \
+      > "$RECOVERY/$id-worktree-evidence.txt"
+  fi
   test -f "$RECOVERY/$id-worktree-evidence.txt"
-  git apply --stat --summary "$SNAPSHOT/index.patch" \
-    > "$RECOVERY/$id-index-evidence.txt"
+  test -s "$RECOVERY/$id-worktree-evidence.txt"
+  if test -s "$SNAPSHOT/index.patch"; then
+    git apply --stat --summary "$SNAPSHOT/index.patch" \
+      > "$RECOVERY/$id-index-evidence.txt"
+  else
+    printf 'No staged changes in snapshot.\n' \
+      > "$RECOVERY/$id-index-evidence.txt"
+  fi
   test -f "$RECOVERY/$id-index-evidence.txt"
-  cp "$SNAPSHOT/untracked-files.txt" "$RECOVERY/$id-untracked-evidence.txt"
+  test -s "$RECOVERY/$id-index-evidence.txt"
+  if test -s "$SNAPSHOT/untracked-files.txt"; then
+    cp "$SNAPSHOT/untracked-files.txt" "$RECOVERY/$id-untracked-evidence.txt"
+  else
+    printf 'No untracked files in snapshot.\n' \
+      > "$RECOVERY/$id-untracked-evidence.txt"
+  fi
   test -f "$RECOVERY/$id-untracked-evidence.txt"
+  test -s "$RECOVERY/$id-untracked-evidence.txt"
 done
 ```
 
@@ -496,8 +518,10 @@ Expected: the seven historical branch comparisons still provide complementary
 commit, stat, and cherry evidence, and the four dirty snapshots now each have
 reviewable worktree, index, and inventory-backed untracked evidence files, so
 branch evidence covers all seven branch-backed workstreams and dirty evidence
-complements the four dirty rows. Empty worktree, index, and untracked evidence
-classes are valid and remain as existing zero-byte files.
+complements the four dirty rows. Empty worktree, index, and untracked snapshot
+classes remain valid, but each generated evidence file is still non-empty
+because it contains either `git apply --stat --summary` output or a
+deterministic sentinel line documenting that the snapshot class was empty.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 
@@ -832,9 +856,9 @@ for id in \
   mobile-memory-gateway \
   pr-476-review
 do
-  test -f "$RECOVERY/$id-worktree-evidence.txt"
-  test -f "$RECOVERY/$id-index-evidence.txt"
-  test -f "$RECOVERY/$id-untracked-evidence.txt"
+  test -s "$RECOVERY/$id-worktree-evidence.txt"
+  test -s "$RECOVERY/$id-index-evidence.txt"
+  test -s "$RECOVERY/$id-untracked-evidence.txt"
   git -C "$REPO" bundle verify "$RECOVERY/dirty/$id/branch.bundle" > /dev/null
   grep -E "^\| $id \| (already-shipped|superseded|viable|blocked) \|" \
     "$RECOVERY/classification.md"
@@ -862,8 +886,9 @@ done
 Expected: only those four exact dirty source paths are force-removed, because
 their committed history, dirty state, and recovery disposition have already
 been proven elsewhere in the archive. Empty worktree, index, and untracked
-evidence classes are valid and remain as existing zero-byte files, and these
-proof checks use the same file-existence semantics as Task 2.
+snapshot classes are still acceptable, but the retirement proof now requires
+non-empty evidence files populated either with captured change summaries or
+deterministic sentinel lines.
 
 - [ ] **Step 5: Delete only proven local branch residue after worktree retirement**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -111,10 +111,11 @@ Run:
 cd /tmp/coven-issue-541
 gh pr create \
   --title "docs: design incomplete work recovery" \
-  --body $'Closes #541\n\nDefines a preservation-first process for recovering dirty worktrees and orphan branches without losing data or duplicating shipped work.\n\nThe implementation is deliberately split into one issue/spec/plan/PR per viable subsystem after snapshot and classification.'
+  --body $'Tracks #541\n\nDefines a preservation-first process for recovering dirty worktrees and orphan branches without losing data or duplicating shipped work.\n\nThe implementation is deliberately split into one issue/spec/plan/PR per viable subsystem after snapshot and classification.'
 ```
 
-Expected: GitHub returns the URL of one open pull request linked to issue #541.
+Expected: GitHub returns the URL of one open pull request tracking issue #541
+without auto-closing it.
 
 ### Task 2: Snapshot Every Dirty Worktree
 
@@ -406,9 +407,24 @@ do
   git -C "$REPO" cherry -v origin/main "$branch" \
     > "$RECOVERY/$id-cherry.txt"
 done
+for id in memory-promote mobile-memory-gateway
+do
+  SNAPSHOT="$RECOVERY/dirty/$id"
+  git apply --stat --summary "$SNAPSHOT/worktree.patch" \
+    > "$RECOVERY/$id-worktree-evidence.txt"
+  git apply --stat --summary "$SNAPSHOT/index.patch" \
+    > "$RECOVERY/$id-index-evidence.txt"
+  (
+    cd "$SNAPSHOT/untracked" &&
+    find . -type f | sed 's#^\./##' | LC_ALL=C sort
+  ) > "$RECOVERY/$id-untracked-evidence.txt"
+done
 ```
 
-Expected: each branch has commit, stat, and patch-equivalence evidence.
+Expected: each branch-backed source has commit, stat, and patch-equivalence
+evidence, and `memory-promote` plus `mobile-memory-gateway` each have
+reviewable worktree, index, and untracked evidence files, so evidence exists
+for all seven rows.
 
 - [ ] **Step 3: Write the ledger with one evidence-backed row per workstream**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -20,6 +20,12 @@
   - Sanitized evidence ledger assigning each workstream `already-shipped`,
     `superseded`, `viable`, or `blocked`. GitHub-visible `Preserved source`
     values use archive IDs only, never local absolute paths.
+- Create only when a row reaches Task 5:
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-open-prs.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-pr-view.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-search.json`
+  - `.git/agent-recovery/issue-541/viable/<workstream-id>-issue-view.json`
+  - Exact-head open-PR and issue-search evidence for each viable workstream.
 - Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
@@ -29,9 +35,10 @@
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/branch.bundle`
 - Create: `.git/agent-recovery/issue-541/dirty/pr-476-review/branch.bundle`
   - Status, commit identifiers, exact branch-name marker, verified
-    `branch.bundle`, binary patches, and copied untracked files for each dirty
+    `branch.bundle`, binary patches, and copied untracked files for each source
     worktree, so committed branch history is preserved before any later source
-    branch deletion.
+    branch deletion. Empty patches remain valid evidence when a formerly dirty
+    worktree is now clean because its changes were committed to an active PR.
 - Create: `.git/agent-recovery/issue-541/branches/docs-universal-runtime-capability-design.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/feat-npm-macos-x64.bundle`
 - Create: `.git/agent-recovery/issue-541/branches/fix-521-ward-surface-confinement.bundle`
@@ -153,7 +160,7 @@ gh pr create \
 Expected: GitHub returns the URL of one open pull request tracking issue #541
 without auto-closing it.
 
-### Task 2: Snapshot Every Dirty Worktree
+### Task 2: Snapshot Every Dirty or Formerly Dirty Source Worktree
 
 **Artifacts:**
 - Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
@@ -217,11 +224,12 @@ printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
 ```
 
 Expected: `branch.bundle` verifies against `docs/psyche-specs`, preserving its
-committed history before any later branch deletion; both patch files exist;
-`index.patch` preserves the staged additions for
-`specs/psyche/COVEN_PREREQUISITES.md`, `specs/psyche/PLAN.md`, and the Psyche
-reconciliation plan; and any copied untracked files match only the paths listed
-in `untracked-files.txt`.
+committed history before any later branch deletion; both patch files exist; and
+any copied untracked files match only the paths listed in
+`untracked-files.txt`. If the worktree is still dirty, the patch files capture
+those changes. If the worktree is now clean because the source branch already
+backs an active PR, the patch files may be empty and `status.txt` becomes the
+evidence of that clean post-commit state.
 
 - [ ] **Step 3: Snapshot `feat-cmem-1ev-memory-promote`**
 
@@ -605,7 +613,9 @@ blocked:
 
 Expected: Task 4 Step 4 replaces every `pending` row with exactly one terminal
 classification (`already-shipped`, `superseded`, `viable`, or `blocked`) and
-one next action before Task 4 Step 5 and Task 9 Step 1 verification.
+one next action before Task 4 Step 5 and Task 9 Step 1 verification. A viable
+row may later keep that classification while Task 5 updates its action to
+`continue existing PR` after verifying one exact-head open PR.
 
 - [ ] **Step 5: Review the ledger against the manifest**
 
@@ -636,62 +646,151 @@ Expected: every workstream appears in both files.
 - Create only for rows classified `viable`:
   - The exact design and plan paths listed in the File and Artifact Map.
 
-- [ ] **Step 1: Create or identify one issue per viable row**
+- [ ] **Step 1: Check for an exact-head open pull request before creating anything**
 
-Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
-matching exact query:
-
-```bash
-gh issue list --repo OpenCoven/coven --state all --search '"mobile pairing"' --limit 20
-gh issue list --repo OpenCoven/coven --state all --search '"Intel macOS" npm' --limit 20
-gh issue list --repo OpenCoven/coven --state all --search '"Ward surface confinement"' --limit 20
-gh issue list --repo OpenCoven/coven --state all --search '"memory promotion"' --limit 20
-gh issue list --repo OpenCoven/coven --state all --search '"Psyche" specs' --limit 20
-gh issue list --repo OpenCoven/coven --state all --search '"universal runtime" capability' --limit 20
-gh issue list --repo OpenCoven/coven --state all --search '"runtime model parity"' --limit 20
-```
-
-Then set the issue title from this fixed mapping:
+Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then map it to its
+current source branch:
 
 ```bash
 case "$WORKSTREAM_ID" in
   mobile-memory-gateway)
-    ISSUE_TITLE="Recover mobile pairing workstream"
+    SOURCE_BRANCH="feat/mobile-memory-gateway"
     ;;
   feat-npm-macos-x64)
-    ISSUE_TITLE="Recover Intel macOS npm packaging workstream"
+    SOURCE_BRANCH="feat/npm-macos-x64"
     ;;
   fix-521-ward-surface-confinement)
-    ISSUE_TITLE="Recover Ward surface confinement workstream"
+    SOURCE_BRANCH="fix/521-ward-surface-confinement"
     ;;
   memory-promote)
-    ISSUE_TITLE="Recover memory promotion workstream"
+    SOURCE_BRANCH="feat/cmem-1ev-memory-promote"
     ;;
   docs-psyche-specs)
-    ISSUE_TITLE="Recover Psyche specification workstream"
+    SOURCE_BRANCH="docs/psyche-specs"
     ;;
   docs-universal-runtime-capability-design)
-    ISSUE_TITLE="Recover universal runtime capability design workstream"
+    SOURCE_BRANCH="docs/universal-runtime-capability-design"
     ;;
   pr-476-review)
-    ISSUE_TITLE="Recover runtime model parity plan workstream"
+    SOURCE_BRANCH="fix/476-review-threads"
     ;;
   *)
     printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
     exit 1
     ;;
 esac
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+mkdir -p "$RECOVERY"
+OPEN_PR_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-open-prs.json"
+PR_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-pr-view.json"
+gh pr list \
+  --repo OpenCoven/coven \
+  --state open \
+  --head "$SOURCE_BRANCH" \
+  --json number,title,url,headRefName > "$OPEN_PR_EVIDENCE"
+PR_COUNT="$(jq 'length' "$OPEN_PR_EVIDENCE")"
 ```
 
-If an accurate issue already exists, reuse it without creating a duplicate:
+Then branch on the exact-head result:
 
 ```bash
-ISSUE_NUMBER=<existing issue number>
-gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
-  --json number,state,title,url
+case "$PR_COUNT" in
+  1)
+    PR_NUMBER="$(jq -r '.[0].number' "$OPEN_PR_EVIDENCE")"
+    gh pr view --repo OpenCoven/coven "$PR_NUMBER" \
+      --json number,title,url,state,headRefName,baseRefName > "$PR_VIEW_EVIDENCE"
+    ;;
+  0)
+    ;;
+  *)
+    printf 'Blocked %s: expected 0 or 1 open PRs for head %s, found %s. Evidence: %s\n' \
+      "$WORKSTREAM_ID" "$SOURCE_BRANCH" "$PR_COUNT" "$OPEN_PR_EVIDENCE" >&2
+    exit 1
+    ;;
+esac
 ```
 
-If no issue accurately owns the concern, create one and verify it immediately:
+If `PR_COUNT=1`, verify the PR accurately owns the workstream, record its
+number and URL in the classification row's `Recovery action` as
+`continue existing PR`, and skip child issue, branch, worktree, claim, and PR
+creation for that row. If `PR_COUNT>1`, change that row to `blocked`, cite
+`$OPEN_PR_EVIDENCE`, and stop rather than guessing. If `PR_COUNT=0`, continue
+to Step 2.
+
+Expected: every viable row has an evidence-backed exact-head PR decision before
+issue reuse or creation begins. If `docs/psyche-specs` still has exactly one
+open PR from head `docs/psyche-specs` at execution time, this step adopts that
+live PR (currently #546) dynamically via the query result rather than
+hardcoding the number.
+
+- [ ] **Step 2: Reuse or create one issue per viable row that does not already have an adopted PR**
+
+Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
+matching exact issue title and search query:
+
+```bash
+case "$WORKSTREAM_ID" in
+  mobile-memory-gateway)
+    ISSUE_TITLE="Recover mobile pairing workstream"
+    ISSUE_SEARCH='"mobile pairing"'
+    ;;
+  feat-npm-macos-x64)
+    ISSUE_TITLE="Recover Intel macOS npm packaging workstream"
+    ISSUE_SEARCH='"Intel macOS" npm'
+    ;;
+  fix-521-ward-surface-confinement)
+    ISSUE_TITLE="Recover Ward surface confinement workstream"
+    ISSUE_SEARCH='"Ward surface confinement"'
+    ;;
+  memory-promote)
+    ISSUE_TITLE="Recover memory promotion workstream"
+    ISSUE_SEARCH='"memory promotion"'
+    ;;
+  docs-psyche-specs)
+    ISSUE_TITLE="Recover Psyche specification workstream"
+    ISSUE_SEARCH='"Psyche" specs'
+    ;;
+  docs-universal-runtime-capability-design)
+    ISSUE_TITLE="Recover universal runtime capability design workstream"
+    ISSUE_SEARCH='"universal runtime" capability'
+    ;;
+  pr-476-review)
+    ISSUE_TITLE="Recover runtime model parity plan workstream"
+    ISSUE_SEARCH='"runtime model parity"'
+    ;;
+  *)
+    printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
+    exit 1
+    ;;
+esac
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
+mkdir -p "$RECOVERY"
+ISSUE_SEARCH_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-search.json"
+ISSUE_VIEW_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-view.json"
+gh issue list \
+  --repo OpenCoven/coven \
+  --state all \
+  --search "$ISSUE_SEARCH" \
+  --json number,title,url,state > "$ISSUE_SEARCH_EVIDENCE"
+ISSUE_COUNT="$(jq 'length' "$ISSUE_SEARCH_EVIDENCE")"
+```
+
+If exactly one accurate issue already exists, reuse it without creating a
+duplicate:
+
+```bash
+case "$ISSUE_COUNT" in
+  1)
+    ISSUE_NUMBER="$(jq -r '.[0].number' "$ISSUE_SEARCH_EVIDENCE")"
+    gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+      --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
+    ;;
+esac
+```
+
+If zero issues match, create one and verify it immediately:
 
 ```markdown
 ## Recovered source
@@ -708,7 +807,9 @@ If no issue accurately owns the concern, create one and verify it immediately:
 ```
 
 ```bash
-ISSUE_BODY="$(cat <<'EOF'
+case "$ISSUE_COUNT" in
+  0)
+    ISSUE_BODY="$(cat <<'EOF'
 ## Recovered source
 
 - Source issue: #541
@@ -722,17 +823,24 @@ ISSUE_BODY="$(cat <<'EOF'
 - Pass all repository-required gates.
 EOF
 )"
-ISSUE_URL="$(gh issue create --repo OpenCoven/coven --title "$ISSUE_TITLE" --body "$ISSUE_BODY")"
-ISSUE_NUMBER="${ISSUE_URL##*/}"
-gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
-  --json number,state,title,url
+    ISSUE_URL="$(gh issue create --repo OpenCoven/coven --title "$ISSUE_TITLE" --body "$ISSUE_BODY")"
+    ISSUE_NUMBER="${ISSUE_URL##*/}"
+    gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+      --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
+    ;;
+esac
 ```
 
-Expected: every viable row has exactly one issue number.
+If more than one issue matches, change that row to `blocked`, cite
+`$ISSUE_SEARCH_EVIDENCE`, and stop rather than choosing one arbitrarily.
 
-- [ ] **Step 2: Create one approved design per viable issue**
+Expected: every viable row without an adopted PR has exactly one verified issue
+number, and every reuse or block decision cites a saved JSON evidence file.
 
-Use the brainstorming workflow separately for each issue. The design must name:
+- [ ] **Step 3: Create one approved design per viable issue**
+
+Use the brainstorming workflow separately for each issue that reached Step 2
+without being blocked. The design must name:
 
 - the current-main files and contracts involved;
 - the exact portion of the preserved source that remains valid;
@@ -740,16 +848,18 @@ Use the brainstorming workflow separately for each issue. The design must name:
 - test and migration behavior;
 - one-concern pull-request boundaries.
 
-Expected: each viable concern has an approved and committed design document.
+Expected: each viable concern that is not already continuing an adopted PR has
+an approved and committed design document.
 
-- [ ] **Step 3: Create one implementation plan per approved design**
+- [ ] **Step 4: Create one implementation plan per approved design**
 
-Use the writing-plans workflow separately for each approved design. Each plan
-must include exact paths, failing tests, targeted commands, full repository
-gates, commit boundaries, explicit `git commit -s` usage, the session-required
-Copilot co-author trailer on child commits, push, and PR creation. Human
-contributor `Co-authored-by:` trailers remain conditional under `AGENTS.md`
-and are separate from the required Copilot trailer.
+Use the writing-plans workflow separately for each approved design that reached
+Step 3 without being blocked. Each plan must include exact paths, failing
+tests, targeted commands, full repository gates, commit boundaries, explicit
+`git commit -s` usage, the session-required Copilot co-author trailer on child
+commits, push, and PR creation. Human contributor `Co-authored-by:` trailers
+remain conditional under `AGENTS.md` and are separate from the required
+Copilot trailer.
 
 Every child plan must reuse this exact child-commit pattern, replacing only
 the commit message and adding any conditional human contributor trailers as
@@ -763,14 +873,14 @@ COPILOT_TRAILER="Co-authored-by: $COPILOT_GH_USER <${COPILOT_GH_ID}+${COPILOT_GH
 git commit -s --trailer "$COPILOT_TRAILER" -m "<child commit message>"
 ```
 
-Expected: independent plans exist for mobile pairing, Intel macOS packaging,
-Ward confinement, memory promotion, Psyche specifications, universal runtime
-design, or runtime parity only when their ledger row is `viable`.
+Expected: independent plans exist only for viable rows that are not already
+continuing an adopted exact-head PR.
 
-- [ ] **Step 4: Recover and publish each viable concern sequentially**
+- [ ] **Step 5: Recover and publish each viable concern sequentially**
 
-For each viable row, set `ISSUE_NUMBER` to its created or reused issue number
-and set `BRANCH_SLUG` from this fixed mapping:
+Skip this step for any row whose Task 5 Step 1 action is `continue existing PR`.
+For each remaining viable row, set `ISSUE_NUMBER` to its created or reused
+issue number and set `BRANCH_SLUG` from this fixed mapping:
 
 ```text
 mobile-memory-gateway -> mobile-pairing-recovery
@@ -826,11 +936,11 @@ coven claim release "issue-$ISSUE_NUMBER"
 ```
 
 Execute that issue's plan, run its full gates, commit each child change with
-the Task 5 Step 3 trailer pattern, add human contributor co-author trailers
+the Task 5 Step 4 trailer pattern, add human contributor co-author trailers
 only when `AGENTS.md` requires them, push, and open its scoped pull request.
 
-Expected: every viable row links to one open pull request from a current-main
-branch.
+Expected: every viable row either continues one adopted exact-head open pull
+request or links to one open pull request from a current-main recovery branch.
 
 ### Task 6: Record Non-Viable Outcomes
 
@@ -955,12 +1065,15 @@ Do not use `--force`. Any non-empty status blocks removal.
 
 - [ ] **Step 4: Retire the original dirty source worktrees only after proof checks**
 
-These four source worktrees remain intentionally dirty until their proof is
-complete. `git worktree remove --force` is allowed only in this step, only for
-these four exact paths, and only after the worktree and index patch evidence,
-verified branch bundle, untracked inventory, terminal ledger classification,
-and either an open replacement PR or recorded non-viable/blocker evidence are
-all present. Unrelated or unsnapshotted worktrees must never use force.
+These four source worktrees remain intentionally present until their proof is
+complete. Their runtime dirtiness may change after snapshotting—for example, a
+formerly dirty tree may now be clean because its changes were committed to an
+accurate active PR. `git worktree remove --force` is allowed only in this
+step, only for these four exact paths, and only after the worktree and index
+patch evidence, verified branch bundle, untracked inventory, terminal ledger
+classification, and either an adopted exact-head open PR, an open replacement
+PR, or recorded non-viable/blocker evidence are all present. Unrelated or
+unsnapshotted worktrees must never use force.
 
 Run:
 
@@ -983,10 +1096,10 @@ do
 done
 ```
 
-If a row is `viable`, confirm its classification row cites the open replacement
-PR URL before removal. Otherwise confirm the row already records its
-`already-shipped`, `superseded`, or `blocked` evidence. Then remove only the
-four original dirty source worktrees:
+If a row is `viable`, confirm its classification row cites either the adopted
+exact-head PR URL or the open replacement PR URL before removal. Otherwise
+confirm the row already records its `already-shipped`, `superseded`, or
+`blocked` evidence. Then remove only the four original dirty source worktrees:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -192,9 +192,11 @@ printf 'docs-psyche-specs\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
 ```
 
 Expected: `branch.bundle` verifies against `docs/psyche-specs`, preserving its
-committed history before any later branch deletion; both patch files exist; and
-the copied untracked tree contains `specs/psyche/COVEN_PREREQUISITES.md`,
-`specs/psyche/PLAN.md`, and the Psyche reconciliation plan.
+committed history before any later branch deletion; both patch files exist;
+`index.patch` preserves the staged additions for
+`specs/psyche/COVEN_PREREQUISITES.md`, `specs/psyche/PLAN.md`, and the Psyche
+reconciliation plan; and any copied untracked files match only the paths listed
+in `untracked-files.txt`.
 
 - [ ] **Step 3: Snapshot `feat-cmem-1ev-memory-promote`**
 
@@ -501,18 +503,20 @@ classes are valid and remain as existing zero-byte files.
 
 Create `.git/agent-recovery/issue-541/classification.md` with a five-column
 table headed `Workstream`, `Classification`, `Main/PR evidence`,
-`Preserved source`, and `Recovery action`. Include exactly these seven rows:
+`Preserved source`, and `Recovery action`. Initialize it as:
 
 ```markdown
 # Issue 541 Recovery Classification
 
-docs-psyche-specs
-memory-promote
-mobile-memory-gateway
-pr-476-review
-docs-universal-runtime-capability-design
-feat-npm-macos-x64
-fix-521-ward-surface-confinement
+| Workstream | Classification | Main/PR evidence | Preserved source | Recovery action |
+| --- | --- | --- | --- | --- |
+| docs-psyche-specs | pending | Pending Task 4 Step 2 evidence review. | dirty/docs-psyche-specs | Pending Task 4 Step 4 classification. |
+| memory-promote | pending | Pending Task 4 Step 2 evidence review. | dirty/memory-promote | Pending Task 4 Step 4 classification. |
+| mobile-memory-gateway | pending | Pending Task 4 Step 2 evidence review. | dirty/mobile-memory-gateway | Pending Task 4 Step 4 classification. |
+| pr-476-review | pending | Pending Task 4 Step 2 evidence review. | dirty/pr-476-review | Pending Task 4 Step 4 classification. |
+| docs-universal-runtime-capability-design | pending | Pending Task 4 Step 2 evidence review. | branches/docs-universal-runtime-capability-design.bundle | Pending Task 4 Step 4 classification. |
+| feat-npm-macos-x64 | pending | Pending Task 4 Step 2 evidence review. | branches/feat-npm-macos-x64.bundle | Pending Task 4 Step 4 classification. |
+| fix-521-ward-surface-confinement | pending | Pending Task 4 Step 2 evidence review. | branches/fix-521-ward-surface-confinement.bundle | Pending Task 4 Step 4 classification. |
 ```
 
 Write the selected classification, concrete commit/PR/issue/path evidence,
@@ -548,7 +552,9 @@ blocked:
   or an unresolved contract choice that cannot be inferred safely.
 ```
 
-Expected: every row has exactly one classification and one next action.
+Expected: Task 4 Step 4 replaces every `pending` row with exactly one terminal
+classification (`already-shipped`, `superseded`, `viable`, or `blocked`) and
+one next action before Task 4 Step 5 and Task 9 Step 1 verification.
 
 - [ ] **Step 5: Review the ledger against the manifest**
 
@@ -1016,8 +1022,14 @@ coven claim status
 gh pr list --state open --limit 100
 ```
 
-Expected: the primary checkout is clean on `main`; all remaining worktrees,
-claims, and open PRs correspond to documented active recovery work.
+Document every remaining recovery-owned worktree, claim, and open PR from these
+outputs. If unrelated active worktrees, claims, or PRs also appear, identify
+them generically as out-of-scope ongoing work and leave them untouched.
+
+Expected: the primary checkout is clean on `main`; every remaining
+recovery-owned worktree, claim, and open PR is documented; and unrelated active
+worktrees, claims, and PRs remain allowed when they are explicitly marked
+out-of-scope rather than removed or treated as audit failures.
 
 - [ ] **Step 4: Reject unsanitized local paths before posting the ledger**
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -145,7 +145,7 @@ coven claim status
 gh pr list --repo OpenCoven/coven --state open --limit 100
 CONTROL_WORKTREE="$(
   git -C "$REPO" worktree list --porcelain | awk -v branch="refs/heads/$CONTROL_BRANCH" '
-    $1 == "worktree" { path = $2 }
+    $1 == "worktree" { path = substr($0, 10) }
     $1 == "branch" && $2 == branch { print path; exit }
   '
 )"
@@ -215,7 +215,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -250,7 +250,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -286,7 +286,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -327,7 +327,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -358,7 +358,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -407,7 +407,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -463,7 +463,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -541,7 +541,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -618,7 +618,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -694,7 +694,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -769,7 +769,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -896,7 +896,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -940,7 +940,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -974,7 +974,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -1033,7 +1033,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -1080,7 +1080,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -1228,7 +1228,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -1279,7 +1279,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -1678,7 +1678,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2026,7 +2026,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2164,7 +2164,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2346,7 +2346,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2379,7 +2379,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2419,7 +2419,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2457,7 +2457,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2512,7 +2512,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2566,7 +2566,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2737,7 +2737,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2843,7 +2843,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -2970,7 +2970,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3008,7 +3008,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3072,7 +3072,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3112,7 +3112,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3155,7 +3155,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3189,7 +3189,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3326,7 +3326,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3368,7 +3368,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3415,7 +3415,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"
@@ -3450,7 +3450,7 @@ resolve_control_worktree() {
   repo="$(cd "$start_common_dir/.." && pwd)"
   control_worktree="$(
     git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
-      $1 == "worktree" { path = $2 }
+      $1 == "worktree" { path = substr($0, 10) }
       $1 == "branch" && $2 == branch { print path; exit }
     '
   )"

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -64,16 +64,35 @@ No production file is modified during preservation or classification.
 - Existing: `docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md`
 - Create: `docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md`
 
-- [ ] **Step 1: Confirm the design worktree is clean except for the plan**
+- [ ] **Step 1: Check claim state, check open pull requests, acquire `issue-541`, and confirm the design worktree state**
 
 Run:
 
 ```bash
-git -C /tmp/coven-issue-541 status --short --branch
+cd /tmp/coven-issue-541
+coven claim status
+gh pr list --repo OpenCoven/coven --state open --limit 100
+coven claim acquire issue-541
+git status --short --branch
 ```
 
-Expected: branch `docs/541-incomplete-work-recovery-design`, with only the plan
-file untracked before it is staged.
+Expected: the shared claim registry and open PR set are reviewed before any
+publication or recovery action; `issue-541` is actively claimed from
+`/tmp/coven-issue-541`; and branch
+`docs/541-incomplete-work-recovery-design` shows only the plan file untracked
+before it is staged.
+
+If this publication session or the later recovery session runs long, keep the
+parent claim alive from `/tmp/coven-issue-541`:
+
+```bash
+cd /tmp/coven-issue-541
+coven claim heartbeat issue-541
+```
+
+Do not release `issue-541` after PR creation. Keep it active until this
+recovery session stops or the full issue #541 recovery effort is complete, then
+release it from `/tmp/coven-issue-541` with `coven claim release issue-541`.
 
 - [ ] **Step 2: Run document safety checks**
 
@@ -392,10 +411,11 @@ Run:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
-git bundle verify "$RECOVERY/branches/docs-universal-runtime-capability-design.bundle"
-git bundle verify "$RECOVERY/branches/feat-npm-macos-x64.bundle"
-git bundle verify "$RECOVERY/branches/fix-521-ward-surface-confinement.bundle"
+git -C "$REPO" bundle verify "$RECOVERY/branches/docs-universal-runtime-capability-design.bundle"
+git -C "$REPO" bundle verify "$RECOVERY/branches/feat-npm-macos-x64.bundle"
+git -C "$REPO" bundle verify "$RECOVERY/branches/fix-521-ward-surface-confinement.bundle"
 ```
 
 Expected: Git reports each bundle is okay and lists its branch ref.
@@ -618,7 +638,8 @@ Expected: every workstream appears in both files.
 
 - [ ] **Step 1: Create or identify one issue per viable row**
 
-Use the matching exact query for each viable row:
+Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
+matching exact query:
 
 ```bash
 gh issue list --repo OpenCoven/coven --state all --search '"mobile pairing"' --limit 20
@@ -630,12 +651,53 @@ gh issue list --repo OpenCoven/coven --state all --search '"universal runtime" c
 gh issue list --repo OpenCoven/coven --state all --search '"runtime model parity"' --limit 20
 ```
 
-If no issue accurately owns the concern, create one whose body includes:
+Then set the issue title from this fixed mapping:
+
+```bash
+case "$WORKSTREAM_ID" in
+  mobile-memory-gateway)
+    ISSUE_TITLE="Recover mobile pairing workstream"
+    ;;
+  feat-npm-macos-x64)
+    ISSUE_TITLE="Recover Intel macOS npm packaging workstream"
+    ;;
+  fix-521-ward-surface-confinement)
+    ISSUE_TITLE="Recover Ward surface confinement workstream"
+    ;;
+  memory-promote)
+    ISSUE_TITLE="Recover memory promotion workstream"
+    ;;
+  docs-psyche-specs)
+    ISSUE_TITLE="Recover Psyche specification workstream"
+    ;;
+  docs-universal-runtime-capability-design)
+    ISSUE_TITLE="Recover universal runtime capability design workstream"
+    ;;
+  pr-476-review)
+    ISSUE_TITLE="Recover runtime model parity plan workstream"
+    ;;
+  *)
+    printf 'Unknown WORKSTREAM_ID: %s\n' "$WORKSTREAM_ID" >&2
+    exit 1
+    ;;
+esac
+```
+
+If an accurate issue already exists, reuse it without creating a duplicate:
+
+```bash
+ISSUE_NUMBER=<existing issue number>
+gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+  --json number,state,title,url
+```
+
+If no issue accurately owns the concern, create one and verify it immediately:
 
 ```markdown
 ## Recovered source
 
-Issue #541 recovery archive and classification ledger.
+- Source issue: #541
+- Source artifacts: issue-541 recovery archive and classification ledger.
 
 ## Acceptance criteria
 
@@ -643,6 +705,27 @@ Issue #541 recovery archive and classification ledger.
 - Rebuild against current `origin/main`; do not blindly replay obsolete code.
 - Add or retain regression coverage for the recovered behavior.
 - Pass all repository-required gates.
+```
+
+```bash
+ISSUE_BODY="$(cat <<'EOF'
+## Recovered source
+
+- Source issue: #541
+- Source artifacts: issue-541 recovery archive and classification ledger.
+
+## Acceptance criteria
+
+- Preserve the still-valid intent identified in the classification evidence.
+- Rebuild against current `origin/main`; do not blindly replay obsolete code.
+- Add or retain regression coverage for the recovered behavior.
+- Pass all repository-required gates.
+EOF
+)"
+ISSUE_URL="$(gh issue create --repo OpenCoven/coven --title "$ISSUE_TITLE" --body "$ISSUE_BODY")"
+ISSUE_NUMBER="${ISSUE_URL##*/}"
+gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+  --json number,state,title,url
 ```
 
 Expected: every viable row has exactly one issue number.
@@ -723,6 +806,23 @@ git -C "$REPO" worktree add \
   origin/main
 cd "$RECOVERY_WORKTREE"
 coven claim acquire "issue-$ISSUE_NUMBER"
+```
+
+For long child recovery sessions, keep the child claim alive from that child
+worktree:
+
+```bash
+cd "$RECOVERY_WORKTREE"
+coven claim heartbeat "issue-$ISSUE_NUMBER"
+```
+
+Keep that child claim active after PR creation while follow-up commits, review
+responses, or final verification continue in the same session. Release it only
+when that pull request merges or the owning recovery session stops:
+
+```bash
+cd "$RECOVERY_WORKTREE"
+coven claim release "issue-$ISSUE_NUMBER"
 ```
 
 Execute that issue's plan, run its full gates, commit each child change with
@@ -930,22 +1030,34 @@ git -C "$REPO" branch -D "$BRANCH_TO_DELETE"
 only after confirming its source worktree is already removed and its verified
 snapshot bundle or pushed replacement branch still proves the committed history.
 
-- [ ] **Step 6: Release stopped recovery claims**
+- [ ] **Step 6: Release only merged or stopped recovery claims**
 
-After each child pull request is opened, release its claim from that worktree:
+For any child recovery workstream whose PR has merged or whose owning recovery
+session has stopped, release its claim from that child worktree:
 
 ```bash
+cd "$RECOVERY_WORKTREE"
 coven claim release "issue-$ISSUE_NUMBER"
 ```
 
-Release the design claim when issue #541 work stops:
+Keep child claims active while follow-up work for an open PR continues. During
+long-running follow-up from that worktree, use:
+
+```bash
+cd "$RECOVERY_WORKTREE"
+coven claim heartbeat "issue-$ISSUE_NUMBER"
+```
+
+Release the parent `issue-541` claim only when the issue #541 recovery session
+stops or the full issue #541 recovery effort is complete:
 
 ```bash
 cd /tmp/coven-issue-541
 coven claim release issue-541
 ```
 
-Expected: `coven claim status` has no abandoned active claim.
+Expected: `coven claim status` shows no abandoned claim; active claims remain
+allowed only for still-running recovery sessions and open follow-up work.
 
 ### Task 8: Reconcile Repository Goals
 

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -13,10 +13,13 @@
 ## File and Artifact Map
 
 - Create: `.git/agent-recovery/issue-541/manifest.tsv`
-  - Immutable inventory of source worktrees, branches, heads, bases, and snapshot paths.
+  - Private immutable inventory of source worktrees, branches, heads, bases,
+    and snapshot paths. Local absolute paths stay here and in private snapshot
+    artifacts only.
 - Create: `.git/agent-recovery/issue-541/classification.md`
-  - Evidence ledger assigning each workstream `already-shipped`, `superseded`,
-    `viable`, or `blocked`.
+  - Sanitized evidence ledger assigning each workstream `already-shipped`,
+    `superseded`, `viable`, or `blocked`. GitHub-visible `Preserved source`
+    values use archive IDs only, never local absolute paths.
 - Create: `.git/agent-recovery/issue-541/dirty/docs-psyche-specs/`
 - Create: `.git/agent-recovery/issue-541/dirty/memory-promote/`
 - Create: `.git/agent-recovery/issue-541/dirty/mobile-memory-gateway/`
@@ -96,7 +99,10 @@ cd /tmp/coven-issue-541
 git commit -s -m "docs: plan incomplete work recovery"
 ```
 
-Expected: a commit containing only the implementation plan.
+Expected: a commit containing only the implementation plan and the
+repository-required DCO sign-off plus the session-required Copilot co-author
+trailer. Human contributor co-author trailers remain conditional under
+`AGENTS.md` and are separate from the required Copilot trailer.
 
 - [ ] **Step 4: Push the design branch**
 
@@ -149,7 +155,9 @@ printf 'id\ttype\tsource\thead\tmerge_base\tsnapshot\n' > "$RECOVERY/manifest.ts
 ```
 
 Expected: the recovery root exists under
-`$COMMON_DIR/agent-recovery/issue-541`.
+`$COMMON_DIR/agent-recovery/issue-541`, and that fetched `origin/main`
+becomes the baseline for every Task 2 and Task 3 `merge_base` record. Task 4
+may fetch `origin/main` again before classification.
 
 - [ ] **Step 2: Snapshot `docs-psyche-specs`**
 
@@ -409,6 +417,8 @@ done
 ```
 
 Expected: `manifest.tsv` has seven data rows plus its header.
+Every Task 3 `merge_base` value still uses the `origin/main` fetched in Task 2
+Step 1.
 
 ### Task 4: Build the Classification Ledger
 
@@ -506,9 +516,14 @@ fix-521-ward-surface-confinement
 ```
 
 Write the selected classification, concrete commit/PR/issue/path evidence,
-preserved source path, and deterministic recovery action directly into each
-row. A row is not complete until another engineer can reproduce its
-classification from the cited source.
+sanitized preserved-source archive ID, and deterministic recovery action
+directly into each row. Use `Preserved source` values such as
+`dirty/docs-psyche-specs`, `dirty/memory-promote`, or
+`branches/feat-npm-macos-x64.bundle`; never write expanded `$REPO`,
+`$COMMON_DIR`, `/tmp`, `/private`, `/Users`, or `/home` paths into
+`classification.md`. Local absolute paths belong only in `manifest.tsv` and
+private snapshot artifacts. A row is not complete until another engineer can
+reproduce its classification from the cited source.
 
 - [ ] **Step 4: Apply the classification rules**
 
@@ -611,7 +626,10 @@ Expected: each viable concern has an approved and committed design document.
 
 Use the writing-plans workflow separately for each approved design. Each plan
 must include exact paths, failing tests, targeted commands, full repository
-gates, commit boundaries, push, and PR creation.
+gates, commit boundaries, explicit `git commit -s` usage, the session-required
+Copilot co-author trailer on child commits, push, and PR creation. Human
+contributor `Co-authored-by:` trailers remain conditional under `AGENTS.md`
+and are separate from the required Copilot trailer.
 
 Expected: independent plans exist for mobile pairing, Intel macOS packaging,
 Ward confinement, memory promotion, Psyche specifications, universal runtime
@@ -658,8 +676,10 @@ cd "$RECOVERY_WORKTREE"
 coven claim acquire "issue-$ISSUE_NUMBER"
 ```
 
-Execute that issue's plan, run its full gates, commit with the required Copilot
-co-author trailer, push, and open its scoped pull request.
+Execute that issue's plan, run its full gates, commit with `git commit -s`,
+include the session-required Copilot co-author trailer on each child commit,
+add human contributor co-author trailers only when `AGENTS.md` requires them,
+push, and open its scoped pull request.
 
 Expected: every viable row links to one open pull request from a current-main
 branch.
@@ -999,10 +1019,37 @@ gh pr list --state open --limit 100
 Expected: the primary checkout is clean on `main`; all remaining worktrees,
 claims, and open PRs correspond to documented active recovery work.
 
-- [ ] **Step 4: Update issue #541**
+- [ ] **Step 4: Reject unsanitized local paths before posting the ledger**
 
-Post a comment containing the classification table, recovery PR links,
-non-viable evidence, and remaining human blockers:
+Run:
+
+```bash
+COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
+python3 - "$CLASSIFICATION" "$REPO" "$COMMON_DIR" <<'PY'
+from pathlib import Path
+import sys
+
+classification = Path(sys.argv[1]).read_text()
+blocked_prefixes = [sys.argv[2], sys.argv[3], "/tmp", "/private", "/Users", "/home"]
+hits = [prefix for prefix in blocked_prefixes if prefix and prefix in classification]
+if hits:
+    raise SystemExit(
+        "classification.md contains unsanitized local path prefix(es): "
+        + ", ".join(hits)
+    )
+PY
+```
+
+Expected: the command exits zero only when `classification.md` contains
+sanitized archive IDs and no local absolute path prefixes.
+
+- [ ] **Step 5: Update issue #541**
+
+Post a comment containing the sanitized classification table, recovery PR
+links, non-viable evidence, and remaining human blockers. Do not post
+`manifest.tsv` or raw snapshot files:
 
 ```bash
 COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
@@ -1010,9 +1057,10 @@ gh issue comment 541 --body-file \
   "$COMMON_DIR/agent-recovery/issue-541/classification.md"
 ```
 
-Expected: issue #541 contains the durable GitHub-visible recovery ledger.
+Expected: issue #541 contains the durable GitHub-visible recovery ledger sourced
+from the sanitized `classification.md`.
 
-- [ ] **Step 5: Close issue #541 when all machine work is delivered**
+- [ ] **Step 6: Close issue #541 when all machine work is delivered**
 
 Close only after every viable concern has an open PR and all local residue has
 been safely preserved or cleaned:

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -260,6 +260,7 @@ parent claim alive from the discovered controller worktree by re-resolving it
 instead of assuming shell variables persist:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -353,6 +354,7 @@ issue-541`.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -447,6 +449,7 @@ file, and the privacy guard reports one staged plan file.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -546,6 +549,7 @@ trailer. Human contributor co-author trailers remain conditional under
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -635,6 +639,7 @@ Expected: the remote branch is created successfully.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -856,6 +861,7 @@ again before classification.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -992,6 +998,7 @@ post-commit state.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1104,9 +1111,6 @@ raw = Path(sys.argv[1]).read_bytes()
 entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
 print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
 PY
-```
-
-```bash
 printf 'memory-promote\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$SOURCE" \
   "$(cat "$DEST/head.txt")" \
@@ -1127,6 +1131,7 @@ captured only in `.ignored.zlist` and `ignored.json`.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1239,9 +1244,6 @@ raw = Path(sys.argv[1]).read_bytes()
 entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
 print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
 PY
-```
-
-```bash
 printf 'mobile-memory-gateway\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$SOURCE" \
   "$(cat "$DEST/head.txt")" \
@@ -1261,6 +1263,7 @@ while ignored paths remain inventory-only.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1373,9 +1376,6 @@ raw = Path(sys.argv[1]).read_bytes()
 entries = [] if not raw else raw.rstrip(b"\0").split(b"\0")
 print(json.dumps([entry.decode("utf-8", "surrogateescape") for entry in entries], indent=2))
 PY
-```
-
-```bash
 printf 'pr-476-review\tdirty-worktree\t%s\t%s\t%s\t%s\n' \
   "$SOURCE" \
   "$(cat "$DEST/head.txt")" \
@@ -1394,6 +1394,7 @@ paths remain captured only in `.ignored.zlist` and `ignored.json`.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1579,6 +1580,7 @@ archive.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1681,6 +1683,7 @@ Expected: three bundle files and three metadata directories are created.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1773,6 +1776,7 @@ Expected: Git reports each bundle is okay and lists its branch ref.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -1985,6 +1989,7 @@ flow.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -2297,11 +2302,6 @@ if ! {
   exit 0
 fi
 PR_COUNT="$(jq 'length' "$OPEN_PR_EVIDENCE")"
-```
-
-Then branch on the exact-source-branch result:
-
-```bash
 case "$PR_COUNT" in
   1)
     printf 'Same-repo exact-head open PR count: 1\n' >> "$BRANCH_FETCH_EVIDENCE"
@@ -2551,6 +2551,7 @@ Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
 matching exact issue title:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -2695,6 +2696,7 @@ ISSUE_BLOCKER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issue-blocker.txt"
 ISSUE_LEDGER_EVIDENCE="$RECOVERY/$WORKSTREAM_ID-issues.json"
 ISSUE_LEDGER_STAGE="$PRIVATE_RECOVERY/issue-ledger-refresh/$WORKSTREAM_ID-issues.stage.json"
 ISSUE_POSTCONDITION_STAGE="$PRIVATE_RECOVERY/issue-ledger-refresh/$WORKSTREAM_ID-issue-postcondition.stage.json"
+ISSUE_CREATED_BY_RUN=false
 rm -f "$ISSUE_LEDGER_STAGE"
 if ! gh api --paginate --slurp \
   "repos/OpenCoven/coven/issues?state=all&per_page=100" \
@@ -2765,33 +2767,26 @@ jq --arg title "$ISSUE_TITLE" \
   '[.[] | .[] | select(.pull_request? | not) | select(.title == $title and .state == "open") | {number, title, url, state}]' \
   "$ISSUE_LEDGER_EVIDENCE" > "$ISSUE_SEARCH_EVIDENCE"
 ISSUE_COUNT="$(jq 'length' "$ISSUE_SEARCH_EVIDENCE")"
-```
-
-Immediately before every exact-title reuse/create decision, refresh the fully
-paginated shared `issue-541/issues.json` ledger into
-`private/issue-ledger-refresh/$WORKSTREAM_ID-issues.stage.json`. If `gh api`
-fails, preserve the existing `issue-541/issues.json`, remove the staging file,
-persist blocker evidence, and stop that row. Only a non-empty JSON value that
-passes `jq -e 'type == "array" and length > 0 and all(.[]; type == "array")'` may replace the
-shared ledger, and that replacement must happen atomically with `mv`. Only
-after the verified shared ledger is in place may the plan copy it to
-`viable/$WORKSTREAM_ID-issues.json`, filter exact-title non-PR `open` matches,
-and count them. Each workstream's `viable/$WORKSTREAM_ID-issue-search.json`
-stores only the filtered matches from that verified persisted ledger, so
-default-limited `gh issue list` output never drives reuse, and a refresh
-failure never truncates the last known-good shared ledger. A sole unrelated or
-closed result in the refreshed ledger leaves `ISSUE_COUNT=0` and must not be
-reused.
-
-If exactly one exact-title open issue already exists, reuse it without creating
-a duplicate:
-
-```bash
 case "$ISSUE_COUNT" in
   1)
     ISSUE_NUMBER="$(jq -r '.[0].number' "$ISSUE_SEARCH_EVIDENCE")"
-    gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+    if ! gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
       --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
+    then
+      {
+        printf 'Blocked %s: exact-title candidate issue #%s could not be read for verification.\n' \
+          "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+        printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Persisted live issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+        printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
+        printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
+      } > "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Issue verification read failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: candidate issue could not be read before exact-title verification."
+      exit 0
+    fi
     if ! jq -e --arg title "$ISSUE_TITLE" \
       '.title == $title and .state == "OPEN"' \
       "$ISSUE_VIEW_EVIDENCE" > /dev/null
@@ -2812,25 +2807,6 @@ case "$ISSUE_COUNT" in
     fi
     ;;
 esac
-```
-
-If zero issues match, create one and verify it immediately:
-
-```markdown
-## Recovered source
-
-- Source issue: #541
-- Source artifacts: issue-541 recovery archive and classification ledger.
-
-## Acceptance criteria
-
-- Preserve the still-valid intent identified in the classification evidence.
-- Rebuild against current `origin/main`; do not blindly replay obsolete code.
-- Add or retain regression coverage for the recovered behavior.
-- Pass all repository-required gates.
-```
-
-```bash
 case "$ISSUE_COUNT" in
   0)
     ISSUE_BODY="$(cat <<'EOF'
@@ -2847,10 +2823,39 @@ case "$ISSUE_COUNT" in
 - Pass all repository-required gates.
 EOF
 )"
-    ISSUE_URL="$(gh issue create --repo OpenCoven/coven --title "$ISSUE_TITLE" --body "$ISSUE_BODY")"
+    if ! ISSUE_URL="$(gh issue create --repo OpenCoven/coven --title "$ISSUE_TITLE" --body "$ISSUE_BODY")"; then
+      {
+        printf 'Blocked %s: gh issue create failed for exact title %s.\n' \
+          "$WORKSTREAM_ID" "$ISSUE_TITLE"
+        printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Persisted live issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+        printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
+      } > "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Issue creation failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: gh issue create failed during exact-title recovery issue creation."
+      exit 0
+    fi
     ISSUE_NUMBER="${ISSUE_URL##*/}"
-    gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+    ISSUE_CREATED_BY_RUN=true
+    if ! gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
       --json number,state,title,url > "$ISSUE_VIEW_EVIDENCE"
+    then
+      {
+        printf 'Blocked %s: created issue #%s could not be read for verification.\n' \
+          "$WORKSTREAM_ID" "$ISSUE_NUMBER"
+        printf 'Task 4 paginated issue evidence: issue-541/issues.json\n'
+        printf 'Persisted live issue ledger: viable/%s-issues.json\n' "$WORKSTREAM_ID"
+        printf 'Filtered issue evidence: viable/%s-issue-search.json\n' "$WORKSTREAM_ID"
+        printf 'Issue view evidence: viable/%s-issue-view.json\n' "$WORKSTREAM_ID"
+      } > "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Created issue verification read failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issues.json, viable/$WORKSTREAM_ID-issue-search.json, viable/$WORKSTREAM_ID-issue-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: created issue could not be read before exact-title verification."
+      exit 0
+    fi
     if ! jq -e --arg title "$ISSUE_TITLE" \
       '.title == $title and .state == "OPEN"' \
       "$ISSUE_VIEW_EVIDENCE" > /dev/null
@@ -2949,10 +2954,57 @@ then
     printf 'Postcondition paginated issue evidence: viable/%s-issue-postcondition.json\n' "$WORKSTREAM_ID"
     printf 'Postcondition filtered issue evidence: viable/%s-issue-postcondition-search.json\n' "$WORKSTREAM_ID"
     printf 'Postcondition issue view evidence: viable/%s-issue-postcondition-view.json\n' "$WORKSTREAM_ID"
+    printf 'Issue created by this run: %s\n' "$ISSUE_CREATED_BY_RUN"
   } > "$ISSUE_BLOCKER_EVIDENCE"
+  if [ "$ISSUE_CREATED_BY_RUN" = true ]; then
+    RACE_CLOSE_COMMENT='Closing as superseded after race-detected exact-title duplicate during issue-541 recovery reconciliation.'
+    printf 'Race cleanup required: this run created issue #%s.\n' "$ISSUE_NUMBER" >> "$ISSUE_BLOCKER_EVIDENCE"
+    printf 'Race cleanup comment: %s\n' "$RACE_CLOSE_COMMENT" >> "$ISSUE_BLOCKER_EVIDENCE"
+    if ! gh issue close --repo OpenCoven/coven "$ISSUE_NUMBER" --comment "$RACE_CLOSE_COMMENT" \
+      >> "$ISSUE_BLOCKER_EVIDENCE" 2>&1
+    then
+      printf 'Race cleanup blocked: gh issue close failed for created issue #%s.\n' "$ISSUE_NUMBER" \
+        >> "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Issue postcondition mismatch and created-issue cleanup failed; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-postcondition-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: race-detected duplicate issue cleanup failed after exact-title creation."
+      exit 0
+    fi
+    if ! gh issue view --repo OpenCoven/coven "$ISSUE_NUMBER" \
+      --json number,state,title,url > "$ISSUE_POSTCONDITION_VIEW_EVIDENCE" 2>> "$ISSUE_BLOCKER_EVIDENCE"
+    then
+      printf 'Race cleanup blocked: could not verify CLOSED state for created issue #%s.\n' "$ISSUE_NUMBER" \
+        >> "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Issue postcondition mismatch and created-issue closure could not be verified; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-postcondition-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: race-detected duplicate issue closure could not be verified as CLOSED."
+      exit 0
+    fi
+    if ! jq -e '.state == "CLOSED"' "$ISSUE_POSTCONDITION_VIEW_EVIDENCE" > /dev/null
+    then
+      printf 'Race cleanup blocked: created issue #%s did not verify CLOSED after gh issue close.\n' "$ISSUE_NUMBER" \
+        >> "$ISSUE_BLOCKER_EVIDENCE"
+      update_classification_row \
+        "blocked" \
+        "Issue postcondition mismatch and created issue remained open after cleanup attempt; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-postcondition-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+        "Blocked: race-detected duplicate issue did not verify CLOSED after cleanup."
+      exit 0
+    fi
+    printf 'Race cleanup outcome: created issue #%s verified CLOSED after superseded/race-detected closure.\n' \
+      "$ISSUE_NUMBER" >> "$ISSUE_BLOCKER_EVIDENCE"
+    update_classification_row \
+      "blocked" \
+      "Issue postcondition mismatch; created issue #$ISSUE_NUMBER was closed as superseded after race detection. See issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-postcondition-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
+      "Blocked: race-detected duplicate issue was closed; rerun exact-title reconciliation before continuing."
+    exit 0
+  fi
+  printf 'Race cleanup skipped: reused pre-existing issue #%s was not created by this run.\n' "$ISSUE_NUMBER" \
+    >> "$ISSUE_BLOCKER_EVIDENCE"
   update_classification_row \
     "blocked" \
-    "Issue postcondition mismatch; see issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-blocker.txt, and the postcondition ledger." \
+    "Issue postcondition mismatch; reused issue #$ISSUE_NUMBER was preserved because it predates this run. See issue-541/issues.json, viable/$WORKSTREAM_ID-issue-postcondition.json, viable/$WORKSTREAM_ID-issue-postcondition-search.json, viable/$WORKSTREAM_ID-issue-postcondition-view.json, and viable/$WORKSTREAM_ID-issue-blocker.txt." \
     "Blocked: postcondition exact-title issue verification failed after reuse/create."
   exit 0
 fi
@@ -2963,12 +3015,34 @@ update_classification_row \
   "Recover via issue #$ISSUE_NUMBER ($ISSUE_URL)."
 ```
 
+When `ISSUE_COUNT=0`, the self-contained block above creates and verifies an
+issue with this exact body:
+
+```markdown
+## Recovered source
+
+- Source issue: #541
+- Source artifacts: issue-541 recovery archive and classification ledger.
+
+## Acceptance criteria
+
+- Preserve the still-valid intent identified in the classification evidence.
+- Rebuild against current `origin/main`; do not blindly replay obsolete code.
+- Add or retain regression coverage for the recovered behavior.
+- Pass all repository-required gates.
+```
+
+
 If `ISSUE_COUNT>1`, write `viable/$WORKSTREAM_ID-issue-blocker.txt`, update
 the row to `blocked`, and stop that row rather than choosing one arbitrarily.
 
 Expected: every viable row without an adopted PR has exactly one verified issue
 number, and every reuse, create, or block decision cites the saved paginated
-issue ledger, per-workstream filtered search evidence, and verification files.
+issue ledger, per-workstream filtered search evidence, and verification files. If
+the postcondition detects a race after this run created a duplicate issue, close
+that newly created issue as superseded with an explicit `--repo OpenCoven/coven`
+comment, verify it is `CLOSED`, leave any reused pre-existing issue untouched,
+and keep the row blocked until a rerun revalidates uniqueness.
 
 - [ ] **Step 3: Create one approved design per viable issue**
 
@@ -3028,6 +3102,7 @@ the commit message and adding any conditional human contributor trailers as
 separate extra `--trailer` arguments:
 
 ```bash
+set -euo pipefail
 COPILOT_GH_ID=223556219
 COPILOT_GH_USER=Copilot
 COPILOT_NOREPLY_DOMAIN=users.noreply.github.com
@@ -3058,6 +3133,7 @@ pr-476-review -> runtime-parity-plan-recovery
 Then run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -3226,7 +3302,18 @@ For long child recovery sessions, keep the child claim alive from that child
 worktree:
 
 ```bash
-cd "$RECOVERY_WORKTREE"
+set -euo pipefail
+CURRENT_BRANCH="$(git branch --show-current)"
+case "$CURRENT_BRANCH" in
+  issue-[0-9]*-*)
+    ISSUE_NUMBER="${CURRENT_BRANCH#issue-}"
+    ISSUE_NUMBER="${ISSUE_NUMBER%%-*}"
+    ;;
+  *)
+    printf 'Blocked: current branch %s does not match issue-<number>-<slug>.\n' "$CURRENT_BRANCH" >&2
+    exit 1
+    ;;
+esac
 coven claim heartbeat "issue-$ISSUE_NUMBER"
 ```
 
@@ -3235,7 +3322,18 @@ responses, or final verification continue in the same session. Release it only
 when that pull request merges or the owning recovery session stops:
 
 ```bash
-cd "$RECOVERY_WORKTREE"
+set -euo pipefail
+CURRENT_BRANCH="$(git branch --show-current)"
+case "$CURRENT_BRANCH" in
+  issue-[0-9]*-*)
+    ISSUE_NUMBER="${CURRENT_BRANCH#issue-}"
+    ISSUE_NUMBER="${ISSUE_NUMBER%%-*}"
+    ;;
+  *)
+    printf 'Blocked: current branch %s does not match issue-<number>-<slug>.\n' "$CURRENT_BRANCH" >&2
+    exit 1
+    ;;
+esac
 coven claim release "issue-$ISSUE_NUMBER"
 ```
 
@@ -3254,6 +3352,7 @@ Immediately after any non-adopted recovery branch opens its PR, capture and
 verify that PR before Task 7 cleanup or Task 9 audit continues:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -3494,6 +3593,7 @@ resume condition to recover the delta later from current `main`.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -3585,6 +3685,7 @@ Expected: every active recovery claim and open PR is understood before cleanup.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -3673,6 +3774,7 @@ issue-541 archive or corresponds to a merged/detached review with no unique
 work. Then run:
 
 ```bash
+set -euo pipefail
 git worktree prune --verbose
 ```
 
@@ -3683,6 +3785,7 @@ Expected: only registrations whose directories no longer exist are removed.
 Check each known linked worktree:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -3779,6 +3882,7 @@ Then prove each branch's PR merged or its tip is represented by current main,
 and remove the five clean worktrees:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -3892,6 +3996,7 @@ resume condition. Unrelated or unsnapshotted worktrees must never use force.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4004,6 +4109,7 @@ row. Only unchanged rows with an empty preserved ignored inventory may use the
 exact-path force-removal exception:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4233,6 +4339,7 @@ recovered source branches:
 Run this immediately before `branch -d`:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4380,13 +4487,18 @@ recheck_branch_ref_tip() {
   fi
   return 0
 }
-recheck_branch_ref_tip pre-delete-d
-CHECK_STATUS=$?
-if [ "$CHECK_STATUS" -eq 2 ]; then
-  exit 0
-fi
-if [ "$CHECK_STATUS" -ne 0 ]; then
-  exit "$CHECK_STATUS"
+if recheck_branch_ref_tip pre-delete-d; then
+  :
+else
+  CHECK_STATUS=$?
+  case "$CHECK_STATUS" in
+    2)
+      exit 0
+      ;;
+    *)
+      exit "$CHECK_STATUS"
+      ;;
+  esac
 fi
 git -C "$REPO" branch -d "$BRANCH_TO_DELETE"
 ```
@@ -4397,6 +4509,7 @@ pushed replacement branch still proves the committed history, then rerun the
 same branch-ref proof immediately before `branch -D`:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4544,13 +4657,18 @@ recheck_branch_ref_tip() {
   fi
   return 0
 }
-recheck_branch_ref_tip pre-delete-D
-CHECK_STATUS=$?
-if [ "$CHECK_STATUS" -eq 2 ]; then
-  exit 0
-fi
-if [ "$CHECK_STATUS" -ne 0 ]; then
-  exit "$CHECK_STATUS"
+if recheck_branch_ref_tip pre-delete-D; then
+  :
+else
+  CHECK_STATUS=$?
+  case "$CHECK_STATUS" in
+    2)
+      exit 0
+      ;;
+    *)
+      exit "$CHECK_STATUS"
+      ;;
+  esac
 fi
 git -C "$REPO" branch -D "$BRANCH_TO_DELETE"
 ```
@@ -4566,7 +4684,18 @@ For any child recovery workstream whose PR has merged or whose owning recovery
 session has stopped, release its claim from that child worktree:
 
 ```bash
-cd "$RECOVERY_WORKTREE"
+set -euo pipefail
+CURRENT_BRANCH="$(git branch --show-current)"
+case "$CURRENT_BRANCH" in
+  issue-[0-9]*-*)
+    ISSUE_NUMBER="${CURRENT_BRANCH#issue-}"
+    ISSUE_NUMBER="${ISSUE_NUMBER%%-*}"
+    ;;
+  *)
+    printf 'Blocked: current branch %s does not match issue-<number>-<slug>.\n' "$CURRENT_BRANCH" >&2
+    exit 1
+    ;;
+esac
 coven claim release "issue-$ISSUE_NUMBER"
 ```
 
@@ -4574,7 +4703,18 @@ Keep child claims active while follow-up work for an open PR continues. During
 long-running follow-up from that worktree, use:
 
 ```bash
-cd "$RECOVERY_WORKTREE"
+set -euo pipefail
+CURRENT_BRANCH="$(git branch --show-current)"
+case "$CURRENT_BRANCH" in
+  issue-[0-9]*-*)
+    ISSUE_NUMBER="${CURRENT_BRANCH#issue-}"
+    ISSUE_NUMBER="${ISSUE_NUMBER%%-*}"
+    ;;
+  *)
+    printf 'Blocked: current branch %s does not match issue-<number>-<slug>.\n' "$CURRENT_BRANCH" >&2
+    exit 1
+    ;;
+esac
 coven claim heartbeat "issue-$ISSUE_NUMBER"
 ```
 
@@ -4582,6 +4722,7 @@ Release the parent `issue-541` claim only when the issue #541 recovery session
 stops or the full issue #541 recovery effort is complete:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4678,6 +4819,7 @@ allowed only for still-running recovery sessions and open follow-up work.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4800,6 +4942,7 @@ next external-PR sweep. Remove the duplicated stale `next` line.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4898,6 +5041,7 @@ Expected: each active goal has one `next` field, completed goals are under
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -4999,6 +5143,7 @@ Expected: all seven workstreams match exactly one terminal classification.
 For every `viable` row, set `PR_URL` to the recorded pull-request URL and run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -5091,6 +5236,7 @@ the URL matches the ledger.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -5286,6 +5432,7 @@ a safe fast-forward-only path.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -5386,6 +5533,7 @@ out-of-scope rather than removed or treated as audit failures.
 Run:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -5491,6 +5639,7 @@ links, non-viable evidence, and remaining human blockers. Do not post
 `manifest.tsv` or raw snapshot files:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path
@@ -5584,6 +5733,7 @@ Close only after every viable concern has an open PR and all local residue has
 been safely preserved or cleaned:
 
 ```bash
+set -euo pipefail
 resolve_control_worktree() {
   local control_branch="docs/541-incomplete-work-recovery-design"
   local start_common_dir repo target_path path branch_ref live_path stale_path

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Preserve and classify every discovered local workstream, recover each viable concern through its own issue and implementation plan, and safely remove only proven stale residue.
 
-**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive with a fixed current-run root at `agent-recovery/issue-541` and immutable private rerun archives for older runs. Run a preservation and classification phase before any cleanup, then hand each viable subsystem to an isolated issue/spec/plan/PR flow based on current `origin/main`.
+**Architecture:** Use the repository's shared Git common directory as a non-worktree recovery archive with a fixed current-run root at `agent-recovery/issue-541` and immutable private rerun archives for older runs. Discover or create the controller worktree for `docs/541-incomplete-work-recovery-design` through repo-local worktree conventions rather than a fixed machine path, then run a preservation and classification phase before any cleanup and hand each viable subsystem to an isolated issue/spec/plan/PR flow based on current `origin/main`.
 
 **Tech Stack:** Git worktrees and bundles, GitHub CLI, Coven claims, Markdown recovery ledger, Rust/Cargo, npm, repository secret and privacy guards.
 
@@ -132,42 +132,139 @@ No production file is modified during preservation or classification.
 - Existing: `docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md`
 - Create: `docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md`
 
-- [ ] **Step 1: Check claim state, check open pull requests, acquire `issue-541`, and confirm the design worktree state**
+- [ ] **Step 1: Discover or create the controller worktree for `docs/541-incomplete-work-recovery-design`, then acquire `issue-541`**
 
 Run:
 
 ```bash
-cd /tmp/coven-issue-541
+set -euo pipefail
+CONTROL_BRANCH="docs/541-incomplete-work-recovery-design"
+START_COMMON_DIR="$(git rev-parse --git-common-dir)"
+REPO="$(cd "$START_COMMON_DIR/.." && pwd)"
 coven claim status
 gh pr list --repo OpenCoven/coven --state open --limit 100
-coven claim acquire issue-541
-git status --short --branch
+CONTROL_WORKTREE="$(
+  git -C "$REPO" worktree list --porcelain | awk -v branch="refs/heads/$CONTROL_BRANCH" '
+    $1 == "worktree" { path = $2 }
+    $1 == "branch" && $2 == branch { print path; exit }
+  '
+)"
+if test -z "$CONTROL_WORKTREE"; then
+  if ! git -C "$REPO" check-ignore -q .worktrees/; then
+    printf 'Repository-local .worktrees/ is not ignored.\n' >&2
+    exit 1
+  fi
+  if ! git -C "$REPO" check-ignore -q .worktrees/issue-541-recovery; then
+    printf 'Repository-local control worktree path is not ignored: %s\n' \
+      '.worktrees/issue-541-recovery' >&2
+    exit 1
+  fi
+  mkdir -p "$REPO/.worktrees"
+  CONTROL_WORKTREE="$REPO/.worktrees/issue-541-recovery"
+  if test -e "$CONTROL_WORKTREE"; then
+    printf 'Control worktree path already exists without a branch registration: %s\n' \
+      "$CONTROL_WORKTREE" >&2
+    exit 1
+  fi
+  if ! git -C "$REPO" show-ref --verify --quiet "refs/heads/$CONTROL_BRANCH"; then
+    git -C "$REPO" fetch origin "$CONTROL_BRANCH:$CONTROL_BRANCH"
+  fi
+  git -C "$REPO" worktree add "$CONTROL_WORKTREE" "$CONTROL_BRANCH"
+fi
+if ! test -d "$CONTROL_WORKTREE"; then
+  printf 'Control worktree path is not present: %s\n' "$CONTROL_WORKTREE" >&2
+  exit 1
+fi
+ACTUAL_BRANCH="$(git -C "$CONTROL_WORKTREE" branch --show-current)"
+if test "$ACTUAL_BRANCH" != "$CONTROL_BRANCH"; then
+  printf 'Control worktree branch mismatch: expected %s, got %s\n' \
+    "$CONTROL_BRANCH" "$ACTUAL_BRANCH" >&2
+  exit 1
+fi
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+(
+  cd "$CONTROL_WORKTREE"
+  coven claim acquire issue-541
+)
+git -C "$CONTROL_WORKTREE" status --short --branch
+printf 'CONTROL_WORKTREE=%s\nCOMMON_DIR=%s\nREPO=%s\n' \
+  "$CONTROL_WORKTREE" "$COMMON_DIR" "$REPO"
 ```
 
-Expected: the shared claim registry and open PR set are reviewed before any
-publication or recovery action; `issue-541` is actively claimed from
-`/tmp/coven-issue-541`; and branch
-`docs/541-incomplete-work-recovery-design` shows only the plan file untracked
-before it is staged.
+Expected: from any `OpenCoven/coven` worktree, the shared claim registry and
+open PR set are reviewed first; `git worktree list --porcelain` discovers an
+existing linked controller for branch `docs/541-incomplete-work-recovery-design`
+or, if none exists, the operator verifies `.worktrees/` is ignored and creates
+a deterministic repo-local controller worktree at
+`.worktrees/issue-541-recovery` from the existing or freshly fetched branch
+without creating a duplicate branch. `CONTROL_WORKTREE`, `COMMON_DIR`, and
+`REPO` are printed explicitly, `CONTROL_WORKTREE` is verified to be on
+`docs/541-incomplete-work-recovery-design`, `issue-541` is acquired from that
+controller worktree, and `git status --short --branch` there shows only the
+plan file untracked before it is staged.
 
 If this publication session or the later recovery session runs long, keep the
-parent claim alive from `/tmp/coven-issue-541`:
+parent claim alive from the discovered controller worktree by re-resolving it
+instead of assuming shell variables persist:
 
 ```bash
-cd /tmp/coven-issue-541
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$CONTROL_WORKTREE"
 coven claim heartbeat issue-541
 ```
 
 Do not release `issue-541` after PR creation. Keep it active until this
 recovery session stops or the full issue #541 recovery effort is complete, then
-release it from `/tmp/coven-issue-541` with `coven claim release issue-541`.
+release it from the discovered controller worktree with `coven claim release
+issue-541`.
 
 - [ ] **Step 2: Run document safety checks**
 
 Run:
 
 ```bash
-cd /tmp/coven-issue-541
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$CONTROL_WORKTREE"
 git add docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
 git diff --cached --check
 python scripts/check-secrets.py
@@ -182,7 +279,28 @@ file, and the privacy guard reports one staged plan file.
 Run:
 
 ```bash
-cd /tmp/coven-issue-541
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$CONTROL_WORKTREE"
 COPILOT_GH_ID=223556219
 COPILOT_GH_USER=Copilot
 COPILOT_NOREPLY_DOMAIN=users.noreply.github.com
@@ -202,7 +320,28 @@ trailer. Human contributor co-author trailers remain conditional under
 Run:
 
 ```bash
-git -C /tmp/coven-issue-541 push -u origin docs/541-incomplete-work-recovery-design
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+git -C "$CONTROL_WORKTREE" push -u origin docs/541-incomplete-work-recovery-design
 ```
 
 Expected: the remote branch is created successfully.
@@ -212,7 +351,28 @@ Expected: the remote branch is created successfully.
 Run:
 
 ```bash
-cd /tmp/coven-issue-541
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$CONTROL_WORKTREE"
 gh pr create \
   --title "docs: design incomplete work recovery" \
   --body $'Tracks #541\n\nDefines a preservation-first process for recovering dirty worktrees and orphan branches without losing data or duplicating shipped work.\n\nThe implementation is deliberately split into one issue/spec/plan/PR per viable subsystem after snapshot and classification.'
@@ -240,7 +400,26 @@ Run:
 
 ```bash
 set -euo pipefail
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 git -C "$REPO" fetch origin main
 RECOVERY_PARENT="$COMMON_DIR/agent-recovery"
@@ -277,7 +456,26 @@ again before classification.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/docs-psyche-specs"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/docs-psyche-specs"
@@ -336,7 +534,26 @@ post-commit state.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/feat-cmem-1ev-memory-promote"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/memory-promote"
@@ -394,7 +611,26 @@ captured only in `.ignored.zlist` and `ignored.json`.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/mobile-memory-gateway"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/mobile-memory-gateway"
@@ -451,7 +687,26 @@ while ignored paths remain inventory-only.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 SOURCE="$REPO/.worktrees/pr-476-review"
 DEST="$COMMON_DIR/agent-recovery/issue-541/dirty/pr-476-review"
@@ -507,7 +762,26 @@ paths remain captured only in `.ignored.zlist` and `ignored.json`.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 test "$(wc -l < "$RECOVERY/manifest.tsv" | tr -d ' ')" = 5
@@ -615,7 +889,26 @@ archive.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 mkdir -p \
@@ -640,7 +933,26 @@ Expected: three bundle files and three metadata directories are created.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 git -C "$REPO" bundle verify "$RECOVERY/branches/docs-universal-runtime-capability-design.bundle"
@@ -655,7 +967,26 @@ Expected: Git reports each bundle is okay and lists its branch ref.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 for entry in \
@@ -695,7 +1026,26 @@ Step 1.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 git -C "$REPO" fetch origin main
@@ -723,7 +1073,26 @@ authoritative fully paginated source for later exact-title issue-reuse filters.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 for branch in \
@@ -852,7 +1221,27 @@ flow.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 for id in \
   docs-psyche-specs \
@@ -883,7 +1272,26 @@ current source branch:
 
 ```bash
 set -euo pipefail
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
@@ -1263,7 +1671,27 @@ Set `WORKSTREAM_ID` to the viable row's exact workstream ID, then use the
 matching exact issue title:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
 PRIVATE_RECOVERY="$COMMON_DIR/agent-recovery/issue-541/private"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
@@ -1591,7 +2019,26 @@ pr-476-review -> runtime-parity-plan-recovery
 Then run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
@@ -1710,7 +2157,26 @@ Immediately after any non-adopted recovery branch opens its PR, capture and
 verify that PR before Task 7 cleanup or Task 9 audit continues:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541/viable"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
@@ -1873,7 +2339,26 @@ resume condition to recover the delta later from current `main`.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 cd "$REPO"
 coven claim status
@@ -1887,7 +2372,26 @@ Expected: every active recovery claim and open PR is understood before cleanup.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 cd "$REPO"
 git worktree prune --dry-run --verbose
@@ -1908,7 +2412,26 @@ Expected: only registrations whose directories no longer exist are removed.
 Check each known linked worktree:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 for path in \
   "$REPO/.worktrees/docs-cli-core-guides" \
@@ -1927,7 +2450,26 @@ Then prove each branch's PR merged or its tip is represented by current main,
 and remove the five clean worktrees:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 for path in \
   "$REPO/.worktrees/docs-cli-core-guides" \
@@ -1963,7 +2505,26 @@ resume condition. Unrelated or unsnapshotted worktrees must never use force.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 for id in \
@@ -1998,7 +2559,26 @@ row. Only unchanged rows with an empty preserved ignored inventory may use the
 exact-path force-removal exception:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 RETIRE_PROOF_ROOT="$RECOVERY/private-retire-proof"
@@ -2150,7 +2730,26 @@ recovered source branches:
 Run this immediately before `branch -d`:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 BRANCH_DELETE_PROOF_ROOT="$COMMON_DIR/agent-recovery/issue-541/private/branch-delete-proof"
 mkdir -p "$BRANCH_DELETE_PROOF_ROOT"
@@ -2237,7 +2836,26 @@ pushed replacement branch still proves the committed history, then rerun the
 same branch-ref proof immediately before `branch -D`:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 BRANCH_DELETE_PROOF_ROOT="$COMMON_DIR/agent-recovery/issue-541/private/branch-delete-proof"
 mkdir -p "$BRANCH_DELETE_PROOF_ROOT"
@@ -2345,7 +2963,28 @@ Release the parent `issue-541` claim only when the issue #541 recovery session
 stops or the full issue #541 recovery effort is complete:
 
 ```bash
-cd /tmp/coven-issue-541
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
+cd "$CONTROL_WORKTREE"
 coven claim release issue-541
 ```
 
@@ -2355,16 +2994,35 @@ allowed only for still-running recovery sessions and open follow-up work.
 ### Task 8: Reconcile Repository Goals
 
 **Files:**
-- Modify: `.copilot/goals.md`
+- Modify: `.copilot/goals.md` in `CONTROL_WORKTREE` only
 
 - [ ] **Step 1: Re-read goals and live issue state**
 
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
-cd "$REPO"
+cd "$CONTROL_WORKTREE"
 sed -n '1,260p' .copilot/goals.md
 for issue in 401 414 521 541; do
   gh issue view "$issue" --json number,state,title,closedAt,url
@@ -2375,7 +3033,7 @@ Expected: #401, #414, and #521 are closed; #541 reflects the recovery PR state.
 
 - [ ] **Step 2: Close stale active goal content**
 
-Move `usability-core-consolidation` to `done` because its named high-risk
+Move `usability-core-consolidation` to `done` in `CONTROL_WORKTREE` because its named high-risk
 follow-up #401 is closed. Set:
 
 ```markdown
@@ -2390,7 +3048,7 @@ Remove obsolete `next` text that presents #401 as future work.
 
 - [ ] **Step 3: Reconcile contribution stewardship**
 
-Keep `contribution-stewardship` active because it is an ongoing maintenance
+Keep `contribution-stewardship` active in `CONTROL_WORKTREE` because it is an ongoing maintenance
 objective. Append a 2026-08-01 checkpoint that records:
 
 - #414 and #521 are closed;
@@ -2407,9 +3065,28 @@ next external-PR sweep. Remove the duplicated stale `next` line.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
-cd "$REPO"
+cd "$CONTROL_WORKTREE"
 grep -n '^## active\|^## paused\|^## done\|^### goal:\|^- next:' \
   .copilot/goals.md
 ```
@@ -2428,7 +3105,27 @@ Expected: each active goal has one `next` field, completed goals are under
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
+REPO="$(cd "$COMMON_DIR/.." && pwd)"
 RECOVERY="$COMMON_DIR/agent-recovery/issue-541"
 for id in \
   docs-psyche-specs \
@@ -2451,7 +3148,26 @@ Expected: all seven workstreams match exactly one terminal classification.
 For every `viable` row, set `PR_URL` to the recorded pull-request URL and run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 cd "$REPO"
 gh pr view "$PR_URL" --repo OpenCoven/coven \
@@ -2466,7 +3182,26 @@ the URL matches the ledger.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 AUDIT_EVIDENCE="$COMMON_DIR/agent-recovery/issue-541/final-audit-primary-checkout.txt"
 cd "$REPO"
@@ -2584,7 +3319,26 @@ a safe fast-forward-only path.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 cd "$REPO"
 git status --short --branch
@@ -2607,7 +3361,26 @@ out-of-scope rather than removed or treated as audit failures.
 Run:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 CLASSIFICATION="$COMMON_DIR/agent-recovery/issue-541/classification.md"
 python3 - "$CLASSIFICATION" "$REPO" "$COMMON_DIR" <<'PY'
@@ -2635,7 +3408,26 @@ links, non-viable evidence, and remaining human blockers. Do not post
 `manifest.tsv` or raw snapshot files:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 cd "$REPO"
 gh issue comment 541 --repo OpenCoven/coven --body-file \
@@ -2651,7 +3443,26 @@ Close only after every viable concern has an open PR and all local residue has
 been safely preserved or cleaned:
 
 ```bash
-COMMON_DIR="$(git -C /tmp/coven-issue-541 rev-parse --git-common-dir)"
+resolve_control_worktree() {
+  local control_branch="docs/541-incomplete-work-recovery-design"
+  local start_common_dir repo control_worktree
+  start_common_dir="$(git rev-parse --git-common-dir)"
+  repo="$(cd "$start_common_dir/.." && pwd)"
+  control_worktree="$(
+    git -C "$repo" worktree list --porcelain | awk -v branch="refs/heads/$control_branch" '
+      $1 == "worktree" { path = $2 }
+      $1 == "branch" && $2 == branch { print path; exit }
+    '
+  )"
+  if test -z "$control_worktree"; then
+    printf 'Missing controller worktree for %s. Re-run Task 1 Step 1.\n' \
+      "$control_branch" >&2
+    exit 1
+  fi
+  printf '%s\n' "$control_worktree"
+}
+CONTROL_WORKTREE="$(resolve_control_worktree)"
+COMMON_DIR="$(git -C "$CONTROL_WORKTREE" rev-parse --git-common-dir)"
 REPO="$(cd "$COMMON_DIR/.." && pwd)"
 cd "$REPO"
 gh issue close 541 --repo OpenCoven/coven --comment \

--- a/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
+++ b/docs/superpowers/plans/2026-08-01-incomplete-work-recovery.md
@@ -4383,12 +4383,19 @@ do
       SOURCE="$REPO/.worktrees/pr-476-review"
       ;;
   esac
-  if ! CLASSIFICATION_FIELDS="$(parse_classification_row "$id")"; then
+  CLASSIFICATION_FIELDS_FILE="$RECOVERY/.classification-fields.$$"
+  if ! parse_classification_row "$id" >"$CLASSIFICATION_FIELDS_FILE"; then
+    rm -f "$CLASSIFICATION_FIELDS_FILE"
     block_retirement "$id" "$BLOCKER" "unparsed" "missing exact row" "$SOURCE" "unparsed" \
       "classification row could not be parsed safely before any live-state checks"
     continue
   fi
-  mapfile -t CLASSIFICATION_ROW <<<"$CLASSIFICATION_FIELDS"
+  CLASSIFICATION_ROW=()
+  CLASSIFICATION_FIELD=
+  while IFS= read -r CLASSIFICATION_FIELD || [ -n "$CLASSIFICATION_FIELD" ]; do
+    CLASSIFICATION_ROW+=("$CLASSIFICATION_FIELD")
+  done < "$CLASSIFICATION_FIELDS_FILE"
+  rm -f "$CLASSIFICATION_FIELDS_FILE"
   if test "${#CLASSIFICATION_ROW[@]}" -ne 4; then
     block_retirement "$id" "$BLOCKER" "unparsed" "unexpected column count" "$SOURCE" "unparsed" \
       "classification row could not be parsed safely before any live-state checks"
@@ -4432,12 +4439,19 @@ do
           continue
           ;;
       esac
-      if ! RECOVERY_ACTION_FIELDS="$(parse_recovery_action "$RECOVERY_ACTION")"; then
+      RECOVERY_ACTION_FIELDS_FILE="$RECOVERY/.recovery-action-fields.$$"
+      if ! parse_recovery_action "$RECOVERY_ACTION" >"$RECOVERY_ACTION_FIELDS_FILE"; then
+        rm -f "$RECOVERY_ACTION_FIELDS_FILE"
         block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
           "viable rows must encode a deterministic recovery action payload"
         continue
       fi
-      mapfile -t ACTION_ROW <<<"$RECOVERY_ACTION_FIELDS"
+      ACTION_ROW=()
+      ACTION_FIELD=
+      while IFS= read -r ACTION_FIELD || [ -n "$ACTION_FIELD" ]; do
+        ACTION_ROW+=("$ACTION_FIELD")
+      done < "$RECOVERY_ACTION_FIELDS_FILE"
+      rm -f "$RECOVERY_ACTION_FIELDS_FILE"
       if test "${#ACTION_ROW[@]}" -ne 6; then
         block_retirement "$id" "$BLOCKER" "$CLASSIFICATION_LABEL" "$MAIN_PR_EVIDENCE" "$PRESERVED_SOURCE" "$RECOVERY_ACTION" \
           "recovery action parsing returned an unexpected field count"

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -5,8 +5,8 @@
 ## Objective
 
 Preserve, classify, recover, and deliver viable work from stale local branches
-and dirty worktrees without losing data, duplicating shipped behavior, or
-mixing unrelated concerns in one pull request.
+and dirty or formerly dirty worktrees without losing data, duplicating shipped
+behavior, or mixing unrelated concerns in one pull request.
 
 The recovery ends when every discovered workstream is in exactly one of these
 states:
@@ -20,10 +20,13 @@ removed.
 
 ## Current Inventory
 
-The primary checkout is clean and matches `origin/main`. There are no open pull
-requests, active claims, stashes, or session todos predating this recovery.
+The primary checkout is clean and matches `origin/main`. This inventory is a
+point-in-time baseline rather than a promise about later execution state:
+claims, open pull requests, and source-worktree dirtiness can change while the
+recovery is being published or executed, so the plan must re-query GitHub and
+snapshot the current state before each recovery action.
 
-Dirty worktrees:
+Source worktrees with preserved or in-flight local work at inventory time:
 
 - `docs/psyche-specs` (`.worktrees/docs-psyche-specs`): Psyche product,
   technical, parity, threat-model, prerequisites, and plan documents.
@@ -46,12 +49,19 @@ pull requests or missing temporary directories. They are hygiene candidates,
 not feature inputs, but will not be removed until their tips are verified
 against GitHub history.
 
+A formerly dirty source worktree may later appear clean because its changes
+were committed and pushed to an accurate open pull request. That is expected:
+the recovery still snapshots the worktree's current status, preserves its
+branch history, records empty patch evidence when applicable, and then decides
+whether to continue the existing pull request or create a new recovery track.
+
 ## Recovery Architecture
 
 ### 1. Preserve before mutation
 
 Create a durable recovery directory outside the repository worktrees. For each
-dirty worktree, store:
+source worktree, store its current state even if it is now clean because its
+changes were already committed to an active pull request:
 
 - `git status --short --branch`
 - the base and head commit identifiers
@@ -67,7 +77,8 @@ branch is pushed, or until the work is explicitly recorded as blocked.
 ### 2. Classify against current authority
 
 Compare each workstream with current `origin/main`, merged pull requests, closed
-issues, and current contracts. Assign one classification:
+issues, current open pull requests from the exact source branch, and current
+contracts. Assign one classification:
 
 - **Already shipped:** main contains equivalent behavior or documentation.
 - **Superseded:** a later implementation intentionally replaced the work.
@@ -80,7 +91,16 @@ squash merges make many merged branches appear unmerged.
 
 ### 3. Recover viable concerns in isolation
 
-Each viable concern receives:
+Before creating a child issue, branch, or worktree, each viable concern maps to
+its exact current source branch and runs an exact-head open-pull-request query.
+If exactly one accurate open pull request already exists, the recovery adopts
+and records that pull request and keeps the row classified `viable` with
+recovery action `continue existing PR`. If no exact-head pull request exists,
+the concern follows the normal issue-reuse-or-create flow. If more than one
+exact-head pull request exists, the row moves to `blocked` with evidence rather
+than guessing.
+
+Each viable concern without an adopted exact-head open pull request receives:
 
 1. A dedicated GitHub issue, unless an existing issue accurately owns it.
 2. A fresh branch and worktree based on current `origin/main`.
@@ -88,6 +108,11 @@ Each viable concern receives:
 4. A minimal transplant of only the still-relevant changes.
 5. Targeted tests followed by all repository-required gates.
 6. A conventional commit, push, and scoped pull request.
+
+For example, if the source branch `docs/psyche-specs` still has exactly one
+open pull request when the query runs, the recovery adopts that live pull
+request (today this is PR #546) instead of creating a duplicate issue, branch,
+worktree, claim, or pull request.
 
 Old commits are not blindly rebased or cherry-picked when current contracts
 have changed. The recovered implementation is rebuilt around current code and
@@ -161,6 +186,8 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Rebase or transplant conflicts are resolved from current contracts; old code
   never wins automatically.
 - A failing required gate blocks push and pull-request creation.
+- More than one exact-head open pull request or more than one matching recovery
+  issue blocks the row with evidence rather than choosing a duplicate target.
 - Ambiguous ownership, policy, or human approval moves the workstream to
   `blocked` with evidence rather than inventing authority.
 - Claims are heartbeated during long work and released when the pull request
@@ -170,9 +197,10 @@ after staging the intended change so it evaluates the actual proposed commit.
 
 ## Success Criteria
 
-- Every dirty or orphaned workstream has a durable snapshot and classification.
-- Every viable concern has its own validated, pushed branch and open pull
-  request.
+- Every dirty, formerly dirty, or orphaned workstream has a durable snapshot
+  and classification.
+- Every viable concern either adopts one accurate exact-head open pull request
+  or has its own validated, pushed branch and open pull request.
 - Already-shipped and superseded work has concrete GitHub or main-branch
   evidence.
 - No uncommitted work is deleted.

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -25,12 +25,15 @@ requests, active claims, stashes, or session todos predating this recovery.
 
 Dirty worktrees:
 
-- `docs/psyche-specs`: Psyche product, technical, parity, threat-model,
-  prerequisites, and plan documents.
-- `feat/cmem-1ev-memory-promote`: memory promotion authority, CLI wiring,
-  privacy tooling, CI, and security documentation.
-- `feat/mobile-memory-gateway`: an uncommitted mobile pairing change.
-- `fix/476-review-threads`: Cave/runtime parity design and implementation plans.
+- `docs/psyche-specs` (`.worktrees/docs-psyche-specs`): Psyche product,
+  technical, parity, threat-model, prerequisites, and plan documents.
+- `feat/cmem-1ev-memory-promote` (`.worktrees/feat-cmem-1ev-memory-promote`):
+  memory promotion authority, CLI wiring, privacy tooling, CI, and security
+  documentation.
+- `feat/mobile-memory-gateway` (`.worktrees/mobile-memory-gateway`): an
+  uncommitted mobile pairing change.
+- `fix/476-review-threads` (`.worktrees/pr-476-review`): Cave/runtime parity
+  design and implementation plans.
 
 Clean orphan branches without open pull requests:
 

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -59,9 +59,14 @@ whether to continue the existing pull request or create a new recovery track.
 
 ### 1. Preserve before mutation
 
-Create a durable recovery directory outside the repository worktrees. For each
-source worktree, store its current state even if it is now clean because its
-changes were already committed to an active pull request:
+Create a durable recovery directory outside the repository worktrees. The fixed
+current-run path remains `agent-recovery/issue-541`, but reruns must never
+reuse it in place: if that path already exists, move the entire prior run into
+an immutable private archive directory under the shared recovery archive, record
+its former location and archival time, then create a fresh current root at the
+same fixed path before writing any new manifest or snapshot. For each source
+worktree, store its current state even if it is now clean because its changes
+were already committed to an active pull request:
 
 - `git status --short --branch`
 - the base and head commit identifiers
@@ -71,8 +76,10 @@ changes were already committed to an active pull request:
 For each orphan branch, create a Git bundle or equivalent ref-preserving
 archive and record its commits relative to current `origin/main`.
 
-Snapshots remain until the corresponding pull request is open and its source
-branch is pushed, or until the work is explicitly recorded as blocked.
+Reruns therefore create a new current run while every prior run remains
+immutable under the archive directory. Snapshots remain until the corresponding
+pull request is open and its source branch is pushed, or until the work is
+explicitly recorded as blocked.
 
 ### 2. Classify against current authority
 
@@ -93,9 +100,13 @@ squash merges make many merged branches appear unmerged.
 
 Before creating a child issue, branch, or worktree, each viable concern maps to
 its exact current source branch, reads that workstream's preserved local
-`head.txt`, and first runs an exact-source-branch open-pull-request query. If
-that query returns zero candidates, the concern follows the normal
-issue-reuse-or-create flow without fetching the source branch. If the query
+`head.txt`, and first captures a fully paginated REST/API list of open pull
+requests for `OpenCoven/coven`. Candidate selection then happens with local
+`jq` filtering only when `.head.ref` equals the expected source branch and
+`.head.repo.full_name` equals `OpenCoven/coven`, so same-named fork PRs never
+count as same-repository candidates. If that same-repo exact-source-branch
+filter returns zero candidates, the concern follows the normal
+issue-reuse-or-create flow without fetching the source branch. If the filter
 returns exactly one candidate open pull request, the recovery then fetches that
 exact branch from `origin`, records the freshly fetched authoritative remote
 tip, and verifies that the candidate's `state` is `OPEN`, its `headRefName`
@@ -105,14 +116,24 @@ matches the expected branch, its `headRepositoryOwner` is `OpenCoven`,
 tip. Only after the PR head matches the fetched authoritative tip does the
 recovery verify via ancestry that the preserved local `head.txt` equals or is
 an ancestor of that PR head, so a clean local worktree that is behind its open
-PR by commits can still be adopted safely. If more than one
-exact-source-branch pull request exists, the row moves directly to `blocked`
-with saved evidence rather than fetching or guessing. If the single-candidate
-branch fetch fails, if the PR head differs from the fetched branch tip, if the
-preserved local head is not an ancestor of the PR head, or if the candidate
-pull request fails any other identity check including closing or merging
-between list and view, the row also moves to `blocked` with saved evidence
-rather than falling through to duplicate-recovery work.
+PR by commits can still be adopted safely.
+
+For dirty-worktree sources, successful identity and ancestry verification is
+still not enough to adopt the existing PR. The recovery must next inspect the
+preserved snapshot's `worktree.patch`, `index.patch`, and
+`untracked-files.txt`; adoption is allowed only when all three dirty classes
+are empty. If any preserved dirty delta remains, the row moves to `blocked`
+with evidence naming the existing PR URL, the preserved snapshot archive IDs,
+and the safe resume condition: land or reconcile that PR first, then recover
+the preserved delta from current `main` in a separate scoped track. While that
+blocker stands, the original source worktree and branch remain untouched. If
+more than one same-repo exact-source-branch pull request exists, the row moves
+directly to `blocked` with saved evidence rather than fetching or guessing. If
+the single-candidate branch fetch fails, if the PR head differs from the
+fetched branch tip, if the preserved local head is not an ancestor of the PR
+head, or if the candidate pull request fails any other identity check including
+closing or merging between list and view, the row also moves to `blocked` with
+saved evidence rather than falling through to duplicate-recovery work.
 
 Each viable concern without an adopted exact-source-branch open pull request
 receives:
@@ -138,11 +159,13 @@ unrelated or closed result remains preserved in `issues.json` but does not get
 reused.
 
 For example, if the source branch `docs/psyche-specs` still has exactly one
-open pull request from that exact source when the query runs, its
-`headRefOid` matches the freshly fetched `origin/docs/psyche-specs` tip, and
-the preserved local `head.txt` is equal to or an ancestor of that PR head, the
-recovery adopts whichever PR GitHub returns at execution time instead of
-creating a duplicate issue, branch, worktree, claim, or pull request.
+same-repo open pull request from that exact source when the query runs, its
+`headRefOid` matches the freshly fetched `origin/docs/psyche-specs` tip, the
+preserved local `head.txt` is equal to or an ancestor of that PR head, and the
+preserved `worktree.patch`, `index.patch`, and `untracked-files.txt` are all
+empty, the recovery adopts whichever PR GitHub returns at execution time
+instead of creating a duplicate issue, branch, worktree, claim, or pull
+request.
 
 Old commits are not blindly rebased or cherry-picked when current contracts
 have changed. The recovered implementation is rebuilt around current code and
@@ -158,8 +181,11 @@ after one of these proofs exists:
 - its snapshot and blocker record preserve all remaining value.
 
 Cleanup includes stale `/tmp` worktree registrations, merged local branches,
-gone upstream references, and expired claims. Unrelated user changes are never
-discarded.
+gone upstream references, and expired claims. Rows blocked because an existing
+PR already covers the preserved head while additional dirty snapshot state
+remains do not qualify for source-worktree or source-branch cleanup; those
+original sources stay in place until the blocked delta is recovered separately.
+Unrelated user changes are never discarded.
 
 Before the final audit, the primary checkout is restored non-destructively to a
 clean `main`. If it is already on `main`, the recovery fetches `origin/main`
@@ -225,12 +251,16 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Rebase or transplant conflicts are resolved from current contracts; old code
   never wins automatically.
 - A failing required gate blocks push and pull-request creation.
-- More than one exact-source-branch open pull request, any candidate PR state,
-  branch, owner, base, or cross-repo mismatch, any single-candidate branch
-  fetch failure, any PR head that differs from the freshly fetched
+- More than one same-repo exact-source-branch open pull request, any candidate
+  PR state, branch, owner, base, or cross-repo mismatch, any single-candidate
+  branch fetch failure, any PR head that differs from the freshly fetched
   authoritative branch tip, any preserved local head that is not an ancestor
-  of the PR head, or more than one exact-title open matching recovery issue
-  blocks the row with evidence rather than choosing a duplicate target.
+  of the PR head, any non-empty preserved dirty snapshot class behind an active
+  PR, or more than one exact-title open matching recovery issue blocks the row
+  with evidence rather than choosing a duplicate target.
+- If `agent-recovery/issue-541` already exists, archival move or fresh-current
+  root creation failure blocks the rerun before any new manifest or snapshot is
+  written.
 - Any unsafe primary-checkout restore condition blocks the final audit rather
   than forcing a branch switch or reset.
 - Ambiguous ownership, policy, or human approval moves the workstream to
@@ -244,13 +274,16 @@ after staging the intended change so it evaluates the actual proposed commit.
 
 - Every dirty, formerly dirty, or orphaned workstream has a durable snapshot
   and classification.
-- Every viable concern either adopts one accurate exact-source-branch open pull
-  request whose queried single candidate survived authoritative branch-tip and
-  ancestry verification, or has its own validated, pushed branch and open pull
-  request after the zero-candidate normal flow.
+- Every viable concern either adopts one accurate same-repo exact-source-branch
+  open pull request whose queried single candidate survived authoritative
+  branch-tip, ancestry, and empty-dirty-snapshot verification, or has its own
+  validated, pushed branch and open pull request after the zero-candidate
+  normal flow.
 - Already-shipped and superseded work has concrete GitHub or main-branch
   evidence.
 - No uncommitted work is deleted.
 - Stale worktrees, branches, and claims are removed only after proof.
+- Every rerun leaves the prior `issue-541` recovery root immutable under the
+  private archive and recreates a fresh current root at the fixed path.
 - `.copilot/goals.md` matches current issue and pull-request reality.
 - The primary checkout remains clean and on `main`.

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -71,7 +71,13 @@ were already committed to an active pull request:
 - `git status --short --branch`
 - the base and head commit identifiers
 - tracked working-tree and index patches
-- copies of untracked files with their relative paths
+- a private NUL-delimited `.untracked.zlist` plus JSON-escaped untracked
+  evidence derived from that inventory
+- an uncompressed `untracked.tar` created from the source worktree with
+  `tar --null -T` so newline pathnames, symlink entries, and file metadata are
+  preserved losslessly
+- a private NUL-delimited `.ignored.zlist` plus JSON-escaped ignored evidence
+  derived from that inventory, without archiving ignored content itself
 
 For each orphan branch, create a Git bundle or equivalent ref-preserving
 archive and record its commits relative to current `origin/main`.
@@ -79,7 +85,9 @@ archive and record its commits relative to current `origin/main`.
 Reruns therefore create a new current run while every prior run remains
 immutable under the archive directory. Snapshots remain until the corresponding
 pull request is open and its source branch is pushed, or until the work is
-explicitly recorded as blocked.
+explicitly recorded as blocked. Snapshot completeness validates the
+NUL-delimited inventories, their JSON evidence, and the uncompressed untracked
+tar archives, including valid empty inventories.
 
 ### 2. Classify against current authority
 
@@ -121,19 +129,21 @@ PR by commits can still be adopted safely.
 For dirty-worktree sources, successful identity and ancestry verification is
 still not enough to adopt the existing PR. The recovery must next inspect the
 preserved snapshot's `worktree.patch`, `index.patch`, and
-`untracked-files.txt`; adoption is allowed only when all three dirty classes
+`.untracked.zlist`; adoption is allowed only when all three dirty classes
 are empty. If any preserved dirty delta remains, the row moves to `blocked`
 with evidence naming the existing PR URL, the preserved snapshot archive IDs,
 and the safe resume condition: land or reconcile that PR first, then recover
-the preserved delta from current `main` in a separate scoped track. While that
-blocker stands, the original source worktree and branch remain untouched. If
-more than one same-repo exact-source-branch pull request exists, the row moves
-directly to `blocked` with saved evidence rather than fetching or guessing. If
-the single-candidate branch fetch fails, if the PR head differs from the
-fetched branch tip, if the preserved local head is not an ancestor of the PR
-head, or if the candidate pull request fails any other identity check including
-closing or merging between list and view, the row also moves to `blocked` with
-saved evidence rather than falling through to duplicate-recovery work.
+the preserved delta from current `main` in a separate scoped track. That
+evidence cites the preserved `.untracked.zlist`, `untracked.json`, and
+`untracked.tar` alongside the tracked patch artifacts. While that blocker
+stands, the original source worktree and branch remain untouched. If more than
+one same-repo exact-source-branch pull request exists, the row moves directly
+to `blocked` with saved evidence rather than fetching or guessing. If the
+single-candidate branch fetch fails, if the PR head differs from the fetched
+branch tip, if the preserved local head is not an ancestor of the PR head, or
+if the candidate pull request fails any other identity check including closing
+or merging between list and view, the row also moves to `blocked` with saved
+evidence rather than falling through to duplicate-recovery work.
 
 Each viable concern without an adopted exact-source-branch open pull request
 receives:
@@ -162,7 +172,7 @@ For example, if the source branch `docs/psyche-specs` still has exactly one
 same-repo open pull request from that exact source when the query runs, its
 `headRefOid` matches the freshly fetched `origin/docs/psyche-specs` tip, the
 preserved local `head.txt` is equal to or an ancestor of that PR head, and the
-preserved `worktree.patch`, `index.patch`, and `untracked-files.txt` are all
+preserved `worktree.patch`, `index.patch`, and `.untracked.zlist` are all
 empty, the recovery adopts whichever PR GitHub returns at execution time
 instead of creating a duplicate issue, branch, worktree, claim, or pull
 request.
@@ -185,7 +195,14 @@ gone upstream references, and expired claims. Rows blocked because an existing
 PR already covers the preserved head while additional dirty snapshot state
 remains do not qualify for source-worktree or source-branch cleanup; those
 original sources stay in place until the blocked delta is recovered separately.
-Unrelated user changes are never discarded.
+Force-removal is also prohibited for any source worktree whose preserved
+`.ignored.zlist` is non-empty. Before any forced removal, the recovery
+regenerates the live `.untracked.zlist`, `untracked.tar`, and `.ignored.zlist`
+with the same lossless method used for the snapshot and compares them
+byte-for-byte to the preserved artifacts. Any ignored content or inventory
+drift blocks removal, records blocker evidence with a resume condition, and
+leaves the source worktree untouched. Unrelated user changes are never
+discarded.
 
 Before the final audit, the primary checkout is restored non-destructively to a
 clean `main`. If it is already on `main`, the recovery fetches `origin/main`

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -93,23 +93,26 @@ squash merges make many merged branches appear unmerged.
 
 Before creating a child issue, branch, or worktree, each viable concern maps to
 its exact current source branch, reads that workstream's preserved local
-`head.txt`, fetches that exact branch from `origin`, records the freshly
-fetched authoritative remote tip, and runs an exact-source-branch
-open-pull-request query. If exactly one candidate open pull request exists, the
-recovery verifies that its `state` is `OPEN`, its `headRefName` matches the
-expected branch, its `headRepositoryOwner` is `OpenCoven`,
+`head.txt`, and first runs an exact-source-branch open-pull-request query. If
+that query returns zero candidates, the concern follows the normal
+issue-reuse-or-create flow without fetching the source branch. If the query
+returns exactly one candidate open pull request, the recovery then fetches that
+exact branch from `origin`, records the freshly fetched authoritative remote
+tip, and verifies that the candidate's `state` is `OPEN`, its `headRefName`
+matches the expected branch, its `headRepositoryOwner` is `OpenCoven`,
 `isCrossRepository` is false, its `baseRefName` is `main`, and its
 `headRefOid` exactly equals the freshly fetched authoritative source-branch
-tip. It then verifies via ancestry that the preserved local `head.txt` equals
-or is an ancestor of that PR head, so a clean local worktree that is behind its
-open PR by commits can still be adopted safely. If no exact-source-branch pull
-request exists, the concern follows the normal issue-reuse-or-create flow. If
-more than one exact-source-branch pull request exists, if the PR head differs
-from the fetched branch tip, if the preserved local head is not an ancestor of
-the PR head, or if the candidate pull request fails any other identity check
-including closing or merging between list and view, the row moves to `blocked`
-with saved evidence rather than guessing or falling through to
-duplicate-recovery work.
+tip. Only after the PR head matches the fetched authoritative tip does the
+recovery verify via ancestry that the preserved local `head.txt` equals or is
+an ancestor of that PR head, so a clean local worktree that is behind its open
+PR by commits can still be adopted safely. If more than one
+exact-source-branch pull request exists, the row moves directly to `blocked`
+with saved evidence rather than fetching or guessing. If the single-candidate
+branch fetch fails, if the PR head differs from the fetched branch tip, if the
+preserved local head is not an ancestor of the PR head, or if the candidate
+pull request fails any other identity check including closing or merging
+between list and view, the row also moves to `blocked` with saved evidence
+rather than falling through to duplicate-recovery work.
 
 Each viable concern without an adopted exact-source-branch open pull request
 receives:
@@ -223,11 +226,11 @@ after staging the intended change so it evaluates the actual proposed commit.
   never wins automatically.
 - A failing required gate blocks push and pull-request creation.
 - More than one exact-source-branch open pull request, any candidate PR state,
-  branch, owner, base, or cross-repo mismatch, any PR head that differs from
-  the freshly fetched authoritative branch tip, any preserved local head that
-  is not an ancestor of the PR head, or more than one exact-title open
-  matching recovery issue blocks the row with evidence rather than choosing a
-  duplicate target.
+  branch, owner, base, or cross-repo mismatch, any single-candidate branch
+  fetch failure, any PR head that differs from the freshly fetched
+  authoritative branch tip, any preserved local head that is not an ancestor
+  of the PR head, or more than one exact-title open matching recovery issue
+  blocks the row with evidence rather than choosing a duplicate target.
 - Any unsafe primary-checkout restore condition blocks the final audit rather
   than forcing a branch switch or reset.
 - Ambiguous ownership, policy, or human approval moves the workstream to
@@ -242,9 +245,9 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Every dirty, formerly dirty, or orphaned workstream has a durable snapshot
   and classification.
 - Every viable concern either adopts one accurate exact-source-branch open pull
-  request whose head matches the freshly fetched authoritative branch tip and
-  still descends from the preserved local snapshot, or has its own validated,
-  pushed branch and open pull request.
+  request whose queried single candidate survived authoritative branch-tip and
+  ancestry verification, or has its own validated, pushed branch and open pull
+  request after the zero-candidate normal flow.
 - Already-shipped and superseded work has concrete GitHub or main-branch
   evidence.
 - No uncommitted work is deleted.

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -96,8 +96,9 @@ its exact current source branch, reads that workstream's snapshotted source
 head, and runs an exact-head open-pull-request query. If exactly one candidate
 open pull request exists, the recovery verifies that its `headRefOid` matches
 the snapshotted source head, its `headRefName` matches the expected branch, its
-`headRepositoryOwner` is `OpenCoven`, and `isCrossRepository` is false before
-adopting it. If no exact-head pull request exists, the concern follows the
+`headRepositoryOwner` is `OpenCoven`, `isCrossRepository` is false, and
+`baseRefName` is `main` before adopting it. If no exact-head pull request
+exists, the concern follows the
 normal issue-reuse-or-create flow. If more than one exact-head pull request
 exists, or if the candidate pull request fails any identity check, the row
 moves to `blocked` with saved evidence rather than guessing.
@@ -141,6 +142,15 @@ after one of these proofs exists:
 Cleanup includes stale `/tmp` worktree registrations, merged local branches,
 gone upstream references, and expired claims. Unrelated user changes are never
 discarded.
+
+Before the final audit, the primary checkout is restored non-destructively to a
+clean `main`. If it is already on `main`, the recovery fetches `origin/main`
+and fast-forwards only when that is safe. If it is on a recovery-owned
+issue-541 branch, the recovery first proves the branch head is fully pushed to
+its configured upstream, then switches to `main` and fast-forwards from
+`origin/main`. Any dirty tracked or untracked state, missing upstream,
+unpushed recovery commits, unrelated current branch, or non-fast-forward `main`
+state blocks the audit and leaves the checkout untouched.
 
 ### 5. Reconcile long-running goals
 
@@ -200,6 +210,8 @@ after staging the intended change so it evaluates the actual proposed commit.
 - More than one exact-head open pull request, any candidate PR identity
   mismatch, or more than one exact-open matching recovery issue blocks the row
   with evidence rather than choosing a duplicate target.
+- Any unsafe primary-checkout restore condition blocks the final audit rather
+  than forcing a branch switch or reset.
 - Ambiguous ownership, policy, or human approval moves the workstream to
   `blocked` with evidence rather than inventing authority.
 - Claims are heartbeated during long work and released when the pull request
@@ -212,7 +224,8 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Every dirty, formerly dirty, or orphaned workstream has a durable snapshot
   and classification.
 - Every viable concern either adopts one accurate exact-head open pull request
-  or has its own validated, pushed branch and open pull request.
+  targeting `main` or has its own validated, pushed branch and open pull
+  request.
 - Already-shipped and superseded work has concrete GitHub or main-branch
   evidence.
 - No uncommitted work is deleted.

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -92,27 +92,38 @@ squash merges make many merged branches appear unmerged.
 ### 3. Recover viable concerns in isolation
 
 Before creating a child issue, branch, or worktree, each viable concern maps to
-its exact current source branch and runs an exact-head open-pull-request query.
-If exactly one accurate open pull request already exists, the recovery adopts
-and records that pull request and keeps the row classified `viable` with
-recovery action `continue existing PR`. If no exact-head pull request exists,
-the concern follows the normal issue-reuse-or-create flow. If more than one
-exact-head pull request exists, the row moves to `blocked` with evidence rather
-than guessing.
+its exact current source branch, reads that workstream's snapshotted source
+head, and runs an exact-head open-pull-request query. If exactly one candidate
+open pull request exists, the recovery verifies that its `headRefOid` matches
+the snapshotted source head, its `headRefName` matches the expected branch, its
+`headRepositoryOwner` is `OpenCoven`, and `isCrossRepository` is false before
+adopting it. If no exact-head pull request exists, the concern follows the
+normal issue-reuse-or-create flow. If more than one exact-head pull request
+exists, or if the candidate pull request fails any identity check, the row
+moves to `blocked` with saved evidence rather than guessing.
 
 Each viable concern without an adopted exact-head open pull request receives:
 
-1. A dedicated GitHub issue, unless an existing issue accurately owns it.
+1. A dedicated GitHub issue, unless exactly one OPEN issue already exists whose
+   title exactly equals that concern's fixed recovery title.
 2. A fresh branch and worktree based on current `origin/main`.
 3. An issue-keyed Coven claim acquired from that worktree.
 4. A minimal transplant of only the still-relevant changes.
 5. Targeted tests followed by all repository-required gates.
 6. A conventional commit, push, and scoped pull request.
 
+Broad issue-search results are still saved for evidence, but only OPEN issues
+whose title exactly matches the fixed `ISSUE_TITLE` count as reusable:
+zero exact-open matches create a new issue, one exact-open match is reused and
+re-verified, and more than one exact-open match blocks the row with evidence.
+A sole unrelated or closed search result is preserved in the evidence files but
+does not get reused.
+
 For example, if the source branch `docs/psyche-specs` still has exactly one
-open pull request when the query runs, the recovery adopts that live pull
-request (today this is PR #546) instead of creating a duplicate issue, branch,
-worktree, claim, or pull request.
+open pull request from that exact source when the query runs and its identity
+checks pass, the recovery adopts whichever PR GitHub returns at execution time
+instead of creating a duplicate issue, branch, worktree, claim, or pull
+request.
 
 Old commits are not blindly rebased or cherry-picked when current contracts
 have changed. The recovered implementation is rebuilt around current code and
@@ -186,8 +197,9 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Rebase or transplant conflicts are resolved from current contracts; old code
   never wins automatically.
 - A failing required gate blocks push and pull-request creation.
-- More than one exact-head open pull request or more than one matching recovery
-  issue blocks the row with evidence rather than choosing a duplicate target.
+- More than one exact-head open pull request, any candidate PR identity
+  mismatch, or more than one exact-open matching recovery issue blocks the row
+  with evidence rather than choosing a duplicate target.
 - Ambiguous ownership, policy, or human approval moves the workstream to
   `blocked` with evidence rather than inventing authority.
 - Claims are heartbeated during long work and released when the pull request

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -67,11 +67,17 @@ its former location and archival time, then create a fresh current root at the
 same fixed path before writing any new manifest or snapshot. Publication and
 execution are driven from a controller worktree for
 `docs/541-incomplete-work-recovery-design` that is discovered with `git worktree
-list --porcelain` from any `OpenCoven/coven` worktree or, when absent, created
-under the repo-local `.worktrees/issue-541-recovery` convention after verifying
-`.worktrees/` is ignored. Every operational command block re-derives
-`CONTROL_WORKTREE`, `COMMON_DIR`, and `REPO` instead of assuming a fixed local
-path or persistent shell variables. For each source worktree, store its current
+list --porcelain` from any `OpenCoven/coven` worktree or, when absent,
+recreated at the deterministic repo-local `.worktrees/issue-541-recovery`
+location after verifying `.worktrees/` is ignored. A discovered registration
+whose directory no longer exists is treated as stale/absent rather than as an
+immediate hard failure; the recovery may use the minimal documented
+`git worktree add --force` exception only when that missing registration is
+proven stale and the controller branch is not present in any live worktree.
+Every operational command block re-derives `CONTROL_WORKTREE`, `COMMON_DIR`,
+and `REPO` instead of assuming a fixed local path or persistent shell
+variables, and every recreated controller path is re-verified on the exact
+branch before the plan continues. For each source worktree, store its current
 state even if it is now clean because its changes were already committed to an
 active pull request:
 
@@ -109,7 +115,12 @@ contracts. Assign one classification:
   human authority decision.
 
 Classification uses semantic comparison, not commit ancestry alone, because
-squash merges make many merged branches appear unmerged.
+squash merges make many merged branches appear unmerged. Branch commit/stat/
+cherry evidence also uses a fixed seven-row map from workstream IDs to the
+preserved `head.txt` files captured in the dirty-worktree and orphan-branch
+snapshots. Before any comparison runs, each referenced SHA must still verify as
+a commit and its paired bundle must still verify, so the source side remains
+immutable even if a live local branch later moves.
 
 ### 3. Recover viable concerns in isolation
 
@@ -258,12 +269,26 @@ python scripts/check-secrets.py
 python3 scripts/check-coven-privacy.py --staged
 ```
 
-Changes to npm or TypeScript packages also run:
+Use repository-native npm and Node validation based on the touched paths:
 
-```sh
-npm run build
-npm test
-```
+- If `packages/channels` is touched, run `npm ci`, `npm run build`, and
+  `npm test` with `working-directory=packages/channels` (or the exact
+  `npm --prefix packages/channels ...` equivalents).
+- If npm CLI wrapper or platform packaging is touched (`packages/cli`,
+  `npm/coven`, platform package manifests, or the publish/prepublish scripts),
+  run the supported `node scripts/test-cli-prepublish.mjs` smoke for the
+  affected target and pair it with the matching release build plus the cargo
+  gates above. The current supported matrix is
+  `macos`/`aarch64-apple-darwin`, `linux-x64`/`x86_64-unknown-linux-gnu`, and
+  `windows`/`x86_64-pc-windows-msvc`. For the Intel macOS recovery row, keep
+  using `--target=macos` unless the child design intentionally introduces a new
+  target contract.
+- If `packages/openclaw-coven` is touched, run `npm install` and
+  `npm exec vitest run` with `working-directory=packages/openclaw-coven`.
+  Do not claim nonexistent package-local build or test scripts there.
+- `packages/cli` and `npm/coven` have no package-local `npm run build` or
+  `npm test` scripts; validate them through the prepublish smoke and the
+  relevant Node tests that it already executes.
 
 Documentation-only pull requests run repository-provided documentation checks
 when present, plus the secret and staged privacy guards. The privacy guard runs

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -92,19 +92,27 @@ squash merges make many merged branches appear unmerged.
 ### 3. Recover viable concerns in isolation
 
 Before creating a child issue, branch, or worktree, each viable concern maps to
-its exact current source branch, reads that workstream's snapshotted source
-head, and runs an exact-head open-pull-request query. If exactly one candidate
-open pull request exists, the recovery verifies that its `state` is `OPEN`,
-its `headRefOid` matches the snapshotted source head, its `headRefName`
-matches the expected branch, its `headRepositoryOwner` is `OpenCoven`,
-`isCrossRepository` is false, and `baseRefName` is `main` before adopting it.
-If no exact-head pull request exists, the concern follows the normal
-issue-reuse-or-create flow. If more than one exact-head pull request exists, or
-if the candidate pull request fails any identity check, including closing or
-merging between list and view, the row moves to `blocked` with saved evidence
-rather than guessing or falling through to duplicate-recovery work.
+its exact current source branch, reads that workstream's preserved local
+`head.txt`, fetches that exact branch from `origin`, records the freshly
+fetched authoritative remote tip, and runs an exact-source-branch
+open-pull-request query. If exactly one candidate open pull request exists, the
+recovery verifies that its `state` is `OPEN`, its `headRefName` matches the
+expected branch, its `headRepositoryOwner` is `OpenCoven`,
+`isCrossRepository` is false, its `baseRefName` is `main`, and its
+`headRefOid` exactly equals the freshly fetched authoritative source-branch
+tip. It then verifies via ancestry that the preserved local `head.txt` equals
+or is an ancestor of that PR head, so a clean local worktree that is behind its
+open PR by commits can still be adopted safely. If no exact-source-branch pull
+request exists, the concern follows the normal issue-reuse-or-create flow. If
+more than one exact-source-branch pull request exists, if the PR head differs
+from the fetched branch tip, if the preserved local head is not an ancestor of
+the PR head, or if the candidate pull request fails any other identity check
+including closing or merging between list and view, the row moves to `blocked`
+with saved evidence rather than guessing or falling through to
+duplicate-recovery work.
 
-Each viable concern without an adopted exact-head open pull request receives:
+Each viable concern without an adopted exact-source-branch open pull request
+receives:
 
 1. A dedicated GitHub issue, unless Task 4's paginated issue ledger contains
    exactly one non-PR open issue whose title exactly equals that concern's
@@ -127,10 +135,11 @@ unrelated or closed result remains preserved in `issues.json` but does not get
 reused.
 
 For example, if the source branch `docs/psyche-specs` still has exactly one
-open pull request from that exact source when the query runs and its identity
-checks pass, the recovery adopts whichever PR GitHub returns at execution time
-instead of creating a duplicate issue, branch, worktree, claim, or pull
-request.
+open pull request from that exact source when the query runs, its
+`headRefOid` matches the freshly fetched `origin/docs/psyche-specs` tip, and
+the preserved local `head.txt` is equal to or an ancestor of that PR head, the
+recovery adopts whichever PR GitHub returns at execution time instead of
+creating a duplicate issue, branch, worktree, claim, or pull request.
 
 Old commits are not blindly rebased or cherry-picked when current contracts
 have changed. The recovered implementation is rebuilt around current code and
@@ -213,9 +222,12 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Rebase or transplant conflicts are resolved from current contracts; old code
   never wins automatically.
 - A failing required gate blocks push and pull-request creation.
-- More than one exact-head open pull request, any candidate PR state or
-  identity mismatch, or more than one exact-title open matching recovery issue
-  blocks the row with evidence rather than choosing a duplicate target.
+- More than one exact-source-branch open pull request, any candidate PR state,
+  branch, owner, base, or cross-repo mismatch, any PR head that differs from
+  the freshly fetched authoritative branch tip, any preserved local head that
+  is not an ancestor of the PR head, or more than one exact-title open
+  matching recovery issue blocks the row with evidence rather than choosing a
+  duplicate target.
 - Any unsafe primary-checkout restore condition blocks the final audit rather
   than forcing a branch switch or reset.
 - Ambiguous ownership, policy, or human approval moves the workstream to
@@ -229,9 +241,10 @@ after staging the intended change so it evaluates the actual proposed commit.
 
 - Every dirty, formerly dirty, or orphaned workstream has a durable snapshot
   and classification.
-- Every viable concern either adopts one accurate exact-head open pull request
-  targeting `main` or has its own validated, pushed branch and open pull
-  request.
+- Every viable concern either adopts one accurate exact-source-branch open pull
+  request whose head matches the freshly fetched authoritative branch tip and
+  still descends from the preserved local snapshot, or has its own validated,
+  pushed branch and open pull request.
 - Already-shipped and superseded work has concrete GitHub or main-branch
   evidence.
 - No uncommitted work is deleted.

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -94,31 +94,37 @@ squash merges make many merged branches appear unmerged.
 Before creating a child issue, branch, or worktree, each viable concern maps to
 its exact current source branch, reads that workstream's snapshotted source
 head, and runs an exact-head open-pull-request query. If exactly one candidate
-open pull request exists, the recovery verifies that its `headRefOid` matches
-the snapshotted source head, its `headRefName` matches the expected branch, its
-`headRepositoryOwner` is `OpenCoven`, `isCrossRepository` is false, and
-`baseRefName` is `main` before adopting it. If no exact-head pull request
-exists, the concern follows the
-normal issue-reuse-or-create flow. If more than one exact-head pull request
-exists, or if the candidate pull request fails any identity check, the row
-moves to `blocked` with saved evidence rather than guessing.
+open pull request exists, the recovery verifies that its `state` is `OPEN`,
+its `headRefOid` matches the snapshotted source head, its `headRefName`
+matches the expected branch, its `headRepositoryOwner` is `OpenCoven`,
+`isCrossRepository` is false, and `baseRefName` is `main` before adopting it.
+If no exact-head pull request exists, the concern follows the normal
+issue-reuse-or-create flow. If more than one exact-head pull request exists, or
+if the candidate pull request fails any identity check, including closing or
+merging between list and view, the row moves to `blocked` with saved evidence
+rather than guessing or falling through to duplicate-recovery work.
 
 Each viable concern without an adopted exact-head open pull request receives:
 
-1. A dedicated GitHub issue, unless exactly one OPEN issue already exists whose
-   title exactly equals that concern's fixed recovery title.
+1. A dedicated GitHub issue, unless Task 4's paginated issue ledger contains
+   exactly one non-PR open issue whose title exactly equals that concern's
+   fixed recovery title.
 2. A fresh branch and worktree based on current `origin/main`.
 3. An issue-keyed Coven claim acquired from that worktree.
 4. A minimal transplant of only the still-relevant changes.
 5. Targeted tests followed by all repository-required gates.
 6. A conventional commit, push, and scoped pull request.
 
-Broad issue-search results are still saved for evidence, but only OPEN issues
-whose title exactly matches the fixed `ISSUE_TITLE` count as reusable:
-zero exact-open matches create a new issue, one exact-open match is reused and
-re-verified, and more than one exact-open match blocks the row with evidence.
-A sole unrelated or closed search result is preserved in the evidence files but
-does not get reused.
+Task 4's fully paginated `issues.json` capture is the authoritative reuse
+source. Each workstream derives its own filtered issue-search evidence by
+running `jq` across every page and keeping only non-PR issues whose title
+exactly matches the fixed `ISSUE_TITLE` and whose state is `open`.
+Zero exact-title open matches create a new issue, one exact-title open match is
+reused and re-verified, and more than one exact-title open match blocks the row
+with evidence. Human-friendly `gh issue list` output may still be useful for
+operators, but it is informational only and never drives reuse. A sole
+unrelated or closed result remains preserved in `issues.json` but does not get
+reused.
 
 For example, if the source branch `docs/psyche-specs` still has exactly one
 open pull request from that exact source when the query runs and its identity
@@ -207,9 +213,9 @@ after staging the intended change so it evaluates the actual proposed commit.
 - Rebase or transplant conflicts are resolved from current contracts; old code
   never wins automatically.
 - A failing required gate blocks push and pull-request creation.
-- More than one exact-head open pull request, any candidate PR identity
-  mismatch, or more than one exact-open matching recovery issue blocks the row
-  with evidence rather than choosing a duplicate target.
+- More than one exact-head open pull request, any candidate PR state or
+  identity mismatch, or more than one exact-title open matching recovery issue
+  blocks the row with evidence rather than choosing a duplicate target.
 - Any unsafe primary-checkout restore condition blocks the final audit rather
   than forcing a branch switch or reset.
 - Ambiguous ownership, policy, or human approval moves the workstream to

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -1,0 +1,178 @@
+# Incomplete Work Recovery Design
+
+**Issue:** [#541](https://github.com/OpenCoven/coven/issues/541)
+
+## Objective
+
+Preserve, classify, recover, and deliver viable work from stale local branches
+and dirty worktrees without losing data, duplicating shipped behavior, or
+mixing unrelated concerns in one pull request.
+
+The recovery ends when every discovered workstream is in exactly one of these
+states:
+
+1. Delivered through a scoped pull request.
+2. Proven already shipped or superseded and recorded as such.
+3. Preserved in a durable recovery snapshot with a documented blocker.
+
+Only after reaching one of those states may its stale branch or worktree be
+removed.
+
+## Current Inventory
+
+The primary checkout is clean and matches `origin/main`. There are no open pull
+requests, active claims, stashes, or session todos predating this recovery.
+
+Dirty worktrees:
+
+- `docs/psyche-specs`: Psyche product, technical, parity, threat-model,
+  prerequisites, and plan documents.
+- `feat/cmem-1ev-memory-promote`: memory promotion authority, CLI wiring,
+  privacy tooling, CI, and security documentation.
+- `feat/mobile-memory-gateway`: an uncommitted mobile pairing change.
+- `fix/476-review-threads`: Cave/runtime parity design and implementation plans.
+
+Clean orphan branches without open pull requests:
+
+- `docs/universal-runtime-capability-design`
+- `feat/npm-macos-x64`
+- `fix/521-ward-surface-confinement`
+
+Several additional branches and worktree registrations correspond to merged
+pull requests or missing temporary directories. They are hygiene candidates,
+not feature inputs, but will not be removed until their tips are verified
+against GitHub history.
+
+## Recovery Architecture
+
+### 1. Preserve before mutation
+
+Create a durable recovery directory outside the repository worktrees. For each
+dirty worktree, store:
+
+- `git status --short --branch`
+- the base and head commit identifiers
+- tracked working-tree and index patches
+- copies of untracked files with their relative paths
+
+For each orphan branch, create a Git bundle or equivalent ref-preserving
+archive and record its commits relative to current `origin/main`.
+
+Snapshots remain until the corresponding pull request is open and its source
+branch is pushed, or until the work is explicitly recorded as blocked.
+
+### 2. Classify against current authority
+
+Compare each workstream with current `origin/main`, merged pull requests, closed
+issues, and current contracts. Assign one classification:
+
+- **Already shipped:** main contains equivalent behavior or documentation.
+- **Superseded:** a later implementation intentionally replaced the work.
+- **Viable:** the intent remains useful and is not present on main.
+- **Blocked:** viability cannot be established safely without a maintainer or
+  human authority decision.
+
+Classification uses semantic comparison, not commit ancestry alone, because
+squash merges make many merged branches appear unmerged.
+
+### 3. Recover viable concerns in isolation
+
+Each viable concern receives:
+
+1. A dedicated GitHub issue, unless an existing issue accurately owns it.
+2. A fresh branch and worktree based on current `origin/main`.
+3. An issue-keyed Coven claim acquired from that worktree.
+4. A minimal transplant of only the still-relevant changes.
+5. Targeted tests followed by all repository-required gates.
+6. A conventional commit, push, and scoped pull request.
+
+Old commits are not blindly rebased or cherry-picked when current contracts
+have changed. The recovered implementation is rebuilt around current code and
+tests while retaining the original intent and attribution.
+
+### 4. Clean only after proof
+
+An original worktree, branch, claim, or stale registration may be removed only
+after one of these proofs exists:
+
+- its replacement pull request is open from a pushed branch;
+- its behavior is identified in a merged pull request or current main;
+- its snapshot and blocker record preserve all remaining value.
+
+Cleanup includes stale `/tmp` worktree registrations, merged local branches,
+gone upstream references, and expired claims. Unrelated user changes are never
+discarded.
+
+### 5. Reconcile long-running goals
+
+Update `.copilot/goals.md` after the recovery outcomes are known. Closed issues
+such as #401, #414, and #521 must not remain listed as future work. Active goals
+should contain only current objectives and a single concrete next action;
+completed or superseded objectives move to `done`.
+
+## Work Queue
+
+Recovery proceeds sequentially to avoid overlapping claims and file changes:
+
+1. Snapshot every dirty and orphaned workstream.
+2. Perform the supersession and merged-history pass.
+3. Recover the mobile pairing patch.
+4. Recover Intel macOS npm packaging.
+5. Reconcile Ward surface confinement.
+6. Recover memory promotion and privacy tooling.
+7. Recover Psyche specifications.
+8. Recover universal runtime capability design.
+9. Reconcile Cave/runtime parity plans.
+10. Clean verified residue and update goals.
+
+If classification shows a queued item is already shipped or superseded, record
+the evidence and skip implementation without changing the order of the
+remaining queue.
+
+## Validation
+
+Every viable code pull request runs targeted tests first, then:
+
+```sh
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Changes to npm or TypeScript packages also run:
+
+```sh
+npm run build
+npm test
+```
+
+Documentation-only pull requests run repository-provided documentation checks
+when present, plus the secret and staged privacy guards. The privacy guard runs
+after staging the intended change so it evaluates the actual proposed commit.
+
+## Failure Handling
+
+- Snapshot creation failure blocks all cleanup for that workstream.
+- Rebase or transplant conflicts are resolved from current contracts; old code
+  never wins automatically.
+- A failing required gate blocks push and pull-request creation.
+- Ambiguous ownership, policy, or human approval moves the workstream to
+  `blocked` with evidence rather than inventing authority.
+- Claims are heartbeated during long work and released when the pull request
+  merges or the recovery session stops.
+- Pull-request descriptions identify the recovered source and explain omitted
+  portions that were obsolete or superseded.
+
+## Success Criteria
+
+- Every dirty or orphaned workstream has a durable snapshot and classification.
+- Every viable concern has its own validated, pushed branch and open pull
+  request.
+- Already-shipped and superseded work has concrete GitHub or main-branch
+  evidence.
+- No uncommitted work is deleted.
+- Stale worktrees, branches, and claims are removed only after proof.
+- `.copilot/goals.md` matches current issue and pull-request reality.
+- The primary checkout remains clean and on `main`.

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -64,9 +64,16 @@ current-run path remains `agent-recovery/issue-541`, but reruns must never
 reuse it in place: if that path already exists, move the entire prior run into
 an immutable private archive directory under the shared recovery archive, record
 its former location and archival time, then create a fresh current root at the
-same fixed path before writing any new manifest or snapshot. For each source
-worktree, store its current state even if it is now clean because its changes
-were already committed to an active pull request:
+same fixed path before writing any new manifest or snapshot. Publication and
+execution are driven from a controller worktree for
+`docs/541-incomplete-work-recovery-design` that is discovered with `git worktree
+list --porcelain` from any `OpenCoven/coven` worktree or, when absent, created
+under the repo-local `.worktrees/issue-541-recovery` convention after verifying
+`.worktrees/` is ignored. Every operational command block re-derives
+`CONTROL_WORKTREE`, `COMMON_DIR`, and `REPO` instead of assuming a fixed local
+path or persistent shell variables. For each source worktree, store its current
+state even if it is now clean because its changes were already committed to an
+active pull request:
 
 - `git status --short --branch`
 - the base and head commit identifiers
@@ -190,7 +197,7 @@ after one of these proofs exists:
 - its behavior is identified in a merged pull request or current main;
 - its snapshot and blocker record preserve all remaining value.
 
-Cleanup includes stale `/tmp` worktree registrations, merged local branches,
+Cleanup includes stale worktree registrations, merged local branches,
 gone upstream references, and expired claims. Rows blocked because an existing
 PR already covers the preserved head while additional dirty snapshot state
 remains do not qualify for source-worktree or source-branch cleanup; those

--- a/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-01-incomplete-work-recovery-design.md
@@ -245,7 +245,7 @@ Recovery proceeds sequentially to avoid overlapping claims and file changes:
 1. Snapshot every dirty and orphaned workstream.
 2. Perform the supersession and merged-history pass.
 3. Recover the mobile pairing patch.
-4. Recover Intel macOS npm packaging.
+4. Recover or block Intel macOS npm packaging.
 5. Reconcile Ward surface confinement.
 6. Recover memory promotion and privacy tooling.
 7. Recover Psyche specifications.
@@ -280,9 +280,14 @@ Use repository-native npm and Node validation based on the touched paths:
   affected target and pair it with the matching release build plus the cargo
   gates above. The current supported matrix is
   `macos`/`aarch64-apple-darwin`, `linux-x64`/`x86_64-unknown-linux-gnu`, and
-  `windows`/`x86_64-pc-windows-msvc`. For the Intel macOS recovery row, keep
-  using `--target=macos` unless the child design intentionally introduces a new
-  target contract.
+  `windows`/`x86_64-pc-windows-msvc`. Current main cannot validate Intel x64,
+  and `--target=macos` must never be used as a proxy for Intel recovery. A
+  viable child design/plan must first restore the concrete
+  `macos-x64`/`@opencoven/cli-macos-x64` contract in current code, with tests
+  proving default darwin x64 mapping and package metadata. After that contract
+  exists, the exact Intel validation command is
+  `node scripts/test-cli-prepublish.mjs --target=macos-x64 --with-cargo-gates`,
+  plus any targeted Node tests documented by the child plan.
 - If `packages/openclaw-coven` is touched, run `npm install` and
   `npm exec vitest run` with `working-directory=packages/openclaw-coven`.
   Do not claim nonexistent package-local build or test scripts there.


### PR DESCRIPTION
Fixes the retirement/classification parsing in the recovery plan so it works on macOS Bash 3.2 without mapfile/readarray.\n\nChecks:\n- git diff --cached --check\n- python scripts/check-secrets.py\n- python3 scripts/check-coven-privacy.py --staged