### PR TITLE
feat(runtime): expose exact writer backlog health

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -285,12 +285,15 @@ fn health_response_with_hub(
     event_writer: Option<crate::event_writer::EventWriterHealth>,
 ) -> HealthResponse {
     let mut response = health_response(daemon);
-    response.event_writer = event_writer;
     if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
         response.hub = serde_json::from_value(summary).ok();
     }
-    response.storage =
-        Some(store::storage_health(coven_home).unwrap_or_else(store::unavailable_storage_health));
+    response.storage = Some(
+        store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
+            store::unavailable_storage_health(error, event_writer.as_ref())
+        }),
+    );
+    response.event_writer = event_writer;
     response
 }
 
@@ -6734,6 +6737,7 @@ mod tests {
         assert!(response.capabilities.structured_errors);
         assert_eq!(response.daemon, None);
         assert_eq!(response.hub, None);
+        assert_eq!(response.event_writer, None);
         assert_eq!(response.storage, None);
     }
 
@@ -6767,6 +6771,58 @@ mod tests {
         assert!(response.body.contains(r#""storage":{"status""#));
         assert!(response.body.contains(r#""writerBacklogEvents":0"#));
         assert!(response.body.contains(r#""freeDiskBytes""#));
+        Ok(())
+    }
+
+    struct HealthRuntime;
+
+    impl SessionRuntime for HealthRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> Result<()> {
+            Ok(())
+        }
+
+        fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
+            Some(crate::event_writer::EventWriterHealth {
+                state: "pressured".to_string(),
+                queued_events: 3,
+                queued_bytes: 4096,
+                capacity_bytes: 2 * 1024 * 1024,
+                dropped_output_events: 1,
+                dropped_output_bytes: 256,
+                connection_opens: 1,
+                transactions: 4,
+                committed_events: 20,
+                last_error: None,
+            })
+        }
+    }
+
+    #[test]
+    fn health_uses_one_live_writer_snapshot_for_both_surfaces() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let response = handle_request_with_runtime(
+            "GET",
+            "/health",
+            temp_dir.path(),
+            None,
+            None,
+            &HealthRuntime,
+        )?;
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+
+        assert_eq!(body["capabilities"]["sessionHandoff"], true);
+        assert_eq!(body["eventWriter"]["queuedEvents"], 3);
+        assert_eq!(body["eventWriter"]["queuedBytes"], 4096);
+        assert_eq!(body["storage"]["writerBacklogEvents"], 3);
+        assert_eq!(body["storage"]["writerBacklogBytes"], 4096);
         Ok(())
     }
 

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -34,6 +34,7 @@ pub struct EventWriterHealth {
     /// `healthy`, `pressured`, or `failed`.  Pressure remains visible for the
     /// daemon lifetime so a rejected raw chunk is never silently forgotten.
     pub state: String,
+    pub queued_events: usize,
     pub queued_bytes: usize,
     pub capacity_bytes: usize,
     pub dropped_output_events: u64,
@@ -60,6 +61,7 @@ struct Shared {
 
 struct Queue {
     items: VecDeque<QueuedEvent>,
+    queued_events: usize,
     queued_bytes: usize,
     failed: Option<String>,
 }
@@ -97,6 +99,7 @@ impl EventWriter {
         let shared = Arc::new(Shared {
             queue: Mutex::new(Queue {
                 items: VecDeque::new(),
+                queued_events: 0,
                 queued_bytes: 0,
                 failed: None,
             }),
@@ -105,6 +108,7 @@ impl EventWriter {
             output_capacity_bytes: capacity_bytes - RESERVED_CRITICAL_BYTES,
             health: Mutex::new(EventWriterHealth {
                 state: "healthy".to_string(),
+                queued_events: 0,
                 queued_bytes: 0,
                 capacity_bytes,
                 dropped_output_events: 0,
@@ -202,8 +206,9 @@ impl EventWriter {
             health.dropped_output_bytes += bytes.saturating_sub(EVENT_OVERHEAD_BYTES) as u64;
             return Ok(false);
         }
+        queue.queued_events += 1;
         queue.queued_bytes += bytes;
-        self.update_queued_bytes(queue.queued_bytes);
+        self.update_queue_health(queue.queued_events, queue.queued_bytes);
         queue.items.push_back(QueuedEvent {
             event,
             bytes,
@@ -233,8 +238,9 @@ impl EventWriter {
                 .wait(queue)
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
         }
+        queue.queued_events += 1;
         queue.queued_bytes += bytes;
-        self.update_queued_bytes(queue.queued_bytes);
+        self.update_queue_health(queue.queued_events, queue.queued_bytes);
         queue.items.push_back(QueuedEvent {
             event,
             bytes,
@@ -265,8 +271,10 @@ impl EventWriter {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    fn update_queued_bytes(&self, bytes: usize) {
-        self.lock_health().queued_bytes = bytes;
+    fn update_queue_health(&self, events: usize, bytes: usize) {
+        let mut health = self.lock_health();
+        health.queued_events = events;
+        health.queued_bytes = bytes;
     }
 }
 
@@ -297,7 +305,7 @@ fn run_worker(
         let result = commit_batch(&mut conn, &coven_home, &batch);
         match result {
             Ok(committed) => {
-                release_bytes(&shared, bytes);
+                release_capacity(&shared, batch.len(), bytes);
                 let mut health = lock_health(&shared);
                 health.transactions += 1;
                 health.committed_events += committed as u64;
@@ -479,10 +487,13 @@ fn record_exit(
     )
 }
 
-fn release_bytes(shared: &Arc<Shared>, bytes: usize) {
+fn release_capacity(shared: &Arc<Shared>, events: usize, bytes: usize) {
     let mut queue = lock_queue(shared);
+    queue.queued_events = queue.queued_events.saturating_sub(events);
     queue.queued_bytes = queue.queued_bytes.saturating_sub(bytes);
-    lock_health(shared).queued_bytes = queue.queued_bytes;
+    let mut health = lock_health(shared);
+    health.queued_events = queue.queued_events;
+    health.queued_bytes = queue.queued_bytes;
     shared.available.notify_all();
 }
 
@@ -497,10 +508,12 @@ fn complete(batch: &[QueuedEvent], result: std::result::Result<(), String>) {
 fn fail_writer(shared: &Arc<Shared>, message: String) -> Vec<QueuedEvent> {
     let mut queue = lock_queue(shared);
     queue.failed = Some(message.clone());
+    queue.queued_events = 0;
     queue.queued_bytes = 0;
     let pending = queue.items.drain(..).collect();
     let mut health = lock_health(shared);
     health.state = "failed".to_string();
+    health.queued_events = 0;
     health.queued_bytes = 0;
     health.last_error = Some(message);
     shared.available.notify_all();
@@ -524,6 +537,88 @@ fn lock_health(shared: &Arc<Shared>) -> std::sync::MutexGuard<'_, EventWriterHea
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn queue_health_counts_events_until_completion() {
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(Queue {
+                items: VecDeque::new(),
+                queued_events: 2,
+                queued_bytes: EVENT_OVERHEAD_BYTES * 2,
+                failed: None,
+            }),
+            available: Condvar::new(),
+            capacity_bytes: DEFAULT_CAPACITY_BYTES,
+            output_capacity_bytes: DEFAULT_CAPACITY_BYTES - RESERVED_CRITICAL_BYTES,
+            health: Mutex::new(EventWriterHealth {
+                state: "healthy".to_string(),
+                queued_events: 2,
+                queued_bytes: EVENT_OVERHEAD_BYTES * 2,
+                capacity_bytes: DEFAULT_CAPACITY_BYTES,
+                dropped_output_events: 0,
+                dropped_output_bytes: 0,
+                connection_opens: 0,
+                transactions: 0,
+                committed_events: 0,
+                last_error: None,
+            }),
+        });
+
+        release_capacity(&shared, 1, EVENT_OVERHEAD_BYTES);
+
+        let health = lock_health(&shared);
+        assert_eq!(health.queued_events, 1);
+        assert_eq!(health.queued_bytes, EVENT_OVERHEAD_BYTES);
+    }
+
+    #[test]
+    fn accepted_output_updates_queue_health_immediately() -> Result<()> {
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(Queue {
+                items: VecDeque::new(),
+                queued_events: 0,
+                queued_bytes: 0,
+                failed: None,
+            }),
+            available: Condvar::new(),
+            capacity_bytes: DEFAULT_CAPACITY_BYTES,
+            output_capacity_bytes: DEFAULT_CAPACITY_BYTES - RESERVED_CRITICAL_BYTES,
+            health: Mutex::new(EventWriterHealth {
+                state: "healthy".to_string(),
+                queued_events: 0,
+                queued_bytes: 0,
+                capacity_bytes: DEFAULT_CAPACITY_BYTES,
+                dropped_output_events: 0,
+                dropped_output_bytes: 0,
+                connection_opens: 0,
+                transactions: 0,
+                committed_events: 0,
+                last_error: None,
+            }),
+        });
+        let writer = EventWriter {
+            shared: Arc::clone(&shared),
+        };
+
+        assert!(writer.enqueue_output(
+            PendingEvent::Output {
+                session_id: "s-1".to_string(),
+                data: "hello".to_string(),
+                created_at: "2026-08-04T00:00:00Z".to_string(),
+            },
+            EVENT_OVERHEAD_BYTES + "hello".len()
+        )?);
+
+        let queue = lock_queue(&shared);
+        assert_eq!(queue.queued_events, 1);
+        assert_eq!(queue.queued_bytes, EVENT_OVERHEAD_BYTES + "hello".len());
+        drop(queue);
+
+        let health = lock_health(&shared);
+        assert_eq!(health.queued_events, 1);
+        assert_eq!(health.queued_bytes, EVENT_OVERHEAD_BYTES + "hello".len());
+        Ok(())
+    }
 
     fn session(id: &str) -> store::SessionRecord {
         store::SessionRecord {
@@ -638,6 +733,8 @@ mod tests {
         let health = writer.health();
         assert_eq!(health.state, "pressured");
         assert_eq!(health.dropped_output_events, 1);
+        assert_eq!(health.queued_events, 0);
+        assert_eq!(health.queued_bytes, 0);
         writer.record_exit(
             "s-1",
             PtyRunResult {
@@ -653,6 +750,7 @@ mod tests {
         let shared = Arc::new(Shared {
             queue: Mutex::new(Queue {
                 items: VecDeque::new(),
+                queued_events: 1,
                 queued_bytes: EVENT_OVERHEAD_BYTES,
                 failed: None,
             }),
@@ -661,6 +759,7 @@ mod tests {
             output_capacity_bytes: DEFAULT_CAPACITY_BYTES - RESERVED_CRITICAL_BYTES,
             health: Mutex::new(EventWriterHealth {
                 state: "healthy".to_string(),
+                queued_events: 1,
                 queued_bytes: EVENT_OVERHEAD_BYTES,
                 capacity_bytes: DEFAULT_CAPACITY_BYTES,
                 dropped_output_events: 0,
@@ -698,6 +797,7 @@ mod tests {
         assert!(lock_queue(&shared).items.is_empty());
         let health = lock_health(&shared);
         assert_eq!(health.state, "failed");
+        assert_eq!(health.queued_events, 0);
         assert_eq!(health.queued_bytes, 0);
     }
 }

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -119,11 +119,8 @@ pub struct HandoffContinuationRecord {
 
 /// Storage and maintenance state exposed through the daemon health contract.
 ///
-/// `writer_backlog_events` / `writer_backlog_bytes` are reported as zero here.
-/// The dedicated event writer landed in #607 after this struct was written and
-/// owns its own queue depth, surfaced separately as `eventWriter.queuedBytes`;
-/// wiring these two fields to it is tracked as follow-up rather than guessed at
-/// during a rebase.
+/// The backlog fields mirror the optional live event-writer snapshot supplied
+/// by the health route and default to zero when no runtime snapshot exists.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageHealth {
@@ -3563,7 +3560,10 @@ fn run_scheduled_maintenance_with_config_and_free_disk(
 
 /// Gather storage pressure without mutating the database. Health callers use
 /// this after daemon startup has initialized the schema.
-pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
+pub fn storage_health(
+    coven_home: &Path,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<StorageHealth> {
     let store_path = coven_home.join("coven.sqlite3");
     let conn = open_store(&store_path)?;
     let free_disk_bytes = fs2::available_space(coven_home)
@@ -3604,6 +3604,7 @@ pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
         "ok"
     };
 
+    let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
     Ok(StorageHealth {
         status: status.to_string(),
         database_bytes,
@@ -3613,15 +3614,19 @@ pub fn storage_health(coven_home: &Path) -> Result<StorageHealth> {
         last_prune_at,
         checkpoint_age_seconds: maintenance_age_seconds(last_checkpoint_at.as_deref()),
         last_checkpoint_at,
-        writer_backlog_events: 0,
-        writer_backlog_bytes: 0,
+        writer_backlog_events,
+        writer_backlog_bytes,
         free_disk_bytes,
         maintenance_blocked,
         last_maintenance_error,
     })
 }
 
-pub fn unavailable_storage_health(_error: impl ToString) -> StorageHealth {
+pub fn unavailable_storage_health(
+    _error: impl ToString,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> StorageHealth {
+    let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
     StorageHealth {
         status: "degraded".to_string(),
         database_bytes: 0,
@@ -3631,8 +3636,8 @@ pub fn unavailable_storage_health(_error: impl ToString) -> StorageHealth {
         prune_age_seconds: None,
         last_checkpoint_at: None,
         checkpoint_age_seconds: None,
-        writer_backlog_events: 0,
-        writer_backlog_bytes: 0,
+        writer_backlog_events,
+        writer_backlog_bytes,
         free_disk_bytes: 0,
         maintenance_blocked: true,
         // The socket API is a compatibility boundary. Do not turn an I/O
@@ -3640,6 +3645,12 @@ pub fn unavailable_storage_health(_error: impl ToString) -> StorageHealth {
         // in the local recovery log.
         last_maintenance_error: Some("storage health unavailable".to_string()),
     }
+}
+
+fn writer_backlog(event_writer: Option<&crate::event_writer::EventWriterHealth>) -> (u64, u64) {
+    event_writer
+        .map(|health| (health.queued_events as u64, health.queued_bytes as u64))
+        .unwrap_or_default()
 }
 
 pub fn record_maintenance_error(coven_home: &Path, error: impl ToString) {
@@ -4975,7 +4986,7 @@ mod tests {
         assert!(!report.checkpoint_ran);
         assert!(!report.blocked_by_free_disk);
 
-        let health = storage_health(home)?;
+        let health = storage_health(home, None)?;
         assert_eq!(
             health.last_prune_at.as_deref(),
             Some("2026-04-27T06:00:00Z")
@@ -5160,12 +5171,37 @@ mod tests {
             },
         )?;
 
-        let health = storage_health(home)?;
+        let health = storage_health(home, None)?;
         assert_eq!(
             health.oldest_retained_event_at.as_deref(),
             Some("2010-01-01T00:00:00Z")
         );
         assert_ne!(health.status, "ok");
+        Ok(())
+    }
+
+    #[test]
+    fn storage_health_uses_live_writer_backlog() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        open_store(&home.join("coven.sqlite3"))?;
+        let writer = crate::event_writer::EventWriterHealth {
+            state: "pressured".to_string(),
+            queued_events: 7,
+            queued_bytes: 8192,
+            capacity_bytes: 2 * 1024 * 1024,
+            dropped_output_events: 1,
+            dropped_output_bytes: 512,
+            connection_opens: 1,
+            transactions: 3,
+            committed_events: 12,
+            last_error: None,
+        };
+
+        let health = storage_health(home, Some(&writer))?;
+
+        assert_eq!(health.writer_backlog_events, 7);
+        assert_eq!(health.writer_backlog_bytes, 8192);
         Ok(())
     }
 

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -14,8 +14,9 @@ the expected socket for the active `COVEN_HOME`.
 `GET /api/v1/health` also includes a `storage` object. It reports the SQLite
 database and WAL sizes, free space on the `COVEN_HOME` filesystem, the oldest
 retained event, ages of the last prune and checkpoint, and the event-writer
-backlog. Current direct-write releases report a zero backlog; a later dedicated
-writer preserves the same fields.
+backlog. The optional `eventWriter` block reports the live queue snapshot, and
+`storage.writerBacklogEvents` / `storage.writerBacklogBytes` mirror that same
+snapshot.
 
 The daemon runs retention in small background transactions after startup. It
 uses the configured raw-artifact and redacted-event retention windows, never
@@ -45,13 +46,20 @@ Coven daemon: running (pid 12345, socket <covenHome>/coven.sock)
 For scripts, `coven daemon status --json` adds an `ok` field that reports
 whether the daemon health response succeeded.
 
-`GET /api/v1/health` also includes an additive `eventWriter` object for a
+`GET /api/v1/health` also includes an optional `eventWriter` object for a
 running daemon. `state: "healthy"` means live-session event persistence is
 keeping up. `"pressured"` means one or more raw PTY chunks were rejected after
 the bounded queue filled; inspect `droppedOutputEvents` and
-`droppedOutputBytes`. `"failed"` means the dedicated SQLite writer could not
-commit, and `lastError` carries the diagnostic. Lifecycle events are never
-dropped for queue pressure.
+`droppedOutputBytes`. `"failed"` means the writer could not commit, and
+`lastError` carries the diagnostic. Lifecycle events are never dropped for
+queue pressure.
+
+The same response includes `storage` health. Its `writerBacklogEvents` and
+`writerBacklogBytes` fields mirror the live `eventWriter` queue snapshot, while
+the remaining fields report SQLite/WAL size, retention and checkpoint age, free
+disk, and maintenance errors. `critical` means the free-disk safety watermark
+has paused scheduled maintenance; `degraded` means storage health could not be
+collected.
 
 ## Status values
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -29,7 +29,7 @@ All error responses use the structured envelope documented in the [API contract]
 | Method | Path | Purpose | Success |
 |---|---|---|---|
 | GET | `/api/v1/api-version` | Read the legacy route-family token. | `{ apiVersion: "v1", supportedApiVersions: ["v1"] }` |
-| GET | `/api/v1/health` | Daemon reachability, version, capabilities, pid, hub summary, and local storage pressure. | `{ ok, apiVersion, covenVersion, capabilities, daemon, hub, storage }` |
+| GET | `/api/v1/health` | Daemon reachability, version, capabilities, pid, hub summary, event-writer state, and local storage pressure. | `{ ok, apiVersion, covenVersion, capabilities, daemon, hub, eventWriter, storage }` |
 | GET | `/api/v1/capabilities` | Control-plane capability catalog with policy hints and action ids. | `{ capabilities: [...] }` |
 | GET | `/api/v1/capabilities/harnesses` | Aggregate of harness-native capability manifests plus Coven skills (`?refresh=1` re-scans). | `{ coven_skills, harness_capabilities, scanned_at }` |
 | GET | `/api/v1/capabilities/:harness` | One harness's capability manifest (`?refresh=1` re-scans). | manifest object · `404 harness_not_found` |
@@ -40,12 +40,17 @@ The health `capabilities` object currently contains all nine fields:
 `eventCursor`, `structuredErrors`, and `sessionHandoff`. `daemon` is either `null` or
 `{ pid, startedAt, socket }`, where the socket is under
 `<covenHome>/coven.sock`; the optional `hub` field is a control-plane summary.
+The optional `eventWriter` field reports the daemon-owned persistence queue,
+including its state, exact queued events/bytes, capacity, dropped output,
+connection, transaction, commit, and last-error counters.
 The optional `storage` field is `{ status, databaseBytes, walBytes,
 oldestRetainedEventAt, lastPruneAt, pruneAgeSeconds, lastCheckpointAt,
 checkpointAgeSeconds, writerBacklogEvents, writerBacklogBytes, freeDiskBytes,
 maintenanceBlocked, lastMaintenanceError? }`. `status` is `ok`, `warning`,
 `critical`, or `degraded`; clients should surface `critical` and `degraded`
 before storage exhaustion rather than treating a reachable daemon as healthy.
+`writerBacklogEvents` and `writerBacklogBytes` mirror the same live queue
+snapshot reported by `eventWriter`.
 
 ## Sessions and events
 


### PR DESCRIPTION
## Context

PR #608 landed the bounded retention and storage-health foundation. This focused follow-up replaces its hard-coded zero backlog with the dedicated event writer’s exact live queue snapshot while preserving the existing `eventWriter` and `sessionHandoff` contracts.

## Implementation

- Count accepted events and bytes until commit completion.
- Mirror one writer snapshot into both `eventWriter` and `storage.writerBacklog*`.
- Preserve zero defaults when no live runtime snapshot exists.
- Add queue-accounting and end-to-end health-contract tests.
- Correct the health documentation to describe the live mirrored values.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `python3 scripts/check-api-contract-docs.py`

## Risk and Rollback

- Risk: Low; additive counter accounting and health wiring only.
- Rollback: Revert this PR; #608 retention behavior remains intact.