### PR TITLE
docs: complete Windows IPC discovery guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,10 +284,11 @@ The full command surface — every subcommand, flag, and JSON output shape — l
 
 The daemon exposes a versioned HTTP API over same-user local IPC. On Unix-like
 hosts, this is `<COVEN_HOME>/coven.sock`; on Windows, it is an owner-only named
-pipe selected by `COVEN_HOME`. Health and `coven daemon status` report the
-active endpoint, so clients must not construct a Windows pipe name from the
-Unix convention. The current public contract is `coven.daemon.v1` (prefix:
-`/api/v1`).
+pipe selected by `COVEN_HOME`. Windows clients discover the fully qualified
+pipe path as `state.daemon_ipc` from `coven config paths --json`; they must not
+construct a pipe name from the Unix convention or use health/status transport
+metadata as a named-pipe path. The current public contract is
+`coven.daemon.v1` (prefix: `/api/v1`).
 
 The complete endpoint index — contract discovery, sessions and events, observability reads, travel, scheduler, and the hub control plane — lives in [`docs/reference/api.md`](docs/reference/api.md). [`docs/API.md`](docs/API.md) covers the architecture and auth posture, and [`docs/API-CONTRACT.md`](docs/API-CONTRACT.md) is the full versioned contract: shapes, error codes, cursor pagination, and compatibility rules.
 
@@ -337,7 +338,7 @@ Developer
   │
   ├── CastCodes workspace ─────────────────────┐
   ├── coven CLI / TUI ─────────────────────────┤ HTTP over local IPC
-  ├── comux (legacy/reference) ────────────────┤ daemon-reported endpoint
+  ├── comux (legacy/reference) ────────────────┤ local IPC API
   └── @opencoven/coven (OpenClaw plugin) ───────┘
                                                 │
                                 ┌───────────────▼──────────────────┐
@@ -476,7 +477,11 @@ Never commit runtime state: `.coven/`, `*.sqlite*`, `*.db`, `*.sock`, `.env*`, a
 
 ## OpenCoven Integrations
 
-Coven is the runtime layer. Other surfaces in the OpenCoven ecosystem sit above it and connect through same-user local IPC: a Unix socket at `COVEN_HOME/coven.sock` on Unix-like hosts or a daemon-reported owner-only named pipe on Windows.
+Coven is the runtime layer. Other surfaces in the OpenCoven ecosystem sit above
+it and connect through same-user local IPC: a Unix socket at
+`COVEN_HOME/coven.sock` on Unix-like hosts or an owner-only named pipe on
+Windows, whose fully qualified client path is `state.daemon_ipc` from
+`coven config paths --json`.
 
 | Integration                                              | Role                                                                       | How it connects                          |
 | -------------------------------------------------------- | -------------------------------------------------------------------------- | ---------------------------------------- |
@@ -538,7 +543,11 @@ comux is a standalone terminal cockpit that proved the tmux-cockpit model for pa
 
 **Q: What is Coven, exactly?**
 
-Coven is a local Rust daemon and CLI that supervises coding-agent CLI sessions (like Codex or Claude Code) inside explicit project boundaries, records everything to SQLite, and exposes it through a versioned HTTP API over same-user local IPC: a Unix socket at `COVEN_HOME/coven.sock` on Unix-like hosts or a daemon-reported owner-only named pipe on Windows.
+Coven is a local Rust daemon and CLI that supervises coding-agent CLI sessions
+(like Codex or Claude Code) inside explicit project boundaries, records
+everything to SQLite, and exposes it through a versioned HTTP API over
+same-user local IPC: a Unix socket at `COVEN_HOME/coven.sock` on Unix-like
+hosts or an owner-only named pipe on Windows.
 
 **Q: Does Coven replace Codex or Claude Code?**
 
@@ -562,7 +571,11 @@ Sacrifice is Coven's intentionally explicit verb for permanently deleting a sess
 
 **Q: What is `COVEN_HOME`?**
 
-The directory where Coven stores all local state: SQLite database, same-user local IPC, logs, and encryption keys. On Unix-like hosts, IPC uses `COVEN_HOME/coven.sock`; on Windows, it uses a daemon-reported owner-only named pipe. Defaults to `~/.coven`. To isolate environments (e.g., in CI), set `COVEN_HOME` to a separate path for each environment.
+The directory where Coven stores all local state: SQLite database, same-user
+local IPC, logs, and encryption keys. On Unix-like hosts, IPC uses
+`COVEN_HOME/coven.sock`; on Windows, it uses an owner-only named pipe.
+Defaults to `~/.coven`. To isolate environments (e.g., in CI), set
+`COVEN_HOME` to a separate path for each environment.
 
 **Q: Is CastCodes the same as Coven?**
 
@@ -574,7 +587,13 @@ OpenClaw is an external coding agent that can optionally integrate with Coven th
 
 **Q: Can I build my own client on top of Coven?**
 
-Yes. The daemon exposes a stable `coven.daemon.v1` HTTP API over same-user local IPC: a Unix socket at `COVEN_HOME/coven.sock` on Unix-like hosts or a daemon-reported owner-only named pipe on Windows. All clients are untrusted for enforcement, but the API surface is stable and versioned. See [`docs/API-CONTRACT.md`](docs/API-CONTRACT.md) and [`docs/CLIENT-INTEGRATION.md`](docs/CLIENT-INTEGRATION.md).
+Yes. The daemon exposes a stable `coven.daemon.v1` HTTP API over same-user
+local IPC: a Unix socket at `COVEN_HOME/coven.sock` on Unix-like hosts or an
+owner-only named pipe on Windows. Windows clients discover the fully qualified
+pipe path as `state.daemon_ipc` from `coven config paths --json`. All clients
+are untrusted for enforcement, but the API surface is stable and versioned.
+See [`docs/API-CONTRACT.md`](docs/API-CONTRACT.md) and
+[`docs/CLIENT-INTEGRATION.md`](docs/CLIENT-INTEGRATION.md).
 
 **Q: What if I want to add a new harness (like Aider or Gemini)?**
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -55,7 +55,10 @@ The boundary is OS-enforced local IPC permissions plus same-user process localit
 
 ### Same-user local IPC locality
 
