### PR TITLE
fix: report stable version in recovery binaries

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -207,6 +207,8 @@ jobs:
         if: matrix.npm-target == 'linux-x64'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
+        env:
+          COVEN_BUILD_VERSION: v${{ needs.verify-tag.outputs.npm_version }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: coven-${{ matrix.npm-target }}

--- a/crates/coven-cli/build.rs
+++ b/crates/coven-cli/build.rs
@@ -7,13 +7,16 @@
 // `cargo build`, the bin inside an extracted npm tarball, etc.).
 //
 // Resolution order:
-//   1. `git describe --tags --always --dirty` against the working tree.
+//   1. `$COVEN_BUILD_VERSION` when a release build explicitly supplies it.
+//      Recovery tags use the stable package version here so native binaries
+//      do not expose the recovery tag suffix.
+//   2. `git describe --tags --always --dirty` against the working tree.
 //      Local source builds and any CI that does a full fetch see this.
-//   2. `$GITHUB_REF_NAME` if it looks like a tag (starts with `v`). Our
+//   3. `$GITHUB_REF_NAME` if it looks like a tag (starts with `v`). Our
 //      release workflow is tag-triggered, and `actions/checkout` defaults
-//      to a shallow fetch with no tags, so step 1 fails in CI and we land
+//      to a shallow fetch with no tags, so step 2 fails in CI and we land
 //      here with `v0.0.17` (or whatever the release tag is).
-//   3. `<CARGO_PKG_VERSION> (unknown source)` — git unavailable AND not
+//   4. `<CARGO_PKG_VERSION> (unknown source)` — git unavailable AND not
 //      running under a tag-triggered GitHub Actions build (e.g. downloaded
 //      source tarball without `.git`).
 
@@ -29,13 +32,22 @@ fn main() {
     // Cargo only re-runs the build script when a tracked env var changes;
     // declaring it here lets a CI re-run with a different tag re-stamp the
     // binary without `cargo clean`.
+    println!("cargo:rerun-if-env-changed=COVEN_BUILD_VERSION");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
 
-    let describe = describe_from_git()
+    let describe = explicit_build_version()
+        .or_else(describe_from_git)
         .or_else(github_ref_name_if_tag)
         .unwrap_or_else(|| format!("{} (unknown source)", env!("CARGO_PKG_VERSION")));
 
     println!("cargo:rustc-env=COVEN_VERSION_DESC={}", describe);
+}
+
+fn explicit_build_version() -> Option<String> {
+    std::env::var("COVEN_BUILD_VERSION")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 fn describe_from_git() -> Option<String> {

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -572,6 +572,29 @@ test('release workflow builds and publishes Intel macOS as a separate target', (
   assert.match(workflow, /node scripts\/publish-npm\.mjs --target=macos-x64 --skip-build --publish --skip-wrapper/);
 });
 
+test('release builds report the stable package version during recovery', () => {
+  const workflow = readFileSync(
+    new URL(['..', '.github', 'workflows', 'release-npm.yml'].join('/'), import.meta.url),
+    'utf8'
+  );
+  const buildJob = workflow.match(/^  build-platform:[\s\S]*?(?=^  [A-Za-z0-9_-]+:)/m)?.[0];
+  assert.ok(buildJob, 'release workflow must contain the platform build job');
+  assert.match(
+    buildJob,
+    /^          COVEN_BUILD_VERSION: v\$\{\{ needs\.verify-tag\.outputs\.npm_version \}\}$/m,
+    'recovery binaries must report the stable npm version, not the recovery tag name'
+  );
+  const buildScript = readFileSync(
+    new URL(['..', 'crates', 'coven-cli', 'build.rs'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(
+    buildScript,
+    /let describe = explicit_build_version\(\)\s*\.or_else\(describe_from_git\)/,
+    'the explicit release version must take precedence over git describe'
+  );
+});
+
 test('CI smoke-tests the Intel macOS wrapper on its native runner', () => {
   const workflowPath = new URL(['..', '.github', 'workflows', 'ci.yml'].join('/'), import.meta.url);
   const workflow = readFileSync(workflowPath, 'utf8');


### PR DESCRIPTION
## Summary
- stamp platform binaries with the verified stable npm version during signed recovery runs
- prevent public binaries from reporting the recovery tag suffix
- add a workflow contract regression test

## Test Plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `node scripts/publish-npm-test.mjs`
- [x] `python3 scripts/check-secrets-test.py`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `git diff origin/main...HEAD --check`

Follow-up to #654.