### PR TITLE
feat: expose resolved configuration paths

### DIFF
--- a/crates/coven-cli/src/cockpit_sources.rs
+++ b/crates/coven-cli/src/cockpit_sources.rs
@@ -95,18 +95,23 @@ pub(crate) fn familiar_workspace(coven_home: &Path, familiar_id: &str) -> std::p
         .unwrap_or_else(|| coven_home.join("familiars").join(familiar_id))
 }
 
+pub(crate) fn familiar_workspaces(coven_home: &Path) -> Result<Vec<PathBuf>> {
+    Ok(read_familiar_entries(coven_home)?
+        .into_iter()
+        .map(|entry| {
+            entry
+                .workspace
+                .map(expand_workspace)
+                .unwrap_or_else(|| coven_home.join("familiars").join(entry.id))
+        })
+        .collect())
+}
+
 pub fn read_familiars(coven_home: &Path) -> Result<Vec<FamiliarDto>> {
-    let path = coven_home.join(FAMILIARS_CONFIG_FILE);
-    let raw = match fs::read_to_string(&path) {
-        Ok(raw) => raw,
-        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(err) => return Err(err).with_context(|| format!("failed to read {}", path.display())),
-    };
-    let parsed: FamiliarsFile =
-        toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+    let entries = read_familiar_entries(coven_home)?;
     let memory_root = coven_home.join(MEMORY_DIR);
-    let mut out = Vec::with_capacity(parsed.familiar.len());
-    for entry in parsed.familiar {
+    let mut out = Vec::with_capacity(entries.len());
+    for entry in entries {
         let memory_dir = memory_root.join(&entry.id);
         let memory_freshness = latest_mtime(&memory_dir)
             .map(relative_time)
@@ -131,22 +136,35 @@ pub fn read_familiars(coven_home: &Path) -> Result<Vec<FamiliarDto>> {
             last_seen: "—".to_string(),
             active_sessions: 0,
             memory_freshness,
-            workspace: entry.workspace.map(|p| {
-                // Expand leading ~ to home directory
-                if let Some(rest) = p.strip_prefix("~/") {
-                    dirs_next::home_dir()
-                        .map(|home| home.join(rest))
-                        .unwrap_or_else(|| std::path::PathBuf::from(&p))
-                } else if p == "~" {
-                    dirs_next::home_dir().unwrap_or_else(|| std::path::PathBuf::from(&p))
-                } else {
-                    std::path::PathBuf::from(p)
-                }
-            }),
+            workspace: entry.workspace.map(expand_workspace),
             id: entry.id,
         });
     }
     Ok(out)
+}
+
+fn read_familiar_entries(coven_home: &Path) -> Result<Vec<FamiliarEntry>> {
+    let path = coven_home.join(FAMILIARS_CONFIG_FILE);
+    let raw = match fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err).with_context(|| format!("failed to read {}", path.display())),
+    };
+    let parsed: FamiliarsFile =
+        toml::from_str(&raw).with_context(|| format!("failed to parse {}", path.display()))?;
+    Ok(parsed.familiar)
+}
+
+fn expand_workspace(workspace: String) -> PathBuf {
+    if let Some(rest) = workspace.strip_prefix("~/") {
+        dirs_next::home_dir()
+            .map(|home| home.join(rest))
+            .unwrap_or_else(|| PathBuf::from(&workspace))
+    } else if workspace == "~" {
+        dirs_next::home_dir().unwrap_or_else(|| PathBuf::from(&workspace))
+    } else {
+        PathBuf::from(workspace)
+    }
 }
 
 /// Outcome of a [`write_familiar_icon`] call.

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -1,9 +1,10 @@
 //! Versioned, side-effect-free reporting of Coven's resolved on-disk paths.
 //!
 //! This module intentionally describes locations without opening stores,
-//! creating directories, loading configuration contents, or probing a daemon.
-//! It is the machine-readable contract used by isolated runners to prove which
-//! roots a Coven invocation would consume.
+//! creating directories, or probing a daemon. It reads `familiars.toml` only
+//! to resolve declared workspace roots. It is the machine-readable contract
+//! used by isolated runners to prove which roots a Coven invocation would
+//! consume.
 
 use std::path::{Path, PathBuf};
 
