### PR TITLE
docs: recover universal runtime capability design

### DIFF
--- a/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Freeze the public `coven.daemon.v1` and session-lifecycle vocabulary first, then layer a new effective runtime-descriptor resolver on top of existing Rust launch specs and raw harness-scan manifests. Keep `/api/v1/capabilities/harnesses` as factual native scan output, add a distinct runtime descriptor read surface, and enforce required capabilities in Rust before launch.
 
-**Tech Stack:** Rust (`crates/coven-cli/src/api.rs`, `harness.rs`, `capabilities.rs`, `daemon.rs`, `store.rs`), markdown API docs, existing Rust tests, secret/privacy guardrails.
+**Tech Stack:** Rust (`crates/coven-cli/src/api.rs`, `harness.rs`, `capabilities.rs`, `daemon.rs`, `store.rs`), the pinned shared schema types from `coven_runtime_spec` (`Capabilities`, `SandboxMapping`, `StreamArgs`), markdown API docs, existing Rust tests, secret/privacy guardrails.
 
 ---
 
@@ -21,7 +21,7 @@
 - Test: `crates/coven-cli/src/api.rs`
 
 - [ ] **Step 1:** Update the public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix.
-- [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`) and clearly distinguish archive state from terminal state.
+- [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`), distinguish archive metadata from lifecycle status, and define `idle` as the persisted conversational state written when a clean child exit leaves the conversation extendable.
 - [ ] **Step 3:** Change `GET /api/v1/api-version` in `crates/coven-cli/src/api.rs` so the payload reports the named contract string instead of the bare `v1` token.
 - [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path.
 - [ ] **Step 5:** Run focused tests for the version routes and session-lifecycle docs assertions, then commit only the O1 contract-freeze changes.
@@ -35,11 +35,12 @@
 - Modify: `crates/coven-cli/src/harness.rs`
 - Test: `crates/coven-cli/src/runtime_descriptors.rs`
 
-- [ ] **Step 1:** Add `runtime_descriptors.rs` with the new derived authority types: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `RuntimeAdmission`, `AvailabilityDescriptor`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, and `NativeIntegrationSummary`.
-- [ ] **Step 2:** Expose the new module from `main.rs` or the existing module tree without moving launch authority out of `harness.rs`.
-- [ ] **Step 3:** Add unit tests that construct descriptors for `codex`, `claude`, `copilot`, and `coven-code`, asserting that only the first three classify as `supported_runtime`.
-- [ ] **Step 4:** Add a regression test proving unknown harness ids never synthesize a descriptor.
-- [ ] **Step 5:** Commit the type layer separately before wiring any API route.
+- [ ] **Step 1:** Add `runtime_descriptors.rs` with the new derived authority types: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `RuntimeAdmission`, `AvailabilityDescriptor`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, `NativeIntegrationSummary`, `RuntimeWarning`, `RuntimeWarningCode`, and `RuntimeWarningScope`.
+- [ ] **Step 2:** Reuse the pinned shared-spec inputs already carried by `HarnessCommandSpec` (`coven_runtime_spec::Capabilities`, `SandboxMapping`, and `StreamArgs`) instead of redefining those schema structs locally; keep Coven's Rust adapter logic authoritative for evaluation and spawn decisions.
+- [ ] **Step 3:** Expose the new module from `main.rs` or the existing module tree without moving launch authority out of `harness.rs`.
+- [ ] **Step 4:** Add unit tests that construct descriptors for `codex`, `claude`, `copilot`, and harness-only `coven-code`, asserting that only the first three classify as `supported_runtime`.
+- [ ] **Step 5:** Add a regression test proving unknown harness ids never synthesize a descriptor and that `RuntimeWarning` values serialize with the documented enum set and stable ordering.
+- [ ] **Step 6:** Commit the type layer separately before wiring any API route.
 
 ### Task 3: Build the supported-runtime resolver from existing Rust facts
 
@@ -52,8 +53,9 @@
 - [ ] **Step 1:** Add a resolver that combines the bundled `HarnessCommandSpec` data with local availability and the existing `HarnessCapabilityManifest` scan results.
 - [ ] **Step 2:** Map the current Rust-owned launch behaviors into the initial capability families from the design: `launch.text`, `model.selection`, `prompt.system`, `access.read_only`, `filesystem.additional_directories`, `conversation.stream`, `conversation.resume`, `conversation.preassigned_session_id`, `reasoning.think`, `reasoning.speed`, and `transport.local`.
 - [ ] **Step 3:** Encode explicit `supported`, `unavailable`, `unverified`, and `unsupported` states with stable reason values rather than client-generated prose.
-- [ ] **Step 4:** Add unit tests covering each supported runtime, missing executables, missing sandbox mapping, conversation capability differences, and the exclusion of observational scan targets from the public list.
-- [ ] **Step 5:** Commit the resolver once the unit tests pass.
+- [ ] **Step 4:** Map raw `CapabilityWarning { kind, path, message }` values into the closed `RuntimeWarning` enum set (`parse_error` → `native_scan_parse_error`, `permission_denied` → `native_scan_permission_denied`) and sort warnings by the documented stable order.
+- [ ] **Step 5:** Add unit tests covering each supported runtime, missing executables, missing sandbox mapping, conversation capability differences, deterministic warning ordering, and the exclusion of observational scan targets from the public list.
+- [ ] **Step 6:** Commit the resolver once the unit tests pass.
 
 ### Task 4: Add a distinct runtime descriptor read surface
 
@@ -67,7 +69,7 @@
 
 - [ ] **Step 1:** Add `GET /api/v1/runtimes` and `GET /api/v1/runtimes/:runtimeId` to `api.rs`, keeping `/api/v1/capabilities/harnesses` and `/api/v1/capabilities/:harnessId` unchanged.
 - [ ] **Step 2:** Return payloads that include `descriptorVersion: "coven.runtime.descriptor.v1"` and the effective descriptor fields from Task 2.
-- [ ] **Step 3:** Add a structured `404 runtime_not_found` path for unknown or unsupported public runtime ids.
+- [ ] **Step 3:** Add a structured `404 runtime_not_found` path for unknown or unsupported public runtime ids, without implying that harness-only tools such as `coven-code` are public runtimes.
 - [ ] **Step 4:** Document the new routes in `docs/API-CONTRACT.md`, `docs/reference/api.md`, `docs/reference/api-contract.md`, and the dedicated `docs/reference/api-runtimes.md` page, explicitly contrasting them with the raw harness-capability scan routes.
 - [ ] **Step 5:** Add focused API tests proving the new runtime routes work, that the old harness-capability routes are unchanged, and that unsupported observational scan targets do not appear in the public runtime listing.
 - [ ] **Step 6:** Commit the read-surface work only after the docs and tests match.
@@ -82,32 +84,34 @@
 - Modify: `docs/reference/api.md`
 - Test: `crates/coven-cli/src/api.rs`
 
-- [ ] **Step 1:** Extend the session launch payload parsing to accept a Rust-owned required-capability field (for example `requiredCapabilities`).
-- [ ] **Step 2:** Reject unknown capability ids up front with `400 invalid_request` and structured details.
-- [ ] **Step 3:** Evaluate the chosen runtime's descriptor before launch and reject any required capability whose state is not `supported`.
-- [ ] **Step 4:** Add the stable `409 runtime_capability_not_met` error code, document it, and include `runtimeId`, `capability`, `state`, and `reason` in `details`.
-- [ ] **Step 5:** Add focused API tests for unknown capability ids, unsupported capability requests, unavailable capability requests, and an accepted launch where every required capability is `supported`.
-- [ ] **Step 6:** Commit the enforcement change separately from broader refactors.
+- [ ] **Step 1:** Extend the session launch payload parsing to accept an optional public `runtimeId` selector plus a Rust-owned required-capability field (for example `requiredCapabilities`), while preserving today's harness-keyed launch path.
+- [ ] **Step 2:** If `runtimeId` is present, resolve it only against the public supported-runtime set; reject `coven-code`, observational-scan ids, and unknown ids with stable `404 runtime_not_found` before argv construction or spawn, and do not fall back to harness launch.
+- [ ] **Step 3:** Reject unknown capability ids up front with `400 invalid_request` and structured details.
+- [ ] **Step 4:** Evaluate the chosen runtime's descriptor before launch and reject any required capability whose state is not `supported`.
+- [ ] **Step 5:** Add the stable `409 runtime_capability_not_met` error code, document it, and include `runtimeId`, `capability`, `state`, and `reason` in `details`.
+- [ ] **Step 6:** Add focused API tests for unknown capability ids, explicit non-public `runtimeId` requests, unsupported capability requests, unavailable capability requests, and an accepted launch where every required capability is `supported`.
+- [ ] **Step 7:** Commit the enforcement change separately from broader refactors.
 
 ### Task 6: Lock the contract with regression coverage and docs guardrails
 
 **Files:**
 - Modify: `crates/coven-cli/src/api.rs`
-- Modify: `crates/coven-cli/tests/doctor_prose_contract.rs`
-- Modify: `crates/coven-cli/tests/doctor_json_contract.rs`
+- Create: `crates/coven-cli/tests/runtime_descriptor_contract.rs`
 - Verify: repository root
 
-- [ ] **Step 1:** Add regression tests that prove the daemon still advertises `coven.daemon.v1`, that the runtime routes remain separate from `/api/v1/capabilities/harnesses`, and that session-lifecycle documentation matches authoritative Rust states.
-- [ ] **Step 2:** Run `cargo fmt --check`.
-- [ ] **Step 3:** Run `cargo clippy --workspace --all-targets -- -D warnings`.
-- [ ] **Step 4:** Run `cargo test --workspace --locked`.
-- [ ] **Step 5:** Run `python scripts/check-secrets.py`.
-- [ ] **Step 6:** Stage the planned implementation diff and run `python3 scripts/check-coven-privacy.py --staged`.
-- [ ] **Step 7:** Inspect `git diff --cached --check` and the scoped diff before the final commit.
-- [ ] **Step 8:** Commit with a conventional subject that stays scoped to runtime capability recovery.
+- [ ] **Step 1:** After Tasks 4 and 5 create the new `crates/coven-cli/tests/runtime_descriptor_contract.rs` integration test, reusing the existing binary-invocation style from current contract tests instead of assuming a pre-existing doctor-only harness.
+- [ ] **Step 2:** Add regression assertions in that file that prove the daemon still advertises `coven.daemon.v1`, that the runtime routes remain separate from `/api/v1/capabilities/harnesses`, and that explicit non-public `runtimeId` requests fail before spawn while harness-only `coven-code` launches remain governed by the current harness policy.
+- [ ] **Step 3:** Add or update focused `api.rs` unit tests so the documented persisted lifecycle vocabulary — including `idle` — matches authoritative Rust states.
+- [ ] **Step 4:** Run `cargo fmt --check`.
+- [ ] **Step 5:** Run `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] **Step 6:** Run `cargo test --workspace --locked`.
+- [ ] **Step 7:** Run `python scripts/check-secrets.py`.
+- [ ] **Step 8:** Stage the planned implementation diff and run `python3 scripts/check-coven-privacy.py --staged`.
+- [ ] **Step 9:** Inspect `git diff --cached --check` and the scoped diff before the final commit.
+- [ ] **Step 10:** Commit with a conventional subject that stays scoped to runtime capability recovery.
 
 ## Self-review
 
 - **Spec coverage:** This plan covers the design's required version freeze, Rust authority types, effective descriptor resolver, separation from `/api/v1/capabilities/harnesses`, required-capability evaluation, and acceptance-level regression/documentation work.
 - **Placeholder scan:** No task relies on `TODO`, `TBD`, or implied follow-up wording; each names exact files and verification commands.
-- **Type consistency:** The plan uses one consistent vocabulary across tasks: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, and `requiredCapabilities`.
+- **Type consistency:** The plan uses one consistent vocabulary across tasks: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, `RuntimeWarning`, and `requiredCapabilities`.

--- a/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
@@ -40,11 +40,11 @@ The public docs in scope are the live pages that still carry stale version or li
 - [ ] **Step 1:** Update the live public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix. Remove stale `supportedApiVersions` guidance from `docs/ARCHITECTURE.md`, and remove stale `pending`/`archived` lifecycle guidance from `docs/sessions/lifecycle.md`.
 - [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`), distinguish archive metadata from lifecycle status, and keep the lifecycle page aligned with the authoritative Rust store vocabulary.
 - [ ] **Step 3:** Change `GET /api/v1/api-version` in `crates/coven-cli/src/api.rs` so the payload reports the named contract string instead of the bare `v1` token.
