### PR TITLE
fix(memory): start daemon before dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ coven doctor
 coven memory open
 ```
 
+`coven memory open` starts or reuses the installed local Coven daemon before
+launching the packaged dashboard. It does not require a checkout or running
+development server from the `coven-memory` repository.
+
 The core npm wrapper supports Node.js 18 or newer. The optional memory
 dashboard requires Node.js 24 or newer; on an older runtime, only
 `coven memory open` is blocked and prints an upgrade instruction.
@@ -301,13 +305,13 @@ and `GET /api/v1/memory/:id`. The daemon resolves and validates memory files;
 clients must not open the archival database, vector index, manifest, or memory
 paths directly.
 
-`coven memory open` delegates to the local
-`@opencoven/coven-memory-dashboard` executable. The npm wrapper supplies only
-the installed Node executable and dashboard entrypoint; memory data and daemon
-transport proofs are never passed through the environment. Direct native
-binary installs can place `coven-memory-dashboard` on `PATH` or install the
-package globally. The dashboard requires Node.js 24 or newer; the rest of the
-npm-wrapped CLI remains available on Node.js 18 or newer.
+`coven memory open` establishes local daemon readiness before delegating to the
+installed `@opencoven/coven-memory-dashboard` executable. The npm wrapper
+supplies only the installed Node executable and dashboard entrypoint; memory
+data and daemon transport proofs are never passed through the environment.
+Direct native binary installs can place `coven-memory-dashboard` on `PATH` or
+install the package globally. The dashboard requires Node.js 24 or newer; the
+rest of the npm-wrapped CLI remains available on Node.js 18 or newer.
 
 Treat the socket API as the product contract. Clients may validate for better UX, but the Rust daemon remains the authority boundary.
 

--- a/crates/coven-cli/src/memory_dashboard.rs
+++ b/crates/coven-cli/src/memory_dashboard.rs
@@ -90,14 +90,32 @@ fn resolve() -> Option<LaunchCommand> {
     )
 }
 
+fn dashboard_not_installed_error() -> anyhow::Error {
+    anyhow!(
+        "The Coven Memory dashboard is not installed.\n\n  \
+         npm install -g @opencoven/coven-memory-dashboard\n\n\
+         Then rerun: coven memory open"
+    )
+}
+
+fn ensure_daemon_ready() -> Result<()> {
+    let coven_home = crate::coven_home_dir()?;
+    let current_exe = std::env::current_exe().context("failed to resolve current executable")?;
+    crate::daemon::ensure_background_server(&coven_home, &current_exe, crate::current_timestamp())?;
+    Ok(())
+}
+
+fn prepare_open_with(
+    resolve_launch: impl FnOnce() -> Option<LaunchCommand>,
+    ensure_daemon: impl FnOnce() -> Result<()>,
+) -> Result<LaunchCommand> {
+    let launch = resolve_launch().ok_or_else(dashboard_not_installed_error)?;
+    ensure_daemon().context("failed to start or reach Coven daemon for Memory")?;
+    Ok(launch)
+}
+
 pub fn run_open() -> Result<()> {
-    let launch = resolve().ok_or_else(|| {
-        anyhow!(
-            "The Coven Memory dashboard is not installed.\n\n  \
-             npm install -g @opencoven/coven-memory-dashboard\n\n\
-             Then rerun: coven memory open"
-        )
-    })?;
+    let launch = prepare_open_with(resolve, ensure_daemon_ready)?;
     let status = Command::new(&launch.program)
         .args(&launch.args)
         .status()
@@ -145,5 +163,61 @@ mod tests {
         fs::write(&entry, "").unwrap();
 
         assert!(resolve_from(None, Some(entry.as_os_str()), None, None).is_none());
+    }
+
+    #[test]
+    fn missing_dashboard_does_not_start_daemon() {
+        let daemon_called = std::cell::Cell::new(false);
+
+        let error = prepare_open_with(
+            || None,
+            || {
+                daemon_called.set(true);
+                Ok(())
+            },
+        )
+        .expect_err("missing dashboard must fail");
+
+        assert!(!daemon_called.get());
+        assert!(error.to_string().contains("dashboard is not installed"));
+    }
+
+    #[test]
+    fn daemon_failure_prevents_dashboard_preparation() {
+        let launch = LaunchCommand {
+            program: PathBuf::from("dashboard"),
+            args: Vec::new(),
+        };
+
+        let error = prepare_open_with(
+            || Some(launch),
+            || anyhow::bail!("socket did not become ready"),
+        )
+        .expect_err("daemon failure must stop launch preparation");
+
+        assert!(error
+            .to_string()
+            .contains("failed to start or reach Coven daemon for Memory"));
+    }
+
+    #[test]
+    fn ready_daemon_returns_the_resolved_dashboard() {
+        let launch = LaunchCommand {
+            program: PathBuf::from("dashboard"),
+            args: vec![OsString::from("entry")],
+        };
+
+        let prepared = prepare_open_with(
+            || {
+                Some(LaunchCommand {
+                    program: launch.program.clone(),
+                    args: launch.args.clone(),
+                })
+            },
+            || Ok(()),
+        )
+        .expect("ready daemon permits dashboard launch");
+
+        assert_eq!(prepared, launch);
     }
 }

--- a/crates/coven-cli/tests/memory_dashboard.rs
+++ b/crates/coven-cli/tests/memory_dashboard.rs
@@ -1,0 +1,51 @@
+#[cfg(unix)]
+mod unix {
+    use anyhow::Result;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn coven_bin() -> PathBuf {
+        PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+    }
+
+    fn stop_daemon(coven_home: &Path) {
+        let _ = Command::new(coven_bin())
+            .args(["daemon", "stop"])
+            .env("COVEN_HOME", coven_home)
+            .output();
+    }
+
+    #[test]
+    fn memory_open_starts_daemon_before_dashboard() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let coven_home = temp.path().join("coven-home");
+        fs::create_dir_all(&coven_home)?;
+        let marker = coven_home.join("dashboard-launched");
+        let dashboard = temp.path().join("fake-dashboard");
+        fs::write(
+            &dashboard,
+            "#!/bin/sh\n\
+             test -S \"$COVEN_HOME/coven.sock\" || exit 42\n\
+             printf launched > \"$COVEN_TEST_DASHBOARD_MARKER\"\n",
+        )?;
+        fs::set_permissions(&dashboard, fs::Permissions::from_mode(0o755))?;
+
+        let output = Command::new(coven_bin())
+            .args(["memory", "open"])
+            .env("COVEN_HOME", &coven_home)
+            .env("COVEN_MEMORY_DASHBOARD_BIN", &dashboard)
+            .env("COVEN_TEST_DASHBOARD_MARKER", &marker)
+            .output()?;
+        stop_daemon(&coven_home);
+
+        assert!(
+            output.status.success(),
+            "memory open failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(fs::read_to_string(marker)?, "launched");
+        Ok(())
+    }
+}

--- a/crates/coven-cli/tests/memory_dashboard.rs
+++ b/crates/coven-cli/tests/memory_dashboard.rs
@@ -17,11 +17,20 @@ mod unix {
             .output();
     }
 
+    struct DaemonGuard(PathBuf);
+
+    impl Drop for DaemonGuard {
+        fn drop(&mut self) {
+            stop_daemon(&self.0);
+        }
+    }
+
     #[test]
     fn memory_open_starts_daemon_before_dashboard() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let coven_home = temp.path().join("coven-home");
         fs::create_dir_all(&coven_home)?;
+        let _daemon_guard = DaemonGuard(coven_home.clone());
         let marker = coven_home.join("dashboard-launched");
         let dashboard = temp.path().join("fake-dashboard");
         fs::write(
@@ -38,7 +47,6 @@ mod unix {
             .env("COVEN_MEMORY_DASHBOARD_BIN", &dashboard)
             .env("COVEN_TEST_DASHBOARD_MARKER", &marker)
             .output()?;
-        stop_daemon(&coven_home);
 
         assert!(
             output.status.success(),

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -34,12 +34,13 @@ separate local-dashboard launcher described after the table.
 
 ## coven memory open
 
-`coven memory open` launches the optional
-`@opencoven/coven-memory-dashboard` companion on a validated loopback address.
-It does not accept `--json`; `coven memory` and `coven memory --json` retain the
-read-only list behavior above. The npm wrapper requires Node.js 24 or newer for
-the dashboard only, while other wrapped Coven commands continue to support
-Node.js 18 or newer.
+`coven memory open` starts or reuses the local Coven daemon, then launches the
+optional `@opencoven/coven-memory-dashboard` companion on a validated loopback
+address. It does not require the dashboard source repository or a separate
+`coven daemon start` step. It does not accept `--json`; `coven memory` and
+`coven memory --json` retain the read-only list behavior above. The npm wrapper
+requires Node.js 24 or newer for the dashboard only, while other wrapped Coven
+commands continue to support Node.js 18 or newer.
 
 ## coven status
 

--- a/docs/superpowers/plans/2026-08-03-memory-open-daemon-autostart.md
+++ b/docs/superpowers/plans/2026-08-03-memory-open-daemon-autostart.md
@@ -1,0 +1,340 @@
+# Memory Open Daemon Auto-Start Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `coven memory open` start or reuse the local Coven daemon before launching the packaged dashboard.
+
+**Architecture:** Keep daemon lifecycle ownership in the Rust CLI. Resolve the optional dashboard first, ensure the daemon through the existing lifecycle API, and launch the dashboard only after readiness succeeds.
+
+**Tech Stack:** Rust, `anyhow`, Coven daemon lifecycle APIs, Cargo integration tests
+
+---
+
+### Task 1: Prepare Memory only after daemon readiness
+
+**Files:**
+- Modify: `crates/coven-cli/src/memory_dashboard.rs:1-115`
+- Test: `crates/coven-cli/src/memory_dashboard.rs:117-160`
+
+- [ ] **Step 1: Add failing preparation-order tests**
+
+Add these tests inside `memory_dashboard::tests`:
+
+```rust
+#[test]
+fn missing_dashboard_does_not_start_daemon() {
+    let daemon_called = std::cell::Cell::new(false);
+
+    let error = prepare_open_with(
+        || None,
+        || {
+            daemon_called.set(true);
+            Ok(())
+        },
+    )
+    .expect_err("missing dashboard must fail");
+
+    assert!(!daemon_called.get());
+    assert!(error.to_string().contains("dashboard is not installed"));
+}
+
+#[test]
+fn daemon_failure_prevents_dashboard_preparation() {
+    let launch = LaunchCommand {
+        program: PathBuf::from("dashboard"),
+        args: Vec::new(),
+    };
+
+    let error = prepare_open_with(
+        || Some(launch),
+        || anyhow::bail!("socket did not become ready"),
+    )
+    .expect_err("daemon failure must stop launch preparation");
+
+    assert!(error
+        .to_string()
+        .contains("failed to start or reach Coven daemon for Memory"));
+}
+
+#[test]
+fn ready_daemon_returns_the_resolved_dashboard() {
+    let launch = LaunchCommand {
+        program: PathBuf::from("dashboard"),
+        args: vec![OsString::from("entry")],
+    };
+
+    let prepared = prepare_open_with(
+        || Some(LaunchCommand {
+            program: launch.program.clone(),
+            args: launch.args.clone(),
+        }),
+        || Ok(()),
+    )
+    .expect("ready daemon permits dashboard launch");
+
+    assert_eq!(prepared, launch);
+}
+```
+
+- [ ] **Step 2: Run the tests and verify the helper is missing**
+
+Run:
+
+```bash
+cargo test -p coven-cli --bin coven memory_dashboard::tests --locked
+```
+
+Expected: compilation fails because `prepare_open_with` is not defined.
+
+- [ ] **Step 3: Implement daemon preparation**
+
+Add these helpers above `run_open`:
+
+```rust
+fn dashboard_not_installed_error() -> anyhow::Error {
+    anyhow!(
+        "The Coven Memory dashboard is not installed.\n\n  \
+         npm install -g @opencoven/coven-memory-dashboard\n\n\
+         Then rerun: coven memory open"
+    )
+}
+
+fn ensure_daemon_ready() -> Result<()> {
+    let coven_home = crate::coven_home_dir()?;
+    let current_exe =
+        std::env::current_exe().context("failed to resolve current executable")?;
+    crate::daemon::ensure_background_server(
+        &coven_home,
+        &current_exe,
+        crate::current_timestamp(),
+    )
+    .context("failed to start or reach Coven daemon for Memory")?;
+    Ok(())
+}
+
+fn prepare_open_with(
+    resolve_launch: impl FnOnce() -> Option<LaunchCommand>,
+    ensure_daemon: impl FnOnce() -> Result<()>,
+) -> Result<LaunchCommand> {
+    let launch = resolve_launch().ok_or_else(dashboard_not_installed_error)?;
+    ensure_daemon()?;
+    Ok(launch)
+}
+```
+
+Change the start of `run_open` to:
+
+```rust
+pub fn run_open() -> Result<()> {
+    let launch = prepare_open_with(resolve, ensure_daemon_ready)?;
+```
+
+Keep the existing `Command::new`, exit-status handling, and launch errors
+unchanged.
+
+- [ ] **Step 4: Run focused unit tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli --bin coven memory_dashboard::tests --locked
+```
+
+Expected: all memory dashboard tests pass.
+
+- [ ] **Step 5: Commit the launch preparation**
+
+```bash
+git add crates/coven-cli/src/memory_dashboard.rs
+git commit -s -m "fix(memory): start daemon before dashboard"
+```
+
+### Task 2: Verify the packaged launch contract end to end
+
+**Files:**
+- Create: `crates/coven-cli/tests/memory_dashboard.rs`
+
+- [ ] **Step 1: Add a Unix process-level regression test**
+
+Create `crates/coven-cli/tests/memory_dashboard.rs`:
+
+```rust
+#[cfg(unix)]
+mod unix {
+    use anyhow::Result;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    fn coven_bin() -> PathBuf {
+        PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+    }
+
+    fn stop_daemon(coven_home: &Path) {
+        let _ = Command::new(coven_bin())
+            .args(["daemon", "stop"])
+            .env("COVEN_HOME", coven_home)
+            .output();
+    }
+
+    #[test]
+    fn memory_open_starts_daemon_before_dashboard() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let coven_home = temp.path().join("coven-home");
+        fs::create_dir_all(&coven_home)?;
+        let marker = coven_home.join("dashboard-launched");
+        let dashboard = temp.path().join("fake-dashboard");
+        fs::write(
+            &dashboard,
+            "#!/bin/sh\n\
+             test -S \"$COVEN_HOME/coven.sock\" || exit 42\n\
+             printf launched > \"$COVEN_TEST_DASHBOARD_MARKER\"\n",
+        )?;
+        fs::set_permissions(&dashboard, fs::Permissions::from_mode(0o755))?;
+
+        let output = Command::new(coven_bin())
+            .args(["memory", "open"])
+            .env("COVEN_HOME", &coven_home)
+            .env("COVEN_MEMORY_DASHBOARD_BIN", &dashboard)
+            .env("COVEN_TEST_DASHBOARD_MARKER", &marker)
+            .output()?;
+        stop_daemon(&coven_home);
+
+        assert!(
+            output.status.success(),
+            "memory open failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(fs::read_to_string(marker)?, "launched");
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 2: Run the process-level test**
+
+Run:
+
+```bash
+cargo test -p coven-cli --test memory_dashboard --locked
+```
+
+Expected: the test passes and its temporary daemon is stopped during cleanup.
+
+- [ ] **Step 3: Commit the regression test**
+
+```bash
+git add crates/coven-cli/tests/memory_dashboard.rs
+git commit -s -m "test(memory): cover daemon-backed dashboard launch"
+```
+
+### Task 3: Document the standalone packaged workflow
+
+**Files:**
+- Modify: `README.md:151-160`
+- Modify: `README.md:304-308`
+- Modify: `docs/reference/cli-observe.md:35-45`
+
+- [ ] **Step 1: Update the root installation guidance**
+
+After the `coven memory open` installation example, add:
+
+```markdown
+`coven memory open` starts or reuses the installed local Coven daemon before
+launching the packaged dashboard. It does not require a checkout or running
+development server from the `coven-memory` repository.
+```
+
+In the architecture paragraph near the bottom, state that the native CLI
+establishes daemon readiness before delegating to the installed dashboard.
+
+- [ ] **Step 2: Update the command reference**
+
+In `docs/reference/cli-observe.md`, replace the first paragraph under
+`## coven memory open` with:
+
+```markdown
+`coven memory open` starts or reuses the local Coven daemon, then launches the
+optional `@opencoven/coven-memory-dashboard` companion on a validated loopback
+address. It does not require the dashboard source repository or a separate
+`coven daemon start` step. It does not accept `--json`; `coven memory` and
+`coven memory --json` retain the read-only list behavior above.
+```
+
+- [ ] **Step 3: Commit documentation**
+
+```bash
+git add README.md docs/reference/cli-observe.md
+git commit -s -m "docs(memory): explain standalone dashboard launch"
+```
+
+### Task 4: Validate and publish
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-03-memory-open-daemon-autostart.md`
+
+- [ ] **Step 1: Run focused tests and formatting**
+
+Run:
+
+```bash
+cargo test -p coven-cli --bin coven memory_dashboard::tests --locked
+cargo test -p coven-cli --test memory_dashboard --locked
+cargo fmt --check
+git diff --check
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Run workspace quality gates**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets --locked -- -D warnings
+cargo test --workspace --locked
+```
+
+Expected: all commands pass. Investigate any failure before publishing; do not
+skip a newly introduced failure.
+
+- [ ] **Step 3: Commit the implementation plan**
+
+```bash
+git add docs/superpowers/plans/2026-08-03-memory-open-daemon-autostart.md
+git commit -s -m "docs(memory): plan daemon auto-start"
+```
+
+- [ ] **Step 4: Push and open the pull request**
+
+```bash
+git push -u origin fix/memory-open-auto-daemon
+gh pr create \
+  --base main \
+  --head fix/memory-open-auto-daemon \
+  --title "fix(memory): start daemon before dashboard" \
+  --body "$(cat <<'EOF'
+## Summary
+- start or reuse the local Coven daemon before launching the packaged Memory dashboard
+- fail in the terminal instead of opening a dashboard that can only return 503
+- add unit, process-level, and documentation coverage for the standalone workflow
+
+## Validation
+- `cargo test -p coven-cli --bin coven memory_dashboard::tests --locked`
+- `cargo test -p coven-cli --test memory_dashboard --locked`
+- `cargo clippy --workspace --all-targets --locked -- -D warnings`
+- `cargo test --workspace --locked`
+EOF
+)"
+```
+
+The PR body must summarize daemon auto-start, fail-before-launch behavior,
+process-level coverage, documentation, and validation.
+
+- [ ] **Step 5: Update Beads**
+
+```bash
+bd comments add cmem-h06 "Implemented daemon auto-start for coven memory open and opened the Coven pull request."
+bd close cmem-h06 --reason="Packaged Memory launch now establishes daemon readiness before opening the dashboard."
+```

--- a/docs/superpowers/specs/2026-08-03-memory-open-daemon-autostart-design.md
+++ b/docs/superpowers/specs/2026-08-03-memory-open-daemon-autostart-design.md
@@ -1,0 +1,106 @@
+# Memory Open Daemon Auto-Start Design
+
+## Context
+
+The Coven Memory dashboard is already distributed as a packaged npm
+dependency. Users do not need the `coven-memory` source repository to run it.
+However, `coven memory open` currently launches only the dashboard process.
+When the local Coven daemon is stopped, the dashboard starts successfully but
+its `/api/memory` proxy cannot reach the daemon and returns
+`503 memory_unavailable`.
+
+The command should establish its complete runtime dependency before opening the
+browser.
+
+## Considered Approaches
+
+### 1. Let the Rust CLI own daemon readiness
+
+Resolve the installed dashboard, reuse or start the daemon through the existing
+daemon lifecycle API, and launch the dashboard only after its socket is ready.
+
+This is the recommended approach. The CLI already owns the daemon executable,
+home directory, lifecycle lock, stale-state reporting, and platform-specific
+background startup. It keeps the Node package focused on serving the dashboard.
+
+### 2. Let the dashboard launcher spawn `coven daemon start`
+
+The Node executable could search `PATH` for `coven` and start it before the
+server.
+
+This creates bidirectional package coupling, duplicates platform process
+handling, and makes the standalone dashboard package responsible for locating
+and supervising a separate executable.
+
+### 3. Read canonical memory directly when the daemon is absent
+
+The dashboard could fall back to filesystem reads.
+
+This is rejected because it bypasses the daemon API, duplicates path and
+privacy validation, and breaks the established authority boundary.
+
+## Design
+
+### Launch sequence
+
+`memory_dashboard::run_open` performs these steps:
+
+1. Resolve the wrapper-provided dashboard entrypoint, explicit override, or
+   `coven-memory-dashboard` executable on `PATH`.
+2. Resolve `COVEN_HOME` and the current Coven executable.
+3. Call `daemon::ensure_background_server` with the normal lifecycle lock and
+   startup timestamp.
+4. Launch the packaged dashboard only after the daemon reports its socket
+   ready.
+
+The dashboard is resolved first so a missing optional package does not start an
+otherwise unnecessary daemon.
+
+### Failure behavior
+
+- Missing dashboard: keep the existing installation guidance and do not start
+  the daemon.
+- Daemon start or readiness failure: return a contextual terminal error and do
+  not launch the dashboard or browser.
+- Stale daemon status: preserve the existing explicit restart guidance from
+  `ensure_background_server`; do not silently terminate a recorded process.
+- Dashboard process failure: preserve the existing launch and exit-status
+  errors.
+- A daemon that becomes unavailable after launch remains a retryable dashboard
+  error; this change guarantees initial readiness, not perpetual availability.
+
+### Testability
+
+Extract a small preparation helper that accepts the resolved launch command and
+an injected daemon-readiness closure. Unit tests verify:
+
+- the daemon is ensured before a valid dashboard command is returned;
+- a missing dashboard fails without invoking daemon startup; and
+- daemon startup failure prevents dashboard launch preparation.
+
+Existing resolution tests continue covering wrapper, override, and `PATH`
+precedence. Existing daemon lifecycle tests remain the authority for
+start/reuse/readiness behavior.
+
+## Documentation
+
+Update the CLI-facing Memory documentation to state that
+`coven memory open` starts or reuses the local daemon automatically. Direct
+execution of `coven-memory-dashboard` remains an advanced entrypoint that
+requires a current daemon.
+
+## Validation
+
+1. Run focused `memory_dashboard` unit tests.
+2. Run daemon lifecycle tests used by `ensure_background_server`.
+3. Run the CLI test suite and workspace Clippy with warnings denied.
+4. Run workspace tests, preserving only documented unrelated skips if needed.
+5. Verify a temporary Coven home can execute `coven memory open` with a fake
+   dashboard launcher and observe daemon readiness before launcher execution.
+
+## Non-Goals
+
+- Bundling the dashboard UI into the Rust binary.
+- Starting the daemon from direct `coven-memory-dashboard` execution.
+- Automatically restarting a stale or incompatible running daemon.
+- Direct filesystem fallback in the dashboard.


### PR DESCRIPTION
## Summary
- start or reuse the local Coven daemon before launching the packaged Memory dashboard
- fail in the terminal instead of opening a dashboard that can only return HTTP 503
- avoid starting the daemon when the optional dashboard is not installed
- add unit, process-level, and documentation coverage for the standalone workflow

## Validation
- `cargo test -p coven-cli --bin coven memory_dashboard::tests --locked`
- `cargo test -p coven-cli --test memory_dashboard --locked`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `python3 scripts/check-coven-privacy.py --files crates/coven-cli/src/memory_dashboard.rs crates/coven-cli/tests/memory_dashboard.rs README.md docs/reference/cli-observe.md`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-api-contract-docs.py`