### PR TITLE
fix: harden bounded retention and storage health

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -289,9 +289,14 @@ fn health_response_with_hub(
         response.hub = serde_json::from_value(summary).ok();
     }
     response.storage = Some(
-        store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
-            store::unavailable_storage_health(error, None, event_writer.as_ref())
-        }),
+        match store::storage_health(coven_home, event_writer.as_ref()) {
+            Ok(storage) => storage,
+            Err(error) => {
+                let mut storage = store::unavailable_storage_health(error, event_writer.as_ref());
+                storage.maintenance_blocked = false;
+                storage
+            }
+        },
     );
     response.event_writer = event_writer;
     response
@@ -6805,14 +6810,6 @@ mod tests {
         }
     }
 
-    fn unavailable_storage_health_for_api_test(
-        error: impl ToString,
-        known_free_disk_bytes: Option<u64>,
-        event_writer: Option<&crate::event_writer::EventWriterHealth>,
-    ) -> store::StorageHealth {
-        store::unavailable_storage_health(error, known_free_disk_bytes, event_writer)
-    }
-
     #[test]
     fn health_uses_one_live_writer_snapshot_for_both_surfaces() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -6835,29 +6832,32 @@ mod tests {
     }
 
     #[test]
-    fn health_response_serializes_degraded_storage_without_false_maintenance_blocking(
-    ) -> anyhow::Result<()> {
-        let writer = HealthRuntime
-            .event_writer_health()
-            .expect("health runtime provides writer snapshot");
-        let mut response = health_response(None);
-        response.event_writer = Some(writer.clone());
-        response.storage = Some(unavailable_storage_health_for_api_test(
-            "storage health unavailable",
-            Some(store::MAINTENANCE_MIN_FREE_DISK_BYTES),
-            Some(&writer),
-        ));
+    fn health_degrades_when_storage_collection_cannot_start() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let parent_file = temp_dir.path().join("not-a-dir");
+        std::fs::write(&parent_file, "marker")?;
+        let missing_home = parent_file.join("missing-home");
+        let response = handle_request_with_runtime(
+            "GET",
+            "/health",
+            &missing_home,
+            None,
+            None,
+            &HealthRuntime,
+        )?;
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
 
-        let body = serde_json::to_value(response)?;
-
+        assert_eq!(response.status, 200);
         assert_eq!(body["storage"]["status"], "degraded");
-        assert_eq!(
-            body["storage"]["freeDiskBytes"],
-            serde_json::json!(store::MAINTENANCE_MIN_FREE_DISK_BYTES)
-        );
+        assert_eq!(body["storage"]["freeDiskBytes"], 0);
         assert_eq!(body["storage"]["maintenanceBlocked"], false);
         assert_eq!(body["storage"]["writerBacklogEvents"], 3);
         assert_eq!(body["storage"]["writerBacklogBytes"], 4096);
+        assert!(body.get("eventWriter").is_some());
+        assert!(body["eventWriter"].is_object());
+        assert!(parent_file.is_file());
+        assert!(!missing_home.exists());
+        assert!(!missing_home.join("coven.sqlite3").exists());
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6844,7 +6844,7 @@ mod tests {
 
         assert_eq!(response.status, 200);
         assert_eq!(body["storage"]["status"], "degraded");
-        assert_eq!(body["storage"]["freeDiskBytes"], 0);
+        assert!(body["storage"]["freeDiskBytes"].is_number());
         assert_eq!(body["storage"]["maintenanceBlocked"], false);
         assert_eq!(body["storage"]["writerBacklogEvents"], 3);
         assert_eq!(body["storage"]["writerBacklogBytes"], 4096);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6844,7 +6844,10 @@ mod tests {
 
         assert_eq!(response.status, 200);
         assert_eq!(body["storage"]["status"], "degraded");
-        assert!(body["storage"]["freeDiskBytes"].is_number());
+        assert!(
+            body["storage"]["freeDiskBytes"].is_u64(),
+            "free-space sampling may be known for the enclosing drive or unknown as zero"
+        );
         assert_eq!(body["storage"]["maintenanceBlocked"], false);
         assert_eq!(body["storage"]["writerBacklogEvents"], 3);
         assert_eq!(body["storage"]["writerBacklogBytes"], 4096);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -290,7 +290,7 @@ fn health_response_with_hub(
     }
     response.storage = Some(
         store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
-            store::unavailable_storage_health(error, event_writer.as_ref())
+            store::unavailable_storage_health(error, None, event_writer.as_ref())
         }),
     );
     response.event_writer = event_writer;
@@ -6805,6 +6805,14 @@ mod tests {
         }
     }
 
