### PR TITLE
fix: mark per-session output truncation

### DIFF
--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -96,6 +96,15 @@ enum PendingEvent {
     },
 }
 
+impl PendingEvent {
+    fn session_id(&self) -> &str {
+        match self {
+            Self::Output { session_id, .. } | Self::Exit { session_id, .. } => session_id,
+            Self::Record(record) => &record.session_id,
+        }
+    }
+}
+
 impl EventWriter {
     pub fn start(coven_home: PathBuf) -> Result<Self> {
         Self::start_with_capacity(coven_home, DEFAULT_CAPACITY_BYTES)
@@ -260,37 +269,79 @@ impl EventWriter {
             bytes <= self.shared.capacity_bytes,
             "critical event exceeds event writer capacity"
         );
+        let session_id = event.session_id().to_string();
         let (completion_tx, completion_rx) = mpsc::sync_channel(1);
         let mut queue = self.lock_queue();
-        loop {
-            if let Some(error) = &queue.failed {
-                return Err(anyhow!(error.clone()));
+        let marker = take_truncation_marker(&mut queue, &session_id);
+        let marker_bytes = marker.as_ref().map_or(0, |item| item.bytes);
+        if marker_bytes.saturating_add(bytes) <= self.shared.capacity_bytes {
+            loop {
+                if let Some(error) = &queue.failed {
+                    return Err(anyhow!(error.clone()));
+                }
+                if queue
+                    .queued_bytes
+                    .saturating_add(marker_bytes)
+                    .saturating_add(bytes)
+                    <= self.shared.capacity_bytes
+                {
+                    break;
+                }
+                queue = self
+                    .shared
+                    .available
+                    .wait(queue)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
             }
-            if queue.queued_bytes.saturating_add(bytes) <= self.shared.capacity_bytes {
-                break;
+
+            if let Some(marker) = marker {
+                queue.queued_events += 1;
+                queue.queued_bytes += marker.bytes;
+                queue.items.push_back(marker);
             }
-            queue = self
-                .shared
-                .available
-                .wait(queue)
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-        }
-        queue.queued_events += 1;
-        queue.queued_bytes += bytes;
-        self.update_queue_health(queue.queued_events, queue.queued_bytes);
-        queue.items.push_back(QueuedEvent {
-            event,
-            bytes,
-            completion: Some(completion_tx),
-        });
-        self.shared.available.notify_one();
-        drop(queue);
-        match completion_rx
-            .recv()
-            .context("event writer stopped before committing a critical event")?
-        {
-            Ok(()) => Ok(()),
-            Err(message) => Err(anyhow!(message)),
+            queue.queued_events += 1;
+            queue.queued_bytes += bytes;
+            self.update_queue_health(queue.queued_events, queue.queued_bytes);
+            queue.items.push_back(QueuedEvent {
+                event,
+                bytes,
+                completion: Some(completion_tx),
+            });
+            self.shared.available.notify_one();
+            drop(queue);
+            receive_completion(
+                completion_rx,
+                "event writer stopped before committing a critical event",
+            )
+        } else {
+            let mut marker =
+                marker.expect("marker is required when combined capacity is impossible");
+            let (marker_tx, marker_rx) = mpsc::sync_channel(1);
+            loop {
+                if let Some(error) = &queue.failed {
+                    return Err(anyhow!(error.clone()));
+                }
+                if queue.queued_bytes.saturating_add(marker.bytes) <= self.shared.capacity_bytes {
+                    break;
+                }
+                queue = self
+                    .shared
+                    .available
+                    .wait(queue)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+            }
+            marker.completion = Some(marker_tx);
+            queue.queued_events += 1;
+            queue.queued_bytes += marker.bytes;
+            queue.items.push_back(marker);
+            self.update_queue_health(queue.queued_events, queue.queued_bytes);
+            self.shared.available.notify_one();
+            drop(queue);
+            receive_completion(
+                marker_rx,
+                "event writer stopped before committing truncation marker",
+            )?;
+            self.enqueue_critical(event, bytes)
         }
     }
 
@@ -610,9 +661,20 @@ fn complete(batch: &[QueuedEvent], result: std::result::Result<(), String>) {
     }
 }
 
+fn receive_completion(
+    receiver: mpsc::Receiver<std::result::Result<(), String>>,
+    context: &'static str,
+) -> Result<()> {
+    match receiver.recv().context(context)? {
+        Ok(()) => Ok(()),
+        Err(message) => Err(anyhow!(message)),
+    }
+}
+
 fn fail_writer(shared: &Arc<Shared>, message: String) -> Vec<QueuedEvent> {
     let mut queue = lock_queue(shared);
     queue.failed = Some(message.clone());
+    queue.truncations.clear();
     queue.queued_events = 0;
     queue.queued_bytes = 0;
     let pending = queue.items.drain(..).collect();
@@ -951,6 +1013,108 @@ mod tests {
                 exit_code: Some(1),
             },
         )?;
+        Ok(())
+    }
+
+    #[test]
+    fn exit_closes_pressure_episode_before_terminal_event() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "failed",
+                exit_code: Some(1),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            ["output_truncated", "exit"]
+        );
+        let marker_payload: serde_json::Value = serde_json::from_str(&events[0].payload_json)?;
+        assert_eq!(marker_payload["droppedEvents"], 1);
+        assert_eq!(marker_payload["droppedBytes"], 2048);
+        Ok(())
+    }
+
+    #[test]
+    fn pressure_episodes_are_isolated_per_session() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        store::insert_session(&conn, &session("s-2"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        assert!(!writer.record_output("s-2", "x".repeat(3072))?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+        writer.record_exit(
+            "s-2",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        for (session_id, dropped_bytes) in [("s-1", 2048), ("s-2", 3072)] {
+            let events = store::list_events(&conn, session_id)?;
+            assert_eq!(events[0].kind, "output_truncated");
+            let marker_payload: serde_json::Value = serde_json::from_str(&events[0].payload_json)?;
+            assert_eq!(marker_payload["droppedEvents"], 1);
+            assert_eq!(marker_payload["droppedBytes"], dropped_bytes);
+            assert_eq!(events[1].kind, "exit");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_critical_event_commits_marker_before_waiting_for_its_own_capacity() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let capacity = RESERVED_CRITICAL_BYTES + 1024;
+        let writer = EventWriter::start_with_capacity(home.path().to_path_buf(), capacity)?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        let record = store::EventRecord {
+            seq: 0,
+            id: "event".to_string(),
+            session_id: "s-1".to_string(),
+            kind: "error".to_string(),
+            payload_json: "{}".to_string(),
+            created_at: "2026-08-04T00:00:00Z".to_string(),
+        };
+        writer.enqueue_critical(PendingEvent::Record(record), capacity - 1)?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            ["output_truncated", "error"]
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -7,7 +7,7 @@
 //! be overtaken by a following exit event.
 
 use std::{
-    collections::VecDeque,
+    collections::{HashMap, VecDeque},
     path::PathBuf,
     sync::{mpsc, Arc, Condvar, Mutex},
     thread,
@@ -67,6 +67,13 @@ struct Queue {
     queued_events: usize,
     queued_bytes: usize,
     failed: Option<String>,
+    truncations: HashMap<String, OutputTruncation>,
+}
+
+struct OutputTruncation {
+    dropped_events: u64,
+    dropped_bytes: u64,
+    created_at: String,
 }
 
 struct QueuedEvent {
@@ -105,6 +112,7 @@ impl EventWriter {
                 queued_events: 0,
                 queued_bytes: 0,
                 failed: None,
+                truncations: HashMap::new(),
             }),
             available: Condvar::new(),
             capacity_bytes,
@@ -200,14 +208,40 @@ impl EventWriter {
         if let Some(error) = &queue.failed {
             return Err(anyhow!(error.clone()));
         }
+        let (session_id, dropped_bytes, created_at) = match &event {
+            PendingEvent::Output {
+                session_id,
+                data,
+                created_at,
+            } => (session_id, data.len(), created_at),
+            _ => unreachable!("enqueue_output only accepts output events"),
+        };
         if bytes > self.shared.output_capacity_bytes
             || queue.queued_bytes.saturating_add(bytes) > self.shared.output_capacity_bytes
         {
+            record_output_drop(&mut queue, session_id, dropped_bytes, created_at);
             let mut health = self.lock_health();
             health.state = "pressured".to_string();
-            health.dropped_output_events += 1;
-            health.dropped_output_bytes += bytes.saturating_sub(EVENT_OVERHEAD_BYTES) as u64;
+            health.dropped_output_events = health.dropped_output_events.saturating_add(1);
+            health.dropped_output_bytes = health
+                .dropped_output_bytes
+                .saturating_add(dropped_bytes as u64);
             return Ok(false);
+        }
+        let marker = take_truncation_marker(&mut queue, session_id);
+        let marker_bytes = marker.as_ref().map_or(0, |item| item.bytes);
+        assert!(
+            queue
+                .queued_bytes
+                .saturating_add(marker_bytes)
+                .saturating_add(bytes)
+                <= self.shared.capacity_bytes,
+            "accepted output exceeded event writer capacity"
+        );
+        if let Some(marker) = marker {
+            queue.queued_events += 1;
+            queue.queued_bytes += marker.bytes;
+            queue.items.push_back(marker);
         }
         queue.queued_events += 1;
         queue.queued_bytes += bytes;
@@ -465,6 +499,43 @@ fn output_record(session_id: &str, data: &str, created_at: &str) -> Result<store
     })
 }
 
+fn record_output_drop(queue: &mut Queue, session_id: &str, dropped_bytes: usize, created_at: &str) {
+    let truncation = queue
+        .truncations
+        .entry(session_id.to_string())
+        .or_insert_with(|| OutputTruncation {
+            dropped_events: 0,
+            dropped_bytes: 0,
+            created_at: created_at.to_string(),
+        });
+    truncation.dropped_events = truncation.dropped_events.saturating_add(1);
+    truncation.dropped_bytes = truncation
+        .dropped_bytes
+        .saturating_add(dropped_bytes as u64);
+}
+
+fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedEvent> {
+    let truncation = queue.truncations.remove(session_id)?;
+    let payload_json = serde_json::to_string(&json!({
+        "droppedEvents": truncation.dropped_events,
+        "droppedBytes": truncation.dropped_bytes,
+    }))
+    .expect("truncation marker payload is always serializable");
+    let bytes = payload_json.len().saturating_add(EVENT_OVERHEAD_BYTES);
+    Some(QueuedEvent {
+        event: PendingEvent::Record(store::EventRecord {
+            seq: 0,
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            kind: "output_truncated".to_string(),
+            payload_json,
+            created_at: truncation.created_at,
+        }),
+        bytes,
+        completion: None,
+    })
+}
+
 fn flush_output(
     conn: &Connection,
     coven_home: &std::path::Path,
@@ -682,6 +753,7 @@ mod tests {
                 queued_events: 2,
                 queued_bytes: EVENT_OVERHEAD_BYTES * 2,
                 failed: None,
+                truncations: HashMap::new(),
             }),
             available: Condvar::new(),
             capacity_bytes: DEFAULT_CAPACITY_BYTES,
@@ -715,6 +787,7 @@ mod tests {
                 queued_events: 0,
                 queued_bytes: 0,
                 failed: None,
+                truncations: HashMap::new(),
             }),
             available: Condvar::new(),
             capacity_bytes: DEFAULT_CAPACITY_BYTES,
@@ -882,6 +955,72 @@ mod tests {
     }
 
     #[test]
+    fn recovered_output_is_preceded_by_one_exact_truncation_marker() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        assert!(!writer.record_output("s-1", "x".repeat(3072))?);
+        assert!(writer.record_output("s-1", "recovered".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            ["output_truncated", "output", "exit"]
+        );
+        let marker_payload: serde_json::Value = serde_json::from_str(&events[0].payload_json)?;
+        assert_eq!(marker_payload["droppedEvents"], 2);
+        assert_eq!(marker_payload["droppedBytes"], 5120);
+        assert!(events[0].created_at <= events[1].created_at);
+        Ok(())
+    }
+
+    #[test]
+    fn accepted_output_without_pressure_has_no_truncation_marker() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(writer.record_output("s-1", "accepted".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            ["output", "exit"]
+        );
+        Ok(())
+    }
+
+    #[test]
     fn writer_failure_drains_queued_critical_completions() {
         let shared = Arc::new(Shared {
             queue: Mutex::new(Queue {
@@ -889,6 +1028,7 @@ mod tests {
                 queued_events: 1,
                 queued_bytes: EVENT_OVERHEAD_BYTES,
                 failed: None,
+                truncations: HashMap::new(),
             }),
             available: Condvar::new(),
             capacity_bytes: DEFAULT_CAPACITY_BYTES,

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -7,7 +7,7 @@
 //! be overtaken by a following exit event.
 
 use std::{
-    collections::{HashMap, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     path::PathBuf,
     sync::{mpsc, Arc, Condvar, Mutex},
     thread,
@@ -68,6 +68,7 @@ struct Queue {
     queued_bytes: usize,
     failed: Option<String>,
     truncations: HashMap<String, OutputTruncation>,
+    closing_sessions: HashSet<String>,
 }
 
 struct OutputTruncation {
@@ -122,6 +123,7 @@ impl EventWriter {
                 queued_bytes: 0,
                 failed: None,
                 truncations: HashMap::new(),
+                closing_sessions: HashSet::new(),
             }),
             available: Condvar::new(),
             capacity_bytes,
@@ -225,7 +227,8 @@ impl EventWriter {
             } => (session_id, data.len(), created_at),
             _ => unreachable!("enqueue_output only accepts output events"),
         };
-        if bytes > self.shared.output_capacity_bytes
+        if queue.closing_sessions.contains(session_id)
+            || bytes > self.shared.output_capacity_bytes
             || queue.queued_bytes.saturating_add(bytes) > self.shared.output_capacity_bytes
         {
             record_output_drop(&mut queue, session_id, dropped_bytes, created_at);
@@ -239,7 +242,7 @@ impl EventWriter {
         }
         let marker = take_truncation_marker(&mut queue, session_id);
         let marker_bytes = marker.as_ref().map_or(0, |item| item.bytes);
-        assert!(
+        anyhow::ensure!(
             queue
                 .queued_bytes
                 .saturating_add(marker_bytes)
@@ -270,9 +273,41 @@ impl EventWriter {
             "critical event exceeds event writer capacity"
         );
         let session_id = event.session_id().to_string();
+        let marker = {
+            let mut queue = self.lock_queue();
+            loop {
+                if let Some(error) = &queue.failed {
+                    return Err(anyhow!(error.clone()));
+                }
+                if queue.closing_sessions.insert(session_id.clone()) {
+                    break take_truncation_marker(&mut queue, &session_id);
+                }
+                queue = self
+                    .shared
+                    .available
+                    .wait(queue)
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+            }
+        };
+
+        let result = self.enqueue_closed_critical(event, bytes, marker);
+        let mut queue = self.lock_queue();
+        queue.closing_sessions.remove(&session_id);
+        self.shared.available.notify_all();
+        result
+    }
+
+    fn enqueue_closed_critical(
+        &self,
+        event: PendingEvent,
+        bytes: usize,
+        marker: Option<QueuedEvent>,
+    ) -> Result<()> {
         let (completion_tx, completion_rx) = mpsc::sync_channel(1);
         let mut queue = self.lock_queue();
-        let marker = take_truncation_marker(&mut queue, &session_id);
+        if let Some(error) = &queue.failed {
+            return Err(anyhow!(error.clone()));
+        }
         let marker_bytes = marker.as_ref().map_or(0, |item| item.bytes);
         if marker_bytes.saturating_add(bytes) <= self.shared.capacity_bytes {
             loop {
@@ -341,8 +376,40 @@ impl EventWriter {
                 marker_rx,
                 "event writer stopped before committing truncation marker",
             )?;
-            self.enqueue_critical(event, bytes)
+            self.enqueue_closed_critical_event(event, bytes)
         }
+    }
+
+    fn enqueue_closed_critical_event(&self, event: PendingEvent, bytes: usize) -> Result<()> {
+        let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+        let mut queue = self.lock_queue();
+        loop {
+            if let Some(error) = &queue.failed {
+                return Err(anyhow!(error.clone()));
+            }
+            if queue.queued_bytes.saturating_add(bytes) <= self.shared.capacity_bytes {
+                break;
+            }
+            queue = self
+                .shared
+                .available
+                .wait(queue)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        queue.queued_events += 1;
+        queue.queued_bytes += bytes;
+        self.update_queue_health(queue.queued_events, queue.queued_bytes);
+        queue.items.push_back(QueuedEvent {
+            event,
+            bytes,
+            completion: Some(completion_tx),
+        });
+        self.shared.available.notify_one();
+        drop(queue);
+        receive_completion(
+            completion_rx,
+            "event writer stopped before committing a critical event",
+        )
     }
 
     fn lock_queue(&self) -> std::sync::MutexGuard<'_, Queue> {
@@ -675,6 +742,7 @@ fn fail_writer(shared: &Arc<Shared>, message: String) -> Vec<QueuedEvent> {
     let mut queue = lock_queue(shared);
     queue.failed = Some(message.clone());
     queue.truncations.clear();
+    queue.closing_sessions.clear();
     queue.queued_events = 0;
     queue.queued_bytes = 0;
     let pending = queue.items.drain(..).collect();
@@ -816,6 +884,7 @@ mod tests {
                 queued_bytes: EVENT_OVERHEAD_BYTES * 2,
                 failed: None,
                 truncations: HashMap::new(),
+                closing_sessions: HashSet::new(),
             }),
             available: Condvar::new(),
             capacity_bytes: DEFAULT_CAPACITY_BYTES,
@@ -850,6 +919,7 @@ mod tests {
                 queued_bytes: 0,
                 failed: None,
                 truncations: HashMap::new(),
+                closing_sessions: HashSet::new(),
             }),
             available: Condvar::new(),
             capacity_bytes: DEFAULT_CAPACITY_BYTES,
@@ -888,6 +958,145 @@ mod tests {
         let health = lock_health(&shared);
         assert_eq!(health.queued_events, 1);
         assert_eq!(health.queued_bytes, EVENT_OVERHEAD_BYTES + "hello".len());
+        Ok(())
+    }
+
+    #[test]
+    fn critical_boundary_prevents_same_session_output_from_overtaking_marker() -> Result<()> {
+        let capacity = RESERVED_CRITICAL_BYTES + 1024;
+        let blocked_bytes = capacity - 256;
+        let shared = Arc::new(Shared {
+            queue: Mutex::new(Queue {
+                items: VecDeque::from([QueuedEvent {
+                    event: PendingEvent::Output {
+                        session_id: "other".to_string(),
+                        data: "blocked".to_string(),
+                        created_at: "2026-08-04T00:00:00Z".to_string(),
+                    },
+                    bytes: blocked_bytes,
+                    completion: None,
+                }]),
+                queued_events: 1,
+                queued_bytes: blocked_bytes,
+                failed: None,
+                truncations: HashMap::from([(
+                    "s-1".to_string(),
+                    OutputTruncation {
+                        dropped_events: 1,
+                        dropped_bytes: 2048,
+                        created_at: "2026-08-04T00:00:01Z".to_string(),
+                    },
+                )]),
+                closing_sessions: HashSet::new(),
+            }),
+            available: Condvar::new(),
+            capacity_bytes: capacity,
+            output_capacity_bytes: capacity - RESERVED_CRITICAL_BYTES,
+            health: Mutex::new(EventWriterHealth {
+                state: "pressured".to_string(),
+                queued_events: 1,
+                queued_bytes: blocked_bytes,
+                capacity_bytes: capacity,
+                dropped_output_events: 1,
+                dropped_output_bytes: 2048,
+                connection_opens: 0,
+                transactions: 0,
+                committed_events: 0,
+                last_error: None,
+            }),
+        });
+        let writer = EventWriter {
+            shared: Arc::clone(&shared),
+        };
+        let critical_writer = writer.clone();
+        let critical = thread::spawn(move || {
+            critical_writer.enqueue_critical(
+                PendingEvent::Record(store::EventRecord {
+                    seq: 0,
+                    id: "critical".to_string(),
+                    session_id: "s-1".to_string(),
+                    kind: "tool_result".to_string(),
+                    payload_json: "{}".to_string(),
+                    created_at: "2026-08-04T00:00:02Z".to_string(),
+                }),
+                EVENT_OVERHEAD_BYTES,
+            )
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if lock_queue(&shared).closing_sessions.contains("s-1") {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "critical event did not claim its session boundary"
+            );
+            thread::sleep(Duration::from_millis(1));
+        }
+
+        assert!(!writer.enqueue_output(
+            PendingEvent::Output {
+                session_id: "s-1".to_string(),
+                data: "later".to_string(),
+                created_at: "2026-08-04T00:00:03Z".to_string(),
+            },
+            EVENT_OVERHEAD_BYTES + "later".len(),
+        )?);
+
+        {
+            let mut queue = lock_queue(&shared);
+            queue.items.clear();
+            queue.queued_events = 0;
+            queue.queued_bytes = 0;
+            shared.available.notify_all();
+        }
+
+        let queued = loop {
+            let mut queue = lock_queue(&shared);
+            if queue.items.len() == 2 {
+                queue.queued_events = 0;
+                queue.queued_bytes = 0;
+                break queue.items.drain(..).collect::<Vec<_>>();
+            }
+            drop(queue);
+            assert!(
+                Instant::now() < deadline,
+                "critical boundary events were not queued"
+            );
+            thread::sleep(Duration::from_millis(1));
+        };
+
+        assert_eq!(
+            queued
+                .iter()
+                .map(|item| match &item.event {
+                    PendingEvent::Record(record) => record.kind.as_str(),
+                    _ => "unexpected",
+                })
+                .collect::<Vec<_>>(),
+            ["output_truncated", "tool_result"]
+        );
+        let marker = match &queued[0].event {
+            PendingEvent::Record(record) => {
+                serde_json::from_str::<serde_json::Value>(&record.payload_json)?
+            }
+            _ => unreachable!("first boundary event must be the truncation marker"),
+        };
+        assert_eq!(marker["droppedEvents"], 1);
+        assert_eq!(marker["droppedBytes"], 2048);
+        let queue = lock_queue(&shared);
+        let later_episode = queue
+            .truncations
+            .get("s-1")
+            .expect("output after the claimed boundary starts the next episode");
+        assert_eq!(later_episode.dropped_events, 1);
+        assert_eq!(later_episode.dropped_bytes, 5);
+        drop(queue);
+
+        complete(&queued, Ok(()));
+        critical.join().expect("critical producer panicked")?;
+        assert!(!lock_queue(&shared).closing_sessions.contains("s-1"));
         Ok(())
     }
 
@@ -1193,6 +1402,7 @@ mod tests {
                 queued_bytes: EVENT_OVERHEAD_BYTES,
                 failed: None,
                 truncations: HashMap::new(),
+                closing_sessions: HashSet::new(),
             }),
             available: Condvar::new(),
             capacity_bytes: DEFAULT_CAPACITY_BYTES,

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -83,9 +83,14 @@ If the daemon metadata is unavailable, `daemon` may be `null`. The `hub` block r
 `eventWriter` is present for the daemon-owned live-session runtime. Its
 `state` is `healthy`, `pressured`, or `failed`. A pressured writer reports raw
 output that could not enter the byte-bounded queue; lifecycle, tool, error, and
-exit events reserve capacity and are not dropped for pressure. A failed writer
-includes `lastError`; clients should surface it as degraded persistence rather
-than treating the daemon's liveness as successful event durability.
+exit events reserve capacity and are not dropped for pressure. Raw output is
+the only lossy class. Each contiguous pressure episode produces one ordered
+`output_truncated` event for the affected session, inserted immediately before
+that session's next accepted event; the marker's `created_at` is the first
+rejected chunk timestamp. Global writer counters remain in the health payload.
+A failed writer includes `lastError`; clients should surface it as degraded
+persistence rather than treating the daemon's liveness as successful event
+durability.
 
 ### Capability fields
 
@@ -573,7 +578,15 @@ Marks an externally-registered session finished. The daemon updates the session 
   "events": [
     {
       "seq": 42,
-      "id": "event-uuid",
+      "id": "event-uuid-a",
+      "session_id": "session-uuid",
+      "kind": "output_truncated",
+      "payload_json": "{\"droppedEvents\":3,\"droppedBytes\":128}",
+      "created_at": "2026-05-09T06:43:09Z"
+    },
+    {
+      "seq": 43,
+      "id": "event-uuid-b",
       "session_id": "session-uuid",
       "kind": "output",
       "payload_json": "{\"data\":\"hello\"}",
@@ -581,7 +594,7 @@ Marks an externally-registered session finished. The daemon updates the session 
     }
   ],
   "nextCursor": {
-    "afterSeq": 42
+    "afterSeq": 43
   },
   "hasMore": false
 }
@@ -589,7 +602,9 @@ Marks an externally-registered session finished. The daemon updates the session 
 
 `nextCursor` is `null` when there are no events. `hasMore` is `true` when a `limit` was applied and more events may exist.
 
-`payload_json` is the redacted preview payload used by clients. Raw sensitive artifacts are never included in this envelope.
+`payload_json` is the redacted preview payload used by clients. Raw sensitive artifacts are never included in this envelope. `output_truncated` is additive and ordered: it appears in the session event stream before the next accepted event for the same session, and it uses `{"droppedEvents": <u64>, "droppedBytes": <u64>}` with `droppedBytes` counting rejected UTF-8 payload bytes only.
+
+Adjacent accepted output callbacks for the same session may coalesce into one `output` event, and that event's `created_at` is the first accepted callback timestamp.
 
 ## Log preview shape (`v1`)
 

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -52,7 +52,10 @@ keeping up. `"pressured"` means one or more raw PTY chunks were rejected after
 the bounded queue filled; inspect `droppedOutputEvents` and
 `droppedOutputBytes`. `"failed"` means the writer could not commit, and
 `lastError` carries the diagnostic. Lifecycle events are never dropped for
-queue pressure.
+queue pressure. The global `droppedOutputEvents` and `droppedOutputBytes`
+counters remain visible here. Each contiguous pressure episode later appears in
+the affected session as one ordered `output_truncated` event, inserted before
+the next accepted event.
 
 The same response includes `storage` health. Its `writerBacklogEvents` and
 `writerBacklogBytes` fields mirror the live `eventWriter` queue snapshot, while

--- a/docs/reference/api-contract.md
+++ b/docs/reference/api-contract.md
@@ -84,7 +84,9 @@ GET /api/v1/health
 
 When present, `eventWriter.state` is `healthy`, `pressured`, or `failed`.
 Pressure reports explicitly rejected raw output; lifecycle and terminal events
-reserve queue capacity and are never discarded for queue pressure.
+reserve queue capacity and are never discarded for queue pressure. Each
+contiguous pressure episode yields one ordered `output_truncated` event in the
+affected session stream, inserted before the next accepted event.
 
 If a client requires a capability the daemon does not advertise, the client should fail loudly with a remediation hint (`upgrade Coven to >= N`).
 

--- a/docs/superpowers/plans/2026-08-05-output-truncation-markers.md
+++ b/docs/superpowers/plans/2026-08-05-output-truncation-markers.md
@@ -1,0 +1,615 @@
+# Per-Session Output Truncation Markers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist one exact `output_truncated` event for each per-session raw-output pressure episode.
+
+**Architecture:** The event-writer queue tracks active truncation episodes by
+session while rejected PTY output remains non-blocking. The next accepted event
+for that session closes the episode by queueing an immutable critical marker
+immediately before that event, preserving append-only ordering and cursor
+semantics.
+
+**Tech Stack:** Rust, rusqlite, serde_json, std synchronization primitives,
+Markdown API documentation
+
+---
+
+### Task 1: Track and close output pressure episodes
+
+**Files:**
+- Modify: `crates/coven-cli/src/event_writer.rs`
+
+- [ ] **Step 1: Write failing recovery-boundary tests**
+
+Add these tests beside `pressure_is_visible_when_raw_output_exceeds_its_budget`:
+
+```rust
+#[test]
+fn recovered_output_is_preceded_by_one_exact_truncation_marker() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let writer = EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        RESERVED_CRITICAL_BYTES + 1024,
+    )?;
+
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+    assert!(!writer.record_output("s-1", "y".repeat(3072))?);
+    assert!(writer.record_output("s-1", "recovered".to_string())?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult {
+            status: "completed",
+            exit_code: Some(0),
+        },
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert_eq!(
+        events.iter().map(|event| event.kind.as_str()).collect::<Vec<_>>(),
+        vec!["output_truncated", "output", "exit"]
+    );
+    let payload: serde_json::Value = serde_json::from_str(&events[0].payload_json)?;
+    assert_eq!(payload["droppedEvents"], 2);
+    assert_eq!(payload["droppedBytes"], 5120);
+    assert!(events[0].created_at <= events[1].created_at);
+    Ok(())
+}
+
+#[test]
+fn accepted_output_without_pressure_has_no_truncation_marker() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let writer = EventWriter::start(home.path().to_path_buf())?;
+
+    assert!(writer.record_output("s-1", "complete".to_string())?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult {
+            status: "completed",
+            exit_code: Some(0),
+        },
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert!(events.iter().all(|event| event.kind != "output_truncated"));
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::recovered_output_is_preceded_by_one_exact_truncation_marker
+```
+
+Expected: FAIL because no `output_truncated` event exists.
+
+- [ ] **Step 3: Add queue-owned episode state**
+
+Import `HashMap` and add the episode type and queue field:
+
+```rust
+use std::{
+    collections::{HashMap, VecDeque},
+    // existing imports
+};
+
+struct Queue {
+    items: VecDeque<QueuedEvent>,
+    truncations: HashMap<String, OutputTruncation>,
+    queued_events: usize,
+    queued_bytes: usize,
+    failed: Option<String>,
+}
+
+struct OutputTruncation {
+    dropped_events: u64,
+    dropped_bytes: u64,
+    created_at: String,
+}
+```
+
+Initialize `truncations: HashMap::new()` in production and test `Queue`
+constructors.
+
+- [ ] **Step 4: Add marker construction helpers**
+
+Add these helpers above `take_batch`:
+
+```rust
+fn record_output_drop(
+    queue: &mut Queue,
+    session_id: &str,
+    dropped_bytes: usize,
+    created_at: &str,
+) {
+    let truncation = queue
+        .truncations
+        .entry(session_id.to_string())
+        .or_insert_with(|| OutputTruncation {
+            dropped_events: 0,
+            dropped_bytes: 0,
+            created_at: created_at.to_string(),
+        });
+    truncation.dropped_events = truncation.dropped_events.saturating_add(1);
+    truncation.dropped_bytes = truncation
+        .dropped_bytes
+        .saturating_add(dropped_bytes as u64);
+}
+
+fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedEvent> {
+    let truncation = queue.truncations.remove(session_id)?;
+    let payload_json = json!({
+        "droppedEvents": truncation.dropped_events,
+        "droppedBytes": truncation.dropped_bytes,
+    })
+    .to_string();
+    let bytes = payload_json.len().saturating_add(EVENT_OVERHEAD_BYTES);
+    Some(QueuedEvent {
+        event: PendingEvent::Record(store::EventRecord {
+            seq: 0,
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            kind: "output_truncated".to_string(),
+            payload_json,
+            created_at: truncation.created_at,
+        }),
+        bytes,
+        completion: None,
+    })
+}
+```
+
+- [ ] **Step 5: Record drops and queue a marker before recovered output**
+
+In `enqueue_output`, extract the output fields before the pressure check. On
+rejection, update the episode and existing health counters. On acceptance,
+remove the marker and push it before the output:
+
+```rust
+let PendingEvent::Output {
+    session_id,
+    data,
+    created_at,
+} = &event
+else {
+    unreachable!("enqueue_output only accepts output events");
+};
+
+if bytes > self.shared.output_capacity_bytes
+    || queue.queued_bytes.saturating_add(bytes) > self.shared.output_capacity_bytes
+{
+    record_output_drop(&mut queue, session_id, data.len(), created_at);
+    let mut health = self.lock_health();
+    health.state = "pressured".to_string();
+    health.dropped_output_events += 1;
+    health.dropped_output_bytes += data.len() as u64;
+    return Ok(false);
+}
+
+let marker = take_truncation_marker(&mut queue, session_id);
+let marker_bytes = marker.as_ref().map_or(0, |item| item.bytes);
+let marker_events = usize::from(marker.is_some());
+debug_assert!(
+    queue
+        .queued_bytes
+        .saturating_add(bytes)
+        .saturating_add(marker_bytes)
+        <= self.shared.capacity_bytes
+);
+queue.queued_events += 1 + marker_events;
+queue.queued_bytes += bytes + marker_bytes;
+self.update_queue_health(queue.queued_events, queue.queued_bytes);
+if let Some(marker) = marker {
+    queue.items.push_back(marker);
+}
+queue.items.push_back(QueuedEvent {
+    event,
+    bytes,
+    completion: None,
+});
+```
+
+- [ ] **Step 6: Run the event-writer tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+```
+
+Expected: all event-writer tests pass.
+
+- [ ] **Step 7: Commit the recovery-boundary implementation**
+
+```bash
+git add crates/coven-cli/src/event_writer.rs
+git commit -s -m "fix: mark recovered output truncation"
+```
+
+### Task 2: Close episodes before critical and terminal events
+
+**Files:**
+- Modify: `crates/coven-cli/src/event_writer.rs`
+
+- [ ] **Step 1: Write failing critical-boundary tests**
+
+Add tests covering exit, independent sessions, and an event that cannot share
+one capacity window with its marker:
+
+```rust
+#[test]
+fn exit_closes_pressure_episode_before_terminal_event() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let writer = EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        RESERVED_CRITICAL_BYTES + 1024,
+    )?;
+
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult {
+            status: "failed",
+            exit_code: Some(1),
+        },
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert_eq!(events[0].kind, "output_truncated");
+    assert_eq!(events[1].kind, "exit");
+    Ok(())
+}
+
+#[test]
+fn pressure_episodes_are_isolated_per_session() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    store::insert_session(&conn, &session("s-2"))?;
+    let writer = EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        RESERVED_CRITICAL_BYTES + 1024,
+    )?;
+
+    assert!(!writer.record_output("s-1", "a".repeat(2048))?);
+    assert!(!writer.record_output("s-2", "b".repeat(3072))?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult {
+            status: "failed",
+            exit_code: Some(1),
+        },
+    )?;
+    writer.record_exit(
+        "s-2",
+        PtyRunResult {
+            status: "failed",
+            exit_code: Some(1),
+        },
+    )?;
+
+    let first: serde_json::Value =
+        serde_json::from_str(&store::list_events(&conn, "s-1")?[0].payload_json)?;
+    let second: serde_json::Value =
+        serde_json::from_str(&store::list_events(&conn, "s-2")?[0].payload_json)?;
+    assert_eq!(first["droppedBytes"], 2048);
+    assert_eq!(second["droppedBytes"], 3072);
+    Ok(())
+}
+
+#[test]
+fn oversized_critical_event_commits_marker_before_waiting_for_its_own_capacity() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let capacity = RESERVED_CRITICAL_BYTES + 1024;
+    let writer = EventWriter::start_with_capacity(home.path().to_path_buf(), capacity)?;
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+
+    writer.enqueue_critical(
+        PendingEvent::Record(store::EventRecord {
+            seq: 0,
+            id: "large-critical".to_string(),
+            session_id: "s-1".to_string(),
+            kind: "error".to_string(),
+            payload_json: "{}".to_string(),
+            created_at: "2026-08-05T00:00:01Z".to_string(),
+        }),
+        capacity - 1,
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert_eq!(events[0].kind, "output_truncated");
+    assert_eq!(events[1].kind, "error");
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::exit_closes_pressure_episode_before_terminal_event
+```
+
+Expected: FAIL because exit currently bypasses the active episode map.
+
+- [ ] **Step 3: Add a session-id accessor**
+
+Add:
+
+```rust
+impl PendingEvent {
+    fn session_id(&self) -> &str {
+        match self {
+            Self::Output { session_id, .. } | Self::Exit { session_id, .. } => session_id,
+            Self::Record(record) => &record.session_id,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Queue marker and critical event atomically when they fit**
+
+Refactor `enqueue_critical` so it removes the session episode while holding the
+queue lock, waits for `marker.bytes + bytes`, pushes the marker first, and gives
+only the caller's event the external completion channel:
+
+```rust
+let session_id = event.session_id().to_string();
+let (completion_tx, completion_rx) = mpsc::sync_channel(1);
+let mut queue = self.lock_queue();
+let mut marker = take_truncation_marker(&mut queue, &session_id);
+let marker_bytes = marker.as_ref().map_or(0, |item| item.bytes);
+
+if marker_bytes.saturating_add(bytes) <= self.shared.capacity_bytes {
+    let required = marker_bytes.saturating_add(bytes);
+    while queue.queued_bytes.saturating_add(required) > self.shared.capacity_bytes {
+        if let Some(error) = &queue.failed {
+            return Err(anyhow!(error.clone()));
+        }
+        queue = self
+            .shared
+            .available
+            .wait(queue)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+    queue.queued_events += 1 + usize::from(marker.is_some());
+    queue.queued_bytes += required;
+    self.update_queue_health(queue.queued_events, queue.queued_bytes);
+    if let Some(marker) = marker.take() {
+        queue.items.push_back(marker);
+    }
+    queue.items.push_back(QueuedEvent {
+        event,
+        bytes,
+        completion: Some(completion_tx),
+    });
+    self.shared.available.notify_one();
+    drop(queue);
+    return receive_completion(completion_rx);
+}
+```
+
+Extract the existing receiver match into:
+
+```rust
+fn receive_completion(
+    completion_rx: mpsc::Receiver<std::result::Result<(), String>>,
+) -> Result<()> {
+    match completion_rx
+        .recv()
+        .context("event writer stopped before committing a critical event")?
+    {
+        Ok(()) => Ok(()),
+        Err(message) => Err(anyhow!(message)),
+    }
+}
+```
+
+- [ ] **Step 5: Handle the oversized sequential case without deadlock**
+
+When `marker_bytes + bytes > capacity`, queue the marker alone with an internal
+completion sender, wait for its commit, then call `enqueue_critical` again for
+the original event:
+
+```rust
+let marker = marker.expect("combined size exceeds capacity only with a marker");
+let (marker_tx, marker_rx) = mpsc::sync_channel(1);
+let marker = QueuedEvent {
+    completion: Some(marker_tx),
+    ..marker
+};
+while queue.queued_bytes.saturating_add(marker.bytes) > self.shared.capacity_bytes {
+    if let Some(error) = &queue.failed {
+        return Err(anyhow!(error.clone()));
+    }
+    queue = self
+        .shared
+        .available
+        .wait(queue)
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+}
+queue.queued_events += 1;
+queue.queued_bytes += marker.bytes;
+self.update_queue_health(queue.queued_events, queue.queued_bytes);
+queue.items.push_back(marker);
+self.shared.available.notify_one();
+drop(queue);
+receive_completion(marker_rx)?;
+self.enqueue_critical(event, bytes)
+```
+
+- [ ] **Step 6: Clear active episodes on writer failure**
+
+In `fail_writer`, add:
+
+```rust
+queue.truncations.clear();
+```
+
+- [ ] **Step 7: Run event-writer and daemon observer tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+cargo test -p coven-cli daemon::tests::output_observer
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 8: Commit critical-boundary behavior**
+
+```bash
+git add crates/coven-cli/src/event_writer.rs
+git commit -s -m "fix: preserve truncation markers before terminal events"
+```
+
+### Task 3: Document the additive event contract
+
+**Files:**
+- Modify: `docs/API-CONTRACT.md`
+- Modify: `docs/reference/api-contract.md`
+- Modify: `docs/daemon/health.md`
+
+- [ ] **Step 1: Document pressure visibility and output coalescing**
+
+After the `eventWriter` health description in `docs/API-CONTRACT.md`, add:
+
+```markdown
+Rejected raw output remains visible in the affected session. Coven emits one
+`output_truncated` event per contiguous pressure episode before that session's
+next accepted event. Its payload contains `droppedEvents` and `droppedBytes`;
+the latter counts rejected UTF-8 payload bytes and excludes queue overhead.
+
+Adjacent accepted `output` callbacks for the same session may coalesce into one
+event. The merged event keeps the first accepted callback's `created_at`.
+```
+
+In the events response section, add an `output_truncated` example:
+
+```json
+{
+  "seq": 43,
+  "id": "event-uuid",
+  "session_id": "session-uuid",
+  "kind": "output_truncated",
+  "payload_json": "{\"droppedEvents\":3,\"droppedBytes\":8192}",
+  "created_at": "2026-05-09T06:43:11Z"
+}
+```
+
+- [ ] **Step 2: Update concise health references**
+
+Add one sentence to both `docs/reference/api-contract.md` and
+`docs/daemon/health.md`:
+
+```markdown
+Each affected session also receives one ordered `output_truncated` event with
+exact dropped-event and dropped-byte totals when its pressure episode closes.
+```
+
+- [ ] **Step 3: Check documentation consistency**
+
+Run:
+
+```bash
+rg -n "output_truncated|droppedEvents|coalesce" \
+  docs/API-CONTRACT.md docs/reference/api-contract.md docs/daemon/health.md
+git diff --check
+```
+
+Expected: all three documents describe the same event name and camelCase
+payload fields; `git diff --check` exits 0.
+
+- [ ] **Step 4: Commit the API documentation**
+
+```bash
+git add docs/API-CONTRACT.md docs/reference/api-contract.md docs/daemon/health.md
+git commit -s -m "docs: define output truncation events"
+```
+
+### Task 4: Verify and publish
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-08-05-output-truncation-markers.md`
+
+- [ ] **Step 1: Run focused behavior tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+cargo test -p coven-cli daemon::tests::output_observer
+```
+
+Expected: all selected tests pass with zero failures.
+
+- [ ] **Step 2: Run repository gates**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python3 scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --range origin/main..HEAD
+git diff --check origin/main...HEAD
+```
+
+Expected: every command exits 0. Run the workspace test from a worktree inside
+`.worktrees/` so Unix socket paths stay below `SUN_LEN`.
+
+- [ ] **Step 3: Request independent code review**
+
+Review the full `origin/main...HEAD` diff against issue #611. Require the
+reviewer to check queue bounds, per-session isolation, ordering, critical-event
+acknowledgements, append-only event semantics, and privacy.
+
+- [ ] **Step 4: Mark the plan complete and commit**
+
+Change all completed checkboxes in this plan to `[x]`, then run:
+
+```bash
+git add docs/superpowers/plans/2026-08-05-output-truncation-markers.md
+git commit -s -m "docs: record output truncation verification"
+```
+
+- [ ] **Step 5: Push and open the issue-linked PR**
+
+```bash
+git push -u origin fix/611-output-truncation-marker
+gh pr create \
+  --repo OpenCoven/coven \
+  --base main \
+  --head fix/611-output-truncation-marker \
+  --title "fix: mark per-session output truncation" \
+  --body-file -
+```
+
+Use the repository PR template, include `Closes #611`, list exact focused and
+repository-wide verification, and explain that markers close at the next
+accepted event boundary to preserve immutable cursor semantics.
+
+- [ ] **Step 6: Monitor review and CI**
+
+Run:
+
+```bash
+gh pr checks --repo OpenCoven/coven --watch --interval 15
+```
+
+Address branch-specific failures and technically valid review feedback. After
+merge, release `issue-611`, delete the remote branch, and remove the worktree.

--- a/docs/superpowers/plans/2026-08-05-output-truncation-markers.md
+++ b/docs/superpowers/plans/2026-08-05-output-truncation-markers.md
@@ -20,7 +20,7 @@ Markdown API documentation
 **Files:**
 - Modify: `crates/coven-cli/src/event_writer.rs`
 
-- [ ] **Step 1: Write failing recovery-boundary tests**
+- [x] **Step 1: Write failing recovery-boundary tests**
 
 Add these tests beside `pressure_is_visible_when_raw_output_exceeds_its_budget`:
 
@@ -80,7 +80,7 @@ fn accepted_output_without_pressure_has_no_truncation_marker() -> Result<()> {
 }
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run:
 
@@ -90,7 +90,7 @@ cargo test -p coven-cli event_writer::tests::recovered_output_is_preceded_by_one
 
 Expected: FAIL because no `output_truncated` event exists.
 
-- [ ] **Step 3: Add queue-owned episode state**
+- [x] **Step 3: Add queue-owned episode state**
 
 Import `HashMap` and add the episode type and queue field:
 
@@ -118,7 +118,7 @@ struct OutputTruncation {
 Initialize `truncations: HashMap::new()` in production and test `Queue`
 constructors.
 
-- [ ] **Step 4: Add marker construction helpers**
+- [x] **Step 4: Add marker construction helpers**
 
 Add these helpers above `take_batch`:
 
@@ -166,7 +166,7 @@ fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedE
 }
 ```
 
-- [ ] **Step 5: Record drops and queue a marker before recovered output**
+- [x] **Step 5: Record drops and queue a marker before recovered output**
 
 In `enqueue_output`, extract the output fields before the pressure check. On
 rejection, update the episode and existing health counters. On acceptance,
@@ -216,7 +216,7 @@ queue.items.push_back(QueuedEvent {
 });
 ```
 
-- [ ] **Step 6: Run the event-writer tests**
+- [x] **Step 6: Run the event-writer tests**
 
 Run:
 
@@ -226,7 +226,7 @@ cargo test -p coven-cli event_writer::tests::
 
 Expected: all event-writer tests pass.
 
-- [ ] **Step 7: Commit the recovery-boundary implementation**
+- [x] **Step 7: Commit the recovery-boundary implementation**
 
 ```bash
 git add crates/coven-cli/src/event_writer.rs
@@ -238,7 +238,7 @@ git commit -s -m "fix: mark recovered output truncation"
 **Files:**
 - Modify: `crates/coven-cli/src/event_writer.rs`
 
-- [ ] **Step 1: Write failing critical-boundary tests**
+- [x] **Step 1: Write failing critical-boundary tests**
 
 Add tests covering exit, independent sessions, and an event that cannot share
 one capacity window with its marker:
@@ -334,7 +334,7 @@ fn oversized_critical_event_commits_marker_before_waiting_for_its_own_capacity()
 }
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [x] **Step 2: Run the tests to verify they fail**
 
 Run:
 
@@ -344,7 +344,7 @@ cargo test -p coven-cli event_writer::tests::exit_closes_pressure_episode_before
 
 Expected: FAIL because exit currently bypasses the active episode map.
 
-- [ ] **Step 3: Add a session-id accessor**
+- [x] **Step 3: Add a session-id accessor**
 
 Add:
 
@@ -359,7 +359,7 @@ impl PendingEvent {
 }
 ```
 
-- [ ] **Step 4: Queue marker and critical event atomically when they fit**
+- [x] **Step 4: Queue marker and critical event atomically when they fit**
 
 Refactor `enqueue_critical` so it removes the session episode while holding the
 queue lock, waits for `marker.bytes + bytes`, pushes the marker first, and gives
@@ -417,7 +417,7 @@ fn receive_completion(
 }
 ```
 
-- [ ] **Step 5: Handle the oversized sequential case without deadlock**
+- [x] **Step 5: Handle the oversized sequential case without deadlock**
 
 When `marker_bytes + bytes > capacity`, queue the marker alone with an internal
 completion sender, wait for its commit, then call `enqueue_critical` again for
@@ -450,7 +450,7 @@ receive_completion(marker_rx)?;
 self.enqueue_critical(event, bytes)
 ```
 
-- [ ] **Step 6: Clear active episodes on writer failure**
+- [x] **Step 6: Clear active episodes on writer failure**
 
 In `fail_writer`, add:
 
@@ -458,7 +458,7 @@ In `fail_writer`, add:
 queue.truncations.clear();
 ```
 
-- [ ] **Step 7: Run event-writer and daemon observer tests**
+- [x] **Step 7: Run event-writer and daemon observer tests**
 
 Run:
 
@@ -469,7 +469,7 @@ cargo test -p coven-cli daemon::tests::output_observer
 
 Expected: all selected tests pass.
 
-- [ ] **Step 8: Commit critical-boundary behavior**
+- [x] **Step 8: Commit critical-boundary behavior**
 
 ```bash
 git add crates/coven-cli/src/event_writer.rs
@@ -483,7 +483,7 @@ git commit -s -m "fix: preserve truncation markers before terminal events"
 - Modify: `docs/reference/api-contract.md`
 - Modify: `docs/daemon/health.md`
 
-- [ ] **Step 1: Document pressure visibility and output coalescing**
+- [x] **Step 1: Document pressure visibility and output coalescing**
 
 After the `eventWriter` health description in `docs/API-CONTRACT.md`, add:
 
@@ -510,7 +510,7 @@ In the events response section, add an `output_truncated` example:
 }
 ```
 
-- [ ] **Step 2: Update concise health references**
+- [x] **Step 2: Update concise health references**
 
 Add one sentence to both `docs/reference/api-contract.md` and
 `docs/daemon/health.md`:
@@ -520,7 +520,7 @@ Each affected session also receives one ordered `output_truncated` event with
 exact dropped-event and dropped-byte totals when its pressure episode closes.
 ```
 
-- [ ] **Step 3: Check documentation consistency**
+- [x] **Step 3: Check documentation consistency**
 
 Run:
 
@@ -533,7 +533,7 @@ git diff --check
 Expected: all three documents describe the same event name and camelCase
 payload fields; `git diff --check` exits 0.
 
-- [ ] **Step 4: Commit the API documentation**
+- [x] **Step 4: Commit the API documentation**
 
 ```bash
 git add docs/API-CONTRACT.md docs/reference/api-contract.md docs/daemon/health.md
@@ -545,7 +545,7 @@ git commit -s -m "docs: define output truncation events"
 **Files:**
 - Modify: `docs/superpowers/plans/2026-08-05-output-truncation-markers.md`
 
-- [ ] **Step 1: Run focused behavior tests**
+- [x] **Step 1: Run focused behavior tests**
 
 Run:
 
@@ -556,7 +556,7 @@ cargo test -p coven-cli daemon::tests::output_observer
 
 Expected: all selected tests pass with zero failures.
 
-- [ ] **Step 2: Run repository gates**
+- [x] **Step 2: Run repository gates**
 
 Run:
 
@@ -572,13 +572,13 @@ git diff --check origin/main...HEAD
 Expected: every command exits 0. Run the workspace test from a worktree inside
 `.worktrees/` so Unix socket paths stay below `SUN_LEN`.
 
-- [ ] **Step 3: Request independent code review**
+- [x] **Step 3: Request independent code review**
 
 Review the full `origin/main...HEAD` diff against issue #611. Require the
 reviewer to check queue bounds, per-session isolation, ordering, critical-event
 acknowledgements, append-only event semantics, and privacy.
 
-- [ ] **Step 4: Mark the plan complete and commit**
+- [x] **Step 4: Mark the plan complete and commit**
 
 Change all completed checkboxes in this plan to `[x]`, then run:
 

--- a/docs/superpowers/specs/2026-08-05-output-truncation-markers-design.md
+++ b/docs/superpowers/specs/2026-08-05-output-truncation-markers-design.md
@@ -1,0 +1,122 @@
+# Per-Session Output Truncation Marker Design
+
+**Goal:** Make every raw PTY output gap visible in the affected session's
+append-only event stream without weakening the event writer's byte bound or
+turning pressure reporting into another event flood.
+
+## Context
+
+The event writer intentionally rejects raw output when its output budget is
+full. Daemon health records exact global dropped-event and dropped-byte totals,
+but the affected session currently proceeds to later events and exit with no
+durable indication that its transcript is incomplete.
+
+The queue reserves 128 KiB for lifecycle and other critical events. Truncation
+markers can use that reservation while raw output remains the only lossy event
+class.
+
+## Considered approaches
+
+### 1. Close-boundary marker with exact totals
+
+Track one active pressure episode per session in queue state. Each rejected
+chunk increments that episode. Before the next accepted event for the same
+session, enqueue one `output_truncated` marker carrying the exact episode
+totals, then enqueue the accepted event.
+
+This is the recommended approach. It produces one immutable event at the
+precise transcript gap, preserves append-only cursor semantics, and cannot
+flood the queue during sustained pressure. The marker becomes visible when the
+episode closes rather than on the first rejected chunk.
+
+### 2. Immediate marker per queued pressure window
+
+Enqueue a marker on the first rejection and coalesce only while that marker
+remains in the queue. This reports pressure sooner, but a sustained episode can
+emit repeated markers whenever the worker drains the previous one. Totals are
+also split across implementation-dependent queue windows.
+
+### 3. Immediate marker updated in place
+
+Insert one marker at episode entry and update its payload as more chunks are
+dropped. This provides early and exact eventual totals, but it makes event rows
+mutable after clients may have consumed their sequence cursor. That violates
+the event log's append-only contract and creates cache/replay ambiguity.
+
+## Event contract
+
+The marker is an ordinary redacted session event:
+
+```json
+{
+  "kind": "output_truncated",
+  "payload_json": "{\"droppedEvents\":3,\"droppedBytes\":8192}",
+  "created_at": "<timestamp of the first rejected chunk>"
+}
+```
+
+`droppedEvents` counts rejected output callbacks in the episode.
+`droppedBytes` counts the rejected UTF-8 payload bytes and excludes queue
+accounting overhead.
+
+An episode begins with the first rejected output chunk for a session. It ends
+at the next accepted event for that session, including accepted output, a
+recorded lifecycle/tool/error event, or exit. Sessions are tracked
+independently, so one noisy session does not merge another session's gap.
+
+Adjacent accepted output chunks may continue to coalesce into one `output`
+event. The coalesced event retains the first accepted chunk's `created_at`.
+
+## Queue and ordering behavior
+
+The queue owns a map of active truncation episodes keyed by session id.
+Rejected output updates only that map and the existing daemon-global health
+counters; the PTY drain remains non-blocking.
+
+When an event for that session can be accepted:
+
+1. Remove the active episode from the map.
+2. Build a critical `output_truncated` event.
+3. Reserve capacity for the marker and accepted event together.
+4. Push the marker immediately before the accepted event.
+
+For accepted output, the existing output-budget check leaves the full critical
+reservation available, so the small marker cannot make the queue exceed its
+total capacity. For critical events and exit, the existing condition-variable
+wait accounts for both items before either is queued.
+
+If a maximum-sized critical event and its marker cannot fit together, the
+writer queues and synchronously acknowledges the marker first, then queues the
+critical event through the existing path. This preserves the prior maximum
+critical-event size instead of creating an impossible capacity wait.
+
+The marker has no independent completion channel. A following critical event's
+acknowledgement proves both records committed in order because they share the
+same single-worker queue and transaction boundary. The oversized sequential
+case gives the marker its own internal acknowledgement before the caller's
+event is queued.
+
+## Failure behavior
+
+- Writer failure clears queued events and in-memory episodes and remains
+  visible through `eventWriter.state = "failed"` and `lastError`.
+- Marker serialization uses fixed scalar fields and cannot include raw output.
+- Unknown event consumers already ignore non-`output` kinds or render the kind
+  generically, so the additive event kind does not require a protocol version
+  change.
+- Raw output remains lossy; markers, lifecycle events, and exit remain
+  non-lossy under queue pressure.
+
+## Testing
+
+Rust tests will prove:
+
+- multiple rejected chunks for one session produce one marker with exact totals;
+- the marker is ordered before recovered output;
+- exit closes an episode and commits the marker before the terminal event;
+- sessions maintain independent episode totals;
+- accepted output with no prior drop produces no marker;
+- health counters and byte-bounded queue accounting remain correct.
+
+API documentation will define the additive event kind and the existing output
+coalescing timestamp behavior.

--- a/docs/superpowers/specs/2026-08-05-output-truncation-markers-design.md
+++ b/docs/superpowers/specs/2026-08-05-output-truncation-markers-design.md
@@ -85,10 +85,17 @@ reservation available, so the small marker cannot make the queue exceed its
 total capacity. For critical events and exit, the existing condition-variable
 wait accounts for both items before either is queued.
 
+Claiming a critical boundary linearizes that event for its session before any
+capacity wait. While the boundary is pending, same-session raw output remains
+non-blocking but is rejected into the next pressure episode; it cannot overtake
+the saved marker or boundary event. Other critical producers for that session
+wait until the owner commits or fails the boundary.
+
 If a maximum-sized critical event and its marker cannot fit together, the
 writer queues and synchronously acknowledges the marker first, then queues the
-critical event through the existing path. This preserves the prior maximum
-critical-event size instead of creating an impossible capacity wait.
+critical event while retaining ownership of the session boundary. This
+preserves the prior maximum critical-event size instead of creating an
+impossible capacity wait.
 
 The marker has no independent completion channel. A following critical event's
 acknowledgement proves both records committed in order because they share the


### PR DESCRIPTION
## Summary
- track bounded-writer pressure episodes independently per session and emit one immutable `output_truncated` marker before that session resumes
- preserve marker ordering before critical records and exit, including maximum-size critical events that cannot share queue capacity
- document the additive event contract, pressure counters, and output coalescing timestamp behavior

## Marker contract
- `kind`: `output_truncated`
- payload: `{"droppedEvents": N, "droppedBytes": N}`
- timestamp: first rejected output chunk in the episode
- contains no raw output content

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p coven-cli event_writer::tests::` (16 passed)
- `cargo test -p coven-cli daemon::tests::output_observer`
- `cargo test --workspace --locked -- --skip codex_json_sigterm_reaps_descendants_and_marks_ledger_failed`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --range origin/main..HEAD`
- `git diff --check origin/main...HEAD`

## Local baseline note
The unmodified `codex_json_sigterm_reaps_descendants_and_marks_ledger_failed` test exceeds its three-second fixture-start assertion on this machine. The same failure reproduces on clean current `main`; current `main` CI is green. The complete locked workspace suite passes locally when only that unchanged baseline timing test is skipped.

Closes #611