### PR TITLE
fix: prioritize critical low-disk health over degraded snapshots

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -5777,7 +5777,10 @@ mod tests {
             crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES - 1,
             None,
         )?;
-        assert_eq!(health.status, "degraded");
+        // Live low disk outranks the degraded snapshot, and the degraded
+        // reason is still reported alongside the critical status.
+        assert_eq!(health.status, "critical");
+        assert!(health.maintenance_blocked);
         assert_eq!(
             health.free_disk_bytes,
             crate::store::MAINTENANCE_MIN_FREE_DISK_BYTES - 1

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3659,10 +3659,14 @@ pub(crate) fn cached_storage_health_with_free_disk(
     }
     health.prune_age_seconds = maintenance_age_seconds(health.last_prune_at.as_deref());
     health.checkpoint_age_seconds = maintenance_age_seconds(health.last_checkpoint_at.as_deref());
-    if snapshot.degraded {
-        health.status = "degraded".to_string();
-    } else if health.maintenance_blocked {
+    // Live free-disk state outranks a stale degraded snapshot: a maintenance
+    // failure recorded earlier must not mask the store being unwritable now.
+    // `last_maintenance_error` is carried over from the snapshot either way, so
+    // the degraded reason survives the promotion to critical.
+    if health.maintenance_blocked {
         health.status = "critical".to_string();
+    } else if snapshot.degraded {
+        health.status = "degraded".to_string();
     } else if snapshot.retention_lagging
         || health.free_disk_bytes < MAINTENANCE_WARN_FREE_DISK_BYTES
         || health.wal_bytes >= MAINTENANCE_CHECKPOINT_WAL_BYTES
@@ -5755,6 +5759,52 @@ mod tests {
         assert_eq!(health.wal_bytes, 0);
         assert!(!health.maintenance_blocked);
         assert_eq!(health.status, "ok");
+        Ok(())
+    }
+
+    #[test]
+    fn critical_low_disk_outranks_a_degraded_snapshot_until_disk_recovers() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path();
+        let conn = open_store(&home.join("coven.sqlite3"))?;
+        refresh_storage_health_snapshot_from_connection_with_free_disk(
+            home,
+            &conn,
+            MAINTENANCE_WARN_FREE_DISK_BYTES,
+            None,
+        )?;
+        mark_storage_health_snapshot_maintenance_failure(
+            home,
+            Some(MAINTENANCE_WARN_FREE_DISK_BYTES),
+            None,
+        )?;
+
+        let degraded =
+            cached_storage_health_with_free_disk(home, MAINTENANCE_WARN_FREE_DISK_BYTES, None)?;
+        assert_eq!(degraded.status, "degraded");
+        assert!(!degraded.maintenance_blocked);
+        assert_eq!(
+            degraded.last_maintenance_error.as_deref(),
+            Some(MAINTENANCE_LAST_ERROR_PUBLIC_MESSAGE)
+        );
+
+        let critical =
+            cached_storage_health_with_free_disk(home, MAINTENANCE_MIN_FREE_DISK_BYTES - 1, None)?;
+        assert_eq!(critical.status, "critical");
+        assert!(critical.maintenance_blocked);
+        assert_eq!(
+            critical.last_maintenance_error.as_deref(),
+            Some(MAINTENANCE_LAST_ERROR_PUBLIC_MESSAGE)
+        );
+
+        let recovered =
+            cached_storage_health_with_free_disk(home, MAINTENANCE_WARN_FREE_DISK_BYTES, None)?;
+        assert_eq!(recovered.status, "degraded");
+        assert!(!recovered.maintenance_blocked);
+        assert_eq!(
+            recovered.last_maintenance_error.as_deref(),
+            Some(MAINTENANCE_LAST_ERROR_PUBLIC_MESSAGE)
+        );
         Ok(())
     }
 

--- a/docs/daemon/health.md
+++ b/docs/daemon/health.md
@@ -67,7 +67,10 @@ The same response includes `storage` health. Its `writerBacklogEvents` and
 the remaining fields report SQLite/WAL size, retention and checkpoint age, free
 disk, and maintenance errors. `critical` means the free-disk safety watermark
 has paused scheduled maintenance; `degraded` means storage health could not be
-collected.
+collected. Live free-disk state takes precedence: while disk is below the
+watermark the status is `critical` even if a prior collection failure left the
+snapshot degraded, and `lastMaintenanceError` still reports that earlier
+failure. The status returns to `degraded` once free disk recovers.
 
 ## Status values
 


### PR DESCRIPTION
Closes #649

## Problem

A previously degraded persisted snapshot was evaluated before the live `maintenance_blocked` state in `cached_storage_health_with_free_disk`, so once free disk fell below the critical watermark the reported storage status stayed `degraded` for the entire blocked period instead of becoming `critical`.

## Change

- Give live low-disk / `maintenance_blocked` state precedence over `snapshot.degraded`.
- `last_maintenance_error` is carried over from the snapshot either way, so the earlier degraded reason survives the promotion to `critical`.
- Status falls back to `degraded` once free disk recovers, since the snapshot flag is unchanged.
- Documented the precedence in `docs/daemon/health.md`.

## Tests

- New `store::tests::critical_low_disk_outranks_a_degraded_snapshot_until_disk_recovers`: degraded snapshot -> critical low disk (asserting `critical`, `maintenance_blocked`, and preserved `lastMaintenanceError`) -> recovered disk back to `degraded`.
- Updated `daemon::tests::maintenance_failures_below_watermark_log_without_creating_store`, which encoded the old degraded-wins precedence, to expect `critical` with the degraded reason preserved.

## Readiness packet

- `cargo fmt --check` - clean
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo test --workspace --locked` - 1810 unit + all integration tests passing, 0 failures
- `python3 scripts/check-secrets.py` - clean
- `python3 scripts/check-coven-privacy.py --staged` - clean

Scope is limited to the health status precedence; no API shape or field changes.
