### PR TITLE
feat: benchmark cold daemon startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,13 +657,16 @@ node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --outp
 cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture
 ```
 
-The runner uses a disposable `COVEN_HOME`, a fixture-only fake Codex executable,
-and the local socket API. It records command startup, daemon session-listing,
-event-tail, and harness-first-output timings without reading real configuration,
-prompts, or session logs. The ignored Rust test prints deterministic TUI
-poll/draw counters. These outputs are trend data: CI uploads them as artifacts
-and validates fixture construction, but does not fail pull requests on
-wall-clock thresholds.
+The runner uses disposable `COVEN_HOME` directories, a fixture-only fake Codex
+executable, and the local socket API. It records command startup, cold daemon
+start-to-health, daemon session-listing, event-tail, and harness-first-output
+timings without reading real configuration, prompts, or session logs. Each cold
+start sample gets a fresh home and a matching daemon stop. The ignored Rust test
+prints deterministic TUI poll/draw counters. These outputs are trend data: CI
+uploads them as artifacts and validates fixture construction, but does not fail
+pull requests on wall-clock thresholds. Cave's managed-start contract retains
+its 8-second hard deadline; benchmark p50/p95/p99 values do not replace that
+product-level timeout.
 
 ### Concurrent runtime baseline
 

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -17,7 +17,9 @@ export function summarizeSamples(samples) {
       sorted.length % 2 === 1
         ? sorted[middle]
         : (sorted[middle - 1] + sorted[middle]) / 2,
+    p50Ms: sorted[Math.ceil(sorted.length * 0.5) - 1],
     p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1],
+    p99Ms: sorted[Math.ceil(sorted.length * 0.99) - 1],
     maxMs: sorted.at(-1)
   };
 }
@@ -456,6 +458,36 @@ export function stopDaemon({ binary, env, run = runCommand }) {
   run({ command: binary, args: ['daemon', 'stop'], allowedExitCodes: [0], env });
 }
 
+export async function measureColdDaemonStarts({
+  binary,
+  fixtureRoot,
+  environment,
+  iterations,
+  makeDirectory = (path) => mkdir(path, { recursive: true }),
+  start = startDaemon,
+  stop = stopDaemon,
+  now = () => process.hrtime.bigint()
+}) {
+  const samplesMs = [];
+
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const covenHome = join(fixtureRoot, `d-${iteration}`);
+    const env = isolatedEnvironment(covenHome, environment);
+    await makeDirectory(join(covenHome, 'user-home'));
+    const startedAt = now();
+
+    try {
+      await start({ binary, covenHome, env });
+      const elapsedMs = Number(now() - startedAt) / 1_000_000;
+      samplesMs.push(Number(elapsedMs.toFixed(3)));
+    } finally {
+      await stop({ binary, covenHome, env });
+    }
+  }
+
+  return { samplesMs, summary: summarizeSamples(samplesMs) };
+}
+
 export async function registerExternalSessions({
   socketPath,
   count,
@@ -652,6 +684,7 @@ export async function collectBenchmarkScenarios({
   environment,
   makeDirectory = (path) => mkdir(path, { recursive: true }),
   collectCore = collectCoreScenarios,
+  measureColdStarts = measureColdDaemonStarts,
   measureHarness = measureHarnessOutput,
   measureEvents = measureEventTails,
   measureLists = measureSessionLists,
@@ -667,6 +700,12 @@ export async function collectBenchmarkScenarios({
   });
 
   if (options.sessionCounts.length > 0) {
+    scenarios.daemon_cold_start = await measureColdStarts({
+      binary: options.binary,
+      fixtureRoot,
+      environment,
+      iterations: options.iterations
+    });
     scenarios.harness_first_output = await measureHarness({
       binary: options.binary,
       fixtureRoot,

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -19,6 +19,7 @@ import {
   prepareEventTail,
   measureEventTails,
   measureCapabilityReads,
+  measureColdDaemonStarts,
   measureSessionLists,
   registerInputEvents,
   registerExternalSessions,
@@ -37,11 +38,13 @@ import {
   waitForHealth
 } from './benchmark-cli.mjs';
 
-test('summarizeSamples reports deterministic median and nearest-rank p95', () => {
+test('summarizeSamples reports deterministic p50, p95, and p99', () => {
   assert.deepEqual(summarizeSamples([9, 1, 5, 3, 7]), {
     minMs: 1,
     medianMs: 5,
+    p50Ms: 5,
     p95Ms: 9,
+    p99Ms: 9,
     maxMs: 9
   });
 });
@@ -400,6 +403,44 @@ test('stopDaemon shuts down through the same isolated command boundary', () => {
   ]);
 });
 
+test('measureColdDaemonStarts uses a fresh home per sample and always stops it', async () => {
+  const calls = [];
+  const ticks = [0n, 1_250_000n, 2_000_000n, 5_500_000n];
+  const report = await measureColdDaemonStarts({
+    binary: '/tmp/coven',
+    fixtureRoot: '/fixture/root',
+    environment: { PATH: '/fixture/bin' },
+    iterations: 2,
+    makeDirectory: async (path) => calls.push(['mkdir', path]),
+    start: async ({ covenHome, env }) => {
+      calls.push(['start', covenHome, env.COVEN_HOME]);
+      return `${covenHome}/coven.sock`;
+    },
+    stop: ({ covenHome, env }) => calls.push(['stop', covenHome, env.COVEN_HOME]),
+    now: () => ticks.shift()
+  });
+
+  assert.deepEqual(report, {
+    samplesMs: [1.25, 3.5],
+    summary: {
+      minMs: 1.25,
+      medianMs: 2.375,
+      p50Ms: 1.25,
+      p95Ms: 3.5,
+      p99Ms: 3.5,
+      maxMs: 3.5
+    }
+  });
+  assert.deepEqual(calls, [
+    ['mkdir', '/fixture/root/d-0/user-home'],
+    ['start', '/fixture/root/d-0', '/fixture/root/d-0'],
+    ['stop', '/fixture/root/d-0', '/fixture/root/d-0'],
+    ['mkdir', '/fixture/root/d-1/user-home'],
+    ['start', '/fixture/root/d-1', '/fixture/root/d-1'],
+    ['stop', '/fixture/root/d-1', '/fixture/root/d-1']
+  ]);
+});
+
 test('registerExternalSessions seeds deterministic rows through the socket API', async () => {
   const calls = [];
   await registerExternalSessions({
@@ -558,6 +599,10 @@ test('collectBenchmarkScenarios merges core and daemon fixture reports', async (
       calls.push(['core', env.COVEN_HOME]);
       return { help: { samplesMs: [1], exitCodes: [0], summary: { minMs: 1 } } };
     },
+    measureColdStarts: async (input) => {
+      calls.push(['cold-start', input.fixtureRoot, input.iterations]);
+      return { samplesMs: [6], summary: { p50Ms: 6, p95Ms: 6, p99Ms: 6 } };
+    },
     measureHarness: async (input) => {
       calls.push(['harness', input.fixtureRoot, input.iterations]);
       return { samplesMs: [3], statusCodes: [201], summary: { minMs: 3 } };
@@ -578,6 +623,7 @@ test('collectBenchmarkScenarios merges core and daemon fixture reports', async (
 
   assert.deepEqual(Object.keys(scenarios), [
     'help',
+    'daemon_cold_start',
     'harness_first_output',
     'event_tail_2',
     'sessions_2',
@@ -586,6 +632,7 @@ test('collectBenchmarkScenarios merges core and daemon fixture reports', async (
   assert.deepEqual(calls, [
     ['mkdir', '/fixture/root/c/user-home'],
     ['core', '/fixture/root/c'],
+    ['cold-start', '/fixture/root', 2],
     ['harness', '/fixture/root', 2],
     ['events', '/fixture/root', [2]],
     ['lists', '/fixture/root', [2]],
@@ -601,6 +648,7 @@ test('collectBenchmarkScenarios records warmed capability reads', async () => {
     environment: { PATH: '/fixture/bin' },
     makeDirectory: async () => {},
     collectCore: () => ({ help: { samplesMs: [1], exitCodes: [0], summary: { minMs: 1 } } }),
+    measureColdStarts: async () => ({ samplesMs: [6], summary: { p50Ms: 6 } }),
     measureHarness: async () => ({ samplesMs: [3], statusCodes: [201], summary: { minMs: 3 } }),
     measureEvents: async () => ({ event_tail_2: { samplesMs: [4], statusCodes: [200], summary: { minMs: 4 } } }),
     measureLists: async () => ({ sessions_2: { samplesMs: [2], statusCodes: [200], summary: { minMs: 2 } } }),


### PR DESCRIPTION
## Summary
- measure cold daemon start-to-health with a fresh isolated `COVEN_HOME` for every sample
- stop each daemon after its sample and report p50/p95/p99 alongside existing summary fields
- document that wall-clock percentiles are trend-only while Cave keeps its 8-second managed-start deadline

## Evidence
Five local production-path samples: 116.100, 105.048, 116.340, 104.685, 109.314 ms (p50 109.314 ms; p95/p99 116.340 ms).

## Verification
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 5 --session-counts=100 --output /tmp/coven-v7d-benchmark.json`

Supports OpenCoven/coven-cave#4318 and OpenCoven/coven#599.