### PR TITLE
fix(mobile): sweep expired pairings and audit device-side completion

### DIFF
--- a/crates/coven-cli/src/mobile_memory/gateway.rs
+++ b/crates/coven-cli/src/mobile_memory/gateway.rs
@@ -648,6 +648,17 @@ fn handle_pairing_confirmation(
             error_response(409, MobileErrorCode::PairingConfirmationRequired)
         }
         Ok(PairingProgress::Complete { device, replayed }) => {
+            // The completing confirmation is whichever side confirms second, so
+            // the device path audits completion too; `replayed` keeps cached
+            // retries from emitting a second event for the same transition.
+            if !replayed {
+                let _ = append_event(
+                    &state.coven_home,
+                    Utc::now(),
+                    MobileAuditEvent::PairingCompleted,
+                    Some(device.id),
+                );
+            }
             success_response(if replayed { 200 } else { 201 }, device)
         }
         Err(error) => {
@@ -1364,5 +1375,74 @@ mod tests {
 
         let audit = std::fs::read_to_string(temp.path().join("mobile/audit.jsonl")).unwrap();
         assert_eq!(audit.matches("\"event\":\"pairing_completed\"").count(), 1);
+    }
+
+    #[test]
+    fn device_completion_audits_once_when_the_host_confirmed_first() {
+        let _guard = TEST_GATEWAY_LOCK.lock().unwrap();
+        let Some((temp, config, _)) = test_listener_config() else {
+            return;
+        };
+        let _gateway = start_mobile_gateway_with_config(temp.path(), &config).unwrap();
+        let state = active_gateway().unwrap();
+        let now = Utc::now();
+        let invitation = state
+            .pairing
+            .begin_pairing([11; 32], now + PAIRING_LIFETIME)
+            .unwrap();
+        let enrolled = state
+            .pairing
+            .enroll(
+                invitation.id,
+                invitation.nonce,
+                sample_pairing_request(invitation.nonce),
+                state.host_fingerprint,
+                now,
+            )
+            .unwrap();
+        let host_path = format!("/api/v1/internal/mobile/pairings/{}/confirm", invitation.id);
+        let host_body = serde_json::json!({ "phrase": enrolled.phrase }).to_string();
+        assert_eq!(
+            handle_local_control("POST", &host_path, Some(&host_body))
+                .unwrap()
+                .unwrap()
+                .status,
+            409
+        );
+
+        let device_path = format!("/api/v1/mobile/pairings/{}/confirm", invitation.id);
+        let device_body = serde_json::json!({ "phrase": enrolled.phrase })
+            .to_string()
+            .into_bytes();
+        let device_request = || MobileHttpRequest {
+            method: "POST".to_owned(),
+            target: device_path.clone(),
+            headers: HashMap::new(),
+            body: device_body.clone(),
+        };
+
+        let completion = handle_pairing_confirmation(&state, &device_path, device_request());
+        assert_eq!(completion.status, 201);
+        let audit_path = temp.path().join("mobile/audit.jsonl");
+        let completions = |label: &str| {
+            std::fs::read_to_string(&audit_path)
+                .unwrap_or_else(|error| panic!("{label}: {error}"))
+                .matches("\"event\":\"pairing_completed\"")
+                .count()
+        };
+        assert_eq!(completions("device completion"), 1);
+
+        assert_eq!(
+            handle_pairing_confirmation(&state, &device_path, device_request()).status,
+            200
+        );
+        assert_eq!(
+            handle_local_control("POST", &host_path, Some(&host_body))
+                .unwrap()
+                .unwrap()
+                .status,
+            200
+        );
+        assert_eq!(completions("replays"), 1);
     }
 }

--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -158,6 +158,26 @@ impl PairingManager {
         pending.retain(|_, pairing| pairing.expires_at > now || retain_expired(pairing));
     }
 
