### PR TITLE
fix: harden v0.2.4 npm recovery

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -357,11 +357,15 @@ jobs:
           require_package() {
           local package_name="$1"
           local output
-          if output=$(npm view "$package_name" name); then
+          if output=$(npm view "$package_name" name 2>&1); then
           return 0
           fi
           printf '%s\n' "$output"
-          echo "::error::Refusing non-latest bootstrap version publish in OpenCoven/coven release-npm.yml because npm package $package_name is unavailable."
+          if ! grep -q 'E404' <<<"$output"; then
+          echo "::error::Package availability for $package_name could not be verified; resolve the npm registry error before publishing."
+          exit 1
+          fi
+          echo "::error::Publish a non-latest bootstrap version for $package_name, configure npm trusted publishing for OpenCoven/coven and release-npm.yml with no environment, then create a new signed recovery tag."
           exit 1
           }
           if [ "$RELEASE_MODE" = "normal" ]; then

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -162,7 +162,9 @@ jobs:
               scripts/publish-npm-test.mjs|\
               docs/reference/releasing.md|\
               docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md|\
-              docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md)
+              docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md|\
+              docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md|\
+              docs/superpowers/plans/2026-08-06-v0.2.4-intel-macos-recovery.md)
                 ;;
               *)
                 echo "::error::Refusing recovery: changed path $changed_path is not release-only."
@@ -346,6 +348,33 @@ jobs:
             exit 1
           fi
           expect_missing @opencoven/cli
+      - name: Preflight npm native package availability
+        env:
+          RELEASE_MODE: ${{ needs.verify-tag.outputs.release_mode }}
+          NATIVE_PACKAGE_SET: ${{ needs.verify-tag.outputs.native_package_set }}
+        run: |
+          set -euo pipefail
+          require_package() {
+          local package_name="$1"
+          local output
+          if output=$(npm view "$package_name" name); then
+          return 0
+          fi
+          printf '%s\n' "$output"
+          echo "::error::Refusing non-latest bootstrap version publish in OpenCoven/coven release-npm.yml because npm package $package_name is unavailable."
+          exit 1
+          }
+          if [ "$RELEASE_MODE" = "normal" ]; then
+          require_package @opencoven/cli-linux-x64
+          require_package @opencoven/cli-windows
+          require_package @opencoven/cli-macos-x64
+          require_package @opencoven/cli-macos
+          elif [ "$NATIVE_PACKAGE_SET" = "post-intel" ]; then
+          require_package @opencoven/cli-macos-x64
+          require_package @opencoven/cli-macos
+          else
+          require_package @opencoven/cli-macos
+          fi
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper
         if: needs.verify-tag.outputs.release_mode == 'normal'
         env:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -365,7 +365,7 @@ jobs:
           echo "::error::Package availability for $package_name could not be verified; resolve the npm registry error before publishing."
           exit 1
           fi
-          echo "::error::Publish a non-latest bootstrap version for $package_name, configure npm trusted publishing for OpenCoven/coven and release-npm.yml with no environment, then create a new signed recovery tag."
+          echo "::error::Publish a bootstrap version for $package_name, configure npm trusted publishing for OpenCoven/coven and release-npm.yml with no environment, then create a new signed recovery tag. npm assigns latest to an initial public publish; do not publish the wrapper until recovery publishes the production package."
           exit 1
           }
           if [ "$RELEASE_MODE" = "normal" ]; then

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -160,6 +160,8 @@ jobs:
               scripts/release-npm-platform-matrix.mjs|\
               scripts/publish-npm.mjs|\
               scripts/publish-npm-test.mjs|\
+              scripts/check-secrets.py|\
+              scripts/check-secrets-test.py|\
               docs/reference/releasing.md|\
               docs/superpowers/specs/2026-08-01-release-partial-publish-recovery-design.md|\
               docs/superpowers/plans/2026-08-01-release-partial-publish-recovery.md|\

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -378,8 +378,11 @@ jobs:
           elif [ "$NATIVE_PACKAGE_SET" = "post-intel" ]; then
           require_package @opencoven/cli-macos-x64
           require_package @opencoven/cli-macos
-          else
+          elif [ "$NATIVE_PACKAGE_SET" = "pre-intel" ]; then
           require_package @opencoven/cli-macos
+          else
+          echo "::error::Unsupported recovery native package set $NATIVE_PACKAGE_SET."
+          exit 1
           fi
       - run: node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper
         if: needs.verify-tag.outputs.release_mode == 'normal'

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -14,7 +14,22 @@ Source package versions stay `0.0.0` in the repo. The published version comes fr
 
 ## One-time setup (per package, per fresh npm publisher)
 
-Before the first OIDC release, configure trusted publishing for every package. With npm 11.16 or newer, an authenticated publisher can configure it from the CLI:
+### Bootstrap a new native package
+
+Trusted publisher configuration is scoped to an existing npm package record. When a new native package such as `@opencoven/cli-macos-x64` has never been published, create that record first with a short-lived, package-scoped credential under a non-latest bootstrap version so normal users never receive the bootstrap artifact from `latest`.
+
+Build the Intel macOS binary from the audited recovery checkout, then publish only the bootstrap artifact:
+
+```bash
+NPM_CONFIG_TAG=bootstrap \
+COVEN_NPM_VERSION=0.0.0-bootstrap.1 \
+NODE_AUTH_TOKEN="$NPM_GRANULAR_TOKEN" \
+node scripts/publish-npm.mjs --target=macos-x64 --skip-build --publish --skip-wrapper
+```
+
+This only creates the npm package record. Do not publish a production version, do not move `latest`, and revoke the temporary credential immediately after the bootstrap publish succeeds.
+
+After every package already has an npm record, configure trusted publishing for every package. With npm 11.16 or newer, an authenticated publisher can configure it from the CLI:
 
 ```sh
 npm trust github @opencoven/cli --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
@@ -24,7 +39,11 @@ npm trust github @opencoven/cli-linux-x64 --repository OpenCoven/coven --file re
 npm trust github @opencoven/cli-windows --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
 ```
 
-Leave the environment unset. Verify the result with `npm trust list <package>`.
+Leave the environment unset (`no environment`). Each package should list `OpenCoven/coven` as the source repository and `release-npm.yml` as the workflow file. Verify the result with `npm trust list <package>`; for example:
+
+```sh
+npm trust list @opencoven/cli-macos-x64
+```
 
 The npm website exposes the same configuration:
 
@@ -117,7 +136,7 @@ The recovery path exists only for one exact registry state per supported histori
 - `@opencoven/cli-macos@X.Y.Z` and `@opencoven/cli@X.Y.Z` do not exist.
 - If the original release wrapper declares the post-Intel set, `@opencoven/cli-macos-x64@X.Y.Z` also does not exist. The workflow rejects incomplete, unexpected, or mixed package sets.
 