-The API is not exposed as TCP by default. On Unix-like hosts, clients connect to the Unix socket owned by the user's Coven state directory; on Windows, they connect through the owner-only named pipe.
+The API is not exposed as TCP by default. On Unix-like hosts, clients connect
+to the Unix socket owned by the user's Coven state directory; on Windows, they
+discover the fully qualified owner-only named-pipe path as `state.daemon_ipc`
+from `coven config paths --json`.
 
 New clients should treat the platform-appropriate local IPC endpoint as the trust anchor and should connect only to the versioned API under `/api/v1/...`.
 

--- a/docs/COMUX-DEMO-LOOP.md
+++ b/docs/COMUX-DEMO-LOOP.md
@@ -121,10 +121,10 @@ Daemon clients should use the versioned local IPC API:
 4. Filter sessions by verified project root before showing them in a project-scoped UI.
 
 On Unix-like hosts, the daemon socket defaults to `~/.coven/coven.sock`; on
-Windows, use the owner-only named-pipe endpoint reported by `coven daemon
-status`. The daemon remains the authority for project roots, cwd, harness ids,
-live-session checks, input, kill requests, archive state, and destructive
-deletion rules.
+Windows, use the fully qualified named-pipe path in `state.daemon_ipc` from
+`coven config paths --json`. The daemon remains the authority for project
+roots, cwd, harness ids, live-session checks, input, kill requests, archive
+state, and destructive deletion rules.
 
 ## Unavailable states
 

--- a/docs/HUB-OPERATIONS.md
+++ b/docs/HUB-OPERATIONS.md
@@ -44,7 +44,7 @@ expectations (`--json` gives the raw `GET /api/v1/hub/status` body; on
 Unix-like hosts, the raw route is also reachable with
 `curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/hub/status`).
 Windows clients need a named-pipe-capable local IPC client and the endpoint
-reported by `coven daemon status`.
+reported as `state.daemon_ipc` by `coven config paths --json`.
 `GET /api/v1/health` includes the same summary in its `hub` block, and
 `coven hub nodes` / `coven hub jobs --state held` drill into the recovered
 registry and queues. For a single record, `coven hub nodes <id>`,

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -42,8 +42,9 @@ Typical Unix-like healthy output:
 Coven daemon: running (pid 12345, socket <covenHome>/coven.sock)
 ```
 
-On Windows, the `socket` field reports the daemon's owner-only named-pipe
-endpoint instead of `<covenHome>/coven.sock`.
+On Windows, the `socket` field is diagnostic transport metadata. Clients use
+`state.daemon_ipc` from `coven config paths --json` for the fully qualified
+owner-only named-pipe path instead of `<covenHome>/coven.sock`.
 
 `running` means Coven found daemon metadata and verified the process/local IPC
 endpoint.

--- a/docs/reference/cli-doctor.md
+++ b/docs/reference/cli-doctor.md
@@ -130,7 +130,8 @@ Typical Unix-like human output from `coven daemon status`:
 Coven daemon: running (pid 12345, socket /path/to/coven-home/coven.sock)
 ```
 
-On Windows, `socket` reports the daemon's owner-only named-pipe endpoint.
+On Windows, `socket` is diagnostic pipe metadata. Clients needing a connection
+path use `state.daemon_ipc` from `coven config paths --json`.
 
 `not running` means no background daemon is running yet. Start it with:
 

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -62,8 +62,9 @@ Coven status
 Next: coven sessions · coven familiars · coven run <harness> "<task>"
 ```
 
-On Windows, the daemon line reports the owner-only named-pipe endpoint instead
-of a `.sock` path.
+On Windows, the daemon line reports diagnostic named-pipe metadata instead of
+a `.sock` path. Clients needing a connection path use `state.daemon_ipc` from
+`coven config paths --json`.
 
 - The `familiars` line counts a familiar as **active** when it has an open
   session; the roster comes from `~/.coven/familiars.toml`.

--- a/docs/start/tinkerers-next-30-minutes.md
+++ b/docs/start/tinkerers-next-30-minutes.md
@@ -22,8 +22,9 @@ curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/health
 curl --unix-socket ~/.coven/coven.sock http://coven/api/v1/capabilities
 ```
 
-On Windows, use a named-pipe-capable local IPC client and the endpoint reported
-by `coven daemon status`; do not construct a `.sock` path.
+On Windows, use a named-pipe-capable local IPC client and the fully qualified
+`state.daemon_ipc` path from `coven config paths --json`; do not construct a
+`.sock` path.
 
 You should see `apiVersion: "coven.daemon.v1"` before building client assumptions.
 


### PR DESCRIPTION
Completes the active-documentation correction for #537: Windows clients obtain the fully qualified named-pipe endpoint from `state.daemon_ipc` in `coven config paths --json`, while health and daemon status remain diagnostic transport metadata.\n\nValidated with:\n- `python3 scripts/check-api-contract-docs-test.py`\n- `python3 scripts/check-api-contract-docs.py`\n- privacy and secret guards