### PR TITLE
feat(memory): add portable reference validation

### DIFF
--- a/crates/coven-memory/src/lib.rs
+++ b/crates/coven-memory/src/lib.rs
@@ -9,6 +9,7 @@ pub mod db;
 pub mod embed;
 pub mod index;
 pub mod ingest;
+pub mod promotion;
 
 use std::path::PathBuf;
 

--- a/crates/coven-memory/src/promotion.rs
+++ b/crates/coven-memory/src/promotion.rs
@@ -1,0 +1,88 @@
+use anyhow::{bail, Result};
+use std::path::{Component, Path};
+
+pub fn validate_portable_reference(reference: &str) -> Result<()> {
+    if reference.trim().is_empty() {
+        bail!("portable reference must not be empty");
+    }
+    if reference.starts_with("agent:") {
+        bail!("runtime-specific session keys are not portable");
+    }
+    if is_absolute_on_any_supported_platform(reference) {
+        bail!("absolute paths are not portable");
+    }
+    if Path::new(reference)
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        bail!("parent traversal is not allowed in portable references");
+    }
+    if let Some(session) = reference.strip_prefix("session://") {
+        let mut parts = session.split('/');
+        if parts.next().is_none_or(str::is_empty)
+            || parts.next().is_none_or(str::is_empty)
+            || parts.next().is_none_or(str::is_empty)
+            || parts.next().is_some()
+        {
+            bail!("session reference must use session://<familiar>/<date>/<slug>");
+        }
+    }
+    Ok(())
+}
+
+fn is_absolute_on_any_supported_platform(value: &str) -> bool {
+    if value.starts_with('/') || value.starts_with('\\') {
+        return true;
+    }
+    let bytes = value.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_portable_reference;
+
+    #[test]
+    fn portable_reference_accepts_relative_path() {
+        validate_portable_reference("memory/example.md").expect("relative path should pass");
+    }
+
+    #[test]
+    fn portable_reference_accepts_session_class() {
+        validate_portable_reference("session://<familiar-id>/2026-07-24/example")
+            .expect("portable session class should pass");
+    }
+
+    #[test]
+    fn portable_reference_rejects_unix_absolute_path() {
+        let error = validate_portable_reference("/absolute/example.md").expect_err("absolute path");
+
+        assert!(error.to_string().contains("absolute"));
+    }
+
+    #[test]
+    fn portable_reference_rejects_windows_absolute_path() {
+        let error =
+            validate_portable_reference(r"C:\absolute\example.md").expect_err("absolute path");
+
+        assert!(error.to_string().contains("absolute"));
+    }
+
+    #[test]
+    fn portable_reference_rejects_parent_traversal() {
+        let error = validate_portable_reference("../example.md").expect_err("parent traversal");
+
+        assert!(error.to_string().contains("traversal"));
+    }
+
+    #[test]
+    fn portable_reference_rejects_runtime_session_key() {
+        let reference = ["agent", "example", "webchat", "direct", "123456789"].join(":");
+        let error = validate_portable_reference(&reference).expect_err("runtime session key");
+
+        assert!(error.to_string().contains("runtime-specific"));
+    }
+}


### PR DESCRIPTION
## Context

- Summary: Adds `coven_memory::promotion::validate_portable_reference`, the portable-reference contract for attested memory promotion. Recovered from work that was stranded uncommitted in a stale worktree (branch `feat/cmem-1ev-memory-promote`, which had already merged).
- Files changed: `crates/coven-memory/src/promotion.rs` (new), `crates/coven-memory/src/lib.rs`
- Closes #

## Implementation

- Approach: The original work was ~10 days old and 74 commits behind `main`, and also carried stale copies of `check-coven-privacy.py`, `check-coven-privacy-test.py`, `SECURITY.md`, `ci.yml` and `parallel_protocol.rs` whose content has since landed on `main` in more evolved form via other PRs. Those duplicates were dropped rather than rebased, and only the validation primitive was replayed onto current `main`.
- `validate_portable_reference` rejects references that cannot survive being moved between machines or runtimes: empty or whitespace-only input, runtime-specific `agent:` session keys, absolute paths (both POSIX and Windows drive-letter forms), parent traversal via `..`, and malformed `session://<familiar>/<date>/<slug>` references.
- User-visible behavior: None. This is a library primitive with no CLI surface and no caller yet.
- Compatibility notes: Purely additive — one new module plus its `pub mod` declaration. Nothing existing changes.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — 1700 passed, 0 failed
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: `python3 scripts/check-coven-privacy.py --range "origin/main...HEAD"`; confirmed the 6 `promotion::tests` execute rather than trusting the aggregate count

## Risk and Rollback

- Risk level: Minimal. No reachable code path changes; the module is currently unreferenced, and `clippy -D warnings` is satisfied because it is `pub` in a library crate.
- Rollback plan: Revert the single commit. No migrations, no persisted state, no behavior change.

## Agent Handoff

- Current state: Validation primitive and its tests only, deliberately scoped down.
- Follow-ups: Wire this into a promotion handler when `coven memory promote` is actually implemented.
- Known gaps: An earlier revision of this PR also carried the `coven memory promote` CLI subcommand, its `resolve_familiar_root` / `resolve_familiars_file` helpers, and 7 further tests. That surface was stripped because the handler was a stub that always returned `memory promotion is not implemented yet`, which would have put a permanently-erroring subcommand on `main`. That scaffolding was intentionally not kept: it consisted of the `Promote` variant on `MemoryCommand`, the two resolver helpers (flag, then `COVEN_FAMILIAR_ROOT` / `COVEN_FAMILIARS_FILE`, then `~/.coven/familiars.toml`, otherwise fail closed), and a handler that only bailed. Whoever implements promotion should write the handler fresh against the contract in this module rather than restoring a stub.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
