### PR TITLE
docs: align Psyche G1 gate contracts

### DIFF
--- a/specs/psyche/DECISION_DOSSIER.md
+++ b/specs/psyche/DECISION_DOSSIER.md
@@ -804,9 +804,9 @@ needs the following independently testable workstreams.
 
 | ID | Workstream | Depends on | Exit result |
 |---|---|---|---|
-| W0 | Canonical specification reconciliation | Dossier approval | Every companion document describes the same product and ownership model. |
-| W1 | Current Coven contract audit | Dossier approval | Every prerequisite is classified with evidence and owner. |
-| W2 | Rust foundation and canonical schemas | W0 | Buildable workspace, schemas, store, fake services, and contract tests. |
+| W0 | Canonical specification reconciliation | G0 | Every companion document describes the same product and ownership model. |
+| W1 | Current Coven contract audit | W0, G1 | Every prerequisite is classified with evidence and owner. |
+| W2 | Rust foundation and canonical schemas | W0, W1, G3 | Buildable workspace, schemas, store, fake services, and contract tests. |
 | W3 | Identity and intent | W2 | Surface-neutral identity snapshots and immutable intent replay pass. |
 | W4 | Graph store and simulation | W2, W3 | Graph/node/attempt state, dependencies, budgets, cancellation, and restart recovery work without real harnesses. |
 | W5 | Single-node Coven execution | W1, W2, W3 | One node dispatches, adopts, follows, cancels, and recovers against real Coven. |
@@ -820,20 +820,22 @@ needs the following independently testable workstreams.
 ### 13.1 Critical path
 
 ```text
-Dossier approval
-  -> W0 specification reconciliation
-  -> W2 foundation and schemas
+G0 decision approval
+  -> W0 / G1 specification coherence
+  -> standalone repository creation
+  -> W1 / G3 current Coven audit
+  -> W2 / G2 foundation and schemas
   -> W3 identity and intent
-  -> W5 single-node real Coven execution
+  -> W5 / G4 single-node real Coven execution
   -> W6 Telegram vertical slice
-  -> W10 Telegram parity
-  -> W11 canary and release
+  -> W10 / G8-G9 Telegram evidence
+  -> W11 / G10-G12 operations, canary, and release
 ```
 
-W1 runs in parallel with W0-W3. W4 may proceed against fakes after schemas
-freeze. W7 and W9 can proceed after their boundaries stabilize. W8 is never on
-the first Telegram release critical path unless Val explicitly makes
-production multi-agent execution a launch requirement.
+W1 begins after G1 and gates W2. W4 may proceed against fakes after W2/W3. W7
+and W9 may progress when their contracts stabilize. W8 is never on the first
+Telegram release critical path unless Val explicitly makes production
+multi-agent execution a launch requirement.
 
 ### 13.2 Recommended first release
 
@@ -867,7 +869,7 @@ release slice of that architecture.
 | G7 - Trusted add-ons | Approval, allowlisting, digest pinning, provenance, revocation, per-invocation audit, protocol denial, crash, and security evidence pass. | Trusted add-on activation. |
 | G8 - Adapter reliability | Fake surface, crash, security, ambiguity, and parity evidence pass repeatedly. | Live Telegram. |
 | G9 - Live Telegram | Required live rows pass twice on dedicated non-production accounts and two client families. | Canary. |
-| G10 - Operations | Doctor, retention, privacy, export/restore, incident response, and rollback drills pass. | Production cutover. |
+| G10 - Operations | Doctor, retention, privacy, export/restore, incident response, migration, token rotation, and rollback drills pass; a release security review finds no open critical or high-severity issue. | Production cutover. |
 | G11 - Canary | Core and Telegram adapter service objectives hold for the operator-approved observation window and update volume with zero unauthorized dispatch. The prior seven-day and 1,000-update values remain provisional until operators approve the canary. | General release. |
 | G12 - Distribution | Signed/checksummed artifacts, SBOM, provenance, clean-host install, and rollback under threshold pass. | Publication. |
 

--- a/specs/psyche/INTEGRATION_REVIEW.md
+++ b/specs/psyche/INTEGRATION_REVIEW.md
@@ -1138,7 +1138,7 @@ requirements remain independently binding.
 | G7 Trusted add-ons | Allowlist, pin/provenance, revocation, audit, protocol denial, crash/security evidence | Add-on activation |
 | G8 Adapter reliability | Fake surface, crash, security, ambiguity, and parity evidence | Live Telegram |
 | G9 Live Telegram | Required live rows pass twice on dedicated accounts and two client families | Canary |
