### PR TITLE
fix(health): keep status reads side-effect free

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -289,12 +289,19 @@ fn health_response_with_hub(
         response.hub = serde_json::from_value(summary).ok();
     }
     response.storage = Some(
-        store::storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
+        store::cached_storage_health(coven_home, event_writer.as_ref()).unwrap_or_else(|error| {
             store::unavailable_storage_health(coven_home, error, None, event_writer.as_ref())
         }),
     );
     response.event_writer = event_writer;
     response
+}
+
+fn hub_mutation_response(
+    coven_home: &Path,
+    operation: impl FnOnce() -> Result<ApiResponse>,
+) -> Result<ApiResponse> {
+    crate::hub::with_status_mutation(coven_home, operation)
 }
 
 #[allow(dead_code)]
@@ -620,28 +627,38 @@ pub fn handle_request_with_runtime(
             let q = query.unwrap_or_default();
             travel_state(coven_home, q)
         }
-        ("POST", "/scheduler/decisions") => scheduler_decision(coven_home, body),
-        ("POST", "/scheduler/redispatch") => scheduler_redispatch(coven_home, body),
+        ("POST", "/scheduler/decisions") => {
+            hub_mutation_response(coven_home, || scheduler_decision(coven_home, body))
+        }
+        ("POST", "/scheduler/redispatch") => {
+            hub_mutation_response(coven_home, || scheduler_redispatch(coven_home, body))
+        }
         ("GET", "/hub/status") => crate::hub::hub_status(coven_home),
