### PR TITLE
feat: coven-afs crate — AgentFS SPEC v0.4 schema + overlay spike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "coven-afs"
+version = "0.1.0"
+dependencies = [
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "coven-cli"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/coven-cli", "crates/coven-memory", "crates/coven-relay"]
+members = ["crates/coven-afs", "crates/coven-cli", "crates/coven-memory", "crates/coven-relay"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/coven-afs/Cargo.toml
+++ b/crates/coven-afs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "coven-afs"
+version = "0.1.0"
+description = "Native OpenCoven agent filesystem: AgentFS SPEC v0.4-compatible SQLite storage with copy-on-write overlay"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+rusqlite = { version = "0.40", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/coven-afs/src/audit.rs
+++ b/crates/coven-afs/src/audit.rs
@@ -1,0 +1,114 @@
+//! Insert-only tool-call audit log (SPEC tool-calls section).
+//!
+//! Records MUST NOT be updated or deleted; this module deliberately exposes
+//! no mutation beyond the single completion-time insert.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::fs::AgentFs;
+use crate::{Error, Result};
+
+/// One recorded tool invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: i64,
+    pub name: String,
+    pub parameters: Option<String>,
+    pub result: Option<String>,
+    pub error: Option<String>,
+    pub started_at: i64,
+    pub completed_at: i64,
+    pub duration_ms: i64,
+}
+
+impl AgentFs {
+    /// Record a completed tool call. Exactly one of `result` / `error` must
+    /// be provided (SPEC mutual-exclusion rule); `duration_ms` is computed as
+    /// `(completed_at - started_at) * 1000`.
+    pub fn record_tool_call(
+        &self,
+        name: &str,
+        parameters: Option<&Value>,
+        result: Option<&Value>,
+        error: Option<&str>,
+        started_at: i64,
+        completed_at: i64,
+    ) -> Result<i64> {
+        if self.is_read_only() {
+            return Err(Error::ReadOnly);
+        }
+        if result.is_some() == error.is_some() {
+            return Err(Error::InvalidArgument(
+                "exactly one of result or error must be set".into(),
+            ));
+        }
+        if completed_at < started_at {
+            return Err(Error::InvalidArgument(
+                "completed_at must be >= started_at".into(),
+            ));
+        }
+        let params_json = parameters.map(serde_json::to_string).transpose()?;
+        let result_json = result.map(serde_json::to_string).transpose()?;
+        let duration_ms = (completed_at - started_at) * 1000;
+        let id: i64 = self.conn.query_row(
+            "INSERT INTO tool_calls (name, parameters, result, error,
+                                     started_at, completed_at, duration_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+             RETURNING id",
+            rusqlite::params![
+                name,
+                params_json,
+                result_json,
+                error,
+                started_at,
+                completed_at,
+                duration_ms
+            ],
+            |r| r.get(0),
+        )?;
+        Ok(id)
+    }
+
+    /// Tool calls with a given name, most recent first.
+    pub fn tool_calls_by_name(&self, name: &str) -> Result<Vec<ToolCall>> {
+        self.query_tool_calls(
+            "SELECT id, name, parameters, result, error, started_at, completed_at, duration_ms
+             FROM tool_calls WHERE name = ?1 ORDER BY started_at DESC",
+            rusqlite::params![name],
+        )
+    }
+
+    /// Tool calls started strictly after `since` (Unix seconds), most recent
+    /// first.
+    pub fn recent_tool_calls(&self, since: i64) -> Result<Vec<ToolCall>> {
+        self.query_tool_calls(
+            "SELECT id, name, parameters, result, error, started_at, completed_at, duration_ms
+             FROM tool_calls WHERE started_at > ?1 ORDER BY started_at DESC",
+            rusqlite::params![since],
+        )
+    }
+
+    fn query_tool_calls(
+        &self,
+        sql: &str,
+        params: &[&dyn rusqlite::types::ToSql],
+    ) -> Result<Vec<ToolCall>> {
+        let mut stmt = self.conn.prepare(sql)?;
+        let rows = stmt
+            .query_map(params, |r| {
+                Ok(ToolCall {
+                    id: r.get(0)?,
+                    name: r.get(1)?,
+                    parameters: r.get(2)?,
+                    result: r.get(3)?,
+                    error: r.get(4)?,
+                    started_at: r.get(5)?,
+                    completed_at: r.get(6)?,
+                    duration_ms: r.get(7)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+}

--- a/crates/coven-afs/src/fs.rs
+++ b/crates/coven-afs/src/fs.rs
@@ -1,0 +1,738 @@
+//! Single-layer virtual filesystem over one SQLite database.
+
+use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+use crate::path::{basename, components, normalize, parent};
+use crate::{now_parts, schema, Error, Result};
+
+/// Inode 1 MUST be the root directory (SPEC).
+pub const ROOT_INO: i64 = 1;
+
+/// File type mask (`S_IFMT`).
+pub const S_IFMT: u32 = 0o170000;
+/// Regular file (`S_IFREG`).
+pub const S_IFREG: u32 = 0o100000;
+/// Directory (`S_IFDIR`).
+pub const S_IFDIR: u32 = 0o040000;
+/// Symbolic link (`S_IFLNK`).
+pub const S_IFLNK: u32 = 0o120000;
+
+/// File metadata, mirroring an `fs_inode` row (SPEC stat operation).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Metadata {
+    pub ino: i64,
+    pub mode: u32,
+    pub nlink: i64,
+    pub uid: i64,
+    pub gid: i64,
+    pub size: i64,
+    pub atime: i64,
+    pub mtime: i64,
+    pub ctime: i64,
+    pub rdev: i64,
+    pub atime_nsec: i64,
+    pub mtime_nsec: i64,
+    pub ctime_nsec: i64,
+}
+
+impl Metadata {
+    pub fn is_dir(&self) -> bool {
+        self.mode & S_IFMT == S_IFDIR
+    }
+
+    pub fn is_file(&self) -> bool {
+        self.mode & S_IFMT == S_IFREG
+    }
+
+    pub fn is_symlink(&self) -> bool {
+        self.mode & S_IFMT == S_IFLNK
+    }
+}
+
+/// A single-layer AgentFS-compatible filesystem.
+pub struct AgentFs {
+    pub(crate) conn: Connection,
+    chunk_size: usize,
+    read_only: bool,
+}
+
+impl AgentFs {
+    /// Create or open a filesystem database at `path` with the default
+    /// 4096-byte chunk size.
+    pub fn create<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
+        Self::create_with_chunk_size(path, schema::DEFAULT_CHUNK_SIZE)
+    }
+
+    /// Create or open a filesystem database with an explicit chunk size.
+    ///
+    /// The chunk size only applies on first initialization; an existing
+    /// database keeps its immutable configured value.
+    pub fn create_with_chunk_size<P: AsRef<std::path::Path>>(
+        path: P,
+        chunk_size: usize,
+    ) -> Result<Self> {
+        if chunk_size == 0 {
+            return Err(Error::InvalidArgument("chunk_size must be > 0".into()));
+        }
+        let conn = Connection::open(path)?;
+        schema::init(&conn, chunk_size)?;
+        Self::from_conn(conn, false)
+    }
+
+    /// Open an existing filesystem database read-only.
+    ///
+    /// Reads on a read-only filesystem skip `atime` maintenance; mutating
+    /// operations fail with [`Error::ReadOnly`].
+    pub fn open_read_only<P: AsRef<std::path::Path>>(path: P) -> Result<Self> {
+        let conn = Connection::open_with_flags(
+            path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        Self::from_conn(conn, true)
+    }
+
+    /// Create an in-memory filesystem (tests, scratch space).
+    pub fn in_memory() -> Result<Self> {
+        Self::in_memory_with_chunk_size(schema::DEFAULT_CHUNK_SIZE)
+    }
+
+    /// Create an in-memory filesystem with an explicit chunk size.
+    pub fn in_memory_with_chunk_size(chunk_size: usize) -> Result<Self> {
+        if chunk_size == 0 {
+            return Err(Error::InvalidArgument("chunk_size must be > 0".into()));
+        }
+        let conn = Connection::open_in_memory()?;
+        schema::init(&conn, chunk_size)?;
+        Self::from_conn(conn, false)
+    }
+
+    fn from_conn(conn: Connection, read_only: bool) -> Result<Self> {
+        let chunk_size = schema::chunk_size(&conn)?;
+        Ok(Self {
+            conn,
+            chunk_size,
+            read_only,
+        })
+    }
+
+    /// The immutable chunk size configured for this filesystem.
+    pub fn chunk_size(&self) -> usize {
+        self.chunk_size
+    }
+
+    pub fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+
+    fn ensure_writable(&self) -> Result<()> {
+        if self.read_only {
+            Err(Error::ReadOnly)
+        } else {
+            Ok(())
+        }
+    }
+
+    // ---- lookup ----------------------------------------------------------
+
+    /// Resolve a path to an inode number (SPEC path resolution). Returns
+    /// `None` if any component is missing.
+    pub fn resolve(&self, path: &str) -> Result<Option<i64>> {
+        let npath = normalize(path);
+        let mut ino = ROOT_INO;
+        for comp in components(&npath) {
+            match self.lookup_child(ino, comp)? {
+                Some(child) => ino = child,
+                None => return Ok(None),
+            }
+        }
+        Ok(Some(ino))
+    }
+
+    fn lookup_child(&self, parent_ino: i64, name: &str) -> Result<Option<i64>> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT ino FROM fs_dentry WHERE parent_ino = ?1 AND name = ?2",
+                params![parent_ino, name],
+                |r| r.get(0),
+            )
+            .optional()?)
+    }
+
+    /// Whether a path exists.
+    pub fn exists(&self, path: &str) -> Result<bool> {
+        Ok(self.resolve(path)?.is_some())
+    }
+
+    /// Read file metadata (SPEC stat), including the link count.
+    pub fn stat(&self, path: &str) -> Result<Metadata> {
+        let ino = self
+            .resolve(path)?
+            .ok_or_else(|| Error::NotFound(normalize(path)))?;
+        self.stat_ino(ino)
+    }
+
+    /// Read metadata for a known inode.
+    pub fn stat_ino(&self, ino: i64) -> Result<Metadata> {
+        self.conn
+            .query_row(
+                "SELECT ino, mode, nlink, uid, gid, size, atime, mtime, ctime, rdev,
+                        atime_nsec, mtime_nsec, ctime_nsec
+                 FROM fs_inode WHERE ino = ?1",
+                [ino],
+                |r| {
+                    Ok(Metadata {
+                        ino: r.get(0)?,
+                        mode: r.get(1)?,
+                        nlink: r.get(2)?,
+                        uid: r.get(3)?,
+                        gid: r.get(4)?,
+                        size: r.get(5)?,
+                        atime: r.get(6)?,
+                        mtime: r.get(7)?,
+                        ctime: r.get(8)?,
+                        rdev: r.get(9)?,
+                        atime_nsec: r.get(10)?,
+                        mtime_nsec: r.get(11)?,
+                        ctime_nsec: r.get(12)?,
+                    })
+                },
+            )
+            .optional()?
+            .ok_or_else(|| Error::NotFound(format!("inode {ino}")))
+    }
+
+    // ---- directories -----------------------------------------------------
+
+    /// Create a directory and any missing ancestors (SPEC: parent directories
+    /// are created implicitly as needed). Returns the directory inode.
+    pub fn mkdir_p(&mut self, path: &str) -> Result<i64> {
+        self.ensure_writable()?;
+        let npath = normalize(path);
+        let (secs, nsec) = now_parts();
+        let mut ino = ROOT_INO;
+        for comp in components(&npath) {
+            match self.lookup_child(ino, comp)? {
+                Some(child) => {
+                    let meta = self.stat_ino(child)?;
+                    if !meta.is_dir() {
+                        return Err(Error::NotADirectory(npath.clone()));
+                    }
+                    ino = child;
+                }
+                None => {
+                    let tx = self.conn.transaction()?;
+                    let child: i64 = tx.query_row(
+                        "INSERT INTO fs_inode (mode, uid, gid, size, atime, mtime, ctime,
+                                               atime_nsec, mtime_nsec, ctime_nsec)
+                         VALUES (?1, 0, 0, 0, ?2, ?2, ?2, ?3, ?3, ?3)
+                         RETURNING ino",
+                        params![S_IFDIR | 0o755, secs, nsec],
+                        |r| r.get(0),
+                    )?;
+                    tx.execute(
+                        "INSERT INTO fs_dentry (name, parent_ino, ino) VALUES (?1, ?2, ?3)",
+                        params![comp, ino, child],
+                    )?;
+                    tx.execute(
+                        "UPDATE fs_inode SET nlink = nlink + 1 WHERE ino = ?1",
+                        [child],
+                    )?;
+                    tx.commit()?;
+                    ino = child;
+                }
+            }
+        }
+        Ok(ino)
+    }
+
+    /// List directory entry names, sorted ascending (SPEC listing).
+    pub fn readdir(&self, path: &str) -> Result<Vec<String>> {
+        let npath = normalize(path);
+        let ino = self
+            .resolve(&npath)?
+            .ok_or_else(|| Error::NotFound(npath.clone()))?;
+        if !self.stat_ino(ino)?.is_dir() {
+            return Err(Error::NotADirectory(npath));
+        }
+        let mut stmt = self
+            .conn
+            .prepare("SELECT name FROM fs_dentry WHERE parent_ino = ?1 ORDER BY name ASC")?;
+        let names = stmt
+            .query_map([ino], |r| r.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(names)
+    }
+
+    /// Remove an empty directory.
+    pub fn remove_dir(&mut self, path: &str) -> Result<()> {
+        self.ensure_writable()?;
+        let npath = normalize(path);
+        if npath == "/" {
+            return Err(Error::InvalidArgument("cannot remove root".into()));
+        }
+        let ino = self
+            .resolve(&npath)?
+            .ok_or_else(|| Error::NotFound(npath.clone()))?;
+        if !self.stat_ino(ino)?.is_dir() {
+            return Err(Error::NotADirectory(npath));
+        }
+        let child_count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM fs_dentry WHERE parent_ino = ?1",
+            [ino],
+            |r| r.get(0),
+        )?;
+        if child_count > 0 {
+            return Err(Error::DirectoryNotEmpty(npath));
+        }
+        let parent_ino = self
+            .resolve(&parent(&npath))?
+            .ok_or_else(|| Error::NotFound(parent(&npath)))?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "DELETE FROM fs_dentry WHERE parent_ino = ?1 AND name = ?2",
+            params![parent_ino, basename(&npath)],
+        )?;
+        tx.execute("DELETE FROM fs_inode WHERE ino = ?1", [ino])?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    // ---- files -----------------------------------------------------------
+
+    /// Create or overwrite a regular file with `data`, chunked at the
+    /// configured chunk size (SPEC file creation). Missing parent directories
+    /// are created implicitly. Returns the file inode.
+    pub fn write_file(&mut self, path: &str, data: &[u8]) -> Result<i64> {
+        self.ensure_writable()?;
+        let npath = normalize(path);
+        if npath == "/" {
+            return Err(Error::IsADirectory(npath));
+        }
+        let parent_ino = self.mkdir_p(&parent(&npath))?;
+        let name = basename(&npath).to_string();
+        let (secs, nsec) = now_parts();
+        let chunk_size = self.chunk_size;
+
+        let tx = self.conn.transaction()?;
+        let existing: Option<i64> = tx
+            .query_row(
+                "SELECT ino FROM fs_dentry WHERE parent_ino = ?1 AND name = ?2",
+                params![parent_ino, name],
+                |r| r.get(0),
+            )
+            .optional()?;
+        let ino = match existing {
+            Some(ino) => {
+                let mode: u32 =
+                    tx.query_row("SELECT mode FROM fs_inode WHERE ino = ?1", [ino], |r| {
+                        r.get(0)
+                    })?;
+                if mode & S_IFMT != S_IFREG {
+                    return Err(Error::NotARegularFile(npath));
+                }
+                tx.execute("DELETE FROM fs_data WHERE ino = ?1", [ino])?;
+                ino
+            }
+            None => {
+                let ino: i64 = tx.query_row(
+                    "INSERT INTO fs_inode (mode, uid, gid, size, atime, mtime, ctime,
+                                           atime_nsec, mtime_nsec, ctime_nsec)
+                     VALUES (?1, 0, 0, 0, ?2, ?2, ?2, ?3, ?3, ?3)
+                     RETURNING ino",
+                    params![S_IFREG | 0o644, secs, nsec],
+                    |r| r.get(0),
+                )?;
+                tx.execute(
+                    "INSERT INTO fs_dentry (name, parent_ino, ino) VALUES (?1, ?2, ?3)",
+                    params![name, parent_ino, ino],
+                )?;
+                tx.execute(
+                    "UPDATE fs_inode SET nlink = nlink + 1 WHERE ino = ?1",
+                    [ino],
+                )?;
+                ino
+            }
+        };
+        for (idx, chunk) in data.chunks(chunk_size).enumerate() {
+            tx.execute(
+                "INSERT INTO fs_data (ino, chunk_index, data) VALUES (?1, ?2, ?3)",
+                params![ino, idx as i64, chunk],
+            )?;
+        }
+        tx.execute(
+            "UPDATE fs_inode SET size = ?1, mtime = ?2, mtime_nsec = ?3,
+                                 ctime = ?2, ctime_nsec = ?3
+             WHERE ino = ?4",
+            params![data.len() as i64, secs, nsec, ino],
+        )?;
+        tx.commit()?;
+        Ok(ino)
+    }
+
+    /// Read an entire regular file (SPEC read: concatenate chunks in order,
+    /// then update `atime` — skipped on read-only connections).
+    pub fn read_file(&self, path: &str) -> Result<Vec<u8>> {
+        let npath = normalize(path);
+        let ino = self
+            .resolve(&npath)?
+            .ok_or_else(|| Error::NotFound(npath.clone()))?;
+        let meta = self.stat_ino(ino)?;
+        if meta.is_dir() {
+            return Err(Error::IsADirectory(npath));
+        }
+        if !meta.is_file() {
+            return Err(Error::NotARegularFile(npath));
+        }
+        let mut stmt = self
+            .conn
+            .prepare("SELECT data FROM fs_data WHERE ino = ?1 ORDER BY chunk_index ASC")?;
+        let mut out = Vec::with_capacity(meta.size as usize);
+        for chunk in stmt.query_map([ino], |r| r.get::<_, Vec<u8>>(0))? {
+            out.extend_from_slice(&chunk?);
+        }
+        if !self.read_only {
+            let (secs, nsec) = now_parts();
+            self.conn.execute(
+                "UPDATE fs_inode SET atime = ?1, atime_nsec = ?2 WHERE ino = ?3",
+                params![secs, nsec, ino],
+            )?;
+        }
+        Ok(out)
+    }
+
+    /// Read `length` bytes starting at byte `offset` (SPEC offset read).
+    /// Returns fewer bytes when the file ends first.
+    pub fn read_at(&self, path: &str, offset: u64, length: usize) -> Result<Vec<u8>> {
+        let npath = normalize(path);
+        let ino = self
+            .resolve(&npath)?
+            .ok_or_else(|| Error::NotFound(npath.clone()))?;
+        let meta = self.stat_ino(ino)?;
+        if !meta.is_file() {
+            return Err(Error::NotARegularFile(npath));
+        }
+        if length == 0 || offset >= meta.size as u64 {
+            return Ok(Vec::new());
+        }
+        let cs = self.chunk_size as u64;
+        let start_chunk = (offset / cs) as i64;
+        let end_chunk = ((offset + length as u64 - 1) / cs) as i64;
+        let mut stmt = self.conn.prepare(
+            "SELECT chunk_index, data FROM fs_data
+             WHERE ino = ?1 AND chunk_index >= ?2 AND chunk_index <= ?3
+             ORDER BY chunk_index ASC",
+        )?;
+        let mut raw = Vec::new();
+        for row in stmt.query_map(params![ino, start_chunk, end_chunk], |r| {
+            r.get::<_, Vec<u8>>(1)
+        })? {
+            raw.extend_from_slice(&row?);
+        }
+        let skip = (offset % cs) as usize;
+        if skip >= raw.len() {
+            return Ok(Vec::new());
+        }
+        let end = (skip + length).min(raw.len());
+        Ok(raw[skip..end].to_vec())
+    }
+
+    /// Delete a regular file or symlink (SPEC deletion: remove dentry,
+    /// decrement `nlink`, drop inode + data on last link).
+    pub fn remove_file(&mut self, path: &str) -> Result<()> {
+        self.ensure_writable()?;
+        let npath = normalize(path);
+        let ino = self
+            .resolve(&npath)?
+            .ok_or_else(|| Error::NotFound(npath.clone()))?;
+        if self.stat_ino(ino)?.is_dir() {
+            return Err(Error::IsADirectory(npath));
+        }
+        let parent_ino = self
+            .resolve(&parent(&npath))?
+            .ok_or_else(|| Error::NotFound(parent(&npath)))?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "DELETE FROM fs_dentry WHERE parent_ino = ?1 AND name = ?2",
+            params![parent_ino, basename(&npath)],
+        )?;
+        tx.execute(
+            "UPDATE fs_inode SET nlink = nlink - 1 WHERE ino = ?1",
+            [ino],
+        )?;
+        let nlink: i64 = tx.query_row("SELECT nlink FROM fs_inode WHERE ino = ?1", [ino], |r| {
+            r.get(0)
+        })?;
+        if nlink <= 0 {
+            tx.execute("DELETE FROM fs_inode WHERE ino = ?1", [ino])?;
+            tx.execute("DELETE FROM fs_data WHERE ino = ?1", [ino])?;
+            tx.execute("DELETE FROM fs_symlink WHERE ino = ?1", [ino])?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Rename/move a file or directory. An existing destination file is
+    /// replaced; an existing destination directory must be empty.
+    pub fn rename(&mut self, src: &str, dst: &str) -> Result<()> {
+        self.ensure_writable()?;
+        let nsrc = normalize(src);
+        let ndst = normalize(dst);
+        if nsrc == "/" || ndst == "/" {
+            return Err(Error::InvalidArgument("cannot rename root".into()));
+        }
+        if nsrc == ndst {
+            return Ok(());
+        }
+        if ndst.starts_with(&format!("{nsrc}/")) {
+            return Err(Error::InvalidArgument(format!(
+                "cannot move {nsrc} into itself"
+            )));
+        }
+        let src_ino = self
+            .resolve(&nsrc)?
+            .ok_or_else(|| Error::NotFound(nsrc.clone()))?;
+        if let Some(dst_ino) = self.resolve(&ndst)? {
+            if dst_ino == src_ino {
+                return Ok(());
+            }
+            if self.stat_ino(dst_ino)?.is_dir() {
+                self.remove_dir(&ndst)?;
+            } else {
+                self.remove_file(&ndst)?;
+            }
+        }
+        let src_parent_ino = self
+            .resolve(&parent(&nsrc))?
+            .ok_or_else(|| Error::NotFound(parent(&nsrc)))?;
+        let dst_parent_ino = self.mkdir_p(&parent(&ndst))?;
+        let (secs, nsec) = now_parts();
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE fs_dentry SET name = ?1, parent_ino = ?2
+             WHERE parent_ino = ?3 AND name = ?4",
+            params![
+                basename(&ndst),
+                dst_parent_ino,
+                src_parent_ino,
+                basename(&nsrc)
+            ],
+        )?;
+        tx.execute(
+            "UPDATE fs_inode SET ctime = ?1, ctime_nsec = ?2 WHERE ino = ?3",
+            params![secs, nsec, src_ino],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Create a hard link to a regular file (SPEC hard link).
+    pub fn hardlink(&mut self, src: &str, dst: &str) -> Result<()> {
+        self.ensure_writable()?;
+        let nsrc = normalize(src);
+        let ndst = normalize(dst);
+        let src_ino = self
+            .resolve(&nsrc)?
+            .ok_or_else(|| Error::NotFound(nsrc.clone()))?;
+        if !self.stat_ino(src_ino)?.is_file() {
+            return Err(Error::NotARegularFile(nsrc));
+        }
+        if self.resolve(&ndst)?.is_some() {
+            return Err(Error::AlreadyExists(ndst));
+        }
+        let dst_parent_ino = self.mkdir_p(&parent(&ndst))?;
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "INSERT INTO fs_dentry (name, parent_ino, ino) VALUES (?1, ?2, ?3)",
+            params![basename(&ndst), dst_parent_ino, src_ino],
+        )?;
+        tx.execute(
+            "UPDATE fs_inode SET nlink = nlink + 1 WHERE ino = ?1",
+            [src_ino],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Create a symbolic link at `linkpath` pointing at `target`.
+    pub fn symlink(&mut self, target: &str, linkpath: &str) -> Result<i64> {
+        self.ensure_writable()?;
+        let npath = normalize(linkpath);
+        if self.resolve(&npath)?.is_some() {
+            return Err(Error::AlreadyExists(npath));
+        }
+        let parent_ino = self.mkdir_p(&parent(&npath))?;
+        let (secs, nsec) = now_parts();
+        let tx = self.conn.transaction()?;
+        let ino: i64 = tx.query_row(
+            "INSERT INTO fs_inode (mode, uid, gid, size, atime, mtime, ctime,
+                                   atime_nsec, mtime_nsec, ctime_nsec)
+             VALUES (?1, 0, 0, ?2, ?3, ?3, ?3, ?4, ?4, ?4)
+             RETURNING ino",
+            params![S_IFLNK | 0o777, target.len() as i64, secs, nsec],
+            |r| r.get(0),
+        )?;
+        tx.execute(
+            "INSERT INTO fs_dentry (name, parent_ino, ino) VALUES (?1, ?2, ?3)",
+            params![basename(&npath), parent_ino, ino],
+        )?;
+        tx.execute(
+            "UPDATE fs_inode SET nlink = nlink + 1 WHERE ino = ?1",
+            [ino],
+        )?;
+        tx.execute(
+            "INSERT INTO fs_symlink (ino, target) VALUES (?1, ?2)",
+            params![ino, target],
+        )?;
+        tx.commit()?;
+        Ok(ino)
+    }
+
+    /// Read a symlink's target.
+    pub fn read_link(&self, path: &str) -> Result<String> {
+        let npath = normalize(path);
+        let ino = self
+            .resolve(&npath)?
+            .ok_or_else(|| Error::NotFound(npath.clone()))?;
+        if !self.stat_ino(ino)?.is_symlink() {
+            return Err(Error::NotASymlink(npath));
+        }
+        Ok(self
+            .conn
+            .query_row("SELECT target FROM fs_symlink WHERE ino = ?1", [ino], |r| {
+                r.get(0)
+            })?)
+    }
+
+    // ---- consistency -----------------------------------------------------
+
+    /// Verify the SPEC filesystem consistency rules plus chunk-shape
+    /// invariants. Returns a list of human-readable violations (empty when
+    /// consistent).
+    pub fn check_consistency(&self) -> Result<Vec<String>> {
+        let mut violations = Vec::new();
+        let c = &self.conn;
+
+        // Rule 1: root inode must exist and be a directory.
+        let root_mode: Option<u32> = c
+            .query_row("SELECT mode FROM fs_inode WHERE ino = 1", [], |r| r.get(0))
+            .optional()?;
+        match root_mode {
+            None => violations.push("rule 1: root inode (ino=1) missing".into()),
+            Some(m) if m & S_IFMT != S_IFDIR => {
+                violations.push("rule 1: root inode is not a directory".into())
+            }
+            _ => {}
+        }
+
+        // Rules 2 + 3: every dentry references a valid inode and parent inode.
+        let orphan_inos: i64 = c.query_row(
+            "SELECT COUNT(*) FROM fs_dentry d
+             WHERE NOT EXISTS (SELECT 1 FROM fs_inode i WHERE i.ino = d.ino)",
+            [],
+            |r| r.get(0),
+        )?;
+        if orphan_inos > 0 {
+            violations.push(format!(
+                "rule 2: {orphan_inos} dentries reference missing inodes"
+            ));
+        }
+        let orphan_parents: i64 = c.query_row(
+            "SELECT COUNT(*) FROM fs_dentry d
+             WHERE NOT EXISTS (SELECT 1 FROM fs_inode i WHERE i.ino = d.parent_ino)",
+            [],
+            |r| r.get(0),
+        )?;
+        if orphan_parents > 0 {
+            violations.push(format!(
+                "rule 3: {orphan_parents} dentries reference missing parent inodes"
+            ));
+        }
+
+        // Rule 4: no duplicate names within a directory.
+        let dupes: i64 = c.query_row(
+            "SELECT COUNT(*) FROM (
+               SELECT parent_ino, name FROM fs_dentry
+               GROUP BY parent_ino, name HAVING COUNT(*) > 1)",
+            [],
+            |r| r.get(0),
+        )?;
+        if dupes > 0 {
+            violations.push(format!("rule 4: {dupes} duplicate (parent, name) pairs"));
+        }
+
+        // Rule 5: every inode used as a dentry parent is a directory.
+        let bad_parents: i64 = c.query_row(
+            "SELECT COUNT(*) FROM fs_dentry d
+             JOIN fs_inode i ON i.ino = d.parent_ino
+             WHERE (i.mode & ?1) != ?2",
+            params![S_IFMT, S_IFDIR],
+            |r| r.get(0),
+        )?;
+        if bad_parents > 0 {
+            violations.push(format!(
+                "rule 5: {bad_parents} dentries under non-directories"
+            ));
+        }
+
+        // Rule 6: inodes holding data chunks are regular files, and
+        // directories hold no chunks.
+        let bad_data_owners: i64 = c.query_row(
+            "SELECT COUNT(DISTINCT d.ino) FROM fs_data d
+             JOIN fs_inode i ON i.ino = d.ino
+             WHERE (i.mode & ?1) != ?2",
+            params![S_IFMT, S_IFREG],
+            |r| r.get(0),
+        )?;
+        if bad_data_owners > 0 {
+            violations.push(format!(
+                "rule 6: {bad_data_owners} non-regular-file inodes own data chunks"
+            ));
+        }
+
+        // Rule 7: file size matches the total size of its data chunks.
+        let size_mismatches: i64 = c.query_row(
+            "SELECT COUNT(*) FROM fs_inode i
+             WHERE (i.mode & ?1) = ?2
+               AND i.size != COALESCE(
+                 (SELECT SUM(LENGTH(d.data)) FROM fs_data d WHERE d.ino = i.ino), 0)",
+            params![S_IFMT, S_IFREG],
+            |r| r.get(0),
+        )?;
+        if size_mismatches > 0 {
+            violations.push(format!(
+                "rule 7: {size_mismatches} inodes with size != sum of chunk lengths"
+            ));
+        }
+
+        // Rule 8: every inode except root has at least one dentry.
+        let unreferenced: i64 = c.query_row(
+            "SELECT COUNT(*) FROM fs_inode i
+             WHERE i.ino != 1
+               AND NOT EXISTS (SELECT 1 FROM fs_dentry d WHERE d.ino = i.ino)",
+            [],
+            |r| r.get(0),
+        )?;
+        if unreferenced > 0 {
+            violations.push(format!("rule 8: {unreferenced} inodes with no dentry"));
+        }
+
+        // Chunk shape: all chunks except the last are exactly chunk_size.
+        let bad_chunks: i64 = c.query_row(
+            "SELECT COUNT(*) FROM fs_data d
+             WHERE LENGTH(d.data) != ?1
+               AND d.chunk_index != (SELECT MAX(chunk_index) FROM fs_data WHERE ino = d.ino)",
+            [self.chunk_size as i64],
+            |r| r.get(0),
+        )?;
+        if bad_chunks > 0 {
+            violations.push(format!(
+                "chunking: {bad_chunks} non-final chunks not exactly {} bytes",
+                self.chunk_size
+            ));
+        }
+
+        Ok(violations)
+    }
+}

--- a/crates/coven-afs/src/kv.rs
+++ b/crates/coven-afs/src/kv.rs
@@ -1,0 +1,61 @@
+//! JSON key-value store (SPEC key-value section).
+
+use rusqlite::OptionalExtension;
+use serde_json::Value;
+
+use crate::fs::AgentFs;
+use crate::{Error, Result};
+
+impl AgentFs {
+    /// Upsert a JSON value under `key` (SPEC set: refreshes `updated_at`).
+    pub fn kv_set(&self, key: &str, value: &Value) -> Result<()> {
+        if self.is_read_only() {
+            return Err(Error::ReadOnly);
+        }
+        self.conn.execute(
+            "INSERT INTO kv_store (key, value, updated_at)
+             VALUES (?1, ?2, unixepoch())
+             ON CONFLICT(key) DO UPDATE SET
+               value = excluded.value,
+               updated_at = unixepoch()",
+            rusqlite::params![key, serde_json::to_string(value)?],
+        )?;
+        Ok(())
+    }
+
+    /// Get the JSON value stored under `key`.
+    pub fn kv_get(&self, key: &str) -> Result<Option<Value>> {
+        let raw: Option<String> = self
+            .conn
+            .query_row("SELECT value FROM kv_store WHERE key = ?1", [key], |r| {
+                r.get(0)
+            })
+            .optional()?;
+        match raw {
+            Some(s) => Ok(Some(serde_json::from_str(&s)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Delete `key`. Returns whether a row was removed.
+    pub fn kv_delete(&self, key: &str) -> Result<bool> {
+        if self.is_read_only() {
+            return Err(Error::ReadOnly);
+        }
+        let n = self
+            .conn
+            .execute("DELETE FROM kv_store WHERE key = ?1", [key])?;
+        Ok(n > 0)
+    }
+
+    /// All keys, sorted ascending.
+    pub fn kv_keys(&self) -> Result<Vec<String>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT key FROM kv_store ORDER BY key ASC")?;
+        let keys = stmt
+            .query_map([], |r| r.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(keys)
+    }
+}

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -1,0 +1,73 @@
+//! # coven-afs
+//!
+//! Native OpenCoven agent filesystem: an [AgentFS SPEC v0.4]-compatible
+//! SQLite storage layer with copy-on-write overlay semantics.
+//!
+//! One SQLite database holds three interfaces:
+//!
+//! - a POSIX-ish virtual filesystem (`fs_inode` / `fs_dentry` / `fs_data`
+//!   chunked blobs, hard links, symlinks),
+//! - an insert-only `tool_calls` audit log,
+//! - a JSON `kv_store`.
+//!
+//! [`OverlayFs`] layers a writable delta database over a read-only base
+//! database with whiteouts (`fs_whiteout`), full-file copy-up, and kernel
+//! inode-cache preservation via `fs_origin`.
+//!
+//! Spec compatibility is deliberate: databases produced by this crate are
+//! readable by upstream `agentfs` tooling and vice versa. See
+//! `specs/coven-agent-fs/RESEARCH.md` for the design rationale.
+//!
+//! This spike intentionally excludes any mount layer (FUSE/NFS); it is the
+//! storage engine only.
+//!
+//! [AgentFS SPEC v0.4]: https://github.com/tursodatabase/agentfs/blob/main/SPEC.md
+
+mod audit;
+mod fs;
+mod kv;
+mod overlay;
+mod path;
+mod schema;
+
+pub use audit::ToolCall;
+pub use fs::{AgentFs, Metadata, ROOT_INO, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
+pub use overlay::OverlayFs;
+pub use path::{basename, components, normalize, parent};
+
+/// Errors produced by coven-afs operations.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("not found: {0}")]
+    NotFound(String),
+    #[error("already exists: {0}")]
+    AlreadyExists(String),
+    #[error("not a directory: {0}")]
+    NotADirectory(String),
+    #[error("is a directory: {0}")]
+    IsADirectory(String),
+    #[error("directory not empty: {0}")]
+    DirectoryNotEmpty(String),
+    #[error("not a regular file: {0}")]
+    NotARegularFile(String),
+    #[error("not a symlink: {0}")]
+    NotASymlink(String),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+    #[error("filesystem is read-only")]
+    ReadOnly,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Current Unix time as `(seconds, nanosecond remainder)`.
+pub(crate) fn now_parts() -> (i64, i64) {
+    let d = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    (d.as_secs() as i64, i64::from(d.subsec_nanos()))
+}

--- a/crates/coven-afs/src/overlay.rs
+++ b/crates/coven-afs/src/overlay.rs
@@ -1,0 +1,284 @@
+//! Copy-on-write overlay: a writable delta filesystem layered over a
+//! read-only base filesystem (SPEC overlay section).
+//!
+//! Lookup order is always: **delta → whiteout → base → not found.**
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::fs::{AgentFs, Metadata};
+use crate::path::{normalize, parent};
+use crate::{now_parts, Error, Result};
+
+/// A copy-on-write overlay filesystem.
+///
+/// Whiteouts, origin mappings, and all writes live in the delta database;
+/// the base database is never modified.
+pub struct OverlayFs {
+    delta: AgentFs,
+    base: AgentFs,
+}
+
+impl OverlayFs {
+    /// Layer a writable `delta` over a read-only `base`.
+    pub fn new(delta: AgentFs, base: AgentFs) -> Result<Self> {
+        if delta.is_read_only() {
+            return Err(Error::ReadOnly);
+        }
+        Ok(Self { delta, base })
+    }
+
+    /// Open `delta_path` writable (creating it if missing) over `base_path`
+    /// opened read-only.
+    pub fn open<P: AsRef<std::path::Path>, Q: AsRef<std::path::Path>>(
+        delta_path: P,
+        base_path: Q,
+    ) -> Result<Self> {
+        let base = AgentFs::open_read_only(base_path)?;
+        let delta = AgentFs::create_with_chunk_size(delta_path, base.chunk_size())?;
+        Self::new(delta, base)
+    }
+
+    /// The writable delta layer.
+    pub fn delta(&self) -> &AgentFs {
+        &self.delta
+    }
+
+    /// The read-only base layer.
+    pub fn base(&self) -> &AgentFs {
+        &self.base
+    }
+
+    // ---- whiteouts ---------------------------------------------------------
+
+    /// Whether `path` has a whiteout in the delta layer.
+    pub fn has_whiteout(&self, path: &str) -> Result<bool> {
+        let npath = normalize(path);
+        Ok(self
+            .delta
+            .conn
+            .query_row("SELECT 1 FROM fs_whiteout WHERE path = ?1", [npath], |_| {
+                Ok(())
+            })
+            .optional()?
+            .is_some())
+    }
+
+    fn create_whiteout(&self, npath: &str) -> Result<()> {
+        let (secs, _) = now_parts();
+        self.delta.conn.execute(
+            "INSERT INTO fs_whiteout (path, parent_path, created_at)
+             VALUES (?1, ?2, ?3)
+             ON CONFLICT(path) DO UPDATE SET created_at = excluded.created_at",
+            params![npath, parent(npath), secs],
+        )?;
+        Ok(())
+    }
+
+    /// Rule: a whiteout MUST be removed when a new file is created at that
+    /// path.
+    fn remove_whiteout(&self, npath: &str) -> Result<()> {
+        self.delta
+            .conn
+            .execute("DELETE FROM fs_whiteout WHERE path = ?1", [npath])?;
+        Ok(())
+    }
+
+    fn child_whiteouts(&self, dir_npath: &str) -> Result<Vec<String>> {
+        let mut stmt = self
+            .delta
+            .conn
+            .prepare("SELECT path FROM fs_whiteout WHERE parent_path = ?1")?;
+        let rows = stmt
+            .query_map([dir_npath], |r| r.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    // ---- origin tracking ---------------------------------------------------
+
+    /// Origin inode for a delta inode, if the file was copied up from base.
+    pub fn origin_ino(&self, delta_ino: i64) -> Result<Option<i64>> {
+        Ok(self
+            .delta
+            .conn
+            .query_row(
+                "SELECT base_ino FROM fs_origin WHERE delta_ino = ?1",
+                [delta_ino],
+                |r| r.get(0),
+            )
+            .optional()?)
+    }
+
+    fn store_origin(&self, delta_ino: i64, base_ino: i64) -> Result<()> {
+        self.delta.conn.execute(
+            "INSERT OR REPLACE INTO fs_origin (delta_ino, base_ino) VALUES (?1, ?2)",
+            params![delta_ino, base_ino],
+        )?;
+        Ok(())
+    }
+
+    // ---- overlay operations ------------------------------------------------
+
+    /// Overlay existence check following delta → whiteout → base.
+    pub fn exists(&self, path: &str) -> Result<bool> {
+        let npath = normalize(path);
+        if self.delta.exists(&npath)? {
+            return Ok(true);
+        }
+        if self.has_whiteout(&npath)? {
+            return Ok(false);
+        }
+        self.base.exists(&npath)
+    }
+
+    /// Overlay stat. For delta inodes with an origin mapping, the base inode
+    /// number is returned (SPEC: preserves kernel inode caches across
+    /// copy-up).
+    pub fn stat(&self, path: &str) -> Result<Metadata> {
+        let npath = normalize(path);
+        if let Some(delta_ino) = self.delta.resolve(&npath)? {
+            let mut meta = self.delta.stat_ino(delta_ino)?;
+            if let Some(base_ino) = self.origin_ino(delta_ino)? {
+                meta.ino = base_ino;
+            }
+            return Ok(meta);
+        }
+        if self.has_whiteout(&npath)? {
+            return Err(Error::NotFound(npath));
+        }
+        self.base.stat(&npath)
+    }
+
+    /// Overlay read following delta → whiteout → base.
+    pub fn read_file(&self, path: &str) -> Result<Vec<u8>> {
+        let npath = normalize(path);
+        if self.delta.exists(&npath)? {
+            return self.delta.read_file(&npath);
+        }
+        if self.has_whiteout(&npath)? {
+            return Err(Error::NotFound(npath));
+        }
+        self.base.read_file(&npath)
+    }
+
+    /// Create or overwrite a file in the delta layer. Clears any whiteout at
+    /// the path and along its ancestor directories; if the path shadows a
+    /// base file, the base inode is recorded in `fs_origin`.
+    pub fn write_file(&mut self, path: &str, data: &[u8]) -> Result<i64> {
+        let npath = normalize(path);
+        let shadowed_base_ino = if self.delta.resolve(&npath)?.is_none() {
+            match self.base.resolve(&npath)? {
+                Some(ino) if self.base.stat_ino(ino)?.is_file() => Some(ino),
+                _ => None,
+            }
+        } else {
+            None
+        };
+        self.remove_whiteout(&npath)?;
+        // Ancestor directories being re-created must also lose their whiteouts.
+        let mut anc = parent(&npath);
+        while anc != "/" {
+            self.remove_whiteout(&anc)?;
+            anc = parent(&anc);
+        }
+        let ino = self.delta.write_file(&npath, data)?;
+        if let Some(base_ino) = shadowed_base_ino {
+            self.store_origin(ino, base_ino)?;
+        }
+        Ok(ino)
+    }
+
+    /// Copy a file from the base layer into the delta layer (full-file
+    /// copy-up), preserving metadata and recording the origin mapping.
+    /// No-op if the path already lives in the delta layer.
+    pub fn copy_up(&mut self, path: &str) -> Result<i64> {
+        let npath = normalize(path);
+        if let Some(ino) = self.delta.resolve(&npath)? {
+            return Ok(ino);
+        }
+        if self.has_whiteout(&npath)? {
+            return Err(Error::NotFound(npath));
+        }
+        let base_meta = self.base.stat(&npath)?;
+        if !base_meta.is_file() {
+            return Err(Error::NotARegularFile(npath));
+        }
+        let data = self.base.read_file(&npath)?;
+        let delta_ino = self.delta.write_file(&npath, &data)?;
+        self.delta.conn.execute(
+            "UPDATE fs_inode SET mode = ?1, uid = ?2, gid = ?3,
+                    atime = ?4, mtime = ?5, ctime = ?6,
+                    atime_nsec = ?7, mtime_nsec = ?8, ctime_nsec = ?9
+             WHERE ino = ?10",
+            params![
+                base_meta.mode,
+                base_meta.uid,
+                base_meta.gid,
+                base_meta.atime,
+                base_meta.mtime,
+                base_meta.ctime,
+                base_meta.atime_nsec,
+                base_meta.mtime_nsec,
+                base_meta.ctime_nsec,
+                delta_ino
+            ],
+        )?;
+        self.store_origin(delta_ino, base_meta.ino)?;
+        Ok(delta_ino)
+    }
+
+    /// Delete a file from the overlay. Removes it from the delta layer when
+    /// present; records a whiteout when the path exists in the base layer
+    /// (SPEC rule 2).
+    pub fn remove_file(&mut self, path: &str) -> Result<()> {
+        let npath = normalize(path);
+        let in_delta = self.delta.resolve(&npath)?.is_some();
+        let in_base = self.base.exists(&npath)?;
+        if !in_delta && (self.has_whiteout(&npath)? || !in_base) {
+            return Err(Error::NotFound(npath));
+        }
+        if in_delta {
+            self.delta.remove_file(&npath)?;
+        }
+        if in_base {
+            self.create_whiteout(&npath)?;
+        }
+        Ok(())
+    }
+
+    /// Merged directory listing: delta entries plus base entries minus
+    /// whiteouts, deduplicated, sorted ascending.
+    pub fn readdir(&self, path: &str) -> Result<Vec<String>> {
+        let npath = normalize(path);
+        let delta_dir =
+            matches!(self.delta.resolve(&npath)?, Some(ino) if self.delta.stat_ino(ino)?.is_dir());
+        let whited_out = self.has_whiteout(&npath)?;
+        let base_dir = !whited_out
+            && matches!(self.base.resolve(&npath)?, Some(ino) if self.base.stat_ino(ino)?.is_dir());
+        if !delta_dir && !base_dir {
+            return Err(Error::NotFound(npath));
+        }
+
+        let mut names: Vec<String> = if delta_dir {
+            self.delta.readdir(&npath)?
+        } else {
+            Vec::new()
+        };
+        if base_dir {
+            let whiteouts = self.child_whiteouts(&npath)?;
+            for name in self.base.readdir(&npath)? {
+                let child = if npath == "/" {
+                    format!("/{name}")
+                } else {
+                    format!("{npath}/{name}")
+                };
+                if whiteouts.contains(&child) || names.contains(&name) {
+                    continue;
+                }
+                names.push(name);
+            }
+        }
+        names.sort();
+        Ok(names)
+    }
+}

--- a/crates/coven-afs/src/overlay.rs
+++ b/crates/coven-afs/src/overlay.rs
@@ -6,7 +6,7 @@
 use rusqlite::{params, OptionalExtension};
 
 use crate::fs::{AgentFs, Metadata};
-use crate::path::{normalize, parent};
+use crate::path::{components, normalize, parent};
 use crate::{now_parts, Error, Result};
 
 /// A copy-on-write overlay filesystem.
@@ -23,6 +23,11 @@ impl OverlayFs {
     pub fn new(delta: AgentFs, base: AgentFs) -> Result<Self> {
         if delta.is_read_only() {
             return Err(Error::ReadOnly);
+        }
+        if !base.is_read_only() {
+            return Err(Error::InvalidArgument(
+                "overlay base must be read-only".into(),
+            ));
         }
         Ok(Self { delta, base })
     }
@@ -117,6 +122,32 @@ impl OverlayFs {
         Ok(())
     }
 
+    /// Whether the base layer can contribute an entry at `npath`.
+    ///
+    /// A whiteout hides its entire base subtree. Likewise, a non-directory
+    /// delta ancestor replaces the corresponding base directory, so lookup
+    /// must not resume in the base at a descendant path.
+    fn base_visible_at(&self, npath: &str) -> Result<bool> {
+        let mut current = String::new();
+        for component in components(npath) {
+            current.push('/');
+            current.push_str(component);
+
+            if self.has_whiteout(&current)? {
+                return Ok(false);
+            }
+
+            if current != npath {
+                if let Some(ino) = self.delta.resolve(&current)? {
+                    if !self.delta.stat_ino(ino)?.is_dir() {
+                        return Ok(false);
+                    }
+                }
+            }
+        }
+        Ok(true)
+    }
+
     // ---- overlay operations ------------------------------------------------
 
     /// Overlay existence check following delta → whiteout → base.
@@ -125,7 +156,7 @@ impl OverlayFs {
         if self.delta.exists(&npath)? {
             return Ok(true);
         }
-        if self.has_whiteout(&npath)? {
+        if !self.base_visible_at(&npath)? {
             return Ok(false);
         }
         self.base.exists(&npath)
@@ -143,7 +174,7 @@ impl OverlayFs {
             }
             return Ok(meta);
         }
-        if self.has_whiteout(&npath)? {
+        if !self.base_visible_at(&npath)? {
             return Err(Error::NotFound(npath));
         }
         self.base.stat(&npath)
@@ -155,7 +186,7 @@ impl OverlayFs {
         if self.delta.exists(&npath)? {
             return self.delta.read_file(&npath);
         }
-        if self.has_whiteout(&npath)? {
+        if !self.base_visible_at(&npath)? {
             return Err(Error::NotFound(npath));
         }
         self.base.read_file(&npath)
@@ -166,14 +197,15 @@ impl OverlayFs {
     /// base file, the base inode is recorded in `fs_origin`.
     pub fn write_file(&mut self, path: &str, data: &[u8]) -> Result<i64> {
         let npath = normalize(path);
-        let shadowed_base_ino = if self.delta.resolve(&npath)?.is_none() {
-            match self.base.resolve(&npath)? {
-                Some(ino) if self.base.stat_ino(ino)?.is_file() => Some(ino),
-                _ => None,
-            }
-        } else {
-            None
-        };
+        let shadowed_base_ino =
+            if self.delta.resolve(&npath)?.is_none() && self.base_visible_at(&npath)? {
+                match self.base.resolve(&npath)? {
+                    Some(ino) if self.base.stat_ino(ino)?.is_file() => Some(ino),
+                    _ => None,
+                }
+            } else {
+                None
+            };
         self.remove_whiteout(&npath)?;
         // Ancestor directories being re-created must also lose their whiteouts.
         let mut anc = parent(&npath);
@@ -196,7 +228,7 @@ impl OverlayFs {
         if let Some(ino) = self.delta.resolve(&npath)? {
             return Ok(ino);
         }
-        if self.has_whiteout(&npath)? {
+        if !self.base_visible_at(&npath)? {
             return Err(Error::NotFound(npath));
         }
         let base_meta = self.base.stat(&npath)?;
@@ -233,8 +265,8 @@ impl OverlayFs {
     pub fn remove_file(&mut self, path: &str) -> Result<()> {
         let npath = normalize(path);
         let in_delta = self.delta.resolve(&npath)?.is_some();
-        let in_base = self.base.exists(&npath)?;
-        if !in_delta && (self.has_whiteout(&npath)? || !in_base) {
+        let in_base = self.base_visible_at(&npath)? && self.base.exists(&npath)?;
+        if !in_delta && !in_base {
             return Err(Error::NotFound(npath));
         }
         if in_delta {
@@ -250,10 +282,12 @@ impl OverlayFs {
     /// whiteouts, deduplicated, sorted ascending.
     pub fn readdir(&self, path: &str) -> Result<Vec<String>> {
         let npath = normalize(path);
-        let delta_dir =
-            matches!(self.delta.resolve(&npath)?, Some(ino) if self.delta.stat_ino(ino)?.is_dir());
-        let whited_out = self.has_whiteout(&npath)?;
-        let base_dir = !whited_out
+        let delta_dir = match self.delta.resolve(&npath)? {
+            Some(ino) if self.delta.stat_ino(ino)?.is_dir() => true,
+            Some(_) => return Err(Error::NotADirectory(npath)),
+            None => false,
+        };
+        let base_dir = self.base_visible_at(&npath)?
             && matches!(self.base.resolve(&npath)?, Some(ino) if self.base.stat_ino(ino)?.is_dir());
         if !delta_dir && !base_dir {
             return Err(Error::NotFound(npath));

--- a/crates/coven-afs/src/path.rs
+++ b/crates/coven-afs/src/path.rs
@@ -1,0 +1,85 @@
+//! Path normalization helpers.
+//!
+//! All public APIs accept arbitrary slash-separated paths and normalize them
+//! to absolute, `/`-rooted, canonical form (no empty components, `.` removed,
+//! `..` resolved lexically, never escaping the root).
+
+/// Normalize a path to canonical absolute form.
+///
+/// `""`, `"/"`, `"."` and `"/../.."` all normalize to `"/"`.
+pub fn normalize(path: &str) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    for c in path.split('/') {
+        match c {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            p => parts.push(p),
+        }
+    }
+    if parts.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{}", parts.join("/"))
+    }
+}
+
+/// Parent of a normalized path. The parent of `/` is `/` (SPEC: for the root
+/// directory, `parent_path` is `/`).
+pub fn parent(normalized: &str) -> String {
+    match normalized.rfind('/') {
+        Some(0) | None => "/".to_string(),
+        Some(idx) => normalized[..idx].to_string(),
+    }
+}
+
+/// Final component of a normalized path. The basename of `/` is `""`.
+pub fn basename(normalized: &str) -> &str {
+    match normalized.rfind('/') {
+        Some(idx) => &normalized[idx + 1..],
+        None => normalized,
+    }
+}
+
+/// Non-empty components of a normalized path, in order.
+pub fn components(normalized: &str) -> impl Iterator<Item = &str> {
+    normalized.split('/').filter(|c| !c.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_to_root() {
+        for p in ["", "/", ".", "//", "/./", "/..", "/a/.."] {
+            assert_eq!(normalize(p), "/", "input {p:?}");
+        }
+    }
+
+    #[test]
+    fn normalizes_relative_and_messy_paths() {
+        assert_eq!(normalize("a/b"), "/a/b");
+        assert_eq!(normalize("/a//b/./c"), "/a/b/c");
+        assert_eq!(normalize("/a/b/../c"), "/a/c");
+        assert_eq!(normalize("/../a"), "/a");
+    }
+
+    #[test]
+    fn parent_and_basename() {
+        assert_eq!(parent("/"), "/");
+        assert_eq!(parent("/a"), "/");
+        assert_eq!(parent("/a/b"), "/a");
+        assert_eq!(basename("/"), "");
+        assert_eq!(basename("/a"), "a");
+        assert_eq!(basename("/a/b"), "b");
+    }
+
+    #[test]
+    fn components_iterates() {
+        let c: Vec<&str> = components("/a/b/c").collect();
+        assert_eq!(c, vec!["a", "b", "c"]);
+        assert_eq!(components("/").count(), 0);
+    }
+}

--- a/crates/coven-afs/src/schema.rs
+++ b/crates/coven-afs/src/schema.rs
@@ -1,0 +1,124 @@
+//! Schema DDL and initialization, verbatim from AgentFS SPEC v0.4.
+//!
+//! Table-name note (research conflict C1): the overlay *guide* upstream shows
+//! `fs_block`; the SPEC and every upstream SDK (Rust/Go/Python/TS `schema` /
+//! `filesystem` sources) use `fs_data`. `fs_data` is frozen here.
+
+use rusqlite::Connection;
+
+use crate::Result;
+
+/// Default chunk size in bytes (SPEC required config default).
+pub const DEFAULT_CHUNK_SIZE: usize = 4096;
+
+/// Root directory mode: `0o040755` (directory, rwxr-xr-x) = 16877.
+const ROOT_MODE: i64 = 0o040755;
+
+const DDL: &str = "
+CREATE TABLE IF NOT EXISTS tool_calls (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  parameters TEXT,
+  result TEXT,
+  error TEXT,
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER NOT NULL,
+  duration_ms INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_name ON tool_calls(name);
+CREATE INDEX IF NOT EXISTS idx_tool_calls_started_at ON tool_calls(started_at);
+
+CREATE TABLE IF NOT EXISTS fs_config (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fs_inode (
+  ino INTEGER PRIMARY KEY AUTOINCREMENT,
+  mode INTEGER NOT NULL,
+  nlink INTEGER NOT NULL DEFAULT 0,
+  uid INTEGER NOT NULL DEFAULT 0,
+  gid INTEGER NOT NULL DEFAULT 0,
+  size INTEGER NOT NULL DEFAULT 0,
+  atime INTEGER NOT NULL,
+  mtime INTEGER NOT NULL,
+  ctime INTEGER NOT NULL,
+  rdev INTEGER NOT NULL DEFAULT 0,
+  atime_nsec INTEGER NOT NULL DEFAULT 0,
+  mtime_nsec INTEGER NOT NULL DEFAULT 0,
+  ctime_nsec INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS fs_dentry (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  parent_ino INTEGER NOT NULL,
+  ino INTEGER NOT NULL,
+  UNIQUE(parent_ino, name)
+);
+CREATE INDEX IF NOT EXISTS idx_fs_dentry_parent ON fs_dentry(parent_ino, name);
+
+CREATE TABLE IF NOT EXISTS fs_data (
+  ino INTEGER NOT NULL,
+  chunk_index INTEGER NOT NULL,
+  data BLOB NOT NULL,
+  PRIMARY KEY (ino, chunk_index)
+);
+
+CREATE TABLE IF NOT EXISTS fs_symlink (
+  ino INTEGER PRIMARY KEY,
+  target TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fs_whiteout (
+  path TEXT PRIMARY KEY,
+  parent_path TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_fs_whiteout_parent ON fs_whiteout(parent_path);
+
+CREATE TABLE IF NOT EXISTS fs_origin (
+  delta_ino INTEGER PRIMARY KEY,
+  base_ino INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS kv_store (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  created_at INTEGER DEFAULT (unixepoch()),
+  updated_at INTEGER DEFAULT (unixepoch())
+);
+CREATE INDEX IF NOT EXISTS idx_kv_store_created_at ON kv_store(created_at);
+";
+
+/// Create all tables and initialize `fs_config` + root inode (ino 1,
+/// mode `0o040755`, `nlink=1` — the root has no parent dentry).
+///
+/// Idempotent: safe to call on an already-initialized database. An existing
+/// `chunk_size` is never modified (configuration is immutable after
+/// filesystem initialization).
+pub fn init(conn: &Connection, chunk_size: usize) -> Result<()> {
+    conn.execute_batch(DDL)?;
+    conn.execute(
+        "INSERT OR IGNORE INTO fs_config (key, value) VALUES ('chunk_size', ?1)",
+        [chunk_size.to_string()],
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO fs_inode (ino, mode, nlink, uid, gid, size, atime, mtime, ctime)
+         VALUES (1, ?1, 1, 0, 0, 0, unixepoch(), unixepoch(), unixepoch())",
+        [ROOT_MODE],
+    )?;
+    Ok(())
+}
+
+/// Read the immutable `chunk_size` from `fs_config`.
+pub fn chunk_size(conn: &Connection) -> Result<usize> {
+    let raw: String = conn.query_row(
+        "SELECT value FROM fs_config WHERE key = 'chunk_size'",
+        [],
+        |r| r.get(0),
+    )?;
+    raw.parse::<usize>().map_err(|_| {
+        crate::Error::InvalidArgument(format!("invalid chunk_size in fs_config: {raw}"))
+    })
+}

--- a/crates/coven-afs/tests/spec_consistency.rs
+++ b/crates/coven-afs/tests/spec_consistency.rs
@@ -1,0 +1,353 @@
+//! Integration tests exercising the AgentFS SPEC v0.4 contract:
+//! filesystem consistency rules, chunking invariants, overlay lookup
+//! semantics, whiteout lifecycle, origin tracking, KV, and the tool-call
+//! audit rules.
+
+use coven_afs::{AgentFs, OverlayFs, ROOT_INO, S_IFDIR, S_IFMT, S_IFREG};
+use serde_json::json;
+
+fn assert_consistent(fs: &AgentFs) {
+    let violations = fs.check_consistency().expect("consistency query");
+    assert!(violations.is_empty(), "violations: {violations:?}");
+}
+
+// ---- initialization ------------------------------------------------------
+
+#[test]
+fn fresh_filesystem_satisfies_spec_init() {
+    let fs = AgentFs::in_memory().unwrap();
+    // Rule 1: root inode (ino=1) exists, mode 0o040755 = 16877, nlink=1.
+    let root = fs.stat_ino(ROOT_INO).unwrap();
+    assert_eq!(root.mode, 16877);
+    assert_eq!(root.mode & S_IFMT, S_IFDIR);
+    assert_eq!(root.nlink, 1);
+    assert_eq!(fs.chunk_size(), 4096);
+    assert_consistent(&fs);
+}
+
+#[test]
+fn reopening_keeps_immutable_chunk_size() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("agent.db");
+    {
+        AgentFs::create_with_chunk_size(&db, 512).unwrap();
+    }
+    // A different requested size on reopen must not change the stored config.
+    let fs = AgentFs::create_with_chunk_size(&db, 4096).unwrap();
+    assert_eq!(fs.chunk_size(), 512);
+}
+
+// ---- files + chunking ----------------------------------------------------
+
+#[test]
+fn write_read_roundtrip_across_chunk_boundaries() {
+    let mut fs = AgentFs::in_memory_with_chunk_size(8).unwrap();
+    for len in [0usize, 1, 7, 8, 9, 16, 17, 100] {
+        let data: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+        fs.write_file("/f", &data).unwrap();
+        assert_eq!(fs.read_file("/f").unwrap(), data, "len {len}");
+        assert_eq!(fs.stat("/f").unwrap().size, len as i64);
+        assert_consistent(&fs);
+    }
+}
+
+#[test]
+fn empty_file_has_inode_but_no_chunks() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/empty", b"").unwrap();
+    let meta = fs.stat("/empty").unwrap();
+    assert_eq!(meta.size, 0);
+    assert_eq!(meta.mode & S_IFMT, S_IFREG);
+    assert_eq!(fs.read_file("/empty").unwrap(), Vec::<u8>::new());
+    assert_consistent(&fs);
+}
+
+#[test]
+fn read_at_offsets() {
+    let mut fs = AgentFs::in_memory_with_chunk_size(4).unwrap();
+    fs.write_file("/f", b"0123456789").unwrap();
+    assert_eq!(fs.read_at("/f", 0, 4).unwrap(), b"0123");
+    assert_eq!(fs.read_at("/f", 3, 4).unwrap(), b"3456"); // spans chunks
+    assert_eq!(fs.read_at("/f", 8, 10).unwrap(), b"89"); // truncated at EOF
+    assert_eq!(fs.read_at("/f", 10, 4).unwrap(), b""); // at EOF
+    assert_eq!(fs.read_at("/f", 99, 4).unwrap(), b""); // past EOF
+}
+
+#[test]
+fn overwrite_replaces_chunks() {
+    let mut fs = AgentFs::in_memory_with_chunk_size(4).unwrap();
+    fs.write_file("/f", b"a longer initial payload").unwrap();
+    fs.write_file("/f", b"tiny").unwrap();
+    assert_eq!(fs.read_file("/f").unwrap(), b"tiny");
+    assert_consistent(&fs); // rule 7 catches stale chunks
+}
+
+#[test]
+fn implicit_parent_directories() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/a/b/c/file.txt", b"x").unwrap();
+    assert!(fs.stat("/a").unwrap().is_dir());
+    assert!(fs.stat("/a/b/c").unwrap().is_dir());
+    assert_eq!(fs.readdir("/a/b/c").unwrap(), vec!["file.txt"]);
+    assert_consistent(&fs);
+}
+
+// ---- delete / rename / links ----------------------------------------------
+
+#[test]
+fn delete_removes_inode_and_data_on_last_link() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/f", b"data").unwrap();
+    fs.remove_file("/f").unwrap();
+    assert!(!fs.exists("/f").unwrap());
+    assert_consistent(&fs); // rule 8 catches orphan inodes
+}
+
+#[test]
+fn hard_links_share_inode_and_survive_source_deletion() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/f", b"shared").unwrap();
+    fs.hardlink("/f", "/g").unwrap();
+    let (fa, fb) = (fs.stat("/f").unwrap(), fs.stat("/g").unwrap());
+    assert_eq!(fa.ino, fb.ino);
+    assert_eq!(fa.nlink, 2);
+    fs.remove_file("/f").unwrap();
+    assert_eq!(fs.read_file("/g").unwrap(), b"shared");
+    assert_eq!(fs.stat("/g").unwrap().nlink, 1);
+    assert_consistent(&fs);
+}
+
+#[test]
+fn rename_moves_dentry_and_replaces_destination() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/a/src.txt", b"payload").unwrap();
+    fs.write_file("/b/dst.txt", b"old").unwrap();
+    fs.rename("/a/src.txt", "/b/dst.txt").unwrap();
+    assert!(!fs.exists("/a/src.txt").unwrap());
+    assert_eq!(fs.read_file("/b/dst.txt").unwrap(), b"payload");
+    assert_consistent(&fs);
+}
+
+#[test]
+fn rename_rejects_moving_dir_into_itself() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.mkdir_p("/a/b").unwrap();
+    assert!(fs.rename("/a", "/a/b/c").is_err());
+}
+
+#[test]
+fn symlink_roundtrip() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/target", b"t").unwrap();
+    fs.symlink("/target", "/link").unwrap();
+    let meta = fs.stat("/link").unwrap();
+    assert!(meta.is_symlink());
+    assert_eq!(meta.size, "/target".len() as i64);
+    assert_eq!(fs.read_link("/link").unwrap(), "/target");
+    fs.remove_file("/link").unwrap();
+    assert!(fs.exists("/target").unwrap());
+    assert_consistent(&fs);
+}
+
+#[test]
+fn remove_dir_requires_empty() {
+    let mut fs = AgentFs::in_memory().unwrap();
+    fs.write_file("/d/f", b"x").unwrap();
+    assert!(fs.remove_dir("/d").is_err());
+    fs.remove_file("/d/f").unwrap();
+    fs.remove_dir("/d").unwrap();
+    assert!(!fs.exists("/d").unwrap());
+    assert_consistent(&fs);
+}
+
+// ---- overlay ---------------------------------------------------------------
+
+fn overlay_fixture() -> (tempfile::TempDir, OverlayFs) {
+    let dir = tempfile::tempdir().unwrap();
+    let base_path = dir.path().join("base.db");
+    {
+        let mut base = AgentFs::create(&base_path).unwrap();
+        base.write_file("/shared.txt", b"from base").unwrap();
+        base.write_file("/docs/readme.md", b"# base readme")
+            .unwrap();
+        base.write_file("/docs/guide.md", b"guide").unwrap();
+    }
+    let overlay = OverlayFs::open(dir.path().join("delta.db"), &base_path).unwrap();
+    (dir, overlay)
+}
+
+#[test]
+fn overlay_lookup_order_delta_whiteout_base() {
+    let (_dir, mut ov) = overlay_fixture();
+    // Base visible through empty delta.
+    assert_eq!(ov.read_file("/shared.txt").unwrap(), b"from base");
+    // Delta shadows base.
+    ov.write_file("/shared.txt", b"from delta").unwrap();
+    assert_eq!(ov.read_file("/shared.txt").unwrap(), b"from delta");
+    // Whiteout hides base (delete removes delta copy AND whiteouts base).
+    ov.remove_file("/shared.txt").unwrap();
+    assert!(!ov.exists("/shared.txt").unwrap());
+    assert!(ov.read_file("/shared.txt").is_err());
+    // Base layer itself is untouched.
+    assert_eq!(ov.base().read_file("/shared.txt").unwrap(), b"from base");
+}
+
+#[test]
+fn whiteout_removed_when_file_recreated() {
+    let (_dir, mut ov) = overlay_fixture();
+    ov.remove_file("/shared.txt").unwrap();
+    assert!(ov.has_whiteout("/shared.txt").unwrap());
+    ov.write_file("/shared.txt", b"reborn").unwrap();
+    // SPEC overlay rule 1: whiteout MUST be removed on re-creation.
+    assert!(!ov.has_whiteout("/shared.txt").unwrap());
+    assert_eq!(ov.read_file("/shared.txt").unwrap(), b"reborn");
+}
+
+#[test]
+fn deleting_delta_only_file_leaves_no_whiteout() {
+    let (_dir, mut ov) = overlay_fixture();
+    ov.write_file("/delta-only.txt", b"x").unwrap();
+    ov.remove_file("/delta-only.txt").unwrap();
+    // SPEC overlay rule 2 is conditional: whiteouts are only for base files.
+    assert!(!ov.has_whiteout("/delta-only.txt").unwrap());
+    assert!(!ov.exists("/delta-only.txt").unwrap());
+}
+
+#[test]
+fn copy_up_preserves_metadata_and_origin_ino() {
+    let (_dir, mut ov) = overlay_fixture();
+    let base_meta = ov.base().stat("/shared.txt").unwrap();
+    let delta_ino = ov.copy_up("/shared.txt").unwrap();
+    // Origin mapping stored (SPEC overlay rule 5)…
+    assert_eq!(ov.origin_ino(delta_ino).unwrap(), Some(base_meta.ino));
+    // …and stat returns the BASE inode number (rule 6: kernel cache safety).
+    let meta = ov.stat("/shared.txt").unwrap();
+    assert_eq!(meta.ino, base_meta.ino);
+    assert_eq!(meta.mode, base_meta.mode);
+    assert_eq!(meta.mtime, base_meta.mtime);
+    assert_eq!(ov.read_file("/shared.txt").unwrap(), b"from base");
+    // Copy-up is idempotent.
+    assert_eq!(ov.copy_up("/shared.txt").unwrap(), delta_ino);
+}
+
+#[test]
+fn overwrite_of_base_file_records_origin() {
+    let (_dir, mut ov) = overlay_fixture();
+    let base_ino = ov.base().stat("/shared.txt").unwrap().ino;
+    ov.write_file("/shared.txt", b"replaced").unwrap();
+    assert_eq!(ov.stat("/shared.txt").unwrap().ino, base_ino);
+}
+
+#[test]
+fn overlay_readdir_merges_and_hides_whiteouts() {
+    let (_dir, mut ov) = overlay_fixture();
+    ov.write_file("/docs/notes.md", b"delta notes").unwrap();
+    ov.remove_file("/docs/guide.md").unwrap();
+    assert_eq!(
+        ov.readdir("/docs").unwrap(),
+        vec!["notes.md".to_string(), "readme.md".to_string()]
+    );
+    // Root merge: delta /docs dir + base names, deduplicated.
+    let root = ov.readdir("/").unwrap();
+    assert_eq!(root, vec!["docs".to_string(), "shared.txt".to_string()]);
+}
+
+#[test]
+fn overlay_layers_stay_spec_consistent() {
+    let (_dir, mut ov) = overlay_fixture();
+    ov.write_file("/shared.txt", b"delta").unwrap();
+    ov.copy_up("/docs/readme.md").unwrap();
+    ov.remove_file("/docs/guide.md").unwrap();
+    assert_consistent(ov.delta());
+    assert_consistent(ov.base());
+}
+
+// ---- kv ---------------------------------------------------------------------
+
+#[test]
+fn kv_roundtrip_upsert_delete() {
+    let fs = AgentFs::in_memory().unwrap();
+    fs.kv_set("session:state", &json!({"phase": "gather"}))
+        .unwrap();
+    fs.kv_set("session:state", &json!({"phase": "publish"}))
+        .unwrap();
+    assert_eq!(
+        fs.kv_get("session:state").unwrap(),
+        Some(json!({"phase": "publish"}))
+    );
+    fs.kv_set("a", &json!(1)).unwrap();
+    assert_eq!(fs.kv_keys().unwrap(), vec!["a", "session:state"]);
+    assert!(fs.kv_delete("a").unwrap());
+    assert!(!fs.kv_delete("a").unwrap());
+    assert_eq!(fs.kv_get("a").unwrap(), None);
+}
+
+// ---- tool calls ---------------------------------------------------------------
+
+#[test]
+fn tool_call_records_and_computes_duration() {
+    let fs = AgentFs::in_memory().unwrap();
+    fs.record_tool_call(
+        "read_file",
+        Some(&json!({"path": "/x"})),
+        Some(&json!({"bytes": 42})),
+        None,
+        1_000,
+        1_003,
+    )
+    .unwrap();
+    fs.record_tool_call("web_search", None, None, Some("timeout"), 1_010, 1_010)
+        .unwrap();
+
+    let calls = fs.tool_calls_by_name("read_file").unwrap();
+    assert_eq!(calls.len(), 1);
+    // SPEC rule 3: duration_ms = (completed_at - started_at) * 1000.
+    assert_eq!(calls[0].duration_ms, 3_000);
+    assert!(calls[0].error.is_none());
+
+    let recent = fs.recent_tool_calls(1_005).unwrap();
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].name, "web_search");
+    assert_eq!(recent[0].duration_ms, 0);
+}
+
+#[test]
+fn tool_call_enforces_result_error_mutual_exclusion() {
+    let fs = AgentFs::in_memory().unwrap();
+    // SPEC rule 1: exactly one of result/error.
+    assert!(fs.record_tool_call("t", None, None, None, 1, 2).is_err());
+    assert!(fs
+        .record_tool_call("t", None, Some(&json!(1)), Some("boom"), 1, 2)
+        .is_err());
+    assert!(fs
+        .record_tool_call("t", None, Some(&json!(1)), None, 2, 1)
+        .is_err());
+}
+
+// ---- read-only ---------------------------------------------------------------
+
+#[test]
+fn read_only_open_rejects_mutation_but_allows_reads() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = dir.path().join("agent.db");
+    {
+        let mut fs = AgentFs::create(&db).unwrap();
+        fs.write_file("/f", b"x").unwrap();
+        fs.kv_set("k", &json!(true)).unwrap();
+    }
+    let mut ro = AgentFs::open_read_only(&db).unwrap();
+    assert_eq!(ro.read_file("/f").unwrap(), b"x");
+    assert_eq!(ro.kv_get("k").unwrap(), Some(json!(true)));
+    assert!(matches!(
+        ro.write_file("/g", b"y"),
+        Err(coven_afs::Error::ReadOnly)
+    ));
+    assert!(matches!(
+        ro.kv_set("k2", &json!(1)),
+        Err(coven_afs::Error::ReadOnly)
+    ));
+    assert!(matches!(
+        ro.record_tool_call("t", None, Some(&json!(1)), None, 1, 2),
+        Err(coven_afs::Error::ReadOnly)
+    ));
+}

--- a/crates/coven-afs/tests/spec_consistency.rs
+++ b/crates/coven-afs/tests/spec_consistency.rs
@@ -253,6 +253,38 @@ fn overlay_readdir_merges_and_hides_whiteouts() {
 }
 
 #[test]
+fn delta_file_hides_base_descendants() {
+    let (_dir, mut ov) = overlay_fixture();
+    ov.write_file("/docs", b"delta file").unwrap();
+
+    assert_eq!(ov.read_file("/docs").unwrap(), b"delta file");
+    assert!(!ov.exists("/docs/readme.md").unwrap());
+    assert!(matches!(
+        ov.stat("/docs/readme.md"),
+        Err(coven_afs::Error::NotFound(_))
+    ));
+    assert!(matches!(
+        ov.read_file("/docs/readme.md"),
+        Err(coven_afs::Error::NotFound(_))
+    ));
+    assert!(matches!(
+        ov.readdir("/docs"),
+        Err(coven_afs::Error::NotADirectory(_))
+    ));
+}
+
+#[test]
+fn overlay_requires_read_only_base() {
+    let delta = AgentFs::in_memory().unwrap();
+    let writable_base = AgentFs::in_memory().unwrap();
+
+    assert!(matches!(
+        OverlayFs::new(delta, writable_base),
+        Err(coven_afs::Error::InvalidArgument(_))
+    ));
+}
+
+#[test]
 fn overlay_layers_stay_spec_consistent() {
     let (_dir, mut ov) = overlay_fixture();
     ov.write_file("/shared.txt", b"delta").unwrap();


### PR DESCRIPTION
Implements bead **coven-d4p** — the core storage spike from [`specs/coven-agent-fs/RESEARCH.md`](https://github.com/OpenCoven/coven/blob/main/specs/coven-agent-fs/RESEARCH.md) (PR #600).

## What

New `crates/coven-afs`: an [AgentFS SPEC v0.4](https://github.com/tursodatabase/agentfs/blob/main/SPEC.md)-compatible SQLite storage engine.

- **Schema verbatim from SPEC v0.4**: `fs_config` (immutable `chunk_size`, default 4096), `fs_inode` (nsec columns + rdev), `fs_dentry` (`UNIQUE(parent_ino,name)`, hard-link capable), `fs_data` chunked BLOBs, `fs_symlink`, `fs_whiteout` (parent_path-indexed), `fs_origin`, `kv_store` (JSON), insert-only `tool_calls`.
- **Research conflict C1 resolved**: `fs_data` confirmed authoritative — it appears in upstream SPEC.md and all four SDKs (Rust/Go/Python/TS); `fs_block` has zero hits in upstream code. Frozen accordingly (noted in `schema.rs`).
- **Core ops**: path resolution, chunked write/read + offset reads, `mkdir_p`, readdir, stat, rename, delete (nlink-aware), hard links, symlinks.
- **Overlay**: writable delta over read-only base; lookup order **delta → whiteout → base**; whiteout lifecycle (created only when shadowing base, removed on re-creation); full-file copy-up preserving metadata; `fs_origin` keeps base inode numbers visible through stat (kernel-cache safety).
- **Audit + KV**: tool-call mutual-exclusion and `duration_ms` rules enforced at the API; no update/delete surface (insert-only by construction).
- **`check_consistency()`** verifies the SPEC's 8 filesystem rules plus chunk-shape invariants — used as an oracle by the tests.

## Not in scope

No mount layer (FUSE/nfsserve) — that's bead **coven-110**, blocked on this.

## Verification

- `cargo test --workspace --locked` — all green (24 new integration tests + 4 path unit tests; 1809 existing coven-cli tests unaffected)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Spec compatibility is deliberate: DBs produced by this crate are readable by upstream `agentfs` tooling and vice versa.