### PR TITLE
fix: recover event writer from transient locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,9 +688,10 @@ entries, so a trend artifact cannot be mistaken for a passing chaos test.
 CI runs this step as `continue-on-error`, so it collects trend data without
 gating merges — matching how the rest of this section describes these
 baselines. The deterministic fixture tests (`benchmark-chaos.test.mjs`) still
-gate. The 32-session scenario is intermittently unable to run on a two-core
-runner, where a live session can record no events at all; see #615. Expect
-`coven-chaos.json` to be absent from the uploaded artifact on those runs.
+gate. On timeout, the collector reports fixture execution count, session/event
+state, and a bounded event-writer health snapshot. The event writer retries
+only transient SQLite busy/locked commit failures before latching a permanent
+failure; unrelated persistence errors remain fail-fast.
 
 ### Architecture rules for contributors
 

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, ErrorCode};
 use serde::Serialize;
 use serde_json::json;
 use uuid::Uuid;
@@ -27,6 +27,8 @@ const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
 const EVENT_OVERHEAD_BYTES: usize = 512;
 const MAX_BATCH_EVENTS: usize = 64;
 const COALESCE_WINDOW: Duration = Duration::from_millis(12);
+const SQLITE_LOCK_COMMIT_ATTEMPTS: usize = 4;
+const SQLITE_LOCK_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -303,7 +305,11 @@ fn run_worker(
     loop {
         let batch = take_batch(&shared);
         let bytes: usize = batch.iter().map(|item| item.bytes).sum();
-        let result = commit_batch(&mut conn, &coven_home, &batch);
+        let result = retry_transient_sqlite_lock(
+            || commit_batch(&mut conn, &coven_home, &batch),
+            SQLITE_LOCK_COMMIT_ATTEMPTS,
+            SQLITE_LOCK_RETRY_DELAY,
+        );
         match result {
             Ok(committed) => {
                 release_capacity(&shared, batch.len(), bytes);
@@ -328,6 +334,33 @@ fn run_worker(
             }
         }
     }
+}
+
+fn retry_transient_sqlite_lock<T>(
+    mut operation: impl FnMut() -> Result<T>,
+    attempts: usize,
+    retry_delay: Duration,
+) -> Result<T> {
+    assert!(attempts > 0, "SQLite retry attempts must be non-zero");
+    for attempt in 0..attempts {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(error) if is_transient_sqlite_lock(&error) && attempt + 1 < attempts => {
+                thread::sleep(retry_delay);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    unreachable!("SQLite retry loop either succeeds or returns its final error")
+}
+
+fn is_transient_sqlite_lock(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<rusqlite::Error>()
+            .and_then(rusqlite::Error::sqlite_error_code)
+            .is_some_and(|code| matches!(code, ErrorCode::DatabaseBusy | ErrorCode::DatabaseLocked))
+    })
 }
 
 fn take_batch(shared: &Arc<Shared>) -> Vec<QueuedEvent> {
@@ -553,6 +586,91 @@ mod tests {
         }))?;
 
         assert_eq!(health.queued_events, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn transient_sqlite_lock_is_retried() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let path = home.path().join("retry.sqlite");
+        let locker = Connection::open(&path)?;
+        locker.execute_batch(
+            "CREATE TABLE events (id INTEGER PRIMARY KEY);
+             BEGIN IMMEDIATE;
+             INSERT INTO events DEFAULT VALUES;",
+        )?;
+        let contender = Connection::open(&path)?;
+        contender.busy_timeout(Duration::ZERO)?;
+        let mut attempts = 0;
+
+        let inserted = retry_transient_sqlite_lock(
+            || {
+                attempts += 1;
+                if attempts == 2 {
+                    locker.execute_batch("ROLLBACK")?;
+                }
+                contender
+                    .execute("INSERT INTO events DEFAULT VALUES", [])
+                    .map_err(Into::into)
+            },
+            3,
+            Duration::ZERO,
+        )?;
+
+        assert_eq!(inserted, 1);
+        assert_eq!(attempts, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn non_lock_sqlite_error_is_not_retried() -> Result<()> {
+        let conn = Connection::open_in_memory()?;
+        let mut attempts = 0;
+
+        let error = retry_transient_sqlite_lock(
+            || {
+                attempts += 1;
+                conn.execute("INSERT INTO missing_table DEFAULT VALUES", [])
+                    .map_err(Into::into)
+            },
+            3,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+
+        assert_eq!(attempts, 1);
+        assert!(format!("{error:#}").contains("no such table"));
+        Ok(())
+    }
+
+    #[test]
+    fn persistent_sqlite_lock_stops_after_attempt_limit() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let path = home.path().join("persistent-lock.sqlite");
+        let locker = Connection::open(&path)?;
+        locker.execute_batch(
+            "CREATE TABLE events (id INTEGER PRIMARY KEY);
+             BEGIN IMMEDIATE;
+             INSERT INTO events DEFAULT VALUES;",
+        )?;
+        let contender = Connection::open(&path)?;
+        contender.busy_timeout(Duration::ZERO)?;
+        let mut attempts = 0;
+
+        let error = retry_transient_sqlite_lock(
+            || {
+                attempts += 1;
+                contender
+                    .execute("INSERT INTO events DEFAULT VALUES", [])
+                    .map_err(Into::into)
+            },
+            3,
+            Duration::ZERO,
+        )
+        .unwrap_err();
+
+        assert_eq!(attempts, 3);
+        assert!(is_transient_sqlite_lock(&error));
         Ok(())
     }
 

--- a/docs/superpowers/plans/2026-08-05-chaos-boundary-diagnostics.md
+++ b/docs/superpowers/plans/2026-08-05-chaos-boundary-diagnostics.md
@@ -1,0 +1,108 @@
+# Chaos Benchmark Event Writer Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent transient SQLite writer contention from killing event
+ingestion, and turn any remaining `sessions_32` output timeout into actionable
+boundary evidence.
+
+**Architecture:** The daemon's single event-writer worker retries only
+`SQLITE_BUSY` and `SQLITE_LOCKED` commit failures within a fixed attempt budget,
+retaining its batch until success or final failure. The existing benchmark
+remains authoritative for scenario execution; small exported formatting helpers
+make diagnostic behavior directly unit-testable.
+
+**Tech Stack:** Rust, rusqlite, Node.js ESM, Node test runner, Coven local socket
+API
+
+---
+
+### Task 1: Add bounded boundary diagnostics
+
+**Files:**
+- Modify: `scripts/benchmark-chaos.mjs`
+- Modify: `scripts/benchmark-chaos.test.mjs`
+
+- [x] **Step 1: Write failing diagnostic tests**
+
+Add tests for the harness marker ordering, event-writer health formatting, and
+the combined timeout evidence.
+
+- [x] **Step 2: Verify the tests fail**
+
+Run:
+
+```bash
+node --test scripts/benchmark-chaos.test.mjs
+```
+
+Expected: FAIL because the diagnostic helpers do not exist.
+
+- [x] **Step 3: Implement the marker and diagnostic helpers**
+
+Write the fixed marker before harness output, count markers on timeout, query
+`/api/v1/health`, and append bounded event-writer fields to the existing session
+diagnostic.
+
+- [x] **Step 4: Run benchmark unit tests**
+
+Run:
+
+```bash
+node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
+```
+
+Expected: PASS.
+
+- [x] **Step 5: Run repository gates**
+
+Run the Rust formatting, clippy, workspace tests, secret scan, and staged
+privacy guard required by `AGENTS.md`.
+
+### Task 2: Recover from transient SQLite writer locks
+
+**Files:**
+- Modify: `crates/coven-cli/src/event_writer.rs`
+
+- [x] **Step 1: Write failing retry tests**
+
+Create real competing SQLite connections and cover transient lock recovery,
+persistent lock exhaustion, and non-lock fail-fast behavior.
+
+- [x] **Step 2: Verify the tests fail**
+
+Run the focused event-writer test filter before defining the retry helper.
+
+- [x] **Step 3: Implement bounded lock-only retry**
+
+Retry a batch only when the error chain preserves a rusqlite
+`DatabaseBusy`/`DatabaseLocked` code. Keep the batch owned by the worker and
+preserve the existing permanent failure path after the final attempt.
+
+- [x] **Step 4: Run event-writer tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+```
+
+Expected: PASS.
+
+### Task 3: Prove the real concurrency path and publish
+
+- [x] **Step 1: Run the real 1/8/32 collector repeatedly**
+
+Build the debug CLI and run `scripts/benchmark-chaos.mjs` at least three times.
+Every report must include passing `sessions_1`, `sessions_8`, and `sessions_32`
+scenarios.
+
+- [x] **Step 2: Run repository gates**
+
+Run formatting, clippy, full workspace tests, benchmark unit tests, secret scan,
+and the staged privacy guard.
+
+- [ ] **Step 3: Commit, push, and open a PR**
+
+Open a focused PR that links and closes issue #615, explains the lock-only retry
+boundary, and includes the repeated real-benchmark evidence.

--- a/docs/superpowers/specs/2026-08-05-chaos-boundary-diagnostics-design.md
+++ b/docs/superpowers/specs/2026-08-05-chaos-boundary-diagnostics-design.md
@@ -1,0 +1,52 @@
+# Chaos Benchmark Event Writer Recovery Design
+
+**Goal:** Fix the intermittent Linux `sessions_32` timeout and retain bounded
+diagnostics if a future output wait fails for another reason.
+
+## Root cause
+
+All 32 fixture children executed, but concurrent session setup held SQLite's
+single-writer lock beyond the event writer connection's five-second
+`busy_timeout`. The worker treated that transient `SQLITE_BUSY` as permanent,
+latched a failed state, and stopped before committing any output events.
+
+## Recovery approach
+
+Retry only errors whose preserved `rusqlite::Error` reports
+`DatabaseBusy` or `DatabaseLocked`. The worker makes at most four total commit
+attempts with a 50 ms pause between attempts. Every attempt creates a fresh
+transaction over the same in-memory batch.
+
+The worker remains single-threaded and does not release queue capacity or
+acknowledge critical events until the batch commits. This preserves batch
+ordering and the existing critical-event acknowledgement guarantee. Exhausted
+lock retries and every non-lock error still enter the existing permanent
+failure path.
+
+## Boundary diagnostics
+
+Keep the 32-session scenario, launch behavior, and timeout unchanged. The
+fixture harness appends one fixed marker before printing its ready line. If an
+output wait expires, the benchmark reports the number of markers, the session
+status and observed event kinds, and a bounded snapshot of
+`/api/v1/health.eventWriter`.
+
+This distinguishes child execution failure from PTY/output ingestion failure,
+writer pressure/failure, and event-query mismatch without converting the
+advisory benchmark itself into a retrying success path.
+
+## Privacy and failure behavior
+
+Markers contain only the fixed word `started`; diagnostics report only their
+count. Event-writer output is restricted to documented scalar health fields,
+control characters are collapsed, values are bounded, and fixture paths are
+redacted. Diagnostic collection is best-effort and never replaces the original
+timeout error.
+
+## Testing
+
+Rust tests create real competing SQLite connections to prove that a transient
+lock is retried, a persistent lock stops at the attempt limit, and a non-lock
+SQLite error is not retried. Node tests pin marker ordering, execution-count
+summaries, event-writer field selection/redaction, and the combined timeout
+diagnostic using injected request and file-read boundaries.

--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -1,6 +1,6 @@
-import { chmod, mkdtemp, mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
@@ -24,6 +24,18 @@ const POLL_DELAY_MS = 25;
 // budget exists only to bound a hang; it does not affect the reported metric,
 // which is measured from the clock, not from the number of polls.
 const LAUNCH_POLL_ATTEMPTS = 2400;
+const EVENT_WRITER_DIAGNOSTIC_FIELDS = [
+  'state',
+  'queuedEvents',
+  'queuedBytes',
+  'capacityBytes',
+  'droppedOutputEvents',
+  'droppedOutputBytes',
+  'connectionOpens',
+  'transactions',
+  'committedEvents',
+  'lastError'
+];
 
 function optionValue(args, index, option) {
   const arg = args[index];
@@ -133,11 +145,8 @@ async function fixtureEnvironment(root, environment) {
   const covenHome = join(root, 'home');
   await mkdir(join(covenHome, 'user-home'), { recursive: true });
   const harness = join(bin, 'codex');
-  await writeFile(
-    harness,
-    '#!/bin/sh\nprintf "COVEN_BENCHMARK_READY\\n"\ntrap "exit 0" INT TERM\nwhile :; do sleep 60; done\n',
-    { mode: 0o700 }
-  );
+  const markerPath = join(root, 'fixture-executions.log');
+  await writeFile(harness, fixtureHarnessScript(), { mode: 0o700 });
   // `writeFile`'s `mode` applies only when the file is created and is masked by
   // the process umask, so it cannot be relied on to leave the bit set.  A
   // harness without it spawns nothing, no output event is ever recorded, and
@@ -146,7 +155,19 @@ async function fixtureEnvironment(root, environment) {
   await chmod(harness, 0o700);
   await assertExecutable(harness);
   const env = isolatedEnvironment(covenHome, environment);
-  return { covenHome, env: { ...env, PATH: `${bin}:${env.PATH ?? ''}` } };
+  return {
+    covenHome,
+    markerPath,
+    env: {
+      ...env,
+      COVEN_BENCHMARK_MARKERS: markerPath,
+      PATH: `${bin}:${env.PATH ?? ''}`
+    }
+  };
+}
+
+export function fixtureHarnessScript() {
+  return '#!/bin/sh\nprintf "started\\n" >> "$COVEN_BENCHMARK_MARKERS"\nprintf "COVEN_BENCHMARK_READY\\n"\ntrap "exit 0" INT TERM\nwhile :; do sleep 60; done\n';
 }
 
 async function assertExecutable(path) {
@@ -156,23 +177,105 @@ async function assertExecutable(path) {
   }
 }
 
-/// Describe what the session actually produced, so a wait timeout distinguishes
-/// "the harness never started" from "the harness was slow".
-async function describeSession(socketPath, sessionId) {
+function redactedDiagnosticText(value, redactions) {
+  let text = String(value).replace(/[\u0000-\u001F\u007F]+/g, ' ').trim();
+  for (const path of [...redactions].sort((left, right) => right.length - left.length)) {
+    if (path) text = text.replaceAll(path, '<fixture>');
+  }
+  return text.slice(0, 240);
+}
+
+function boundedDiagnosticValue(value, redactions) {
+  if (value === null) return 'null';
+  if (value === undefined) return 'unavailable';
+  const text = redactedDiagnosticText(value, redactions);
+  return typeof value === 'string' ? JSON.stringify(text) : text;
+}
+
+export function formatEventWriterHealth(health, redactions = []) {
+  const writer = health?.eventWriter;
+  if (!writer || typeof writer !== 'object') return 'eventWriter=unavailable';
+  const fields = EVENT_WRITER_DIAGNOSTIC_FIELDS.map(
+    (field) => {
+      const value =
+        field === 'state' && /^[a-z_]+$/.test(writer[field] ?? '')
+          ? writer[field]
+          : boundedDiagnosticValue(writer[field], redactions);
+      return `${field}=${value}`;
+    }
+  );
+  return `eventWriter={${fields.join(' ')}}`;
+}
+
+async function fixtureExecutionSummary(markerPath, expectedExecutions, read) {
+  try {
+    const markers = await read(markerPath, 'utf8');
+    const count = markers.split('\n').filter((line) => line === 'started').length;
+    return `fixtureExecutions=${count}/${expectedExecutions}`;
+  } catch (error) {
+    if (error?.code === 'ENOENT') return `fixtureExecutions=0/${expectedExecutions}`;
+    return `fixtureExecutions=unavailable/${expectedExecutions}`;
+  }
+}
+
+/// Describe each boundary involved in first output, so a timeout distinguishes
+/// child execution, PTY/event ingestion, writer pressure, and read-path failure.
+export async function describeScenarioFailure({
+  socketPath,
+  sessionId,
+  markerPath,
+  expectedExecutions,
+  request = socketRequest,
+  read = readFile
+}) {
+  let sessionEvidence;
   try {
     const [session, events] = await Promise.all([
-      socketRequest(socketPath, { method: 'GET', path: `/api/v1/sessions/${sessionId}` }),
-      socketRequest(socketPath, { method: 'GET', path: `/api/v1/sessions/${sessionId}/events?limit=20` })
+      request(socketPath, { method: 'GET', path: `/api/v1/sessions/${sessionId}` }),
+      request(socketPath, { method: 'GET', path: `/api/v1/sessions/${sessionId}/events?limit=20` })
     ]);
     const status = session.statusCode === 200 ? JSON.parse(session.body).status : `HTTP ${session.statusCode}`;
     const kinds =
       events.statusCode === 200
         ? (JSON.parse(events.body).events ?? []).map((event) => event.kind)
         : [`HTTP ${events.statusCode}`];
-    return `status=${status} events=[${kinds.join(', ') || 'none'}]`;
+    sessionEvidence = `status=${status} events=[${kinds.join(', ') || 'none'}]`;
   } catch (error) {
-    return `session state unavailable: ${error.message}`;
+    sessionEvidence = `sessionState=unavailable(${boundedDiagnosticValue(
+      error instanceof Error ? error.message : error,
+      [dirname(markerPath)]
+    )})`;
   }
+
+  const fixtureEvidence = await fixtureExecutionSummary(markerPath, expectedExecutions, read);
+  let writerEvidence;
+  try {
+    const response = await request(socketPath, { method: 'GET', path: '/api/v1/health' });
+    writerEvidence =
+      response.statusCode === 200
+        ? formatEventWriterHealth(JSON.parse(response.body), [dirname(markerPath)])
+        : `eventWriter=HTTP_${response.statusCode}`;
+  } catch (error) {
+    writerEvidence = `eventWriter=unavailable(${boundedDiagnosticValue(
+      error instanceof Error ? error.message : error,
+      [dirname(markerPath)]
+    )})`;
+  }
+
+  return `${sessionEvidence} ${fixtureEvidence} ${writerEvidence}`;
+}
+
+export function formatScenarioTimeout({
+  concurrency,
+  error,
+  diagnostic,
+  fixtureRoot
+}) {
+  const message = redactedDiagnosticText(
+    error instanceof Error ? error.message : error,
+    [fixtureRoot]
+  );
+  return `sessions_${concurrency}: ${message} — ${diagnostic}`;
 }
 
 async function waitForSessionExit(socketPath, sessionId, request = socketRequest) {
@@ -217,7 +320,7 @@ export async function storeFootprint(covenHome) {
 }
 
 export async function runConcurrencyScenario({ binary, root, concurrency, environment = process.env }) {
-  const { covenHome, env } = await fixtureEnvironment(root, environment);
+  const { covenHome, env, markerPath } = await fixtureEnvironment(root, environment);
   const socketPath = await startDaemon({ binary, covenHome, env });
   const footprintBefore = await storeFootprint(covenHome);
   let ids = [];
@@ -237,9 +340,18 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
             delayMs: POLL_DELAY_MS
           });
         } catch (error) {
-          throw new Error(
-            `sessions_${concurrency}: ${error.message} — ${await describeSession(socketPath, id)}`
-          );
+          const diagnostic = await describeScenarioFailure({
+            socketPath,
+            sessionId: id,
+            markerPath,
+            expectedExecutions: concurrency
+          });
+          throw new Error(formatScenarioTimeout({
+            concurrency,
+            error,
+            diagnostic,
+            fixtureRoot: root
+          }));
         }
         return { id, firstOutputMs: Number(process.hrtime.bigint() - launchedAt) / 1_000_000 };
       })

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -76,7 +76,11 @@ test('fixture harness records child execution before emitting output', async () 
   const module = await import('./benchmark-chaos.mjs');
   assert.equal(typeof module.fixtureHarnessScript, 'function');
   const script = module.fixtureHarnessScript();
-  assert.ok(script.indexOf('COVEN_BENCHMARK_MARKERS') < script.indexOf('COVEN_BENCHMARK_READY'));
+  const markerIndex = script.indexOf('COVEN_BENCHMARK_MARKERS');
+  const readyIndex = script.indexOf('COVEN_BENCHMARK_READY');
+  assert.notEqual(markerIndex, -1);
+  assert.notEqual(readyIndex, -1);
+  assert.ok(markerIndex < readyIndex);
   assert.match(script, /printf "started\\n"/);
 });
 

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -71,3 +71,110 @@ test('report contains no fixture paths or prompt content', () => {
   assert.equal(Object.hasOwn(report.environment, 'runner'), false);
   assert.equal(validateReport(report), report);
 });
+
+test('fixture harness records child execution before emitting output', async () => {
+  const module = await import('./benchmark-chaos.mjs');
+  assert.equal(typeof module.fixtureHarnessScript, 'function');
+  const script = module.fixtureHarnessScript();
+  assert.ok(script.indexOf('COVEN_BENCHMARK_MARKERS') < script.indexOf('COVEN_BENCHMARK_READY'));
+  assert.match(script, /printf "started\\n"/);
+});
+
+test('event writer diagnostics expose bounded operational fields and redact fixture paths', async () => {
+  const module = await import('./benchmark-chaos.mjs');
+  assert.equal(typeof module.formatEventWriterHealth, 'function');
+  assert.equal(
+    module.formatEventWriterHealth({
+      eventWriter: {
+        state: 'failed',
+        queuedEvents: 4,
+        queuedBytes: 8192,
+        capacityBytes: 16384,
+        droppedOutputEvents: 2,
+        droppedOutputBytes: 512,
+        connectionOpens: 1,
+        transactions: 7,
+        committedEvents: 21,
+        lastError: 'write failed at /fixture/root/coven.sqlite3\nretry stopped'
+      }
+    }, ['/fixture/root']),
+    'eventWriter={state=failed queuedEvents=4 queuedBytes=8192 capacityBytes=16384 droppedOutputEvents=2 droppedOutputBytes=512 connectionOpens=1 transactions=7 committedEvents=21 lastError="write failed at <fixture>/coven.sqlite3 retry stopped"}'
+  );
+});
+
+test('timeout diagnostics combine session, child execution, and writer evidence', async () => {
+  const module = await import('./benchmark-chaos.mjs');
+  assert.equal(typeof module.describeScenarioFailure, 'function');
+  const responses = new Map([
+    ['/api/v1/sessions/session-1', { statusCode: 200, body: '{"status":"running"}' }],
+    ['/api/v1/sessions/session-1/events?limit=20', {
+      statusCode: 200,
+      body: '{"events":[{"kind":"started"}]}'
+    }],
+    ['/api/v1/health', {
+      statusCode: 200,
+      body: '{"eventWriter":{"state":"healthy","queuedEvents":0,"queuedBytes":0,"capacityBytes":2097152,"droppedOutputEvents":0,"droppedOutputBytes":0,"connectionOpens":1,"transactions":8,"committedEvents":31,"lastError":null}}'
+    }]
+  ]);
+
+  const diagnostic = await module.describeScenarioFailure({
+    socketPath: '/fixture/socket',
+    sessionId: 'session-1',
+    markerPath: '/fixture/markers',
+    expectedExecutions: 32,
+    request: async (_socketPath, request) => responses.get(request.path),
+    read: async () => 'started\nstarted\n'
+  });
+
+  assert.equal(
+    diagnostic,
+    'status=running events=[started] fixtureExecutions=2/32 eventWriter={state=healthy queuedEvents=0 queuedBytes=0 capacityBytes=2097152 droppedOutputEvents=0 droppedOutputBytes=0 connectionOpens=1 transactions=8 committedEvents=31 lastError=null}'
+  );
+});
+
+test('diagnostics collapse ASCII controls and tolerate non-Error throws', async () => {
+  const module = await import('./benchmark-chaos.mjs');
+  assert.equal(
+    module.formatEventWriterHealth({
+      eventWriter: {
+        state: 'failed',
+        lastError: 'locked\u0000then\u001Bretried'
+      }
+    }),
+    'eventWriter={state=failed queuedEvents=unavailable queuedBytes=unavailable capacityBytes=unavailable droppedOutputEvents=unavailable droppedOutputBytes=unavailable connectionOpens=unavailable transactions=unavailable committedEvents=unavailable lastError="locked then retried"}'
+  );
+
+  const diagnostic = await module.describeScenarioFailure({
+    socketPath: '/fixture/socket',
+    sessionId: 'session-1',
+    markerPath: '/fixture/markers',
+    expectedExecutions: 1,
+    request: async () => {
+      throw null;
+    },
+    read: async () => {
+      const error = new Error('missing');
+      error.code = 'ENOENT';
+      throw error;
+    }
+  });
+
+  assert.equal(
+    diagnostic,
+    'sessionState=unavailable(null) fixtureExecutions=0/1 eventWriter=unavailable(null)'
+  );
+});
+
+test('scenario timeout messages redact fixture paths from the original error', async () => {
+  const module = await import('./benchmark-chaos.mjs');
+  assert.equal(typeof module.formatScenarioTimeout, 'function');
+  assert.equal(
+    module.formatScenarioTimeout({
+      concurrency: 32,
+      error: new Error('connect ENOENT /fixture/private/daemon.sock'),
+      diagnostic: 'status=running events=[none]',
+      fixtureRoot: '/fixture/private'
+    }),
+    'sessions_32: connect ENOENT <fixture>/daemon.sock — status=running events=[none]'
+  );
+});


### PR DESCRIPTION
## Summary
- retry only transient SQLite busy/locked event-writer failures with a bounded backoff
- add bounded, redacted chaos timeout evidence for session state, child execution, and writer health
- collapse ASCII control characters and keep diagnostics resilient to non-Error throws

## Context
Clean replacement for conflicting PR #631, reconstructed on current `main` with DCO-compliant, public author metadata and all review feedback applied.

## Test Plan
- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --locked
- [x] node --test scripts/benchmark-chaos.test.mjs
- [x] python scripts/check-secrets.py
- [x] python3 scripts/check-coven-privacy.py --staged
- [x] git diff --check origin/main...HEAD

Closes #615