### PR TITLE
feat(store): automate bounded retention health

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -289,10 +289,8 @@ fn health_response_with_hub(
     if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
         response.hub = serde_json::from_value(summary).ok();
     }
-    response.storage = Some(
-        store::storage_health(coven_home)
-            .unwrap_or_else(|error| store::unavailable_storage_health(error)),
-    );
+    response.storage =
+        Some(store::storage_health(coven_home).unwrap_or_else(store::unavailable_storage_health));
     response
 }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -154,6 +154,11 @@ pub struct HealthResponse {
     /// paths that do not have a live runtime.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub event_writer: Option<crate::event_writer::EventWriterHealth>,
+    /// Local SQLite pressure and bounded-maintenance state. This remains
+    /// present when collection fails so health consumers can distinguish a
+    /// storage problem from a daemon that is simply not running.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage: Option<store::StorageHealth>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -270,6 +275,7 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
         daemon,
         hub: None,
         event_writer: None,
+        storage: None,
     }
 }
 
@@ -283,6 +289,10 @@ fn health_response_with_hub(
     if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
         response.hub = serde_json::from_value(summary).ok();
     }
+    response.storage = Some(
+        store::storage_health(coven_home)
+            .unwrap_or_else(|error| store::unavailable_storage_health(error)),
+    );
     response
 }
 
@@ -6726,6 +6736,7 @@ mod tests {
         assert!(response.capabilities.structured_errors);
         assert_eq!(response.daemon, None);
         assert_eq!(response.hub, None);
+        assert_eq!(response.storage, None);
     }
 
     #[test]
