### PR TITLE
docs: name coven-docs the canonical public documentation source (#659)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Launch, observe, attach, and coordinate agent work through one neutral runtime s
 | 🌐 **Ecosystem**                                      | 💬 **Community**                            | 🛠️ **Development**                                             |
 | :---------------------------------------------------- | :------------------------------------------ | :------------------------------------------------------------- |
 | [**Website**](https://opencoven.ai/)                  | [**Discord**](https://discord.gg/opencoven) | [**GitHub Issues**](https://github.com/OpenCoven/coven/issues) |
-| [**Documentation**](https://docs.opencoven.ai/)       | [**X (\@OpenCvn)**](https://x.com/OpenCvn)  | [**Public Roadmap**](docs/ROADMAP.md)                          |
+| [**Documentation**](https://docs.opencoven.ai/)       | [**X (\@OpenCvn)**](https://x.com/OpenCvn)  | [**Public Roadmap**](https://docs.opencoven.ai/roadmap)        |
 | [**Submit Feedback**](https://feedback.opencoven.ai/) |                                             | [**Contributing**](CONTRIBUTING.md)                            |
 
 ---
@@ -419,7 +419,7 @@ coven/
 ├── crates/
 │   ├── coven-cli/              # Main Rust binary — the `coven` command
 │   └── coven-relay/            # Internal relay crate
-├── docs/                       # Full documentation suite (see Documentation section)
+├── docs/                       # Code-adjacent docs (canonical public suite: docs.opencoven.ai)
 ├── npm/                        # npm wrapper package source for @opencoven/cli
 ├── packages/
 │   └── openclaw-coven/         # External OpenClaw bridge plugin (@opencoven/coven)
@@ -441,7 +441,7 @@ coven/
 - **`crates/coven-cli`** — Everything that becomes the `coven` binary. This is where daemon, PTY adapter, session store, local IPC API, and CLI surface live in Rust.
 - **`packages/openclaw-coven`** — The opt-in bridge between OpenClaw and Coven. Lives here (not in OpenClaw core) to keep the trust boundary clean. Published as `@opencoven/coven`.
 - **`scripts/check-secrets.py`** — Required pre-release and pre-PR scan. Run it before pushing to avoid leaking credentials into git history.
-- **`docs/`** — The canonical documentation suite. All product docs, architecture, API contract, safety model, and roadmap live here.
+- **`docs/`** — Code-adjacent documentation kept beside the source it describes (normative contracts, plans/specs, repo policy, and command-adjacent reference). The canonical public documentation suite lives at [docs.opencoven.ai](https://docs.opencoven.ai/) (source: [OpenCoven/coven-docs](https://github.com/OpenCoven/coven-docs)).
 
 ---
 
@@ -509,6 +509,13 @@ comux is a standalone terminal cockpit that proved the tmux-cockpit model for pa
 ---
 
 ## Documentation
+
+The canonical public documentation suite lives at
+[docs.opencoven.ai](https://docs.opencoven.ai/) (source:
+[OpenCoven/coven-docs](https://github.com/OpenCoven/coven-docs)). The pages
+below are code-adjacent docs kept in this repository beside the source they
+describe — normative contracts, plans/specs, repo policy, and
+command-adjacent reference.
 
 | Document                                                | What it covers                                                        |
 | ------------------------------------------------------- | --------------------------------------------------------------------- |
@@ -828,8 +835,8 @@ MIT © Valentina Alexander and the OpenCoven contributors — see [LICENSE](LICE
 | 💬 Discord              | [discord.gg/opencoven](https://discord.gg/opencoven)       |
 | 🐦 X / Twitter          | [@OpenCvn](https://x.com/OpenCvn)                          |
 | 🐛 Issues & Bug Reports | [GitHub Issues](https://github.com/OpenCoven/coven/issues) |
-| 📖 Documentation        | [`docs/` directory](docs/)                                 |
-| 🗺️ Public Roadmap       | [docs/ROADMAP.md](docs/ROADMAP.md)                         |
+| 📖 Documentation        | [docs.opencoven.ai](https://docs.opencoven.ai/)            |
+| 🗺️ Public Roadmap       | [docs.opencoven.ai/roadmap](https://docs.opencoven.ai/roadmap) |
 
 ---
 

--- a/docs/DOCS-MAINTENANCE.md
+++ b/docs/DOCS-MAINTENANCE.md
@@ -1,20 +1,26 @@
 ---
-title: "Coven documentation maintenance and public-docs rules"
-description: "Maintenance rules for the public Coven docs: safe examples, canonical names, what to keep private, when to update pages, and how to handle stale content."
+title: "Coven documentation maintenance and code-adjacent docs rules"
+description: "Maintenance rules for the code-adjacent Coven docs in this repository: what stays here vs. the canonical coven-docs site, safe examples, canonical names, what to keep private, when to update pages, and how to handle stale content."
 ---
 
 # Documentation Maintenance
 
-These rules keep the public docs useful, accurate, and free of private material.
+These rules keep the docs in this repository useful, accurate, and free of private material.
 
-## Public docs stance
+## Canonical source vs. code-adjacent docs
 
-Docs in this repository are public product docs. They should describe OpenCoven and Coven without depending on private workspaces, private chats, private infrastructure, or unreleased assumptions.
+The **canonical public documentation suite** is [coven-docs](https://github.com/OpenCoven/coven-docs), published at [docs.opencoven.ai](https://docs.opencoven.ai/). Public product guides, concepts, and reference belong there.
+
+Docs in this repository are **code-adjacent**: they are kept beside the source they describe so they can change in lockstep with it. That includes normative contracts (`API-CONTRACT.md`, `ENGINE-CONTRACT.md`, `reference/api-contract.md`), repo policy, plans/specs (`superpowers/plans/`, `superpowers/specs/`), package-adjacent reference, and this maintenance guide. Do not describe the local `docs/` tree as the canonical public documentation suite.
+
+When public product content is migrated to coven-docs, replace the local page with a link to the canonical site — but do not remove a local page until the equivalent content exists canonically upstream.
+
+Whether a doc lives here or in coven-docs, it must describe OpenCoven and Coven without depending on private workspaces, private chats, private infrastructure, or unreleased assumptions.
 
 Use examples that are safe to publish:
 
 - `/path/to/project`
-- `/Users/example/.coven/coven.sock`
+- `~/.coven/coven.sock`
 - `session-1`
 - `intent-1`
 - `https://github.com/OpenCoven/coven`

--- a/scripts/canonical-docs-ownership-test.mjs
+++ b/scripts/canonical-docs-ownership-test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+// Issue #659: coven-docs (https://docs.opencoven.ai/) is the canonical public
+// documentation source. The coven repository must NOT call its own local
+// `docs/` tree "the canonical documentation suite". Its ownership/maintenance
+// prose must point at the canonical site and reframe local docs/ as
+// code-adjacent (kept beside code), not the public canonical suite.
+//
+// Constraint from the issue: do NOT remove local docs until content exists
+// canonically upstream. So these tests only assert prose/ownership framing,
+// never the removal of any local doc path (those remain asserted by
+// cli-docs-test.mjs and onboarding-docs-test.mjs).
+
+const CANONICAL_URL = 'https://docs.opencoven.ai';
+
+function readRepoFile(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+test('README no longer calls its local docs/ tree the canonical documentation suite', () => {
+  const readme = readRepoFile('README.md');
+
+  // The specific stale claim the issue targets (README "Key directories" bullet).
+  assert.doesNotMatch(
+    readme,
+    /The canonical documentation suite\. All product docs/,
+    'README must not describe the local docs/ tree as "The canonical documentation suite"',
+  );
+
+  // More generally: coven must not assert its own docs/ tree is *the* canonical
+  // public documentation suite anywhere.
+  assert.doesNotMatch(
+    readme,
+    /\bcanonical documentation suite\b/i,
+    'README must not claim any local docs/ tree is the canonical documentation suite',
+  );
+});
+
+test('README points to the canonical public docs site as canonical', () => {
+  const readme = readRepoFile('README.md');
+  assert.match(
+    readme,
+    new RegExp(CANONICAL_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    'README must link the canonical public documentation site',
+  );
+  // The Key directories entry for docs/ must reframe it as code-adjacent and
+  // reference the canonical site instead of claiming to be it.
+  assert.match(
+    readme,
+    /`docs\/`\*\*[\s\S]*?docs\.opencoven\.ai/,
+    'README docs/ directory entry must reference the canonical docs site (docs.opencoven.ai)',
+  );
+});
+
+test('DOCS-MAINTENANCE reframes local docs/ as code-adjacent, not the canonical public suite', () => {
+  const maint = readRepoFile('docs/DOCS-MAINTENANCE.md');
+
+  // Must name the canonical public source.
+  assert.match(
+    maint,
+    new RegExp(CANONICAL_URL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    'DOCS-MAINTENANCE must name the canonical public docs site',
+  );
+  assert.match(
+    maint,
+    /coven-docs/,
+    'DOCS-MAINTENANCE must name the coven-docs canonical repository',
+  );
+
+  // Must no longer flatly assert these are "public product docs" as the
+  // canonical public source; the canonical public source is coven-docs.
+  assert.doesNotMatch(
+    maint,
+    /^Docs in this repository are public product docs\.$/m,
+    'DOCS-MAINTENANCE must not assert local docs/ are the public product docs source',
+  );
+
+  // Must state code-adjacent framing.
+  assert.match(
+    maint,
+    /code-adjacent/i,
+    'DOCS-MAINTENANCE must describe local docs/ as code-adjacent',
+  );
+});
+
+test('README resources table roadmap link uses the canonical public docs site', () => {
+  const readme = readRepoFile('README.md');
+  // The resources table Public Roadmap entry must not point at a local
+  // docs/ROADMAP.md page while docs.opencoven.ai is the canonical site.
+  assert.doesNotMatch(
+    readme,
+    /\[\*\*Public Roadmap\*\*\]\(docs\/ROADMAP\.md\)/,
+    'Public Roadmap resource link must use the canonical docs site, not local docs/ROADMAP.md',
+  );
+});


### PR DESCRIPTION
Partially addresses #659 (non-destructive slice).

Reframes documentation ownership so `coven` no longer presents its `docs/` tree as the canonical public suite, without removing anything.

## Change
- `README.md` + `docs/DOCS-MAINTENANCE.md`: name `docs.opencoven.ai` (source `OpenCoven/coven-docs`) as the canonical public documentation; reframe the local `docs/` tree as code-adjacent (contracts / policy / plans / package docs); repoint a couple of public links.
- Adds `scripts/canonical-docs-ownership-test.mjs` asserting the ownership framing.
- **No local docs removed** → existing docs-path CI checks still pass.

## Deliberately NOT included (blocked — see the note on #659)
The upstream-first migration of the ~262 `docs/` files, the public-vs-keep-local per-file boundary, link replacement + local removals, and the lockstep updates to `scripts/cli-docs-test.mjs` / `scripts/onboarding-docs-test.mjs` all require the `coven-docs` repo (not available here) and a plan-owner boundary decision. This PR is the safe, self-contained first step.