### PR TITLE
test(harness): close O1.1 conformance gaps (#641)

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4151,6 +4151,23 @@ exit 0
     #[cfg(unix)]
     #[test]
     fn cancellation_guard_blocks_supervised_signals_for_spawned_helpers() -> Result<()> {
+        // Snapshot the CALLING thread's supervised-signal membership BEFORE the
+        // guard is installed. `finish()` restores the calling thread's mask via
+        // SIG_SETMASK to whatever it saved at install time, so the post-finish
+        // membership must equal this pre-install snapshot exactly. Gap (3) of
+        // the Psyche O1.1 conformance plan (#641) is this deterministic
+        // round-trip assertion — previously only the mid-install BLOCKED state
+        // (on a freshly spawned helper thread) was checked.
+        let probe_calling_mask = || {
+            let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
+            let result =
+                unsafe { libc::pthread_sigmask(libc::SIG_BLOCK, std::ptr::null(), &mut mask) };
+            assert_eq!(result, 0, "failed to read calling thread signal mask");
+            [libc::SIGTERM, libc::SIGINT, libc::SIGHUP]
+                .map(|signal| unsafe { libc::sigismember(&mask, signal) })
+        };
+        let pre_install_mask = probe_calling_mask();
+
         let cancellation = SupervisedStreamCancellationGuard::install("test stream")?;
         let inherited_mask = thread::spawn(|| {
             let mut mask: libc::sigset_t = unsafe { std::mem::zeroed() };
@@ -4165,6 +4182,14 @@ exit 0
 
         assert_eq!(inherited_mask, [1, 1, 1]);
         assert_eq!(cancellation.finish()?, None);
+
+        // Post-finish: the calling thread's supervised-signal membership must be
+        // exactly what it was before install — SIGTERM/SIGINT/SIGHUP unchanged.
+        assert_eq!(
+            probe_calling_mask(),
+            pre_install_mask,
+            "finish() did not restore the calling thread's signal mask to its pre-install value"
+        );
         Ok(())
     }
 
@@ -4265,9 +4290,22 @@ exit 0
         let temp_dir = tempfile::tempdir()?;
         let fake_harness = temp_dir.path().join("fake-stream");
         let pid_file = temp_dir.path().join("harness.pid");
+        let descendant_pid_file = temp_dir.path().join("descendant.pid");
+        // The malformed-stream fixture spawns a long-lived DESCENDANT (a
+        // detached `sleep`) before emitting invalid JSON. Gap (2) of the
+        // Psyche O1.1 conformance plan (#641): a protocol/JSON failure must
+        // reap the entire process tree, not merely the direct child. We record
+        // both the direct child's pid ($$) and the descendant's pid ($!) so the
+        // assertions below can confirm both are gone (kill(pid,0) == ESRCH).
         std::fs::write(
             &fake_harness,
-            "#!/bin/sh\nprintf '%s\\n' \"$$\" > harness.pid\nprintf '%s\\n' 'not-json'\nsleep 30\n",
+            r#"#!/bin/sh
+printf '%s\n' "$$" > harness.pid
+sleep 30 </dev/null >/dev/null 2>&1 &
+printf '%s\n' "$!" > descendant.pid
+printf '%s\n' 'not-json'
+while :; do sleep 1; done
+"#,
         )?;
         let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
         permissions.set_mode(0o755);
@@ -4285,25 +4323,27 @@ exit 0
         .expect_err("malformed native JSONL must fail");
         assert!(format!("{error:#}").contains("invalid JSON"));
 
-        let harness_pid: libc::pid_t = std::fs::read_to_string(pid_file)?.trim().parse()?;
-        let deadline = Instant::now() + Duration::from_secs(1);
-        let mut reaped = false;
-        while Instant::now() < deadline {
-            if unsafe { libc::kill(harness_pid, 0) } == -1
-                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-            {
-                reaped = true;
-                break;
+        for (label, path) in [("harness", pid_file), ("descendant", descendant_pid_file)] {
+            let pid: libc::pid_t = std::fs::read_to_string(path)?.trim().parse()?;
+            let deadline = Instant::now() + Duration::from_secs(1);
+            let mut reaped = false;
+            while Instant::now() < deadline {
+                if unsafe { libc::kill(pid, 0) } == -1
+                    && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+                {
+                    reaped = true;
+                    break;
+                }
+                thread::sleep(Duration::from_millis(10));
             }
-            thread::sleep(Duration::from_millis(10));
-        }
-        if !reaped {
-            unsafe {
-                libc::kill(harness_pid, libc::SIGKILL);
-                libc::waitpid(harness_pid, std::ptr::null_mut(), 0);
+            if !reaped {
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                    libc::waitpid(pid, std::ptr::null_mut(), 0);
+                }
             }
+            assert!(reaped, "malformed JSON left {label} {pid} alive");
         }
-        assert!(reaped, "malformed JSON left harness {harness_pid} alive");
         Ok(())
     }
 

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -379,6 +379,202 @@ printf '%s\n' '{"type":"turn.completed"}'
     );
 }
 
+/// Gap (1) from the Psyche O1.1 conformance plan (#641): the existing
+/// continuation e2e above resumes by passing the LEDGER row id to `--continue`.
+/// That path resolves through `store::get_session`. But `coven run --continue`
+/// also accepts the STABLE conversation key (the harness `conversation_id`,
+/// e.g. the Codex `thread_id`) and falls back to
+/// `store::get_latest_session_by_conversation_id` when the argument is not a
+/// ledger row id. This test drives that second, previously-uncovered e2e
+/// branch: it seeds a first turn, then resumes using the conversation key
+/// `thread-unix-123` (never a `sessions.id`). It asserts sibling correlation
+/// (fresh row, shared `conversation_id`) plus the native harness resume argv
+/// (`resume\n<thread>`), matching the ledger-id case.
+#[cfg(unix)]
+#[test]
+fn codex_json_stream_continues_by_stable_conversation_key() {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+    let coven_home = temp_dir.path().join("coven-home");
+    fs::create_dir_all(&coven_home).expect("failed to create coven home");
+    let project_root = temp_dir.path().join("project");
+    fs::create_dir_all(&project_root).expect("failed to create project root");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    let fake_codex = fake_bin.join("codex");
+    fs::write(
+        &fake_codex,
+        r#"#!/bin/sh
+printf '%s\n' "$@" > args.txt
+        thread_id=thread-unix-123
+        case " $* " in
+          *" resume "*) thread_id=thread-unix-456 ;;
+        esac
+        printf '%s\n' "{\"type\":\"thread.started\",\"thread_id\":\"$thread_id\"}"
+printf '%s\n' '{"type":"turn.started"}'
+printf '%s\n' '{"type":"item.completed","item":{"id":"item-1","type":"agent_message","text":"reply for stream client"}}'
+printf '%s\n' '{"type":"turn.completed"}'
+"#,
+    )
+    .expect("failed to write fake codex");
+    let mut permissions = fs::metadata(&fake_codex)
+        .expect("failed to stat fake codex")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_codex, permissions).expect("failed to chmod fake codex");
+
+    let mut paths = vec![fake_bin.clone()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    let path = std::env::join_paths(paths).expect("test PATH should be joinable");
+
+    // First turn: establishes a ledger row whose stable conversation key is the
+    // Codex thread id `thread-unix-123`.
+    let out = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["run", "codex", "--stream-json", "--", "first"])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn coven binary");
+    assert!(
+        out.status.success(),
+        "initial coven run failed: status={:?} stdout={} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let first_frames: Vec<serde_json::Value> = String::from_utf8(out.stdout)
+        .expect("stdout not utf-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    let old_id = first_frames[0]["session_id"]
+        .as_str()
+        .expect("system.init carries the old ledger id")
+        .to_string();
+
+    // Sanity: the seeded row's stable conversation key is the Codex thread id,
+    // and it is a *different* value than the ledger row id. Resuming by the
+    // conversation key therefore cannot resolve via `store::get_session`.
+    let conn = rusqlite::Connection::open(coven_home.join("coven.sqlite3"))
+        .expect("failed to open Coven session ledger");
+    let seeded_conversation_id: Option<String> = conn
+        .query_row(
+            "SELECT conversation_id FROM sessions WHERE id = ?1",
+            [&old_id],
+            |row| row.get(0),
+        )
+        .expect("seeded session must be readable");
+    assert_eq!(
+        seeded_conversation_id.as_deref(),
+        Some("thread-unix-123"),
+        "the first turn must persist the stable conversation key"
+    );
+    assert_ne!(
+        old_id, "thread-unix-123",
+        "the stable conversation key must not collide with the ledger row id"
+    );
+
+    let read_evidence = |id: &str| {
+        conn.query_row(
+            "SELECT status, exit_code, archived_at, conversation_id
+             FROM sessions WHERE id = ?1",
+            [id],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<i32>>(1)?,
+                    row.get::<_, Option<String>>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            },
+        )
+        .expect("session evidence should be readable")
+    };
+    let old_evidence = read_evidence(&old_id);
+
+    // Resume by STABLE CONVERSATION KEY (not the ledger id). This drives the
+    // `get_latest_session_by_conversation_id` fallback branch end-to-end.
+    let resumed = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args([
+            "run",
+            "codex",
+            "--stream-json",
+            "--continue",
+            "thread-unix-123",
+            "--",
+            "follow-up",
+        ])
+        .current_dir(&project_root)
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn resumed coven binary");
+    assert!(
+        resumed.status.success(),
+        "conversation-key continuation failed: status={:?} stdout={} stderr={}",
+        resumed.status,
+        String::from_utf8_lossy(&resumed.stdout),
+        String::from_utf8_lossy(&resumed.stderr),
+    );
+    let resumed_frames: Vec<serde_json::Value> = String::from_utf8(resumed.stdout)
+        .expect("stdout not utf-8")
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).expect("Coven stdout must remain JSONL"))
+        .collect();
+    let sibling_id = resumed_frames[0]["session_id"]
+        .as_str()
+        .expect("resumed system.init carries a ledger id");
+    assert_ne!(
+        sibling_id, old_id,
+        "conversation-key continuation must use a fresh row"
+    );
+    assert_eq!(
+        resumed_frames.last().expect("result frame")["session_id"],
+        sibling_id,
+        "init and result must identify the sibling row"
+    );
+
+    // The prior turn's terminal/archive evidence must be untouched.
+    assert_eq!(
+        read_evidence(&old_id),
+        old_evidence,
+        "conversation-key continuation must not rewrite the source row"
+    );
+
+    // Sibling correlation: fresh row sharing the same stable conversation group.
+    let sibling_evidence = read_evidence(sibling_id);
+    assert_eq!(sibling_evidence.0, "completed");
+    assert_eq!(sibling_evidence.1, Some(0));
+    assert_eq!(sibling_evidence.2, None, "the sibling starts unarchived");
+    assert_eq!(
+        sibling_evidence.3.as_deref(),
+        Some("thread-unix-123"),
+        "the sibling shares the stable conversation group"
+    );
+
+    // Native harness resume argv: Codex must be told to resume its native
+    // thread id, proving the fallback resolved the same conversation group.
+    assert!(
+        fs::read_to_string(project_root.join("args.txt"))
+            .expect("fake codex should record resumed argv")
+            .contains("resume\nthread-unix-123\n"),
+        "Codex must resume its native thread id via the conversation-key path"
+    );
+}
+
 /// A Codex protocol failure is a failed Coven run even when the Codex wrapper
 /// exits 0. The terminal CLI status and persisted ledger must agree so clients
 /// never see a failed turn recorded as a successful process exit.


### PR DESCRIPTION
Closes #641.

Adds the three coverage cases the O1.1 conformance plan merged without. Test/fixture-only — no production behavior change.

- **Stable-key continuation:** end-to-end resume keyed by the stable conversation key (not the ledger id), asserting sibling correlation + native harness resume arguments.
- **Descendant reaping:** the malformed-stream fixture now spawns a long-lived descendant and asserts both the direct child *and* the descendant are reaped after protocol failure.
- **Signal-mask restore:** deterministic post-finish assertion that the calling thread's signal mask is restored to its pre-install value.

## Readiness
- secret scan — clean.
- Red-before-green was established per gap via temporary break-revert probes (kill(pid) vs kill(-pid); no-op restore; ledger-only fallback); CI runs the full `cargo test --workspace --locked`. Reviewers may re-run the probes to independently confirm.
- Branch based on `origin/main` (`f3d9585`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
