### PR TITLE
perf: complete runtime baseline metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,13 +677,18 @@ node scripts/benchmark-chaos.mjs --binary target/debug/coven --output /tmp/coven
 
 The command always exercises 1, 8, and 32 concurrent deterministic harness
 sessions, records launch-to-first-output percentiles, throughput, cancellation
-acknowledgement, and SQLite file growth, and writes a redacted JSON report.
-It deliberately labels metrics that the current runtime cannot expose (SQLite
-connection/transaction counts and an event-writer queue) rather than deriving
-or inventing them. The bounded writer work in #596 must replace those labels
-with direct counters; Cave owns the slow-WebSocket-consumer lane in #4317.
-Fault-injection and platform-specific crash coverage remain explicit matrix
-entries, so a trend artifact cannot be mistaken for a passing chaos test.
+acknowledgement, SQLite file growth, writer connection/transaction deltas, peak
+writer backlog, and sampled daemon RSS, and writes a redacted JSON report. The
+writer measurements come from the live health contract; RSS is resolved by the
+exact daemon PID through `coven pc top --json`, without retaining process names
+or command lines. Cave owns the slow-WebSocket-consumer lane in #4317.
+
+Unsafe host-level faults use deterministic equivalents rather than filling a
+real disk or killing an unrelated process: the report names the exact Rust
+regressions for the free-disk watermark, real SQLite lock/retry behavior, and
+persisted-session crash recovery. These coverage entries remain separate from
+trend measurements, so a timing artifact cannot be mistaken for a passing
+failure-path test.
 
 CI runs this step as `continue-on-error`, so it collects trend data without
 gating merges — matching how the rest of this section describes these

--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -6,13 +6,14 @@ import { fileURLToPath } from 'node:url';
 import {
   harnessSessionRequest,
   isolatedEnvironment,
+  runCommand,
   socketRequest,
   startDaemon,
   stopDaemon,
   waitForOutputEvent
 } from './benchmark-cli.mjs';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const DEFAULT_CONCURRENCY = [1, 8, 32];
 const POLL_ATTEMPTS = 160;
 const POLL_DELAY_MS = 25;
