### PR TITLE
fix(ci): repair branch-triage and gate its auto-merge

### DIFF
--- a/.github/actions/branch-triage/README.md
+++ b/.github/actions/branch-triage/README.md
@@ -1,8 +1,8 @@
 # branch-triage action
 
-Composite GitHub Action that classifies, rebases, merges, and prunes
-branches in a repository. Designed for repos that accumulate many
-short-lived feature branches and need periodic cleanup.
+Composite GitHub Action that classifies, merges, and prunes branches in a
+repository. Designed for repos that accumulate many short-lived feature
+branches and need periodic cleanup.
 
 ## What it does
 
@@ -10,13 +10,13 @@ short-lived feature branches and need periodic cleanup.
 
    | Category | Definition | Action |
    |---|---|---|
-   | OPEN | Has an open PR | Rebase onto base + merge |
+   | OPEN | Has an open PR | Merge if it passes the gate below |
    | MERGED | Has a merged PR | Delete local + remote |
    | SUPERSEDED | No PR, 0 unique commits vs base | Delete |
    | REVIEW | No PR, >0 unique commits | Skip — report only |
 
 2. **Deletes** MERGED and SUPERSEDED branches (remote + local).
-3. **Rebases** each OPEN-PR branch onto the base, then merges the PR.
+3. **Merges** each OPEN-PR branch that clears the merge gate.
 4. **Skips** REVIEW branches — reports them in the job summary so a human can decide.
 5. **Writes** a Markdown summary to the GitHub job summary.
 
@@ -37,6 +37,7 @@ short-lived feature branches and need periodic cleanup.
 | `merged-count` | PRs merged |
 | `deleted-count` | Branches deleted |
 | `kept-count` | REVIEW branches left untouched |
+| `skipped-count` | Open PRs the merge gate refused |
 
 ## Usage
 
@@ -67,13 +68,46 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-## Conflict resolution policy
+## Merge gate
 
-When rebasing an OPEN-PR branch:
-- Files **not owned by the branch** (not in its diff vs base) → take base version automatically.
-- Files **owned by the branch** → rebase is aborted and the PR is skipped with a warning; resolve manually.
+This action runs unattended, and on a repository without branch protection it
+is the only thing standing between a red or contested PR and the default
+branch. It therefore fails closed: a PR is merged only when **every** condition
+below holds, and is otherwise reported in the job summary and left alone.
 
-This avoids silently dropping logic or security changes the branch intentionally introduces.
+| Condition | Skipped when |
+|---|---|
+| Not a draft | PR is a draft |
+| No blocking review | `reviewDecision` is `CHANGES_REQUESTED` |
+| Mergeable | `mergeable` is not `MERGEABLE` (conflicting, or not yet computed) |
+| No failing checks | any check is `FAILURE`, `TIMED_OUT`, `CANCELLED`, `STARTUP_FAILURE`, `ACTION_REQUIRED`, or `ERROR` |
+| No in-flight checks | any check is `QUEUED`, `IN_PROGRESS`, `WAITING`, or `PENDING` |
+| CI actually ran | the check rollup is empty — no CI ran at all |
+| Merge state is clean | `mergeStateStatus` is anything other than `CLEAN` |
+
+Mergeability that GitHub has not finished computing counts as a skip, not a
+pass — a PR held for that reason merges on the next run.
+
+The gate is evaluated **before** the action writes anything to the branch, so a
+blocked PR is never rebased or force-pushed.
+
+## Why there is no rebase step
+
+Earlier versions rebased each OPEN-PR branch onto the base and force-pushed
+before merging. That was removed:
+
+- The force-push invalidated the very CI results the merge decision rests on —
+  the action merged against checks that described the pre-rebase commits.
+- Being behind the base does not block a merge unless branch protection
+  requires strictly up-to-date branches; where it does, `mergeStateStatus` is
+  `BEHIND` or `BLOCKED` and the gate skips the PR for a human to refresh.
+- The conflict auto-resolver it depended on could not work: its
+  `git diff | while read` loop ran in a subshell, so the `continue 2` meant to
+  abandon a conflicted PR never propagated to the outer loop, and
+  `git rebase --abort` ran against a subshell that was about to exit.
+
+A PR that conflicts with the base is now reported and left for manual
+resolution.
 
 ## Relationship to Coven skill
 