-Fix the trusted-publisher configuration on a temporary recovery branch created from the original release tag. Then create a **new signed recovery tag** whose commit descends from that tag. The workflow requires the original tag to be an ancestor and every intervening changed path to be on its release-only allowlist; unlike normal releases, recovery tags do not need to include unrelated later `main` commits.
+Fix the trusted-publisher configuration on a temporary recovery branch created from the original release tag. For the `v0.2.4` recovery, bootstrap `@opencoven/cli-macos-x64` as above and configure trusted publishing for it before pushing `v0.2.4-recovery.1`. Then create a **new signed recovery tag** whose commit descends from that tag. The workflow requires the original tag to be an ancestor and every intervening changed path to be on its release-only allowlist; unlike normal releases, recovery tags do not need to include unrelated later `main` commits.
 
 ```sh
 git fetch origin --tags
@@ -129,7 +148,7 @@ git push origin release/vX.Y.Z-recovery.N vX.Y.Z-recovery.N
 
 Never move or reuse the original release tag or a recovery tag. Increment `N` if a later, separately-reviewed recovery attempt is required.
 
-Before publishing, the recovery workflow verifies both signed tags, ancestry, the changed-path allowlist, the original wrapper's complete package set, and the exact npm registry state above. It then skips the already-published Linux and Windows packages and publishes the missing macOS package or packages before the wrapper through OIDC with provenance.
+Before publishing, the recovery workflow verifies both signed tags, ancestry, the changed-path allowlist, the original wrapper's complete package set, and the exact npm registry state above. It then skips the already-published Linux and Windows packages and publishes the missing macOS package or packages before the wrapper, producing the real `0.2.4` release through GitHub OIDC with provenance.
 
 ## Recovering from a refused release
 

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -16,7 +16,7 @@ Source package versions stay `0.0.0` in the repo. The published version comes fr
 
 ### Bootstrap a new native package
 
-Trusted publisher configuration is scoped to an existing npm package record. When a new native package such as `@opencoven/cli-macos-x64` has never been published, create that record first with a short-lived, package-scoped credential under a non-latest bootstrap version so normal users never receive the bootstrap artifact from `latest`.
+Trusted publisher configuration is scoped to an existing npm package record. When a new native package such as `@opencoven/cli-macos-x64` has never been published, create that record first with a short-lived, package-scoped credential under a bootstrap version. npm assigns `latest` to an initial public publish even when the `bootstrap` dist-tag is requested, so complete the trusted-publisher setup and recovery before publishing a wrapper that can select the bootstrap artifact.
 
 Build the Intel macOS binary from the audited recovery checkout, then publish only the bootstrap artifact:
 
@@ -27,7 +27,7 @@ NODE_AUTH_TOKEN="$NPM_GRANULAR_TOKEN" \
 node scripts/publish-npm.mjs --target=macos-x64 --skip-build --publish --skip-wrapper
 ```
 
-This only creates the npm package record. Do not publish a production version, do not move `latest`, and revoke the temporary credential immediately after the bootstrap publish succeeds.
+This only creates the npm package record. Do not publish a production version or publish the wrapper before recovery replaces the bootstrap artifact with the OIDC-published production version, and revoke the temporary credential immediately after the bootstrap publish succeeds.
 
 After every package already has an npm record, configure trusted publishing for every package. With npm 11.16 or newer, an authenticated publisher can configure it from the CLI:
 

--- a/docs/reference/releasing.md
+++ b/docs/reference/releasing.md
@@ -18,7 +18,7 @@ Source package versions stay `0.0.0` in the repo. The published version comes fr
 
 Trusted publisher configuration is scoped to an existing npm package record. When a new native package such as `@opencoven/cli-macos-x64` has never been published, create that record first with a short-lived, package-scoped credential under a bootstrap version. npm assigns `latest` to an initial public publish even when the `bootstrap` dist-tag is requested, so complete the trusted-publisher setup and recovery before publishing a wrapper that can select the bootstrap artifact.
 
