### PR TITLE
docs(psyche): close G2 termination-persistence contract gap (#652)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-psyche-w2-g2-foundation.md
+++ b/docs/superpowers/plans/2026-08-05-psyche-w2-g2-foundation.md
@@ -2870,6 +2870,32 @@ async fn unknown_contract_fails_before_adoption() {
     assert!(matches!(result, Err(PortError::ContractUnsupported { .. })));
     assert_eq!(fake.calls(), vec![FakeCall::Negotiate]);
 }
+
+#[tokio::test]
+async fn termination_dispatch_appends_validated_outcome_before_returning() {
+    // Seed revision 1 (session-bound) and the derived TerminationRequested
+    // revision 2, then dispatch. `persist_then_terminate` must validate the
+    // port's evidence, derive revision 3, and durably append it before it
+    // returns Ok.
+    let (mut persistence, dir) = real_store_termination_persistence();
+    let requested = seed_session_bound_then_requested(&mut persistence);
+    let port = FakeCoven::builder()
+        .acknowledge_termination(acknowledgement_for(&requested))
+        .build()
+        .unwrap();
+
+    let disposition = persist_then_terminate(&mut persistence, &port, requested.clone())
+        .await
+        .expect("validated outcome must be durable before Ok");
+
+    // Reopen the store: revision 3 must be byte-exact and digest-linked.
+    let revisions = reopen(&dir).execution_binding_revisions(&requested.attempt_id).unwrap();
+    assert_eq!(revisions.len(), 3);
+    assert_eq!(
+        canonical_bytes(&revisions[2]).unwrap(),
+        canonical_bytes(&derive_termination_outcome_revision(&requested, &disposition).unwrap()).unwrap(),
+    );
+}
 ```
 
 - [ ] **Step 2: Run and verify RED**
@@ -2878,7 +2904,9 @@ async fn unknown_contract_fails_before_adoption() {
 cargo test -p psyche-test-support --test fakes
 ```
 
-Expected: compile failure because port and fake types are absent.
+Expected: compile failure because port and fake types (including
+`persist_outcome`, `derive_termination_outcome_revision`, and the
+acknowledged-outcome fake control) are absent.
 
 - [ ] **Step 3: Implement behavior-level port types**
 
@@ -3097,6 +3125,24 @@ pub trait TerminationPersistence {
         &mut self,
         requested: ExecutionBinding,
     ) -> Result<Vec<u8>, Self::Error>;
+
+    /// Durably appends the next digest-linked `ExecutionBinding` revision that
+    /// carries the validated acknowledged/unresolved outcome, returning only
+    /// after that exact revision has committed. `outcome` is the next revision
+    /// derived from the persisted `TerminationRequested` revision by
+    /// `derive_termination_outcome_revision`; its digest link, immutable
+    /// execution correlation, and frozen session/termination fields must match
+    /// the already-durable predecessor or the implementation must reject the
+    /// append as a fork/gap rather than committing. The success value is the
+    /// committed RFC 8785 canonical byte vector of that next revision, never a
+    /// parsed `ExecutionBinding`, so the coordinator can prove byte-exact
+    /// durability before returning any disposition. An exact idempotent replay
+    /// of the same next revision returns the same bytes; every other divergence
+    /// propagates the store error.
+    fn persist_outcome(
+        &mut self,
+        outcome: ExecutionBinding,
+    ) -> Result<Vec<u8>, Self::Error>;
 }
 
 pub enum TerminationDispatchError<E> {
@@ -3104,6 +3150,8 @@ pub enum TerminationDispatchError<E> {
     Persistence(E),
     PersistedBindingMismatch,
     Port(PortError),
+    OutcomeEvidenceMismatch,
+    PersistedOutcomeMismatch,
 }
 
 pub async fn persist_then_terminate<S, P>(
@@ -3125,12 +3173,45 @@ where
     if persisted_bytes != expected_bytes {
         return Err(TerminationDispatchError::PersistedBindingMismatch);
     }
-    let request = TerminationRequest::from_persisted_binding(requested)
+    let request = TerminationRequest::from_persisted_binding(requested.clone())
         .map_err(TerminationDispatchError::Contract)?;
-    port.terminate(request)
+    let disposition = port
+        .terminate(request)
         .await
-        .map_err(TerminationDispatchError::Port)
+        .map_err(TerminationDispatchError::Port)?;
+    // The disposition is not returned until its validated outcome is durable.
+    // Validate the port's acknowledged/unresolved evidence against the exact
+    // persisted `TerminationRequested` revision, derive the next digest-linked
+    // outcome revision, and durably append it before returning.
+    let outcome = derive_termination_outcome_revision(&requested, &disposition)
+        .map_err(|_| TerminationDispatchError::OutcomeEvidenceMismatch)?;
+    let expected_outcome_bytes = canonical_bytes(&outcome)
+        .map_err(TerminationDispatchError::Contract)?;
+    let persisted_outcome_bytes = persistence
+        .persist_outcome(outcome)
+        .map_err(TerminationDispatchError::Persistence)?;
+    if persisted_outcome_bytes != expected_outcome_bytes {
+        return Err(TerminationDispatchError::PersistedOutcomeMismatch);
+    }
+    Ok(disposition)
 }
+
+/// Validates the port's `TerminationDisposition` evidence against the exact
+/// persisted `TerminationRequested` binding and derives the next digest-linked
+/// `ExecutionBinding` revision that records the acknowledged or unresolved
+/// outcome. It rejects any evidence whose termination request ID, session,
+/// execution correlation, or authority-evidence digest does not match the
+/// persisted correlation, and it rejects an acknowledgement timestamp outside
+/// the persisted termination window. The derived revision increments the
+/// revision number, sets `previous_revision_digest` to the persisted
+/// requested revision's digest, preserves the immutable execution correlation
+/// and frozen session/termination fields, and never derives a deadline from
+/// response-arrival time. It is the only construction path for an outcome
+/// revision, so no caller can append an unvalidated or forked outcome.
+fn derive_termination_outcome_revision(
+    persisted_requested: &ExecutionBinding,
+    disposition: &TerminationDisposition,
+) -> Result<ExecutionBinding, ContractError>;
 
 pub enum TerminationDisposition {
     Acknowledged { evidence: CancellationAcknowledgementEvidence },
@@ -3246,15 +3327,39 @@ success does the private constructor derive its read-only reason from the
 validated requested binding and permit
 `CovenPort::terminate`.
 
-The W2 real-store test wrapper implements `TerminationPersistence` by calling
+The coordinator does not return the `TerminationDisposition` the port yields.
+Before any disposition returns, `derive_termination_outcome_revision` validates
+the acknowledged/unresolved evidence against the persisted `TerminationRequested`
+correlation — matching the termination request ID, frozen session, immutable
+execution correlation, and authority-evidence digest, and rejecting an
+acknowledgement timestamp outside the persisted termination window — then
+derives the next digest-linked revision. Mismatched or invalid evidence returns
+`OutcomeEvidenceMismatch` with no append. The coordinator then calls
+`TerminationPersistence::persist_outcome`, whose success contract is to append
+that exact next revision durably and return its committed RFC 8785 canonical
+bytes; the coordinator compares them byte-for-byte with
+`canonical_bytes(&outcome)` and fails closed as `PersistedOutcomeMismatch` on
+any divergence. A persistence failure propagates and the disposition is not
+returned. Because the outcome append occurs before the coordinator returns
+`Ok(disposition)`, a returned success can never lack durable evidence, and the
+`persist_outcome` predecessor-digest check makes a concurrent intervening
+revision fail as a fork/gap rather than forking the chain. On restart, replaying
+the same outcome revision is idempotent and yields the same durable disposition.
+
+The W2 real-store test wrapper implements `TerminationPersistence` — both
+`persist_requested` and `persist_outcome` — by calling
 `execution_binding_revisions` to load the candidate's exact digest-linked
 predecessor, rejecting an absent session or any session mismatch, then calling
-`Store::insert`. It computes the candidate's canonical bytes before insertion
+`Store::insert`. `persist_outcome` loads the durable `TerminationRequested`
+revision as the outcome revision's predecessor and refuses to insert unless its
+`previous_revision_digest`, immutable execution correlation, and frozen
+session/termination fields match that predecessor. Each method computes the
+candidate's canonical bytes before insertion
 and returns that byte vector only after `insert` has either committed those
 exact bytes or proved an exact idempotent replay; every `StoreError` propagates.
 The predecessor digest makes a concurrent intervening revision fail as a
-fork/gap rather than turning the precheck into a TOCTOU bypass. It never returns
-a success-shaped fallback. This preserves the dependency direction
+fork/gap rather than turning the precheck into a TOCTOU bypass. Neither method
+returns a success-shaped fallback. This preserves the dependency direction
 `psyche-coven -> psyche-core`: the boundary defines the narrow persistence
 behavior, while `psyche-test-support` owns the local real-store wrapper for G2
 proof and the later W5 composition root owns the production wrapper. Every
@@ -3262,12 +3367,17 @@ wrapper must run the same conformance assertion. First-time session binding in
 the termination revision, session rebind, unknown attempt/revision, write
 failure, or persisted-byte mismatch returns before the port call. Because the
 trait accepts only the construction-closed request,
-individual adapters do not become the validation authority. The adapter accepts
-acknowledgement or unresolved evidence only when its termination request ID and
-timestamp match that persisted correlation. It then derives the next revision
+individual adapters do not become the validation authority. The outcome append
+is likewise an executable coordinator/persistence boundary, not an adapter
+courtesy: the coordinator's `derive_termination_outcome_revision` accepts
+acknowledgement or unresolved evidence only when its termination request ID,
+session, execution correlation, authority-evidence digest, and — for an
+acknowledgement — its timestamp within the persisted termination window match
+that persisted correlation. It then derives the next revision
 from the termination-requested revision, preserving its digest link and
-immutable execution correlation. It never derives a deadline from response
-arrival time.
+immutable execution correlation, and commits it through
+`TerminationPersistence::persist_outcome` before the disposition returns. It
+never derives a deadline from response arrival time.
 
 Name the table-driven public-coordinator test
 `termination_dispatch_rejects_invalid_request_before_persistence`; it accepts a
@@ -3290,6 +3400,31 @@ persistence implementation returning different bytes for a structurally equal
 timestamp instant; every case requires zero port calls and no new binding
 revision. The reusable assertion is part of the fake/real conformance contract
 that W5 must run unchanged.
+
+Name the outcome-durability ordering test
+`termination_dispatch_appends_validated_outcome_before_returning`. It seeds a
+session-bound revision 1 and the derived `TerminationRequested` revision 2, then
+runs one acknowledged and one unresolved case end to end: `FakeCoven::terminate`
+returns valid `CancellationAcknowledgementEvidence` (respectively
+`CancellationUnresolvedEvidence`) bound to the persisted correlation, and after
+`persist_then_terminate` returns `Ok`, the test reopens the SQLite file and
+asserts that revision 3 is durable, byte-exact against `canonical_bytes` of the
+derived outcome revision, digest-linked to revision 2, and carrying the same
+frozen session and immutable execution correlation; the returned disposition
+equals the port's evidence. Its negative cases independently use evidence whose
+termination request ID, session, execution correlation, or authority-evidence
+digest does not match the persisted request (each expecting
+`OutcomeEvidenceMismatch`), an acknowledgement timestamp outside the persisted
+termination window, an injected `persist_outcome` failure, a `persist_outcome`
+returning different bytes for a structurally equal timestamp instant (expecting
+`PersistedOutcomeMismatch`), and a concurrent intervening revision 3 committed
+by another writer before the append (expecting the append to fail as a fork/gap
+via the predecessor-digest check); every negative case leaves no revision 3 and
+returns an error rather than `Ok`. A replay/restart case reopens the store after
+a committed outcome, re-runs the same disposition, and asserts the idempotent
+append yields the same durable revision 3 with no duplicate or fork. This
+reusable assertion is also part of the fake/real conformance contract that W5
+must run unchanged.
 
 Add a strict canonical `tests/fixtures/result-bundle.json` containing one
 primary `application/json` result and one `text/plain` artifact. In
@@ -3396,9 +3531,14 @@ The core-owned `CancellationAcknowledgementEvidence` is the separate O5
 authority evidence required by C-S9. `psyche-coven` imports it from
 `psyche-core`; it does not define a parallel acknowledgement type.
 The adapter maps the O5 response into the canonical evidence only after exact
-session/request/correlation/digest validation, then appends the resulting
-`ExecutionBinding` revision. An unresolved O5 response maps to the core-owned
-`CancellationUnresolvedEvidence`. This dependency remains
+session/request/correlation/digest validation. The coordinator, not the adapter,
+then derives the next `ExecutionBinding` revision from that validated evidence
+via `derive_termination_outcome_revision` and appends it durably through
+`TerminationPersistence::persist_outcome` before returning the disposition, so
+the append is a proven executable boundary rather than a best-effort adapter
+side effect. An unresolved O5 response maps to the core-owned
+`CancellationUnresolvedEvidence` and follows the same validate-derive-append
+path. This dependency remains
 `psyche-coven -> psyche-core`; core/store never depend on the adapter.
 
 Acknowledgement evidence is not derived from `SessionSnapshot::terminal_state`,
@@ -4360,7 +4500,8 @@ Use this complete manifest shape:
       "list_command": "cargo test -p psyche-test-support --test fakes -- --list --format terse",
       "tests": [
         "advertised_adoption_requires_a_scripted_adoption_step",
-        "termination_dispatch_requires_durable_session_bound_revision"
+        "termination_dispatch_requires_durable_session_bound_revision",
+        "termination_dispatch_appends_validated_outcome_before_returning"
       ]
     },
     "psyche-test-support/state_machine": {
@@ -4514,7 +4655,7 @@ including why `ExpectedUnsupported` is diagnostic rather than passed evidence.
 | Migrations | `cargo test -p psyche-store --test migrations -- --exact fresh_store_applies_v1_once_and_reopens` | not run remotely | none |
 | State-machine/property | `cargo test -p psyche-test-support --test state_machine -- --exact model_and_store_agree_after_any_foundation_operation_sequence` | not run remotely | none |
 | Crash/restart | `cargo test -p psyche-store --features test-fault-injection --test crash -- --exact killed_writer_exposes_only_committed_state_after_reopen` | not run remotely | none |
-| Fake boundaries and durable termination ordering | `cargo test -p psyche-test-support --test fakes -- --exact advertised_adoption_requires_a_scripted_adoption_step && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_requires_durable_session_bound_revision` | not run remotely | none |
+| Fake boundaries and durable termination ordering | `cargo test -p psyche-test-support --test fakes -- --exact advertised_adoption_requires_a_scripted_adoption_step && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_requires_durable_session_bound_revision && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_appends_validated_outcome_before_returning` | not run remotely | none |
 | Execution request RFC3339 golden bytes | `cargo test -p psyche-coven --test request_digest -- --exact execution_request_launch_matches_golden_bytes_and_digest && cargo test -p psyche-coven --test request_digest -- --exact execution_request_input_matches_golden_bytes_and_digest` | not run remotely | none |
 | Validated termination dispatch | `cargo test -p psyche-coven --test bindings -- --exact termination_dispatch_rejects_invalid_request_before_persistence` | not run remotely | none |
 | G2 cancellation-state vocabulary | `cargo test -p psyche-core --test contracts -- --exact cancellation_state_vocabulary_requires_matching_o5_evidence` | not run remotely | none |

--- a/docs/superpowers/plans/2026-08-05-psyche-w2-g2-foundation.md
+++ b/docs/superpowers/plans/2026-08-05-psyche-w2-g2-foundation.md
@@ -4,6 +4,8 @@
 
 **Goal:** Finish Psyche W2 and produce terminal G2 evidence for canonical versioned records, durable SQLite migrations, behavior-level fake boundaries, and migration/state-machine/property/crash tests.
 
+**Termination persistence design:** [`../specs/2026-08-07-psyche-g2-atomic-termination-persistence-design.md`](../specs/2026-08-07-psyche-g2-atomic-termination-persistence-design.md)
+
 **Architecture:** Extend the merged four-crate bootstrap with the focused crates named by the canonical architecture. `psyche-core` owns policy-free identifiers, digests, schema names, and minimum record shapes; `psyche-store` owns SQLite, migrations, immutable records, append-only execution-binding revisions and transitions, quarantine, retention, and its package-local crash helper; `psyche-coven` and `psyche-surfaces` own behavior-level traits for their respective boundaries; `psyche-test-support` owns deterministic scripted fakes and reusable conformance fixtures. `psyche-runtime` remains the only composition root. W3-W9 retain identity resolution, graph admission, orchestration policy, real Coven integration, Telegram behavior, verification, and add-on trust.
 
 **Tech Stack:** Rust 2024 on 1.85, serde/serde_json, RFC 8785 JSON canonicalization, SHA-256, ULID, rusqlite with bundled SQLite, Tokio, proptest, tempfile, assert_cmd, cargo-deny, gitleaks.
@@ -2872,7 +2874,7 @@ async fn unknown_contract_fails_before_adoption() {
 }
 
 #[tokio::test]
-async fn termination_dispatch_appends_validated_outcome_before_returning() {
+async fn termination_dispatch_persists_acknowledged_outcome_before_success() {
     // Seed revision 1 (session-bound) and the derived TerminationRequested
     // revision 2, then dispatch. `persist_then_terminate` must validate the
     // port's evidence, derive revision 3, and durably append it before it
@@ -3116,6 +3118,11 @@ impl TerminationRequest {
     pub fn reason_code(&self) -> &str { &self.reason_code }
 }
 
+pub enum TerminationPersistenceFailure<E> {
+    Conflict(E),
+    Write(E),
+}
+
 pub trait TerminationPersistence {
     type Error;
 
@@ -3124,7 +3131,7 @@ pub trait TerminationPersistence {
     fn persist_requested(
         &mut self,
         requested: ExecutionBinding,
-    ) -> Result<Vec<u8>, Self::Error>;
+    ) -> Result<Vec<u8>, TerminationPersistenceFailure<Self::Error>>;
 
     /// Durably appends the next digest-linked `ExecutionBinding` revision that
     /// carries the validated acknowledged/unresolved outcome, returning only
@@ -3138,19 +3145,21 @@ pub trait TerminationPersistence {
     /// parsed `ExecutionBinding`, so the coordinator can prove byte-exact
     /// durability before returning any disposition. An exact idempotent replay
     /// of the same next revision returns the same bytes; every other divergence
-    /// propagates the store error.
+    /// returns the corresponding typed conflict or write failure.
     fn persist_outcome(
         &mut self,
         outcome: ExecutionBinding,
-    ) -> Result<Vec<u8>, Self::Error>;
+    ) -> Result<Vec<u8>, TerminationPersistenceFailure<Self::Error>>;
 }
 
 pub enum TerminationDispatchError<E> {
     Contract(ContractError),
-    Persistence(E),
+    RequestPersistence(E),
     PersistedBindingMismatch,
     Port(PortError),
     OutcomeEvidenceMismatch,
+    OutcomePersistenceIndeterminate(E),
+    RevisionConflict(E),
     PersistedOutcomeMismatch,
 }
 
@@ -3169,7 +3178,12 @@ where
         .map_err(TerminationDispatchError::Contract)?;
     let persisted_bytes = persistence
         .persist_requested(requested.clone())
-        .map_err(TerminationDispatchError::Persistence)?;
+        .map_err(|failure| match failure {
+            TerminationPersistenceFailure::Conflict(error) =>
+                TerminationDispatchError::RevisionConflict(error),
+            TerminationPersistenceFailure::Write(error) =>
+                TerminationDispatchError::RequestPersistence(error),
+        })?;
     if persisted_bytes != expected_bytes {
         return Err(TerminationDispatchError::PersistedBindingMismatch);
     }
@@ -3189,7 +3203,12 @@ where
         .map_err(TerminationDispatchError::Contract)?;
     let persisted_outcome_bytes = persistence
         .persist_outcome(outcome)
-        .map_err(TerminationDispatchError::Persistence)?;
+        .map_err(|failure| match failure {
+            TerminationPersistenceFailure::Conflict(error) =>
+                TerminationDispatchError::RevisionConflict(error),
+            TerminationPersistenceFailure::Write(error) =>
+                TerminationDispatchError::OutcomePersistenceIndeterminate(error),
+        })?;
     if persisted_outcome_bytes != expected_outcome_bytes {
         return Err(TerminationDispatchError::PersistedOutcomeMismatch);
     }
@@ -3339,12 +3358,25 @@ derives the next digest-linked revision. Mismatched or invalid evidence returns
 that exact next revision durably and return its committed RFC 8785 canonical
 bytes; the coordinator compares them byte-for-byte with
 `canonical_bytes(&outcome)` and fails closed as `PersistedOutcomeMismatch` on
-any divergence. A persistence failure propagates and the disposition is not
-returned. Because the outcome append occurs before the coordinator returns
+any divergence. A requested-revision write failure is
+`RequestPersistence`; an outcome write failure after Coven has responded is
+`OutcomePersistenceIndeterminate`; and a changed replay, fork, gap, or
+intervening revision is `RevisionConflict`. None returns the disposition.
+Because the outcome append occurs before the coordinator returns
 `Ok(disposition)`, a returned success can never lack durable evidence, and the
 `persist_outcome` predecessor-digest check makes a concurrent intervening
-revision fail as a fork/gap rather than forking the chain. On restart, replaying
-the same outcome revision is idempotent and yields the same durable disposition.
+revision fail rather than forking the chain.
+
+Startup reconciliation treats a durable `TerminationRequested` tip as
+incomplete work. It reconstructs the same construction-closed request, replays
+`CovenPort::terminate` with the persisted termination request ID as the stable
+idempotency identity, validates the stable response, and appends the missing
+outcome. This covers crashes after the requested append, after the port
+response, and before the outcome append. A crash after the outcome commit but
+before the caller observes success is an exact idempotent replay. A different
+response under the same termination identity is `RevisionConflict`; recovery
+never silently rebases, replaces an existing successor, or invents a successful
+outcome.
 
 The W2 real-store test wrapper implements `TerminationPersistence` — both
 `persist_requested` and `persist_outcome` — by calling
@@ -3356,7 +3388,10 @@ revision as the outcome revision's predecessor and refuses to insert unless its
 session/termination fields match that predecessor. Each method computes the
 candidate's canonical bytes before insertion
 and returns that byte vector only after `insert` has either committed those
-exact bytes or proved an exact idempotent replay; every `StoreError` propagates.
+exact bytes or proved an exact idempotent replay. The wrapper classifies a
+changed same-revision replay, fork, gap, historical rewrite, or intervening
+successor as `TerminationPersistenceFailure::Conflict`; all other store/write
+failures are `TerminationPersistenceFailure::Write`.
 The predecessor digest makes a concurrent intervening revision fail as a
 fork/gap rather than turning the precheck into a TOCTOU bypass. Neither method
 returns a success-shaped fallback. This preserves the dependency direction
@@ -3401,30 +3436,47 @@ timestamp instant; every case requires zero port calls and no new binding
 revision. The reusable assertion is part of the fake/real conformance contract
 that W5 must run unchanged.
 
-Name the outcome-durability ordering test
-`termination_dispatch_appends_validated_outcome_before_returning`. It seeds a
-session-bound revision 1 and the derived `TerminationRequested` revision 2, then
-runs one acknowledged and one unresolved case end to end: `FakeCoven::terminate`
-returns valid `CancellationAcknowledgementEvidence` (respectively
-`CancellationUnresolvedEvidence`) bound to the persisted correlation, and after
-`persist_then_terminate` returns `Ok`, the test reopens the SQLite file and
-asserts that revision 3 is durable, byte-exact against `canonical_bytes` of the
-derived outcome revision, digest-linked to revision 2, and carrying the same
-frozen session and immutable execution correlation; the returned disposition
-equals the port's evidence. Its negative cases independently use evidence whose
-termination request ID, session, execution correlation, or authority-evidence
-digest does not match the persisted request (each expecting
-`OutcomeEvidenceMismatch`), an acknowledgement timestamp outside the persisted
-termination window, an injected `persist_outcome` failure, a `persist_outcome`
-returning different bytes for a structurally equal timestamp instant (expecting
-`PersistedOutcomeMismatch`), and a concurrent intervening revision 3 committed
-by another writer before the append (expecting the append to fail as a fork/gap
-via the predecessor-digest check); every negative case leaves no revision 3 and
-returns an error rather than `Ok`. A replay/restart case reopens the store after
-a committed outcome, re-runs the same disposition, and asserts the idempotent
-append yields the same durable revision 3 with no duplicate or fork. This
-reusable assertion is also part of the fake/real conformance contract that W5
-must run unchanged.
+Use separate exact outcome-coordinator tests so the evidence manifest cannot
+hide a missing recovery or conflict case behind one broad test:
+
+- `termination_dispatch_persists_acknowledged_outcome_before_success`;
+- `termination_dispatch_persists_unresolved_outcome_before_success`;
+- `termination_dispatch_exact_replay_is_idempotent`;
+- `termination_dispatch_crash_after_response_leaves_recoverable_request`;
+- `termination_dispatch_restart_recovers_missing_outcome`;
+- `termination_dispatch_rejects_conflicting_replay_response`;
+- `termination_dispatch_rejects_invalid_outcome_evidence`;
+- `termination_dispatch_reports_indeterminate_outcome_persistence`;
+- `termination_dispatch_rejects_concurrent_intervening_revision`; and
+- `termination_dispatch_rejects_outcome_byte_attestation_mismatch`.
+
+The acknowledged and unresolved tests seed a session-bound revision 1 and the
+derived `TerminationRequested` revision 2, then run the public coordinator end
+to end. After `persist_then_terminate` returns `Ok`, each test reopens the
+SQLite file and asserts revision 3 is durable, byte-exact against
+`canonical_bytes` of the derived outcome, digest-linked to revision 2, and
+carries the same frozen session and immutable execution correlation. Exact
+replay reopens the store and proves the same disposition produces no duplicate
+or fork.
+
+The crash test uses a deterministic test-support fault point after the valid
+port response and before `persist_outcome`, then reopens the store and proves
+the requested revision is durable while no outcome exists. The restart test
+creates a fresh coordinator over that state, scripts the same response for the
+same idempotency identity, and proves the missing outcome is committed before
+success. A different replay response must return `RevisionConflict` without
+mutation.
+
+The invalid-evidence test independently changes the termination request ID,
+session, execution correlation, authority-evidence digest, and acknowledgement
+timestamp. The persistence test injects an outcome write failure and expects
+`OutcomePersistenceIndeterminate`. The concurrency test commits an intervening
+revision 3 before append and expects `RevisionConflict`. The byte-attestation
+test returns different committed bytes for a structurally equal timestamp
+instant and expects `PersistedOutcomeMismatch`. Every negative test reopens the
+store, proves no illegal terminal revision was appended, and proves no
+success-shaped result escaped. These reusable assertions are part of the
+fake/real conformance contract that W5 must run unchanged.
 
 Add a strict canonical `tests/fixtures/result-bundle.json` containing one
 primary `application/json` result and one `text/plain` artifact. In
@@ -4501,7 +4553,16 @@ Use this complete manifest shape:
       "tests": [
         "advertised_adoption_requires_a_scripted_adoption_step",
         "termination_dispatch_requires_durable_session_bound_revision",
-        "termination_dispatch_appends_validated_outcome_before_returning"
+        "termination_dispatch_persists_acknowledged_outcome_before_success",
+        "termination_dispatch_persists_unresolved_outcome_before_success",
+        "termination_dispatch_exact_replay_is_idempotent",
+        "termination_dispatch_crash_after_response_leaves_recoverable_request",
+        "termination_dispatch_restart_recovers_missing_outcome",
+        "termination_dispatch_rejects_conflicting_replay_response",
+        "termination_dispatch_rejects_invalid_outcome_evidence",
+        "termination_dispatch_reports_indeterminate_outcome_persistence",
+        "termination_dispatch_rejects_concurrent_intervening_revision",
+        "termination_dispatch_rejects_outcome_byte_attestation_mismatch"
       ]
     },
     "psyche-test-support/state_machine": {
@@ -4655,7 +4716,7 @@ including why `ExpectedUnsupported` is diagnostic rather than passed evidence.
 | Migrations | `cargo test -p psyche-store --test migrations -- --exact fresh_store_applies_v1_once_and_reopens` | not run remotely | none |
 | State-machine/property | `cargo test -p psyche-test-support --test state_machine -- --exact model_and_store_agree_after_any_foundation_operation_sequence` | not run remotely | none |
 | Crash/restart | `cargo test -p psyche-store --features test-fault-injection --test crash -- --exact killed_writer_exposes_only_committed_state_after_reopen` | not run remotely | none |
-| Fake boundaries and durable termination ordering | `cargo test -p psyche-test-support --test fakes -- --exact advertised_adoption_requires_a_scripted_adoption_step && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_requires_durable_session_bound_revision && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_appends_validated_outcome_before_returning` | not run remotely | none |
+| Fake boundaries and durable termination ordering | `cargo test -p psyche-test-support --test fakes -- --exact advertised_adoption_requires_a_scripted_adoption_step && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_requires_durable_session_bound_revision && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_persists_acknowledged_outcome_before_success && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_persists_unresolved_outcome_before_success && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_exact_replay_is_idempotent && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_crash_after_response_leaves_recoverable_request && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_restart_recovers_missing_outcome && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_rejects_conflicting_replay_response && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_rejects_invalid_outcome_evidence && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_reports_indeterminate_outcome_persistence && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_rejects_concurrent_intervening_revision && cargo test -p psyche-test-support --test fakes -- --exact termination_dispatch_rejects_outcome_byte_attestation_mismatch` | not run remotely | none |
 | Execution request RFC3339 golden bytes | `cargo test -p psyche-coven --test request_digest -- --exact execution_request_launch_matches_golden_bytes_and_digest && cargo test -p psyche-coven --test request_digest -- --exact execution_request_input_matches_golden_bytes_and_digest` | not run remotely | none |
 | Validated termination dispatch | `cargo test -p psyche-coven --test bindings -- --exact termination_dispatch_rejects_invalid_request_before_persistence` | not run remotely | none |
 | G2 cancellation-state vocabulary | `cargo test -p psyche-core --test contracts -- --exact cancellation_state_vocabulary_requires_matching_o5_evidence` | not run remotely | none |

--- a/docs/superpowers/specs/2026-08-07-psyche-g2-atomic-termination-persistence-design.md
+++ b/docs/superpowers/specs/2026-08-07-psyche-g2-atomic-termination-persistence-design.md
@@ -1,0 +1,200 @@
+# Psyche G2 Atomic Termination Persistence Design
+
+**Status:** Approved design for issue #652
+
+**Scope:** Correct the G2 coordinator contract so Psyche never returns a
+successful Coven termination disposition before the corresponding validated
+outcome revision is durable.
+
+## Problem
+
+The G2 plan currently makes `TerminationRequested` durable before invoking
+`CovenPort::terminate`, but the returned acknowledged or unresolved disposition
+can escape without a coordinator-level proof that its outcome revision was
+validated and committed. Store-level append tests alone do not close this gap:
+the executable coordinator path must own the validate, derive, persist, and
+attest sequence.
+
+This design uses "atomic" to mean that callers cannot observe a successful
+termination result without its durable Psyche outcome. It does not claim a
+distributed transaction across Psyche and Coven.
+
+## Required State Machine
+
+For one execution attempt, termination advances the append-only binding ledger:
+
+```text
+session-bound -> termination-requested -> acknowledged | unresolved
+```
+
+The following invariants are mandatory:
+
+1. Every successor increments the revision number by one and names the exact
+   canonical digest of its predecessor.
+2. Session, execution correlation, termination identity, termination reason,
+   and termination authority window become frozen no later than the
+   `termination-requested` revision.
+3. An acknowledged or unresolved revision can only be derived from the exact
+   durable `termination-requested` predecessor.
+4. Exact replay is idempotent. A changed response for the same termination
+   identity is a revision conflict.
+5. A gap, fork, historical rewrite, rebinding, authority removal, or intervening
+   revision fails without mutation.
+6. `Ok(TerminationDisposition)` implies the matching terminal revision is
+   durable and byte-exact after reopening storage.
+
+## Components and Boundaries
+
+### Validated request construction
+
+`TerminationRequest` remains construction-closed. The coordinator accepts a
+candidate `ExecutionBinding`, validates that it is a
+`TerminationRequested` successor of an already session-bound revision, durably
+appends it, and compares the store's committed canonical bytes with the
+candidate bytes. The port is not called if any precondition, append, or
+attestation fails.
+
+### Termination coordinator
+
+`persist_then_terminate` owns the complete ordering:
+
+1. Validate the requested revision.
+2. Durably append and attest the exact `TerminationRequested` bytes.
+3. Construct the read-only `TerminationRequest`.
+4. Invoke `CovenPort::terminate` with the persisted termination identity as its
+   idempotency identity.
+5. Validate the returned acknowledgement or unresolved evidence against the
+   persisted termination authority.
+6. Derive the one legal next digest-linked revision.
+7. Durably append and attest the exact outcome bytes.
+8. Return the disposition.
+
+No adapter may append the outcome as a best-effort side effect, and no caller
+may bypass the coordinator with an unchecked request or outcome constructor.
+
+### Outcome derivation
+
+`derive_termination_outcome_revision` accepts the durable requested revision and
+the port disposition. It validates the termination request ID, Coven session,
+immutable execution correlation, authority-evidence digest, and persisted
+termination window. Acknowledgement timestamps must fall within the inclusive
+window. Unresolved evidence is bound to the same authority and may not derive a
+new deadline from response arrival time.
+
+The function preserves all frozen fields, increments the revision once, and
+sets `previous_revision_digest` to the canonical digest of the requested
+revision.
+
+### Persistence boundary
+
+`TerminationPersistence` exposes separate requested and outcome append
+operations. Both operations:
+
+- validate the exact durable predecessor;
+- append transactionally;
+- treat an exact historical replay as idempotent;
+- reject every changed same-revision replay, fork, gap, or intervening
+  successor as a conflict; and
+- return the committed RFC 8785 canonical bytes only after durable commit or
+  proof of exact replay.
+
+Persistence failures must distinguish a revision conflict from a storage/write
+failure so the coordinator can preserve the approved error semantics.
+
+### Restart reconciler
+
+Startup reconciliation finds durable attempts whose tip is
+`TerminationRequested`. It reconstructs the same construction-closed request,
+replays `CovenPort::terminate` with the same termination identity, validates the
+stable response, and appends the missing outcome.
+
+The important crash windows are:
+
+| Crash point | Durable state | Recovery |
+|---|---|---|
+| Before requested append | Session-bound only | No port call occurred; retry from the predecessor |
+| After requested append, before port call | Termination requested | Replay the same port request |
+| After port response, before outcome append | Termination requested | Replay the same idempotency identity and append the stable response |
+| After outcome append, before caller observes success | Terminal outcome | Exact replay proves the same revision; no duplicate is appended |
+
+A different replay response, a changed authority field, or an intervening
+revision produces an explicit conflict. Recovery never invents a successful
+outcome and never replaces ambiguity with a success-shaped fallback.
+
+## Error Contract
+
+The coordinator exposes phase-specific failures:
+
+| Category | Durable effect | Port call | Returned success |
+|---|---|---|---|
+| Invalid request | None | No | No |
+| Requested-revision persistence failure | No requested revision | No | No |
+| Port failure | Requested revision remains | Yes | No |
+| Invalid or mismatched response evidence | Requested revision remains | Yes | No |
+| Outcome persistence failure | Requested revision may remain without an outcome | Yes | No; report indeterminate outcome persistence |
+| Revision conflict | Existing chain is preserved | Depends on conflict point | No; report explicit ambiguity |
+| Persisted-byte attestation mismatch | Store state is not trusted | Depends on phase | No |
+
+Request persistence, outcome persistence, and revision conflict must not collapse
+into one generic persistence variant. In particular, a failure after Coven has
+responded is reported as indeterminate outcome persistence because the caller
+must not infer that Coven did nothing.
+
+## Concurrency and Replay
+
+The requested revision's digest is the compare-and-append authority for the
+outcome. If another writer commits any successor first, an outcome append based
+on the old tip fails as a conflict. The coordinator does not reload and
+silently rebase.
+
+An exact repeated request and stable disposition return the already-durable
+outcome. A different disposition under the same termination request ID cannot
+create another revision with the same predecessor and is reported as a
+conflicting replay. Historical exact replay remains valid even when a later
+revision exists; historical changed bytes remain invalid.
+
+## Verification
+
+The G2 exact-test manifest and evidence matrix must name executable tests for:
+
+- acknowledged success;
+- unresolved success;
+- exact replay;
+- crash after port response but before outcome append;
+- restart recovery from the durable requested revision;
+- conflicting replay response;
+- mismatched or invalid evidence;
+- outcome-write failure;
+- concurrent intervening revision; and
+- requested- and outcome-byte attestation mismatches.
+
+Every success test reopens the SQLite store and proves that the terminal
+revision is durable, byte-exact, digest-linked to the requested revision, and
+preserves all frozen correlation fields. The crash/restart test uses a
+deterministic test-support fault point immediately after the validated port
+response and before the outcome append, then creates a fresh coordinator over
+the reopened store and stable fake port.
+
+Negative tests prove no illegal terminal revision was appended and no
+success-shaped result escaped. Manifest/listing validation must reject a
+missing exact test, an unused manifest entry, or a zero-test filter.
+
+## Non-goals
+
+This correction does not implement Psyche crates, change Coven's O5 protocol,
+add multi-agent cancellation policy, add Telegram behavior, or define
+user-facing retry UX. It only closes the G2 coordinator persistence and recovery
+contract needed before Psyche implementation begins.
+
+## Acceptance Criteria
+
+Issue #652 is design-complete when the G2 plan:
+
+1. makes the validate-derive-append sequence part of the public coordinator
+   contract;
+2. makes successful outcome durability byte-attested and reopen-verifiable;
+3. specifies same-identity replay and conflicting-response behavior;
+4. specifies restart reconciliation for every crash window;
+5. preserves phase-specific errors, including indeterminate outcome
+   persistence and explicit revision conflict; and
+6. names every required exact test in the G2 manifest and evidence matrix.


### PR DESCRIPTION
Addresses #652.

**Scope note — this is a spec/plan-doc change, not code.** The termination-persistence contract described in #652 (`TerminationPersistence`, the executable G2 coordinator, `persist_then_terminate`) currently exists ONLY as prose in `docs/superpowers/plans/2026-08-05-psyche-w2-g2-foundation.md`; the referenced crates (`psyche-core`/`store`/`test-support`) do not exist in the tree yet. So there is no compilable red-before-green target — this PR closes the *contract gap in the plan* so the eventual implementation is unambiguous.

## Change
- Extends `TerminationPersistence` with a `persist_outcome` boundary.
- Adds a `derive_termination_outcome_revision` step.
- Rewrites `persist_then_terminate` so outcome validation + byte-exact next-revision append happen **before** a `TerminationDisposition` is returned.
- Adds a spec-level test matrix: acknowledged + unresolved end-to-end, mismatched/invalid evidence, persistence failure, replay/restart, and concurrent intervening revision.

See the tracking note on #652. A maintainer should decide whether to land this plan clarification now or defer until the psyche crates exist so it can be enforced by real tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
