### PR TITLE
docs(specs): correct AFS architecture claims

### DIFF
--- a/specs/coven-agent-fs/RESEARCH.md
+++ b/specs/coven-agent-fs/RESEARCH.md
@@ -5,11 +5,11 @@ Confidence: **high** = inspected primary source; **medium** = primary w/ caveats
 
 ## Executive summary
 
-1. **Turso AgentFS is a small, fully-reimplementable design** — one SQLite file holding a POSIX-ish inode FS (fs_inode/fs_dentry/fs_data 4KB chunks), a CoW overlay (whiteouts + fs_origin), an insert-only tool_calls audit table, and a KV store. MIT, Rust, BETA (0.2.x). [S1][S2][S6] (high)
+1. **Turso AgentFS is a small, fully-reimplementable design** — one SQLite file holding a POSIX-ish inode FS (fs_inode/fs_dentry/fs_data 4KB chunks), a CoW overlay (whiteouts + fs_origin), an insert-only tool_calls audit table, and a KV store. MIT, Rust, BETA (0.6.4). [S1][S2][S4][S6] (high)
 2. **Copy-up is full-file, not block-level** — first write to a base file copies the whole file into the delta. Fine for code files; bad for huge binaries. [S3][S6] (high)
 3. **macOS mounting without kexts is a solved problem**: AgentFS serves NFSv3 in userspace via HuggingFace's `nfsserve` crate and uses macOS's native `mount_nfs`. Linux uses `fuser` (FUSE3). FSKit (macOS 15+) is the strategic future path but immature. [S5][S7][S12] (high)
-4. **The design space splits into four families** — SQLite VFS (AgentFS), microVM snapshots (E2B/Firecracker), CoW filesystems (ZFS/btrfs), and convention-only isolation (git worktrees, what OpenCoven uses today). Only the SQLite family gives SQL-queryable audit + single-file portability + cross-platform mounts. [S8–S11] (medium)
-5. **git worktrees' known weakness is exactly OpenCoven's pain**: isolation is conventional, not enforced — nothing stops an agent writing outside its worktree (cf. the GitHub Desktop worktree destruction incidents in coven-cave). An AFS overlay closes that hole. [S4][S11] (high fact, inference re: fit)
+4. **The design space splits into four families** — SQLite VFS (AgentFS), microVM snapshots (E2B/Firecracker), CoW filesystems (ZFS/btrfs), and convention-only isolation (git worktrees, what OpenCoven uses today). Only the SQLite family combines SQL-queryable audit, a single-file standalone mode, and cross-platform mounts. [S8–S11] (medium)
+5. **git worktrees' known weakness is exactly OpenCoven's pain**: isolation is conventional, not enforced — nothing stops an agent writing outside its worktree (cf. the GitHub Desktop worktree destruction incidents in coven-cave). An AFS overlay plus an OS sandbox closes that hole; the mount alone does not restrict absolute-path writes. [S4][S11] (high fact, inference re: fit)
 6. **Recommendation: build native, spec-compatible.** Implement a `coven-afs` crate inside the coven daemon (already Rust + rusqlite 0.40), adopting AgentFS SPEC v0.4's schema as the base contract, extending it with coven-native audit (session/familiar/bead provenance). Reuse `fuser` + `nfsserve` for mounts. Do NOT adopt the Turso SDK as a dependency — the spec is the valuable artifact, the code is beta. (inference)
 
 ## Findings per RQ
@@ -24,24 +24,25 @@ Confidence: **high** = inspected primary source; **medium** = primary w/ caveats
 
 ### RQ2 — What are the alternative designs?
 
-See comparison table. Notables beyond the table: EdenFS/ProjFS prove lazy-materialization daemons scale to monorepos [S13]; Firecracker snapshot-restore is 5–30ms and captures RAM+disk, but is Linux-server-shaped, not desktop-shaped [S9]; Letta memory blocks are a semantic (non-POSIX) alternative — complementary, not competing [S14].
+See comparison table. Notables beyond the table: EdenFS/ProjFS prove lazy-materialization daemons scale to monorepos [S13]; Firecracker snapshot-restore is 5–30ms and captures guest memory plus microVM/device state, while disk images and memory/disk consistency remain operator-managed [S9]; Letta memory blocks are a semantic (non-POSIX) alternative — complementary, not competing [S14].
 
 ### RQ3 — What do agent harnesses actually need?
 