-Build the Intel macOS binary from the audited recovery checkout, then publish only the bootstrap artifact:
+Build the Intel macOS binary from the audited recovery checkout, export the short-lived granular token as `NPM_GRANULAR_TOKEN`, then publish only the bootstrap artifact:
 
 ```bash
 NPM_CONFIG_TAG=bootstrap \

--- a/docs/superpowers/plans/2026-08-06-v0.2.4-intel-macos-recovery.md
+++ b/docs/superpowers/plans/2026-08-06-v0.2.4-intel-macos-recovery.md
@@ -1,0 +1,312 @@
+# v0.2.4 Intel macOS npm Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fail the npm release workflow clearly when a selected native package has not been bootstrapped, then safely recover the missing Intel macOS `0.2.4` package through OIDC.
+
+**Architecture:** Keep registry availability checks in the `npm-publish` job because the selected release mode and verified historical package set are available there. The check only establishes that an npm package record exists; `npm publish` remains the authority for validating the GitHub OIDC trusted-publisher exchange. Extend the existing Node workflow-contract tests and release runbook rather than adding a new release mechanism.
+
+**Tech Stack:** GitHub Actions YAML, Bash, Node.js built-in test runner, npm registry CLI, Markdown.
+
+---
+
+## File Structure
+
+- `.github/workflows/release-npm.yml` — allow this recovery's design and plan paths, and add the native-package availability preflight before real publication.
+- `scripts/publish-npm-test.mjs` — enforce the preflight's package selection, failure guidance, and ordering relative to every publish command.
+- `docs/reference/releasing.md` — document non-`latest` bootstrap of a new native package, trusted-publisher setup, and signed recovery execution.
+- `docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md` — approved recovery decision record; already committed.
+- `docs/superpowers/plans/2026-08-06-v0.2.4-intel-macos-recovery.md` — this executable plan; its path must be part of the recovery allowlist.
+
+### Task 1: Specify the workflow preflight contract
+
+**Files:**
+- Modify: `scripts/publish-npm-test.mjs:730-820`
+- Test: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Add the failing workflow-contract test immediately before `release workflow publishes only missing packages during recovery`**
+
+```js
+test('release workflow preflights selected native package availability before publishing', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const publishStart = workflow.indexOf('  npm-publish:');
+  const publish = workflow.slice(publishStart);
+  const preflightStart = publish.indexOf('name: Preflight npm native package availability');
+  const firstPublishStart = publish.indexOf(
+    'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper'
+  );
+
+  assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
+  assert.ok(firstPublishStart !== -1, 'npm-publish must contain its first native publish command');
+  assert.ok(
+    preflightStart < firstPublishStart,
+    'native package availability preflight must run before the first publish command'
+  );
+  const preflight = publish.slice(preflightStart, firstPublishStart);
+
+  assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
+  assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
+  assert.match(preflight, /npm view "\$package_name" name/);
+  assert.match(preflight, /@opencoven\/cli-linux-x64/);
+  assert.match(preflight, /@opencoven\/cli-windows/);
+  assert.match(preflight, /@opencoven\/cli-macos/);
+  assert.match(preflight, /@opencoven\/cli-macos-x64/);
+  assert.match(preflight, /RELEASE_MODE.*normal/s);
+  assert.match(preflight, /NATIVE_PACKAGE_SET.*post-intel/s);
+  assert.match(preflight, /non-latest bootstrap version/);
+  assert.match(preflight, /release-npm\.yml/);
+});
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+node --test --test-name-pattern='preflights selected native package' scripts/publish-npm-test.mjs
+```
+
+Expected: FAIL with `npm-publish must preflight selected native package records`.
+
+- [ ] **Step 3: Commit the failing contract test**
+
+```bash
+git add scripts/publish-npm-test.mjs
+git commit -s -m "test: specify npm native package preflight" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 2: Add the release-only availability preflight
+
+**Files:**
+- Modify: `.github/workflows/release-npm.yml:150-158`
+- Modify: `.github/workflows/release-npm.yml:340-390`
+- Test: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Extend the recovery changed-path allowlist**
+
+In the `verify-tag` recovery `case`, add the approved design and this plan after the existing release design and plan entries:
+
+```yaml
+              docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md|\
+              docs/superpowers/plans/2026-08-06-v0.2.4-intel-macos-recovery.md)
+```
+
+This permits only the recovery artifacts on the branch that must descend from `v0.2.4`; do not broaden the allowlist with glob patterns.
+
+- [ ] **Step 2: Add the preflight after `Confirm expected partial npm state` and before the Linux publish command**
+
+```yaml
+      - name: Preflight npm native package availability
+        env:
+          RELEASE_MODE: ${{ needs.verify-tag.outputs.release_mode }}
+          NATIVE_PACKAGE_SET: ${{ needs.verify-tag.outputs.native_package_set }}
+        run: |
+          set -euo pipefail
+          require_package() {
+            local package_name="$1"
+            local output
+            if output=$(npm view "$package_name" name 2>&1); then
+              return
+            fi
+            printf '%s\n' "$output"
+            echo "::error::Required npm package $package_name is not readable from the registry. Publish a non-latest bootstrap version for this package, configure its trusted publisher for OpenCoven/coven and release-npm.yml with no environment, then create a new signed recovery tag."
+            exit 1
+          }
+
+          if [ "$RELEASE_MODE" = "normal" ]; then
+            require_package @opencoven/cli-linux-x64
+            require_package @opencoven/cli-windows
+            require_package @opencoven/cli-macos-x64
+            require_package @opencoven/cli-macos
+          elif [ "$NATIVE_PACKAGE_SET" = "post-intel" ]; then
+            require_package @opencoven/cli-macos-x64
+            require_package @opencoven/cli-macos
+          elif [ "$NATIVE_PACKAGE_SET" = "pre-intel" ]; then
+            require_package @opencoven/cli-macos
+          else
+            echo "::error::Unsupported recovery native package set $NATIVE_PACKAGE_SET."
+            exit 1
+          fi
+```
+
+Keep the existing `macos-x64` condition exactly as it is:
+
+```yaml
+if: needs.verify-tag.outputs.release_mode == 'normal' || needs.verify-tag.outputs.native_package_set == 'post-intel'
+```
+
+Do not add authentication tokens, `workflow_dispatch`, or a second publishing mechanism. Do not claim that `npm view` validates OIDC authorization.
+
+- [ ] **Step 3: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+node --test --test-name-pattern='preflights selected native package' scripts/publish-npm-test.mjs
+```
+
+Expected: PASS with one matching test and all other tests skipped by the name pattern.
+
+- [ ] **Step 4: Run the complete release-contract suite**
+
+Run:
+
+```bash
+node scripts/publish-npm-test.mjs
+```
+
+Expected: PASS with zero failures.
+
+- [ ] **Step 5: Commit the workflow and completed contract test**
+
+```bash
+git add .github/workflows/release-npm.yml scripts/publish-npm-test.mjs
+git commit -s -m "fix: preflight npm native package availability" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 3: Document package bootstrap and signed recovery
+
+**Files:**
+- Modify: `docs/reference/releasing.md:17-65`
+- Modify: `docs/reference/releasing.md:150-190`
+- Test: `scripts/publish-npm-test.mjs`
+
+- [ ] **Step 1: Document the bootstrap prerequisite before the trusted-publisher commands**
+
+Add a `### Bootstrap a new native package` subsection to `One-time setup`. State that npm trusted publishers are configured per existing package record and that a newly introduced native package must first be published under a non-`latest` tag.
+
+Include this command, preceded by an instruction to build the Intel macOS binary from the audited recovery checkout and authenticate with a short-lived, package-scoped credential:
+
+```bash
+NPM_CONFIG_TAG=bootstrap \
+COVEN_NPM_VERSION=0.0.0-bootstrap.1 \
+NODE_AUTH_TOKEN="$NPM_GRANULAR_TOKEN" \
+node scripts/publish-npm.mjs --target=macos-x64 --skip-build --publish --skip-wrapper
+```
+
+State explicitly that the command creates only the npm package record; it must not publish the production release version or move the `latest` dist-tag.
+
+- [ ] **Step 2: Update trusted-publisher setup and recovery instructions**
+
+Add the `npm >= 11.16` trusted-publisher command:
+
+```bash
+npm trust github @opencoven/cli-macos-x64 --repository OpenCoven/coven --file release-npm.yml --allow-publish --yes
+```
+
+Then require `npm trust list @opencoven/cli-macos-x64` to confirm the sole publisher has repository `OpenCoven/coven`, file `release-npm.yml`, and no environment.
+
+In `Recover a partial npm publication`, require the bootstrap and trusted-publisher steps before pushing `v0.2.4-recovery.1`. Retain the exact registry-state validation and clarify that recovery restores the actual `0.2.4` package with GitHub OIDC provenance.
+
+- [ ] **Step 3: Add a runbook assertion to the existing release documentation test**
+
+In `releasing guide documents signed partial-publish recovery`, extend the text assertions with:
+
+```js
+assert.match(releasingGuide, /non-latest bootstrap version/);
+assert.match(releasingGuide, /NPM_CONFIG_TAG=bootstrap/);
+assert.match(releasingGuide, /npm trust github @opencoven\/cli-macos-x64/);
+assert.match(releasingGuide, /v0\.2\.4-recovery\.1/);
+```
+
+- [ ] **Step 4: Run documentation and workflow contract tests**
+
+Run:
+
+```bash
+node --test --test-name-pattern='releasing guide documents|preflights selected native package' scripts/publish-npm-test.mjs
+node scripts/publish-npm-test.mjs
+```
+
+Expected: both commands PASS with zero failures.
+
+- [ ] **Step 5: Inspect the recovery-only diff**
+
+Run:
+
+```bash
+git diff --check v0.2.4..HEAD
+git diff --name-only v0.2.4..HEAD
+```
+
+Expected: no whitespace errors; only `.github/workflows/release-npm.yml`, `scripts/publish-npm-test.mjs`, `docs/reference/releasing.md`, and the approved `docs/superpowers` design and plan paths appear.
+
+- [ ] **Step 6: Commit the release runbook**
+
+```bash
+git add docs/reference/releasing.md scripts/publish-npm-test.mjs
+git commit -s -m "docs: explain npm native package bootstrap" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 4: Bootstrap and execute the recovery release
+
+**Files:**
+- Modify: none
+- Test: npm registry and GitHub Actions release run
+
+- [ ] **Step 1: Confirm the package bootstrap is isolated from `latest`**
+
+Run as an npm owner:
+
+```bash
+npm view @opencoven/cli-macos-x64 dist-tags --json
+npm trust list @opencoven/cli-macos-x64
+```
+
+Expected: `bootstrap` points to `0.0.0-bootstrap.1`; no `latest` tag is created; the trusted publisher is `OpenCoven/coven` / `release-npm.yml` with no environment.
+
+- [ ] **Step 2: Verify the partial `0.2.4` registry state before tagging**
+
+Run:
+
+```bash
+for package_name in @opencoven/cli-linux-x64 @opencoven/cli-windows; do
+  npm view "$package_name@0.2.4" version
+done
+for package_name in @opencoven/cli-macos @opencoven/cli-macos-x64 @opencoven/cli; do
+  if npm view "$package_name@0.2.4" version; then
+    echo "unexpectedly published: $package_name@0.2.4"
+    exit 1
+  fi
+done
+```
+
+Expected: Linux and Windows print `0.2.4`; macOS ARM, macOS x64, and the wrapper return npm `E404`.
+
+- [ ] **Step 3: Create and push the new signed recovery tag**
+
+Run from the reviewed release-only commit:
+
+```bash
+git tag -s v0.2.4-recovery.1 -m "Recover partial v0.2.4 npm publication"
+git push origin fix/634-v0.2.4-npm-recovery v0.2.4-recovery.1
+```
+
+Expected: GitHub Actions starts **Release npm packages** for
+`v0.2.4-recovery.1`. Do not move `v0.2.4`, reuse a recovery tag, or rerun the
+failed original workflow.
+
+- [ ] **Step 4: Confirm complete npm publication and provenance**
+
+Run after the GitHub Actions run succeeds:
+
+```bash
+for package_name in @opencoven/cli @opencoven/cli-macos @opencoven/cli-macos-x64 @opencoven/cli-linux-x64 @opencoven/cli-windows; do
+  npm view "$package_name@0.2.4" version dist-tags
+done
+```
+
+Expected: every package reports `0.2.4`; `latest` is `0.2.4`; the three
+recovered packages show npm provenance from the recovery workflow.
+
+- [ ] **Step 5: Commit no release artifact changes**
+
+The signed tag is the release trigger. Do not create a commit for registry
+state, credentials, or generated package contents.

--- a/docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md
@@ -1,0 +1,86 @@
+# v0.2.4 Intel macOS npm Recovery
+
+## Context
+
+The signed `v0.2.4` release successfully published
+`@opencoven/cli-linux-x64@0.2.4` and
+`@opencoven/cli-windows@0.2.4`, then failed publishing the new
+`@opencoven/cli-macos-x64@0.2.4`. npm returned a PUT `404` because this
+per-package OIDC publisher relationship cannot exist until the package itself
+has an npm record.
+
+`@opencoven/cli-macos` cannot replace the failed package: the wrapper maps
+`darwin-arm64` to `@opencoven/cli-macos` and maps `darwin-x64` to
+`@opencoven/cli-macos-x64`.
+
+## Decision
+
+Preserve the incomplete `0.2.4` release rather than omit Intel macOS or cut a
+new patch. First bootstrap the missing npm package under a non-`latest` tag,
+then publish the actual `0.2.4` package only through the existing signed-tag
+OIDC workflow.
+
+The recovery remains limited to a branch descending from `v0.2.4` and a new
+signed `v0.2.4-recovery.1` tag. It must not merge unrelated `main` commits.
+
+## Bootstrap Procedure
+
+An npm owner performs the one-time package initialization:
+
+1. Publish `@opencoven/cli-macos-x64@0.0.0-bootstrap.1` with a short-lived,
+   package-scoped credential and the `bootstrap` dist-tag. Do not assign
+   `latest`.
+2. Configure its sole trusted publisher as GitHub Actions from
+   `OpenCoven/coven`, workflow `release-npm.yml`, with no environment.
+3. Verify the bootstrap version is readable and the trusted publisher points
+   to the exact workflow filename.
+
+The bootstrap artifact only establishes the package record. It is not a
+supported release and cannot be selected by ordinary installs because it is
+not tagged `latest`.
+
+## Workflow Change
+
+Add a preflight step in `npm-publish`, before the first real publish command.
+It checks that every native package enabled by the release matrix is publicly
+readable:
+
+- normal release: Linux x64, Windows, macOS ARM, and macOS x64;
+- `pre-intel` recovery: macOS ARM only;
+- `post-intel` recovery: macOS ARM and macOS x64.
+
+For a missing package, the step fails with a message that explains the
+bootstrap and trusted-publisher requirement. It does not claim to validate
+OIDC permissions: npm exchanges the job's OIDC identity during `npm publish`,
+and that exchange is the only authoritative registry authorization check.
+
+The existing `macos-x64` condition stays unchanged. It must run only for
+normal releases or `post-intel` recoveries.
+
+## Documentation and Tests
+
+Update the release runbook to describe bootstrapping a new native package
+before its first OIDC release and to use that process for this recovery.
+Extend `scripts/publish-npm-test.mjs` with workflow-contract assertions that
+the preflight exists and is positioned before every publish command.
+
+## Recovery Execution
+
+After the workflow patch merges into the release-only branch:
+
+1. Confirm the exact partial registry state: Linux and Windows `0.2.4`
+   exist; macOS ARM, macOS x64, and the wrapper do not.
+2. Create and push an annotated, authorized, signed
+   `v0.2.4-recovery.1` tag from the release-only branch.
+3. The workflow verifies tag ancestry and package state, skips the already
+   published Linux and Windows packages, and publishes macOS x64, macOS ARM,
+   then the wrapper with OIDC provenance.
+4. Confirm all five `0.2.4` packages are published before creating the GitHub
+   release.
+
+## Non-Goals
+
+- Publishing the real `0.2.4` Intel package with a long-lived token.
+- Changing platform support or redirecting Intel macOS to the ARM binary.
+- Retagging `v0.2.4` or reusing a recovery tag.
+- Adding a manual workflow dispatch or an npm token to GitHub Actions.

--- a/docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md
@@ -27,7 +27,7 @@ signed `v0.2.4-recovery.1` tag. It must not merge unrelated `main` commits.
 
 An npm owner performs the one-time package initialization:
 
-1. Publish `@opencoven/cli-macos-x64@0.0.0-bootstrap.1` with a short-lived,
+1. Publish `@opencoven/cli-macos-x64` version `0.0.0-bootstrap.1` with a short-lived,
    package-scoped credential and the `bootstrap` dist-tag. Do not assign
    `latest`.
 2. Configure its sole trusted publisher as GitHub Actions from

--- a/docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-v0.2.4-intel-macos-recovery-design.md
@@ -28,8 +28,9 @@ signed `v0.2.4-recovery.1` tag. It must not merge unrelated `main` commits.
 An npm owner performs the one-time package initialization:
 
 1. Publish `@opencoven/cli-macos-x64` version `0.0.0-bootstrap.1` with a short-lived,
-   package-scoped credential and the `bootstrap` dist-tag. Do not assign
-   `latest`.
+   package-scoped credential and the `bootstrap` dist-tag. npm also assigns
+   `latest` on this first public publish; do not publish the wrapper until
+   recovery replaces it with the production version.
 2. Configure its sole trusted publisher as GitHub Actions from
    `OpenCoven/coven`, workflow `release-npm.yml`, with no environment.
 3. Verify the bootstrap version is readable and the trusted publisher points

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -239,6 +239,27 @@ class SecretGuardLockfileTests(unittest.TestCase):
 
         self.assertEqual(hits, [])
 
+    def test_opencoven_npm_package_spec_does_not_trigger_high_entropy(self) -> None:
+        text = "Publish `@opencoven/cli-macos-x64@0.0.0-bootstrap.1` under bootstrap."
+
+        hits = check_secrets.scan_text(
+            text, "docs/superpowers/specs/example.md"
+        )
+
+        self.assertEqual(hits, [])
+
+    def test_non_opencoven_npm_package_spec_still_triggers_high_entropy(self) -> None:
+        text = "Publish `@exampleorg/cli-macos-x64@0.0.0-bootstrap.1` under bootstrap."
+
+        hits = check_secrets.scan_text(
+            text, "docs/superpowers/specs/example.md"
+        )
+
+        self.assertEqual(
+            hits,
+            [("docs/superpowers/specs/example.md", 1, "high_entropy")],
+        )
+
     def test_repo_relative_path_heuristic_still_rejects_other_mixed_case_tokens(self) -> None:
         token = "OpenCoven/covenLikeFakePayloadMixedCase1234567890"
 

--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -260,6 +260,18 @@ class SecretGuardLockfileTests(unittest.TestCase):
             [("docs/superpowers/specs/example.md", 1, "high_entropy")],
         )
 
+    def test_opencoven_package_spec_without_scope_prefix_still_triggers_high_entropy(self) -> None:
+        text = "Token `opencoven/cli-macos-x64@0.0.0-bootstrap.1` is not a scoped npm package."
+
+        hits = check_secrets.scan_text(
+            text, "docs/superpowers/specs/example.md"
+        )
+
+        self.assertEqual(
+            hits,
+            [("docs/superpowers/specs/example.md", 1, "high_entropy")],
+        )
+
     def test_repo_relative_path_heuristic_still_rejects_other_mixed_case_tokens(self) -> None:
         token = "OpenCoven/covenLikeFakePayloadMixedCase1234567890"
 

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -549,6 +549,28 @@ def is_opencoven_repo_relative_path_token(
     )
 
 
+_OPENCOVEN_NPM_PACKAGE_SPEC_TOKEN = re.compile(
+    r"(?:@)?opencoven/(?P<package>[A-Za-z0-9_.-]+)"
+    r"@(?P<version>[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?)"
+)
+
+
+def is_opencoven_npm_package_spec_token(
+    token: str, *, strict: bool = False
+) -> bool:
+    match = _OPENCOVEN_NPM_PACKAGE_SPEC_TOKEN.fullmatch(token)
+    if not match:
+        return False
+    version_parts = [
+        part for part in re.split(r"[.+-]", match.group("version")) if part
+    ]
+    return bool(
+        version_parts
+        and is_safe_path_segment(match.group("package"), strict=strict)
+        and path_segments_are_safe(version_parts, strict=strict)
+    )
+
+
 def is_github_advisory_url_like_token(token: str) -> bool:
     normalized = token.strip("/")
     return bool(
@@ -883,6 +905,7 @@ def is_known_safe_entropy_token(
         or is_local_path_like_token(token)
         or is_public_repo_url_like_token(token)
         or is_opencoven_repo_relative_path_token(token)
+        or is_opencoven_npm_package_spec_token(token)
         or is_github_advisory_url_like_token(token)
         or is_github_commit_url_like_token(token)
         or is_github_action_sha_ref_token(token)

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -550,14 +550,23 @@ def is_opencoven_repo_relative_path_token(
 
 
 _OPENCOVEN_NPM_PACKAGE_SPEC_TOKEN = re.compile(
-    r"(?:@)?opencoven/(?P<package>[A-Za-z0-9_.-]+)"
+    r"opencoven/(?P<package>[A-Za-z0-9_.-]+)"
     r"@(?P<version>[0-9]+\.[0-9]+\.[0-9]+(?:[-+][A-Za-z0-9.-]+)?)"
 )
 
 
 def is_opencoven_npm_package_spec_token(
-    token: str, *, strict: bool = False
+    line: str,
+    token_match: re.Match[str],
+    *,
+    strict: bool = False,
 ) -> bool:
+    if (
+        token_match.start() == 0
+        or line[token_match.start() - 1] != "@"
+    ):
+        return False
+    token = token_match.group(0)
     match = _OPENCOVEN_NPM_PACKAGE_SPEC_TOKEN.fullmatch(token)
     if not match:
         return False
@@ -905,7 +914,9 @@ def is_known_safe_entropy_token(
         or is_local_path_like_token(token)
         or is_public_repo_url_like_token(token)
         or is_opencoven_repo_relative_path_token(token)
-        or is_opencoven_npm_package_spec_token(token)
+        or is_opencoven_npm_package_spec_token(
+            line, token_match
+        )
         or is_github_advisory_url_like_token(token)
         or is_github_commit_url_like_token(token)
         or is_github_action_sha_ref_token(token)

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -820,44 +820,54 @@ test('release workflow preflights selected native package availability before pu
   const publishEnd =
     jobStarts.find((match) => match.index > publishStart)?.index ?? workflow.length;
   const publish = workflow.slice(publishStart, publishEnd);
-  const preflightStart = publish.indexOf('name: Preflight npm native package availability');
+  const preflightStepMatch = publish.match(
+    /^      - name: Preflight npm native package availability$/m
+  );
+  assert.ok(preflightStepMatch, 'npm-publish must preflight selected native package records');
+  const preflightStart = preflightStepMatch.index;
   const nativePublishCommands = [
     'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper',
     'node scripts/publish-npm.mjs --target=windows --skip-build --publish --skip-wrapper',
     'node scripts/publish-npm.mjs --target=macos-x64 --skip-build --publish --skip-wrapper',
-    'node scripts/publish-npm.mjs --target=macos --skip-build --publish --skip-wrapper',
+    'node scripts/publish-npm.mjs --target=macos --skip-build --publish --skip-wrapper'
   ];
-  const nativePublishStarts = nativePublishCommands.map((command) => publish.indexOf(command));
+  const nativePublishStarts = nativePublishCommands.map((command) => {
+    const nativePublishMatch = publish.match(
+      new RegExp(String.raw`^      - run: ${command.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm')
+    );
+    assert.ok(nativePublishMatch, `npm-publish must contain ${command}`);
+    return nativePublishMatch.index;
+  });
 