+    /// Take the pending map, dropping every expired pairing except `addressed`.
+    ///
+    /// Completed pairings are held until their invitation expires so either
+    /// confirmer can retry, so nothing else would evict them once both sides
+    /// stop calling; sweeping on each operation bounds the map without a timer.
+    /// The addressed pairing survives the sweep so the caller still reports its
+    /// own expiry as `PairingExpired` rather than `PairingConsumed`.
+    fn lock_pending(
+        &self,
+        now: DateTime<Utc>,
+        addressed: Uuid,
+    ) -> Result<MutexGuard<'_, HashMap<Uuid, PendingPairing>>, PairingError> {
+        let mut pending = self
+            .pending
+            .lock()
+            .map_err(|_| PairingError::InvalidRequest)?;
+        Self::prune_expired(&mut pending, now, |pairing| pairing.id == addressed);
+        Ok(pending)
+    }
+
     pub fn enroll(
         &self,
         pairing_id: Uuid,
@@ -166,10 +186,7 @@ impl PairingManager {
         host_fingerprint: [u8; 32],
         now: DateTime<Utc>,
     ) -> Result<EnrolledPairing, PairingError> {
-        let mut pending = self
-            .pending
-            .lock()
-            .map_err(|_| PairingError::InvalidRequest)?;
+        let mut pending = self.lock_pending(now, pairing_id)?;
         let pairing = pending
             .get_mut(&pairing_id)
             .ok_or(PairingError::PairingConsumed)?;
@@ -258,10 +275,7 @@ impl PairingManager {
         pairing_id: Uuid,
         now: DateTime<Utc>,
     ) -> Result<Option<[String; 6]>, PairingError> {
-        let mut pending = self
-            .pending
-            .lock()
-            .map_err(|_| PairingError::InvalidRequest)?;
+        let mut pending = self.lock_pending(now, pairing_id)?;
         let pairing = pending
             .get(&pairing_id)
             .ok_or(PairingError::PairingConsumed)?;
@@ -279,10 +293,7 @@ impl PairingManager {
         now: DateTime<Utc>,
         host: bool,
     ) -> Result<PairingProgress, PairingError> {
-        let mut pending = self
-            .pending
-            .lock()
-            .map_err(|_| PairingError::InvalidRequest)?;
+        let mut pending = self.lock_pending(now, pairing_id)?;
         let pairing = pending
             .get_mut(&pairing_id)
             .ok_or(PairingError::PairingConsumed)?;
@@ -759,6 +770,59 @@ mod tests {
         assert!(manager.pending.lock().unwrap().contains_key(&next.id));
         assert!(!manager.pending.lock().unwrap().contains_key(&pairing_id));
         assert_eq!(manager.registry.list_status().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn any_pairing_operation_prunes_other_expired_entries() {
+        for prune_via in ["phrase", "confirm", "enroll"] {
+            let harness = PairingHarness::new();
+            let pending = harness.enroll();
+            harness.confirm_host(&pending.phrase);
+            assert_complete(harness.confirm_device(&pending.phrase), false);
+
+            let live_id = Uuid::from_u128(2);
+            let live_nonce = [11; 32];
+            harness
+                .manager
+                .begin_pairing_with_id(live_id, live_nonce, harness.now + Duration::minutes(30))
+                .unwrap();
+            assert_eq!(harness.manager.pending.lock().unwrap().len(), 2);
+
+            let after_first_expiry = harness.now + Duration::minutes(6);
+            match prune_via {
+                "phrase" => assert_eq!(
+                    harness.manager.phrase(live_id, after_first_expiry).unwrap(),
+                    None
+                ),
+                "confirm" => assert_eq!(
+                    harness
+                        .manager
+                        .confirm_host(live_id, &pending.phrase, after_first_expiry)
+                        .unwrap_err(),
+                    PairingError::PairingConfirmationRequired
+                ),
+                _ => {
+                    harness
+                        .manager
+                        .enroll(
+                            live_id,
+                            live_nonce,
+                            harness.request.clone(),
+                            [3; 32],
+                            after_first_expiry,
+                        )
+                        .unwrap();
+                }
+            }
+
+            let remaining = harness.manager.pending.lock().unwrap();
+            assert_eq!(
+                remaining.len(),
+                1,
+                "{prune_via} left the expired completed pairing behind"
+            );
+            assert!(remaining.contains_key(&live_id));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Context

- Summary: closes the two non-blocking follow-ups filed as bead `coven-t5r` when `coven-jj6` made mobile pairing completion idempotent — opportunistic pruning of expired completed pairings, and transition-exact `PairingCompleted` audit emission.
- Files changed: `crates/coven-cli/src/mobile_memory/pairing.rs`, `crates/coven-cli/src/mobile_memory/gateway.rs`
- Closes: bead `coven-t5r` (no GitHub issue)

## Implementation

- Approach:
  - **Pruning.** A completed pairing is retained until its invitation expires so either confirmer can retry. Only `begin_pairing` and `enroll_by_nonce` swept the pending map, so an expired completed entry survived indefinitely when no further pairing ever started. `enroll`, `phrase`, and `confirm` now take the map through a new `lock_pending(now, addressed)` helper that sweeps expired entries on lock acquisition while retaining the addressed pairing — so that pairing's own expiry still reports `PairingExpired` rather than degrading to `PairingConsumed`.
  - **Audit exactness.** Only the host confirmation path emitted `PairingCompleted`. The completing confirmation is whichever side confirms *second*, so when the host confirmed first the device's completing confirmation registered the device and emitted no completion event at all. `handle_pairing_confirmation` now emits it, gated on `replayed` so cached retries stay silent.
- User-visible behavior: exactly one `pairing_completed` audit record per successful completion, in either confirmation order. No wire-contract, status-code, or response-shape change.
- Compatibility notes: none. No persistent storage, no new fields, no API surface change.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — 1816 unit passed, 2 ignored, all integration/smoke suites green
- [x] `python3 scripts/check-secrets.py` — clean (current tree and history)
- [x] Additional manual checks: `python3 scripts/check-coven-privacy.py --staged` passed; `git diff --check` clean.
- TDD evidence: both new tests were written first and observed RED — `any_pairing_operation_prunes_other_expired_entries` (2 entries remained, expected 1) and `device_completion_audits_once_when_the_host_confirmed_first` (0 audit events, expected 1) — then GREEN after the fixes, 40/40 `mobile_memory::` tests passing.

## Risk and Rollback

- Risk level: low. In-memory lifecycle only; the sweep retains the addressed pairing, so every existing expiry/consumption error path is unchanged and still covered by the pre-existing tests.
- Rollback plan: revert the commit; no migration or persisted state involved.

## Agent Handoff

- Current state: complete and locally verified.
- Follow-ups: none filed. Parent bead `coven-jj6` is implemented on `main` and is closeable.
- Known gaps: the sweep is opportunistic (bounded by pairing traffic), not timer-driven; with zero pairing activity a single expired completed entry can persist until the next operation. That matches the bead's "pruned opportunistically or on schedule" criterion and avoids adding a background task to the gateway.