--- a/.github/actions/branch-triage/action.yml
+++ b/.github/actions/branch-triage/action.yml
@@ -1,8 +1,8 @@
 name: Branch Triage
 description: >
-  Classify, rebase, merge, and prune git branches.
-  Merges open PRs, deletes merged/superseded branches, removes orphaned
-  worktrees, and writes a Markdown summary to the job summary.
+  Classify, merge, and prune git branches.
+  Merges open PRs that pass a CI-and-review gate, deletes merged/superseded
+  branches, and writes a Markdown summary to the job summary.
 
 inputs:
   base-branch:
@@ -43,6 +43,9 @@ outputs:
   kept-count:
     description: Number of REVIEW branches left untouched (need manual decision).
     value: ${{ steps.triage.outputs.kept_count }}
+  skipped-count:
+    description: Number of open PRs the merge gate refused to merge.
+    value: ${{ steps.triage.outputs.skipped_count }}
 
 runs:
   using: composite

--- a/.github/actions/branch-triage/triage.sh
+++ b/.github/actions/branch-triage/triage.sh
@@ -12,6 +12,7 @@
 #   merged_count    — number of PRs merged
 #   deleted_count   — number of branches deleted
 #   kept_count      — number of REVIEW branches skipped
+#   skipped_count   — number of open PRs the merge gate refused
 
 set -euo pipefail
 
@@ -23,6 +24,7 @@ STALE="${STALE_DAYS:-30}"
 merged_count=0
 deleted_count=0
 kept_count=0
+skipped_count=0
 
 # ── colour helpers ────────────────────────────────────────────────────────────
 bold()  { printf '\033[1m%s\033[0m' "$*"; }
@@ -75,11 +77,53 @@ last_commit_days_ago() {
   echo $(( (now - ts) / 86400 ))
 }
 
