### PR TITLE
fix(npm): restore Intel macOS packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Install native link dependencies (Linux only)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
-      - run: cargo build --release --target ${{ matrix.rust-target }}
+      - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
       - run: node scripts/test-cli-prepublish.mjs --target=${{ matrix.npm-target }} --skip-build --skip-secrets-scan
         env:
           COVEN_NPM_DRY_RUN_VERSION: 999.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,9 @@ jobs:
           - os: macos-26
             npm-target: macos
             rust-target: aarch64-apple-darwin
+          - os: macos-15-intel
+            npm-target: macos-x64
+            rust-target: x86_64-apple-darwin
           - os: ubuntu-latest
             npm-target: linux-x64
             rust-target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -56,6 +56,7 @@ jobs:
       release_mode: ${{ steps.release-context.outputs.release_mode }}
       release_tag: ${{ steps.release-context.outputs.release_tag }}
       npm_version: ${{ steps.release-context.outputs.npm_version }}
+      native_package_set: ${{ steps.recovery-contract.outputs.native_package_set || 'post-intel' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6.0.0
         with:
@@ -63,7 +64,7 @@ jobs:
       - name: Derive stable or recovery release context
         id: release-context
         run: node scripts/release-npm-context.mjs "$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
-      - name: Confirm tag is annotated, signer-authorized, and points to main
+      - name: Confirm tag is annotated and signer-authorized
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_RELEASE_ALLOWED_SIGNERS: ${{ vars.NPM_RELEASE_ALLOWED_SIGNERS }}
@@ -115,12 +116,12 @@ jobs:
             exit 1
           fi
           printf '%s\n' "$verify_output"
-          git fetch --no-tags origin main
-          if ! git merge-base --is-ancestor "$TAGGED_COMMIT_SHA" origin/main; then
-            echo "::error::Refusing release: tagged commit $TAGGED_COMMIT_SHA is not contained in origin/main."
-            exit 1
-          fi
           if [ "$RELEASE_MODE" != "recovery" ]; then
+            git fetch --no-tags origin main
+            if ! git merge-base --is-ancestor "$TAGGED_COMMIT_SHA" origin/main; then
+              echo "::error::Refusing release: tagged commit $TAGGED_COMMIT_SHA is not contained in origin/main."
+              exit 1
+            fi
             exit 0
           fi
           if ! BASE_TAG_OBJECT_SHA=$(git rev-parse "$RELEASE_TAG^{tag}" 2>/dev/null); then
@@ -154,6 +155,8 @@ jobs:
             case "$changed_path" in
               .github/workflows/release-npm.yml|\
               scripts/release-npm-context.mjs|\
+              scripts/release-npm-recovery-contract.mjs|\
+              scripts/publish-npm.mjs|\
               scripts/publish-npm-test.mjs|\
               docs/reference/releasing.md|\
               docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md|\
@@ -165,6 +168,15 @@ jobs:
                 ;;
             esac
           done < <(git diff --name-only "$BASE_COMMIT_SHA..$TAGGED_COMMIT_SHA")
+      - name: Verify recovery package contract
+        id: recovery-contract
+        if: steps.release-context.outputs.release_mode == 'recovery'
+        env:
+          RELEASE_TAG: ${{ steps.release-context.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          BASE_COMMIT_SHA=$(git rev-parse "$RELEASE_TAG^{}")
+          node scripts/release-npm-recovery-contract.mjs "$BASE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
 
   build-platform:
     name: Build ${{ matrix.npm-target }}
@@ -179,6 +191,10 @@ jobs:
           - npm-target: macos
             rust-target: aarch64-apple-darwin
             runner: macos-26
+            binary: coven
+          - npm-target: macos-x64
+            rust-target: x86_64-apple-darwin
+            runner: macos-15-intel
             binary: coven
           - npm-target: linux-x64
             rust-target: x86_64-unknown-linux-gnu
@@ -221,6 +237,11 @@ jobs:
       - run: chmod +x target/aarch64-apple-darwin/release/coven
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
         with:
+          name: coven-macos-x64
+          path: target/x86_64-apple-darwin/release
+      - run: chmod +x target/x86_64-apple-darwin/release/coven
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
+        with:
           name: coven-linux-x64
           path: target/x86_64-unknown-linux-gnu/release
       - run: chmod +x target/x86_64-unknown-linux-gnu/release/coven
@@ -228,7 +249,11 @@ jobs:
         with:
           name: coven-windows
           path: target/x86_64-pc-windows-msvc/release
-      - run: node scripts/publish-npm.mjs --target=macos --skip-build --dry-run
+      - run: node scripts/publish-npm.mjs --target=macos --skip-build --dry-run --skip-wrapper
+        env:
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+      - run: node scripts/publish-npm.mjs --target=macos-x64 --skip-build --dry-run --skip-wrapper
+        if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper
@@ -239,6 +264,10 @@ jobs:
         if: needs.verify-tag.outputs.release_mode == 'normal'
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+      - run: node scripts/publish-npm.mjs --wrapper-only --dry-run
+        env:
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+          COVEN_NPM_NATIVE_PACKAGE_SET: ${{ needs.verify-tag.outputs.native_package_set }}
 
   npm-publish:
     name: npm publish
@@ -263,6 +292,11 @@ jobs:
       - run: chmod +x target/aarch64-apple-darwin/release/coven
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
         with:
+          name: coven-macos-x64
+          path: target/x86_64-apple-darwin/release
+      - run: chmod +x target/x86_64-apple-darwin/release/coven
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
+        with:
           name: coven-linux-x64
           path: target/x86_64-unknown-linux-gnu/release
       - run: chmod +x target/x86_64-unknown-linux-gnu/release/coven
@@ -283,6 +317,7 @@ jobs:
         if: needs.verify-tag.outputs.release_mode == 'recovery'
         env:
           NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+          NATIVE_PACKAGE_SET: ${{ needs.verify-tag.outputs.native_package_set }}
         run: |
           set -euo pipefail
           expect_published() {
@@ -310,6 +345,12 @@ jobs:
           expect_published @opencoven/cli-linux-x64
           expect_published @opencoven/cli-windows
           expect_missing @opencoven/cli-macos
+          if [ "${NATIVE_PACKAGE_SET:?}" = "post-intel" ]; then
+            expect_missing @opencoven/cli-macos-x64
+          elif [ "$NATIVE_PACKAGE_SET" != "pre-intel" ]; then
+            echo "::error::Unsupported recovery native package set $NATIVE_PACKAGE_SET."
+            exit 1
+          fi
           expect_missing @opencoven/cli
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper
         if: needs.verify-tag.outputs.release_mode == 'normal'
@@ -319,6 +360,14 @@ jobs:
         if: needs.verify-tag.outputs.release_mode == 'normal'
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
-      - run: node scripts/publish-npm.mjs --target=macos --skip-build --publish
+      - run: node scripts/publish-npm.mjs --target=macos-x64 --skip-build --publish --skip-wrapper
+        if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
         env:
           COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+      - run: node scripts/publish-npm.mjs --target=macos --skip-build --publish --skip-wrapper
+        env:
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+      - run: node scripts/publish-npm.mjs --wrapper-only --publish
+        env:
+          COVEN_NPM_VERSION: ${{ needs.verify-tag.outputs.npm_version }}
+          COVEN_NPM_NATIVE_PACKAGE_SET: ${{ needs.verify-tag.outputs.native_package_set }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -57,6 +57,7 @@ jobs:
       release_tag: ${{ steps.release-context.outputs.release_tag }}
       npm_version: ${{ steps.release-context.outputs.npm_version }}
       native_package_set: ${{ steps.recovery-contract.outputs.native_package_set || 'post-intel' }}
+      platform_matrix: ${{ steps.platform-matrix.outputs.platform_matrix }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6.0.0
         with:
@@ -156,6 +157,7 @@ jobs:
               .github/workflows/release-npm.yml|\
               scripts/release-npm-context.mjs|\
               scripts/release-npm-recovery-contract.mjs|\
+              scripts/release-npm-platform-matrix.mjs|\
               scripts/publish-npm.mjs|\
               scripts/publish-npm-test.mjs|\
               docs/reference/releasing.md|\
@@ -177,6 +179,11 @@ jobs:
           set -euo pipefail
           BASE_COMMIT_SHA=$(git rev-parse "$RELEASE_TAG^{}")
           node scripts/release-npm-recovery-contract.mjs "$BASE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
+      - name: Derive release platform matrix
+        id: platform-matrix
+        env:
+          NATIVE_PACKAGE_SET: ${{ steps.recovery-contract.outputs.native_package_set || 'post-intel' }}
+        run: node scripts/release-npm-platform-matrix.mjs "$NATIVE_PACKAGE_SET" >> "$GITHUB_OUTPUT"
 
   build-platform:
     name: Build ${{ matrix.npm-target }}
@@ -186,24 +193,7 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - npm-target: macos
-            rust-target: aarch64-apple-darwin
-            runner: macos-26
-            binary: coven
-          - npm-target: macos-x64
-            rust-target: x86_64-apple-darwin
-            runner: macos-15-intel
-            binary: coven
-          - npm-target: linux-x64
-            rust-target: x86_64-unknown-linux-gnu
-            runner: ubuntu-latest
-            binary: coven
-          - npm-target: windows
-            rust-target: x86_64-pc-windows-msvc
-            runner: windows-latest
-            binary: coven.exe
+      matrix: ${{ fromJSON(needs.verify-tag.outputs.platform_matrix) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable @ 2026-05-20
@@ -236,10 +226,12 @@ jobs:
           path: target/aarch64-apple-darwin/release
       - run: chmod +x target/aarch64-apple-darwin/release/coven
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
+        if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
         with:
           name: coven-macos-x64
           path: target/x86_64-apple-darwin/release
       - run: chmod +x target/x86_64-apple-darwin/release/coven
+        if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
         with:
           name: coven-linux-x64
@@ -291,10 +283,12 @@ jobs:
           path: target/aarch64-apple-darwin/release
       - run: chmod +x target/aarch64-apple-darwin/release/coven
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
+        if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
         with:
           name: coven-macos-x64
           path: target/x86_64-apple-darwin/release
       - run: chmod +x target/x86_64-apple-darwin/release/coven
+        if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.0
         with:
           name: coven-linux-x64

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install native link dependencies
         if: matrix.npm-target == 'linux-x64'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
-      - run: cargo build --release --target ${{ matrix.rust-target }}
+      - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: coven-${{ matrix.npm-target }}

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ dashboard requires Node.js 24 or newer; on an older runtime, only
 | -------------------------- | ---------------------------------------------- |
 | `@opencoven/cli`           | Universal wrapper — auto-selects your platform |
 | `@opencoven/cli-macos`     | macOS Apple Silicon                            |
+| `@opencoven/cli-macos-x64` | macOS Intel x64                                |
 | `@opencoven/cli-linux-x64` | Linux x64                                      |
 | `@opencoven/cli-windows`   | Windows x64                                    |
 | `@opencoven/coven-memory-dashboard` | Optional loopback memory dashboard companion |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,6 +197,7 @@ The npm wrapper packages are live for early adopters:
 
 - `@opencoven/cli`
 - `@opencoven/cli-macos`
+- `@opencoven/cli-macos-x64`
 - `@opencoven/cli-linux-x64`
 - `@opencoven/cli-windows` once the next Windows-enabled release is published
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -101,6 +101,7 @@ Shipped:
 - Published npm wrapper packages:
   - `@opencoven/cli`
   - `@opencoven/cli-macos`
+  - `@opencoven/cli-macos-x64`
   - `@opencoven/cli-linux-x64`
 - External OpenClaw bridge package kept outside OpenClaw core as an advanced compatibility path.
 - Architecture, operational model, product spec, brand docs, and MVP plan.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -34,6 +34,7 @@ coven run claude "describe this repo"
 | Environment | Recommended path | Notes |
 | --- | --- | --- |
 | macOS Apple Silicon | [npm wrapper](/install/npm) or [macOS install](/install/macos) | Uses the universal `@opencoven/cli` package and the native macOS package. |
+| Intel macOS x64 | [npm wrapper](/install/npm) or [macOS install](/install/macos) | Uses the universal `@opencoven/cli` package and the Intel native macOS package. |
 | glibc-based Linux x64 | [npm wrapper](/install/npm) or [Linux install](/install/linux) | Alpine/musl is not part of the npm binary target today; build from source there. |
 | Windows x64 | [Windows install](/install/windows) | Run Coven and harness CLIs from the same PowerShell, Windows Terminal, or native Windows shell. |
 | WSL2 | [WSL2 install](/install/wsl2) | Treat WSL2 as a Linux environment and keep `COVEN_HOME` on the WSL filesystem. |

--- a/docs/install/npm.md
+++ b/docs/install/npm.md
@@ -40,6 +40,7 @@ available.
 | Platform | Native package |
 | --- | --- |
 | macOS Apple Silicon | `@opencoven/cli-macos` |
+| Intel macOS x64 | `@opencoven/cli-macos-x64` |
 | glibc-based Linux x64 | `@opencoven/cli-linux-x64` |
 | Windows x64 | `@opencoven/cli-windows` |
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -8,7 +8,7 @@ description: "Reference for the coven CLI commands: doctor, status, reset, daemo
 ---
 
 
-The user-facing command is always `coven`. Wrapper packages like `@opencoven/cli`, `@opencoven/cli-macos`, and `@opencoven/cli-linux-x64` install the same binary.
+The user-facing command is always `coven`. Wrapper packages like `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-macos-x64`, and `@opencoven/cli-linux-x64` install the same binary.
 
 ```mermaid
 flowchart TB

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -165,10 +165,10 @@ The new workflow does not expose a manual publish path. If you ever need to publ
 1. Cut a signed tag locally as above so the artifact you publish is reproducible.
 2. Build the native binaries:
    ```sh
-   cargo build --release --target aarch64-apple-darwin
-   cargo build --release --target x86_64-apple-darwin
-   cargo build --release --target x86_64-unknown-linux-gnu
-   cargo build --release --target x86_64-pc-windows-msvc
+   cargo build --release --package coven-cli --target aarch64-apple-darwin
+   cargo build --release --package coven-cli --target x86_64-apple-darwin
+   cargo build --release --package coven-cli --target x86_64-unknown-linux-gnu
+   cargo build --release --package coven-cli --target x86_64-pc-windows-msvc
    ```
 3. Authenticate to npm with a freshly issued, narrowly-scoped granular token that covers all five packages (delete it immediately after).
 4. Run `scripts/publish-npm.mjs --publish` for each target with `COVEN_NPM_VERSION` set to the tag version. The script's fallback path accepts `NPM_TOKEN` / `NODE_AUTH_TOKEN` when OIDC is not detected.

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -6,7 +6,7 @@ read_when:
 title: "Releasing Coven to npm"
 ---
 
-Coven publishes the `@opencoven/cli` wrapper and its three native platform packages (`@opencoven/cli-macos`, `@opencoven/cli-linux-x64`, `@opencoven/cli-windows`) automatically from the **Release npm packages** GitHub Actions workflow.
+Coven publishes the `@opencoven/cli` wrapper and its four native platform packages (`@opencoven/cli-macos`, `@opencoven/cli-macos-x64`, `@opencoven/cli-linux-x64`, `@opencoven/cli-windows`) automatically from the **Release npm packages** GitHub Actions workflow.
 
 The release is **driven by a signed git tag**. No `workflow_dispatch`, no manual approval click, no long-lived npm token: a maintainer runs `git tag -s vX.Y.Z` + `git push`, and the workflow verifies the tag signature, runs the full gate matrix, dry-runs, then publishes using **npm trusted publishing over GitHub Actions OIDC**, attaching a provenance attestation to every package.
 
@@ -19,6 +19,7 @@ Before the first OIDC release, configure trusted publishing for every package. W
 ```sh
 npm trust github @opencoven/cli --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
 npm trust github @opencoven/cli-macos --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
+npm trust github @opencoven/cli-macos-x64 --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
 npm trust github @opencoven/cli-linux-x64 --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
 npm trust github @opencoven/cli-windows --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
 ```
@@ -27,7 +28,7 @@ Leave the environment unset. Verify the result with `npm trust list <package>`.
 
 The npm website exposes the same configuration:
 
-For each of `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-linux-x64`, `@opencoven/cli-windows`:
+For each of `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-macos-x64`, `@opencoven/cli-linux-x64`, `@opencoven/cli-windows`:
 
 1. Sign in to npmjs.com as an account with publish rights on `@opencoven`.
 2. Open the package settings page (e.g. `https://www.npmjs.com/package/@opencoven/cli/access`).
@@ -38,7 +39,7 @@ For each of `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-linux-x64`
    - **Environment name**: leave blank (the workflow no longer uses a GitHub environment for the publish step).
 4. Save.
 
-Once all four packages are configured, the legacy `NPM_ACCESS_TOKEN` secret on the `npm-publish` GitHub environment is no longer needed and should be deleted as the final step of cutover so it cannot be reused to bypass OIDC:
+Once all five packages are configured, the legacy `NPM_ACCESS_TOKEN` secret on the `npm-publish` GitHub environment is no longer needed and should be deleted as the final step of cutover so it cannot be reused to bypass OIDC:
 
 ```sh
 gh secret delete NPM_ACCESS_TOKEN --env npm-publish --repo OpenCoven/coven
@@ -80,24 +81,26 @@ That single push is the entire release. The workflow takes over from there.
 
 1. **Release gates** — `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --workspace --locked`, `python3 scripts/check-secrets.py`.
 2. **Verify signed release tag** — confirms the pushed ref is an annotated tag (not lightweight) and that GitHub has cryptographically verified the maintainer's signature. The workflow consults `gh api /repos/{owner}/{repo}/git/tags/{sha}` and requires `.verification.verified == true`. Any other state aborts the release.
-3. **Build platform binaries** — matrix builds the release binary for `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, and `x86_64-pc-windows-msvc`, then uploads each as an artifact.
+3. **Build platform binaries** — matrix builds the release binary for `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-unknown-linux-gnu`, and `x86_64-pc-windows-msvc`, then uploads each as an artifact.
 4. **npm publish dry-run** — repacks the wrapper and native packages at the tag version and runs `npm publish --dry-run` for each. This is the same code path as the real publish minus the registry write, so a failure here means the real publish would also fail.
-5. **npm publish** — authenticates via GitHub Actions OIDC (`permissions: id-token: write`), then runs `npm publish --provenance --access public` for the three native packages and the wrapper. Each published tarball gets a provenance attestation linking it to this exact workflow run and commit SHA, visible on each package's npm page.
+5. **npm publish** — authenticates via GitHub Actions OIDC (`permissions: id-token: write`), then runs `npm publish --provenance --access public` for the four native packages and the wrapper. Each published tarball gets a provenance attestation linking it to this exact workflow run and commit SHA, visible on each package's npm page.
 
 ### Postflight
 
 ```sh
 npm view @opencoven/cli version dist-tags
 npm view @opencoven/cli-macos version dist-tags
+npm view @opencoven/cli-macos-x64 version dist-tags
 npm view @opencoven/cli-linux-x64 version dist-tags
 npm view @opencoven/cli-windows version dist-tags
 ```
 
-All four should now show the tag's version as `latest`. The package pages on npmjs.com should display a **"Provenance"** badge with a link back to the GitHub Actions run.
+All five should now show the tag's version as `latest`. The package pages on npmjs.com should display a **"Provenance"** badge with a link back to the GitHub Actions run.
 
 Create or update the matching GitHub Release from the successful workflow artifacts. Package the downloaded binaries with the same public asset names as prior releases:
 
 - `coven-vX.Y.Z-macos-aarch64.tar.gz`
+- `coven-vX.Y.Z-macos-x64.tar.gz`
 - `coven-vX.Y.Z-linux-x64.tar.gz`
 - `coven-vX.Y.Z-windows-x64.zip`
 - `SHA256SUMS`
@@ -108,24 +111,25 @@ If publishing stopped after Linux and Windows succeeded but before macOS and the
 
 ### Recover a partial npm publication
 
-The recovery path exists for one exact registry state:
+The recovery path exists only for one exact registry state per supported historical native-package set:
 
 - `@opencoven/cli-linux-x64@X.Y.Z` and `@opencoven/cli-windows@X.Y.Z` already exist.
 - `@opencoven/cli-macos@X.Y.Z` and `@opencoven/cli@X.Y.Z` do not exist.
+- If the original release wrapper declares the post-Intel set, `@opencoven/cli-macos-x64@X.Y.Z` also does not exist. The workflow rejects incomplete, unexpected, or mixed package sets.
 
-Fix the trusted-publisher configuration and land the release-only workflow repair on `main`. Then create a **new signed recovery tag** whose commit descends from the original release. The workflow requires that the original release tag is an ancestor and that every intervening changed path is on its release-only allowlist.
+Fix the trusted-publisher configuration on a temporary recovery branch created from the original release tag. Then create a **new signed recovery tag** whose commit descends from that tag. The workflow requires the original tag to be an ancestor and every intervening changed path to be on its release-only allowlist; unlike normal releases, recovery tags do not need to include unrelated later `main` commits.
 
 ```sh
-git fetch origin main --tags
-git checkout main
-git pull --ff-only origin main
+git fetch origin --tags
+git switch -c release/vX.Y.Z-recovery.N vX.Y.Z
+# Cherry-pick only the reviewed release-recovery fixes; do not merge main.
 git tag -s vX.Y.Z-recovery.N -m "Recover partial vX.Y.Z npm publication"
-git push origin vX.Y.Z-recovery.N
+git push origin release/vX.Y.Z-recovery.N vX.Y.Z-recovery.N
 ```
 
 Never move or reuse the original release tag or a recovery tag. Increment `N` if a later, separately-reviewed recovery attempt is required.
 
-Before publishing, the recovery workflow verifies both signed tags, ancestry, the changed-path allowlist, and the exact npm registry state above. It then skips the already-published Linux and Windows packages and publishes macOS followed by the wrapper through OIDC with provenance.
+Before publishing, the recovery workflow verifies both signed tags, ancestry, the changed-path allowlist, the original wrapper's complete package set, and the exact npm registry state above. It then skips the already-published Linux and Windows packages and publishes the missing macOS package or packages before the wrapper through OIDC with provenance.
 
 ## Recovering from a refused release
 
@@ -162,10 +166,11 @@ The new workflow does not expose a manual publish path. If you ever need to publ
 2. Build the native binaries:
    ```sh
    cargo build --release --target aarch64-apple-darwin
+   cargo build --release --target x86_64-apple-darwin
    cargo build --release --target x86_64-unknown-linux-gnu
    cargo build --release --target x86_64-pc-windows-msvc
    ```
-3. Authenticate to npm with a freshly issued, narrowly-scoped granular token that covers all four packages (delete it immediately after).
+3. Authenticate to npm with a freshly issued, narrowly-scoped granular token that covers all five packages (delete it immediately after).
 4. Run `scripts/publish-npm.mjs --publish` for each target with `COVEN_NPM_VERSION` set to the tag version. The script's fallback path accepts `NPM_TOKEN` / `NODE_AUTH_TOKEN` when OIDC is not detected.
 5. Publish the wrapper last, after all native packages are live, so users do not see a wrapper that points at native packages that don't yet exist at that version.
 6. Revoke the temporary token.

--- a/npm/coven-platform-template/README.md
+++ b/npm/coven-platform-template/README.md
@@ -2,4 +2,4 @@
 
 This package contains one platform-specific Coven CLI binary. Install `@opencoven/cli` instead of depending on this package directly; npm will select the matching optional dependency on supported systems.
 
-Current platform packages cover macOS Apple Silicon, glibc-based Linux x64, and Windows x64. Alpine Linux is not supported.
+Current platform packages cover macOS Apple Silicon, Intel macOS x64, glibc-based Linux x64, and Windows x64. Alpine Linux is not supported.

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -29,6 +29,7 @@ upgrade instruction while other Coven commands continue to work.
 Current early-adopter packages target:
 
 - `@opencoven/cli-macos` for macOS Apple Silicon
+- `@opencoven/cli-macos-x64` for Intel macOS x64
 - `@opencoven/cli-linux-x64` for glibc-based Linux x64 distributions
 - `@opencoven/cli-windows` for Windows x64
 

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -7,6 +7,7 @@ const require = createRequire(import.meta.url);
 
 const PLATFORM_PACKAGES = {
   'darwin-arm64': '@opencoven/cli-macos',
+  'darwin-x64': '@opencoven/cli-macos-x64',
   'linux-x64': '@opencoven/cli-linux-x64',
   'win32-x64': '@opencoven/cli-windows'
 };
@@ -19,7 +20,7 @@ const MEMORY_DASHBOARD_MIN_NODE_MAJOR = 24;
 function resolveBinary() {
   if (!packageName) {
     throw new Error(
-      `Unsupported platform ${platformKey}. Coven v0 publishes native npm packages for macOS Apple Silicon, glibc-based Linux x64, and Windows x64.`
+      `Unsupported platform ${platformKey}. Coven v0 publishes native npm packages for macOS Apple Silicon, Intel macOS x64, glibc-based Linux x64, and Windows x64.`
     );
   }
 

--- a/npm/coven/package.json
+++ b/npm/coven/package.json
@@ -19,6 +19,7 @@
   "optionalDependencies": {
     "@opencoven/coven-memory-dashboard": "^0.1.0",
     "@opencoven/cli-macos": "0.0.0",
+    "@opencoven/cli-macos-x64": "0.0.0",
     "@opencoven/cli-linux-x64": "0.0.0",
     "@opencoven/cli-windows": "0.0.0"
   },

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,4 +43,4 @@ Session rituals use Coven language while staying safe: archive hides old work wi
 
 ## Status
 
-This wrapper is live for early adopters. The release workflow publishes `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-linux-x64`, and `@opencoven/cli-windows`; check npm for the current `latest` tag before making version-specific claims. Coven itself is still an early local-first MVP, so command/API compatibility should be tracked in the repo docs and release notes.
+This wrapper is live for early adopters. The release workflow publishes `@opencoven/cli`, `@opencoven/cli-macos`, `@opencoven/cli-macos-x64`, `@opencoven/cli-linux-x64`, and `@opencoven/cli-windows`; check npm for the current `latest` tag before making version-specific claims. Coven itself is still an early local-first MVP, so command/API compatibility should be tracked in the repo docs and release notes.

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -20,6 +20,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defaultTargetName, isMainModule, isOidcContext, nativeTargetNamesForPackageSet, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 import { parseReleaseTag } from './release-npm-context.mjs';
 import { nativePackageSet } from './release-npm-recovery-contract.mjs';
+import { platformMatrix } from './release-npm-platform-matrix.mjs';
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
@@ -235,6 +236,20 @@ test('native package sets keep historical recovery explicit', () => {
   assert.deepEqual(nativeTargetNamesForPackageSet('pre-intel'), ['macos', 'linux-x64', 'windows']);
   assert.deepEqual(nativeTargetNamesForPackageSet('post-intel'), ['macos', 'macos-x64', 'linux-x64', 'windows']);
   assert.throws(() => nativeTargetNamesForPackageSet('unexpected'), /Unsupported native package set/);
+});
+
+test('release platform matrix omits Intel macOS for pre-Intel recovery', () => {
+  assert.deepEqual(platformMatrix('pre-intel'), {
+    include: [
+      { 'npm-target': 'macos', 'rust-target': 'aarch64-apple-darwin', runner: 'macos-26', binary: 'coven' },
+      { 'npm-target': 'linux-x64', 'rust-target': 'x86_64-unknown-linux-gnu', runner: 'ubuntu-latest', binary: 'coven' },
+      { 'npm-target': 'windows', 'rust-target': 'x86_64-pc-windows-msvc', runner: 'windows-latest', binary: 'coven.exe' }
+    ]
+  });
+  assert.equal(
+    platformMatrix('post-intel').include.some((entry) => entry['npm-target'] === 'macos-x64'),
+    true
+  );
 });
 
 test('linux x64 target publishes under linux native package name', () => {
@@ -510,8 +525,12 @@ test('release workflow builds and dry-runs linux x64 package', () => {
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
-  assert.match(workflow, /npm-target: linux-x64/);
-  assert.match(workflow, /rust-target: x86_64-unknown-linux-gnu/);
+  const matrixScript = readFileSync(
+    new URL(['..', 'scripts', 'release-npm-platform-matrix.mjs'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(matrixScript, /'npm-target': 'linux-x64'/);
+  assert.match(matrixScript, /'rust-target': 'x86_64-unknown-linux-gnu'/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=linux-x64 --skip-build --dry-run --skip-wrapper/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=linux-x64 --skip-build --publish --skip-wrapper/);
 });
@@ -522,10 +541,15 @@ test('release workflow builds macOS package on arm64 runner', () => {
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
-  assert.match(workflow, /npm-target: macos/);
-  assert.match(workflow, /rust-target: aarch64-apple-darwin/);
-  assert.match(workflow, /runner: macos-26/);
-  assert.doesNotMatch(workflow, /runner: macos-latest/);
+  const matrixScript = readFileSync(
+    new URL(['..', 'scripts', 'release-npm-platform-matrix.mjs'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(matrixScript, /'npm-target': 'macos'/);
+  assert.match(matrixScript, /'rust-target': 'aarch64-apple-darwin'/);
+  assert.match(matrixScript, /runner: 'macos-26'/);
+  assert.doesNotMatch(matrixScript, /runner: 'macos-latest'/);
+  assert.match(workflow, /matrix: \$\{\{ fromJSON\(needs\.verify-tag\.outputs\.platform_matrix\) \}\}/);
 });
 
 test('release workflow builds and publishes Intel macOS as a separate target', () => {
@@ -534,10 +558,15 @@ test('release workflow builds and publishes Intel macOS as a separate target', (
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
-  assert.match(workflow, /npm-target: macos-x64/);
-  assert.match(workflow, /rust-target: x86_64-apple-darwin/);
-  assert.match(workflow, /runner: macos-15-intel/);
-  assert.match(workflow, /name: coven-macos-x64/);
+  const matrixScript = readFileSync(
+    new URL(['..', 'scripts', 'release-npm-platform-matrix.mjs'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(matrixScript, /'npm-target': 'macos-x64'/);
+  assert.match(matrixScript, /'rust-target': 'x86_64-apple-darwin'/);
+  assert.match(matrixScript, /runner: 'macos-15-intel'/);
+  assert.match(workflow, /name: coven-\$\{\{ matrix\.npm-target \}\}/);
+  assert.match(workflow, /release-npm-platform-matrix\.mjs/);
   assert.match(workflow, /cargo build --release --package coven-cli --target \$\{\{ matrix\.rust-target \}\}/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --dry-run --skip-wrapper/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --publish --skip-wrapper/);
@@ -557,10 +586,14 @@ test('release workflow builds and dry-runs windows package', () => {
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
-  assert.match(workflow, /npm-target: windows/);
-  assert.match(workflow, /rust-target: x86_64-pc-windows-msvc/);
-  assert.match(workflow, /runner: windows-latest/);
-  assert.match(workflow, /binary: coven\.exe/);
+  const matrixScript = readFileSync(
+    new URL(['..', 'scripts', 'release-npm-platform-matrix.mjs'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(matrixScript, /'npm-target': 'windows'/);
+  assert.match(matrixScript, /'rust-target': 'x86_64-pc-windows-msvc'/);
+  assert.match(matrixScript, /runner: 'windows-latest'/);
+  assert.match(matrixScript, /binary: 'coven\.exe'/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=windows --skip-build --dry-run --skip-wrapper/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=windows --skip-build --publish --skip-wrapper/);
 });

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -542,6 +542,13 @@ test('release workflow builds and publishes Intel macOS as a separate target', (
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --publish --skip-wrapper/);
 });
 
+test('CI smoke-tests the Intel macOS wrapper on its native runner', () => {
+  const workflowPath = new URL(['..', '.github', 'workflows', 'ci.yml'].join('/'), import.meta.url);
+  const workflow = readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /os: macos-15-intel[\s\S]*npm-target: macos-x64[\s\S]*rust-target: x86_64-apple-darwin/);
+  assert.match(workflow, /node scripts\/test-cli-prepublish\.mjs --target=\$\{\{ matrix\.npm-target \}\} --skip-build --skip-secrets-scan/);
+});
+
 test('release workflow builds and dry-runs windows package', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -538,6 +538,7 @@ test('release workflow builds and publishes Intel macOS as a separate target', (
   assert.match(workflow, /rust-target: x86_64-apple-darwin/);
   assert.match(workflow, /runner: macos-15-intel/);
   assert.match(workflow, /name: coven-macos-x64/);
+  assert.match(workflow, /cargo build --release --package coven-cli --target \$\{\{ matrix\.rust-target \}\}/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --dry-run --skip-wrapper/);
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --publish --skip-wrapper/);
 });
@@ -546,6 +547,7 @@ test('CI smoke-tests the Intel macOS wrapper on its native runner', () => {
   const workflowPath = new URL(['..', '.github', 'workflows', 'ci.yml'].join('/'), import.meta.url);
   const workflow = readFileSync(workflowPath, 'utf8');
   assert.match(workflow, /os: macos-15-intel[\s\S]*npm-target: macos-x64[\s\S]*rust-target: x86_64-apple-darwin/);
+  assert.match(workflow, /cargo build --release --package coven-cli --target \$\{\{ matrix\.rust-target \}\}/);
   assert.match(workflow, /node scripts\/test-cli-prepublish\.mjs --target=\$\{\{ matrix\.npm-target \}\} --skip-build --skip-secrets-scan/);
 });
 

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -17,8 +17,9 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { defaultTargetName, isMainModule, isOidcContext, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
+import { defaultTargetName, isMainModule, isOidcContext, nativeTargetNamesForPackageSet, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 import { parseReleaseTag } from './release-npm-context.mjs';
+import { nativePackageSet } from './release-npm-recovery-contract.mjs';
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
@@ -56,6 +57,30 @@ test('parseReleaseTag rejects malformed and unrelated prerelease tags', () => {
       /stable vX.Y.Z tag or vX.Y.Z-recovery.N/
     );
   }
+});
+
+test('nativePackageSet accepts only complete historical native package sets', () => {
+  assert.equal(
+    nativePackageSet({
+      '@opencoven/cli-macos': '0.0.0',
+      '@opencoven/cli-linux-x64': '0.0.0',
+      '@opencoven/cli-windows': '0.0.0'
+    }),
+    'pre-intel'
+  );
+  assert.equal(
+    nativePackageSet({
+      '@opencoven/cli-macos': '0.0.0',
+      '@opencoven/cli-macos-x64': '0.0.0',
+      '@opencoven/cli-linux-x64': '0.0.0',
+      '@opencoven/cli-windows': '0.0.0'
+    }),
+    'post-intel'
+  );
+  assert.throws(
+    () => nativePackageSet({ '@opencoven/cli-macos': '0.0.0', '@opencoven/cli-linux-x64': '0.0.0' }),
+    /only supports the complete pre-Intel or post-Intel package sets/
+  );
 });
 
 const SIGNAL_TEST_PACKAGES = {
@@ -200,6 +225,16 @@ test('validatePublishVersion allows real publish with explicit release version',
 
 test('macOS target publishes under human-facing native package name', () => {
   assert.equal(targetPackageName('macos'), '@opencoven/cli-macos');
+});
+
+test('Intel macOS target publishes under its own native package name', () => {
+  assert.equal(targetPackageName('macos-x64'), '@opencoven/cli-macos-x64');
+});
+
+test('native package sets keep historical recovery explicit', () => {
+  assert.deepEqual(nativeTargetNamesForPackageSet('pre-intel'), ['macos', 'linux-x64', 'windows']);
+  assert.deepEqual(nativeTargetNamesForPackageSet('post-intel'), ['macos', 'macos-x64', 'linux-x64', 'windows']);
+  assert.throws(() => nativeTargetNamesForPackageSet('unexpected'), /Unsupported native package set/);
 });
 
 test('linux x64 target publishes under linux native package name', () => {
@@ -426,6 +461,15 @@ test('wrapper binary maps linux x64 to linux native package and documents glibc 
   assert.match(bin, /glibc-based Linux x64/);
 });
 
+test('wrapper binary maps Intel macOS to the Intel native package', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const bin = readFileSync(binPath, 'utf8');
+  assert.match(bin, /'darwin-x64': '@opencoven\/cli-macos-x64'/);
+  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
+  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  assert.equal(packageJson.optionalDependencies['@opencoven/cli-macos-x64'], '0.0.0');
+});
+
 test('wrapper binary maps windows x64 to windows native package and exe binary', () => {
   const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
   const bin = readFileSync(binPath, 'utf8');
@@ -482,6 +526,20 @@ test('release workflow builds macOS package on arm64 runner', () => {
   assert.match(workflow, /rust-target: aarch64-apple-darwin/);
   assert.match(workflow, /runner: macos-26/);
   assert.doesNotMatch(workflow, /runner: macos-latest/);
+});
+
+test('release workflow builds and publishes Intel macOS as a separate target', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /npm-target: macos-x64/);
+  assert.match(workflow, /rust-target: x86_64-apple-darwin/);
+  assert.match(workflow, /runner: macos-15-intel/);
+  assert.match(workflow, /name: coven-macos-x64/);
+  assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --dry-run --skip-wrapper/);
+  assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --publish --skip-wrapper/);
 });
 
 test('release workflow builds and dry-runs windows package', () => {
@@ -729,8 +787,8 @@ test('release workflow publishes only missing packages during recovery', () => {
   );
   assert.match(
     publish,
-    /name: Confirm expected partial npm state[\s\S]*@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows[\s\S]*@opencoven\/cli-macos[\s\S]*@opencoven\/cli/,
-    'recovery must prove the exact two-published, two-missing package state'
+    /name: Confirm expected partial npm state[\s\S]*@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows[\s\S]*@opencoven\/cli-macos[\s\S]*@opencoven\/cli-macos-x64[\s\S]*@opencoven\/cli/,
+    'recovery must prove the supported pre-Intel or post-Intel registry state'
   );
   assert.match(
     publish,
@@ -749,8 +807,18 @@ test('release workflow publishes only missing packages during recovery', () => {
   );
   assert.match(
     dryRun,
-    /--target=macos --skip-build --dry-run\s*\n\s*env:/,
-    'macOS plus wrapper dry-run must run in normal and recovery modes'
+    /--target=macos --skip-build --dry-run --skip-wrapper\s*\n\s*env:/,
+    'Apple Silicon macOS dry-run must run in normal and recovery modes'
+  );
+  assert.match(
+    dryRun,
+    /--target=macos-x64 --skip-build --dry-run --skip-wrapper[\s\S]*native_package_set == 'post-intel'/,
+    'Intel macOS dry-run must run for normal and post-Intel recovery releases'
+  );
+  assert.match(
+    dryRun,
+    /--wrapper-only --dry-run[\s\S]*COVEN_NPM_NATIVE_PACKAGE_SET/,
+    'wrapper dry-run must use the verified historical package set'
   );
   assert.match(
     publish,
@@ -764,8 +832,18 @@ test('release workflow publishes only missing packages during recovery', () => {
   );
   assert.match(
     publish,
-    /--target=macos --skip-build --publish\s*\n\s*env:/,
-    'macOS plus wrapper publication must run in normal and recovery modes'
+    /--target=macos --skip-build --publish --skip-wrapper\s*\n\s*env:/,
+    'Apple Silicon macOS publication must run in normal and recovery modes'
+  );
+  assert.match(
+    publish,
+    /--target=macos-x64 --skip-build --publish --skip-wrapper[\s\S]*native_package_set == 'post-intel'/,
+    'Intel macOS publication must run for normal and post-Intel recovery releases'
+  );
+  assert.match(
+    publish,
+    /--wrapper-only --publish[\s\S]*COVEN_NPM_NATIVE_PACKAGE_SET/,
+    'wrapper publication must happen after all selected native packages'
   );
   assert.doesNotMatch(
     workflow,
@@ -830,10 +908,11 @@ test('releasing guide documents signed partial-publish recovery', () => {
 
   assert.match(guide, /vX\.Y\.Z-recovery\.N/);
   assert.match(guide, /new signed recovery tag/i);
-  assert.match(guide, /original release tag is an ancestor/i);
+  assert.match(guide, /original tag to be an ancestor/i);
   assert.match(guide, /never move or reuse/i);
   assert.match(guide, /@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows/);
   assert.match(guide, /@opencoven\/cli-macos[\s\S]*@opencoven\/cli/);
+  assert.match(guide, /@opencoven\/cli-macos-x64/);
   assert.match(guide, /npm trust github/);
 });
 

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -18,6 +18,13 @@ const targets = {
     rustTarget: 'aarch64-apple-darwin',
     binaryName: 'coven'
   },
+  'macos-x64': {
+    packageName: '@opencoven/cli-macos-x64',
+    os: 'darwin',
+    cpu: 'x64',
+    rustTarget: 'x86_64-apple-darwin',
+    binaryName: 'coven'
+  },
   'linux-x64': {
     packageName: '@opencoven/cli-linux-x64',
     os: 'linux',
@@ -32,6 +39,11 @@ const targets = {
     rustTarget: 'x86_64-pc-windows-msvc',
     binaryName: 'coven.exe'
   }
+};
+
+const nativePackageSets = {
+  'pre-intel': ['macos', 'linux-x64', 'windows'],
+  'post-intel': ['macos', 'macos-x64', 'linux-x64', 'windows']
 };
 
 if (isMainModule()) {
@@ -54,41 +66,50 @@ function main() {
   const dryRun = args.has('--dry-run') || !args.has('--publish');
   const skipBuild = args.has('--skip-build');
   const skipWrapper = args.has('--skip-wrapper');
+  const wrapperOnly = args.has('--wrapper-only');
   const version = releaseVersion(process.env, wrapperPackageVersion());
   const target = targets[targetName];
 
-  if (!target) {
+  if (wrapperOnly && skipWrapper) {
+    fail('--wrapper-only and --skip-wrapper cannot be used together');
+  }
+  if (!wrapperOnly && !target) {
     fail(`Unsupported npm target ${targetName}. Known targets: ${Object.keys(targets).join(', ')}`);
   }
 
   validatePublishVersion(version, dryRun);
   validatePublishToken(process.env, dryRun);
 
-  if (!skipBuild) {
-    run('cargo', ['build', '--release', '--target', target.rustTarget]);
-  }
-
-  const binaryPath = path.join(repoRoot, 'target', target.rustTarget, 'release', target.binaryName);
-  if (!existsSync(binaryPath)) {
-    fail(`Built binary not found at ${binaryPath}`);
-  }
-
   rmSync(distRoot, { recursive: true, force: true });
   mkdirSync(distRoot, { recursive: true });
 
-  const platformDir = writePlatformPackage(targetName, target, binaryPath, version);
+  if (!wrapperOnly) {
+    if (!skipBuild) {
+      run('cargo', ['build', '--release', '--target', target.rustTarget]);
+    }
 
-  publishPackage(target.packageName, version, dryRun, platformDir);
+    const binaryPath = path.join(repoRoot, 'target', target.rustTarget, 'release', target.binaryName);
+    if (!existsSync(binaryPath)) {
+      fail(`Built binary not found at ${binaryPath}`);
+    }
+
+    const platformDir = writePlatformPackage(targetName, target, binaryPath, version);
+    publishPackage(target.packageName, version, dryRun, platformDir);
+  }
 
   if (!skipWrapper) {
     for (const packageName of wrapperPackageNames) {
-      const wrapperDir = writeWrapperPackage(version, packageName);
+      const wrapperDir = writeWrapperPackage(version, packageName, nativeTargetNamesForPackageSet());
       publishPackage(packageName, version, dryRun, wrapperDir);
     }
   }
 
   console.log(`Prepared npm packages in ${distRoot}`);
-  console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${target.packageName}${skipWrapper ? '' : ` and ${wrapperPackageNames.join(', ')}`} at version ${version}.`);
+  const publishedNames = [
+    ...(wrapperOnly ? [] : [target.packageName]),
+    ...(skipWrapper ? [] : wrapperPackageNames)
+  ];
+  console.log(`${dryRun ? 'Dry-run completed' : 'Publish completed'} for ${publishedNames.join(', ')} at version ${version}.`);
 }
 
 function publishPackage(packageName, version, dryRun, cwd) {
@@ -140,7 +161,7 @@ function writePlatformPackage(targetName, target, binaryPath, version) {
   return outDir;
 }
 
-function writeWrapperPackage(version, packageName = primaryWrapperPackageName) {
+function writeWrapperPackage(version, packageName = primaryWrapperPackageName, nativeTargetNames = nativeTargetNamesForPackageSet()) {
   const outDir = path.join(distRoot, wrapperPackageDirName(packageName));
   cpSync(path.join(repoRoot, 'npm', 'coven'), outDir, { recursive: true });
   const packagePath = path.join(outDir, 'package.json');
@@ -149,7 +170,12 @@ function writeWrapperPackage(version, packageName = primaryWrapperPackageName) {
   packageJson.version = version;
   for (const optionalName of Object.keys(packageJson.optionalDependencies)) {
     if (optionalName.startsWith('@opencoven/cli-')) {
-      packageJson.optionalDependencies[optionalName] = version;
+      const targetName = Object.entries(targets).find(([, target]) => target.packageName === optionalName)?.[0];
+      if (targetName && !nativeTargetNames.includes(targetName)) {
+        delete packageJson.optionalDependencies[optionalName];
+      } else {
+        packageJson.optionalDependencies[optionalName] = version;
+      }
     }
   }
   writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
@@ -186,6 +212,14 @@ export function targetPackageName(targetName) {
   return targets[targetName]?.packageName;
 }
 
+export function nativeTargetNamesForPackageSet(packageSet = process.env.COVEN_NPM_NATIVE_PACKAGE_SET ?? 'post-intel') {
+  const targetNames = nativePackageSets[packageSet];
+  if (!targetNames) {
+    throw new Error(`Unsupported native package set ${packageSet}. Known sets: ${Object.keys(nativePackageSets).join(', ')}`);
+  }
+  return [...targetNames];
+}
+
 export function wrapperPackageNameList() {
   return [...wrapperPackageNames];
 }
@@ -197,6 +231,9 @@ export function wrapperPackageDirName(packageName) {
 export function defaultTargetName(platform, arch) {
   if (platform === 'darwin' && arch === 'arm64') {
     return 'macos';
+  }
+  if (platform === 'darwin' && arch === 'x64') {
+    return 'macos-x64';
   }
   if (platform === 'win32' && arch === 'x64') {
     return 'windows';
@@ -212,9 +249,13 @@ if ('NODE_TEST_CONTEXT' in process.env) {
     assert.strictEqual(defaultTargetName('darwin', 'arm64'), 'macos');
   });
 
+  test('defaultTargetName maps darwin x64 to macos-x64', () => {
+    assert.strictEqual(defaultTargetName('darwin', 'x64'), 'macos-x64');
+  });
+
   test('defaultTargetName falls back to platform-arch for non-special cases', () => {
     assert.strictEqual(defaultTargetName('linux', 'x64'), 'linux-x64');
-    assert.strictEqual(defaultTargetName('darwin', 'x64'), 'darwin-x64');
+    assert.strictEqual(defaultTargetName('freebsd', 'x64'), 'freebsd-x64');
   });
 
   test('defaultTargetName maps win32 x64 to windows', () => {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -85,7 +85,7 @@ function main() {
 
   if (!wrapperOnly) {
     if (!skipBuild) {
-      run('cargo', ['build', '--release', '--target', target.rustTarget]);
+      run('cargo', ['build', '--release', '--package', 'coven-cli', '--target', target.rustTarget]);
     }
 
     const binaryPath = path.join(repoRoot, 'target', target.rustTarget, 'release', target.binaryName);

--- a/scripts/release-npm-platform-matrix.mjs
+++ b/scripts/release-npm-platform-matrix.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import { nativeTargetNamesForPackageSet } from './publish-npm.mjs';
+import { pathToFileURL } from 'node:url';
+
+const TARGETS = {
+  macos: {
+    'npm-target': 'macos',
+    'rust-target': 'aarch64-apple-darwin',
+    runner: 'macos-26',
+    binary: 'coven'
+  },
+  'macos-x64': {
+    'npm-target': 'macos-x64',
+    'rust-target': 'x86_64-apple-darwin',
+    runner: 'macos-15-intel',
+    binary: 'coven'
+  },
+  'linux-x64': {
+    'npm-target': 'linux-x64',
+    'rust-target': 'x86_64-unknown-linux-gnu',
+    runner: 'ubuntu-latest',
+    binary: 'coven'
+  },
+  windows: {
+    'npm-target': 'windows',
+    'rust-target': 'x86_64-pc-windows-msvc',
+    runner: 'windows-latest',
+    binary: 'coven.exe'
+  }
+};
+
+export function platformMatrix(packageSet = 'post-intel') {
+  return {
+    include: nativeTargetNamesForPackageSet(packageSet).map((targetName) => TARGETS[targetName])
+  };
+}
+
+function isMainModule(argv1 = process.argv[1], moduleUrl = import.meta.url) {
+  return Boolean(argv1) && pathToFileURL(argv1).href === moduleUrl;
+}
+
+if (isMainModule()) {
+  process.stdout.write(`platform_matrix=${JSON.stringify(platformMatrix(process.argv[2] ?? 'post-intel'))}\n`);
+}

--- a/scripts/release-npm-recovery-contract.mjs
+++ b/scripts/release-npm-recovery-contract.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const PRE_INTEL_NATIVE_PACKAGES = [
+  '@opencoven/cli-macos',
+  '@opencoven/cli-linux-x64',
+  '@opencoven/cli-windows'
+];
+const POST_INTEL_NATIVE_PACKAGES = [
+  '@opencoven/cli-macos',
+  '@opencoven/cli-macos-x64',
+  '@opencoven/cli-linux-x64',
+  '@opencoven/cli-windows'
+];
+
+export function nativePackageSet(optionalDependencies) {
+  const nativePackages = Object.keys(optionalDependencies ?? {})
+    .filter((name) => name.startsWith('@opencoven/cli-'))
+    .sort();
+  const expectedSets = [
+    ['pre-intel', PRE_INTEL_NATIVE_PACKAGES],
+    ['post-intel', POST_INTEL_NATIVE_PACKAGES]
+  ];
+
+  for (const [name, expected] of expectedSets) {
+    if (nativePackages.length === expected.length && nativePackages.every((value, index) => value === [...expected].sort()[index])) {
+      return name;
+    }
+  }
+
+  throw new Error(
+    `Unsupported native package set: ${nativePackages.join(', ') || '(none)'}. ` +
+      'Recovery only supports the complete pre-Intel or post-Intel package sets.'
+  );
+}
+
+function isMainModule(argv1 = process.argv[1], moduleUrl = import.meta.url) {
+  return Boolean(argv1) && pathToFileURL(argv1).href === moduleUrl;
+}
+
+if (isMainModule()) {
+  const baseCommit = process.argv[2];
+  if (!baseCommit) {
+    throw new Error('Usage: release-npm-recovery-contract.mjs <base-release-commit>');
+  }
+  const packageText = execFileSync('git', ['show', `${baseCommit}:npm/coven/package.json`], {
+    encoding: 'utf8'
+  });
+  const packageJson = JSON.parse(packageText);
+  const packageSet = nativePackageSet(packageJson.optionalDependencies);
+  process.stdout.write(`native_package_set=${packageSet}\n`);
+}

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -13,7 +13,7 @@
 //      is resolved, executable, and can start the daemon with isolated state.
 //
 // Flags:
-//   --target=<name>       Override the npm target (macos, linux-x64, windows).
+//   --target=<name>       Override the npm target (macos, macos-x64, linux-x64, windows).
 //                         Defaults to the local platform.
 //   --dashboard-tarball=<path>
 //                         Install a locally packed dashboard companion and
@@ -48,6 +48,7 @@ const DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
 const PLATFORM_TARGETS = {
   macos: { packageName: '@opencoven/cli-macos', binaryName: 'coven' },
+  'macos-x64': { packageName: '@opencoven/cli-macos-x64', binaryName: 'coven' },
   'linux-x64': { packageName: '@opencoven/cli-linux-x64', binaryName: 'coven' },
   windows: { packageName: '@opencoven/cli-windows', binaryName: 'coven.exe' }
 };

--- a/scripts/test-cli-prepublish.mjs
+++ b/scripts/test-cli-prepublish.mjs
@@ -5,7 +5,7 @@
 //   1. Verifies prerequisites (node, npm, cargo).
 //   2. Runs the secrets scan, onboarding, PR readiness, and publish guardrails.
 //   3. Stages the dist tree by running publish-npm.mjs in --dry-run mode
-//      (which also runs `cargo build --release --target <rust-target>` unless
+//      (which also runs `cargo build --release --package coven-cli --target <rust-target>` unless
 //      --skip-build is passed) and lets `npm publish --dry-run` validate the
 //      platform + wrapper tarballs.
 //   4. `npm pack`s the native and wrapper packages, installs them into a fresh
@@ -20,7 +20,7 @@
 //                         verify `coven memory open --help` through the wrapper.
 //   --skip-build          Reuse an existing release binary at
 //                         target/<rust-target>/release/coven instead of
-//                         re-running `cargo build --release --target ...`.
+//                         re-running `cargo build --release --package coven-cli --target ...`.
 //   --with-cargo-gates    Also run `cargo fmt --check`, `cargo clippy`, and
 //                         `cargo test --workspace --locked` (the CI verify
 //                         gates). Off by default to keep local runs fast.


### PR DESCRIPTION
## Summary

Restores Intel macOS x64 as a first-class npm distribution target and makes partial-release recovery reject ambiguous package states.

Closes #571

## Root cause

The wrapper, package metadata, publish script, and release matrix only described Apple Silicon macOS. The recovery workflow also assumed one fixed three-native-package state and required recovery tags to include later main history, which made a release-only recovery unsafe or impossible.

## Changes

- Routes darwin-x64 to @opencoven/cli-macos-x64 and adds its optional dependency.
- Builds, dry-runs, and publishes x86_64-apple-darwin on an Intel macOS runner before the wrapper.
- Adds an Intel macOS PR-CI onboarding smoke, so wrapper installation and daemon lifecycle run on the native architecture before release.
- Restricts npm-artifact builds to `coven-cli`, avoiding unrelated `ort-sys` Intel macOS artifacts while preserving the exact packaged binary.
- Adds fail-closed pre-Intel/post-Intel recovery-set verification and packages the wrapper against the verified set.
- Omits the Intel macOS build and artifact downloads for pre-Intel recovery, while retaining it for normal and post-Intel releases.
- Allows signed recovery tags to descend from the original release with release-only changes, without inheriting unrelated later main commits.
- Updates release and install documentation, trusted-publisher setup, and release-contract tests.

## Review follow-up

- Rewrote the previous unsigned test commit; every branch commit now has the required `Signed-off-by:` trailer.
- Added a tested dynamic release matrix so pre-Intel recovery cannot require an excluded Intel package or runner.

## Validation

- `node --test scripts/publish-npm-test.mjs scripts/cli-docs-test.mjs scripts/onboarding-docs-test.mjs scripts/pr-readiness-test.mjs` (91 passing)
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --range origin/main...HEAD`
- `git diff --check`
- Exact-head CI: [run 30958824982](https://github.com/OpenCoven/coven/actions/runs/30958824982) completed with 12 successful CI checks; the unrelated Dependabot auto-merge check was skipped. This includes the native Intel macOS packaging smoke.
- `node scripts/test-cli-prepublish.mjs --target=linux-x64 --with-cargo-gates` completed its preflight, secret, docs, formatter, linter, and test gates, but its final optimized package build is blocked by this WSL host's `cc` wrapper loading a missing `libisl.so.23`. The failure is outside this diff; exact-head Linux and macOS CI provide the packaging proof.

## Risks and follow-up

The Intel binary and wrapper smoke run in PR CI on macos-15-intel. This WSL host cannot execute Apple targets. Before the first release, configure npm trusted publishing for @opencoven/cli-macos-x64.