### PR TITLE
perf: add bounded daemon event writer

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -148,6 +148,10 @@ pub struct HealthResponse {
     /// response is built without store access (e.g. CLI status printing).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hub: Option<HubHealth>,
+    /// Daemon-owned event persistence health.  Omitted for status rendering
+    /// paths that do not have a live runtime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_writer: Option<crate::event_writer::EventWriterHealth>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -215,6 +219,10 @@ pub trait SessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()>;
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()>;
     fn kill_session(&self, session_id: &str) -> Result<()>;
+
+    fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
+        None
+    }
 }
 
 pub struct NoopSessionRuntime;
@@ -250,11 +258,17 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
         },
         daemon,
         hub: None,
+        event_writer: None,
     }
 }
 
-fn health_response_with_hub(coven_home: &Path, daemon: Option<DaemonStatus>) -> HealthResponse {
+fn health_response_with_hub(
+    coven_home: &Path,
+    daemon: Option<DaemonStatus>,
+    event_writer: Option<crate::event_writer::EventWriterHealth>,
+) -> HealthResponse {
     let mut response = health_response(daemon);
+    response.event_writer = event_writer;
     if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
         response.hub = serde_json::from_value(summary).ok();
     }
@@ -315,7 +329,10 @@ pub fn handle_request_with_runtime(
                 "supportedApiVersions": SUPPORTED_API_ROUTE_VERSIONS,
             }),
         ),