-- [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path, plus exact doc checks that fail if `supportedApiVersions` or the stale lifecycle guidance reappear in the live pages.
+- [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path, plus exact docs assertions that keep `supportedApiVersions` documented for `GET /api/v1/api-version`, reject any claim that `GET /api/v1/health` returns it, and keep the stale lifecycle guidance out of the live pages.
 - [ ] **Step 5:** Run focused tests for the version routes and these exact doc checks:
 
   ```sh
-  rg -n 'supportedApiVersions' docs/ARCHITECTURE.md docs/API-CONTRACT.md docs/reference/api.md docs/reference/api-contract.md
+  rg -n 'supportedApiVersions' docs/reference/api-contract.md
   rg -n 'pending|archived' docs/sessions/lifecycle.md
   ```
 

--- a/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
@@ -37,7 +37,7 @@ The public docs in scope are the live pages that still carry stale version or li
 - Test: `docs/sessions/lifecycle.md`
 - Test: `crates/coven-cli/src/api.rs`
 
-- [ ] **Step 1:** Update the live public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix. Remove stale `supportedApiVersions` guidance from `docs/ARCHITECTURE.md`, and remove stale `pending`/`archived` lifecycle guidance from `docs/sessions/lifecycle.md`.
+- [ ] **Step 1:** Update the live public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix. Remove stale `supportedApiVersions` guidance from `docs/ARCHITECTURE.md`, and remove `pending`/`archived` from the authoritative lifecycle-status set in `docs/sessions/lifecycle.md` without deleting valid archive metadata or ritual documentation.
 - [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`), distinguish archive metadata from lifecycle status, and keep the lifecycle page aligned with the authoritative Rust store vocabulary.
 - [ ] **Step 3:** Change `GET /api/v1/api-version` in `crates/coven-cli/src/api.rs` so the payload reports the named contract string instead of the bare `v1` token.
 - [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path, plus exact docs assertions that keep `supportedApiVersions` documented for `GET /api/v1/api-version`, reject any claim that `GET /api/v1/health` returns it, and keep the stale lifecycle guidance out of the live pages.
@@ -45,7 +45,8 @@ The public docs in scope are the live pages that still carry stale version or li
 
   ```sh
   rg -n 'supportedApiVersions' docs/reference/api-contract.md
-  rg -n 'pending|archived' docs/sessions/lifecycle.md
+  rg -n 'created|running|completed|failed|killed|idle|orphaned' docs/sessions/lifecycle.md
+  rg -n 'archived_at|Archive / summon / sacrifice' docs/sessions/lifecycle.md
   ```
 
   then commit only the O1 contract-freeze changes.

--- a/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a Rust-owned effective runtime capability surface for supported harnesses without changing the meaning of existing harness-scan routes or widening the supported harness set.
 
-**Architecture:** Freeze the public `coven.daemon.v1` and session-lifecycle vocabulary first, then layer a new effective runtime-descriptor resolver on top of existing Rust launch specs and raw harness-scan manifests. Keep `/api/v1/capabilities/harnesses` as factual native scan output, add a distinct runtime descriptor read surface, and enforce required capabilities in Rust before launch.
+**Architecture:** Freeze the public `coven.daemon.v1` and session-lifecycle vocabulary first, then layer a new effective runtime-descriptor resolver on top of existing Rust launch specs and raw harness-scan manifests. Keep `/api/v1/capabilities/harnesses` as factual native scan output, add a distinct runtime descriptor read surface, keep `harness` required on session create, make `runtimeId` an optional consistency check, and enforce required capabilities in Rust before launch.
 
 **Tech Stack:** Rust (`crates/coven-cli/src/api.rs`, `harness.rs`, `capabilities.rs`, `daemon.rs`, `store.rs`), the pinned shared schema types from `coven_runtime_spec` (`Capabilities`, `SandboxMapping`, `StreamArgs`), markdown API docs, existing Rust tests, secret/privacy guardrails.
 
@@ -35,11 +35,11 @@
 - Modify: `crates/coven-cli/src/harness.rs`
 - Test: `crates/coven-cli/src/runtime_descriptors.rs`
 
-- [ ] **Step 1:** Add `runtime_descriptors.rs` with the new derived authority types: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `RuntimeAdmission`, `AvailabilityDescriptor`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, `NativeIntegrationSummary`, `RuntimeWarning`, `RuntimeWarningCode`, and `RuntimeWarningScope`.
+- [ ] **Step 1:** Add `runtime_descriptors.rs` with the new derived authority types: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `RuntimeAdmission`, `AvailabilityDescriptor`, `CapabilityDescriptor`, `CapabilityState`, the closed v1 `CapabilityReason` enum, `NativeIntegrationSummary`, `RuntimeWarning`, `RuntimeWarningCode`, and `RuntimeWarningScope`.
 - [ ] **Step 2:** Reuse the pinned shared-spec inputs already carried by `HarnessCommandSpec` (`coven_runtime_spec::Capabilities`, `SandboxMapping`, and `StreamArgs`) instead of redefining those schema structs locally; keep Coven's Rust adapter logic authoritative for evaluation and spawn decisions.
 - [ ] **Step 3:** Expose the new module from `main.rs` or the existing module tree without moving launch authority out of `harness.rs`.
 - [ ] **Step 4:** Add unit tests that construct descriptors for `codex`, `claude`, `copilot`, and harness-only `coven-code`, asserting that only the first three classify as `supported_runtime`.
-- [ ] **Step 5:** Add a regression test proving unknown harness ids never synthesize a descriptor and that `RuntimeWarning` values serialize with the documented enum set and stable ordering.
+- [ ] **Step 5:** Add a regression test proving unknown harness ids never synthesize a descriptor, that `CapabilityReason` serializes with the exact documented snake_case values, and that `RuntimeWarning` values serialize with the documented enum set and stable ordering.
 - [ ] **Step 6:** Commit the type layer separately before wiring any API route.
 
 ### Task 3: Build the supported-runtime resolver from existing Rust facts
@@ -52,7 +52,7 @@
 
 - [ ] **Step 1:** Add a resolver that combines the bundled `HarnessCommandSpec` data with local availability and the existing `HarnessCapabilityManifest` scan results.
 - [ ] **Step 2:** Map the current Rust-owned launch behaviors into the initial capability families from the design: `launch.text`, `model.selection`, `prompt.system`, `access.read_only`, `filesystem.additional_directories`, `conversation.stream`, `conversation.resume`, `conversation.preassigned_session_id`, `reasoning.think`, `reasoning.speed`, and `transport.local`.
-- [ ] **Step 3:** Encode explicit `supported`, `unavailable`, `unverified`, and `unsupported` states with stable reason values rather than client-generated prose.
+- [ ] **Step 3:** Encode explicit `supported`, `unavailable`, `unverified`, and `unsupported` states with the exact v1 mapping rules: `supported -> reason null`; `unavailable -> harness_not_installed | version_too_old`; `unverified -> version_unknown`; `unsupported -> capability_not_advertised | policy_denied | platform_unsupported`.
 - [ ] **Step 4:** Map raw `CapabilityWarning { kind, path, message }` values into the closed `RuntimeWarning` enum set (`parse_error` → `native_scan_parse_error`, `permission_denied` → `native_scan_permission_denied`) and sort warnings by the documented stable order.
 - [ ] **Step 5:** Add unit tests covering each supported runtime, missing executables, missing sandbox mapping, conversation capability differences, deterministic warning ordering, and the exclusion of observational scan targets from the public list.
 - [ ] **Step 6:** Commit the resolver once the unit tests pass.
@@ -69,8 +69,8 @@
 
 - [ ] **Step 1:** Add `GET /api/v1/runtimes` and `GET /api/v1/runtimes/:runtimeId` to `api.rs`, keeping `/api/v1/capabilities/harnesses` and `/api/v1/capabilities/:harnessId` unchanged.
 - [ ] **Step 2:** Return payloads that include `descriptorVersion: "coven.runtime.descriptor.v1"` and the effective descriptor fields from Task 2.
-- [ ] **Step 3:** Add a structured `404 runtime_not_found` path for unknown or unsupported public runtime ids, without implying that harness-only tools such as `coven-code` are public runtimes.
-- [ ] **Step 4:** Document the new routes in `docs/API-CONTRACT.md`, `docs/reference/api.md`, `docs/reference/api-contract.md`, and the dedicated `docs/reference/api-runtimes.md` page, explicitly contrasting them with the raw harness-capability scan routes.
+- [ ] **Step 3:** Add a structured `404 descriptor_unavailable` path for unknown or unsupported public runtime ids, without implying that harness-only tools such as `coven-code` are public runtimes.
+- [ ] **Step 4:** Document the new routes in `docs/API-CONTRACT.md`, `docs/reference/api.md`, `docs/reference/api-contract.md`, and the dedicated `docs/reference/api-runtimes.md` page, explicitly contrasting them with the raw harness-capability scan routes and using exact example error payloads.
 - [ ] **Step 5:** Add focused API tests proving the new runtime routes work, that the old harness-capability routes are unchanged, and that unsupported observational scan targets do not appear in the public runtime listing.
 - [ ] **Step 6:** Commit the read-surface work only after the docs and tests match.
 
@@ -84,13 +84,14 @@
 - Modify: `docs/reference/api.md`
 - Test: `crates/coven-cli/src/api.rs`
 
-- [ ] **Step 1:** Extend the session launch payload parsing to accept an optional public `runtimeId` selector plus a Rust-owned required-capability field (for example `requiredCapabilities`), while preserving today's harness-keyed launch path.
-- [ ] **Step 2:** If `runtimeId` is present, resolve it only against the public supported-runtime set; reject `coven-code`, observational-scan ids, and unknown ids with stable `404 runtime_not_found` before argv construction or spawn, and do not fall back to harness launch.
-- [ ] **Step 3:** Reject unknown capability ids up front with `400 invalid_request` and structured details.
-- [ ] **Step 4:** Evaluate the chosen runtime's descriptor before launch and reject any required capability whose state is not `supported`.
-- [ ] **Step 5:** Add the stable `409 runtime_capability_not_met` error code, document it, and include `runtimeId`, `capability`, `state`, and `reason` in `details`.
-- [ ] **Step 6:** Add focused API tests for unknown capability ids, explicit non-public `runtimeId` requests, unsupported capability requests, unavailable capability requests, and an accepted launch where every required capability is `supported`.
-- [ ] **Step 7:** Commit the enforcement change separately from broader refactors.
+- [ ] **Step 1:** Extend the session launch payload parsing so `harness` stays required, `runtimeId` is optional, and `requiredCapabilities` remains Rust-owned, while preserving today's harness-only launch path when `runtimeId` is absent.
+- [ ] **Step 2:** If `runtimeId` is present, resolve it only against the public supported-runtime set; reject `coven-code`, observational-scan ids, and unknown ids with stable `404 descriptor_unavailable` before argv construction or spawn, and do not fall back to harness launch.
+- [ ] **Step 3:** After a public `runtimeId` resolves, compare it to the canonical public runtime mapped from `harness`; when they differ, or when the harness has no canonical public runtime mapping, fail before spawn with stable `400 runtime_harness_mismatch`.
+- [ ] **Step 4:** Reject unknown capability ids up front with `400 invalid_request` and structured details.
+- [ ] **Step 5:** Evaluate the chosen runtime's descriptor before launch and reject any required capability whose state is not `supported`.
+- [ ] **Step 6:** Add the stable `409 runtime_capability_not_met` error code, document it, and include `runtimeId`, `capability`, `state`, and `reason` in `details`.
+- [ ] **Step 7:** Add focused API tests for: harness-only launches without `runtimeId`; matching `harness`/`runtimeId` launches; explicit non-public `runtimeId` requests returning `descriptor_unavailable`; explicit supported mismatches returning `runtime_harness_mismatch`; unsupported capability requests; unavailable capability requests; and accepted launches where every required capability is `supported` and therefore `reason` is `null`.
+- [ ] **Step 8:** Commit the enforcement change separately from broader refactors.
 
 ### Task 6: Lock the contract with regression coverage and docs guardrails
 
@@ -100,7 +101,7 @@
 - Verify: repository root
 
 - [ ] **Step 1:** After Tasks 4 and 5 create the new `crates/coven-cli/tests/runtime_descriptor_contract.rs` integration test, reusing the existing binary-invocation style from current contract tests instead of assuming a pre-existing doctor-only harness.
-- [ ] **Step 2:** Add regression assertions in that file that prove the daemon still advertises `coven.daemon.v1`, that the runtime routes remain separate from `/api/v1/capabilities/harnesses`, and that explicit non-public `runtimeId` requests fail before spawn while harness-only `coven-code` launches remain governed by the current harness policy.
+- [ ] **Step 2:** Add regression assertions in that file that prove the daemon still advertises `coven.daemon.v1`, that the runtime routes remain separate from `/api/v1/capabilities/harnesses`, that explicit non-public `runtimeId` requests fail with `descriptor_unavailable` before spawn, that supported mismatches fail with `runtime_harness_mismatch`, and that harness-only `coven-code` launches remain governed by the current harness policy.
 - [ ] **Step 3:** Add or update focused `api.rs` unit tests so the documented persisted lifecycle vocabulary — including `idle` — matches authoritative Rust states.
 - [ ] **Step 4:** Run `cargo fmt --check`.
 - [ ] **Step 5:** Run `cargo clippy --workspace --all-targets -- -D warnings`.
@@ -112,6 +113,6 @@
 
 ## Self-review
 
-- **Spec coverage:** This plan covers the design's required version freeze, Rust authority types, effective descriptor resolver, separation from `/api/v1/capabilities/harnesses`, required-capability evaluation, and acceptance-level regression/documentation work.
+- **Spec coverage:** This plan covers the design's required version freeze, Rust authority types, effective descriptor resolver, separation from `/api/v1/capabilities/harnesses`, exact `harness`/`runtimeId` session semantics, required-capability evaluation, and acceptance-level regression/documentation work.
 - **Placeholder scan:** No task relies on `TODO`, `TBD`, or implied follow-up wording; each names exact files and verification commands.
-- **Type consistency:** The plan uses one consistent vocabulary across tasks: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, `RuntimeWarning`, and `requiredCapabilities`.
+- **Type consistency:** The plan uses one consistent vocabulary across tasks: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, `RuntimeWarning`, `requiredCapabilities`, `descriptor_unavailable`, and `runtime_harness_mismatch`.

--- a/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
@@ -1,0 +1,113 @@
+# Universal Runtime Capability Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Rust-owned effective runtime capability surface for supported harnesses without changing the meaning of existing harness-scan routes or widening the supported harness set.
+
+**Architecture:** Freeze the public `coven.daemon.v1` and session-lifecycle vocabulary first, then layer a new effective runtime-descriptor resolver on top of existing Rust launch specs and raw harness-scan manifests. Keep `/api/v1/capabilities/harnesses` as factual native scan output, add a distinct runtime descriptor read surface, and enforce required capabilities in Rust before launch.
+
+**Tech Stack:** Rust (`crates/coven-cli/src/api.rs`, `harness.rs`, `capabilities.rs`, `daemon.rs`, `store.rs`), markdown API docs, existing Rust tests, secret/privacy guardrails.
+
+---
+
+### Task 1: Freeze the O1 public contract vocabulary
+
+**Files:**
+- Modify: `docs/API-CONTRACT.md`
+- Modify: `docs/reference/api-contract.md`
+- Modify: `docs/reference/api.md`
+- Modify: `docs/SESSION-LIFECYCLE.md`
+- Modify: `crates/coven-cli/src/api.rs`
+- Test: `crates/coven-cli/src/api.rs`
+
+- [ ] **Step 1:** Update the public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix.
+- [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`) and clearly distinguish archive state from terminal state.
+- [ ] **Step 3:** Change `GET /api/v1/api-version` in `crates/coven-cli/src/api.rs` so the payload reports the named contract string instead of the bare `v1` token.
+- [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path.
+- [ ] **Step 5:** Run focused tests for the version routes and session-lifecycle docs assertions, then commit only the O1 contract-freeze changes.
+
+### Task 2: Introduce Rust-owned effective runtime descriptor types
+
+**Files:**
+- Create: `crates/coven-cli/src/runtime_descriptors.rs`
+- Modify: `crates/coven-cli/src/main.rs`
+- Modify: `crates/coven-cli/src/api.rs`
+- Modify: `crates/coven-cli/src/harness.rs`
+- Test: `crates/coven-cli/src/runtime_descriptors.rs`
+
+- [ ] **Step 1:** Add `runtime_descriptors.rs` with the new derived authority types: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `RuntimeAdmission`, `AvailabilityDescriptor`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, and `NativeIntegrationSummary`.
+- [ ] **Step 2:** Expose the new module from `main.rs` or the existing module tree without moving launch authority out of `harness.rs`.
+- [ ] **Step 3:** Add unit tests that construct descriptors for `codex`, `claude`, `copilot`, and `coven-code`, asserting that only the first three classify as `supported_runtime`.
+- [ ] **Step 4:** Add a regression test proving unknown harness ids never synthesize a descriptor.
+- [ ] **Step 5:** Commit the type layer separately before wiring any API route.
+
+### Task 3: Build the supported-runtime resolver from existing Rust facts
+
+**Files:**
+- Modify: `crates/coven-cli/src/runtime_descriptors.rs`
+- Modify: `crates/coven-cli/src/harness.rs`
+- Modify: `crates/coven-cli/src/capabilities.rs`
+- Test: `crates/coven-cli/src/runtime_descriptors.rs`
+
+- [ ] **Step 1:** Add a resolver that combines the bundled `HarnessCommandSpec` data with local availability and the existing `HarnessCapabilityManifest` scan results.
+- [ ] **Step 2:** Map the current Rust-owned launch behaviors into the initial capability families from the design: `launch.text`, `model.selection`, `prompt.system`, `access.read_only`, `filesystem.additional_directories`, `conversation.stream`, `conversation.resume`, `conversation.preassigned_session_id`, `reasoning.think`, `reasoning.speed`, and `transport.local`.
+- [ ] **Step 3:** Encode explicit `supported`, `unavailable`, `unverified`, and `unsupported` states with stable reason values rather than client-generated prose.
+- [ ] **Step 4:** Add unit tests covering each supported runtime, missing executables, missing sandbox mapping, conversation capability differences, and the exclusion of observational scan targets from the public list.
+- [ ] **Step 5:** Commit the resolver once the unit tests pass.
+
+### Task 4: Add a distinct runtime descriptor read surface
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs`
+- Modify: `docs/API-CONTRACT.md`
+- Modify: `docs/reference/api.md`
+- Modify: `docs/reference/api-contract.md`
+- Create: `docs/reference/api-runtimes.md`
+- Test: `crates/coven-cli/src/api.rs`
+
+- [ ] **Step 1:** Add `GET /api/v1/runtimes` and `GET /api/v1/runtimes/:runtimeId` to `api.rs`, keeping `/api/v1/capabilities/harnesses` and `/api/v1/capabilities/:harnessId` unchanged.
+- [ ] **Step 2:** Return payloads that include `descriptorVersion: "coven.runtime.descriptor.v1"` and the effective descriptor fields from Task 2.
+- [ ] **Step 3:** Add a structured `404 runtime_not_found` path for unknown or unsupported public runtime ids.
+- [ ] **Step 4:** Document the new routes in `docs/API-CONTRACT.md`, `docs/reference/api.md`, `docs/reference/api-contract.md`, and the dedicated `docs/reference/api-runtimes.md` page, explicitly contrasting them with the raw harness-capability scan routes.
+- [ ] **Step 5:** Add focused API tests proving the new runtime routes work, that the old harness-capability routes are unchanged, and that unsupported observational scan targets do not appear in the public runtime listing.
+- [ ] **Step 6:** Commit the read-surface work only after the docs and tests match.
+
+### Task 5: Enforce required capabilities before launch
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs`
+- Modify: `crates/coven-cli/src/runtime_descriptors.rs`
+- Modify: `crates/coven-cli/src/session_launch.rs`
+- Modify: `docs/API-CONTRACT.md`
+- Modify: `docs/reference/api.md`
+- Test: `crates/coven-cli/src/api.rs`
+
+- [ ] **Step 1:** Extend the session launch payload parsing to accept a Rust-owned required-capability field (for example `requiredCapabilities`).
+- [ ] **Step 2:** Reject unknown capability ids up front with `400 invalid_request` and structured details.
+- [ ] **Step 3:** Evaluate the chosen runtime's descriptor before launch and reject any required capability whose state is not `supported`.
+- [ ] **Step 4:** Add the stable `409 runtime_capability_not_met` error code, document it, and include `runtimeId`, `capability`, `state`, and `reason` in `details`.
+- [ ] **Step 5:** Add focused API tests for unknown capability ids, unsupported capability requests, unavailable capability requests, and an accepted launch where every required capability is `supported`.
+- [ ] **Step 6:** Commit the enforcement change separately from broader refactors.
+
+### Task 6: Lock the contract with regression coverage and docs guardrails
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs`
+- Modify: `crates/coven-cli/tests/doctor_prose_contract.rs`
+- Modify: `crates/coven-cli/tests/doctor_json_contract.rs`
+- Verify: repository root
+
+- [ ] **Step 1:** Add regression tests that prove the daemon still advertises `coven.daemon.v1`, that the runtime routes remain separate from `/api/v1/capabilities/harnesses`, and that session-lifecycle documentation matches authoritative Rust states.
+- [ ] **Step 2:** Run `cargo fmt --check`.
+- [ ] **Step 3:** Run `cargo clippy --workspace --all-targets -- -D warnings`.
+- [ ] **Step 4:** Run `cargo test --workspace --locked`.
+- [ ] **Step 5:** Run `python scripts/check-secrets.py`.
+- [ ] **Step 6:** Stage the planned implementation diff and run `python3 scripts/check-coven-privacy.py --staged`.
+- [ ] **Step 7:** Inspect `git diff --cached --check` and the scoped diff before the final commit.
+- [ ] **Step 8:** Commit with a conventional subject that stays scoped to runtime capability recovery.
+
+## Self-review
+
+- **Spec coverage:** This plan covers the design's required version freeze, Rust authority types, effective descriptor resolver, separation from `/api/v1/capabilities/harnesses`, required-capability evaluation, and acceptance-level regression/documentation work.
+- **Placeholder scan:** No task relies on `TODO`, `TBD`, or implied follow-up wording; each names exact files and verification commands.
+- **Type consistency:** The plan uses one consistent vocabulary across tasks: `EffectiveRuntimeDescriptor`, `RuntimeSupportClass`, `CapabilityDescriptor`, `CapabilityState`, `CapabilityReason`, and `requiredCapabilities`.

--- a/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-universal-runtime-capability-recovery.md
@@ -8,23 +8,47 @@
 
 **Tech Stack:** Rust (`crates/coven-cli/src/api.rs`, `harness.rs`, `capabilities.rs`, `daemon.rs`, `store.rs`), the pinned shared schema types from `coven_runtime_spec` (`Capabilities`, `SandboxMapping`, `StreamArgs`), markdown API docs, existing Rust tests, secret/privacy guardrails.
 
+## File map
+
+- Modify: `docs/API-CONTRACT.md`
+- Modify: `docs/ARCHITECTURE.md`
+- Modify: `docs/reference/api-contract.md`
+- Modify: `docs/reference/api.md`
+- Modify: `docs/sessions/lifecycle.md`
+- Modify: `crates/coven-cli/src/api.rs`
+- Test: `docs/ARCHITECTURE.md`
+- Test: `docs/sessions/lifecycle.md`
+- Test: `crates/coven-cli/src/api.rs`
+
+The public docs in scope are the live pages that still carry stale version or lifecycle guidance. The freeze must update the version contract docs and the two user-facing anchors called out in the issue: `docs/ARCHITECTURE.md` and `docs/sessions/lifecycle.md`.
+
 ---
 
-### Task 1: Freeze the O1 public contract vocabulary
+### Task 1: Freeze the O1 public contract vocabulary in the live docs
 
 **Files:**
+- Modify: `docs/ARCHITECTURE.md`
 - Modify: `docs/API-CONTRACT.md`
 - Modify: `docs/reference/api-contract.md`
 - Modify: `docs/reference/api.md`
-- Modify: `docs/SESSION-LIFECYCLE.md`
+- Modify: `docs/sessions/lifecycle.md`
 - Modify: `crates/coven-cli/src/api.rs`
+- Test: `docs/ARCHITECTURE.md`
+- Test: `docs/sessions/lifecycle.md`
 - Test: `crates/coven-cli/src/api.rs`
 
-- [ ] **Step 1:** Update the public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix.
-- [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`), distinguish archive metadata from lifecycle status, and define `idle` as the persisted conversational state written when a clean child exit leaves the conversation extendable.
+- [ ] **Step 1:** Update the live public docs so they use one canonical external API version vocabulary: `coven.daemon.v1` for the contract name and `/api/v1` for the route prefix. Remove stale `supportedApiVersions` guidance from `docs/ARCHITECTURE.md`, and remove stale `pending`/`archived` lifecycle guidance from `docs/sessions/lifecycle.md`.
+- [ ] **Step 2:** Enumerate the exact persisted session statuses used by Rust (`created`, `running`, `completed`, `failed`, `killed`, `idle`, `orphaned`), distinguish archive metadata from lifecycle status, and keep the lifecycle page aligned with the authoritative Rust store vocabulary.
 - [ ] **Step 3:** Change `GET /api/v1/api-version` in `crates/coven-cli/src/api.rs` so the payload reports the named contract string instead of the bare `v1` token.
-- [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path.
-- [ ] **Step 5:** Run focused tests for the version routes and session-lifecycle docs assertions, then commit only the O1 contract-freeze changes.
+- [ ] **Step 4:** Add or update route tests in `crates/coven-cli/src/api.rs` covering the named version response and the current unknown-version failure path, plus exact doc checks that fail if `supportedApiVersions` or the stale lifecycle guidance reappear in the live pages.
+- [ ] **Step 5:** Run focused tests for the version routes and these exact doc checks:
+
+  ```sh
+  rg -n 'supportedApiVersions' docs/ARCHITECTURE.md docs/API-CONTRACT.md docs/reference/api.md docs/reference/api-contract.md
+  rg -n 'pending|archived' docs/sessions/lifecycle.md
+  ```
+
+  then commit only the O1 contract-freeze changes.
 
 ### Task 2: Introduce Rust-owned effective runtime descriptor types
 
@@ -102,7 +126,7 @@
 
 - [ ] **Step 1:** After Tasks 4 and 5 create the new `crates/coven-cli/tests/runtime_descriptor_contract.rs` integration test, reusing the existing binary-invocation style from current contract tests instead of assuming a pre-existing doctor-only harness.
 - [ ] **Step 2:** Add regression assertions in that file that prove the daemon still advertises `coven.daemon.v1`, that the runtime routes remain separate from `/api/v1/capabilities/harnesses`, that explicit non-public `runtimeId` requests fail with `descriptor_unavailable` before spawn, that supported mismatches fail with `runtime_harness_mismatch`, and that harness-only `coven-code` launches remain governed by the current harness policy.
-- [ ] **Step 3:** Add or update focused `api.rs` unit tests so the documented persisted lifecycle vocabulary — including `idle` — matches authoritative Rust states.
+- [ ] **Step 3:** Add or update focused `api.rs` unit tests so the documented persisted lifecycle vocabulary in `docs/sessions/lifecycle.md` matches authoritative Rust states.
 - [ ] **Step 4:** Run `cargo fmt --check`.
 - [ ] **Step 5:** Run `cargo clippy --workspace --all-targets -- -D warnings`.
 - [ ] **Step 6:** Run `cargo test --workspace --locked`.

--- a/docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md
@@ -159,8 +159,116 @@ runtime-descriptor addressing distinct:
   `supported_runtime` set.
 - If `runtimeId` is outside that set — including `coven-code`,
   `observational_scan` entries, or unknown ids — the daemon must fail before
-  argv construction or spawn with stable `404 runtime_not_found`. It must not
-  silently fall back to a harness-keyed launch.
+  argv construction or spawn with stable `404 descriptor_unavailable`. It must
+  not silently fall back to a harness-keyed launch.
+
+### v1 session request semantics
+
+`POST /api/v1/sessions` keeps the current required `harness` field in v1.
+`runtimeId` is optional and acts only as an explicit public-runtime selector and
+consistency check; it never replaces `harness`.
+
+The canonical public runtime mapping is intentionally closed:
+
+| `harness` | Canonical public `runtimeId` |
+|---|---|
+| `codex` | `codex` |
+| `claude` | `claude` |
+| `copilot` | `copilot` |
+| `coven-code` | none — harness-only, not a public runtime |
+
+The launch rules are:
+
+1. `harness` remains required and is validated with today's harness launch
+   policy first.
+2. If `runtimeId` is absent, the daemon preserves the existing harness-only
+   launch behavior exactly.
+3. If `runtimeId` is present, the daemon first resolves it against the public
+   supported-runtime descriptor set. Unknown, unsupported, or non-public ids —
+   including `coven-code` and observational-only scan ids — fail before spawn
+   with `404 descriptor_unavailable`.
+4. If `runtimeId` resolves, it must equal the canonical public runtime mapped
+   from `harness`. If it does not, or if the selected harness has no canonical
+   public runtime mapping, the daemon fails before spawn with stable
+   `400 runtime_harness_mismatch`.
+5. Only after both checks pass may the daemon evaluate required capabilities.
+   There is no fallback, downgrade, or ignore path for a supplied `runtimeId`.
+
+### Exact session request examples
+
+Accepted legacy harness-only launch:
+
+```json
+{
+  "projectRoot": "/repo",
+  "harness": "codex",
+  "prompt": "Fix the tests"
+}
+```
+
+Accepted explicit public runtime match:
+
+```json
+{
+  "projectRoot": "/repo",
+  "harness": "codex",
+  "runtimeId": "codex",
+  "prompt": "Fix the tests"
+}
+```
+
+Rejected public-runtime/harness mismatch:
+
+```json
+{
+  "error": {
+    "code": "runtime_harness_mismatch",
+    "details": {
+      "harness": "codex",
+      "runtimeId": "claude",
+      "canonicalRuntimeId": "codex"
+    }
+  }
+}
+```
+
+Rejected non-public runtime id:
+
+```json
+{
+  "error": {
+    "code": "descriptor_unavailable",
+    "details": {
+      "runtimeId": "coven-code"
+    }
+  }
+}
+```
+
+Preserved harness-only internal-tool launch:
+
+```json
+{
+  "projectRoot": "/repo",
+  "harness": "coven-code",
+  "prompt": "Open the TUI"
+}
+```
+
+Rejected attempt to pair a harness-only tool with a public runtime selector:
+
+```json
+{
+  "error": {
+    "code": "runtime_harness_mismatch",
+    "details": {
+      "harness": "coven-code",
+      "runtimeId": "codex",
+      "canonicalRuntimeId": null
+    }
+  }
+}
+```
 
 ## 3. Rust authority types
 
@@ -291,8 +399,32 @@ Each capability has exactly one state:
   evidence for safe use
 - `unsupported` - not provided by the supported runtime contract
 
-The descriptor must also carry a machine-readable `reason` for non-supported
-states. Clients may improve copy, but they must not reinterpret the state.
+The descriptor must also carry a machine-readable `reason`. Descriptor v1 keeps
+that reason vocabulary closed:
+
+- `harness_not_installed`
+- `version_unknown`
+- `version_too_old`
+- `capability_not_advertised`
+- `policy_denied`
+- `platform_unsupported`
+
+`supported` is the only state that serializes `reason: null`. Every
+non-supported capability state must serialize exactly one of the closed enum
+values above. The initial v1 mapping is:
+
+| `state` | `reason` | Required mapping rule |
+|---|---|---|
+| `supported` | `null` | Capability is available and enforceable on this host. |
+| `unavailable` | `harness_not_installed` | The required harness executable or local adapter prerequisite is missing. |
+| `unavailable` | `version_too_old` | The harness version is known and below the minimum version needed for the capability. |
+| `unverified` | `version_unknown` | The harness exists, but the daemon cannot determine a trustworthy version or equivalent evidence yet. |
+| `unsupported` | `capability_not_advertised` | The supported runtime contract or passive native evidence does not advertise the capability. |
+| `unsupported` | `policy_denied` | Coven intentionally withholds the capability even if a native surface may exist, because the public support policy does not admit it. |
+| `unsupported` | `platform_unsupported` | The capability is outside the supported runtime contract for the current OS or host class. |
+
+Clients may improve copy, but they must not reinterpret either the `state` or
+the closed `CapabilityReason` value.
 
 ## 5. Relationship to `/api/v1/capabilities/harnesses`
 
@@ -335,11 +467,12 @@ The evaluation algorithm is:
 The internal Rust result should distinguish:
 
 - `accepted`
+- `descriptor_unavailable`
+- `runtime_harness_mismatch`
 - `unknown_capability`
 - `unsupported_capability`
 - `unavailable_capability`
 - `unverified_capability`
-- `unsupported_runtime`
 
 ### Error and compatibility behavior
 
@@ -349,21 +482,25 @@ For the recovered design, the compatibility rules are:
 
 - Unknown required capability id: `400 invalid_request`
 - Unknown or publicly unsupported runtime id on the future `/api/v1/runtimes`
-  surface: `404 runtime_not_found`
+  surface: `404 descriptor_unavailable`
 - Explicit `runtimeId` on a future launch request that is not in the public
   supported-runtime set — including `coven-code` — must fail with the same
-  stable `404 runtime_not_found` before argv construction or spawn, while
+  stable `404 descriptor_unavailable` before argv construction or spawn, while
   harness-keyed launches without `runtimeId` continue under the current harness
   policy.
+- Explicit supported `runtimeId` values that do not equal the canonical public
+  runtime mapped from the required `harness` must fail before spawn with stable
+  `400 runtime_harness_mismatch`.
 - Known capability not in `supported` state: fail closed before launch with
   `409 runtime_capability_not_met` and `details` containing at least
   `{ runtimeId, capability, state, reason }`
 - Clients branch on code and `details`, never prose
 
 Because issue #567 is still open, this design does **not** claim that
-`runtime_not_found` or `runtime_capability_not_met` already exists today. The
-future implementation must add them explicitly and document them in
-`docs/API-CONTRACT.md` and `docs/reference/api.md` in the same change.
+`descriptor_unavailable`, `runtime_harness_mismatch`, or
+`runtime_capability_not_met` already exists today. The future implementation
+must add them explicitly and document them in `docs/API-CONTRACT.md` and
+`docs/reference/api.md` in the same change.
 
 ## 7. Lifecycle and descriptor truth
 
@@ -398,13 +535,20 @@ following are true:
 4. **Support policy stays scoped.** The public descriptor list includes only
    Codex, Claude Code, and GitHub Copilot CLI. `coven-code` remains excluded as
    a public runtime, and observational scans do not silently become supported.
-5. **Required capabilities fail closed.** The daemon rejects unknown or unmet
+5. **Session requests stay unambiguous.** `harness` remains required,
+   `runtimeId` stays optional, unsupported/non-public runtime ids return
+   `descriptor_unavailable`, supported mismatches return
+   `runtime_harness_mismatch`, and supplied `runtimeId` values are never
+   ignored or used as fallback hints.
+6. **Required capabilities fail closed.** The daemon rejects unknown or unmet
    required capabilities before launch.
-6. **Capability states are machine-readable.** Non-supported states expose exact
-   `state` and `reason` values.
-7. **Docs and tests land together.** Any new runtime endpoint or error code ships
-   with contract docs and executable regression coverage.
-8. **No speculative adapters.** The work does not promise registry adapters,
+7. **Capability states are machine-readable.** Non-supported states expose exact
+   `state` values plus the closed v1 `CapabilityReason` enum, and `supported`
+   serializes `reason: null`.
+8. **Docs and tests land together.** Any new runtime endpoint or error code ships
+   with exact request/error examples in contract docs and executable regression
+   coverage that asserts the exact enum/code values.
+9. **No speculative adapters.** The work does not promise registry adapters,
    downloadable plugins, or widened harness support.
 
 ## Implementation boundary

--- a/docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md
@@ -1,0 +1,331 @@
+# Universal Runtime Capability Recovery Design
+
+- **Date:** 2026-08-03
+- **Status:** recovered scoped design; documentation only
+- **Issue:** [#572](https://github.com/OpenCoven/coven/issues/572)
+- **Related work:** preserved design at `7323395a7dc4af99e7557ee0929fafee9c651720:docs/superpowers/specs/2026-07-29-universal-runtime-capability-design.md`, Psyche audit/contract work in [#566](https://github.com/OpenCoven/coven/pull/566) and [#567](https://github.com/OpenCoven/coven/issues/567)
+
+## Decision summary
+
+Recover the useful parts of the abandoned universal-runtime design, but narrow it to
+Coven's current authority boundary and public support policy.
+
+The recovered design keeps three principles:
+
+1. **Rust remains the authority** for launch, capability evaluation, and denial.
+2. **Raw harness-native discovery stays separate** from effective launch
+   capability truth.
+3. **Public runtime support stays limited** to Codex, Claude Code, and GitHub
+   Copilot CLI until a separate policy decision widens that set.
+
+This recovery does **not** promise endpoint or production implementation work in
+this PR. It records the future contract shape and the acceptance bar for later
+implementation.
+
+## Current state to preserve and reconcile
+
+### What the daemon already exposes
+
+Under `/api/v1`, Coven already exposes the named public contract
+`coven.daemon.v1` through `GET /api/v1/health`. The current implementation also
+serves `GET /api/v1/api-version`, but today that route returns the route token
+`"v1"` and `supportedApiVersions: ["v1"]`, while public docs describe the named
+contract string `"coven.daemon.v1"`. Psyche issue #567 correctly treats that as
+an O1 contract gap that must be frozen before runtime-capability work can claim
+production conformance.
+
+### What `/api/v1/capabilities/harnesses` already means
+
+`GET /api/v1/capabilities/harnesses` is already a shipped read surface. Its job
+is narrow and factual: report Coven-owned skills plus harness-native discoveries
+such as global instructions, skills, plugins, warnings, and scan timestamps.
+It is **not** an effective launch descriptor, **not** a required-capability
+handshake, and **not** the source of truth for whether a runtime may be used for
+some requested behavior.
+
+### What Rust types already exist
+
+Coven already has the core authority ingredients for a future effective runtime
+layer:
+
+- `api.rs` defines the public daemon contract boundary and structured error
+  envelope.
+- `harness.rs` defines `HarnessCommandSpec`, `Capabilities`,
+  `SandboxMapping`, `StreamArgs`, and `ContinuityArgs` for launch-time behavior.
+- `capabilities.rs` defines `HarnessCapabilityManifest` and the aggregate
+  response returned by `/api/v1/capabilities/harnesses`.
+- `store.rs` and `daemon.rs` define authoritative session lifecycle behavior,
+  including persisted states such as `created`, `running`, `completed`,
+  `failed`, `killed`, `idle`, and `orphaned`.
+
+The recovered design must build from those Rust-owned types instead of moving
+authority into TypeScript or inventing a separate client-owned interpretation.
+
+### What policy must constrain the design
+
+Repository guidance in `AGENTS.md`, `README.md`, and `CONTRIBUTING.md` freezes
+public supported harnesses to **Codex, Claude Code, and GitHub Copilot CLI**
+until policy and adapter contracts stabilize. `coven-code` remains an internal
+tool/runtime detail, not a public familiar runtime. Read-only scans for other
+harness ids may continue to exist, but they must not silently become public
+runtime support.
+
+## Goals
+
+1. Define one future Rust-owned **effective runtime descriptor** contract for
+   supported harnesses.
+2. Keep the raw harness-native scan surface intact and backward compatible.
+3. Define required-capability evaluation that fails closed before launch.
+4. Align future runtime-capability work with Psyche's O1 requirement to freeze
+   exact version and lifecycle vocabulary.
+5. Prevent speculative harness adapters, widened support policy, or client-side
+   authority drift.
+
+## Non-goals
+
+- No production implementation in this PR.
+- No new public promise that `cursor`, `gemini`, `opencode`, or any registry
+  adapter is supported as a Coven runtime.
+- No promise that a new endpoint lands before issue #567's version/lifecycle
+  contract freeze.
+- No client-side fallback that infers runtime capability from docs, labels,
+  scanned files, or UI heuristics.
+- No change to the existing meaning of `/api/v1/capabilities/harnesses`.
+
+## Recovered design
+
+## 1. Versioning model
+
+Future runtime-capability work must live under the existing daemon API contract,
+not beside it.
+
+- **Daemon contract:** `coven.daemon.v1` remains the public API contract name.
+- **Route prefix:** `/api/v1` remains the transport path.
+- **Descriptor schema:** the effective runtime payload names its own additive
+  schema version, `coven.runtime.descriptor.v1`.
+
+That split gives Coven one stable rule:
+
+- `/api/v1/*` negotiates the daemon contract;
+- `descriptorVersion` negotiates the runtime-descriptor document shape.
+
+Breaking descriptor-shape changes require either a new descriptor version or a
+new daemon contract version, depending on whether the break is confined to the
+descriptor payload or changes broader API semantics.
+
+### Recovery rule for issue #567
+
+No implementation may claim this design is current until the daemon's public
+version vocabulary is internally consistent. For O1, the named string
+`coven.daemon.v1` is the canonical public vocabulary; the bare route token
+`v1` is routing syntax, not the externally meaningful contract name.
+
+## 2. Public runtime support classes
+
+The future resolver distinguishes four support classes:
+
+- `supported_runtime` - public supported harnesses: `codex`, `claude`,
+  `copilot`.
+- `internal_tool` - Rust-owned tools not exposed as public runtimes:
+  `coven-code`.
+- `observational_scan` - harness ids that may appear in raw scan output but are
+  not public runtime commitments.
+- `unknown` - not recognized by the runtime-descriptor resolver.
+
+Only `supported_runtime` entries may appear in the future public effective
+runtime-descriptor listing. `internal_tool` and `observational_scan` entries may
+have internal structs or diagnostics, but they are excluded from the public
+runtime handshake unless a later policy decision explicitly widens support.
+
+## 3. Rust authority types
+
+Future implementation should add explicit Rust-owned effective-descriptor types,
+separate from both `HarnessCommandSpec` and `HarnessCapabilityManifest`:
+
+```rust
+pub struct EffectiveRuntimeDescriptor {
+    pub descriptor_version: String,
+    pub runtime_id: String,
+    pub runtime_label: String,
+    pub support_class: RuntimeSupportClass,
+    pub admission: RuntimeAdmission,
+    pub availability: AvailabilityDescriptor,
+    pub capabilities: BTreeMap<String, CapabilityDescriptor>,
+    pub native_integrations: NativeIntegrationSummary,
+    pub warnings: Vec<RuntimeWarning>,
+}
+```
+
+Supporting types should include:
+
+- `RuntimeSupportClass`
+- `RuntimeAdmission`
+- `AvailabilityDescriptor`
+- `CapabilityDescriptor`
+- `CapabilityState`
+- `CapabilityReason`
+- `NativeIntegrationSummary`
+- `RequiredCapabilitySet`
+- `RequiredCapabilityEvaluation`
+
+These are **derived authority types**. They do not replace existing launch
+specs or scan manifests. Instead:
+
+- `HarnessCommandSpec` stays the source for launch mechanics;
+- `HarnessCapabilityManifest` stays the source for raw native scan data; and
+- `EffectiveRuntimeDescriptor` becomes the source for client-facing capability
+  truth.
+
+## 4. Effective descriptor semantics
+
+The resolver computes one descriptor per supported runtime from this
+intersection:
+
+```text
+supported harness policy
+  ∩ bundled Rust launch spec
+  ∩ current host availability
+  ∩ passive native scan evidence
+  ∩ local enforcement capability
+  = EffectiveRuntimeDescriptor
+```
+
+Initial capability families should be limited to behavior that already has a
+clear Rust launch or lifecycle interpretation:
+
+- `launch.text`
+- `model.selection`
+- `prompt.system`
+- `access.read_only`
+- `filesystem.additional_directories`
+- `conversation.stream`
+- `conversation.resume`
+- `conversation.preassigned_session_id`
+- `reasoning.think`
+- `reasoning.speed`
+- `transport.local`
+
+Capabilities such as remote SSH execution, attachments, profile binding, or
+structured tool telemetry may be added later, but only when a Rust-owned
+contract and enforcement model exist.
+
+Each capability has exactly one state:
+
+- `supported` - available and enforceable on this host
+- `unavailable` - conceptually supported, but missing a required local
+  dependency or host condition
+- `unverified` - declared or inferred, but not yet backed by sufficient local
+  evidence for safe use
+- `unsupported` - not provided by the supported runtime contract
+
+The descriptor must also carry a machine-readable `reason` for non-supported
+states. Clients may improve copy, but they must not reinterpret the state.
+
+## 5. Relationship to `/api/v1/capabilities/harnesses`
+
+The existing harness-capability routes remain intact:
+
+- `GET /api/v1/capabilities/harnesses`
+- `GET /api/v1/capabilities/:harnessId`
+
+They continue to expose raw native discoveries and warnings with the current
+snake_case payloads.
+
+Future effective runtime descriptors must use a **separate read surface** so the
+existing route does not acquire a second meaning. The preferred shape is:
+
+- `GET /api/v1/runtimes`
+- `GET /api/v1/runtimes/:runtimeId`
+- optional later refresh action only after the O1 contract freeze lands
+
+This keeps the distinctions clean:
+
+- `/capabilities` = control-plane catalog
+- `/capabilities/harnesses` = raw native scan facts
+- `/runtimes` = effective runtime capability truth
+
+## 6. Required capability evaluation
+
+Future runtime launches must accept a caller-supplied required-capability set,
+validated in Rust before the daemon constructs argv or spawns a process.
+
+The evaluation algorithm is:
+
+1. Reject the request if a required capability id is unknown to the daemon.
+2. Resolve the effective descriptor for the requested supported runtime.
+3. Reject the request if any required capability is not in `supported` state.
+4. Return the descriptor-backed denial reason in structured details.
+5. Launch only when every required capability is `supported`.
+
+### Evaluation result shape
+
+The internal Rust result should distinguish:
+
+- `accepted`
+- `unknown_capability`
+- `unsupported_capability`
+- `unavailable_capability`
+- `unverified_capability`
+- `unsupported_runtime`
+
+### Error and compatibility behavior
+
+The HTTP API continues to use the existing structured error envelope.
+
+For the recovered design, the compatibility rules are:
+
+- Unknown required capability id: `400 invalid_request`
+- Unknown or publicly unsupported runtime id on the future `/api/v1/runtimes`
+  surface: `404 runtime_not_found`
+- Known capability not in `supported` state: fail closed before launch with
+  `409 runtime_capability_not_met` and `details` containing at least
+  `{ runtimeId, capability, state, reason }`
+- Clients branch on code and `details`, never prose
+
+Because issue #567 is still open, this design does **not** claim that
+`runtime_not_found` or `runtime_capability_not_met` already exists today. The
+future implementation must add them explicitly and document them in
+`docs/API-CONTRACT.md` and `docs/reference/api.md` in the same change.
+
+## 7. Lifecycle and descriptor truth
+
+Psyche's W1 audit requires exact terminal vocabulary and exact capability
+negotiation. The recovered runtime design therefore adopts two hard rules:
+
+1. Effective runtime descriptors must reference only authoritative persisted
+   lifecycle states documented by Coven's Rust store/runtime behavior.
+2. Conversation-only states such as `idle` must be documented precisely and must
+   not be collapsed into generic success prose.
+
+A runtime descriptor may advertise conversation features such as resume or
+streaming, but it must not redefine session terminal semantics.
+
+## 8. Future implementation acceptance
+
+A future implementation satisfies this recovered design only if all of the
+following are true:
+
+1. **Version vocabulary is frozen first.** O1 lands and public docs/tests agree
+   on `coven.daemon.v1` and the exact persisted lifecycle vocabulary.
+2. **Rust owns descriptor generation.** No TypeScript package or UI computes the
+   effective capability truth independently.
+3. **Raw scans stay raw.** `/api/v1/capabilities/harnesses` remains backward
+   compatible and distinct from effective descriptors.
+4. **Support policy stays scoped.** The public descriptor list includes only
+   Codex, Claude Code, and GitHub Copilot CLI. `coven-code` remains excluded as
+   a public runtime, and observational scans do not silently become supported.
+5. **Required capabilities fail closed.** The daemon rejects unknown or unmet
+   required capabilities before launch.
+6. **Capability states are machine-readable.** Non-supported states expose exact
+   `state` and `reason` values.
+7. **Docs and tests land together.** Any new runtime endpoint or error code ships
+   with contract docs and executable regression coverage.
+8. **No speculative adapters.** The work does not promise registry adapters,
+   downloadable plugins, or widened harness support.
+
+## Implementation boundary
+
+This recovery PR is documentation only. It restores the design intent as a
+scoped future contract and records the acceptance bar. It does **not** add a
+new endpoint, change the daemon API, change launch behavior, or widen the
+supported harness set.

--- a/docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md
@@ -50,10 +50,17 @@ layer:
 
 - `api.rs` defines the public daemon contract boundary and structured error
   envelope.
-- `harness.rs` defines `HarnessCommandSpec`, `Capabilities`,
-  `SandboxMapping`, `StreamArgs`, and `ContinuityArgs` for launch-time behavior.
-- `capabilities.rs` defines `HarnessCapabilityManifest` and the aggregate
-  response returned by `/api/v1/capabilities/harnesses`.
+- `harness.rs` defines `HarnessCommandSpec` and `ContinuityArgs` for
+  launch-time behavior. Its `capabilities`, `sandbox`, and `stream_args`
+  fields use the pinned shared-spec dependency
+  `coven_runtime_spec::{Capabilities, SandboxMapping, StreamArgs}`
+  (`crates/coven-cli/Cargo.toml` pins tag `v0.2.0`; `Cargo.lock` locks commit
+  `2f0e068027f36b1dd32d919f54a40a3baede54c2`). Those shared types are schema
+  inputs, but Coven's Rust adapters and launch-time capability evaluation remain
+  authoritative for actual argv construction, denial, and spawn behavior.
+- `capabilities.rs` defines `HarnessCapabilityManifest`, raw
+  `CapabilityWarning { kind, path, message }`, and the aggregate response
+  returned by `/api/v1/capabilities/harnesses`.
 - `store.rs` and `daemon.rs` define authoritative session lifecycle behavior,
   including persisted states such as `created`, `running`, `completed`,
   `failed`, `killed`, `idle`, and `orphaned`.
@@ -137,6 +144,24 @@ runtime-descriptor listing. `internal_tool` and `observational_scan` entries may
 have internal structs or diagnostics, but they are excluded from the public
 runtime handshake unless a later policy decision explicitly widens support.
 
+### Harness launches versus public runtime descriptors
+
+The recovered design keeps current harness-keyed launches and future public
+runtime-descriptor addressing distinct:
+
+- Existing launch surfaces that name a harness directly continue under today's
+  Rust harness policy. That includes the current supported public harnesses and
+  existing harness-only launches such as `coven-code`.
+- Those harness-keyed launches do **not** require a public runtime descriptor to
+  exist first.
+- A future request that explicitly supplies `runtimeId` opts into the public
+  runtime-descriptor resolver. Rust must resolve that id only against the public
+  `supported_runtime` set.
+- If `runtimeId` is outside that set — including `coven-code`,
+  `observational_scan` entries, or unknown ids — the daemon must fail before
+  argv construction or spawn with stable `404 runtime_not_found`. It must not
+  silently fall back to a harness-keyed launch.
+
 ## 3. Rust authority types
 
 Future implementation should add explicit Rust-owned effective-descriptor types,
@@ -154,6 +179,14 @@ pub struct EffectiveRuntimeDescriptor {
     pub native_integrations: NativeIntegrationSummary,
     pub warnings: Vec<RuntimeWarning>,
 }
+
+pub struct RuntimeWarning {
+    pub code: RuntimeWarningCode,
+    pub scope: RuntimeWarningScope,
+    pub capability_id: Option<String>,
+    pub path: Option<String>,
+    pub message: String,
+}
 ```
 
 Supporting types should include:
@@ -167,6 +200,8 @@ Supporting types should include:
 - `NativeIntegrationSummary`
 - `RequiredCapabilitySet`
 - `RequiredCapabilityEvaluation`
+- `RuntimeWarningCode`
+- `RuntimeWarningScope`
 
 These are **derived authority types**. They do not replace existing launch
 specs or scan manifests. Instead:
@@ -175,6 +210,44 @@ specs or scan manifests. Instead:
 - `HarnessCapabilityManifest` stays the source for raw native scan data; and
 - `EffectiveRuntimeDescriptor` becomes the source for client-facing capability
   truth.
+
+`RuntimeWarning` is a stable contract type, not an open-ended passthrough bag.
+For descriptor v1 its fields and enums are:
+
+- `code` (`RuntimeWarningCode`, serialized snake_case):
+  - `launch_spec_gap`
+  - `host_availability_undetermined`
+  - `native_scan_parse_error`
+  - `native_scan_permission_denied`
+- `scope` (`RuntimeWarningScope`, serialized snake_case):
+  - `runtime`
+  - `capability`
+  - `native_integration`
+- `capability_id` (`Option<String>`) — present only when the warning is tied to
+  one capability family such as `conversation.stream`.
+- `path` (`Option<String>`) — present only for warnings derived from local file
+  inspection.
+- `message` (`String`) — human-readable explanatory prose. Clients may display
+  it, but compatibility branches on `code`, `scope`, and the other structured
+  fields rather than prose text.
+
+Descriptor v1 warning mapping is intentionally closed:
+
+- raw `CapabilityWarning.kind == "parse_error"` maps to
+  `code = native_scan_parse_error`;
+- raw `CapabilityWarning.kind == "permission_denied"` maps to
+  `code = native_scan_permission_denied`; and
+- any widened raw warning-kind vocabulary requires an explicit descriptor-schema
+  update rather than passthrough strings.
+
+`warnings` is an ordered list, not a set. The resolver returns it in this
+stable order:
+
+1. `scope` order: `runtime`, then `capability`, then `native_integration`;
+2. within a scope, `code` order as declared above;
+3. then `capability_id` (lexicographic, missing last);
+4. then `path` (lexicographic, missing last); and
+5. finally `message` (lexicographic).
 
 ## 4. Effective descriptor semantics
 
@@ -277,6 +350,11 @@ For the recovered design, the compatibility rules are:
 - Unknown required capability id: `400 invalid_request`
 - Unknown or publicly unsupported runtime id on the future `/api/v1/runtimes`
   surface: `404 runtime_not_found`
+- Explicit `runtimeId` on a future launch request that is not in the public
+  supported-runtime set — including `coven-code` — must fail with the same
+  stable `404 runtime_not_found` before argv construction or spawn, while
+  harness-keyed launches without `runtimeId` continue under the current harness
+  policy.
 - Known capability not in `supported` state: fail closed before launch with
   `409 runtime_capability_not_met` and `details` containing at least
   `{ runtimeId, capability, state, reason }`
@@ -293,9 +371,15 @@ Psyche's W1 audit requires exact terminal vocabulary and exact capability
 negotiation. The recovered runtime design therefore adopts two hard rules:
 
 1. Effective runtime descriptors must reference only authoritative persisted
-   lifecycle states documented by Coven's Rust store/runtime behavior.
-2. Conversation-only states such as `idle` must be documented precisely and must
-   not be collapsed into generic success prose.
+   lifecycle states documented by Coven's Rust store/runtime behavior:
+   `created`, `running`, `completed`, `failed`, `killed`, `idle`, and
+   `orphaned`. Archive remains separate metadata in `archived_at`, not a
+   lifecycle status.
+2. `idle` is an authoritative persisted status, not a UI-only synonym. Rust
+   writes `idle` when a conversation-grouped session child exits cleanly but
+   the conversation remains extendable via `conversation_id`; the exit event for
+   that child still records `completed`, so consumers must preserve both pieces
+   of meaning instead of flattening `idle` into generic success prose.
 
 A runtime descriptor may advertise conversation features such as resume or
 streaming, but it must not redefine session terminal semantics.


### PR DESCRIPTION
## Summary
- recover and reconcile the universal runtime capability design against current daemon/API contracts
- keep runtime descriptor and capability evaluation authoritative in Rust
- define optional runtimeId matching, stable capability reasons, compatibility behavior, and future implementation tests
- preserve the supported public harness set without promoting internal coven-code surfaces

## Validation
- git diff --check origin/main...HEAD
- python scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --staged

Closes #572
Tracks #541.