### PR TITLE
fix: prevent maintenance gate lock takeover

### DIFF
--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -12,10 +12,11 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, Condvar, Mutex},
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result};
+use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -23,7 +24,6 @@ const GATE_DIR: &str = "coven-maintenance-gate";
 const OWNER_FILE: &str = "owner";
 const WRITERS_DIR: &str = "writers";
 const LOCK_FILE: &str = "lock";
-const LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
 const LOCK_WAIT: Duration = Duration::from_secs(5);
 const WRITER_TTL: Duration = Duration::from_secs(90);
 const OWNER_TTL: Duration = Duration::from_secs(120);
@@ -553,36 +553,37 @@ impl OwnerLease {
     }
 }
 
+#[derive(Debug)]
 struct GateLock {
-    path: PathBuf,
+    file: fs::File,
 }
 
 impl GateLock {
     fn acquire(path: PathBuf) -> Result<Self> {
-        let started = SystemTime::now();
+        Self::acquire_with_wait(path, LOCK_WAIT)
+    }
+
+    fn acquire_with_wait(path: PathBuf, wait: Duration) -> Result<Self> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        let started = Instant::now();
         loop {
-            match fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-            {
-                Ok(_) => return Ok(Self { path }),
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    if is_stale(&path, LOCK_STALE_AFTER) {
-                        let _ = fs::remove_file(&path);
-                    }
-                    if SystemTime::now()
-                        .duration_since(started)
-                        .unwrap_or_default()
-                        > LOCK_WAIT
-                    {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(Self { file }),
+                Err(error) if crate::state_lock::is_lock_contended(&error) => {
+                    if started.elapsed() >= wait {
                         return Err(GateError::Contended.into());
                     }
                     thread::sleep(Duration::from_millis(10));
                 }
                 Err(error) => {
                     return Err(error)
-                        .with_context(|| format!("failed to acquire {}", path.display()))
+                        .with_context(|| format!("failed to acquire {}", path.display()));
                 }
             }
         }
@@ -591,16 +592,8 @@ impl GateLock {
 
 impl Drop for GateLock {
     fn drop(&mut self) {
-        let _ = fs::remove_file(&self.path);
+        let _ = FileExt::unlock(&self.file);
     }
-}
-
-fn is_stale(path: &Path, after: Duration) -> bool {
-    fs::metadata(path)
-        .and_then(|m| m.modified())
-        .ok()
-        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
-        .is_some_and(|age| age > after)
 }
 
 fn writer_file_name(id: &str) -> String {
@@ -626,6 +619,56 @@ fn unix_now() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs::FileTimes;
+
+    fn assert_contended(error: &anyhow::Error) {
+        assert!(error
+            .downcast_ref::<GateError>()
+            .is_some_and(|error| matches!(error, GateError::Contended)));
+    }
+
+    #[test]
+    fn live_gate_lock_blocks_a_second_acquirer() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        let _first = GateLock::acquire(gate.lock_path())?;
+
+        let error = GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO).unwrap_err();
+
+        assert_contended(&error);
+        Ok(())
+    }
+
+    #[test]
+    fn dropping_gate_lock_allows_the_next_acquirer() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        let first = GateLock::acquire(gate.lock_path())?;
+        drop(first);
+
+        let _second = GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn stale_mtime_does_not_allow_live_gate_lock_takeover() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        let _first = GateLock::acquire(gate.lock_path())?;
+        let lock_file = fs::OpenOptions::new().write(true).open(gate.lock_path())?;
+        lock_file.set_times(
+            FileTimes::new().set_modified(SystemTime::now() - Duration::from_secs(120)),
+        )?;
+
+        let error = GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO).unwrap_err();
+
+        assert_contended(&error);
+        Ok(())
+    }
 
     #[test]
     fn owner_rejects_a_writer_until_release() -> Result<()> {

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -565,13 +565,8 @@ impl GateLock {
     }
 
     fn acquire_with_wait(path: PathBuf, wait: Duration) -> Result<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&path)
