### PR TITLE
fix: preserve handoff transcript prefixes

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2043,10 +2043,7 @@ fn emit_handoff(coven_home: &Path, session_id: &str, body: Option<&str>) -> Resu
         return session_not_live_response(session_id);
     }
     let workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
-    let event_cursor = store::list_events(&conn, session_id)?
-        .last()
-        .map(|event| event.seq)
-        .unwrap_or(0);
+    let event_cursor = store::latest_event_seq(&conn, session_id)?;
     let now = current_timestamp();
     let record = store::create_handoff(
         &mut conn,
@@ -2118,15 +2115,12 @@ fn claim_session_handoff(coven_home: &Path, path: &str, body: Option<&str>) -> R
     let source_workspace: WorkspaceSnapshot = serde_json::from_str(&handoff.workspace_json)
         .context("stored handoff workspace snapshot is invalid")?;
     let current_workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
-    let current_cursor = store::list_events(&conn, session_id)?
-        .last()
-        .map(|event| event.seq)
-        .unwrap_or(0);
-    if current_cursor != handoff.event_cursor {
+    let current_cursor = store::latest_event_seq(&conn, session_id)?;
+    if current_cursor < handoff.event_cursor {
         return api_error(
             409,
             "transcript_diverged",
-            "Source transcript changed after the handoff snapshot.",
+            "Source transcript no longer contains the handoff snapshot.",
             Some(
                 json!({ "handoffId": handoff_id, "expectedCursor": handoff.event_cursor, "actualCursor": current_cursor }),
             ),
@@ -2182,15 +2176,12 @@ fn acknowledge_session_handoff(
     if handoff.session_id != session_id {
         return api_error(404, "handoff_not_found", "Handoff was not found.", None);
     }
-    let current_cursor = store::list_events(&conn, session_id)?
-        .last()
-        .map(|event| event.seq)
-        .unwrap_or(0);
-    if current_cursor != handoff.event_cursor {
+    let current_cursor = store::latest_event_seq(&conn, session_id)?;
+    if current_cursor < handoff.event_cursor {
         return api_error(
             409,
             "transcript_diverged",
-            "Source transcript changed after the handoff snapshot.",
+            "Source transcript no longer contains the handoff snapshot.",
             Some(
                 json!({ "handoffId": handoff_id, "expectedCursor": handoff.event_cursor, "actualCursor": current_cursor }),
             ),
@@ -9349,13 +9340,19 @@ mod tests {
             Some(r#"{"data":"new source input"}"#),
         )?;
         assert_eq!(input.status, 202);
-        let transcript_conflict = handle_request_with_body(
+        let claimed = handle_request_with_body(
             "POST", &format!("/sessions/session-1/handoffs/{handoff_id}/claim"), temp.path(), None,
             Some(&json!({ "expectedGeneration": generation, "claimant": "device:phone-1", "idempotencyKey": "claim-1", "destinationWorkspace": workspace }).to_string()),
         )?;
-        assert_eq!(transcript_conflict.status, 409);
-        let body: Value = serde_json::from_str(&transcript_conflict.body)?;
-        assert_eq!(body["error"]["code"], "transcript_diverged");
+        assert_eq!(claimed.status, 200);
+        let acknowledged = handle_request_with_body(
+            "POST",
+            &format!("/sessions/session-1/handoffs/{handoff_id}/ack"),
+            temp.path(),
+            None,
+            Some(r#"{"claimant":"device:phone-1"}"#),
+        )?;
+        assert_eq!(acknowledged.status, 200);
 
         let fresh = handle_request_with_body(
             "POST",

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2043,23 +2043,21 @@ fn emit_handoff(coven_home: &Path, session_id: &str, body: Option<&str>) -> Resu
         return session_not_live_response(session_id);
     }
     let workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
-    let event_cursor = store::latest_event_seq(&conn, session_id)?;
     let now = current_timestamp();
     let record = store::create_handoff(
         &mut conn,
         &format!("handoff_{}", Uuid::new_v4()),
         session_id,
         &serde_json::to_string(&packet)?,
-        event_cursor,
         &serde_json::to_string(&workspace)?,
         &now,
     )?;
     json_response(
         201,
         &json!({
+            "eventCursor": record.event_cursor,
             "handoff": record,
             "packet": packet,
-            "eventCursor": event_cursor,
             "workspace": workspace,
         }),
     )

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2115,17 +2115,6 @@ fn claim_session_handoff(coven_home: &Path, path: &str, body: Option<&str>) -> R
     let source_workspace: WorkspaceSnapshot = serde_json::from_str(&handoff.workspace_json)
         .context("stored handoff workspace snapshot is invalid")?;
     let current_workspace = WorkspaceSnapshot::capture(Path::new(&session.project_root));
-    let current_cursor = store::latest_event_seq(&conn, session_id)?;
-    if current_cursor < handoff.event_cursor {
-        return api_error(
-            409,
-            "transcript_diverged",
-            "Source transcript no longer contains the handoff snapshot.",
-            Some(
-                json!({ "handoffId": handoff_id, "expectedCursor": handoff.event_cursor, "actualCursor": current_cursor }),
-            ),
-        );
-    }
     if !source_workspace.compatible_with(&current_workspace)
         || !source_workspace.compatible_with(&request.destination_workspace)
     {
@@ -2176,22 +2165,10 @@ fn acknowledge_session_handoff(
     if handoff.session_id != session_id {
         return api_error(404, "handoff_not_found", "Handoff was not found.", None);
     }
-    let current_cursor = store::latest_event_seq(&conn, session_id)?;
-    if current_cursor < handoff.event_cursor {
-        return api_error(
-            409,
-            "transcript_diverged",
-            "Source transcript no longer contains the handoff snapshot.",
-            Some(
-                json!({ "handoffId": handoff_id, "expectedCursor": handoff.event_cursor, "actualCursor": current_cursor }),
-            ),
-        );
-    }
     let acknowledged = match store::acknowledge_handoff(
         &mut conn,
         handoff_id,
         &request.claimant,
-        current_cursor,
         &current_timestamp(),
     ) {
         Ok(record) => record,
@@ -9332,6 +9309,14 @@ mod tests {
         let offered: Value = serde_json::from_str(&offered.body)?;
         let handoff_id = offered["handoff"]["id"].as_str().unwrap();
         let generation = offered["handoff"]["generation"].as_i64().unwrap();
+        let conn = crate::store::open_store(&temp.path().join("coven.sqlite3"))?;
+        crate::store::insert_json_event(
+            &conn,
+            "session-1",
+            "output",
+            &json!({ "data": "new source output" }),
+            "2026-08-04T00:00:01Z",
+        )?;
         let input = handle_request_with_body(
             "POST",
             "/sessions/session-1/input",

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3070,6 +3070,16 @@ pub fn claim_handoff(
         [handoff_id],
         handoff_record_from_row,
     )?;
+    let actual_cursor: i64 = transaction
+        .query_row(
+            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+            [&current.session_id],
+            |row| row.get(0),
+        )
+        .context("failed to read latest event sequence")?;
+    if actual_cursor < current.event_cursor {
+        bail!("transcript_diverged");
+    }
     if current.generation != expected_generation {
         bail!("stale_generation");
     }
@@ -3109,7 +3119,6 @@ pub fn acknowledge_handoff(
     conn: &mut Connection,
     handoff_id: &str,
     claimant: &str,
-    event_cursor: i64,
     now: &str,
 ) -> Result<HandoffRecord> {
     let transaction = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
@@ -3118,11 +3127,18 @@ pub fn acknowledge_handoff(
         [handoff_id],
         handoff_record_from_row,
     )?;
+    let actual_cursor: i64 = transaction
+        .query_row(
+            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+            [&current.session_id],
+            |row| row.get(0),
+        )
+        .context("failed to read latest event sequence")?;
+    if actual_cursor < current.event_cursor {
+        bail!("transcript_diverged");
+    }
     if current.claimant.as_deref() != Some(claimant) {
         bail!("claimant_mismatch");
-    }
-    if event_cursor < current.event_cursor {
-        bail!("transcript_diverged");
     }
     match current.state.as_str() {
         "acknowledged" => {
@@ -3439,8 +3455,19 @@ pub fn prune_sensitive_artifacts(
 }
 
 pub fn prune_events_older_than(conn: &Connection, cutoff: &str) -> Result<usize> {
-    conn.execute("DELETE FROM events WHERE created_at < ?1", params![cutoff])
-        .context("failed to prune events")
+    conn.execute(
+        "DELETE FROM events AS event
+         WHERE event.created_at < ?1
+           AND NOT EXISTS (
+               SELECT 1
+               FROM session_handoffs AS handoff
+               WHERE handoff.session_id = event.session_id
+                 AND handoff.state IN ('offered', 'claimed')
+                 AND event.rowid <= handoff.event_cursor
+           )",
+        params![cutoff],
+    )
+    .context("failed to prune events")
 }
 
 /// Delete at most one maintenance batch of expired events in a single
@@ -3457,11 +3484,18 @@ pub fn prune_events_older_than_bounded(
         .context("failed to start bounded event-prune transaction")?;
     let pruned = tx
         .execute(
-            "DELETE FROM events
-             WHERE rowid IN (
-                SELECT rowid FROM events
-                WHERE created_at < ?1
-                ORDER BY created_at, rowid
+            "DELETE FROM events AS event
+             WHERE event.rowid IN (
+                SELECT candidate.rowid FROM events AS candidate
+                WHERE candidate.created_at < ?1
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM session_handoffs AS handoff
+                      WHERE handoff.session_id = candidate.session_id
+                        AND handoff.state IN ('offered', 'claimed')
+                        AND candidate.rowid <= handoff.event_cursor
+                  )
+                ORDER BY candidate.created_at, candidate.rowid
                 LIMIT ?2
              )",
             params![cutoff, limit.max(1)],
@@ -6301,14 +6335,33 @@ mod tests {
     }
 
     #[test]
-    fn acknowledge_handoff_rejects_cursor_before_snapshot_and_accepts_append_only_cursor(
-    ) -> Result<()> {
+    fn unresolved_handoff_events_are_not_pruned() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let mut conn = open_store(&temp_dir.path().join("coven.db"))?;
         let now = "2026-04-27T06:00:00Z";
+        let cutoff = "2026-04-15T00:00:00Z";
         insert_session(&conn, &session_record("session-1", now))?;
+        insert_json_event(
+            &conn,
+            "session-1",
+            "output",
+            &serde_json::json!({ "data": "old handoff event" }),
+            "2026-04-01T00:00:00Z",
+        )?;
+        let event_cursor = latest_event_seq(&conn, "session-1")?;
 
-        let offered = create_handoff(&mut conn, "handoff-1", "session-1", "{}", 3, "{}", now)?;
+        let offered = create_handoff(
+            &mut conn,
+            "handoff-1",
+            "session-1",
+            "{}",
+            event_cursor,
+            "{}",
+            now,
+        )?;
+        assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
+        assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 1)?, 0);
+
         claim_handoff(
             &mut conn,
             &offered.id,
@@ -6317,13 +6370,80 @@ mod tests {
             "claim-1",
             now,
         )?;
+        assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
+        assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 1)?, 0);
 
-        let error = acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", 2, now)
-            .expect_err("cursor before handoff snapshot must be rejected");
+        acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", now)?;
+        assert_eq!(prune_events_older_than(&conn, cutoff)?, 1);
+        assert!(list_events(&conn, "session-1")?.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn handoff_transition_rejects_missing_cursor() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let mut conn = open_store(&temp_dir.path().join("coven.db"))?;
+        let now = "2026-04-27T06:00:00Z";
+        insert_session(&conn, &session_record("session-1", now))?;
+        insert_json_event(
+            &conn,
+            "session-1",
+            "output",
+            &serde_json::json!({ "data": "handoff event" }),
+            now,
+        )?;
+        let event_cursor = latest_event_seq(&conn, "session-1")?;
+
+        let invalid_offered = create_handoff(
+            &mut conn,
+            "handoff-missing",
+            "session-1",
+            "{}",
+            event_cursor + 1,
+            "{}",
+            now,
+        )?;
+        let error = claim_handoff(
+            &mut conn,
+            &invalid_offered.id,
+            invalid_offered.generation,
+            "device:phone-1",
+            "claim-1",
+            now,
+        )
+        .expect_err("claim must reject a missing handoff cursor");
         assert_eq!(error.to_string(), "transcript_diverged");
+        assert_eq!(
+            get_handoff(&conn, &invalid_offered.id)?.unwrap().state,
+            "offered"
+        );
 
-        let acknowledged = acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", 4, now)?;
-        assert_eq!(acknowledged.state, "acknowledged");
+        let claimed_offered = create_handoff(
+            &mut conn,
+            "handoff-claimed",
+            "session-1",
+            "{}",
+            event_cursor,
+            "{}",
+            now,
+        )?;
+        claim_handoff(
+            &mut conn,
+            &claimed_offered.id,
+            claimed_offered.generation,
+            "device:phone-1",
+            "claim-2",
+            now,
+        )?;
+        conn.execute("DELETE FROM events WHERE rowid = ?1", [event_cursor])?;
+
+        let error = acknowledge_handoff(&mut conn, &claimed_offered.id, "device:phone-1", now)
+            .expect_err("acknowledgement must reject a removed handoff cursor");
+        assert_eq!(error.to_string(), "transcript_diverged");
+        assert_eq!(
+            get_handoff(&conn, &claimed_offered.id)?.unwrap().state,
+            "claimed"
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -46,6 +46,12 @@ const BOUNDED_PRUNE_SENSITIVE_ARTIFACTS_BY_CREATED_AT_SQL: &str = "DELETE FROM s
         ORDER BY created_at, rowid
         LIMIT ?2
      )";
+const EVENT_NOT_PINNED_BY_UNRESOLVED_HANDOFF_SQL: &str = "NOT EXISTS (
+  SELECT 1 FROM session_handoffs AS handoff
+  WHERE handoff.session_id = event.session_id
+    AND handoff.state IN ('offered', 'claimed')
+    AND event.rowid <= handoff.event_cursor
+)";
 pub const DEFAULT_SESSION_PAGE_LIMIT: usize = 100;
 pub const MAX_SESSION_PAGE_LIMIT: usize = 1_000;
 
@@ -2999,13 +3005,17 @@ pub fn create_handoff(
     id: &str,
     session_id: &str,
     packet_json: &str,
-    event_cursor: i64,
     workspace_json: &str,
     now: &str,
 ) -> Result<HandoffRecord> {
     let transaction = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
     let generation: i64 = transaction.query_row(
         "SELECT COALESCE(MAX(generation), 0) + 1 FROM session_handoffs WHERE session_id = ?1",
+        [session_id],
+        |row| row.get(0),
+    )?;
+    let event_cursor: i64 = transaction.query_row(
+        "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
         [session_id],
         |row| row.get(0),
     )?;
@@ -3256,6 +3266,7 @@ pub fn list_events(conn: &Connection, session_id: &str) -> Result<Vec<EventRecor
     list_events_with_options(conn, session_id, &EventsQueryOptions::default())
 }
 
+#[cfg(test)]
 pub fn latest_event_seq(conn: &Connection, session_id: &str) -> Result<i64> {
     conn.query_row(
         "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
@@ -3435,7 +3446,11 @@ pub fn count_prunable_sensitive_artifacts(
 
 pub fn count_events_older_than(conn: &Connection, cutoff: &str) -> Result<i64> {
     conn.query_row(
-        "SELECT COUNT(*) FROM events WHERE created_at < ?1",
+        &format!(
+            "SELECT COUNT(*) FROM events AS event
+             WHERE event.created_at < ?1
+               AND {EVENT_NOT_PINNED_BY_UNRESOLVED_HANDOFF_SQL}"
+        ),
         params![cutoff],
         |row| row.get(0),
     )
@@ -3456,15 +3471,11 @@ pub fn prune_sensitive_artifacts(
 
 pub fn prune_events_older_than(conn: &Connection, cutoff: &str) -> Result<usize> {
     conn.execute(
-        "DELETE FROM events AS event
-         WHERE event.created_at < ?1
-           AND NOT EXISTS (
-               SELECT 1
-               FROM session_handoffs AS handoff
-               WHERE handoff.session_id = event.session_id
-                 AND handoff.state IN ('offered', 'claimed')
-                 AND event.rowid <= handoff.event_cursor
-           )",
+        &format!(
+            "DELETE FROM events AS event
+             WHERE event.created_at < ?1
+               AND {EVENT_NOT_PINNED_BY_UNRESOLVED_HANDOFF_SQL}"
+        ),
         params![cutoff],
     )
     .context("failed to prune events")
@@ -3484,20 +3495,16 @@ pub fn prune_events_older_than_bounded(
         .context("failed to start bounded event-prune transaction")?;
     let pruned = tx
         .execute(
-            "DELETE FROM events AS event
-             WHERE event.rowid IN (
-                SELECT candidate.rowid FROM events AS candidate
-                WHERE candidate.created_at < ?1
-                  AND NOT EXISTS (
-                      SELECT 1
-                      FROM session_handoffs AS handoff
-                      WHERE handoff.session_id = candidate.session_id
-                        AND handoff.state IN ('offered', 'claimed')
-                        AND candidate.rowid <= handoff.event_cursor
-                  )
-                ORDER BY candidate.created_at, candidate.rowid
-                LIMIT ?2
-             )",
+            &format!(
+                "DELETE FROM events AS event
+                 WHERE event.rowid IN (
+                    SELECT event.rowid FROM events AS event
+                    WHERE event.created_at < ?1
+                      AND {EVENT_NOT_PINNED_BY_UNRESOLVED_HANDOFF_SQL}
+                    ORDER BY event.created_at, event.rowid
+                    LIMIT ?2
+                 )"
+            ),
             params![cutoff, limit.max(1)],
         )
         .context("failed to prune bounded event batch")?;
@@ -6348,17 +6355,9 @@ mod tests {
             &serde_json::json!({ "data": "old handoff event" }),
             "2026-04-01T00:00:00Z",
         )?;
-        let event_cursor = latest_event_seq(&conn, "session-1")?;
-
-        let offered = create_handoff(
-            &mut conn,
-            "handoff-1",
-            "session-1",
-            "{}",
-            event_cursor,
-            "{}",
-            now,
-        )?;
+        let offered = create_handoff(&mut conn, "handoff-1", "session-1", "{}", "{}", now)?;
+        assert_eq!(offered.event_cursor, latest_event_seq(&conn, "session-1")?);
+        assert_eq!(count_events_older_than(&conn, cutoff)?, 0);
         assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
         assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 1)?, 0);
 
@@ -6370,10 +6369,12 @@ mod tests {
             "claim-1",
             now,
         )?;
+        assert_eq!(count_events_older_than(&conn, cutoff)?, 0);
         assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
         assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 1)?, 0);
 
         acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", now)?;
+        assert_eq!(count_events_older_than(&conn, cutoff)?, 1);
         assert_eq!(prune_events_older_than(&conn, cutoff)?, 1);
         assert!(list_events(&conn, "session-1")?.is_empty());
         Ok(())
@@ -6392,16 +6393,12 @@ mod tests {
             &serde_json::json!({ "data": "handoff event" }),
             now,
         )?;
-        let event_cursor = latest_event_seq(&conn, "session-1")?;
-
-        let invalid_offered = create_handoff(
-            &mut conn,
-            "handoff-missing",
-            "session-1",
-            "{}",
-            event_cursor + 1,
-            "{}",
-            now,
+        let invalid_offered =
+            create_handoff(&mut conn, "handoff-missing", "session-1", "{}", "{}", now)?;
+        let latest_cursor = latest_event_seq(&conn, "session-1")?;
+        conn.execute(
+            "UPDATE session_handoffs SET event_cursor = ?2 WHERE id = ?1",
+            params![invalid_offered.id, latest_cursor + 1],
         )?;
         let error = claim_handoff(
             &mut conn,
@@ -6418,15 +6415,8 @@ mod tests {
             "offered"
         );
 
-        let claimed_offered = create_handoff(
-            &mut conn,
-            "handoff-claimed",
-            "session-1",
-            "{}",
-            event_cursor,
-            "{}",
-            now,
-        )?;
+        let claimed_offered =
+            create_handoff(&mut conn, "handoff-claimed", "session-1", "{}", "{}", now)?;
         claim_handoff(
             &mut conn,
             &claimed_offered.id,
@@ -6435,7 +6425,10 @@ mod tests {
             "claim-2",
             now,
         )?;
-        conn.execute("DELETE FROM events WHERE rowid = ?1", [event_cursor])?;
+        conn.execute(
+            "DELETE FROM events WHERE rowid = ?1",
+            [claimed_offered.event_cursor],
+        )?;
 
         let error = acknowledge_handoff(&mut conn, &claimed_offered.id, "device:phone-1", now)
             .expect_err("acknowledgement must reject a removed handoff cursor");

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3080,16 +3080,6 @@ pub fn claim_handoff(
         [handoff_id],
         handoff_record_from_row,
     )?;
-    let actual_cursor: i64 = transaction
-        .query_row(
-            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
-            [&current.session_id],
-            |row| row.get(0),
-        )
-        .context("failed to read latest event sequence")?;
-    if actual_cursor < current.event_cursor {
-        bail!("transcript_diverged");
-    }
     if current.generation != expected_generation {
         bail!("stale_generation");
     }
@@ -3101,6 +3091,16 @@ pub fn claim_handoff(
             return Ok(current);
         }
         bail!("handoff_already_claimed");
+    }
+    let actual_cursor: i64 = transaction
+        .query_row(
+            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+            [&current.session_id],
+            |row| row.get(0),
+        )
+        .context("failed to read latest event sequence")?;
+    if actual_cursor < current.event_cursor {
+        bail!("transcript_diverged");
     }
     let input_in_flight: bool = transaction.query_row(
         "SELECT EXISTS(SELECT 1 FROM session_input_leases WHERE session_id = ?1)",
@@ -3137,16 +3137,6 @@ pub fn acknowledge_handoff(
         [handoff_id],
         handoff_record_from_row,
     )?;
-    let actual_cursor: i64 = transaction
-        .query_row(
-            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
-            [&current.session_id],
-            |row| row.get(0),
-        )
-        .context("failed to read latest event sequence")?;
-    if actual_cursor < current.event_cursor {
-        bail!("transcript_diverged");
-    }
     if current.claimant.as_deref() != Some(claimant) {
         bail!("claimant_mismatch");
     }
@@ -3157,6 +3147,16 @@ pub fn acknowledge_handoff(
         }
         "claimed" => {}
         _ => bail!("handoff_not_claimed"),
+    }
+    let actual_cursor: i64 = transaction
+        .query_row(
+            "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+            [&current.session_id],
+            |row| row.get(0),
+        )
+        .context("failed to read latest event sequence")?;
+    if actual_cursor < current.event_cursor {
+        bail!("transcript_diverged");
     }
     transaction.execute(
         "UPDATE session_handoffs SET state = 'acknowledged', updated_at = ?2 WHERE id = ?1",
@@ -6373,10 +6373,26 @@ mod tests {
         assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
         assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 1)?, 0);
 
-        acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", now)?;
+        let acknowledged = acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", now)?;
         assert_eq!(count_events_older_than(&conn, cutoff)?, 1);
         assert_eq!(prune_events_older_than(&conn, cutoff)?, 1);
         assert!(list_events(&conn, "session-1")?.is_empty());
+
+        assert_eq!(
+            acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", now)?,
+            acknowledged
+        );
+        assert_eq!(
+            claim_handoff(
+                &mut conn,
+                &offered.id,
+                offered.generation,
+                "device:phone-1",
+                "claim-1",
+                now,
+            )?,
+            acknowledged
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3121,7 +3121,7 @@ pub fn acknowledge_handoff(
     if current.claimant.as_deref() != Some(claimant) {
         bail!("claimant_mismatch");
     }
-    if current.event_cursor != event_cursor {
+    if event_cursor < current.event_cursor {
         bail!("transcript_diverged");
     }
     match current.state.as_str() {
@@ -6297,6 +6297,33 @@ mod tests {
             latest_event_seq(&conn, "session-1")?,
             list_events(&conn, "session-1")?[2].seq
         );
+        Ok(())
+    }
+
+    #[test]
+    fn acknowledge_handoff_rejects_cursor_before_snapshot_and_accepts_append_only_cursor(
+    ) -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let mut conn = open_store(&temp_dir.path().join("coven.db"))?;
+        let now = "2026-04-27T06:00:00Z";
+        insert_session(&conn, &session_record("session-1", now))?;
+
+        let offered = create_handoff(&mut conn, "handoff-1", "session-1", "{}", 3, "{}", now)?;
+        claim_handoff(
+            &mut conn,
+            &offered.id,
+            offered.generation,
+            "device:phone-1",
+            "claim-1",
+            now,
+        )?;
+
+        let error = acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", 2, now)
+            .expect_err("cursor before handoff snapshot must be rejected");
+        assert_eq!(error.to_string(), "transcript_diverged");
+
+        let acknowledged = acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", 4, now)?;
+        assert_eq!(acknowledged.state, "acknowledged");
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -3240,6 +3240,15 @@ pub fn list_events(conn: &Connection, session_id: &str) -> Result<Vec<EventRecor
     list_events_with_options(conn, session_id, &EventsQueryOptions::default())
 }
 
+pub fn latest_event_seq(conn: &Connection, session_id: &str) -> Result<i64> {
+    conn.query_row(
+        "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+        [session_id],
+        |row| row.get(0),
+    )
+    .context("failed to read latest event sequence")
+}
+
 pub fn event_kind_exists(conn: &Connection, session_id: &str, kind: &str) -> Result<bool> {
     use rusqlite::OptionalExtension;
 
@@ -6263,6 +6272,31 @@ mod tests {
         assert!(events[0].seq > 0);
         assert!(events[1].seq > events[0].seq);
         assert!(events[2].seq > events[1].seq);
+        Ok(())
+    }
+
+    #[test]
+    fn latest_event_seq_returns_zero_for_empty_and_last_rowid_for_session() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = open_store(&temp_dir.path().join("coven.db"))?;
+        insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+
+        assert_eq!(latest_event_seq(&conn, "session-1")?, 0);
+
+        for i in 1..=3 {
+            insert_json_event(
+                &conn,
+                "session-1",
+                "output",
+                &serde_json::json!({ "data": format!("line {i}") }),
+                "2026-04-27T06:01:00Z",
+            )?;
+        }
+
+        assert_eq!(
+            latest_event_seq(&conn, "session-1")?,
+            list_events(&conn, "session-1")?[2].seq
+        );
         Ok(())
     }
 

--- a/docs/superpowers/plans/2026-08-06-session-handoff-cursor.md
+++ b/docs/superpowers/plans/2026-08-06-session-handoff-cursor.md
@@ -1,0 +1,228 @@
+# Session Handoff Cursor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make live-session handoffs scalable and claimable after append-only source transcript growth.
+
+**Architecture:** The SQLite store owns the current event cursor through a scalar `MAX(rowid)` query. API claim and acknowledgement treat the offered cursor as a transcript prefix: later events are safe, while a cursor lower than the offer remains a divergence. The transactional store acknowledgement repeats that lower-bound guard.
+
+**Tech Stack:** Rust, rusqlite, existing `coven-cli` API and store unit tests.
+
+---
+
+### Task 1: Add scalar event-cursor storage
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs:2959-2977, 6246-6267`
+
+- [ ] **Step 1: Write the failing cursor test**
+
+Add this test next to `events_have_monotonic_seq_fields`:
+
+```rust
+#[test]
+fn latest_event_seq_returns_zero_for_empty_and_last_rowid_for_session() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let conn = open_store(&temp_dir.path().join("coven.db"))?;
+    insert_session(&conn, &session_record("session-1", "2026-04-27T06:00:00Z"))?;
+    assert_eq!(latest_event_seq(&conn, "session-1")?, 0);
+
+    for i in 1..=3 {
+        insert_json_event(
+            &conn,
+            "session-1",
+            "output",
+            &serde_json::json!({ "data": format!("line {i}") }),
+            "2026-04-27T06:01:00Z",
+        )?;
+    }
+    assert_eq!(latest_event_seq(&conn, "session-1")?, list_events(&conn, "session-1")?[2].seq);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run: `cargo test -p coven-cli latest_event_seq_returns_zero_for_empty_and_last_rowid_for_session --locked`
+
+Expected: FAIL because `latest_event_seq` does not exist.
+
+- [ ] **Step 3: Implement the scalar helper**
+
+Add beside `list_events`:
+
+```rust
+pub fn latest_event_seq(conn: &Connection, session_id: &str) -> Result<i64> {
+    conn.query_row(
+        "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+        [session_id],
+        |row| row.get(0),
+    )
+    .context("failed to read latest event sequence")
+}
+```
+
+Do not add a cache or load `payload_json`; `list_events_with_options` remains
+the API for callers that actually need event records.
+
+- [ ] **Step 4: Run the focused store test**
+
+Run: `cargo test -p coven-cli latest_event_seq_returns_zero_for_empty_and_last_rowid_for_session --locked`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the store helper**
+
+```bash
+git add crates/coven-cli/src/store.rs
+git commit -s -m "fix: query handoff event cursors directly"
+```
+
+### Task 2: Permit append-only handoff transcript growth
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs:2038-2049, 2119-2135, 2183-2199, 9332-9358`
+- Modify: `crates/coven-cli/src/store.rs:3108-3125`
+
+- [ ] **Step 1: Replace the failing API expectation**
+
+In `handoff_claim_fails_closed_when_transcript_or_workspace_diverges`, replace
+the `transcript_conflict` assertion after the accepted input with a successful
+claim and acknowledgement:
+
+```rust
+assert_eq!(claimed.status, 200);
+let acknowledged = handle_request_with_body(
+    "POST",
+    &format!("/sessions/session-1/handoffs/{handoff_id}/ack"),
+    temp.path(),
+    None,
+    Some(r#"{"claimant":"device:phone-1"}"#),
+)?;
+assert_eq!(acknowledged.status, 200);
+```
+
+Keep the later wrong-workspace assertion, but emit a new handoff only after
+the first handoff is acknowledged.
+
+- [ ] **Step 2: Add a lower-cursor store guard test**
+
+Add a store test that creates a handoff with `event_cursor: 3`, claims it, then
+calls `acknowledge_handoff(..., 2, ...)` and asserts the error string is
+`transcript_diverged`. Call it again with `4` and assert the record reaches
+`acknowledged`.
+
+- [ ] **Step 3: Run the altered tests and verify current behavior fails**
+
+Run:
+
+```bash
+cargo test -p coven-cli handoff_claim_fails_closed_when_transcript_or_workspace_diverges --locked
+cargo test -p coven-cli acknowledge_handoff --locked
+```
+
+Expected: the API test fails with HTTP 409 after the appended input and the
+store test fails with `transcript_diverged` for cursor `4`.
+
+- [ ] **Step 4: Implement prefix semantics and direct cursor reads**
+
+Replace all three `store::list_events(&conn, session_id)?.last()` expressions
+in `emit_handoff`, `claim_session_handoff`, and
+`acknowledge_session_handoff` with:
+
+```rust
+let event_cursor = store::latest_event_seq(&conn, session_id)?;
+```
+
+In both API checks, reject only a truncated cursor:
+
+```rust
+if current_cursor < handoff.event_cursor {
+    return api_error(
+        409,
+        "transcript_diverged",
+        "Source transcript no longer contains the handoff snapshot.",
+        Some(json!({
+            "handoffId": handoff_id,
+            "expectedCursor": handoff.event_cursor,
+            "actualCursor": current_cursor,
+        })),
+    );
+}
+```
+
+In `store::acknowledge_handoff`, replace the equality guard with:
+
+```rust
+if event_cursor < current.event_cursor {
+    bail!("transcript_diverged");
+}
+```
+
+Do not weaken workspace compatibility, generation, claimant, state, or input
+lease checks.
+
+- [ ] **Step 5: Run focused regression coverage**
+
+Run:
+
+```bash
+cargo test -p coven-cli handoff_claim_fails_closed_when_transcript_or_workspace_diverges --locked
+cargo test -p coven-cli handoff_claim_acknowledgement_import_fences_source_and_is_idempotent --locked
+cargo test -p coven-cli acknowledge_handoff --locked
+```
+
+Expected: PASS; a later source event permits claim and acknowledgement, while
+a lower cursor and the existing workspace conflict still fail closed.
+
+- [ ] **Step 6: Commit handoff semantics**
+
+```bash
+git add crates/coven-cli/src/api.rs crates/coven-cli/src/store.rs
+git commit -s -m "fix: preserve append-only handoff cursors"
+```
+
+### Task 3: Run the issue acceptance gates
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Format and lint the changed crate**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo clippy -p coven-cli --all-targets -- -D warnings
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 2: Run the complete affected test suite**
+
+Run: `cargo test -p coven-cli --locked`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repository hygiene gates**
+
+Run:
+
+```bash
+python scripts/check-secrets.py
+git add crates/coven-cli/src/api.rs crates/coven-cli/src/store.rs
+python3 scripts/check-coven-privacy.py --staged
+git diff --cached --check
+```
+
+Expected: every command exits 0.
+
+- [ ] **Step 4: Push and open the issue-linked pull request**
+
+```bash
+git push -u origin fix/613-handoff-cursors
+gh pr create --base main --title "fix: preserve append-only handoff cursors" \
+  --body "Fixes #613."
+```
+
+Expected: the PR references #613 and contains the two implementation commits.

--- a/docs/superpowers/plans/2026-08-06-session-handoff-cursor.md
+++ b/docs/superpowers/plans/2026-08-06-session-handoff-cursor.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make live-session handoffs scalable and claimable after append-only source transcript growth.
 
-**Architecture:** The SQLite store owns the current event cursor through a scalar `MAX(rowid)` query. Retention pins each unresolved handoff's source events through its offered cursor. The store reads and validates that cursor inside the existing `IMMEDIATE` transaction for claim and acknowledgement, so a successful state transition cannot race a pruning transaction.
+**Architecture:** The SQLite store owns the current event cursor through a scalar `MAX(rowid)` query. Offer creation reads that cursor and inserts its pin in one `IMMEDIATE` transaction. Retention and dry-run counting share one unresolved-handoff predicate, while claim and acknowledgement revalidate the cursor inside their own `IMMEDIATE` transaction.
 
 **Tech Stack:** Rust, rusqlite, existing `coven-cli` API and store unit tests.
 
@@ -91,8 +91,9 @@ after an offer must permit claim and acknowledgement. Add store tests with
 real event rows, not synthetic cursor values:
 
 ```rust
-let cursor = latest_event_seq(&conn, "session-1")?;
-let offered = create_handoff(&mut conn, "handoff-1", "session-1", "{}", cursor, "{}", now)?;
+let offered = create_handoff(&mut conn, "handoff-1", "session-1", "{}", "{}", now)?;
+assert_eq!(offered.event_cursor, latest_event_seq(&conn, "session-1")?);
+assert_eq!(count_events_older_than(&conn, cutoff)?, 0);
 assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
 claim_handoff(&mut conn, &offered.id, offered.generation, "device:phone-1", "claim-1", now)?;
 assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 10)?, 0);
@@ -101,10 +102,11 @@ assert_eq!(acknowledged.state, "acknowledged");
 assert_eq!(prune_events_older_than(&conn, cutoff)?, 1);
 ```
 
-Create a second offered handoff with an `event_cursor` greater than the actual
-latest sequence. Assert `claim_handoff` returns `transcript_diverged` without
-changing state. Claim a valid handoff, delete its cursor event directly in the
-test transaction, and assert `acknowledge_handoff` returns
+Create a second offered handoff, then set its stored `event_cursor` to one
+greater than the actual latest sequence with a direct test-only SQL update.
+Assert `claim_handoff` returns `transcript_diverged` without changing state.
+Claim a valid handoff, delete its cursor event directly in the test
+transaction, and assert `acknowledge_handoff` returns
 `transcript_diverged`. These tests prove the store—not an API preflight—is the
 transition authority.
 
@@ -119,17 +121,15 @@ cargo test -p coven-cli handoff_transition_rejects_missing_cursor --locked
 ```
 
 Expected: the append-only API test already passes; the new retention and
-transactional-guard tests fail because both pruning paths ignore handoffs and
-the store accepts a stale caller-derived cursor.
+transactional-guard tests fail because both pruning paths and dry-run counting
+ignore handoffs, and offer creation still accepts a caller-derived cursor.
 
-- [ ] **Step 3: Make retention respect unresolved handoff pins**
+- [ ] **Step 3: Centralize the unresolved-handoff pin predicate**
 
-In both `prune_events_older_than` and `prune_events_older_than_bounded`, only
-delete an expired event when no `offered` or `claimed` handoff for its session
-pins that row:
+Define one private SQL constant for an `events AS event` alias:
 
 ```sql
-AND NOT EXISTS (
+NOT EXISTS (
     SELECT 1
     FROM session_handoffs AS handoff
     WHERE handoff.session_id = event.session_id
@@ -138,17 +138,38 @@ AND NOT EXISTS (
 )
 ```
 
-Use an `events AS event` alias inside each pruning subquery. Keep the current
+Use this exact constant in `count_events_older_than`,
+`prune_events_older_than`, and the bounded prune subquery. Keep the current
 cutoff ordering, bounded batch limit, FTS trigger behavior, and transaction
-shape intact.
+shape intact. The count query must report zero for an expired event pinned by
+an `offered` or `claimed` handoff, then one after acknowledgement.
 
-- [ ] **Step 4: Move cursor validation into handoff transactions**
+- [ ] **Step 4: Atomically create and validate handoff cursors**
+
+Remove the `event_cursor` parameter from `create_handoff`. After it starts its
+existing `IMMEDIATE` transaction, query:
+
+```rust
+let event_cursor = transaction.query_row(
+    "SELECT COALESCE(MAX(rowid), 0) FROM events WHERE session_id = ?1",
+    [session_id],
+    |row| row.get(0),
+)?;
+```
+
+Use that value in the `session_handoffs` insert. Update `emit_handoff` to stop
+calling `latest_event_seq` before `create_handoff`, and return
+`record.event_cursor` in its JSON response. Update every direct store test to
+use the new signature.
+
+Keep the claim and acknowledgement validation inside their `IMMEDIATE`
+transactions:
 
 Remove the API-side `latest_event_seq` preflight checks from claim and
-acknowledgement; retain the helper in `emit_handoff`. In `claim_handoff`, after
-loading the record in its `IMMEDIATE` transaction, read the current sequence
-from the same transaction and reject `actual_cursor < current.event_cursor`
-with `bail!("transcript_diverged")`.
+acknowledgement. In `claim_handoff`, after loading the record in its
+`IMMEDIATE` transaction, read the current sequence from the same transaction
+and reject `actual_cursor < current.event_cursor` with
+`bail!("transcript_diverged")`.
 
 ```rust
 let actual_cursor = latest_event_seq(&transaction, &current.session_id)?;

--- a/docs/superpowers/plans/2026-08-06-session-handoff-cursor.md
+++ b/docs/superpowers/plans/2026-08-06-session-handoff-cursor.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make live-session handoffs scalable and claimable after append-only source transcript growth.
 
-**Architecture:** The SQLite store owns the current event cursor through a scalar `MAX(rowid)` query. API claim and acknowledgement treat the offered cursor as a transcript prefix: later events are safe, while a cursor lower than the offer remains a divergence. The transactional store acknowledgement repeats that lower-bound guard.
+**Architecture:** The SQLite store owns the current event cursor through a scalar `MAX(rowid)` query. Retention pins each unresolved handoff's source events through its offered cursor. The store reads and validates that cursor inside the existing `IMMEDIATE` transaction for claim and acknowledgement, so a successful state transition cannot race a pruning transaction.
 
 **Tech Stack:** Rust, rusqlite, existing `coven-cli` API and store unit tests.
 
@@ -78,89 +78,89 @@ git add crates/coven-cli/src/store.rs
 git commit -s -m "fix: query handoff event cursors directly"
 ```
 
-### Task 2: Permit append-only handoff transcript growth
+### Task 2: Pin and transactionally validate handoff transcript prefixes
 
 **Files:**
-- Modify: `crates/coven-cli/src/api.rs:2038-2049, 2119-2135, 2183-2199, 9332-9358`
-- Modify: `crates/coven-cli/src/store.rs:3108-3125`
+- Modify: `crates/coven-cli/src/api.rs:2038-2049, 2104-2145, 2168-2210, 9250-9390`
+- Modify: `crates/coven-cli/src/store.rs:3040-3145, 3441-3472, 6246-6328`
 
-- [ ] **Step 1: Replace the failing API expectation**
+- [ ] **Step 1: Write failing retention and transactional-guard tests**
 
-In `handoff_claim_fails_closed_when_transcript_or_workspace_diverges`, replace
-the `transcript_conflict` assertion after the accepted input with a successful
-claim and acknowledgement:
+Keep the append-only API assertion added by the prior task: input appended
+after an offer must permit claim and acknowledgement. Add store tests with
+real event rows, not synthetic cursor values:
 
 ```rust
-assert_eq!(claimed.status, 200);
-let acknowledged = handle_request_with_body(
-    "POST",
-    &format!("/sessions/session-1/handoffs/{handoff_id}/ack"),
-    temp.path(),
-    None,
-    Some(r#"{"claimant":"device:phone-1"}"#),
-)?;
-assert_eq!(acknowledged.status, 200);
+let cursor = latest_event_seq(&conn, "session-1")?;
+let offered = create_handoff(&mut conn, "handoff-1", "session-1", "{}", cursor, "{}", now)?;
+assert_eq!(prune_events_older_than(&conn, cutoff)?, 0);
+claim_handoff(&mut conn, &offered.id, offered.generation, "device:phone-1", "claim-1", now)?;
+assert_eq!(prune_events_older_than_bounded(&conn, cutoff, 10)?, 0);
+let acknowledged = acknowledge_handoff(&mut conn, &offered.id, "device:phone-1", now)?;
+assert_eq!(acknowledged.state, "acknowledged");
+assert_eq!(prune_events_older_than(&conn, cutoff)?, 1);
 ```
 
-Keep the later wrong-workspace assertion, but emit a new handoff only after
-the first handoff is acknowledged.
+Create a second offered handoff with an `event_cursor` greater than the actual
+latest sequence. Assert `claim_handoff` returns `transcript_diverged` without
+changing state. Claim a valid handoff, delete its cursor event directly in the
+test transaction, and assert `acknowledge_handoff` returns
+`transcript_diverged`. These tests prove the store—not an API preflight—is the
+transition authority.
 
-- [ ] **Step 2: Add a lower-cursor store guard test**
+- [ ] **Step 2: Run the new tests and verify current behavior fails**
 
-Add a store test that creates a handoff with `event_cursor: 3`, claims it, then
-calls `acknowledge_handoff(..., 2, ...)` and asserts the error string is
-`transcript_diverged`. Call it again with `4` and assert the record reaches
-`acknowledged`.
-
-- [ ] **Step 3: Run the altered tests and verify current behavior fails**
-
-Run:
+Run the exact new store test names and:
 
 ```bash
 cargo test -p coven-cli handoff_claim_fails_closed_when_transcript_or_workspace_diverges --locked
-cargo test -p coven-cli acknowledge_handoff --locked
+cargo test -p coven-cli unresolved_handoff_events_are_not_pruned --locked
+cargo test -p coven-cli handoff_transition_rejects_missing_cursor --locked
 ```
 
-Expected: the API test fails with HTTP 409 after the appended input and the
-store test fails with `transcript_diverged` for cursor `4`.
+Expected: the append-only API test already passes; the new retention and
+transactional-guard tests fail because both pruning paths ignore handoffs and
+the store accepts a stale caller-derived cursor.
 
-- [ ] **Step 4: Implement prefix semantics and direct cursor reads**
+- [ ] **Step 3: Make retention respect unresolved handoff pins**
 
-Replace all three `store::list_events(&conn, session_id)?.last()` expressions
-in `emit_handoff`, `claim_session_handoff`, and
-`acknowledge_session_handoff` with:
+In both `prune_events_older_than` and `prune_events_older_than_bounded`, only
+delete an expired event when no `offered` or `claimed` handoff for its session
+pins that row:
 
-```rust
-let event_cursor = store::latest_event_seq(&conn, session_id)?;
+```sql
+AND NOT EXISTS (
+    SELECT 1
+    FROM session_handoffs AS handoff
+    WHERE handoff.session_id = event.session_id
+      AND handoff.state IN ('offered', 'claimed')
+      AND event.rowid <= handoff.event_cursor
+)
 ```
 
-In both API checks, reject only a truncated cursor:
+Use an `events AS event` alias inside each pruning subquery. Keep the current
+cutoff ordering, bounded batch limit, FTS trigger behavior, and transaction
+shape intact.
+
+- [ ] **Step 4: Move cursor validation into handoff transactions**
+
+Remove the API-side `latest_event_seq` preflight checks from claim and
+acknowledgement; retain the helper in `emit_handoff`. In `claim_handoff`, after
+loading the record in its `IMMEDIATE` transaction, read the current sequence
+from the same transaction and reject `actual_cursor < current.event_cursor`
+with `bail!("transcript_diverged")`.
 
 ```rust
-if current_cursor < handoff.event_cursor {
-    return api_error(
-        409,
-        "transcript_diverged",
-        "Source transcript no longer contains the handoff snapshot.",
-        Some(json!({
-            "handoffId": handoff_id,
-            "expectedCursor": handoff.event_cursor,
-            "actualCursor": current_cursor,
-        })),
-    );
-}
-```
-
-In `store::acknowledge_handoff`, replace the equality guard with:
-
-```rust
-if event_cursor < current.event_cursor {
+let actual_cursor = latest_event_seq(&transaction, &current.session_id)?;
+if actual_cursor < current.event_cursor {
     bail!("transcript_diverged");
 }
 ```
 
-Do not weaken workspace compatibility, generation, claimant, state, or input
-lease checks.
+Change `acknowledge_handoff` to derive and validate that same transaction-local
+cursor itself; remove its caller-provided `event_cursor` parameter. Update its
+API caller and direct store tests. Do not weaken workspace compatibility,
+generation, claimant, state, or input-lease checks.
 
 - [ ] **Step 5: Run focused regression coverage**
 
@@ -169,17 +169,19 @@ Run:
 ```bash
 cargo test -p coven-cli handoff_claim_fails_closed_when_transcript_or_workspace_diverges --locked
 cargo test -p coven-cli handoff_claim_acknowledgement_import_fences_source_and_is_idempotent --locked
-cargo test -p coven-cli acknowledge_handoff --locked
+cargo test -p coven-cli unresolved_handoff_events_are_not_pruned --locked
+cargo test -p coven-cli handoff_transition_rejects_missing_cursor --locked
 ```
 
-Expected: PASS; a later source event permits claim and acknowledgement, while
-a lower cursor and the existing workspace conflict still fail closed.
+Expected: PASS; a later source event permits claim and acknowledgement,
+retention cannot remove an unresolved handoff prefix, acknowledged handoffs
+release their pin, and missing cursors still fail closed.
 
-- [ ] **Step 6: Commit handoff semantics**
+- [ ] **Step 6: Commit pinned handoff semantics**
 
 ```bash
 git add crates/coven-cli/src/api.rs crates/coven-cli/src/store.rs
-git commit -s -m "fix: preserve append-only handoff cursors"
+git commit -s -m "fix: pin handoff transcript prefixes"
 ```
 
 ### Task 3: Run the issue acceptance gates

--- a/docs/superpowers/specs/2026-08-06-session-handoff-cursor-design.md
+++ b/docs/superpowers/specs/2026-08-06-session-handoff-cursor-design.md
@@ -26,6 +26,12 @@ retention cannot delete the required prefix after a successful preflight check
 and before the handoff state commits. The retention pin ends when the handoff
 is acknowledged or otherwise leaves those unresolved states.
 
+Offer creation reads the latest cursor and inserts the `offered` handoff in one
+`IMMEDIATE` transaction, so retention cannot prune the prefix between cursor
+selection and pin creation. Dry-run event-prune counts use the same unresolved
+handoff exclusion as mutating prune queries, ensuring operator previews match
+what deletion can actually remove.
+
 ## Alternatives rejected
 
 Limiting the event-list query still loads an event record and obscures that the
@@ -40,3 +46,5 @@ acknowledgement, while a lower cursor still returns `transcript_diverged`.
 Test both unbounded and bounded retention paths to prove unresolved handoffs
 pin their prefix and acknowledged handoffs no longer do. Retain existing
 workspace, claimant, and generation conflict tests.
+Test that an offer records its cursor atomically and that dry-run counts exclude
+pinned events.

--- a/docs/superpowers/specs/2026-08-06-session-handoff-cursor-design.md
+++ b/docs/superpowers/specs/2026-08-06-session-handoff-cursor-design.md
@@ -1,0 +1,33 @@
+# Session handoff cursor design
+
+## Goal
+
+Fix issue #613 without changing the handoff's workspace, claimant, or
+generation safeguards. A handoff offered from a live source session remains
+claimable and acknowledgeable when later source events extend its transcript.
+
+## Design
+
+Add a store helper that returns the latest event sequence for one session with
+a scalar SQLite aggregate. It must return `0` when the session has no events
+and must not materialize event payloads. The emit, claim, and acknowledgement
+handlers use this helper instead of `list_events(...).last()`.
+
+Treat the offered cursor as a required transcript prefix. Claim and
+acknowledgement reject only when the current cursor is lower than the offered
+cursor; a larger current cursor is a normal append-only extension. The store
+acknowledgement guard uses the same lower-than predicate so the API and
+transactional persistence boundary cannot disagree.
+
+## Alternatives rejected
+
+Limiting the event-list query still loads an event record and obscures that the
+operation needs only a scalar. An in-memory cursor cache would add restart and
+cross-process consistency risks to an answer SQLite already owns.
+
+## Validation
+
+Add focused store coverage for empty and latest cursors. Extend handoff API
+coverage to prove output or input appended after an offer permits claim and
+acknowledgement, while a lower cursor still returns `transcript_diverged`.
+Retain existing workspace, claimant, and generation conflict tests.

--- a/docs/superpowers/specs/2026-08-06-session-handoff-cursor-design.md
+++ b/docs/superpowers/specs/2026-08-06-session-handoff-cursor-design.md
@@ -19,6 +19,13 @@ cursor; a larger current cursor is a normal append-only extension. The store
 acknowledgement guard uses the same lower-than predicate so the API and
 transactional persistence boundary cannot disagree.
 
+While a handoff is `offered` or `claimed`, retention must preserve that
+session's events through its offered cursor. Both state transitions read and
+validate the latest cursor inside their existing `IMMEDIATE` transaction, so
+retention cannot delete the required prefix after a successful preflight check
+and before the handoff state commits. The retention pin ends when the handoff
+is acknowledged or otherwise leaves those unresolved states.
+
 ## Alternatives rejected
 
 Limiting the event-list query still loads an event record and obscures that the
@@ -30,4 +37,6 @@ cross-process consistency risks to an answer SQLite already owns.
 Add focused store coverage for empty and latest cursors. Extend handoff API
 coverage to prove output or input appended after an offer permits claim and
 acknowledgement, while a lower cursor still returns `transcript_diverged`.
-Retain existing workspace, claimant, and generation conflict tests.
+Test both unbounded and bounded retention paths to prove unresolved handoffs
+pin their prefix and acknowledged handoffs no longer do. Retain existing
+workspace, claimant, and generation conflict tests.


### PR DESCRIPTION
Fixes #613.\n\n## Summary\n- replace full event-history cursor scans with scalar store reads\n- permit append-only transcript growth while retaining fail-closed cursor checks inside handoff transactions\n- pin unresolved handoff prefixes through retention, make offer creation atomic with cursor selection, and align dry-run counts with pruning\n- preserve terminal claim/ack idempotency after retention\n\n## Validation\n- cargo fmt --check\n- cargo clippy --workspace --all-targets -- -D warnings\n- cargo test --workspace --locked\n- python scripts/check-secrets.py\n- privacy guard