### PR TITLE
fix(session): bound handoff cursor read and flush truncation across direct events (#613, #642)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2132,11 +2132,16 @@ fn claim_session_handoff(coven_home: &Path, path: &str, body: Option<&str>) -> R
         .context("stored handoff workspace snapshot is invalid")?;
     let current_workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
     let current_cursor = store::max_event_seq(&conn, session_id)?;
-    if current_cursor != handoff.event_cursor {
+    // Prefix / forward-allowed contract: the handoff snapshot describes a prefix
+    // of the live transcript. Forward movement (the running session emitting more
+    // output after the snapshot) is expected and NOT divergence. Only a backward
+    // cursor -- the transcript being truncated or rewritten below the snapshot
+    // point -- means the recorded prefix no longer exists, so we fail closed.
+    if current_cursor < handoff.event_cursor {
         return api_error(
             409,
             "transcript_diverged",
-            "Source transcript changed after the handoff snapshot.",
+            "Source transcript was truncated below the handoff snapshot.",
             Some(
                 json!({ "handoffId": handoff_id, "expectedCursor": handoff.event_cursor, "actualCursor": current_cursor }),
             ),
@@ -2165,7 +2170,13 @@ fn claim_session_handoff(coven_home: &Path, path: &str, body: Option<&str>) -> R
     };
     json_response(
         200,
-        &json!({ "handoff": claimed, "sourceInputFenced": true }),
+        &json!({
+            "handoff": claimed,
+            "sourceInputFenced": true,
+            // The claimant must resume from the snapshot point, not the current
+            // (possibly-advanced) tail, so it replays exactly the recorded prefix.
+            "resumeFrom": handoff.event_cursor,
+        }),
     )
 }
 
@@ -2193,21 +2204,25 @@ fn acknowledge_session_handoff(
         return api_error(404, "handoff_not_found", "Handoff was not found.", None);
     }
     let current_cursor = store::max_event_seq(&conn, session_id)?;
-    if current_cursor != handoff.event_cursor {
+    // Prefix / forward-allowed contract: only a backward cursor (truncated or
+    // rewritten transcript) is divergence. Forward movement is allowed.
+    if current_cursor < handoff.event_cursor {
         return api_error(
             409,
             "transcript_diverged",
-            "Source transcript changed after the handoff snapshot.",
+            "Source transcript was truncated below the handoff snapshot.",
             Some(
                 json!({ "handoffId": handoff_id, "expectedCursor": handoff.event_cursor, "actualCursor": current_cursor }),
             ),
         );
     }
+    // Acknowledge against the snapshot cursor -- the prefix the handoff recorded --
+    // not the (possibly-advanced) live tail, so store-level consistency holds.
     let acknowledged = match store::acknowledge_handoff(
         &mut conn,
         handoff_id,
         &request.claimant,
-        current_cursor,
+        handoff.event_cursor,
         &current_timestamp(),
     ) {
         Ok(record) => record,
@@ -9427,6 +9442,16 @@ mod tests {
     #[test]
     fn handoff_claim_fails_closed_when_transcript_or_workspace_diverges() -> anyhow::Result<()> {
         let (temp, workspace) = portable_handoff_fixture()?;
+        // Produce transcript output BEFORE the handoff so the snapshot cursor is
+        // non-zero, then offer the handoff at that cursor.
+        let input = handle_request_with_body(
+            "POST",
+            "/sessions/session-1/input",
+            temp.path(),
+            None,
+            Some(r#"{"data":"pre-handoff output"}"#),
+        )?;
+        assert_eq!(input.status, 202);
         let offered = handle_request_with_body(
             "POST",
             "/sessions/session-1/handoffs",
@@ -9437,14 +9462,21 @@ mod tests {
         let offered: Value = serde_json::from_str(&offered.body)?;
         let handoff_id = offered["handoff"]["id"].as_str().unwrap();
         let generation = offered["handoff"]["generation"].as_i64().unwrap();
-        let input = handle_request_with_body(
-            "POST",
-            "/sessions/session-1/input",
-            temp.path(),
-            None,
-            Some(r#"{"data":"new source input"}"#),
-        )?;
-        assert_eq!(input.status, 202);
+        let snapshot_cursor = offered["eventCursor"].as_i64().unwrap();
+        assert!(snapshot_cursor > 0);
+
+        // Simulate a truncated/rewritten transcript: the current cursor moves
+        // BACKWARD below the snapshot point. This is the only case the prefix
+        // contract treats as divergence.
+        {
+            let conn = crate::store::open_store(&temp.path().join("coven.sqlite3"))?;
+            conn.execute(
+                "DELETE FROM events WHERE session_id = ?1 AND rowid = (
+                     SELECT MAX(rowid) FROM events WHERE session_id = ?1
+                 )",
+                rusqlite::params!["session-1"],
+            )?;
+        }
         let transcript_conflict = handle_request_with_body(
             "POST", &format!("/sessions/session-1/handoffs/{handoff_id}/claim"), temp.path(), None,
             Some(&json!({ "expectedGeneration": generation, "claimant": "device:phone-1", "idempotencyKey": "claim-1", "destinationWorkspace": workspace }).to_string()),
@@ -9483,6 +9515,69 @@ mod tests {
         assert_eq!(workspace_conflict.status, 409);
         let body: Value = serde_json::from_str(&workspace_conflict.body)?;
         assert_eq!(body["error"]["code"], "workspace_diverged");
+        Ok(())
+    }
+
+    #[test]
+    fn handoff_claim_allows_forward_cursor_and_exposes_resume_from() -> anyhow::Result<()> {
+        let (temp, workspace) = portable_handoff_fixture()?;
+        // Offer a handoff on a live, running session. The snapshot cursor is
+        // captured at emit time.
+        let offered = handle_request_with_body(
+            "POST",
+            "/sessions/session-1/handoffs",
+            temp.path(),
+            None,
+            Some(&handoff_packet().to_string()),
+        )?;
+        assert_eq!(offered.status, 201);
+        let offered: Value = serde_json::from_str(&offered.body)?;
+        let handoff_id = offered["handoff"]["id"].as_str().unwrap();
+        let generation = offered["handoff"]["generation"].as_i64().unwrap();
+        let snapshot_cursor = offered["eventCursor"].as_i64().unwrap();
+
+        // The running session keeps producing output BETWEEN emit and claim,
+        // moving the transcript cursor strictly forward.
+        let input = handle_request_with_body(
+            "POST",
+            "/sessions/session-1/input",
+            temp.path(),
+            None,
+            Some(r#"{"data":"busy session output"}"#),
+        )?;
+        assert_eq!(input.status, 202);
+
+        // Under the prefix / forward-allowed contract, a forward cursor is not
+        // divergence: the claim succeeds and tells the claimant where to resume.
+        let claimed = handle_request_with_body(
+            "POST",
+            &format!("/sessions/session-1/handoffs/{handoff_id}/claim"),
+            temp.path(),
+            None,
+            Some(
+                &json!({
+                    "expectedGeneration": generation,
+                    "claimant": "device:phone-1",
+                    "idempotencyKey": "claim-forward",
+                    "destinationWorkspace": workspace,
+                })
+                .to_string(),
+            ),
+        )?;
+        assert_eq!(claimed.status, 200);
+        let claimed: Value = serde_json::from_str(&claimed.body)?;
+        assert_eq!(claimed["resumeFrom"].as_i64(), Some(snapshot_cursor));
+        assert_eq!(claimed["handoff"]["state"], "claimed");
+
+        // Acknowledgement also tolerates the forward cursor.
+        let acknowledgement = handle_request_with_body(
+            "POST",
+            &format!("/sessions/session-1/handoffs/{handoff_id}/ack"),
+            temp.path(),
+            None,
+            Some(r#"{"claimant":"device:phone-1"}"#),
+        )?;
+        assert_eq!(acknowledgement.status, 200);
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -235,6 +235,22 @@ pub trait SessionRuntime {
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()>;
     fn kill_session(&self, session_id: &str) -> Result<()>;
 
+    /// Persist a direct live-session event (`input`, `kill`, `cast`) through the
+    /// daemon's shared `EventWriter` when one is available, returning
+    /// `Some(result)`. Routing these events through the writer flushes any
+    /// pending output-truncation marker *before* the event, so a truncation
+    /// episode can never be recorded after a boundary event that should have
+    /// closed it (issue #642). Runtimes without a writer return `None`, and the
+    /// caller falls back to a direct `store::insert_event`.
+    fn record_session_event(
+        &self,
+        _session_id: &str,
+        _kind: &str,
+        _payload: &Value,
+    ) -> Option<Result<()>> {
+        None
+    }
+
     fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
         None
     }
@@ -377,7 +393,7 @@ pub fn handle_request_with_runtime(
             let (status, response) = control_plane::route_action(payload);
             json_response(status, &response)
         }
-        ("POST", "/cast") => submit_cast(coven_home, body),
+        ("POST", "/cast") => submit_cast(coven_home, body, runtime),
         ("GET", "/cast-codes") => cast_codes_response(),
         // Filesystem-backed reads under ~/.coven/. Missing files return [].
         ("GET", "/familiars") => {
@@ -2043,10 +2059,7 @@ fn emit_handoff(coven_home: &Path, session_id: &str, body: Option<&str>) -> Resu
         return session_not_live_response(session_id);
     }
     let workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
-    let event_cursor = store::list_events(&conn, session_id)?
-        .last()
-        .map(|event| event.seq)
-        .unwrap_or(0);
+    let event_cursor = store::max_event_seq(&conn, session_id)?;
     let now = current_timestamp();
     let record = store::create_handoff(
         &mut conn,
@@ -2118,10 +2131,7 @@ fn claim_session_handoff(coven_home: &Path, path: &str, body: Option<&str>) -> R
     let source_workspace: WorkspaceSnapshot = serde_json::from_str(&handoff.workspace_json)
         .context("stored handoff workspace snapshot is invalid")?;
     let current_workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
-    let current_cursor = store::list_events(&conn, session_id)?
-        .last()
-        .map(|event| event.seq)
-        .unwrap_or(0);
+    let current_cursor = store::max_event_seq(&conn, session_id)?;
     if current_cursor != handoff.event_cursor {
         return api_error(
             409,
@@ -2182,10 +2192,7 @@ fn acknowledge_session_handoff(
     if handoff.session_id != session_id {
         return api_error(404, "handoff_not_found", "Handoff was not found.", None);
     }
-    let current_cursor = store::list_events(&conn, session_id)?
-        .last()
-        .map(|event| event.seq)
-        .unwrap_or(0);
+    let current_cursor = store::max_event_seq(&conn, session_id)?;
     if current_cursor != handoff.event_cursor {
         return api_error(
             409,
@@ -2555,7 +2562,7 @@ fn record_input(
             )
         }
     } else {
-        insert_event(&conn, coven_home, session_id, "input", payload)?;
+        record_direct_session_event(runtime, &conn, coven_home, session_id, "input", payload)?;
         json_response(202, &json!({ "ok": true, "accepted": true }))
     };
     store::release_session_input_lease(&conn, &lease_id)?;
@@ -2607,7 +2614,8 @@ fn kill_session(
     }
     let now = current_timestamp();
     store::update_session_status(&conn, session_id, "killed", None, &now)?;
-    insert_event(
+    record_direct_session_event(
+        runtime,
         &conn,
         coven_home,
         session_id,
@@ -2798,7 +2806,11 @@ fn cast_codes_response() -> Result<ApiResponse> {
     json_response(200, &codes)
 }
 
-fn submit_cast(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
+fn submit_cast(
+    coven_home: &Path,
+    body: Option<&str>,
+    runtime: &dyn SessionRuntime,
+) -> Result<ApiResponse> {
     let payload = match parse_body(body) {
         Ok(payload) => payload,
         Err(error) => {
@@ -2834,7 +2846,8 @@ fn submit_cast(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
             Some(json!({ "sessionId": session_id })),
         );
     }
-    insert_event(
+    record_direct_session_event(
+        runtime,
         &conn,
         coven_home,
         session_id,
@@ -3086,6 +3099,25 @@ fn insert_event(
             created_at: current_timestamp(),
         },
     )
+}
+
+/// Persist a direct live-session event, preferring the daemon's shared
+/// `EventWriter` so any pending output-truncation marker is flushed ahead of the
+/// event (issue #642). When the runtime owns no writer (tests, non-live paths),
+/// fall back to a direct insert — behavior is otherwise identical because both
+/// paths persist through `store::insert_event_with_privacy`.
+fn record_direct_session_event(
+    runtime: &dyn SessionRuntime,
+    conn: &rusqlite::Connection,
+    coven_home: &Path,
+    session_id: &str,
+    kind: &str,
+    payload: Value,
+) -> Result<()> {
+    match runtime.record_session_event(session_id, kind, &payload) {
+        Some(result) => result,
+        None => insert_event(conn, coven_home, session_id, kind, payload),
+    }
 }
 
 fn update_familiar_icon(
@@ -9091,6 +9123,70 @@ mod tests {
             self.kills.borrow_mut().push(session_id.to_string());
             Ok(())
         }
+    }
+
+    /// Runtime whose direct-event persistence is backed by a real
+    /// `EventWriter`, so accepted `input`/`kill`/`cast` events flush the
+    /// writer's pending truncation marker ahead of the boundary event (#642).
+    struct WriterBackedRuntime {
+        writer: crate::event_writer::EventWriter,
+    }
+
+    impl SessionRuntime for WriterBackedRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> Result<()> {
+            Ok(())
+        }
+
+        fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn record_session_event(
+            &self,
+            session_id: &str,
+            kind: &str,
+            payload: &Value,
+        ) -> Option<Result<()>> {
+            Some(self.writer.record(session_id, kind, payload.clone()))
+        }
+    }
+
+    #[test]
+    fn accepted_input_flushes_pending_truncation_marker_before_the_event() -> Result<()> {
+        // #642: an accepted `input` event must be preceded by the writer's
+        // pending output-truncation marker. Routing the event through the
+        // shared EventWriter (instead of a direct store::insert_event) is what
+        // closes the gap; a direct insert would persist `input` while the marker
+        // stayed queued, leaving the boundary event ahead of the truncation.
+        let coven_home = tempfile::tempdir()?;
+        insert_test_session(coven_home.path(), "sess-trunc")?;
+        let writer = crate::event_writer::EventWriter::start_with_capacity(
+            coven_home.path().to_path_buf(),
+            crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+        // Force a dropped output chunk -> pending truncation episode.
+        assert!(!writer.record_output("sess-trunc", "x".repeat(2048))?);
+        let runtime = WriterBackedRuntime { writer };
+
+        let response = record_input(
+            coven_home.path(),
+            "sess-trunc",
+            Some(r#"{"data":"ls\n"}"#),
+            &runtime,
+        )?;
+        assert_eq!(response.status, 202);
+
+        let conn = crate::store::open_store(&coven_home.path().join("coven.sqlite3"))?;
+        let kinds: Vec<String> = crate::store::list_events(&conn, "sess-trunc")?
+            .into_iter()
+            .map(|event| event.kind)
+            .collect();
+        assert_eq!(kinds, vec!["output_truncated", "input"]);
+        Ok(())
     }
 
     struct FailingLaunchRuntime;

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -402,6 +402,23 @@ impl SessionRuntime for LiveSessionRuntime {
         LiveSessionRuntime::kill_session(self, session_id)
     }
 
+    /// Route accepted `input`/`kill`/`cast` events through the shared
+    /// `EventWriter` so its pending output-truncation marker is flushed ahead of
+    /// the event (issue #642). These events previously persisted via a direct
+    /// `store::insert_event`, which bypassed the writer's truncation state and
+    /// let a truncation marker land *after* a boundary event that should have
+    /// closed the gap. Falls back to `None` (direct insert) when the runtime has
+    /// no writer.
+    fn record_session_event(
+        &self,
+        session_id: &str,
+        kind: &str,
+        payload: &Value,
+    ) -> Option<Result<()>> {
+        let writer = self.event_writer.as_ref()?;
+        Some(writer.record(session_id, kind, payload.clone()))
+    }
+
     /// Must stay in this trait impl: `api::handle_request_with_runtime` reaches
     /// the runtime through `&dyn SessionRuntime`, so an inherent method of the
     /// same name is unreachable and `GET /health` silently falls back to the

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 use crate::{pty_runner::PtyRunResult, store, STORE_FILE_NAME};
 
 const DEFAULT_CAPACITY_BYTES: usize = 2 * 1024 * 1024;
-const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
+pub(crate) const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
 const EVENT_OVERHEAD_BYTES: usize = 512;
 const MAX_BATCH_EVENTS: usize = 64;
 const COALESCE_WINDOW: Duration = Duration::from_millis(12);
@@ -111,7 +111,7 @@ impl EventWriter {
         Self::start_with_capacity(coven_home, DEFAULT_CAPACITY_BYTES)
     }
 
-    fn start_with_capacity(coven_home: PathBuf, capacity_bytes: usize) -> Result<Self> {
+    pub(crate) fn start_with_capacity(coven_home: PathBuf, capacity_bytes: usize) -> Result<Self> {
         anyhow::ensure!(
             capacity_bytes > RESERVED_CRITICAL_BYTES,
             "event writer capacity must reserve room for critical events"
@@ -174,7 +174,8 @@ impl EventWriter {
 
     /// Persist a non-output event.  These events reserve capacity and wait for
     /// the writer's commit acknowledgement instead of being silently dropped.
-    #[allow(dead_code)]
+    /// Accepted `input`/`kill`/`cast` events route here so a pending
+    /// output-truncation marker is flushed ahead of the boundary event.
     pub fn record(&self, session_id: &str, kind: &str, payload: serde_json::Value) -> Result<()> {
         let record = store::EventRecord {
             seq: 0,
@@ -1390,6 +1391,74 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["output", "exit"]
         );
+        Ok(())
+    }
+
+    #[test]
+    fn direct_session_events_flush_their_own_truncation_marker() -> Result<()> {
+        // Issue #642: accepted input/kill/cast events must route through the
+        // writer's `record` path so a pending truncation marker is flushed
+        // ahead of each boundary event, and separate pressure episodes must
+        // yield separate markers rather than combining across a boundary.
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        // Episode 1: one dropped chunk, then an accepted `input` boundary event.
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        writer.record("s-1", "input", json!({ "data": "ls\n" }))?;
+
+        // Episode 2: two dropped chunks, then an accepted `kill` boundary event.
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        assert!(!writer.record_output("s-1", "x".repeat(3072))?);
+        writer.record("s-1", "kill", json!({ "status": "killed" }))?;
+
+        // Episode 3: one dropped chunk, then recovered output.
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        assert!(writer.record_output("s-1", "recovered".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "output_truncated",
+                "input",
+                "output_truncated",
+                "kill",
+                "output_truncated",
+                "output",
+                "exit",
+            ]
+        );
+
+        // Each marker carries only the drops from its own episode — nothing
+        // combines across the input/kill boundary events.
+        let marker_before_input: serde_json::Value = serde_json::from_str(&events[0].payload_json)?;
+        assert_eq!(marker_before_input["droppedEvents"], 1);
+        assert_eq!(marker_before_input["droppedBytes"], 2048);
+
+        let marker_before_kill: serde_json::Value = serde_json::from_str(&events[2].payload_json)?;
+        assert_eq!(marker_before_kill["droppedEvents"], 2);
+        assert_eq!(marker_before_kill["droppedBytes"], 5120);
+
+        let marker_before_output: serde_json::Value =
+            serde_json::from_str(&events[4].payload_json)?;
+        assert_eq!(marker_before_output["droppedEvents"], 1);
+        assert_eq!(marker_before_output["droppedBytes"], 2048);
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3240,6 +3240,24 @@ pub fn list_events(conn: &Connection, session_id: &str) -> Result<Vec<EventRecor
     list_events_with_options(conn, session_id, &EventsQueryOptions::default())
 }
 
+/// Return the highest event `seq` (SQLite rowid) for a session, or 0 when the
+/// session has no events. This is the cursor the handoff protocol snapshots.
+///
+/// Reading the cursor previously materialized every event row for the session
+/// (including raw PTY output payloads) just to inspect the last `seq`. A scalar
+/// `MAX(rowid)` reads a single value and matches that old full-scan result
+/// exactly, including the empty-transcript case (0).
+pub fn max_event_seq(conn: &Connection, session_id: &str) -> Result<i64> {
+    let max: i64 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get(0),
+        )
+        .context("failed to query max event seq")?;
+    Ok(max)
+}
+
 pub fn event_kind_exists(conn: &Connection, session_id: &str, kind: &str) -> Result<bool> {
     use rusqlite::OptionalExtension;
 
@@ -6295,6 +6313,43 @@ mod tests {
 
         assert_eq!(tail.len(), 2);
         assert!(tail[0].seq > after_seq);
+        Ok(())
+    }
+
+    #[test]
+    fn max_event_seq_matches_full_scan_last_seq() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+
+        // Empty transcript: both the old full-scan read and max_event_seq must
+        // agree on 0.
+        let old_empty = list_events(&conn, "session-1")?
+            .last()
+            .map(|event| event.seq)
+            .unwrap_or(0);
+        assert_eq!(old_empty, 0);
+        assert_eq!(max_event_seq(&conn, "session-1")?, 0);
+
+        for i in 1..=5 {
+            insert_json_event(
+                &conn,
+                "session-1",
+                "output",
+                &serde_json::json!({ "data": format!("line {i}") }),
+                "2026-04-27T06:01:00Z",
+            )?;
+        }
+
+        let old_last = list_events(&conn, "session-1")?
+            .last()
+            .map(|event| event.seq)
+            .unwrap_or(0);
+        assert_eq!(max_event_seq(&conn, "session-1")?, old_last);
+
+        // A distinct session must not leak into another session's max.
+        insert_session(&conn, &session_record("session-2", "2026-04-27T06:00:00Z"))?;
+        assert_eq!(max_event_seq(&conn, "session-2")?, 0);
         Ok(())
     }
 


### PR DESCRIPTION
Closes #613. Closes #642.

## #613(A) — bound the handoff cursor read
`emit_handoff` / `claim_session_handoff` / `acknowledge_session_handoff` read the latest sequence via `store::list_events(...).last()`, materializing **every** event row (incl. raw PTY payloads) to read one integer — an unbounded cost paid on every handoff. Added `store::max_event_seq` (`SELECT MAX(seq)`) and replaced the three full scans. Semantically equivalent to the old `.last().seq`.

## #613(B) — allow forward-cursor claims (prefix / forward-allowed contract)
As merged, a `running` session that emitted **any** output between handoff emit and claim 409'd permanently (`current_cursor != handoff.event_cursor`), so a busy session's handoff was never claimable.

- Divergence is now only `current_cursor < handoff.event_cursor` (transcript truncated/rewritten below the snapshot). Forward movement is expected and allowed.
- The claim response surfaces `resumeFrom = handoff.event_cursor`, so the claimant replays exactly the recorded prefix rather than the possibly-advanced live tail.
- `acknowledge_session_handoff` acknowledges against the snapshot cursor (not the live tail) to keep the store-level consistency invariant.
- `emit_handoff` still requires `running` (unchanged).
- Intent chosen deliberately (prefix over strict-quiesced) — see the discussion on #613.

## #642 — flush truncation markers across direct session events
Accepted input/kill/targeted-cast events bypassed the shared `EventWriter`, so a pending truncation marker could be emitted *after* the event that should close the gap. Now routed through `EventWriter` so the marker flushes first; adds ordering + separate-episode coverage.

## Tests
- `handoff_claim_allows_forward_cursor_and_exposes_resume_from` (new) — forward cursor claims succeed and expose `resumeFrom` (red→green: 409→200).
- `handoff_claim_fails_closed_when_transcript_or_workspace_diverges` (updated) — now simulates truncation (backward cursor) + preserves workspace-divergence coverage, still 409.
- `#642` marker-ordering / separate-episode tests.

## Readiness
- `cargo fmt --check` — clean · `cargo clippy -p coven-cli --all-targets -- -D warnings` — clean
- `cargo test -p coven-cli` — all handoff/api tests green (16/16 handoff). The 65 `memory_import` failures are pre-existing WSL `/mnt/c` filesystem-semantics artifacts, confirmed identical on clean `HEAD` via `git stash` — not introduced here; CI runs on Linux.
- secret + privacy scans — clean. Branch based on `origin/main` (`f3d9585`). Commits SSH-signed.