### PR TITLE
feat: enforce repository maintenance gates

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -213,6 +213,14 @@ pub struct SessionLaunch {
 
 pub trait SessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()>;
+    fn launch_session_with_writer(
+        &self,
+        launch: &SessionLaunch,
+        writer: crate::maintenance_gate::WriterLease,
+    ) -> Result<()> {
+        drop(writer);
+        self.launch_session(launch)
+    }
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()>;
     fn kill_session(&self, session_id: &str) -> Result<()>;
 }
@@ -1713,6 +1721,35 @@ fn launch_session(
             }
         };
     launch.familiar_id = familiar_ctx.as_ref().map(|familiar| familiar.id.clone());
+    let writer = match crate::maintenance_gate::MaintenanceGate::discover_optional(Path::new(
+        &launch.project_root,
+    ))
+    .and_then(|gate| match gate {
+        Some(gate) => gate
+            .acquire_writer(format!("daemon-session-{}", launch.id), "session")
+            .map(Some),
+        None => Ok(None),
+    }) {
+        Ok(writer) => writer,
+        Err(error) => {
+            let gate_error = error.downcast_ref::<crate::maintenance_gate::GateError>();
+            let (code, details) = match gate_error {
+                Some(crate::maintenance_gate::GateError::OwnerHeld(owner)) => (
+                    "maintenance_locked",
+                    Some(json!({ "owner": owner, "sessionId": launch.id })),
+                ),
+                Some(_) => (
+                    "maintenance_state_invalid",
+                    Some(json!({ "sessionId": launch.id })),
+                ),
+                None => (
+                    "maintenance_gate_unavailable",
+                    Some(json!({ "sessionId": launch.id })),
+                ),
+            };
+            return api_error(423, code, &error.to_string(), details);
+        }
+    };
     let conn = store::open_store(&store_path(coven_home))?;
     let now = current_timestamp();
     let record = session_launch::new_session_record(session_launch::NewSessionParams {
@@ -1728,7 +1765,10 @@ fn launch_session(
         visibility: None,
     });
     store::insert_session(&conn, &record)?;
-    if let Err(error) = runtime.launch_session(&launch) {
+    if let Err(error) = match writer {
+        Some(writer) => runtime.launch_session_with_writer(&launch, writer),
+        None => runtime.launch_session(&launch),
+    } {
         // Don't propagate to the accept loop — that crashes the daemon.
         // Runtime launch failures are user-facing (missing harness CLI,
         // missing auth, child closed stdin during stream-mode init):
@@ -7438,6 +7478,46 @@ mod tests {
             .to_string_lossy()
         );
         assert!(list.body.contains(r#""title":"Demo""#));
+        Ok(())
+    }
+
+    #[test]
+    fn launch_request_returns_structured_maintenance_lock_without_creating_session(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let init = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(&project_root)
+            .status()?;
+        assert!(init.success());
+        let gate = crate::maintenance_gate::MaintenanceGate::discover(&project_root)?;
+        let owner = gate.acquire_owner("cave-delete")?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "prompt": "hello coven"
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 423);
+        assert!(response.body.contains(r#""code":"maintenance_locked""#));
+        assert!(response.body.contains("cave-delete"));
+        assert!(runtime.launches.borrow().is_empty());
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        assert!(store::list_sessions(&conn)?.is_empty());
+        owner.release()?;
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -112,9 +112,24 @@ struct LiveSessionHandle {
     registration: Arc<LiveSessionRegistration>,
 }
 
-#[derive(Default)]
 struct LiveSessionRegistration {
     exited: AtomicBool,
+    writer: Mutex<Option<crate::maintenance_gate::WriterLease>>,
+}
+
+impl LiveSessionRegistration {
+    fn new(writer: Option<crate::maintenance_gate::WriterLease>) -> Self {
+        Self {
+            exited: AtomicBool::new(false),
+            writer: Mutex::new(writer),
+        }
+    }
+
+    fn release_writer(&self) {
+        if let Ok(mut writer) = self.writer.lock() {
+            drop(writer.take());
+        }
+    }
 }
 
 struct LiveSessionExitCleanup {
@@ -156,6 +171,7 @@ impl LiveSessionExitCleanup {
         };
         drop(sessions);
         drop(removed);
+        self.registration.release_writer();
         if was_poisoned {
             report_poisoned();
         }
@@ -192,7 +208,7 @@ impl LiveSessionRuntime {
             kind,
             input,
             killer,
-            Arc::new(LiveSessionRegistration::default()),
+            Arc::new(LiveSessionRegistration::new(None)),
         )
     }
 
@@ -232,6 +248,7 @@ impl LiveSessionRuntime {
         Ok(())
     }
 
+    #[cfg(test)]
     fn observer_for_session(
         &self,
         session_id: String,
@@ -239,7 +256,18 @@ impl LiveSessionRuntime {
         pty_runner::DetachedPtyObserver,
         Arc<LiveSessionRegistration>,
     ) {
-        let registration = Arc::new(LiveSessionRegistration::default());
+        self.observer_for_session_with_writer(session_id, None)
+    }
+
+    fn observer_for_session_with_writer(
+        &self,
+        session_id: String,
+        writer: Option<crate::maintenance_gate::WriterLease>,
+    ) -> (
+        pty_runner::DetachedPtyObserver,
+        Arc<LiveSessionRegistration>,
+    ) {
+        let registration = Arc::new(LiveSessionRegistration::new(writer));
         let cleanup = LiveSessionExitCleanup {
             session_id: session_id.clone(),
             sessions: Arc::downgrade(&self.sessions),
@@ -346,6 +374,32 @@ static CLAUDE_JSON_TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::At
 
 impl SessionRuntime for LiveSessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()> {
+        self.launch_session_inner(launch, None)
+    }
+
+    fn launch_session_with_writer(
+        &self,
+        launch: &SessionLaunch,
+        writer: crate::maintenance_gate::WriterLease,
+    ) -> Result<()> {
+        self.launch_session_inner(launch, Some(writer))
+    }
+
+    fn send_input(&self, session_id: &str, payload: &Value) -> Result<()> {
+        LiveSessionRuntime::send_input(self, session_id, payload)
+    }
+
+    fn kill_session(&self, session_id: &str) -> Result<()> {
+        LiveSessionRuntime::kill_session(self, session_id)
+    }
+}
+
+impl LiveSessionRuntime {
+    fn launch_session_inner(
+        &self,
+        launch: &SessionLaunch,
+        writer: Option<crate::maintenance_gate::WriterLease>,
+    ) -> Result<()> {
         let familiar_ctx = match (&self.coven_home, launch.familiar_id.as_deref()) {
             (Some(home), familiar_id) => {
                 crate::familiar_identity::resolve_optional(home, familiar_id)?
@@ -367,7 +421,8 @@ impl SessionRuntime for LiveSessionRuntime {
                 ..Default::default()
             },
         )?;
-        let (observer, registration) = self.observer_for_session(launch.id.clone());
+        let (observer, registration) =
+            self.observer_for_session_with_writer(launch.id.clone(), writer);
         let observer = Some(observer);
 
         if launch.launch_mode == crate::harness::HarnessLaunchMode::Stream {
@@ -3618,7 +3673,7 @@ mod tests {
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
         let runtime = LiveSessionRuntime::default();
-        let registration = Arc::new(LiveSessionRegistration::default());
+        let registration = Arc::new(LiveSessionRegistration::new(None));
         runtime.register_kind_with_registration(
             "poison-report-session".to_string(),
             LiveSessionKind::Pty,

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -26,6 +26,7 @@ mod executor_node;
 mod familiar_identity;
 mod harness;
 mod hub;
+mod maintenance_gate;
 mod memory_dashboard;
 mod memory_import;
 pub mod mobile_memory;
@@ -425,6 +426,11 @@ enum Command {
     Claim {
         #[command(subcommand)]
         command: ClaimCommand,
+    },
+    #[command(about = "Acquire and inspect repository maintenance exclusion")]
+    Maintenance {
+        #[command(subcommand)]
+        command: MaintenanceCommand,
     },
     #[command(about = "Install Coven Parallel Work Protocol git hooks")]
     Hooks {
@@ -994,6 +1000,37 @@ enum ClaimCommand {
 }
 
 #[derive(Subcommand, Debug)]
+enum MaintenanceCommand {
+    #[command(about = "Fence new Coven writers and begin draining existing writers")]
+    Acquire {
+        #[arg(help = "Stable owner id, usually supplied by the coordinating client")]
+        owner: String,
+        #[arg(
+            long,
+            default_value_t = 0,
+            help = "Wait up to this many milliseconds for existing writers to drain"
+        )]
+        wait_ms: u64,
+        #[arg(long, help = "Print the owner fence and writer state as JSON")]
+        json: bool,
+    },
+    #[command(about = "Renew an existing maintenance owner lease")]
+    Heartbeat {
+        owner: String,
+        generation: String,
+        #[arg(long, help = "Print the owner fence and writer state as JSON")]
+        json: bool,
+    },
+    #[command(about = "Release an existing maintenance owner fence")]
+    Release { owner: String, generation: String },
+    #[command(about = "Show the maintenance owner and active writer intents")]
+    Status {
+        #[arg(long, help = "Print state as JSON")]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 enum HooksCommand {
     #[command(about = "Install pre-commit and pre-push protocol hooks")]
     Install,
@@ -1282,6 +1319,7 @@ fn run_cli(cli: Cli) -> Result<()> {
             ClaimCommand::Canary { branch } => parallel_protocol::claim_canary(&branch),
             ClaimCommand::Status { json } => parallel_protocol::claim_status(json),
         },
+        Some(Command::Maintenance { command }) => run_maintenance_command(command),
         Some(Command::Hooks { command }) => match command {
             HooksCommand::Install => parallel_protocol::hooks_install(),
         },
@@ -1314,6 +1352,99 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Models { args }) => run_engine_passthrough(Some("models"), &args),
         Some(Command::Acp { args }) => run_engine_passthrough(Some("acp"), &args),
         Some(Command::Code { args }) => run_engine_passthrough(None, &args),
+    }
+}
+
+fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let gate = maintenance_gate::MaintenanceGate::discover(&cwd)?;
+    match command {
+        MaintenanceCommand::Status { json } => {
+            let status = gate.status()?;
+            render_maintenance_status(&status, json)
+        }
+        MaintenanceCommand::Acquire {
+            owner,
+            wait_ms,
+            json,
+        } => {
+            let mut lease = gate.acquire_owner(owner)?;
+            let deadline = std::time::Instant::now() + Duration::from_millis(wait_ms);
+            let mut status = lease.refresh_phase()?;
+            while !status.writers.is_empty() && std::time::Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(25));
+                status = lease.refresh_phase()?;
+            }
+            if json {
+                println!("{}", serde_json::to_string(&status)?);
+            } else {
+                let owner = status.owner.expect("owner lease remains present");
+                println!(
+                    "maintenance {} generation {} until {}",
+                    match owner.phase {
+                        maintenance_gate::OwnerPhase::Held => "held",
+                        maintenance_gate::OwnerPhase::Draining => "draining",
+                    },
+                    owner.generation,
+                    owner.expires_at
+                );
+                if !status.writers.is_empty() {
+                    println!("waiting for {} writer intent(s)", status.writers.len());
+                }
+            }
+            Ok(())
+        }
+        MaintenanceCommand::Heartbeat {
+            owner,
+            generation,
+            json,
+        } => {
+            let status = gate.heartbeat_owner(&owner, &generation)?;
+            render_maintenance_status(&status, json)
+        }
+        MaintenanceCommand::Release { owner, generation } => {
+            gate.release_owner(&owner, &generation)?;
+            println!("released maintenance fence for {owner}");
+            Ok(())
+        }
+    }
+}
+
+fn render_maintenance_status(status: &maintenance_gate::GateStatus, json: bool) -> Result<()> {
+    if json {
+        println!("{}", serde_json::to_string(status)?);
+        return Ok(());
+    }
+    match &status.owner {
+        Some(owner) => println!(
+            "owner: {} ({:?}, generation {}, expires {})",
+            owner.owner_id, owner.phase, owner.generation, owner.expires_at
+        ),
+        None => println!("owner: none"),
+    }
+    if status.writers.is_empty() {
+        println!("writers: none");
+    } else {
+        for writer in &status.writers {
+            println!(
+                "writer: {} {} until {}",
+                writer.kind, writer.id, writer.expires_at
+            );
+        }
+    }
+    Ok(())
+}
+
+fn acquire_session_writer(
+    project_root: &Path,
+    kind: &str,
+) -> Result<Option<maintenance_gate::WriterLease>> {
+    let gate = maintenance_gate::MaintenanceGate::discover_optional(project_root)?;
+    match gate {
+        Some(gate) => gate
+            .acquire_writer(format!("{}-{}", kind, Uuid::new_v4()), kind)
+            .map(Some),
+        None => Ok(None),
     }
 }
 
@@ -2910,6 +3041,7 @@ fn launch_patch_session(request: &patch::PatchRequest) -> Result<String> {
         request.harness_id.as_str(),
         session_launch::HarnessCheck::Available,
     )?;
+    let _maintenance_writer = acquire_session_writer(&request.repo.root, "patch-session")?;
     let coven_home = coven_home_dir()?;
     let store_path = coven_home.join(STORE_FILE_NAME);
     let conn = store::open_store(&store_path)?;
@@ -3654,6 +3786,7 @@ fn run_session(
             )),
             session_launch::LaunchPathError::Cwd(error) => error.context("failed to resolve cwd"),
         })?;
+    let _maintenance_writer = acquire_session_writer(&project_root, "session")?;
     let coven_home = coven_home_dir()?;
     let store_path = coven_store_path()?;
     let conn = store::open_store(&store_path)?;

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -1,0 +1,671 @@
+//! Repository-wide maintenance exclusion for Coven writers.
+//!
+//! The files live below git's *common* directory, not a worktree's `.git`
+//! link, so every worktree of one checkout observes the same state.  This is
+//! deliberately a protocol built from exclusive file creation and fenced
+//! records rather than an advisory process lock: Cave and the CLI are separate
+//! processes and must make the same decision before they mutate a repository.
+
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{Arc, Condvar, Mutex},
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+const GATE_DIR: &str = "coven-maintenance-gate";
+const OWNER_FILE: &str = "owner";
+const WRITERS_DIR: &str = "writers";
+const LOCK_FILE: &str = "lock";
+const LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
+const LOCK_WAIT: Duration = Duration::from_secs(5);
+const WRITER_TTL: Duration = Duration::from_secs(90);
+const OWNER_TTL: Duration = Duration::from_secs(120);
+const RENEW_EVERY: Duration = Duration::from_secs(20);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Owner {
+    pub owner_id: String,
+    pub generation: String,
+    pub expires_at: u64,
+    pub phase: OwnerPhase,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OwnerPhase {
+    Draining,
+    Held,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WriterIntent {
+    pub id: String,
+    pub kind: String,
+    pub generation: String,
+    pub expires_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GateStatus {
+    pub owner: Option<Owner>,
+    pub writers: Vec<WriterIntent>,
+}
+
+#[derive(Debug)]
+pub enum GateError {
+    OwnerHeld(Owner),
+    OwnerMalformed { path: PathBuf },
+    WriterMalformed { path: PathBuf },
+    OwnerChanged,
+    LeaseExpired,
+    Contended,
+}
+
+impl std::fmt::Display for GateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::OwnerHeld(owner) => write!(
+                f,
+                "repository maintenance is {} by {} until {}",
+                match owner.phase {
+                    OwnerPhase::Draining => "draining for",
+                    OwnerPhase::Held => "held",
+                },
+                owner.owner_id,
+                owner.expires_at
+            ),
+            Self::OwnerMalformed { path } => write!(
+                f,
+                "maintenance owner state is malformed at {}; refusing to proceed",
+                path.display()
+            ),
+            Self::WriterMalformed { path } => write!(
+                f,
+                "maintenance writer state is malformed at {}; refusing to proceed",
+                path.display()
+            ),
+            Self::OwnerChanged => write!(f, "maintenance ownership changed; acquire a new fence"),
+            Self::LeaseExpired => write!(f, "maintenance lease expired; acquire a new fence"),
+            Self::Contended => write!(f, "maintenance state is contended; retry"),
+        }
+    }
+}
+
+impl std::error::Error for GateError {}
+
+#[derive(Debug, Clone)]
+pub struct MaintenanceGate {
+    common_dir: PathBuf,
+}
+
+impl MaintenanceGate {
+    /// Resolve the common directory for `project_root`. This accepts a
+    /// worktree root as well as the primary checkout.
+    pub fn discover(project_root: &Path) -> Result<Self> {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+            .output()
+            .context("failed to resolve git common directory")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "repository maintenance gating requires a git worktree: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let common_dir = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        let common_dir = fs::canonicalize(&common_dir)
+            .with_context(|| format!("failed to canonicalize {}", common_dir.display()))?;
+        Ok(Self { common_dir })
+    }
+
+    /// Session launches are also supported for ordinary directories. Those
+    /// directories have no shared git identity, so there is no repository-wide
+    /// exclusion domain to join; callers use this only for launch paths, never
+    /// for claim or owner commands (which require a repository).
+    pub fn discover_optional(project_root: &Path) -> Result<Option<Self>> {
+        let output = std::process::Command::new("git")
+            .arg("-C")
+            .arg(project_root)
+            .args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
+            .output()
+            .context("failed to resolve git common directory")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // An ordinary directory has no common Git identity to coordinate
+            // against. Other Git failures (for example, a broken worktree or
+            // inaccessible common directory) must not silently disable the
+            // maintenance fence.
+            if stderr.contains("not a git repository") {
+                return Ok(None);
+            }
+            anyhow::bail!(
+                "failed to resolve repository maintenance gate: {}",
+                stderr.trim()
+            );
+        }
+        let common_dir = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        Ok(Some(Self {
+            common_dir: fs::canonicalize(&common_dir)
+                .with_context(|| format!("failed to canonicalize {}", common_dir.display()))?,
+        }))
+    }
+
+    #[cfg(test)]
+    fn at(common_dir: PathBuf) -> Self {
+        Self { common_dir }
+    }
+
+    fn dir(&self) -> PathBuf {
+        self.common_dir.join(GATE_DIR)
+    }
+
+    fn owner_path(&self) -> PathBuf {
+        self.dir().join(OWNER_FILE)
+    }
+
+    fn writers_dir(&self) -> PathBuf {
+        self.dir().join(WRITERS_DIR)
+    }
+
+    fn lock_path(&self) -> PathBuf {
+        self.dir().join(LOCK_FILE)
+    }
+
+    fn ensure_layout(&self) -> Result<()> {
+        fs::create_dir_all(self.writers_dir()).with_context(|| {
+            format!(
+                "failed to create maintenance directory {}",
+                self.dir().display()
+            )
+        })
+    }
+
+    /// Register a writer before a process can begin touching a repository.
+    /// A returned lease renews itself until it is dropped, so an owner can
+    /// distinguish a live session from a process that died mid-operation.
+    pub fn acquire_writer(
+        &self,
+        id: impl Into<String>,
+        kind: impl Into<String>,
+    ) -> Result<WriterLease> {
+        self.ensure_layout()?;
+        let intent = WriterIntent {
+            id: id.into(),
+            kind: kind.into(),
+            generation: Uuid::new_v4().to_string(),
+            expires_at: unix_now() + WRITER_TTL.as_secs(),
+        };
+        let path = self.writers_dir().join(writer_file_name(&intent.id));
+        self.with_lock(|| {
+            if let Some(owner) = self.read_owner()? {
+                if owner.expires_at > unix_now() {
+                    return Err(GateError::OwnerHeld(owner).into());
+                }
+                fs::remove_file(self.owner_path())
+                    .with_context(|| "failed to remove expired maintenance owner")?;
+            }
+            self.write_new(&path, &intent)
+                .with_context(|| format!("failed to publish writer intent {}", path.display()))?;
+            Ok(())
+        })?;
+        Ok(WriterLease::new(self.clone(), path, intent))
+    }
+
+    /// Acquire an owner fence. New writers are refused from the instant this
+    /// record is published. Existing writers remain visible while Cave drains
+    /// them; the phase becomes `held` only after they have all left.
+    pub fn acquire_owner(&self, owner_id: impl Into<String>) -> Result<OwnerLease> {
+        self.ensure_layout()?;
+        let owner = Owner {
+            owner_id: owner_id.into(),
+            generation: Uuid::new_v4().to_string(),
+            expires_at: unix_now() + OWNER_TTL.as_secs(),
+            phase: OwnerPhase::Draining,
+        };
+        self.with_lock(|| {
+            if let Some(existing) = self.read_owner()? {
+                if existing.expires_at > unix_now() {
+                    return Err(GateError::OwnerHeld(existing).into());
+                }
+                fs::remove_file(self.owner_path())
+                    .with_context(|| "failed to remove expired maintenance owner")?;
+            }
+            self.write_new(&self.owner_path(), &owner)
+                .with_context(|| "failed to publish maintenance owner")?;
+            Ok(())
+        })?;
+        let mut lease = OwnerLease {
+            gate: self.clone(),
+            owner,
+        };
+        lease.refresh_phase()?;
+        Ok(lease)
+    }
+
+    pub fn status(&self) -> Result<GateStatus> {
+        self.ensure_layout()?;
+        self.with_lock(|| {
+            let now = unix_now();
+            let owner = self.read_owner()?;
+            let writers = self.read_writers(now)?;
+            Ok(GateStatus { owner, writers })
+        })
+    }
+
+    pub fn heartbeat_owner(&self, owner_id: &str, generation: &str) -> Result<GateStatus> {
+        let mut lease = OwnerLease {
+            gate: self.clone(),
+            owner: Owner {
+                owner_id: owner_id.to_string(),
+                generation: generation.to_string(),
+                expires_at: 0,
+                phase: OwnerPhase::Draining,
+            },
+        };
+        lease.refresh_phase()
+    }
+
+    pub fn release_owner(&self, owner_id: &str, generation: &str) -> Result<()> {
+        OwnerLease {
+            gate: self.clone(),
+            owner: Owner {
+                owner_id: owner_id.to_string(),
+                generation: generation.to_string(),
+                expires_at: 0,
+                phase: OwnerPhase::Draining,
+            },
+        }
+        .release()
+    }
+
+    fn read_owner(&self) -> Result<Option<Owner>> {
+        let path = self.owner_path();
+        let data = match fs::read(&path) {
+            Ok(data) => data,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to read {}", path.display()))
+            }
+        };
+        serde_json::from_slice(&data)
+            .map(Some)
+            .map_err(|_| GateError::OwnerMalformed { path }.into())
+    }
+
+    fn read_writers(&self, now: u64) -> Result<Vec<WriterIntent>> {
+        let mut writers = Vec::new();
+        for entry in fs::read_dir(self.writers_dir())? {
+            let entry = entry?;
+            let path = entry.path();
+            if !entry.file_type()?.is_file() {
+                return Err(GateError::WriterMalformed { path }.into());
+            }
+            let data = fs::read(&path)?;
+            let writer: WriterIntent = serde_json::from_slice(&data)
+                .map_err(|_| GateError::WriterMalformed { path: path.clone() })?;
+            if writer.expires_at > now {
+                writers.push(writer);
+            } else {
+                fs::remove_file(&path).with_context(|| {
+                    format!("failed to remove expired writer {}", path.display())
+                })?;
+            }
+        }
+        writers.sort_by(|a, b| a.id.cmp(&b.id));
+        Ok(writers)
+    }
+
+    fn renew_writer(&self, path: &Path, generation: &str) -> Result<()> {
+        self.with_lock(|| {
+            let data = fs::read(path).with_context(|| "writer intent vanished")?;
+            let mut intent: WriterIntent =
+                serde_json::from_slice(&data).map_err(|_| GateError::WriterMalformed {
+                    path: path.to_path_buf(),
+                })?;
+            if intent.generation != generation {
+                return Err(GateError::OwnerChanged.into());
+            }
+            intent.expires_at = unix_now() + WRITER_TTL.as_secs();
+            self.replace(path, &intent)
+        })
+    }
+
+    fn release_writer(&self, path: &Path, generation: &str) {
+        let _ = self.with_lock(|| {
+            let Ok(data) = fs::read(path) else {
+                return Ok(());
+            };
+            let Ok(intent) = serde_json::from_slice::<WriterIntent>(&data) else {
+                return Ok(());
+            };
+            if intent.generation == generation {
+                let _ = fs::remove_file(path);
+            }
+            Ok(())
+        });
+    }
+
+    fn with_lock<T>(&self, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+        self.ensure_layout()?;
+        let _lock = GateLock::acquire(self.lock_path())?;
+        operation()
+    }
+
+    fn write_new<T: Serialize>(&self, path: &Path, value: &T) -> Result<()> {
+        let bytes = serde_json::to_vec(value)?;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        Ok(())
+    }
+
+    fn replace<T: Serialize>(&self, path: &Path, value: &T) -> Result<()> {
+        let staged = path.with_file_name(format!(
+            "@{}.{}",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            Uuid::new_v4()
+        ));
+        fs::write(&staged, serde_json::to_vec(value)?)?;
+        replace_file(&staged, path)
+            .with_context(|| format!("failed to replace {}", path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(not(windows))]
+fn replace_file(staged: &Path, path: &Path) -> std::io::Result<()> {
+    fs::rename(staged, path)
+}
+
+#[cfg(windows)]
+fn replace_file(staged: &Path, path: &Path) -> std::io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+
+    const MOVEFILE_REPLACE_EXISTING: u32 = 0x1;
+    const MOVEFILE_WRITE_THROUGH: u32 = 0x8;
+    #[link(name = "Kernel32")]
+    extern "system" {
+        #[link_name = "MoveFileExW"]
+        fn move_file_ex_w(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+    let existing = staged
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let new = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    if unsafe {
+        move_file_ex_w(
+            existing.as_ptr(),
+            new.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    } == 0
+    {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct WriterLease {
+    gate: MaintenanceGate,
+    path: PathBuf,
+    generation: String,
+    stopper: Arc<(Mutex<bool>, Condvar)>,
+    renewer: Option<thread::JoinHandle<()>>,
+}
+
+impl WriterLease {
+    fn new(gate: MaintenanceGate, path: PathBuf, intent: WriterIntent) -> Self {
+        let stopper = Arc::new((Mutex::new(false), Condvar::new()));
+        let thread_stopper = Arc::clone(&stopper);
+        let thread_gate = gate.clone();
+        let thread_path = path.clone();
+        let generation = intent.generation.clone();
+        let renewer = thread::spawn(move || {
+            loop {
+                let (stopped, wake) = &*thread_stopper;
+                let guard = stopped.lock().expect("writer lease stop lock poisoned");
+                let (guard, _) = wake
+                    .wait_timeout(guard, RENEW_EVERY)
+                    .expect("writer lease wait poisoned");
+                if *guard {
+                    return;
+                }
+                drop(guard);
+                if thread_gate.renew_writer(&thread_path, &generation).is_err() {
+                    // Keep trying: a transient rename failure must not make a
+                    // still-running session invisible to a maintenance owner.
+                }
+            }
+        });
+        Self {
+            gate,
+            path,
+            generation: intent.generation,
+            stopper,
+            renewer: Some(renewer),
+        }
+    }
+}
+
+impl Drop for WriterLease {
+    fn drop(&mut self) {
+        let (stopped, wake) = &*self.stopper;
+        if let Ok(mut stopped) = stopped.lock() {
+            *stopped = true;
+            wake.notify_one();
+        }
+        if let Some(renewer) = self.renewer.take() {
+            let _ = renewer.join();
+        }
+        self.gate.release_writer(&self.path, &self.generation);
+    }
+}
+
+pub struct OwnerLease {
+    gate: MaintenanceGate,
+    owner: Owner,
+}
+
+impl OwnerLease {
+    #[cfg(test)]
+    pub fn owner(&self) -> &Owner {
+        &self.owner
+    }
+
+    pub fn refresh_phase(&mut self) -> Result<GateStatus> {
+        self.gate.with_lock(|| {
+            let current = self.gate.read_owner()?.ok_or(GateError::OwnerChanged)?;
+            if current.generation != self.owner.generation
+                || current.owner_id != self.owner.owner_id
+            {
+                return Err(GateError::OwnerChanged.into());
+            }
+            if current.expires_at <= unix_now() {
+                return Err(GateError::LeaseExpired.into());
+            }
+            let writers = self.gate.read_writers(unix_now())?;
+            let mut next = current;
+            next.expires_at = unix_now() + OWNER_TTL.as_secs();
+            next.phase = if writers.is_empty() {
+                OwnerPhase::Held
+            } else {
+                OwnerPhase::Draining
+            };
+            self.gate.replace(&self.gate.owner_path(), &next)?;
+            self.owner = next.clone();
+            Ok(GateStatus {
+                owner: Some(next),
+                writers,
+            })
+        })
+    }
+
+    #[cfg(test)]
+    pub fn assert_held(&self) -> Result<()> {
+        let current = self.gate.read_owner()?.ok_or(GateError::OwnerChanged)?;
+        if current.generation != self.owner.generation || current.owner_id != self.owner.owner_id {
+            return Err(GateError::OwnerChanged.into());
+        }
+        if current.expires_at <= unix_now() {
+            return Err(GateError::LeaseExpired.into());
+        }
+        if current.phase != OwnerPhase::Held {
+            anyhow::bail!("maintenance owner is still draining writers")
+        }
+        Ok(())
+    }
+
+    pub fn release(self) -> Result<()> {
+        self.gate.with_lock(|| {
+            let current = self.gate.read_owner()?.ok_or(GateError::OwnerChanged)?;
+            if current.generation != self.owner.generation
+                || current.owner_id != self.owner.owner_id
+            {
+                return Err(GateError::OwnerChanged.into());
+            }
+            if current.expires_at <= unix_now() {
+                return Err(GateError::LeaseExpired.into());
+            }
+            fs::remove_file(self.gate.owner_path())
+                .context("failed to release maintenance owner")?;
+            Ok(())
+        })
+    }
+}
+
+struct GateLock {
+    path: PathBuf,
+}
+
+impl GateLock {
+    fn acquire(path: PathBuf) -> Result<Self> {
+        let started = SystemTime::now();
+        loop {
+            match fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(_) => return Ok(Self { path }),
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                    if is_stale(&path, LOCK_STALE_AFTER) {
+                        let _ = fs::remove_file(&path);
+                    }
+                    if SystemTime::now()
+                        .duration_since(started)
+                        .unwrap_or_default()
+                        > LOCK_WAIT
+                    {
+                        return Err(GateError::Contended.into());
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to acquire {}", path.display()))
+                }
+            }
+        }
+    }
+}
+
+impl Drop for GateLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn is_stale(path: &Path, after: Duration) -> bool {
+    fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age > after)
+}
+
+fn writer_file_name(id: &str) -> String {
+    format!(
+        "{}.json",
+        id.chars()
+            .map(|c| if c.is_ascii_alphanumeric() || matches!(c, '-' | '_') {
+                c
+            } else {
+                '_'
+            })
+            .collect::<String>()
+    )
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owner_rejects_a_writer_until_release() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let owner = gate.acquire_owner("cave")?;
+        assert_eq!(owner.owner().phase, OwnerPhase::Held);
+        let error = gate.acquire_writer("session-1", "session").unwrap_err();
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|e| matches!(e, GateError::OwnerHeld(_))));
+        owner.release()?;
+        drop(gate.acquire_writer("session-1", "session")?);
+        Ok(())
+    }
+
+    #[test]
+    fn owner_drains_existing_writer_then_becomes_held() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        let writer = gate.acquire_writer("session-1", "session")?;
+        let mut owner = gate.acquire_owner("cave")?;
+        assert_eq!(owner.owner().phase, OwnerPhase::Draining);
+        drop(writer);
+        assert!(owner.refresh_phase()?.writers.is_empty());
+        owner.assert_held()?;
+        owner.release()?;
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_owner_fails_closed() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        fs::write(gate.owner_path(), b"not-json")?;
+        let error = gate.acquire_writer("session-1", "session").unwrap_err();
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|e| matches!(e, GateError::OwnerMalformed { .. })));
+        Ok(())
+    }
+}

--- a/crates/coven-cli/src/parallel_protocol.rs
+++ b/crates/coven-cli/src/parallel_protocol.rs
@@ -86,6 +86,7 @@ pub(crate) fn run_wt_command(
 
 pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
+    let _writer = claim_writer(&repo, "claim-acquire")?;
     let agent_id = agent_id(&repo);
 
     // Creating the claim file is the only step that decides the race, so it
@@ -164,6 +165,7 @@ pub(crate) fn claim_acquire(branch: &str) -> Result<()> {
 
 pub(crate) fn claim_release(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
+    let _writer = claim_writer(&repo, "claim-release")?;
     let agent_id = agent_id(&repo);
     match read_claim(&repo, branch)? {
         ClaimFileState::Parsed(existing) => {
@@ -193,6 +195,7 @@ pub(crate) fn claim_release(branch: &str) -> Result<()> {
 
 pub(crate) fn claim_heartbeat(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
+    let _writer = claim_writer(&repo, "claim-heartbeat")?;
     let agent_id = agent_id(&repo);
     let now = unix_now();
     let mut claim = match read_claim(&repo, branch)? {
@@ -230,6 +233,7 @@ pub(crate) fn claim_heartbeat(branch: &str) -> Result<()> {
 
 pub(crate) fn claim_canary(branch: &str) -> Result<()> {
     let repo = Repo::discover()?;
+    let _writer = claim_writer(&repo, "claim-canary")?;
     let head = current_head()?;
     let canary_path = repo.common_dir.join("AGENT_HEAD_AT_START");
     fs::write(&canary_path, format!("branch={branch}\nhead={head}\n"))
@@ -961,6 +965,14 @@ impl Repo {
         };
         Ok(Self { root, common_dir })
     }
+}
+
+fn claim_writer(repo: &Repo, kind: &str) -> Result<crate::maintenance_gate::WriterLease> {
+    let gate = crate::maintenance_gate::MaintenanceGate::discover(&repo.root)?;
+    gate.acquire_writer(
+        format!("claim-{}-{}", std::process::id(), uuid::Uuid::new_v4()),
+        kind,
+    )
 }
 
 fn install_hook(hooks_dir: &Path, hook: &str, contents: &str) -> Result<()> {

--- a/crates/coven-cli/tests/parallel_protocol.rs
+++ b/crates/coven-cli/tests/parallel_protocol.rs
@@ -67,6 +67,37 @@ fn claim_acquire_blocks_other_agent_until_release() -> anyhow::Result<()> {
 }
 
 #[test]
+fn maintenance_fence_blocks_claim_mutations_and_releases_cleanly() -> anyhow::Result<()> {
+    let repo = TestRepo::new()?;
+    let acquired = repo.coven(["maintenance", "acquire", "cave-delete", "--json"])?;
+    assert_success("maintenance acquire", &acquired);
+    let owner: serde_json::Value = serde_json::from_slice(&acquired.stdout)?;
+    let generation = owner["owner"]["generation"]
+        .as_str()
+        .expect("maintenance acquire returns fenced generation");
+
+    let blocked = repo.coven_with_env(
+        ["claim", "acquire", "issue-538"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_failure("claim acquire while fenced", &blocked);
+    assert_stderr_contains(
+        "claim acquire while fenced",
+        &blocked,
+        "repository maintenance",
+    );
+
+    let released = repo.coven(["maintenance", "release", "cave-delete", generation])?;
+    assert_success("maintenance release", &released);
+    let claim = repo.coven_with_env(
+        ["claim", "acquire", "issue-538"],
+        [("COVEN_AGENT_ID", "cody")],
+    )?;
+    assert_success("claim acquire after maintenance release", &claim);
+    Ok(())
+}
+
+#[test]
 fn default_claim_identity_blocks_same_user_in_another_worktree() -> anyhow::Result<()> {
     let repo = TestRepo::new()?;
     let first_worktree = repo.add_worktree("first-session", "feature/first-session")?;

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -135,6 +135,9 @@ All API errors use the following stable envelope. Clients must branch on `error.
 | `project_root_violation`| 400        | Reserved. Cwd-outside-root currently emits `invalid_request` with the violation message in the body; promoting to its own code would let clients branch without parsing prose. |
 | `pty_spawn_failed`     | 500         | Reserved. PTY spawn failures currently emit `launch_failed`; promoting to its own code would let clients distinguish "the PTY couldn't open" (likely a host issue) from "the harness CLI errored at startup" (likely an auth/config issue). |
 | `launch_failed`        | 500         | Daemon accepted the launch payload but the runtime (PTY/pipe spawn, initial-message write, harness CLI startup) failed. `details.sessionId` is the row that was inserted and marked `failed`. |
+| `maintenance_locked`   | 423         | A valid repository maintenance owner is draining or holds the common-directory gate. `details.owner` carries its fenced generation and deadline. |
+| `maintenance_state_invalid` | 423  | The repository maintenance protocol contains malformed or ambiguous state. Coven fails closed rather than launching a writer. |
+| `maintenance_gate_unavailable` | 423 | Coven could not establish a repository maintenance writer intent. |
 | `send_input_failed`    | 500         | Daemon accepted the input payload but the runtime write failed (closed pipe, killed process, IO error). `details.sessionId` is the affected session. |
 | `kill_failed`          | 500         | Daemon accepted the kill request but the runtime signal/kill call failed (permission, missing process, IO error). `details.sessionId` is the affected session. |
 | `runtime_unavailable`  | 503         | The session runtime is unavailable.              |

--- a/docs/reference/cli-maintenance.md
+++ b/docs/reference/cli-maintenance.md
@@ -1,0 +1,41 @@
+---
+summary: "Repository-wide exclusion for destructive maintenance."
+read_when:
+  - Coordinating a worktree or branch deletion with live Coven sessions
+  - Integrating a maintenance client such as Coven Cave
+title: "coven maintenance"
+description: "Reference for the fenced maintenance gate shared by Coven sessions and claim mutations."
+---
+
+`coven maintenance` creates a repository-wide exclusion window below the Git
+common directory. Unlike a worktree-local lock, every Coven worktree, direct
+CLI session, and daemon-backed session uses the same writer-intent registry.
+
+```sh
+# Start a fence. Keep both values: generation is required to renew or release.
+coven maintenance acquire cave-delete-42 --wait-ms 5000 --json
+
+# Before each destructive boundary, renew and require phase=held.
+coven maintenance heartbeat cave-delete-42 <generation> --json
+
+# After post-verification, release the exact fence.
+coven maintenance release cave-delete-42 <generation>
+```
+
+The acquire result is either `held` (no writer remains) or `draining` with a
+list of active writer intents. Publishing `draining` already rejects new
+writers, allowing the owner to wait for previously-started sessions and claim
+mutations without admitting another one. Owners are fenced by a random
+generation and an expiry deadline. Heartbeat and release reject a different or
+expired generation; malformed owner or writer records also fail closed.
+
+Direct `coven run`, `coven patch`, daemon `POST /sessions`, and claim
+`acquire`, `release`, `heartbeat`, and `canary` register renewable writer
+intents before their mutation/launch path. A daemon session retains the intent
+until its child exits. Session launch errors caused by an owner are returned as
+HTTP `423 maintenance_locked` with structured owner details for clients.
+
+The protocol coordinates one shared Git common directory. It cannot stop raw
+Git commands, uninstrumented harnesses, or a separate clone on another host;
+those callers must use a supported Coven launch path (or the same maintenance
+protocol) to participate.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -113,6 +113,7 @@ flowchart TB
 | `coven wt --list/--doctor/--prune-merged/--prune-stale DAYS` | Inspect and clean Coven protocol worktrees; see [cli-wt](cli-wt.md). |
 | `coven claim acquire/release/heartbeat/canary <branch>` | Manage TTL-bounded branch ownership for the current agent; see [cli-claim](cli-claim.md). |
 | `coven claim status` | Print branch claims from the current repository; see [cli-claim](cli-claim.md). |
+| `coven maintenance acquire/heartbeat/release/status` | Fence new Coven writers for one repository and drain existing session/claim writers; see [cli-maintenance](cli-maintenance.md). |
 | `coven hooks install` | Install local protocol hooks that block unsafe commits and protected pushes; see [cli-claim](cli-claim.md). |
 | `coven engine status/install/which` | Manage the pinned Coven engine (`coven-code`); see [cli-engine](cli-engine.md). |
 | `coven executor probe/run-job` | Stateless executor-node protocol commands, hub-dispatched over SSH; see [cli-executor](cli-executor.md). |


### PR DESCRIPTION
Closes #538

## Summary

Coven now provides a repository-wide maintenance fence that coordinates every worktree through Git's common directory.

## Root cause

Session launches and claim mutations had no shared exclusion protocol. A maintenance client could begin destructive repository work while another Coven process was starting or holding a session/claim, leaving no atomic way to reject new writers or drain existing ones.

## Solution

- Add a generation-fenced, expiring maintenance owner record and renewable writer intents.
- Gate direct CLI launches, daemon session launches, and claim mutations before their mutable/launch paths.
- Keep daemon session writer intents alive until their child exits.
- Return structured HTTP 423 maintenance errors for blocked daemon session launches.
- Document the CLI protocol and its coordination boundary.

## Validation

- `cargo fmt --check`
- `cargo check -p coven-cli`
- Targeted maintenance, API, and parallel-protocol tests (in progress under shared build contention)
- `python3 scripts/check-coven-privacy.py --staged`
- `git diff --check`

## Risks and follow-up

The fence coordinates supported Coven paths sharing one Git common directory; it cannot stop raw Git commands, uninstrumented harnesses, or separate clones. A coordinating maintenance client must heartbeat its owner lease and require `held` before destructive work.