### PR TITLE
fix(daemon): restore event_writer_health to the SessionRuntime impl

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -401,6 +401,16 @@ impl SessionRuntime for LiveSessionRuntime {
     fn kill_session(&self, session_id: &str) -> Result<()> {
         LiveSessionRuntime::kill_session(self, session_id)
     }
+
+    /// Must stay in this trait impl: `api::handle_request_with_runtime` reaches
+    /// the runtime through `&dyn SessionRuntime`, so an inherent method of the
+    /// same name is unreachable and `GET /health` silently falls back to the
+    /// trait's `None` default.
+    fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
+        self.event_writer
+            .as_ref()
+            .map(crate::event_writer::EventWriter::health)
+    }
 }
 
 impl LiveSessionRuntime {
@@ -578,12 +588,6 @@ impl LiveSessionRuntime {
             .lock()
             .map_err(|_| anyhow::anyhow!("live session killer lock poisoned"))?;
         killer.kill()
-    }
-
-    fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
-        self.event_writer
-            .as_ref()
-            .map(crate::event_writer::EventWriter::health)
     }
 }
 


### PR DESCRIPTION
`main` has been red since 114f9c8. This is the compile fix.

## What broke

#603 restructured `daemon.rs`, splitting `impl SessionRuntime for LiveSessionRuntime` into a thin delegating trait impl and a new inherent `impl LiveSessionRuntime`. #607 added `event_writer_health` to what was, at the time it was written, the trait impl.

Neither PR conflicted textually, and both were green on their own base. Merged together, the method landed in the **inherent** block:

```
384: impl SessionRuntime for LiveSessionRuntime {   <- where it belongs
406: impl LiveSessionRuntime {
583:     fn event_writer_health(&self) -> ...        <- where it ended up
```

## Why this is not just a lint

`api::handle_request_with_runtime` holds the runtime as `&dyn SessionRuntime`:

```rust
("GET", "/health") => json_response(
    200,
    &health_response_with_hub(coven_home, daemon, runtime.event_writer_health()),
),
```

Through a trait object, an inherent method of the same name is unreachable — the call resolved to `SessionRuntime`'s default:

```rust
fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
    None
}
```

So `GET /api/v1/health` reported `eventWriter: null` for a live daemon, and every counter #607 added — `state`, `queuedBytes`, `droppedOutputEvents`, `lastError` — was silently unavailable. `EventWriter::health` was flagged dead for the same reason, transitively.

`-D dead-code` was reporting a real functional regression, not a style nit.

## The fix

Move the method back into the trait impl, with a comment recording why it must stay there so the next reorganization of these blocks doesn't repeat it.

## Verification

```
cargo clippy -p coven-cli --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 36s
```

Clean. Before the fix, the same command failed with `method 'event_writer_health' is never used` and `method 'health' is never used`.

## Not covered here

`CLI performance baseline` is also failing on `main` and is a separate problem — first-output latency in the `sessions_1` scenario. I'm measuring it against a pre-#607 build and will raise it separately rather than bundle an unrelated change into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)