### PR TITLE
docs: plan final single-source audit waves

### DIFF
--- a/docs/superpowers/plans/2026-08-07-documentation-wave-a-install-platform.md
+++ b/docs/superpowers/plans/2026-08-07-documentation-wave-a-install-platform.md
@@ -1,0 +1,553 @@
+# Documentation Wave A: Install and Platform Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the remaining public installation, platform, deployment, and onboarding guidance into `coven-docs`, then reduce the corresponding `coven` pages and runtime links to canonical pointers.
+
+**Architecture:** Land a canonical `coven-docs` PR first, organized around install methods, platform notes, deployments, onboarding, and uninstall/debugging. After that PR merges, land a dependent `coven` cleanup that preserves the local state-layout and legacy-TUI contracts while converting public pages, tests, and runtime help to `docs.opencoven.ai`.
+
+**Tech Stack:** Fumadocs MDX, Node.js documentation guards, Rust CLI smoke tests, GitHub CLI, pnpm, Cargo.
+
+---
+
+### Task 1: Create isolated Wave A worktrees
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Check for duplicate work**
+
+Run:
+
+```bash
+cd "$HOME/Documents/GitHub/OpenCoven/coven"
+coven claim status
+(cd "$HOME/Documents/GitHub/OpenCoven/coven-docs" && coven claim status)
+gh pr list --repo OpenCoven/coven --state open
+gh pr list --repo OpenCoven/coven-docs --state open
+```
+
+Expected: no active claim or open PR implementing issue `#670` Wave A.
+
+- [ ] **Step 2: Create the canonical worktree and claim**
+
+Run:
+
+```bash
+git -C "$HOME/Documents/GitHub/OpenCoven/coven-docs" fetch origin main
+git -C "$HOME/Documents/GitHub/OpenCoven/coven-docs" worktree add \
+  -b docs/670-wave-a-install-platform \
+  /tmp/coven-docs-670-wave-a \
+  origin/main
+cd /tmp/coven-docs-670-wave-a
+coven claim acquire issue-670
+```
+
+Expected: worktree at `/tmp/coven-docs-670-wave-a` and an active `issue-670` claim.
+
+### Task 2: Add failing canonical install coverage
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-a/scripts/check-cli-docs.mjs`
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/guide/meta.json`
+
+- [ ] **Step 1: Extend the guide navigation**
+
+Add `platforms` and `deployments` after `install`:
+
+```json
+{
+  "title": "Guide",
+  "description": "Start with Coven's local runtime",
+  "root": true,
+  "icon": "LuBookOpen",
+  "pages": [
+    "getting-started",
+    "install",
+    "platforms",
+    "deployments",
+    "concepts",
+    "architecture"
+  ]
+}
+```
+
+- [ ] **Step 2: Add exact install assertions**
+
+In `scripts/check-cli-docs.mjs`, add `install-debugging` and `uninstall` to
+`requiredPages`, then read the three guide pages and require these source-backed
+phrases:
+
+```js
+const guideRoot = join(docsRoot, 'guide');
+const requiredGuidePages = ['install', 'platforms', 'deployments'];
+const requiredInstallMentions = [
+  'npm install -g @opencoven/cli',
+  'cargo install --path crates/coven-cli',
+  'Apple Silicon',
+  'glibc',
+  'PowerShell',
+  'WSL2',
+  'Linux filesystem',
+  'launchd',
+  'systemd',
+  'Docker',
+  'Podman',
+  'Nix',
+  'Raspberry Pi',
+  'COVEN_HOME',
+  'coven doctor',
+  'coven daemon status',
+];
+```
+
+Iterate over `requiredGuidePages`, fail if a page is absent or lacks
+`read_when:`, and fail when any `requiredInstallMentions` value is absent from
+the joined guide source.
+
+- [ ] **Step 3: Run the guard and confirm it fails**
+
+Run:
+
+```bash
+cd /tmp/coven-docs-670-wave-a
+pnpm run check:cli-docs
+```
+
+Expected: failure naming missing `platforms.mdx`, `deployments.mdx`, or required
+install phrases.
+
+- [ ] **Step 4: Commit the failing guard**
+
+```bash
+git add scripts/check-cli-docs.mjs content/docs/guide/meta.json
+git commit -s -m "test: require canonical platform install guidance" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 3: Canonicalize install methods and platform behavior
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/guide/install.mdx`
+- Create: `/tmp/coven-docs-670-wave-a/content/docs/guide/platforms.mdx`
+- Create: `/tmp/coven-docs-670-wave-a/content/docs/guide/deployments.mdx`
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/cli/install.mdx`
+
+- [ ] **Step 1: Expand the install landing page**
+
+Keep the existing frontmatter and add:
+
+```mdx
+## Choose an install route
+
+| Route | Best for | Verification |
+| --- | --- | --- |
+| `npm install -g @opencoven/cli` | Published platform wrapper | `coven doctor` |
+| `cargo install --path crates/coven-cli` | Source checkout contributors | `coven --version` |
+| `cargo build --workspace` | Active development | `cargo test --workspace --locked` |
+
+Use the npm wrapper for normal installs. Use source routes only when the
+published package does not cover the target or when contributing to Coven.
+```
+
+Link to `/docs/guide/platforms`, `/docs/guide/deployments`,
+`/docs/cli/install-debugging`, and `/docs/cli/uninstall`.
+
+- [ ] **Step 2: Create the platform page**
+
+Create `content/docs/guide/platforms.mdx` with frontmatter and sections:
+
+```mdx
+## macOS
+
+- Apple Silicon uses the native macOS package.
+- Use `launchd` only when you need login-time daemon startup.
+
+## Linux
+
+- Published Linux packages target glibc-based x64 systems.
+- Use `systemd --user` for persistent same-user daemon operation.
+
+## Windows
+
+- Run install and verification from PowerShell.
+- The daemon uses an owner-only named pipe selected from `COVEN_HOME`.
+- WSL2 is a separate Linux environment; do not mix Windows and WSL state.
+
+## WSL2
+
+- Keep repositories and `COVEN_HOME` on the Linux filesystem when possible.
+- Avoid `/mnt/c` for daemon-heavy workloads.
+
+## Raspberry Pi
+
+- Use a 64-bit operating system.
+- Build from source when no published package matches the architecture.
+```
+
+Include `coven doctor`, `coven daemon status`, and links to daemon
+configuration and install debugging.
+
+- [ ] **Step 3: Create the deployment page**
+
+Create `content/docs/guide/deployments.mdx` with:
+
+```mdx
+## Headless and cloud hosts
+
+Use SSH as the same operating-system user that owns `COVEN_HOME`. Keep daemon
+IPC local; do not expose it directly.
+
+## Docker and Podman
+
+Mount a persistent `COVEN_HOME`, keep the daemon and client in the same trust
+boundary, and verify with `coven doctor`.
+
+## Nix
+
+Treat Nix as an environment/build route, not a separate runtime contract.
+
+## Service managers
+
+Use `launchd` on macOS and `systemd --user` on Linux. Both must preserve the
+same `COVEN_HOME` and PATH used by the interactive shell.
+```
+
+Link remote-access concerns to `/docs/daemon/security`.
+
+- [ ] **Step 4: Expand the CLI install reference**
+
+In `content/docs/cli/install.mdx`, add exact npm, Cargo, and source-checkout
+commands, plus a platform package note. Do not promise support for an
+architecture unless a package exists in the current release workflow.
+
+- [ ] **Step 5: Run the guard**
+
+```bash
+pnpm run check:cli-docs
+```
+
+Expected: `CLI docs check passed.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add content/docs/guide content/docs/cli/install.mdx
+git commit -s -m "docs: canonicalize install and platform guidance" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 4: Canonicalize onboarding, debugging, updates, and uninstall
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/guide/getting-started.mdx`
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/cli/interactive.mdx`
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/cli/install-debugging.mdx`
+- Modify: `/tmp/coven-docs-670-wave-a/content/docs/cli/uninstall.mdx`
+- Modify: `/tmp/coven-docs-670-wave-a/scripts/check-cli-docs.mjs`
+
+- [ ] **Step 1: Add source-backed onboarding behavior**
+
+Document that the default interactive path uses the managed `coven-code`
+engine, while `COVEN_LEGACY_TUI=1` is a deprecated compatibility escape hatch.
+Keep first-session verification:
+
+```bash
+coven doctor
+coven daemon start
+coven run codex "explain this repo in 5 bullets"
+coven sessions
+```
+
+- [ ] **Step 2: Add debugging and update recovery**
+
+Ensure `install-debugging.mdx` includes:
+
+```bash
+# Unix-like shells
+npm view @opencoven/cli version
+which -a coven
+rustup update stable
+cargo build --workspace
+```
+
+Add the native PowerShell equivalent:
+
+```powershell
+Get-Command -All coven
+```
+
+Explain PATH refresh, wrapper/native mismatch, Windows/WSL separation, and
+rollback by reinstalling a verified prior package version rather than copying
+binaries between platforms. Label `which -a coven` as Unix-like-only.
+
+- [ ] **Step 3: Add uninstall behavior**
+
+Ensure `uninstall.mdx` says to run `coven daemon stop`, remove the npm or Cargo
+installation, and preserve `~/.coven` by default. Destructive state removal
+must be an explicit final step.
+
+- [ ] **Step 4: Strengthen the guard**
+
+Add required mentions:
+
+```js
+[
+  'COVEN_LEGACY_TUI=1',
+  'npm view @opencoven/cli version',
+  'which -a coven',
+  'Get-Command -All coven',
+  'rustup update stable',
+  'coven daemon stop',
+  'cargo uninstall coven-cli',
+]
+```
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+pnpm run check:cli-docs
+pnpm run check:links
+pnpm build
+git add content/docs/guide/getting-started.mdx content/docs/cli scripts/check-cli-docs.mjs
+git commit -s -m "docs: complete canonical onboarding lifecycle" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: all commands pass.
+
+### Task 5: Merge the canonical Wave A PR
+
+**Files:**
+- No new file changes.
+
+- [ ] **Step 1: Push and open the PR**
+
+```bash
+git push -u origin docs/670-wave-a-install-platform
+gh pr create --repo OpenCoven/coven-docs \
+  --title "docs: canonicalize install and platform guidance" \
+  --body "Implements Wave A of OpenCoven/coven#670. Adds canonical install methods, platform notes, deployments, onboarding, debugging, updates, and uninstall guidance. The dependent coven cleanup must merge after this PR."
+```
+
+- [ ] **Step 2: Wait for review and required checks**
+
+Run:
+
+```bash
+gh pr checks --repo OpenCoven/coven-docs --watch
+```
+
+Expected: all required checks pass.
+
+- [ ] **Step 3: Merge**
+
+Use a squash commit with the repository-required Copilot trailer.
+
+### Task 6: Create the dependent `coven` cleanup worktree
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Release the docs claim and acquire it in `coven`**
+
+```bash
+cd /tmp/coven-docs-670-wave-a
+coven claim release issue-670
+git -C "$HOME/Documents/GitHub/OpenCoven/coven" fetch origin main
+git -C "$HOME/Documents/GitHub/OpenCoven/coven" worktree add \
+  -b docs/670-wave-a-install-platform-cleanup \
+  /tmp/coven-670-wave-a \
+  origin/main
+cd /tmp/coven-670-wave-a
+coven claim acquire issue-670
+```
+
+### Task 7: Change stale local documentation guards first
+
+**Files:**
+- Modify: `/tmp/coven-670-wave-a/scripts/onboarding-docs-test.mjs`
+- Modify: `/tmp/coven-670-wave-a/crates/coven-cli/tests/smoke.rs`
+
+- [ ] **Step 1: Replace substantive platform-page assertions**
+
+Replace `platformDocs` with canonical pointer expectations:
+
+```js
+const platformDocs = [
+  'docs/platforms/macos.md',
+  'docs/platforms/linux.md',
+  'docs/platforms/windows.md',
+  'docs/platforms/wsl2.md',
+  'docs/platforms/headless.md',
+  'docs/platforms/cloud-vm.md',
+  'docs/platforms/raspberry-pi.md',
+];
+
+for (const path of platformDocs) {
+  assert.match(readRepoFile(path), /https:\/\/docs\.opencoven\.ai\/docs\/guide\/(?:platforms|deployments)/);
+}
+```
+
+Require `docs/install/coven-home.md` to point to
+`https://docs.opencoven.ai/docs/daemon/configuration`. The detailed
+source-adjacent state-layout contract remains at `docs/daemon/coven-home.md`.
+
+- [ ] **Step 2: Update the Rust smoke expectation**
+
+Change the expected doctor line to:
+
+```rust
+"Install docs: https://docs.opencoven.ai/docs/guide/install",
+```
+
+- [ ] **Step 3: Run and verify failure**
+
+```bash
+node scripts/onboarding-docs-test.mjs
+cargo test -p coven-cli --test smoke \
+  doctor_missing_harness_prints_cross_platform_setup_loop -- --nocapture
+```
+
+Expected: failure because local pages and runtime output still use repository
+URLs and substantive content.
+
+- [ ] **Step 4: Commit the guard changes**
+
+```bash
+git add scripts/onboarding-docs-test.mjs crates/coven-cli/tests/smoke.rs
+git commit -s -m "test: require canonical install entry points" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 8: Reduce local install, platform, and onboarding pages
+
+**Files:**
+- Modify: `/tmp/coven-670-wave-a/crates/coven-cli/src/main.rs`
+- Modify: `/tmp/coven-670-wave-a/docs/install/cargo.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/coven-home.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/development-channels.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/docker.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/from-source.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/headless-server.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/index.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/launchd.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/linux.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/macos.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/nix.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/npm.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/podman.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/raspberry-pi.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/systemd.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/uninstall.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/updating.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/windows.md`
+- Modify: `/tmp/coven-670-wave-a/docs/install/wsl2.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/cloud-vm.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/headless.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/linux.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/macos.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/raspberry-pi.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/windows.md`
+- Modify: `/tmp/coven-670-wave-a/docs/platforms/wsl2.md`
+- Modify: `/tmp/coven-670-wave-a/docs/start/doctor.md`
+- Modify: `/tmp/coven-670-wave-a/docs/start/first-session.md`
+- Modify: `/tmp/coven-670-wave-a/docs/start/quickstart.md`
+- Modify: `/tmp/coven-670-wave-a/docs/start/onboarding.md`
+- Modify: `/tmp/coven-670-wave-a/docs/start/showcase.md`
+- Keep substantive: `/tmp/coven-670-wave-a/docs/start/coven-tui.md`
+- Do not modify: `/tmp/coven-670-wave-a/docs/daemon/coven-home.md`
+
+- [ ] **Step 1: Update runtime help**
+
+Change `doctor_next_steps` to:
+
+```rust
+"Install docs: https://docs.opencoven.ai/docs/guide/install".to_string(),
+```
+
+- [ ] **Step 2: Replace public pages with concise pointers**
+
+Use this shape with the page's existing title and the target assigned below:
+
+```md
+---
+title: "Windows installation"
+description: "Pointer to canonical Windows and WSL installation guidance."
+---
+
+Canonical guidance: **https://docs.opencoven.ai/docs/guide/platforms**
+
+Source-adjacent state layout remains in [`../daemon/coven-home.md`](../daemon/coven-home.md).
+```
+
+Use `/docs/guide/install` for install methods, `/docs/guide/platforms` for
+OS-specific pages, `/docs/guide/deployments` for headless/cloud/container
+pages, `/docs/cli/uninstall` for uninstall, and
+`/docs/guide/getting-started` for onboarding pages. Point
+`docs/install/coven-home.md` to `/docs/daemon/configuration`.
+
+- [ ] **Step 3: Fix the retained legacy-TUI links**
+
+In `docs/start/coven-tui.md`, replace broken `/SESSION-LIFECYCLE` links with
+the retained local contract:
+
+```md
+../SESSION-LIFECYCLE.md
+```
+
+- [ ] **Step 4: Validate**
+
+```bash
+node scripts/onboarding-docs-test.mjs
+cargo test -p coven-cli --test smoke \
+  doctor_missing_harness_prints_cross_platform_setup_loop -- --nocapture
+python3 scripts/check-secrets.py
+git diff --check
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/coven-cli/src/main.rs crates/coven-cli/tests/smoke.rs \
+  scripts/onboarding-docs-test.mjs docs/install docs/platforms docs/start
+git commit -s -m "docs: point install and platform guidance canonical" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 9: Validate and merge the dependent cleanup
+
+**Files:**
+- No additional file changes expected.
+
+- [ ] **Step 1: Run required gates**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+COVEN_NPM_DRY_RUN_VERSION=999.0.0 \
+  node scripts/test-cli-prepublish.mjs --target=macos
+python3 scripts/check-secrets.py
+git diff --check
+git add -A
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 2: Push and open the dependent PR**
+
+```bash
+git push -u origin docs/670-wave-a-install-platform-cleanup
+gh pr create --repo OpenCoven/coven \
+  --title "docs: point install and platform guidance canonical" \
+  --body "Implements Wave A cleanup for #670. Depends on the merged canonical coven-docs Wave A PR. Preserves local state-layout and legacy-TUI contracts while moving public install, platform, deployment, and onboarding guidance to docs.opencoven.ai."
+```
+
+- [ ] **Step 3: Merge only after full CI and review**
+
+After merge, release `issue-670`, remove both Wave A worktrees, and delete the
+local branches.