-From the surveyed products (high, per-source): (a) POSIX view so git/grep/existing tools work with zero integration [S2]; (b) enforced write boundaries, not conventions [S4][S11]; (c) queryable provenance — what changed, which tool call caused it [S6][S15]; (d) cheap branch/discard per session [S3][S16]; (e) portability of a whole agent run as one artifact [S1].
+From the surveyed products (high, per-source): (a) POSIX view so git/grep/existing tools work with zero integration [S2]; (b) enforced write boundaries, not conventions [S4][S11]; (c) queryable provenance — what changed, which tool call caused it [S6][S15]; (d) cheap branch/discard per session [S3][S16]; (e) portable standalone filesystems, or reproducible overlay artifacts that bundle or identify an immutable base [S1][S3].
 
 ### RQ4 — Right native architecture for OpenCoven? (inference, grounded in above)
 
 - **`coven-afs` crate** in the coven workspace, owned by the daemon. rusqlite 0.40 already bundled — zero new storage deps.
 - **Schema: AgentFS SPEC v0.4 as baseline** (fs_config/inode/dentry/data/symlink, whiteouts, origin, kv, tool_calls), plus coven extension tables: `afs_provenance(op → session_id, familiar, bead_id, turn)` joining file mutations to coven's existing session events. Spec-compatibility keeps `agentfs` CLI/tooling usable against our DBs for free.
 - **Mounts**: `fuser` on Linux, `nfsserve` on 127.0.0.1 for macOS (same as AgentFS — proven, kext-free). Windows: SDK-only initially (AgentFS also has no Windows mount).
+- **Enforcement**: pair the mount with a platform sandbox that denies writes outside the mounted workspace. Linux namespaces/bubblewrap are the proven path; macOS needs a separately validated sandbox strategy. Overlay semantics protect the base only when all writes are forced through the merged view.
 - **API surface**: extend `coven.daemon.v1` socket API — `afs.session.create/join/diff/discard/commit`, `afs.mount`, `afs.timeline`. Cave desktop renders diff/timeline as a UI surface.
 - **Workflow fit**: AFS session per agent run layered over the project root; "commit" materializes the delta into a real git worktree/branch for the existing PR pipeline — AFS replaces the risky live-worktree phase, not git itself.
-- **Block-level CoW deferrable**: full-file copy-up (Turso's choice) is acceptable v1; chunked fs_data already bounds the write amplification for appends.
+- **Copy-up tradeoff to measure**: Turso performs full-file copy-up on the first write to a base file. Chunked `fs_data` bounds row size, not total bytes copied, so v1 acceptance depends on benchmarks against expected repositories and large generated artifacts.
 
 ### RQ5 — Build vs adapt?
 
-- **Adopt the spec, not the code.** SPEC v0.4 is ~22KB, MIT, precise enough to reimplement in days; the CLI/SDK are BETA (0.2.x, repo created 2025-10). Depending on Turso's crate couples us to their Turso-DB direction and cloud sync. (medium/inference)
+- **Adopt the spec, not the code.** SPEC v0.4 is ~22KB, MIT, precise enough to reimplement in days; the CLI/SDK remain explicitly BETA at 0.6.4. Depending on Turso's crate couples us to their release direction and cloud-sync choices; reassess before implementation rather than freezing this August 2026 recommendation indefinitely. (medium/inference)
 - Reuse verbatim: `fuser`, `nfsserve` crates (both battle-tested; AgentFS itself vendors their licenses). (high)
 - Effort estimate: core FS + overlay ≈ the SPEC's operation list, all plain SQL; the daemon integration and Cave UI are the larger halves. (inference)
 


### PR DESCRIPTION
## Summary
- require OS sandbox enforcement alongside the AFS overlay
- distinguish standalone portability from overlay delta/base dependencies
- correct Firecracker snapshot, copy-up amplification, and AgentFS 0.6.4 maturity claims

## Test Plan
- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --locked
- [x] python scripts/check-secrets.py
- [x] python3 scripts/check-coven-privacy.py --staged