### PR TITLE
test(memory): assert real preview side-effect paths

### DIFF
--- a/crates/coven-cli/tests/memory_import.rs
+++ b/crates/coven-cli/tests/memory_import.rs
@@ -210,8 +210,11 @@ fn preview_conflict_is_whole_plan_ineligible_and_creates_nothing() -> Result<()>
     assert_eq!(report["entries"][0]["status"], "conflict");
     assert_eq!(report["entries"][1]["status"], "create");
     assert!(!temp.path().join("memory/sage/notes-new.md").exists());
-    assert!(!temp.path().join("memory-import").exists());
-    assert!(!temp.path().join("journal").exists());
+    assert!(!temp.path().join("memory-migrations").exists());
+    assert!(!temp
+        .path()
+        .join("memory/sage/.coven-migration-work")
+        .exists());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- assert the actual `memory-migrations` bundle root during conflict previews
- assert the familiar-scoped `.coven-migration-work` staging directory
- follow up PR #568 after its review correction missed the merge boundary

## Verification

- mutation proof: the old assertions passed with both real side-effect directories present; corrected assertions failed on the injected regression
- `cargo fmt --all --check`
- `cargo test -p coven-cli --test memory_import` (14 passed)
- `git diff --check`