-  assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
   const preflightEndStart = publish.indexOf('\n      - ', preflightStart + 1);
   const preflightEnd = preflightEndStart === -1 ? publish.length : preflightEndStart;
   const preflight = publish.slice(preflightStart, preflightEnd);
   nativePublishStarts.forEach((nativePublishStart, index) => {
-    assert.ok(
-      nativePublishStart !== -1,
-      `npm-publish must contain ${nativePublishCommands[index]}`
-    );
     assert.ok(
       preflightStart < nativePublishStart,
       `native package availability preflight must run before ${nativePublishCommands[index]}`
     );
   });
 
-  assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
-  assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
-  assert.match(preflight, /npm view "\$package_name" name/);
-  assert.match(preflight, /@opencoven\/cli-linux-x64/);
-  assert.match(preflight, /@opencoven\/cli-windows/);
-  assert.match(preflight, /@opencoven\/cli-macos(?:\s|$)/);
-  assert.match(preflight, /@opencoven\/cli-macos-x64/);
+  assert.match(
+    preflight,
+    /^          RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}$/m
+  );
+  assert.match(
+    preflight,
+    /^          NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}$/m
+  );
+  assert.match(
+    preflight,
+    /^          if output=\$\(npm view "\$package_name" name\); then$/m
+  );
   assert.match(preflight, /\[ "\$RELEASE_MODE" = "normal" \]/);
   assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);
   assert.match(preflight, /non-latest bootstrap version/);
   assert.match(preflight, /release-npm\.yml/);
 
   const normalBranchMatch = preflight.match(
-    /\[ "\$RELEASE_MODE" = "normal" \][\s\S]*?(?=\n\s*elif\b)/
+    /\[ "\$RELEASE_MODE" = "normal" \][\s\S]*?(?=\n\s*(?:elif|else|fi)\b)/
   );
   assert.ok(normalBranchMatch, 'preflight must contain the normal package-check branch');
   const normalBranch = normalBranchMatch[0];