--- a/docs/superpowers/plans/2026-08-07-documentation-wave-b-harness-support.md
+++ b/docs/superpowers/plans/2026-08-07-documentation-wave-b-harness-support.md
@@ -54,12 +54,12 @@ Add these exact source-backed requirements:
 
 ```js
 const builtInHarnesses = ['codex', 'claude', 'coven-code', 'copilot'];
-const optInRecipes = ['grok', 'hermes'];
+const optInRecipes = ['grok', 'hermes', 'opencode'];
 ```
 
-Require all built-ins in the main support table, require `grok` and `hermes`
-to be described as installable recipes, and reject wording that calls either
-one bundled.
+Require all built-ins in the main support table, require `grok`, `hermes`, and
+`opencode` to be described as installable recipes, and reject wording that
+calls any of them bundled.
 
 - [ ] **Step 3: Require memory import**
 
@@ -121,8 +121,8 @@ Use this exact distinction:
 
 ## Trusted installable recipes
 
-`grok` and `hermes` are opt-in recipes installed through `coven adapter
-install`; they are not bundled defaults.
+`grok`, `hermes`, and `opencode` are opt-in recipes installed through
+`coven adapter install`; they are not bundled defaults.
 ```
 
 Keep OpenClaw documented as an external bridge rather than a built-in harness.
@@ -139,6 +139,7 @@ copilot login
 coven engine install
 coven adapter install grok
 coven adapter install hermes
+coven adapter install opencode
 ```
 
 Explain same-shell PATH/auth checks, project-root refusal, working-directory

