### PR TITLE
fix(session): preserve direct event truncation boundaries (#642)

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -235,6 +235,15 @@ pub trait SessionRuntime {
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()>;
     fn kill_session(&self, session_id: &str) -> Result<()>;
 
+    fn record_session_event(
+        &self,
+        _session_id: &str,
+        _kind: &str,
+        _payload: &Value,
+    ) -> Option<Result<()>> {
+        None
+    }
+
     fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
         None
     }
@@ -377,7 +386,7 @@ pub fn handle_request_with_runtime(
             let (status, response) = control_plane::route_action(payload);
             json_response(status, &response)
         }
-        ("POST", "/cast") => submit_cast(coven_home, body),
+        ("POST", "/cast") => submit_cast(coven_home, body, runtime),
         ("GET", "/cast-codes") => cast_codes_response(),
         // Filesystem-backed reads under ~/.coven/. Missing files return [].
         ("GET", "/familiars") => {
@@ -2521,7 +2530,7 @@ fn record_input(
             )
         }
     } else {
-        insert_event(&conn, coven_home, session_id, "input", payload)?;
+        record_direct_session_event(runtime, &conn, coven_home, session_id, "input", payload)?;
         json_response(202, &json!({ "ok": true, "accepted": true }))
     };
     store::release_session_input_lease(&conn, &lease_id)?;
@@ -2573,7 +2582,8 @@ fn kill_session(
     }
     let now = current_timestamp();
     store::update_session_status(&conn, session_id, "killed", None, &now)?;