-        ("POST", "/hub/nodes") => crate::hub::register_node(coven_home, body),
+        ("POST", "/hub/nodes") => {
+            hub_mutation_response(coven_home, || crate::hub::register_node(coven_home, body))
+        }
         ("GET", "/hub/nodes") => crate::hub::list_nodes(coven_home),
         ("POST", path) if path.starts_with("/hub/nodes/") && path.ends_with("/health") => {
             let node_id = path
                 .trim_start_matches("/hub/nodes/")
                 .trim_end_matches("/health");
-            crate::hub::report_node_health(coven_home, node_id, body)
+            hub_mutation_response(coven_home, || {
+                crate::hub::report_node_health(coven_home, node_id, body)
+            })
         }
         ("POST", path) if path.starts_with("/hub/nodes/") && path.ends_with("/poll") => {
             let node_id = path
                 .trim_start_matches("/hub/nodes/")
                 .trim_end_matches("/poll");
-            crate::hub::poll_node(coven_home, node_id)
+            hub_mutation_response(coven_home, || crate::hub::poll_node(coven_home, node_id))
         }
         ("POST", path) if path.starts_with("/hub/nodes/") && path.ends_with("/dispatch") => {
             let node_id = path
                 .trim_start_matches("/hub/nodes/")
                 .trim_end_matches("/dispatch");
-            crate::hub::dispatch_to_node(coven_home, node_id, body)
+            hub_mutation_response(coven_home, || {
+                crate::hub::dispatch_to_node(coven_home, node_id, body)
+            })
         }
         ("GET", path) if path.starts_with("/hub/dispatches/") => {
             let job_id = path.trim_start_matches("/hub/dispatches/");
@@ -651,7 +668,9 @@ pub fn handle_request_with_runtime(
             let node_id = path.trim_start_matches("/hub/nodes/");
             crate::hub::get_node(coven_home, node_id)
         }
-        ("POST", "/hub/jobs") => crate::hub::enqueue_job(coven_home, body),
+        ("POST", "/hub/jobs") => {
+            hub_mutation_response(coven_home, || crate::hub::enqueue_job(coven_home, body))
+        }
         ("GET", "/hub/jobs") => {
             let q = query.unwrap_or_default();
             crate::hub::list_jobs(coven_home, q)
@@ -660,13 +679,17 @@ pub fn handle_request_with_runtime(
             let job_id = path
                 .trim_start_matches("/hub/jobs/")
                 .trim_end_matches("/assign");
-            crate::hub::assign_job(coven_home, job_id, body)
+            hub_mutation_response(coven_home, || {
+                crate::hub::assign_job(coven_home, job_id, body)
+            })
         }
         ("POST", path) if path.starts_with("/hub/jobs/") && path.ends_with("/complete") => {
             let job_id = path
                 .trim_start_matches("/hub/jobs/")
                 .trim_end_matches("/complete");
-            crate::hub::complete_job(coven_home, job_id, body)
+            hub_mutation_response(coven_home, || {
+                crate::hub::complete_job(coven_home, job_id, body)
+            })
         }
         ("GET", path) if path.starts_with("/hub/jobs/") => {
             let job_id = path.trim_start_matches("/hub/jobs/");
@@ -6847,6 +6870,79 @@ mod tests {
             );
         }
         Ok(())
+    }
+
+    fn sqlite_file_contents(coven_home: &Path) -> anyhow::Result<Vec<Option<Vec<u8>>>> {
+        ["coven.sqlite3", "coven.sqlite3-wal", "coven.sqlite3-shm"]
+            .into_iter()
+            .map(|file_name| {
+                let path = coven_home.join(file_name);
+                if path.exists() {
+                    Ok(Some(std::fs::read(path)?))
+                } else {
+                    Ok(None)
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn health_and_hub_status_do_not_touch_initialized_store_files() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let store_path = temp_dir.path().join("coven.sqlite3");
+        crate::store::initialize_store(&store_path)?;
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        crate::hub::initialize_hub_identity(&conn)?;
+        crate::hub::refresh_status_snapshot_from_connection(temp_dir.path(), &conn)?;
+        crate::store::refresh_storage_health_snapshot_from_connection(
+            temp_dir.path(),
+            &conn,
+            None,
+        )?;
+        drop(conn);
+
+        let before = sqlite_file_contents(temp_dir.path())?;
+        let health = handle_request("GET", "/health", temp_dir.path(), None)?;
+        let status = handle_request("GET", "/api/v1/hub/status", temp_dir.path(), None)?;
+        let after = sqlite_file_contents(temp_dir.path())?;
+
+        assert_eq!(health.status, 200);
+        assert_eq!(status.status, 200);
+        assert_eq!(after, before);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn health_and_hub_status_work_without_store_directory_write_access() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let store_path = temp_dir.path().join("coven.sqlite3");
+        crate::store::initialize_store(&store_path)?;
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        crate::hub::initialize_hub_identity(&conn)?;
+        crate::hub::refresh_status_snapshot_from_connection(temp_dir.path(), &conn)?;
+        crate::store::refresh_storage_health_snapshot_from_connection(
+            temp_dir.path(),
+            &conn,
+            None,
+        )?;
+        drop(conn);
+
+        let before = sqlite_file_contents(temp_dir.path())?;
+        let original_permissions = std::fs::metadata(temp_dir.path())?.permissions();
+        std::fs::set_permissions(temp_dir.path(), std::fs::Permissions::from_mode(0o500))?;
+        let result = (|| -> anyhow::Result<()> {
+            let health = handle_request("GET", "/health", temp_dir.path(), None)?;
+            let status = handle_request("GET", "/api/v1/hub/status", temp_dir.path(), None)?;
+            assert_eq!(health.status, 200);
+            assert_eq!(status.status, 200);
+            assert_eq!(sqlite_file_contents(temp_dir.path())?, before);
+            Ok(())
+        })();
+        std::fs::set_permissions(temp_dir.path(), original_permissions)?;
+        result
     }
 
     #[test]

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6766,11 +6766,15 @@ mod tests {
         assert!(response.body.contains(r#""scheduler":true"#));
         assert!(response.body.contains(r#""hub":true"#));
         assert!(response.body.contains(r#""executorDispatch":true"#));
-        assert!(response.body.contains(r#""role":"hub""#));
         assert!(response.body.contains(r#""structuredErrors":true"#));
         assert!(response.body.contains(r#""storage":{"status""#));
         assert!(response.body.contains(r#""writerBacklogEvents":0"#));
         assert!(response.body.contains(r#""freeDiskBytes""#));
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert!(
+            body.get("hub").is_none(),
+            "health must omit hub state when no initialized store exists"
+        );
         Ok(())
     }
 
@@ -6803,6 +6807,46 @@ mod tests {
                 last_error: None,
             })
         }
+    }
+
+    #[test]
+    fn health_does_not_create_store_files_in_writable_empty_home() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let writable_probe = temp_dir.path().join("writable-probe");
+        std::fs::write(&writable_probe, "probe")?;
+        std::fs::remove_file(writable_probe)?;
+
+        let response = handle_request("GET", "/health", temp_dir.path(), None)?;
+
+        assert_eq!(response.status, 200);
+        for file_name in ["coven.sqlite3", "coven.sqlite3-wal", "coven.sqlite3-shm"] {
+            assert!(
+                !temp_dir.path().join(file_name).exists(),
+                "{file_name} must not be created by health"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn hub_status_does_not_create_store_files_in_writable_empty_home() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let writable_probe = temp_dir.path().join("writable-probe");
+        std::fs::write(&writable_probe, "probe")?;
+        std::fs::remove_file(writable_probe)?;
+
+        let response = handle_request("GET", "/api/v1/hub/status", temp_dir.path(), None)?;
+
+        assert_eq!(response.status, 503);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "hub_unavailable");
+        for file_name in ["coven.sqlite3", "coven.sqlite3-wal", "coven.sqlite3-shm"] {
+            assert!(
+                !temp_dir.path().join(file_name).exists(),
+                "{file_name} must not be created by hub status"
+            );
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2157,9 +2157,26 @@ fn start_store_maintenance_scheduler(coven_home: &Path) -> Result<()> {
 
             // The store helper owns the bounded convergence loop so one
             // scheduler tick cannot multiply the configured batch budget.
-            if let Err(error) = crate::store::run_scheduled_maintenance(&home, &now) {
-                let details = format!("store maintenance pass failed: {error:#}");
-                record_store_maintenance_failure(&home, &details);
+            match crate::store::run_scheduled_maintenance(&home, &now) {
+                Ok(_) => {
+                    let store_path = home.join("coven.sqlite3");
+                    match crate::store::open_initialized_store(&store_path).and_then(|conn| {
+                        crate::store::refresh_storage_health_snapshot_from_connection(
+                            &home, &conn, None,
+                        )
+                    }) {
+                        Ok(()) => {}
+                        Err(error) => {
+                            let details =
+                                format!("storage health snapshot refresh failed: {error:#}");
+                            record_store_maintenance_failure(&home, &details);
+                        }
+                    }
+                }
+                Err(error) => {
+                    let details = format!("store maintenance pass failed: {error:#}");
+                    record_store_maintenance_failure(&home, &details);
+                }
             }
         })
         .context("failed to spawn store maintenance scheduler")?;
@@ -2180,6 +2197,17 @@ fn record_store_maintenance_failure_with_free_disk_check(
     free_disk_check: std::io::Result<u64>,
 ) {
     append_daemon_recovery_log(coven_home, details);
+    let known_free_disk_bytes = free_disk_check.as_ref().ok().copied();
+    if let Err(error) = crate::store::mark_storage_health_snapshot_maintenance_failure(
+        coven_home,
+        known_free_disk_bytes,
+        None,
+    ) {
+        append_daemon_recovery_log(
+            coven_home,
+            &format!("failed to mark storage health snapshot degraded: {error:#}"),
+        );
+    }
     match free_disk_check {
         Ok(free_disk_bytes) if free_disk_bytes >= crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES => {
             crate::store::record_maintenance_error(coven_home, details);
@@ -2461,6 +2489,29 @@ fn initialize_daemon_store(coven_home: &Path) -> Result<()> {
     let conn = crate::store::open_initialized_store(&store_path)?;
     crate::hub::initialize_hub_identity(&conn)
         .context("failed to initialize hub identity during daemon startup")?;
+    if let Err(error) = crate::hub::refresh_status_snapshot_from_connection(coven_home, &conn) {
+        append_daemon_recovery_log(
+            coven_home,
+            &format!("hub status snapshot refresh failed during daemon startup: {error:#}"),
+        );
+    }
+    if let Err(error) =
+        crate::store::refresh_storage_health_snapshot_from_connection(coven_home, &conn, None)
+    {
+        append_daemon_recovery_log(
+            coven_home,
+            &format!("storage health snapshot refresh failed during daemon startup: {error:#}"),
+        );
+        if let Err(cache_error) = crate::store::cache_unavailable_storage_health(coven_home, None) {
+            append_daemon_recovery_log(
+                coven_home,
+                &format!(
+                    "failed to cache unavailable storage health during daemon startup: \
+                     {cache_error:#}"
+                ),
+            );
+        }
+    }
     Ok(())
 }
 
@@ -3166,6 +3217,33 @@ mod tests {
         assert_eq!(status["hubId"], hub_id);
         assert_eq!(status["nodesTotal"], 0);
         assert_eq!(status["nodesAvailable"], 0);
+        Ok(())
+    }
+
+    #[test]
+    fn daemon_store_initialization_degrades_health_for_malformed_privacy_config() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::write(
+            temp_dir.path().join("privacy.toml"),
+            "log_retention_days = \"broken\"\n",
+        )?;
+
+        initialize_daemon_store(temp_dir.path())?;
+
+        let health = crate::api::handle_request("GET", "/health", temp_dir.path(), None)?;
+        assert_eq!(health.status, 200);
+        let health: serde_json::Value = serde_json::from_str(&health.body)?;
+        assert_eq!(health["storage"]["status"], "degraded");
+        assert_eq!(
+            health["storage"]["lastMaintenanceError"],
+            "storage health unavailable"
+        );
+        assert!(!health
+            .to_string()
+            .contains(temp_dir.path().to_string_lossy().as_ref()));
+
+        let hub_status = crate::hub::hub_status(temp_dir.path())?;
+        assert_eq!(hub_status.status, 200);
         Ok(())
     }
 
@@ -5688,6 +5766,101 @@ mod tests {
         let log = std::fs::read_to_string(daemon_recovery_log_path(temp_dir.path()))?;
         assert!(log.contains("store maintenance pass failed"));
         assert!(!temp_dir.path().join("coven.sqlite3").exists());
+        let health = crate::store::cached_storage_health_with_free_disk(
+            temp_dir.path(),
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES - 1,
+            None,
+        )?;
+        assert_eq!(health.status, "degraded");
+        assert_eq!(
+            health.free_disk_bytes,
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES - 1
+        );
+        assert_eq!(
+            health.last_maintenance_error.as_deref(),
+            Some("storage health unavailable")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn maintenance_failure_preserves_last_good_health_until_successful_refresh() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let store_path = home.join("coven.sqlite3");
+        let conn = crate::store::open_store(&store_path)?;
+        for (key, value) in [
+            ("maintenance_last_prune_at", "2026-08-05T12:00:00Z"),
+            ("maintenance_last_checkpoint_at", "2026-08-05T12:01:00Z"),
+        ] {
+            conn.execute(
+                "INSERT INTO store_meta(key, value) VALUES(?1, ?2)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                rusqlite::params![key, value],
+            )?;
+        }
+        let writer = crate::event_writer::EventWriterHealth {
+            state: "pressured".to_string(),
+            queued_events: 7,
+            queued_bytes: 8192,
+            capacity_bytes: 2 * 1024 * 1024,
+            dropped_output_events: 1,
+            dropped_output_bytes: 512,
+            connection_opens: 1,
+            transactions: 3,
+            committed_events: 12,
+            last_error: None,
+        };
+        crate::store::refresh_storage_health_snapshot_from_connection_with_free_disk(
+            home,
+            &conn,
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES,
+            Some(&writer),
+        )?;
+        let before = crate::store::cached_storage_health_with_free_disk(
+            home,
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES,
+            Some(&writer),
+        )?;
+        drop(conn);
+
+        record_store_maintenance_failure_with_free_disk_check(
+            home,
+            "store maintenance pass failed: failed to read /private/home",
+            Ok(crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES),
+        );
+
+        let degraded = crate::store::cached_storage_health_with_free_disk(
+            home,
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES,
+            None,
+        )?;
+        assert_eq!(degraded.status, "degraded");
+        assert_eq!(degraded.database_bytes, before.database_bytes);
+        assert_eq!(degraded.last_prune_at, before.last_prune_at);
+        assert_eq!(degraded.last_checkpoint_at, before.last_checkpoint_at);
+        assert_eq!(degraded.writer_backlog_events, 7);
+        assert_eq!(degraded.writer_backlog_bytes, 8192);
+        assert_eq!(
+            degraded.last_maintenance_error.as_deref(),
+            Some("maintenance pass failed")
+        );
+
+        crate::store::run_scheduled_maintenance(home, "2026-08-05T12:02:00Z")?;
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        crate::store::refresh_storage_health_snapshot_from_connection_with_free_disk(
+            home,
+            &conn,
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES,
+            None,
+        )?;
+        let recovered = crate::store::cached_storage_health_with_free_disk(
+            home,
+            crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES,
+            None,
+        )?;
+        assert_ne!(recovered.status, "degraded");
+        assert!(recovered.last_maintenance_error.is_none());
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2456,7 +2456,12 @@ pub(crate) fn acquire_serve_lock(coven_home: &Path) -> Result<std::fs::File> {
 }
 
 fn initialize_daemon_store(coven_home: &Path) -> Result<()> {
-    crate::store::initialize_store(&coven_home.join("coven.sqlite3"))
+    let store_path = coven_home.join("coven.sqlite3");
+    crate::store::initialize_store(&store_path)?;
+    let conn = crate::store::open_initialized_store(&store_path)?;
+    crate::hub::initialize_hub_identity(&conn)
+        .context("failed to initialize hub identity during daemon startup")?;
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3132,8 +3137,35 @@ mod tests {
     fn daemon_store_initialization_prepares_request_connections() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         initialize_daemon_store(temp_dir.path())?;
-        let conn = crate::store::open_initialized_store(&temp_dir.path().join("coven.sqlite3"))?;
+        let store_path = temp_dir.path().join("coven.sqlite3");
+        let conn = crate::store::open_initialized_store(&store_path)?;
         assert!(crate::store::list_sessions(&conn)?.is_empty());
+        let hub_id: String = conn.query_row(
+            "SELECT value FROM store_meta WHERE key = ?1",
+            [crate::hub::HUB_ID_META_KEY],
+            |row| row.get(0),
+        )?;
+        assert!(hub_id.starts_with("hub_"));
+
+        initialize_daemon_store(temp_dir.path())?;
+        let health = crate::api::handle_request("GET", "/health", temp_dir.path(), None)?;
+        assert_eq!(health.status, 200);
+        let health: serde_json::Value = serde_json::from_str(&health.body)?;
+        assert_eq!(health["hub"]["hubId"], hub_id);
+        assert_eq!(health["hub"]["nodesTotal"], 0);
+        assert_eq!(health["hub"]["nodesAvailable"], 0);
+
+        let summary = crate::hub::hub_health_summary(temp_dir.path())?;
+        assert_eq!(summary["hubId"], hub_id);
+        assert_eq!(summary["nodesTotal"], 0);
+        assert_eq!(summary["nodesAvailable"], 0);
+
+        let status = crate::hub::hub_status(temp_dir.path())?;
+        assert_eq!(status.status, 200);
+        let status: serde_json::Value = serde_json::from_str(&status.body)?;
+        assert_eq!(status["hubId"], hub_id);
+        assert_eq!(status["nodesTotal"], 0);
+        assert_eq!(status["nodesAvailable"], 0);
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -2158,21 +2158,7 @@ fn start_store_maintenance_scheduler(coven_home: &Path) -> Result<()> {
             // The store helper owns the bounded convergence loop so one
             // scheduler tick cannot multiply the configured batch budget.
             match crate::store::run_scheduled_maintenance(&home, &now) {
-                Ok(_) => {
-                    let store_path = home.join("coven.sqlite3");
-                    match crate::store::open_initialized_store(&store_path).and_then(|conn| {
-                        crate::store::refresh_storage_health_snapshot_from_connection(
-                            &home, &conn, None,
-                        )
-                    }) {
-                        Ok(()) => {}
-                        Err(error) => {
-                            let details =
-                                format!("storage health snapshot refresh failed: {error:#}");
-                            record_store_maintenance_failure(&home, &details);
-                        }
-                    }
-                }
+                Ok(report) => refresh_storage_health_after_maintenance(&home, &report),
                 Err(error) => {
                     let details = format!("store maintenance pass failed: {error:#}");
                     record_store_maintenance_failure(&home, &details);
@@ -2181,6 +2167,26 @@ fn start_store_maintenance_scheduler(coven_home: &Path) -> Result<()> {
         })
         .context("failed to spawn store maintenance scheduler")?;
     Ok(())
+}
+
+fn refresh_storage_health_after_maintenance(
+    coven_home: &Path,
+    report: &crate::store::ScheduledMaintenanceReport,
+) {
+    if report.blocked_by_free_disk {
+        return;
+    }
+
+    let store_path = coven_home.join("coven.sqlite3");
+    match crate::store::open_initialized_store(&store_path).and_then(|conn| {
+        crate::store::refresh_storage_health_snapshot_from_connection(coven_home, &conn, None)
+    }) {
+        Ok(()) => {}
+        Err(error) => {
+            let details = format!("storage health snapshot refresh failed: {error:#}");
+            record_store_maintenance_failure(coven_home, &details);
+        }
+    }
 }
 
 fn record_store_maintenance_failure(coven_home: &Path, details: &str) {
@@ -5780,6 +5786,27 @@ mod tests {
             health.last_maintenance_error.as_deref(),
             Some("storage health unavailable")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn blocked_maintenance_report_skips_store_refresh() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let report = crate::store::ScheduledMaintenanceReport {
+            raw_artifacts_pruned: 0,
+            events_pruned: 0,
+            checkpoint_ran: false,
+            blocked_by_free_disk: true,
+        };
+
+        refresh_storage_health_after_maintenance(temp_dir.path(), &report);
+
+        for file_name in ["coven.sqlite3", "coven.sqlite3-wal", "coven.sqlite3-shm"] {
+            assert!(
+                !temp_dir.path().join(file_name).exists(),
+                "blocked maintenance must not create {file_name}"
+            );
+        }
         Ok(())
     }
 

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -7,10 +7,17 @@
 //! nodes that go unavailable keep their subqueue held on the hub until they
 //! recover or the scheduler explicitly redispatches their work.
 
-use std::path::Path;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        OnceLock, RwLock,
+    },
+};
 
 use anyhow::{bail, Context, Result};
-use rusqlite::{Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -32,8 +39,26 @@ const JOB_STATE_ASSIGNED: &str = "assigned";
 const JOB_STATE_HELD: &str = "held";
 const TERMINAL_JOB_STATES: [&str; 3] = ["completed", "failed", "cancelled"];
 
+#[derive(Clone)]
+struct VersionedStatusSnapshot {
+    revision: u64,
+    value: Option<Value>,
+}
+
+static HUB_STATUS_SNAPSHOTS: OnceLock<RwLock<HashMap<PathBuf, VersionedStatusSnapshot>>> =
+    OnceLock::new();
+static HUB_STATUS_REVISION: AtomicU64 = AtomicU64::new(0);
+
 fn store_path(coven_home: &Path) -> std::path::PathBuf {
     coven_home.join("coven.sqlite3")
+}
+
+fn hub_status_snapshots() -> &'static RwLock<HashMap<PathBuf, VersionedStatusSnapshot>> {
+    HUB_STATUS_SNAPSHOTS.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+fn next_status_revision() -> u64 {
+    HUB_STATUS_REVISION.fetch_add(1, Ordering::Relaxed) + 1
 }
 
 fn hub_id(conn: &Connection) -> Result<String> {
@@ -186,39 +211,13 @@ pub(crate) fn apply_redispatch_outcome(
     Ok(true)
 }
 
-pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
-    let conn = store::open_existing_store_read_only(&store_path(coven_home))?
-        .context("Coven store does not exist")?;
-    let nodes = store::list_nodes(&conn)?;
-    let available = nodes.iter().filter(|node| node.available).count();
-    Ok(json!({
-        "role": HUB_ROLE,
-        "hubId": read_hub_id(&conn)?.context("hub identity is not initialized")?,
-        "nodesTotal": nodes.len(),
-        "nodesAvailable": available,
-    }))
-}
-
-pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
-    let Some(conn) = store::open_existing_store_read_only(&store_path(coven_home))? else {
-        return api_error(
-            503,
-            "hub_unavailable",
-            "Hub state is unavailable until daemon startup completes.",
-            None,
-        );
+fn status_snapshot(conn: &Connection) -> Result<Option<Value>> {
+    let Some(hub_id) = read_hub_id(conn)? else {
+        return Ok(None);
     };
-    let Some(hub_id) = read_hub_id(&conn)? else {
-        return api_error(
-            503,
-            "hub_unavailable",
-            "Hub identity is unavailable until daemon startup completes.",
-            None,
-        );
-    };
-    let nodes = store::list_nodes(&conn)?;
-    let jobs = store::list_hub_jobs(&conn, None)?;
-    let queues = store::list_executor_queues(&conn)?;
+    let nodes = store::list_nodes(conn)?;
+    let jobs = store::list_hub_jobs(conn, None)?;
+    let queues = store::list_executor_queues(conn)?;
     let count_state = |state: &str| jobs.iter().filter(|job| job.state == state).count();
     let node_views: Vec<Value> = nodes.iter().map(node_response).collect();
     let queue_views: Vec<Value> = queues
@@ -232,23 +231,158 @@ pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
             })
         })
         .collect();
-    json_response(
-        200,
-        &json!({
-            "role": HUB_ROLE,
-            "hubId": hub_id,
-            "nodes": node_views,
-            "nodesTotal": nodes.len(),
-            "nodesAvailable": nodes.iter().filter(|node| node.available).count(),
-            "globalQueue": {
-                "queued": count_state(JOB_STATE_QUEUED),
-                "assigned": count_state(JOB_STATE_ASSIGNED),
-                "held": count_state(JOB_STATE_HELD),
-                "total": jobs.len(),
+    Ok(Some(json!({
+        "role": HUB_ROLE,
+        "hubId": hub_id,
+        "nodes": node_views,
+        "nodesTotal": nodes.len(),
+        "nodesAvailable": nodes.iter().filter(|node| node.available).count(),
+        "globalQueue": {
+            "queued": count_state(JOB_STATE_QUEUED),
+            "assigned": count_state(JOB_STATE_ASSIGNED),
+            "held": count_state(JOB_STATE_HELD),
+            "total": jobs.len(),
+        },
+        "executorQueues": queue_views,
+    })))
+}
+
+pub(crate) fn refresh_status_snapshot_from_connection(
+    coven_home: &Path,
+    conn: &Connection,
+) -> Result<()> {
+    let revision = next_status_revision();
+    if let Err(error) = refresh_status_snapshot_from_connection_at(coven_home, conn, revision) {
+        invalidate_status_snapshot_at(coven_home, revision);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn refresh_status_snapshot_from_connection_at(
+    coven_home: &Path,
+    conn: &Connection,
+    revision: u64,
+) -> Result<()> {
+    let snapshot = status_snapshot(conn)?;
+    let mut snapshots = hub_status_snapshots()
+        .write()
+        .map_err(|_| anyhow::anyhow!("hub status snapshot lock poisoned"))?;
+    if snapshots
+        .get(coven_home)
+        .is_none_or(|current| revision >= current.revision)
+    {
+        snapshots.insert(
+            coven_home.to_path_buf(),
+            VersionedStatusSnapshot {
+                revision,
+                value: snapshot,
             },
-            "executorQueues": queue_views,
-        }),
-    )
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn refresh_status_snapshot(coven_home: &Path) -> Result<()> {
+    refresh_status_snapshot_at(coven_home, next_status_revision())
+}
+
+fn refresh_status_snapshot_at(coven_home: &Path, revision: u64) -> Result<()> {
+    let path = store_path(coven_home);
+    if !path.exists() {
+        invalidate_status_snapshot_at(coven_home, revision);
+        return Ok(());
+    }
+    let conn = match store::open_initialized_store(&path) {
+        Ok(conn) => conn,
+        Err(error) => {
+            invalidate_status_snapshot_at(coven_home, revision);
+            return Err(error);
+        }
+    };
+    if let Err(error) = refresh_status_snapshot_from_connection_at(coven_home, &conn, revision) {
+        invalidate_status_snapshot_at(coven_home, revision);
+        return Err(error);
+    }
+    Ok(())
+}
+
+pub(crate) fn with_status_mutation(
+    coven_home: &Path,
+    operation: impl FnOnce() -> Result<ApiResponse>,
+) -> Result<ApiResponse> {
+    with_status_mutation_using(coven_home, operation, refresh_status_snapshot)
+}
+
+fn with_status_mutation_using(
+    coven_home: &Path,
+    operation: impl FnOnce() -> Result<ApiResponse>,
+    refresh: impl FnOnce(&Path) -> Result<()>,
+) -> Result<ApiResponse> {
+    let operation_result = operation();
+    let refresh_result = refresh(coven_home);
+    if let Err(error) = refresh_result {
+        crate::daemon::append_daemon_recovery_log(
+            coven_home,
+            &format!("hub status snapshot refresh failed after mutation: {error:#}"),
+        );
+    }
+    operation_result
+}
+
+fn invalidate_status_snapshot_at(coven_home: &Path, revision: u64) {
+    if let Ok(mut snapshots) = hub_status_snapshots().write() {
+        if snapshots
+            .get(coven_home)
+            .is_none_or(|current| revision >= current.revision)
+        {
+            snapshots.insert(
+                coven_home.to_path_buf(),
+                VersionedStatusSnapshot {
+                    revision,
+                    value: None,
+                },
+            );
+        }
+    }
+}
+
+fn cached_status_snapshot(coven_home: &Path) -> Result<Option<Value>> {
+    Ok(hub_status_snapshots()
+        .read()
+        .map_err(|_| anyhow::anyhow!("hub status snapshot lock poisoned"))?
+        .get(coven_home)
+        .and_then(|snapshot| snapshot.value.clone()))
+}
+
+pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
+    let snapshot =
+        cached_status_snapshot(coven_home)?.context("hub status snapshot is unavailable")?;
+    Ok(json!({
+        "role": snapshot["role"],
+        "hubId": snapshot["hubId"],
+        "nodesTotal": snapshot["nodesTotal"],
+        "nodesAvailable": snapshot["nodesAvailable"],
+    }))
+}
+
+pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
+    hub_status_from_snapshot_result(cached_status_snapshot(coven_home))
+}
+
+fn hub_status_from_snapshot_result(snapshot: Result<Option<Value>>) -> Result<ApiResponse> {
+    let snapshot = match snapshot {
+        Ok(Some(snapshot)) => snapshot,
+        Ok(None) | Err(_) => {
+            return api_error(
+                503,
+                "hub_unavailable",
+                "Hub state is unavailable until daemon startup completes.",
+                None,
+            );
+        }
+    };
+    json_response(200, &snapshot)
 }
 
 #[derive(Debug, Deserialize)]
@@ -272,6 +406,11 @@ fn default_true() -> bool {
     true
 }
 
+fn begin_node_registration_transaction(conn: &mut Connection) -> Result<Transaction<'_>> {
+    conn.transaction_with_behavior(TransactionBehavior::Immediate)
+        .context("failed to begin node registration transaction")
+}
+
 pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
     let payload = match parse_body(body) {
         Ok(payload) => payload,
@@ -288,9 +427,7 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
         return api_error(400, "invalid_request", "role is required.", None);
     }
     let mut conn = store::open_store(&store_path(coven_home))?;
-    let transaction = conn
-        .transaction()
-        .context("failed to begin node registration transaction")?;
+    let transaction = begin_node_registration_transaction(&mut conn)?;
     let now = current_timestamp();
     let existing = store::get_node(&transaction, &request.node_id)?;
     let capabilities_json = serde_json::to_string(&request.capabilities)
@@ -1226,6 +1363,172 @@ mod tests {
     }
 
     #[test]
+    fn node_registration_reserves_the_writer_before_reading_existing_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store_path = super::store_path(temp.path());
+        let mut registration = crate::store::open_store(&store_path)?;
+        let mut contender = crate::store::open_initialized_store(&store_path)?;
+        contender.busy_timeout(std::time::Duration::ZERO)?;
+
+        let transaction = super::begin_node_registration_transaction(&mut registration)?;
+        assert!(crate::store::get_node(&transaction, "node_reserved")?.is_none());
+
+        let contender_blocked = contender
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .is_err();
+        assert!(
+            contender_blocked,
+            "registration must reserve SQLite's writer before reading existing node state"
+        );
+
+        drop(transaction);
+        contender
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?
+            .rollback()?;
+        Ok(())
+    }
+
+    #[test]
+    fn older_status_refresh_cannot_overwrite_newer_snapshot() -> anyhow::Result<()> {
+        let cache_key = tempfile::tempdir()?;
+        let older = tempfile::tempdir()?;
+        let newer = tempfile::tempdir()?;
+
+        let older_response = super::register_node(
+            older.path(),
+            Some(r#"{"nodeId":"node_old","role":"stationary_executor"}"#),
+        )?;
+        assert_eq!(older_response.status, 201);
+        let newer_response = super::register_node(
+            newer.path(),
+            Some(r#"{"nodeId":"node_new","role":"stationary_executor"}"#),
+        )?;
+        assert_eq!(newer_response.status, 201);
+
+        let older_conn = crate::store::open_initialized_store(&super::store_path(older.path()))?;
+        let newer_conn = crate::store::open_initialized_store(&super::store_path(newer.path()))?;
+        let older_revision = super::next_status_revision();
+        let newer_revision = super::next_status_revision();
+        super::refresh_status_snapshot_from_connection_at(
+            cache_key.path(),
+            &newer_conn,
+            newer_revision,
+        )?;
+        super::refresh_status_snapshot_from_connection_at(
+            cache_key.path(),
+            &older_conn,
+            older_revision,
+        )?;
+
+        let status = super::hub_status(cache_key.path())?;
+        let body: serde_json::Value = serde_json::from_str(&status.body)?;
+        assert_eq!(body["nodes"][0]["nodeId"], "node_new");
+        Ok(())
+    }
+
+    #[test]
+    fn mutation_error_refreshes_partially_committed_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store_path = super::store_path(temp.path());
+        crate::store::initialize_store(&store_path)?;
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        super::initialize_hub_identity(&conn)?;
+        super::refresh_status_snapshot_from_connection(temp.path(), &conn)?;
+        drop(conn);
+
+        let error = super::with_status_mutation(temp.path(), || {
+            let response = super::register_node(
+                temp.path(),
+                Some(r#"{"nodeId":"node_committed","role":"stationary_executor"}"#),
+            )?;
+            assert_eq!(response.status, 201);
+            anyhow::bail!("simulated post-commit failure");
+        })
+        .expect_err("operation must retain its original failure");
+        assert!(error.to_string().contains("simulated post-commit failure"));
+
+        let status = super::hub_status(temp.path())?;
+        let body: serde_json::Value = serde_json::from_str(&status.body)?;
+        assert_eq!(body["nodes"][0]["nodeId"], "node_committed");
+        Ok(())
+    }
+
+    #[test]
+    fn successful_mutation_survives_refresh_failure_and_invalidates_status() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store_path = super::store_path(temp.path());
+        crate::store::initialize_store(&store_path)?;
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        super::initialize_hub_identity(&conn)?;
+        super::refresh_status_snapshot_from_connection(temp.path(), &conn)?;
+        drop(conn);
+
+        let failure_revision = super::next_status_revision();
+        let response = super::with_status_mutation_using(
+            temp.path(),
+            || {
+                super::register_node(
+                    temp.path(),
+                    Some(r#"{"nodeId":"node_committed","role":"stationary_executor"}"#),
+                )
+            },
+            |home| {
+                super::invalidate_status_snapshot_at(home, failure_revision);
+                anyhow::bail!("simulated snapshot refresh failure")
+            },
+        )?;
+        assert_eq!(response.status, 201);
+
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        assert!(crate::store::get_node(&conn, "node_committed")?.is_some());
+
+        let status = super::hub_status(temp.path())?;
+        assert_eq!(status.status, 503);
+        let body: serde_json::Value = serde_json::from_str(&status.body)?;
+        assert_eq!(body["error"]["code"], "hub_unavailable");
+
+        let log = std::fs::read_to_string(crate::daemon::daemon_recovery_log_path(temp.path()))?;
+        assert!(log.contains("hub status snapshot refresh failed"));
+        assert!(log.contains("simulated snapshot refresh failure"));
+        Ok(())
+    }
+
+    #[test]
+    fn mutation_error_remains_primary_when_snapshot_refresh_also_fails() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let failure_revision = super::next_status_revision();
+
+        let error = super::with_status_mutation_using(
+            temp.path(),
+            || anyhow::bail!("operation failed"),
+            |home| {
+                super::invalidate_status_snapshot_at(home, failure_revision);
+                anyhow::bail!("simulated snapshot refresh failure")
+            },
+        )
+        .expect_err("operation failure must remain the result");
+
+        assert!(error.to_string().contains("operation failed"));
+        assert!(!error.to_string().contains("snapshot refresh failure"));
+        let log = std::fs::read_to_string(crate::daemon::daemon_recovery_log_path(temp.path()))?;
+        assert!(log.contains("hub status snapshot refresh failed"));
+        assert!(log.contains("simulated snapshot refresh failure"));
+        Ok(())
+    }
+
+    #[test]
+    fn hub_status_maps_snapshot_read_failure_to_structured_unavailable() -> anyhow::Result<()> {
+        let response = super::hub_status_from_snapshot_result(Err(anyhow::anyhow!(
+            "hub status snapshot lock poisoned"
+        )))?;
+
+        assert_eq!(response.status, 503);
+        let body: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "hub_unavailable");
+        Ok(())
+    }
+
+    #[test]
     fn hub_status_exposes_role_and_node_availability() -> anyhow::Result<()> {
         let temp = tempfile::tempdir()?;
         register_gpu_node(&temp, "node_a")?;
@@ -1680,6 +1983,13 @@ mod tests {
         let (_, node) = get(&temp, "/api/v1/hub/nodes/node_gone")?;
         assert_eq!(node["available"], false);
         assert!(!node["lastError"].as_str().unwrap().is_empty());
+
+        let (_, status) = get(&temp, "/api/v1/hub/status")?;
+        let status_node = status["nodes"]
+            .as_array()
+            .and_then(|nodes| nodes.iter().find(|node| node["nodeId"] == "node_gone"))
+            .ok_or_else(|| anyhow::anyhow!("failed dispatch node missing from hub status"))?;
+        assert_eq!(status_node["available"], false);
         Ok(())
     }
 

--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -10,7 +10,7 @@
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
@@ -38,6 +38,20 @@ fn store_path(coven_home: &Path) -> std::path::PathBuf {
 
 fn hub_id(conn: &Connection) -> Result<String> {
     store::get_or_insert_store_meta(conn, HUB_ID_META_KEY, &format!("hub_{}", Uuid::new_v4()))
+}
+
+fn read_hub_id(conn: &Connection) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM store_meta WHERE key = ?1",
+        [HUB_ID_META_KEY],
+        |row| row.get(0),
+    )
+    .optional()
+    .context("failed to read hub id")
+}
+
+pub(crate) fn initialize_hub_identity(conn: &Connection) -> Result<String> {
+    hub_id(conn)
 }
 
 fn parse_capabilities(json_text: &str) -> Vec<String> {
@@ -173,19 +187,35 @@ pub(crate) fn apply_redispatch_outcome(
 }
 
 pub fn hub_health_summary(coven_home: &Path) -> Result<Value> {
-    let conn = store::open_store(&store_path(coven_home))?;
+    let conn = store::open_existing_store_read_only(&store_path(coven_home))?
+        .context("Coven store does not exist")?;
     let nodes = store::list_nodes(&conn)?;
     let available = nodes.iter().filter(|node| node.available).count();
     Ok(json!({
         "role": HUB_ROLE,
-        "hubId": hub_id(&conn)?,
+        "hubId": read_hub_id(&conn)?.context("hub identity is not initialized")?,
         "nodesTotal": nodes.len(),
         "nodesAvailable": available,
     }))
 }
 
 pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
-    let conn = store::open_store(&store_path(coven_home))?;
+    let Some(conn) = store::open_existing_store_read_only(&store_path(coven_home))? else {
+        return api_error(
+            503,
+            "hub_unavailable",
+            "Hub state is unavailable until daemon startup completes.",
+            None,
+        );
+    };
+    let Some(hub_id) = read_hub_id(&conn)? else {
+        return api_error(
+            503,
+            "hub_unavailable",
+            "Hub identity is unavailable until daemon startup completes.",
+            None,
+        );
+    };
     let nodes = store::list_nodes(&conn)?;
     let jobs = store::list_hub_jobs(&conn, None)?;
     let queues = store::list_executor_queues(&conn)?;
@@ -206,7 +236,7 @@ pub fn hub_status(coven_home: &Path) -> Result<ApiResponse> {
         200,
         &json!({
             "role": HUB_ROLE,
-            "hubId": hub_id(&conn)?,
+            "hubId": hub_id,
             "nodes": node_views,
             "nodesTotal": nodes.len(),
             "nodesAvailable": nodes.iter().filter(|node| node.available).count(),
@@ -257,9 +287,12 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
     if request.role.trim().is_empty() {
         return api_error(400, "invalid_request", "role is required.", None);
     }
-    let conn = store::open_store(&store_path(coven_home))?;
+    let mut conn = store::open_store(&store_path(coven_home))?;
+    let transaction = conn
+        .transaction()
+        .context("failed to begin node registration transaction")?;
     let now = current_timestamp();
-    let existing = store::get_node(&conn, &request.node_id)?;
+    let existing = store::get_node(&transaction, &request.node_id)?;
     let capabilities_json = serde_json::to_string(&request.capabilities)
         .context("failed to serialize node capabilities")?;
     let transport_config_json = match &request.transport_config {
@@ -319,7 +352,11 @@ pub fn register_node(coven_home: &Path, body: Option<&str>) -> Result<ApiRespons
             .unwrap_or_else(|| now.clone()),
         updated_at: now,
     };
-    store::upsert_node(&conn, &record)?;
+    store::upsert_node(&transaction, &record)?;
+    hub_id(&transaction)?;
+    transaction
+        .commit()
+        .context("failed to commit node registration")?;
     json_response(
         if existing.is_some() { 200 } else { 201 },
         &node_response(&record),
@@ -1104,6 +1141,87 @@ mod tests {
             ),
         )?;
         assert_eq!(status, 201);
+        Ok(())
+    }
+
+    #[test]
+    fn registering_node_initializes_hub_identity_for_health() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        register_gpu_node(&temp, "node_a")?;
+
+        let (status, health) = get(&temp, "/api/v1/health")?;
+        assert_eq!(status, 200);
+        assert_eq!(health["hub"]["role"], "hub");
+        assert_eq!(health["hub"]["nodesTotal"], 1);
+        assert_eq!(health["hub"]["nodesAvailable"], 1);
+        let hub_id = health["hub"]["hubId"]
+            .as_str()
+            .expect("registration should initialize the hub identity");
+        assert!(hub_id.starts_with("hub_"));
+
+        let (status, _) = post(
+            &temp,
+            "/api/v1/hub/nodes",
+            r#"{"nodeId":"node_a","role":"compute_executor","transport":"ssh","capabilities":["gpu","long-running-loop"]}"#,
+        )?;
+        assert_eq!(status, 200);
+        let (_, health_after_registration) = get(&temp, "/api/v1/health")?;
+        assert_eq!(health_after_registration["hub"]["hubId"], hub_id);
+
+        let (_, status) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(status["hubId"], hub_id);
+        Ok(())
+    }
+
+    #[test]
+    fn hub_status_reports_unavailable_without_creating_or_mutating_store() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store_path = super::store_path(temp.path());
+
+        let (status, body) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(status, 503);
+        assert_eq!(body["error"]["code"], "hub_unavailable");
+        assert!(!store_path.exists());
+
+        let conn = crate::store::open_store(&store_path)?;
+        drop(conn);
+        let before = std::fs::metadata(&store_path)?.len();
+        let (status, body) = get(&temp, "/api/v1/hub/status")?;
+        assert_eq!(status, 503);
+        assert_eq!(body["error"]["code"], "hub_unavailable");
+        assert_eq!(std::fs::metadata(&store_path)?.len(), before);
+        Ok(())
+    }
+
+    #[test]
+    fn node_registration_rolls_back_when_hub_identity_initialization_fails() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let store_path = super::store_path(temp.path());
+        let conn = crate::store::open_store(&store_path)?;
+        conn.execute_batch(
+            "CREATE TRIGGER reject_hub_identity_insert
+             BEFORE INSERT ON store_meta
+             WHEN NEW.key = 'travel_source_hub_id'
+             BEGIN
+                 SELECT RAISE(FAIL, 'hub identity insertion rejected');
+             END;",
+        )?;
+        drop(conn);
+
+        let result = handle_request_with_body(
+            "POST",
+            "/api/v1/hub/nodes",
+            temp.path(),
+            None,
+            Some(r#"{"nodeId":"node_atomic","role":"compute_executor","capabilities":["gpu"]}"#),
+        );
+        assert!(result.is_err());
+
+        let conn = crate::store::open_initialized_store(&store_path)?;
+        assert!(
+            crate::store::get_node(&conn, "node_atomic")?.is_none(),
+            "failed hub identity initialization must roll back node registration"
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3158,7 +3158,17 @@ fn run_logs_command(command: LogsCommand) -> Result<()> {
 
 fn prune_logs_command(dry_run: bool, raw_days: Option<u64>, event_days: Option<u64>) -> Result<()> {
     let home = coven_home_dir()?;
-    let config = privacy::load_with_settings(&home, settings::cached()).unwrap_or_default();
+    prune_logs_at_home(&home, dry_run, raw_days, event_days)
+}
+
+fn prune_logs_at_home(
+    home: &Path,
+    dry_run: bool,
+    raw_days: Option<u64>,
+    event_days: Option<u64>,
+) -> Result<()> {
+    let config = privacy::load_with_settings(home, settings::cached())
+        .context("failed to load privacy configuration for log pruning")?;
     let raw_days = raw_days
         .unwrap_or(config.raw_artifact_retention_days)
         .max(1);
@@ -6407,6 +6417,59 @@ mod tests {
             }
             other => panic!("expected logs prune command, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn logs_prune_rejects_malformed_privacy_config_without_deleting_events() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let store_path = home.join(STORE_FILE_NAME);
+        let conn = store::open_store(&store_path)?;
+        store::insert_session(
+            &conn,
+            &test_session_record("prune-session", "completed", "codex", "Prune test", None),
+        )?;
+        store::insert_event(
+            &conn,
+            &store::EventRecord {
+                seq: 0,
+                id: "old-event".to_string(),
+                session_id: "prune-session".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"message":"old"}"#.to_string(),
+                created_at: "2000-01-01T00:00:00Z".to_string(),
+            },
+        )?;
+        drop(conn);
+        std::fs::write(home.join("privacy.toml"), "log_retention_days = [")?;
+
+        let result = prune_logs_at_home(home, false, None, None);
+        let conn = store::open_store(&store_path)?;
+        let remaining = store::list_events(&conn, "prune-session")?;
+
+        assert!(
+            result.is_err() && remaining.len() == 1,
+            "malformed privacy config must fail closed; result={result:?}, remaining_events={}",
+            remaining.len()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn logs_prune_rejects_malformed_privacy_config_without_creating_store() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let store_path = home.join(STORE_FILE_NAME);
+        std::fs::write(home.join("privacy.toml"), "log_retention_days = [")?;
+
+        let result = prune_logs_at_home(home, false, None, None);
+
+        assert!(
+            result.is_err() && !store_path.exists(),
+            "malformed privacy config must fail before store access; result={result:?}, store_exists={}",
+            store_path.exists()
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -1,11 +1,11 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{OnceLock, RwLock},
 };
 
 #[cfg(test)]
-use std::{collections::HashMap, sync::Mutex};
+use std::sync::Mutex;
 
 use anyhow::{bail, Context, Result};
 use base64::Engine;
@@ -155,6 +155,20 @@ pub struct StorageHealth {
     pub maintenance_blocked: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_maintenance_error: Option<String>,
+}
+
+#[derive(Clone)]
+struct StorageHealthSnapshot {
+    health: StorageHealth,
+    retention_lagging: bool,
+    degraded: bool,
+}
+
+static STORAGE_HEALTH_SNAPSHOTS: OnceLock<RwLock<HashMap<PathBuf, StorageHealthSnapshot>>> =
+    OnceLock::new();
+
+fn storage_health_snapshots() -> &'static RwLock<HashMap<PathBuf, StorageHealthSnapshot>> {
+    STORAGE_HEALTH_SNAPSHOTS.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -3600,6 +3614,7 @@ fn run_scheduled_maintenance_with_config_and_free_disk(
 
 /// Gather storage pressure without mutating the database. Health callers use
 /// this after daemon startup has initialized the schema.
+#[cfg(test)]
 pub fn storage_health(
     coven_home: &Path,
     event_writer: Option<&crate::event_writer::EventWriterHealth>,
@@ -3613,21 +3628,190 @@ pub fn storage_health(
     ))
 }
 
+pub fn cached_storage_health(
+    coven_home: &Path,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<StorageHealth> {
+    let free_disk_bytes = fs2::available_space(coven_home)
+        .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
+    cached_storage_health_with_free_disk(coven_home, free_disk_bytes, event_writer)
+}
+
+pub(crate) fn cached_storage_health_with_free_disk(
+    coven_home: &Path,
+    free_disk_bytes: u64,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<StorageHealth> {
+    let snapshot = storage_health_snapshots()
+        .read()
+        .map_err(|_| anyhow::anyhow!("storage health snapshot lock poisoned"))?
+        .get(coven_home)
+        .cloned()
+        .context("storage health snapshot is unavailable")?;
+    let mut health = snapshot.health;
+    let store_path = coven_home.join("coven.sqlite3");
+    health.database_bytes = file_size(&store_path);
+    health.wal_bytes = file_size(&wal_path(&store_path));
+    health.free_disk_bytes = free_disk_bytes;
+    health.maintenance_blocked = health.free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES;
+    if event_writer.is_some() {
+        (health.writer_backlog_events, health.writer_backlog_bytes) = writer_backlog(event_writer);
+    }
+    health.prune_age_seconds = maintenance_age_seconds(health.last_prune_at.as_deref());
+    health.checkpoint_age_seconds = maintenance_age_seconds(health.last_checkpoint_at.as_deref());
+    if snapshot.degraded {
+        health.status = "degraded".to_string();
+    } else if health.maintenance_blocked {
+        health.status = "critical".to_string();
+    } else if snapshot.retention_lagging
+        || health.free_disk_bytes < MAINTENANCE_WARN_FREE_DISK_BYTES
+        || health.wal_bytes >= MAINTENANCE_CHECKPOINT_WAL_BYTES
+        || health.last_maintenance_error.is_some()
+    {
+        health.status = "warning".to_string();
+    } else {
+        health.status = "ok".to_string();
+    }
+    Ok(health)
+}
+
+pub fn refresh_storage_health_snapshot_from_connection(
+    coven_home: &Path,
+    conn: &Connection,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<()> {
+    let free_disk_bytes = fs2::available_space(coven_home)
+        .with_context(|| format!("failed to inspect free disk for {}", coven_home.display()))?;
+    refresh_storage_health_snapshot_from_connection_with_free_disk(
+        coven_home,
+        conn,
+        free_disk_bytes,
+        event_writer,
+    )
+}
+
+pub(crate) fn refresh_storage_health_snapshot_from_connection_with_free_disk(
+    coven_home: &Path,
+    conn: &Connection,
+    free_disk_bytes: u64,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<()> {
+    let previous = if free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES {
+        storage_health_snapshots()
+            .read()
+            .map_err(|_| anyhow::anyhow!("storage health snapshot lock poisoned"))?
+            .get(coven_home)
+            .cloned()
+    } else {
+        None
+    };
+    let mut snapshot =
+        storage_health_snapshot_from_connection(coven_home, conn, free_disk_bytes, event_writer)?;
+    if let Some(previous) = previous {
+        let database_bytes = snapshot.health.database_bytes;
+        let wal_bytes = snapshot.health.wal_bytes;
+        snapshot = previous;
+        snapshot.health.status = "critical".to_string();
+        snapshot.health.database_bytes = database_bytes;
+        snapshot.health.wal_bytes = wal_bytes;
+        snapshot.health.free_disk_bytes = free_disk_bytes;
+        snapshot.health.maintenance_blocked = true;
+        if event_writer.is_some() {
+            (
+                snapshot.health.writer_backlog_events,
+                snapshot.health.writer_backlog_bytes,
+            ) = writer_backlog(event_writer);
+        }
+    }
+    storage_health_snapshots()
+        .write()
+        .map_err(|_| anyhow::anyhow!("storage health snapshot lock poisoned"))?
+        .insert(coven_home.to_path_buf(), snapshot);
+    Ok(())
+}
+
+pub fn cache_unavailable_storage_health(
+    coven_home: &Path,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<()> {
+    let known_free_disk_bytes = fs2::available_space(coven_home).ok();
+    mark_storage_health_snapshot_degraded(
+        coven_home,
+        known_free_disk_bytes,
+        event_writer,
+        "storage health unavailable",
+    )
+}
+
+pub(crate) fn mark_storage_health_snapshot_maintenance_failure(
+    coven_home: &Path,
+    known_free_disk_bytes: Option<u64>,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<()> {
+    mark_storage_health_snapshot_degraded(
+        coven_home,
+        known_free_disk_bytes,
+        event_writer,
+        MAINTENANCE_LAST_ERROR_PUBLIC_MESSAGE,
+    )
+}
+
+fn mark_storage_health_snapshot_degraded(
+    coven_home: &Path,
+    known_free_disk_bytes: Option<u64>,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+    prior_snapshot_error: &str,
+) -> Result<()> {
+    let mut snapshots = storage_health_snapshots()
+        .write()
+        .map_err(|_| anyhow::anyhow!("storage health snapshot lock poisoned"))?;
+    if let Some(snapshot) = snapshots.get_mut(coven_home) {
+        snapshot.degraded = true;
+        snapshot.health.status = "degraded".to_string();
+        snapshot.health.last_maintenance_error = Some(prior_snapshot_error.to_string());
+        if let Some(free_disk_bytes) = known_free_disk_bytes {
+            snapshot.health.free_disk_bytes = free_disk_bytes;
+            snapshot.health.maintenance_blocked = free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES;
+        }
+        if event_writer.is_some() {
+            (
+                snapshot.health.writer_backlog_events,
+                snapshot.health.writer_backlog_bytes,
+            ) = writer_backlog(event_writer);
+        }
+        return Ok(());
+    }
+
+    let health = unavailable_storage_health(
+        coven_home,
+        "storage health snapshot refresh failed",
+        known_free_disk_bytes,
+        event_writer,
+    );
+    snapshots.insert(
+        coven_home.to_path_buf(),
+        StorageHealthSnapshot {
+            health,
+            retention_lagging: false,
+            degraded: true,
+        },
+    );
+    Ok(())
+}
+
+#[cfg(test)]
 fn storage_health_with_free_disk(
     coven_home: &Path,
     free_disk_bytes: u64,
     event_writer: Option<&crate::event_writer::EventWriterHealth>,
 ) -> Result<StorageHealth> {
-    let store_path = coven_home.join("coven.sqlite3");
-    let database_bytes = file_size(&store_path);
-    let wal_bytes = file_size(&wal_path(&store_path));
-    let maintenance_blocked = free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES;
-    let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
-    if maintenance_blocked {
+    if free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES {
+        let store_path = coven_home.join("coven.sqlite3");
+        let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
         return Ok(StorageHealth {
             status: "critical".to_string(),
-            database_bytes,
-            wal_bytes,
+            database_bytes: file_size(&store_path),
+            wal_bytes: file_size(&wal_path(&store_path)),
             oldest_retained_event_at: None,
             last_prune_at: None,
             prune_age_seconds: None,
@@ -3640,6 +3824,54 @@ fn storage_health_with_free_disk(
             last_maintenance_error: None,
         });
     }
+    let config = privacy::load_with_settings(coven_home, crate::settings::cached())
+        .context("failed to load privacy settings for storage health")?;
+    let retention_cutoff = retention_cutoff(
+        &Utc::now().to_rfc3339_opts(SecondsFormat::Nanos, true),
+        config.log_retention_days.max(1),
+    )?;
+    parse_rfc3339_utc(&retention_cutoff).context("failed to parse calculated retention cutoff")?;
+    let store_path = coven_home.join("coven.sqlite3");
+    let conn = open_existing_store_read_only(&store_path)?
+        .ok_or_else(|| anyhow::anyhow!("Coven store is unavailable"))?;
+    Ok(
+        storage_health_snapshot_from_connection(coven_home, &conn, free_disk_bytes, event_writer)?
+            .health,
+    )
+}
+
+fn storage_health_snapshot_from_connection(
+    coven_home: &Path,
+    conn: &Connection,
+    free_disk_bytes: u64,
+    event_writer: Option<&crate::event_writer::EventWriterHealth>,
+) -> Result<StorageHealthSnapshot> {
+    let store_path = coven_home.join("coven.sqlite3");
+    let database_bytes = file_size(&store_path);
+    let wal_bytes = file_size(&wal_path(&store_path));
+    let maintenance_blocked = free_disk_bytes < MAINTENANCE_MIN_FREE_DISK_BYTES;
+    let (writer_backlog_events, writer_backlog_bytes) = writer_backlog(event_writer);
+    if maintenance_blocked {
+        return Ok(StorageHealthSnapshot {
+            health: StorageHealth {
+                status: "critical".to_string(),
+                database_bytes,
+                wal_bytes,
+                oldest_retained_event_at: None,
+                last_prune_at: None,
+                prune_age_seconds: None,
+                last_checkpoint_at: None,
+                checkpoint_age_seconds: None,
+                writer_backlog_events,
+                writer_backlog_bytes,
+                free_disk_bytes,
+                maintenance_blocked: true,
+                last_maintenance_error: None,
+            },
+            retention_lagging: false,
+            degraded: false,
+        });
+    }
 
     let config = privacy::load_with_settings(coven_home, crate::settings::cached())
         .context("failed to load privacy settings for storage health")?;
@@ -3649,8 +3881,6 @@ fn storage_health_with_free_disk(
     )?;
     let retention_cutoff = parse_rfc3339_utc(&retention_cutoff)
         .context("failed to parse calculated retention cutoff")?;
-    let conn = open_existing_store_read_only(&store_path)?
-        .ok_or_else(|| anyhow::anyhow!("Coven store is unavailable"))?;
     // `MIN(created_at)` is NULL on an empty ledger, so the column type has to be
     // stated: `row.get` cannot infer `Option<String>` from the comparison below.
     let oldest_retained_event_at: Option<String> = conn
@@ -3660,10 +3890,10 @@ fn storage_health_with_free_disk(
         .as_deref()
         .and_then(parse_rfc3339_utc)
         .is_some_and(|oldest_at| oldest_at < retention_cutoff);
-    let last_prune_at = get_store_meta(&conn, MAINTENANCE_LAST_PRUNE_KEY)?;
-    let last_checkpoint_at = get_store_meta(&conn, MAINTENANCE_LAST_CHECKPOINT_KEY)?;
+    let last_prune_at = get_store_meta(conn, MAINTENANCE_LAST_PRUNE_KEY)?;
+    let last_checkpoint_at = get_store_meta(conn, MAINTENANCE_LAST_CHECKPOINT_KEY)?;
     let last_maintenance_error =
-        public_maintenance_error(get_store_meta(&conn, MAINTENANCE_LAST_ERROR_KEY)?);
+        public_maintenance_error(get_store_meta(conn, MAINTENANCE_LAST_ERROR_KEY)?);
     let status = if maintenance_blocked {
         "critical"
     } else if retention_lagging
@@ -3676,23 +3906,28 @@ fn storage_health_with_free_disk(
         "ok"
     };
 
-    Ok(StorageHealth {
-        status: status.to_string(),
-        database_bytes,
-        wal_bytes,
-        oldest_retained_event_at,
-        prune_age_seconds: maintenance_age_seconds(last_prune_at.as_deref()),
-        last_prune_at,
-        checkpoint_age_seconds: maintenance_age_seconds(last_checkpoint_at.as_deref()),
-        last_checkpoint_at,
-        writer_backlog_events,
-        writer_backlog_bytes,
-        free_disk_bytes,
-        maintenance_blocked,
-        last_maintenance_error,
+    Ok(StorageHealthSnapshot {
+        health: StorageHealth {
+            status: status.to_string(),
+            database_bytes,
+            wal_bytes,
+            oldest_retained_event_at,
+            prune_age_seconds: maintenance_age_seconds(last_prune_at.as_deref()),
+            last_prune_at,
+            checkpoint_age_seconds: maintenance_age_seconds(last_checkpoint_at.as_deref()),
+            last_checkpoint_at,
+            writer_backlog_events,
+            writer_backlog_bytes,
+            free_disk_bytes,
+            maintenance_blocked,
+            last_maintenance_error,
+        },
+        retention_lagging,
+        degraded: false,
     })
 }
 
+#[cfg(test)]
 fn storage_health_with_free_disk_or_unavailable(
     coven_home: &Path,
     free_disk_bytes: u64,
@@ -5483,6 +5718,102 @@ mod tests {
             .expect_err("malformed privacy config must fail closed above the watermark");
 
         assert!(error.to_string().contains("privacy"));
+        Ok(())
+    }
+
+    #[test]
+    fn cached_storage_health_clears_recovered_disk_and_wal_status() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        open_store(&home.join("coven.sqlite3"))?;
+        storage_health_snapshots().write().unwrap().insert(
+            home.to_path_buf(),
+            StorageHealthSnapshot {
+                health: StorageHealth {
+                    status: "critical".to_string(),
+                    database_bytes: 1,
+                    wal_bytes: MAINTENANCE_CHECKPOINT_WAL_BYTES,
+                    oldest_retained_event_at: None,
+                    last_prune_at: None,
+                    prune_age_seconds: None,
+                    last_checkpoint_at: None,
+                    checkpoint_age_seconds: None,
+                    writer_backlog_events: 0,
+                    writer_backlog_bytes: 0,
+                    free_disk_bytes: MAINTENANCE_MIN_FREE_DISK_BYTES - 1,
+                    maintenance_blocked: true,
+                    last_maintenance_error: None,
+                },
+                retention_lagging: false,
+                degraded: false,
+            },
+        );
+
+        let health =
+            cached_storage_health_with_free_disk(home, MAINTENANCE_WARN_FREE_DISK_BYTES, None)?;
+
+        assert_eq!(health.wal_bytes, 0);
+        assert!(!health.maintenance_blocked);
+        assert_eq!(health.status, "ok");
+        Ok(())
+    }
+
+    #[test]
+    fn low_disk_refresh_retains_prior_lag_and_error_causes() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let path = home.join("coven.sqlite3");
+        let conn = open_store(&path)?;
+        insert_session(&conn, &session_record("session-1", "2010-01-01T00:00:00Z"))?;
+        insert_event(
+            &conn,
+            &EventRecord {
+                seq: 0,
+                id: "ancient".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: r#"{"data":"ancient"}"#.to_string(),
+                created_at: "2010-01-01T00:00:00Z".to_string(),
+            },
+        )?;
+        record_maintenance_error(home, "failed to read /private/home");
+
+        refresh_storage_health_snapshot_from_connection_with_free_disk(
+            home,
+            &conn,
+            MAINTENANCE_WARN_FREE_DISK_BYTES,
+            None,
+        )?;
+        let before =
+            cached_storage_health_with_free_disk(home, MAINTENANCE_WARN_FREE_DISK_BYTES, None)?;
+        assert_eq!(before.status, "warning");
+        assert_eq!(
+            before.oldest_retained_event_at.as_deref(),
+            Some("2010-01-01T00:00:00Z")
+        );
+        assert_eq!(
+            before.last_maintenance_error.as_deref(),
+            Some(MAINTENANCE_LAST_ERROR_PUBLIC_MESSAGE)
+        );
+
+        refresh_storage_health_snapshot_from_connection_with_free_disk(
+            home,
+            &conn,
+            MAINTENANCE_MIN_FREE_DISK_BYTES - 1,
+            None,
+        )?;
+        let recovered =
+            cached_storage_health_with_free_disk(home, MAINTENANCE_WARN_FREE_DISK_BYTES, None)?;
+
+        assert_eq!(recovered.status, "warning");
+        assert_eq!(
+            recovered.oldest_retained_event_at,
+            before.oldest_retained_event_at
+        );
+        assert_eq!(
+            recovered.last_maintenance_error,
+            before.last_maintenance_error
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- serve `/health` and `/hub/status` from daemon-owned, versioned in-memory snapshots so GET requests never open or mutate SQLite/WAL/SHM state
- initialize and backfill stable hub identity at writable startup/registration boundaries, refresh snapshots after mutations, and fail unavailable instead of serving stale state
- cache storage health at writable startup/maintenance boundaries and degrade safely when privacy configuration or refresh fails
- fail closed on malformed privacy configuration before manual log pruning can open or delete from the store

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked` (1,810 unit tests pass; one unrelated daemon-start integration race reproduces unchanged on `main`)
- focused health, hub, storage-health, daemon-startup, WAL side-effect, concurrency, and error-path regressions
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `git diff --check`

Follow-up to #637. Supersedes #645, whose head was contaminated by an unsigned autofix commit with unsuitable attribution.