-| G10 Operations | Doctor, retention, privacy, export/restore, incident response, migration, token rotation, rollback, release security review with no open critical/high issue | Production cutover |
+| G10 Operations | Doctor, retention, privacy, export/restore, incident response, migration, token rotation, rollback, release security review with no open critical or high-severity issue | Production cutover |
 | G11 Canary | Approved core/adapter objectives for approved window/volume; zero unauthorized dispatch | General release |
 | G12 Distribution | Signed/checksummed artifacts, SBOM, provenance, clean-host install, rollback threshold | Publication |
 

--- a/specs/psyche/INTEGRATION_REVIEW.md
+++ b/specs/psyche/INTEGRATION_REVIEW.md
@@ -1138,7 +1138,7 @@ requirements remain independently binding.
 | G7 Trusted add-ons | Allowlist, pin/provenance, revocation, audit, protocol denial, crash/security evidence | Add-on activation |
 | G8 Adapter reliability | Fake surface, crash, security, ambiguity, and parity evidence | Live Telegram |
 | G9 Live Telegram | Required live rows pass twice on dedicated accounts and two client families | Canary |
-| G10 Operations | Doctor, retention, privacy, export/restore, incident response, rollback | Production cutover |
+| G10 Operations | Doctor, retention, privacy, export/restore, incident response, migration, token rotation, rollback, release security review with no open critical/high issue | Production cutover |
 | G11 Canary | Approved core/adapter objectives for approved window/volume; zero unauthorized dispatch | General release |
 | G12 Distribution | Signed/checksummed artifacts, SBOM, provenance, clean-host install, rollback threshold | Publication |
 

--- a/specs/psyche/PLAN.md
+++ b/specs/psyche/PLAN.md
@@ -266,7 +266,7 @@ pass. No calendar date overrides evidence.
 | G7 - Trusted add-ons | Allowlist, digest/provenance, revocation, audit, protocol denial, crash/security evidence. | Add-on activation. |
 | G8 - Adapter reliability | Fake surface, crash, security, ambiguity, and parity evidence. | Live Telegram. |
 | G9 - Live Telegram | Required live rows pass twice on dedicated accounts and two client families. | Canary. |
-| G10 - Operations | Doctor, retention, privacy, export/restore, incident response, rollback. | Production cutover. |
+| G10 - Operations | Doctor, retention, privacy, export/restore, incident response, migration, token rotation, rollback, and a release security review with no open critical or high-severity issue. | Production cutover. |
 | G11 - Canary | Approved core and Telegram objectives hold for the operator-approved window/volume with zero unauthorized dispatch. | General release. |
 | G12 - Distribution | Signed/checksummed artifacts, SBOM, provenance, clean-host install, rollback under threshold. | Publication. |
 

--- a/specs/psyche/PRODUCT.md
+++ b/specs/psyche/PRODUCT.md
@@ -617,7 +617,7 @@ G11.
 | G7 - Trusted add-ons | Approval, allowlisting, digest pinning, provenance, revocation, invocation audit, protocol denial, crash, and security evidence pass. | Trusted add-on activation. |
 | G8 - Adapter reliability | Fake-surface, crash, security, ambiguity, and parity evidence pass repeatedly. | Live Telegram. |
 | G9 - Live Telegram | Every required live parity row passes twice on dedicated non-production accounts and two client families. | Canary. |
-| G10 - Operations | Doctor, retention, privacy, export/restore, incident response, and rollback drills pass. | Production cutover. |
+| G10 - Operations | Doctor, retention, privacy, export/restore, incident response, migration, token rotation, and rollback drills pass; a release security review finds no open critical or high-severity issue. | Production cutover. |
 | G11 - Canary | Approved core and Telegram service objectives hold for the approved window and volume with zero unauthorized dispatch. | General release. |
 | G12 - Distribution | Signed/checksummed artifacts, SBOM, provenance, clean-host install, and rollback under threshold pass. | Publication. |
 