-    insert_event(
+    record_direct_session_event(
+        runtime,
         &conn,
         coven_home,
         session_id,
@@ -2764,7 +2774,11 @@ fn cast_codes_response() -> Result<ApiResponse> {
     json_response(200, &codes)
 }
 
-fn submit_cast(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
+fn submit_cast(
+    coven_home: &Path,
+    body: Option<&str>,
+    runtime: &dyn SessionRuntime,
+) -> Result<ApiResponse> {
     let payload = match parse_body(body) {
         Ok(payload) => payload,
         Err(error) => {
@@ -2800,7 +2814,8 @@ fn submit_cast(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
             Some(json!({ "sessionId": session_id })),
         );
     }
-    insert_event(
+    record_direct_session_event(
+        runtime,
         &conn,
         coven_home,
         session_id,
@@ -3052,6 +3067,20 @@ fn insert_event(
             created_at: current_timestamp(),
         },
     )
+}
+
+fn record_direct_session_event(
+    runtime: &dyn SessionRuntime,
+    conn: &rusqlite::Connection,
+    coven_home: &Path,
+    session_id: &str,
+    kind: &str,
+    payload: Value,
+) -> Result<()> {
+    match runtime.record_session_event(session_id, kind, &payload) {
+        Some(result) => result,
+        None => insert_event(conn, coven_home, session_id, kind, payload),
+    }
 }
 
 fn update_familiar_icon(
@@ -9036,6 +9065,10 @@ mod tests {
         kills: std::cell::RefCell<Vec<String>>,
     }
 
+    struct WriterBackedRuntime {
+        writer: crate::event_writer::EventWriter,
+    }
+
     impl SessionRuntime for RecordingRuntime {
         fn launch_session(&self, launch: &SessionLaunch) -> Result<()> {
             self.launches.borrow_mut().push(launch.clone());
@@ -9056,6 +9089,29 @@ mod tests {
         fn kill_session(&self, session_id: &str) -> Result<()> {
             self.kills.borrow_mut().push(session_id.to_string());
             Ok(())
+        }
+    }
+
+    impl SessionRuntime for WriterBackedRuntime {
+        fn launch_session(&self, _launch: &SessionLaunch) -> Result<()> {
+            Ok(())
+        }
+
+        fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn record_session_event(
+            &self,
+            session_id: &str,
+            kind: &str,
+            payload: &Value,
+        ) -> Option<Result<()>> {
+            Some(self.writer.record(session_id, kind, payload.clone()))
         }
     }
 
@@ -9124,6 +9180,103 @@ mod tests {
         };
         crate::store::insert_session(&conn, &session)?;
         Ok(())
+    }
+
+    fn assert_direct_event_truncation_episodes(
+        coven_home: &std::path::Path,
+        session_id: &str,
+        boundary_kind: &str,
+        request: impl FnOnce(&WriterBackedRuntime) -> Result<ApiResponse>,
+    ) -> Result<()> {
+        insert_test_session(coven_home, session_id)?;
+        let runtime = WriterBackedRuntime {
+            writer: crate::event_writer::EventWriter::start_with_capacity(
+                coven_home.to_path_buf(),
+                crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
+            )?,
+        };
+
+        assert!(!runtime.writer.record_output(session_id, "x".repeat(2048))?);
+        let response = request(&runtime)?;
+        assert_eq!(response.status, 202);
+        assert!(!runtime.writer.record_output(session_id, "x".repeat(3072))?);
+        assert!(runtime
+            .writer
+            .record_output(session_id, "recovered".to_string())?);
+        runtime.writer.record_exit(
+            session_id,
+            crate::pty_runner::PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let conn = crate::store::open_store(&coven_home.join("coven.sqlite3"))?;
+        let events = crate::store::list_events(&conn, session_id)?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "output_truncated",
+                boundary_kind,
+                "output_truncated",
+                "output",
+                "exit"
+            ]
+        );
+        for (event, dropped_bytes) in [(&events[0], 2048), (&events[2], 3072)] {
+            let payload: Value = serde_json::from_str(&event.payload_json)?;
+            assert_eq!(payload["droppedEvents"], 1);
+            assert_eq!(payload["droppedBytes"], dropped_bytes);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn input_truncation_episodes_close_at_direct_event() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        assert_direct_event_truncation_episodes(temp_dir.path(), "sess-input", "input", |runtime| {
+            handle_request_with_runtime(
+                "POST",
+                "/sessions/sess-input/input",
+                temp_dir.path(),
+                None,
+                Some(r#"{ "data": "ls\n" }"#),
+                runtime,
+            )
+        })
+    }
+
+    #[test]
+    fn kill_truncation_episodes_close_at_direct_event() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        assert_direct_event_truncation_episodes(temp_dir.path(), "sess-kill", "kill", |runtime| {
+            handle_request_with_runtime(
+                "POST",
+                "/sessions/sess-kill/kill",
+                temp_dir.path(),
+                None,
+                None,
+                runtime,
+            )
+        })
+    }
+
+    #[test]
+    fn targeted_cast_truncation_episodes_close_at_direct_event() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        assert_direct_event_truncation_episodes(temp_dir.path(), "sess-cast", "cast", |runtime| {
+            handle_request_with_runtime(
+                "POST",
+                "/cast",
+                temp_dir.path(),
+                None,
+                Some(r#"{ "code": "/handoff", "target": "sess-cast" }"#),
+                runtime,
+            )
+        })
     }
 
     fn portable_handoff_fixture() -> anyhow::Result<(tempfile::TempDir, WorkspaceSnapshot)> {

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -222,6 +222,15 @@ pub struct SessionLaunch {
     pub caller_familiar_id: Option<String>,
 }
 
+#[derive(Debug)]
+pub enum SessionEventBoundaryError {
+    Runtime(anyhow::Error),
+    Coordination(anyhow::Error),
+    Persistence(anyhow::Error),
+}
+
+pub type SessionEventBoundaryResult = std::result::Result<(), SessionEventBoundaryError>;
+
 pub trait SessionRuntime {
     fn launch_session(&self, launch: &SessionLaunch) -> Result<()>;
     fn launch_session_with_writer(
@@ -234,6 +243,16 @@ pub trait SessionRuntime {
     }
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()>;
     fn kill_session(&self, session_id: &str) -> Result<()>;
+
+    fn with_session_event_boundary(
+        &self,
+        _session_id: &str,
+        _kind: &str,
+        _payload: &Value,
+        _action: &mut dyn FnMut() -> SessionEventBoundaryResult,
+    ) -> Option<SessionEventBoundaryResult> {
+        None
+    }
 
     fn record_session_event(
         &self,
@@ -2533,27 +2552,43 @@ fn record_input(
             Some(json!({ "sessionId": session_id })),
         );
     }
-    let result = if let Err(error) = runtime.send_input(session_id, &payload) {
-        // Match the typed sentinel from the daemon runtime instead of
-        // substring-matching the error message — refactoring the prose
-        // later can't accidentally route the not-live case to the
-        // generic 500 path.
-        if error
-            .downcast_ref::<crate::daemon::NotLiveError>()
-            .is_some()
-        {
-            session_not_live_response(session_id)
-        } else {
-            api_error(
-                500,
-                "send_input_failed",
-                &error.to_string(),
-                Some(json!({ "sessionId": session_id })),
-            )
+    let action_payload = payload.clone();
+    let mut action = || {
+        runtime
+            .send_input(session_id, &action_payload)
+            .map_err(SessionEventBoundaryError::Runtime)
+    };
+    let result = match perform_direct_session_event(
+        runtime,
+        &conn,
+        coven_home,
+        session_id,
+        "input",
+        payload,
+        &mut action,
+    ) {
+        Ok(()) => json_response(202, &json!({ "ok": true, "accepted": true })),
+        Err(SessionEventBoundaryError::Runtime(error)) => {
+            // Match the typed sentinel from the daemon runtime instead of
+            // substring-matching the error message — refactoring the prose
+            // later can't accidentally route the not-live case to the
+            // generic 500 path.
+            if error
+                .downcast_ref::<crate::daemon::NotLiveError>()
+                .is_some()
+            {
+                session_not_live_response(session_id)
+            } else {
+                api_error(
+                    500,
+                    "send_input_failed",
+                    &error.to_string(),
+                    Some(json!({ "sessionId": session_id })),
+                )
+            }
         }
-    } else {
-        record_direct_session_event(runtime, &conn, coven_home, session_id, "input", payload)
-            .and_then(|()| json_response(202, &json!({ "ok": true, "accepted": true })))
+        Err(SessionEventBoundaryError::Coordination(error))
+        | Err(SessionEventBoundaryError::Persistence(error)) => Err(error),
     };
     let release = store::release_session_input_lease(&conn, &lease_id);
     match (result, release) {
@@ -2592,34 +2627,46 @@ fn kill_session(
         );
     }
 
-    // Same structured-error pattern as the launch + input handlers: a
-    // runtime kill failure (libc::kill returning EPERM, etc.) must
-    // become a 500 response, not an Err that brings down the daemon.
-    if let Err(error) = runtime.kill_session(session_id) {
-        if error
-            .downcast_ref::<crate::daemon::NotLiveError>()
-            .is_some()
-        {
-            return session_not_live_response(session_id);
-        }
-        return api_error(
-            500,
-            "kill_failed",
-            &error.to_string(),
-            Some(json!({ "sessionId": session_id })),
-        );
-    }
-    let now = current_timestamp();
-    store::update_session_status(&conn, session_id, "killed", None, &now)?;
-    record_direct_session_event(
+    let kill_payload = json!({ "status": "killed" });
+    let mut action = || {
+        runtime
+            .kill_session(session_id)
+            .map_err(SessionEventBoundaryError::Runtime)?;
+        let now = current_timestamp();
+        store::update_session_status(&conn, session_id, "killed", None, &now)
+            .map_err(SessionEventBoundaryError::Coordination)
+    };
+    match perform_direct_session_event(
         runtime,
         &conn,
         coven_home,
         session_id,
         "kill",
-        json!({ "status": "killed" }),
-    )?;
-    json_response(202, &json!({ "ok": true, "accepted": true }))
+        kill_payload,
+        &mut action,
+    ) {
+        Ok(()) => json_response(202, &json!({ "ok": true, "accepted": true })),
+        // Same structured-error pattern as the launch + input handlers: a
+        // runtime kill failure (libc::kill returning EPERM, etc.) must
+        // become a 500 response, not an Err that brings down the daemon.
+        Err(SessionEventBoundaryError::Runtime(error)) => {
+            if error
+                .downcast_ref::<crate::daemon::NotLiveError>()
+                .is_some()
+            {
+                session_not_live_response(session_id)
+            } else {
+                api_error(
+                    500,
+                    "kill_failed",
+                    &error.to_string(),
+                    Some(json!({ "sessionId": session_id })),
+                )
+            }
+        }
+        Err(SessionEventBoundaryError::Coordination(error))
+        | Err(SessionEventBoundaryError::Persistence(error)) => Err(error),
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -3119,6 +3166,25 @@ fn record_direct_session_event(
     match runtime.record_session_event(session_id, kind, &payload) {
         Some(result) => result,
         None => insert_event(conn, coven_home, session_id, kind, payload),
+    }
+}
+
+fn perform_direct_session_event(
+    runtime: &dyn SessionRuntime,
+    conn: &rusqlite::Connection,
+    coven_home: &Path,
+    session_id: &str,
+    kind: &str,
+    payload: Value,
+    action: &mut dyn FnMut() -> SessionEventBoundaryResult,
+) -> SessionEventBoundaryResult {
+    match runtime.with_session_event_boundary(session_id, kind, &payload, action) {
+        Some(result) => result,
+        None => {
+            action()?;
+            insert_event(conn, coven_home, session_id, kind, payload)
+                .map_err(SessionEventBoundaryError::Persistence)
+        }
     }
 }
 
@@ -9107,6 +9173,19 @@ mod tests {
     struct WriterBackedRuntime {
         writer: crate::event_writer::EventWriter,
         inputs: std::cell::RefCell<Vec<String>>,
+        input_output: Option<String>,
+        input_error: Option<&'static str>,
+    }
+
+    impl WriterBackedRuntime {
+        fn new(writer: crate::event_writer::EventWriter) -> Self {
+            Self {
+                writer,
+                inputs: std::cell::RefCell::new(Vec::new()),
+                input_output: None,
+                input_error: None,
+            }
+        }
     }
 
     impl SessionRuntime for RecordingRuntime {
@@ -9145,6 +9224,12 @@ mod tests {
             self.inputs
                 .borrow_mut()
                 .push(format!("{session_id}:{data}"));
+            if let Some(output) = self.input_output.as_ref() {
+                assert!(!self.writer.record_output(session_id, output.clone())?);
+            }
+            if let Some(error) = self.input_error {
+                anyhow::bail!(error);
+            }
             Ok(())
         }
 
@@ -9159,6 +9244,43 @@ mod tests {
             payload: &Value,
         ) -> Option<Result<()>> {
             Some(self.writer.record(session_id, kind, payload.clone()))
+        }
+
+        fn with_session_event_boundary(
+            &self,
+            session_id: &str,
+            kind: &str,
+            payload: &Value,
+            action: &mut dyn FnMut() -> SessionEventBoundaryResult,
+        ) -> Option<SessionEventBoundaryResult> {
+            Some(match kind {
+                "input" => {
+                    let reservation =
+                        match self
+                            .writer
+                            .reserve_record(session_id, kind, payload.clone())
+                        {
+                            Ok(reservation) => reservation,
+                            Err(error) => {
+                                return Some(Err(SessionEventBoundaryError::Persistence(error)));
+                            }
+                        };
+                    match action() {
+                        Ok(()) => reservation
+                            .commit()
+                            .map_err(SessionEventBoundaryError::Persistence),
+                        Err(error) => {
+                            reservation.cancel();
+                            Err(error)
+                        }
+                    }
+                }
+                _ => action().and_then(|()| {
+                    self.writer
+                        .record(session_id, kind, payload.clone())
+                        .map_err(SessionEventBoundaryError::Persistence)
+                }),
+            })
         }
 
         fn can_record_session_event(
@@ -9245,13 +9367,11 @@ mod tests {
         request: impl FnOnce(&WriterBackedRuntime) -> Result<ApiResponse>,
     ) -> Result<()> {
         insert_test_session(coven_home, session_id)?;
-        let runtime = WriterBackedRuntime {
-            writer: crate::event_writer::EventWriter::start_with_capacity(
+        let runtime =
+            WriterBackedRuntime::new(crate::event_writer::EventWriter::start_with_capacity(
                 coven_home.to_path_buf(),
                 crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
-            )?,
-            inputs: std::cell::RefCell::new(Vec::new()),
-        };
+            )?);
 
         assert!(!runtime.writer.record_output(session_id, "x".repeat(2048))?);
         let response = request(&runtime)?;
@@ -9341,13 +9461,11 @@ mod tests {
     {
         let temp_dir = tempfile::tempdir()?;
         insert_test_session(temp_dir.path(), "session-1")?;
-        let runtime = WriterBackedRuntime {
-            writer: crate::event_writer::EventWriter::start_with_capacity(
+        let runtime =
+            WriterBackedRuntime::new(crate::event_writer::EventWriter::start_with_capacity(
                 temp_dir.path().to_path_buf(),
                 crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
-            )?,
-            inputs: std::cell::RefCell::new(Vec::new()),
-        };
+            )?);
         let body = serde_json::to_string(&json!({ "data": "x".repeat(256 * 1024) }))?;
 
         let response = handle_request_with_runtime(
@@ -9378,10 +9496,9 @@ mod tests {
     ) -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         insert_test_session(temp_dir.path(), "session-1")?;
-        let runtime = WriterBackedRuntime {
-            writer: crate::event_writer::EventWriter::start(temp_dir.path().to_path_buf())?,
-            inputs: std::cell::RefCell::new(Vec::new()),
-        };
+        let runtime = WriterBackedRuntime::new(crate::event_writer::EventWriter::start(
+            temp_dir.path().to_path_buf(),
+        )?);
         let body = serde_json::to_string(&json!({
             "code": "x".repeat(3 * 1024 * 1024),
             "target": "session-1",
@@ -9412,10 +9529,9 @@ mod tests {
     fn writer_backed_untargeted_cast_bypasses_writer_capacity_and_persists_to_cockpit() -> Result<()>
     {
         let temp_dir = tempfile::tempdir()?;
-        let runtime = WriterBackedRuntime {
-            writer: crate::event_writer::EventWriter::start(temp_dir.path().to_path_buf())?,
-            inputs: std::cell::RefCell::new(Vec::new()),
-        };
+        let runtime = WriterBackedRuntime::new(crate::event_writer::EventWriter::start(
+            temp_dir.path().to_path_buf(),
+        )?);
         let code = "x".repeat(3 * 1024 * 1024);
         let body = serde_json::to_string(&json!({ "code": code }))?;
         assert!(body.len() < crate::daemon::MAX_SOCKET_BODY_BYTES);
@@ -9447,10 +9563,9 @@ mod tests {
     ) -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         insert_test_session(temp_dir.path(), "session-1")?;
-        let runtime = WriterBackedRuntime {
-            writer: crate::event_writer::EventWriter::start(temp_dir.path().to_path_buf())?,
-            inputs: std::cell::RefCell::new(Vec::new()),
-        };
+        let runtime = WriterBackedRuntime::new(crate::event_writer::EventWriter::start(
+            temp_dir.path().to_path_buf(),
+        )?);
         let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
         conn.execute_batch(
             "CREATE TRIGGER reject_input_event
@@ -9480,6 +9595,59 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(lease_count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn failed_input_boundary_restores_truncation_episode() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let mut runtime =
+            WriterBackedRuntime::new(crate::event_writer::EventWriter::start_with_capacity(
+                temp_dir.path().to_path_buf(),
+                crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
+            )?);
+        runtime.input_output = Some("b".repeat(3072));
+        runtime.input_error = Some("simulated input transport failure");
+
+        assert!(!runtime
+            .writer
+            .record_output("session-1", "a".repeat(2048))?);
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{"data":"hello"}"#),
+            &runtime,
+        )?;
+        assert_eq!(response.status, 500);
+        assert!(response.body.contains(r#""code":"send_input_failed""#));
+
+        assert!(runtime
+            .writer
+            .record_output("session-1", "recovered".to_string())?);
+        runtime.writer.record_exit(
+            "session-1",
+            crate::pty_runner::PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        let events = crate::store::list_events(&conn, "session-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            ["output_truncated", "output", "exit"]
+        );
+        let marker: Value = serde_json::from_str(&events[0].payload_json)?;
+        assert_eq!(marker["droppedEvents"], 2);
+        assert_eq!(marker["droppedBytes"], 5120);
+        assert!(!events.iter().any(|event| event.kind == "input"));
         Ok(())
     }
 

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2844,19 +2844,23 @@ fn submit_cast(
         );
     }
     let cast_event = json!({ "cast_id": cast_id, "code": code, "target": target });
-    match runtime.can_record_session_event(session_id, "cast", &cast_event) {
-        Some(Ok(true)) | None => {}
-        Some(Ok(false)) => {
-            return api_error(
-                413,
-                "cast_too_large",
-                "Cast payload exceeds the daemon event writer capacity.",
-                Some(json!({ "sessionId": session_id })),
-            );
+    if target.is_some() {
+        match runtime.can_record_session_event(session_id, "cast", &cast_event) {
+            Some(Ok(true)) | None => {}
+            Some(Ok(false)) => {
+                return api_error(
+                    413,
+                    "cast_too_large",
+                    "Cast payload exceeds the daemon event writer capacity.",
+                    Some(json!({ "sessionId": session_id })),
+                );
+            }
+            Some(Err(error)) => return Err(error.context("failed to preflight cast event")),
         }
-        Some(Err(error)) => return Err(error.context("failed to preflight cast event")),
+        record_direct_session_event(runtime, &conn, coven_home, session_id, "cast", cast_event)?;
+    } else {
+        insert_event(&conn, coven_home, session_id, "cast", cast_event)?;
     }
-    record_direct_session_event(runtime, &conn, coven_home, session_id, "cast", cast_event)?;
     json_response(
         202,
         &CastResultDto {
@@ -9398,6 +9402,40 @@ mod tests {
         assert_eq!(response_body["error"]["code"], "cast_too_large");
         let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
         assert!(crate::store::list_events(&conn, "session-1")?.is_empty());
+        let health = runtime.writer.health();
+        assert_eq!(health.queued_events, 0);
+        assert_eq!(health.committed_events, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn writer_backed_untargeted_cast_bypasses_writer_capacity_and_persists_to_cockpit() -> Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let runtime = WriterBackedRuntime {
+            writer: crate::event_writer::EventWriter::start(temp_dir.path().to_path_buf())?,
+            inputs: std::cell::RefCell::new(Vec::new()),
+        };
+        let code = "x".repeat(3 * 1024 * 1024);
+        let body = serde_json::to_string(&json!({ "code": code }))?;
+        assert!(body.len() < crate::daemon::MAX_SOCKET_BODY_BYTES);
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/cast",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 202);
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        let events = crate::store::list_events(&conn, "__cockpit__")?;
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "cast");
+        let payload: Value = serde_json::from_str(&events[0].payload_json)?;
+        assert_eq!(payload["code"].as_str(), Some(code.as_str()));
         let health = runtime.writer.health();
         assert_eq!(health.queued_events, 0);
         assert_eq!(health.committed_events, 0);

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -244,6 +244,16 @@ pub trait SessionRuntime {
         None
     }
 
+    /// `None` keeps writerless runtimes on the direct-insertion path.
+    fn can_record_session_event(
+        &self,
+        _session_id: &str,
+        _kind: &str,
+        _payload: &Value,
+    ) -> Option<Result<bool>> {
+        None
+    }
+
     fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
         None
     }
@@ -2501,6 +2511,18 @@ fn record_input(
             Some(json!({ "sessionId": session_id })),
         );
     }
+    match runtime.can_record_session_event(session_id, "input", &payload) {
+        Some(Ok(true)) | None => {}
+        Some(Ok(false)) => {
+            return api_error(
+                413,
+                "input_too_large",
+                "Input payload exceeds the daemon event writer capacity.",
+                Some(json!({ "sessionId": session_id })),
+            );
+        }
+        Some(Err(error)) => return Err(error.context("failed to preflight input event")),
+    }
     let lease_id = Uuid::new_v4().to_string();
     if !store::acquire_session_input_lease(&mut conn, &lease_id, session_id, &current_timestamp())?
     {
@@ -2530,11 +2552,18 @@ fn record_input(
             )
         }
     } else {
-        record_direct_session_event(runtime, &conn, coven_home, session_id, "input", payload)?;
-        json_response(202, &json!({ "ok": true, "accepted": true }))
+        record_direct_session_event(runtime, &conn, coven_home, session_id, "input", payload)
+            .and_then(|()| json_response(202, &json!({ "ok": true, "accepted": true })))
     };
-    store::release_session_input_lease(&conn, &lease_id)?;
-    result
+    let release = store::release_session_input_lease(&conn, &lease_id);
+    match (result, release) {
+        (Ok(response), Ok(())) => Ok(response),
+        (Ok(_), Err(error)) => Err(error.context("failed to release session input lease")),
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(release_error)) => Err(error.context(format!(
+            "failed to release session input lease: {release_error:#}"
+        ))),
+    }
 }
 
 fn kill_session(
@@ -9067,6 +9096,7 @@ mod tests {
 
     struct WriterBackedRuntime {
         writer: crate::event_writer::EventWriter,
+        inputs: std::cell::RefCell<Vec<String>>,
     }
 
     impl SessionRuntime for RecordingRuntime {
@@ -9097,7 +9127,14 @@ mod tests {
             Ok(())
         }
 
-        fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+        fn send_input(&self, session_id: &str, payload: &Value) -> Result<()> {
+            let data = payload
+                .get("data")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            self.inputs
+                .borrow_mut()
+                .push(format!("{session_id}:{data}"));
             Ok(())
         }
 
@@ -9112,6 +9149,15 @@ mod tests {
             payload: &Value,
         ) -> Option<Result<()>> {
             Some(self.writer.record(session_id, kind, payload.clone()))
+        }
+
+        fn can_record_session_event(
+            &self,
+            _session_id: &str,
+            _kind: &str,
+            payload: &Value,
+        ) -> Option<Result<bool>> {
+            Some(self.writer.can_record_critical_payload(payload))
         }
     }
 
@@ -9194,6 +9240,7 @@ mod tests {
                 coven_home.to_path_buf(),
                 crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
             )?,
+            inputs: std::cell::RefCell::new(Vec::new()),
         };
 
         assert!(!runtime.writer.record_output(session_id, "x".repeat(2048))?);
@@ -9277,6 +9324,84 @@ mod tests {
                 runtime,
             )
         })
+    }
+
+    #[test]
+    fn oversized_writer_backed_input_is_rejected_before_send_without_lease_or_event() -> Result<()>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let runtime = WriterBackedRuntime {
+            writer: crate::event_writer::EventWriter::start_with_capacity(
+                temp_dir.path().to_path_buf(),
+                crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
+            )?,
+            inputs: std::cell::RefCell::new(Vec::new()),
+        };
+        let body = serde_json::to_string(&json!({ "data": "x".repeat(256 * 1024) }))?;
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 413);
+        assert!(response.body.contains(r#""code":"input_too_large""#));
+        assert!(runtime.inputs.borrow().is_empty());
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        assert!(crate::store::list_events(&conn, "session-1")?.is_empty());
+        let lease_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM session_input_leases WHERE session_id = ?1",
+            ["session-1"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(lease_count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn writer_persistence_error_after_send_releases_input_lease_without_fallback_event(
+    ) -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let runtime = WriterBackedRuntime {
+            writer: crate::event_writer::EventWriter::start(temp_dir.path().to_path_buf())?,
+            inputs: std::cell::RefCell::new(Vec::new()),
+        };
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        conn.execute_batch(
+            "CREATE TRIGGER reject_input_event
+             BEFORE INSERT ON events
+             WHEN NEW.kind = 'input'
+             BEGIN
+                 SELECT RAISE(ABORT, 'simulated event writer failure');
+             END;",
+        )?;
+
+        let error = handle_request_with_runtime(
+            "POST",
+            "/sessions/session-1/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{"data":"hello"}"#),
+            &runtime,
+        )
+        .expect_err("writer failure must surface without a fallback insertion");
+
+        assert!(error.to_string().contains("event writer commit failed"));
+        assert_eq!(runtime.inputs.borrow().as_slice(), ["session-1:hello"]);
+        assert!(crate::store::list_events(&conn, "session-1")?.is_empty());
+        let lease_count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM session_input_leases WHERE session_id = ?1",
+            ["session-1"],
+            |row| row.get(0),
+        )?;
+        assert_eq!(lease_count, 0);
+        Ok(())
     }
 
     fn portable_handoff_fixture() -> anyhow::Result<(tempfile::TempDir, WorkspaceSnapshot)> {

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -2843,14 +2843,20 @@ fn submit_cast(
             Some(json!({ "sessionId": session_id })),
         );
     }
-    record_direct_session_event(
-        runtime,
-        &conn,
-        coven_home,
-        session_id,
-        "cast",
-        json!({ "cast_id": cast_id, "code": code, "target": target }),
-    )?;
+    let cast_event = json!({ "cast_id": cast_id, "code": code, "target": target });
+    match runtime.can_record_session_event(session_id, "cast", &cast_event) {
+        Some(Ok(true)) | None => {}
+        Some(Ok(false)) => {
+            return api_error(
+                413,
+                "cast_too_large",
+                "Cast payload exceeds the daemon event writer capacity.",
+                Some(json!({ "sessionId": session_id })),
+            );
+        }
+        Some(Err(error)) => return Err(error.context("failed to preflight cast event")),
+    }
+    record_direct_session_event(runtime, &conn, coven_home, session_id, "cast", cast_event)?;
     json_response(
         202,
         &CastResultDto {
@@ -9360,6 +9366,41 @@ mod tests {
             |row| row.get(0),
         )?;
         assert_eq!(lease_count, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_writer_backed_targeted_cast_is_rejected_without_event_or_writer_side_effect(
+    ) -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let runtime = WriterBackedRuntime {
+            writer: crate::event_writer::EventWriter::start(temp_dir.path().to_path_buf())?,
+            inputs: std::cell::RefCell::new(Vec::new()),
+        };
+        let body = serde_json::to_string(&json!({
+            "code": "x".repeat(3 * 1024 * 1024),
+            "target": "session-1",
+        }))?;
+        assert!(body.len() < crate::daemon::MAX_SOCKET_BODY_BYTES);
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/cast",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 413);
+        let response_body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(response_body["error"]["code"], "cast_too_large");
+        let conn = crate::store::open_store(&temp_dir.path().join("coven.sqlite3"))?;
+        assert!(crate::store::list_events(&conn, "session-1")?.is_empty());
+        let health = runtime.writer.health();
+        assert_eq!(health.queued_events, 0);
+        assert_eq!(health.committed_events, 0);
         Ok(())
     }
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -402,6 +402,17 @@ impl SessionRuntime for LiveSessionRuntime {
         LiveSessionRuntime::kill_session(self, session_id)
     }
 
+    fn record_session_event(
+        &self,
+        session_id: &str,
+        kind: &str,
+        payload: &Value,
+    ) -> Option<Result<()>> {
+        self.event_writer
+            .as_ref()
+            .map(|writer| writer.record(session_id, kind, payload.clone()))
+    }
+
     /// Must stay in this trait impl: `api::handle_request_with_runtime` reaches
     /// the runtime through `&dyn SessionRuntime`, so an inherent method of the
     /// same name is unreachable and `GET /health` silently falls back to the

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -25,7 +25,7 @@ use std::os::unix::{
 };
 
 use crate::{
-    api::{SessionLaunch, SessionRuntime},
+    api::{SessionEventBoundaryError, SessionEventBoundaryResult, SessionLaunch, SessionRuntime},
     pty_runner,
 };
 
@@ -116,6 +116,7 @@ struct LiveSessionHandle {
 struct LiveSessionRegistration {
     exited: AtomicBool,
     writer: Mutex<Option<crate::maintenance_gate::WriterLease>>,
+    event_order: Mutex<()>,
 }
 
 impl LiveSessionRegistration {
@@ -123,6 +124,7 @@ impl LiveSessionRegistration {
         Self {
             exited: AtomicBool::new(false),
             writer: Mutex::new(writer),
+            event_order: Mutex::new(()),
         }
     }
 
@@ -400,6 +402,68 @@ impl SessionRuntime for LiveSessionRuntime {
 
     fn kill_session(&self, session_id: &str) -> Result<()> {
         LiveSessionRuntime::kill_session(self, session_id)
+    }
+
+    fn with_session_event_boundary(
+        &self,
+        session_id: &str,
+        kind: &str,
+        payload: &Value,
+        action: &mut dyn FnMut() -> SessionEventBoundaryResult,
+    ) -> Option<SessionEventBoundaryResult> {
+        let writer = self.event_writer.as_ref()?;
+        Some((|| -> SessionEventBoundaryResult {
+            match kind {
+                "input" => {
+                    let reservation = writer
+                        .reserve_record(session_id, kind, payload.clone())
+                        .map_err(SessionEventBoundaryError::Persistence)?;
+                    match action() {
+                        Ok(()) => reservation
+                            .commit()
+                            .map_err(SessionEventBoundaryError::Persistence),
+                        Err(error) => {
+                            reservation.cancel();
+                            Err(error)
+                        }
+                    }
+                }
+                "kill" => {
+                    let registration = {
+                        let sessions = self.sessions.lock().map_err(|_| {
+                            SessionEventBoundaryError::Coordination(anyhow::anyhow!(
+                                "live session registry lock poisoned"
+                            ))
+                        })?;
+                        sessions
+                            .get(session_id)
+                            .map(|handle| Arc::clone(&handle.registration))
+                            .ok_or_else(|| {
+                                SessionEventBoundaryError::Runtime(anyhow::Error::new(
+                                    NotLiveError {
+                                        session_id: session_id.to_string(),
+                                    },
+                                ))
+                            })?
+                    };
+                    let _event_order = registration.event_order.lock().map_err(|_| {
+                        SessionEventBoundaryError::Coordination(anyhow::anyhow!(
+                            "live session event-order lock poisoned"
+                        ))
+                    })?;
+                    action()?;
+                    writer
+                        .record(session_id, kind, payload.clone())
+                        .map_err(SessionEventBoundaryError::Persistence)
+                }
+                _ => {
+                    action()?;
+                    writer
+                        .record(session_id, kind, payload.clone())
+                        .map_err(SessionEventBoundaryError::Persistence)
+                }
+            }
+        })())
     }
 
     fn record_session_event(
@@ -836,6 +900,15 @@ fn output_observer_with_cleanup(
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             *closed = true;
+            let registration = cleanup
+                .as_ref()
+                .map(|cleanup| Arc::clone(&cleanup.registration));
+            let _event_order = registration.as_ref().map(|registration| {
+                registration
+                    .event_order
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+            });
             if let Some(cleanup) = cleanup {
                 cleanup.mark_exited();
             }
@@ -4052,6 +4125,50 @@ mod tests {
         }
     }
 
+    struct SignalingKiller {
+        killed: Arc<(Mutex<bool>, std::sync::Condvar)>,
+    }
+
+    impl RuntimeKiller for SignalingKiller {
+        fn kill(&mut self) -> Result<()> {
+            let (lock, cvar) = &*self.killed;
+            *lock.lock().unwrap() = true;
+            cvar.notify_all();
+            Ok(())
+        }
+    }
+
+    struct ExitTriggeringKiller {
+        on_exit: Option<Box<dyn FnOnce(pty_runner::PtyRunResult) + Send>>,
+        started: Arc<(Mutex<bool>, std::sync::Condvar)>,
+        exit_thread: Arc<Mutex<Option<std::thread::JoinHandle<()>>>>,
+    }
+
+    impl RuntimeKiller for ExitTriggeringKiller {
+        fn kill(&mut self) -> Result<()> {
+            let on_exit = self.on_exit.take().expect("exit callback is present");
+            let started = Arc::clone(&self.started);
+            let handle = std::thread::spawn(move || {
+                let (lock, cvar) = &*started;
+                *lock.lock().unwrap() = true;
+                cvar.notify_all();
+                on_exit(pty_runner::PtyRunResult {
+                    status: "killed",
+                    exit_code: None,
+                });
+            });
+            let (lock, cvar) = &*self.started;
+            let mut guard = lock.lock().unwrap();
+            while !*guard {
+                guard = cvar.wait(guard).unwrap();
+            }
+            drop(guard);
+            std::thread::yield_now();
+            *self.exit_thread.lock().unwrap() = Some(handle);
+            Ok(())
+        }
+    }
+
     struct RegistryLockCheckingKiller {
         sessions: Weak<Mutex<HashMap<String, LiveSessionHandle>>>,
         dropped_after_unlock: Arc<AtomicBool>,
@@ -4080,11 +4197,15 @@ mod tests {
     /// `send_input` is mid-write to that exact session.
     #[derive(Clone)]
     struct BlockingWriter {
+        entered: std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
         unblock: std::sync::Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
     }
 
     impl Write for BlockingWriter {
         fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let (entered_lock, entered_cvar) = &*self.entered;
+            *entered_lock.lock().unwrap() = true;
+            entered_cvar.notify_all();
             let (lock, cvar) = &*self.unblock;
             let mut guard = lock.lock().unwrap();
             while !*guard {
@@ -4103,48 +4224,138 @@ mod tests {
         use std::sync::{Arc, Condvar, Mutex as StdMutex};
         use std::thread;
 
-        let runtime = Arc::new(LiveSessionRuntime::default());
+        let temp_dir = tempfile::tempdir().unwrap();
+        let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME)).unwrap();
+        crate::store::insert_session(&conn, &session_record("wedged-session")).unwrap();
+        drop(conn);
+
+        let runtime = Arc::new(LiveSessionRuntime::with_coven_home(
+            temp_dir.path().to_path_buf(),
+        ));
+        let entered = Arc::new((StdMutex::new(false), Condvar::new()));
         let unblock = Arc::new((StdMutex::new(false), Condvar::new()));
         let writer = BlockingWriter {
+            entered: Arc::clone(&entered),
             unblock: Arc::clone(&unblock),
         };
-        let killed = Arc::new(StdMutex::new(false));
+        let killed = Arc::new((StdMutex::new(false), Condvar::new()));
         runtime
             .register(
                 "wedged-session".to_string(),
                 Box::new(writer),
-                Box::new(RecordingKiller {
-                    killed: killed.clone(),
+                Box::new(SignalingKiller {
+                    killed: Arc::clone(&killed),
                 }),
             )
             .unwrap();
 
-        // Kick off a send that will block on the writer.
         let sender_runtime = Arc::clone(&runtime);
         let sender = thread::spawn(move || {
-            SessionRuntime::send_input(
+            let payload = serde_json::json!({ "data": "wedge" });
+            let mut action = || {
+                SessionRuntime::send_input(&*sender_runtime, "wedged-session", &payload)
+                    .map_err(crate::api::SessionEventBoundaryError::Runtime)
+            };
+            SessionRuntime::with_session_event_boundary(
                 &*sender_runtime,
                 "wedged-session",
-                &serde_json::json!({ "data": "wedge" }),
+                "input",
+                &payload,
+                &mut action,
             )
+            .expect("writer-backed runtime handles input boundaries")
         });
 
-        // Give the sender a moment to take the input lock + block.
-        thread::sleep(std::time::Duration::from_millis(50));
+        {
+            let (lock, cvar) = &*entered;
+            let mut guard = lock.lock().unwrap();
+            while !*guard {
+                guard = cvar.wait(guard).unwrap();
+            }
+        }
 
-        // Kill must succeed regardless of the wedged send.
-        SessionRuntime::kill_session(&*runtime, "wedged-session")
-            .expect("kill_session must not be blocked by a hung send_input on the same session");
-        assert!(*killed.lock().unwrap());
+        let killer_runtime = Arc::clone(&runtime);
+        let killer = thread::spawn(move || {
+            let payload = serde_json::json!({ "status": "killed" });
+            let mut action = || {
+                SessionRuntime::kill_session(&*killer_runtime, "wedged-session")
+                    .map_err(crate::api::SessionEventBoundaryError::Runtime)
+            };
+            SessionRuntime::with_session_event_boundary(
+                &*killer_runtime,
+                "wedged-session",
+                "kill",
+                &payload,
+                &mut action,
+            )
+            .expect("writer-backed runtime handles kill boundaries")
+        });
 
-        // Let the writer unblock so the sender thread can finish (its
-        // post-kill state isn't what we're testing).
+        {
+            let (lock, cvar) = &*killed;
+            let mut guard = lock.lock().unwrap();
+            while !*guard {
+                guard = cvar.wait(guard).unwrap();
+            }
+        }
         {
             let (lock, cvar) = &*unblock;
             *lock.lock().unwrap() = true;
             cvar.notify_all();
         }
-        let _ = sender.join();
+        sender.join().unwrap().unwrap();
+        killer.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn kill_event_commits_before_concurrent_exit() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME))?;
+        crate::store::insert_session(&conn, &session_record("kill-exit-session"))?;
+        drop(conn);
+
+        let runtime = LiveSessionRuntime::with_coven_home(temp_dir.path().to_path_buf());
+        let (observer, registration) =
+            runtime.observer_for_session("kill-exit-session".to_string());
+        let pty_runner::DetachedPtyObserver { on_exit, .. } = observer;
+        let started = Arc::new((Mutex::new(false), std::sync::Condvar::new()));
+        let exit_thread = Arc::new(Mutex::new(None));
+        runtime.register_kind_with_registration(
+            "kill-exit-session".to_string(),
+            LiveSessionKind::Pty,
+            Box::new(SharedBuffer::default()),
+            Box::new(ExitTriggeringKiller {
+                on_exit: Some(on_exit),
+                started,
+                exit_thread: Arc::clone(&exit_thread),
+            }),
+            registration,
+        )?;
+
+        let response = crate::api::handle_request_with_runtime(
+            "POST",
+            "/sessions/kill-exit-session/kill",
+            temp_dir.path(),
+            None,
+            None,
+            &runtime,
+        )?;
+        assert_eq!(response.status, 202);
+        exit_thread
+            .lock()
+            .unwrap()
+            .take()
+            .expect("exit thread was started")
+            .join()
+            .unwrap();
+
+        let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME))?;
+        let kinds = crate::store::list_events(&conn, "kill-exit-session")?
+            .into_iter()
+            .map(|event| event.kind)
+            .collect::<Vec<_>>();
+        assert_eq!(kinds, ["kill", "exit"]);
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -413,6 +413,17 @@ impl SessionRuntime for LiveSessionRuntime {
             .map(|writer| writer.record(session_id, kind, payload.clone()))
     }
 
+    fn can_record_session_event(
+        &self,
+        _session_id: &str,
+        _kind: &str,
+        payload: &Value,
+    ) -> Option<Result<bool>> {
+        self.event_writer
+            .as_ref()
+            .map(|writer| writer.can_record_critical_payload(payload))
+    }
+
     /// Must stay in this trait impl: `api::handle_request_with_runtime` reaches
     /// the runtime through `&dyn SessionRuntime`, so an inherent method of the
     /// same name is unreachable and `GET /health` silently falls back to the

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -83,6 +83,58 @@ struct QueuedEvent {
     completion: Option<mpsc::SyncSender<std::result::Result<(), String>>>,
 }
 
+pub(crate) struct EventBoundaryReservation {
+    writer: EventWriter,
+    session_id: String,
+    event: Option<PendingEvent>,
+    bytes: usize,
+    detached: Option<OutputTruncation>,
+    active: bool,
+}
+
+impl EventBoundaryReservation {
+    pub(crate) fn commit(mut self) -> Result<()> {
+        let event = self.event.take().expect("reservation event is present");
+        let marker = self
+            .detached
+            .take()
+            .map(|truncation| truncation_marker(&self.session_id, truncation));
+        let result = self
+            .writer
+            .enqueue_closed_critical(event, self.bytes, marker);
+        self.writer.release_boundary(&self.session_id);
+        self.active = false;
+        result
+    }
+
+    /// Restore the detached episode when the reserved action is rejected.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn cancel(mut self) {
+        self.restore();
+    }
+
+    fn restore(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut queue = self.writer.lock_queue();
+        if let Some(detached) = self.detached.take() {
+            restore_truncation(&mut queue, &self.session_id, detached);
+        }
+        queue.closing_sessions.remove(&self.session_id);
+        self.writer.shared.available.notify_all();
+        self.event.take();
+        drop(queue);
+        self.active = false;
+    }
+}
+
+impl Drop for EventBoundaryReservation {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
 enum PendingEvent {
     Output {
         session_id: String,
@@ -186,6 +238,15 @@ impl EventWriter {
     /// commit before the boundary event, and the caller waits for the writer's
     /// commit acknowledgement instead of silently dropping the event.
     pub fn record(&self, session_id: &str, kind: &str, payload: serde_json::Value) -> Result<()> {
+        self.reserve_record(session_id, kind, payload)?.commit()
+    }
+
+    pub(crate) fn reserve_record(
+        &self,
+        session_id: &str,
+        kind: &str,
+        payload: serde_json::Value,
+    ) -> Result<EventBoundaryReservation> {
         let record = store::EventRecord {
             seq: 0,
             id: Uuid::new_v4().to_string(),
@@ -199,7 +260,33 @@ impl EventWriter {
             .payload_json
             .len()
             .saturating_add(EVENT_OVERHEAD_BYTES);
-        self.enqueue_critical(PendingEvent::Record(record), bytes)
+        anyhow::ensure!(
+            bytes <= self.shared.capacity_bytes,
+            "critical event exceeds event writer capacity"
+        );
+        let event = PendingEvent::Record(record);
+        let mut queue = self.lock_queue();
+        loop {
+            if let Some(error) = &queue.failed {
+                return Err(anyhow!(error.clone()));
+            }
+            if queue.closing_sessions.insert(session_id.to_string()) {
+                let detached = queue.truncations.remove(session_id);
+                return Ok(EventBoundaryReservation {
+                    writer: self.clone(),
+                    session_id: session_id.to_string(),
+                    event: Some(event),
+                    bytes,
+                    detached,
+                    active: true,
+                });
+            }
+            queue = self
+                .shared
+                .available
+                .wait(queue)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
     }
 
     /// Insert the terminal event only after every prior accepted event has
@@ -301,10 +388,14 @@ impl EventWriter {
         };
 
         let result = self.enqueue_closed_critical(event, bytes, marker);
-        let mut queue = self.lock_queue();
-        queue.closing_sessions.remove(&session_id);
-        self.shared.available.notify_all();
+        self.release_boundary(&session_id);
         result
+    }
+
+    fn release_boundary(&self, session_id: &str) {
+        let mut queue = self.lock_queue();
+        queue.closing_sessions.remove(session_id);
+        self.shared.available.notify_all();
     }
 
     fn enqueue_closed_critical(
@@ -642,15 +733,14 @@ fn record_output_drop(queue: &mut Queue, session_id: &str, dropped_bytes: usize,
         .saturating_add(dropped_bytes as u64);
 }
 
-fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedEvent> {
-    let truncation = queue.truncations.remove(session_id)?;
+fn truncation_marker(session_id: &str, truncation: OutputTruncation) -> QueuedEvent {
     let payload_json = serde_json::to_string(&json!({
         "droppedEvents": truncation.dropped_events,
         "droppedBytes": truncation.dropped_bytes,
     }))
     .expect("truncation marker payload is always serializable");
     let bytes = payload_json.len().saturating_add(EVENT_OVERHEAD_BYTES);
-    Some(QueuedEvent {
+    QueuedEvent {
         event: PendingEvent::Record(store::EventRecord {
             seq: 0,
             id: Uuid::new_v4().to_string(),
@@ -661,7 +751,30 @@ fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedE
         }),
         bytes,
         completion: None,
-    })
+    }
+}
+
+fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedEvent> {
+    queue
+        .truncations
+        .remove(session_id)
+        .map(|truncation| truncation_marker(session_id, truncation))
+}
+
+fn restore_truncation(queue: &mut Queue, session_id: &str, detached: OutputTruncation) {
+    match queue.truncations.entry(session_id.to_string()) {
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(detached);
+        }
+        std::collections::hash_map::Entry::Occupied(mut entry) => {
+            let current = entry.get_mut();
+            current.dropped_events = detached
+                .dropped_events
+                .saturating_add(current.dropped_events);
+            current.dropped_bytes = detached.dropped_bytes.saturating_add(current.dropped_bytes);
+            current.created_at = detached.created_at;
+        }
+    }
 }
 
 fn flush_output(
@@ -1107,6 +1220,94 @@ mod tests {
         complete(&queued, Ok(()));
         critical.join().expect("critical producer panicked")?;
         assert!(!lock_queue(&shared).closing_sessions.contains("s-1"));
+        Ok(())
+    }
+
+    #[test]
+    fn reserved_record_splits_output_arriving_before_action_completion() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(!writer.record_output("s-1", "a".repeat(2048))?);
+        let reservation = writer.reserve_record("s-1", "input", json!({ "data": "ls\n" }))?;
+        assert!(!writer.record_output("s-1", "b".repeat(3072))?);
+        reservation.commit()?;
+        assert!(writer.record_output("s-1", "recovered".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "output_truncated",
+                "input",
+                "output_truncated",
+                "output",
+                "exit",
+            ],
+        );
+        assert_truncation(&events[0], 1, 2048)?;
+        assert_truncation(&events[2], 1, 3072)?;
+        Ok(())
+    }
+
+    #[test]
+    fn cancelled_record_restores_one_contiguous_output_episode() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(!writer.record_output("s-1", "a".repeat(2048))?);
+        let reservation = writer.reserve_record("s-1", "input", json!({ "data": "ls\n" }))?;
+        assert!(!writer.record_output("s-1", "b".repeat(3072))?);
+        reservation.cancel();
+        assert!(writer.record_output("s-1", "recovered".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            ["output_truncated", "output", "exit"],
+        );
+        assert_truncation(&events[0], 2, 5120)?;
+        Ok(())
+    }
+
+    fn assert_truncation(
+        event: &store::EventRecord,
+        dropped_events: u64,
+        dropped_bytes: u64,
+    ) -> Result<()> {
+        let payload: serde_json::Value = serde_json::from_str(&event.payload_json)?;
+        assert_eq!(payload["droppedEvents"], dropped_events);
+        assert_eq!(payload["droppedBytes"], dropped_bytes);
         Ok(())
     }
 

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -172,6 +172,15 @@ impl EventWriter {
         self.enqueue_output(event, bytes)
     }
 
+    /// Check whether a critical record with this payload can fit in this
+    /// writer. This lets request handlers reject known-oversized input before
+    /// its transport side effect occurs.
+    pub(crate) fn can_record_critical_payload(&self, payload: &serde_json::Value) -> Result<bool> {
+        let payload_json =
+            serde_json::to_string(payload).context("failed to serialize event writer payload")?;
+        Ok(payload_json.len().saturating_add(EVENT_OVERHEAD_BYTES) <= self.shared.capacity_bytes)
+    }
+
     /// Persist a non-output event on the critical path for accepted direct
     /// live-session input, kill, and cast events. Pending truncation markers
     /// commit before the boundary event, and the caller waits for the writer's

--- a/crates/coven-cli/src/event_writer.rs
+++ b/crates/coven-cli/src/event_writer.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 use crate::{pty_runner::PtyRunResult, store, STORE_FILE_NAME};
 
 const DEFAULT_CAPACITY_BYTES: usize = 2 * 1024 * 1024;
-const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
+pub(crate) const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
 const EVENT_OVERHEAD_BYTES: usize = 512;
 const MAX_BATCH_EVENTS: usize = 64;
 const COALESCE_WINDOW: Duration = Duration::from_millis(12);
@@ -111,7 +111,7 @@ impl EventWriter {
         Self::start_with_capacity(coven_home, DEFAULT_CAPACITY_BYTES)
     }
 
-    fn start_with_capacity(coven_home: PathBuf, capacity_bytes: usize) -> Result<Self> {
+    pub(crate) fn start_with_capacity(coven_home: PathBuf, capacity_bytes: usize) -> Result<Self> {
         anyhow::ensure!(
             capacity_bytes > RESERVED_CRITICAL_BYTES,
             "event writer capacity must reserve room for critical events"
@@ -172,9 +172,10 @@ impl EventWriter {
         self.enqueue_output(event, bytes)
     }
 
-    /// Persist a non-output event.  These events reserve capacity and wait for
-    /// the writer's commit acknowledgement instead of being silently dropped.
-    #[allow(dead_code)]
+    /// Persist a non-output event on the critical path for accepted direct
+    /// live-session input, kill, and cast events. Pending truncation markers
+    /// commit before the boundary event, and the caller waits for the writer's
+    /// commit acknowledgement instead of silently dropping the event.
     pub fn record(&self, session_id: &str, kind: &str, payload: serde_json::Value) -> Result<()> {
         let record = store::EventRecord {
             seq: 0,
@@ -1293,6 +1294,66 @@ mod tests {
             assert_eq!(marker_payload["droppedEvents"], 1);
             assert_eq!(marker_payload["droppedBytes"], dropped_bytes);
             assert_eq!(events[1].kind, "exit");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn direct_session_records_split_truncation_episodes() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+        store::insert_session(&conn, &session("s-1"))?;
+        let writer = EventWriter::start_with_capacity(
+            home.path().to_path_buf(),
+            RESERVED_CRITICAL_BYTES + 1024,
+        )?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        writer.record("s-1", "input", json!({ "value": "input" }))?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        assert!(!writer.record_output("s-1", "x".repeat(3072))?);
+        writer.record("s-1", "kill", json!({ "signal": "SIGTERM" }))?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        writer.record("s-1", "cast", json!({ "spell": "cast" }))?;
+
+        assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+        assert!(writer.record_output("s-1", "recovered".to_string())?);
+        writer.record_exit(
+            "s-1",
+            PtyRunResult {
+                status: "completed",
+                exit_code: Some(0),
+            },
+        )?;
+
+        let events = store::list_events(&conn, "s-1")?;
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| event.kind.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "output_truncated",
+                "input",
+                "output_truncated",
+                "kill",
+                "output_truncated",
+                "cast",
+                "output_truncated",
+                "output",
+                "exit",
+            ]
+        );
+
+        for (event_index, dropped_events, dropped_bytes) in
+            [(0, 1, 2048), (2, 2, 5120), (4, 1, 2048), (6, 1, 2048)]
+        {
+            let marker_payload: serde_json::Value =
+                serde_json::from_str(&events[event_index].payload_json)?;
+            assert_eq!(marker_payload["droppedEvents"], dropped_events);
+            assert_eq!(marker_payload["droppedBytes"], dropped_bytes);
         }
         Ok(())
     }

--- a/docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md
+++ b/docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md
@@ -5,11 +5,12 @@
 **Goal:** Ensure accepted live-session input, kill, and targeted cast events
 close pending raw-output truncation episodes at their exact event boundary.
 
-**Architecture:** Extend `SessionRuntime` with an optional writer-backed event
-operation. `LiveSessionRuntime` delegates it to the daemon-owned
-`EventWriter`, while writerless runtimes preserve the direct store insert.
-The API calls one helper after a successful live action; that helper never
-falls back after a writer failure.
+**Architecture:** Extend `EventWriter` with a cancellable per-session boundary
+reservation and extend `SessionRuntime` with an object-safe action wrapper.
+Input reserves before transport I/O and commits or restores its truncation
+episode afterward. Kill remains immediately issuable while a per-session guard
+orders its durable event before process exit. Writerless runtimes preserve the
+direct store path, and no writer failure falls back.
 
 **Tech Stack:** Rust, SQLite via rusqlite, serde_json, existing `EventWriter`,
 Rust unit/integration tests.
@@ -19,13 +20,14 @@ Rust unit/integration tests.
 ## File Structure
 
 - `crates/coven-cli/src/event_writer.rs` owns byte-bounded queueing,
-  per-session truncation episodes, and critical-event ordering. Expose only
-  test-visible capacity controls and prove generic direct records split
-  episodes.
+  per-session truncation episodes, critical-event ordering, and the new
+  reservation token that commits or restores one detached episode.
 - `crates/coven-cli/src/api.rs` owns `SessionRuntime`, HTTP action handlers,
-  direct-store fallback, and endpoint-level regressions.
+  phase-specific action/persistence errors, direct-store fallback, and
+  endpoint-level regressions.
 - `crates/coven-cli/src/daemon.rs` owns the live runtime implementation that
-  has access to the shared daemon `EventWriter`.
+  has access to the shared daemon `EventWriter` and the per-registration
+  kill/exit ordering guard.
 
 ### Task 1: Lock generic critical-record boundary behavior
 
@@ -436,3 +438,617 @@ git diff origin/main...HEAD -- crates/coven-cli/src/api.rs crates/coven-cli/src/
 Expected: only #642’s writer-routing, test-support visibility, and regression
 coverage are present; no handoff cursor changes from superseded PR #661 are
 reintroduced.
+
+### Task 4: Reserve and restore input boundaries
+
+**Files:**
+- Modify: `crates/coven-cli/src/event_writer.rs:63-80`
+- Modify: `crates/coven-cli/src/event_writer.rs:184-217`
+- Modify: `crates/coven-cli/src/event_writer.rs:284-376`
+- Modify: `crates/coven-cli/src/event_writer.rs:630-665`
+- Test: `crates/coven-cli/src/event_writer.rs:970-1110`
+
+- [ ] **Step 1: Add failing reservation concurrency tests**
+
+Add these tests beside
+`critical_boundary_prevents_same_session_output_from_overtaking_marker`:
+
+```rust
+#[test]
+fn reserved_record_splits_output_arriving_before_action_completion() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let writer = EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        RESERVED_CRITICAL_BYTES + 1024,
+    )?;
+
+    assert!(!writer.record_output("s-1", "a".repeat(2048))?);
+    let reservation = writer.reserve_record("s-1", "input", json!({ "data": "ls\n" }))?;
+    assert!(!writer.record_output("s-1", "b".repeat(3072))?);
+    reservation.commit()?;
+    assert!(writer.record_output("s-1", "recovered".to_string())?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult { status: "completed", exit_code: Some(0) },
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert_eq!(
+        events.iter().map(|event| event.kind.as_str()).collect::<Vec<_>>(),
+        ["output_truncated", "input", "output_truncated", "output", "exit"],
+    );
+    assert_truncation(&events[0], 1, 2048)?;
+    assert_truncation(&events[2], 1, 3072)?;
+    Ok(())
+}
+
+#[test]
+fn cancelled_record_restores_one_contiguous_output_episode() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let writer = EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        RESERVED_CRITICAL_BYTES + 1024,
+    )?;
+
+    assert!(!writer.record_output("s-1", "a".repeat(2048))?);
+    let reservation = writer.reserve_record("s-1", "input", json!({ "data": "ls\n" }))?;
+    assert!(!writer.record_output("s-1", "b".repeat(3072))?);
+    reservation.cancel();
+    assert!(writer.record_output("s-1", "recovered".to_string())?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult { status: "completed", exit_code: Some(0) },
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert_eq!(
+        events.iter().map(|event| event.kind.as_str()).collect::<Vec<_>>(),
+        ["output_truncated", "output", "exit"],
+    );
+    assert_truncation(&events[0], 2, 5120)?;
+    Ok(())
+}
+```
+
+Add the focused helper in the test module:
+
+```rust
+fn assert_truncation(
+    event: &store::EventRecord,
+    dropped_events: u64,
+    dropped_bytes: u64,
+) -> Result<()> {
+    let payload: serde_json::Value = serde_json::from_str(&event.payload_json)?;
+    assert_eq!(payload["droppedEvents"], dropped_events);
+    assert_eq!(payload["droppedBytes"], dropped_bytes);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the tests to verify the reservation API is absent**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::reserved_record_
+cargo test -p coven-cli event_writer::tests::cancelled_record_
+```
+
+Expected: compile failure because `reserve_record` and its token do not exist.
+
+- [ ] **Step 3: Add the consuming reservation token**
+
+Add this type after `QueuedEvent`:
+
+```rust
+pub(crate) struct EventBoundaryReservation {
+    writer: EventWriter,
+    session_id: String,
+    event: Option<PendingEvent>,
+    bytes: usize,
+    detached: Option<OutputTruncation>,
+}
+
+impl EventBoundaryReservation {
+    pub(crate) fn commit(mut self) -> Result<()> {
+        let event = self.event.take().expect("reservation event is present");
+        let marker = self
+            .detached
+            .take()
+            .map(|truncation| truncation_marker(&self.session_id, truncation));
+        let result = self.writer.enqueue_closed_critical(event, self.bytes, marker);
+        self.writer.release_boundary(&self.session_id);
+        result
+    }
+
+    pub(crate) fn cancel(mut self) {
+        self.restore();
+    }
+
+    fn restore(&mut self) {
+        let mut queue = self.writer.lock_queue();
+        if let Some(detached) = self.detached.take() {
+            restore_truncation(&mut queue, &self.session_id, detached);
+        }
+        queue.closing_sessions.remove(&self.session_id);
+        self.writer.shared.available.notify_all();
+        self.event.take();
+    }
+}
+
+impl Drop for EventBoundaryReservation {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+```
+
+Add the release helper inside `impl EventWriter`:
+
+```rust
+fn release_boundary(&self, session_id: &str) {
+    let mut queue = self.lock_queue();
+    queue.closing_sessions.remove(session_id);
+    self.shared.available.notify_all();
+}
+```
+
+- [ ] **Step 4: Add reservation construction and reuse it from `record`**
+
+Replace `EventWriter::record` with:
+
+```rust
+pub fn record(&self, session_id: &str, kind: &str, payload: serde_json::Value) -> Result<()> {
+    self.reserve_record(session_id, kind, payload)?.commit()
+}
+
+pub(crate) fn reserve_record(
+    &self,
+    session_id: &str,
+    kind: &str,
+    payload: serde_json::Value,
+) -> Result<EventBoundaryReservation> {
+    let record = store::EventRecord {
+        seq: 0,
+        id: Uuid::new_v4().to_string(),
+        session_id: session_id.to_string(),
+        kind: kind.to_string(),
+        payload_json: serde_json::to_string(&payload)
+            .context("failed to serialize event writer payload")?,
+        created_at: crate::api::current_timestamp(),
+    };
+    let bytes = record.payload_json.len().saturating_add(EVENT_OVERHEAD_BYTES);
+    anyhow::ensure!(
+        bytes <= self.shared.capacity_bytes,
+        "critical event exceeds event writer capacity"
+    );
+    let event = PendingEvent::Record(record);
+    let mut queue = self.lock_queue();
+    loop {
+        if let Some(error) = &queue.failed {
+            return Err(anyhow!(error.clone()));
+        }
+        if queue.closing_sessions.insert(session_id.to_string()) {
+            let detached = queue.truncations.remove(session_id);
+            return Ok(EventBoundaryReservation {
+                writer: self.clone(),
+                session_id: session_id.to_string(),
+                event: Some(event),
+                bytes,
+                detached,
+            });
+        }
+        queue = self
+            .shared
+            .available
+            .wait(queue)
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+    }
+}
+```
+
+Keep `record_exit` on `enqueue_critical`; it must wait behind an outstanding
+input reservation.
+
+- [ ] **Step 5: Refactor marker construction and cancellation merge**
+
+Replace `take_truncation_marker` with:
+
+```rust
+fn truncation_marker(session_id: &str, truncation: OutputTruncation) -> QueuedEvent {
+    let payload_json = serde_json::to_string(&json!({
+        "droppedEvents": truncation.dropped_events,
+        "droppedBytes": truncation.dropped_bytes,
+    }))
+    .expect("truncation marker payload is always serializable");
+    let bytes = payload_json.len().saturating_add(EVENT_OVERHEAD_BYTES);
+    QueuedEvent {
+        event: PendingEvent::Record(store::EventRecord {
+            seq: 0,
+            id: Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            kind: "output_truncated".to_string(),
+            payload_json,
+            created_at: truncation.created_at,
+        }),
+        bytes,
+        completion: None,
+    }
+}
+
+fn take_truncation_marker(queue: &mut Queue, session_id: &str) -> Option<QueuedEvent> {
+    queue
+        .truncations
+        .remove(session_id)
+        .map(|truncation| truncation_marker(session_id, truncation))
+}
+
+fn restore_truncation(
+    queue: &mut Queue,
+    session_id: &str,
+    detached: OutputTruncation,
+) {
+    match queue.truncations.entry(session_id.to_string()) {
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(detached);
+        }
+        std::collections::hash_map::Entry::Occupied(mut entry) => {
+            let current = entry.get_mut();
+            current.dropped_events = detached
+                .dropped_events
+                .saturating_add(current.dropped_events);
+            current.dropped_bytes = detached
+                .dropped_bytes
+                .saturating_add(current.dropped_bytes);
+            current.created_at = detached.created_at;
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run all event-writer tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+```
+
+Expected: PASS, including reservation commit, cancellation merge, existing
+critical ordering, capacity, failure, and exit tests.
+
+- [ ] **Step 7: Commit the reservation primitive**
+
+```bash
+git add crates/coven-cli/src/event_writer.rs
+git commit -s -m "fix: reserve direct event truncation boundaries"
+```
+
+### Task 5: Coordinate input actions and kill/exit ordering
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs:225-260`
+- Modify: `crates/coven-cli/src/api.rs:2490-2630`
+- Modify: `crates/coven-cli/src/api.rs:3100-3130`
+- Modify: `crates/coven-cli/src/daemon.rs:85-175`
+- Modify: `crates/coven-cli/src/daemon.rs:384-425`
+- Modify: `crates/coven-cli/src/daemon.rs:800-850`
+- Test: `crates/coven-cli/src/api.rs:9100-9500`
+- Test: `crates/coven-cli/src/daemon.rs:3980-4160`
+
+- [ ] **Step 1: Add the phase-specific boundary result**
+
+Add beside `SessionRuntime`:
+
+```rust
+pub enum SessionEventBoundaryError {
+    Runtime(anyhow::Error),
+    Coordination(anyhow::Error),
+    Persistence(anyhow::Error),
+}
+
+pub type SessionEventBoundaryResult =
+    std::result::Result<(), SessionEventBoundaryError>;
+```
+
+Add this object-safe default method to `SessionRuntime`:
+
+```rust
+fn with_session_event_boundary(
+    &self,
+    _session_id: &str,
+    _kind: &str,
+    _payload: &Value,
+    _action: &mut dyn FnMut() -> SessionEventBoundaryResult,
+) -> Option<SessionEventBoundaryResult> {
+    None
+}
+```
+
+- [ ] **Step 2: Centralize writer-backed and writerless action execution**
+
+Add below `record_direct_session_event`:
+
+```rust
+fn perform_direct_session_event(
+    runtime: &dyn SessionRuntime,
+    conn: &rusqlite::Connection,
+    coven_home: &Path,
+    session_id: &str,
+    kind: &str,
+    payload: Value,
+    action: &mut dyn FnMut() -> SessionEventBoundaryResult,
+) -> SessionEventBoundaryResult {
+    match runtime.with_session_event_boundary(
+        session_id,
+        kind,
+        &payload,
+        action,
+    ) {
+        Some(result) => result,
+        None => {
+            action()?;
+            insert_event(conn, coven_home, session_id, kind, payload)
+                .map_err(SessionEventBoundaryError::Persistence)
+        }
+    }
+}
+```
+
+The `Some(result)` branch must never run the action or persistence again.
+
+- [ ] **Step 3: Move input and kill through the action boundary**
+
+For input, replace the separate `send_input` and event calls with:
+
+```rust
+let mut action = || {
+    runtime
+        .send_input(session_id, &payload)
+        .map_err(SessionEventBoundaryError::Runtime)
+};
+let result = perform_direct_session_event(
+    runtime,
+    &conn,
+    coven_home,
+    session_id,
+    "input",
+    payload,
+    &mut action,
+);
+```
+
+Map `SessionEventBoundaryError::Runtime(error)` through the existing
+`NotLiveError`/`send_input_failed` response logic. Return
+`Coordination(error)` and `Persistence(error)` as internal errors without a
+success-shaped response.
+
+For kill, make the action own both the runtime effect and status update:
+
+```rust
+let kill_payload = json!({ "status": "killed" });
+let mut action = || {
+    runtime
+        .kill_session(session_id)
+        .map_err(SessionEventBoundaryError::Runtime)?;
+    let now = current_timestamp();
+    store::update_session_status(&conn, session_id, "killed", None, &now)
+        .map_err(SessionEventBoundaryError::Coordination)
+};
+let result = perform_direct_session_event(
+    runtime,
+    &conn,
+    coven_home,
+    session_id,
+    "kill",
+    kill_payload,
+    &mut action,
+);
+```
+
+Map runtime failures through the existing `NotLiveError`/`kill_failed`
+responses. Propagate coordination and persistence errors.
+
+- [ ] **Step 4: Add the daemon input reservation and kill guard**
+
+Add `event_order` to `LiveSessionRegistration`:
+
+```rust
+struct LiveSessionRegistration {
+    exited: AtomicBool,
+    writer: Mutex<Option<crate::maintenance_gate::WriterLease>>,
+    event_order: Mutex<()>,
+}
+```
+
+Initialize it with `Mutex::new(())`.
+
+Implement the new trait method:
+
+```rust
+fn with_session_event_boundary(
+    &self,
+    session_id: &str,
+    kind: &str,
+    payload: &Value,
+    action: &mut dyn FnMut() -> crate::api::SessionEventBoundaryResult,
+) -> Option<crate::api::SessionEventBoundaryResult> {
+    let writer = self.event_writer.as_ref()?;
+    Some((|| -> crate::api::SessionEventBoundaryResult {
+        match kind {
+            "input" => {
+                let reservation = writer
+                    .reserve_record(session_id, kind, payload.clone())
+                    .map_err(crate::api::SessionEventBoundaryError::Persistence)?;
+                match action() {
+                    Ok(()) => reservation
+                        .commit()
+                        .map_err(crate::api::SessionEventBoundaryError::Persistence),
+                    Err(error) => {
+                        reservation.cancel();
+                        Err(error)
+                    }
+                }
+            }
+            "kill" => {
+                let registration = {
+                    let sessions = self.sessions.lock().map_err(|_| {
+                        crate::api::SessionEventBoundaryError::Coordination(anyhow::anyhow!(
+                            "live session registry lock poisoned"
+                        ))
+                    })?;
+                    sessions
+                        .get(session_id)
+                        .map(|handle| Arc::clone(&handle.registration))
+                        .ok_or_else(|| {
+                            crate::api::SessionEventBoundaryError::Runtime(anyhow::Error::new(
+                                NotLiveError { session_id: session_id.to_string() },
+                            ))
+                        })?
+                };
+                let _event_order = registration.event_order.lock().map_err(|_| {
+                    crate::api::SessionEventBoundaryError::Coordination(anyhow::anyhow!(
+                        "live session event-order lock poisoned"
+                    ))
+                })?;
+                action()?;
+                writer
+                    .record(session_id, kind, payload.clone())
+                    .map_err(crate::api::SessionEventBoundaryError::Persistence)
+            }
+            _ => {
+                action()?;
+                writer
+                    .record(session_id, kind, payload.clone())
+                    .map_err(crate::api::SessionEventBoundaryError::Persistence)
+            }
+        }
+    })())
+}
+```
+
+Keep `record_session_event` for targeted cast.
+
+- [ ] **Step 5: Make exit take the same registration guard**
+
+At the start of `on_exit`, before `cleanup.mark_exited()` and
+`writer.record_exit`, acquire the registration guard:
+
+```rust
+let registration = cleanup
+    .as_ref()
+    .map(|cleanup| Arc::clone(&cleanup.registration));
+let _event_order = registration.as_ref().map(|registration| {
+    registration
+        .event_order
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+});
+```
+
+Keep the guard alive until after `record_exit` returns. This ordering must not
+reuse the output `event_closed` mutex because the input/output drain path has
+different blocking requirements.
+
+- [ ] **Step 6: Add deterministic blocked-input and exit-race regressions**
+
+Extend the existing `BlockingWriter` test support with an `entered` flag so the
+test waits for the write to block instead of sleeping:
+
+```rust
+struct BlockingWriter {
+    entered: Arc<(StdMutex<bool>, Condvar)>,
+    unblock: Arc<(StdMutex<bool>, Condvar)>,
+}
+```
+
+In `write`, set `entered` to true and notify before waiting on `unblock`.
+
+Replace the sleep in
+`kill_session_succeeds_even_while_send_input_is_blocked_on_a_hung_child` with
+a wait on `entered`. Exercise input through
+`SessionRuntime::with_session_event_boundary`, then exercise kill through the
+same boundary. Assert the killer flag becomes true before `unblock` is set.
+
+Add `kill_event_commits_before_concurrent_exit` using
+`observer_for_session`, a killer that launches `on_exit` on a separate thread,
+and a writer-backed `LiveSessionRuntime`. After the kill boundary returns, join
+the exit thread and assert the durable kinds end in:
+
+```rust
+["kill", "exit"]
+```
+
+Add an API test whose writer-backed runtime fails its input action after a
+reservation. Inject dropped output before and during the action, recover output,
+and assert one combined marker followed by `output`, with no `input` event.
+
+- [ ] **Step 7: Run focused concurrency tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::reserved_record_
+cargo test -p coven-cli event_writer::tests::cancelled_record_
+cargo test -p coven-cli daemon::tests::kill_session_succeeds_even_while_send_input_is_blocked_on_a_hung_child
+cargo test -p coven-cli daemon::tests::kill_event_commits_before_concurrent_exit
+cargo test -p coven-cli api::tests::failed_input_boundary_restores_truncation_episode
+cargo test -p coven-cli truncation_episodes
+```
+
+Expected: PASS. The kill flag is set before blocked input is released, durable
+kill precedes exit, and failed input restores one episode.
+
+- [ ] **Step 8: Commit runtime coordination**
+
+```bash
+git add crates/coven-cli/src/api.rs crates/coven-cli/src/daemon.rs
+git commit -s -m "fix: order direct actions at writer boundaries"
+```
+
+### Task 6: Validate the corrected pull request
+
+**Files:**
+- Verify: `crates/coven-cli/src/api.rs`
+- Verify: `crates/coven-cli/src/daemon.rs`
+- Verify: `crates/coven-cli/src/event_writer.rs`
+- Verify: `docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md`
+- Verify: `docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md`
+
+- [ ] **Step 1: Run focused direct-event tests**
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+cargo test -p coven-cli truncation_episodes
+cargo test -p coven-cli oversized_writer_backed
+cargo test -p coven-cli writer_failure
+```
+
+Expected: PASS with no zero-test filter.
+
+- [ ] **Step 2: Run repository gates**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+git add crates/coven-cli/src/api.rs crates/coven-cli/src/daemon.rs crates/coven-cli/src/event_writer.rs docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: every command succeeds.
+
+- [ ] **Step 3: Review the final branch diff**
+
+```bash
+git diff origin/main...HEAD --check
+git diff origin/main...HEAD -- crates/coven-cli/src/api.rs crates/coven-cli/src/daemon.rs crates/coven-cli/src/event_writer.rs docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md
+```
+
+Expected: the branch contains the approved spec, implementation correction,
+tests, and plan update with no unrelated changes.

--- a/docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md
+++ b/docs/superpowers/plans/2026-08-07-direct-event-truncation-boundaries.md
@@ -1,0 +1,438 @@
+# Direct-Event Truncation Boundaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure accepted live-session input, kill, and targeted cast events
+close pending raw-output truncation episodes at their exact event boundary.
+
+**Architecture:** Extend `SessionRuntime` with an optional writer-backed event
+operation. `LiveSessionRuntime` delegates it to the daemon-owned
+`EventWriter`, while writerless runtimes preserve the direct store insert.
+The API calls one helper after a successful live action; that helper never
+falls back after a writer failure.
+
+**Tech Stack:** Rust, SQLite via rusqlite, serde_json, existing `EventWriter`,
+Rust unit/integration tests.
+
+---
+
+## File Structure
+
+- `crates/coven-cli/src/event_writer.rs` owns byte-bounded queueing,
+  per-session truncation episodes, and critical-event ordering. Expose only
+  test-visible capacity controls and prove generic direct records split
+  episodes.
+- `crates/coven-cli/src/api.rs` owns `SessionRuntime`, HTTP action handlers,
+  direct-store fallback, and endpoint-level regressions.
+- `crates/coven-cli/src/daemon.rs` owns the live runtime implementation that
+  has access to the shared daemon `EventWriter`.
+
+### Task 1: Lock generic critical-record boundary behavior
+
+**Files:**
+- Modify: `crates/coven-cli/src/event_writer.rs:25-31`
+- Modify: `crates/coven-cli/src/event_writer.rs:109-193`
+- Test: `crates/coven-cli/src/event_writer.rs:1229-1410`
+
+- [ ] **Step 1: Write the failing generic-record regression**
+
+Add this test beside `exit_closes_pressure_episode_before_terminal_event`:
+
+```rust
+#[test]
+fn direct_session_records_split_truncation_episodes() -> Result<()> {
+    let home = tempfile::tempdir()?;
+    let conn = store::open_store(&home.path().join(STORE_FILE_NAME))?;
+    store::insert_session(&conn, &session("s-1"))?;
+    let writer = EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        RESERVED_CRITICAL_BYTES + 1024,
+    )?;
+
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+    writer.record("s-1", "input", json!({ "data": "ls\n" }))?;
+
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+    assert!(!writer.record_output("s-1", "x".repeat(3072))?);
+    writer.record("s-1", "kill", json!({ "status": "killed" }))?;
+
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+    writer.record("s-1", "cast", json!({ "code": "/handoff" }))?;
+
+    assert!(!writer.record_output("s-1", "x".repeat(2048))?);
+    assert!(writer.record_output("s-1", "recovered".to_string())?);
+    writer.record_exit(
+        "s-1",
+        PtyRunResult {
+            status: "completed",
+            exit_code: Some(0),
+        },
+    )?;
+
+    let events = store::list_events(&conn, "s-1")?;
+    assert_eq!(
+        events.iter().map(|event| event.kind.as_str()).collect::<Vec<_>>(),
+        [
+            "output_truncated", "input",
+            "output_truncated", "kill",
+            "output_truncated", "cast",
+            "output_truncated", "output", "exit",
+        ]
+    );
+    for (index, expected) in [(0, (1, 2048)), (2, (2, 5120)), (4, (1, 2048)), (6, (1, 2048))] {
+        let marker: serde_json::Value = serde_json::from_str(&events[index].payload_json)?;
+        assert_eq!(marker["droppedEvents"], expected.0);
+        assert_eq!(marker["droppedBytes"], expected.1);
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the regression before changing production visibility**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::direct_session_records_split_truncation_episodes
+```
+
+Expected: PASS; `EventWriter::record` already owns critical marker ordering.
+This characterization test protects that invariant before API routing changes.
+
+- [ ] **Step 3: Make the existing small-capacity constructor test-visible**
+
+Change only the visibility of these two existing items; their bodies and
+values stay unchanged:
+
+```rust
+pub(crate) const RESERVED_CRITICAL_BYTES: usize = 128 * 1024;
+
+pub(crate) fn start_with_capacity(
+    coven_home: PathBuf,
+    capacity_bytes: usize,
+) -> Result<Self>
+```
+
+Keep `EventWriter::start` calling `start_with_capacity`. Remove
+`#[allow(dead_code)]` from `record` and document that accepted direct
+live-session events use this critical path.
+
+- [ ] **Step 4: Run all event-writer tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+```
+
+Expected: PASS, including the new generic-record episode-splitting regression.
+
+- [ ] **Step 5: Commit the writer-boundary characterization**
+
+```bash
+git add crates/coven-cli/src/event_writer.rs
+git commit -s -m "test: cover direct event truncation boundaries"
+```
+
+### Task 2: Route accepted live API events through the shared writer
+
+**Files:**
+- Modify: `crates/coven-cli/src/api.rs:225-241`
+- Modify: `crates/coven-cli/src/api.rs:370-405`
+- Modify: `crates/coven-cli/src/api.rs:2451-2529`
+- Modify: `crates/coven-cli/src/api.rs:2531-2588`
+- Modify: `crates/coven-cli/src/api.rs:2767-2821`
+- Modify: `crates/coven-cli/src/api.rs:3033-3048`
+- Test: `crates/coven-cli/src/api.rs:8590-10020`
+- Modify: `crates/coven-cli/src/daemon.rs:384-414`
+
+- [ ] **Step 1: Add failing endpoint regressions**
+
+Add a `WriterBackedRuntime` test fixture in `api.rs` test module:
+
+```rust
+struct WriterBackedRuntime {
+    writer: crate::event_writer::EventWriter,
+}
+
+impl SessionRuntime for WriterBackedRuntime {
+    fn launch_session(&self, _: &SessionLaunch) -> Result<()> {
+        Ok(())
+    }
+
+    fn send_input(&self, _: &str, _: &Value) -> Result<()> {
+        Ok(())
+    }
+
+    fn kill_session(&self, _: &str) -> Result<()> {
+        Ok(())
+    }
+
+    fn record_session_event(
+        &self,
+        session_id: &str,
+        kind: &str,
+        payload: &Value,
+    ) -> Option<Result<()>> {
+        Some(self.writer.record(session_id, kind, payload.clone()))
+    }
+}
+```
+
+Add a test helper that checks the durable sequence and exact marker totals:
+
+```rust
+fn assert_split_boundary(
+    home: &Path,
+    session_id: &str,
+    expected_boundary: &str,
+) -> Result<()> {
+    let conn = store::open_store(&store_path(home))?;
+    let events = store::list_events(&conn, session_id)?;
+    assert_eq!(
+        events.iter().map(|event| event.kind.as_str()).collect::<Vec<_>>(),
+        ["output_truncated", expected_boundary, "output_truncated", "output", "exit"]
+    );
+    for (index, expected) in [(0, (1, 2048)), (2, (1, 3072))] {
+        let marker: Value = serde_json::from_str(&events[index].payload_json)?;
+        assert_eq!(marker["droppedEvents"], expected.0);
+        assert_eq!(marker["droppedBytes"], expected.1);
+    }
+    Ok(())
+}
+```
+
+Add tests named `accepted_input_splits_truncation_episodes`,
+`accepted_kill_splits_truncation_episodes`, and
+`targeted_cast_splits_truncation_episodes`. Each test uses this body pattern:
+
+```rust
+let home = tempfile::tempdir()?;
+insert_test_session(home.path(), "sess-input")?;
+let runtime = WriterBackedRuntime {
+    writer: crate::event_writer::EventWriter::start_with_capacity(
+        home.path().to_path_buf(),
+        crate::event_writer::RESERVED_CRITICAL_BYTES + 1024,
+    )?,
+};
+assert!(!runtime.writer.record_output("sess-input", "x".repeat(2048))?);
+let response = handle_request_with_runtime(
+    "POST",
+    "/sessions/sess-input/input",
+    home.path(),
+    None,
+    Some(r#"{"data":"ls\n"}"#),
+    &runtime,
+)?;
+assert_eq!(response.status, 202);
+assert!(!runtime.writer.record_output("sess-input", "y".repeat(3072))?);
+assert!(runtime.writer.record_output("sess-input", "recovered".to_string())?);
+runtime.writer.record_exit(
+    "sess-input",
+    crate::pty_runner::PtyRunResult {
+        status: "completed",
+        exit_code: Some(0),
+    },
+)?;
+assert_split_boundary(home.path(), "sess-input", "input")?;
+```
+
+Repeat the pattern with these endpoint-specific substitutions:
+
+- `sess-kill`, `POST /sessions/sess-kill/kill`, `None`, and `"kill"`;
+- `sess-cast`, `POST /cast`, `Some(r#"{"code":"/handoff","target":"sess-cast"}"#)`,
+  and `"cast"`.
+
+For every test, retain the writer capacity, first `2048`-byte rejected output,
+second `3072`-byte rejected output, recovered output, terminal exit, and
+`assert_split_boundary` call shown above. Each test therefore proves the
+boundary marker is immediate and later pressure is a distinct episode.
+
+- [ ] **Step 2: Run the endpoint regressions to confirm the present bug**
+
+Run:
+
+```bash
+cargo test -p coven-cli truncation_episodes
+```
+
+Expected: FAIL. Current handlers call `insert_event` directly, so the first
+`output_truncated` marker is not immediately before the direct event.
+
+- [ ] **Step 3: Add the optional runtime persistence operation**
+
+In `SessionRuntime`, add the default writerless operation:
+
+```rust
+fn record_session_event(
+    &self,
+    _session_id: &str,
+    _kind: &str,
+    _payload: &Value,
+) -> Option<Result<()>> {
+    None
+}
+```
+
+In `LiveSessionRuntime`'s trait implementation, add:
+
+```rust
+fn record_session_event(
+    &self,
+    session_id: &str,
+    kind: &str,
+    payload: &Value,
+) -> Option<Result<()>> {
+    self.event_writer
+        .as_ref()
+        .map(|writer| writer.record(session_id, kind, payload.clone()))
+}
+```
+
+Do not change `NoopSessionRuntime` or existing test runtimes; the trait
+default retains their direct-store behavior.
+
+- [ ] **Step 4: Centralize the writer-first API helper**
+
+Immediately below `insert_event`, add:
+
+```rust
+fn record_direct_session_event(
+    runtime: &dyn SessionRuntime,
+    conn: &rusqlite::Connection,
+    coven_home: &Path,
+    session_id: &str,
+    kind: &str,
+    payload: Value,
+) -> Result<()> {
+    match runtime.record_session_event(session_id, kind, &payload) {
+        Some(result) => result,
+        None => insert_event(conn, coven_home, session_id, kind, payload),
+    }
+}
+```
+
+This `Some(result) => result` branch is required: a failed writer must remain
+an error and may not silently reinsert the event through the store.
+
+- [ ] **Step 5: Replace all three accepted live-event direct inserts**
+
+Apply the helper only after the existing action succeeds:
+
+```rust
+// record_input success branch
+record_direct_session_event(
+    runtime, &conn, coven_home, session_id, "input", payload,
+)?;
+
+// kill_session after update_session_status
+record_direct_session_event(
+    runtime, &conn, coven_home, session_id, "kill",
+    json!({ "status": "killed" }),
+)?;
+```
+
+Change the route to pass the runtime and update `submit_cast`:
+
+```rust
+("POST", "/cast") => submit_cast(coven_home, body, runtime),
+
+fn submit_cast(
+    coven_home: &Path,
+    body: Option<&str>,
+    runtime: &dyn SessionRuntime,
+) -> Result<ApiResponse>
+```
+
+Within the existing `submit_cast` body, replace its sole
+`insert_event(&conn, coven_home, session_id, "cast", ...)` call with:
+
+```rust
+record_direct_session_event(
+    runtime,
+    &conn,
+    coven_home,
+    session_id,
+    "cast",
+    json!({ "cast_id": cast_id, "code": code, "target": target }),
+)?;
+```
+
+Do not route offline reconciliation, handoff bookkeeping, historical import,
+or unrelated direct store writes through this helper.
+
+- [ ] **Step 6: Run focused API and writer tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli event_writer::tests::
+cargo test -p coven-cli truncation_episodes
+cargo test -p coven-cli 'api::tests::(input_request|kill_request|post_cast)'
+```
+
+Expected: PASS. Existing writerless-runtime tests continue using the default
+direct-store path; all three writer-backed endpoint tests show distinct
+markers on either side of the accepted boundary.
+
+- [ ] **Step 7: Commit the routing change and regressions**
+
+```bash
+git add crates/coven-cli/src/api.rs crates/coven-cli/src/daemon.rs crates/coven-cli/src/event_writer.rs
+git commit -s -m "fix: preserve direct event truncation boundaries"
+```
+
+### Task 3: Validate the complete issue contract
+
+**Files:**
+- Verify: `crates/coven-cli/src/api.rs`
+- Verify: `crates/coven-cli/src/daemon.rs`
+- Verify: `crates/coven-cli/src/event_writer.rs`
+
+- [ ] **Step 1: Format the changed Rust sources**
+
+Run:
+
+```bash
+cargo fmt --check
+```
+
+Expected: PASS. If formatting is needed, run `cargo fmt`, then rerun
+`cargo fmt --check`.
+
+- [ ] **Step 2: Run the required Rust quality gates**
+
+Run:
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+```
+
+Expected: PASS with no warnings and no failing workspace tests.
+
+- [ ] **Step 3: Run repository safety gates**
+
+Run:
+
+```bash
+python scripts/check-secrets.py
+git add crates/coven-cli/src/api.rs crates/coven-cli/src/daemon.rs crates/coven-cli/src/event_writer.rs
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: both commands exit successfully. The privacy guard covers only the
+implementation changes, not unrelated worktree state.
+
+- [ ] **Step 4: Review the final diff before opening the replacement PR**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --check
+git diff origin/main...HEAD -- crates/coven-cli/src/api.rs crates/coven-cli/src/daemon.rs crates/coven-cli/src/event_writer.rs
+```
+
+Expected: only #642’s writer-routing, test-support visibility, and regression
+coverage are present; no handoff cursor changes from superseded PR #661 are
+reintroduced.

--- a/docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md
+++ b/docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md
@@ -12,75 +12,112 @@ commits that marker immediately before the critical event. Raw output submitted
 while a critical boundary is pending is rejected into a new episode, so it
 cannot cross the claimed boundary.
 
-The HTTP handlers for accepted input, kill, and targeted cast events currently
-write directly to `Store::insert_event`. Those inserts bypass the writer, so a
-pending marker can be delayed until later recovered output or exit. Drops on
-both sides of the direct event can then be represented as one misleading
-episode.
+The HTTP handlers for accepted input, kill, and targeted cast events previously
+wrote directly to `Store::insert_event`. Routing their accepted events through
+the writer closes that bypass, but claiming the writer boundary only after
+`send_input` or `kill_session` returns is still too late. Output can arrive
+during input transport and join the preceding episode, while a fast process
+exit can persist `exit` before the handler persists `kill`.
 
 ## Considered Approaches
 
-### 1. Route accepted direct events through `EventWriter` (selected)
+### 1. Reserve input boundaries and coordinate kill/exit ordering (selected)
 
-Add an explicit writer-backed persistence operation to `SessionRuntime`.
-Daemon-backed runtimes return a handled result after calling
-`EventWriter::record`; writerless runtimes return unhandled so the API uses the
-existing direct store insertion.
+Add an `EventWriter` reservation that detaches the current truncation episode
+before input transport begins. Successful input commits the detached marker and
+event together. Failed input cancels the reservation and merges the detached
+episode back into any drops observed during the failed action.
 
-This reuses the writer's single queue, per-session critical-boundary claim,
-commit acknowledgement, and failure propagation. It gives all live events one
-ordering authority and is the only approach that prevents a concurrently
-arriving output callback from crossing a direct-event boundary.
+Kill keeps the existing non-blocking runtime guarantee: it is issued without
+waiting for a blocked input transport. A per-session exit-order guard spans the
+kill action, killed-status update, and durable kill event. The process exit
+callback takes the same guard before recording `exit`, so exit cannot overtake
+an accepted kill. Targeted cast has no separate runtime side effect and keeps
+the existing synchronous `EventWriter::record` path.
 
-### 2. Flush a pending marker, then keep direct insertion
+This design preserves one ordering authority without making a hung input prevent
+the daemon from issuing kill.
 
-The API could expose a marker-only flush before calling `Store::insert_event`.
-This repairs the visible ordering but retains two independent persistence
-authorities and requires new synchronization to prevent output from arriving
-between marker flush and direct insertion.
+### 2. Serialize every action under the writer claim
 
-### 3. Move all event ordering into the store
+The handler could claim the existing critical boundary before input or kill and
+hold it until the action finishes. This is simpler, but a blocked input would
+prevent the kill action itself from running, violating the live-session
+recovery contract.
 
-The store could coordinate output and direct inserts transactionally. This
-would duplicate queue pressure accounting and make the non-blocking PTY path
-depend on SQLite work. It is broader than the issue and weakens the existing
-writer boundary.
+### 3. Coordinate only kill and exit
+
+A per-session kill/exit mutex alone prevents exit from overtaking kill, but it
+does not stop output observed during `send_input` from joining the preceding
+truncation episode. It fixes only half of the concurrency gap.
 
 ## Design
 
 ### Runtime persistence contract
 
-`SessionRuntime` gains a method for a non-output live-session event that
+`SessionRuntime` adds an object-safe
+`with_session_event_boundary(session_id, kind, payload, action)` operation that
 returns either:
 
 - a handled `Result` after writer-backed persistence; or
 - an explicit unhandled result when the runtime has no shared writer.
 
-The daemon implementation calls `EventWriter::record(session_id, kind,
-payload)`. The trait default is unhandled, preserving API tests and
-non-daemon runtimes that do not own an event writer. The API helper uses the
-direct store insert only for that explicit unhandled case; it must not fall
-back after a writer error.
+The `action` argument is an API-owned `&mut dyn FnMut() -> Result<()>`. This
+keeps transport calls and store status updates in the API while allowing the
+daemon runtime to place synchronization around them. The trait default returns
+unhandled; the API then executes the action followed by its existing direct
+insert. A handled runtime owns the action and persistence attempt completely,
+and the API must not retry either operation or fall back after an error.
 
-The `EventWriter::record` event remains critical and synchronous. It therefore
-uses the existing per-session close/claim protocol and waits for the worker's
-commit acknowledgement. Its existing marker construction remains the sole
-implementation of `output_truncated`.
+For input, the daemon implementation begins a writer reservation before calling
+the action. The reservation owns the detached `OutputTruncation`, keeps the
+session in boundary mode, and exposes consuming `commit` and `cancel`
+operations.
+
+Cancellation restores the detached episode without manufacturing a marker. If
+output arrived while the action was pending, cancellation merges counts and
+bytes into that later episode and preserves the earlier `created_at`. Commit
+constructs the marker through the existing marker builder, queues
+`output_truncated -> input`, waits for durable acknowledgement, and then
+releases the boundary. A consumed or dropped reservation cannot commit twice.
+
+The existing `EventWriter::record` path remains critical and synchronous for
+targeted cast and other action-free boundaries. Its marker construction remains
+the sole implementation of `output_truncated`.
+
+### Kill and exit coordination
+
+Each live session registration owns an exit-order guard shared by
+`with_session_event_boundary` for `kill` and the detached process observer. The
+API action closure contains both `kill_session` and the killed-status update.
+The daemon runtime:
+
+1. acquires the guard;
+2. invokes the API action, which issues the runtime kill without waiting for an
+   input reservation and updates the durable status to `killed`;
+3. records the critical `kill` event through the writer; and
+4. releases the guard.
+
+The exit callback acquires the same guard before cleanup and
+`EventWriter::record_exit`. A fast child exit therefore waits until the kill
+event is durable. A blocked input may delay kill-event persistence, but it does
+not delay issuing the kill that unblocks or terminates the child.
 
 ### Accepted-event ordering
 
-After the existing action succeeds, each handler persists its accepted event
-through the new runtime operation:
+Each accepted event uses the ordering appropriate to its side effect:
 
-1. accepted `session.input` persists `input`;
-2. accepted `session.kill` persists `kill`; and
-3. accepted targeted cast dispatch persists `cast`.
+1. `session.input` reserves the boundary, performs transport I/O, then commits
+   `input`; a transport failure cancels the reservation;
+2. `session.kill` uses the exit-order guard around kill, status, and durable
+   `kill` persistence; and
+3. targeted cast dispatch synchronously persists `cast`.
 
-The action still occurs before its event, matching current behavior. A failed
-action produces no accepted event. A writer persistence failure remains an
-explicit handler failure after the action, as direct store-write failures do
-today; the API must not report success-shaped output or silently reinsert the
-event through the store.
+The action still occurs before its accepted event, matching current behavior.
+A failed action produces no accepted event. A writer persistence failure
+remains an explicit handler failure after the action, as direct store-write
+failures do today; the API must not report success-shaped output or silently
+reinsert the event through the store.
 
 When an output-pressure episode is pending for that session, the writer queues
 and commits:
@@ -102,15 +139,19 @@ defined by the existing truncation design.
 
 The change does not route historical import, offline maintenance, or
 non-live-session events through the writer. It does not change output
-coalescing, capacity limits, or lifecycle/exit routing, which already use the
-writer.
+coalescing, capacity limits, or event payload schemas. It strengthens lifecycle
+ordering by sharing one per-session guard between accepted kill and exit.
 
 ## Failure Behavior
 
 - A writer failure is returned to the API handler and is never replaced with a
   direct insert, avoiding duplicate or out-of-order events.
+- An input transport failure cancels its reservation and restores the complete
+  pending truncation episode; it persists neither `input` nor a boundary marker.
 - A writerless runtime continues to use the existing direct store insert,
   preserving its current error behavior.
+- Kill is issued even while input transport is blocked. Exit persistence waits
+  for the accepted kill event rather than overtaking it.
 - Critical-event queue pressure waits for durable capacity and commit
   acknowledgement; it is not lossy.
 - Raw PTY output remains the only lossy event class. The existing health
@@ -118,8 +159,8 @@ writer.
 
 ## Verification
 
-Add source-backed regressions that create one dropped-output episode, accept a
-direct event, create a second episode, then recover output. Cover input, kill,
+Retain source-backed regressions that create one dropped-output episode, accept
+a direct event, create a second episode, then recover output. Cover input, kill,
 and targeted cast independently. Each test asserts:
 
 1. the first `output_truncated` marker is immediately before the direct event;
@@ -127,6 +168,16 @@ and targeted cast independently. Each test asserts:
 3. the two markers carry only the drops from their respective episodes; and
 4. no event crosses the direct-event boundary.
 
-Retain focused writer tests for its critical record ordering and run the
-relevant API/daemon tests plus the repository's required formatter, lints,
-workspace tests, secret scan, and privacy guard before merge.
+Add deterministic concurrency regressions:
+
+1. block input transport after reservation, inject output, release input, and
+   prove that output belongs to the later episode;
+2. fail input after output arrives and prove cancellation merges both drop
+   totals with no marker or input event;
+3. block input, issue kill concurrently, and prove the runtime kill executes
+   before input is released; and
+4. trigger process exit during kill and prove durable order is `kill -> exit`.
+
+Retain focused writer tests for critical record ordering and run the relevant
+API/daemon tests plus the repository's required formatter, lints, workspace
+tests, secret scan, and privacy guard before merge.

--- a/docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md
+++ b/docs/superpowers/specs/2026-08-07-direct-event-truncation-boundaries-design.md
@@ -1,0 +1,132 @@
+# Direct-Event Truncation Boundary Design
+
+**Goal:** Preserve one exact `output_truncated` boundary before every accepted
+live-session input, kill, or targeted cast event that follows dropped raw PTY
+output.
+
+## Context
+
+The bounded daemon `EventWriter` owns output-pressure episodes by session. Its
+critical-event path claims a session, removes any pending episode marker, and
+commits that marker immediately before the critical event. Raw output submitted
+while a critical boundary is pending is rejected into a new episode, so it
+cannot cross the claimed boundary.
+
+The HTTP handlers for accepted input, kill, and targeted cast events currently
+write directly to `Store::insert_event`. Those inserts bypass the writer, so a
+pending marker can be delayed until later recovered output or exit. Drops on
+both sides of the direct event can then be represented as one misleading
+episode.
+
+## Considered Approaches
+
+### 1. Route accepted direct events through `EventWriter` (selected)
+
+Add an explicit writer-backed persistence operation to `SessionRuntime`.
+Daemon-backed runtimes return a handled result after calling
+`EventWriter::record`; writerless runtimes return unhandled so the API uses the
+existing direct store insertion.
+
+This reuses the writer's single queue, per-session critical-boundary claim,
+commit acknowledgement, and failure propagation. It gives all live events one
+ordering authority and is the only approach that prevents a concurrently
+arriving output callback from crossing a direct-event boundary.
+
+### 2. Flush a pending marker, then keep direct insertion
+
+The API could expose a marker-only flush before calling `Store::insert_event`.
+This repairs the visible ordering but retains two independent persistence
+authorities and requires new synchronization to prevent output from arriving
+between marker flush and direct insertion.
+
+### 3. Move all event ordering into the store
+
+The store could coordinate output and direct inserts transactionally. This
+would duplicate queue pressure accounting and make the non-blocking PTY path
+depend on SQLite work. It is broader than the issue and weakens the existing
+writer boundary.
+
+## Design
+
+### Runtime persistence contract
+
+`SessionRuntime` gains a method for a non-output live-session event that
+returns either:
+
+- a handled `Result` after writer-backed persistence; or
+- an explicit unhandled result when the runtime has no shared writer.
+
+The daemon implementation calls `EventWriter::record(session_id, kind,
+payload)`. The trait default is unhandled, preserving API tests and
+non-daemon runtimes that do not own an event writer. The API helper uses the
+direct store insert only for that explicit unhandled case; it must not fall
+back after a writer error.
+
+The `EventWriter::record` event remains critical and synchronous. It therefore
+uses the existing per-session close/claim protocol and waits for the worker's
+commit acknowledgement. Its existing marker construction remains the sole
+implementation of `output_truncated`.
+
+### Accepted-event ordering
+
+After the existing action succeeds, each handler persists its accepted event
+through the new runtime operation:
+
+1. accepted `session.input` persists `input`;
+2. accepted `session.kill` persists `kill`; and
+3. accepted targeted cast dispatch persists `cast`.
+
+The action still occurs before its event, matching current behavior. A failed
+action produces no accepted event. A writer persistence failure remains an
+explicit handler failure after the action, as direct store-write failures do
+today; the API must not report success-shaped output or silently reinsert the
+event through the store.
+
+When an output-pressure episode is pending for that session, the writer queues
+and commits:
+
+```text
+output_truncated -> input|kill|cast
+```
+
+The event is a critical boundary. Output arriving after the claim cannot join
+the preceding episode; later pressure produces a second marker before the
+next recovered output or boundary event. Sessions remain independent.
+
+### Compatibility and scope
+
+This is an internal persistence-routing change. Request and response schemas,
+event payload shapes, output drop counters, and the append-only event stream
+contract do not change. `output_truncated` remains the additive event kind
+defined by the existing truncation design.
+
+The change does not route historical import, offline maintenance, or
+non-live-session events through the writer. It does not change output
+coalescing, capacity limits, or lifecycle/exit routing, which already use the
+writer.
+
+## Failure Behavior
+
+- A writer failure is returned to the API handler and is never replaced with a
+  direct insert, avoiding duplicate or out-of-order events.
+- A writerless runtime continues to use the existing direct store insert,
+  preserving its current error behavior.
+- Critical-event queue pressure waits for durable capacity and commit
+  acknowledgement; it is not lossy.
+- Raw PTY output remains the only lossy event class. The existing health
+  counters continue to describe all rejected output.
+
+## Verification
+
+Add source-backed regressions that create one dropped-output episode, accept a
+direct event, create a second episode, then recover output. Cover input, kill,
+and targeted cast independently. Each test asserts:
+
+1. the first `output_truncated` marker is immediately before the direct event;
+2. the recovered output is preceded by a second marker;
+3. the two markers carry only the drops from their respective episodes; and
+4. no event crosses the direct-event boundary.
+
+Retain focused writer tests for its critical record ordering and run the
+relevant API/daemon tests plus the repository's required formatter, lints,
+workspace tests, secret scan, and privacy guard before merge.


### PR DESCRIPTION
## Summary
- route accepted live input, kill, and targeted cast events through the daemon EventWriter
- preserve separate output-truncation episodes at each direct-event boundary
- reject oversized writer-backed inputs and targeted casts before side effects while preserving direct cockpit casts

## Test Plan
- [x] cargo fmt --check
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo test --workspace --locked
- [x] python scripts/check-secrets.py
- [x] python3 scripts/check-coven-privacy.py --staged

Closes #642
Supersedes #661