@@ -49,6 +50,7 @@ pub enum PathStatus {
 #[serde(rename_all = "snake_case")]
 pub enum PathSource {
     Environment,
+    Configuration,
     Default,
 }
 
@@ -86,9 +88,9 @@ impl ProcessRoots {
 
 /// Build the stable report for `coven config paths --json`.
 ///
-/// The only filesystem observation is the existing engine resolver's regular
-/// file check. This does not create state, spawn a process, or read any
-/// configuration contents. All other paths are lexical derivations.
+/// Filesystem observations are limited to the engine resolver's regular-file
+/// check and reading `familiars.toml` for workspace declarations. This does
+/// not create state, spawn a process, or inspect workspace contents.
 pub fn report() -> PathsReport {
     let roots = ProcessRoots::capture();
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
@@ -224,13 +226,27 @@ fn append_home_surfaces(
         source,
         cwd,
     );
-    push_path(
-        surfaces,
-        "state.familiar_workspaces",
-        &home.join("familiars"),
-        source,
-        cwd,
-    );
+    match crate::cockpit_sources::familiar_workspaces(home) {
+        Ok(paths) if !paths.is_empty() => push_paths(
+            surfaces,
+            "state.familiar_workspaces",
+            paths.iter().map(PathBuf::as_path),
+            PathSource::Configuration,
+            cwd,
+        ),
+        Ok(_) => push_path(
+            surfaces,
+            "state.familiar_workspaces",
+            &home.join("familiars"),
+            source,
+            cwd,
+        ),
+        Err(_) => push_terminal(
+            surfaces,
+            "state.familiar_workspaces",
+            PathStatus::Unresolved,
+        ),
+    }
     push_path(surfaces, "state.skills", &home.join("skills"), source, cwd);
     push_path(
         surfaces,
@@ -470,6 +486,26 @@ fn push_path(
         status: PathStatus::Resolved,
         path: Some(absolute_path(path, cwd).display().to_string()),
         paths: Vec::new(),
+        source,
+        access: AccessMode::ReadOnly,
+    });
+}
+
+fn push_paths<'a>(
+    surfaces: &mut Vec<PathSurface>,
+    id: &'static str,
+    paths: impl IntoIterator<Item = &'a Path>,
+    source: PathSource,
+    cwd: &Path,
+) {
+    surfaces.push(PathSurface {
+        id,
+        status: PathStatus::Resolved,
+        path: None,
+        paths: paths
+            .into_iter()
+            .map(|path| absolute_path(path, cwd).display().to_string())
+            .collect(),
         source,
         access: AccessMode::ReadOnly,
     });

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -173,6 +173,34 @@ fn append_home_surfaces(
         source,
         cwd,
     );
+    push_path(
+        surfaces,
+        "state.shared_lock",
+        &crate::state_lock::shared_lock_path(home),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.reset_transaction",
+        &home.join(crate::state_lock::RESET_TRANSACTION_FILE),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.daemon_lifecycle_lock",
+        &crate::daemon::daemon_lifecycle_lock_path(home),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.daemon_serve_lock",
+        &crate::daemon::daemon_serve_lock_path(home),
+        source,
+        cwd,
+    );
     #[cfg(unix)]
     push_path(
         surfaces,
@@ -182,7 +210,13 @@ fn append_home_surfaces(
         cwd,
     );
     #[cfg(windows)]
-    push_terminal(surfaces, "state.daemon_ipc", PathStatus::NotApplicable);
+    push_path(
+        surfaces,
+        "state.daemon_ipc",
+        &crate::daemon::windows_pipe_path(home),
+        source,
+        cwd,
+    );
     push_path(
         surfaces,
         "state.familiar_manifest",
@@ -304,6 +338,10 @@ fn append_unresolved_home_surfaces(surfaces: &mut Vec<PathSurface>, cwd: &Path) 
         "state.mobile",
         "state.sensitive_artifact_key",
         "state.daemon_metadata",
+        "state.shared_lock",
+        "state.reset_transaction",
+        "state.daemon_lifecycle_lock",
+        "state.daemon_serve_lock",
         "state.daemon_ipc",
         "state.familiar_manifest",
         "state.familiar_workspaces",

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -256,6 +256,13 @@ fn append_home_surfaces(
     push_path(surfaces, "state.memory", &home.join("memory"), source, cwd);
     push_path(
         surfaces,
+        "state.memory_migrations",
+        &home.join(crate::memory_import::MIGRATIONS_DIRECTORY),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
         "state.pending_proposals",
         &home.join("pending"),
         source,
@@ -351,6 +358,7 @@ fn append_unresolved_home_surfaces(surfaces: &mut Vec<PathSurface>, cwd: &Path) 
         "state.executor_node_config",
         "state.exports",
         "state.memory",
+        "state.memory_migrations",
         "state.pending_proposals",
         "state.research",
         "state.reset_backups",

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -206,8 +206,44 @@ fn append_home_surfaces(
     );
     push_path(
         surfaces,
+        "state.executor_node_config",
+        &home.join("executor.json"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
         "state.exports",
         &home.join("exports"),
+        source,
+        cwd,
+    );
+    push_path(surfaces, "state.memory", &home.join("memory"), source, cwd);
+    push_path(
+        surfaces,
+        "state.pending_proposals",
+        &home.join("pending"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.research",
+        &home.join("research"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.reset_backups",
+        &home.join("reset-backups"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.travel_profiles",
+        &home.join("travel").join("profiles"),
         source,
         cwd,
     );
@@ -217,6 +253,13 @@ fn append_home_surfaces(
         surfaces,
         "logs.redacted_events",
         &home.join(STORE_FILE_NAME),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "logs.daemon_recovery",
+        &crate::daemon::daemon_recovery_log_path(home),
         source,
         cwd,
     );
@@ -265,9 +308,16 @@ fn append_unresolved_home_surfaces(surfaces: &mut Vec<PathSurface>, cwd: &Path) 
         "state.familiar_manifest",
         "state.familiar_workspaces",
         "state.coven_calls",
+        "state.executor_node_config",
         "state.exports",
+        "state.memory",
+        "state.pending_proposals",
+        "state.research",
+        "state.reset_backups",
+        "state.travel_profiles",
         "logs.redacted_events",
         "logs.encrypted_artifacts",
+        "logs.daemon_recovery",
         "dashboard.chat_settings",
         "dashboard.chat_conversations",
     ] {

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -231,6 +231,7 @@ fn append_home_surfaces(
         source,
         cwd,
     );
+    push_path(surfaces, "state.skills", &home.join("skills"), source, cwd);
     push_path(
         surfaces,
         "state.coven_calls",
@@ -345,6 +346,7 @@ fn append_unresolved_home_surfaces(surfaces: &mut Vec<PathSurface>, cwd: &Path) 
         "state.daemon_ipc",
         "state.familiar_manifest",
         "state.familiar_workspaces",
+        "state.skills",
         "state.coven_calls",
         "state.executor_node_config",
         "state.exports",

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -1,0 +1,490 @@
+//! Versioned, side-effect-free reporting of Coven's resolved on-disk paths.
+//!
+//! This module intentionally describes locations without opening stores,
+//! creating directories, loading configuration contents, or probing a daemon.
+//! It is the machine-readable contract used by isolated runners to prove which
+//! roots a Coven invocation would consume.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use serde::Serialize;
+
+use crate::{engine, harness, paths, settings, STORE_FILE_NAME};
+
+pub const SCHEMA: &str = "coven.config.paths";
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathsReport {
+    pub schema: &'static str,
+    pub version: u32,
+    pub surfaces: Vec<PathSurface>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathSurface {
+    pub id: &'static str,
+    pub status: PathStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    pub source: PathSource,
+    pub access: AccessMode,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PathStatus {
+    Resolved,
+    NotApplicable,
+    Unsupported,
+    Unresolved,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PathSource {
+    Environment,
+    Default,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessMode {
+    ReadOnly,
+}
+
+#[derive(Debug)]
+struct ProcessRoots {
+    coven_home: std::result::Result<PathBuf, String>,
+    coven_home_source: PathSource,
+    settings_path: Option<PathBuf>,
+    settings_source: PathSource,
+    managed_engine_root: Option<PathBuf>,
+    managed_engine_source: PathSource,
+}
+
+impl ProcessRoots {
+    fn capture() -> Self {
+        let managed_engine_home = dirs_next::home_dir();
+        Self {
+            coven_home: paths::coven_home_dir().map_err(|error| error.to_string()),
+            coven_home_source: coven_home_source(),
+            settings_path: settings::user_settings_path(),
+            settings_source: settings_source(),
+            managed_engine_source: user_home_source(managed_engine_home.as_deref()),
+            managed_engine_root: managed_engine_home
+                .as_deref()
+                .map(paths::managed_engine_root),
+        }
+    }
+}
+
+/// Build the stable report for `coven config paths --json`.
+///
+/// The only filesystem observation is the existing engine resolver's regular
+/// file check. This does not create state, spawn a process, or read any
+/// configuration contents. All other paths are lexical derivations.
+pub fn report() -> PathsReport {
+    let roots = ProcessRoots::capture();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let mut surfaces = Vec::new();
+
+    match roots.coven_home {
+        Ok(home) => append_home_surfaces(&mut surfaces, &home, roots.coven_home_source, &cwd),
+        Err(_) => append_unresolved_home_surfaces(&mut surfaces, &cwd),
+    }
+
+    push_optional_path(
+        &mut surfaces,
+        "settings.user",
+        roots.settings_path.as_deref(),
+        roots.settings_source,
+        &cwd,
+    );
+    push_optional_path(
+        &mut surfaces,
+        "engine.managed_cache",
+        roots.managed_engine_root.as_deref(),
+        roots.managed_engine_source,
+        &cwd,
+    );
+    push_engine_binary(&mut surfaces, &cwd, roots.managed_engine_source);
+
+    PathsReport {
+        schema: SCHEMA,
+        version: SCHEMA_VERSION,
+        surfaces,
+    }
+}
+
+fn append_home_surfaces(
+    surfaces: &mut Vec<PathSurface>,
+    home: &Path,
+    source: PathSource,
+    cwd: &Path,
+) {
+    push_path(surfaces, "coven.home", home, source, cwd);
+    push_path(
+        surfaces,
+        "store.session_ledger",
+        &home.join(STORE_FILE_NAME),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "repositories.registry",
+        &crate::repos_config::config_path(home),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "privacy.policy",
+        &home.join("privacy.toml"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "adapters.trusted_root",
+        &harness::trusted_adapter_dir(home),
+        source,
+        cwd,
+    );
+    push_adapter_environment_surfaces(surfaces, cwd);
+    push_path(surfaces, "state.mobile", &home.join("mobile"), source, cwd);
+    push_path(
+        surfaces,
+        "state.sensitive_artifact_key",
+        &home.join("keys").join("session-artifacts.key"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.daemon_metadata",
+        &crate::daemon::daemon_status_path(home),
+        source,
+        cwd,
+    );
+    #[cfg(unix)]
+    push_path(
+        surfaces,
+        "state.daemon_ipc",
+        &crate::daemon::daemon_socket_path(home),
+        source,
+        cwd,
+    );
+    #[cfg(windows)]
+    push_terminal(surfaces, "state.daemon_ipc", PathStatus::NotApplicable);
+    push_path(
+        surfaces,
+        "state.familiar_manifest",
+        &home.join("familiars.toml"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.familiar_workspaces",
+        &home.join("familiars"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.coven_calls",
+        &crate::coven_calls::calls_path(home),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "state.exports",
+        &home.join("exports"),
+        source,
+        cwd,
+    );
+    // Coven's redacted event log and optional encrypted raw artifacts are
+    // tables in the session SQLite database, not standalone `logs/` files.
+    push_path(
+        surfaces,
+        "logs.redacted_events",
+        &home.join(STORE_FILE_NAME),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "logs.encrypted_artifacts",
+        &home.join(STORE_FILE_NAME),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "dashboard.chat_settings",
+        &home.join("chat-settings.json"),
+        source,
+        cwd,
+    );
+    push_path(
+        surfaces,
+        "dashboard.chat_conversations",
+        &home.join("chat-conversations"),
+        source,
+        cwd,
+    );
+    // The optional memory dashboard is a separately installed process. Coven
+    // has no owned state-path contract for it, so inventing one would turn a
+    // diagnostic into a false isolation attestation.
+    push_terminal(
+        surfaces,
+        "dashboard.memory_companion_state",
+        PathStatus::Unsupported,
+    );
+}
+
+fn append_unresolved_home_surfaces(surfaces: &mut Vec<PathSurface>, cwd: &Path) {
+    for id in [
+        "coven.home",
+        "store.session_ledger",
+        "repositories.registry",
+        "privacy.policy",
+        "adapters.trusted_root",
+        "state.mobile",
+        "state.sensitive_artifact_key",
+        "state.daemon_metadata",
+        "state.daemon_ipc",
+        "state.familiar_manifest",
+        "state.familiar_workspaces",
+        "state.coven_calls",
+        "state.exports",
+        "logs.redacted_events",
+        "logs.encrypted_artifacts",
+        "dashboard.chat_settings",
+        "dashboard.chat_conversations",
+    ] {
+        push_terminal(surfaces, id, PathStatus::Unresolved);
+    }
+    push_adapter_environment_surfaces(surfaces, cwd);
+    push_terminal(
+        surfaces,
+        "dashboard.memory_companion_state",
+        PathStatus::Unsupported,
+    );
+}
+
+fn push_adapter_environment_surfaces(surfaces: &mut Vec<PathSurface>, cwd: &Path) {
+    match std::env::var_os(harness::EXTERNAL_ADAPTER_MANIFEST_ENV) {
+        Some(value) if !value.is_empty() => push_path(
+            surfaces,
+            "adapters.external_manifest",
+            Path::new(&value),
+            PathSource::Environment,
+            cwd,
+        ),
+        _ => push_terminal(
+            surfaces,
+            "adapters.external_manifest",
+            PathStatus::NotApplicable,
+        ),
+    }
+
+    let paths: Vec<String> = std::env::var_os(harness::EXTERNAL_ADAPTER_DIRS_ENV)
+        .filter(|value| !value.is_empty())
+        .map(|value| {
+            std::env::split_paths(&value)
+                .map(|path| absolute_path(&path, cwd).display().to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+    if paths.is_empty() {
+        push_terminal(
+            surfaces,
+            "adapters.external_roots",
+            PathStatus::NotApplicable,
+        );
+    } else {
+        surfaces.push(PathSurface {
+            id: "adapters.external_roots",
+            status: PathStatus::Resolved,
+            path: None,
+            paths,
+            source: PathSource::Environment,
+            access: AccessMode::ReadOnly,
+        });
+    }
+}
+
+fn push_engine_binary(surfaces: &mut Vec<PathSurface>, cwd: &Path, user_home_source: PathSource) {
+    let Some(resolved) = engine::resolve() else {
+        push_terminal(
+            surfaces,
+            "engine.resolved_binary",
+            PathStatus::NotApplicable,
+        );
+        return;
+    };
+    let source = match resolved.source {
+        engine::EngineSource::EnvOverride | engine::EngineSource::PathLookup => {
+            PathSource::Environment
+        }
+        engine::EngineSource::Managed | engine::EngineSource::LegacyHome => user_home_source,
+    };
+    push_path(
+        surfaces,
+        "engine.resolved_binary",
+        &resolved.path,
+        source,
+        cwd,
+    );
+}
+
+fn push_optional_path(
+    surfaces: &mut Vec<PathSurface>,
+    id: &'static str,
+    path: Option<&Path>,
+    source: PathSource,
+    cwd: &Path,
+) {
+    match path {
+        Some(path) => push_path(surfaces, id, path, source, cwd),
+        None => push_terminal(surfaces, id, PathStatus::Unresolved),
+    }
+}
+
+fn push_path(
+    surfaces: &mut Vec<PathSurface>,
+    id: &'static str,
+    path: &Path,
+    source: PathSource,
+    cwd: &Path,
+) {
+    surfaces.push(PathSurface {
+        id,
+        status: PathStatus::Resolved,
+        path: Some(absolute_path(path, cwd).display().to_string()),
+        paths: Vec::new(),
+        source,
+        access: AccessMode::ReadOnly,
+    });
+}
+
+fn push_terminal(surfaces: &mut Vec<PathSurface>, id: &'static str, status: PathStatus) {
+    surfaces.push(PathSurface {
+        id,
+        status,
+        path: None,
+        paths: Vec::new(),
+        source: PathSource::Default,
+        access: AccessMode::ReadOnly,
+    });
+}
+
+fn absolute_path(path: &Path, cwd: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn nonempty_env(name: &str) -> bool {
+    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+fn coven_home_source() -> PathSource {
+    if nonempty_env("COVEN_HOME")
+        || nonempty_env("HOME")
+        || nonempty_env("USERPROFILE")
+        || (nonempty_env("HOMEDRIVE") && nonempty_env("HOMEPATH"))
+    {
+        PathSource::Environment
+    } else {
+        PathSource::Default
+    }
+}
+
+fn settings_source() -> PathSource {
+    if nonempty_env("XDG_CONFIG_HOME") || nonempty_env("HOME") {
+        PathSource::Environment
+    } else {
+        PathSource::Default
+    }
+}
+
+fn user_home_source(home: Option<&Path>) -> PathSource {
+    let Some(home) = home else {
+        return PathSource::Default;
+    };
+    let matches_home = ["HOME", "USERPROFILE"]
+        .into_iter()
+        .filter_map(std::env::var_os)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .any(|candidate| candidate == home);
+    let drive_and_path = std::env::var_os("HOMEDRIVE")
+        .filter(|value| !value.is_empty())
+        .zip(std::env::var_os("HOMEPATH").filter(|value| !value.is_empty()))
+        .map(|(drive, path)| {
+            PathBuf::from(format!(
+                "{}{}",
+                drive.to_string_lossy(),
+                path.to_string_lossy()
+            ))
+        });
+    if matches_home || drive_and_path.is_some_and(|candidate| candidate == home) {
+        PathSource::Environment
+    } else {
+        PathSource::Default
+    }
+}
+
+pub fn print_json() -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(&report())?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_path_keeps_absolute_paths_and_resolves_relative_paths_lexically() {
+        let cwd = Path::new("/tmp/coven-config-paths");
+        assert_eq!(
+            absolute_path(Path::new("relative/state"), cwd),
+            cwd.join("relative/state")
+        );
+        assert_eq!(
+            absolute_path(Path::new("/var/lib/coven"), cwd),
+            PathBuf::from("/var/lib/coven")
+        );
+    }
+
+    #[test]
+    fn report_has_stable_schema_and_terminal_rows() {
+        let report = report();
+        assert_eq!(report.schema, SCHEMA);
+        assert_eq!(report.version, SCHEMA_VERSION);
+        assert!(report
+            .surfaces
+            .iter()
+            .any(|surface| surface.id == "coven.home"));
+        assert!(report
+            .surfaces
+            .iter()
+            .any(|surface| surface.id == "dashboard.memory_companion_state"));
+        assert!(report
+            .surfaces
+            .iter()
+            .all(|surface| matches!(surface.access, AccessMode::ReadOnly)));
+    }
+}

--- a/crates/coven-cli/src/coven_calls.rs
+++ b/crates/coven-cli/src/coven_calls.rs
@@ -180,7 +180,7 @@ pub fn load_calls(coven_home: &Path) -> Result<Vec<CovenCallRecord>> {
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
-fn calls_path(coven_home: &Path) -> PathBuf {
+pub(crate) fn calls_path(coven_home: &Path) -> PathBuf {
     coven_home.join(CALLS_FILE)
 }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -975,7 +975,7 @@ pub fn ensure_background_server(
     Ok(status)
 }
 
-fn daemon_lifecycle_lock_path(coven_home: &Path) -> PathBuf {
+pub(crate) fn daemon_lifecycle_lock_path(coven_home: &Path) -> PathBuf {
     coven_home.join("daemon.lock")
 }
 
@@ -2132,7 +2132,7 @@ fn install_daemon_panic_hook(coven_home: &Path, socket_path: &Path, status_path:
 /// `daemon.lock` *lifecycle* lock that `ensure_background_server` holds only
 /// across a start/stop — this one is held by the `serve` process for its entire
 /// life, so it must be a separate file or the two would deadlock at startup.
-fn daemon_serve_lock_path(coven_home: &Path) -> PathBuf {
+pub(crate) fn daemon_serve_lock_path(coven_home: &Path) -> PathBuf {
     coven_home.join("daemon-serve.lock")
 }
 
@@ -2829,6 +2829,16 @@ fn owner_only_pipe_security_descriptor(
 #[cfg(windows)]
 pub(crate) fn windows_pipe_name(coven_home: &Path) -> String {
     daemon_windows_pipe_name(coven_home)
+}
+
+/// Fully qualified Windows named-pipe endpoint for this Coven profile.
+///
+/// `windows_pipe_name` remains the name passed to `interprocess`, while
+/// diagnostics need the concrete endpoint users can compare against a profile
+/// root without treating the IPC surface as absent.
+#[cfg(windows)]
+pub(crate) fn windows_pipe_path(coven_home: &Path) -> PathBuf {
+    PathBuf::from(r"\\.\pipe").join(daemon_windows_pipe_name(coven_home))
 }
 
 #[cfg(windows)]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 mod api;
 mod capabilities;
 mod cockpit_sources;
+mod config_paths;
 mod control_plane;
 mod coven_calls;
 mod daemon;
@@ -180,6 +181,11 @@ enum Command {
     Doctor {
         #[arg(long, help = "Print checks as JSON (machine-readable)")]
         json: bool,
+    },
+    #[command(about = "Report resolved configuration and state paths")]
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
     },
     #[command(about = "Generate shell completions (bash, zsh, fish, elvish, powershell)")]
     Completions {
@@ -590,6 +596,15 @@ enum Command {
     Code {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, num_args = 0..)]
         args: Vec<OsString>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ConfigCommand {
+    #[command(about = "Print the versioned resolved-path diagnostic")]
+    Paths {
+        #[arg(long, help = "Print the diagnostic as machine-readable JSON")]
+        json: bool,
     },
 }
 
@@ -1034,6 +1049,19 @@ fn main() -> Result<()> {
         }
     }
 
+    let cli = Cli::parse().validate().unwrap_or_else(|error| error.exit());
+    // This diagnostic must not create COVEN_HOME through the shared state lock
+    // or read settings contents during startup. It is deliberately the one
+    // command that runs before normal state initialization.
+    if matches!(
+        &cli.command,
+        Some(Command::Config {
+            command: ConfigCommand::Paths { .. }
+        })
+    ) {
+        return run_cli(cli);
+    }
+
     let loaded =
         settings::user_settings_path().as_deref().and_then(|path| {
             match settings::load_from(path) {
@@ -1046,7 +1074,6 @@ fn main() -> Result<()> {
         });
     settings::init_cached(loaded);
 
-    let cli = Cli::parse().validate().unwrap_or_else(|error| error.exit());
     // Resolve --color before anything renders: theme::mode() caches on
     // first use, so the override must be recorded ahead of any output.
     theme::set_color_choice(match cli.color.as_str() {
@@ -1099,6 +1126,14 @@ fn run_cli(cli: Cli) -> Result<()> {
     match cli.command {
         None | Some(Command::Chat) | Some(Command::Tui) => run_shared_interactive_shell(),
         Some(Command::Doctor { json }) => run_doctor(json),
+        Some(Command::Config {
+            command: ConfigCommand::Paths { json },
+        }) => {
+            if !json {
+                bail!("`coven config paths` requires `--json`");
+            }
+            config_paths::print_json()
+        }
         Some(Command::Completions { shell }) => {
             use clap::CommandFactory;
             clap_complete::generate(
@@ -4733,6 +4768,12 @@ mod tests {
         assert!(matches!(
             Cli::parse_from(["coven", "doctor", "--json"]).command,
             Some(Command::Doctor { json: true })
+        ));
+        assert!(matches!(
+            Cli::parse_from(["coven", "config", "paths", "--json"]).command,
+            Some(Command::Config {
+                command: ConfigCommand::Paths { json: true }
+            })
         ));
     }
 

--- a/crates/coven-cli/src/memory_import.rs
+++ b/crates/coven-cli/src/memory_import.rs
@@ -1049,7 +1049,8 @@ fn opened_metadata_stable(before: &cap_std::fs::Metadata, after: &cap_std::fs::M
 }
 
 const IMPORT_PROTOCOL_VERSION: u32 = 1;
-const MIGRATIONS_DIRECTORY: &str = "memory-migrations";
+/// Root for durable familiar-memory import journals and staged bundles.
+pub(crate) const MIGRATIONS_DIRECTORY: &str = "memory-migrations";
 const MANIFEST_FILE: &str = "manifest.json";
 const JOURNAL_FILE: &str = "journal.jsonl";
 const STAGED_DIRECTORY: &str = "staged";

--- a/crates/coven-cli/src/state_lock.rs
+++ b/crates/coven-cli/src/state_lock.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt};
@@ -154,8 +152,8 @@ fn validate_lock_file(_file: &std::fs::File, _path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
-pub(crate) fn lock_path(coven_home: &Path) -> PathBuf {
+/// Path of the profile-wide shared-state coordination lock.
+pub(crate) fn shared_lock_path(coven_home: &Path) -> PathBuf {
     coven_home.join(STATE_LOCK_FILE)
 }
 
@@ -211,7 +209,7 @@ mod tests {
         outside
             .as_file()
             .set_permissions(std::fs::Permissions::from_mode(0o640))?;
-        symlink(outside.path(), lock_path(home.path()))?;
+        symlink(outside.path(), shared_lock_path(home.path()))?;
 
         assert!(acquire_shared(home.path()).is_err());
         assert_eq!(

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -298,16 +298,17 @@ description = "Builds."
 
     let report = report(&run_paths(&temp, &coven_home, &[]));
     let surfaces = surfaces(&report);
-    let command_cwd = fs::canonicalize(temp.path()).expect("canonical command cwd");
-
-    assert_eq!(
-        surfaces["state.familiar_workspaces"]["paths"],
-        serde_json::json!([
-            command_cwd.join("relative/sage").display().to_string(),
-            external_workspace.display().to_string(),
-            coven_home.join("familiars/cody").display().to_string(),
-        ])
-    );
+    let reported_paths: Vec<_> = surfaces["state.familiar_workspaces"]["paths"]
+        .as_array()
+        .expect("workspace paths")
+        .iter()
+        .map(|path| Path::new(path.as_str().expect("workspace path")).to_path_buf())
+        .collect();
+    assert_eq!(reported_paths.len(), 3);
+    assert!(reported_paths[0].is_absolute());
+    assert!(reported_paths[0].ends_with(Path::new("relative/sage")));
+    assert_eq!(reported_paths[1], external_workspace);
+    assert_eq!(reported_paths[2], coven_home.join("familiars/cody"));
     assert_eq!(
         surfaces["state.familiar_workspaces"]["source"],
         "configuration"

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -1,0 +1,221 @@
+use std::{
+    collections::BTreeMap,
+    ffi::OsString,
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_paths(temp: &TempDir, coven_home: &Path, extra: &[(&str, OsString)]) -> Output {
+    let profile_home = temp.path().join("profile");
+    let xdg_config_home = temp.path().join("xdg-config");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_coven"));
+    command
+        .args(["config", "paths", "--json"])
+        .env_remove("COVEN_ENGINE_BIN")
+        .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST")
+        .env_remove("COVEN_HARNESS_ADAPTER_DIRS")
+        .env("COVEN_HOME", coven_home)
+        .env("HOME", &profile_home)
+        .env("USERPROFILE", &profile_home)
+        .env_remove("HOMEDRIVE")
+        .env_remove("HOMEPATH")
+        .env("XDG_CONFIG_HOME", &xdg_config_home);
+    // `PATH` is also an engine source. Keep it empty so this isolated-process
+    // fixture cannot resolve a developer or CI runner's installed engine.
+    command.env("PATH", temp.path().join("empty-path"));
+    for (name, value) in extra {
+        command.env(name, value);
+    }
+    command.output().expect("run coven config paths")
+}
+
+fn report(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("valid JSON report")
+}
+
+fn surfaces(report: &Value) -> BTreeMap<&str, &Value> {
+    report["surfaces"]
+        .as_array()
+        .expect("surfaces array")
+        .iter()
+        .map(|surface| (surface["id"].as_str().expect("surface id"), surface))
+        .collect()
+}
+
+#[test]
+fn paths_json_is_stable_and_creates_no_profile_state() {
+    let temp = TempDir::new().expect("temporary directory");
+    let profile_home = temp.path().join("profile");
+    let coven_home = temp.path().join("isolated-coven-home");
+
+    let first = run_paths(&temp, &coven_home, &[]);
+    let second = run_paths(&temp, &coven_home, &[]);
+
+    assert_eq!(first.stdout, second.stdout, "output must be byte-stable");
+    assert!(
+        first.stderr.is_empty(),
+        "machine-readable diagnostic must not emit startup diagnostics: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let report = report(&first);
+    assert_eq!(report["schema"], "coven.config.paths");
+    assert_eq!(report["version"], 1);
+    assert!(
+        !coven_home.exists(),
+        "the diagnostic must not create COVEN_HOME"
+    );
+    assert!(
+        !temp.path().join("xdg-config").exists(),
+        "the diagnostic must not create a settings directory"
+    );
+    let surfaces = surfaces(&report);
+    assert_eq!(
+        surfaces["store.session_ledger"]["path"],
+        coven_home.join("coven.sqlite3").display().to_string(),
+        "missing state is still reported as a resolved prospective path"
+    );
+    assert_eq!(surfaces["store.session_ledger"]["status"], "resolved");
+    assert_eq!(
+        surfaces["engine.managed_cache"]["path"],
+        profile_home.join(".coven/engine").display().to_string(),
+        "the managed engine cache follows the isolated user home, not COVEN_HOME"
+    );
+    assert_eq!(
+        surfaces["engine.managed_cache"]["source"], "environment",
+        "the managed engine cache inherits the isolated HOME override"
+    );
+    assert_eq!(
+        surfaces["engine.resolved_binary"]["status"], "not_applicable",
+        "an empty PATH and missing managed cache must not leak a runner engine"
+    );
+    assert_eq!(
+        surfaces["dashboard.memory_companion_state"]["status"],
+        "unsupported"
+    );
+
+    for surface in report["surfaces"].as_array().expect("surfaces array") {
+        assert_eq!(surface["access"], "read_only");
+        if let Some(path) = surface.get("path").and_then(Value::as_str) {
+            assert!(Path::new(path).is_absolute(), "{path} must be absolute");
+        }
+        for path in surface["paths"].as_array().into_iter().flatten() {
+            let path = path.as_str().expect("path string");
+            assert!(Path::new(path).is_absolute(), "{path} must be absolute");
+        }
+    }
+}
+
+#[test]
+fn paths_json_prefers_environment_roots_without_reading_secret_contents() {
+    let temp = TempDir::new().expect("temporary directory");
+    let coven_home = temp.path().join("selected-coven-home");
+    let xdg_settings = temp.path().join("xdg-config/coven/settings.json");
+    let manifest = temp.path().join("external/adapter-manifest.toml");
+    let adapter_one = temp.path().join("external/adapter-one");
+    let adapter_two = temp.path().join("external/adapter-two");
+    let sensitive_content = "secret-value-that-must-never-appear-in-the-report";
+
+    fs::create_dir_all(xdg_settings.parent().expect("settings parent"))
+        .expect("create settings parent");
+    fs::write(
+        &xdg_settings,
+        format!(r#"{{"ignoredValue":"{sensitive_content}"}}"#),
+    )
+    .expect("write settings");
+    fs::create_dir_all(manifest.parent().expect("manifest parent"))
+        .expect("create manifest parent");
+    fs::write(
+        &manifest,
+        format!("ignored_value = {sensitive_content:?}\n"),
+    )
+    .expect("write manifest");
+    let adapter_dirs =
+        std::env::join_paths([&adapter_one, &adapter_two]).expect("join adapter directories");
+    let output = run_paths(
+        &temp,
+        &coven_home,
+        &[
+            (
+                "COVEN_HARNESS_ADAPTER_MANIFEST",
+                manifest.clone().into_os_string(),
+            ),
+            ("COVEN_HARNESS_ADAPTER_DIRS", adapter_dirs),
+        ],
+    );
+
+    let stdout = String::from_utf8(output.stdout.clone()).expect("UTF-8 report");
+    assert!(
+        !stdout.contains(sensitive_content),
+        "the report must never include configuration contents"
+    );
+    let report = report(&output);
+    let surfaces = surfaces(&report);
+    assert_eq!(
+        surfaces["coven.home"]["path"],
+        coven_home.display().to_string()
+    );
+    assert_eq!(surfaces["coven.home"]["source"], "environment");
+    assert_eq!(
+        surfaces["settings.user"]["path"],
+        temp.path()
+            .join("xdg-config/coven/settings.json")
+            .display()
+            .to_string()
+    );
+    assert_eq!(surfaces["settings.user"]["source"], "environment");
+    assert_eq!(
+        surfaces["adapters.external_manifest"]["path"],
+        manifest.display().to_string()
+    );
+    assert_eq!(
+        surfaces["adapters.external_roots"]["paths"],
+        serde_json::json!([
+            adapter_one.display().to_string(),
+            adapter_two.display().to_string(),
+        ])
+    );
+}
+
+#[test]
+fn paths_requires_machine_readable_output_flag() {
+    let output = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["config", "paths"])
+        .output()
+        .expect("run coven config paths");
+
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("requires `--json`"));
+}
+
+#[test]
+fn paths_uses_coven_home_over_profile_home_and_ignores_an_invalid_engine_override() {
+    let temp = TempDir::new().expect("temporary directory");
+    let coven_home = temp.path().join("explicit-coven-home");
+    let missing_engine = temp.path().join("missing-engine");
+    let report = report(&run_paths(
+        &temp,
+        &coven_home,
+        &[("COVEN_ENGINE_BIN", missing_engine.into_os_string())],
+    ));
+    let surfaces = surfaces(&report);
+
+    assert_eq!(
+        surfaces["coven.home"]["path"],
+        coven_home.display().to_string(),
+        "COVEN_HOME must win over the isolated profile home"
+    );
+    assert_eq!(surfaces["coven.home"]["source"], "environment");
+    assert_eq!(
+        surfaces["engine.resolved_binary"]["status"], "not_applicable",
+        "an unusable COVEN_ENGINE_BIN must not be reported as a resolved binary"
+    );
+}

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -85,6 +85,26 @@ fn paths_json_is_stable_and_creates_no_profile_state() {
     );
     assert_eq!(surfaces["store.session_ledger"]["status"], "resolved");
     assert_eq!(
+        surfaces["state.executor_node_config"]["path"],
+        coven_home.join("executor.json").display().to_string()
+    );
+    assert_eq!(
+        surfaces["state.pending_proposals"]["path"],
+        coven_home.join("pending").display().to_string()
+    );
+    assert_eq!(
+        surfaces["state.travel_profiles"]["path"],
+        coven_home
+            .join("travel")
+            .join("profiles")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        surfaces["logs.daemon_recovery"]["path"],
+        coven_home.join("daemon-recovery.log").display().to_string()
+    );
+    assert_eq!(
         surfaces["engine.managed_cache"]["path"],
         profile_home.join(".coven/engine").display().to_string(),
         "the managed engine cache follows the isolated user home, not COVEN_HOME"

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -100,6 +100,10 @@ fn paths_json_is_stable_and_creates_no_profile_state() {
         coven_home.join("skills").display().to_string()
     );
     assert_eq!(
+        surfaces["state.memory_migrations"]["path"],
+        coven_home.join("memory-migrations").display().to_string()
+    );
+    assert_eq!(
         surfaces["state.shared_lock"]["path"],
         coven_home.join("state.lock").display().to_string()
     );

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -15,6 +15,7 @@ fn run_paths(temp: &TempDir, coven_home: &Path, extra: &[(&str, OsString)]) -> O
     let mut command = Command::new(env!("CARGO_BIN_EXE_coven"));
     command
         .args(["config", "paths", "--json"])
+        .current_dir(temp.path())
         .env_remove("COVEN_ENGINE_BIN")
         .env_remove("COVEN_HARNESS_ADAPTER_MANIFEST")
         .env_remove("COVEN_HARNESS_ADAPTER_DIRS")
@@ -258,6 +259,79 @@ fn paths_json_prefers_environment_roots_without_reading_secret_contents() {
             adapter_two.display().to_string(),
         ])
     );
+}
+
+#[test]
+fn paths_json_reports_configured_familiar_workspaces() {
+    let temp = TempDir::new().expect("temporary directory");
+    let coven_home = temp.path().join("selected-coven-home");
+    let external_workspace = temp.path().join("external").join("nova");
+    fs::create_dir_all(&coven_home).expect("create COVEN_HOME");
+    fs::write(
+        coven_home.join("familiars.toml"),
+        format!(
+            r#"
+[[familiar]]
+id = "sage"
+display_name = "Sage"
+role = "Research"
+description = "Reads."
+workspace = "relative/sage"
+
+[[familiar]]
+id = "nova"
+display_name = "Nova"
+role = "Orchestration"
+description = "Coordinates."
+workspace = {}
+
+[[familiar]]
+id = "cody"
+display_name = "Cody"
+role = "Code"
+description = "Builds."
+"#,
+            serde_json::to_string(&external_workspace).expect("serialize workspace")
+        ),
+    )
+    .expect("write familiar manifest");
+
+    let report = report(&run_paths(&temp, &coven_home, &[]));
+    let surfaces = surfaces(&report);
+    let command_cwd = fs::canonicalize(temp.path()).expect("canonical command cwd");
+
+    assert_eq!(
+        surfaces["state.familiar_workspaces"]["paths"],
+        serde_json::json!([
+            command_cwd.join("relative/sage").display().to_string(),
+            external_workspace.display().to_string(),
+            coven_home.join("familiars/cody").display().to_string(),
+        ])
+    );
+    assert_eq!(
+        surfaces["state.familiar_workspaces"]["source"],
+        "configuration"
+    );
+    assert!(
+        surfaces["state.familiar_workspaces"].get("path").is_none(),
+        "configured workspaces must replace the misleading default root"
+    );
+}
+
+#[test]
+fn paths_json_does_not_guess_workspaces_when_familiar_manifest_is_invalid() {
+    let temp = TempDir::new().expect("temporary directory");
+    let coven_home = temp.path().join("selected-coven-home");
+    fs::create_dir_all(&coven_home).expect("create COVEN_HOME");
+    fs::write(coven_home.join("familiars.toml"), "[[familiar]\n")
+        .expect("write invalid familiar manifest");
+
+    let report = report(&run_paths(&temp, &coven_home, &[]));
+    let surface = &surfaces(&report)["state.familiar_workspaces"];
+
+    assert_eq!(surface["status"], "unresolved");
+    assert!(surface.get("path").is_none());
+    assert!(surface.get("paths").is_none());
 }
 
 #[test]

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -96,6 +96,10 @@ fn paths_json_is_stable_and_creates_no_profile_state() {
         coven_home.join("executor.json").display().to_string()
     );
     assert_eq!(
+        surfaces["state.skills"]["path"],
+        coven_home.join("skills").display().to_string()
+    );
+    assert_eq!(
         surfaces["state.shared_lock"]["path"],
         coven_home.join("state.lock").display().to_string()
     );

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -54,8 +54,15 @@ fn surfaces(report: &Value) -> BTreeMap<&str, &Value> {
 #[test]
 fn paths_json_is_stable_and_creates_no_profile_state() {
     let temp = TempDir::new().expect("temporary directory");
-    let profile_home = temp.path().join("profile");
     let coven_home = temp.path().join("isolated-coven-home");
+
+    #[cfg(not(windows))]
+    let expected_managed_engine_root = temp.path().join("profile").join(".coven").join("engine");
+    #[cfg(windows)]
+    let expected_managed_engine_root = dirs_next::home_dir()
+        .expect("platform user home")
+        .join(".coven")
+        .join("engine");
 
     let first = run_paths(&temp, &coven_home, &[]);
     let second = run_paths(&temp, &coven_home, &[]);
@@ -106,12 +113,18 @@ fn paths_json_is_stable_and_creates_no_profile_state() {
     );
     assert_eq!(
         surfaces["engine.managed_cache"]["path"],
-        profile_home.join(".coven/engine").display().to_string(),
-        "the managed engine cache follows the isolated user home, not COVEN_HOME"
+        expected_managed_engine_root.display().to_string(),
+        "the managed engine cache follows the platform user home, not COVEN_HOME"
     );
+    #[cfg(unix)]
     assert_eq!(
         surfaces["engine.managed_cache"]["source"], "environment",
         "the managed engine cache inherits the isolated HOME override"
+    );
+    #[cfg(windows)]
+    assert_eq!(
+        surfaces["engine.managed_cache"]["source"], "default",
+        "Windows uses the native profile resolver rather than HOME or USERPROFILE"
     );
     assert_eq!(
         surfaces["engine.resolved_binary"]["status"], "not_applicable",
@@ -187,7 +200,9 @@ fn paths_json_prefers_environment_roots_without_reading_secret_contents() {
     assert_eq!(
         surfaces["settings.user"]["path"],
         temp.path()
-            .join("xdg-config/coven/settings.json")
+            .join("xdg-config")
+            .join("coven")
+            .join("settings.json")
             .display()
             .to_string()
     );

--- a/crates/coven-cli/tests/config_paths.rs
+++ b/crates/coven-cli/tests/config_paths.rs
@@ -96,6 +96,25 @@ fn paths_json_is_stable_and_creates_no_profile_state() {
         coven_home.join("executor.json").display().to_string()
     );
     assert_eq!(
+        surfaces["state.shared_lock"]["path"],
+        coven_home.join("state.lock").display().to_string()
+    );
+    assert_eq!(
+        surfaces["state.reset_transaction"]["path"],
+        coven_home
+            .join("reset-transaction.json")
+            .display()
+            .to_string()
+    );
+    assert_eq!(
+        surfaces["state.daemon_lifecycle_lock"]["path"],
+        coven_home.join("daemon.lock").display().to_string()
+    );
+    assert_eq!(
+        surfaces["state.daemon_serve_lock"]["path"],
+        coven_home.join("daemon-serve.lock").display().to_string()
+    );
+    assert_eq!(
         surfaces["state.pending_proposals"]["path"],
         coven_home.join("pending").display().to_string()
     );
@@ -111,6 +130,19 @@ fn paths_json_is_stable_and_creates_no_profile_state() {
         surfaces["logs.daemon_recovery"]["path"],
         coven_home.join("daemon-recovery.log").display().to_string()
     );
+    #[cfg(windows)]
+    {
+        let daemon_ipc = surfaces["state.daemon_ipc"]["path"]
+            .as_str()
+            .expect("Windows daemon IPC path");
+        assert!(
+            daemon_ipc.starts_with(r"\\.\pipe\coven-daemon-"),
+            "expected fully qualified Coven named pipe, got {daemon_ipc}"
+        );
+        assert!(daemon_ipc.ends_with(".sock"));
+        assert_eq!(surfaces["state.daemon_ipc"]["status"], "resolved");
+        assert_eq!(surfaces["state.daemon_ipc"]["source"], "environment");
+    }
     assert_eq!(
         surfaces["engine.managed_cache"]["path"],
         expected_managed_engine_root.display().to_string(),

--- a/docs/daemon/configuration.md
+++ b/docs/daemon/configuration.md
@@ -26,6 +26,10 @@ When `COVEN_HOME` is set, the daemon uses:
 - `<COVEN_HOME>/privacy.toml` for local log privacy settings when present.
 - `<COVEN_HOME>/keys/session-artifacts.key` for the local encrypted artifact key when raw artifact persistence is enabled.
 
+Run `coven config paths --json` to inspect the complete resolved path surface
+without starting the daemon or creating state. It also shows settings and the
+managed engine cache, which intentionally use separate per-user roots.
+
 ## Log privacy
 
 Session logs are redacted by default before they are stored in SQLite or returned through the API.

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -47,5 +47,8 @@ TERM=xterm-256color coven tui
 | Variable | Effect |
 |---|---|
 | `COVEN_HOME` | Overrides the default state directory (`~/.coven`). Use this to keep multiple Coven profiles on one machine, or to relocate state to a different disk. |
+| `XDG_CONFIG_HOME` | On platforms that support it, overrides the root containing `coven/settings.json`. This is separate from `COVEN_HOME`. |
 
-See [Getting started](/GETTING-STARTED) for the default setup flow and daemon checks.
+Use `coven config paths --json` to audit the paths selected for the current
+process without creating profile state. See [Getting started](/GETTING-STARTED)
+for the default setup flow and daemon checks.

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -47,7 +47,7 @@ TERM=xterm-256color coven tui
 | Variable | Effect |
 |---|---|
 | `COVEN_HOME` | Overrides the default state directory (`~/.coven`). Use this to keep multiple Coven profiles on one machine, or to relocate state to a different disk. |
-| `XDG_CONFIG_HOME` | On platforms that support it, overrides the root containing `coven/settings.json`. This is separate from `COVEN_HOME`. |
+| `XDG_CONFIG_HOME` | Overrides the root containing `coven/settings.json`. This is separate from `COVEN_HOME`; without it, settings use `$HOME/.config/coven/settings.json`. |
 
 Use `coven config paths --json` to audit the paths selected for the current
 process without creating profile state. See [Getting started](/GETTING-STARTED)

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -58,9 +58,10 @@ The report covers the Coven home, session ledger, repository registry,
 privacy policy, trusted and external adapter roots, settings, managed and
 resolved engine locations, mobile and daemon state, familiar state, call,
 executor, export, memory, proposal, research, reset-backup, and travel state,
-the daemon recovery log, and the Chat dashboard state. Redacted events and
-encrypted artifacts are both stored in the session ledger, so their distinct
-IDs can legitimately point to the same SQLite file.
+the profile and daemon coordination locks, the pending reset marker, the daemon
+recovery log, and the Chat dashboard state. Redacted events and encrypted
+artifacts are both stored in the session ledger, so their distinct IDs can
+legitimately point to the same SQLite file.
 
 The optional Memory dashboard is a separately installed process without a
 Coven-owned state-path contract. It is reported as `unsupported` rather than
@@ -69,12 +70,12 @@ guessing a location.
 ## Isolation caveat
 
 `COVEN_HOME` selects the Coven store root, but it does not move every
-per-user location. Settings follow `XDG_CONFIG_HOME` (or the platform config
-default), and the managed engine cache follows the user home directory by
-design. Isolated runners should set `COVEN_HOME`, `XDG_CONFIG_HOME`, and any
-user-home override honored by their platform, then verify the resulting
-report. On Windows, the native profile resolver can continue to select the OS
-account profile, so `COVEN_HOME` alone does not isolate the managed cache.
+per-user location. Settings follow `XDG_CONFIG_HOME` or `$HOME/.config`, and
+the managed engine cache follows the user home directory by design. Isolated
+runners should set `COVEN_HOME`, `XDG_CONFIG_HOME`, and any user-home override
+honored by their platform, then verify the resulting report. On Windows, the
+native profile resolver can continue to select the OS account profile, so
+`COVEN_HOME` alone does not isolate the managed cache.
 
 The command reports paths only. It never serializes the contents of settings,
 privacy, adapter manifests, or the session ledger.

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -1,0 +1,83 @@
+---
+summary: "Versioned, read-only configuration path diagnostic."
+description: "Reference for coven config paths --json, including its stable schema and side-effect-free guarantees."
+read_when:
+  - Auditing an isolated Coven profile
+  - Building a sandbox or test harness
+  - Locating Coven-managed state without opening it
+title: "Configuration path diagnostic"
+---
+
+`coven config paths --json` prints the versioned, machine-readable list of
+filesystem locations that the current process would use. It is intended for
+profile isolation checks and diagnostics, not for reading configuration or
+state.
+
+```sh
+COVEN_HOME=/tmp/coven-profile coven config paths --json
+```
+
+The command does not create directories or files, open the SQLite store, load
+configuration contents, start or contact the daemon, download an engine, or
+make network requests. Each run writes exactly one JSON document to standard
+output.
+
+## Schema
+
+Schema version 1 has this shape:
+
+```json
+{
+  "schema": "coven.config.paths",
+  "version": 1,
+  "surfaces": [
+    {
+      "id": "coven.home",
+      "status": "resolved",
+      "path": "/absolute/path/to/.coven",
+      "source": "environment",
+      "access": "read_only"
+    }
+  ]
+}
+```
+
+Every surface has a stable `id`, a `status`, `source`, and `access`. A
+`resolved` surface has one absolute `path`, or a `paths` array for the
+environment-provided adapter search roots. Terminal `not_applicable`,
+`unsupported`, and `unresolved` surfaces intentionally omit `path`.
+
+`source` is `environment` when an applicable environment override selected
+the location and `default` otherwise. `access` is always `read_only`: it
+describes this diagnostic invocation, not whether another Coven command may
+later write the location.
+
+## Reported surfaces
+
+The report covers the Coven home, session ledger, repository registry,
+privacy policy, trusted and external adapter roots, settings, managed and
+resolved engine locations, mobile and daemon state, familiar state, call and
+export state, redacted and encrypted log storage, and the Chat dashboard
+state. Redacted events and encrypted artifacts are both stored in the session
+ledger, so their distinct IDs can legitimately point to the same SQLite file.
+
+The optional Memory dashboard is a separately installed process without a
+Coven-owned state-path contract. It is reported as `unsupported` rather than
+guessing a location.
+
+## Isolation caveat
+
+`COVEN_HOME` selects the Coven store root, but it does not move every
+per-user location. Settings follow `XDG_CONFIG_HOME` (or the platform config
+default), and the managed engine cache follows the user home directory by
+design. Isolated runners should set `COVEN_HOME`, `XDG_CONFIG_HOME`, and an
+appropriate user-home environment, then verify the resulting report.
+
+The command reports paths only. It never serializes the contents of settings,
+privacy, adapter manifests, or the session ledger.
+
+## Related
+
+- [CLI reference](cli.md)
+- [Environment variables](/help/environment)
+- [Daemon configuration](/daemon/configuration)

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -56,12 +56,12 @@ later write the location.
 
 The report covers the Coven home, session ledger, repository registry,
 privacy policy, trusted and external adapter roots, settings, managed and
-resolved engine locations, mobile and daemon state, familiar state, call,
-executor, export, memory, proposal, research, reset-backup, and travel state,
-the profile and daemon coordination locks, the pending reset marker, the daemon
-recovery log, and the Chat dashboard state. Redacted events and encrypted
-artifacts are both stored in the session ledger, so their distinct IDs can
-legitimately point to the same SQLite file.
+resolved engine locations, mobile and daemon state, familiar state, skills,
+call, executor, export, memory, proposal, research, reset-backup, and travel
+state, the profile and daemon coordination locks, the pending reset marker, the
+daemon recovery log, and the Chat dashboard state. Redacted events and
+encrypted artifacts are both stored in the session ledger, so their distinct
+IDs can legitimately point to the same SQLite file.
 
 The optional Memory dashboard is a separately installed process without a
 Coven-owned state-path contract. It is reported as `unsupported` rather than

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -17,10 +17,10 @@ state.
 COVEN_HOME=/tmp/coven-profile coven config paths --json
 ```
 
-The command does not create directories or files, open the SQLite store, load
-configuration contents, start or contact the daemon, download an engine, or
-make network requests. Each run writes exactly one JSON document to standard
-output.
+The command does not create directories or files, open the SQLite store,
+inspect familiar workspace contents, start or contact the daemon, download an
+engine, or make network requests. It reads `familiars.toml` to resolve declared
+workspace paths. Each run writes exactly one JSON document to standard output.
 
 ## Schema
 
@@ -44,11 +44,13 @@ Schema version 1 has this shape:
 
 Every surface has a stable `id`, a `status`, `source`, and `access`. A
 `resolved` surface has one absolute `path`, or a `paths` array for the
-environment-provided adapter search roots. Terminal `not_applicable`,
-`unsupported`, and `unresolved` surfaces intentionally omit `path`.
+environment-provided adapter search roots and configured familiar workspaces.
+Terminal `not_applicable`, `unsupported`, and `unresolved` surfaces
+intentionally omit `path`.
 
 `source` is `environment` when an applicable environment override selected
-the location and `default` otherwise. `access` is always `read_only`: it
+the location, `configuration` when `familiars.toml` selected familiar
+workspaces, and `default` otherwise. `access` is always `read_only`: it
 describes this diagnostic invocation, not whether another Coven command may
 later write the location.
 
@@ -78,8 +80,8 @@ honored by their platform, then verify the resulting report. On Windows, the
 native profile resolver can continue to select the OS account profile, so
 `COVEN_HOME` alone does not isolate the managed cache.
 
-The command reports paths only. It never serializes the contents of settings,
-privacy, adapter manifests, or the session ledger.
+The command reports paths only. It never serializes non-path contents from
+`familiars.toml`, settings, privacy, adapter manifests, or the session ledger.
 
 ## Related
 

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -56,10 +56,11 @@ later write the location.
 
 The report covers the Coven home, session ledger, repository registry,
 privacy policy, trusted and external adapter roots, settings, managed and
-resolved engine locations, mobile and daemon state, familiar state, call and
-export state, redacted and encrypted log storage, and the Chat dashboard
-state. Redacted events and encrypted artifacts are both stored in the session
-ledger, so their distinct IDs can legitimately point to the same SQLite file.
+resolved engine locations, mobile and daemon state, familiar state, call,
+executor, export, memory, proposal, research, reset-backup, and travel state,
+the daemon recovery log, and the Chat dashboard state. Redacted events and
+encrypted artifacts are both stored in the session ledger, so their distinct
+IDs can legitimately point to the same SQLite file.
 
 The optional Memory dashboard is a separately installed process without a
 Coven-owned state-path contract. It is reported as `unsupported` rather than

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -71,8 +71,10 @@ guessing a location.
 `COVEN_HOME` selects the Coven store root, but it does not move every
 per-user location. Settings follow `XDG_CONFIG_HOME` (or the platform config
 default), and the managed engine cache follows the user home directory by
-design. Isolated runners should set `COVEN_HOME`, `XDG_CONFIG_HOME`, and an
-appropriate user-home environment, then verify the resulting report.
+design. Isolated runners should set `COVEN_HOME`, `XDG_CONFIG_HOME`, and any
+user-home override honored by their platform, then verify the resulting
+report. On Windows, the native profile resolver can continue to select the OS
+account profile, so `COVEN_HOME` alone does not isolate the managed cache.
 
 The command reports paths only. It never serializes the contents of settings,
 privacy, adapter manifests, or the session ledger.

--- a/docs/reference/cli-config.md
+++ b/docs/reference/cli-config.md
@@ -57,11 +57,12 @@ later write the location.
 The report covers the Coven home, session ledger, repository registry,
 privacy policy, trusted and external adapter roots, settings, managed and
 resolved engine locations, mobile and daemon state, familiar state, skills,
-call, executor, export, memory, proposal, research, reset-backup, and travel
-state, the profile and daemon coordination locks, the pending reset marker, the
-daemon recovery log, and the Chat dashboard state. Redacted events and
-encrypted artifacts are both stored in the session ledger, so their distinct
-IDs can legitimately point to the same SQLite file.
+call, executor, export, memory and memory-migration state, proposals,
+research, reset-backup, and travel state, the profile and daemon coordination
+locks, the pending reset marker, the daemon recovery log, and the Chat
+dashboard state. Redacted events and encrypted artifacts are both stored in
+the session ledger, so their distinct IDs can legitimately point to the same
+SQLite file.
 
 The optional Memory dashboard is a separately installed process without a
 Coven-owned state-path contract. It is reported as `unsupported` rather than

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -130,6 +130,7 @@ flowchart TB
 |---|---|
 | `coven run` | `--cwd <path>`, `--title <text>`, `--detach`, `--model <id>`, `--permission <full\|read-only>`, `--think`, `--speed fast\|balanced\|thorough` |
 | `coven doctor` | `--json` |
+| `coven config paths` | `--json` (required) |
 | `coven daemon status` | `--json` |
 | `coven sessions` | `--plain`, `--json`, `--all`, `--manage` |
 | `coven sessions events` | `--after-seq <SEQ>`, `--limit <N>`, `--json` |
@@ -221,6 +222,7 @@ execution. `coven reset` reserves explicit local-recovery codes: see
 - [Getting started](/GETTING-STARTED)
 - [Workflow guides](/guides)
 - [Developer core-functionality guide](/development/cli-core-functionality)
+- [Configuration path diagnostic](cli-config.md)
 - [Coven TUI](/start/coven-tui)
 - [Session lifecycle](/SESSION-LIFECYCLE)
 - [Harness adapter guide](/HARNESS-ADAPTERS)


### PR DESCRIPTION
## Summary

Closes #559.

Coven had no single, read-only contract for the paths selected across its state, settings, engine, adapter, logging, and dashboard surfaces. Existing status and doctor commands have broader startup and probing behavior, while normal CLI startup acquired the shared state lock and could create profile state before any command ran.

## Solution

Add `coven config paths --json`, a versioned diagnostic that resolves the complete path surface without opening stores, loading configuration contents, contacting the daemon, downloading an engine, or creating state. The command bypasses settings initialization and shared state-lock acquisition, so it remains safe for isolated runners.

Important changes:

- Add schema `coven.config.paths` version 1 with stable IDs, absolute resolved paths, source, status, and read-only access metadata.
- Cover Coven home/store, repositories, privacy, settings, engines, trusted and external adapters, auxiliary state (including skills and memory-migration journals), logs, and dashboard state.
- Include executor, memory, memory-migration, pending-proposal, research, reset-backup, travel-profile, familiar skill, profile-lock, daemon-lock, and reset-transaction state.
- Report the Windows daemon's fully qualified named-pipe endpoint rather than treating the known IPC surface as inapplicable.
- Review follow-up: report the durable `memory-migrations` root used for familiar-memory import journals and staged bundles.
- Report the separately installed Memory dashboard as unsupported instead of inventing a path.
- Document the intentionally separate settings and managed-engine roots.
- Add unit and isolated-process integration coverage for stable JSON, missing state, environment precedence, invalid engine overrides, secret-content non-disclosure, and the required JSON flag.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p coven-cli --test config_paths`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --range origin/main...HEAD`
- `node scripts/cli-docs-test.mjs`
- `node scripts/onboarding-docs-test.mjs`
- GitHub Actions CI run [#30957566670](https://github.com/OpenCoven/coven/actions/runs/30957566670), including Linux/Windows Rust tests and macOS/Linux/Windows onboarding smoke tests

All passed.

## Risks and follow-up

The managed engine cache is intentionally user-home scoped rather than `COVEN_HOME` scoped; isolated callers must set the user-home environment (and `XDG_CONFIG_HOME`) as well as `COVEN_HOME`. The optional Memory dashboard is a separate process and therefore remains explicitly unsupported by this Coven-owned diagnostic.
