### PR TITLE
feat(runtime): define versioned harness contract

### DIFF
--- a/crates/coven-cli/src/harness_contract.rs
+++ b/crates/coven-cli/src/harness_contract.rs
@@ -1,0 +1,543 @@
+//! Versioned contract shared by the Coven runner and harness adapters.
+//!
+//! This module deliberately contains no process-spawning code.  The daemon
+//! remains the authority for cwd validation, process ownership, and policy;
+//! adapters negotiate only the capability and event vocabulary they can
+//! faithfully implement.  Keeping this boundary pure makes the wire rules
+//! fixture-testable for bundled and external adapters alike.
+
+use std::collections::BTreeSet;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+pub const CONTRACT_NAME: &str = "coven.harness";
+pub const CONTRACT_V1: &str = "coven.harness.v1";
+
+/// Extensions understood by the v1 runner.  Base lifecycle, text input,
+/// streamed output, cancellation, and errors are mandatory v1 semantics; the
+/// extension list is for additive behavior only.
+const KNOWN_EXTENSIONS: &[&str] = &["input.image.v1", "output.tool-use.v1"];
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractOffer {
+    pub contract: String,
+    pub versions: Vec<String>,
+    #[serde(default)]
+    pub required_extensions: Vec<String>,
+    #[serde(default)]
+    pub optional_extensions: Vec<String>,
+}
+
+impl ContractOffer {
+    pub fn v1() -> Self {
+        Self {
+            contract: CONTRACT_NAME.to_string(),
+            versions: vec![CONTRACT_V1.to_string()],
+            required_extensions: Vec::new(),
+            optional_extensions: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NegotiatedContract {
+    pub version: String,
+    pub extensions: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl fmt::Display for ContractError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ContractError {}
+
+fn contract_error(code: &'static str, message: impl Into<String>) -> ContractError {
+    ContractError {
+        code,
+        message: message.into(),
+    }
+}
+
+/// Select the newest mutually supported contract and validate required
+/// extensions on *both* sides.  Optional extensions are deliberately ignored
+/// when unknown, which is the v1 forward-compatibility rule.
+pub fn negotiate(
+    runner: &ContractOffer,
+    adapter: &ContractOffer,
+) -> Result<NegotiatedContract, ContractError> {
+    if runner.contract != CONTRACT_NAME || adapter.contract != CONTRACT_NAME {
+        return Err(contract_error(
+            "contract_name_mismatch",
+            format!(
+                "runner and adapter must both use `{CONTRACT_NAME}` (got `{}` and `{}`)",
+                runner.contract, adapter.contract
+            ),
+        ));
+    }
+
+    let version = runner
+        .versions
+        .iter()
+        .filter(|version| adapter.versions.contains(*version))
+        .filter(|version| version.as_str() == CONTRACT_V1)
+        .max()
+        .cloned()
+        .ok_or_else(|| {
+            contract_error(
+                "unsupported_contract_version",
+                format!(
+                    "no mutually supported harness contract version; runner={:?}, adapter={:?}",
+                    runner.versions, adapter.versions
+                ),
+            )
+        })?;
+
+    let runner_extensions = known_extensions(runner)?;
+    let adapter_extensions = known_extensions(adapter)?;
+    for extension in &runner.required_extensions {
+        if !adapter_extensions.contains(extension) {
+            return Err(contract_error(
+                "required_extension_unavailable",
+                format!("adapter does not offer runner-required extension `{extension}`"),
+            ));
+        }
+    }
+    for extension in &adapter.required_extensions {
+        if !runner_extensions.contains(extension) {
+            return Err(contract_error(
+                "required_extension_unavailable",
+                format!("runner does not offer adapter-required extension `{extension}`"),
+            ));
+        }
+    }
+
+    Ok(NegotiatedContract {
+        version,
+        extensions: runner_extensions
+            .intersection(&adapter_extensions)
+            .cloned()
+            .collect(),
+    })
+}
+
+fn known_extensions(offer: &ContractOffer) -> Result<BTreeSet<String>, ContractError> {
+    let mut extensions = BTreeSet::new();
+    for (required, extension) in offer
+        .required_extensions
+        .iter()
+        .map(|extension| (true, extension))
+        .chain(
+            offer
+                .optional_extensions
+                .iter()
+                .map(|extension| (false, extension)),
+        )
+    {
+        if KNOWN_EXTENSIONS.contains(&extension.as_str()) {
+            extensions.insert(extension.clone());
+        } else if required {
+            return Err(contract_error(
+                "unknown_required_extension",
+                format!("required extension `{extension}` is not understood by v1"),
+            ));
+        }
+    }
+    Ok(extensions)
+}
+
+/// Frames sent by the runner after negotiation.  Input is structured so an
+/// adapter never has to infer session ownership from a PTY byte stream.  Image
+/// input is admitted only when `input.image.v1` was negotiated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RunnerFrame {
+    Input {
+        session_id: String,
+        request_id: String,
+        content: InputContent,
+    },
+    Cancel {
+        session_id: String,
+        request_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputContent {
+    Text { text: String },
+    Image { media_type: String, data: String },
+}
+
+/// Frames sent by an adapter after v1 negotiation.  Serde intentionally
+/// accepts unknown fields: all newly added fields are optional unless they are
+/// introduced as a required, negotiated extension.  Unknown frame *types* and
+/// missing base fields still fail closed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AdapterFrame {
+    Ready {
+        session_id: String,
+    },
+    Output {
+        session_id: String,
+        sequence: u64,
+        kind: OutputKind,
+        text: String,
+    },
+    CancellationAcknowledged {
+        session_id: String,
+        request_id: String,
+    },
+    Terminal {
+        session_id: String,
+        sequence: u64,
+        outcome: TerminalOutcome,
+        #[serde(default)]
+        error: Option<AdapterError>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputKind {
+    Text,
+    Raw,
+    Semantic,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalOutcome {
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdapterError {
+    pub code: String,
+    pub message: String,
+}
+
+/// Per-session conformance state.  It preserves already accepted output if a
+/// later terminal frame fails: partial output is evidence, never a success
+/// fallback, and every session must end with one explicit terminal outcome.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionConformance {
+    session_id: String,
+    ready: bool,
+    last_sequence: Option<u64>,
+    terminal: Option<TerminalOutcome>,
+    cancellation_requested: Option<String>,
+}
+
+impl SessionConformance {
+    pub fn new(session_id: impl Into<String>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            ready: false,
+            last_sequence: None,
+            terminal: None,
+            cancellation_requested: None,
+        }
+    }
+
+    pub fn request_cancellation(
+        &mut self,
+        request_id: impl Into<String>,
+    ) -> Result<(), ContractError> {
+        if self.terminal.is_some() {
+            return Err(contract_error(
+                "session_already_terminal",
+                "cannot cancel a session after its terminal frame",
+            ));
+        }
+        self.cancellation_requested = Some(request_id.into());
+        Ok(())
+    }
+
+    pub fn accept(&mut self, frame: &AdapterFrame) -> Result<(), ContractError> {
+        let session_id = match frame {
+            AdapterFrame::Ready { session_id }
+            | AdapterFrame::CancellationAcknowledged { session_id, .. }
+            | AdapterFrame::Output { session_id, .. }
+            | AdapterFrame::Terminal { session_id, .. } => session_id,
+        };
+        if session_id != &self.session_id {
+            return Err(contract_error(
+                "session_id_mismatch",
+                format!(
+                    "frame is for `{session_id}`, expected `{}`",
+                    self.session_id
+                ),
+            ));
+        }
+        if self.terminal.is_some() {
+            return Err(contract_error(
+                "frame_after_terminal",
+                "adapter emitted a frame after the terminal outcome",
+            ));
+        }
+
+        if matches!(frame, AdapterFrame::Ready { .. }) {
+            if self.ready {
+                return Err(contract_error(
+                    "duplicate_ready_frame",
+                    "adapter emitted ready more than once",
+                ));
+            }
+            self.ready = true;
+            return Ok(());
+        }
+        if !self.ready {
+            return Err(contract_error(
+                "output_before_ready",
+                "adapter emitted a non-ready frame before ready",
+            ));
+        }
+
+        match frame {
+            AdapterFrame::Ready { .. } => unreachable!("ready frame returns above"),
+            AdapterFrame::Output { sequence, .. } => self.accept_sequence(*sequence),
+            AdapterFrame::CancellationAcknowledged { request_id, .. } => {
+                if self.cancellation_requested.as_deref() != Some(request_id) {
+                    return Err(contract_error(
+                        "unexpected_cancellation_acknowledgement",
+                        format!("no matching cancellation request `{request_id}`"),
+                    ));
+                }
+                Ok(())
+            }
+            AdapterFrame::Terminal {
+                sequence,
+                outcome,
+                error,
+                ..
+            } => {
+                self.accept_sequence(*sequence)?;
+                if *outcome == TerminalOutcome::Failed
+                    && error.as_ref().is_none_or(|error| {
+                        error.code.trim().is_empty() || error.message.trim().is_empty()
+                    })
+                {
+                    return Err(contract_error(
+                        "missing_terminal_error",
+                        "a failed terminal frame must include a non-empty error code and message",
+                    ));
+                }
+                if *outcome != TerminalOutcome::Failed && error.is_some() {
+                    return Err(contract_error(
+                        "unexpected_terminal_error",
+                        "completed or cancelled terminal frames must not carry an error object",
+                    ));
+                }
+                if self.cancellation_requested.is_some() && *outcome != TerminalOutcome::Cancelled {
+                    return Err(contract_error(
+                        "cancellation_outcome_mismatch",
+                        "a cancellation request must end in the cancelled terminal outcome",
+                    ));
+                }
+                self.terminal = Some(*outcome);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn finish(self) -> Result<TerminalOutcome, ContractError> {
+        self.terminal.ok_or_else(|| {
+            contract_error(
+                "missing_terminal_frame",
+                "adapter stream ended without an explicit terminal outcome",
+            )
+        })
+    }
+
+    fn accept_sequence(&mut self, sequence: u64) -> Result<(), ContractError> {
+        if self
+            .last_sequence
+            .is_some_and(|previous| sequence <= previous)
+        {
+            return Err(contract_error(
+                "non_monotonic_sequence",
+                format!("sequence {sequence} is not greater than the prior frame"),
+            ));
+        }
+        self.last_sequence = Some(sequence);
+        Ok(())
+    }
+}
+
+pub fn parse_adapter_frame(json: &str) -> Result<AdapterFrame, ContractError> {
+    serde_json::from_str(json).map_err(|error| {
+        contract_error(
+            "invalid_adapter_frame",
+            format!("adapter frame does not satisfy the negotiated v1 schema: {error}"),
+        )
+    })
+}
+
+pub fn parse_runner_frame(json: &str) -> Result<RunnerFrame, ContractError> {
+    serde_json::from_str(json).map_err(|error| {
+        contract_error(
+            "invalid_runner_frame",
+            format!("runner frame does not satisfy the negotiated v1 schema: {error}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coven_runtime_spec::Capabilities;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GoldenFixture {
+        adapter_id: String,
+        offer: ContractOffer,
+        #[serde(default)]
+        capabilities: Option<Capabilities>,
+        session_id: String,
+        #[serde(default)]
+        cancellation_request_id: Option<String>,
+        frames: Vec<serde_json::Value>,
+    }
+
+    fn fixture(raw: &str) -> GoldenFixture {
+        serde_json::from_str(raw).expect("golden fixture must be valid JSON")
+    }
+
+    fn assert_fixture(raw: &str) {
+        let fixture = fixture(raw);
+        if let Some(expected_capabilities) = fixture.capabilities {
+            let actual = crate::harness::built_in_harnesses()
+                .into_iter()
+                .find(|summary| summary.id == fixture.adapter_id)
+                .unwrap_or_else(|| panic!("{} must remain a bundled adapter", fixture.adapter_id));
+            assert_eq!(
+                actual.capabilities, expected_capabilities,
+                "{} golden fixture drifted from its declared built-in capabilities",
+                fixture.adapter_id
+            );
+        }
+        negotiate(&ContractOffer::v1(), &fixture.offer)
+            .unwrap_or_else(|error| panic!("{} did not negotiate: {error}", fixture.adapter_id));
+        let mut session = SessionConformance::new(&fixture.session_id);
+        for frame in fixture.frames {
+            let type_name = frame["type"].as_str().unwrap_or_default();
+            if type_name == "cancellation_acknowledged" {
+                session
+                    .request_cancellation(
+                        fixture
+                            .cancellation_request_id
+                            .as_deref()
+                            .expect("cancellation fixture needs a request id"),
+                    )
+                    .unwrap();
+            }
+            session
+                .accept(&parse_adapter_frame(&frame.to_string()).unwrap())
+                .unwrap();
+        }
+        session.finish().unwrap();
+    }
+
+    #[test]
+    fn golden_fixtures_cover_built_ins_and_external_adapter() {
+        for raw in [
+            include_str!("../tests/fixtures/harness-contract/v1/codex.json"),
+            include_str!("../tests/fixtures/harness-contract/v1/claude.json"),
+            include_str!("../tests/fixtures/harness-contract/v1/copilot.json"),
+            include_str!("../tests/fixtures/harness-contract/v1/coven-code.json"),
+            include_str!("../tests/fixtures/harness-contract/v1/external.json"),
+        ] {
+            assert_fixture(raw);
+        }
+    }
+
+    #[test]
+    fn unknown_optional_extension_and_field_are_forward_compatible() {
+        let mut adapter = ContractOffer::v1();
+        adapter
+            .optional_extensions
+            .push("future.telemetry.v9".to_string());
+        let negotiated = negotiate(&ContractOffer::v1(), &adapter).unwrap();
+        assert!(negotiated.extensions.is_empty());
+
+        let frame = parse_adapter_frame(
+            r#"{"type":"output","session_id":"s","sequence":1,"kind":"text","text":"ok","futureField":{"safe":true}}"#,
+        )
+        .unwrap();
+        assert!(matches!(frame, AdapterFrame::Output { .. }));
+    }
+
+    #[test]
+    fn unsupported_version_and_unknown_required_extension_fail_closed() {
+        let mut adapter = ContractOffer::v1();
+        adapter.versions = vec!["coven.harness.v2".to_string()];
+        assert_eq!(
+            negotiate(&ContractOffer::v1(), &adapter).unwrap_err().code,
+            "unsupported_contract_version"
+        );
+
+        let mut adapter = ContractOffer::v1();
+        adapter
+            .required_extensions
+            .push("future.telemetry.v9".to_string());
+        assert_eq!(
+            negotiate(&ContractOffer::v1(), &adapter).unwrap_err().code,
+            "unknown_required_extension"
+        );
+    }
+
+    #[test]
+    fn missing_required_frame_fields_and_partial_failure_are_explicit() {
+        assert_eq!(
+            parse_adapter_frame(
+                r#"{"type":"output","session_id":"s","sequence":1,"text":"missing kind"}"#
+            )
+            .unwrap_err()
+            .code,
+            "invalid_adapter_frame"
+        );
+
+        let mut session = SessionConformance::new("s");
+        session
+            .accept(&parse_adapter_frame(r#"{"type":"ready","session_id":"s"}"#).unwrap())
+            .unwrap();
+        session
+            .accept(&parse_adapter_frame(r#"{"type":"output","session_id":"s","sequence":1,"kind":"text","text":"partial output survives"}"#).unwrap())
+            .unwrap();
+        session
+            .accept(&parse_adapter_frame(r#"{"type":"terminal","session_id":"s","sequence":2,"outcome":"failed","error":{"code":"provider_error","message":"upstream failed"}}"#).unwrap())
+            .unwrap();
+        assert_eq!(session.finish().unwrap(), TerminalOutcome::Failed);
+    }
+
+    #[test]
+    fn structured_input_and_cancellation_have_required_session_and_request_ids() {
+        let input = parse_runner_frame(
+            r#"{"type":"input","session_id":"s","request_id":"turn-1","content":{"type":"text","text":"hello"}}"#,
+        )
+        .unwrap();
+        assert!(matches!(input, RunnerFrame::Input { .. }));
+        assert_eq!(
+            parse_runner_frame(r#"{"type":"cancel","session_id":"s"}"#)
+                .unwrap_err()
+                .code,
+            "invalid_runner_frame"
+        );
+    }
+}

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -25,6 +25,9 @@ mod eval_loop;
 mod executor_node;
 mod familiar_identity;
 mod harness;
+/// Public at the crate root so every adapter entrypoint shares one contract
+/// vocabulary instead of re-declaring embedded runner details.
+pub mod harness_contract;
 mod hub;
 mod memory_dashboard;
 mod memory_import;

--- a/crates/coven-cli/tests/fixtures/harness-contract/v1/claude.json
+++ b/crates/coven-cli/tests/fixtures/harness-contract/v1/claude.json
@@ -1,0 +1,13 @@
+{
+  "adapterId": "claude",
+  "offer": { "contract": "coven.harness", "versions": ["coven.harness.v1"], "optionalExtensions": ["input.image.v1"] },
+  "capabilities": { "stream": true, "preassigned_session_id": true, "think": true, "speed": true },
+  "sessionId": "fixture-claude",
+  "cancellationRequestId": "cancel-claude",
+  "frames": [
+    { "type": "ready", "session_id": "fixture-claude" },
+    { "type": "output", "session_id": "fixture-claude", "sequence": 1, "kind": "semantic", "text": "partial turn" },
+    { "type": "cancellation_acknowledged", "session_id": "fixture-claude", "request_id": "cancel-claude" },
+    { "type": "terminal", "session_id": "fixture-claude", "sequence": 2, "outcome": "cancelled" }
+  ]
+}

--- a/crates/coven-cli/tests/fixtures/harness-contract/v1/codex.json
+++ b/crates/coven-cli/tests/fixtures/harness-contract/v1/codex.json
@@ -1,0 +1,11 @@
+{
+  "adapterId": "codex",
+  "offer": { "contract": "coven.harness", "versions": ["coven.harness.v1"] },
+  "capabilities": { "stream": false, "preassigned_session_id": false, "think": false, "speed": false },
+  "sessionId": "fixture-codex",
+  "frames": [
+    { "type": "ready", "session_id": "fixture-codex" },
+    { "type": "output", "session_id": "fixture-codex", "sequence": 1, "kind": "semantic", "text": "reply" },
+    { "type": "terminal", "session_id": "fixture-codex", "sequence": 2, "outcome": "completed" }
+  ]
+}

--- a/crates/coven-cli/tests/fixtures/harness-contract/v1/copilot.json
+++ b/crates/coven-cli/tests/fixtures/harness-contract/v1/copilot.json
@@ -1,0 +1,11 @@
+{
+  "adapterId": "copilot",
+  "offer": { "contract": "coven.harness", "versions": ["coven.harness.v1"] },
+  "capabilities": { "stream": false, "preassigned_session_id": true, "think": true, "speed": true },
+  "sessionId": "fixture-copilot",
+  "frames": [
+    { "type": "ready", "session_id": "fixture-copilot" },
+    { "type": "output", "session_id": "fixture-copilot", "sequence": 1, "kind": "text", "text": "partial output" },
+    { "type": "terminal", "session_id": "fixture-copilot", "sequence": 2, "outcome": "failed", "error": { "code": "provider_error", "message": "upstream rejected the turn" } }
+  ]
+}

--- a/crates/coven-cli/tests/fixtures/harness-contract/v1/coven-code.json
+++ b/crates/coven-cli/tests/fixtures/harness-contract/v1/coven-code.json
@@ -1,0 +1,11 @@
+{
+  "adapterId": "coven-code",
+  "offer": { "contract": "coven.harness", "versions": ["coven.harness.v1"], "optionalExtensions": ["input.image.v1", "output.tool-use.v1"] },
+  "capabilities": { "stream": true, "preassigned_session_id": true, "think": true, "speed": true },
+  "sessionId": "fixture-coven-code",
+  "frames": [
+    { "type": "ready", "session_id": "fixture-coven-code" },
+    { "type": "output", "session_id": "fixture-coven-code", "sequence": 1, "kind": "semantic", "text": "engine response" },
+    { "type": "terminal", "session_id": "fixture-coven-code", "sequence": 2, "outcome": "completed" }
+  ]
+}

--- a/crates/coven-cli/tests/fixtures/harness-contract/v1/external.json
+++ b/crates/coven-cli/tests/fixtures/harness-contract/v1/external.json
@@ -1,0 +1,10 @@
+{
+  "adapterId": "external-fixture",
+  "offer": { "contract": "coven.harness", "versions": ["coven.harness.v1"], "optionalExtensions": ["future.telemetry.v9"] },
+  "sessionId": "fixture-external",
+  "frames": [
+    { "type": "ready", "session_id": "fixture-external", "futureReadyField": true },
+    { "type": "output", "session_id": "fixture-external", "sequence": 1, "kind": "raw", "text": "external adapter raw output", "futureOutputField": "ignored" },
+    { "type": "terminal", "session_id": "fixture-external", "sequence": 2, "outcome": "completed" }
+  ]
+}

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -18,6 +18,12 @@ The goal is a harness-neutral runtime:
 - Provider auth, model/provider config, tools, skills, and memory stay inside that external harness.
 - Clients can discover supported adapters with `coven adapter list` instead of hard-coding "Codex vs Claude" assumptions.
 
+The runner-to-adapter wire and lifecycle boundary is now specified separately
+as [the versioned adapter contract](reference/adapter-spec.md). Manifest data
+describes invocation; the contract defines how an adapter proves capability,
+input, output, terminal state, cancellation, and error behavior without
+depending on embedded runner internals.
+
 ## Current adapter shape
 
 A Coven harness adapter defines:

--- a/docs/HARNESS-ADAPTERS.md
+++ b/docs/HARNESS-ADAPTERS.md
@@ -19,7 +19,7 @@ The goal is a harness-neutral runtime:
 - Clients can discover supported adapters with `coven adapter list` instead of hard-coding "Codex vs Claude" assumptions.
 
 The runner-to-adapter wire and lifecycle boundary is now specified separately
-as [the versioned adapter contract](reference/adapter-spec.md). Manifest data
+as [the versioned adapter contract](/reference/adapter-spec). Manifest data
 describes invocation; the contract defines how an adapter proves capability,
 input, output, terminal state, cancellation, and error behavior without
 depending on embedded runner internals.

--- a/docs/harnesses/index.md
+++ b/docs/harnesses/index.md
@@ -10,6 +10,10 @@ description: "Coven supports coding-agent CLIs as harnesses through PTY adapters
 
 A **harness** is an external coding-agent CLI that Coven can launch and supervise inside an explicit project root. Coven owns the PTY, the session record, and the event log; the harness owns the conversation, the tool calls, and provider authentication.
 
+For adapter authors, the versioned [Adapter contract](/ADAPTER-SPEC) defines
+the negotiated capability, stream, lifecycle, cancellation, and error boundary
+between the Rust runner and each harness integration.
+
 <Columns>
   <Card title="Codex" href="/harnesses/codex" icon="binary">
     OpenAI Codex CLI. Harness id `codex`.

--- a/docs/harnesses/index.md
+++ b/docs/harnesses/index.md
@@ -10,7 +10,7 @@ description: "Coven supports coding-agent CLIs as harnesses through PTY adapters
 
 A **harness** is an external coding-agent CLI that Coven can launch and supervise inside an explicit project root. Coven owns the PTY, the session record, and the event log; the harness owns the conversation, the tool calls, and provider authentication.
 
-For adapter authors, the versioned [Adapter contract](/ADAPTER-SPEC) defines
+For adapter authors, the versioned [Adapter contract](/reference/adapter-spec) defines
 the negotiated capability, stream, lifecycle, cancellation, and error boundary
 between the Rust runner and each harness integration.
 

--- a/docs/reference/adapter-spec.md
+++ b/docs/reference/adapter-spec.md
@@ -1,9 +1,133 @@
 ---
-summary: "What a new harness adapter must implement."
+summary: "The versioned contract every Coven harness adapter must satisfy."
 read_when:
   - Authoring a new adapter
-title: "Adapter spec"
-description: "Specification for Coven harness adapters: the PTY contract, session metadata, project root canonicalization, and capability negotiation each adapter implements."
+  - Updating harness streaming or cancellation behavior
+title: "Adapter contract"
+description: "Coven harness contract v1: negotiated capabilities, input, streamed output, lifecycle, cancellation, errors, compatibility, and conformance fixtures."
 ---
 
-Stub — fill in.
+# Adapter contract
+
+`coven.harness.v1` is the compatibility boundary between Coven's Rust-owned
+runner and a harness adapter. It prevents a harness integration from depending
+on hidden runner behavior while preserving Coven's authority over project-root
+validation, policy, process ownership, persistence, and the daemon API.
+
+The contract is deliberately narrower than a harness's native protocol. An
+adapter translates one external CLI into this contract; it never delegates
+authority decisions back to a client or to untrusted adapter output.
+
+## Negotiation
+
+Before a v1 adapter is admitted, the runner and adapter exchange an offer:
+
+```json
+{
+  "contract": "coven.harness",
+  "versions": ["coven.harness.v1"],
+  "requiredExtensions": [],
+  "optionalExtensions": ["input.image.v1"]
+}
+```
+
+The runner selects the highest mutually supported version. There is no
+implicit downgrade: a missing intersection fails with
+`unsupported_contract_version` before any harness argv is constructed or a
+process is spawned. A different contract name fails with
+`contract_name_mismatch`.
+
+The current v1 extensions are `input.image.v1` and `output.tool-use.v1`.
+Their use is optional. An unknown optional extension is ignored; an unknown
+required extension fails closed with `unknown_required_extension`; and a known
+required extension that the peer does not offer fails with
+`required_extension_unavailable`.
+
+## Required v1 behavior
+
+These behaviors are part of the v1 base contract and do not need extension
+names:
+
+- The adapter reports a `ready` frame for the Coven session id.
+- Text input is a runner `input` frame with a session id, request id, and
+  typed content. It is accepted only while the session is live. Image content
+  requires the negotiated `input.image.v1` extension.
+- Output is framed, ordered, and tagged with the Coven session id. `text`,
+  `raw`, and `semantic` output are distinct kinds; raw output is evidence, not
+  a success signal.
+- Output and terminal frames use a strictly increasing `sequence` value.
+- The adapter emits exactly one terminal frame: `completed`, `failed`, or
+  `cancelled`. A `failed` terminal includes a non-empty machine-readable
+  `error.code` and a human-readable `error.message`.
+- A cancellation request is explicit. The adapter may acknowledge it with
+  `cancellation_acknowledged` and must then terminate `cancelled`, or it may
+  terminate `cancelled` directly. Coven may force-stop its owned process tree
+  after the cancellation deadline; that is recorded as forced cancellation,
+  never as a clean completion.
+
+The runner retains any output emitted before a failure or cancellation. Missing
+terminal frames, frames after terminal, mismatched session ids, non-monotonic
+sequences, malformed required fields, and unknown frame types are protocol
+failures. They must mark the run failed rather than becoming a
+success-shaped fallback.
+
+## Frame examples
+
+The runner sends a structured input or cancellation request:
+
+```json
+{"type":"input","session_id":"session-1","request_id":"turn-1","content":{"type":"text","text":"Fix the failing test."}}
+{"type":"cancel","session_id":"session-1","request_id":"cancel-1"}
+```
+
+The adapter then replies with its lifecycle and output frames:
+
+```json
+{"type":"ready","session_id":"session-1"}
+{"type":"output","session_id":"session-1","sequence":1,"kind":"semantic","text":"I found the failing test."}
+{"type":"terminal","session_id":"session-1","sequence":2,"outcome":"completed"}
+```
+
+Failure preserves prior frames and closes explicitly:
+
+```json
+{"type":"terminal","session_id":"session-1","sequence":2,"outcome":"failed","error":{"code":"provider_error","message":"Provider rejected the turn."}}
+```
+
+Fields added in a later version are optional by default. V1 readers ignore an
+unknown field on a known frame, but never ignore a missing base field or an
+unknown `type`. This makes compatible additions safe without treating spelling
+errors in required protocol elements as capability.
+
+## Version and migration policy
+
+`coven.harness.v1` is additive within v1. Removing or changing a required
+field, frame type, lifecycle meaning, cancellation meaning, or error behavior
+requires a new contract version. The daemon API version (`coven.daemon.v1`) and
+the harness contract version are independent: the first governs client-to-
+daemon requests, while this contract governs the runner-to-adapter boundary.
+
+Existing manifest/PTY recipes remain supported during migration through the
+legacy compatibility bridge. They are not treated as v1 adapters merely
+because their command arguments happen to work. New adapters should implement
+and advertise v1; existing adapters graduate after their golden fixture passes
+and their real smoke test proves the declared lifecycle and cancellation path.
+There is no flag-day release: legacy recipes retain their conservative,
+one-shot behavior until they opt into the negotiated contract.
+
+## Conformance suite
+
+The committed golden vectors live at
+`crates/coven-cli/tests/fixtures/harness-contract/v1/`. They cover Codex,
+Claude Code, Copilot CLI, Coven Code, and an external adapter. The Rust suite
+checks negotiation, forward-compatible optional fields, required-field failure,
+monotonic lifecycle ordering, partial failure, and cancellation acknowledgement.
+
+Run the focused suite with:
+
+```bash
+cargo test -p coven-cli harness_contract
+```
+
+Golden fixtures contain only synthetic session ids and output. Do not put real
+paths, prompts, transcripts, credentials, or provider responses in them.

--- a/docs/reference/harness-adapters.md
+++ b/docs/reference/harness-adapters.md
@@ -6,6 +6,8 @@ title: "Harness adapters"
 description: "Reference for Coven harness adapters: the PTY contract, session metadata, project root canonicalization, and capability negotiation each adapter implements."
 ---
 
-> Canonical content currently lives in the [harness adapter guide](/HARNESS-ADAPTERS) (`docs/HARNESS-ADAPTERS.md`). This reference page will be filled in once the adapter contract stabilizes.
-
-Stub — fill in.
+The invocation and support-policy guide is [Harness adapter guide](/HARNESS-ADAPTERS).
+The normative runner-to-adapter protocol is [Adapter contract](/ADAPTER-SPEC):
+negotiation, capability extensions, input/output framing, lifecycle,
+cancellation, errors, migration policy, and conformance fixtures all live
+there.

--- a/docs/reference/harness-adapters.md
+++ b/docs/reference/harness-adapters.md
@@ -7,7 +7,7 @@ description: "Reference for Coven harness adapters: the PTY contract, session me
 ---
 
 The invocation and support-policy guide is [Harness adapter guide](/HARNESS-ADAPTERS).
-The normative runner-to-adapter protocol is [Adapter contract](/ADAPTER-SPEC):
+The normative runner-to-adapter protocol is [Adapter contract](/reference/adapter-spec):
 negotiation, capability extensions, input/output framing, lifecycle,
 cancellation, errors, migration policy, and conformance fixtures all live
 there.


### PR DESCRIPTION
Closes #595

## Summary

Harness adapters previously relied on versionless, embedded runner/PTY behavior. That made compatibility, cancellation, partial output, and extension evolution implicit.

## Solution

Define `coven.harness.v1` as a typed, negotiated boundary with fail-closed required capabilities and forward-compatible optional additions. Add synthetic golden conformance vectors for Codex, Claude Code, Copilot CLI, Coven Code, and one external adapter.

## Important changes

- Adds negotiation, typed input/output frames, terminal errors, sequence validation, and cancellation conformance state.
- Makes unsupported versions and unknown required extensions explicit protocol failures.
- Documents lifecycle, migration/no-flag-day policy, fixture privacy, and the canonical adapter contract.

## Validation

- `cargo fmt --all -- --check`
- Focused harness-contract suite: 5 passed
- `node --test scripts/cli-docs-test.mjs` (6 passed)
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- Exact-head CI: Rust checks (ubuntu-latest), secret guard, contract, package, and smoke checks passed. Windows Rust/npm checks remain in progress.

## Risks / follow-up

This establishes the contract and conformance boundary without forcing a flag-day conversion of existing PTY recipes. Individual live adapters should opt into v1 incrementally with real smoke tests for their advertised lifecycle and cancellation paths.