### PR TITLE
fix(health): keep status reads side-effect free

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6766,7 +6766,7 @@ mod tests {
         assert!(response.body.contains(r#""scheduler":true"#));
         assert!(response.body.contains(r#""hub":true"#));
         assert!(response.body.contains(r#""executorDispatch":true"#));
-        assert!(response.body.contains(r#""role":"hub""#));
+        assert!(!response.body.contains(r#""role":"hub""#));
         assert!(response.body.contains(r#""structuredErrors":true"#));
         assert!(response.body.contains(r#""storage":{"status""#));
         assert!(response.body.contains(r#""writerBacklogEvents":0"#));

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6766,7 +6766,8 @@ mod tests {
         assert!(response.body.contains(r#""scheduler":true"#));
         assert!(response.body.contains(r#""hub":true"#));
         assert!(response.body.contains(r#""executorDispatch":true"#));
-        assert!(!response.body.contains(r#""role":"hub""#));
+let body: serde_json::Value = serde_json::from_str(&response.body)?;
+assert!(body.get("hub").is_none() || body["hub"].is_null());
         assert!(response.body.contains(r#""structuredErrors":true"#));
         assert!(response.body.contains(r#""storage":{"status""#));
         assert!(response.body.contains(r#""writerBacklogEvents":0"#));

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6806,6 +6806,25 @@ mod tests {
     }
 
     #[test]
+    fn health_does_not_create_store_files_in_writable_empty_home() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let writable_probe = temp_dir.path().join("writable-probe");
+        std::fs::write(&writable_probe, "probe")?;
+        std::fs::remove_file(writable_probe)?;
+
+        let response = handle_request("GET", "/health", temp_dir.path(), None)?;
+
+        assert_eq!(response.status, 200);
+        for file_name in ["coven.sqlite3", "coven.sqlite3-wal", "coven.sqlite3-shm"] {
+            assert!(
+                !temp_dir.path().join(file_name).exists(),
+                "{file_name} must not be created by health"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
     fn health_uses_one_live_writer_snapshot_for_both_surfaces() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let response = handle_request_with_runtime(

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2456,7 +2456,10 @@ pub(crate) fn acquire_serve_lock(coven_home: &Path) -> Result<std::fs::File> {
 }
 
 fn initialize_daemon_store(coven_home: &Path) -> Result<()> {
-    crate::store::initialize_store(&coven_home.join("coven.sqlite3"))
+    crate::store::initialize_store(&coven_home.join("coven.sqlite3"))?;
+    crate::hub::initialize_hub_identity(coven_home)
+        .context("failed to initialize hub identity during daemon startup")?;
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3134,6 +3137,12 @@ mod tests {
         initialize_daemon_store(temp_dir.path())?;
         let conn = crate::store::open_initialized_store(&temp_dir.path().join("coven.sqlite3"))?;
         assert!(crate::store::list_sessions(&conn)?.is_empty());
+        let hub_id: String = conn.query_row(
+            "SELECT value FROM store_meta WHERE key = ?1",
+            [crate::hub::HUB_ID_META_KEY],
+            |row| row.get(0),
+        )?;
+        assert!(hub_id.starts_with("hub_"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -40,6 +40,20 @@ fn hub_id(conn: &Connection) -> Result<String> {
     store::get_or_insert_store_meta(conn, HUB_ID_META_KEY, &format!("hub_{}", Uuid::new_v4()))
 }
 
+fn read_hub_id(conn: &Connection) -> Result<String> {
+    conn.query_row(
+        "SELECT value FROM store_meta WHERE key = ?1",
+        [HUB_ID_META_KEY],
+        |row| row.get(0),
+    )
+    .context("failed to read hub id")
+}
+
+pub(crate) fn initialize_hub_identity(coven_home: &Path) -> Result<String> {
+    let conn = store::open_initialized_store(&store_path(coven_home))?;
+    hub_id(&conn)
+}
+
 fn parse_capabilities(json_text: &str) -> Vec<String> {
     serde_json::from_str(json_text).unwrap_or_default()
 }
@@ -177,23 +191,17 @@ pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
         .context("Coven store does not exist")?;
     let nodes = store::list_nodes(&conn)?;
     let available = nodes.iter().filter(|node| node.available).count();
-    let hub_id: String = conn
-        .query_row(
-            "SELECT value FROM store_meta WHERE key = ?1",
-            [HUB_ID_META_KEY],
-            |row| row.get(0),
-        )
-        .context("failed to read hub id")?;
     Ok(json!({
         "role": HUB_ROLE,
-        "hubId": hub_id,
+        "hubId": read_hub_id(&conn)?,
         "nodesTotal": nodes.len(),
         "nodesAvailable": available,
     }))
 }
 
 pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
-    let conn = store::open_store(&store_path(coven_home))?;
+    let conn = store::open_existing_store_read_only(&store_path(coven_home))?
+        .context("Coven store does not exist")?;
     let nodes = store::list_nodes(&conn)?;
     let jobs = store::list_hub_jobs(&conn, None)?;
     let queues = store::list_executor_queues(&conn)?;
@@ -214,7 +222,7 @@ pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
         200,
         &json!({
             "role": HUB_ROLE,
-            "hubId": hub_id(&conn)?,
+            "hubId": read_hub_id(&conn)?,
             "nodes": node_views,
             "nodesTotal": nodes.len(),
             "nodesAvailable": nodes.iter().filter(|node| node.available).count(),

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -173,12 +173,20 @@ pub(crate) fn apply_redispatch_outcome(
 }
 
 pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
-    let conn = store::open_store(&store_path(coven_home))?;
+    let conn = store::open_existing_store_read_only(&store_path(coven_home))?
+        .context("Coven store does not exist")?;
     let nodes = store::list_nodes(&conn)?;
     let available = nodes.iter().filter(|node| node.available).count();
+    let hub_id: String = conn
+        .query_row(
+            "SELECT value FROM store_meta WHERE key = ?1",
+            [HUB_ID_META_KEY],
+            |row| row.get(0),
+        )
+        .context("failed to read hub id")?;
     Ok(json!({
         "role": HUB_ROLE,
-        "hubId": hub_id(&conn)?,
+        "hubId": hub_id,
         "nodesTotal": nodes.len(),
         "nodesAvailable": available,
     }))

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -328,6 +328,7 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
         updated_at: now,
     };
     store::upsert_node(&conn, &record)?;
+    hub_id(&conn)?;
     json_response(
         if existing.is_some() { 200 } else { 201 },
         &node_response(&record),
@@ -1112,6 +1113,35 @@ mod tests {
             ),
         )?;
         assert_eq!(status, 201);
+        Ok(())
+    }
+
+    #[test]
+    fn registering_node_initializes_hub_identity_for_health() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_a")?;
+
+        let (status, health) = get(&temp, "/api/v1/health")?;
+        assert_eq!(status, 200);
+        assert_eq!(health["hub"]["role"], "hub");
+        assert_eq!(health["hub"]["nodesTotal"], 1);
+        assert_eq!(health["hub"]["nodesAvailable"], 1);
+        let hub_id = health["hub"]["hubId"]
+            .as_str()
+            .expect("registration should initialize the hub identity");
+        assert!(hub_id.starts_with("hub_"));
+
+        let (status, _) = post(
+            &temp,
+            "/api/v1/hub/nodes",
+            r#"{"nodeId":"node_a","role":"compute_executor","transport":"ssh","capabilities":["gpu","long-running-loop"]}"#,
+        )?;
+        assert_eq!(status, 200);
+        let (_, health_after_registration) = get(&temp, "/api/v1/health")?;
+        assert_eq!(health_after_registration["hub"]["hubId"], hub_id);
+
+        let (_, status) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(status["hubId"], hub_id);
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3158,7 +3158,17 @@ fn run_logs_command(command: LogsCommand) -> Result<()> {
 
 fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u64>) -> Result<()> {
     let home = coven_home_dir()?;
-    let config = privacy::load_with_settings(&home, settings::cached()).unwrap_or_default();
+    prune_logs_at_home(&home, dry_run, raw_days, event_days)
+}
+
+fn prune_logs_at_home(
+    home: &Path,
+    dry_run: bool,
+    raw_days: Option<u64>,
+    event_days: Option<u64>,
+) -> Result<()> {
+    let config = privacy::load_with_settings(home, settings::cached())
+        .context("failed to load privacy configuration for log pruning")?;
     let raw_days = raw_days
         .unwrap_or(config.raw_artifact_retention_days)
         .max(1);
@@ -6407,6 +6417,59 @@ mod tests {
             }
             other => panic!("expected logs prune command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn logs_prune_rejects_malformed_privacy_config_without_deleting_events() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let store_path = home.join(STORE_FILE_NAME);
+        let conn = store::open_store(&store_path)?;
+        store::insert_session(
+            &conn,
+            &test_session_record("prune-session", "completed", "codex", "Prune test", None),
+        )?;
+        store::insert_event(
+            &conn,
+            &store::EventRecord {
+                seq: 0,
+                id: "old-event".to_string(),
+                session_id: "prune-session".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"message":"old"}"#.to_string(),
+                created_at: "2000-01-01T00:00:00Z".to_string(),
+            },
+        )?;
+        drop(conn);
+        std::fs::write(home.join("privacy.toml"), "log_retention_days = [")?;
+
+        let result = prune_logs_at_home(home, false, None, None);
+        let conn = store::open_store(&store_path)?;
+        let remaining = store::list_events(&conn, "prune-session")?;
+
+        assert!(
+            result.is_err() && remaining.len() == 1,
+            "malformed privacy config must fail closed; result={result:?}, remaining_events={}",
+            remaining.len()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn logs_prune_rejects_malformed_privacy_config_without_creating_store() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let store_path = home.join(STORE_FILE_NAME);
+        std::fs::write(home.join("privacy.toml"), "log_retention_days = [")?;
+
+        let result = prune_logs_at_home(home, false, None, None);
+
+        assert!(
+            result.is_err() && !store_path.exists(),
+            "malformed privacy config must fail before store access; result={result:?}, store_exists={}",
+            store_path.exists()
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep `/health` and `/hub/status` on read-only existing-store connections so status reads cannot create SQLite files or mutate metadata
- initialize and backfill the stable hub identity at writable daemon startup and node registration boundaries
- fail closed on malformed privacy configuration before manual log pruning can open or delete from the store

## Validation
- `cargo test -p coven-cli hub --no-fail-fast` (34 passed)
- `cargo test -p coven-cli daemon_store_initialization_prepares_request_connections --no-fail-fast`
- `cargo test -p coven-cli routes_health_request_to_json --no-fail-fast`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `git diff --check`

Follow-up to #637.