@@ -869,20 +879,26 @@ test('release workflow preflights selected native package availability before pu
   ]) {
     assert.match(
       normalBranch,
-      new RegExp(String.raw`require_package\b[^\n]*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\s|$)`),
+      new RegExp(
+        String.raw`^          require_package\b[^\n]*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\s|$)`,
+        'm'
+      ),
       `normal branch must require ${packageName}`
     );
   }
 
   const postIntelBranchMatch = preflight.match(
-    /elif \[ "\$NATIVE_PACKAGE_SET" = "post-intel" \][\s\S]*?(?=\n\s*elif\b)/
+    /elif \[ "\$NATIVE_PACKAGE_SET" = "post-intel" \][\s\S]*?(?=\n\s*(?:elif|else|fi)\b)/
   );
   assert.ok(postIntelBranchMatch, 'preflight must contain the post-intel package-check branch');
   const postIntelBranch = postIntelBranchMatch[0];
   for (const packageName of ['@opencoven/cli-macos', '@opencoven/cli-macos-x64']) {
     assert.match(
       postIntelBranch,
-      new RegExp(String.raw`require_package\b[^\n]*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\s|$)`),
+      new RegExp(
+        String.raw`^          require_package\b[^\n]*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\s|$)`,
+        'm'
+      ),
       `post-intel branch must require ${packageName}`
     );
   }

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -898,6 +898,40 @@ test('release workflow publishes only missing packages during recovery', () => {
   );
 });
 