-            .with_context(|| format!("failed to open {}", path.display()))?;
+        let file = crate::state_lock::open_lock_file(&path)
+            .with_context(|| format!("failed to open maintenance lock {}", path.display()))?;
         let started = Instant::now();
         loop {
             match file.try_lock_exclusive() {
@@ -621,6 +616,8 @@ fn unix_now() -> u64 {
 mod tests {
     use super::*;
     use std::fs::FileTimes;
+    #[cfg(unix)]
+    use std::os::unix::fs::symlink;
 
     fn assert_contended(error: &anyhow::Error) {
         assert!(error
@@ -668,6 +665,40 @@ mod tests {
         let error = GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO).unwrap_err();
 
         assert_contended(&error);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_gate_lock_is_refused_without_touching_the_target() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        let outside = tempfile::NamedTempFile::new()?;
+        fs::write(outside.path(), b"outside-lock-target")?;
+        symlink(outside.path(), gate.lock_path())?;
+
+        let error = GateLock::acquire(gate.lock_path()).expect_err("symlinked gate lock must fail");
+
+        assert!(format!("{error:#}").contains(&gate.lock_path().display().to_string()));
+        assert_eq!(fs::read(outside.path())?, b"outside-lock-target");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn multiply_linked_gate_lock_is_refused() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let gate = MaintenanceGate::at(temp.path().to_path_buf());
+        gate.ensure_layout()?;
+        fs::write(gate.lock_path(), b"lock")?;
+        let alias = temp.path().join("lock-alias");
+        fs::hard_link(gate.lock_path(), &alias)?;
+
+        let error =
+            GateLock::acquire(gate.lock_path()).expect_err("multiply linked gate lock must fail");
+
+        assert!(format!("{error:#}").contains(&gate.lock_path().display().to_string()));
         Ok(())
     }
 

--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -1,10 +1,11 @@
 //! Repository-wide maintenance exclusion for Coven writers.
 //!
 //! The files live below git's *common* directory, not a worktree's `.git`
-//! link, so every worktree of one checkout observes the same state.  This is
-//! deliberately a protocol built from exclusive file creation and fenced
-//! records rather than an advisory process lock: Cave and the CLI are separate
-//! processes and must make the same decision before they mutate a repository.
+//! link, so every worktree of one checkout observes the same state. Owner and
+//! writer state remain fenced records, while short metadata mutations are
+//! serialized by a cross-process advisory lock used by Coven processes. Cave
+//! participates through Coven's CLI/API commands rather than implementing the
+//! lock itself.
 
 use std::{
     fs,

--- a/docs/superpowers/plans/2026-08-05-maintenance-gate-lock.md
+++ b/docs/superpowers/plans/2026-08-05-maintenance-gate-lock.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the unsafe stale-file maintenance lock with a bounded, cross-process advisory lock that cannot be stolen from a live holder.
+**Goal:** Replace the unsafe stale-file maintenance lock with a bounded, cross-process advisory lock that cannot be stolen from a live holder while preserving the repository's validated lock-path open semantics.
 
-**Architecture:** Keep `MaintenanceGate::with_lock` and all owner/writer lease records unchanged. `GateLock` will hold an open file protected by `fs2::FileExt::try_lock_exclusive`, retry recognized contention for the existing five-second window, and release through RAII without unlinking the persistent lock file.
+**Architecture:** Keep `MaintenanceGate::with_lock` and all owner/writer lease records unchanged. `GateLock` will hold an open file returned by `crate::state_lock::open_lock_file(&path)`, protect it with `fs2::FileExt::try_lock_exclusive`, retry recognized contention for the existing five-second window, and release through RAII without unlinking the persistent lock file.
 
 **Tech Stack:** Rust standard library, `fs2`, `anyhow`, Cargo test/clippy/fmt, repository privacy and secret guards.
 
@@ -12,7 +12,7 @@
 
 ## File Structure
 
-- Modify `crates/coven-cli/src/maintenance_gate.rs`: replace stale-file takeover with a timed advisory lock and add focused unit tests.
+- Modify `crates/coven-cli/src/maintenance_gate.rs`: replace stale-file takeover with a timed advisory lock opened through the existing validated helper and add focused unit tests.
 - Keep `crates/coven-cli/src/state_lock.rs` unchanged: reuse its existing `is_lock_contended` helper rather than duplicating platform-specific error recognition.
 - Keep public CLI/API documentation unchanged: external maintenance behavior and contracts do not change.
 
@@ -33,12 +33,14 @@ coven claim heartbeat issue-612
 
 Expected: `issue-612` remains owned by `buns@coven-fix-612-maintenance-lock` with a renewed expiry.
 
-- [ ] **Step 2: Write tests for live contention, release, and stale mtime**
+- [ ] **Step 2: Write tests for live contention, release, stale mtime, symlink refusal, and hard-link refusal**
 
 Add these imports and tests inside `maintenance_gate.rs`'s existing `#[cfg(test)] mod tests`:
 
 ```rust
 use std::fs::FileTimes;
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
 
 fn assert_contended(error: &anyhow::Error) {
     assert!(error
@@ -94,6 +96,40 @@ fn stale_mtime_does_not_allow_live_gate_lock_takeover() -> Result<()> {
     assert_contended(&error);
     Ok(())
 }
+
+#[cfg(unix)]
+#[test]
+fn symlinked_gate_lock_is_refused_without_touching_the_target() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    gate.ensure_layout()?;
+    let outside = tempfile::NamedTempFile::new()?;
+    fs::write(outside.path(), b"outside-lock-target")?;
+    symlink(outside.path(), gate.lock_path())?;
+
+    let error = GateLock::acquire(gate.lock_path()).expect_err("symlinked gate lock must fail");
+
+    assert!(format!("{error:#}").contains(&gate.lock_path().display().to_string()));
+    assert_eq!(fs::read(outside.path())?, b"outside-lock-target");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn multiply_linked_gate_lock_is_refused() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    gate.ensure_layout()?;
+    fs::write(gate.lock_path(), b"lock")?;
+    let alias = temp.path().join("lock-alias");
+    fs::hard_link(gate.lock_path(), &alias)?;
+
+    let error =
+        GateLock::acquire(gate.lock_path()).expect_err("multiply linked gate lock must fail");
+
+    assert!(format!("{error:#}").contains(&gate.lock_path().display().to_string()));
+    Ok(())
+}
 ```
 
 - [ ] **Step 3: Run the focused tests and confirm they fail before implementation**
@@ -105,7 +141,7 @@ cd /tmp/coven-fix-612-maintenance-lock
 cargo test -p coven-cli maintenance_gate::tests --locked
 ```
 
-Expected: compilation fails because `GateLock::acquire_with_wait` does not exist yet. This confirms the tests require the new bounded advisory-lock seam.
+Expected: the new Unix regression tests fail against the plain `std::fs::OpenOptions` implementation because it follows a symlinked maintenance lock path and accepts a multiply linked lock file.
 
 ### Task 2: Replace Stale-File Takeover with an Advisory Lock
 
@@ -159,13 +195,8 @@ impl GateLock {
     }
 
     fn acquire_with_wait(path: PathBuf, wait: Duration) -> Result<Self> {
-        let file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&path)
-            .with_context(|| format!("failed to open {}", path.display()))?;
+        let file = crate::state_lock::open_lock_file(&path)
+            .with_context(|| format!("failed to open maintenance lock {}", path.display()))?;
         let started = Instant::now();
         loop {
             match file.try_lock_exclusive() {
@@ -203,7 +234,7 @@ cd /tmp/coven-fix-612-maintenance-lock
 cargo test -p coven-cli maintenance_gate::tests --locked
 ```
 
-Expected: all maintenance-gate unit tests pass, including the three new lock tests.
+Expected: all maintenance-gate unit tests pass, including the contention/release tests plus the new Unix symlink and hard-link regression tests.
 
 - [ ] **Step 5: Format and inspect the focused diff**
 
@@ -216,7 +247,7 @@ git --no-pager diff --check
 git --no-pager diff -- crates/coven-cli/src/maintenance_gate.rs
 ```
 
-Expected: formatting succeeds, `diff --check` prints nothing, and the diff contains only the advisory-lock replacement and focused tests.
+Expected: formatting succeeds, `diff --check` prints nothing, and the diff contains only the validated helper open, focused regression tests, and the aligned design artifacts.
 
 - [ ] **Step 6: Commit the implementation**
 
@@ -298,7 +329,7 @@ gh pr create \
   --base main \
   --head fix/612-maintenance-lock \
   --title "fix: prevent maintenance gate lock takeover" \
-  --body $'## Summary\n- replace stale-file takeover with the existing cross-platform `fs2` advisory locking model\n- preserve the five-second contention timeout and maintenance API behavior\n- add regression coverage for live contention, release, and stale mtimes\n\n## Upgrade note\nRestart long-running Coven daemons after upgrading so every process uses the advisory-lock protocol.\n\nCloses #612'
+  --body $'## Summary\n- replace stale-file takeover with the existing validated lock-file helper plus `fs2` advisory locking\n- preserve the five-second contention timeout and maintenance API behavior\n- add regression coverage for live contention, release, stale mtimes, symlinks, and hard links\n\n## Upgrade note\nRestart long-running Coven daemons after upgrading so every process uses the advisory-lock protocol.\n\nCloses #612'
 ```
 
 Expected: GitHub creates a pull request targeting `main` and linking issue #612.

--- a/docs/superpowers/plans/2026-08-05-maintenance-gate-lock.md
+++ b/docs/superpowers/plans/2026-08-05-maintenance-gate-lock.md
@@ -1,0 +1,315 @@
+# Maintenance Gate Lock Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the unsafe stale-file maintenance lock with a bounded, cross-process advisory lock that cannot be stolen from a live holder.
+
+**Architecture:** Keep `MaintenanceGate::with_lock` and all owner/writer lease records unchanged. `GateLock` will hold an open file protected by `fs2::FileExt::try_lock_exclusive`, retry recognized contention for the existing five-second window, and release through RAII without unlinking the persistent lock file.
+
+**Tech Stack:** Rust standard library, `fs2`, `anyhow`, Cargo test/clippy/fmt, repository privacy and secret guards.
+
+---
+
+## File Structure
+
+- Modify `crates/coven-cli/src/maintenance_gate.rs`: replace stale-file takeover with a timed advisory lock and add focused unit tests.
+- Keep `crates/coven-cli/src/state_lock.rs` unchanged: reuse its existing `is_lock_contended` helper rather than duplicating platform-specific error recognition.
+- Keep public CLI/API documentation unchanged: external maintenance behavior and contracts do not change.
+
+### Task 1: Add Regression Coverage
+
+**Files:**
+- Modify: `crates/coven-cli/src/maintenance_gate.rs:626-671`
+- Test: `crates/coven-cli/src/maintenance_gate.rs`
+
+- [ ] **Step 1: Refresh the shared issue claim**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+coven claim heartbeat issue-612
+```
+
+Expected: `issue-612` remains owned by `buns@coven-fix-612-maintenance-lock` with a renewed expiry.
+
+- [ ] **Step 2: Write tests for live contention, release, and stale mtime**
+
+Add these imports and tests inside `maintenance_gate.rs`'s existing `#[cfg(test)] mod tests`:
+
+```rust
+use std::fs::FileTimes;
+
+fn assert_contended(error: &anyhow::Error) {
+    assert!(error
+        .downcast_ref::<GateError>()
+        .is_some_and(|error| matches!(error, GateError::Contended)));
+}
+
+#[test]
+fn live_gate_lock_blocks_a_second_acquirer() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    gate.ensure_layout()?;
+    let _first = GateLock::acquire(gate.lock_path())?;
+
+    let error =
+        GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO).unwrap_err();
+
+    assert_contended(&error);
+    Ok(())
+}
+
+#[test]
+fn dropping_gate_lock_allows_the_next_acquirer() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    gate.ensure_layout()?;
+    let first = GateLock::acquire(gate.lock_path())?;
+    drop(first);
+
+    let _second =
+        GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO)?;
+
+    Ok(())
+}
+
+#[test]
+fn stale_mtime_does_not_allow_live_gate_lock_takeover() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let gate = MaintenanceGate::at(temp.path().to_path_buf());
+    gate.ensure_layout()?;
+    let _first = GateLock::acquire(gate.lock_path())?;
+    let lock_file = fs::OpenOptions::new()
+        .write(true)
+        .open(gate.lock_path())?;
+    lock_file.set_times(
+        FileTimes::new()
+            .set_modified(SystemTime::now() - Duration::from_secs(120)),
+    )?;
+
+    let error =
+        GateLock::acquire_with_wait(gate.lock_path(), Duration::ZERO).unwrap_err();
+
+    assert_contended(&error);
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Run the focused tests and confirm they fail before implementation**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+cargo test -p coven-cli maintenance_gate::tests --locked
+```
+
+Expected: compilation fails because `GateLock::acquire_with_wait` does not exist yet. This confirms the tests require the new bounded advisory-lock seam.
+
+### Task 2: Replace Stale-File Takeover with an Advisory Lock
+
+**Files:**
+- Modify: `crates/coven-cli/src/maintenance_gate.rs:7-14`
+- Modify: `crates/coven-cli/src/maintenance_gate.rs:556-604`
+- Test: `crates/coven-cli/src/maintenance_gate.rs`
+
+- [ ] **Step 1: Import the advisory-lock trait and monotonic timer**
+
+Change the relevant imports to:
+
+```rust
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{Arc, Condvar, Mutex},
+    thread,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use fs2::FileExt;
+use serde::{Deserialize, Serialize};
+```
+
+- [ ] **Step 2: Remove the stale-lock age constant**
+
+Delete:
+
+```rust
+const LOCK_STALE_AFTER: Duration = Duration::from_secs(30);
+```
+
+Keep `LOCK_WAIT` at five seconds and the existing 10-millisecond retry interval.
+
+- [ ] **Step 3: Replace `GateLock` with a file-handle-backed advisory lock**
+
+Replace the current `GateLock`, its `Drop` implementation, and `is_stale` with:
+
+```rust
+#[derive(Debug)]
+struct GateLock {
+    file: fs::File,
+}
+
+impl GateLock {
+    fn acquire(path: PathBuf) -> Result<Self> {
+        Self::acquire_with_wait(path, LOCK_WAIT)
+    }
+
+    fn acquire_with_wait(path: PathBuf, wait: Duration) -> Result<Self> {
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        let started = Instant::now();
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => return Ok(Self { file }),
+                Err(error) if crate::state_lock::is_lock_contended(&error) => {
+                    if started.elapsed() >= wait {
+                        return Err(GateError::Contended.into());
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to acquire {}", path.display()));
+                }
+            }
+        }
+    }
+}
+
+impl Drop for GateLock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+```
+
+This deliberately leaves the lock file on disk. The file's mtime is no longer consulted, and no holder removes a path that another holder may own.
+
+- [ ] **Step 4: Run the focused tests**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+cargo test -p coven-cli maintenance_gate::tests --locked
+```
+
+Expected: all maintenance-gate unit tests pass, including the three new lock tests.
+
+- [ ] **Step 5: Format and inspect the focused diff**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+cargo fmt
+git --no-pager diff --check
+git --no-pager diff -- crates/coven-cli/src/maintenance_gate.rs
+```
+
+Expected: formatting succeeds, `diff --check` prints nothing, and the diff contains only the advisory-lock replacement and focused tests.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+git add crates/coven-cli/src/maintenance_gate.rs
+python3 scripts/check-coven-privacy.py --staged
+git commit -m "fix: prevent maintenance gate lock takeover" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: the privacy guard passes, then one implementation commit records the production fix and regression tests.
+
+### Task 3: Run Repository Gates and Open the Fix PR
+
+**Files:**
+- Verify: `crates/coven-cli/src/maintenance_gate.rs`
+- Verify: `docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md`
+- Verify: `docs/superpowers/plans/2026-08-05-maintenance-gate-lock.md`
+
+- [ ] **Step 1: Run Rust formatting and lint gates**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: both commands exit successfully with no warnings.
+
+- [ ] **Step 2: Run the locked workspace test suite**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+cargo test --workspace --locked
+```
+
+Expected: all workspace tests pass.
+
+- [ ] **Step 3: Run the secret guard**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+python scripts/check-secrets.py
+```
+
+Expected: the secret scan reports a clean result. The staged privacy guard already ran before each commit through the repository hook and explicitly before the implementation commit.
+
+- [ ] **Step 4: Confirm branch scope and commit history**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+git status --short
+git --no-pager log --oneline origin/main..HEAD
+git --no-pager diff --stat origin/main...HEAD
+```
+
+Expected: the worktree is clean; history contains the design, plan, and implementation commits; the diff is limited to the two design artifacts and `maintenance_gate.rs`.
+
+- [ ] **Step 5: Push and open the pull request**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+git push -u origin fix/612-maintenance-lock
+gh pr create \
+  --repo OpenCoven/coven \
+  --base main \
+  --head fix/612-maintenance-lock \
+  --title "fix: prevent maintenance gate lock takeover" \
+  --body $'## Summary\n- replace stale-file takeover with the existing cross-platform `fs2` advisory locking model\n- preserve the five-second contention timeout and maintenance API behavior\n- add regression coverage for live contention, release, and stale mtimes\n\n## Upgrade note\nRestart long-running Coven daemons after upgrading so every process uses the advisory-lock protocol.\n\nCloses #612'
+```
+
+Expected: GitHub creates a pull request targeting `main` and linking issue #612.
+
+- [ ] **Step 6: Keep the claim until integration completes**
+
+Run:
+
+```bash
+cd /tmp/coven-fix-612-maintenance-lock
+coven claim heartbeat issue-612
+```
+
+Expected: the claim remains active while the pull request is under review. Release it only when the PR merges or work stops.

--- a/docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md
+++ b/docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md
@@ -23,7 +23,8 @@ advisory lock provided by the existing `fs2` dependency.
 will:
 
 1. Open the persistent gate lock file for reading and writing, creating it when
-   absent.
+   absent, through the repository's existing no-follow, single-link validated
+   lock-file helper.
 2. Call `try_lock_exclusive`.
 3. Retry recognized contention every 10 milliseconds.
 4. Return `GateError::Contended` after the existing five-second wait.
@@ -54,8 +55,9 @@ upgrading so every participant uses the same lock protocol.
 
 Only errors recognized as lock contention are retried. The existing bounded
 wait and `GateError::Contended` result are preserved. File-open and lock errors
-remain explicit and include the affected path. Unlock errors are not surfaced
-from `Drop`, consistent with existing lock cleanup behavior.
+remain explicit and include maintenance-lock path context on top of the shared
+helper's validation failures. Unlock errors are not surfaced from `Drop`,
+consistent with existing lock cleanup behavior.
 
 ## Tests
 
@@ -63,7 +65,9 @@ Add focused unit tests that demonstrate:
 
 - a second `GateLock` cannot acquire while the first holder is live;
 - acquisition succeeds after the first holder drops; and
-- an old lock-file modification time does not allow takeover of a live holder.
+- an old lock-file modification time does not allow takeover of a live holder;
+- a symlinked maintenance lock path is refused without touching the target; and
+- a multiply linked maintenance lock file is refused.
 
 Existing maintenance owner and writer tests continue to cover unchanged
 protocol behavior.
@@ -73,4 +77,5 @@ protocol behavior.
 - Redesigning owner or writer lease records.
 - Adding PID, generation, or heartbeat data to the internal lock file.
 - Changing maintenance CLI or HTTP response contracts.
-- Broad filesystem hardening beyond the stale-lock race.
+- Broad hardening of owner or writer metadata files beyond the stale-lock race,
+  while preserving lock-path safety through the existing validated helper.

--- a/docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md
+++ b/docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md
@@ -1,0 +1,72 @@
+# Maintenance Gate Lock Design
+
+## Problem
+
+The maintenance gate serializes owner and writer metadata updates with an
+exclusive-create lock file. A contender deletes that file after 30 seconds
+without proving the holder exited, and the original holder later deletes
+whatever file occupies the path. A live but stalled holder can therefore
+overlap another critical section and remove the replacement lock.
+
+## Scope
+
+Fix issue #612 without changing the public maintenance commands, owner and
+writer lease records, timeout behavior, or Cave integration. The change is
+limited to the internal lock used by `MaintenanceGate::with_lock`.
+
+## Design
+
+Replace the exclusive-create and stale-file protocol with a cross-process
+advisory lock provided by the existing `fs2` dependency.
+
+`GateLock` will retain an open `std::fs::File` rather than a path. Acquisition
+will:
+
+1. Open the persistent gate lock file for reading and writing, creating it when
+   absent.
+2. Call `try_lock_exclusive`.
+3. Retry recognized contention every 10 milliseconds.
+4. Return `GateError::Contended` after the existing five-second wait.
+5. Return other I/O errors with the lock path in the error context.
+
+The lock file remains in place. No process removes it, and its modification time
+has no protocol meaning. The operating system releases the lock when the file
+handle is unlocked, closed, or the process exits, so a stalled live holder
+cannot be mistaken for a dead holder.
+
+`Drop` will best-effort unlock the held file handle, matching the repository's
+existing `StateLock` RAII behavior. Closing the handle remains the final
+release mechanism if explicit unlock fails.
+
+## Compatibility
+
+All callers continue through `MaintenanceGate::with_lock`; no caller or public
+API changes are required. Cave uses the documented `coven maintenance`
+commands, so it does not need to implement the advisory lock independently.
+Owner generations, writer generations, heartbeat intervals, lease expiry, and
+fail-closed malformed-record handling remain unchanged.
+
+## Error Handling
+
+Only errors recognized as lock contention are retried. The existing bounded
+wait and `GateError::Contended` result are preserved. File-open and lock errors
+remain explicit and include the affected path. Unlock errors are not surfaced
+from `Drop`, consistent with existing lock cleanup behavior.
+
+## Tests
+
+Add focused unit tests that demonstrate:
+
+- a second `GateLock` cannot acquire while the first holder is live;
+- acquisition succeeds after the first holder drops; and
+- an old lock-file modification time does not allow takeover of a live holder.
+
+Existing maintenance owner and writer tests continue to cover unchanged
+protocol behavior.
+
+## Non-Goals
+
+- Redesigning owner or writer lease records.
+- Adding PID, generation, or heartbeat data to the internal lock file.
+- Changing maintenance CLI or HTTP response contracts.
+- Broad filesystem hardening beyond the stale-lock race.

--- a/docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md
+++ b/docs/superpowers/specs/2026-08-05-maintenance-gate-lock-design.md
@@ -46,6 +46,10 @@ commands, so it does not need to implement the advisory lock independently.
 Owner generations, writer generations, heartbeat intervals, lease expiry, and
 fail-closed malformed-record handling remain unchanged.
 
+An already-running binary built before this fix does not participate in the
+advisory lock. Long-running Coven daemons must therefore be restarted after
+upgrading so every participant uses the same lock protocol.
+
 ## Error Handling
 
 Only errors recognized as lock contention are retried. The existing bounded


### PR DESCRIPTION
Summary: replaces stale-file takeover with existing cross-platform fs2 advisory locking; uses validated no-follow/single-link lock opening; preserves five-second contention timeout and maintenance API behavior; adds live contention/release/stale-mtime/symlink/hard-link regression tests.

Tests:
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace --locked
- python scripts/check-secrets.py

Upgrade note: restart long-running Coven daemons after upgrading so all processes use the advisory-lock protocol.

Closes #612