### PR TITLE
fix(bench): bound cold-start samples to daemon readiness

### DIFF
--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -535,12 +535,15 @@ export async function startDaemonMeasuringReadiness({
   now = () => process.hrtime.bigint()
 }) {
   const startedAt = now();
-  const { completion } = launch({
+  const { child, completion } = launch({
     command: binary,
     args: ['daemon', 'start'],
     allowedExitCodes: [0],
     env
   });
+  // Observe early command failures while readiness polling is still active.
+  // The original promise remains available for the caller to await on success.
+  completion.catch(() => {});
 
   try {
     const socketPath = await resolveSocket(covenHome, { attempts: 400, delayMs: 25 });
@@ -548,8 +551,7 @@ export async function startDaemonMeasuringReadiness({
     const readyElapsedMs = Number(now() - startedAt) / 1_000_000;
     return { socketPath, readyElapsedMs, completion };
   } catch (error) {
-    // Never leave the launch promise unhandled when readiness fails.
-    completion.catch(() => {});
+    child?.kill('SIGKILL');
     throw error;
   }
 }

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { chmod, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { request as requestHttp } from 'node:http';
 import { fileURLToPath } from 'node:url';
@@ -123,6 +123,48 @@ export function runCommand({
     throw new Error(`command exited with ${result.status}${stderr ? `: ${stderr}` : ''}`);
   }
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+export function startCommand({
+  command,
+  args,
+  allowedExitCodes = [0],
+  env,
+  timeoutMs = COMMAND_TIMEOUT_MS
+}) {
+  const child = spawn(command, args, { env });
+  let stdout = '';
+  let stderr = '';
+  child.stdout?.setEncoding('utf8').on('data', (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr?.setEncoding('utf8').on('data', (chunk) => {
+    stderr += chunk;
+  });
+
+  const completion = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error(`command timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('close', (status) => {
+      clearTimeout(timer);
+      if (!Number.isInteger(status) || !allowedExitCodes.includes(status)) {
+        const detail = stderr.trim();
+        reject(new Error(`command exited with ${status}${detail ? `: ${detail}` : ''}`));
+        return;
+      }
+      resolve({ status, stdout, stderr });
+    });
+  });
+
+  return { child, completion };
 }
 
 export function externalSessionRequest({ id, projectRoot }) {
@@ -454,6 +496,64 @@ export async function startDaemon({
   return socketPath;
 }
 
+export async function waitForDaemonSocketPath(
+  covenHome,
+  { attempts, delayMs, readSocket = daemonSocketPath }
+) {
+  let lastError;
+
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return await readSocket(covenHome);
+    } catch (error) {
+      lastError = error;
+    }
+
+    if (attempt + 1 < attempts && delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw new Error(
+    `daemon metadata did not appear: ${lastError?.message ?? 'unknown error'}`
+  );
+}
+
+// `coven daemon start` keeps working after the daemon answers health: on unix it
+// runs a duplicate-daemon sweep that builds a full process table. Timing the
+// blocking command therefore charges cold startup for unrelated runner state.
+// Launch without blocking, stop the clock at the first valid health response,
+// and hand the still-running command back so the caller can await it — and any
+// post-readiness cleanup — outside the measured interval.
+export async function startDaemonMeasuringReadiness({
+  binary,
+  covenHome,
+  env,
+  launch = startCommand,
+  resolveSocket = waitForDaemonSocketPath,
+  wait = waitForHealth,
+  now = () => process.hrtime.bigint()
+}) {
+  const startedAt = now();
+  const { completion } = launch({
+    command: binary,
+    args: ['daemon', 'start'],
+    allowedExitCodes: [0],
+    env
+  });
+
+  try {
+    const socketPath = await resolveSocket(covenHome, { attempts: 400, delayMs: 25 });
+    await wait(socketPath, { attempts: 400, delayMs: 25 });
+    const readyElapsedMs = Number(now() - startedAt) / 1_000_000;
+    return { socketPath, readyElapsedMs, completion };
+  } catch (error) {
+    // Never leave the launch promise unhandled when readiness fails.
+    completion.catch(() => {});
+    throw error;
+  }
+}
+
 export function stopDaemon({ binary, env, run = runCommand }) {
   run({ command: binary, args: ['daemon', 'stop'], allowedExitCodes: [0], env });
 }
@@ -464,9 +564,8 @@ export async function measureColdDaemonStarts({
   environment,
   iterations,
   makeDirectory = (path) => mkdir(path, { recursive: true }),
-  start = startDaemon,
-  stop = stopDaemon,
-  now = () => process.hrtime.bigint()
+  start = startDaemonMeasuringReadiness,
+  stop = stopDaemon
 }) {
   const samplesMs = [];
 
@@ -474,12 +573,13 @@ export async function measureColdDaemonStarts({
     const covenHome = join(fixtureRoot, `d-${iteration}`);
     const env = isolatedEnvironment(covenHome, environment);
     await makeDirectory(join(covenHome, 'user-home'));
-    const startedAt = now();
 
     try {
-      await start({ binary, covenHome, env });
-      const elapsedMs = Number(now() - startedAt) / 1_000_000;
-      samplesMs.push(Number(elapsedMs.toFixed(3)));
+      const { readyElapsedMs, completion } = await start({ binary, covenHome, env });
+      samplesMs.push(Number(readyElapsedMs.toFixed(3)));
+      // Command completion and its post-readiness cleanup are deliberately
+      // awaited after the sample is recorded, outside the timed interval.
+      await completion;
     } finally {
       await stop({ binary, covenHome, env });
     }

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -494,6 +494,51 @@ test('startDaemonMeasuringReadiness stops the clock at the first healthy respons
   assert.equal(result.readyElapsedMs, 10);
 });
 
+test('startDaemonMeasuringReadiness observes launch completion before polling readiness', async () => {
+  const order = [];
+  const completion = {
+    catch() {
+      order.push('observe-completion');
+      return Promise.resolve();
+    }
+  };
+
+  await startDaemonMeasuringReadiness({
+    binary: '/tmp/coven',
+    covenHome: '/fixture/coven-home',
+    env: { COVEN_HOME: '/fixture/coven-home' },
+    launch: () => ({ child: null, completion }),
+    resolveSocket: async () => {
+      assert.deepEqual(order, ['observe-completion']);
+      return '/fixture/coven.sock';
+    },
+    wait: async () => {}
+  });
+});
+
+test('startDaemonMeasuringReadiness kills the launch child when readiness fails', async () => {
+  const signals = [];
+
+  await assert.rejects(
+    startDaemonMeasuringReadiness({
+      binary: '/tmp/coven',
+      covenHome: '/fixture/coven-home',
+      env: { COVEN_HOME: '/fixture/coven-home' },
+      launch: () => ({
+        child: { kill: (signal) => signals.push(signal) },
+        completion: Promise.resolve({ status: 0 })
+      }),
+      resolveSocket: async () => {
+        throw new Error('daemon metadata did not appear');
+      },
+      wait: async () => {}
+    }),
+    /daemon metadata did not appear/
+  );
+
+  assert.deepEqual(signals, ['SIGKILL']);
+});
+
 test('measureColdDaemonStarts excludes post-readiness command work from samples', async () => {
   const order = [];
   const report = await measureColdDaemonStarts({

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -32,8 +32,10 @@ import {
   stopLiveSession,
   socketRequest,
   startDaemon,
+  startDaemonMeasuringReadiness,
   stopDaemon,
   summarizeSamples,
+  waitForDaemonSocketPath,
   waitForOutputEvent,
   waitForHealth
 } from './benchmark-cli.mjs';
@@ -405,7 +407,7 @@ test('stopDaemon shuts down through the same isolated command boundary', () => {
 
 test('measureColdDaemonStarts uses a fresh home per sample and always stops it', async () => {
   const calls = [];
-  const ticks = [0n, 1_250_000n, 2_000_000n, 5_500_000n];
+  const readyTimings = [1.25, 3.5];
   const report = await measureColdDaemonStarts({
     binary: '/tmp/coven',
     fixtureRoot: '/fixture/root',
@@ -414,10 +416,13 @@ test('measureColdDaemonStarts uses a fresh home per sample and always stops it',
     makeDirectory: async (path) => calls.push(['mkdir', path]),
     start: async ({ covenHome, env }) => {
       calls.push(['start', covenHome, env.COVEN_HOME]);
-      return `${covenHome}/coven.sock`;
+      return {
+        socketPath: `${covenHome}/coven.sock`,
+        readyElapsedMs: readyTimings.shift(),
+        completion: Promise.resolve({ status: 0 })
+      };
     },
-    stop: ({ covenHome, env }) => calls.push(['stop', covenHome, env.COVEN_HOME]),
-    now: () => ticks.shift()
+    stop: ({ covenHome, env }) => calls.push(['stop', covenHome, env.COVEN_HOME])
   });
 
   assert.deepEqual(report, {
@@ -439,6 +444,125 @@ test('measureColdDaemonStarts uses a fresh home per sample and always stops it',
     ['start', '/fixture/root/d-1', '/fixture/root/d-1'],
     ['stop', '/fixture/root/d-1', '/fixture/root/d-1']
   ]);
+});
+
+test('startDaemonMeasuringReadiness stops the clock at the first healthy response', async () => {
+  const order = [];
+  let clock = 0n;
+  const tick = (ms) => {
+    clock += BigInt(ms) * 1_000_000n;
+  };
+  let finishCommand;
+  const completion = new Promise((resolve) => {
+    finishCommand = resolve;
+  });
+
+  const result = await startDaemonMeasuringReadiness({
+    binary: '/tmp/coven',
+    covenHome: '/fixture/coven-home',
+    env: { COVEN_HOME: '/fixture/coven-home' },
+    launch: (command) => {
+      order.push(['launch', command.args.join(' ')]);
+      // The real command keeps running (duplicate-daemon sweep) after health.
+      return { child: null, completion };
+    },
+    resolveSocket: async (home) => {
+      order.push(['resolveSocket', home]);
+      tick(4);
+      return '/fixture/coven.sock';
+    },
+    wait: async (path) => {
+      order.push(['wait', path]);
+      tick(6);
+    },
+    now: () => clock
+  });
+
+  assert.equal(result.socketPath, '/fixture/coven.sock');
+  // 4ms resolving metadata + 6ms waiting for health, and nothing after.
+  assert.equal(result.readyElapsedMs, 10);
+  assert.deepEqual(order, [
+    ['launch', 'daemon start'],
+    ['resolveSocket', '/fixture/coven-home'],
+    ['wait', '/fixture/coven.sock']
+  ]);
+
+  // Post-readiness command work is charged to nobody: it lands after the sample.
+  tick(500);
+  finishCommand({ status: 0 });
+  await result.completion;
+  assert.equal(result.readyElapsedMs, 10);
+});
+
+test('measureColdDaemonStarts excludes post-readiness command work from samples', async () => {
+  const order = [];
+  const report = await measureColdDaemonStarts({
+    binary: '/tmp/coven',
+    fixtureRoot: '/fixture/root',
+    environment: { PATH: '/fixture/bin' },
+    iterations: 1,
+    makeDirectory: async () => {},
+    start: async () => ({
+      socketPath: '/fixture/coven.sock',
+      readyElapsedMs: 12.5,
+      completion: Promise.resolve().then(() => order.push('command-completed'))
+    }),
+    stop: () => order.push('stop')
+  });
+
+  assert.deepEqual(report.samplesMs, [12.5]);
+  // Completion is awaited, but only after the readiness sample is recorded,
+  // and always before the daemon is stopped.
+  assert.deepEqual(order, ['command-completed', 'stop']);
+});
+
+test('measureColdDaemonStarts still stops the daemon when readiness fails', async () => {
+  const order = [];
+  await assert.rejects(
+    measureColdDaemonStarts({
+      binary: '/tmp/coven',
+      fixtureRoot: '/fixture/root',
+      environment: { PATH: '/fixture/bin' },
+      iterations: 1,
+      makeDirectory: async () => {},
+      start: async () => {
+        throw new Error('daemon health did not become ready');
+      },
+      stop: () => order.push('stop')
+    }),
+    /daemon health did not become ready/
+  );
+  assert.deepEqual(order, ['stop']);
+});
+
+test('waitForDaemonSocketPath retries until daemon metadata is written', async () => {
+  let attempts = 0;
+
+  const socketPath = await waitForDaemonSocketPath('/fixture/coven-home', {
+    attempts: 5,
+    delayMs: 0,
+    readSocket: async () => {
+      attempts += 1;
+      if (attempts < 3) throw new Error('ENOENT: no such file');
+      return '/fixture/coven.sock';
+    }
+  });
+
+  assert.equal(socketPath, '/fixture/coven.sock');
+  assert.equal(attempts, 3);
+});
+
+test('waitForDaemonSocketPath reports the last failure after exhausting attempts', async () => {
+  await assert.rejects(
+    waitForDaemonSocketPath('/fixture/coven-home', {
+      attempts: 2,
+      delayMs: 0,
+      readSocket: async () => {
+        throw new Error('ENOENT: no such file');
+      }
+    }),
+    /daemon metadata did not appear: ENOENT: no such file/
+  );
 });
 
 test('registerExternalSessions seeds deterministic rows through the socket API', async () => {


### PR DESCRIPTION
## What

Issue #648 asks for two corrections to the benchmark harness. PR #662 covers the percentile reporting half. **This PR covers the other half: readiness-bound cold-start timing.**

## The defect

`measureColdDaemonStarts` timed the full blocking `coven daemon start` command via `runCommand` (`spawnSync`). But that command doesn't return when the daemon becomes ready — `ensure_background_server` (`crates/coven-cli/src/daemon.rs`) calls `cleanup_unreachable_duplicate_daemons` *after* the daemon is already serving, and that does a `System::new_all()` + `refresh_all()` full process-table scan.

So the reported "cold start" was `daemon startup + a process-table sweep whose cost scales with whatever else is running on the machine`.

## The fix

- `startCommand(...)` — non-blocking `spawn` wrapper returning `{ child, completion }`.
- `waitForDaemonSocketPath(...)` — polls for `daemon.json`, which no longer exists at call time now that the command isn't awaited.
- `startDaemonMeasuringReadiness(...)` — launches without blocking and stops the clock at the **first healthy health response**, returning `{ socketPath, readyElapsedMs, completion }`.
- `measureColdDaemonStarts` records the sample, then awaits `completion` *outside* the timed interval. `stopDaemon` still runs in `finally`.

`startDaemon` is deliberately left intact — `benchmark-chaos.mjs` and four other scenarios use it as untimed setup.

## Verification

`node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs` — **72/72 pass** (CI's exact command). Seven focused tests cover the readiness clock, post-readiness exclusion, cleanup-on-failure, and socket-path retry/exhaustion.

Measured against a real debug-built daemon, same run, back to back:

| | sample 1 | sample 2 | sample 3 |
|---|---|---|---|
| readiness-bound (this PR) | 36.5ms | 32.2ms | 30.4ms |
| blocking command (before) | 115.3ms | 153.3ms | 161.5ms |

The readiness-bound numbers are both lower and much tighter. The blocking numbers drift upward *within a single run* as processes accumulate — which is precisely the runner-state sensitivity #648 describes.

Gates: secret scan clean, privacy guard clean. Diff is JS-only (2 files).

## Issue closure

Closes #648. PR #662 has landed on `main`, so this PR now completes the readiness-bound cold-start half against the corrected percentile baseline.