+test('release workflow preflights selected native package availability before publishing', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const publishStart = workflow.indexOf('  npm-publish:');
+  const publish = workflow.slice(publishStart);
+  const preflightStart = publish.indexOf('name: Preflight npm native package availability');
+  const firstPublishStart = publish.indexOf(
+    'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper'
+  );
+
+  assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
+  assert.ok(firstPublishStart !== -1, 'npm-publish must contain its first native publish command');
+  assert.ok(
+    preflightStart < firstPublishStart,
+    'native package availability preflight must run before the first publish command'
+  );
+  const preflight = publish.slice(preflightStart, firstPublishStart);
+
+  assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
+  assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
+  assert.match(preflight, /npm view "\$package_name" name/);
+  assert.match(preflight, /@opencoven\/cli-linux-x64/);
+  assert.match(preflight, /@opencoven\/cli-windows/);
+  assert.match(preflight, /@opencoven\/cli-macos/);
+  assert.match(preflight, /@opencoven\/cli-macos-x64/);
+  assert.match(preflight, /RELEASE_MODE.*normal/s);
+  assert.match(preflight, /NATIVE_PACKAGE_SET.*post-intel/s);
+  assert.match(preflight, /non-latest bootstrap version/);
+  assert.match(preflight, /release-npm\.yml/);
+});
+
 test('release workflow triggers only on signed v* tag pushes (no workflow_dispatch fallback)', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -867,7 +867,7 @@ test('release workflow preflights selected native package availability before pu
   assert.match(preflight, /release-npm\.yml/);
 
   const normalBranchMatch = preflight.match(
-    /\[ "\$RELEASE_MODE" = "normal" \][\s\S]*?(?=\n\s*(?:elif|else|fi)\b)/
+    /^          if \[ "\$RELEASE_MODE" = "normal" \]; then[\s\S]*?(?=^          (?:elif|else|fi)\b)/m
   );
   assert.ok(normalBranchMatch, 'preflight must contain the normal package-check branch');
   const normalBranch = normalBranchMatch[0];
@@ -888,7 +888,7 @@ test('release workflow preflights selected native package availability before pu
   }
 
   const postIntelBranchMatch = preflight.match(
-    /elif \[ "\$NATIVE_PACKAGE_SET" = "post-intel" \][\s\S]*?(?=\n\s*(?:elif|else|fi)\b)/
+    /^          elif \[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]; then[\s\S]*?(?=^          (?:elif|else|fi)\b)/m
   );
   assert.ok(postIntelBranchMatch, 'preflight must contain the post-intel package-check branch');
   const postIntelBranch = postIntelBranchMatch[0];
@@ -902,6 +902,17 @@ test('release workflow preflights selected native package availability before pu
       `post-intel branch must require ${packageName}`
     );
   }
+
+  const preIntelElseBranchMatch = preflight.match(
+    /^          else\b[\s\S]*?(?=^          fi\b)/m
+  );
+  assert.ok(preIntelElseBranchMatch, 'preflight must contain the top-level pre-Intel else branch');
+  const preIntelElseBranch = preIntelElseBranchMatch[0];
+  assert.match(
+    preIntelElseBranch,
+    /^          require_package\b[^\n]*@opencoven\/cli-macos(?:\s|$)/m,
+    'pre-Intel else branch must require @opencoven/cli-macos'
+  );
 });
 
 test('release workflow publishes only missing packages during recovery', () => {

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -926,8 +926,8 @@ test('release workflow preflights selected native package availability before pu
   assert.match(preflight, /@opencoven\/cli-windows/);
   assert.match(preflight, /@opencoven\/cli-macos/);
   assert.match(preflight, /@opencoven\/cli-macos-x64/);
-  assert.match(preflight, /RELEASE_MODE.*normal/s);
-  assert.match(preflight, /NATIVE_PACKAGE_SET.*post-intel/s);
+  assert.match(preflight, /\[ "\$RELEASE_MODE" = "normal" \]/);
+  assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);
   assert.match(preflight, /non-latest bootstrap version/);
   assert.match(preflight, /release-npm\.yml/);
 });

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -871,7 +871,7 @@ test('release workflow preflights selected native package availability before pu
   );
   assert.match(
     preflight,
-    /^          echo "::error::Publish a non-latest bootstrap version for \$package_name, configure npm trusted publishing for OpenCoven\/coven and release-npm\.yml with no environment, then create a new signed recovery tag\."$/m
+    /^          echo "::error::Publish a bootstrap version for \$package_name, configure npm trusted publishing for OpenCoven\/coven and release-npm\.yml with no environment, then create a new signed recovery tag\. npm assigns latest to an initial public publish; do not publish the wrapper until recovery publishes the production package\."$/m
   );
 
   const normalBranchMatch = preflight.match(
@@ -1073,7 +1073,7 @@ test('releasing guide documents signed partial-publish recovery', () => {
   assert.match(guide, /@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows/);
   assert.match(guide, /@opencoven\/cli-macos[\s\S]*@opencoven\/cli/);
   assert.match(guide, /@opencoven\/cli-macos-x64/);
-  assert.match(guide, /non-latest bootstrap version/);
+  assert.match(guide, /npm assigns `latest` to an initial public publish/);
   assert.match(guide, /NPM_CONFIG_TAG=bootstrap/);
   assert.match(guide, /npm trust github @opencoven\/cli-macos-x64/);
   assert.match(guide, /v0\.2\.4-recovery\.1/);

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1073,6 +1073,10 @@ test('releasing guide documents signed partial-publish recovery', () => {
   assert.match(guide, /@opencoven\/cli-linux-x64[\s\S]*@opencoven\/cli-windows/);
   assert.match(guide, /@opencoven\/cli-macos[\s\S]*@opencoven\/cli/);
   assert.match(guide, /@opencoven\/cli-macos-x64/);
+  assert.match(guide, /non-latest bootstrap version/);
+  assert.match(guide, /NPM_CONFIG_TAG=bootstrap/);
+  assert.match(guide, /npm trust github @opencoven\/cli-macos-x64/);
+  assert.match(guide, /v0\.2\.4-recovery\.1/);
   assert.match(guide, /npm trust github/);
 });
 

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -807,6 +807,45 @@ test('release workflow fail-closes signed recovery tags', () => {
   );
 });
 
+test('release workflow preflights selected native package availability before publishing', () => {
+  const workflowPath = new URL(
+    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
+    import.meta.url
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+  const jobStarts = [...workflow.matchAll(/^  [A-Za-z0-9_-]+:/gm)];
+  const publishJobStart = jobStarts.find((match) => match[0] === '  npm-publish:');
+  assert.ok(publishJobStart, 'npm-publish job must exist in release workflow');
+  const publishStart = publishJobStart.index;
+  const publishEnd =
+    jobStarts.find((match) => match.index > publishStart)?.index ?? workflow.length;
+  const publish = workflow.slice(publishStart, publishEnd);
+  const preflightStart = publish.indexOf('name: Preflight npm native package availability');
+  const firstPublishStart = publish.indexOf(
+    'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper'
+  );
+
+  assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
+  assert.ok(firstPublishStart !== -1, 'npm-publish must contain its first native publish command');
+  assert.ok(
+    preflightStart < firstPublishStart,
+    'native package availability preflight must run before the first publish command'
+  );
+  const preflight = publish.slice(preflightStart, firstPublishStart);
+
+  assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
+  assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
+  assert.match(preflight, /npm view "\$package_name" name/);
+  assert.match(preflight, /@opencoven\/cli-linux-x64/);
+  assert.match(preflight, /@opencoven\/cli-windows/);
+  assert.match(preflight, /@opencoven\/cli-macos/);
+  assert.match(preflight, /@opencoven\/cli-macos-x64/);
+  assert.match(preflight, /\[ "\$RELEASE_MODE" = "normal" \]/);
+  assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);
+  assert.match(preflight, /non-latest bootstrap version/);
+  assert.match(preflight, /release-npm\.yml/);
+});
+
 test('release workflow publishes only missing packages during recovery', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
@@ -898,44 +937,7 @@ test('release workflow publishes only missing packages during recovery', () => {
   );
 });
 
-test('release workflow preflights selected native package availability before publishing', () => {
-  const workflowPath = new URL(
-    ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),
-    import.meta.url
-  );
-  const workflow = readFileSync(workflowPath, 'utf8');
-  const jobStarts = [...workflow.matchAll(/^  [A-Za-z0-9_-]+:/gm)];
-  const publishJobStart = jobStarts.find((match) => match[0] === '  npm-publish:');
-  assert.ok(publishJobStart, 'npm-publish job must exist in release workflow');
-  const publishStart = publishJobStart.index;
-  const publishEnd =
-    jobStarts.find((match) => match.index > publishStart)?.index ?? workflow.length;
-  const publish = workflow.slice(publishStart, publishEnd);
-  const preflightStart = publish.indexOf('name: Preflight npm native package availability');
-  const firstPublishStart = publish.indexOf(
-    'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper'
-  );
 
-  assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
-  assert.ok(firstPublishStart !== -1, 'npm-publish must contain its first native publish command');
-  assert.ok(
-    preflightStart < firstPublishStart,
-    'native package availability preflight must run before the first publish command'
-  );
-  const preflight = publish.slice(preflightStart, firstPublishStart);
-
-  assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
-  assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
-  assert.match(preflight, /npm view "\$package_name" name/);
-  assert.match(preflight, /@opencoven\/cli-linux-x64/);
-  assert.match(preflight, /@opencoven\/cli-windows/);
-  assert.match(preflight, /@opencoven\/cli-macos/);
-  assert.match(preflight, /@opencoven\/cli-macos-x64/);
-  assert.match(preflight, /\[ "\$RELEASE_MODE" = "normal" \]/);
-  assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);
-  assert.match(preflight, /non-latest bootstrap version/);
-  assert.match(preflight, /release-npm\.yml/);
-});
 
 test('release workflow triggers only on signed v* tag pushes (no workflow_dispatch fallback)', () => {
   const workflowPath = new URL(

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -859,12 +859,20 @@ test('release workflow preflights selected native package availability before pu
   );
   assert.match(
     preflight,
-    /^          if output=\$\(npm view "\$package_name" name\); then$/m
+    /^          if output=\$\(npm view "\$package_name" name 2>&1\); then$/m
   );
+  assert.match(preflight, /^          printf '%s\\n' "\$output"$/m);
+  assert.match(preflight, /^          if ! grep -q 'E404' <<<"\$output"; then$/m);
   assert.match(preflight, /\[ "\$RELEASE_MODE" = "normal" \]/);
   assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);
-  assert.match(preflight, /non-latest bootstrap version/);
-  assert.match(preflight, /release-npm\.yml/);
+  assert.match(
+    preflight,
+    /^          echo "::error::Package availability for \$package_name could not be verified; resolve the npm registry error before publishing\."$/m
+  );
+  assert.match(
+    preflight,
+    /^          echo "::error::Publish a non-latest bootstrap version for \$package_name, configure npm trusted publishing for OpenCoven\/coven and release-npm\.yml with no environment, then create a new signed recovery tag\."$/m
+  );
 
   const normalBranchMatch = preflight.match(
     /^          if \[ "\$RELEASE_MODE" = "normal" \]; then[\s\S]*?(?=^          (?:elif|else|fi)\b)/m

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -904,8 +904,13 @@ test('release workflow preflights selected native package availability before pu
     import.meta.url
   );
   const workflow = readFileSync(workflowPath, 'utf8');
-  const publishStart = workflow.indexOf('  npm-publish:');
-  const publish = workflow.slice(publishStart);
+  const jobStarts = [...workflow.matchAll(/^  [A-Za-z0-9_-]+:/gm)];
+  const publishJobStart = jobStarts.find((match) => match[0] === '  npm-publish:');
+  assert.ok(publishJobStart, 'npm-publish job must exist in release workflow');
+  const publishStart = publishJobStart.index;
+  const publishEnd =
+    jobStarts.find((match) => match.index > publishStart)?.index ?? workflow.length;
+  const publish = workflow.slice(publishStart, publishEnd);
   const preflightStart = publish.indexOf('name: Preflight npm native package availability');
   const firstPublishStart = publish.indexOf(
     'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper'

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -830,6 +830,9 @@ test('release workflow preflights selected native package availability before pu
   const nativePublishStarts = nativePublishCommands.map((command) => publish.indexOf(command));
 
   assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
+  const preflightEndStart = publish.indexOf('\n      - ', preflightStart + 1);
+  const preflightEnd = preflightEndStart === -1 ? publish.length : preflightEndStart;
+  const preflight = publish.slice(preflightStart, preflightEnd);
   nativePublishStarts.forEach((nativePublishStart, index) => {
     assert.ok(
       nativePublishStart !== -1,
@@ -840,7 +843,6 @@ test('release workflow preflights selected native package availability before pu
       `native package availability preflight must run before ${nativePublishCommands[index]}`
     );
   });
-  const preflight = publish.slice(preflightStart, Math.min(...nativePublishStarts));
 
   assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
   assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
@@ -853,6 +855,37 @@ test('release workflow preflights selected native package availability before pu
   assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);
   assert.match(preflight, /non-latest bootstrap version/);
   assert.match(preflight, /release-npm\.yml/);
+
+  const normalBranchMatch = preflight.match(
+    /\[ "\$RELEASE_MODE" = "normal" \][\s\S]*?(?=\n\s*elif\b)/
+  );
+  assert.ok(normalBranchMatch, 'preflight must contain the normal package-check branch');
+  const normalBranch = normalBranchMatch[0];
+  for (const packageName of [
+    '@opencoven/cli-linux-x64',
+    '@opencoven/cli-windows',
+    '@opencoven/cli-macos',
+    '@opencoven/cli-macos-x64'
+  ]) {
+    assert.match(
+      normalBranch,
+      new RegExp(String.raw`require_package\b[^\n]*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\s|$)`),
+      `normal branch must require ${packageName}`
+    );
+  }
+
+  const postIntelBranchMatch = preflight.match(
+    /elif \[ "\$NATIVE_PACKAGE_SET" = "post-intel" \][\s\S]*?(?=\n\s*elif\b)/
+  );
+  assert.ok(postIntelBranchMatch, 'preflight must contain the post-intel package-check branch');
+  const postIntelBranch = postIntelBranchMatch[0];
+  for (const packageName of ['@opencoven/cli-macos', '@opencoven/cli-macos-x64']) {
+    assert.match(
+      postIntelBranch,
+      new RegExp(String.raw`require_package\b[^\n]*${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:\s|$)`),
+      `post-intel branch must require ${packageName}`
+    );
+  }
 });
 
 test('release workflow publishes only missing packages during recovery', () => {

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -821,24 +821,33 @@ test('release workflow preflights selected native package availability before pu
     jobStarts.find((match) => match.index > publishStart)?.index ?? workflow.length;
   const publish = workflow.slice(publishStart, publishEnd);
   const preflightStart = publish.indexOf('name: Preflight npm native package availability');
-  const firstPublishStart = publish.indexOf(
-    'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper'
-  );
+  const nativePublishCommands = [
+    'node scripts/publish-npm.mjs --target=linux-x64 --skip-build --publish --skip-wrapper',
+    'node scripts/publish-npm.mjs --target=windows --skip-build --publish --skip-wrapper',
+    'node scripts/publish-npm.mjs --target=macos-x64 --skip-build --publish --skip-wrapper',
+    'node scripts/publish-npm.mjs --target=macos --skip-build --publish --skip-wrapper',
+  ];
+  const nativePublishStarts = nativePublishCommands.map((command) => publish.indexOf(command));
 
   assert.ok(preflightStart !== -1, 'npm-publish must preflight selected native package records');
-  assert.ok(firstPublishStart !== -1, 'npm-publish must contain its first native publish command');
-  assert.ok(
-    preflightStart < firstPublishStart,
-    'native package availability preflight must run before the first publish command'
-  );
-  const preflight = publish.slice(preflightStart, firstPublishStart);
+  nativePublishStarts.forEach((nativePublishStart, index) => {
+    assert.ok(
+      nativePublishStart !== -1,
+      `npm-publish must contain ${nativePublishCommands[index]}`
+    );
+    assert.ok(
+      preflightStart < nativePublishStart,
+      `native package availability preflight must run before ${nativePublishCommands[index]}`
+    );
+  });
+  const preflight = publish.slice(preflightStart, Math.min(...nativePublishStarts));
 
   assert.match(preflight, /RELEASE_MODE: \$\{\{ needs\.verify-tag\.outputs\.release_mode \}\}/);
   assert.match(preflight, /NATIVE_PACKAGE_SET: \$\{\{ needs\.verify-tag\.outputs\.native_package_set \}\}/);
   assert.match(preflight, /npm view "\$package_name" name/);
   assert.match(preflight, /@opencoven\/cli-linux-x64/);
   assert.match(preflight, /@opencoven\/cli-windows/);
-  assert.match(preflight, /@opencoven\/cli-macos/);
+  assert.match(preflight, /@opencoven\/cli-macos(?:\s|$)/);
   assert.match(preflight, /@opencoven\/cli-macos-x64/);
   assert.match(preflight, /\[ "\$RELEASE_MODE" = "normal" \]/);
   assert.match(preflight, /\[ "\$NATIVE_PACKAGE_SET" = "post-intel" \]/);

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1014,8 +1014,6 @@ test('release workflow publishes only missing packages during recovery', () => {
   );
 });
 
-
-
 test('release workflow triggers only on signed v* tag pushes (no workflow_dispatch fallback)', () => {
   const workflowPath = new URL(
     ['..', '.github', 'workflows', 'release-npm.yml'].join('/'),

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -911,16 +911,26 @@ test('release workflow preflights selected native package availability before pu
     );
   }
 
-  const preIntelElseBranchMatch = preflight.match(
+  const preIntelBranchMatch = preflight.match(
+    /^          elif \[ "\$NATIVE_PACKAGE_SET" = "pre-intel" \]; then[\s\S]*?(?=^          (?:elif|else|fi)\b)/m
+  );
+  assert.ok(preIntelBranchMatch, 'preflight must contain the pre-intel package-check branch');
+  const preIntelBranch = preIntelBranchMatch[0];
+  assert.match(
+    preIntelBranch,
+    /^          require_package\b[^\n]*@opencoven\/cli-macos(?:\s|$)/m,
+    'pre-intel branch must require @opencoven/cli-macos'
+  );
+  const unsupportedBranchMatch = preflight.match(
     /^          else\b[\s\S]*?(?=^          fi\b)/m
   );
-  assert.ok(preIntelElseBranchMatch, 'preflight must contain the top-level pre-Intel else branch');
-  const preIntelElseBranch = preIntelElseBranchMatch[0];
+  assert.ok(unsupportedBranchMatch, 'preflight must fail closed for unsupported package sets');
+  const unsupportedBranch = unsupportedBranchMatch[0];
   assert.match(
-    preIntelElseBranch,
-    /^          require_package\b[^\n]*@opencoven\/cli-macos(?:\s|$)/m,
-    'pre-Intel else branch must require @opencoven/cli-macos'
+    unsupportedBranch,
+    /^          echo "::error::Unsupported recovery native package set \$NATIVE_PACKAGE_SET\."$/m
   );
+  assert.match(unsupportedBranch, /^          exit 1$/m);
 });
 
 test('release workflow publishes only missing packages during recovery', () => {


### PR DESCRIPTION
## Summary
- preflight selected native npm package records before OIDC publication and distinguish missing packages from registry errors
- document non-latest bootstrap and exact trusted-publisher setup for Intel macOS
- preserve the signed recovery-only contract for v0.2.4

## Test Plan
- [x] `node scripts/publish-npm-test.mjs`
- [x] `git diff --check`

## Release blocker
An npm owner must bootstrap `@opencoven/cli-macos-x64@0.0.0-bootstrap.1` under the `bootstrap` tag and configure the `OpenCoven/coven` / `release-npm.yml` trusted publisher with no environment before pushing `v0.2.4-recovery.1`.