--- a/specs/psyche/TECH.md
+++ b/specs/psyche/TECH.md
@@ -1519,7 +1519,7 @@ Coven
 recomputes the metadata digest and streamed-byte hash. Repeating the same
 client-scoped `artifact_request_id` and request digest returns the original
 artifact; any field or byte change returns the W1-confirmed public
-intent-conflict response. Psyche verifies every echoed response field before
+intent conflict response. Psyche verifies every echoed response field before
 use. Coven expiry may shorten but never extend Psyche's requested lifetime.
 Without the capability, no media bytes or path enter Coven and the media parity
 release gate cannot pass.

--- a/specs/psyche/TECH.md
+++ b/specs/psyche/TECH.md
@@ -114,7 +114,9 @@ snapshot, intent, graph node, execution request, evidence policy, and effect.
 
 The root config declares `schema_version = "psyche.config.v1"`. Unknown fields
 are errors except under an explicitly versioned `extensions` table. Raw token
-values are not valid configuration.
+values are not valid configuration. The Coven API version below illustrates a
+candidate configuration shape; W1 must replace it with the verified public
+version before implementation.
 
 ```toml
 schema_version = "psyche.config.v1"
@@ -1058,7 +1060,7 @@ CLI, admin socket, and internal boundary errors use `psyche.error.v1`:
     "retryable": false,
     "correlation_id": "corr_01J...",
     "details": {
-      "capability": "coven.approvals.v1"
+      "capability": "required-capability-id"
     }
   }
 }
@@ -1070,15 +1072,19 @@ the local CLI explicitly requests a privileged diagnostic view.
 
 ## Coven capability profile
 
-At startup Psyche calls `GET /api/v1/health`, requires
-`apiVersion == "coven.daemon.v1"`, then calls `GET /api/v1/capabilities`.
-Psyche never assumes an endpoint is authorized merely because it exists.
+W1 must identify Coven's current public, versioned health and capability
+discovery contracts. The names `GET /api/v1/health`,
+`coven.daemon.v1`, and `GET /api/v1/capabilities` are candidate references,
+not W0 requirements. If W1 confirms them, Psyche may use that profile;
+otherwise the audited public names govern. Psyche never assumes an endpoint is
+authorized merely because it exists.
 
 W0 freezes behavior requirements, not speculative Coven names. W1 must classify
 each requirement as `current`, `current_but_undocumented`, `planned`,
 `optional`, or `rejected`, with a code/test citation and owner. Only `current`
-or `current_but_undocumented` behavior with executable conformance can satisfy
-G4.
+behavior with executable conformance can satisfy G4.
+`current_but_undocumented` behavior must become a public, versioned contract
+before it is reclassified as `current` and used for G4.
 
 The single-node execution profile requires:
 
@@ -1144,7 +1150,8 @@ resources. Coven does not authorize Telegram or another surface effect.
 
 Psyche uses daemon-managed sessions, not external sessions, because Coven owns
 the admitted process lifecycle. Exact endpoint, capability, and error names are
-W1 outputs and remain absent from this W0 protocol.
+W1 outputs. Any names shown in W0 are explicitly non-normative candidate
+examples.
 
 ### Adoption-unknown operator recovery
 
@@ -1511,10 +1518,11 @@ project/familiar-snapshot/graph/attempt/source binding, request ID, and expiry.
 Coven
 recomputes the metadata digest and streamed-byte hash. Repeating the same
 client-scoped `artifact_request_id` and request digest returns the original
-artifact; any field or byte change returns `409 intent_conflict`. Psyche
-verifies every echoed response field before use. Coven expiry may shorten but
-never extend Psyche's requested lifetime. Without the capability, no media
-bytes or path enter Coven and the media parity release gate cannot pass.
+artifact; any field or byte change returns the W1-confirmed public
+intent-conflict response. Psyche verifies every echoed response field before
+use. Coven expiry may shorten but never extend Psyche's requested lifetime.
+Without the capability, no media bytes or path enter Coven and the media parity
+release gate cannot pass.
 
 1. Persist Telegram file identifiers and declared metadata.
 2. Ask Telegram for the file path using the account client.
@@ -1730,9 +1738,9 @@ is a deterministic rendering of the same object:
       "correlation_id": "corr_01J..."
     },
     {
-      "check_id": "capability.coven.memory.read",
+      "check_id": "capability.required-memory-read",
       "component": "coven",
-      "scope": { "type": "capability", "id": "coven.memory.read" },
+      "scope": { "type": "capability", "id": "required-memory-read" },
       "status": "degraded",
       "reason_code": "optional_capability_missing",
       "blocking": false,

--- a/specs/psyche/TELEGRAM_PARITY.md
+++ b/specs/psyche/TELEGRAM_PARITY.md
@@ -53,7 +53,7 @@ permissive fallback would create risk.
 | Canonical reply/action authorization | `psyche.surface_effect.v1` plus `psyche.telegram_effect.v1` | G8 |
 | Logical/physical send durability and ambiguity | `psyche.delivery.v1`, `psyche.recovery.v1` | G8 |
 | Live Bot API behavior | Required rows marked `L` | G9 |
-| Doctor, retention, export/restore, migration, rollback | Psyche operations contracts | G10 |
+| Doctor, retention, export/restore, migration, token rotation, rollback, release security review | Psyche operations contracts | G10 |
 | Production observation window and service objectives | Approved canary report | G11 |
 
 G6 controls production child-session dispatch and is not implied by any

--- a/specs/psyche/THREAT_MODEL.md
+++ b/specs/psyche/THREAT_MODEL.md
@@ -385,19 +385,29 @@ Response:
 
 ## Security acceptance
 
-G1 cannot pass, and Psyche cannot release, until:
+G1 cannot pass until:
 
 - all six companion documents share the surface-neutral product and authority
   model;
-- all invariants have automated negative tests;
-- crash tests prove durable acknowledgement;
-- webhook, media, callback, identity, and Coven-boundary fuzz targets run in
-  CI;
-- a security review finds no open critical or high-severity issue;
-- release artifacts pass secret scanning and provenance verification;
-- minimum export/restore and ambiguous-recovery drills pass on a clean host
-  profile;
-- migration and token-rotation drills pass on a dedicated account;
-- W1 classifies Coven requirements before any implementation assignment; and
-- repository creation and W1 remain blocked until G1; implementation planning,
-  issues, and production code remain blocked until G3.
+- their trust boundaries, invariants, abuse cases, recovery rules, and
+  acceptance-gate allocations are internally consistent; and
+- repository creation and W1 remain blocked until G1.
+
+Executable security evidence belongs to the later gate that owns the affected
+behavior:
+
+- G2 requires automated negative, state-machine, property, migration, and
+  unknown-version tests for the contract foundation;
+- G3 requires W1 to classify Coven requirements before implementation
+  assignments, issues, or production code;
+- G4 requires denial, restart, cancellation, binding, and ambiguity evidence
+  against a pinned real Coven build;
+- G8-G9 require adapter crash, fuzz, security, ambiguity, parity, and dedicated
+  live-account evidence;
+- G10 requires privacy, export/restore, incident-response, migration,
+  token-rotation, and rollback drills plus a release security review with no
+  open critical or high-severity issue; and
+- G12 requires clean-host, secret-scan, signed/checksummed artifact, SBOM,
+  provenance, and distribution rollback evidence.
+
+Passing G1 does not substitute for any of this executable evidence.

--- a/specs/psyche/THREAT_MODEL.md
+++ b/specs/psyche/THREAT_MODEL.md
@@ -404,8 +404,8 @@ behavior:
   against a pinned real Coven build;
 - G8-G9 require adapter crash, fuzz, security, ambiguity, parity, and dedicated
   live-account evidence;
-- G10 requires privacy, export/restore, incident-response, migration,
-  token-rotation, and rollback drills plus a release security review with no
+- G10 requires privacy, export/restore, incident response, migration,
+  token rotation, and rollback drills plus a release security review with no
   open critical or high-severity issue; and
 - G12 requires clean-host, secret-scan, signed/checksummed artifact, SBOM,
   provenance, and distribution rollback evidence.


### PR DESCRIPTION
## Summary
- keep G1 limited to specification and security-model coherence
- align W1/W2 dependencies and the critical path with the canonical plan
- require public, versioned `current` Coven contracts for G4
- treat pre-W1 Coven identifiers as non-normative candidates
- assign executable security evidence to explicit later gates

## Validation
- `git diff --check`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- focused contradiction scans across `specs/psyche/*.md`
- independent final review: no significant issues

Closes #564