### PR TITLE
fix(ci): resolve triage branches through their remote-tracking refs

### DIFF
--- a/.github/actions/branch-triage/triage.sh
+++ b/.github/actions/branch-triage/triage.sh
@@ -65,13 +65,19 @@ pr_title_for() {
 branch_is_open_pr()   { open_branches  | grep -qxF "$1"; }
 branch_is_merged_pr() { merged_branches | grep -qxF "$1"; }
 
+# Branch names reach these helpers with the `origin/` prefix stripped, because
+# that bare form is what `gh pr list` reports as `headRefName` and what the
+# report prints. Git, however, can only resolve the remote-tracking ref: a CI
+# checkout has exactly one local branch (the base), so `git log <branch>` exits
+# 128 for every other name and `set -e` kills the run. Always resolve through
+# `origin/`, and never let a single unresolvable ref abort the whole triage.
 unique_commits() {
-  git log --oneline "$1" ^"origin/$BASE" 2>/dev/null | wc -l | tr -d ' '
+  git log --oneline "origin/$1" ^"origin/$BASE" 2>/dev/null | wc -l | tr -d ' ' || echo 0
 }
 
 last_commit_days_ago() {
   local ts
-  ts=$(git log -1 --format="%ct" "$1" 2>/dev/null || echo 0)
+  ts=$(git log -1 --format="%ct" "origin/$1" 2>/dev/null || echo 0)
   local now
   now=$(date +%s)
   echo $(( (now - ts) / 86400 ))
@@ -186,7 +192,7 @@ if [[ ${#REVIEW_LIST[@]} -gt 0 ]]; then
   for branch in "${REVIEW_LIST[@]}"; do
     uniq=$(unique_commits "$branch")
     echo "  $(yellow '→') $branch  ($(bold $uniq) unique commit(s))"
-    git log --oneline "$branch" ^"origin/$BASE" 2>/dev/null | head -5 | sed 's/^/      /'
+    git log --oneline "origin/$branch" ^"origin/$BASE" 2>/dev/null | head -5 | sed 's/^/      /' || true
   done
   (( kept_count += ${#REVIEW_LIST[@]} )) || true
 fi


### PR DESCRIPTION
The first branch-triage run to get past #610's syntax fix failed at exit 128. This is the next bug in the same script — also previously unreachable.

## What happened

[Run 30996272122](https://github.com/OpenCoven/coven/actions/runs/30996272122), dispatched with `dry-run: true`:

```
[triage] Classifying branches…
BRANCH                       CATEGORY     UNIQUE   PR
##[error]Process completed with exit code 128.
```

It printed the header — further than any previous run has ever reached — and then died on the first branch.

## Cause

The loop feeds bare branch names:

```bash
done < <(git branch -r | sed 's|^\s*origin/||' | grep -v '^HEAD' | sort)
```

That bare form is correct for the report and for matching `gh pr list`'s `headRefName`. It is *not* resolvable by git. A CI checkout has exactly one local branch — the base — so `git log <branch>` exits 128 for every other name. `2>/dev/null` hides the message but not the status, and `set -euo pipefail` aborts on the first branch.

The scheduled job could never have classified anything: nine runs aborted at line 81, and the tenth would have aborted here.

## Fix

Resolve every branch lookup through `origin/<branch>`, in all three places (`unique_commits`, `last_commit_days_ago`, and the REVIEW-list report), and stop a single unresolvable ref from aborting the whole triage.

## Verification

Against a clone with only `main` local — the CI shape:

```
OLD  git log --oneline <bare> ^origin/main        -> exit 128
NEW  git log --oneline origin/<bare> ^origin/main -> exit 0, 2 commits
```

`bash -n` parses; secret and privacy guards clean.

## Note

This is the second latent failure found in this script once it started executing, which is why #610 gated the merge path rather than only repairing the parse. Steps 3–6 — the deletes, the merge gate, and the summary — still have never run. I would dispatch another `dry-run` after this merges before trusting the scheduled job, and I would expect further findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)