### PR TITLE
fix(security): recognize nested lockfile package keys

### DIFF
--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -33,6 +33,41 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
 
+    def test_nested_scoped_node_modules_keys_do_not_trigger_high_entropy(self) -> None:
+        lines = [
+            '    "node_modules/@mariozechner/pi-ai/node_modules/http-proxy-agent": {',
+            '    "node_modules/@scope/parent/node_modules/@nested/child/node_modules/final-package": {',
+        ]
+
+        for line in lines:
+            with self.subTest(line=line):
+                self.assertIsNotNone(check_secrets.LOCKFILE_NODE_MODULE_KEY.fullmatch(line))
+                self.assertEqual(
+                    check_secrets.scan_text(line, "packages/example/package-lock.json"),
+                    [],
+                )
+
+    def test_nested_unscoped_node_modules_keys_do_not_trigger_high_entropy(self) -> None:
+        lines = [
+            '    "node_modules/parent-package/node_modules/child-package": {',
+            '    "node_modules/parent-package/node_modules/child-package/node_modules/grandchild-package": {',
+        ]
+
+        for line in lines:
+            with self.subTest(line=line):
+                self.assertIsNotNone(check_secrets.LOCKFILE_NODE_MODULE_KEY.fullmatch(line))
+                self.assertEqual(
+                    check_secrets.scan_text(line, "packages/example/package-lock.json"),
+                    [],
+                )
+
+    def test_nested_node_modules_shaped_source_line_still_triggers_entropy(self) -> None:
+        line = '    "node_modules/@mariozechner/pi-ai/node_modules/http-proxy-agent": {'
+
+        hits = check_secrets.scan_text(line, "src/dependency-map.ts")
+
+        self.assertEqual(hits, [("src/dependency-map.ts", 1, "high_entropy")])
+
     def test_lockfile_integrity_hashes_do_not_trigger_high_entropy(self) -> None:
         digest = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         text = "\n".join(

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -24,7 +24,9 @@ EXCLUDED_PARTS = {".git", "target", "node_modules", ".coven", ".comux", ".comux-
 EXCLUDED_PATHS = {"scripts/check-secrets.py", "scripts/check-secrets-test.py"}
 LOCKFILE_NAMES = ("pnpm-lock.yaml", "package-lock.json", "yarn.lock")
 LOCKFILE_PACKAGE_KEY = re.compile(r"^\s*(?:['\"]?/?@?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?(?:@[A-Za-z0-9][^:'\"]*)?['\"]?)\s*:\s*(?:\{\})?\s*$")
-LOCKFILE_NODE_MODULE_KEY = re.compile(r'''^\s*["']?node_modules/(?:@?[A-Za-z0-9_.-]+/)?[A-Za-z0-9_.-]+["']?\s*:\s*\{?\s*$''')
+LOCKFILE_NODE_MODULE_KEY = re.compile(
+    r'''^\s*["']?node_modules/(?:@[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+|[A-Za-z0-9_.-]+)(?:/node_modules/(?:@[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+|[A-Za-z0-9_.-]+))*["']?\s*:\s*\{?\s*$'''
+)
 LOCKFILE_PACKAGE_VERSION_ENTRY = re.compile(r"^\s*['\"]?@?[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?['\"]?\s*:\s*\d+\.\d+\.\d+(?:[-+][A-Za-z0-9_.-]+)?\s*$")
 LOCKFILE_INTEGRITY_LINE = re.compile(r'''["']?\bintegrity\b["']?\s*:\s*["']?(?:sha256|sha384|sha512)-[A-Za-z0-9+/=]+["']?''')
 LOCKFILE_RESOLVED_LINE = re.compile(r'''["']?\bresolved\b["']?\s*:\s*["']?https://registry\.npmjs\.org/[A-Za-z0-9_+/@.,~%:-]+\.tgz["']?''')


### PR DESCRIPTION
A live false-positive source in the secret guard. Small and self-contained.

## The gap

`LOCKFILE_NODE_MODULE_KEY` matched only a single level of nesting. Tested against `main`'s regex:

```
MATCH  "node_modules/foo": {
MISS   "node_modules/foo/node_modules/bar": {
MISS   "node_modules/@scope/pkg/node_modules/dep": {
```

npm emits nested keys routinely — any time a transitive dependency needs its own copy of something. Those lines therefore fell through the lockfile-structure exemption and were scanned as ordinary content, where a long scoped package path is exactly the shape that trips the entropy rule.

Concretely, any PR touching a `package-lock.json` could fail `Secret guard` on lines that are pure lockfile structure. `AGENTS.md` is explicit that the answer to a secret-guard hit is to fix the content, never to allowlist past it — which makes a false positive here especially expensive, since the correct response to a real hit and a spurious one look nothing alike.

## The fix

Extend the pattern to allow repeated `/node_modules/<pkg>` segments, scoped or unscoped.

**The exemption stays scoped to lockfiles.** A nested-shaped line in a source file still trips the entropy rule:

```
in a source file  -> [('src/dependency-map.ts', 1, 'high_entropy')]
in a lockfile     -> []
```

The third added test pins that, so this cannot silently become a general relaxation of the scanner.

## Verification

```
python3 scripts/check-secrets-test.py     # Ran 84 tests — OK
python3 scripts/check-secrets.py          # Secret guard passed: no current-tree or history findings
python3 scripts/check-coven-privacy.py --staged   # passed
```

All four nesting forms now match, including three-deep and scoped-inside-scoped.

## Provenance

Cherry-picked from `2fc591e` on `docs-psyche-o1-contract-plan`. That branch turned out to hold 26 commits made *after* #574 merged — a follow-up wave on continuation lifecycle and the O1 docs guard that never shipped, and which `git merge-tree` reports as 18 conflicts against current `main`, including add/add on both contract-guard scripts.

This commit is independent of all that and useful on its own, so it is extracted rather than left to wait on a reconcile. The rest of that branch still needs a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)