-        ("GET", "/health") => json_response(200, &health_response_with_hub(coven_home, daemon)),
+        ("GET", "/health") => json_response(
+            200,
+            &health_response_with_hub(coven_home, daemon, runtime.event_writer_health()),
+        ),
         ("GET", "/capabilities") => json_response(200, &control_plane::capabilities()),
         ("GET", "/overview") => overview_response(coven_home),
         ("POST", "/actions") => {

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -85,6 +85,7 @@ impl std::error::Error for NotLiveError {}
 #[derive(Default)]
 pub struct LiveSessionRuntime {
     coven_home: Option<PathBuf>,
+    event_writer: Option<crate::event_writer::EventWriter>,
     sessions: Arc<Mutex<HashMap<String, LiveSessionHandle>>>,
 }
 
@@ -163,11 +164,19 @@ impl LiveSessionExitCleanup {
 }
 
 impl LiveSessionRuntime {
+    #[cfg(test)]
     pub fn with_coven_home(coven_home: PathBuf) -> Self {
-        Self {
+        Self::try_with_coven_home(coven_home)
+            .expect("daemon event writer must start for a live session runtime")
+    }
+
+    pub fn try_with_coven_home(coven_home: PathBuf) -> Result<Self> {
+        let event_writer = crate::event_writer::EventWriter::start(coven_home.clone())?;
+        Ok(Self {
             coven_home: Some(coven_home),
+            event_writer: Some(event_writer),
             sessions: Arc::default(),
-        }
+        })
     }
 
     #[allow(dead_code)]
@@ -246,7 +255,7 @@ impl LiveSessionRuntime {
             registration: Arc::clone(&registration),
         };
         (
-            output_observer_with_cleanup(self.coven_home.clone(), session_id, Some(cleanup)),
+            output_observer_with_cleanup(self.event_writer.clone(), session_id, Some(cleanup)),
             registration,
         )
     }
@@ -515,6 +524,12 @@ impl SessionRuntime for LiveSessionRuntime {
             .map_err(|_| anyhow::anyhow!("live session killer lock poisoned"))?;
         killer.kill()
     }
+
+    fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
+        self.event_writer
+            .as_ref()
+            .map(crate::event_writer::EventWriter::health)
+    }
 }
 
 fn piped_killer(pid: u32) -> Box<dyn RuntimeKiller> {
@@ -682,18 +697,26 @@ impl RuntimeKiller for Box<dyn portable_pty::ChildKiller + Send + Sync> {
 
 #[cfg(test)]
 fn output_observer(coven_home: PathBuf, session_id: String) -> pty_runner::DetachedPtyObserver {
-    output_observer_with_cleanup(Some(coven_home), session_id, None)
+    let writer =
+        crate::event_writer::EventWriter::start(coven_home).expect("test event writer must start");
+    output_observer_with_cleanup(Some(writer), session_id, None)
 }
 
 fn output_observer_with_cleanup(
-    coven_home: Option<PathBuf>,
+    writer: Option<crate::event_writer::EventWriter>,
     session_id: String,
     cleanup: Option<LiveSessionExitCleanup>,
 ) -> pty_runner::DetachedPtyObserver {
-    let output_home = coven_home.clone();
+    let output_writer = writer.clone();
     let output_session_id = session_id.clone();
-    let exit_home = coven_home;
+    let exit_writer = writer;
     let exit_session_id = session_id;
+    // The piped runner drains stdout and stderr independently.  Serialize the
+    // final output submission with exit so a late stderr callback cannot add a
+    // newly accepted output event after the exit barrier has committed.
+    let event_closed = Arc::new(Mutex::new(false));
+    let output_closed = Arc::clone(&event_closed);
+    let exit_closed = event_closed;
     // UTF-8 boundary safety is enforced by `drain_detached_output` in
     // pty_runner per-source (separate buffers for stdout and stderr in
     // stream mode), so each chunk we receive here is already valid
@@ -706,100 +729,66 @@ fn output_observer_with_cleanup(
             }
             let text = String::from_utf8(chunk)
                 .unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned());
-            if let Some(output_home) = output_home.as_deref() {
-                let _ = record_session_event(
-                    output_home,
-                    &output_session_id,
-                    "output",
-                    json!({ "data": text }),
+            let closed = output_closed
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if *closed {
+                eprintln!(
+                    "coven daemon: discarded output observed after exit barrier for session `{output_session_id}`"
                 );
+                return;
+            }
+            if let Some(writer) = output_writer.as_ref() {
+                match writer.record_output(&output_session_id, text) {
+                    Ok(true) => {}
+                    Ok(false) => eprintln!(
+                        "coven daemon: event writer is pressured; raw output for session `{output_session_id}` was rejected"
+                    ),
+                    Err(error) => eprintln!(
+                        "coven daemon: event writer failed while recording output for session `{output_session_id}`: {error:#}"
+                    ),
+                }
             }
         }),
         on_exit: Box::new(move |result| {
+            let mut closed = exit_closed
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *closed = true;
             if let Some(cleanup) = cleanup {
                 cleanup.mark_exited();
             }
-            if let Some(exit_home) = exit_home.as_deref() {
-                if let Err(error) = record_session_exit(exit_home, &exit_session_id, result) {
+            if let Some(writer) = exit_writer.as_ref() {
+                if let Err(error) = writer.record_exit(&exit_session_id, result) {
                     eprintln!(
                         "coven daemon: failed to persist exit for session `{exit_session_id}`: {error:#}"
                     );
                 }
             }
+            drop(closed);
         }),
     }
 }
 
+#[cfg(test)]
 fn record_session_exit(
     coven_home: &Path,
     session_id: &str,
     result: pty_runner::PtyRunResult,
 ) -> Result<()> {
-    let conn = crate::store::open_store(&coven_home.join("coven.sqlite3"))?;
-    if let Some(session) = crate::store::get_session(&conn, session_id)? {
-        if session.status == "running" {
-            // For conversation-grouped sessions (chat), a clean harness exit
-            // is not the end of the conversation — the user can prompt again
-            // and the daemon will resume into a sibling session under the
-            // same `conversation_id`. Persist `idle` so API consumers (the
-            // cockpit / dashboard) can distinguish "harness child terminated
-            // cleanly, conversation still extendable" from "session failed".
-            // Failed exits (non-zero / wait error) still surface as failure
-            // so consumers don't mistake a crashed harness for a fresh slot.
-            let persisted_status =
-                if session.conversation_id.is_some() && result.status == "completed" {
-                    "idle"
-                } else {
-                    result.status
-                };
-            crate::store::update_session_status_if_current(
-                &conn,
-                session_id,
-                "running",
-                persisted_status,
-                result.exit_code,
-                &crate::api::current_timestamp(),
-            )?;
-        }
-    }
-    crate::store::insert_event_with_privacy(
-        &conn,
-        coven_home,
-        &crate::store::EventRecord {
-            seq: 0,
-            id: uuid::Uuid::new_v4().to_string(),
-            session_id: session_id.to_string(),
-            kind: "exit".to_string(),
-            payload_json: serde_json::to_string(&json!({
-                "status": result.status,
-                "exitCode": result.exit_code,
-            }))
-            .context("failed to serialize exit event payload")?,
-            created_at: crate::api::current_timestamp(),
-        },
-    )
+    crate::event_writer::EventWriter::start(coven_home.to_path_buf())?
+        .record_exit(session_id, result)
 }
 
+#[cfg(test)]
 fn record_session_event(
     coven_home: &Path,
     session_id: &str,
     kind: &str,
     payload: Value,
 ) -> Result<()> {
-    let conn = crate::store::open_store(&coven_home.join("coven.sqlite3"))?;
-    crate::store::insert_event_with_privacy(
-        &conn,
-        coven_home,
-        &crate::store::EventRecord {
-            seq: 0,
-            id: uuid::Uuid::new_v4().to_string(),
-            session_id: session_id.to_string(),
-            kind: kind.to_string(),
-            payload_json: serde_json::to_string(&payload)
-                .context("failed to serialize session event payload")?,
-            created_at: crate::api::current_timestamp(),
-        },
-    )
+    crate::event_writer::EventWriter::start(coven_home.to_path_buf())?
+        .record(session_id, kind, payload)
 }
 
 pub fn daemon_status_path(coven_home: &Path) -> PathBuf {
@@ -2350,9 +2339,9 @@ pub fn serve_forever(
     );
     recover_orphaned_sessions(coven_home, &started_at)?;
     recover_stale_created_sessions(coven_home, &started_at)?;
-    let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
+    let runtime = Arc::new(LiveSessionRuntime::try_with_coven_home(
         coven_home.to_path_buf(),
-    ));
+    )?);
     start_threads_proposal_scheduler(coven_home)?;
 
     if let Some(addr) = tcp_addr {
@@ -2875,9 +2864,9 @@ pub fn serve_forever(
     write_status(coven_home, &status)?;
     recover_orphaned_sessions(coven_home, &started_at)?;
 
-    let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
+    let runtime = Arc::new(LiveSessionRuntime::try_with_coven_home(
         coven_home.to_path_buf(),
-    ));
+    )?);
     start_threads_proposal_scheduler(coven_home)?;
 
     const MAX_INFLIGHT: usize = 64;

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -3166,26 +3166,30 @@ mod tests {
     }
 
     #[test]
-    fn output_observer_records_each_callback_as_an_event() -> Result<()> {
+    fn output_observer_coalesces_callbacks_and_flushes_before_exit() -> Result<()> {
         // UTF-8 boundary safety lives in pty_runner::drain_detached_output
-        // now (see its tests). The observer's only job is to take each
-        // chunk it receives and persist it as an `output` event. This
-        // test pins that minimal contract by feeding the observer two
-        // pre-decoded chunks and checking they show up verbatim in the
-        // events table.
+        // now (see its tests). The writer may combine adjacent chunks, but
+        // every accepted byte must be persisted before the terminal event.
         let temp_dir = tempfile::tempdir()?;
         let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
         let session = session_record("buffered");
         crate::store::insert_session(&conn, &session)?;
 
         let observer = output_observer(temp_dir.path().to_path_buf(), session.id.clone());
-        let pty_runner::DetachedPtyObserver { mut on_output, .. } = observer;
+        let pty_runner::DetachedPtyObserver {
+            mut on_output,
+            on_exit,
+        } = observer;
 
         // The drain layer would only ever hand us valid-UTF-8 slices,
         // so simulate that: a complete emoji and then a plain ASCII
         // chunk, each fully decodable on its own.
         on_output("🎉".as_bytes().to_vec());
         on_output(b" done".to_vec());
+        on_exit(pty_runner::PtyRunResult {
+            status: "completed",
+            exit_code: Some(0),
+        });
 
         let events = crate::store::list_events(&conn, &session.id)?;
         let mut decoded = String::new();

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -1,0 +1,619 @@
+//! Bounded, daemon-owned persistence for high-volume live-session events.
+//!
+//! PTY drains must never open a SQLite connection for every raw read.  This
+//! module owns one connection on one worker thread, accepts a byte-bounded
+//! stream of events, and commits short batches.  Terminal events reserve space
+//! and wait for a commit acknowledgement, so an accepted output chunk cannot
+//! be overtaken by a following exit event.
+
+use std::{
+    collections::VecDeque,
+    path::PathBuf,
+    sync::{mpsc, Arc, Condvar, Mutex},
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{anyhow, Context, Result};
+use rusqlite::Connection;
+use serde::Serialize;
+use serde_json::json;
+use uuid::Uuid;
+
+use crate::{pty_runner::PtyRunResult, store, STORE_FILE_NAME};
+
+const DEFAULT_CAPACITY_BYTES: usize = 2 * 1024 * 1024;
+const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
+const EVENT_OVERHEAD_BYTES: usize = 512;
+const MAX_BATCH_EVENTS: usize = 64;
+const COALESCE_WINDOW: Duration = Duration::from_millis(12);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EventWriterHealth {
+    /// `healthy`, `pressured`, or `failed`.  Pressure remains visible for the
+    /// daemon lifetime so a rejected raw chunk is never silently forgotten.
+    pub state: String,
+    pub queued_bytes: usize,
+    pub capacity_bytes: usize,
+    pub dropped_output_events: u64,
+    pub dropped_output_bytes: u64,
+    pub connection_opens: u64,
+    pub transactions: u64,
+    pub committed_events: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct EventWriter {
+    shared: Arc<Shared>,
+}
+
+struct Shared {
+    queue: Mutex<Queue>,
+    available: Condvar,
+    capacity_bytes: usize,
+    output_capacity_bytes: usize,
+    health: Mutex<EventWriterHealth>,
+}
+
+struct Queue {
+    items: VecDeque<QueuedEvent>,
+    queued_bytes: usize,
+    failed: Option<String>,
+}
+
+struct QueuedEvent {
+    event: PendingEvent,
+    bytes: usize,
+    completion: Option<mpsc::SyncSender<std::result::Result<(), String>>>,
+}
+
+enum PendingEvent {
+    Output {
+        session_id: String,
+        data: String,
+        created_at: String,
+    },
+    Record(store::EventRecord),
+    Exit {
+        session_id: String,
+        result: PtyRunResult,
+        created_at: String,
+    },
+}
+
+impl EventWriter {
+    pub fn start(coven_home: PathBuf) -> Result<Self> {
+        Self::start_with_capacity(coven_home, DEFAULT_CAPACITY_BYTES)
+    }
+
+    fn start_with_capacity(coven_home: PathBuf, capacity_bytes: usize) -> Result<Self> {
+        anyhow::ensure!(
+            capacity_bytes > RESERVED_CRITICAL_BYTES,
+            "event writer capacity must reserve room for critical events"
+        );
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(Queue {
+                items: VecDeque::new(),
+                queued_bytes: 0,
+                failed: None,
+            }),
+            available: Condvar::new(),
+            capacity_bytes,
+            output_capacity_bytes: capacity_bytes - RESERVED_CRITICAL_BYTES,
+            health: Mutex::new(EventWriterHealth {
+                state: "healthy".to_string(),
+                queued_bytes: 0,
+                capacity_bytes,
+                dropped_output_events: 0,
+                dropped_output_bytes: 0,
+                connection_opens: 0,
+                transactions: 0,
+                committed_events: 0,
+                last_error: None,
+            }),
+        });
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let worker_shared = Arc::clone(&shared);
+        thread::Builder::new()
+            .name("coven-event-writer".to_string())
+            .spawn(move || run_worker(worker_shared, coven_home, ready_tx))
+            .context("failed to spawn Coven event writer")?;
+        match ready_rx
+            .recv()
+            .context("event writer stopped before opening its store connection")?
+        {
+            Ok(()) => Ok(Self { shared }),
+            Err(message) => Err(anyhow!(message)),
+        }
+    }
+
+    /// Queue raw PTY output without blocking the drain thread.  Raw output is
+    /// the only lossy class under pressure; the health response carries the
+    /// exact rejected count and byte total.
+    pub fn record_output(&self, session_id: &str, data: String) -> Result<bool> {
+        if data.is_empty() {
+            return Ok(true);
+        }
+        let bytes = data.len().saturating_add(EVENT_OVERHEAD_BYTES);
+        let event = PendingEvent::Output {
+            session_id: session_id.to_string(),
+            data,
+            created_at: crate::api::current_timestamp(),
+        };
+        self.enqueue_output(event, bytes)
+    }
+
+    /// Persist a non-output event.  These events reserve capacity and wait for
+    /// the writer's commit acknowledgement instead of being silently dropped.
+    #[allow(dead_code)]
+    pub fn record(&self, session_id: &str, kind: &str, payload: serde_json::Value) -> Result<()> {
+        let record = store::EventRecord {
+            seq: 0,
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            kind: kind.to_string(),
+            payload_json: serde_json::to_string(&payload)
+                .context("failed to serialize event writer payload")?,
+            created_at: crate::api::current_timestamp(),
+        };
+        let bytes = record
+            .payload_json
+            .len()
+            .saturating_add(EVENT_OVERHEAD_BYTES);
+        self.enqueue_critical(PendingEvent::Record(record), bytes)
+    }
+
+    /// Insert the terminal event only after every prior accepted event has
+    /// committed.  The caller receives database failures synchronously.
+    pub fn record_exit(&self, session_id: &str, result: PtyRunResult) -> Result<()> {
+        let bytes = EVENT_OVERHEAD_BYTES;
+        self.enqueue_critical(
+            PendingEvent::Exit {
+                session_id: session_id.to_string(),
+                result,
+                created_at: crate::api::current_timestamp(),
+            },
+            bytes,
+        )
+    }
+
+    pub fn health(&self) -> EventWriterHealth {
+        self.shared
+            .health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn enqueue_output(&self, event: PendingEvent, bytes: usize) -> Result<bool> {
+        let mut queue = self.lock_queue();
+        if let Some(error) = &queue.failed {
+            return Err(anyhow!(error.clone()));
+        }
+        if bytes > self.shared.output_capacity_bytes
+            || queue.queued_bytes.saturating_add(bytes) > self.shared.output_capacity_bytes
+        {
+            let mut health = self.lock_health();
+            health.state = "pressured".to_string();
+            health.dropped_output_events += 1;
+            health.dropped_output_bytes += bytes.saturating_sub(EVENT_OVERHEAD_BYTES) as u64;
+            return Ok(false);
+        }
+        queue.queued_bytes += bytes;
+        self.update_queued_bytes(queue.queued_bytes);
+        queue.items.push_back(QueuedEvent {
+            event,
+            bytes,
+            completion: None,
+        });
+        self.shared.available.notify_one();
+        Ok(true)
+    }
+
+    fn enqueue_critical(&self, event: PendingEvent, bytes: usize) -> Result<()> {
+        anyhow::ensure!(
+            bytes <= self.shared.capacity_bytes,
+            "critical event exceeds event writer capacity"
+        );
+        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let mut queue = self.lock_queue();
+        loop {
+            if let Some(error) = &queue.failed {
+                return Err(anyhow!(error.clone()));
+            }
+            if queue.queued_bytes.saturating_add(bytes) <= self.shared.capacity_bytes {
+                break;
+            }
+            queue = self
+                .shared
+                .available
+                .wait(queue)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        queue.queued_bytes += bytes;
+        self.update_queued_bytes(queue.queued_bytes);
+        queue.items.push_back(QueuedEvent {
+            event,
+            bytes,
+            completion: Some(completion_tx),
+        });
+        self.shared.available.notify_one();
+        drop(queue);
+        match completion_rx
+            .recv()
+            .context("event writer stopped before committing a critical event")?
+        {
+            Ok(()) => Ok(()),
+            Err(message) => Err(anyhow!(message)),
+        }
+    }
+
+    fn lock_queue(&self) -> std::sync::MutexGuard<'_, Queue> {
+        self.shared
+            .queue
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn lock_health(&self) -> std::sync::MutexGuard<'_, EventWriterHealth> {
+        self.shared
+            .health
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    fn update_queued_bytes(&self, bytes: usize) {
+        self.lock_health().queued_bytes = bytes;
+    }
+}
+
+fn run_worker(
+    shared: Arc<Shared>,
+    coven_home: PathBuf,
+    ready: mpsc::SyncSender<std::result::Result<(), String>>,
+) {
+    let path = coven_home.join(STORE_FILE_NAME);
+    let mut conn = match store::open_initialized_store(&path) {
+        Ok(conn) => {
+            let mut health = lock_health(&shared);
+            health.connection_opens = 1;
+            let _ = ready.send(Ok(()));
+            conn
+        }
+        Err(error) => {
+            let message = format!("failed to open daemon event writer: {error:#}");
+            fail_writer(&shared, message.clone());
+            let _ = ready.send(Err(message));
+            return;
+        }
+    };
+
+    loop {
+        let batch = take_batch(&shared);
+        let bytes: usize = batch.iter().map(|item| item.bytes).sum();
+        let result = commit_batch(&mut conn, &coven_home, &batch);
+        release_bytes(&shared, bytes);
+        match result {
+            Ok(committed) => {
+                let mut health = lock_health(&shared);
+                health.transactions += 1;
+                health.committed_events += committed as u64;
+                drop(health);
+                complete(&batch, Ok(()));
+            }
+            Err(error) => {
+                let message = format!("event writer commit failed: {error:#}");
+                fail_writer(&shared, message.clone());
+                complete(&batch, Err(message));
+                return;
+            }
+        }
+    }
+}
+
+fn take_batch(shared: &Arc<Shared>) -> Vec<QueuedEvent> {
+    let mut queue = lock_queue(shared);
+    while queue.items.is_empty() {
+        queue = shared
+            .available
+            .wait(queue)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+    let mut batch = vec![queue.items.pop_front().expect("queue was checked")];
+    let deadline = Instant::now() + COALESCE_WINDOW;
+    while batch.len() < MAX_BATCH_EVENTS {
+        if let Some(item) = queue.items.pop_front() {
+            batch.push(item);
+            continue;
+        }
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            break;
+        };
+        let (next, timeout) = shared
+            .available
+            .wait_timeout(queue, remaining)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        queue = next;
+        if timeout.timed_out() {
+            break;
+        }
+    }
+    batch
+}
+
+fn commit_batch(
+    conn: &mut Connection,
+    coven_home: &std::path::Path,
+    batch: &[QueuedEvent],
+) -> Result<usize> {
+    let transaction = conn
+        .transaction()
+        .context("failed to begin event writer transaction")?;
+    let mut committed = 0;
+    let mut output: Option<store::EventRecord> = None;
+    for item in batch {
+        match &item.event {
+            PendingEvent::Output {
+                session_id,
+                data,
+                created_at,
+            } => {
+                if let Some(pending) = output
+                    .as_mut()
+                    .filter(|pending| pending.session_id == *session_id)
+                {
+                    let mut payload: serde_json::Value =
+                        serde_json::from_str(&pending.payload_json)
+                            .context("event writer output payload was not JSON")?;
+                    let existing = payload
+                        .get_mut("data")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or_default()
+                        .to_string();
+                    payload["data"] = serde_json::Value::String(format!("{existing}{data}"));
+                    pending.payload_json =
+                        serde_json::to_string(&payload).context("failed to coalesce raw output")?;
+                } else {
+                    flush_output(&transaction, coven_home, &mut output, &mut committed)?;
+                    output = Some(output_record(session_id, data, created_at)?);
+                }
+            }
+            PendingEvent::Record(record) => {
+                flush_output(&transaction, coven_home, &mut output, &mut committed)?;
+                store::insert_event_with_privacy(&transaction, coven_home, record)?;
+                committed += 1;
+            }
+            PendingEvent::Exit {
+                session_id,
+                result,
+                created_at,
+            } => {
+                flush_output(&transaction, coven_home, &mut output, &mut committed)?;
+                record_exit(&transaction, coven_home, session_id, result, created_at)?;
+                committed += 1;
+            }
+        }
+    }
+    flush_output(&transaction, coven_home, &mut output, &mut committed)?;
+    transaction
+        .commit()
+        .context("failed to commit event writer transaction")?;
+    Ok(committed)
+}
+
+fn output_record(session_id: &str, data: &str, created_at: &str) -> Result<store::EventRecord> {
+    Ok(store::EventRecord {
+        seq: 0,
+        id: Uuid::new_v4().to_string(),
+        session_id: session_id.to_string(),
+        kind: "output".to_string(),
+        payload_json: serde_json::to_string(&json!({ "data": data }))
+            .context("failed to serialize raw output")?,
+        created_at: created_at.to_string(),
+    })
+}
+
+fn flush_output(
+    conn: &Connection,
+    coven_home: &std::path::Path,
+    output: &mut Option<store::EventRecord>,
+    committed: &mut usize,
+) -> Result<()> {
+    if let Some(record) = output.take() {
+        store::insert_event_with_privacy(conn, coven_home, &record)?;
+        *committed += 1;
+    }
+    Ok(())
+}
+
+fn record_exit(
+    conn: &Connection,
+    coven_home: &std::path::Path,
+    session_id: &str,
+    result: &PtyRunResult,
+    created_at: &str,
+) -> Result<()> {
+    if let Some(session) = store::get_session(conn, session_id)? {
+        if session.status == "running" {
+            let persisted_status =
+                if session.conversation_id.is_some() && result.status == "completed" {
+                    "idle"
+                } else {
+                    result.status
+                };
+            store::update_session_status_if_current(
+                conn,
+                session_id,
+                "running",
+                persisted_status,
+                result.exit_code,
+                created_at,
+            )?;
+        }
+    }
+    store::insert_event_with_privacy(
+        conn,
+        coven_home,
+        &store::EventRecord {
+            seq: 0,
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            kind: "exit".to_string(),
+            payload_json: serde_json::to_string(&json!({
+                "status": result.status,
+                "exitCode": result.exit_code,
+            }))
+            .context("failed to serialize exit event payload")?,
+            created_at: created_at.to_string(),
+        },
+    )
+}
+
+fn release_bytes(shared: &Arc<Shared>, bytes: usize) {
+    let mut queue = lock_queue(shared);
+    queue.queued_bytes = queue.queued_bytes.saturating_sub(bytes);
+    lock_health(shared).queued_bytes = queue.queued_bytes;
+    shared.available.notify_all();
+}
+
+fn complete(batch: &[QueuedEvent], result: std::result::Result<(), String>) {
+    for item in batch {
+        if let Some(completion) = &item.completion {
+            let _ = completion.send(result.clone());
+        }
+    }
+}
+
+fn fail_writer(shared: &Arc<Shared>, message: String) {
+    let mut queue = lock_queue(shared);
+    queue.failed = Some(message.clone());
+    let mut health = lock_health(shared);
+    health.state = "failed".to_string();
+    health.last_error = Some(message);
+    shared.available.notify_all();
+}
+
+fn lock_queue(shared: &Arc<Shared>) -> std::sync::MutexGuard<'_, Queue> {
+    shared
+        .queue
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn lock_health(shared: &Arc<Shared>) -> std::sync::MutexGuard<'_, EventWriterHealth> {
+    shared
+        .health
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session(id: &str) -> store::SessionRecord {
+        store::SessionRecord {
+            id: id.to_string(),
+            project_root: "/repo".to_string(),
+            harness: "codex".to_string(),
+            title: id.to_string(),
+            status: "running".to_string(),
+            exit_code: None,
+            archived_at: None,
+            created_at: "2026-08-04T00:00:00Z".to_string(),
+            updated_at: "2026-08-04T00:00:00Z".to_string(),
+            conversation_id: None,
+            familiar_id: None,
+            labels: Vec::new(),
+            visibility: "private".to_string(),
+            external: false,
+            transcript_path: None,
+        }
+    }
+
+    #[test]
+    fn coalesces_output_and_flushes_it_before_exit() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start(home.path().to_path_buf())?;
+        assert!(writer.record_output("s-1", "hello ".to_string())?);
+        assert!(writer.record_output("s-1", "world".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].kind, "output");
+        assert!(events[0].payload_json.contains("hello world"));
+        assert_eq!(events[1].kind, "exit");
+        assert_eq!(
+            store::get_session(&conn, "s-1")?.unwrap().status,
+            "completed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn one_connection_and_batched_transactions_handle_noisy_output() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        for id in 0..8 {
+            store::insert_session(&conn, &session(&format!("s-{id}")))?;
+        }
+        let writer = EventWriter::start_with_capacity(home.path().to_path_buf(), 512 * 1024)?;
+        for index in 0..128 {
+            assert!(writer.record_output(&format!("s-{}", index % 8), "x".repeat(256))?);
+        }
+        for id in 0..8 {
+            writer.record_exit(
+                &format!("s-{id}"),
+                PtyRunResult {
+                    status: "completed",
+                    exit_code: Some(0),
+                },
+            )?;
+        }
+        let health = writer.health();
+        assert_eq!(health.connection_opens, 1);
+        // The old path opened a connection and committed once per callback
+        // (136 times here).  This stays well below the issue's 80% reduction
+        // target even though terminal events synchronously acknowledge.
+        assert!(
+            health.transactions <= 16,
+            "expected batching, got {health:?}"
+        );
+        assert_eq!(health.dropped_output_events, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn pressure_is_visible_when_raw_output_exceeds_its_budget() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        let health = writer.health();
+        assert_eq!(health.state, "pressured");
+        assert_eq!(health.dropped_output_events, 1);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "failed",
+                exit_code: Some(1),
+            },
+        )?;
+        Ok(())
+    }
+}

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -285,7 +285,7 @@ fn run_worker(
         }
         Err(error) => {
             let message = format!("failed to open daemon event writer: {error:#}");
-            fail_writer(&shared, message.clone());
+            let _ = fail_writer(&shared, message.clone());
             let _ = ready.send(Err(message));
             return;
         }
@@ -295,9 +295,9 @@ fn run_worker(
         let batch = take_batch(&shared);
         let bytes: usize = batch.iter().map(|item| item.bytes).sum();
         let result = commit_batch(&mut conn, &coven_home, &batch);
-        release_bytes(&shared, bytes);
         match result {
             Ok(committed) => {
+                release_bytes(&shared, bytes);
                 let mut health = lock_health(&shared);
                 health.transactions += 1;
                 health.committed_events += committed as u64;
@@ -306,8 +306,15 @@ fn run_worker(
             }
             Err(error) => {
                 let message = format!("event writer commit failed: {error:#}");
-                fail_writer(&shared, message.clone());
+                // Latch failure before releasing capacity. Otherwise a producer
+                // can enqueue a critical event in the release/failure window and
+                // wait forever after this worker exits.
+                let pending = fail_writer(&shared, message.clone());
                 complete(&batch, Err(message));
+                complete(
+                    &pending,
+                    Err("event writer stopped after a commit failure".to_string()),
+                );
                 return;
             }
         }
@@ -487,13 +494,17 @@ fn complete(batch: &[QueuedEvent], result: std::result::Result<(), String>) {
     }
 }
 
-fn fail_writer(shared: &Arc<Shared>, message: String) {
+fn fail_writer(shared: &Arc<Shared>, message: String) -> Vec<QueuedEvent> {
     let mut queue = lock_queue(shared);
     queue.failed = Some(message.clone());
+    queue.queued_bytes = 0;
+    let pending = queue.items.drain(..).collect();
     let mut health = lock_health(shared);
     health.state = "failed".to_string();
+    health.queued_bytes = 0;
     health.last_error = Some(message);
     shared.available.notify_all();
+    pending
 }
 
 fn lock_queue(shared: &Arc<Shared>) -> std::sync::MutexGuard<'_, Queue> {
@@ -562,6 +573,26 @@ mod tests {
     }
 
     #[test]
+    fn flushes_live_output_after_the_coalesce_window() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start(home.path().to_path_buf())?;
+        assert!(writer.record_output("s-1", "still running".to_string())?);
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let events = store::list_events(&conn, "s-1")?;
+            if events.iter().any(|event| event.kind == "output") {
+                break;
+            }
+            anyhow::ensure!(Instant::now() < deadline, "live output did not flush");
+            thread::sleep(Duration::from_millis(10));
+        }
+        Ok(())
+    }
+
+    #[test]
     fn one_connection_and_batched_transactions_handle_noisy_output() -> Result<()> {
         let home = tempfile::tempdir()?;
         let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
@@ -615,5 +646,58 @@ mod tests {
             },
         )?;
         Ok(())
+    }
+
+    #[test]
+    fn writer_failure_drains_queued_critical_completions() {
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(Queue {
+                items: VecDeque::new(),
+                queued_bytes: EVENT_OVERHEAD_BYTES,
+                failed: None,
+            }),
+            available: Condvar::new(),
+            capacity_bytes: DEFAULT_CAPACITY_BYTES,
+            output_capacity_bytes: DEFAULT_CAPACITY_BYTES - RESERVED_CRITICAL_BYTES,
+            health: Mutex::new(EventWriterHealth {
+                state: "healthy".to_string(),
+                queued_bytes: EVENT_OVERHEAD_BYTES,
+                capacity_bytes: DEFAULT_CAPACITY_BYTES,
+                dropped_output_events: 0,
+                dropped_output_bytes: 0,
+                connection_opens: 0,
+                transactions: 0,
+                committed_events: 0,
+                last_error: None,
+            }),
+        });
+        let (completion, receiver) = mpsc::sync_channel(1);
+        lock_queue(&shared).items.push_back(QueuedEvent {
+            event: PendingEvent::Record(store::EventRecord {
+                seq: 0,
+                id: "event".to_string(),
+                session_id: "s-1".to_string(),
+                kind: "error".to_string(),
+                payload_json: "{}".to_string(),
+                created_at: "2026-08-04T00:00:00Z".to_string(),
+            }),
+            bytes: EVENT_OVERHEAD_BYTES,
+            completion: Some(completion),
+        });
+
+        let pending = fail_writer(&shared, "simulated failure".to_string());
+        complete(
+            &pending,
+            Err("event writer stopped after a commit failure".to_string()),
+        );
+
+        assert!(receiver
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap()
+            .is_err());
+        assert!(lock_queue(&shared).items.is_empty());
+        let health = lock_health(&shared);
+        assert_eq!(health.state, "failed");
+        assert_eq!(health.queued_bytes, 0);
     }
 }

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -22,6 +22,7 @@ mod encrypted_artifacts;
 mod engine;
 mod engine_install;
 mod eval_loop;