@@ -100,16 +101,20 @@ export function redactedEnvironment(environment = process.env) {
 export function storageMetricStatus() {
   return {
     sqliteConnectionOpens: {
-      status: 'unavailable',
-      reason: 'The current daemon does not expose per-process connection counters.'
+      status: 'measured',
+      source: 'eventWriter.connectionOpens'
     },
     sqliteTransactions: {
-      status: 'unavailable',
-      reason: 'The current daemon does not expose committed transaction counters.'
+      status: 'measured',
+      source: 'eventWriter.transactions'
     },
     eventQueueDepth: {
-      status: 'not_applicable',
-      reason: 'Events are persisted synchronously; #596 owns the bounded writer queue.'
+      status: 'measured',
+      source: 'eventWriter.queuedEvents/eventWriter.queuedBytes'
+    },
+    rss: {
+      status: 'measured',
+      source: 'daemon PID sampled through coven pc top --json'
     }
   };
 }
@@ -121,12 +126,14 @@ export function chaosCoverage() {
       reason: 'Cave owns WebSocket consumer buffering and replay (#4317).'
     },
     diskFull: {
-      status: 'blocked_by_injection',
-      reason: 'A cross-platform storage fault hook is not present in the daemon.'
+      status: 'covered_by_storage_regressions',
+      reason: 'A deterministic free-space seam exercises the fail-closed path without filling a host disk.',
+      evidence: 'store::tests::scheduled_maintenance_below_watermark_does_not_open_or_write_the_store'
     },
     lockedDatabase: {
-      status: 'covered_by_store_regressions',
-      reason: 'The store suite owns deterministic SQLite lock assertions.'
+      status: 'covered_by_event_writer_regressions',
+      reason: 'The writer suite holds real SQLite locks across bounded retry and recovery assertions.',
+      evidence: 'event_writer::tests::transient_sqlite_lock_is_retried'
     },
     stalledChild: {
       status: 'covered',
@@ -134,9 +141,100 @@ export function chaosCoverage() {
     },
     crashRestart: {
       status: 'covered_by_daemon_regressions',
-      reason: 'Daemon recovery tests own process-crash and orphan-recovery assertions.'
+      reason: 'Daemon recovery tests own process-crash and orphan-recovery assertions.',
+      evidence: 'daemon::tests::recovers_persisted_running_sessions_as_orphaned'
     }
   };
+}
+
+function requiredCounter(writer, field) {
+  const value = writer?.[field];
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`event writer health has invalid ${field}`);
+  }
+  return value;
+}
+
+export function summarizeRuntimeMetrics(samples) {
+  if (samples.length === 0) throw new Error('cannot summarize runtime metrics without samples');
+  const first = samples[0].eventWriter;
+  const last = samples.at(-1).eventWriter;
+  const opensStart = requiredCounter(first, 'connectionOpens');
+  const opensEnd = requiredCounter(last, 'connectionOpens');
+  const transactionsStart = requiredCounter(first, 'transactions');
+  const transactionsEnd = requiredCounter(last, 'transactions');
+  const rssSamples = samples
+    .map((sample) => sample.residentSetBytes)
+    .filter((value) => Number.isSafeInteger(value) && value >= 0);
+  if (rssSamples.length === 0) throw new Error('runtime metrics contain no RSS samples');
+
+  return {
+    sqliteConnectionOpens: {
+      start: opensStart,
+      end: opensEnd,
+      delta: opensEnd - opensStart
+    },
+    sqliteTransactions: {
+      start: transactionsStart,
+      end: transactionsEnd,
+      delta: transactionsEnd - transactionsStart
+    },
+    eventQueueDepth: {
+      peakEvents: Math.max(...samples.map((sample) => requiredCounter(sample.eventWriter, 'queuedEvents'))),
+      peakBytes: Math.max(...samples.map((sample) => requiredCounter(sample.eventWriter, 'queuedBytes')))
+    },
+    rss: {
+      samplesBytes: rssSamples,
+      peakBytes: Math.max(...rssSamples)
+    }
+  };
+}
+
+export function residentSetBytesFromProcessList(output, daemonPid) {
+  const processes = JSON.parse(output)?.processes;
+  if (!Array.isArray(processes)) throw new Error('pc top output has no process list');
+  const daemon = processes.find((process) => process?.pid === daemonPid);
+  if (!daemon) throw new Error(`daemon pid ${daemonPid} is absent from pc top output`);
+  if (!Number.isSafeInteger(daemon.memory_mb) || daemon.memory_mb < 0) {
+    throw new Error(`daemon pid ${daemonPid} has invalid RSS`);
+  }
+  return daemon.memory_mb * 1024 * 1024;
+}
+
+async function daemonResidentSetBytes(binary, covenHome, env) {
+  const daemon = JSON.parse(await readFile(join(covenHome, 'daemon.json'), 'utf8'));
+  if (!Number.isSafeInteger(daemon.pid) || daemon.pid <= 0) {
+    throw new Error('daemon metadata has no valid pid');
+  }
+  const result = runCommand({
+    command: binary,
+    args: ['pc', 'top', '--json', '--n', '100000'],
+    env
+  });
+  return residentSetBytesFromProcessList(result.stdout, daemon.pid);
+}
+
+async function runtimeHealthSnapshot(socketPath, request = socketRequest) {
+  const response = await request(socketPath, { method: 'GET', path: '/api/v1/health' });
+  if (response.statusCode !== 200) throw new Error(`health returned ${response.statusCode}`);
+  const health = JSON.parse(response.body);
+  if (!health.eventWriter || typeof health.eventWriter !== 'object') {
+    throw new Error('health has no live event writer metrics');
+  }
+  return { eventWriter: health.eventWriter };
+}
+
+async function observeWriterHealth(socketPath, samples, isRunning) {
+  while (isRunning()) {
+    samples.push(await runtimeHealthSnapshot(socketPath));
+    await new Promise((resolve) => setTimeout(resolve, POLL_DELAY_MS));
+  }
+}
+
+async function fullRuntimeSnapshot({ binary, covenHome, env, socketPath }) {
+  const snapshot = await runtimeHealthSnapshot(socketPath);
+  snapshot.residentSetBytes = await daemonResidentSetBytes(binary, covenHome, env);
+  return snapshot;
 }
 
 async function fixtureEnvironment(root, environment) {
@@ -322,41 +420,51 @@ export async function storeFootprint(covenHome) {
 export async function runConcurrencyScenario({ binary, root, concurrency, environment = process.env }) {
   const { covenHome, env, markerPath } = await fixtureEnvironment(root, environment);
   const socketPath = await startDaemon({ binary, covenHome, env });
-  const footprintBefore = await storeFootprint(covenHome);
   let ids = [];
 
   try {
+    const footprintBefore = await storeFootprint(covenHome);
+    const runtimeSamples = [await fullRuntimeSnapshot({ binary, covenHome, env, socketPath })];
     const startedAt = process.hrtime.bigint();
-    const launches = await Promise.all(
-      Array.from({ length: concurrency }, async () => {
-        const launchedAt = process.hrtime.bigint();
-        const response = await socketRequest(socketPath, harnessSessionRequest({ projectRoot: root }));
-        if (response.statusCode !== 201) throw new Error(`launch returned ${response.statusCode}`);
-        const id = JSON.parse(response.body).id;
-        if (typeof id !== 'string' || id.length === 0) throw new Error('launch response has no id');
-        try {
-          await waitForOutputEvent(socketPath, id, {
-            attempts: LAUNCH_POLL_ATTEMPTS,
-            delayMs: POLL_DELAY_MS
-          });
-        } catch (error) {
-          const diagnostic = await describeScenarioFailure({
-            socketPath,
-            sessionId: id,
-            markerPath,
-            expectedExecutions: concurrency
-          });
-          throw new Error(formatScenarioTimeout({
-            concurrency,
-            error,
-            diagnostic,
-            fixtureRoot: root
-          }));
-        }
-        return { id, firstOutputMs: Number(process.hrtime.bigint() - launchedAt) / 1_000_000 };
-      })
-    );
-    ids = launches.map((launch) => launch.id);
+    let observing = true;
+    const observation = observeWriterHealth(socketPath, runtimeSamples, () => observing);
+    let launches;
+    try {
+      launches = await Promise.all(
+        Array.from({ length: concurrency }, async () => {
+          const launchedAt = process.hrtime.bigint();
+          const response = await socketRequest(socketPath, harnessSessionRequest({ projectRoot: root }));
+          if (response.statusCode !== 201) throw new Error(`launch returned ${response.statusCode}`);
+          const id = JSON.parse(response.body).id;
+          if (typeof id !== 'string' || id.length === 0) throw new Error('launch response has no id');
+          ids.push(id);
+          try {
+            await waitForOutputEvent(socketPath, id, {
+              attempts: LAUNCH_POLL_ATTEMPTS,
+              delayMs: POLL_DELAY_MS
+            });
+          } catch (error) {
+            const diagnostic = await describeScenarioFailure({
+              socketPath,
+              sessionId: id,
+              markerPath,
+              expectedExecutions: concurrency
+            });
+            throw new Error(formatScenarioTimeout({
+              concurrency,
+              error,
+              diagnostic,
+              fixtureRoot: root
+            }));
+          }
+          return { id, firstOutputMs: Number(process.hrtime.bigint() - launchedAt) / 1_000_000 };
+        })
+      );
+    } finally {
+      observing = false;
+      await observation;
+    }
+    runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
     const completedAt = process.hrtime.bigint();
     const elapsedMs = Number(completedAt - startedAt) / 1_000_000;
 
@@ -371,6 +479,7 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
     const cancellationMs = Number(process.hrtime.bigint() - cancellationStartedAt) / 1_000_000;
     ids = [];
     const footprintAfter = await storeFootprint(covenHome);
+    runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
 
     return {
       status: 'passed',
@@ -379,7 +488,10 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
       throughputSessionsPerSecond: Number((concurrency / (elapsedMs / 1_000)).toFixed(3)),
       cancellation: { allSessionsMs: Number(cancellationMs.toFixed(3)), terminalStates: concurrency },
       diskGrowthBytes: footprintAfter.totalBytes - footprintBefore.totalBytes,
-      storage: storageMetricStatus()
+      storage: {
+        availability: storageMetricStatus(),
+        measurements: summarizeRuntimeMetrics(runtimeSamples)
+      }
     };
   } finally {
     await Promise.all(

--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -464,9 +464,9 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
       observing = false;
       await observation;
     }
-    runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
     const completedAt = process.hrtime.bigint();
     const elapsedMs = Number(completedAt - startedAt) / 1_000_000;
+    runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
 
     const cancellationStartedAt = process.hrtime.bigint();
     await Promise.all(

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import {
@@ -249,5 +250,13 @@ test('scenario timeout messages redact fixture paths from the original error', a
       fixtureRoot: '/fixture/private'
     }),
     'sessions_32: connect ENOENT <fixture>/daemon.sock — status=running events=[none]'
+  );
+});
+
+test('closes the throughput timing window before diagnostic sampling', async () => {
+  const source = await readFile(new URL('./benchmark-chaos.mjs', import.meta.url), 'utf8');
+  assert.match(
+    source,
+    /const completedAt = process\.hrtime\.bigint\(\);\n\s+const elapsedMs = .*;\n\s+runtimeSamples\.push\(await fullRuntimeSnapshot/
   );
 });

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -5,6 +5,8 @@ import {
   buildReport,
   chaosCoverage,
   parseOptions,
+  residentSetBytesFromProcessList,
+  summarizeRuntimeMetrics,
   storageMetricStatus,
   summarize,
   validateReport
@@ -49,10 +51,76 @@ test('summarizes p50, p95, and p99 using nearest rank', () => {
   });
 });
 
-test('records unavailable writer counters without pretending they are measured', () => {
-  assert.equal(storageMetricStatus().sqliteConnectionOpens.status, 'unavailable');
-  assert.equal(storageMetricStatus().eventQueueDepth.status, 'not_applicable');
-  assert.equal(chaosCoverage().diskFull.status, 'blocked_by_injection');
+test('describes live writer metrics and deterministic fault equivalents', () => {
+  assert.equal(storageMetricStatus().sqliteConnectionOpens.status, 'measured');
+  assert.equal(storageMetricStatus().eventQueueDepth.status, 'measured');
+  assert.equal(chaosCoverage().diskFull.status, 'covered_by_storage_regressions');
+  assert.match(
+    chaosCoverage().diskFull.evidence,
+    /scheduled_maintenance_below_watermark_does_not_open_or_write_the_store/
+  );
+});
+
+test('summarizes writer counter deltas, peak backlog, and sampled RSS', () => {
+  assert.deepEqual(
+    summarizeRuntimeMetrics([
+      {
+        eventWriter: {
+          connectionOpens: 1,
+          transactions: 2,
+          queuedEvents: 0,
+          queuedBytes: 0
+        },
+        residentSetBytes: 10 * 1024 * 1024
+      },
+      {
+        eventWriter: {
+          connectionOpens: 1,
+          transactions: 9,
+          queuedEvents: 5,
+          queuedBytes: 4096
+        },
+        residentSetBytes: 14 * 1024 * 1024
+      },
+      {
+        eventWriter: {
+          connectionOpens: 1,
+          transactions: 12,
+          queuedEvents: 0,
+          queuedBytes: 0
+        },
+        residentSetBytes: 12 * 1024 * 1024
+      }
+    ]),
+    {
+      sqliteConnectionOpens: { start: 1, end: 1, delta: 0 },
+      sqliteTransactions: { start: 2, end: 12, delta: 10 },
+      eventQueueDepth: { peakEvents: 5, peakBytes: 4096 },
+      rss: {
+        samplesBytes: [10 * 1024 * 1024, 14 * 1024 * 1024, 12 * 1024 * 1024],
+        peakBytes: 14 * 1024 * 1024
+      }
+    }
+  );
+});
+
+test('selects daemon RSS by exact PID without retaining process details', () => {
+  assert.equal(
+    residentSetBytesFromProcessList(
+      JSON.stringify({
+        processes: [
+          { pid: 41, name: 'other', memory_mb: 99, argv: ['private'] },
+          { pid: 42, name: 'coven', memory_mb: 17, argv: ['/private/coven'] }
+        ]
+      }),
+      42
+    ),
+    17 * 1024 * 1024
+  );
+  assert.throws(
+    () => residentSetBytesFromProcessList('{"processes":[]}', 42),
+    /daemon pid 42 is absent/
+  );
 });
 
 test('report contains no fixture paths or prompt content', () => {
@@ -66,6 +134,7 @@ test('report contains no fixture paths or prompt content', () => {
     environment: { GITHUB_ACTIONS: 'true', HOME: '/private/fixture', PROMPT: 'secret prompt' }
   });
   const serialized = JSON.stringify(report);
+  assert.equal(report.schemaVersion, 2);
   assert.doesNotMatch(serialized, /private\/fixture|secret prompt/);
   assert.equal(Object.hasOwn(report.environment, 'host'), false);
   assert.equal(Object.hasOwn(report.environment, 'runner'), false);

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -120,7 +120,7 @@ export function runCommand({
     const stderr = result.stderr.trim();
     throw new Error(`command exited with ${result.status}${stderr ? `: ${stderr}` : ''}`);
   }
-  return { status: result.status };
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
 
 export function externalSessionRequest({ id, projectRoot }) {

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -320,12 +320,13 @@ test('runScenario uses the supplied isolated environment', () => {
 test('runCommand accepts an expected nonzero exit and preserves environment isolation', () => {
   const result = runCommand({
     command: process.execPath,
-    args: ['--eval', "process.exit(process.env.COVEN_HOME === '/fixture/home' ? 1 : 7)"],
+    args: ['--eval', "process.stdout.write('captured'); process.exit(process.env.COVEN_HOME === '/fixture/home' ? 1 : 7)"],
     allowedExitCodes: [1],
     env: { ...process.env, COVEN_HOME: '/fixture/home' }
   });
 
   assert.equal(result.status, 1);
+  assert.equal(result.stdout, 'captured');
 });
 
 test('runCommand includes captured stderr when a lifecycle command fails', () => {


### PR DESCRIPTION
Closes #598

## Outcome
- samples live event-writer connection, transaction, and backlog counters during 1/8/32-session scenarios
- records daemon RSS by exact PID through the existing system diagnostics command without retaining process details
- replaces unavailable chaos placeholders with named deterministic fault-regression evidence
- bumps the chaos artifact schema to v2 and documents the complete matrix

## Verification
- node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs (59/59)
- four full 1/8/32 benchmark runs passed; v2 artifacts recorded live writer counters, backlog peaks, and RSS
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- python scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --staged
- cargo test --workspace --locked: changed tests pass; two runs hit different unchanged host-load-sensitive claim/PTY tests. Every failed test passed on exact serial rerun; CI remains authoritative for the full gate.