### PR TITLE
refactor(store): avoid discarded error allocation

### DIFF
--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3699,8 +3699,7 @@ fn writer_backlog(event_writer: Option<&crate::event_writer::EventWriterHealth>)
         .unwrap_or_default()
 }
 
-pub fn record_maintenance_error(coven_home: &Path, error: impl ToString) {
-    let _ = error.to_string();
+pub fn record_maintenance_error(coven_home: &Path, _details: impl ToString) {
     if let Ok(Some(conn)) = open_existing_store_writable(&coven_home.join("coven.sqlite3")) {
         let _ = set_store_meta(
             &conn,


### PR DESCRIPTION
## Summary
- remove the needless allocation of private maintenance-error details before persisting the sanitized public sentinel
- resolve the final review thread raised on #626 after that PR merged concurrently

## Test Plan
- [x] cargo fmt --check
- [x] cargo clippy -p coven-cli --all-targets -- -D warnings
- [x] python scripts/check-secrets.py
- [x] python3 scripts/check-coven-privacy.py --staged