+mod event_writer;
 mod executor_node;
 mod familiar_identity;
 mod harness;

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -58,6 +58,16 @@ proof of `coven.daemon.v1` support.
     "startedAt": "2026-05-09T06:43:00Z",
     "socket": "/var/lib/coven/coven.sock"
   },
+  "eventWriter": {
+    "state": "healthy",
+    "queuedBytes": 0,
+    "capacityBytes": 2097152,
+    "droppedOutputEvents": 0,
+    "droppedOutputBytes": 0,
+    "connectionOpens": 1,
+    "transactions": 42,
+    "committedEvents": 513
+  },
   "hub": {
     "role": "hub",
     "hubId": "hub_01J...",
@@ -68,6 +78,13 @@ proof of `coven.daemon.v1` support.
 ```
 
 If the daemon metadata is unavailable, `daemon` may be `null`. The `hub` block reports the daemon's control-plane role and node availability summary; full node detail lives at `GET /api/v1/hub/status`.
+
+`eventWriter` is present for the daemon-owned live-session runtime. Its
+`state` is `healthy`, `pressured`, or `failed`. A pressured writer reports raw
+output that could not enter the byte-bounded queue; lifecycle, tool, error, and
+exit events reserve capacity and are not dropped for pressure. A failed writer
+includes `lastError`; clients should surface it as degraded persistence rather
+than treating the daemon's liveness as successful event durability.
 
 ### Capability fields
 

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -18,12 +18,20 @@ coven daemon status
 Typical healthy output:
 
 ```text
-Coven daemon: running (pid 12345, socket /home/alex/.coven/coven.sock)
+Coven daemon: running (pid 12345, socket <covenHome>/coven.sock)
 ```
 
 `running` means Coven found daemon metadata and verified the process/socket.
 For scripts, `coven daemon status --json` adds an `ok` field that reports
 whether the daemon health response succeeded.
+
+`GET /api/v1/health` also includes an additive `eventWriter` object for a
+running daemon. `state: "healthy"` means live-session event persistence is
+keeping up. `"pressured"` means one or more raw PTY chunks were rejected after
+the bounded queue filled; inspect `droppedOutputEvents` and
+`droppedOutputBytes`. `"failed"` means the dedicated SQLite writer could not
+commit, and `lastError` carries the diagnostic. Lifecycle events are never
+dropped for queue pressure.
 
 ## Status values
 

--- a/docs/reference/api-contract.md
+++ b/docs/reference/api-contract.md
@@ -67,9 +67,23 @@ GET /api/v1/health
     "eventCursor": "sequence",
     "structuredErrors": true
   },
-  "daemon": { "pid": 12345, "startedAt": "2026-07-14T12:00:00Z", "socket": "<covenHome>/coven.sock" }
+  "daemon": { "pid": 12345, "startedAt": "2026-07-14T12:00:00Z", "socket": "<covenHome>/coven.sock" },
+  "eventWriter": {
+    "state": "healthy",
+    "queuedBytes": 0,
+    "capacityBytes": 2097152,
+    "droppedOutputEvents": 0,
+    "droppedOutputBytes": 0,
+    "connectionOpens": 1,
+    "transactions": 42,
+    "committedEvents": 513
+  }
 }
 ```
+
+When present, `eventWriter.state` is `healthy`, `pressured`, or `failed`.
+Pressure reports explicitly rejected raw output; lifecycle and terminal events
+reserve queue capacity and are never discarded for queue pressure.
 
 If a client requires a capability the daemon does not advertise, the client should fail loudly with a remediation hint (`upgrade Coven to >= N`).
 


### PR DESCRIPTION
## Summary

Closes #596

Live PTY callbacks previously opened a SQLite store and committed one event per callback. Under noisy concurrent sessions this churned connections and transactions on the output-drain path.

## Solution

Add a daemon-owned, long-lived SQLite event writer with a byte-accounted bounded queue. Raw output is non-blocking and may be explicitly rejected under pressure; lifecycle and exit events reserve capacity, commit synchronously, and preserve accepted-output-before-exit ordering.

## Important changes

- Coalesce adjacent same-session raw output in short transaction batches.
- Keep one writer connection and expose transaction/connection/drop counters through the additive health eventWriter response.
- Latch writer failures and expose them as degraded persistence health.
- Drain queued critical acknowledgements when a commit fails, so no producer remains blocked after the worker exits.
- Flush a live output batch after the coalescing window and test the observer's output-before-exit barrier.
- Add ordering, pressure, and eight-session batching tests; the workload demonstrates one connection and at most 16 transactions versus 136 per-callback operations (>80% reduction).
- Document the health contract.

## Validation

- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- node --test scripts/cli-docs-test.mjs
- node --test scripts/onboarding-docs-test.mjs
- python3 scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --range origin/main...HEAD
- python3 scripts/check-api-contract-docs-test.py
- python3 scripts/check-api-contract-docs.py
- git diff --check

## Risks and follow-up

The queue intentionally drops only raw output under sustained pressure; counts and byte totals remain visible for the daemon lifetime. Native GUI/platform coverage remains CI-owned; validation here ran in WSL.