### PR TITLE
perf: add concurrent runtime baseline artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,11 @@ jobs:
       - name: Build coven
         run: cargo build -p coven-cli --locked
       - name: Validate benchmark runner
-        run: node --test scripts/benchmark-cli.test.mjs
+        run: node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
       - name: Collect non-gating baseline artifact
         run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
+      - name: Collect concurrent runtime baseline artifact
+        run: node scripts/benchmark-chaos.mjs --binary target/debug/coven --output coven-chaos.json
       - name: Collect deterministic TUI scheduling metric
         run: |
           set -o pipefail
@@ -63,6 +65,7 @@ jobs:
           name: coven-cli-performance-baseline
           path: |
             coven-perf.json
+            coven-chaos.json
             coven-tui-metrics.txt
           if-no-files-found: error
 

--- a/README.md
+++ b/README.md
@@ -664,6 +664,26 @@ poll/draw counters. These outputs are trend data: CI uploads them as artifacts
 and validates fixture construction, but does not fail pull requests on
 wall-clock thresholds.
 
+### Concurrent runtime baseline
+
+Run the complementary concurrent-session baseline before making a throughput,
+storage, or cancellation optimization:
+
+```bash
+cargo build -p coven-cli --locked
+node scripts/benchmark-chaos.mjs --binary target/debug/coven --output /tmp/coven-chaos.json
+```
+
+The command always exercises 1, 8, and 32 concurrent deterministic harness
+sessions, records launch-to-first-output percentiles, throughput, cancellation
+acknowledgement, and SQLite file growth, and writes a redacted JSON report.
+It deliberately labels metrics that the current runtime cannot expose (SQLite
+connection/transaction counts and an event-writer queue) rather than deriving
+or inventing them. The bounded writer work in #596 must replace those labels
+with direct counters; Cave owns the slow-WebSocket-consumer lane in #4317.
+Fault-injection and platform-specific crash coverage remain explicit matrix
+entries, so a trend artifact cannot be mistaken for a passing chaos test.
+
 ### Architecture rules for contributors
 
 - **Rust is the authority layer.** Process launch, cwd/project-root validation, PTY lifecycle, session persistence, and socket request enforcement are all Rust's responsibility. TypeScript clients improve UX but are never the trust boundary.