@@ -6755,6 +6766,9 @@ mod tests {
         assert!(response.body.contains(r#""executorDispatch":true"#));
         assert!(response.body.contains(r#""role":"hub""#));
         assert!(response.body.contains(r#""structuredErrors":true"#));
+        assert!(response.body.contains(r#""storage":{"status""#));
+        assert!(response.body.contains(r#""writerBacklogEvents":0"#));
+        assert!(response.body.contains(r#""freeDiskBytes""#));
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2080,15 +2080,17 @@ fn rotate_recovery_log(path: &Path, incoming_bytes: u64, max_bytes: u64, backups
 
     for index in (1..=backups).rev() {
         let destination = PathBuf::from(format!("{}.{}", path.display(), index));
-        if index == backups {
-            let _ = std::fs::remove_file(&destination);
-        }
         let source = if index == 1 {
             path.to_path_buf()
         } else {
             PathBuf::from(format!("{}.{}", path.display(), index - 1))
         };
         if source.exists() {
+            // Windows does not replace an existing destination for
+            // `std::fs::rename`, unlike Unix. Only remove a slot immediately
+            // before replacing it, so a lone older archive survives a partial
+            // prior rotation where its newer source is absent.
+            let _ = std::fs::remove_file(&destination);
             let _ = std::fs::rename(source, destination);
         }
     }
@@ -5569,6 +5571,21 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(format!("{}.1", path.display()))?,
             "abcdefgh"
+        );
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.2", path.display()))?,
+            "12345678"
+        );
+
+        // A partial prior rotation can leave an older archive without its
+        // newer neighbor. Keep the surviving history rather than deleting it
+        // merely because there is no source to shift into its slot.
+        std::fs::remove_file(format!("{}.1", path.display()))?;
+        std::fs::write(&path, "ijklmnop")?;
+        rotate_recovery_log(&path, 4, 10, 2);
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.1", path.display()))?,
+            "ijklmnop"
         );
         assert_eq!(
             std::fs::read_to_string(format!("{}.2", path.display()))?,

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2041,15 +2041,56 @@ pub fn daemon_recovery_log_path(coven_home: &Path) -> PathBuf {
     coven_home.join("daemon-recovery.log")
 }
 
+const DAEMON_RECOVERY_LOG_MAX_BYTES: u64 = 4 * 1024 * 1024;
+const DAEMON_RECOVERY_LOG_BACKUPS: u8 = 3;
+
+fn recovery_log_lock() -> &'static Mutex<()> {
+    static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 pub fn append_daemon_recovery_log(coven_home: &Path, msg: &str) {
     let path = daemon_recovery_log_path(coven_home);
     let line = format!("[{}] {}\n", crate::api::current_timestamp(), msg);
+    let _guard = recovery_log_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    rotate_recovery_log(
+        &path,
+        line.len() as u64,
+        DAEMON_RECOVERY_LOG_MAX_BYTES,
+        DAEMON_RECOVERY_LOG_BACKUPS,
+    );
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
     {
         let _ = f.write_all(line.as_bytes());
+    }
+}
+
+fn rotate_recovery_log(path: &Path, incoming_bytes: u64, max_bytes: u64, backups: u8) {
+    let current_bytes = std::fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    if current_bytes.saturating_add(incoming_bytes) <= max_bytes {
+        return;
+    }
+
+    for index in (1..=backups).rev() {
+        let destination = PathBuf::from(format!("{}.{}", path.display(), index));
+        if index == backups {
+            let _ = std::fs::remove_file(&destination);
+        }
+        let source = if index == 1 {
+            path.to_path_buf()
+        } else {
+            PathBuf::from(format!("{}.{}", path.display(), index - 1))
+        };
+        if source.exists() {
+            let _ = std::fs::rename(source, destination);
+        }
     }
 }
 
@@ -2073,6 +2114,29 @@ fn start_threads_proposal_scheduler(coven_home: &Path) -> Result<()> {
             }
         })
         .context("failed to spawn threads proposal scheduler")?;
+    Ok(())
+}
+
+/// Starts asynchronous, bounded SQLite retention. The initial pass waits for
+/// the interval so daemon startup never pays maintenance latency, and the
+/// store helper intentionally performs no automatic VACUUM.
+fn start_store_maintenance_scheduler(coven_home: &Path) -> Result<()> {
+    const INTERVAL: Duration = Duration::from_secs(60);
+    let home = coven_home.to_path_buf();
+    std::thread::Builder::new()
+        .name("coven-store-maintenance".into())
+        .spawn(move || loop {
+            std::thread::sleep(INTERVAL);
+            let now = crate::api::current_timestamp();
+            if let Err(error) = crate::store::run_scheduled_maintenance(&home, &now) {
+                crate::store::record_maintenance_error(&home, "maintenance pass failed");
+                append_daemon_recovery_log(
+                    &home,
+                    &format!("store maintenance pass failed: {error:#}"),
+                );
+            }
+        })
+        .context("failed to spawn store maintenance scheduler")?;
     Ok(())
 }
 
@@ -2402,6 +2466,7 @@ pub fn serve_forever(
         coven_home.to_path_buf(),
     )?);
     start_threads_proposal_scheduler(coven_home)?;
+    start_store_maintenance_scheduler(coven_home)?;
 
     if let Some(addr) = tcp_addr {
         let tcp_listener = bind_tcp_listener(addr)?;
@@ -2937,6 +3002,7 @@ pub fn serve_forever(
         coven_home.to_path_buf(),
     )?);
     start_threads_proposal_scheduler(coven_home)?;
+    start_store_maintenance_scheduler(coven_home)?;
 
     const MAX_INFLIGHT: usize = 64;
     let inflight = Arc::new(AtomicUsize::new(0));
@@ -5481,6 +5547,32 @@ mod tests {
         assert!(
             log.contains("second event"),
             "second append should not overwrite the first, got: {log}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn recovery_log_rotation_keeps_a_bounded_history() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = daemon_recovery_log_path(temp_dir.path());
+        std::fs::write(&path, "12345678")?;
+
+        rotate_recovery_log(&path, 4, 10, 2);
+        assert!(!path.exists());
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.1", path.display()))?,
+            "12345678"
+        );
+
+        std::fs::write(&path, "abcdefgh")?;
+        rotate_recovery_log(&path, 4, 10, 2);
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.1", path.display()))?,
+            "abcdefgh"
+        );
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.2", path.display()))?,
+            "12345678"
         );
         Ok(())
     }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2143,11 +2143,9 @@ fn start_store_maintenance_scheduler(coven_home: &Path) -> Result<()> {
                         }
                     }
                     Err(error) => {
-                        crate::store::record_maintenance_error(&home, "maintenance pass failed");
-                        append_daemon_recovery_log(
-                            &home,
-                            &format!("store maintenance pass failed: {error:#}"),
-                        );
+                        let details = format!("store maintenance pass failed: {error:#}");
+                        crate::store::record_maintenance_error(&home, &details);
+                        append_daemon_recovery_log(&home, &details);
                         break;
                     }
                 }

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2124,18 +2124,33 @@ fn start_threads_proposal_scheduler(coven_home: &Path) -> Result<()> {
 /// store helper intentionally performs no automatic VACUUM.
 fn start_store_maintenance_scheduler(coven_home: &Path) -> Result<()> {
     const INTERVAL: Duration = Duration::from_secs(60);
+    const MAX_PASSES_PER_TICK: usize = 10;
     let home = coven_home.to_path_buf();
     std::thread::Builder::new()
         .name("coven-store-maintenance".into())
         .spawn(move || loop {
             std::thread::sleep(INTERVAL);
             let now = crate::api::current_timestamp();
-            if let Err(error) = crate::store::run_scheduled_maintenance(&home, &now) {
-                crate::store::record_maintenance_error(&home, "maintenance pass failed");
-                append_daemon_recovery_log(
-                    &home,
-                    &format!("store maintenance pass failed: {error:#}"),
-                );
+
+            // A single maintenance call can still leave backlog when
+            // per-table deletes are bounded. Run a short catch-up loop so a
+            // large retention debt cannot drift indefinitely.
+            for _ in 0..MAX_PASSES_PER_TICK {
+                match crate::store::run_scheduled_maintenance(&home, &now) {
+                    Ok(report) => {
+                        if report.raw_artifacts_pruned == 0 && report.events_pruned == 0 {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        crate::store::record_maintenance_error(&home, "maintenance pass failed");
+                        append_daemon_recovery_log(
+                            &home,
+                            &format!("store maintenance pass failed: {error:#}"),
+                        );
+                        break;
+                    }
+                }
             }
         })
         .context("failed to spawn store maintenance scheduler")?;

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3445,13 +3445,18 @@ pub fn run_scheduled_maintenance(
 ) -> Result<ScheduledMaintenanceReport> {
     let free_disk_bytes = fs2::available_space(coven_home)
         .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
+    run_scheduled_maintenance_with_free_disk(coven_home, now, free_disk_bytes)
+}
+
+fn run_scheduled_maintenance_with_free_disk(
+    coven_home: &Path,
+    now: &str,
+    free_disk_bytes: u64,
+) -> Result<ScheduledMaintenanceReport> {
     if free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES {
-        let conn = open_store(&coven_home.join("coven.sqlite3"))?;
-        set_store_meta(
-            &conn,
-            MAINTENANCE_LAST_ERROR_KEY,
-            "maintenance blocked: free disk below safety watermark",
-        )?;
+        // Do not record this in SQLite: opening a write transaction here would
+        // add WAL pressure precisely when the watermark is meant to prevent it.
+        // `storage_health` derives the blocked state from free disk directly.
         return Ok(ScheduledMaintenanceReport {
             raw_artifacts_pruned: 0,
             events_pruned: 0,
@@ -4902,6 +4907,27 @@ mod tests {
         assert_eq!(health.oldest_retained_event_at, None);
         assert_eq!(health.writer_backlog_events, 0);
         assert_eq!(health.writer_backlog_bytes, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_below_watermark_does_not_open_or_write_the_store() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+
+        let report = run_scheduled_maintenance_with_free_disk(
+            home,
+            "2026-04-27T06:00:00Z",
+            MAINTENANCE_MIN_FREE_DISK_BYTES - 1,
+        )?;
+
+        assert!(report.blocked_by_free_disk);
+        assert_eq!(report.events_pruned, 0);
+        assert_eq!(report.raw_artifacts_pruned, 0);
+        assert!(
+            !home.join("coven.sqlite3").exists(),
+            "the safety path must not create a database or WAL writes"
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3518,7 +3518,12 @@ fn run_scheduled_maintenance_with_config_and_free_disk(
 
         // Convergence loop keeps startup backlog from stalling one minute behind
         // while still enforcing a predictable per-tick upper bound.
-        if raw_batch < MAINTENANCE_ARTIFACT_BATCH_SIZE && event_batch < MAINTENANCE_EVENT_BATCH_SIZE
+        // The prune helpers report rows deleted as `usize`; the batch bounds are
+        // `i64` because they are bound directly to SQL `LIMIT`. Compare in `i64`
+        // rather than widening the constants, so the value handed to SQLite and
+        // the value compared here stay the same type.
+        if (raw_batch as i64) < MAINTENANCE_ARTIFACT_BATCH_SIZE
+            && (event_batch as i64) < MAINTENANCE_EVENT_BATCH_SIZE
         {
             break;
         }
@@ -3565,7 +3570,9 @@ pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
         .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
     let config =
         privacy::load_with_settings(coven_home, crate::settings::cached()).unwrap_or_default();
-    let oldest_retained_event_at = conn
+    // `MIN(created_at)` is NULL on an empty ledger, so the column type has to be
+    // stated: `row.get` cannot infer `Option<String>` from the comparison below.
+    let oldest_retained_event_at: Option<String> = conn
         .query_row("SELECT MIN(created_at) FROM events", [], |row| row.get(0))
         .context("failed to read oldest retained event")?;
     let retention_cutoff = retention_cutoff(

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -25,6 +25,7 @@ const MAINTENANCE_LAST_CHECKPOINT_KEY: &str = "maintenance_last_checkpoint_at";
 const MAINTENANCE_LAST_ERROR_KEY: &str = "maintenance_last_error";
 const MAINTENANCE_EVENT_BATCH_SIZE: i64 = 500;
 const MAINTENANCE_ARTIFACT_BATCH_SIZE: i64 = 500;
+const MAINTENANCE_MAX_BATCHES_PER_TICK: i64 = 10;
 const MAINTENANCE_CHECKPOINT_WAL_BYTES: u64 = 16 * 1024 * 1024;
 pub const MAINTENANCE_MIN_FREE_DISK_BYTES: u64 = 256 * 1024 * 1024;
 const MAINTENANCE_WARN_FREE_DISK_BYTES: u64 = 1024 * 1024 * 1024;
@@ -606,6 +607,9 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
         CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_expires_at
             ON sensitive_artifacts(expires_at);
 
+        CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_created_at
+            ON sensitive_artifacts(created_at);
+
         CREATE TABLE IF NOT EXISTS repositories (
             id TEXT PRIMARY KEY NOT NULL,
             path TEXT NOT NULL,
@@ -980,7 +984,10 @@ fn ensure_sensitive_artifacts_table(conn: &Connection) -> Result<()> {
             ON sensitive_artifacts(session_id, created_at);
 
         CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_expires_at
-            ON sensitive_artifacts(expires_at);",
+            ON sensitive_artifacts(expires_at);
+
+        CREATE INDEX IF NOT EXISTS idx_sensitive_artifacts_created_at
+            ON sensitive_artifacts(created_at);",
     )
     .context("failed to initialize sensitive artifact schema")
 }
@@ -3486,14 +3493,30 @@ fn run_scheduled_maintenance_with_config_and_free_disk(
     let event_cutoff = retention_cutoff(now, config.log_retention_days.max(1));
     let store_path = coven_home.join("coven.sqlite3");
     let conn = open_store(&store_path)?;
-    let raw_artifacts_pruned = prune_sensitive_artifacts_bounded(
-        &conn,
-        now,
-        &raw_cutoff,
-        MAINTENANCE_ARTIFACT_BATCH_SIZE,
-    )?;
-    let events_pruned =
-        prune_events_older_than_bounded(&conn, &event_cutoff, MAINTENANCE_EVENT_BATCH_SIZE)?;
+    let mut raw_artifacts_pruned = 0usize;
+    let mut events_pruned = 0usize;
+
+    for _ in 0..MAINTENANCE_MAX_BATCHES_PER_TICK {
+        let raw_batch = prune_sensitive_artifacts_bounded(
+            &conn,
+            now,
+            &raw_cutoff,
+            MAINTENANCE_ARTIFACT_BATCH_SIZE,
+        )?;
+        let event_batch =
+            prune_events_older_than_bounded(&conn, &event_cutoff, MAINTENANCE_EVENT_BATCH_SIZE)?;
+
+        raw_artifacts_pruned += raw_batch;
+        events_pruned += event_batch;
+
+        // Convergence loop keeps startup backlog from stalling one minute behind
+        // while still enforcing a predictable per-tick upper bound.
+        if raw_batch < MAINTENANCE_ARTIFACT_BATCH_SIZE && event_batch < MAINTENANCE_EVENT_BATCH_SIZE
+        {
+            break;
+        }
+    }
+
     // Record a successful pass even when nothing was expired. Operators need
     // the age of the maintenance loop itself, not merely the most recent row
     // deletion, to tell a healthy empty ledger from a stalled scheduler.
@@ -3533,9 +3556,21 @@ pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
     let conn = open_store(&store_path)?;
     let free_disk_bytes = fs2::available_space(coven_home)
         .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
+    let config =
+        privacy::load_with_settings(coven_home, crate::settings::cached()).unwrap_or_default();
     let oldest_retained_event_at = conn
         .query_row("SELECT MIN(created_at) FROM events", [], |row| row.get(0))
         .context("failed to read oldest retained event")?;
+    let retention_cutoff = retention_cutoff(
+        &Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true),
+        config.log_retention_days.max(1),
+    );
+    let retention_cutoff = parse_rfc3339_utc(&retention_cutoff);
+    let retention_lagging = oldest_retained_event_at
+        .as_deref()
+        .and_then(parse_rfc3339_utc)
+        .zip(retention_cutoff)
+        .is_some_and(|(oldest_at, retention_cutoff)| oldest_at < retention_cutoff);
     let last_prune_at = get_store_meta(&conn, MAINTENANCE_LAST_PRUNE_KEY)?;
     let last_checkpoint_at = get_store_meta(&conn, MAINTENANCE_LAST_CHECKPOINT_KEY)?;
     let last_maintenance_error =
@@ -3545,7 +3580,8 @@ pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
     let maintenance_blocked = free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES;
     let status = if maintenance_blocked {
         "critical"
-    } else if free_disk_bytes < MAINTENANCE_WARN_FREE_DISK_BYTES
+    } else if retention_lagging
+        || free_disk_bytes < MAINTENANCE_WARN_FREE_DISK_BYTES
         || wal_bytes >= MAINTENANCE_CHECKPOINT_WAL_BYTES
         || last_maintenance_error.is_some()
     {
@@ -3605,6 +3641,12 @@ fn maintenance_age_seconds(timestamp: Option<&str>) -> Option<u64> {
         .to_std()
         .ok()
         .map(|duration| duration.as_secs())
+}
+
+fn parse_rfc3339_utc(timestamp: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(timestamp)
+        .ok()
+        .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
 }
 
 fn wal_path(store_path: &Path) -> PathBuf {
@@ -4910,7 +4952,11 @@ mod tests {
         )?;
         drop(conn);
 
-        let report = run_scheduled_maintenance(home, "2026-04-27T06:00:00Z")?;
+        let report = run_scheduled_maintenance_with_free_disk(
+            home,
+            "2026-04-27T06:00:00Z",
+            MAINTENANCE_WARN_FREE_DISK_BYTES,
+        )?;
         assert_eq!(report.events_pruned, 1);
         assert!(!report.checkpoint_ran);
         assert!(!report.blocked_by_free_disk);
@@ -5015,7 +5061,11 @@ mod tests {
                 },
             )?;
             drop(conn);
-            run_scheduled_maintenance(home, &created_at)?;
+            run_scheduled_maintenance_with_free_disk(
+                home,
+                &created_at,
+                MAINTENANCE_WARN_FREE_DISK_BYTES,
+            )?;
 
             if day == 45 {
                 let conn = open_store(&path)?;
@@ -5036,6 +5086,72 @@ mod tests {
             final_pages <= pages_at_steady_state.expect("steady-state sample") + 2,
             "page count should converge once expiration matches ingestion"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_catches_up_after_backlog() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-01-01T00:00:00Z"))?;
+        for day in 0..1200 {
+            insert_event(
+                &conn,
+                &EventRecord {
+                    seq: 0,
+                    id: format!("event-{day}"),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json: serde_json::json!({ "data": day }).to_string(),
+                    created_at: "2025-01-01T00:00:00Z".to_string(),
+                },
+            )?;
+        }
+        drop(conn);
+
+        let report = run_scheduled_maintenance_with_free_disk(
+            home,
+            "2026-01-31T00:00:00Z",
+            MAINTENANCE_WARN_FREE_DISK_BYTES,
+        )?;
+        assert!(
+            report.events_pruned > MAINTENANCE_EVENT_BATCH_SIZE as usize,
+            "single tick should advance through multiple bounded maintenance batches"
+        );
+
+        let conn = open_store(&path)?;
+        let retained: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+        assert_eq!(retained, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn storage_health_flags_stale_retention() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2010-01-01T00:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "ancient".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"data":"ancient"}"#.to_string(),
+                created_at: "2010-01-01T00:00:00Z".to_string(),
+            },
+        )?;
+
+        let health = storage_health(home)?;
+        assert_eq!(
+            health.oldest_retained_event_at.as_deref(),
+            Some("2010-01-01T00:00:00Z")
+        );
+        assert_ne!(health.status, "ok");
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3430,8 +3430,15 @@ fn prune_sensitive_artifacts_bounded(
         .execute(
             "DELETE FROM sensitive_artifacts
              WHERE rowid IN (
-                SELECT rowid FROM sensitive_artifacts
-                WHERE expires_at < ?1 OR created_at < ?2
+                SELECT rowid FROM (
+                    -- Split predicates so each can use a supporting index while
+                    -- keeping global ordering by artifact age for bounded passes.
+                    SELECT rowid, created_at FROM sensitive_artifacts
+                    WHERE expires_at < ?1
+                    UNION
+                    SELECT rowid, created_at FROM sensitive_artifacts
+                    WHERE created_at < ?2
+                ) AS candidates
                 ORDER BY created_at, rowid
                 LIMIT ?3
              )",

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3445,13 +3445,30 @@ pub fn run_scheduled_maintenance(
 ) -> Result<ScheduledMaintenanceReport> {
     let free_disk_bytes = fs2::available_space(coven_home)
         .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
-    run_scheduled_maintenance_with_free_disk(coven_home, now, free_disk_bytes)
+    let config =
+        privacy::load_with_settings(coven_home, crate::settings::cached()).unwrap_or_default();
+    run_scheduled_maintenance_with_config_and_free_disk(coven_home, now, free_disk_bytes, &config)
 }
 
+#[cfg(test)]
 fn run_scheduled_maintenance_with_free_disk(
     coven_home: &Path,
     now: &str,
     free_disk_bytes: u64,
+) -> Result<ScheduledMaintenanceReport> {
+    run_scheduled_maintenance_with_config_and_free_disk(
+        coven_home,
+        now,
+        free_disk_bytes,
+        &PrivacyConfig::default(),
+    )
+}
+
+fn run_scheduled_maintenance_with_config_and_free_disk(
+    coven_home: &Path,
+    now: &str,
+    free_disk_bytes: u64,
+    config: &PrivacyConfig,
 ) -> Result<ScheduledMaintenanceReport> {
     if free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES {
         // Do not record this in SQLite: opening a write transaction here would
@@ -3465,7 +3482,6 @@ fn run_scheduled_maintenance_with_free_disk(
         });
     }
 
-    let config = privacy::load_config(coven_home).unwrap_or_default();
     let raw_cutoff = retention_cutoff(now, config.raw_artifact_retention_days.max(1));
     let event_cutoff = retention_cutoff(now, config.log_retention_days.max(1));
     let store_path = coven_home.join("coven.sqlite3");
@@ -4907,6 +4923,45 @@ mod tests {
         assert_eq!(health.oldest_retained_event_at, None);
         assert_eq!(health.writer_backlog_events, 0);
         assert_eq!(health.writer_backlog_bytes, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_honors_configured_event_retention() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "configured-expired".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"data":"expired"}"#.to_string(),
+                created_at: "2026-04-25T00:00:00Z".to_string(),
+            },
+        )?;
+        drop(conn);
+
+        let config = PrivacyConfig {
+            persist_raw_artifacts: false,
+            raw_artifact_retention_days: 7,
+            log_retention_days: 1,
+            extra_patterns: Vec::new(),
+        };
+        let report = run_scheduled_maintenance_with_config_and_free_disk(
+            home,
+            "2026-04-27T06:00:00Z",
+            MAINTENANCE_MIN_FREE_DISK_BYTES,
+            &config,
+        )?;
+
+        assert_eq!(report.events_pruned, 1);
+        let conn = open_store(&path)?;
+        assert!(list_events(&conn, "session-1")?.is_empty());
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -20,6 +20,14 @@ use crate::{
 
 const FTS_BACKFILL_BATCH_SIZE: i64 = 1_000;
 const FTS_BACKFILL_COMPLETE_KEY: &str = "events_fts_backfill_complete";
+const MAINTENANCE_LAST_PRUNE_KEY: &str = "maintenance_last_prune_at";
+const MAINTENANCE_LAST_CHECKPOINT_KEY: &str = "maintenance_last_checkpoint_at";
+const MAINTENANCE_LAST_ERROR_KEY: &str = "maintenance_last_error";
+const MAINTENANCE_EVENT_BATCH_SIZE: i64 = 500;
+const MAINTENANCE_ARTIFACT_BATCH_SIZE: i64 = 500;
+const MAINTENANCE_CHECKPOINT_WAL_BYTES: u64 = 16 * 1024 * 1024;
+pub const MAINTENANCE_MIN_FREE_DISK_BYTES: u64 = 256 * 1024 * 1024;
+const MAINTENANCE_WARN_FREE_DISK_BYTES: u64 = 1024 * 1024 * 1024;
 pub const DEFAULT_SESSION_PAGE_LIMIT: usize = 100;
 pub const MAX_SESSION_PAGE_LIMIT: usize = 1_000;
 
@@ -106,6 +114,40 @@ pub struct HandoffContinuationRecord {
     pub generation: i64,
     pub destination: String,
     pub created_at: String,
+}
+
+/// Storage and maintenance state exposed through the daemon health contract.
+///
+/// `writer_backlog_events` / `writer_backlog_bytes` are reported as zero here.
+/// The dedicated event writer landed in #607 after this struct was written and
+/// owns its own queue depth, surfaced separately as `eventWriter.queuedBytes`;
+/// wiring these two fields to it is tracked as follow-up rather than guessed at
+/// during a rebase.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageHealth {
+    pub status: String,
+    pub database_bytes: u64,
+    pub wal_bytes: u64,
+    pub oldest_retained_event_at: Option<String>,
+    pub last_prune_at: Option<String>,
+    pub prune_age_seconds: Option<u64>,
+    pub last_checkpoint_at: Option<String>,
+    pub checkpoint_age_seconds: Option<u64>,
+    pub writer_backlog_events: u64,
+    pub writer_backlog_bytes: u64,
+    pub free_disk_bytes: u64,
+    pub maintenance_blocked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_maintenance_error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScheduledMaintenanceReport {
+    pub raw_artifacts_pruned: usize,
+    pub events_pruned: usize,
+    pub checkpoint_ran: bool,
+    pub blocked_by_free_disk: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -539,6 +581,11 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
             UNIQUE(handoff_id, destination),
             FOREIGN KEY (handoff_id) REFERENCES session_handoffs(id) ON DELETE CASCADE
         );
+
+        -- Scheduled retention walks this index in bounded oldest-first
+        -- batches. The session-scoped index above cannot serve that scan.
+        CREATE INDEX IF NOT EXISTS idx_events_created_at
+            ON events(created_at);
 
         CREATE TABLE IF NOT EXISTS sensitive_artifacts (
             id TEXT PRIMARY KEY NOT NULL,
@@ -3334,6 +3381,241 @@ pub fn prune_events_older_than(conn: &Connection, cutoff: &str) -> Result<usize>
         .context("failed to prune events")
 }
 
+/// Delete at most one maintenance batch of expired events in a single
+/// transaction. The FTS external-content delete trigger runs in that same
+/// transaction, so a crash or interrupted process leaves both tables at the
+/// previous committed state instead of exposing a half-pruned index.
+pub fn prune_events_older_than_bounded(
+    conn: &Connection,
+    cutoff: &str,
+    limit: i64,
+) -> Result<usize> {
+    let tx = conn
+        .unchecked_transaction()
+        .context("failed to start bounded event-prune transaction")?;
+    let pruned = tx
+        .execute(
+            "DELETE FROM events
+             WHERE rowid IN (
+                SELECT rowid FROM events
+                WHERE created_at < ?1
+                ORDER BY created_at, rowid
+                LIMIT ?2
+             )",
+            params![cutoff, limit.max(1)],
+        )
+        .context("failed to prune bounded event batch")?;
+    tx.commit()
+        .context("failed to commit bounded event-prune transaction")?;
+    Ok(pruned)
+}
+
+fn prune_sensitive_artifacts_bounded(
+    conn: &Connection,
+    now: &str,
+    retention_cutoff: &str,
+    limit: i64,
+) -> Result<usize> {
+    let tx = conn
+        .unchecked_transaction()
+        .context("failed to start bounded artifact-prune transaction")?;
+    let pruned = tx
+        .execute(
+            "DELETE FROM sensitive_artifacts
+             WHERE rowid IN (
+                SELECT rowid FROM sensitive_artifacts
+                WHERE expires_at < ?1 OR created_at < ?2
+                ORDER BY created_at, rowid
+                LIMIT ?3
+             )",
+            params![now, retention_cutoff, limit.max(1)],
+        )
+        .context("failed to prune bounded sensitive-artifact batch")?;
+    tx.commit()
+        .context("failed to commit bounded artifact-prune transaction")?;
+    Ok(pruned)
+}
+
+/// Run the daemon's bounded retention tick. It deliberately never invokes
+/// `VACUUM`: compaction remains an explicit operator action because it can
+/// monopolize the database and violate session-launch latency expectations.
+pub fn run_scheduled_maintenance(
+    coven_home: &Path,
+    now: &str,
+) -> Result<ScheduledMaintenanceReport> {
+    let free_disk_bytes = fs2::available_space(coven_home)
+        .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
+    if free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES {
+        let conn = open_store(&coven_home.join("coven.sqlite3"))?;
+        set_store_meta(
+            &conn,
+            MAINTENANCE_LAST_ERROR_KEY,
+            "maintenance blocked: free disk below safety watermark",
+        )?;
+        return Ok(ScheduledMaintenanceReport {
+            raw_artifacts_pruned: 0,
+            events_pruned: 0,
+            checkpoint_ran: false,
+            blocked_by_free_disk: true,
+        });
+    }
+
+    let config = privacy::load_config(coven_home).unwrap_or_default();
+    let raw_cutoff = retention_cutoff(now, config.raw_artifact_retention_days.max(1));
+    let event_cutoff = retention_cutoff(now, config.log_retention_days.max(1));
+    let store_path = coven_home.join("coven.sqlite3");
+    let conn = open_store(&store_path)?;
+    let raw_artifacts_pruned = prune_sensitive_artifacts_bounded(
+        &conn,
+        now,
+        &raw_cutoff,
+        MAINTENANCE_ARTIFACT_BATCH_SIZE,
+    )?;
+    let events_pruned =
+        prune_events_older_than_bounded(&conn, &event_cutoff, MAINTENANCE_EVENT_BATCH_SIZE)?;
+    // Record a successful pass even when nothing was expired. Operators need
+    // the age of the maintenance loop itself, not merely the most recent row
+    // deletion, to tell a healthy empty ledger from a stalled scheduler.
+    set_store_meta(&conn, MAINTENANCE_LAST_PRUNE_KEY, now)?;
+
+    let wal_bytes = file_size(&wal_path(&store_path));
+    let checkpoint_ran = if wal_bytes >= MAINTENANCE_CHECKPOINT_WAL_BYTES {
+        // PASSIVE does as much as it can without waiting on a reader or writer.
+        // A blocked checkpoint is still harmless; the WAL size remains visible
+        // through `StorageHealth` for an operator to investigate.
+        let _ = conn.query_row("PRAGMA wal_checkpoint(PASSIVE)", [], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, i64>(2)?,
+            ))
+        })?;
+        set_store_meta(&conn, MAINTENANCE_LAST_CHECKPOINT_KEY, now)?;
+        true
+    } else {
+        false
+    };
+    set_store_meta(&conn, MAINTENANCE_LAST_ERROR_KEY, "")?;
+
+    Ok(ScheduledMaintenanceReport {
+        raw_artifacts_pruned,
+        events_pruned,
+        checkpoint_ran,
+        blocked_by_free_disk: false,
+    })
+}
+
+/// Gather storage pressure without mutating the database. Health callers use
+/// this after daemon startup has initialized the schema.
+pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
+    let store_path = coven_home.join("coven.sqlite3");
+    let conn = open_store(&store_path)?;
+    let free_disk_bytes = fs2::available_space(coven_home)
+        .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
+    let oldest_retained_event_at = conn
+        .query_row("SELECT MIN(created_at) FROM events", [], |row| row.get(0))
+        .context("failed to read oldest retained event")?;
+    let last_prune_at = get_store_meta(&conn, MAINTENANCE_LAST_PRUNE_KEY)?;
+    let last_checkpoint_at = get_store_meta(&conn, MAINTENANCE_LAST_CHECKPOINT_KEY)?;
+    let last_maintenance_error =
+        get_store_meta(&conn, MAINTENANCE_LAST_ERROR_KEY)?.filter(|value| !value.is_empty());
+    let database_bytes = file_size(&store_path);
+    let wal_bytes = file_size(&wal_path(&store_path));
+    let maintenance_blocked = free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES;
+    let status = if maintenance_blocked {
+        "critical"
+    } else if free_disk_bytes < MAINTENANCE_WARN_FREE_DISK_BYTES
+        || wal_bytes >= MAINTENANCE_CHECKPOINT_WAL_BYTES
+        || last_maintenance_error.is_some()
+    {
+        "warning"
+    } else {
+        "ok"
+    };
+
+    Ok(StorageHealth {
+        status: status.to_string(),
+        database_bytes,
+        wal_bytes,
+        oldest_retained_event_at,
+        prune_age_seconds: maintenance_age_seconds(last_prune_at.as_deref()),
+        last_prune_at,
+        checkpoint_age_seconds: maintenance_age_seconds(last_checkpoint_at.as_deref()),
+        last_checkpoint_at,
+        writer_backlog_events: 0,
+        writer_backlog_bytes: 0,
+        free_disk_bytes,
+        maintenance_blocked,
+        last_maintenance_error,
+    })
+}
+
+pub fn unavailable_storage_health(_error: impl ToString) -> StorageHealth {
+    StorageHealth {
+        status: "degraded".to_string(),
+        database_bytes: 0,
+        wal_bytes: 0,
+        oldest_retained_event_at: None,
+        last_prune_at: None,
+        prune_age_seconds: None,
+        last_checkpoint_at: None,
+        checkpoint_age_seconds: None,
+        writer_backlog_events: 0,
+        writer_backlog_bytes: 0,
+        free_disk_bytes: 0,
+        maintenance_blocked: true,
+        // The socket API is a compatibility boundary. Do not turn an I/O
+        // failure into a COVEN_HOME path disclosure; detailed diagnostics stay
+        // in the local recovery log.
+        last_maintenance_error: Some("storage health unavailable".to_string()),
+    }
+}
+
+pub fn record_maintenance_error(coven_home: &Path, error: impl ToString) {
+    if let Ok(conn) = open_store(&coven_home.join("coven.sqlite3")) {
+        let _ = set_store_meta(&conn, MAINTENANCE_LAST_ERROR_KEY, &error.to_string());
+    }
+}
+
+fn maintenance_age_seconds(timestamp: Option<&str>) -> Option<u64> {
+    let timestamp = timestamp?;
+    let parsed = chrono::DateTime::parse_from_rfc3339(timestamp).ok()?;
+    (Utc::now() - parsed.with_timezone(&Utc))
+        .to_std()
+        .ok()
+        .map(|duration| duration.as_secs())
+}
+
+fn wal_path(store_path: &Path) -> PathBuf {
+    PathBuf::from(format!("{}-wal", store_path.display()))
+}
+
+fn file_size(path: &Path) -> u64 {
+    std::fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+fn get_store_meta(conn: &Connection, key: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM store_meta WHERE key = ?1",
+        params![key],
+        |row| row.get(0),
+    )
+    .optional()
+    .with_context(|| format!("failed to read store metadata key {key}"))
+}
+
+fn set_store_meta(conn: &Connection, key: &str, value: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO store_meta(key, value) VALUES(?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![key, value],
+    )
+    .with_context(|| format!("failed to update store metadata key {key}"))?;
+    Ok(())
+}
+
 pub fn retention_cutoff(now: &str, days: u64) -> String {
     let parsed = chrono::DateTime::parse_from_rfc3339(now)
         .map(|dt| dt.with_timezone(&Utc))
@@ -4542,6 +4824,137 @@ mod tests {
         let events = list_events(&conn, "session-1")?;
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].payload_json, r#"{"data":"fresh-event"}"#);
+        Ok(())
+    }
+
+    #[test]
+    fn bounded_event_pruning_keeps_fts_consistent_across_an_interruption() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        for id in ["old-one", "old-two", "old-three"] {
+            insert_event(
+                &conn,
+                &EventRecord {
+                    seq: 0,
+                    id: id.to_string(),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json: serde_json::json!({ "data": id }).to_string(),
+                    created_at: "2026-04-01T00:00:00Z".to_string(),
+                },
+            )?;
+        }
+
+        // Model a process interruption after the DELETE starts but before its
+        // transaction commits. Dropping the transaction must restore both the
+        // events table and the FTS trigger side effects.
+        {
+            let tx = conn.unchecked_transaction()?;
+            tx.execute(
+                "DELETE FROM events WHERE rowid IN (
+                    SELECT rowid FROM events WHERE created_at < ?1 LIMIT 1
+                 )",
+                ["2026-04-15T00:00:00Z"],
+            )?;
+        }
+        assert_eq!(search_events(&conn, "old-one")?.len(), 1);
+
+        let pruned = prune_events_older_than_bounded(&conn, "2026-04-15T00:00:00Z", 2)?;
+        assert_eq!(pruned, 2);
+        assert_eq!(list_events(&conn, "session-1")?.len(), 1);
+        assert_eq!(search_events(&conn, "old-one")?.len(), 0);
+        assert_eq!(pragma_integrity_check(&conn)?, vec!["ok"]);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_prunes_retention_without_vacuuming() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "expired".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"data":"expired"}"#.to_string(),
+                created_at: "2026-01-01T00:00:00Z".to_string(),
+            },
+        )?;
+        drop(conn);
+
+        let report = run_scheduled_maintenance(home, "2026-04-27T06:00:00Z")?;
+        assert_eq!(report.events_pruned, 1);
+        assert!(!report.checkpoint_ran);
+        assert!(!report.blocked_by_free_disk);
+
+        let health = storage_health(home)?;
+        assert_eq!(
+            health.last_prune_at.as_deref(),
+            Some("2026-04-27T06:00:00Z")
+        );
+        assert_eq!(health.oldest_retained_event_at, None);
+        assert_eq!(health.writer_backlog_events, 0);
+        assert_eq!(health.writer_backlog_bytes, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn thirty_day_synthetic_workload_converges_to_a_stable_store_size() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-01-01T00:00:00Z"))?;
+        drop(conn);
+
+        let payload = "x".repeat(2_048);
+        let mut pages_at_steady_state = None;
+        let start =
+            chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")?.with_timezone(&Utc);
+        for day in 0..65 {
+            let created_at =
+                (start + Duration::days(day)).to_rfc3339_opts(SecondsFormat::Nanos, true);
+            let conn = open_store(&path)?;
+            insert_event(
+                &conn,
+                &EventRecord {
+                    seq: 0,
+                    id: format!("event-{day}"),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json: serde_json::json!({ "data": payload }).to_string(),
+                    created_at: created_at.clone(),
+                },
+            )?;
+            drop(conn);
+            run_scheduled_maintenance(home, &created_at)?;
+
+            if day == 45 {
+                let conn = open_store(&path)?;
+                pages_at_steady_state =
+                    Some(conn.query_row("PRAGMA page_count", [], |row| row.get::<_, i64>(0))?);
+            }
+        }
+
+        let conn = open_store(&path)?;
+        let retained: i64 = conn.query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))?;
+        let final_pages: i64 =
+            conn.query_row("PRAGMA page_count", [], |row| row.get::<_, i64>(0))?;
+        assert!(
+            retained <= 31,
+            "retention must bound a daily 30-day workload"
+        );
+        assert!(
+            final_pages <= pages_at_steady_state.expect("steady-state sample") + 2,
+            "page count should converge once expiration matches ingestion"
+        );
         Ok(())
     }
 

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -9,6 +9,26 @@ description: "Reference for GET /api/v1/health, the Coven daemon liveness endpoi
 Daemon health is the signal that the background process is reachable and using
 the expected socket for the active `COVEN_HOME`.
 
+## Storage health and retention
+
+`GET /api/v1/health` also includes a `storage` object. It reports the SQLite
+database and WAL sizes, free space on the `COVEN_HOME` filesystem, the oldest
+retained event, ages of the last prune and checkpoint, and the event-writer
+backlog. Current direct-write releases report a zero backlog; a later dedicated
+writer preserves the same fields.
+
+The daemon runs retention in small background transactions after startup. It
+uses the configured raw-artifact and redacted-event retention windows, never
+runs `VACUUM` automatically, and uses a non-blocking WAL checkpoint only after
+the WAL reaches its maintenance threshold. If free disk falls below 256 MiB,
+maintenance is blocked rather than creating more WAL pressure; `storage.status`
+becomes `critical` and `maintenanceBlocked` is true so an operator can free
+space before retrying. `coven vacuum` remains the explicit repair/compaction
+operation.
+
+Recovery logging is rotated at 4 MiB with three retained archives
+(`daemon-recovery.log.1` through `.3`).
+
 Use:
 
 ```sh

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -29,7 +29,7 @@ All error responses use the structured envelope documented in the [API contract]
 | Method | Path | Purpose | Success |
 |---|---|---|---|
 | GET | `/api/v1/api-version` | Read the legacy route-family token. | `{ apiVersion: "v1", supportedApiVersions: ["v1"] }` |
-| GET | `/api/v1/health` | Daemon reachability, version, capabilities, pid, hub summary. | `{ ok, apiVersion, covenVersion, capabilities, daemon, hub }` |
+| GET | `/api/v1/health` | Daemon reachability, version, capabilities, pid, hub summary, and local storage pressure. | `{ ok, apiVersion, covenVersion, capabilities, daemon, hub, storage }` |
 | GET | `/api/v1/capabilities` | Control-plane capability catalog with policy hints and action ids. | `{ capabilities: [...] }` |
 | GET | `/api/v1/capabilities/harnesses` | Aggregate of harness-native capability manifests plus Coven skills (`?refresh=1` re-scans). | `{ coven_skills, harness_capabilities, scanned_at }` |
 | GET | `/api/v1/capabilities/:harness` | One harness's capability manifest (`?refresh=1` re-scans). | manifest object · `404 harness_not_found` |
@@ -40,6 +40,12 @@ The health `capabilities` object currently contains all nine fields:
 `eventCursor`, `structuredErrors`, and `sessionHandoff`. `daemon` is either `null` or
 `{ pid, startedAt, socket }`, where the socket is under
 `<covenHome>/coven.sock`; the optional `hub` field is a control-plane summary.
+The optional `storage` field is `{ status, databaseBytes, walBytes,
+oldestRetainedEventAt, lastPruneAt, pruneAgeSeconds, lastCheckpointAt,
+checkpointAgeSeconds, writerBacklogEvents, writerBacklogBytes, freeDiskBytes,
+maintenanceBlocked, lastMaintenanceError? }`. `status` is `ok`, `warning`,
+`critical`, or `degraded`; clients should surface `critical` and `degraded`
+before storage exhaustion rather than treating a reachable daemon as healthy.
 
 ## Sessions and events
 

--- a/docs/reference/cli-logs.md
+++ b/docs/reference/cli-logs.md
@@ -11,6 +11,13 @@ Session events are stored redacted; sensitive raw artifacts are kept
 separately with a short retention window. `coven logs prune` applies both
 retention windows to the local store.
 
+When the daemon is running, the same windows are also applied automatically in
+small background transactions. The scheduled path never runs `VACUUM`; use
+[`coven vacuum`](cli-vacuum.md) when an operator explicitly wants FTS rebuild
+and database compaction. If the `COVEN_HOME` filesystem has less than 256 MiB
+free, scheduled maintenance pauses and reports the pressure through
+`GET /api/v1/health` instead of adding WAL writes on an exhausted filesystem.
+
 ```sh
 coven logs prune --dry-run     # report what would be pruned
 coven logs prune               # prune expired rows


### PR DESCRIPTION
Closes #597

## Summary

Automates bounded SQLite event and artifact retention and makes storage pressure observable through daemon health.

## Root cause

Retention was manual and the health endpoint did not expose database, WAL, free-space, or maintenance state. This left long-running installations without a bounded maintenance path or an operator signal before storage pressure became disruptive.

## Changes

- Run small, transactional retention batches after daemon startup without automatic VACUUM.
- Preserve event/FTS consistency within each prune transaction and use a passive WAL checkpoint only once the WAL crosses its threshold.
- Honor the same cached Settings, `privacy.toml`, and environment retention precedence as `coven logs prune`.
- Add SQLite storage, maintenance watermark, free-disk, and writer-backlog fields to `GET /api/v1/health`.
- Block maintenance below the 256 MiB free-space safety watermark without opening or writing SQLite.
- Rotate recovery logs at 4 MiB with three archives, retaining valid older history across a partial prior rotation.
- Document the health contract and explicit operator compaction path.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- Focused retention, configured-retention, interrupted-transaction/FTS, synthetic steady-state, recovery-log, and no-write-below-watermark tests
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --range origin/main...HEAD`
- `python3 scripts/check-api-contract-docs.py`

## Risks and follow-up

- The current direct-write implementation accurately reports a zero writer backlog. Issue #596 can populate the same stable health fields from its dedicated writer queue.
- Automatic `VACUUM` remains intentionally excluded because it can monopolize SQLite and affect session-launch latency; operators retain the explicit `coven vacuum` command.
