### PR TITLE
fix(bench): report sampled runtime metrics accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,11 +677,13 @@ node scripts/benchmark-chaos.mjs --binary target/debug/coven --output /tmp/coven
 
 The command always exercises 1, 8, and 32 concurrent deterministic harness
 sessions, records launch-to-first-output percentiles, throughput, cancellation
-acknowledgement, SQLite file growth, writer connection/transaction deltas, peak
-writer backlog, and sampled daemon RSS, and writes a redacted JSON report. The
-writer measurements come from the live health contract; RSS is resolved by the
-exact daemon PID through `coven pc top --json`, without retaining process names
-or command lines. Cave owns the slow-WebSocket-consumer lane in #4317.
+to-terminal latency, SQLite file growth, writer connection/transaction deltas,
+maximum sampled writer backlog, and sampled daemon RSS, and writes a redacted
+JSON report. The writer queue values are periodic samples rather than
+daemon-maintained high-water marks. Writer measurements come from the live
+health contract; RSS is resolved by the exact daemon PID through
+`coven pc top --json`, without retaining process names or command lines. Cave
+owns the slow-WebSocket-consumer lane in #4317.
 
 Unsafe host-level faults use deterministic equivalents rather than filling a
 real disk or killing an unrelated process: the report names the exact Rust

--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -13,7 +13,7 @@ import {
   waitForOutputEvent
 } from './benchmark-cli.mjs';
 
-const SCHEMA_VERSION = 2;
+const SCHEMA_VERSION = 3;
 const DEFAULT_CONCURRENCY = [1, 8, 32];
 const POLL_ATTEMPTS = 160;
 const POLL_DELAY_MS = 25;
@@ -110,7 +110,7 @@ export function storageMetricStatus() {
     },
     eventQueueDepth: {
       status: 'measured',
-      source: 'eventWriter.queuedEvents/eventWriter.queuedBytes'
+      source: 'periodic samples of eventWriter.queuedEvents/eventWriter.queuedBytes'
     },
     rss: {
       status: 'measured',
@@ -180,8 +180,8 @@ export function summarizeRuntimeMetrics(samples) {
       delta: transactionsEnd - transactionsStart
     },
     eventQueueDepth: {
-      peakEvents: Math.max(...samples.map((sample) => requiredCounter(sample.eventWriter, 'queuedEvents'))),
-      peakBytes: Math.max(...samples.map((sample) => requiredCounter(sample.eventWriter, 'queuedBytes')))
+      maxSampledEvents: Math.max(...samples.map((sample) => requiredCounter(sample.eventWriter, 'queuedEvents'))),
+      maxSampledBytes: Math.max(...samples.map((sample) => requiredCounter(sample.eventWriter, 'queuedBytes')))
     },
     rss: {
       samplesBytes: rssSamples,
@@ -429,6 +429,7 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
     let observing = true;
     const observation = observeWriterHealth(socketPath, runtimeSamples, () => observing);
     let launches;
+    let completedAt;
     try {
       launches = await Promise.all(
         Array.from({ length: concurrency }, async () => {
@@ -460,11 +461,11 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
           return { id, firstOutputMs: Number(process.hrtime.bigint() - launchedAt) / 1_000_000 };
         })
       );
+      completedAt = process.hrtime.bigint();
     } finally {
       observing = false;
       await observation;
     }
-    const completedAt = process.hrtime.bigint();
     const elapsedMs = Number(completedAt - startedAt) / 1_000_000;
     runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
 

--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -110,7 +110,7 @@ export function storageMetricStatus() {
     },
     eventQueueDepth: {
       status: 'measured',
-      source: 'periodic samples of eventWriter.queuedEvents/eventWriter.queuedBytes'
+      source: 'maxima of periodic eventWriter.queuedEvents/eventWriter.queuedBytes samples'
     },
     rss: {
       status: 'measured',

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -62,7 +62,7 @@ test('describes live writer metrics and deterministic fault equivalents', () => 
   );
 });
 
-test('summarizes writer counter deltas, peak backlog, and sampled RSS', () => {
+test('summarizes writer counter deltas, sampled backlog maxima, and sampled RSS', () => {
   assert.deepEqual(
     summarizeRuntimeMetrics([
       {
@@ -96,7 +96,7 @@ test('summarizes writer counter deltas, peak backlog, and sampled RSS', () => {
     {
       sqliteConnectionOpens: { start: 1, end: 1, delta: 0 },
       sqliteTransactions: { start: 2, end: 12, delta: 10 },
-      eventQueueDepth: { peakEvents: 5, peakBytes: 4096 },
+      eventQueueDepth: { maxSampledEvents: 5, maxSampledBytes: 4096 },
       rss: {
         samplesBytes: [10 * 1024 * 1024, 14 * 1024 * 1024, 12 * 1024 * 1024],
         peakBytes: 14 * 1024 * 1024
@@ -135,7 +135,7 @@ test('report contains no fixture paths or prompt content', () => {
     environment: { GITHUB_ACTIONS: 'true', HOME: '/private/fixture', PROMPT: 'secret prompt' }
   });
   const serialized = JSON.stringify(report);
-  assert.equal(report.schemaVersion, 2);
+  assert.equal(report.schemaVersion, 3);
   assert.doesNotMatch(serialized, /private\/fixture|secret prompt/);
   assert.equal(Object.hasOwn(report.environment, 'host'), false);
   assert.equal(Object.hasOwn(report.environment, 'runner'), false);
@@ -257,6 +257,6 @@ test('closes the throughput timing window before diagnostic sampling', async () 
   const source = await readFile(new URL('./benchmark-chaos.mjs', import.meta.url), 'utf8');
   assert.match(
     source,
-    /const completedAt = process\.hrtime\.bigint\(\);\n\s+const elapsedMs = .*;\n\s+runtimeSamples\.push\(await fullRuntimeSnapshot/
+    /completedAt = process\.hrtime\.bigint\(\);\n\s+} finally \{\n\s+observing = false;\n\s+await observation;\n\s+}\n\s+const elapsedMs = .*;\n\s+runtimeSamples\.push\(await fullRuntimeSnapshot/
   );
 });


### PR DESCRIPTION
## Summary
- close the throughput timing window before observer shutdown
- label periodic writer queue observations as sampled maxima and bump the report schema
- describe cancellation as cancellation-to-terminal latency rather than acknowledgement

## Validation
- `node --test scripts/benchmark-chaos.test.mjs`
- `cargo build -p coven-cli --locked --quiet`
- `node scripts/benchmark-chaos.mjs --binary target/debug/coven --output /tmp/coven-chaos-metric-semantics.json` (1/8/32 scenarios passed)
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`