### PR TITLE
fix(run): preserve continuation lifecycle evidence

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3783,6 +3783,30 @@ fn exit_with_session_code(exit_code: i32, stream_json: bool) -> ! {
     std::process::exit(exit_code);
 }
 
+fn continuation_sibling_record(
+    source: &store::SessionRecord,
+    id: String,
+    now: String,
+) -> store::SessionRecord {
+    session_launch::new_session_record(session_launch::NewSessionParams {
+        id,
+        project_root: source.project_root.clone(),
+        harness: source.harness.clone(),
+        title: source.title.clone(),
+        status: DEFAULT_SESSION_STATUS.to_string(),
+        now,
+        conversation_id: Some(
+            source
+                .conversation_id
+                .clone()
+                .unwrap_or_else(|| source.id.clone()),
+        ),
+        familiar_id: source.familiar_id.clone(),
+        labels: source.labels.clone(),
+        visibility: Some(source.visibility.clone()),
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_session(
     harness_id: &str,
@@ -3813,6 +3837,9 @@ fn run_session(
 
     if prompt_args.is_empty() && continue_session.is_none() {
         anyhow::bail!("nothing to do; pass a prompt, or use --continue [ID] to resume a session");
+    }
+    if detach && continue_session.is_some() {
+        anyhow::bail!("--detach and --continue are mutually exclusive");
     }
 
     let selected_harness =
@@ -3942,8 +3969,11 @@ fn run_session(
     let resumed_id: Option<String> = match continue_session {
         None => None,
         Some("") => {
-            let latest =
-                store::latest_active_for_project(&conn, project_root.to_str().unwrap_or(""))?;
+            let latest = store::latest_active_for_project(
+                &conn,
+                project_root.to_str().unwrap_or(""),
+                &selected_harness.id,
+            )?;
             if latest.is_none() {
                 anyhow::bail!(
                     "no active session to continue in {}; pass an explicit --continue <ID> or omit the flag",
@@ -3955,17 +3985,24 @@ fn run_session(
         Some(id) => Some(id.to_string()),
     };
 
-    let (record, is_resume) = if let Some(ref id) = resumed_id {
-        // Verify the session exists; reuse its row.
+    let (record, resumed_from) = if let Some(ref id) = resumed_id {
         let existing = match store::get_session(&conn, id)? {
             Some(record) => Some(record),
             None => store::get_latest_session_by_conversation_id(&conn, id)?,
         };
         match existing {
-            Some(mut r) => {
-                // Mutate updated_at to now; keep labels/visibility/title from the original.
-                r.updated_at = now.clone();
-                (r, true)
+            Some(source) => {
+                if source.harness != selected_harness.id {
+                    anyhow::bail!(
+                        "session `{id}` uses harness `{}` but requested harness `{}`; continue it with the matching harness",
+                        source.harness,
+                        selected_harness.id,
+                    );
+                }
+                (
+                    continuation_sibling_record(&source, Uuid::new_v4().to_string(), now.clone()),
+                    Some(source),
+                )
             }
             None => anyhow::bail!(
                 "session `{}` not found in local store; run `coven sessions --all` to list session ids",
@@ -3985,12 +4022,17 @@ fn run_session(
             labels,
             visibility: visibility.map(str::to_string),
         });
-        (r, false)
+        (r, None)
     };
+    let is_resume = resumed_from.is_some();
+    let resume_group_id = resumed_from.as_ref().map(|source| {
+        source
+            .conversation_id
+            .clone()
+            .unwrap_or_else(|| source.id.clone())
+    });
 
-    if !is_resume {
-        store::insert_session(&conn, &record)?;
-    }
+    store::insert_session(&conn, &record)?;
 
     if !stream_json {
         println!(
@@ -4001,10 +4043,6 @@ fn run_session(
         println!("  harness: {}", record.harness);
         println!("  cwd:     {}", cwd.display());
         println!("  title:   {}", record.title);
-    }
-
-    if detach && is_resume {
-        anyhow::bail!("--detach and --continue are mutually exclusive");
     }
 
     let stream_started = std::time::Instant::now();
@@ -4083,7 +4121,10 @@ fn run_session(
         let mut handle = stdout.lock();
         let stream_conversation_hint = if is_resume {
             harness::ConversationHint::Resume {
-                id: record.id.clone(),
+                id: resume_group_id
+                    .as_ref()
+                    .expect("resume group exists")
+                    .clone(),
             }
         } else {
             harness::ConversationHint::Init {
@@ -4108,6 +4149,7 @@ fn run_session(
                 &command,
                 stream_json_input,
                 &selected_harness.id,
+                &record.id,
                 &mut handle,
             )
         });
@@ -4182,17 +4224,8 @@ fn run_session(
     let conversation_hint = if is_resume {
         // Cave historically resumes through Coven's stable ledger id. Codex
         // requires its own thread id, which we capture from `thread.started`
-        // and persist on the ledger row after the first turn. Accepting either
-        // form above keeps existing clients compatible while direct callers
-        // may pass the native thread id too.
-        let resume_id = if selected_harness.id == "codex" {
-            record
-                .conversation_id
-                .clone()
-                .unwrap_or_else(|| record.id.clone())
-        } else {
-            record.id.clone()
-        };
+        // and persist as the conversation group after the first turn.
+        let resume_id = resume_group_id.expect("resume group exists");
         Some(harness::ConversationHint::Resume { id: resume_id })
     } else {
         None
@@ -4220,7 +4253,7 @@ fn run_session(
             conversation_hint.as_ref(),
             familiar_for_args,
             launch_options,
-        )?
+        )
     } else {
         pty_runner::build_harness_command_with_conversation(
             &selected_harness.id,
@@ -4230,7 +4263,31 @@ fn run_session(
             conversation_hint.as_ref(),
             familiar_for_args,
             launch_options,
-        )?
+        )
+    };
+    let command = match command {
+        Ok(command) => command,
+        Err(error) => {
+            store::update_session_status(
+                &conn,
+                &record.id,
+                FAILED_SESSION_STATUS,
+                None,
+                &current_timestamp(),
+            )?;
+            if stream_json {
+                emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
+                    subtype: "error_during_execution".into(),
+                    duration_ms: stream_started.elapsed().as_millis() as u64,
+                    is_error: true,
+                    num_turns: 1,
+                    session_id: record.id.clone(),
+                    harness_session_id: None,
+                    error: Some(format!("{error:#}")),
+                }))?;
+            }
+            return Err(error);
+        }
     };
     if stream_json && selected_harness.id == "codex" {
         let output_session_id = record.id.clone();
@@ -4270,13 +4327,15 @@ fn run_session(
                 return Err(error);
             }
         };
-        if let Some(thread_id) = outcome.harness_session_id.as_deref() {
-            store::update_session_conversation_id(
-                &conn,
-                &record.id,
-                thread_id,
-                &current_timestamp(),
-            )?;
+        if !is_resume {
+            if let Some(thread_id) = outcome.harness_session_id.as_deref() {
+                store::update_session_conversation_id(
+                    &conn,
+                    &record.id,
+                    thread_id,
+                    &current_timestamp(),
+                )?;
+            }
         }
         let is_error =
             outcome.error.is_some() || outcome.process.exit_code.is_some_and(|code| code != 0);
@@ -5471,6 +5530,47 @@ mod tests {
         let missing = resolve_session_ref(&conn, "zzzz").unwrap_err();
         assert!(missing.to_string().contains("coven sessions --all"));
         Ok(())
+    }
+
+    #[test]
+    fn continuation_sibling_preserves_terminal_source_rows() {
+        for status in ["completed", "failed", "killed", "orphaned"] {
+            let old = store::SessionRecord {
+                id: format!("{status}-old"),
+                project_root: "/repo".to_string(),
+                harness: "claude".to_string(),
+                title: "Original title".to_string(),
+                status: status.to_string(),
+                exit_code: Some(17),
+                archived_at: Some("2026-08-01T00:00:00Z".to_string()),
+                created_at: "2026-07-31T00:00:00Z".to_string(),
+                updated_at: "2026-08-01T00:00:00Z".to_string(),
+                conversation_id: None,
+                familiar_id: Some("sage".to_string()),
+                labels: vec!["kept".to_string()],
+                visibility: "workspace".to_string(),
+                external: false,
+                transcript_path: Some("/repo/transcript.log".to_string()),
+            };
+            let snapshot = old.clone();
+
+            let sibling = continuation_sibling_record(
+                &old,
+                format!("{status}-new"),
+                "2026-08-03T00:00:00Z".to_string(),
+            );
+
+            assert_eq!(old, snapshot, "{status} source evidence changed");
+            assert_eq!(sibling.id, format!("{status}-new"));
+            assert_eq!(sibling.status, DEFAULT_SESSION_STATUS);
+            assert_eq!(sibling.exit_code, None);
+            assert_eq!(sibling.archived_at, None);
+            assert_eq!(sibling.conversation_id.as_deref(), Some(old.id.as_str()));
+            assert_eq!(sibling.title, old.title);
+            assert_eq!(sibling.familiar_id, old.familiar_id);
+            assert_eq!(sibling.labels, old.labels);
+            assert_eq!(sibling.visibility, old.visibility);
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufRead, BufReader, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -417,32 +417,22 @@ const CODEX_JSON_ACTIVITY_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const CODEX_POST_EXIT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 const CODEX_CHILD_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const CODEX_STDERR_TAIL_BYTES: usize = 8 * 1024;
+const NATIVE_POST_EXIT_DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
 
-// `codex exec --json` runs in a separate Unix session so a timeout can clean
-// up an npm/Node/Codex tree in one operation. That also means a TERM sent to
-// coven itself would otherwise leave the child group behind. The scoped guard
-// below records the cancellation in an async-signal-safe handler; the runner
-// then performs ordinary cleanup and emits its terminal result.
+// Supervised streams run in separate Unix sessions so Coven can clean up an
+// entire harness tree in one operation. That also means a TERM sent to Coven
+// itself would otherwise leave the child group behind. The scoped guard below
+// records the signal atomically; the owning runner observes it on its bounded
+// polling interval, terminates through its stable process-tree handle, and
+// reaps the direct child.
 #[cfg(unix)]
-static CODEX_JSON_CANCELLATION_SIGNAL: AtomicI32 = AtomicI32::new(0);
+static SUPERVISED_STREAM_CANCELLATION_SIGNAL: AtomicI32 = AtomicI32::new(0);
 #[cfg(unix)]
-static CODEX_JSON_PROCESS_GROUP: AtomicI32 = AtomicI32::new(0);
-#[cfg(unix)]
-static CODEX_JSON_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
+static SUPERVISED_STREAM_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
 
 #[cfg(unix)]
-extern "C" fn record_codex_json_cancellation(signal: libc::c_int) {
-    // Atomic operations and kill(2) are async-signal-safe. The supervisor
-    // turns the flag into a failed ledger/result update on its next <=50 ms
-    // poll; killing the group here prevents a detached Codex descendant from
-    // surviving if that poll is delayed.
-    let process_group = CODEX_JSON_PROCESS_GROUP.load(Ordering::Relaxed);
-    if process_group > 0 {
-        unsafe {
-            let _ = libc::kill(-process_group, libc::SIGKILL);
-        }
-    }
-    CODEX_JSON_CANCELLATION_SIGNAL.store(signal, Ordering::Relaxed);
+extern "C" fn cancel_supervised_stream(signal: libc::c_int) {
+    SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(signal, Ordering::Relaxed);
 }
 
 /// Temporarily converts TERM/INT/HUP into a supervised bridge cancellation.
@@ -452,32 +442,115 @@ extern "C" fn record_codex_json_cancellation(signal: libc::c_int) {
 /// before releasing that lock, preserving normal signal behavior for other
 /// Coven commands and unit tests.
 #[cfg(unix)]
-struct CodexCancellationGuard {
+struct SupervisedStreamCancellationGuard {
     _lock: MutexGuard<'static, ()>,
     previous_handlers: Vec<(libc::c_int, libc::sigaction)>,
+    signal_mask: SupervisedSignalMask,
+    active: bool,
 }
 
 #[cfg(unix)]
-impl CodexCancellationGuard {
-    fn install() -> Result<Self> {
-        let lock = CODEX_JSON_CANCELLATION_LOCK
+struct SupervisedSignalMask {
+    previous: libc::sigset_t,
+    supervisor_unblocked: bool,
+}
+
+#[cfg(unix)]
+impl SupervisedSignalMask {
+    fn block() -> io::Result<Self> {
+        let signals = supervised_signal_set();
+        let mut previous = unsafe { std::mem::zeroed() };
+        let result = unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &signals, &mut previous) };
+        if result != 0 {
+            return Err(io::Error::from_raw_os_error(result));
+        }
+        Ok(Self {
+            previous,
+            supervisor_unblocked: false,
+        })
+    }
+
+    fn unblock_supervisor(&mut self) -> io::Result<()> {
+        let result = unsafe {
+            libc::pthread_sigmask(libc::SIG_SETMASK, &self.previous, std::ptr::null_mut())
+        };
+        if result != 0 {
+            return Err(io::Error::from_raw_os_error(result));
+        }
+        self.supervisor_unblocked = true;
+        Ok(())
+    }
+
+    fn reblock(&mut self) -> io::Result<()> {
+        if !self.supervisor_unblocked {
+            return Ok(());
+        }
+        let signals = supervised_signal_set();
+        let result =
+            unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, &signals, std::ptr::null_mut()) };
+        if result != 0 {
+            return Err(io::Error::from_raw_os_error(result));
+        }
+        self.supervisor_unblocked = false;
+        Ok(())
+    }
+
+    fn restore(&mut self) -> io::Result<()> {
+        let result = unsafe {
+            libc::pthread_sigmask(libc::SIG_SETMASK, &self.previous, std::ptr::null_mut())
+        };
+        if result != 0 {
+            return Err(io::Error::from_raw_os_error(result));
+        }
+        self.supervisor_unblocked = true;
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+impl Drop for SupervisedSignalMask {
+    fn drop(&mut self) {
+        if !self.supervisor_unblocked {
+            let _ = self.restore();
+        }
+    }
+}
+
+#[cfg(unix)]
+fn supervised_signal_set() -> libc::sigset_t {
+    let mut signals = unsafe { std::mem::zeroed() };
+    unsafe {
+        libc::sigemptyset(&mut signals);
+        for signal in [libc::SIGTERM, libc::SIGINT, libc::SIGHUP] {
+            libc::sigaddset(&mut signals, signal);
+        }
+    }
+    signals
+}
+
+#[cfg(unix)]
+impl SupervisedStreamCancellationGuard {
+    fn install(context: &str) -> Result<Self> {
+        let lock = SUPERVISED_STREAM_CANCELLATION_LOCK
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        CODEX_JSON_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
-        CODEX_JSON_PROCESS_GROUP.store(0, Ordering::Relaxed);
+        let mut signal_mask = SupervisedSignalMask::block()
+            .context("failed to block supervised stream cancellation signals")?;
+        SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
 
         let mut previous_handlers = Vec::with_capacity(3);
         for signal in [libc::SIGTERM, libc::SIGINT, libc::SIGHUP] {
             // SAFETY: sigaction is the POSIX interface for installing a signal
-            // handler. The handler uses only atomics and kill(2), and each
+            // handler. The handler only records into an atomic, and each
             // successful installation retains the prior disposition for Drop.
             unsafe {
                 let mut action: libc::sigaction = std::mem::zeroed();
-                action.sa_sigaction = record_codex_json_cancellation as *const () as usize;
+                action.sa_sigaction = cancel_supervised_stream as *const () as usize;
                 libc::sigemptyset(&mut action.sa_mask);
                 action.sa_flags = 0;
                 let mut previous: libc::sigaction = std::mem::zeroed();
                 if libc::sigaction(signal, &action, &mut previous) != 0 {
+                    let error = std::io::Error::last_os_error();
                     for (installed_signal, installed_previous) in previous_handlers.iter().rev() {
                         let _ = libc::sigaction(
                             *installed_signal,
@@ -485,9 +558,12 @@ impl CodexCancellationGuard {
                             std::ptr::null_mut(),
                         );
                     }
-                    CODEX_JSON_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
-                    return Err(std::io::Error::last_os_error()).with_context(|| {
-                        format!("failed to install Codex cancellation handler for signal {signal}")
+                    SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+                    let _ = signal_mask.restore();
+                    return Err(error).with_context(|| {
+                        format!(
+                            "failed to install {context} cancellation handler for signal {signal}"
+                        )
                     });
                 }
                 previous_handlers.push((signal, previous));
@@ -497,27 +573,58 @@ impl CodexCancellationGuard {
         Ok(Self {
             _lock: lock,
             previous_handlers,
+            signal_mask,
+            active: true,
         })
     }
 
-    fn arm(&self, process_group: u32) {
-        CODEX_JSON_PROCESS_GROUP.store(process_group as i32, Ordering::Relaxed);
-    }
-
-    fn disarm(&self) {
-        CODEX_JSON_PROCESS_GROUP.store(0, Ordering::Relaxed);
-    }
-
     fn cancelled_signal(&self) -> Option<libc::c_int> {
-        let signal = CODEX_JSON_CANCELLATION_SIGNAL.load(Ordering::Relaxed);
+        let signal = SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed);
         (signal != 0).then_some(signal)
+    }
+
+    fn activate(&mut self) -> Result<Option<libc::c_int>> {
+        self.signal_mask
+            .unblock_supervisor()
+            .context("failed to unblock supervised stream cancellation signals")?;
+        Ok(self.cancelled_signal())
+    }
+
+    fn finish(mut self) -> Result<Option<libc::c_int>> {
+        self.signal_mask
+            .reblock()
+            .context("failed to re-block supervised stream cancellation signals")?;
+        let cancelled_signal = self.cancelled_signal();
+        let mut restore_error = None;
+        unsafe {
+            for (signal, previous) in self.previous_handlers.iter().rev() {
+                if libc::sigaction(*signal, previous, std::ptr::null_mut()) != 0
+                    && restore_error.is_none()
+                {
+                    restore_error = Some(std::io::Error::last_os_error());
+                }
+            }
+        }
+        SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+        self.active = false;
+
+        self.signal_mask
+            .restore()
+            .context("failed to restore supervised stream signal mask")?;
+        if let Some(error) = restore_error {
+            return Err(error).context("failed to restore supervised stream cancellation handlers");
+        }
+        Ok(cancelled_signal)
     }
 }
 
 #[cfg(unix)]
-impl Drop for CodexCancellationGuard {
+impl Drop for SupervisedStreamCancellationGuard {
     fn drop(&mut self) {
-        CODEX_JSON_PROCESS_GROUP.store(0, Ordering::Relaxed);
+        if !self.active {
+            return;
+        }
+        let _ = self.signal_mask.reblock();
         // SAFETY: every entry was captured from a successful sigaction call
         // in install. Restoring it here makes the scope transparent once the
         // bridge has reaped its child tree.
@@ -526,40 +633,81 @@ impl Drop for CodexCancellationGuard {
                 let _ = libc::sigaction(*signal, previous, std::ptr::null_mut());
             }
         }
-        CODEX_JSON_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+        SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
+        let _ = self.signal_mask.restore();
     }
 }
 
 #[cfg(not(unix))]
-struct CodexCancellationGuard;
+struct SupervisedStreamCancellationGuard;
 
 #[cfg(not(unix))]
-impl CodexCancellationGuard {
-    fn install() -> Result<Self> {
+impl SupervisedStreamCancellationGuard {
+    fn install(_context: &str) -> Result<Self> {
         Ok(Self)
     }
 
-    fn arm(&self, _process_group: u32) {}
+    fn cancelled_signal(&self) -> Option<i32> {
+        None
+    }
 
-    fn disarm(&self) {}
+    fn activate(&mut self) -> Result<Option<i32>> {
+        Ok(None)
+    }
+
+    fn finish(self) -> Result<Option<i32>> {
+        Ok(None)
+    }
+}
+
+fn wait_for_supervised_child(
+    child: &mut std::process::Child,
+    context: &str,
+) -> Result<std::process::ExitStatus> {
+    child.wait().with_context(|| context.to_string())
+}
+
+fn terminate_and_wait_for_supervised_child(
+    process_tree: &mut StrictChildProcessTree,
+    child: &mut std::process::Child,
+    context: &str,
+) -> Result<std::process::ExitStatus> {
+    process_tree.terminate(child);
+    wait_for_supervised_child(child, context)
 }
 
 #[cfg(unix)]
-fn codex_cancellation_error(guard: &CodexCancellationGuard) -> Option<String> {
-    guard.cancelled_signal().map(|signal| {
-        let name = match signal {
-            libc::SIGTERM => "SIGTERM",
-            libc::SIGINT => "SIGINT",
-            libc::SIGHUP => "SIGHUP",
-            _ => "a termination signal",
-        };
-        format!("Codex turn cancelled by {name}; the process tree was terminated")
-    })
+fn supervised_stream_cancellation_error(
+    guard: &SupervisedStreamCancellationGuard,
+    context: &str,
+) -> Option<String> {
+    guard
+        .cancelled_signal()
+        .map(|signal| supervised_stream_cancellation_error_for_signal(signal, context))
+}
+
+#[cfg(unix)]
+fn supervised_stream_cancellation_error_for_signal(signal: libc::c_int, context: &str) -> String {
+    let name = match signal {
+        libc::SIGTERM => "SIGTERM",
+        libc::SIGINT => "SIGINT",
+        libc::SIGHUP => "SIGHUP",
+        _ => "a termination signal",
+    };
+    format!("{context} cancelled by {name}; the process tree was terminated")
 }
 
 #[cfg(not(unix))]
-fn codex_cancellation_error(_guard: &CodexCancellationGuard) -> Option<String> {
+fn supervised_stream_cancellation_error(
+    _guard: &SupervisedStreamCancellationGuard,
+    _context: &str,
+) -> Option<String> {
     None
+}
+
+#[cfg(not(unix))]
+fn supervised_stream_cancellation_error_for_signal(_signal: i32, _context: &str) -> String {
+    unreachable!("non-Unix cancellation guards never report a signal")
 }
 
 fn codex_json_activity_timeout() -> Duration {
@@ -620,11 +768,7 @@ impl ChildProcessTree {
         }
     }
 
-    pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
-        self.terminate_impl(child, true);
-    }
-
-    fn terminate_impl(&mut self, child: &mut std::process::Child, _allow_taskkill_fallback: bool) {
+    fn terminate_impl(&mut self, child: &mut std::process::Child) {
         if self.terminated {
             return;
         }
@@ -635,29 +779,10 @@ impl ChildProcessTree {
         }
         #[cfg(windows)]
         {
-            let terminated_by_job = self
-                .job_handle
-                .take()
-                .map(|job| {
-                    let succeeded = unsafe {
-                        windows_sys::Win32::System::JobObjects::TerminateJobObject(job, 1) != 0
-                    };
-                    unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
-                    succeeded
-                })
-                .unwrap_or(false);
-            if !terminated_by_job && _allow_taskkill_fallback {
-                // A Job Object can be unavailable when a parent policy forbids
-                // assignment. Fall back to Windows' documented tree kill for
-                // npm's cmd.exe -> node.exe -> codex.exe chain.
-                if let Some(taskkill) = trusted_windows_taskkill_path() {
-                    let pid = self.pid.to_string();
-                    let _ = std::process::Command::new(taskkill)
-                        .args(["/PID", &pid, "/T", "/F"])
-                        .stdin(Stdio::null())
-                        .stdout(Stdio::null())
-                        .stderr(Stdio::null())
-                        .status();
+            if let Some(job) = self.job_handle.take() {
+                unsafe {
+                    windows_sys::Win32::System::JobObjects::TerminateJobObject(job, 1);
+                    windows_sys::Win32::Foundation::CloseHandle(job);
                 }
             }
         }
@@ -666,8 +791,7 @@ impl ChildProcessTree {
 }
 
 /// A process tree whose descendants were contained before its first
-/// instruction ran. Its termination path deliberately cannot select the
-/// legacy `taskkill` fallback used by the Codex runner.
+/// instruction ran.
 pub(crate) struct StrictChildProcessTree(ChildProcessTree);
 
 impl StrictChildProcessTree {
@@ -699,7 +823,7 @@ impl StrictChildProcessTree {
     }
 
     pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
-        self.0.terminate_impl(child, false);
+        self.0.terminate_impl(child);
     }
 }
 
@@ -708,6 +832,53 @@ fn terminate_unix_process_group(pid: u32) {
     // The launch config puts the child at the head of a new session, so the
     // negative pid reaches its wrapper and every descendant.
     let _ = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+}
+
+#[cfg(unix)]
+fn poll_child_exit_without_reaping(child: &std::process::Child) -> io::Result<bool> {
+    loop {
+        // POSIX leaves siginfo contents unspecified when WNOHANG finds no
+        // waitable child, so initialize it for every call and trust si_pid
+        // only when waitid explicitly fills it.
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child.id() as _,
+                &mut info,
+                libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(unsafe { info.si_pid() } != 0);
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(all(unix, test))]
+fn wait_for_child_exit_without_reaping(child: &std::process::Child) -> io::Result<()> {
+    loop {
+        let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
+        let result = unsafe {
+            libc::waitid(
+                libc::P_PID,
+                child.id() as _,
+                &mut info,
+                libc::WEXITED | libc::WNOWAIT,
+            )
+        };
+        if result == 0 {
+            return Ok(());
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
 }
 
 #[cfg(unix)]
@@ -731,34 +902,6 @@ impl Drop for ChildProcessTree {
             unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
         }
     }
-}
-
-#[cfg(windows)]
-fn trusted_windows_taskkill_path() -> Option<PathBuf> {
-    use std::os::windows::ffi::OsStringExt;
-    use windows_sys::Win32::System::SystemInformation::GetSystemDirectoryW;
-
-    let mut buffer = vec![0u16; 260];
-    let len = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) };
-    if len == 0 {
-        return None;
-    }
-    let len = len as usize;
-    if len >= buffer.len() {
-        buffer.resize(len + 1, 0);
-        let len = unsafe { GetSystemDirectoryW(buffer.as_mut_ptr(), buffer.len() as u32) };
-        if len == 0 || len as usize >= buffer.len() {
-            return None;
-        }
-        buffer.truncate(len as usize);
-    } else {
-        buffer.truncate(len);
-    }
-
-    let path = PathBuf::from(std::ffi::OsString::from_wide(&buffer)).join("taskkill.exe");
-    // A missing binary (or an unexpected system directory) must surface as
-    // "no trusted taskkill" rather than a silently ignored spawn failure.
-    path.is_file().then_some(path)
 }
 
 #[cfg(windows)]
@@ -974,33 +1117,49 @@ where
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
-    configure_child_process_tree_command(&mut child_command);
-    let cancellation = CodexCancellationGuard::install()?;
-    if let Some(error) = codex_cancellation_error(&cancellation) {
+    let mut cancellation = SupervisedStreamCancellationGuard::install("Codex")?;
+    if let Some(error) = supervised_stream_cancellation_error(&cancellation, "Codex turn") {
         anyhow::bail!(error);
     }
-    let mut child = child_command.spawn().with_context(|| {
-        format!(
-            "failed to spawn harness `{}` in Codex JSON mode",
-            command.program()
-        )
-    })?;
-    let mut process_tree = ChildProcessTree::attach(&child);
-    cancellation.arm(process_tree.pid);
+    let (mut child, mut process_tree) = spawn_strict_child_process_tree(&mut child_command)
+        .with_context(|| {
+            format!(
+                "failed to spawn harness `{}` in Codex JSON mode",
+                command.program()
+            )
+        })?;
+    if let Some(signal) = cancellation.cancelled_signal() {
+        let _ = terminate_and_wait_for_supervised_child(
+            &mut process_tree,
+            &mut child,
+            "failed waiting for cancelled Codex process",
+        );
+        let signal = cancellation.finish()?.unwrap_or(signal);
+        anyhow::bail!(supervised_stream_cancellation_error_for_signal(
+            signal,
+            "Codex turn"
+        ));
+    }
 
     let stdout = match child.stdout.take() {
         Some(stdout) => stdout,
         None => {
-            process_tree.terminate(&mut child);
-            let _ = child.wait();
+            let _ = terminate_and_wait_for_supervised_child(
+                &mut process_tree,
+                &mut child,
+                "failed waiting for Codex after missing stdout",
+            );
             anyhow::bail!("Codex JSON runner did not expose stdout");
         }
     };
     let stderr = match child.stderr.take() {
         Some(stderr) => stderr,
         None => {
-            process_tree.terminate(&mut child);
-            let _ = child.wait();
+            let _ = terminate_and_wait_for_supervised_child(
+                &mut process_tree,
+                &mut child,
+                "failed waiting for Codex after missing stderr",
+            );
             anyhow::bail!("Codex JSON runner did not expose stderr");
         }
     };
@@ -1010,8 +1169,11 @@ where
         let stdin = match child.stdin.take() {
             Some(stdin) => stdin,
             None => {
-                process_tree.terminate(&mut child);
-                let _ = child.wait();
+                let _ = terminate_and_wait_for_supervised_child(
+                    &mut process_tree,
+                    &mut child,
+                    "failed waiting for Codex after missing stdin",
+                );
                 anyhow::bail!("Codex JSON runner did not expose stdin for its prompt");
             }
         };
@@ -1064,35 +1226,84 @@ where
         let _ = stderr_sender.send(CodexRunnerMessage::StderrClosed(tail));
     });
     drop(sender);
+    let activation_signal = match cancellation.activate() {
+        Ok(signal) => signal,
+        Err(error) => {
+            let _ = terminate_and_wait_for_supervised_child(
+                &mut process_tree,
+                &mut child,
+                "failed waiting for Codex after cancellation activation error",
+            );
+            return Err(error);
+        }
+    };
 
     let mut state = CodexJsonState::default();
     let mut last_activity = Instant::now();
     let mut status = None;
+    let mut direct_child_exited = false;
     let mut post_exit_deadline = None;
     let mut stdout_closed = false;
     let mut stderr_tail = None;
     let mut stdin_complete = !stdin_pending;
 
     loop {
-        if let Some(error) = codex_cancellation_error(&cancellation) {
-            state.protocol_error.get_or_insert(error);
-            process_tree.terminate(&mut child);
-            status = Some(
-                child
-                    .wait()
-                    .context("failed waiting for cancelled Codex process")?,
-            );
+        if let Some(signal) = activation_signal {
+            state.protocol_error.get_or_insert_with(|| {
+                supervised_stream_cancellation_error_for_signal(signal, "Codex turn")
+            });
+            status = Some(terminate_and_wait_for_supervised_child(
+                &mut process_tree,
+                &mut child,
+                "failed waiting for cancelled Codex process",
+            )?);
             break;
         }
-        if status.is_none() {
-            status = child
+        if let Some(error) = supervised_stream_cancellation_error(&cancellation, "Codex turn") {
+            state.protocol_error.get_or_insert(error);
+            status = Some(terminate_and_wait_for_supervised_child(
+                &mut process_tree,
+                &mut child,
+                "failed waiting for cancelled Codex process",
+            )?);
+            break;
+        }
+        if !direct_child_exited {
+            #[cfg(unix)]
+            let observed_exit = match poll_child_exit_without_reaping(&child)
+                .context("failed polling Codex JSON process")
+            {
+                Ok(observed_exit) => observed_exit,
+                Err(error) => {
+                    let _ = terminate_and_wait_for_supervised_child(
+                        &mut process_tree,
+                        &mut child,
+                        "failed waiting for Codex after poll error",
+                    );
+                    return Err(error);
+                }
+            };
+            #[cfg(not(unix))]
+            let observed_exit = match child
                 .try_wait()
-                .context("failed polling Codex JSON process")?;
-            if status.is_some() {
+                .context("failed polling Codex JSON process")?
+            {
+                Some(exit_status) => {
+                    status = Some(exit_status);
+                    true
+                }
+                None => false,
+            };
+            if observed_exit {
+                direct_child_exited = true;
+                // Reserve the Unix pid with WNOWAIT until the whole process
+                // group has been terminated. Windows uses its stable Job
+                // Object handle after try_wait.
+                process_tree.terminate(&mut child);
                 post_exit_deadline = Some(Instant::now() + post_exit_drain_timeout);
             }
         }
-        if status.is_some() && stdout_closed && stderr_tail.is_some() && stdin_complete {
+        if direct_child_exited && stdout_closed && stderr_tail.is_some() && stdin_complete {
             break;
         }
 
@@ -1120,12 +1331,11 @@ where
                         activity_timeout.as_secs()
                     )
                 });
-                process_tree.terminate(&mut child);
-                status = Some(
-                    child
-                        .wait()
-                        .context("failed waiting for timed-out Codex process")?,
-                );
+                status = Some(terminate_and_wait_for_supervised_child(
+                    &mut process_tree,
+                    &mut child,
+                    "failed waiting for timed-out Codex process",
+                )?);
                 break;
             }
             remaining
@@ -1137,18 +1347,20 @@ where
                     Ok(true) => last_activity = Instant::now(),
                     Ok(false) => {}
                     Err(error) => {
-                        process_tree.terminate(&mut child);
-                        let _ = child.wait();
+                        let _ = terminate_and_wait_for_supervised_child(
+                            &mut process_tree,
+                            &mut child,
+                            "failed waiting for Codex after assistant callback error",
+                        );
                         return Err(error);
                     }
                 }
                 if state.protocol_error.is_some() {
-                    process_tree.terminate(&mut child);
-                    status = Some(
-                        child
-                            .wait()
-                            .context("failed waiting for failed Codex turn")?,
-                    );
+                    status = Some(terminate_and_wait_for_supervised_child(
+                        &mut process_tree,
+                        &mut child,
+                        "failed waiting for failed Codex turn",
+                    )?);
                     break;
                 }
             }
@@ -1156,12 +1368,11 @@ where
                 state
                     .protocol_error
                     .get_or_insert_with(|| format!("failed reading Codex JSON output: {error}"));
-                process_tree.terminate(&mut child);
-                status = Some(
-                    child
-                        .wait()
-                        .context("failed waiting for Codex after stdout error")?,
-                );
+                status = Some(terminate_and_wait_for_supervised_child(
+                    &mut process_tree,
+                    &mut child,
+                    "failed waiting for Codex after stdout error",
+                )?);
                 break;
             }
             Ok(CodexRunnerMessage::StdoutClosed) => stdout_closed = true,
@@ -1169,12 +1380,11 @@ where
             Ok(CodexRunnerMessage::StdinComplete(Ok(()))) => stdin_complete = true,
             Ok(CodexRunnerMessage::StdinComplete(Err(error))) => {
                 state.protocol_error.get_or_insert(error);
-                process_tree.terminate(&mut child);
-                status = Some(
-                    child
-                        .wait()
-                        .context("failed waiting for Codex after stdin write error")?,
-                );
+                status = Some(terminate_and_wait_for_supervised_child(
+                    &mut process_tree,
+                    &mut child,
+                    "failed waiting for Codex after stdin write error",
+                )?);
                 break;
             }
             Err(RecvTimeoutError::Timeout) => {}
@@ -1193,16 +1403,14 @@ where
     // A signal can arrive just after the final polling iteration. Honor it
     // before reporting a completed turn so cancellation always reaches the
     // ledger and terminal result when the runner still owns the child tree.
-    if let Some(error) = codex_cancellation_error(&cancellation) {
+    if let Some(error) = supervised_stream_cancellation_error(&cancellation, "Codex turn") {
         state.protocol_error.get_or_insert(error);
         process_tree.terminate(&mut child);
     }
 
     let status = match status {
         Some(status) => status,
-        None => child
-            .wait()
-            .context("failed waiting for Codex JSON process")?,
+        None => wait_for_supervised_child(&mut child, "failed waiting for Codex JSON process")?,
     };
     let stderr_tail = stderr_tail.unwrap_or_default();
 
@@ -1222,17 +1430,17 @@ where
     if !state.emitted_assistant && state.protocol_error.is_none() {
         state.protocol_error = Some("Codex completed without an assistant message".to_string());
     }
+    if let Some(signal) = cancellation.finish()? {
+        state.protocol_error.get_or_insert_with(|| {
+            supervised_stream_cancellation_error_for_signal(signal, "Codex turn")
+        });
+    }
     let failed = !status.success() || state.protocol_error.is_some();
     let exit_code = if failed {
         status.code().filter(|code| *code != 0).or(Some(1))
     } else {
         status.code()
     };
-    // The direct child has reached a terminal status. Do not leave its former
-    // pid armed in the async signal handler during the final return/drop
-    // window, where a recycled pid could otherwise be targeted.
-    cancellation.disarm();
-
     Ok(CodexJsonRunResult {
         process: PtyRunResult {
             status: if failed { "failed" } else { "completed" },
@@ -1556,11 +1764,12 @@ pub fn run_piped_attached_captured(
 /// emits Coven's own `system.init` / `result` around the call). The command's
 /// argv is built from the harness declaration (`stream_args`, continuity,
 /// model, sandbox, and identity handling); this runner only spawns it and
-/// forwards each non-empty JSONL line unchanged to `out`.
+/// normalizes each frame's top-level Coven session id before writing to `out`.
 pub fn stream_harness<W: Write>(
     command: &HarnessCommand,
     forward_stdin: bool,
     harness_id: &str,
+    ledger_session_id: &str,
     out: &mut W,
 ) -> Result<i32> {
     stream_harness_with_program(
@@ -1569,8 +1778,135 @@ pub fn stream_harness<W: Write>(
         command.args.clone(),
         forward_stdin,
         harness_id,
+        ledger_session_id,
         out,
     )
+}
+
+enum NativeStreamMessage {
+    Line(String),
+    ReadError(String),
+    Closed,
+}
+
+fn spawn_native_stdout_reader(
+    stdout: std::process::ChildStdout,
+    sender: mpsc::Sender<NativeStreamMessage>,
+) {
+    thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let message = match line {
+                Ok(line) => NativeStreamMessage::Line(line),
+                Err(error) => {
+                    let _ = sender.send(NativeStreamMessage::ReadError(error.to_string()));
+                    let _ = sender.send(NativeStreamMessage::Closed);
+                    return;
+                }
+            };
+            if sender.send(message).is_err() {
+                return;
+            }
+        }
+        let _ = sender.send(NativeStreamMessage::Closed);
+    });
+}
+
+fn spawn_native_stdin_forwarder(child_stdin: std::process::ChildStdin, stopped: Arc<AtomicBool>) {
+    #[cfg(unix)]
+    thread::spawn(move || {
+        use std::os::fd::AsRawFd;
+
+        let stdin = io::stdin();
+        let fd = stdin.as_raw_fd();
+        let mut child_stdin = child_stdin;
+        let mut buffer = [0_u8; 4096];
+        while !stopped.load(Ordering::Relaxed) {
+            let mut poll_fd = libc::pollfd {
+                fd,
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let ready = unsafe { libc::poll(&mut poll_fd, 1, 50) };
+            if ready == 0 {
+                continue;
+            }
+            if ready < 0 {
+                if io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                    continue;
+                }
+                break;
+            }
+            let count = unsafe { libc::read(fd, buffer.as_mut_ptr().cast(), buffer.len()) };
+            if count <= 0 {
+                break;
+            }
+            if stopped.load(Ordering::Relaxed)
+                || child_stdin.write_all(&buffer[..count as usize]).is_err()
+                || child_stdin.flush().is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    #[cfg(not(unix))]
+    thread::spawn(move || {
+        let stdin = io::stdin();
+        let mut handle = stdin.lock();
+        let mut child_stdin = child_stdin;
+        let mut buffer = String::new();
+        while !stopped.load(Ordering::Relaxed) {
+            buffer.clear();
+            match handle.read_line(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    if stopped.load(Ordering::Relaxed)
+                        || child_stdin.write_all(buffer.as_bytes()).is_err()
+                        || child_stdin.flush().is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+}
+
+fn normalize_native_stream_line<W: Write>(
+    line: &str,
+    harness_id: &str,
+    ledger_session_id: &str,
+    out: &mut W,
+) -> Result<()> {
+    if line.trim().is_empty() {
+        return Ok(());
+    }
+    let mut frame: serde_json::Value = serde_json::from_str(line)
+        .with_context(|| format!("invalid JSON from {harness_id} native stream"))?;
+    let object = frame
+        .as_object_mut()
+        .with_context(|| format!("invalid JSON object from {harness_id} native stream"))?;
+    if !object.contains_key("harness_session_id") {
+        if let Some(native_session_id) = object
+            .get("session_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+        {
+            object.insert(
+                "harness_session_id".to_string(),
+                serde_json::Value::String(native_session_id),
+            );
+        }
+    }
+    object.insert(
+        "session_id".to_string(),
+        serde_json::Value::String(ledger_session_id.to_string()),
+    );
+    serde_json::to_writer(&mut *out, &frame)
+        .with_context(|| format!("forwarding {harness_id} stdout"))?;
+    writeln!(out).with_context(|| format!("forwarding {harness_id} stdout"))?;
+    out.flush()
+        .with_context(|| format!("flushing {harness_id} stdout"))
 }
 
 fn stream_harness_with_program<W: Write>(
@@ -1579,9 +1915,11 @@ fn stream_harness_with_program<W: Write>(
     args: Vec<String>,
     forward_stdin: bool,
     harness_id: &str,
+    ledger_session_id: &str,
     out: &mut W,
 ) -> Result<i32> {
-    let mut child = std::process::Command::new(program)
+    let mut command = std::process::Command::new(program);
+    command
         .args(&args)
         .current_dir(cwd)
         .stdin(if forward_stdin {
@@ -1590,50 +1928,179 @@ fn stream_harness_with_program<W: Write>(
             Stdio::null()
         })
         .stdout(Stdio::piped())
-        .stderr(Stdio::inherit())
-        .spawn()
-        .with_context(|| format!("failed to spawn {harness_id} in stream-json mode"))?;
+        .stderr(Stdio::inherit());
+    let cancellation_context = format!("{harness_id} native stream");
+    let mut cancellation = SupervisedStreamCancellationGuard::install(&cancellation_context)?;
+    if let Some(signal) = cancellation.cancelled_signal() {
+        let signal = cancellation.finish()?.unwrap_or(signal);
+        anyhow::bail!(supervised_stream_cancellation_error_for_signal(
+            signal,
+            &cancellation_context
+        ));
+    }
+    let (mut child, mut process_tree) = match spawn_strict_child_process_tree(&mut command)
+        .with_context(|| format!("failed to spawn {harness_id} in stream-json mode"))
+    {
+        Ok(spawned) => spawned,
+        Err(error) => {
+            let cancellation_signal = cancellation.finish()?;
+            if let Some(signal) = cancellation_signal {
+                anyhow::bail!(supervised_stream_cancellation_error_for_signal(
+                    signal,
+                    &cancellation_context
+                ));
+            }
+            return Err(error);
+        }
+    };
+    if let Some(signal) = cancellation.cancelled_signal() {
+        process_tree.terminate(&mut child);
+        let _ = child.wait();
+        let signal = cancellation.finish()?.unwrap_or(signal);
+        anyhow::bail!(supervised_stream_cancellation_error_for_signal(
+            signal,
+            &cancellation_context
+        ));
+    }
 
-    if forward_stdin {
-        let Some(mut child_stdin) = child.stdin.take() else {
-            anyhow::bail!("stdin requested but {harness_id} has no piped stdin");
-        };
-        thread::spawn(move || {
-            let stdin = io::stdin();
-            let mut handle = stdin.lock();
-            let mut buf = String::new();
-            loop {
-                buf.clear();
-                match handle.read_line(&mut buf) {
-                    Ok(0) | Err(_) => break,
-                    Ok(_) => {
-                        if child_stdin.write_all(buf.as_bytes()).is_err() {
-                            break;
-                        }
-                        let _ = child_stdin.flush();
+    let child_stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            process_tree.terminate(&mut child);
+            let _ = child.wait();
+            anyhow::bail!("stdout requested but {harness_id} has no piped stdout");
+        }
+    };
+    let stdin_stopped = Arc::new(AtomicBool::new(false));
+    let child_stdin = if forward_stdin {
+        match child.stdin.take() {
+            Some(stdin) => Some(stdin),
+            None => {
+                process_tree.terminate(&mut child);
+                let _ = child.wait();
+                anyhow::bail!("stdin requested but {harness_id} has no piped stdin");
+            }
+        }
+    } else {
+        None
+    };
+
+    let (sender, receiver) = mpsc::channel();
+    spawn_native_stdout_reader(child_stdout, sender);
+    if let Some(child_stdin) = child_stdin {
+        spawn_native_stdin_forwarder(child_stdin, Arc::clone(&stdin_stopped));
+    }
+
+    let activation_signal = match cancellation.activate() {
+        Ok(signal) => signal,
+        Err(error) => {
+            stdin_stopped.store(true, Ordering::Relaxed);
+            process_tree.terminate(&mut child);
+            let _ = child.wait();
+            return Err(error);
+        }
+    };
+
+    let mut direct_child_exited = false;
+    #[cfg(unix)]
+    let status = None;
+    #[cfg(not(unix))]
+    let mut status = None;
+    let mut stdout_closed = false;
+    let mut post_exit_deadline = None;
+    let result = (|| -> Result<()> {
+        if let Some(signal) = activation_signal {
+            anyhow::bail!(supervised_stream_cancellation_error_for_signal(
+                signal,
+                &cancellation_context
+            ));
+        }
+        loop {
+            if let Some(error) =
+                supervised_stream_cancellation_error(&cancellation, &cancellation_context)
+            {
+                anyhow::bail!(error);
+            }
+
+            if !direct_child_exited {
+                #[cfg(unix)]
+                let observed_exit = poll_child_exit_without_reaping(&child)
+                    .with_context(|| format!("polling {harness_id}"))?;
+                #[cfg(not(unix))]
+                let observed_exit = match child
+                    .try_wait()
+                    .with_context(|| format!("polling {harness_id}"))?
+                {
+                    Some(exit_status) => {
+                        status = Some(exit_status);
+                        true
                     }
+                    None => false,
+                };
+                if observed_exit {
+                    direct_child_exited = true;
+                    // Unix's WNOWAIT keeps the pid reserved until the group is
+                    // gone. On Windows the Job Object is a stable tree handle,
+                    // so terminating it after try_wait is safe.
+                    process_tree.terminate(&mut child);
+                    post_exit_deadline = Some(Instant::now() + NATIVE_POST_EXIT_DRAIN_TIMEOUT);
                 }
             }
-        });
-    }
 
-    let Some(child_stdout) = child.stdout.take() else {
-        anyhow::bail!("stdout requested but {harness_id} has no piped stdout");
-    };
-    let reader = BufReader::new(child_stdout);
-    for line in reader.lines() {
-        let line = line.with_context(|| format!("reading {harness_id} stdout"))?;
-        if line.trim().is_empty() {
-            continue;
+            if direct_child_exited && stdout_closed {
+                break;
+            }
+            let timeout = post_exit_deadline
+                .map(|deadline| {
+                    deadline
+                        .checked_duration_since(Instant::now())
+                        .unwrap_or_default()
+                })
+                .unwrap_or(CODEX_CHILD_POLL_INTERVAL);
+            if direct_child_exited && timeout.is_zero() {
+                break;
+            }
+            if stdout_closed {
+                thread::sleep(timeout.min(CODEX_CHILD_POLL_INTERVAL));
+                continue;
+            }
+
+            match receiver.recv_timeout(timeout.min(CODEX_CHILD_POLL_INTERVAL)) {
+                Ok(NativeStreamMessage::Line(line)) => {
+                    normalize_native_stream_line(&line, harness_id, ledger_session_id, out)?;
+                }
+                Ok(NativeStreamMessage::ReadError(error)) => {
+                    anyhow::bail!("reading {harness_id} stdout: {error}");
+                }
+                Ok(NativeStreamMessage::Closed) => stdout_closed = true,
+                Err(RecvTimeoutError::Timeout) => {}
+                Err(RecvTimeoutError::Disconnected) => {
+                    stdout_closed = true;
+                }
+            }
         }
-        writeln!(out, "{line}").with_context(|| format!("forwarding {harness_id} stdout"))?;
-        out.flush()
-            .with_context(|| format!("flushing {harness_id} stdout"))?;
-    }
+        Ok(())
+    })();
 
-    let status = child
+    stdin_stopped.store(true, Ordering::Relaxed);
+    if result.is_err() {
+        process_tree.terminate(&mut child);
+    }
+    let waited_status = child
         .wait()
-        .with_context(|| format!("waiting on {harness_id}"))?;
+        .with_context(|| format!("waiting on {harness_id}"));
+    let cancellation_signal = cancellation.finish()?;
+    if let Some(signal) = cancellation_signal {
+        anyhow::bail!(supervised_stream_cancellation_error_for_signal(
+            signal,
+            &cancellation_context
+        ));
+    }
+    result?;
+    let status = match status {
+        Some(status) => status,
+        None => waited_status?,
+    };
     Ok(status.code().unwrap_or(1))
 }
 
@@ -1715,7 +2182,7 @@ fn stream_harness_with_claude_args_and_permission_bypass<W: Write>(
     }
     args.extend(["--".to_string(), prompt.to_string()]);
 
-    stream_harness_with_program(program, cwd, args, forward_stdin, "claude", out)
+    stream_harness_with_program(program, cwd, args, forward_stdin, "claude", session_id, out)
 }
 
 #[allow(dead_code)]
@@ -3381,7 +3848,7 @@ exit 0
         assert!(outcome
             .error
             .as_deref()
-            .is_some_and(|error| error.contains("pipes remained open")));
+            .is_some_and(|error| error.contains("without an assistant message")));
         let pid = std::fs::read_to_string(temp_dir.path().join("descendant.pid"))?;
         let pid = pid.trim();
         let mut alive = true;
@@ -3553,10 +4020,9 @@ exit 7
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
             "-p\n--output-format\nstream-json\n--verbose\n--session-id\nsession-123\n--\nhello prompt\n"
         );
-        assert_eq!(
-            String::from_utf8(out)?,
-            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]},\"session_id\":\"session-123\",\"stop_reason\":\"end_turn\"}\n"
-        );
+        let frame: serde_json::Value = serde_json::from_slice(&out)?;
+        assert_eq!(frame["session_id"], "session-123");
+        assert_eq!(frame["harness_session_id"], "session-123");
         Ok(())
     }
 
@@ -3572,7 +4038,7 @@ exit 7
             &fake_harness,
             r#"#!/bin/sh
 printf '%s\n' "$@" > args.txt
-printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"streamy"}]},"session_id":"session-123","stop_reason":"end_turn"}'
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"streamy","session_id":"nested-unchanged"}]},"session_id":"native-old","harness_session_id":"native-old","stop_reason":"end_turn"}'
 exit 0
 "#,
         )?;
@@ -3593,6 +4059,7 @@ exit 0
             ],
             false,
             "streamy",
+            "ledger-current",
             &mut out,
         )?;
 
@@ -3601,10 +4068,336 @@ exit 0
             std::fs::read_to_string(temp_dir.path().join("args.txt"))?,
             "--jsonl\n--resume\nsession-123\n--\nhello prompt\n"
         );
+        let frame: serde_json::Value = serde_json::from_slice(&out)?;
+        assert_eq!(frame["session_id"], "ledger-current");
+        assert_eq!(frame["harness_session_id"], "native-old");
         assert_eq!(
-            String::from_utf8(out)?,
-            "{\"type\":\"assistant\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"streamy\"}]},\"session_id\":\"session-123\",\"stop_reason\":\"end_turn\"}\n"
+            frame["message"]["content"][0]["session_id"],
+            "nested-unchanged"
         );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_recorded_before_spawn_is_returned_by_checks_and_finish() -> Result<()> {
+        let cancellation = SupervisedStreamCancellationGuard::install("test stream")?;
+        cancel_supervised_stream(libc::SIGTERM);
+
+        assert_eq!(cancellation.cancelled_signal(), Some(libc::SIGTERM));
+        assert_eq!(cancellation.finish()?, Some(libc::SIGTERM));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_handler_has_no_process_group_side_effect_by_construction() {
+        let source = include_str!("pty_runner.rs");
+        assert!(
+            !source.contains(concat!("SUPERVISED_STREAM_", "PROCESS_GROUP")),
+            "the signal handler design must not retain a numeric process-group target"
+        );
+        let handler = source
+            .split_once("extern \"C\" fn cancel_supervised_stream")
+            .expect("cancellation handler exists")
+            .1
+            .split_once("/// Temporarily converts")
+            .expect("cancellation handler is followed by its guard documentation")
+            .0;
+        assert!(
+            !handler.contains("libc::kill"),
+            "the async signal handler must only record cancellation"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wait_without_reaping_keeps_child_pid_reserved() -> Result<()> {
+        let mut command = std::process::Command::new("/bin/sh");
+        command.arg("-c").arg("exit 0");
+        configure_child_process_tree_command(&mut command);
+        let mut child = command.spawn()?;
+        let pid = child.id() as libc::pid_t;
+
+        wait_for_child_exit_without_reaping(&child)?;
+
+        assert_eq!(
+            unsafe { libc::kill(pid, 0) },
+            0,
+            "wait helper reaped the child before process-tree cleanup"
+        );
+        assert!(child.wait()?.success());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nonblocking_wait_without_reaping_does_not_report_live_child_exited() -> Result<()> {
+        let mut command = std::process::Command::new("/bin/sh");
+        command.arg("-c").arg("sleep 1");
+        configure_child_process_tree_command(&mut command);
+        let mut child = command.spawn()?;
+
+        assert!(
+            !poll_child_exit_without_reaping(&child)?,
+            "WNOHANG reported a live direct child as exited"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cancellation_guard_blocks_supervised_signals_for_spawned_helpers() -> Result<()> {
+        let cancellation = SupervisedStreamCancellationGuard::install("test stream")?;
+        let inherited_mask = thread::spawn(|| {
+            let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
+            let result =
+                unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, std::ptr::null(), &mut mask) };
+            assert_eq!(result, 0);
+            [libc::SIGINT, libc::SIGTERM, libc::SIGHUP]
+                .map(|signal| unsafe { libc::sigismember(&mask, signal) })
+        })
+        .join()
+        .expect("signal-mask probe thread panicked");
+
+        assert_eq!(inherited_mask, [1, 1, 1]);
+        assert_eq!(cancellation.finish()?, None);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_stream_does_not_wait_for_stdout_inheriting_descendant() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_harness = temp_dir.path().join("stdout-descendant-stream");
+        std::fs::write(
+            &fake_harness,
+            r#"#!/bin/sh
+printf '%s\n' '{"type":"assistant","session_id":"native","message":{"role":"assistant","content":[]}}'
+sleep 3 &
+exit 17
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_harness, permissions)?;
+
+        let started = Instant::now();
+        let code = stream_harness_with_program(
+            fake_harness.to_str().unwrap(),
+            temp_dir.path(),
+            Vec::new(),
+            false,
+            "streamy",
+            "ledger-current",
+            &mut Vec::new(),
+        )?;
+
+        assert_eq!(code, 17);
+        assert!(
+            started.elapsed() < Duration::from_millis(1500),
+            "native stream waited for a descendant-held stdout pipe"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn successful_native_stream_cleans_closed_output_descendant() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_harness = temp_dir.path().join("successful-stream");
+        let descendant_pid_file = temp_dir.path().join("descendant.pid");
+        std::fs::write(
+            &fake_harness,
+            r#"#!/bin/sh
+sleep 30 </dev/null >/dev/null 2>&1 &
+printf '%s\n' "$!" > descendant.pid
+printf '%s\n' '{"type":"assistant","session_id":"native","message":{"role":"assistant","content":[]}}'
+exit 0
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_harness, permissions)?;
+
+        let code = stream_harness_with_program(
+            fake_harness.to_str().unwrap(),
+            temp_dir.path(),
+            Vec::new(),
+            false,
+            "streamy",
+            "ledger-current",
+            &mut Vec::new(),
+        )?;
+
+        assert_eq!(code, 0);
+        let descendant_pid: libc::pid_t = std::fs::read_to_string(descendant_pid_file)?
+            .trim()
+            .parse()?;
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while unsafe { libc::kill(descendant_pid, 0) } == 0 && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(
+            unsafe { libc::kill(descendant_pid, 0) },
+            -1,
+            "successful native stream left detached descendant {descendant_pid} alive"
+        );
+        assert_eq!(
+            std::io::Error::last_os_error().raw_os_error(),
+            Some(libc::ESRCH)
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_stream_malformed_json_terminates_and_reaps_harness() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_harness = temp_dir.path().join("fake-stream");
+        let pid_file = temp_dir.path().join("harness.pid");
+        std::fs::write(
+            &fake_harness,
+            "#!/bin/sh\nprintf '%s\\n' \"$$\" > harness.pid\nprintf '%s\\n' 'not-json'\nsleep 30\n",
+        )?;
+        let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_harness, permissions)?;
+
+        let error = stream_harness_with_program(
+            fake_harness.to_str().unwrap(),
+            temp_dir.path(),
+            Vec::new(),
+            false,
+            "streamy",
+            "ledger-current",
+            &mut Vec::new(),
+        )
+        .expect_err("malformed native JSONL must fail");
+        assert!(format!("{error:#}").contains("invalid JSON"));
+
+        let harness_pid: libc::pid_t = std::fs::read_to_string(pid_file)?.trim().parse()?;
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut reaped = false;
+        while Instant::now() < deadline {
+            if unsafe { libc::kill(harness_pid, 0) } == -1
+                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+            {
+                reaped = true;
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        if !reaped {
+            unsafe {
+                libc::kill(harness_pid, libc::SIGKILL);
+                libc::waitpid(harness_pid, std::ptr::null_mut(), 0);
+            }
+        }
+        assert!(reaped, "malformed JSON left harness {harness_pid} alive");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_stream_sigterm_returns_promptly_and_reaps_process_tree() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let fake_harness = temp_dir.path().join("long-lived-stream");
+        let harness_pid_file = temp_dir.path().join("harness.pid");
+        let descendant_pid_file = temp_dir.path().join("descendant.pid");
+        std::fs::write(
+            &fake_harness,
+            r#"#!/bin/sh
+printf '%s\n' "$$" > harness.pid
+sleep 30 &
+printf '%s\n' "$!" > descendant.pid
+while :; do sleep 1; done
+"#,
+        )?;
+        let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_harness, permissions)?;
+
+        let signal_dir = temp_dir.path().to_path_buf();
+        let signaler = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(3);
+            while Instant::now() < deadline {
+                if signal_dir.join("harness.pid").exists()
+                    && signal_dir.join("descendant.pid").exists()
+                {
+                    let sent = unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
+                    assert_eq!(sent, 0, "failed to signal test process");
+                    return;
+                }
+                thread::sleep(Duration::from_millis(10));
+            }
+            panic!("native stream fixture did not start before signal deadline");
+        });
+
+        let started = Instant::now();
+        let error = stream_harness_with_program(
+            fake_harness.to_str().unwrap(),
+            temp_dir.path(),
+            Vec::new(),
+            false,
+            "streamy",
+            "ledger-current",
+            &mut Vec::new(),
+        )
+        .expect_err("SIGTERM must cancel a native stream");
+        signaler.join().expect("signal thread panicked");
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "native stream cancellation was not prompt"
+        );
+        assert!(
+            format!("{error:#}").contains("streamy native stream cancelled by SIGTERM"),
+            "unexpected cancellation error: {error:#}"
+        );
+
+        let _signal_lock = SUPERVISED_STREAM_CANCELLATION_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut restored: libc::sigaction = unsafe { std::mem::zeroed() };
+        assert_eq!(
+            unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut restored) },
+            0
+        );
+        assert_ne!(
+            restored.sa_sigaction, cancel_supervised_stream as *const () as usize,
+            "native stream runner did not restore the previous SIGTERM handler"
+        );
+
+        for (label, path) in [
+            ("harness", harness_pid_file),
+            ("descendant", descendant_pid_file),
+        ] {
+            let pid: libc::pid_t = std::fs::read_to_string(path)?.trim().parse()?;
+            let deadline = Instant::now() + Duration::from_secs(1);
+            while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
+                thread::sleep(Duration::from_millis(10));
+            }
+            assert_eq!(
+                unsafe { libc::kill(pid, 0) },
+                -1,
+                "cancelled native stream {label} {pid} survived"
+            );
+            assert_eq!(
+                std::io::Error::last_os_error().raw_os_error(),
+                Some(libc::ESRCH)
+            );
+        }
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -2347,17 +2347,21 @@ pub fn sacrifice_session(conn: &Connection, session_id: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn latest_active_for_project(conn: &Connection, project_root: &str) -> Result<Option<String>> {
+pub fn latest_active_for_project(
+    conn: &Connection,
+    project_root: &str,
+    harness: &str,
+) -> Result<Option<String>> {
     conn.query_row(
         "SELECT id FROM sessions
-         WHERE project_root = ?1 AND archived_at IS NULL
+         WHERE project_root = ?1 AND harness = ?2 AND archived_at IS NULL
          ORDER BY created_at DESC
          LIMIT 1",
-        params![project_root],
+        params![project_root, harness],
         |row| row.get::<_, String>(0),
     )
     .optional()
-    .context("failed to query latest active session for project")
+    .context("failed to query latest active session for project and harness")
 }
 
 fn fts_literal_query(query: &str) -> Option<String> {
@@ -4788,7 +4792,7 @@ mod tests {
     }
 
     #[test]
-    fn latest_active_returns_newest_non_archived_for_project() -> Result<()> {
+    fn latest_active_returns_newest_non_archived_for_project_and_harness() -> Result<()> {
         let temp = tempfile::tempdir()?;
         let conn = open_store(&temp.path().join("test.sqlite3"))?;
         conn.execute_batch(
@@ -4799,8 +4803,8 @@ mod tests {
                       ('other_proj', '/other', 'claude', 't', 'created', '2026-01-04', '2026-01-04');
              UPDATE sessions SET archived_at='2026-01-03' WHERE id='archived';",
         )?;
-        let hit = latest_active_for_project(&conn, "/p")?;
-        assert_eq!(hit.as_deref(), Some("newer"));
+        let hit = latest_active_for_project(&conn, "/p", "codex")?;
+        assert_eq!(hit.as_deref(), Some("older"));
         Ok(())
     }
 

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -167,7 +167,7 @@ fn stream_json_stdout_stays_jsonl_when_harness_spews_pty_noise() {
 
 #[cfg(unix)]
 #[test]
-fn codex_json_stream_normalizes_assistant_and_thread_id() {
+fn codex_json_stream_resumes_with_a_sibling_and_preserves_terminal_evidence() {
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
 
@@ -183,7 +183,11 @@ fn codex_json_stream_normalizes_assistant_and_thread_id() {
         &fake_codex,
         r#"#!/bin/sh
 printf '%s\n' "$@" > args.txt
-printf '%s\n' '{"type":"thread.started","thread_id":"thread-unix-123"}'
+        thread_id=thread-unix-123
+        case " $* " in
+          *" resume "*) thread_id=thread-unix-456 ;;
+        esac
+        printf '%s\n' "{\"type\":\"thread.started\",\"thread_id\":\"$thread_id\"}"
 printf '%s\n' '{"type":"turn.started"}'
 printf '%s\n' '{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"reply for stream client"}}'
 printf '%s\n' '{"type":"turn.completed"}'
@@ -259,6 +263,120 @@ printf '%s\n' '{"type":"turn.completed"}'
         "--model\nexec\nexec\n--json\n--skip-git-repo-check\n--color\nnever\n--\n--json\n",
         "Codex must put its JSON option after the real exec subcommand"
     );
+
+    let old_id = frames[0]["session_id"]
+        .as_str()
+        .expect("system.init carries the old ledger id")
+        .to_string();
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3"))
+        .expect("failed to open Coven session ledger");
+    conn.execute(
+        "UPDATE sessions SET archived_at = ?2, updated_at = ?2 WHERE id = ?1",
+        rusqlite::params![old_id, "2026-08-03T20:00:00Z"],
+    )
+    .expect("failed to archive old fixture row");
+    let read_evidence = |id: &str| {
+        conn.query_row(
+            "SELECT status, exit_code, archived_at, created_at, updated_at, conversation_id
+             FROM sessions WHERE id = ?1",
+            [id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<i32>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                ))
+            },
+        )
+        .expect("session evidence should be readable")
+    };
+    let old_evidence = read_evidence(&old_id);
+
+    let resumed = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            "--continue",
+            &old_id,
+            "--",
+            "follow-up",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn resumed coven binary");
+    assert!(
+        resumed.status.success(),
+        "resumed Coven run failed: status={:?} stdout={} stderr={}",
+        resumed.status,
+        String::from_utf8_lossy(&resumed.stdout),
+        String::from_utf8_lossy(&resumed.stderr),
+    );
+    let resumed_frames: Vec<serde_json::Value> = String::from_utf8(resumed.stdout)
+        .expect("stdout not utf-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    let sibling_id = resumed_frames[0]["session_id"]
+        .as_str()
+        .expect("resumed system.init carries a ledger id");
+    assert_ne!(sibling_id, old_id, "continuation must use a fresh row");
+    assert_eq!(
+        resumed_frames.last().expect("result frame")["session_id"],
+        sibling_id,
+        "init and result must identify the sibling row"
+    );
+    assert_eq!(
+        read_evidence(&old_id),
+        old_evidence,
+        "continuation must not rewrite terminal or archive evidence"
+    );
+    let sibling_evidence = read_evidence(sibling_id);
+    assert_eq!(sibling_evidence.0, "completed");
+    assert_eq!(sibling_evidence.1, Some(0));
+    assert_eq!(sibling_evidence.2, None, "the sibling starts unarchived");
+    assert_eq!(
+        sibling_evidence.5.as_deref(),
+        Some("thread-unix-123"),
+        "the sibling shares the stable conversation group"
+    );
+    assert!(
+        fs::read_to_string(project_root.join("args.txt"))
+            .expect("fake codex should record resumed argv")
+            .contains("resume\nthread-unix-123\n"),
+        "Codex must resume its native thread id"
+    );
+
+    let missing = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            "--continue",
+            "missing-session",
+            "--",
+            "follow-up",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .expect("failed to run unknown-target check");
+    assert!(!missing.status.success(), "unknown continuation must fail");
+    assert!(
+        String::from_utf8_lossy(&missing.stderr).contains("not found in local store"),
+        "unexpected unknown-target error: {}",
+        String::from_utf8_lossy(&missing.stderr)
+    );
 }
 
 /// A Codex protocol failure is a failed Coven run even when the Codex wrapper
@@ -297,6 +415,7 @@ exit 0
     if let Some(existing) = std::env::var_os("PATH") {
         paths.extend(std::env::split_paths(&existing));
     }
+
     let path = std::env::join_paths(paths).expect("test PATH should be joinable");
     let out = Command::new(env!("CARGO_BIN_EXE_coven"))
         .args(["run", "codex", "--stream-json", "--", "fail once"])
@@ -340,6 +459,239 @@ exit 0
         .expect("failed session should remain in the ledger");
     assert_eq!(status, "failed");
     assert_eq!(exit_code, Some(1));
+}
+
+#[cfg(unix)]
+#[test]
+fn continuation_selects_and_accepts_only_the_requested_harness() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex");
+    fs::write(&fake_codex, "#!/bin/sh\nexit 0\n").expect("failed to write fake codex");
+    let mut permissions = fs::metadata(&fake_codex).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(fake_bin).chain(
+            std::env::var_os("PATH")
+                .iter()
+                .flat_map(std::env::split_paths),
+        ),
+    )
+    .unwrap();
+
+    let seed = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--detach", "--", "seed"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(seed.status.success());
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3")).unwrap();
+    let source_id: String = conn
+        .query_row("SELECT id FROM sessions LIMIT 1", [], |row| row.get(0))
+        .unwrap();
+    conn.execute(
+        "INSERT INTO sessions (
+             id, project_root, harness, title, status, created_at, updated_at
+         ) VALUES (
+             'newer-claude', ?1, 'claude', 'newer', 'completed',
+             '9999-01-01T00:00:00Z', '9999-01-01T00:00:00Z'
+         )",
+        [project_root.to_string_lossy().as_ref()],
+    )
+    .unwrap();
+    drop(conn);
+
+    let automatic = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--continue", "--", "automatic"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(
+        automatic.status.success(),
+        "automatic continuation failed: {}",
+        String::from_utf8_lossy(&automatic.stderr)
+    );
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3")).unwrap();
+    let automatic_group: String = conn
+        .query_row(
+            "SELECT conversation_id FROM sessions
+             WHERE id NOT IN (?1, 'newer-claude')",
+            [&source_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        automatic_group, source_id,
+        "automatic continuation must skip the newer other-harness row"
+    );
+    drop(conn);
+
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--continue", "newer-claude", "--", "resume"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("uses harness `claude`") && stderr.contains("requested harness `codex`"),
+        "unexpected mismatch error: {stderr}"
+    );
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3")).unwrap();
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 3, "mismatch must not create another sibling row");
+}
+
+#[cfg(unix)]
+#[test]
+fn claude_native_stream_uses_the_current_coven_ledger_id() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).unwrap();
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let fake_claude = fake_bin.join("claude");
+    fs::write(
+        &fake_claude,
+        r#"#!/bin/sh
+printf '%s\n' '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"reply","session_id":"nested-native"}]},"session_id":"native-claude-id","stop_reason":"end_turn"}'
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&fake_claude).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_claude, permissions).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(fake_bin).chain(
+            std::env::var_os("PATH")
+                .iter()
+                .flat_map(std::env::split_paths),
+        ),
+    )
+    .unwrap();
+
+    let first = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "claude", "--stream-json", "--", "first"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(first.status.success());
+    let first_frames: Vec<serde_json::Value> = String::from_utf8(first.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let source_id = first_frames[0]["session_id"].as_str().unwrap().to_string();
+
+    let resumed = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "claude",
+            "--stream-json",
+            "--continue",
+            &source_id,
+            "--",
+            "again",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(resumed.status.success());
+    let frames: Vec<serde_json::Value> = String::from_utf8(resumed.stdout)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    let sibling_id = frames[0]["session_id"].as_str().unwrap();
+    assert_ne!(sibling_id, source_id);
+    for frame in &frames {
+        assert_eq!(frame["session_id"], sibling_id);
+    }
+    let native = frames
+        .iter()
+        .find(|frame| frame["type"] == "assistant")
+        .unwrap();
+    assert_eq!(native["harness_session_id"], "native-claude-id");
+    assert_eq!(
+        native["message"]["content"][0]["session_id"],
+        "nested-native"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn command_construction_failure_marks_created_row_failed() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).unwrap();
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).unwrap();
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).unwrap();
+    let fake_codex = fake_bin.join("codex");
+    fs::write(&fake_codex, "#!/bin/sh\nexit 0\n").unwrap();
+    let mut permissions = fs::metadata(&fake_codex).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).unwrap();
+    let path = std::env::join_paths(
+        std::iter::once(fake_bin).chain(
+            std::env::var_os("PATH")
+                .iter()
+                .flat_map(std::env::split_paths),
+        ),
+    )
+    .unwrap();
+
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--model",
+            "openai/bad;model",
+            "--",
+            "prompt",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("model id is unsafe"));
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3")).unwrap();
+    let status: String = conn
+        .query_row("SELECT status FROM sessions", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(status, "failed");
 }
 
 /// Cancelling Coven itself must also reap the separate Unix Codex session

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -474,20 +474,21 @@ Endpoints that return this shape:
 
 The `external` field is `true` for sessions registered via `POST /api/v1/sessions/external`; it is `false` for all daemon-launched sessions. The `transcript_path` field carries the absolute path to the external session's transcript file when provided at registration; it is `null` for daemon-launched sessions and for external sessions where no path was supplied.
 
-| Status | Terminal in the current ledger | Meaning |
-|---|---:|---|
-| `created` | No | Durable row exists; no live runtime has been established. Recovery moves a stale unowned row to `failed`. |
-| `running` | No | A daemon-owned or registered external runtime is live. |
-| `idle` | No | A conversational turn completed and the session remains reusable. |
-| `completed` | Yes | Runtime completion was successful. |
-| `failed` | Yes | Launch or runtime completion failed. |
-| `killed` | Yes | A kill request was accepted and persisted; this is not proof of acknowledged process termination. |
-| `orphaned` | Yes | Recovery cannot prove ownership of a row previously marked running. |
+Classify the row kind before interpreting `status`. Synthetic `active` rows can appear in raw store or list output, but `active` is not a harness-session state.
 
-Archive visibility is stored separately in `archived_at` and does not change
-the lifecycle status. Synthetic Cast quest-anchor rows may use `active`; that
-store value is not a harness-session state and must be classified by row kind
-before interpreting status.
+| Harness-session status | Terminal? | Meaning |
+|---|---|---|
+| `created` | No | Ledger row exists before runtime ownership. Stale unowned `created` rows recover to `failed`. |
+| `running` | No | Reported live state. Inspect `external` to determine whether Coven owns and supervises the runtime. |
+| `idle` | No | Reusable conversational session is waiting for more work. |
+| `completed` | Yes | Harness session completed successfully. |
+| `failed` | Yes | Launch or execution failed. |
+| `killed` | Yes | Terminal in the current ledger. This status is not proof that process termination was acknowledged. |
+| `orphaned` | Yes | Runtime ownership was lost and the outcome remains unresolved. |
+
+Archive is not a session status. It is stored separately in `archived_at`; archive and summon preserve the existing lifecycle status of every non-running session, including `created` and `idle`.
+
+External `running` sessions are not daemon-control targets: `POST /api/v1/sessions/:id/input` returns `409 session_not_live` because Coven has no owned live runtime, and `POST /api/v1/sessions/:id/kill` returns `422 external_session_not_killable` as documented below.
 
 ## `POST /api/v1/sessions/external`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,8 @@ not proof of `coven.daemon.v1` support.
 flowchart LR
   subgraph Clients["Client layer"]
     User[Developer]
-    CLI["coven CLI / TUI"]
+    CLI["coven run CLI"]
+    SocketClients["TUI / socket clients"]
     Comux["comux cockpit"]
     OpenClaw[OpenClaw]
     Plugin["OpenClaw bridge plugin"]
@@ -52,8 +53,12 @@ flowchart LR
 
   User --> CLI
   CLI -->|direct commands| Rust["Coven Rust CLI"]
-  Rust --> Daemon
+  Rust --> Boundary
+  Rust --> Store
+  Rust --> Events
 
+  User --> SocketClients
+  SocketClients -->|"HTTP over Unix socket"| Daemon
   Comux -->|"HTTP over Unix socket"| Daemon
   OpenClaw --> Plugin
   Plugin -->|"HTTP over Unix socket"| Daemon
@@ -80,24 +85,34 @@ flowchart LR
 ```mermaid
 sequenceDiagram
   participant U as User
-  participant C as coven CLI/TUI
+  participant C as coven Rust CLI
+  participant X as Socket client
   participant D as Rust daemon
   participant S as SQLite store
   participant H as Harness PTY
 
   U->>C: coven run codex "fix tests"
   activate C
-  C->>D: POST /api/v1/sessions (projectRoot, cwd, harness, prompt)
-  activate D
-  D->>D: canonicalize projectRoot + cwd
-  D->>D: reject outside-root or unsupported harness
-  D->>S: create session metadata
-  D->>H: spawn validated argv in PTY
+  C->>C: canonicalize root/cwd; validate harness
+  C->>S: insert new row (status=created)
+  C->>S: transition row to running
+  C->>H: launch validated argv directly
   activate H
   H-->>S: output / exit events
-  D-->>C: session id + running status
-  deactivate D
   deactivate C
+
+  X->>D: POST /api/v1/sessions
+  activate D
+  D->>D: canonicalize root/cwd; validate harness
+  D->>S: insert new row (status=running)
+  D->>H: launch validated argv in PTY
+  alt launch fails
+    D->>S: transition new row to failed
+    D-->>X: 500 launch_failed
+  else launch succeeds
+    D-->>X: 201 SessionRecord
+  end
+  deactivate D
 
   Note over U,C: Browse and manage sessions
 

--- a/docs/SESSION-LIFECYCLE.md
+++ b/docs/SESSION-LIFECYCLE.md
@@ -1,10 +1,10 @@
 ---
 title: "Session lifecycle"
-summary: "How a Coven harness session moves through created, running, idle, completed, failed, killed, and orphaned statuses, with archive visibility stored separately."
+summary: "How a Coven session moves through created, running, idle, and terminal states, with archive visibility and summon behavior."
 read_when:
   - Understanding session states
   - Implementing attach, archive, summon, or sacrifice behavior
-description: "How a Coven harness session moves through its seven ledger statuses while archive visibility remains separate."
+description: "How a Coven session moves through created, running, idle, and terminal states, with archive visibility and summon behavior."
 ---
 
 # Session Lifecycle
@@ -13,77 +13,76 @@ This document explains what happens from `coven run` through completion, replay,
 
 ## Lifecycle states
 
-The current store records harness-session status as a string.
+Classify the row kind before interpreting its status. Synthetic `active` rows can appear in raw store or list output, but `active` is not a harness-session state.
 
-| Status | Terminal in the current ledger | Meaning |
-|---|---:|---|
-| `created` | No | Durable row exists; no live runtime has been established. Recovery moves a stale unowned row to `failed`. |
-| `running` | No | A daemon-owned or registered external runtime is live. |
-| `idle` | No | A conversational turn completed and the session remains reusable. |
-| `completed` | Yes | Runtime completion was successful. |
-| `failed` | Yes | Launch or runtime completion failed. |
-| `killed` | Yes | A kill request was accepted and persisted; this is not proof of acknowledged process termination. |
-| `orphaned` | Yes | Recovery cannot prove ownership of a row previously marked running. |
+| Harness-session status | Ledger-terminal? | Meaning |
+|---|---|---|
+| `created` | No | Ledger row exists before runtime ownership. Stale unowned `created` rows recover to `failed`. |
+| `running` | No | Reported live state. Inspect the external flag before inferring daemon runtime ownership. |
+| `idle` | No | A daemon/socket-managed, conversation-grouped session (`conversation_id` present) exited successfully and is waiting for more work. CLI and socket/chat continuation create a new row. |
+| `completed` | Yes | A direct CLI run persisted a successful harness result (even when `conversation_id` is present), a daemon-managed session without `conversation_id` exited successfully, or an externally registered running session was completed with an absent, `null`, or zero `exitCode`. |
+| `failed` | Yes | Launch or execution failed, or an externally registered running session was completed with a nonzero `exitCode`. |
+| `killed` | Yes | Terminal in the current ledger. This status is not proof that process termination was acknowledged. |
+| `orphaned` | Yes | Runtime ownership was lost and the outcome remains unresolved. |
 
-Archive visibility is stored separately in `archived_at` and does not change
-the lifecycle status. Synthetic Cast quest-anchor rows may use `active`; that
-store value is not a harness-session state and must be classified by row kind
-before interpreting status.
+Archive visibility is stored separately as `archived_at`; it is not a `SessionRecord.status`. Archiving may hide any non-running session, including one with `created` or `idle` status, without changing that status. Summoning clears `archived_at` and reveals the same status again.
 
 ```mermaid
 stateDiagram-v2
-  [*] --> created: coven run / POST /sessions
-  created --> running: PTY spawn succeeds
-  created --> failed: launch fails / stale unowned recovery
-  running --> idle: clean conversational exit (conversation_id set)
-  running --> completed: clean one-shot exit
+  [*] --> running: socket/chat POST creates a new row
+  [*] --> created: CLI / detached / store path inserts row
+  created --> running: execution starts
+  created --> failed: stale unowned recovery
+  running --> failed: runtime launch fails
+  running --> idle: daemon/socket exits 0 with conversation_id
+  [*] --> created: CLI --continue creates a sibling row
+  running --> completed: direct CLI exits 0, or daemon/socket exits 0 without conversation_id
+  running --> completed: external complete with exitCode absent/null/0
   running --> failed: harness exits non-zero
-  running --> killed: kill request accepted and persisted
-  running --> orphaned: recovery cannot prove daemon ownership
+  running --> failed: external complete with nonzero exitCode
+  running --> killed: kill dispatch accepted
+  running --> orphaned: daemon-owned runtime ownership is lost
 
-  completed --> completed: archive sets / summon clears archived_at
-  failed --> failed: archive sets / summon clears archived_at
-  killed --> killed: archive sets / summon clears archived_at
-  orphaned --> orphaned: archive sets / summon clears archived_at
-
+  created --> [*]: coven sacrifice --yes
+  idle --> [*]: coven sacrifice --yes
   completed --> [*]: coven sacrifice --yes
   failed --> [*]: coven sacrifice --yes
   killed --> [*]: coven sacrifice --yes
   orphaned --> [*]: coven sacrifice --yes
 ```
 
-The diagram above is normative for the current store. A clean exit persists
-`idle` when `conversation_id` is set so the conversation remains extendable;
-a clean one-shot exit persists `completed`. `running` sessions cannot be
-archived or sacrificed directly — kill them or wait for exit first. Archive
-and summon change `archived_at`, not lifecycle status. `created → running` is
-the transition that establishes live execution; persistence-only transitions
-remain in the Rust authority layer.
+The diagram above describes harness-session statuses in the current ledger. On a clean exit, only the daemon/socket-managed path in `daemon.rs` converts a successful harness result to `idle`, and only when `conversation_id` is present. A direct CLI run persists the harness result, normally `completed`, even when its row has `conversation_id`; a daemon-managed row without `conversation_id` also persists as `completed` after a clean exit. Automatic `coven run <harness> --continue` selects the latest non-archived row with both the same project root and the requested harness. Explicit `coven run <harness> --continue <ID>` performs a direct id or conversation lookup and may select an archived row, but rejects a source whose harness differs from the requested harness. Both forms accept any current status and create a fresh, initially unarchived sibling in the same conversation group. The selected source row is unchanged, including its status, exit code, archive overlay, and timestamps. Socket/chat continuation through `POST /api/v1/sessions` also inserts a new row. It shares grouping with a prior conversation only when the caller explicitly supplies the same `conversationId`; a resume hint does not derive that id automatically. Archive and summon are omitted because they only set or clear the separate `archived_at` visibility overlay; they do not create lifecycle states. Archive rejects only `running`, and sacrifice may permanently delete any non-running row whether visible or archived. A `running → killed` ledger transition records accepted kill dispatch, not acknowledged process termination.
+
+For an externally registered `running` session, `POST /api/v1/sessions/:id/complete` records the caller-owned outcome: an absent, `null`, or zero `exitCode` moves the row to `completed`, while a nonzero `exitCode` moves it to `failed`. This completion path does not give the daemon runtime ownership. External running sessions remain exempt from daemon orphan recovery, and daemon input and kill requests remain rejected.
 
 ## Launch path
 
-The normal launch flow:
+All launch paths perform the same validation:
 
 1. User or client sends a task through the CLI or local API.
 2. Coven resolves the project root.
 3. Coven canonicalizes the project root and working directory.
 4. Coven rejects outside-root working directories.
 5. Coven verifies the harness id is supported.
-6. Coven creates a session record in SQLite.
-7. The daemon spawns the harness in a PTY using argv APIs.
-8. Output and exit data are written as events.
-9. Session status and exit code are updated.
+6. Coven persists a session record in SQLite.
+
+The lifecycle around launch depends on the entry point:
+
+- `POST /api/v1/sessions` always inserts a new row as `running` before launching the runtime. The new row shares a prior conversation's grouping only when the caller explicitly supplies the same `conversationId`; a resume hint alone does not derive it. The prior row is unchanged. If PTY spawn or the initial write fails, the daemon transitions the new row to `failed`.
+- A new direct CLI `coven run` inserts a `created` row, transitions it to `running`, and then launches the harness. Automatic continuation selects by the same project root and harness; explicit continuation rejects a harness mismatch. Either form accepts any source status but leaves the source unchanged, including its archive and terminal evidence. Continuation creates a fresh, unarchived sibling with a new id and a stable resume/group key: the source row's `conversation_id` when present, otherwise its id. The harness resumes with that key, and the sibling owns the new `created` → `running` → terminal lifecycle. A detached run remains `created`; stale unowned `created` rows recover to `failed`.
+
+Once execution starts, output and exit data are written as events, and the terminal status and exit code are persisted when the harness exits.
 
 The Rust layer performs the authority checks even when a TypeScript client has already validated the request for UX.
 
 ```mermaid
 sequenceDiagram
-  participant Client as Client (CLI / TUI / comux / plugin)
+  participant Client as Socket client (TUI / comux / plugin)
   participant Daemon as Coven daemon
   participant Store as SQLite store
   participant PTY as Harness PTY
 
-  Client->>Daemon: POST /api/v1/sessions { projectRoot, cwd, harness, prompt }
+  Client->>Daemon: POST /api/v1/sessions { projectRoot, cwd, harness, prompt, conversationId? }
   Daemon->>Daemon: canonicalize projectRoot
   alt projectRoot invalid
     Daemon-->>Client: 400 invalid_request
@@ -96,22 +95,22 @@ sequenceDiagram
   alt harness unknown
     Daemon-->>Client: 400 invalid_request (with install hint)
   end
-  Daemon->>Store: insert session (status=created)
+  Daemon->>Store: insert new session (status=running)
+  Note over Daemon,Store: Grouping is shared only when caller supplies the same conversationId
   Daemon->>PTY: spawn argv (prefix args + prompt)
   alt spawn / initial-write fails
     Daemon->>Store: update status=failed
     Daemon-->>Client: 500 launch_failed (details.sessionId set)
   else PTY spawn ok
-    Daemon->>Store: update status=running
-    Daemon-->>Client: 200 SessionRecord
+    Daemon-->>Client: 201 SessionRecord
     PTY-->>Store: append output / exit events
     PTY->>Daemon: process exits with code
-    alt non-zero exit or wait error
-      Daemon->>Store: update status=failed, exit_code
-    else clean exit with conversation_id
+    alt daemon exit code 0 and conversation_id present
       Daemon->>Store: update status=idle, exit_code
-    else clean one-shot exit
+    else daemon exit code 0 without conversation_id
       Daemon->>Store: update status=completed, exit_code
+    else exit code non-zero
+      Daemon->>Store: update status=failed, exit_code
     end
   end
 ```
@@ -174,10 +173,7 @@ Use sacrifice only when the session and its logs should be removed from the loca
 
 ## Orphan recovery
 
-If the daemon starts and finds daemon-owned, non-external sessions that were
-marked `running` from a previous daemon lifetime, those sessions are marked
-`orphaned`. Registered external sessions are excluded because the daemon does
-not own their runtime.
+If the daemon starts and finds daemon-owned sessions that were marked `running` from a previous daemon lifetime, those sessions are marked `orphaned`. Externally registered running sessions are exempt because the daemon does not own their lifecycle.
 
 An orphaned session means Coven no longer owns a live process for that record. The event log may still be useful, but live input and kill operations should fail.
 
@@ -194,9 +190,17 @@ Do not intentionally write secrets, environment dumps, private URLs, or token-be
   Output is a flat list of hits ordered most-recent-first; pass `--json` to get the raw
   SearchHit array for client tools.
 - `coven run <harness> --continue` resumes the most recently created, non-archived
-  session whose `project_root` matches the current directory. The harness is launched
-  with `ConversationHint::Resume` so codex/claude pick up the prior turn's context.
-- `coven run <harness> --continue <ID>` resumes by explicit session id.
+  session whose `project_root` and `harness` match the current request, without restricting its
+  current status. The selected row remains unchanged, including any archive or terminal
+  evidence. Coven creates a fresh, unarchived sibling with a new id; its stable
+  resume/group key is the selected row's `conversation_id` when present, otherwise the
+  selected row's id. The harness resumes using that key, and the new row owns the new
+  lifecycle.
+- `coven run <harness> --continue <ID>` resumes by explicit session id or conversation
+  lookup. It can select an archived row and accepts any current status, but rejects a
+  source whose harness differs from `<harness>`. As with automatic
+  continuation, the selected row remains unchanged and a fresh, unarchived sibling with
+  a new id owns the resumed lifecycle, using the same stable resume/group key rule.
 - `coven run <harness> --labels foo,bar --visibility workspace --archive "task"` tags
   and archives a one-shot run in a single command. `--labels` and `--visibility` are
   creation-time only (ignored when resuming). Valid visibility values: `private`

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -13,7 +13,8 @@ The daemon does not use OAuth, JWTs, bearer tokens, API keys, or browser cookies
 
 ## Handshake
 
-Always start with:
+Always start with `GET /api/v1/health` as the compatibility handshake for the
+named `coven.daemon.v1` contract:
 
 ```http
 GET /api/v1/health

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -49,7 +49,7 @@ The health `capabilities` object currently contains all nine fields:
 | POST | `/api/v1/sessions` | Launch a project-scoped harness session. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request`, `500 launch_failed` |
 | POST | `/api/v1/sessions/external` | Register (or idempotently re-register) an externally launched session. | session descriptor | `201` new / `200` existing | `400`, `409 session_id_conflict` |
 | GET | `/api/v1/sessions/:id` | Fetch one session. | — | `SessionRecord` | `404 session_not_found` |
-| POST | `/api/v1/sessions/:id/complete` | Mark an external session completed. | `{ exitCode?, ... }` | updated record | `404`, `409` (not external) |
+| POST | `/api/v1/sessions/:id/complete` | Mark an external session completed. | `{ exitCode?, ... }` | updated record | `404 session_not_found`, `422 not_external_session` |
 | GET | `/api/v1/sessions/:id/events` | Read redacted session events. | `?afterSeq`, `?afterEventId`, `?limit` | `{ events, nextCursor, hasMore }` | `404 session_not_found` |
 | GET | `/api/v1/sessions/:id/log` | Read bounded redacted log previews. | — | `[{ ts, level, message }]` | `404 session_not_found` |
 | POST | `/api/v1/sessions/:id/input` | Forward input to a live session. | `{ data }` | `{ ok, accepted }` | `400`, `404`, `409 session_not_live`, `500 send_input_failed` |

--- a/docs/reference/cli-run.md
+++ b/docs/reference/cli-run.md
@@ -26,12 +26,12 @@ coven run <harness> <prompt> [flags]
 | `--think` | Request deeper reasoning. Claude, Coven Code, and Copilot map this to `--effort high`; unsupported harnesses warn and continue. |
 | `--speed <level>` | Set a latency/reasoning hint: `fast`, `balanced`, or `thorough`. Claude, Coven Code, and Copilot map these to `--effort low`, `medium`, or `high`; unsupported harnesses warn and continue. |
 | `--detach` | Create the session record without launching the harness. |
-| `--continue [id]` | Resume a specific session, or the latest active session for this project when `id` is omitted. |
+| `--continue [id]` | Resume a specific session, or the latest non-archived session for this project and requested harness when `id` is omitted. An explicit id or conversation lookup from another harness is rejected. Continuation creates a fresh, unarchived sibling row in the same conversation group; the selected row and its terminal/archive evidence remain unchanged. |
 | `--labels <a,b>` | Attach comma-separated labels to a new session. |
 | `--visibility <private\|workspace\|shared>` | Set session visibility metadata. |
 | `--archive` | Archive the session after the run completes. |
 | `--familiar <id>` | Inject familiar identity context. |
-| `--stream-json` | Emit Coven JSONL events on stdout. Codex runs as `codex exec --json` over ordinary pipes and is normalized into `assistant` / `result` events; on Windows its npm `.cmd` shim receives the prompt on stdin rather than through ConPTY. Other external non-stream adapters have raw PTY output wrapped in `output` events. See `docs/STREAM-JSON.md`. |
+| `--stream-json` | Emit Coven JSONL events on stdout. Every top-level `session_id` identifies the current Coven ledger row, including native harness frames during continuation; native conversation identity is retained separately as `harness_session_id` when supplied. Malformed native JSONL fails the run. Codex runs as `codex exec --json` over ordinary pipes and is normalized into `assistant` / `result` events; on Windows its npm `.cmd` shim receives the prompt on stdin rather than through ConPTY. Other external non-stream adapters have raw PTY output wrapped in `output` events. See `docs/STREAM-JSON.md`. |
 | `--stream-json-input` | With `--stream-json`, read JSONL user messages from stdin for Claude stream mode. |
 
 Examples:

--- a/docs/sessions/lifecycle.md
+++ b/docs/sessions/lifecycle.md
@@ -1,28 +1,31 @@
 ---
-summary: "The seven harness-session statuses, their daemon transitions, and separate archive visibility."
+summary: "Harness-session lifecycle statuses, plus archive visibility, summon, and sacrifice behavior."
 read_when:
   - Designing a client that follows session state
   - Debugging a stuck or orphaned session
 title: "Session lifecycle for client developers"
-description: "Coven harness-session states for client developers, with daemon transitions and the separate archive visibility field."
+description: "Coven harness-session statuses for client developers, including reusable idle sessions, terminal outcomes, archive visibility, summon, and sacrifice."
 ---
 
-Every Coven harness session uses the same status vocabulary, regardless of which harness is driving it.
+Harness-session rows use the same state vocabulary regardless of which harness is driving them.
 
 ```mermaid
 stateDiagram-v2
-  [*] --> Created: POST /api/v1/sessions
-  Created --> Running: daemon spawns PTY
-  Created --> Failed: launch fails / stale unowned recovery
-  Running --> Idle: conversational turn completes; reusable
-  Running --> Completed: harness exits 0
+  [*] --> Running: socket/chat POST creates a new row
+  [*] --> Created: CLI/detached path inserts row
+  Created --> Running: CLI/detached launch begins
+  Created --> Failed: stale unowned recovery
+  Running --> Failed: runtime launch fails
+  Running --> Idle: daemon/socket exits 0 with conversation_id
+  [*] --> Created: CLI --continue creates a sibling row
+  Running --> Completed: direct CLI exits 0, or daemon/socket exits 0 without conversation_id
+  Running --> Completed: external complete with exitCode absent/null/0
   Running --> Failed: harness exits non-zero
-  Running --> Killed: kill request accepted and persisted
-  Running --> Orphaned: recovery cannot prove ownership
-  Completed --> Completed: archive sets / summon clears archived_at
-  Failed --> Failed: archive sets / summon clears archived_at
-  Killed --> Killed: archive sets / summon clears archived_at
-  Orphaned --> Orphaned: archive sets / summon clears archived_at
+  Running --> Failed: external complete with nonzero exitCode
+  Running --> Killed: kill dispatch accepted
+  Running --> Orphaned: daemon-owned runtime ownership lost
+  Created --> [*]: coven sacrifice --yes
+  Idle --> [*]: coven sacrifice --yes
   Completed --> [*]: coven sacrifice --yes
   Failed --> [*]: coven sacrifice --yes
   Killed --> [*]: coven sacrifice --yes
@@ -31,20 +34,23 @@ stateDiagram-v2
 
 ## State definitions
 
-| Status | Terminal in the current ledger | Meaning |
-|---|---:|---|
-| `created` | No | Durable row exists; no live runtime has been established. Recovery moves a stale unowned row to `failed`. |
-| `running` | No | A daemon-owned or registered external runtime is live. |
-| `idle` | No | A conversational turn completed and the session remains reusable. |
-| `completed` | Yes | Runtime completion was successful. |
-| `failed` | Yes | Launch or runtime completion failed. |
-| `killed` | Yes | A kill request was accepted and persisted; this is not proof of acknowledged process termination. |
-| `orphaned` | Yes | Recovery cannot prove ownership of a row previously marked running. |
+Classify the row kind before interpreting its status. Synthetic `active` rows can appear in raw store or list output, but `active` is not a harness-session state.
 
-Archive visibility is stored separately in `archived_at` and does not change
-the lifecycle status. Synthetic Cast quest-anchor rows may use `active`; that
-store value is not a harness-session state and must be classified by row kind
-before interpreting status.
+| Harness-session status | Ledger-terminal? | Meaning |
+|---|---|---|
+| `created` | No | Ledger row exists before runtime ownership. Stale unowned `created` rows recover to `failed`. |
+| `running` | No | Reported live state. Inspect whether the row is external before inferring Coven runtime ownership. |
+| `idle` | No | A daemon/socket-managed, conversation-grouped session (`conversation_id` present) exited successfully and is waiting for more work. CLI and socket/chat continuation create a new row. |
+| `completed` | Yes | A direct CLI run persisted a successful harness result (even when `conversation_id` is present), a daemon-managed session without `conversation_id` exited successfully, or an externally registered running session was completed with an absent, `null`, or zero `exitCode`. |
+| `failed` | Yes | Launch or execution failed, or an externally registered running session was completed with a nonzero `exitCode`. |
+| `killed` | Yes | Terminal in the current ledger. This status is not proof that process termination was acknowledged. |
+| `orphaned` | Yes | Runtime ownership was lost and the outcome remains unresolved. |
+
+Archive visibility is stored separately in `archived_at`; it is not a status and therefore does not appear in the lifecycle graph. Archive may set this overlay on any non-running session, including one with `created` or `idle` status, and summon clears it. Both operations preserve the harness-session status.
+
+On a clean exit, only the daemon/socket-managed path in `daemon.rs` converts a successful harness result to `idle`, and only when `conversation_id` is present. A direct CLI run persists the harness result, normally `completed`, even when its row has `conversation_id`; a daemon-managed row without `conversation_id` also persists as `completed` after a clean exit. Automatic CLI `coven run <harness> --continue` selects the latest non-archived row for the same project root and harness. Explicit `coven run <harness> --continue <ID>` performs a direct id or conversation lookup and may select an archived row, but rejects a source from another harness. Both forms create a fresh, initially unarchived sibling row grouped by the selected row's `conversation_id`, or by its ledger id when no conversation id exists. The selected row is never reopened or rewritten, so its status, exit code, archive overlay, and timestamps remain terminal evidence. Socket/chat continuation through `POST /api/v1/sessions` also creates a new row, but shares grouping only when the caller explicitly supplies the same `conversationId`; a resume hint does not derive that id automatically.
+
+For an externally registered `running` session, `POST /api/v1/sessions/:id/complete` records the caller-owned outcome: an absent, `null`, or zero `exitCode` moves the row to `completed`, while a nonzero `exitCode` moves it to `failed`. This completion path does not give the daemon runtime ownership. External running sessions remain exempt from daemon orphan recovery, and daemon input and kill requests remain rejected.
 
 ## Launch
 
@@ -52,7 +58,7 @@ before interpreting status.
 coven run codex "describe this repo"
 ```
 
-Equivalent socket call:
+Socket client launch (a separate entry path):
 
 ```http
 POST /api/v1/sessions
@@ -66,7 +72,7 @@ Content-Type: application/json
 }
 ```
 
-The Rust daemon revalidates `projectRoot` and `cwd` before spawning the PTY. See [Authority boundary](/concepts/authority-boundary).
+For this socket path, the daemon inserts a new row as `running` before launching the runtime; a successful request returns `201 SessionRecord`, while a launch failure transitions that new row from `running` to `failed`. The new row shares a prior conversation's grouping only when the caller explicitly supplies the same `conversationId`; a resume hint alone does not derive it. The prior row is unchanged. A new direct CLI `coven run` inserts a `created` row, transitions it to `running`, and launches the harness. CLI continuation follows the same created-to-running path on a fresh sibling row while preserving the selected row exactly. When the harness exits, the direct CLI persists its result, normally `completed` on success, on the new row. The Rust authority layer validates `projectRoot` and `cwd` on each entry path before spawning the PTY. See [Authority boundary](/concepts/authority-boundary).
 
 ## Attach
 
@@ -78,30 +84,28 @@ coven attach <session-id>
 
 ## Archive / summon / sacrifice
 
-These are the three rituals around non-running sessions. Archive and summon
-change `archived_at` without changing the lifecycle status:
+These rituals control stored-session visibility and deletion:
 
 <Columns>
   <Card title="Archive" href="/rituals/archive" icon="archive">
     Hide a non-running session. Reversible. Events preserved.
   </Card>
   <Card title="Summon" href="/rituals/summon" icon="moon-star">
-    Restore an archived session to the active list with its original terminal status, then replay/follow it.
+    Clear an archived session's visibility overlay and restore it to the active list with its unchanged status, then replay/follow it.
   </Card>
   <Card title="Sacrifice" href="/rituals/sacrifice" icon="flame">
-    Permanently delete. Refuses live sessions. Requires `--yes`.
+    Permanently delete any non-running session, visible or archived. Requires `--yes`.
   </Card>
 </Columns>
 
 ## Orphan recovery
 
-If the daemon restarts while a daemon-owned PTY was marked `running`, recovery
-marks the session `orphaned`. On startup, the daemon:
+When the daemon starts, it recovers stale unowned rows:
 
 1. Reads the session ledger.
-2. Marks previously `running` daemon-owned rows as `orphaned` when ownership cannot be proved.
-3. Marks stale unowned `created` rows as `failed`.
-4. Refuses to re-attach to a dead PTY.
+2. Marks stale `created` rows as `failed`.
+3. Marks stale daemon-owned `running` rows as `orphaned`, preserving their unresolved outcome. Externally registered running sessions are exempt because the daemon does not own their lifecycle.
+4. Refuses to re-attach to a PTY it no longer owns.
 
 See [Orphan recovery](/daemon/orphan-recovery).
 

--- a/docs/superpowers/plans/2026-08-03-psyche-o1-contract-implementation.md
+++ b/docs/superpowers/plans/2026-08-03-psyche-o1-contract-implementation.md
@@ -17,8 +17,8 @@
 - `packages/openclaw-coven/src/client.test.ts` - prove health parsing does not promote untrusted capability values into typed authority.
 - `packages/openclaw-coven/src/runtime.ts` - apply the OpenClaw bridge's fail-closed named-contract/capability policy and explicit lifecycle interpretation.
 - `packages/openclaw-coven/src/runtime.test.ts` - prove mismatches stop before launch and `idle`/unknown states are not inferred as completed work.
-- `packages/openclaw-coven/package.json` - declare the existing pnpm toolchain, provide reproducible test/typecheck scripts, and add exact test-time dependencies.
-- `packages/openclaw-coven/pnpm-lock.yaml` - update the existing package lock without introducing a second package manager.
+- `packages/openclaw-coven/package.json` - provide reproducible test/typecheck scripts and exact test-time dependencies.
+- `packages/openclaw-coven/package-lock.json` - keep the package's CI install reproducible.
 - `.github/workflows/ci.yml` - run the OpenClaw bridge checks in CI.
 - `docs/API-CONTRACT.md` - canonical single-page handshake, legacy route diagnostic, and `SessionRecord.status` contract.
 - `docs/reference/api-contract.md` - condensed named-contract negotiation guidance.
@@ -36,98 +36,42 @@
 
 **Files:**
 - Modify: `packages/openclaw-coven/package.json`
-- Modify: `packages/openclaw-coven/pnpm-lock.yaml`
+- Modify: `packages/openclaw-coven/package-lock.json`
 - Modify: `.github/workflows/ci.yml`
 
-- [ ] **Step 1: Add package scripts and exact development dependencies**
+- [ ] **Step 1: Declare the package checks and exact test dependencies**
 
-Update `packages/openclaw-coven/package.json` with:
+Preserve all package metadata and peer dependencies. Add the exact OpenClaw test
+version required by `openclaw.build.openclawVersion`, TypeScript, Node types, and
+Vitest. The package scripts are `typecheck` (`tsc --noEmit`) and `test`
+(`vitest run`); do not refer to a nonexistent `build` script. Keep the npm
+lockfile used by the package's CI job synchronized with `package.json`.
 
-```json
-{
-  "packageManager": "pnpm@10.11.1",
-  "scripts": {
-    "build": "tsc --noEmit",
-    "test": "vitest run",
-    "typecheck": "tsc --noEmit"
-  },
-  "devDependencies": {
-    "@types/node": "^24.0.0",
-    "openclaw": "2026.4.26",
-    "typescript": "^5.9.0",
-    "vitest": "^4.1.10"
-  }
-}
-```
-
-Preserve every existing package metadata, peer dependency, and OpenClaw plugin
-field. The exact OpenClaw development version matches
-`openclaw.build.openclawVersion`; the published peer range remains unchanged.
-The package already carries `pnpm-lock.yaml`, so keep pnpm as its sole lockfile
-and record the locally verified pnpm version instead of adding an npm lock.
-
-- [ ] **Step 2: Update and prove the existing pnpm lockfile**
+- [ ] **Step 2: Install reproducibly and prove the package checks**
 
 Run:
 
 ```bash
-corepack enable
-corepack prepare pnpm@10.11.1 --activate
-pnpm --dir packages/openclaw-coven install --lockfile-only --ignore-scripts
-pnpm --dir packages/openclaw-coven install --frozen-lockfile --ignore-scripts
-```
-
-Expected: `packages/openclaw-coven/pnpm-lock.yaml` is updated in place,
-dependencies install with the lockfile frozen, the existing
-`autoInstallPeers: false` setting remains intact, no npm lockfile appears, and
-no package lifecycle script runs.
-
-- [ ] **Step 3: Prove the baseline package tests execute**
-
-Run:
-
-```bash
+npm --prefix packages/openclaw-coven ci --ignore-scripts
 npm --prefix packages/openclaw-coven run typecheck
 npm --prefix packages/openclaw-coven test -- src/client.test.ts src/runtime.test.ts
 ```
 
-Expected: the existing tests execute rather than failing module resolution. If
-the pre-change baseline has a real assertion or type failure, record the exact
-failure before changing O1 behavior; do not weaken compiler or test settings.
+Expected: the frozen `package-lock.json` install succeeds without lifecycle
+scripts, TypeScript passes, and the focused Vitest suites execute.
 
-- [ ] **Step 4: Add a dedicated CI job**
+- [ ] **Step 3: Keep CI synchronized with the package**
 
-Add this job to `.github/workflows/ci.yml`:
+The `openclaw-bridge` job must use the repository's current checkout and Node
+action versions, install from `packages/openclaw-coven/package-lock.json` with
+`npm ci --ignore-scripts`, then run `npm run typecheck` and `npm test`. Do not
+add a build invocation unless a `build` script is first added to `package.json`.
+Task 5 adds the documentation guard to the existing Python policy job.
 
-```yaml
-  openclaw-bridge:
-    name: OpenClaw bridge
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7
-        with:
-          node-version: 24
-      - name: Activate pinned pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.11.1 --activate
-      - run: pnpm install --frozen-lockfile --ignore-scripts
-        working-directory: packages/openclaw-coven
-      - run: pnpm run build
-        working-directory: packages/openclaw-coven
-      - run: pnpm test
-        working-directory: packages/openclaw-coven
-```
-
-Use the repository's current checkout/setup-node major versions and Node 24;
-do not copy older action versions into the workflow. Task 5 adds the docs guard
-to the existing Python-based secret-guard job after the guard exists.
-
-- [ ] **Step 5: Commit the package test workflow**
+- [ ] **Step 4: Commit the package test workflow**
 
 ```bash
-git add packages/openclaw-coven/package.json packages/openclaw-coven/pnpm-lock.yaml .github/workflows/ci.yml
+git add packages/openclaw-coven/package.json packages/openclaw-coven/package-lock.json .github/workflows/ci.yml
 git commit -m "test(openclaw): add reproducible package checks"
 ```
 
@@ -349,6 +293,46 @@ it("reports an unsupported named Coven contract in doctor", async () => {
     ],
   });
 });
+
+it.each([
+  [undefined, "missing"],
+  [1, "missing"],
+  ["", "missing"],
+  ["v1", "v1"],
+] as const)(
+  "treats missing or malformed Coven API version %j as unavailable before launch",
+  async (apiVersion, actual) => {
+    const launchSession = vi.fn(async () => session());
+    const runtime = new CovenAcpRuntime({
+      config,
+      client: fakeClient({
+        health: vi.fn(async () => ({
+          ...(await fakeClient().health()),
+          apiVersion,
+        })),
+        launchSession,
+      }),
+    });
+
+    const detail =
+      `expected apiVersion coven.daemon.v1, got ${actual}; ` +
+      "upgrade Coven to a compatible version";
+    await expect(runtime.doctor()).resolves.toMatchObject({
+      ok: false,
+      code: "COVEN_UNSUPPORTED_API_VERSION",
+      details: [detail],
+    });
+    await expect(
+      runtime.ensureSession({
+        sessionKey: "agent:codex:test",
+        agent: "codex",
+        mode: "oneshot",
+        cwd: workspaceDir,
+      }),
+    ).rejects.toThrow(detail);
+    expect(launchSession).not.toHaveBeenCalled();
+  },
+);
 
 it.each([
   [
@@ -732,6 +716,33 @@ it("does not treat conversational idle as one-shot completion", async () => {
   expect(events.at(-1)).toEqual({ type: "done", stopReason: "completed" });
 });
 
+it.each([
+  ["completed", "completed"],
+  ["failed", "error"],
+  ["killed", "cancelled"],
+  ["orphaned", "error"],
+])("maps terminal session status %s to %s", async (status, stopReason) => {
+  const runtime = new CovenAcpRuntime({
+    config,
+    client: fakeClient({
+      listEvents: vi.fn(async () => []),
+      getSession: vi.fn(async () => session({ status })),
+    }),
+  });
+  const handle = await runtime.ensureSession({
+    sessionKey: "agent:codex:test",
+    agent: "codex",
+    mode: "oneshot",
+    cwd: workspaceDir,
+  });
+
+  const events = await collect(
+    runtime.runTurn({ handle, text: "Fix tests", mode: "prompt", requestId: "req-terminal" }),
+  );
+
+  expect(events.at(-1)).toEqual({ type: "done", stopReason });
+});
+
 it.each(["future_state", "active"])(
   "fails closed on unsupported harness-session status %s",
   async (status) => {
@@ -763,7 +774,8 @@ it.each(["future_state", "active"])(
 Run:
 
 ```bash
-npm --prefix packages/openclaw-coven test -- src/runtime.test.ts -t "idle|unsupported harness-session"
+npm --prefix packages/openclaw-coven test -- src/runtime.test.ts -t \
+  "idle|terminal session status|unsupported harness-session"
 ```
 
 Expected: `idle` is currently treated as terminal completion, and the unknown status is also inferred terminal.
@@ -798,7 +810,19 @@ Change the poll condition to:
 if (sessionDisposition(latest.status) === "terminal") {
 ```
 
-Do not describe `killed` as process-exit acknowledgement. This helper classifies only the current ledger status; O5 owns cancellation acknowledgement.
+Also extend `normalizeStopReason` so persisted terminal results map explicitly:
+
+```typescript
+completed -> completed
+failed -> error
+killed -> cancelled
+orphaned -> error
+```
+
+The `orphaned` value is unresolved ownership evidence and must never be reported
+as successful completion. Do not describe `killed` as process-exit
+acknowledgement. These helpers classify only the current ledger status; O5 owns
+cancellation acknowledgement.
 
 - [ ] **Step 4: Run the focused runtime tests**
 
@@ -808,7 +832,9 @@ Run:
 npm --prefix packages/openclaw-coven test -- src/runtime.test.ts
 ```
 
-Expected: all runtime tests pass; `idle` continues polling, unknown values end in the existing sanitized polling-error path, and current `killed` behavior is unchanged.
+Expected: all runtime tests pass; `idle` continues polling, unknown values end
+in the existing sanitized polling-error path, `orphaned` reports an error, and
+`killed` reports cancellation without claiming process-exit acknowledgement.
 
 - [ ] **Step 5: Commit lifecycle interpretation**
 
@@ -908,9 +934,11 @@ store value is not a harness-session state and must be classified by row kind
 before interpreting status.
 ```
 
-Update lifecycle diagrams to include `running -> idle`, `running -> killed`,
-and archive/summon paths for every terminal status. Do not rename `created` to
-`pending`, and do not describe `killed` as termination acknowledgement.
+Update lifecycle diagrams to include `running -> idle` and `running -> killed`.
+Omit archive and summon from lifecycle-state transitions, or show them only as
+an independent `archived_at` visibility overlay applicable to every non-running
+status, including `created` and `idle`. Do not rename `created` to `pending`,
+and do not describe `killed` as termination acknowledgement.
 
 - [ ] **Step 4: Inspect the documentation diff**
 
@@ -941,230 +969,60 @@ git commit -m "docs(api): clarify contract and session lifecycle"
 
 - [ ] **Step 1: Write failing guardrail tests**
 
-Create `scripts/check-api-contract-docs-test.py`:
+Build focused stdlib `unittest` fixtures around `validate_documents`. Tests must
+prove the guard accepts the canonical corpus and rejects each independent drift:
 
-```python
-from __future__ import annotations
+- any contract guide fails to tie `/api/v1/health` to `coven.daemon.v1` as the
+  `apiVersion`/named-contract compatibility handshake in the same paragraph or
+  Markdown table row;
+- `/api/v1/api-version` is presented as the named-contract handshake, including
+  affirmative text followed by an unrelated or later denial;
+- capabilities are described without the authorization boundary;
+- any lifecycle status is missing or has the wrong terminal classification;
+- stale, unowned `created` recovery is not mapped unambiguously to `failed` in
+  the same sentence or Markdown table row, or that unit names a competing
+  recovery target;
+- `killed` is described as acknowledged termination;
+- synthetic `active` is presented as a harness-session status; or
+- archive visibility is not kept separate in `archived_at`.
 
-import importlib.util
-import pathlib
-import unittest
-
-SCRIPT = pathlib.Path(__file__).with_name("check-api-contract-docs.py")
-SPEC = importlib.util.spec_from_file_location("check_api_contract_docs", SCRIPT)
-assert SPEC and SPEC.loader
-module = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(module)
-
-
-class ApiContractDocsTests(unittest.TestCase):
-    def canonical_documents(self) -> dict[str, str]:
-        contract = """
-Clients negotiate compatibility with GET /api/v1/health and coven.daemon.v1.
-Capabilities advertise availability and never grant permission.
-GET /api/v1/api-version is a legacy route-family diagnostic.
-New clients must not use the legacy route as proof of coven.daemon.v1 compatibility.
-| `created` | No | stale unowned rows recover as `failed`. |
-| `running` | No | live |
-| `idle` | No | reusable |
-| `completed` | Yes | success |
-| `failed` | Yes | failure |
-| `killed` | Yes | accepted |
-| `orphaned` | Yes | unresolved |
-`killed` is not proof of acknowledged process termination.
-Synthetic `active` is not a harness-session state.
-Archive visibility is stored separately in `archived_at`.
-"""
-        return {
-            path: contract
-            for path in module.CONTRACT_DOCS + module.LIFECYCLE_DOCS
-        }
-
-    def test_accepts_canonical_handshake_and_lifecycle(self) -> None:
-        self.assertEqual(module.validate_documents(self.canonical_documents()), [])
-
-    def test_rejects_legacy_endpoint_as_named_handshake(self) -> None:
-        documents = self.canonical_documents()
-        documents["docs/reference/api-contract.md"] = (
-            "The legacy route-family GET /api/v1/api-version is the "
-            "coven.daemon.v1 compatibility handshake."
-        )
-        errors = module.validate_documents(documents)
-        self.assertTrue(any("legacy route" in error for error in errors))
-
-    def test_requires_health_handshake_in_every_contract_guide(self) -> None:
-        documents = self.canonical_documents()
-        documents["docs/ARCHITECTURE.md"] = "coven.daemon.v1"
-        errors = module.validate_documents(documents)
-        self.assertTrue(any("missing health handshake" in error for error in errors))
-
-    def test_requires_all_lifecycle_and_authority_boundaries(self) -> None:
-        documents = self.canonical_documents()
-        documents["docs/API-CONTRACT.md"] = (
-            "GET /api/v1/health coven.daemon.v1 `created` `running` `completed`"
-        )
-        errors = module.validate_documents(documents)
-        self.assertTrue(any("missing lifecycle status idle" in error for error in errors))
-        self.assertTrue(any("capabilities versus authorization" in error for error in errors))
-        self.assertTrue(any("synthetic active distinction" in error for error in errors))
-
-    def test_rejects_idle_as_terminal(self) -> None:
-        documents = self.canonical_documents()
-        documents["docs/SESSION-LIFECYCLE.md"] = documents[
-            "docs/SESSION-LIFECYCLE.md"
-        ].replace("| `idle` | No |", "| `idle` | Yes |")
-        errors = module.validate_documents(documents)
-        self.assertTrue(
-            any("incorrect terminal classification for idle" in error for error in errors)
-        )
-
-
-if __name__ == "__main__":
-    unittest.main()
-```
+Do not weaken a negative fixture by satisfying its requirement elsewhere in the
+same document. Keep tests behavioral rather than embedding a full final script
+snapshot.
 
 - [ ] **Step 2: Run the guardrail tests and confirm failure**
-
-Run:
 
 ```bash
 python3 scripts/check-api-contract-docs-test.py
 ```
 
-Expected: import fails because `scripts/check-api-contract-docs.py` does not exist.
+Expected: the new behavioral tests fail because the guard is absent or does not
+yet enforce every relationship above.
 
 - [ ] **Step 3: Implement the stdlib guardrail**
 
-Create `scripts/check-api-contract-docs.py`:
-
-```python
-#!/usr/bin/env python3
-from __future__ import annotations
-
-import pathlib
-import re
-import sys
-
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-CONTRACT_DOCS = (
-    "docs/API-CONTRACT.md",
-    "docs/API.md",
-    "docs/reference/api-contract.md",
-    "docs/reference/api.md",
-    "docs/daemon/socket-api.md",
-    "docs/daemon/capabilities-handshake.md",
-    "docs/ARCHITECTURE.md",
-)
-LIFECYCLE_DOCS = (
-    "docs/API-CONTRACT.md",
-    "docs/SESSION-LIFECYCLE.md",
-    "docs/sessions/lifecycle.md",
-)
-STATUSES = ("created", "running", "idle", "completed", "failed", "killed", "orphaned")
-TERMINAL = {
-    "created": "No",
-    "running": "No",
-    "idle": "No",
-    "completed": "Yes",
-    "failed": "Yes",
-    "killed": "Yes",
-    "orphaned": "Yes",
-}
-
-
-def validate_documents(documents: dict[str, str]) -> list[str]:
-    errors: list[str] = []
-    for path in CONTRACT_DOCS:
-        text = documents[path]
-        if "/api/v1/health" not in text or "coven.daemon.v1" not in text:
-            errors.append(f"{path}: missing health handshake")
-        lowered = text.lower()
-        if "capabilit" not in lowered or not any(
-            term in lowered for term in ("never grant permission", "not authorization")
-        ):
-            errors.append(f"{path}: capabilities versus authorization is missing")
-        for paragraph in re.split(r"\n\s*\n", text):
-            if "/api/v1/api-version" not in paragraph or "coven.daemon.v1" not in paragraph:
-                continue
-            lowered = paragraph.lower()
-            if "not" not in lowered or "proof" not in lowered:
-                errors.append(f"{path}: legacy route presented as named-contract handshake")
-
-    for path in LIFECYCLE_DOCS:
-        text = documents[path]
-        for status in STATUSES:
-            if f"`{status}`" not in text:
-                errors.append(f"{path}: missing lifecycle status {status}")
-                continue
-            terminal = TERMINAL[status]
-            pattern = rf"\|\s*`{status}`\s*\|\s*{terminal}\b"
-            if not re.search(pattern, text):
-                errors.append(
-                    f"{path}: incorrect terminal classification for {status}"
-                )
-        lowered = text.lower()
-        if "not proof of acknowledged process termination" not in lowered:
-            errors.append(f"{path}: killed acknowledgement boundary is missing")
-        if not all(term in lowered for term in ("synthetic", "`active`", "not a harness-session state")):
-            errors.append(f"{path}: synthetic active distinction is missing")
-        if "stored separately in `archived_at`" not in lowered:
-            errors.append(f"{path}: archive separation is missing")
-
-    contract = documents["docs/API-CONTRACT.md"]
-    lowered_contract = contract.lower()
-    if not all(term in lowered_contract for term in ("stale unowned", "recover", "`failed`")):
-        errors.append("docs/API-CONTRACT.md: stale created recovery is missing")
-    if "not proof of acknowledged process termination" not in lowered_contract:
-        errors.append("docs/API-CONTRACT.md: killed acknowledgement boundary is missing")
-    if not all(term in lowered_contract for term in ("synthetic", "`active`", "not a harness-session state")):
-        errors.append("docs/API-CONTRACT.md: synthetic active distinction is missing")
-    if "stored separately in `archived_at`" not in contract:
-        errors.append("docs/API-CONTRACT.md: archive separation is missing")
-    return errors
-
-
-def main() -> int:
-    paths = sorted(set(CONTRACT_DOCS + LIFECYCLE_DOCS))
-    documents = {
-        relative: (ROOT / relative).read_text(encoding="utf-8")
-        for relative in paths
-    }
-    errors = validate_documents(documents)
-
-    for error in errors:
-        print(error, file=sys.stderr)
-    return 1 if errors else 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())
-```
+Implement `validate_documents(documents) -> list[str]` and a repository-reading
+`main()` using only Python's standard library. The guard must cover every
+contract and lifecycle guide listed by the tests, validate relationships within
+the relevant paragraph/table row rather than by loose whole-file keyword
+presence, report path-specific diagnostics, and exit nonzero for any error.
+Keep the implementation synchronized with the committed guard tests; this plan
+intentionally does not duplicate the script as an exact snapshot.
 
 - [ ] **Step 4: Run unit and repository guardrail checks**
-
-Run:
 
 ```bash
 python3 scripts/check-api-contract-docs-test.py
 python3 scripts/check-api-contract-docs.py
 ```
 
-Expected: both commands exit 0.
+Expected: both commands exit 0 without reducing any negative coverage.
 
 - [ ] **Step 5: Add the guardrail to the existing Python CI job**
 
-Add these steps after the current privacy/secret unit tests in the
-`secret-guard` job:
-
-```yaml
-      - run: python3 scripts/check-api-contract-docs-test.py
-      - run: python3 scripts/check-api-contract-docs.py
-```
-
-Keep the current `actions/checkout@v7.0.1` and `actions/setup-python@v7`
-versions unchanged. The guard belongs here because it is a Python repository
-policy check, while the `openclaw-bridge` job remains scoped to package build
-and tests.
+Add both commands to the existing `secret-guard` job after its current Python
+unit checks. Preserve the workflow's current checkout and setup-python action
+versions. The OpenClaw job remains scoped to its package typecheck and tests.
 
 - [ ] **Step 6: Commit the documentation guardrail**
 
@@ -1188,7 +1046,6 @@ cargo test -p coven-cli api::tests::rejects_unknown_api_version_prefixes
 cargo test -p coven-cli api::tests::unknown_harness_capability_manifest_fails_closed_with_structured_error
 cargo test -p coven-cli daemon::tests::exit_event_does_not_overwrite_killed_session_status
 cargo test -p coven-cli daemon::tests::clean_exit_on_conversational_session_persists_as_idle
-npm --prefix packages/openclaw-coven run build
 npm --prefix packages/openclaw-coven run typecheck
 npm --prefix packages/openclaw-coven test -- src/client.test.ts src/runtime.test.ts
 python3 scripts/check-api-contract-docs-test.py
@@ -1204,7 +1061,6 @@ cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace --locked
 python scripts/check-secrets.py
-npm --prefix packages/openclaw-coven run build
 npm --prefix packages/openclaw-coven test
 ```
 
@@ -1233,9 +1089,13 @@ and G4/G6 remain blocked.
 
 ```bash
 git add crates/coven-cli/src/api.rs \
+  crates/coven-cli/src/main.rs \
+  crates/coven-cli/src/pty_runner.rs \
+  crates/coven-cli/src/store.rs \
+  crates/coven-cli/tests/stream_json_integration.rs \
   .github/workflows/ci.yml \
   packages/openclaw-coven/package.json \
-  packages/openclaw-coven/pnpm-lock.yaml \
+  packages/openclaw-coven/package-lock.json \
   packages/openclaw-coven/src/client.ts \
   packages/openclaw-coven/src/client.test.ts \
   packages/openclaw-coven/src/runtime.ts \
@@ -1244,6 +1104,7 @@ git add crates/coven-cli/src/api.rs \
   docs/API.md \
   docs/reference/api-contract.md \
   docs/reference/api.md \
+  docs/reference/cli-run.md \
   docs/daemon/socket-api.md \
   docs/daemon/capabilities-handshake.md \
   docs/ARCHITECTURE.md \
@@ -1252,7 +1113,8 @@ git add crates/coven-cli/src/api.rs \
   scripts/check-api-contract-docs.py \
   scripts/check-api-contract-docs-test.py \
   specs/psyche/O1_CONTRACT_DESIGN.md \
-  specs/psyche/PLAN.md
+  specs/psyche/PLAN.md \
+  docs/superpowers/plans/2026-08-03-psyche-o1-contract-implementation.md
 python3 scripts/check-coven-privacy.py --staged
 git diff --cached --check
 ```

--- a/scripts/check-api-contract-docs-test.py
+++ b/scripts/check-api-contract-docs-test.py
@@ -716,6 +716,70 @@ Archive visibility is stored separately in `archived_at`.
                     errors,
                 )
 
+    def test_rejects_stale_created_recovery_as_running(self) -> None:
+        documents = self.canonical_documents()
+        documents["docs/API-CONTRACT.md"] = documents[
+            "docs/API-CONTRACT.md"
+        ].replace(
+            "stale unowned rows recover as `failed`.",
+            "stale unowned `created` rows recover as `running`.",
+        )
+        documents["docs/API-CONTRACT.md"] += (
+            "\nAn unrelated operation is marked as `failed`.\n"
+        )
+        errors = module.validate_documents(documents)
+        self.assertTrue(any("stale created recovery" in error for error in errors))
+
+    def test_rejects_unrelated_failure_in_same_created_row(self) -> None:
+        documents = self.canonical_documents()
+        documents["docs/API-CONTRACT.md"] = documents[
+            "docs/API-CONTRACT.md"
+        ].replace(
+            "stale unowned rows recover as `failed`.",
+            "stale unowned rows recover as `running`; another operation marks `failed`.",
+        )
+        errors = module.validate_documents(documents)
+        self.assertTrue(any("stale created recovery" in error for error in errors))
+
+    def test_rejects_ambiguous_stale_created_recovery_targets(self) -> None:
+        for replacement in (
+            "stale unowned rows recover as `running` or as `failed`.",
+            "stale unowned rows recover as `failed` or as `running`.",
+        ):
+            with self.subTest(replacement=replacement):
+                documents = self.canonical_documents()
+                documents["docs/API-CONTRACT.md"] = documents[
+                    "docs/API-CONTRACT.md"
+                ].replace("stale unowned rows recover as `failed`.", replacement)
+                errors = module.validate_documents(documents)
+                self.assertTrue(
+                    any("stale created recovery" in error for error in errors)
+                )
+
+    def test_accepts_line_wrapped_stale_created_recovery_sentence(self) -> None:
+        documents = self.canonical_documents()
+        documents["docs/API-CONTRACT.md"] = documents[
+            "docs/API-CONTRACT.md"
+        ].replace(
+            "stale unowned rows recover as `failed`.",
+            "Rows begin without runtime ownership.",
+        )
+        documents["docs/API-CONTRACT.md"] += (
+            "\nStale unowned `created` rows recover\nas `failed`.\n"
+        )
+        self.assertEqual(module.validate_documents(documents), [])
+
+    def test_requires_stale_and_unowned_created_recovery(self) -> None:
+        documents = self.canonical_documents()
+        documents["docs/API-CONTRACT.md"] = documents[
+            "docs/API-CONTRACT.md"
+        ].replace(
+            "stale unowned rows recover as `failed`.",
+            "Unowned rows recover as `failed`.",
+        )
+        errors = module.validate_documents(documents)
+        self.assertTrue(any("stale created recovery" in error for error in errors))
+
     def test_main_reports_missing_document_without_traceback(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             stderr = io.StringIO()

--- a/scripts/check-api-contract-docs.py
+++ b/scripts/check-api-contract-docs.py
@@ -260,6 +260,49 @@ def field_absence_is_explicit(clause: str) -> bool:
     )
 
 
+def has_stale_created_failure_recovery(text: str) -> bool:
+    units: list[tuple[str, bool]] = []
+    prose_lines: list[str] = []
+    for line in text.lower().splitlines():
+        if line.lstrip().startswith("|"):
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            if cells and cells[0].strip("`") == "created":
+                units.append((" ".join(cells[1:]), True))
+            prose_lines.append("")
+        else:
+            prose_lines.append(line)
+    for paragraph in re.split(r"\n\s*\n", "\n".join(prose_lines)):
+        sentence_text = re.sub(r"\s*\n\s*", " ", paragraph)
+        units.extend(
+            (unit, False) for unit in re.split(r"(?<=[.!?])\s+", sentence_text)
+        )
+
+    for unit, created_row in units:
+        recovery = re.search(r"\brecover(?:s|ed)?\b", unit)
+        if not (
+            recovery
+            and re.search(r"\bstale\b", unit)
+            and re.search(r"\bunowned\b", unit)
+            and (created_row or re.search(r"\bcreated\b", unit))
+        ):
+            continue
+        recovery_clause = unit[recovery.start() :]
+        targets = re.findall(
+            r"(?:\b(?:as|to)\s+|(?:->|→)\s*)`?"
+            r"(created|running|idle|completed|failed|killed|orphaned)`?\b",
+            recovery_clause,
+        )
+        targets.extend(
+            re.findall(
+                r"\bor\s+`?(created|running|idle|completed|failed|killed|orphaned)`?\b",
+                recovery_clause,
+            )
+        )
+        if targets and set(targets) == {"failed"}:
+            return True
+    return False
+
+
 def validate_documents(documents: dict[str, str]) -> list[str]:
     errors: list[str] = []
     for path in CONTRACT_DOCS:
@@ -293,21 +336,22 @@ def validate_documents(documents: dict[str, str]) -> list[str]:
                     f"{path}: incorrect terminal classification for {status}"
                 )
         lowered = text.lower()
-        if "not proof of acknowledged process termination" not in lowered:
+        if not re.search(
+            r"not proof (?:of acknowledged process termination|"
+            r"that process termination was acknowledged)",
+            lowered,
+        ):
             errors.append(f"{path}: killed acknowledgement boundary is missing")
         if not all(
             term in lowered
             for term in ("synthetic", "`active`", "not a harness-session state")
         ):
             errors.append(f"{path}: synthetic active distinction is missing")
-        if "stored separately in `archived_at`" not in lowered:
+        if not re.search(r"stored separately (?:in|as) `archived_at`", lowered):
             errors.append(f"{path}: archive separation is missing")
 
     contract = documents["docs/API-CONTRACT.md"]
-    lowered_contract = contract.lower()
-    if not all(
-        term in lowered_contract for term in ("stale unowned", "recover", "`failed`")
-    ):
+    if not has_stale_created_failure_recovery(contract):
         errors.append("docs/API-CONTRACT.md: stale created recovery is missing")
     return errors
 


### PR DESCRIPTION
## Summary
- preserve terminal source session rows and create sibling continuation sessions
- scope continuation lookup by harness, normalize stream IDs, and clean up child processes correctly
- align lifecycle documentation and API contract guards with the runtime behavior

## Context
Salvages the genuinely missing post-merge work from the stale local Psyche O1 branch without carrying its outdated repository snapshot forward. Follow-up to #574.

## Test Plan
- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --locked
- [x] python3 scripts/check-api-contract-docs-test.py
- [x] python3 scripts/check-api-contract-docs.py
- [x] python scripts/check-secrets.py
- [x] python3 scripts/check-coven-privacy.py --staged
- [x] git diff --check origin/main...HEAD