--- a/docs/superpowers/plans/2026-08-07-documentation-wave-b-harness-support.md
+++ b/docs/superpowers/plans/2026-08-07-documentation-wave-b-harness-support.md
@@ -1,0 +1,464 @@
+# Documentation Wave B: Harness and Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `coven-docs` authoritative for harness setup, troubleshooting, diagnostics, environment, permissions, paths, community support, issue filing, and memory import, then remove the duplicate public help pages from `coven`.
+
+**Architecture:** Expand existing harness and troubleshooting pages, add one canonical support hub and one memory-import page, and enforce them with existing documentation guards. After the canonical PR merges, delete public help leaves, reduce harness/model overviews to pointers, and retain `docs/HARNESS-ADAPTERS.md` plus implementation-specific adapter notes.
+
+**Tech Stack:** Fumadocs MDX, Node.js documentation guards, YAML issue templates, Rust CLI source verification, pnpm.
+
+---
+
+### Task 1: Create the Wave B canonical worktree
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Coordinate and claim**
+
+```bash
+cd "$HOME/Documents/GitHub/OpenCoven/coven"
+coven claim status
+(cd "$HOME/Documents/GitHub/OpenCoven/coven-docs" && coven claim status)
+gh pr list --repo OpenCoven/coven --state open
+gh pr list --repo OpenCoven/coven-docs --state open
+git -C "$HOME/Documents/GitHub/OpenCoven/coven-docs" fetch origin main
+git -C "$HOME/Documents/GitHub/OpenCoven/coven-docs" worktree add \
+  -b docs/670-wave-b-harness-support \
+  /tmp/coven-docs-670-wave-b \
+  origin/main
+cd /tmp/coven-docs-670-wave-b
+coven claim acquire issue-670
+```
+
+Expected: no duplicate Wave B work and an active claim.
+
+### Task 2: Add failing harness, support, and memory guards
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-b/scripts/check-harness-docs.mjs`
+- Modify: `/tmp/coven-docs-670-wave-b/scripts/check-memory-models-docs.mjs`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/reference/meta.json`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/memory-models/meta.json`
+
+- [ ] **Step 1: Add canonical navigation entries**
+
+Add `"support"` to `content/docs/reference/meta.json` after
+`"troubleshooting"`. Add `"memory-import"` to
+`content/docs/memory-models/meta.json` after `"memory"`.
+
+- [ ] **Step 2: Strengthen harness assertions**
+
+Add these exact source-backed requirements:
+
+```js
+const builtInHarnesses = ['codex', 'claude', 'coven-code', 'copilot'];
+const optInRecipes = ['grok', 'hermes'];
+```
+
+Require all built-ins in the main support table, require `grok` and `hermes`
+to be described as installable recipes, and reject wording that calls either
+one bundled.
+
+- [ ] **Step 3: Require memory import**
+
+Add `'memory-import'` to `requiredPages` and add:
+
+```js
+[
+  'coven memory import',
+  'coven memory restore',
+  '--familiar',
+  '--apply',
+  '--bundle',
+  '--json',
+  '--source openclaw',
+  '--openclaw-root',
+  'preview',
+  'Windows supports preview',
+]
+```
+
+to `requiredMentions`.
+
+- [ ] **Step 4: Run guards and confirm failure**
+
+```bash
+pnpm run check:harness-docs
+pnpm run check:memory-models-docs
+```
+
+Expected: failures for missing `support.mdx`, `memory-import.mdx`, or required
+phrases.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-harness-docs.mjs scripts/check-memory-models-docs.mjs \
+  content/docs/reference/meta.json content/docs/memory-models/meta.json
+git commit -s -m "test: require canonical harness support guidance" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 3: Expand canonical harness setup and recovery
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/harnesses/installing.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/harnesses/troubleshooting.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/harnesses/provider-auth.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/harnesses/project-roots.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/harnesses/working-directories.mdx`
+
+- [ ] **Step 1: Document the supported harness classes**
+
+Use this exact distinction:
+
+```mdx
+## Bundled harness ids
+
+`codex`, `claude`, `coven-code`, and `copilot` are built-in adapters.
+
+## Trusted installable recipes
+
+`grok` and `hermes` are opt-in recipes installed through `coven adapter
+install`; they are not bundled defaults.
+```
+
+Keep OpenClaw documented as an external bridge rather than a built-in harness.
+
+- [ ] **Step 2: Add deterministic recovery**
+
+Document:
+
+```bash
+coven doctor
+codex login
+claude doctor
+copilot login
+coven engine install
+coven adapter install grok
+coven adapter install hermes
+```
+
+Explain same-shell PATH/auth checks, project-root refusal, working-directory
+validation, and PTY requirements.
+
+- [ ] **Step 3: Run and commit**
+
+```bash
+pnpm run check:harness-docs
+git add content/docs/harnesses scripts/check-harness-docs.mjs
+git commit -s -m "docs: complete canonical harness recovery guidance" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: harness guard passes.
+
+### Task 4: Add the canonical support hub
+
+**Files:**
+- Create: `/tmp/coven-docs-670-wave-b/content/docs/reference/support.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/reference/troubleshooting.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/cli/doctor.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/daemon/configuration.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/daemon/security.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/daemon/observability.mdx`
+
+- [ ] **Step 1: Create `support.mdx`**
+
+Use frontmatter and these sections:
+
+```mdx
+## Start with diagnostics
+
+Run `coven doctor`, `coven daemon status --json`, and the failing command with
+the smallest reproducible project.
+
+## Collect a safe report
+
+Include platform, install route, Coven version, command, expected behavior, and
+redacted diagnostics. Do not include provider tokens, private prompts, raw
+environment dumps, or sensitive absolute paths.
+
+## Community and issue filing
+
+- GitHub issues: https://github.com/OpenCoven/coven/issues
+- Discord: https://discord.gg/opencoven
+```
+
+Link to troubleshooting, doctor, observability, and security pages.
+
+- [ ] **Step 2: Move environment, path, permission, and diagnostics facts**
+
+Add:
+
+- `NO_COLOR`, `COLORTERM`, `TERM`, `COVEN_HOME`, and
+  `coven config paths --json` to configuration/doctor guidance;
+- same-user ownership and permission repair guidance to security;
+- diagnostic bundle/redaction rules to observability;
+- harness missing, daemon startup, and stuck-session routes to troubleshooting.
+
+- [ ] **Step 3: Validate and commit**
+
+```bash
+pnpm run check:links
+git add content/docs/reference content/docs/cli/doctor.mdx \
+  content/docs/daemon
+git commit -s -m "docs: add canonical support and diagnostics hub" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: build and links pass.
+
+### Task 5: Add the canonical memory-import workflow
+
+**Files:**
+- Create: `/tmp/coven-docs-670-wave-b/content/docs/memory-models/memory-import.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/memory-models/index.mdx`
+- Modify: `/tmp/coven-docs-670-wave-b/content/docs/memory-models/memory.mdx`
+
+- [ ] **Step 1: Write the workflow**
+
+Document this sequence:
+
+```bash
+# Preview native memory for one registered familiar.
+coven memory import --familiar sage
+
+# Apply the exact previewed bytes.
+coven memory import --familiar sage --apply
+
+# Preview an explicit OpenClaw workspace.
+coven memory import \
+  --familiar sage \
+  --source openclaw \
+  --openclaw-root /path/to/openclaw \
+  --json
+
+# Logically restore a verified import bundle.
+coven memory restore --familiar sage --bundle blake3-DIGEST
+```
+
+State that import previews before applying, private bundle content must not be
+committed, and restore is logical rather than a destructive filesystem rewind.
+State explicitly that Windows supports preview only; apply and restore fail
+before mutation until equivalent durability and marker guarantees are
+available.
+
+- [ ] **Step 2: Link the page**
+
+Add `/docs/memory-models/memory-import` from `index.mdx` and `memory.mdx`.
+
+- [ ] **Step 3: Validate and commit**
+
+```bash
+pnpm run check:memory-models-docs
+pnpm run check:links
+pnpm build
+git add content/docs/memory-models scripts/check-memory-models-docs.mjs
+git commit -s -m "docs: canonicalize memory import and restore" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 6: Merge the canonical Wave B PR
+
+**Files:**
+- No new changes.
+
+- [ ] **Step 1: Push and open**
+
+```bash
+git push -u origin docs/670-wave-b-harness-support
+gh pr create --repo OpenCoven/coven-docs \
+  --title "docs: canonicalize harness and support guidance" \
+  --body "Implements Wave B of OpenCoven/coven#670. Adds canonical harness recovery, support, diagnostics, issue-filing, environment, permissions, paths, and memory-import guidance. The dependent coven cleanup must merge second."
+```
+
+- [ ] **Step 2: Wait for checks and merge**
+
+```bash
+gh pr checks --repo OpenCoven/coven-docs --watch
+```
+
+Expected: all required checks pass before squash merge.
+
+### Task 7: Add failing local ownership checks
+
+**Files:**
+- Modify: `/tmp/coven-670-wave-b/scripts/onboarding-docs-test.mjs`
+- Modify: `/tmp/coven-670-wave-b/scripts/cli-docs-test.mjs`
+
+- [ ] **Step 1: Create the cleanup worktree**
+
+```bash
+cd /tmp/coven-docs-670-wave-b
+coven claim release issue-670
+git -C "$HOME/Documents/GitHub/OpenCoven/coven" fetch origin main
+git -C "$HOME/Documents/GitHub/OpenCoven/coven" worktree add \
+  -b docs/670-wave-b-harness-support-cleanup \
+  /tmp/coven-670-wave-b \
+  origin/main
+cd /tmp/coven-670-wave-b
+coven claim acquire issue-670
+```
+
+- [ ] **Step 2: Replace obsolete substantive-help assertions**
+
+Remove deleted help leaves from `criticalDocs`. Add:
+
+```js
+test('public support routes point to canonical docs', () => {
+  assert.match(readRepoFile('docs/help/index.md'), /https:\/\/docs\.opencoven\.ai\/docs\/reference\/support/);
+  assert.match(readRepoFile('.github/ISSUE_TEMPLATE/bug-report.yml'), /https:\/\/docs\.opencoven\.ai\/docs\/reference\/support/);
+});
+```
+
+In `cli-docs-test.mjs`, require harness/model index pages to link to
+`https://docs.opencoven.ai/docs/harnesses` and
+`https://docs.opencoven.ai/docs/memory-models/provider-boundary`.
+
+- [ ] **Step 3: Run and confirm failure**
+
+```bash
+node scripts/onboarding-docs-test.mjs
+node scripts/cli-docs-test.mjs
+```
+
+Expected: failures because local pages and the issue template still use local
+public routes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/onboarding-docs-test.mjs scripts/cli-docs-test.mjs
+git commit -s -m "test: require canonical harness support links" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 8: Remove duplicate help leaves and reduce harness/model pages
+
+**Files:**
+- Modify: `/tmp/coven-670-wave-b/docs/help/index.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/community.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/daemon-wont-start.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/diagnostics-bundle.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/environment.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/filing-issues.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/harness-not-found.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/memory-import.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/paths.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/permissions.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/session-stuck.md`
+- Delete: `/tmp/coven-670-wave-b/docs/help/troubleshooting.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/claude-code.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/codex.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/copilot-cli.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/index.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/installing.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/project-root.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/provider-auth.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/troubleshooting.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/what-is-a-harness.md`
+- Modify: `/tmp/coven-670-wave-b/docs/harnesses/working-directory.md`
+- Modify: `/tmp/coven-670-wave-b/docs/models/index.md`
+- Modify: `/tmp/coven-670-wave-b/docs/models/provider-boundary.md`
+- Modify: `/tmp/coven-670-wave-b/docs/models/why-coven-does-not-own-credentials.md`
+- Modify: `/tmp/coven-670-wave-b/README.md`
+- Modify: `/tmp/coven-670-wave-b/.github/ISSUE_TEMPLATE/bug-report.yml`
+- Modify: inbound links reported by `rg 'docs/help/|/help/' docs README.md .github scripts`
+
+- [ ] **Step 1: Preserve local contracts**
+
+Do not reduce:
+
+```text
+docs/HARNESS-ADAPTERS.md
+docs/harnesses/grok-build.md
+docs/harnesses/hermes.md
+docs/harnesses/openclaw.md
+docs/harnesses/opencode.md
+docs/harnesses/custom.md
+docs/reference/harness-adapters.md
+```
+
+- [ ] **Step 2: Replace index pages with pointers**
+
+`docs/help/index.md` must point to:
+
+```md
+https://docs.opencoven.ai/docs/reference/support
+https://docs.opencoven.ai/docs/reference/troubleshooting
+https://docs.opencoven.ai/docs/cli/doctor
+```
+
+Harness public pages point to these corresponding routes:
+
+```text
+index -> https://docs.opencoven.ai/docs/harnesses
+what-is-a-harness -> https://docs.opencoven.ai/docs/harnesses/what-is-a-harness
+installing -> https://docs.opencoven.ai/docs/harnesses/installing
+provider-auth -> https://docs.opencoven.ai/docs/harnesses/provider-auth
+project-root -> https://docs.opencoven.ai/docs/harnesses/project-roots
+working-directory -> https://docs.opencoven.ai/docs/harnesses/working-directories
+codex -> https://docs.opencoven.ai/docs/harnesses/codex
+claude-code -> https://docs.opencoven.ai/docs/harnesses/claude-code
+copilot-cli -> https://docs.opencoven.ai/docs/harnesses/copilot
+troubleshooting -> https://docs.opencoven.ai/docs/harnesses/troubleshooting
+```
+
+All three model/provider pages point to
+`https://docs.opencoven.ai/docs/memory-models/provider-boundary`.
+Replace current README links to `docs/harnesses/index.md` with
+`https://docs.opencoven.ai/docs/harnesses`.
+
+- [ ] **Step 3: Retarget inbound links**
+
+Update the bug-report template and current documentation links to canonical
+support routes. Historical implementation plans may retain descriptive text,
+but links used as current instructions must become canonical.
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+node scripts/onboarding-docs-test.mjs
+node scripts/cli-docs-test.mjs
+python3 scripts/check-secrets.py
+git diff --check
+git add -A
+python3 scripts/check-coven-privacy.py --staged
+git commit -s -m "docs: point harness and support guidance canonical" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: all commands pass.
+
+### Task 9: Validate and merge Wave B cleanup
+
+**Files:**
+- No additional changes expected.
+
+- [ ] **Step 1: Run the full applicable gates**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+COVEN_NPM_DRY_RUN_VERSION=999.0.0 \
+  node scripts/test-cli-prepublish.mjs --target=macos
+python3 scripts/check-secrets.py
+git diff --check
+```
+
+- [ ] **Step 2: Push and open**
+
+```bash
+git push -u origin docs/670-wave-b-harness-support-cleanup
+gh pr create --repo OpenCoven/coven \
+  --title "docs: point harness and support guidance canonical" \
+  --body "Implements Wave B cleanup for #670 after the canonical coven-docs Wave B merge. Retains normative adapter contracts while removing duplicate public harness, help, diagnostics, and memory-import guidance."
+```
+
+- [ ] **Step 3: Merge after review and full CI**
+
+Release `issue-670` and remove both Wave B worktrees after merge.

--- a/docs/superpowers/plans/2026-08-07-documentation-wave-c-daemon-cli-reference.md
+++ b/docs/superpowers/plans/2026-08-07-documentation-wave-c-daemon-cli-reference.md
@@ -1,0 +1,551 @@
+# Documentation Wave C: Daemon, CLI, and Reference Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish canonical daemon operations, CLI command, automation/JSON, and API usage guidance, then reduce remaining local public pages without weakening normative contracts.
+
+**Architecture:** Add focused canonical daemon health, remote-access, and cloud-host pages; refresh CLI and API usage; add an automation/JSON guide; and strengthen canonical guards. The dependent cleanup keeps `API-CONTRACT.md`, lifecycle, safety, auth, adapter, settings, stream, and authority contracts local while converting public operational pages to concise canonical pointers.
+
+**Tech Stack:** Fumadocs MDX, OpenAPI prose, Node.js docs guards, Python API-contract guards, Rust source verification, pnpm.
+
+---
+
+### Task 1: Create the Wave C canonical worktree
+
+**Files:**
+- No file changes.
+
+- [ ] **Step 1: Coordinate and claim**
+
+```bash
+cd "$HOME/Documents/GitHub/OpenCoven/coven"
+coven claim status
+(cd "$HOME/Documents/GitHub/OpenCoven/coven-docs" && coven claim status)
+gh pr list --repo OpenCoven/coven --state open
+gh pr list --repo OpenCoven/coven-docs --state open
+git -C "$HOME/Documents/GitHub/OpenCoven/coven-docs" fetch origin main
+git -C "$HOME/Documents/GitHub/OpenCoven/coven-docs" worktree add \
+  -b docs/670-wave-c-daemon-cli-reference \
+  /tmp/coven-docs-670-wave-c \
+  origin/main
+cd /tmp/coven-docs-670-wave-c
+coven claim acquire issue-670
+```
+
+### Task 2: Add failing daemon and CLI coverage
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-c/scripts/check-daemon-docs.mjs`
+- Modify: `/tmp/coven-docs-670-wave-c/scripts/check-cli-docs.mjs`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/meta.json`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/guide/meta.json`
+
+- [ ] **Step 1: Add navigation**
+
+Add the daemon health page:
+
+```json
+"health"
+```
+
+Add `"automation-json"` to guide navigation after `"deployments"`. Wave C
+starts only after Wave A is merged.
+
+- [ ] **Step 2: Extend daemon required pages**
+
+Add:
+
+```js
+const requiredPages = [
+  'index',
+  'lifecycle',
+  'configuration',
+  'health',
+  'socket-api',
+  'security',
+  'observability',
+  'recovery-upgrades',
+];
+```
+
+Require `daemon/index.mdx` to link `/docs/daemon/health`.
+
+- [ ] **Step 3: Extend CLI/source-backed assertions**
+
+Add:
+
+```js
+[
+  'coven run copilot',
+  'coven sessions search',
+  'coven sessions show',
+  'coven sessions events',
+  'coven sessions log',
+  'coven reset',
+  'coven maintenance',
+  '--permission',
+  '--add-dir',
+  '--stream-json',
+  '--stream-json-input',
+  'coven config paths --json',
+]
+```
+
+- [ ] **Step 4: Run guards and confirm failure**
+
+```bash
+pnpm run check:daemon-docs
+pnpm run check:cli-docs
+```
+
+Expected: failures for missing pages, links, or command mentions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-daemon-docs.mjs scripts/check-cli-docs.mjs \
+  content/docs/daemon/meta.json content/docs/guide/meta.json
+git commit -s -m "test: require canonical daemon operations guidance" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 3: Add canonical daemon health and configuration guidance
+
+**Files:**
+- Create: `/tmp/coven-docs-670-wave-c/content/docs/daemon/health.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/index.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/configuration.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/observability.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/recovery-upgrades.mdx`
+
+- [ ] **Step 1: Create `health.mdx`**
+
+Document the `/api/v1/health` compatibility handshake and operational blocks:
+
+```mdx
+## Compatibility
+
+Require `apiVersion: "coven.daemon.v1"` before assuming response shapes.
+Capabilities advertise availability; they do not grant authorization.
+
+## Operational health
+
+Interpret `eventWriter` and `storage` independently. Storage warnings include
+retention lag and free-space pressure. Below the 256 MiB safety watermark the
+daemon refuses SQLite open/write work; the 4 MiB threshold is the critical
+replacement trigger for already-open storage.
+```
+
+Link to API, observability, recovery, and the source contract.
+
+- [ ] **Step 2: Complete configuration facts**
+
+Add `daemon.lock`, `daemon-serve.lock`, `daemon-recovery.log`,
+`privacy.toml`, supported environment overrides, unsupported knob names, and
+`coven config paths --json`.
+
+- [ ] **Step 3: Update navigation and recovery links**
+
+Add health cards/links from `index.mdx`, `observability.mdx`, and
+`recovery-upgrades.mdx`.
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+pnpm run check:daemon-docs
+pnpm run check:links
+git add content/docs/daemon scripts/check-daemon-docs.mjs
+git commit -s -m "docs: canonicalize daemon health and configuration" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 4: Add canonical remote and cloud-host operation
+
+**Files:**
+- Create: `/tmp/coven-docs-670-wave-c/content/docs/daemon/remote-access.mdx`
+- Create: `/tmp/coven-docs-670-wave-c/content/docs/daemon/cloud-host-runbook.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/security.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/lifecycle.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/index.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/daemon/meta.json`
+- Modify: `/tmp/coven-docs-670-wave-c/scripts/check-daemon-docs.mjs`
+
+- [ ] **Step 1: Add remote-operation navigation and guard coverage**
+
+Add `"remote-access"` and `"cloud-host-runbook"` after `"security"` in
+`content/docs/daemon/meta.json`. Add both names to `requiredPages` in
+`scripts/check-daemon-docs.mjs`, and require `daemon/index.mdx` to link:
+
+```text
+/docs/daemon/remote-access
+/docs/daemon/cloud-host-runbook
+```
+
+- [ ] **Step 2: Write remote-access guidance**
+
+State:
+
+```mdx
+- Prefer SSH and run the client as the same user that owns `COVEN_HOME`.
+- Keep Unix sockets and Windows named pipes local.
+- Unix-only TCP fallback must bind loopback unless an explicit trusted host is
+  required.
+- `--allow-host` narrows accepted Host/Origin values; it is not authentication.
+- Do not expose the daemon directly through Tailscale or a public interface.
+```
+
+- [ ] **Step 3: Write the cloud-host runbook**
+
+Include systemd user service setup, loopback binding, SSH/Tailscale access to
+the host rather than the daemon port, persistent `COVEN_HOME`, and verification
+with `coven daemon status --json`.
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+pnpm run check:daemon-docs
+pnpm run check:links
+git add content/docs/daemon scripts/check-daemon-docs.mjs
+git commit -s -m "docs: add daemon remote and cloud-host runbooks" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 5: Refresh CLI, automation, and API usage
+
+**Files:**
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/cli/index.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/cli/daemon.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/cli/doctor.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/cli/run.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/cli/sessions.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/cli/repo-workflow.mdx`
+- Create: `/tmp/coven-docs-670-wave-c/content/docs/guide/automation-json.mdx`
+- Modify: `/tmp/coven-docs-670-wave-c/content/docs/reference/api.mdx`
+
+- [ ] **Step 1: Add complete current command coverage**
+
+Document:
+
+```bash
+coven run copilot "review this repository"
+coven sessions search "query"
+coven sessions show SESSION_ID
+coven sessions events SESSION_ID
+coven sessions log SESSION_ID
+coven reset --list-features
+coven maintenance status --json
+coven config paths --json
+```
+
+Cover `--permission`, `--add-dir`, `--stream-json`,
+`--stream-json-input`, and `--json` using source-verified spelling.
+
+- [ ] **Step 2: Add automation/JSON guidance**
+
+Create `automation-json.mdx` with:
+
+```bash
+coven doctor --json
+coven daemon status --json
+coven sessions --json
+```
+
+Explain stable structured fields versus human prose, process exit status,
+same-user local IPC, and the boundary between CLI automation and the daemon
+API.
+
+- [ ] **Step 3: Correct API routing prose**
+
+Ensure `reference/api.mdx` states:
+
+```text
+POST /api/v1/actions
+```
+
+with the action identifier in JSON field `action`. Do not document
+`POST /api/v1/actions/{id}`.
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+pnpm run check:cli-docs
+pnpm run check:links
+pnpm build
+git add content/docs/cli content/docs/guide content/docs/reference/api.mdx \
+  scripts/check-cli-docs.mjs
+git commit -s -m "docs: complete canonical CLI and API usage" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 6: Merge the canonical Wave C PR
+
+**Files:**
+- No new changes.
+
+- [ ] **Step 1: Push and open**
+
+```bash
+git push -u origin docs/670-wave-c-daemon-cli-reference
+gh pr create --repo OpenCoven/coven-docs \
+  --title "docs: complete daemon CLI and API guidance" \
+  --body "Implements Wave C of OpenCoven/coven#670. Adds canonical daemon health, remote access, cloud-host operation, CLI automation, session inspection, and API usage guidance. The dependent coven cleanup must merge second."
+```
+
+- [ ] **Step 2: Wait for all checks and merge**
+
+```bash
+gh pr checks --repo OpenCoven/coven-docs --watch
+```
+
+Expected: all required checks pass.
+
+### Task 7: Update local contract and pointer guards
+
+**Files:**
+- Modify: `/tmp/coven-670-wave-c/scripts/check-api-contract-docs.py`
+- Modify: `/tmp/coven-670-wave-c/scripts/check-api-contract-docs-test.py`
+- Modify: `/tmp/coven-670-wave-c/scripts/cli-docs-test.mjs`
+- Modify: `/tmp/coven-670-wave-c/scripts/onboarding-docs-test.mjs`
+
+- [ ] **Step 1: Create the cleanup worktree**
+
+```bash
+cd /tmp/coven-docs-670-wave-c
+coven claim release issue-670
+git -C "$HOME/Documents/GitHub/OpenCoven/coven" fetch origin main
+git -C "$HOME/Documents/GitHub/OpenCoven/coven" worktree add \
+  -b docs/670-wave-c-daemon-cli-reference-cleanup \
+  /tmp/coven-670-wave-c \
+  origin/main
+cd /tmp/coven-670-wave-c
+coven claim acquire issue-670
+```
+
+- [ ] **Step 2: Preserve mandatory API guardrails**
+
+Keep assertions that `docs/API.md` contains:
+
+```text
+/api/v1/health
+coven.daemon.v1
+capabilities are not authorization
+/api/v1/api-version
+legacy
+```
+
+Change long-form daemon/CLI page assertions to canonical pointer assertions.
+
+- [ ] **Step 3: Run and confirm failure**
+
+```bash
+python3 scripts/check-api-contract-docs.py
+python3 -m unittest scripts/check-api-contract-docs-test.py
+node scripts/cli-docs-test.mjs
+node scripts/onboarding-docs-test.mjs
+```
+
+Expected: failures until the local public pages are reduced.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/check-api-contract-docs.py scripts/check-api-contract-docs-test.py \
+  scripts/cli-docs-test.mjs scripts/onboarding-docs-test.mjs
+git commit -s -m "test: enforce local contract and canonical usage split" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 8: Reduce remaining daemon, CLI, guide, and API usage pages
+
+**Files:**
+- Modify: `/tmp/coven-670-wave-c/docs/API.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/index.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/configuration.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/diagnostics.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/health.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/lifecycle.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/logs.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/socket-api.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/remote-access.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/cloud-host-runbook.md`
+- Modify: `/tmp/coven-670-wave-c/docs/daemon/upgrades.md`
+- Modify: `/tmp/coven-670-wave-c/docs/guides/core-access.md`
+- Modify: `/tmp/coven-670-wave-c/docs/guides/index.md`
+- Modify: `/tmp/coven-670-wave-c/docs/guides/automation-json.md`
+- Modify: `/tmp/coven-670-wave-c/docs/guides/multi-agent-worktrees.md`
+- Modify: `/tmp/coven-670-wave-c/docs/guides/session-operations.md`
+- Modify: `/tmp/coven-670-wave-c/docs/guides/troubleshooting-core-access.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/api.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/api-actions.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/api-capabilities.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/api-contract.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/api-events.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/api-sessions.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-archive.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-attach.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-claim.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-config.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-coven.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-daemon.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-doctor.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-engine.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-executor.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-kill.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-logs.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-maintenance.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-observe.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-patch.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-reset.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-run.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-sacrifice.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-sessions.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-summon.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-vacuum.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-ward.md`
+- Modify: `/tmp/coven-670-wave-c/docs/reference/cli-wt.md`
+- Modify: `/tmp/coven-670-wave-c/README.md`
+
+- [ ] **Step 1: Keep normative documents untouched**
+
+Do not reduce:
+
+```text
+docs/API-CONTRACT.md
+docs/AUTH.md
+docs/SAFETY-MODEL.md
+docs/SESSION-LIFECYCLE.md
+docs/HARNESS-ADAPTERS.md
+docs/SETTINGS.md
+docs/STREAM-JSON.md
+docs/daemon/auth-posture.md
+docs/daemon/coven-home.md
+docs/daemon/safety-model.md
+docs/daemon/trust-boundary.md
+docs/daemon/session-handoff.md
+docs/development/cli-core-functionality.md
+```
+
+- [ ] **Step 2: Reduce operational pages to pointers**
+
+Use exact canonical destinations:
+
+```text
+daemon health -> https://docs.opencoven.ai/docs/daemon/health
+daemon configuration -> https://docs.opencoven.ai/docs/daemon/configuration
+daemon diagnostics and logs -> https://docs.opencoven.ai/docs/daemon/observability
+daemon remote access -> https://docs.opencoven.ai/docs/daemon/remote-access
+cloud host -> https://docs.opencoven.ai/docs/daemon/cloud-host-runbook
+daemon upgrades -> https://docs.opencoven.ai/docs/daemon/recovery-upgrades
+automation JSON -> https://docs.opencoven.ai/docs/guide/automation-json
+CLI usage -> https://docs.opencoven.ai/docs/cli
+API usage -> https://docs.opencoven.ai/docs/reference/api
+```
+
+`docs/API.md` must remain a short pointer plus the required handshake,
+capability/authorization, and legacy-route guardrails.
+
+Use these command-page mappings:
+
+```text
+cli-coven -> /docs/cli/interactive
+cli-daemon -> /docs/cli/daemon
+cli-doctor -> /docs/cli/doctor
+cli-run -> /docs/cli/run
+cli-archive, cli-attach, cli-kill, cli-sacrifice, cli-sessions, cli-summon -> /docs/cli/sessions
+cli-observe, cli-logs, cli-vacuum -> /docs/cli/observe
+cli-executor -> /docs/cli/hub-scheduler
+cli-engine -> /docs/cli/engine-auth
+cli-claim, cli-maintenance, cli-ward, cli-wt -> /docs/cli/repo-workflow
+cli-patch -> /docs/cli/patch-openclaw
+cli-config -> /docs/daemon/configuration
+cli-reset -> /docs/cli
+```
+
+Use these guide mappings:
+
+```text
+guides/index, guides/core-access -> /docs/guide/getting-started
+guides/session-operations -> /docs/cli/sessions
+guides/automation-json -> /docs/guide/automation-json
+guides/multi-agent-worktrees -> /docs/cli/repo-workflow
+guides/troubleshooting-core-access -> /docs/reference/troubleshooting
+```
+
+In `README.md`, replace the local `cli-logs.md` pruning link with
+`https://docs.opencoven.ai/docs/cli/observe` and the local
+`cli-reset.md` link with `https://docs.opencoven.ai/docs/cli`.
+
+- [ ] **Step 3: Correct version-sensitive local wording**
+
+In `docs/reference/future-harnesses.md`, remove a pinned Hermes version and use:
+
+```md
+Hermes is a trusted installable recipe. Verify the current recipe and release
+before documenting a version number.
+```
+
+- [ ] **Step 4: Validate and commit**
+
+```bash
+python3 scripts/check-api-contract-docs.py
+python3 -m unittest scripts/check-api-contract-docs-test.py
+node scripts/cli-docs-test.mjs
+node scripts/onboarding-docs-test.mjs
+python3 scripts/check-secrets.py
+git diff --check
+git add -A
+python3 scripts/check-coven-privacy.py --staged
+git commit -s -m "docs: point daemon CLI and API usage canonical" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Expected: all commands pass.
+
+### Task 9: Final cross-repository audit and goal closure
+
+**Files:**
+- Update after merge, outside the Git branch: primary Coven checkout `.copilot/goals.md`
+
+- [ ] **Step 1: Search for residual canonicality violations**
+
+Run:
+
+```bash
+local_public_doc_link='\]\((?:https://github\.com/OpenCoven/coven/blob/main/)?docs/(?:install|platforms|harnesses|help|daemon|reference/cli)[^)]*\)|\]\(/(?:install|platforms|harnesses|help|daemon|reference/cli)[^)]*\)'
+rg -n "$local_public_doc_link" \
+  README.md CONTRIBUTING.md docs/index.md docs/GETTING-STARTED.md \
+  docs/TROUBLESHOOTING.md .github/ISSUE_TEMPLATE
+```
+
+Expected: no matches. Current public entry points must not send users to local
+copies. Retained normative contracts, guard scripts, and historical
+`docs/superpowers/**` records are intentionally outside this search.
+
+- [ ] **Step 2: Run complete repository gates**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+COVEN_NPM_DRY_RUN_VERSION=999.0.0 \
+  node scripts/test-cli-prepublish.mjs --target=macos
+python3 scripts/check-secrets.py
+git diff --check
+```
+
+- [ ] **Step 3: Push and open the final cleanup PR**
+
+```bash
+git push -u origin docs/670-wave-c-daemon-cli-reference-cleanup
+gh pr create --repo OpenCoven/coven \
+  --title "docs: complete canonical documentation migration" \
+  --body "Completes Wave C and closes #670. Depends on the merged canonical coven-docs Wave C PR. Retains normative source contracts while making docs.opencoven.ai authoritative for daemon operation, CLI usage, automation, and public API guidance."
+```
+
+- [ ] **Step 4: Merge and clean up**
+
+After full CI and review, squash merge with `Closes #670`, release the claim,
+delete remote branches, and remove the Wave C worktrees. Then, from the primary
+Coven checkout, move `documentation-single-source` from `## active` to
+`## done` in `.copilot/goals.md`, set the completion date, and record the six
+merged Wave A/B/C PRs and issue `#670`.

--- a/docs/superpowers/specs/2026-08-07-final-documentation-single-source-audit-design.md
+++ b/docs/superpowers/specs/2026-08-07-final-documentation-single-source-audit-design.md
@@ -1,0 +1,254 @@
+# Final Documentation Single-Source Audit Design
+
+## Goal
+
+Complete the remaining documentation migration so public Coven guidance has one
+authoritative home in `OpenCoven/coven-docs`, while `OpenCoven/coven` retains
+only documentation that must evolve with source code or repository policy.
+
+The initial migration in `coven-docs#49` and `coven#668` established the
+ownership boundary, corrected major runtime guidance, removed empty
+placeholders, and replaced broad duplicate entry pages. This design covers the
+remaining substantive install, platform, onboarding, harness, help, daemon,
+CLI, guide, and reference pages.
+
+## Ownership Boundary
+
+`coven-docs` owns public:
+
+- installation, update, uninstall, and platform guidance;
+- onboarding and supported harness setup;
+- CLI and daemon operation;
+- troubleshooting, diagnostics, community, and issue-filing guidance;
+- public API usage, automation examples, and memory workflows.
+
+`coven` retains:
+
+- normative API, adapter, lifecycle, safety, and authority-boundary contracts;
+- contributor, security, release, and repository policy;
+- maintainer source maps and verification procedures;
+- implementation specifications, plans, design records, and historical notes;
+- package- and crate-specific READMEs.
+
+A local page does not remain merely because it contains one implementation
+detail. Mixed pages are split: public procedures move to `coven-docs`, while a
+concise local contract or maintainer note remains only when it must change with
+the source.
+
+## Delivery Architecture
+
+Deliver the audit in three focused waves. Each wave uses an ordered PR pair:
+
+1. merge the canonical `coven-docs` additions and corrections;
+2. rebase and merge the dependent `coven` pointer, deletion, link, and guard
+   cleanup.
+
+### Wave A: Install, Platform, and Onboarding
+
+Audit:
+
+- `docs/install/**`
+- `docs/platforms/**`
+- `docs/start/**`
+
+Canonical targets include:
+
+- `content/docs/guide/install.mdx`
+- `content/docs/guide/getting-started.mdx`
+- `content/docs/cli/install.mdx`
+- `content/docs/cli/install-debugging.mdx`
+- `content/docs/cli/uninstall.mdx`
+- daemon lifecycle and configuration pages where service operation belongs
+
+The initial inventory indicates that several platform and onboarding overview
+pages can already become pointers, while richer package-manager, WSL2,
+launchd, systemd, container, Raspberry Pi, update, and rollback procedures must
+be upstreamed first.
+
+### Wave B: Harness and Support
+
+Audit:
+
+- `docs/harnesses/**`
+- `docs/help/**`
+- directly related `docs/models/**` pages
+
+Canonical targets include:
+
+- `content/docs/harnesses/**`
+- `content/docs/reference/troubleshooting.mdx`
+- `content/docs/cli/doctor.mdx`
+- `content/docs/daemon/observability.mdx`
+- `content/docs/memory-models/**`
+
+`docs/HARNESS-ADAPTERS.md` remains local as the normative adapter contract.
+Public setup, missing-harness recovery, diagnostics, permissions, paths,
+community, issue filing, and memory-import procedures move upstream.
+
+### Wave C: Daemon, CLI, Guides, and API Reference
+
+Audit:
+
+- `docs/daemon/**`
+- `docs/reference/**`
+- `docs/guides/**`
+- directly related top-level API, auth, safety, lifecycle, settings, client,
+  and stream contracts
+
+Canonical targets include:
+
+- `content/docs/daemon/**`
+- `content/docs/cli/**`
+- `content/docs/reference/**`
+- `content/docs/openapi/**`
+- `content/docs/guide/**`
+
+Normative API and authority documents remain local. Public daemon operations,
+remote-access procedures, health interpretation, CLI command usage, automation
+examples, and endpoint usage move upstream or become canonical pointers.
+
+## Page Decision Matrix
+
+Each wave maintains a page-level matrix with these fields:
+
+| Field | Purpose |
+| --- | --- |
+| Local page | Repository path under audit |
+| Canonical target | Existing or proposed stable `docs.opencoven.ai` route |
+| Ownership | Public, normative/local, or mixed |
+| Unique facts | Material not yet present in canonical docs |
+| Verification source | Rust, TypeScript, package manifest, workflow, or policy source |
+| Inbound links | Repository files and tests that reference the local page |
+| Disposition | Keep, upstream then pointer, pointer/delete, or correct in place |
+| Status | Audited, upstreamed, canonical merged, cleanup merged |
+
+The matrix is an implementation artifact, not a new permanent documentation
+system. Its final decisions should be reflected in the changed pages, PR
+descriptions, and the persistent goal.
+
+## Decision Rules
+
+For every substantive page:
+
+1. Classify the page by ownership rather than filename.
+2. Verify version-sensitive commands, flags, paths, support claims, and
+   platform behavior against current source.
+3. Compare sections and facts against canonical docs; topical similarity alone
+   is not sufficient evidence of duplication.
+4. Choose one disposition:
+   - **Keep local:** normative, policy, maintainer, implementation, or
+     historical material.
+   - **Upstream then pointer:** useful public facts are absent or materially
+     weaker in canonical docs.
+   - **Pointer/delete now:** canonical coverage is complete and stable.
+   - **Correct in place:** retained local material contains stale or invalid
+     claims.
+5. Do not remove or reduce a page until its canonical target is merged.
+6. Update every inbound link and documentation guard in the same cleanup PR.
+
+Short local pointers are acceptable when repository readers need a stable
+entry point. Delete pages only when no repository navigation, source contract,
+or compatibility reason requires the path to remain.
+
+## Canonical Content Rules
+
+Add missing facts to the narrowest coherent existing page. Create a new
+canonical page only when combining the topic with an existing page would make
+that page ambiguous or difficult to navigate.
+
+Canonical additions must:
+
+- describe current supported behavior, not historical implementation intent;
+- use cross-platform terminology where behavior differs;
+- label Unix-only commands and examples;
+- avoid version-sensitive package claims unless verified during the change;
+- link back to local normative contracts when public guidance depends on them;
+- avoid copying maintainer-only source maps or implementation history.
+
+## Local Contract Reduction
+
+When a mixed page is reduced:
+
+- retain the invariant, compatibility rule, ownership boundary, or maintainer
+  verification procedure;
+- remove step-by-step public setup and troubleshooting prose after it is
+  canonical;
+- add a direct canonical link for operational examples;
+- preserve phrases required by existing contract guards unless the guard is
+  deliberately migrated to a more appropriate local contract;
+- do not turn implementation plans or historical records into present-tense
+  public guidance.
+
+## Link and Guard Migration
+
+Before deleting or replacing a local page:
+
+1. enumerate Markdown, workflow, issue-template, script, and package links;
+2. retarget public navigation to a stable canonical route;
+3. retarget source-adjacent references to the retained local contract;
+4. update tests that incorrectly require obsolete public pages;
+5. keep guards that enforce normative phrases, but move those phrases to the
+   correct local contract when necessary.
+
+A cleanup PR must not reintroduce duplicate prose solely to satisfy a stale
+test. The test should assert the new ownership boundary.
+
+## Validation
+
+For each `coven-docs` PR:
+
+- run the existing production build;
+- run link validation;
+- run topic-specific documentation checks;
+- regenerate and validate OpenAPI artifacts when the source schema or generated
+  endpoint guidance changes.
+
+For each `coven` cleanup PR:
+
+- run targeted documentation and onboarding guards;
+- run API-contract documentation checks when API pages change;
+- run the secret scan and staged privacy guard;
+- run the existing package smoke checks when their documentation assertions
+  change;
+- wait for the complete required CI matrix before merge.
+
+Each PR review must also confirm:
+
+- every removed page has no unresolved inbound link;
+- every external pointer uses a stable canonical route;
+- all verified unique public facts exist in the merged canonical page;
+- retained local pages state a source-adjacent ownership reason.
+
+## Failure Handling and Ordering
+
+Canonical and cleanup PRs cannot merge out of order. If a canonical target is
+missing, disputed, or fails validation, the local page remains unchanged.
+
+If source verification disproves a public claim, correct the authoritative
+documentation rather than upstreaming the stale text. If a topic has no clear
+canonical home, record it as an explicit exception and retain the local page
+until a coherent destination is approved.
+
+Each wave is independently reviewable and reversible. A failure in one wave
+does not block already-correct ownership decisions in another wave.
+
+## Completion Criteria
+
+The documentation single-source goal is complete when:
+
+- every substantive page in the target directories has an explicit audited
+  disposition;
+- all accepted canonical additions and dependent cleanups are merged;
+- no repository link or test treats a removed public page as canonical;
+- remaining local pages have a clear normative, policy, maintainer,
+  implementation, historical, or package-specific reason to exist;
+- no known current behavior is documented differently across the two
+  repositories.
+
+## Non-Goals
+
+- Rewriting implementation plans, historical release notes, or design records.
+- Moving normative source contracts into the public docs repository.
+- Adding speculative harnesses or unsupported platform behavior.
+- Renaming product surfaces or redesigning the documentation site.
+- Replacing all repository documentation with external links.


### PR DESCRIPTION
## Summary

- define the final documentation single-source audit boundary
- split delivery into install/platform, harness/support, and daemon/CLI/reference waves
- provide reviewed canonical-first implementation plans with DCO-compliant commit workflow

Refs #670.

Supersedes #672 because the original planning commits lacked DCO signoffs.

## Validation

- privacy guard
- secret scan
- diff check
- independent plan review