### PR TITLE
fix(bench): correct runtime baseline and cold-start metric semantics (#636, #648)

### DIFF
--- a/scripts/benchmark-chaos.mjs
+++ b/scripts/benchmark-chaos.mjs
@@ -110,7 +110,9 @@ export function storageMetricStatus() {
     },
     eventQueueDepth: {
       status: 'measured',
-      source: 'maxima of periodic eventWriter.queuedEvents/eventWriter.queuedBytes samples'
+      source:
+        'sampled maxima of periodic eventWriter.queuedEvents/eventWriter.queuedBytes samples ' +
+        'taken across the full measured interval, through session cancellation'
     },
     rss: {
       status: 'measured',
@@ -126,9 +128,12 @@ export function chaosCoverage() {
       reason: 'Cave owns WebSocket consumer buffering and replay (#4317).'
     },
     diskFull: {
-      status: 'covered_by_storage_regressions',
-      reason: 'A deterministic free-space seam exercises the fail-closed path without filling a host disk.',
-      evidence: 'store::tests::scheduled_maintenance_below_watermark_does_not_open_or_write_the_store'
+      status: 'blocked',
+      reason:
+        'No regression yet exercises a real SQLITE_FULL / write-fault / recovery seam. ' +
+        'The scheduled-maintenance watermark test only proves low-disk gating (the store ' +
+        'is never opened below the free-disk watermark); it never fills a store or forces a ' +
+        'write to fail, so it cannot back a diskFull chaos-coverage claim.'
     },
     lockedDatabase: {
       status: 'covered_by_event_writer_regressions',
@@ -428,8 +433,9 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
     const startedAt = process.hrtime.bigint();
     let observing = true;
     const observation = observeWriterHealth(socketPath, runtimeSamples, () => observing);
+    let elapsedMs;
+    let cancellationMs;
     let launches;
-    let completedAt;
     try {
       launches = await Promise.all(
         Array.from({ length: concurrency }, async () => {
@@ -461,23 +467,28 @@ export async function runConcurrencyScenario({ binary, root, concurrency, enviro
           return { id, firstOutputMs: Number(process.hrtime.bigint() - launchedAt) / 1_000_000 };
         })
       );
-      completedAt = process.hrtime.bigint();
+      // Close the throughput window the instant every launch resolves, before
+      // any snapshot or cancellation work can inflate the denominator.
+      const completedAt = process.hrtime.bigint();
+      elapsedMs = Number(completedAt - startedAt) / 1_000_000;
+      runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
+
+      const cancellationStartedAt = process.hrtime.bigint();
+      await Promise.all(
+        ids.map(async (id) => {
+          const response = await socketRequest(socketPath, { method: 'POST', path: `/api/v1/sessions/${id}/kill` });
+          if (response.statusCode !== 202) throw new Error(`cancel returned ${response.statusCode}`);
+          await waitForSessionExit(socketPath, id);
+        })
+      );
+      cancellationMs = Number(process.hrtime.bigint() - cancellationStartedAt) / 1_000_000;
     } finally {
+      // Keep the periodic 25ms observer sampling through launch AND cancellation
+      // so the sampled queue/RSS maxima cover the full measured interval; only
+      // tear it down once cancellation timing has been captured.
       observing = false;
       await observation;
     }
-    const elapsedMs = Number(completedAt - startedAt) / 1_000_000;
-    runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));
-
-    const cancellationStartedAt = process.hrtime.bigint();
-    await Promise.all(
-      ids.map(async (id) => {
-        const response = await socketRequest(socketPath, { method: 'POST', path: `/api/v1/sessions/${id}/kill` });
-        if (response.statusCode !== 202) throw new Error(`cancel returned ${response.statusCode}`);
-        await waitForSessionExit(socketPath, id);
-      })
-    );
-    const cancellationMs = Number(process.hrtime.bigint() - cancellationStartedAt) / 1_000_000;
     ids = [];
     const footprintAfter = await storeFootprint(covenHome);
     runtimeSamples.push(await fullRuntimeSnapshot({ binary, covenHome, env, socketPath }));

--- a/scripts/benchmark-chaos.test.mjs
+++ b/scripts/benchmark-chaos.test.mjs
@@ -55,9 +55,22 @@ test('summarizes p50, p95, and p99 using nearest rank', () => {
 test('describes live writer metrics and deterministic fault equivalents', () => {
   assert.equal(storageMetricStatus().sqliteConnectionOpens.status, 'measured');
   assert.equal(storageMetricStatus().eventQueueDepth.status, 'measured');
-  assert.equal(chaosCoverage().diskFull.status, 'covered_by_storage_regressions');
-  assert.match(
-    chaosCoverage().diskFull.evidence,
+});
+
+test('marks diskFull chaos coverage as unproven until a write-fault seam is tested', () => {
+  // scheduled_maintenance_below_watermark_does_not_open_or_write_the_store only
+  // proves low-disk gating: it asserts the store is never opened when free disk
+  // is below the maintenance watermark.  It never triggers SQLITE_FULL, a write
+  // fault, or recovery, so it cannot back a "covered" claim for diskFull chaos.
+  const diskFull = chaosCoverage().diskFull;
+  assert.equal(diskFull.status, 'blocked');
+  assert.equal(
+    Object.hasOwn(diskFull, 'evidence'),
+    false,
+    'a blocked status must not cite a test as proving the fault path'
+  );
+  assert.doesNotMatch(
+    JSON.stringify(diskFull),
     /scheduled_maintenance_below_watermark_does_not_open_or_write_the_store/
   );
 });
@@ -253,10 +266,38 @@ test('scenario timeout messages redact fixture paths from the original error', a
   );
 });
 
-test('closes the throughput timing window before diagnostic sampling', async () => {
+test('closes the throughput timing window the instant launches resolve', async () => {
+  // The throughput denominator must be captured the moment every launch
+  // resolves, before any observer teardown or diagnostic sampling adds latency.
   const source = await readFile(new URL('./benchmark-chaos.mjs', import.meta.url), 'utf8');
   assert.match(
     source,
-    /completedAt = process\.hrtime\.bigint\(\);\n\s+} finally \{\n\s+observing = false;\n\s+await observation;\n\s+}\n\s+const elapsedMs = .*;\n\s+runtimeSamples\.push\(await fullRuntimeSnapshot/
+    /completedAt = process\.hrtime\.bigint\(\);\n\s+elapsedMs = Number\(completedAt - startedAt\) \/ 1_000_000;/
+  );
+});
+
+test('samples writer health across the full measured interval through cancellation', async () => {
+  // The periodic 25ms observer must keep running until cancellation completes,
+  // so sampled queue/RSS maxima cover launch AND teardown, not just launch.
+  // Stopping it before the cancellation loop (the previous behaviour) left the
+  // cancellation interval sampled only by the two manual bracket snapshots.
+  const source = await readFile(new URL('./benchmark-chaos.mjs', import.meta.url), 'utf8');
+  const observerTeardown = source.indexOf('observing = false;');
+  const cancellationStart = source.indexOf('const cancellationStartedAt = process.hrtime.bigint();');
+  const cancellationMeasured = source.indexOf(
+    'cancellationMs = Number(process.hrtime.bigint() - cancellationStartedAt) / 1_000_000;'
+  );
+  assert.ok(observerTeardown !== -1, 'observer teardown must exist');
+  assert.ok(cancellationStart !== -1, 'cancellation timer must exist');
+  assert.ok(cancellationMeasured !== -1, 'cancellation interval must be measured');
+  // The observer must still be running when cancellation begins and completes:
+  // its teardown has to come after the cancellation interval is measured.
+  assert.ok(
+    observerTeardown > cancellationStart,
+    'observer must not stop before the cancellation loop starts'
+  );
+  assert.ok(
+    observerTeardown > cancellationMeasured,
+    'observer must stop only after the cancellation interval is measured'
   );
 });

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -10,18 +10,34 @@ const COMMAND_TIMEOUT_MS = 120_000;
 export function summarizeSamples(samples) {
   const sorted = [...samples].sort((left, right) => left - right);
   const middle = Math.floor(sorted.length / 2);
+  const lastIndex = sorted.length - 1;
 
-  return {
+  const summary = {
     minMs: sorted[0],
     medianMs:
       sorted.length % 2 === 1
         ? sorted[middle]
         : (sorted[middle - 1] + sorted[middle]) / 2,
-    p50Ms: sorted[Math.ceil(sorted.length * 0.5) - 1],
-    p95Ms: sorted[Math.ceil(sorted.length * 0.95) - 1],
-    p99Ms: sorted[Math.ceil(sorted.length * 0.99) - 1],
-    maxMs: sorted.at(-1)
+    p50Ms: sorted[Math.ceil(sorted.length * 0.5) - 1]
   };
+
+  // A nearest-rank tail percentile is only meaningful when its rank is strictly
+  // below the maximum sample; otherwise it collapses onto maxMs and reports the
+  // extreme as if it were a stable tail.  With the handful of samples CI takes
+  // for cold-start timings, p95 (n < 20) and p99 (n < 100) both land on the max,
+  // so omit any percentile that cannot be distinguished from it rather than
+  // echoing an unsupported number.
+  const tailPercentile = (fraction) => {
+    const rank = Math.ceil(sorted.length * fraction) - 1;
+    return rank < lastIndex ? sorted[rank] : undefined;
+  };
+  const p95Ms = tailPercentile(0.95);
+  if (p95Ms !== undefined) summary.p95Ms = p95Ms;
+  const p99Ms = tailPercentile(0.99);
+  if (p99Ms !== undefined) summary.p99Ms = p99Ms;
+
+  summary.maxMs = sorted.at(-1);
+  return summary;
 }
 
 export function parseOptions(args) {

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -38,15 +38,37 @@ import {
   waitForHealth
 } from './benchmark-cli.mjs';
 
-test('summarizeSamples reports deterministic p50, p95, and p99', () => {
+test('summarizeSamples omits tail percentiles that collapse onto the maximum', () => {
+  // With only 5 samples the nearest-rank p95 and p99 both land on the last
+  // (maximum) element, so reporting them as tail percentiles is misleading: they
+  // are indistinguishable from maxMs.  They must be omitted below the support
+  // threshold rather than echoing the max.
   assert.deepEqual(summarizeSamples([9, 1, 5, 3, 7]), {
     minMs: 1,
     medianMs: 5,
     p50Ms: 5,
-    p95Ms: 9,
-    p99Ms: 9,
     maxMs: 9
   });
+});
+
+test('summarizeSamples reports p95 only once enough samples support it', () => {
+  const samples = Array.from({ length: 20 }, (_value, index) => index + 1);
+  const summary = summarizeSamples(samples);
+  // Nearest-rank p95 of 20 ascending samples is index ceil(20*0.95)-1 = 18 -> 19,
+  // strictly below the maximum of 20, so it is now statistically distinguishable.
+  assert.equal(summary.p95Ms, 19);
+  assert.equal(summary.maxMs, 20);
+  // 20 samples still cannot support p99 (its nearest rank is the max), so omit it.
+  assert.equal(Object.hasOwn(summary, 'p99Ms'), false);
+});
+
+test('summarizeSamples reports p99 only when its rank clears the maximum', () => {
+  const samples = Array.from({ length: 100 }, (_value, index) => index + 1);
+  const summary = summarizeSamples(samples);
+  // ceil(100*0.99)-1 = 98 -> 99, strictly below the maximum of 100.
+  assert.equal(summary.p95Ms, 95);
+  assert.equal(summary.p99Ms, 99);
+  assert.equal(summary.maxMs, 100);
 });
 
 test('parseOptions requires a binary path', () => {
@@ -426,8 +448,6 @@ test('measureColdDaemonStarts uses a fresh home per sample and always stops it',
       minMs: 1.25,
       medianMs: 2.375,
       p50Ms: 1.25,
-      p95Ms: 3.5,
-      p99Ms: 3.5,
       maxMs: 3.5
     }
   });


### PR DESCRIPTION
Refs #636. Refs #648.

Corrects the completed-window, sampled-maxima, and small-sample percentile semantics. Deliberately leaves disk-full coverage blocked until a real `SQLITE_FULL` write-failure and recovery regression lands.

## Verification
- exact-head CI: all required checks green
- `node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs` (65/65)
- `python scripts/check-secrets.py`
- `git diff ... --check`