### PR TITLE
fix(ci): use a prune flag that git actually accepts

### DIFF
--- a/.github/actions/branch-triage/triage.sh
+++ b/.github/actions/branch-triage/triage.sh
@@ -182,7 +182,10 @@ for branch in "${MERGED_LIST[@]}" "${SUPERSEDED_LIST[@]}"; do
 done
 
 # Prune gone tracking refs
-git remote prune origin -q
+# `git remote prune` has no `-q`; it exits 129 on the unknown switch and, under
+# `set -e`, takes the whole run with it. `git fetch --prune` does accept `-q`
+# and prunes the same refs.
+git fetch origin --prune -q
 git branch -v | grep '\[gone\]' | awk '{print $1}' | xargs -r git branch -D 2>/dev/null || true
 
 # ── Step 4 — REVIEW branches — report, do not touch ──────────────────────────


### PR DESCRIPTION
The second triage dry-run cleared classification for the first time, then died in step 3.

## What happened

[Run 30997204042](https://github.com/OpenCoven/coven/actions/runs/30997204042), `dry-run: true`:

```
[triage] Classifying branches…
BRANCH                       CATEGORY     UNIQUE   PR
────────────────────────────────────────────────────────────
error: unknown switch `q'
usage: git remote prune [<options>] <name>
##[error]Process completed with exit code 129.
```

`git remote prune` has no `-q`. It rejects the switch and exits 129, and under `set -euo pipefail` that ends the run before any branch is deleted and before the merge gate, the REVIEW report, and the job summary ever execute.

## Fix

`git fetch --prune` accepts `-q` and prunes the same refs. Verified both forms directly:

```
git remote prune origin -q    exit=129   error: unknown switch `q'
git fetch origin --prune -q   exit=0
```

## Two nearby things I suspected and cleared rather than changed

- **`git branch -v | grep '\[gone\]'`** looked like it needed `-vv`. It does not. Built a branch with a deleted upstream to check: `-v` prints `[gone]` and matches the grep; `-vv` prints `[origin/feature: gone]` and would **not**. Changing it would have broken a working line.
- **`xargs -r`** is available on the Linux runner.

Also worth recording: the empty classification table in that run was **correct**, not a symptom. Only `main` existed on the remote at the time, and the loop skips the base branch by design.

## Where this leaves the workflow

Third defect found since this script started executing, each one in code that the previous failure had made unreachable — the `()#` parse error (#610), bare branch names passed to `git log` (#624), and now this. **Steps 4–6 have still never run.**

The scheduled Monday 09:00 UTC job is **not** a dry-run and holds `contents: write` + `pull-requests: write`, with branch deletion in step 3. Worth continuing to dispatch dry-runs until one completes end-to-end before that fires.

`bash -n` parses; secret and privacy guards clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)