+# Reason this PR must not be auto-merged, or empty when it is safe to merge.
+#
+# This action runs unattended and `main` is not branch-protected, so nothing
+# except this gate stands between a red or contested PR and the default branch.
+# Fail closed: anything we cannot positively confirm as green and uncontested
+# is reported and left for a human.
+merge_block_reason() {
+  local pr="$1" json
+  json=$(gh pr view "$pr" \
+    --json isDraft,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup 2>/dev/null) || {
+    echo "could not read PR state"
+    return 0
+  }
+
+  jq -r '
+    def named: (.name // .context // "check");
+    def concl: (.conclusion // .state // "");
+    def stat:  (.status // "");
+
+    ([ .statusCheckRollup[]?
+       | select(concl | IN("FAILURE", "TIMED_OUT", "CANCELLED",
+                           "STARTUP_FAILURE", "ACTION_REQUIRED", "ERROR"))
+       | named ]) as $failing
+    | ([ .statusCheckRollup[]?
+         | select((stat | IN("QUEUED", "IN_PROGRESS", "WAITING", "PENDING"))
+                  or (concl == "" and stat == ""))
+         | named ]) as $pending
+    | if .isDraft then "draft"
+      elif .reviewDecision == "CHANGES_REQUESTED" then "changes requested by a reviewer"
+      elif .mergeable == "CONFLICTING" then "conflicts with the base branch"
+      elif .mergeable != "MERGEABLE" then "mergeability not yet computed by GitHub"
+      elif ($failing | length) > 0 then "failing checks: " + ($failing | join(", "))
+      elif ($pending | length) > 0 then "checks still running: " + ($pending | join(", "))
+      elif (.statusCheckRollup | length) == 0 then "no checks have run"
+      elif .mergeStateStatus == "BLOCKED" then "blocked by branch protection"
+      elif .mergeStateStatus != "CLEAN" then
+        "merge state is " + (.mergeStateStatus // "unknown") + ", not CLEAN"
+      else "" end
+  ' <<<"$json"
+}
+
 # ── Step 2 — classify ─────────────────────────────────────────────────────────
 declare -a OPEN_LIST=()      # branches with open PRs
 declare -a MERGED_LIST=()    # branches with merged PRs
-declare -a SUPERSEDED_LIST=()# no PR, 0 unique commits (or stale)
+declare -a SUPERSEDED_LIST=() # no PR, 0 unique commits (or stale)
 declare -a REVIEW_LIST=()    # no PR, >0 unique commits — need human decision
+declare -a SKIPPED_LIST=()   # open PRs the merge gate refused, as "#N — reason"
 
 log "Classifying branches…"
 echo ""
@@ -149,59 +193,37 @@ fi
 
 # ── Step 5 — merge OPEN PRs ───────────────────────────────────────────────────
 echo ""
-log "Rebasing and merging open PRs (one at a time)…"
+log "Merging open PRs that pass the gate (one at a time)…"
 
 for branch in "${OPEN_LIST[@]}"; do
   pr=$(pr_number_for "$branch")
   title=$(pr_title_for "$branch")
   log "  PR #$pr — $title"
 
-  if [[ "$DRY" == "true" ]]; then
-    log "  [dry-run] would rebase $branch onto $BASE and merge #$pr"
+  # Gate first: never touch a PR we would not be allowed to merge. Rebasing and
+  # force-pushing a blocked PR is itself destructive, so this runs before any
+  # write to the branch.
+  reason=$(merge_block_reason "$pr")
+  if [[ -n "$reason" ]]; then
+    warn "  $(yellow 'skipped') #$pr — $reason"
+    SKIPPED_LIST+=("#$pr ($branch) — $reason")
+    (( skipped_count++ )) || true
     continue
   fi
 
-  # Checkout and rebase
-  git checkout "$branch" -q 2>/dev/null || {
-    git checkout -b "$branch" "origin/$branch" -q
-  }
-  git fetch origin "$BASE":$BASE -q 2>/dev/null || true
-
-  if ! git rebase "origin/$BASE" -q 2>/dev/null; then
-    # Auto-resolve: take base for files not owned by this branch
-    owned=$(git diff --name-only "origin/$BASE"..."$branch" 2>/dev/null || true)
-    git diff --name-only --diff-filter=U | while IFS= read -r conflict; do
-      if echo "$owned" | grep -qxF "$conflict"; then
-        warn "    conflict in owned file $conflict — leaving for manual resolution"
-        git rebase --abort
-        warn "    aborted rebase for #$pr; skipping"
-        continue 2
-      else
-        git checkout "origin/$BASE" -- "$conflict"
-        git add "$conflict"
-      fi
-    done
-    git rebase --continue --no-edit -q 2>/dev/null || {
-      git rebase --abort 2>/dev/null || true
-      warn "  rebase failed for #$pr ($branch) — skipping"
-      continue
-    }
+  if [[ "$DRY" == "true" ]]; then
+    log "  [dry-run] would merge #$pr ($STRATEGY)"
+    continue
   fi
 
-  git push --force-with-lease origin "$branch" -q
-
-  # Merge
   merge_flag="--$STRATEGY"
-  if gh pr merge "$pr" $merge_flag --delete-branch 2>&1; then
+  if gh pr merge "$pr" "$merge_flag" --delete-branch 2>&1; then
     log "  $(green '✓') merged #$pr"
     (( merged_count++ )) || true
   else
     warn "  merge failed for #$pr — check CI or conflicts"
+    SKIPPED_LIST+=("#$pr ($branch) — merge API call failed")
   fi
-
-  # Re-sync base before next iteration
-  git checkout "$BASE" -q
-  git pull -q
 done
 
 # ── Step 6 — final state ──────────────────────────────────────────────────────
@@ -220,10 +242,20 @@ echo "  Remote branches remaining (excl. $BASE): $remaining_branches"
   echo "| Metric | Count |"
   echo "|--------|-------|"
   echo "| PRs merged | $merged_count |"
+  echo "| PRs held by the merge gate | $skipped_count |"
   echo "| Branches deleted | $deleted_count |"
   echo "| REVIEW branches skipped | $kept_count |"
   echo "| Open PRs remaining | $remaining_open |"
   echo ""
+
+  if [[ ${#SKIPPED_LIST[@]} -gt 0 ]]; then
+    echo "### 🚦 PRs held by the merge gate"
+    echo ""
+    for entry in "${SKIPPED_LIST[@]}"; do
+      echo "- $entry"
+    done
+    echo ""
+  fi
 
   if [[ ${#REVIEW_LIST[@]} -gt 0 ]]; then
     echo "### ⚠️ REVIEW branches (need manual decision)"
@@ -245,6 +277,7 @@ echo "  Remote branches remaining (excl. $BASE): $remaining_branches"
   echo "merged_count=$merged_count"
   echo "deleted_count=$deleted_count"
   echo "kept_count=$kept_count"
+  echo "skipped_count=$skipped_count"
 } >> "${GITHUB_OUTPUT:-/dev/null}"
 
-log "Done. merged=$merged_count deleted=$deleted_count kept=$kept_count"
+log "Done. merged=$merged_count skipped=$skipped_count deleted=$deleted_count kept=$kept_count"


### PR DESCRIPTION
## What

The weekly **Branch Triage** job has failed **every run since it landed** (#209) — 8 for 8, never once succeeded. That is why merged and closed branch refs have piled up on the remote.

The cause is one missing space, `.github/actions/branch-triage/triage.sh:81`:

```bash
declare -a SUPERSEDED_LIST=()# no PR, 0 unique commits (or stale)
#                          ^^ bash parses `()#` → syntax error near unexpected token `('
```

Lines 79, 80 and 82 all have the space. The script died there before classifying a single branch.

## Why this PR is more than one character

Repairing the parse would arm a step that has **never actually executed**. Step 5 rebased, force-pushed, and `gh pr merge`d *every* open PR with no CI or review check at all. `main` is not branch-protected, so on the next scheduled run that would have force-pushed and merged PRs carrying `CHANGES_REQUESTED` reviews and red CI.

So the merge path now fails closed. `merge_block_reason` refuses a PR that:

| Condition | Skipped when |
|---|---|
| Not a draft | PR is a draft |
| No blocking review | `reviewDecision` is `CHANGES_REQUESTED` |
| Mergeable | `mergeable` is not `MERGEABLE` |
| No failing checks | any check is `FAILURE`, `TIMED_OUT`, `CANCELLED`, `STARTUP_FAILURE`, `ACTION_REQUIRED`, `ERROR` |
| No in-flight checks | any check is `QUEUED`, `IN_PROGRESS`, `WAITING`, `PENDING` |
| CI actually ran | the check rollup is empty |
| Merge state is clean | `mergeStateStatus` is anything but `CLEAN` |

The gate runs **before** anything is written to the branch, so a blocked PR is never rebased or force-pushed. Held PRs are listed with their reason in the job summary, under a new `skipped-count` output.

## Rebase + force-push removed

- The force-push invalidated the very CI results the merge decision rests on — the action merged against checks describing the *pre-rebase* commits.
- Being behind the base does not block a merge without strict branch protection; where it does, `mergeStateStatus` is `BEHIND`/`BLOCKED` and the gate skips.
- The conflict auto-resolver could not have worked: its `git diff | while read` loop ran in a subshell, so the `continue 2` meant to abandon a conflicted PR never propagated to the outer loop, and `git rebase --abort` ran against a subshell about to exit.

Conflicting PRs are now reported and left for manual resolution.

## Verification

`bash -n` fails on the old script at line 81 and passes on the new one. The extracted gate was run against all 12 currently-open PRs:

```
#609  → merge          #603  → changes requested by a reviewer
#607  → merge          #608  → changes requested by a reviewer
#606  → merge          #600  → failing checks: Secret guard
#605  → merge          #592  → failing checks: auto-merge
#604  → merge          #591  → failing checks: auto-merge
#601  → merge          #590  → no checks have run
```

Merge this and run the workflow with `dry-run: true` first to confirm the classification table before letting it delete or merge anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)