--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -1,0 +1,285 @@
+import { mkdtemp, mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  harnessSessionRequest,
+  isolatedEnvironment,
+  socketRequest,
+  startDaemon,
+  stopDaemon,
+  waitForOutputEvent
+} from './benchmark-cli.mjs';
+
+const SCHEMA_VERSION = 1;
+const DEFAULT_CONCURRENCY = [1, 8, 32];
+const POLL_ATTEMPTS = 160;
+const POLL_DELAY_MS = 25;
+
+function optionValue(args, index, option) {
+  const arg = args[index];
+  if (arg === option) return [args[index + 1], index + 1];
+  return [arg.slice(`${option}=`.length), index];
+}
+
+export function parseOptions(args) {
+  let binary;
+  let output;
+  let concurrency = DEFAULT_CONCURRENCY;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--binary' || arg.startsWith('--binary=')) {
+      [binary, index] = optionValue(args, index, '--binary');
+    } else if (arg === '--output' || arg.startsWith('--output=')) {
+      [output, index] = optionValue(args, index, '--output');
+    } else if (arg === '--concurrency' || arg.startsWith('--concurrency=')) {
+      const [raw, nextIndex] = optionValue(args, index, '--concurrency');
+      index = nextIndex;
+      concurrency = raw?.split(',').map((value) => Number.parseInt(value, 10)) ?? [];
+      if (
+        concurrency.length === 0 ||
+        concurrency.some((value) => !Number.isSafeInteger(value) || value <= 0)
+      ) {
+        throw new Error('--concurrency must contain positive integers');
+      }
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+
+  if (!binary) throw new Error('--binary is required');
+  if (!output) throw new Error('--output is required');
+  return { binary, output, concurrency };
+}
+
+export function summarize(samples) {
+  if (samples.length === 0) throw new Error('cannot summarize no samples');
+  const sorted = [...samples].sort((left, right) => left - right);
+  const percentile = (p) => sorted[Math.ceil(sorted.length * p) - 1];
+  return {
+    count: sorted.length,
+    minMs: sorted[0],
+    p50Ms: percentile(0.5),
+    p95Ms: percentile(0.95),
+    p99Ms: percentile(0.99),
+    maxMs: sorted.at(-1)
+  };
+}
+
+export function redactedEnvironment(environment = process.env) {
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    ci: environment.GITHUB_ACTIONS === 'true'
+  };
+}
+
+export function storageMetricStatus() {
+  return {
+    sqliteConnectionOpens: {
+      status: 'unavailable',
+      reason: 'The current daemon does not expose per-process connection counters.'
+    },
+    sqliteTransactions: {
+      status: 'unavailable',
+      reason: 'The current daemon does not expose committed transaction counters.'
+    },
+    eventQueueDepth: {
+      status: 'not_applicable',
+      reason: 'Events are persisted synchronously; #596 owns the bounded writer queue.'
+    }
+  };
+}
+
+export function chaosCoverage() {
+  return {
+    slowClient: {
+      status: 'covered_by_cave',
+      reason: 'Cave owns WebSocket consumer buffering and replay (#4317).'
+    },
+    diskFull: {
+      status: 'blocked_by_injection',
+      reason: 'A cross-platform storage fault hook is not present in the daemon.'
+    },
+    lockedDatabase: {
+      status: 'covered_by_store_regressions',
+      reason: 'The store suite owns deterministic SQLite lock assertions.'
+    },
+    stalledChild: {
+      status: 'covered',
+      reason: 'Each fixture child remains alive until the measured cancellation request.'
+    },
+    crashRestart: {
+      status: 'covered_by_daemon_regressions',
+      reason: 'Daemon recovery tests own process-crash and orphan-recovery assertions.'
+    }
+  };
+}
+
+async function fixtureEnvironment(root, environment) {
+  const bin = join(root, 'bin');
+  await mkdir(bin, { recursive: true });
+  const covenHome = join(root, 'home');
+  await mkdir(join(covenHome, 'user-home'), { recursive: true });
+  const harness = join(bin, 'codex');
+  await writeFile(
+    harness,
+    '#!/bin/sh\nprintf "COVEN_BENCHMARK_READY\\n"\ntrap "exit 0" INT TERM\nwhile :; do sleep 60; done\n',
+    { mode: 0o700 }
+  );
+  const env = isolatedEnvironment(covenHome, environment);
+  return { covenHome, env: { ...env, PATH: `${bin}:${env.PATH ?? ''}` } };
+}
+
+async function waitForSessionExit(socketPath, sessionId, request = socketRequest) {
+  let lastError;
+  for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await request(socketPath, {
+        method: 'GET',
+        path: `/api/v1/sessions/${sessionId}`
+      });
+      if (response.statusCode === 200) {
+        const session = JSON.parse(response.body);
+        if (session.status !== 'running') return session.status;
+      } else {
+        lastError = new Error(`session lookup returned ${response.statusCode}`);
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, POLL_DELAY_MS));
+  }
+  throw new Error(`session did not leave running state: ${lastError?.message ?? 'unknown error'}`);
+}
+
+async function fileSize(path) {
+  try {
+    return (await stat(path)).size;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return 0;
+    throw error;
+  }
+}
+
+export async function storeFootprint(covenHome) {
+  const database = join(covenHome, 'coven.sqlite3');
+  const [databaseBytes, walBytes, shmBytes] = await Promise.all([
+    fileSize(database),
+    fileSize(`${database}-wal`),
+    fileSize(`${database}-shm`)
+  ]);
+  return { databaseBytes, walBytes, shmBytes, totalBytes: databaseBytes + walBytes + shmBytes };
+}
+
+export async function runConcurrencyScenario({ binary, root, concurrency, environment = process.env }) {
+  const { covenHome, env } = await fixtureEnvironment(root, environment);
+  const socketPath = await startDaemon({ binary, covenHome, env });
+  const footprintBefore = await storeFootprint(covenHome);
+  let ids = [];
+
+  try {
+    const startedAt = process.hrtime.bigint();
+    const launches = await Promise.all(
+      Array.from({ length: concurrency }, async () => {
+        const launchedAt = process.hrtime.bigint();
+        const response = await socketRequest(socketPath, harnessSessionRequest({ projectRoot: root }));
+        if (response.statusCode !== 201) throw new Error(`launch returned ${response.statusCode}`);
+        const id = JSON.parse(response.body).id;
+        if (typeof id !== 'string' || id.length === 0) throw new Error('launch response has no id');
+        await waitForOutputEvent(socketPath, id, { attempts: POLL_ATTEMPTS, delayMs: POLL_DELAY_MS });
+        return { id, firstOutputMs: Number(process.hrtime.bigint() - launchedAt) / 1_000_000 };
+      })
+    );
+    ids = launches.map((launch) => launch.id);
+    const completedAt = process.hrtime.bigint();
+    const elapsedMs = Number(completedAt - startedAt) / 1_000_000;
+
+    const cancellationStartedAt = process.hrtime.bigint();
+    await Promise.all(
+      ids.map(async (id) => {
+        const response = await socketRequest(socketPath, { method: 'POST', path: `/api/v1/sessions/${id}/kill` });
+        if (response.statusCode !== 202) throw new Error(`cancel returned ${response.statusCode}`);
+        await waitForSessionExit(socketPath, id);
+      })
+    );
+    const cancellationMs = Number(process.hrtime.bigint() - cancellationStartedAt) / 1_000_000;
+    ids = [];
+    const footprintAfter = await storeFootprint(covenHome);
+
+    return {
+      status: 'passed',
+      concurrency,
+      launchToFirstMeaningfulOutput: summarize(launches.map((launch) => launch.firstOutputMs)),
+      throughputSessionsPerSecond: Number((concurrency / (elapsedMs / 1_000)).toFixed(3)),
+      cancellation: { allSessionsMs: Number(cancellationMs.toFixed(3)), terminalStates: concurrency },
+      diskGrowthBytes: footprintAfter.totalBytes - footprintBefore.totalBytes,
+      storage: storageMetricStatus()
+    };
+  } finally {
+    await Promise.all(
+      ids.map((id) => socketRequest(socketPath, { method: 'POST', path: `/api/v1/sessions/${id}/kill` }).catch(() => {}))
+    );
+    stopDaemon({ binary, env });
+  }
+}
+
+export function buildReport({ concurrency, scenarios, environment = process.env }) {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    environment: redactedEnvironment(environment),
+    matrix: { concurrency, scenarios },
+    chaos: chaosCoverage()
+  };
+}
+
+export function validateReport(report) {
+  if (report?.schemaVersion !== SCHEMA_VERSION) throw new Error('unsupported report schema');
+  for (const expected of DEFAULT_CONCURRENCY) {
+    if (!report.matrix.concurrency.includes(expected)) {
+      throw new Error(`required concurrency ${expected} is absent`);
+    }
+    if (report.matrix.scenarios[`sessions_${expected}`]?.status !== 'passed') {
+      throw new Error(`sessions_${expected} did not pass`);
+    }
+  }
+  return report;
+}
+
+export async function main(args = process.argv.slice(2)) {
+  const options = parseOptions(args);
+  for (const required of DEFAULT_CONCURRENCY) {
+    if (!options.concurrency.includes(required)) {
+      throw new Error(`full baseline requires concurrency ${required}`);
+    }
+  }
+  const fixtureRoot = await mkdtemp(join(tmpdir(), 'coven-chaos-baseline-'));
+  try {
+    const scenarios = {};
+    for (const concurrency of options.concurrency) {
+      scenarios[`sessions_${concurrency}`] = await runConcurrencyScenario({
+        binary: options.binary,
+        root: join(fixtureRoot, `s-${concurrency}`),
+        concurrency
+      });
+    }
+    const report = validateReport(buildReport({ concurrency: options.concurrency, scenarios }));
+    const serialized = `${JSON.stringify(report)}\n`;
+    const temporary = `${options.output}.${process.pid}.tmp`;
+    await writeFile(temporary, serialized, { encoding: 'utf8', mode: 0o600 });
+    await rename(temporary, options.output);
+    return report;
+  } finally {
+    await rm(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`benchmark-chaos: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildReport,
+  chaosCoverage,
+  parseOptions,
+  storageMetricStatus,
+  summarize,
+  validateReport
+} from './benchmark-chaos.mjs';
+
+test('parses the required output and full concurrency matrix', () => {
+  assert.deepEqual(
+    parseOptions(['--binary=/tmp/coven', '--output=/tmp/report.json']),
+    { binary: '/tmp/coven', output: '/tmp/report.json', concurrency: [1, 8, 32] }
+  );
+});
+
+test('rejects an incomplete full baseline matrix', () => {
+  assert.throws(
+    () => validateReport(buildReport({
+      concurrency: [1, 8],
+      scenarios: { sessions_1: { status: 'passed' }, sessions_8: { status: 'passed' } }
+    })),
+    /required concurrency 32/
+  );
+});
+
+test('rejects an absent or invalid concurrency value', () => {
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--output=/tmp/report.json', '--concurrency']),
+    /--concurrency must contain positive integers/
+  );
+  assert.throws(
+    () => parseOptions(['--binary=/tmp/coven', '--output=/tmp/report.json', '--concurrency=1,zero']),
+    /--concurrency must contain positive integers/
+  );
+});
+
+test('summarizes p50, p95, and p99 using nearest rank', () => {
+  assert.deepEqual(summarize([9, 1, 5, 3, 7]), {
+    count: 5,
+    minMs: 1,
+    p50Ms: 5,
+    p95Ms: 9,
+    p99Ms: 9,
+    maxMs: 9
+  });
+});
+
+test('records unavailable writer counters without pretending they are measured', () => {
+  assert.equal(storageMetricStatus().sqliteConnectionOpens.status, 'unavailable');
+  assert.equal(storageMetricStatus().eventQueueDepth.status, 'not_applicable');
+  assert.equal(chaosCoverage().diskFull.status, 'blocked_by_injection');
+});
+
+test('report contains no fixture paths or prompt content', () => {
+  const report = buildReport({
+    concurrency: [1, 8, 32],
+    scenarios: {
+      sessions_1: { status: 'passed' },
+      sessions_8: { status: 'passed' },
+      sessions_32: { status: 'passed' }
+    },
+    environment: { GITHUB_ACTIONS: 'true', HOME: '/private/fixture', PROMPT: 'secret prompt' }
+  });
+  const serialized = JSON.stringify(report);
+  assert.doesNotMatch(serialized, /private\/fixture|secret prompt/);
+  assert.equal(Object.hasOwn(report.environment, 'host'), false);
+  assert.equal(Object.hasOwn(report.environment, 'runner'), false);
+  assert.equal(validateReport(report), report);
+});


### PR DESCRIPTION
Closes #598

## Summary

The existing benchmark artifact measures sequential command, list, and tail paths. It did not provide an isolated concurrent-harness baseline, cancellation latency, or a storage-footprint measurement, which left performance and chaos regressions without a comparable artifact.

## Solution

- add a deterministic, isolated benchmark runner for 1, 8, and 32 concurrent harness sessions;
- measure successful session throughput, first meaningful output percentiles, cancellation completion, and SQLite file-footprint delta;
- publish a machine-readable JSON artifact from the non-gating CI baseline job; and
- document the local command and add focused script tests for argument parsing, percentile calculation, metric status, and privacy-safe report shape.

## Validation

- `node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs` (52 passing)
- `node --check scripts/benchmark-chaos.mjs`
- `node scripts/benchmark-chaos.mjs --binary target/debug/coven --output /tmp/coven-598-chaos.json` (1/8/32-session matrix passed)
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `git merge-tree --write-tree origin/main HEAD`

`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, and the repository secret/privacy scans were also started in the isolated worktree; this shared WSL host is concurrently compiling unrelated worktrees, so their final completion is recorded in the PR checks rather than treated as a local pass here.

## Limits and follow-up

The report intentionally marks per-process SQLite connection/transaction counts and writer-queue depth as unavailable/not applicable until the storage instrumentation and bounded queue work in #596 land; it does not fabricate those values. Slow-client transport behavior belongs to Cave's adapter work in OpenCoven/coven-cave#4317. Disk-full and cross-platform forced-process-termination injectors are not currently available, and their blocked status is explicit in the artifact.

The baseline is trend-oriented and has no time-based regression threshold yet. It is an artifact, not a CI gate.