+    fn unavailable_storage_health_for_api_test(
+        error: impl ToString,
+        known_free_disk_bytes: Option<u64>,
+        event_writer: Option<&crate::event_writer::EventWriterHealth>,
+    ) -> store::StorageHealth {
+        store::unavailable_storage_health(error, known_free_disk_bytes, event_writer)
+    }
+
     #[test]
     fn health_uses_one_live_writer_snapshot_for_both_surfaces() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -6821,6 +6829,33 @@ mod tests {
         assert_eq!(body["capabilities"]["sessionHandoff"], true);
         assert_eq!(body["eventWriter"]["queuedEvents"], 3);
         assert_eq!(body["eventWriter"]["queuedBytes"], 4096);
+        assert_eq!(body["storage"]["writerBacklogEvents"], 3);
+        assert_eq!(body["storage"]["writerBacklogBytes"], 4096);
+        Ok(())
+    }
+
+    #[test]
+    fn health_response_serializes_degraded_storage_without_false_maintenance_blocking(
+    ) -> anyhow::Result<()> {
+        let writer = HealthRuntime
+            .event_writer_health()
+            .expect("health runtime provides writer snapshot");
+        let mut response = health_response(None);
+        response.event_writer = Some(writer.clone());
+        response.storage = Some(unavailable_storage_health_for_api_test(
+            "storage health unavailable",
+            Some(store::MAINTENANCE_MIN_FREE_DISK_BYTES),
+            Some(&writer),
+        ));
+
+        let body = serde_json::to_value(response)?;
+
+        assert_eq!(body["storage"]["status"], "degraded");
+        assert_eq!(
+            body["storage"]["freeDiskBytes"],
+            serde_json::json!(store::MAINTENANCE_MIN_FREE_DISK_BYTES)
+        );
+        assert_eq!(body["storage"]["maintenanceBlocked"], false);
         assert_eq!(body["storage"]["writerBacklogEvents"], 3);
         assert_eq!(body["storage"]["writerBacklogBytes"], 4096);
         Ok(())

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -289,14 +289,9 @@ fn health_response_with_hub(
         response.hub = serde_json::from_value(summary).ok();
     }
     response.storage = Some(
-        match store::storage_health(coven_home, event_writer.as_ref()) {
-            Ok(storage) => storage,
-            Err(error) => {
-                let mut storage = store::unavailable_storage_health(error, event_writer.as_ref());
-                storage.maintenance_blocked = false;
-                storage
-            }
-        },
+        store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
+            store::unavailable_storage_health(error, None, event_writer.as_ref())
+        }),
     );
     response.event_writer = event_writer;
     response

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -290,7 +290,7 @@ fn health_response_with_hub(
     }
     response.storage = Some(
         store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
-            store::unavailable_storage_health(error, None, event_writer.as_ref())
+            store::unavailable_storage_health(coven_home, error, None, event_writer.as_ref())
         }),
     );
     response.event_writer = event_writer;

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2050,9 +2050,7 @@ fn recovery_log_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
-pub fn append_daemon_recovery_log(coven_home: &Path, msg: &str) {
-    let path = daemon_recovery_log_path(coven_home);
-    let timestamp = crate::api::current_timestamp();
+fn format_daemon_recovery_log_entry(timestamp: &str, msg: &str) -> String {
     let prefix = format!("[{timestamp}] ");
     let max_bytes = DAEMON_RECOVERY_LOG_MAX_BYTES as usize;
     let full_len = prefix.len().saturating_add(msg.len()).saturating_add(1);
@@ -2072,6 +2070,12 @@ pub fn append_daemon_recovery_log(coven_home: &Path, msg: &str) {
         line.push_str(&msg[..truncate_at]);
         line.push_str(DAEMON_RECOVERY_LOG_TRUNCATION_MARKER);
     }
+    line
+}
+
+pub fn append_daemon_recovery_log(coven_home: &Path, msg: &str) {
+    let path = daemon_recovery_log_path(coven_home);
+    let line = format_daemon_recovery_log_entry(&crate::api::current_timestamp(), msg);
     let _guard = recovery_log_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2043,6 +2043,7 @@ pub fn daemon_recovery_log_path(coven_home: &Path) -> PathBuf {
 
 const DAEMON_RECOVERY_LOG_MAX_BYTES: u64 = 4 * 1024 * 1024;
 const DAEMON_RECOVERY_LOG_BACKUPS: u8 = 3;
+const DAEMON_RECOVERY_LOG_TRUNCATION_MARKER: &str = "... [truncated]\n";
 
 fn recovery_log_lock() -> &'static Mutex<()> {
     static LOCK: std::sync::OnceLock<Mutex<()>> = std::sync::OnceLock::new();
@@ -2051,7 +2052,26 @@ fn recovery_log_lock() -> &'static Mutex<()> {
 
 pub fn append_daemon_recovery_log(coven_home: &Path, msg: &str) {
     let path = daemon_recovery_log_path(coven_home);
-    let line = format!("[{}] {}\n", crate::api::current_timestamp(), msg);
+    let timestamp = crate::api::current_timestamp();
+    let prefix = format!("[{timestamp}] ");
+    let max_bytes = DAEMON_RECOVERY_LOG_MAX_BYTES as usize;
+    let full_len = prefix.len().saturating_add(msg.len()).saturating_add(1);
+    let mut line = String::with_capacity(full_len.min(max_bytes));
+    line.push_str(&prefix);
+    if full_len <= max_bytes {
+        line.push_str(msg);
+        line.push('\n');
+    } else {
+        let message_bytes = max_bytes
+            .saturating_sub(prefix.len())
+            .saturating_sub(DAEMON_RECOVERY_LOG_TRUNCATION_MARKER.len());
+        let mut truncate_at = message_bytes.min(msg.len());
+        while !msg.is_char_boundary(truncate_at) {
+            truncate_at -= 1;
+        }
+        line.push_str(&msg[..truncate_at]);
+        line.push_str(DAEMON_RECOVERY_LOG_TRUNCATION_MARKER);
+    }
     let _guard = recovery_log_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -5570,14 +5590,52 @@ mod tests {
         append_daemon_recovery_log(temp_dir.path(), "first event");
         append_daemon_recovery_log(temp_dir.path(), "second event");
         let log = std::fs::read_to_string(daemon_recovery_log_path(temp_dir.path()))?;
+        let mut entries = log.split_inclusive('\n');
+        for expected in ["first event", "second event"] {
+            let entry = entries.next().expect("expected recovery log entry");
+            assert!(
+                entry.starts_with('['),
+                "entry should start with a timestamp"
+            );
+            let (_, message) = entry
+                .split_once("] ")
+                .expect("entry should separate timestamp and message");
+            assert_eq!(message, format!("{expected}\n"));
+        }
+        assert!(entries.next().is_none(), "unexpected recovery log entry");
+        Ok(())
+    }
+
+    #[test]
+    fn append_daemon_recovery_log_truncates_oversized_ascii_entry() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let message = "x".repeat(DAEMON_RECOVERY_LOG_MAX_BYTES as usize + 1024);
+
+        append_daemon_recovery_log(temp_dir.path(), &message);
+
+        let log = std::fs::read(daemon_recovery_log_path(temp_dir.path()))?;
         assert!(
-            log.contains("first event"),
-            "log should record the first event, got: {log}"
+            log.len() <= DAEMON_RECOVERY_LOG_MAX_BYTES as usize,
+            "active recovery log exceeded its byte bound: {}",
+            log.len()
         );
         assert!(
-            log.contains("second event"),
-            "second append should not overwrite the first, got: {log}"
+            log.ends_with(b"... [truncated]\n"),
+            "oversized entry should end with a truncation marker"
         );
+        Ok(())
+    }
+
+    #[test]
+    fn append_daemon_recovery_log_truncates_multibyte_entry_on_char_boundary() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let message = "🧙".repeat(DAEMON_RECOVERY_LOG_MAX_BYTES as usize / "🧙".len() + 1024);
+
+        append_daemon_recovery_log(temp_dir.path(), &message);
+
+        let log = std::fs::read_to_string(daemon_recovery_log_path(temp_dir.path()))?;
+        assert!(log.len() <= DAEMON_RECOVERY_LOG_MAX_BYTES as usize);
+        assert!(log.ends_with("... [truncated]\n"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3163,10 +3163,10 @@ fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u
         .unwrap_or(config.raw_artifact_retention_days)
         .max(1);
     let event_days = event_days.unwrap_or(config.log_retention_days).max(1);
-    let conn = store::open_store(&home.join(STORE_FILE_NAME))?;
     let now = current_timestamp();
-    let raw_cutoff = store::retention_cutoff(&now, raw_days);
-    let event_cutoff = store::retention_cutoff(&now, event_days);
+    let raw_cutoff = store::retention_cutoff(&now, raw_days)?;
+    let event_cutoff = store::retention_cutoff(&now, event_days)?;
+    let conn = store::open_store(&home.join(STORE_FILE_NAME))?;
     let raw_count = store::count_prunable_sensitive_artifacts(&conn, &now, &raw_cutoff)?;
     let event_count = store::count_events_older_than(&conn, &event_cutoff)?;
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3603,7 +3603,11 @@ pub fn storage_health(
 ) -> Result<StorageHealth> {
     let free_disk_bytes = fs2::available_space(coven_home)
         .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
-    storage_health_with_free_disk(coven_home, free_disk_bytes, event_writer)
+    Ok(storage_health_with_free_disk_or_unavailable(
+        coven_home,
+        free_disk_bytes,
+        event_writer,
+    ))
 }
 
 fn storage_health_with_free_disk(
@@ -3686,8 +3690,19 @@ fn storage_health_with_free_disk(
     })
 }
 
+fn storage_health_with_free_disk_or_unavailable(
+    coven_home: &Path,
+    free_disk_bytes: u64,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> StorageHealth {
+    storage_health_with_free_disk(coven_home, free_disk_bytes, event_writer).unwrap_or_else(
+        |error| unavailable_storage_health(error, Some(free_disk_bytes), event_writer),
+    )
+}
+
 pub fn unavailable_storage_health(
     _error: impl ToString,
+    known_free_disk_bytes: Option<u64>,
     event_writer: Option<&crate::event_writer::EventWriterHealth>,
 ) -> StorageHealth {
     let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
@@ -3702,8 +3717,8 @@ pub fn unavailable_storage_health(
         checkpoint_age_seconds: None,
         writer_backlog_events,
         writer_backlog_bytes,
-        free_disk_bytes: 0,
-        maintenance_blocked: true,
+        free_disk_bytes: known_free_disk_bytes.unwrap_or(0),
+        maintenance_blocked: false,
         // The socket API is a compatibility boundary. Do not turn an I/O
         // failure into a COVEN_HOME path disclosure; detailed diagnostics stay
         // in the local recovery log.
@@ -5210,6 +5225,63 @@ mod tests {
         Ok(())
     }
 
+    fn unavailable_storage_health_for_test(
+        error: impl ToString,
+        known_free_disk_bytes: Option<u64>,
+        event_writer: Option<&crate::event_writer::EventWriterHealth>,
+    ) -> StorageHealth {
+        unavailable_storage_health(error, known_free_disk_bytes, event_writer)
+    }
+
+    fn storage_health_after_sampling_free_disk_for_test(
+        coven_home: &Path,
+        free_disk_bytes: u64,
+        event_writer: Option<&crate::event_writer::EventWriterHealth>,
+    ) -> StorageHealth {
+        storage_health_with_free_disk_or_unavailable(coven_home, free_disk_bytes, event_writer)
+    }
+
+    #[test]
+    fn storage_health_fallback_with_known_healthy_free_disk_is_degraded_without_blocking(
+    ) -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        open_store(&home.join("coven.sqlite3"))?;
+        std::fs::write(
+            home.join("privacy.toml"),
+            "log_retention_days = \"broken\"\n",
+        )?;
+        let writer = crate::event_writer::EventWriterHealth {
+            state: "pressured".to_string(),
+            queued_events: 7,
+            queued_bytes: 8192,
+            capacity_bytes: 2 * 1024 * 1024,
+            dropped_output_events: 1,
+            dropped_output_bytes: 512,
+            connection_opens: 1,
+            transactions: 3,
+            committed_events: 12,
+            last_error: None,
+        };
+
+        let health = storage_health_after_sampling_free_disk_for_test(
+            home,
+            MAINTENANCE_MIN_FREE_DISK_BYTES,
+            Some(&writer),
+        );
+
+        assert_eq!(health.status, "degraded");
+        assert_eq!(health.free_disk_bytes, MAINTENANCE_MIN_FREE_DISK_BYTES);
+        assert!(!health.maintenance_blocked);
+        assert_eq!(health.writer_backlog_events, 7);
+        assert_eq!(health.writer_backlog_bytes, 8192);
+        assert_eq!(
+            health.last_maintenance_error.as_deref(),
+            Some("storage health unavailable")
+        );
+        Ok(())
+    }
+
     #[test]
     fn storage_health_above_watermark_errors_for_missing_store_without_creation() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
@@ -5237,6 +5309,34 @@ mod tests {
 
         assert!(error.to_string().contains("privacy"));
         Ok(())
+    }
+
+    #[test]
+    fn unavailable_storage_health_without_known_free_disk_preserves_backlog_without_blocking() {
+        let writer = crate::event_writer::EventWriterHealth {
+            state: "pressured".to_string(),
+            queued_events: 7,
+            queued_bytes: 8192,
+            capacity_bytes: 2 * 1024 * 1024,
+            dropped_output_events: 1,
+            dropped_output_bytes: 512,
+            connection_opens: 1,
+            transactions: 3,
+            committed_events: 12,
+            last_error: None,
+        };
+
+        let health = unavailable_storage_health_for_test("boom", None, Some(&writer));
+
+        assert_eq!(health.status, "degraded");
+        assert_eq!(health.free_disk_bytes, 0);
+        assert!(!health.maintenance_blocked);
+        assert_eq!(health.writer_backlog_events, 7);
+        assert_eq!(health.writer_backlog_bytes, 8192);
+        assert_eq!(
+            health.last_maintenance_error.as_deref(),
+            Some("storage health unavailable")
+        );
     }
 
     #[test]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -2860,35 +2860,36 @@ pub fn insert_event_with_privacy(
     insert_event_raw(conn, record, &redacted_payload, redaction_status, sensitive)?;
 
     if config.persist_raw_artifacts && sensitive {
-        let artifact_result =
-            retention_expires_at(&record.created_at, config.raw_artifact_retention_days).and_then(
-                |expires_at| {
-                    SensitiveArtifactStore::load(coven_home)
-                        .and_then(|store| {
-                            store.encrypt(
-                                &record.session_id,
-                                &record.id,
-                                &record.kind,
-                                record.payload_json.as_bytes(),
-                            )
-                        })
-                        .and_then(|encrypted| {
-                            insert_sensitive_artifact(
-                                conn,
-                                &SensitiveArtifactRecord {
-                                    id: record.id.clone(),
-                                    session_id: record.session_id.clone(),
-                                    event_id: record.id.clone(),
-                                    kind: record.kind.clone(),
-                                    nonce: encrypted.nonce,
-                                    ciphertext: encrypted.ciphertext,
-                                    created_at: record.created_at.clone(),
-                                    expires_at,
-                                },
-                            )
-                        })
-                },
-            );
+        let artifact_result = retention_expires_at(
+            &record.created_at,
+            config.raw_artifact_retention_days.max(1),
+        )
+        .and_then(|expires_at| {
+            SensitiveArtifactStore::load(coven_home)
+                .and_then(|store| {
+                    store.encrypt(
+                        &record.session_id,
+                        &record.id,
+                        &record.kind,
+                        record.payload_json.as_bytes(),
+                    )
+                })
+                .and_then(|encrypted| {
+                    insert_sensitive_artifact(
+                        conn,
+                        &SensitiveArtifactRecord {
+                            id: record.id.clone(),
+                            session_id: record.session_id.clone(),
+                            event_id: record.id.clone(),
+                            kind: record.kind.clone(),
+                            nonce: encrypted.nonce,
+                            ciphertext: encrypted.ciphertext,
+                            created_at: record.created_at.clone(),
+                            expires_at,
+                        },
+                    )
+                })
+        });
         redaction_status = if artifact_result.is_ok() {
             "redacted_raw_encrypted"
         } else {
@@ -3698,20 +3699,22 @@ fn storage_health_with_free_disk_or_unavailable(
     event_writer: Option<&crate::event_writer::EventWriterHealth>,
 ) -> StorageHealth {
     storage_health_with_free_disk(coven_home, free_disk_bytes, event_writer).unwrap_or_else(
-        |error| unavailable_storage_health(error, Some(free_disk_bytes), event_writer),
+        |error| unavailable_storage_health(coven_home, error, Some(free_disk_bytes), event_writer),
     )
 }
 
 pub fn unavailable_storage_health(
+    coven_home: &Path,
     _error: impl ToString,
     known_free_disk_bytes: Option<u64>,
     event_writer: Option<&crate::event_writer::EventWriterHealth>,
 ) -> StorageHealth {
+    let store_path = coven_home.join("coven.sqlite3");
     let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
     StorageHealth {
         status: "degraded".to_string(),
-        database_bytes: 0,
-        wal_bytes: 0,
+        database_bytes: file_size(&store_path),
+        wal_bytes: file_size(&wal_path(&store_path)),
         oldest_retained_event_at: None,
         last_prune_at: None,
         prune_age_seconds: None,
@@ -4937,6 +4940,33 @@ mod tests {
     }
 
     #[test]
+    fn raw_artifact_zero_day_retention_uses_the_one_day_minimum() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("privacy.toml"),
+            "persist_raw_artifacts = true\nraw_artifact_retention_days = 0\n",
+        )?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        let fake = fake_openai_key();
+        let record = EventRecord {
+            seq: 0,
+            id: "event-zero-retention".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "output".to_string(),
+            payload_json: serde_json::json!({ "data": format!("secret {fake}") }).to_string(),
+            created_at: "2026-04-27T06:01:00Z".to_string(),
+        };
+
+        insert_event_with_privacy(&conn, temp_dir.path(), &record)?;
+
+        let artifact = get_sensitive_artifact(&conn, "session-1", "event-zero-retention")?
+            .expect("artifact should use the minimum retention instead of expiring immediately");
+        assert_eq!(artifact.expires_at, "2026-04-28T06:01:00.000000000Z");
+        Ok(())
+    }
+
+    #[test]
     fn raw_artifact_key_failure_keeps_redacted_event_only() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         std::fs::write(
@@ -5372,14 +5402,6 @@ mod tests {
         Ok(())
     }
 
-    fn unavailable_storage_health_for_test(
-        error: impl ToString,
-        known_free_disk_bytes: Option<u64>,
-        event_writer: Option<&crate::event_writer::EventWriterHealth>,
-    ) -> StorageHealth {
-        unavailable_storage_health(error, known_free_disk_bytes, event_writer)
-    }
-
     fn storage_health_after_sampling_free_disk_for_test(
         coven_home: &Path,
         free_disk_bytes: u64,
@@ -5393,7 +5415,11 @@ mod tests {
     ) -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let home = temp_dir.path();
-        open_store(&home.join("coven.sqlite3"))?;
+        let store_path = home.join("coven.sqlite3");
+        open_store(&store_path)?;
+        let expected_database_bytes = std::fs::metadata(&store_path)?.len();
+        let wal_path = wal_path(&store_path);
+        std::fs::write(&wal_path, b"wal")?;
         std::fs::write(
             home.join("privacy.toml"),
             "log_retention_days = \"broken\"\n",
@@ -5418,6 +5444,8 @@ mod tests {
         );
 
         assert_eq!(health.status, "degraded");
+        assert_eq!(health.database_bytes, expected_database_bytes);
+        assert_eq!(health.wal_bytes, 3);
         assert_eq!(health.free_disk_bytes, MAINTENANCE_MIN_FREE_DISK_BYTES);
         assert!(!health.maintenance_blocked);
         assert_eq!(health.writer_backlog_events, 7);
@@ -5476,7 +5504,9 @@ mod tests {
     }
 
     #[test]
-    fn unavailable_storage_health_without_known_free_disk_preserves_backlog_without_blocking() {
+    fn unavailable_storage_health_without_known_free_disk_preserves_backlog_without_blocking(
+    ) -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
         let writer = crate::event_writer::EventWriterHealth {
             state: "pressured".to_string(),
             queued_events: 7,
@@ -5490,7 +5520,7 @@ mod tests {
             last_error: None,
         };
 
-        let health = unavailable_storage_health_for_test("boom", None, Some(&writer));
+        let health = unavailable_storage_health(temp_dir.path(), "boom", None, Some(&writer));
 
         assert_eq!(health.status, "degraded");
         assert_eq!(health.free_disk_bytes, 0);
@@ -5501,6 +5531,7 @@ mod tests {
             health.last_maintenance_error.as_deref(),
             Some("storage health unavailable")
         );
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -30,6 +30,22 @@ const MAINTENANCE_MAX_BATCHES_PER_TICK: i64 = 10;
 const MAINTENANCE_CHECKPOINT_WAL_BYTES: u64 = 16 * 1024 * 1024;
 pub const MAINTENANCE_MIN_FREE_DISK_BYTES: u64 = 256 * 1024 * 1024;
 const MAINTENANCE_WARN_FREE_DISK_BYTES: u64 = 1024 * 1024 * 1024;
+const BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_EXPIRY_SQL: &str = "DELETE FROM sensitive_artifacts
+     WHERE rowid IN (
+        SELECT rowid FROM sensitive_artifacts
+        INDEXED BY idx_sensitive_artifacts_expires_at
+        WHERE expires_at < ?1
+        ORDER BY expires_at, rowid
+        LIMIT ?2
+     )";
+const BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_CREATED_AT_SQL: &str = "DELETE FROM sensitive_artifacts
+     WHERE rowid IN (
+        SELECT rowid FROM sensitive_artifacts
+        INDEXED BY idx_sensitive_artifacts_created_at
+        WHERE created_at < ?1
+        ORDER BY created_at, rowid
+        LIMIT ?2
+     )";
 pub const DEFAULT_SESSION_PAGE_LIMIT: usize = 100;
 pub const MAX_SESSION_PAGE_LIMIT: usize = 1_000;
 
@@ -3436,31 +3452,33 @@ fn prune_sensitive_artifacts_bounded(
     retention_cutoff: &str,
     limit: i64,
 ) -> Result<usize> {
+    let limit = limit.max(1);
     let tx = conn
         .unchecked_transaction()
         .context("failed to start bounded artifact-prune transaction")?;
-    let pruned = tx
+    let expired_pruned = tx
         .execute(
-            "DELETE FROM sensitive_artifacts
-             WHERE rowid IN (
-                SELECT rowid FROM (
-                    -- Split predicates so each can use a supporting index while
-                    -- keeping global ordering by artifact age for bounded passes.
-                    SELECT rowid, created_at FROM sensitive_artifacts
-                    WHERE expires_at < ?1
-                    UNION
-                    SELECT rowid, created_at FROM sensitive_artifacts
-                    WHERE created_at < ?2
-                ) AS candidates
-                ORDER BY created_at, rowid
-                LIMIT ?3
-             )",
-            params![now, retention_cutoff, limit.max(1)],
+            BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_EXPIRY_SQL,
+            params![now, limit],
         )
-        .context("failed to prune bounded sensitive-artifact batch")?;
+        .context("failed to prune bounded expired sensitive-artifact batch")?;
+    let remaining_capacity = limit.saturating_sub(
+        i64::try_from(expired_pruned).context("bounded artifact prune deleted too many rows")?,
+    );
+    let aged_pruned = if remaining_capacity > 0 {
+        tx.execute(
+            BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_CREATED_AT_SQL,
+            params![retention_cutoff, remaining_capacity],
+        )
+        .context("failed to prune bounded aged sensitive-artifact batch")?
+    } else {
+        0
+    };
     tx.commit()
         .context("failed to commit bounded artifact-prune transaction")?;
-    Ok(pruned)
+    expired_pruned
+        .checked_add(aged_pruned)
+        .context("bounded sensitive-artifact prune overflowed")
 }
 
 /// Run the daemon's bounded retention tick. It deliberately never invokes
@@ -3616,10 +3634,10 @@ fn storage_health_with_free_disk(
         });
     }
 
+    let config = privacy::load_with_settings(coven_home, crate::settings::cached())
+        .context("failed to load privacy settings for storage health")?;
     let conn = open_existing_store_read_only(&store_path)?
         .ok_or_else(|| anyhow::anyhow!("Coven store is unavailable"))?;
-    let config =
-        privacy::load_with_settings(coven_home, crate::settings::cached()).unwrap_or_default();
     // `MIN(created_at)` is NULL on an empty ledger, so the column type has to be
     // stated: `row.get` cannot infer `Option<String>` from the comparison below.
     let oldest_retained_event_at: Option<String> = conn
@@ -5154,6 +5172,10 @@ mod tests {
     ) -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let home = temp_dir.path();
+        std::fs::write(
+            home.join("privacy.toml"),
+            "log_retention_days = \"broken\"\n",
+        )?;
         let writer = crate::event_writer::EventWriterHealth {
             state: "pressured".to_string(),
             queued_events: 7,
@@ -5198,6 +5220,23 @@ mod tests {
 
         assert!(error.to_string().contains("store"));
         assert!(!home.join("coven.sqlite3").exists());
+    }
+
+    #[test]
+    fn storage_health_above_watermark_returns_err_for_malformed_privacy_config() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        open_store(&home.join("coven.sqlite3"))?;
+        std::fs::write(
+            home.join("privacy.toml"),
+            "log_retention_days = \"broken\"\n",
+        )?;
+
+        let error = storage_health_with_free_disk(home, MAINTENANCE_MIN_FREE_DISK_BYTES, None)
+            .expect_err("malformed privacy config must fail closed above the watermark");
+
+        assert!(error.to_string().contains("privacy"));
+        Ok(())
     }
 
     #[test]
@@ -5424,6 +5463,156 @@ mod tests {
             2
         );
         assert_eq!(count_sensitive_artifacts(&conn)?, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn bounded_sensitive_artifact_pruning_respects_total_limit_and_converges() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "event-1".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({ "data": "raw payload" }).to_string(),
+                created_at: "2026-04-20T00:00:00Z".to_string(),
+            },
+        )?;
+
+        for record in [
+            SensitiveArtifactRecord {
+                id: "expired-only".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![1, 2, 3],
+                created_at: "2026-04-26T12:00:00Z".to_string(),
+                expires_at: "2026-04-26T18:00:00Z".to_string(),
+            },
+            SensitiveArtifactRecord {
+                id: "age-only".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![4, 5, 6],
+                created_at: "2026-04-20T00:00:00Z".to_string(),
+                expires_at: "2026-05-20T00:00:00Z".to_string(),
+            },
+            SensitiveArtifactRecord {
+                id: "expired-and-aged-1".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![7, 8, 9],
+                created_at: "2026-04-18T00:00:00Z".to_string(),
+                expires_at: "2026-04-19T00:00:00Z".to_string(),
+            },
+            SensitiveArtifactRecord {
+                id: "expired-and-aged-2".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![10, 11, 12],
+                created_at: "2026-04-17T00:00:00Z".to_string(),
+                expires_at: "2026-04-18T00:00:00Z".to_string(),
+            },
+            SensitiveArtifactRecord {
+                id: "fresh".to_string(),
+                session_id: "session-1".to_string(),
+                event_id: "event-1".to_string(),
+                kind: "output".to_string(),
+                nonce: vec![0; 24],
+                ciphertext: vec![13, 14, 15],
+                created_at: "2026-04-27T00:00:00Z".to_string(),
+                expires_at: "2026-05-27T00:00:00Z".to_string(),
+            },
+        ] {
+            insert_sensitive_artifact(&conn, &record)?;
+        }
+
+        let now = "2026-04-27T00:00:00Z";
+        let cutoff = retention_cutoff(now, 1);
+        assert_eq!(count_prunable_sensitive_artifacts(&conn, now, &cutoff)?, 4);
+
+        let first_pruned = prune_sensitive_artifacts_bounded(&conn, now, &cutoff, 2)?;
+        assert_eq!(first_pruned, 2);
+        assert_eq!(count_sensitive_artifacts(&conn)?, 3);
+        assert_eq!(count_prunable_sensitive_artifacts(&conn, now, &cutoff)?, 2);
+
+        let second_pruned = prune_sensitive_artifacts_bounded(&conn, now, &cutoff, 2)?;
+        assert_eq!(second_pruned, 2);
+        assert_eq!(count_sensitive_artifacts(&conn)?, 1);
+        assert_eq!(count_prunable_sensitive_artifacts(&conn, now, &cutoff)?, 0);
+
+        let third_pruned = prune_sensitive_artifacts_bounded(&conn, now, &cutoff, 2)?;
+        assert_eq!(third_pruned, 0);
+        assert!(get_sensitive_artifact(&conn, "session-1", "fresh")?.is_some());
+        assert_eq!(pragma_integrity_check(&conn)?, vec!["ok"]);
+        Ok(())
+    }
+
+    fn explain_query_plan<P: rusqlite::Params>(
+        conn: &Connection,
+        sql: &str,
+        params: P,
+    ) -> Result<Vec<String>> {
+        let explain_sql = format!("EXPLAIN QUERY PLAN {sql}");
+        let mut stmt = conn
+            .prepare(&explain_sql)
+            .with_context(|| format!("failed to prepare query plan for {sql}"))?;
+        let rows = stmt
+            .query_map(params, |row| row.get::<_, String>(3))
+            .context("failed to run query plan")?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .context("failed to read query plan")
+    }
+
+    #[test]
+    fn bounded_sensitive_artifact_prune_queries_use_supporting_indexes() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+
+        let expiry_plan = explain_query_plan(
+            &conn,
+            BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_EXPIRY_SQL,
+            params!["2026-04-27T00:00:00Z", 2],
+        )?;
+        let retention_plan = explain_query_plan(
+            &conn,
+            BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_CREATED_AT_SQL,
+            params!["2026-04-26T00:00:00Z", 2],
+        )?;
+
+        for (plan, expected_index) in [
+            (&expiry_plan, "idx_sensitive_artifacts_expires_at"),
+            (&retention_plan, "idx_sensitive_artifacts_created_at"),
+        ] {
+            assert!(
+                plan.iter().any(|detail| detail.contains(expected_index)),
+                "expected {expected_index} in query plan: {plan:?}"
+            );
+            assert!(
+                !plan
+                    .iter()
+                    .any(|detail| detail.contains("SCAN sensitive_artifacts")),
+                "unexpected full table scan: {plan:?}"
+            );
+            assert!(
+                !plan
+                    .iter()
+                    .any(|detail| detail.contains("USE TEMP B-TREE FOR ORDER BY")),
+                "unexpected temp b-tree sort: {plan:?}"
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -2860,33 +2860,35 @@ pub fn insert_event_with_privacy(
     insert_event_raw(conn, record, &redacted_payload, redaction_status, sensitive)?;
 
     if config.persist_raw_artifacts && sensitive {
-        let artifact_result = SensitiveArtifactStore::load(coven_home)
-            .and_then(|store| {
-                store.encrypt(
-                    &record.session_id,
-                    &record.id,
-                    &record.kind,
-                    record.payload_json.as_bytes(),
-                )
-            })
-            .and_then(|encrypted| {
-                insert_sensitive_artifact(
-                    conn,
-                    &SensitiveArtifactRecord {
-                        id: record.id.clone(),
-                        session_id: record.session_id.clone(),
-                        event_id: record.id.clone(),
-                        kind: record.kind.clone(),
-                        nonce: encrypted.nonce,
-                        ciphertext: encrypted.ciphertext,
-                        created_at: record.created_at.clone(),
-                        expires_at: retention_expires_at(
-                            &record.created_at,
-                            config.raw_artifact_retention_days,
-                        ),
-                    },
-                )
-            });
+        let artifact_result =
+            retention_expires_at(&record.created_at, config.raw_artifact_retention_days).and_then(
+                |expires_at| {
+                    SensitiveArtifactStore::load(coven_home)
+                        .and_then(|store| {
+                            store.encrypt(
+                                &record.session_id,
+                                &record.id,
+                                &record.kind,
+                                record.payload_json.as_bytes(),
+                            )
+                        })
+                        .and_then(|encrypted| {
+                            insert_sensitive_artifact(
+                                conn,
+                                &SensitiveArtifactRecord {
+                                    id: record.id.clone(),
+                                    session_id: record.session_id.clone(),
+                                    event_id: record.id.clone(),
+                                    kind: record.kind.clone(),
+                                    nonce: encrypted.nonce,
+                                    ciphertext: encrypted.ciphertext,
+                                    created_at: record.created_at.clone(),
+                                    expires_at,
+                                },
+                            )
+                        })
+                },
+            );
         redaction_status = if artifact_result.is_ok() {
             "redacted_raw_encrypted"
         } else {
@@ -3530,8 +3532,8 @@ fn run_scheduled_maintenance_with_config_and_free_disk(
         });
     }
 
-    let raw_cutoff = retention_cutoff(now, config.raw_artifact_retention_days.max(1));
-    let event_cutoff = retention_cutoff(now, config.log_retention_days.max(1));
+    let raw_cutoff = retention_cutoff(now, config.raw_artifact_retention_days.max(1))?;
+    let event_cutoff = retention_cutoff(now, config.log_retention_days.max(1))?;
     let store_path = coven_home.join("coven.sqlite3");
     let conn = open_store(&store_path)?;
     let mut raw_artifacts_pruned = 0usize;
@@ -3640,6 +3642,12 @@ fn storage_health_with_free_disk(
 
     let config = privacy::load_with_settings(coven_home, crate::settings::cached())
         .context("failed to load privacy settings for storage health")?;
+    let retention_cutoff = retention_cutoff(
+        &Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true),
+        config.log_retention_days.max(1),
+    )?;
+    let retention_cutoff = parse_rfc3339_utc(&retention_cutoff)
+        .context("failed to parse calculated retention cutoff")?;
     let conn = open_existing_store_read_only(&store_path)?
         .ok_or_else(|| anyhow::anyhow!("Coven store is unavailable"))?;
     // `MIN(created_at)` is NULL on an empty ledger, so the column type has to be
@@ -3647,16 +3655,10 @@ fn storage_health_with_free_disk(
     let oldest_retained_event_at: Option<String> = conn
         .query_row("SELECT MIN(created_at) FROM events", [], |row| row.get(0))
         .context("failed to read oldest retained event")?;
-    let retention_cutoff = retention_cutoff(
-        &Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true),
-        config.log_retention_days.max(1),
-    );
-    let retention_cutoff = parse_rfc3339_utc(&retention_cutoff);
     let retention_lagging = oldest_retained_event_at
         .as_deref()
         .and_then(parse_rfc3339_utc)
-        .zip(retention_cutoff)
-        .is_some_and(|(oldest_at, retention_cutoff)| oldest_at < retention_cutoff);
+        .is_some_and(|oldest_at| oldest_at < retention_cutoff);
     let last_prune_at = get_store_meta(&conn, MAINTENANCE_LAST_PRUNE_KEY)?;
     let last_checkpoint_at = get_store_meta(&conn, MAINTENANCE_LAST_CHECKPOINT_KEY)?;
     let last_maintenance_error =
@@ -3795,18 +3797,29 @@ fn set_store_meta(conn: &Connection, key: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn retention_cutoff(now: &str, days: u64) -> String {
-    let parsed = chrono::DateTime::parse_from_rfc3339(now)
-        .map(|dt| dt.with_timezone(&Utc))
-        .unwrap_or_else(|_| Utc::now());
-    (parsed - Duration::days(days as i64)).to_rfc3339_opts(SecondsFormat::Nanos, true)
+fn retention_duration(days: u64) -> Result<Duration> {
+    let days = i64::try_from(days).context("retention days exceed the supported integer range")?;
+    Duration::try_days(days).context("retention days exceed the supported duration range")
 }
 
-fn retention_expires_at(created_at: &str, days: u64) -> String {
+pub fn retention_cutoff(now: &str, days: u64) -> Result<String> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(now)
+        .map(|dt| dt.with_timezone(&Utc))
+        .context("invalid retention cutoff timestamp")?;
+    let cutoff = parsed
+        .checked_sub_signed(retention_duration(days)?)
+        .context("retention cutoff timestamp exceeds the supported date range")?;
+    Ok(cutoff.to_rfc3339_opts(SecondsFormat::Nanos, true))
+}
+
+fn retention_expires_at(created_at: &str, days: u64) -> Result<String> {
     let parsed = chrono::DateTime::parse_from_rfc3339(created_at)
         .map(|dt| dt.with_timezone(&Utc))
-        .unwrap_or_else(|_| Utc::now());
-    (parsed + Duration::days(days as i64)).to_rfc3339_opts(SecondsFormat::Nanos, true)
+        .context("invalid retention expiry timestamp")?;
+    let expires_at = parsed
+        .checked_add_signed(retention_duration(days)?)
+        .context("retention expiry timestamp exceeds the supported date range")?;
+    Ok(expires_at.to_rfc3339_opts(SecondsFormat::Nanos, true))
 }
 
 pub fn artifact_payload(record: &SensitiveArtifactRecord) -> EncryptedPayload {
@@ -4959,6 +4972,38 @@ mod tests {
     }
 
     #[test]
+    fn raw_artifact_unrepresentable_retention_keeps_redacted_event_only() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("privacy.toml"),
+            "persist_raw_artifacts = true\nraw_artifact_retention_days = 100000000\n",
+        )?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        let fake = fake_openai_key();
+        let record = EventRecord {
+            seq: 0,
+            id: "event-overflow".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "input".to_string(),
+            payload_json: serde_json::json!({ "data": format!("secret {fake}") }).to_string(),
+            created_at: "2026-04-27T06:01:00Z".to_string(),
+        };
+
+        insert_event_with_privacy(&conn, temp_dir.path(), &record)?;
+
+        let (payload, status): (String, String) = conn.query_row(
+            "SELECT payload_json, redaction_status FROM events WHERE id = 'event-overflow'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )?;
+        assert!(!payload.contains(&fake));
+        assert_eq!(status, "redacted_raw_unavailable");
+        assert_eq!(count_sensitive_artifacts(&conn)?, 0);
+        Ok(())
+    }
+
+    #[test]
     fn pruning_removes_expired_artifacts_and_old_events() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let conn = open_store(&temp_dir.path().join("coven.db"))?;
@@ -4995,7 +5040,7 @@ mod tests {
 
         let pruned_artifacts =
             prune_sensitive_artifacts(&conn, "2026-05-01T00:00:00Z", "2026-04-24T00:00:00Z")?;
-        let cutoff = retention_cutoff("2026-05-01T00:00:00Z", 7);
+        let cutoff = retention_cutoff("2026-05-01T00:00:00Z", 7)?;
         let pruned_events = prune_events_older_than(&conn, &cutoff)?;
 
         assert_eq!(pruned_artifacts, 1);
@@ -5124,6 +5169,108 @@ mod tests {
         assert_eq!(report.events_pruned, 1);
         let conn = open_store(&path)?;
         assert!(list_events(&conn, "session-1")?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_unrepresentable_retention_preserves_existing_rows() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "retained-event".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"data":"retain me"}"#.to_string(),
+                created_at: "2026-04-25T00:00:00Z".to_string(),
+            },
+        )?;
+        drop(conn);
+        let config = PrivacyConfig {
+            persist_raw_artifacts: false,
+            raw_artifact_retention_days: 7,
+            log_retention_days: u64::MAX,
+            extra_patterns: Vec::new(),
+        };
+
+        run_scheduled_maintenance_with_config_and_free_disk(
+            home,
+            "2026-04-27T06:00:00Z",
+            MAINTENANCE_MIN_FREE_DISK_BYTES,
+            &config,
+        )
+        .expect_err("unrepresentable retention must fail closed");
+
+        let conn = open_store(&path)?;
+        assert_eq!(list_events(&conn, "session-1")?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_unrepresentable_retention_does_not_create_store() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let config = PrivacyConfig {
+            persist_raw_artifacts: false,
+            raw_artifact_retention_days: u64::MAX,
+            log_retention_days: 30,
+            extra_patterns: Vec::new(),
+        };
+
+        run_scheduled_maintenance_with_config_and_free_disk(
+            home,
+            "2026-04-27T06:00:00Z",
+            MAINTENANCE_MIN_FREE_DISK_BYTES,
+            &config,
+        )
+        .expect_err("unrepresentable retention must fail before opening the store");
+
+        assert!(!home.join("coven.sqlite3").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_invalid_timestamp_does_not_create_store() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+
+        run_scheduled_maintenance_with_config_and_free_disk(
+            home,
+            "not-a-timestamp",
+            MAINTENANCE_MIN_FREE_DISK_BYTES,
+            &PrivacyConfig::default(),
+        )
+        .expect_err("invalid maintenance timestamps must fail before opening the store");
+
+        assert!(!home.join("coven.sqlite3").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn scheduled_maintenance_timestamp_range_overflow_does_not_create_store() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let config = PrivacyConfig {
+            persist_raw_artifacts: false,
+            raw_artifact_retention_days: 7,
+            log_retention_days: 100_000_000,
+            extra_patterns: Vec::new(),
+        };
+
+        run_scheduled_maintenance_with_config_and_free_disk(
+            home,
+            "2026-04-27T06:00:00Z",
+            MAINTENANCE_MIN_FREE_DISK_BYTES,
+            &config,
+        )
+        .expect_err("timestamp range overflow must fail before opening the store");
+
+        assert!(!home.join("coven.sqlite3").exists());
         Ok(())
     }
 
@@ -5308,6 +5455,23 @@ mod tests {
             .expect_err("malformed privacy config must fail closed above the watermark");
 
         assert!(error.to_string().contains("privacy"));
+        Ok(())
+    }
+
+    #[test]
+    fn storage_health_unrepresentable_retention_does_not_open_missing_store() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        std::fs::write(
+            home.join("privacy.toml"),
+            "log_retention_days = 9223372036854775807\n",
+        )?;
+
+        let error = storage_health_with_free_disk(home, MAINTENANCE_MIN_FREE_DISK_BYTES, None)
+            .expect_err("unrepresentable retention must fail before opening the store");
+
+        assert!(error.to_string().contains("retention"));
+        assert!(!home.join("coven.sqlite3").exists());
         Ok(())
     }
 
@@ -5552,7 +5716,7 @@ mod tests {
             },
         )?;
 
-        let cutoff = retention_cutoff("2026-04-27T00:00:00Z", 1);
+        let cutoff = retention_cutoff("2026-04-27T00:00:00Z", 1)?;
 
         assert_eq!(
             count_prunable_sensitive_artifacts(&conn, "2026-04-27T00:00:00Z", &cutoff)?,
@@ -5639,7 +5803,7 @@ mod tests {
         }
 
         let now = "2026-04-27T00:00:00Z";
-        let cutoff = retention_cutoff(now, 1);
+        let cutoff = retention_cutoff(now, 1)?;
         assert_eq!(count_prunable_sensitive_artifacts(&conn, now, &cutoff)?, 4);
 
         let first_pruned = prune_sensitive_artifacts_bounded(&conn, now, &cutoff, 2)?;

--- a/docs/superpowers/plans/2026-08-05-retention-health-replacement.md
+++ b/docs/superpowers/plans/2026-08-05-retention-health-replacement.md
@@ -1,0 +1,712 @@
+# Retention Health Replacement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port PR #608's bounded SQLite retention and storage-health work onto current `main` without regressing live event-writer or session-handoff health.
+
+**Architecture:** Preserve current `main` as the authority and import PR #608 file-by-file from its exact head. Add accepted-but-uncommitted event counts to the existing writer snapshot, feed that snapshot into the imported storage-health collector, and expose `eventWriter` and `storage` side by side.
+
+**Tech Stack:** Rust, rusqlite/SQLite, fs2, serde, Cargo, Git three-way patches, GitHub CLI.
+
+---
+
+## File Structure
+
+- Modify `crates/coven-cli/src/event_writer.rs`: maintain exact queued event and byte counts through commit completion.
+- Modify `crates/coven-cli/src/store.rs`: port bounded retention, storage health, indexes, deterministic seams, and tests from PR #608.
+- Modify `crates/coven-cli/src/daemon.rs`: port recovery-log rotation and the scheduled maintenance thread.
+- Modify `crates/coven-cli/src/api.rs`: preserve current health fields and add storage health populated from the writer snapshot.
+- Modify `docs/daemon/health.md`: document both event-writer and storage health without stale future-work claims.
+- Modify `docs/reference/api.md`: add the storage response while retaining current capability and event-writer documentation.
+- Modify `docs/reference/cli-logs.md`: document scheduled retention and explicit compaction.
+
+## Fixed Port Inputs
+
+Resolve PR #608's head and base through the GitHub REST API and fetch them as
+`origin/pr-608` and `origin/pr-608-base` throughout. Run every command from the
+dedicated `fix/597-retention-health-v2` worktree; command blocks normalize to
+that worktree's root with `git rev-parse`.
+
+Every implementation commit must use `git commit -s` and include verified
+GitHub-linked `Co-authored-by` trailers for Timothy Wayne Gregg
+(`CompleteDotTech`) and Copilot. Resolve their numeric IDs with `gh api
+users/<login>` rather than embedding addresses in this document.
+
+Before committing, populate the trailer variables from REST-resolved IDs:
+
+```bash
+TIMOTHY_ID="$(gh api users/CompleteDotTech --jq .id)"
+COPILOT_ID="$(gh api users/Copilot --jq .id)"
+TIMOTHY_COAUTHOR_TRAILER="Co-authored-by: Timothy Wayne Gregg <${TIMOTHY_ID}+CompleteDotTech@users.noreply.github.com>"
+COPILOT_COAUTHOR_TRAILER="Co-authored-by: Copilot <${COPILOT_ID}+Copilot@users.noreply.github.com>"
+```
+
+### Task 1: Add Exact Event-Writer Backlog Counts
+
+**Files:**
+- Modify: `crates/coven-cli/src/event_writer.rs:31-115`
+- Modify: `crates/coven-cli/src/event_writer.rs:191-275`
+- Modify: `crates/coven-cli/src/event_writer.rs:482-506`
+- Test: `crates/coven-cli/src/event_writer.rs:524-703`
+
+- [ ] **Step 1: Refresh the claim and verify the source PR**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+coven claim heartbeat issue-597
+PR_HEAD="$(gh api repos/OpenCoven/coven/pulls/608 --jq .head.sha)"
+PR_BASE="$(gh api repos/OpenCoven/coven/pulls/608 --jq .base.sha)"
+git fetch origin "$PR_HEAD":refs/remotes/origin/pr-608 --force
+git fetch origin "$PR_BASE":refs/remotes/origin/pr-608-base --force
+test "$(git rev-parse origin/pr-608)" = "$PR_HEAD"
+test "$(git rev-parse origin/pr-608-base)" = "$PR_BASE"
+```
+
+Expected: claim renewal succeeds and the fetched PR head matches the fixed SHA.
+
+- [ ] **Step 2: Write a failing queue-accounting unit test**
+
+Add this test to `event_writer.rs`:
+
+```rust
+#[test]
+fn queue_health_counts_events_until_completion() {
+    let shared = Arc::new(Shared {
+        queue: Mutex::new(Queue {
+            items: VecDeque::new(),
+            queued_events: 2,
+            queued_bytes: EVENT_OVERHEAD_BYTES * 2,
+            failed: None,
+        }),
+        available: Condvar::new(),
+        capacity_bytes: DEFAULT_CAPACITY_BYTES,
+        output_capacity_bytes: DEFAULT_CAPACITY_BYTES - RESERVED_CRITICAL_BYTES,
+        health: Mutex::new(EventWriterHealth {
+            state: "healthy".to_string(),
+            queued_events: 2,
+            queued_bytes: EVENT_OVERHEAD_BYTES * 2,
+            capacity_bytes: DEFAULT_CAPACITY_BYTES,
+            dropped_output_events: 0,
+            dropped_output_bytes: 0,
+            connection_opens: 0,
+            transactions: 0,
+            committed_events: 0,
+            last_error: None,
+        }),
+    });
+
+    release_capacity(&shared, 1, EVENT_OVERHEAD_BYTES);
+
+    let health = lock_health(&shared);
+    assert_eq!(health.queued_events, 1);
+    assert_eq!(health.queued_bytes, EVENT_OVERHEAD_BYTES);
+}
+```
+
+- [ ] **Step 3: Run the test and verify RED**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo test -p coven-cli queue_health_counts_events_until_completion --locked
+```
+
+Expected: compilation fails because `queued_events` and `release_capacity` do not exist.
+
+- [ ] **Step 4: Add queued-event state**
+
+Update the structs and initializers:
+
+```rust
+pub struct EventWriterHealth {
+    pub state: String,
+    pub queued_events: usize,
+    pub queued_bytes: usize,
+    pub capacity_bytes: usize,
+    pub dropped_output_events: u64,
+    pub dropped_output_bytes: u64,
+    pub connection_opens: u64,
+    pub transactions: u64,
+    pub committed_events: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_error: Option<String>,
+}
+
+struct Queue {
+    items: VecDeque<QueuedEvent>,
+    queued_events: usize,
+    queued_bytes: usize,
+    failed: Option<String>,
+}
+```
+
+Set both new fields to zero in `EventWriter::start_with_capacity`.
+
+- [ ] **Step 5: Update enqueue and health synchronization**
+
+For both `enqueue_output` and `enqueue_critical`, increment before publishing:
+
+```rust
+queue.queued_events += 1;
+queue.queued_bytes += bytes;
+self.update_queue_health(queue.queued_events, queue.queued_bytes);
+```
+
+Replace `update_queued_bytes` with:
+
+```rust
+fn update_queue_health(&self, events: usize, bytes: usize) {
+    let mut health = self.lock_health();
+    health.queued_events = events;
+    health.queued_bytes = bytes;
+}
+```
+
+- [ ] **Step 6: Release counts only after commit completion**
+
+Replace `release_bytes` with:
+
+```rust
+fn release_capacity(shared: &Arc<Shared>, events: usize, bytes: usize) {
+    let mut queue = lock_queue(shared);
+    queue.queued_events = queue.queued_events.saturating_sub(events);
+    queue.queued_bytes = queue.queued_bytes.saturating_sub(bytes);
+    let mut health = lock_health(shared);
+    health.queued_events = queue.queued_events;
+    health.queued_bytes = queue.queued_bytes;
+    shared.available.notify_all();
+}
+```
+
+After a successful batch commit, call:
+
+```rust
+release_capacity(&shared, batch.len(), bytes);
+```
+
+In `fail_writer`, set both queue and health event/byte counts to zero. Add
+`queued_events` to every test fixture that constructs `Queue` or
+`EventWriterHealth`.
+
+- [ ] **Step 7: Run focused writer tests**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo test -p coven-cli event_writer::tests --locked
+cargo fmt --check
+git diff --check
+```
+
+Expected: all event-writer tests pass and formatting checks are clean.
+
+- [ ] **Step 8: Commit writer accounting**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git add crates/coven-cli/src/event_writer.rs
+python3 scripts/check-coven-privacy.py --staged
+git commit -s -m "feat(runtime): expose queued event backlog" \
+  -m "$TIMOTHY_COAUTHOR_TRAILER" -m "$COPILOT_COAUTHOR_TRAILER"
+```
+
+Expected: one signed commit containing only event-writer accounting and tests.
+
+### Task 2: Port Bounded Retention and Storage Health
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs`
+- Test: `crates/coven-cli/src/store.rs`
+
+- [ ] **Step 1: Apply PR #608's store patch with three-way context**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git diff --binary origin/pr-608-base..origin/pr-608 -- \
+  crates/coven-cli/src/store.rs > /tmp/coven-pr608-store.patch
+git apply --3way /tmp/coven-pr608-store.patch
+```
+
+Expected: the PR's store additions are imported. If Git reports conflicts,
+retain every current-main schema/session-handoff change and add the PR's
+maintenance constants, `StorageHealth`, `ScheduledMaintenanceReport`, indexes,
+bounded prune functions, scheduler helpers, storage-health helpers, and tests.
+
+- [ ] **Step 2: Write the writer-snapshot storage test before integration**
+
+Update the imported storage-health test to construct:
+
+```rust
+let writer = crate::event_writer::EventWriterHealth {
+    state: "pressured".to_string(),
+    queued_events: 7,
+    queued_bytes: 8192,
+    capacity_bytes: 2 * 1024 * 1024,
+    dropped_output_events: 1,
+    dropped_output_bytes: 512,
+    connection_opens: 1,
+    transactions: 3,
+    committed_events: 12,
+    last_error: None,
+};
+
+let health = storage_health(home, Some(&writer))?;
+assert_eq!(health.writer_backlog_events, 7);
+assert_eq!(health.writer_backlog_bytes, 8192);
+```
+
+Update existing imported calls to pass `None`.
+
+- [ ] **Step 3: Run the imported focused tests and verify RED**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo test -p coven-cli scheduled_maintenance --locked
+cargo test -p coven-cli storage_health_flags_stale_retention --locked
+```
+
+Expected: compilation fails until the imported PR code is reconciled with
+current types and the new writer-snapshot signature.
+
+- [ ] **Step 4: Fix the convergence-loop compile errors**
+
+Keep SQL limits as `i64` and compare returned delete counts as `usize`:
+
+```rust
+if raw_batch < MAINTENANCE_ARTIFACT_BATCH_SIZE as usize
+    && event_batch < MAINTENANCE_EVENT_BATCH_SIZE as usize
+{
+    break;
+}
+```
+
+Give the oldest event an explicit type:
+
+```rust
+let oldest_retained_event_at: Option<String> = conn
+    .query_row("SELECT MIN(created_at) FROM events", [], |row| row.get(0))
+    .context("failed to read oldest retained event")?;
+```
+
+Adjust the exact query form to the imported code while preserving
+`Option<String>`.
+
+- [ ] **Step 5: Derive storage backlog from the writer snapshot**
+
+Change the public collector to:
+
+```rust
+pub fn storage_health(
+    coven_home: &Path,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<StorageHealth>
+```
+
+Derive the fields with:
+
+```rust
+let (writer_backlog_events, writer_backlog_bytes) = event_writer
+    .map(|health| {
+        (
+            health.queued_events as u64,
+            health.queued_bytes as u64,
+        )
+    })
+    .unwrap_or_default();
+```
+
+Use those variables in the returned `StorageHealth`.
+
+Change the unavailable constructor to:
+
+```rust
+pub fn unavailable_storage_health(
+    _error: impl ToString,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> StorageHealth
+```
+
+Populate its backlog fields from the same snapshot helper instead of literals.
+
+- [ ] **Step 6: Preserve the reviewed retention behavior**
+
+Verify the imported code includes all of these exact symbols:
+
+```text
+idx_events_created_at
+idx_sensitive_artifacts_created_at
+prune_events_older_than_bounded
+prune_sensitive_artifacts_bounded
+run_scheduled_maintenance
+run_scheduled_maintenance_with_free_disk
+run_scheduled_maintenance_with_config_and_free_disk
+storage_health
+unavailable_storage_health
+record_maintenance_error
+```
+
+Verify the low-disk return occurs before `open_store`, automatic maintenance
+never calls `VACUUM`, checkpoint mode remains `PRAGMA wal_checkpoint(PASSIVE)`,
+and the catch-up loop remains bounded by
+`MAINTENANCE_MAX_BATCHES_PER_TICK`.
+
+- [ ] **Step 7: Run focused store tests**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo test -p coven-cli bounded_event_pruning_keeps_fts_consistent --locked
+cargo test -p coven-cli scheduled_maintenance --locked
+cargo test -p coven-cli thirty_day_synthetic_workload_converges --locked
+cargo test -p coven-cli storage_health_flags_stale_retention --locked
+cargo fmt --check
+git diff --check
+```
+
+Expected: all imported and updated retention/storage tests pass.
+
+- [ ] **Step 8: Commit the store port**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git add crates/coven-cli/src/store.rs
+python3 scripts/check-coven-privacy.py --staged
+git commit -s -m "feat(store): automate bounded retention health" \
+  -m "$TIMOTHY_COAUTHOR_TRAILER" -m "$COPILOT_COAUTHOR_TRAILER"
+```
+
+Expected: one signed store commit preserving contributor credit.
+
+### Task 3: Port Maintenance Scheduling and Recovery-Log Rotation
+
+**Files:**
+- Modify: `crates/coven-cli/src/daemon.rs`
+- Test: `crates/coven-cli/src/daemon.rs`
+
+- [ ] **Step 1: Apply the daemon patch**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git diff --binary origin/pr-608-base..origin/pr-608 -- \
+  crates/coven-cli/src/daemon.rs > /tmp/coven-pr608-daemon.patch
+git apply --3way /tmp/coven-pr608-daemon.patch
+```
+
+Expected: import `DAEMON_RECOVERY_LOG_MAX_BYTES`,
+`DAEMON_RECOVERY_LOG_BACKUPS`, `recovery_log_lock`,
+`rotate_recovery_log`, `start_store_maintenance_scheduler`, both daemon-start
+call sites, and the recovery rotation test. Preserve current main's event
+writer, maintenance gate, session handoff, and lifecycle behavior.
+
+- [ ] **Step 2: Verify scheduler failure behavior**
+
+The imported scheduler must retain:
+
+```rust
+let details = format!("store maintenance pass failed: {error:#}");
+crate::store::record_maintenance_error(&home, &details);
+append_daemon_recovery_log(&home, &details);
+```
+
+The scheduler starts after the live runtime is created on both Unix and
+Windows, waits one interval before the first pass, uses a capped catch-up loop,
+and never blocks daemon startup on maintenance work.
+
+- [ ] **Step 3: Run daemon tests**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo test -p coven-cli append_daemon_recovery_log_creates_and_appends --locked
+cargo test -p coven-cli recovery_log_rotation_keeps_a_bounded_history --locked
+cargo fmt --check
+git diff --check
+```
+
+Expected: recovery log tests pass and no current daemon behavior is deleted.
+
+- [ ] **Step 4: Commit daemon integration**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git add crates/coven-cli/src/daemon.rs
+python3 scripts/check-coven-privacy.py --staged
+git commit -s -m "feat(daemon): schedule bounded store maintenance" \
+  -m "$TIMOTHY_COAUTHOR_TRAILER" -m "$COPILOT_COAUTHOR_TRAILER"
+```
+
+Expected: one signed daemon commit.
+
+### Task 4: Integrate Storage into the Current Health Contract
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs`
+- Modify: `docs/daemon/health.md`
+- Modify: `docs/reference/api.md`
+- Modify: `docs/reference/cli-logs.md`
+- Test: `crates/coven-cli/src/api.rs`
+
+- [ ] **Step 1: Apply the API and documentation patches**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git diff --binary origin/pr-608-base..origin/pr-608 -- \
+  crates/coven-cli/src/api.rs \
+  docs/daemon/health.md \
+  docs/reference/api.md \
+  docs/reference/cli-logs.md > /tmp/coven-pr608-health-docs.patch
+git apply --3way /tmp/coven-pr608-health-docs.patch
+```
+
+Expected: `docs/reference/cli-logs.md` applies cleanly. Resolve other conflicts
+by preserving all current `HealthCapabilities`, `event_writer`, runtime trait,
+session-handoff, and current documentation, then adding storage health.
+
+- [ ] **Step 2: Preserve both health objects**
+
+The response must contain:
+
+```rust
+pub struct HealthResponse {
+    pub ok: bool,
+    pub api_version: String,
+    pub coven_version: String,
+    pub capabilities: HealthCapabilities,
+    pub daemon: Option<DaemonStatus>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hub: Option<HubHealth>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_writer: Option<crate::event_writer::EventWriterHealth>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage: Option<store::StorageHealth>,
+}
+```
+
+Keep `session_handoff: true` in `health_response`.
+
+- [ ] **Step 3: Build storage and event-writer health from one snapshot**
+
+Use:
+
+```rust
+fn health_response_with_hub(
+    coven_home: &Path,
+    daemon: Option<DaemonStatus>,
+    event_writer: Option<crate::event_writer::EventWriterHealth>,
+) -> HealthResponse {
+    let mut response = health_response(daemon);
+    if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
+        response.hub = serde_json::from_value(summary).ok();
+    }
+    response.storage = Some(
+        store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
+            store::unavailable_storage_health(error, event_writer.as_ref())
+        }),
+    );
+    response.event_writer = event_writer;
+    response
+}
+```
+
+Keep the `/health` route passing `runtime.event_writer_health()`.
+
+- [ ] **Step 4: Write a health integration test with a real snapshot fixture**
+
+Add a local runtime fixture:
+
+```rust
+struct HealthRuntime;
+
+impl SessionRuntime for HealthRuntime {
+    fn launch_session(&self, _launch: &SessionLaunch) -> Result<()> {
+        Ok(())
+    }
+
+    fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+        Ok(())
+    }
+
+    fn kill_session(&self, _session_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
+        Some(crate::event_writer::EventWriterHealth {
+            state: "pressured".to_string(),
+            queued_events: 3,
+            queued_bytes: 4096,
+            capacity_bytes: 2 * 1024 * 1024,
+            dropped_output_events: 1,
+            dropped_output_bytes: 256,
+            connection_opens: 1,
+            transactions: 4,
+            committed_events: 20,
+            last_error: None,
+        })
+    }
+}
+```
+
+Call `handle_request_with_runtime` for `/health`, parse the JSON, and assert:
+
+```rust
+assert_eq!(body["capabilities"]["sessionHandoff"], true);
+assert_eq!(body["eventWriter"]["queuedEvents"], 3);
+assert_eq!(body["eventWriter"]["queuedBytes"], 4096);
+assert_eq!(body["storage"]["writerBacklogEvents"], 3);
+assert_eq!(body["storage"]["writerBacklogBytes"], 4096);
+```
+
+- [ ] **Step 5: Correct stale documentation**
+
+In `docs/daemon/health.md`, remove the PR text claiming a future writer will
+populate backlog. State that `storage.writerBacklogEvents` and
+`storage.writerBacklogBytes` mirror the live `eventWriter` queue snapshot.
+
+In `docs/reference/api.md`, retain all current capability fields including
+`sessionHandoff`, document both optional `eventWriter` and `storage` objects,
+and do not remove current session-handoff or event-writer content.
+
+- [ ] **Step 6: Run health and documentation tests**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo test -p coven-cli builds_health_response --locked
+cargo test -p coven-cli routes_health_request_to_json --locked
+cargo test -p coven-cli health_is_the_named_contract_handshake --locked
+python3 scripts/check-api-contract-docs.py
+cargo fmt --check
+git diff --check
+```
+
+Expected: health tests prove both surfaces and the API docs checker passes.
+
+- [ ] **Step 7: Commit API and docs integration**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git add crates/coven-cli/src/api.rs \
+  docs/daemon/health.md \
+  docs/reference/api.md \
+  docs/reference/cli-logs.md
+python3 scripts/check-coven-privacy.py --staged
+git commit -s -m "feat(api): expose integrated storage health" \
+  -m "$TIMOTHY_COAUTHOR_TRAILER" -m "$COPILOT_COAUTHOR_TRAILER"
+```
+
+Expected: one signed integration commit preserving current API behavior.
+
+### Task 5: Validate, Open the Replacement, and Supersede PR #608
+
+**Files:**
+- Verify all seven modified implementation/documentation files.
+- Verify `docs/superpowers/specs/2026-08-05-retention-health-replacement-design.md`.
+- Verify `docs/superpowers/plans/2026-08-05-retention-health-replacement.md`.
+
+- [ ] **Step 1: Run the complete repository gates**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+python3 scripts/check-api-contract-docs.py
+```
+
+Expected: every command passes.
+
+- [ ] **Step 2: Confirm DCO, attribution, and scope**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git status --short
+git --no-pager log --format='%h%n%B%n---' origin/main..HEAD
+git --no-pager diff --stat origin/main...HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Expected: worktree clean; every implementation commit has `Signed-off-by`,
+the Timothy Wayne Gregg and Copilot co-author trailers are present, and the diff
+contains only:
+
+```text
+crates/coven-cli/src/api.rs
+crates/coven-cli/src/daemon.rs
+crates/coven-cli/src/event_writer.rs
+crates/coven-cli/src/store.rs
+docs/daemon/health.md
+docs/reference/api.md
+docs/reference/cli-logs.md
+docs/superpowers/plans/2026-08-05-retention-health-replacement.md
+docs/superpowers/specs/2026-08-05-retention-health-replacement-design.md
+```
+
+- [ ] **Step 3: Push and create the replacement PR**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+git push -u origin fix/597-retention-health-v2
+gh pr create \
+  --repo OpenCoven/coven \
+  --base main \
+  --head fix/597-retention-health-v2 \
+  --title "feat(store): automate bounded retention health" \
+  --body $'## Context\n\n- Summary: Port the reviewed retention and storage-health work from #608 onto current main without regressing event-writer or session-handoff health.\n- Files changed: Rust daemon/store/API/event-writer code and directly related health/log documentation.\n- Closes #597\n\n## Implementation\n\n- Approach: Squash-port #608 onto current main as signed maintainer commits with original contributor attribution.\n- User-visible behavior: Bounded scheduled retention, storage pressure in `/health`, real writer backlog values, and bounded recovery-log rotation.\n- Compatibility notes: `eventWriter` and `sessionHandoff` remain present; `storage` is additive. Automatic maintenance never runs `VACUUM`.\n\n## Verification\n\n- [x] `cargo fmt --check`\n- [x] `cargo clippy --workspace --all-targets -- -D warnings`\n- [x] `cargo test --workspace --locked`\n- [x] `python3 scripts/check-secrets.py`\n- [x] Additional manual checks: `python3 scripts/check-api-contract-docs.py`; focused retention, writer-health, watermark, FTS, and recovery-log tests.\n\n## Risk and Rollback\n\n- Risk level: Medium; changes background SQLite maintenance and additive health fields.\n- Rollback plan: Revert this PR to stop scheduled retention and remove the additive storage health block.\n\n## Agent Handoff\n\n- Current state: Replacement for conflicted/DCO-blocked #608.\n- Follow-ups: Non-blocking review notes from #608 remain separate.\n- Known gaps: No automatic `VACUUM`; compaction remains operator-triggered.'
+```
+
+Expected: a new PR targeting `main` is created.
+
+- [ ] **Step 4: Supersede PR #608**
+
+Store the new URL and comment before closing:
+
+```bash
+NEW_PR_URL="$(gh pr view --repo OpenCoven/coven --json url --jq .url)"
+gh pr comment 608 --repo OpenCoven/coven \
+  --body "Superseded by ${NEW_PR_URL}, which ports this work onto current main, integrates live event-writer health, preserves contributor attribution, and resolves the DCO/compile blockers."
+gh pr close 608 --repo OpenCoven/coven
+```
+
+Expected: PR #608 is closed with a clear pointer to the replacement.
+
+- [ ] **Step 5: Keep the claim active through integration**
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+coven claim heartbeat issue-597
+```
+
+Expected: `issue-597` remains active until the replacement merges or work stops.

--- a/docs/superpowers/plans/2026-08-05-retention-health-replacement.md
+++ b/docs/superpowers/plans/2026-08-05-retention-health-replacement.md
@@ -331,7 +331,9 @@ Change the unavailable constructor to:
 
 ```rust
 pub fn unavailable_storage_health(
+    coven_home: &Path,
     _error: impl ToString,
+    known_free_disk_bytes: Option<u64>,
     event_writer: Option<&crate::event_writer::EventWriterHealth>,
 ) -> StorageHealth
 ```
@@ -520,7 +522,7 @@ fn health_response_with_hub(
     }
     response.storage = Some(
         store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
-            store::unavailable_storage_health(error, event_writer.as_ref())
+            store::unavailable_storage_health(coven_home, error, None, event_writer.as_ref())
         }),
     );
     response.event_writer = event_writer;

--- a/docs/superpowers/specs/2026-08-05-retention-health-replacement-design.md
+++ b/docs/superpowers/specs/2026-08-05-retention-health-replacement-design.md
@@ -1,0 +1,127 @@
+# Retention Health Replacement Design
+
+## Problem
+
+PR #608 implements bounded SQLite retention and storage-pressure health, but its
+head no longer compiles, conflicts with current `main`, predates the live event
+writer and session-handoff health contract, and contains commits that fail DCO.
+The useful retention work must be ported without regressing features that
+landed after the original branch diverged.
+
+## Scope
+
+Create a maintainer replacement for PR #608 from current `origin/main`.
+Resolve only the current merge blockers:
+
+- port the bounded retention, storage health, recovery-log rotation, indexes,
+  tests, and documentation from PR #608;
+- fix the compile errors in the maintenance convergence loop;
+- integrate storage health with the current event-writer and session-handoff
+  health contract;
+- replace unsigned contributor history with signed maintainer commits while
+  preserving contributor attribution.
+
+The non-blocking review notes on PR #608 remain out of scope unless a directly
+coupled correctness issue must be fixed for the port to work.
+
+## Port Strategy
+
+Start from current `origin/main` and squash-port PR #608's net changes. Resolve
+the conflicts once against the current code rather than cherry-picking or
+merging the unsigned seven-commit history.
+
+The replacement implementation commit will include verified GitHub-linked
+`Co-authored-by` trailers for Timothy Wayne Gregg (`CompleteDotTech`) and
+Copilot, using numeric IDs resolved through the GitHub REST API.
+
+The maintainer commit will also carry the repository-required DCO signoff.
+
+## Health Contract Integration
+
+The current `/health` response remains authoritative:
+
+- preserve `capabilities.sessionHandoff`;
+- preserve the existing optional `eventWriter` block;
+- add the optional `storage` block from PR #608 alongside it.
+
+`EventWriterHealth` will gain an exact `queued_events` field maintained with
+the existing queued-byte count. It counts accepted but not yet committed
+events, including an in-flight batch, and is decremented at the same completion
+boundary as queued bytes. The health route will obtain one writer-health
+snapshot from `SessionRuntime`, expose that snapshot as `eventWriter`, and pass
+it to storage-health collection.
+
+`StorageHealth.writerBacklogEvents` and
+`StorageHealth.writerBacklogBytes` will be derived from that live snapshot
+rather than hard-coded to zero. When no runtime writer snapshot is available,
+the values are zero because there is no observed daemon queue.
+
+## Retention and Maintenance Behavior
+
+Port PR #608's reviewed behavior:
+
+- bounded transactional event and sensitive-artifact pruning;
+- indexes that serve the retention scans;
+- a capped per-tick catch-up loop that converges without monopolizing SQLite;
+- retention precedence matching `coven logs prune`;
+- injectable configuration and free-disk seams for deterministic tests;
+- no SQLite open or write below the 256 MiB safety watermark;
+- passive WAL checkpointing only above the threshold;
+- no automatic `VACUUM`;
+- retention-lag participation in storage warning status;
+- bounded recovery-log rotation that preserves valid older archives after a
+  partial prior rotation.
+
+The convergence loop will compare compatible integer types, and
+`oldest_retained_event_at` will have an explicit optional string type so the
+replacement compiles on current Rust targets.
+
+## Error Handling
+
+Maintenance remains fail-closed under disk pressure. Storage-health collection
+returns the explicit unavailable representation when metrics cannot be read,
+while the health response retains the rest of the current daemon contract.
+Transactional pruning continues to rely on SQLite rollback and existing FTS
+triggers for consistency.
+
+No automatic compaction is introduced. Operators continue to use
+`coven vacuum` when they intentionally accept the exclusive compaction cost.
+
+## Tests
+
+Preserve and reconcile PR #608's tests for:
+
+- bounded event and artifact pruning;
+- FTS consistency after interrupted work;
+- configured retention precedence;
+- deterministic free-disk watermark behavior;
+- multi-batch convergence and synthetic steady-state size;
+- retention-lag warning status;
+- passive checkpoint reporting;
+- recovery-log rotation and partial-rotation recovery;
+- storage-health API serialization and documentation.
+
+Add or update tests proving:
+
+- `EventWriterHealth.queuedEvents` tracks the real in-memory queue;
+- `queuedEvents` and `queuedBytes` remain present in `eventWriter`;
+- storage backlog fields are populated from the same writer snapshot;
+- `sessionHandoff` remains present after the health response merge.
+
+Run focused retention, event-writer, health, and recovery-log tests before the
+complete repository gates.
+
+## Delivery
+
+Open a replacement PR from `fix/597-retention-health-v2` that closes issue
+#597 and credits the original contributor. After the replacement is open and
+validated, comment on PR #608 with the replacement link and close #608 as
+superseded.
+
+## Non-Goals
+
+- Addressing every non-blocking observation from PR #608.
+- Redesigning the event writer or its queue limits.
+- Changing retention defaults or public field names introduced by PR #608.
+- Adding automatic `VACUUM`.
+- Rewriting or force-pushing the contributor's fork branch.


### PR DESCRIPTION
## Context

- Summary: Complete bounded event and raw-artifact retention, storage pressure reporting, and fail-closed retention configuration handling.
- Files changed: Rust store, health API, prune command, and implementation/design evidence.
- Closes #597

## Implementation

- Approach: Keep scheduled pruning in small indexed transactions, preserve FTS integrity, leave full VACUUM operator-triggered, expose database/WAL/checkpoint/prune/backlog/free-disk health, and reject malformed or unrepresentable retention values before opening the store.
- User-visible behavior: Health reports degraded storage collection distinctly from a confirmed low-disk maintenance block; prune and raw-artifact paths fail closed on invalid timestamp ranges.
- Compatibility notes: Existing health fields remain compatible; the storage status gains accurate degraded semantics.

## Verification

- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --locked
- [x] python scripts/check-secrets.py
- [x] python3 scripts/check-coven-privacy.py --range origin/main...HEAD
- [x] Focused store suite: 88 passed, including 30-day convergence, interrupted FTS pruning, index plans, malformed config, low-disk safety, and retention overflow.

## Risk and Rollback

- Risk level: Medium; maintenance and health paths change, but pruning remains bounded and fully transaction-backed.
- Rollback plan: Revert the squash commit; no destructive schema migration is introduced.

## Agent Handoff

- Current state: Ready for CI and maintainer review.
- Follow-ups: None.
- Known gaps: None.