### PR TITLE
docs(afs): specify coven-afs daemon API, provenance, and Cave surfaces

### DIFF
--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -1,0 +1,438 @@
+# Native OpenCoven Agent File System (AFS) — Design
+
+**Status:** Draft v1 · 2026-08-08
+**Companion to:** [RESEARCH.md](./RESEARCH.md) (deep-research brief, 2026-08-03)
+**Implements:** RESEARCH.md next steps 3 and 4 — daemon API surface, provenance
+extension tables, Cave surfaces, and the frozen interop stance.
+
+This document specifies how the `coven-afs` storage engine becomes a product
+surface: what the daemon exposes, how file operations join Coven's existing
+session provenance, how a session's delta becomes a git branch for the existing
+PR pipeline, and what Cave renders. It does **not** restate the filesystem
+semantics — those are AgentFS SPEC v0.4 plus `crates/coven-afs`.
+
+Scope boundaries:
+
+- **In scope:** `coven.daemon.v1` API additions, extension schema, commit
+  materialization, Cave read surfaces, interop freeze.
+- **Out of scope:** mount implementation details (spike `coven-110`), sandbox
+  enforcement design, Windows mounts, cloud sync.
+
+---
+
+## 1. Interop stance (frozen)
+
+Coven databases are **SPEC v0.4-compatible, coven-extended**. Three rules make
+that concrete and testable:
+
+**E1 — Spec tables are untouched.** Coven never adds, renames, drops, or
+retypes a column in `fs_config`, `fs_inode`, `fs_dentry`, `fs_data`,
+`fs_symlink`, `fs_whiteout`, `fs_origin`, `kv_store`, or `tool_calls`. SPEC v0.4
+sanctions extension columns on `tool_calls` (session, cost, nesting, tokens);
+we decline that allowance so a single rule covers every table.
+
+**E2 — Extensions are additive tables named `afs_*`.** All Coven state lives in
+new tables under the `afs_` prefix. `DROP TABLE` on every `afs_*` table must
+leave a database whose filesystem semantics are unchanged — extensions carry
+provenance and lifecycle metadata, never filesystem truth. Nothing in
+`coven-afs`'s read/write path may consult an `afs_*` table to resolve a path,
+inode, or byte.
+
+**E3 — Both directions must work.** Upstream `agentfs` tooling opens and mutates
+a Coven database correctly (E1 + E2 guarantee it). Coven opens a database
+produced by upstream `agentfs` correctly: every `afs_*` table is created lazily
+and every column in them is nullable or defaulted, so a foreign database is
+simply one with no provenance yet. A missing `afs_session` row means "unbound
+session", not an error.
+
+The cost of E1–E3 is that a mutation made by upstream tooling produces no
+provenance row. That is accepted and surfaced: see §4.4 (unattributed
+mutations), which is why diff is computed from the filesystem tables and not
+from the provenance log.
+
+Interop is a **conformance test**, not a claim: CI creates a database with
+`coven-afs`, runs the SPEC's consistency rules against it, drops every `afs_*`
+table, and re-runs them.
+
+---
+
+## 2. On-disk layout
+
+```
+<COVEN_HOME>/afs/
+  bases/<base-fingerprint>.db     read-only base snapshots, content-addressed
+  sessions/<afs-session-id>.db    writable deltas (one per AFS session)
+  mounts/<afs-session-id>/        mount point (macOS NFS / Linux FUSE)
+```
+
+A **base** is an immutable snapshot of a project root, identified by
+`base-fingerprint`: a hash over the ingest inputs (project root path, git commit
+if the root is a repository, ingest filter version). Bases are shared by every
+session opened against the same fingerprint, so N concurrent agent sessions on
+one repository cost one base plus N small deltas.
+
+A **delta** is one SQLite database per AFS session, holding the writable overlay
+and all `afs_*` provenance. Deltas are private to the same-user trust boundary:
+`0o600`, inside `COVEN_HOME`, never written to the project root.
+
+Discard deletes the delta file. Bases are reference-counted and swept when no
+delta and no open mount refers to them.
+
+---
+
+## 3. Daemon API surface
+
+AFS extends the existing `coven.daemon.v1` contract additively (see
+[API versioning](../../docs/daemon/api-versioning.md)). Same-user local IPC only
+— like session handoff, these routes must never be proxied to a remote
+listener. A remote companion needs a separately paired transport.
+
+### 3.1 Capability flags
+
+`GET /api/v1/health` gains:
+
+```json
+{
+  "capabilities": {
+    "afs": true,
+    "afsMount": "nfs",
+    "afsCommit": true
+  }
+}
+```
+
+`afs` gates the whole route family. `afsMount` is `"nfs"` (macOS), `"fuse"`
+(Linux), or `false` when no mount backend is available — a client must branch on
+it rather than assume mounting works, because SDK-only operation is a supported
+mode. `afsCommit` is false when the daemon cannot materialize commits (no git,
+or a read-only project root). Capabilities advertise availability and never
+grant permission.
+
+### 3.2 Operations
+
+The RESEARCH.md operation names are the contract's vocabulary; each maps to one
+route in the daemon's REST idiom.
+
+| Operation | Route | Purpose |
+|---|---|---|
+| `afs.session.create` | `POST /api/v1/afs/sessions` | Ingest/reuse a base, create a delta, bind provenance. |
+| `afs.session.list` | `GET /api/v1/afs/sessions` | List AFS sessions with state and change counts. |
+| `afs.session.get` | `GET /api/v1/afs/sessions/:id` | Fetch one AFS session. |
+| `afs.session.join` | `POST /api/v1/afs/sessions/:id/join` | Attach a second actor to an existing delta. |
+| `afs.session.diff` | `GET /api/v1/afs/sessions/:id/diff` | Change set, or one path's unified diff. |
+| `afs.session.commit` | `POST /api/v1/afs/sessions/:id/commit` | Materialize the delta into a git branch. |
+| `afs.session.discard` | `POST /api/v1/afs/sessions/:id/discard` | Unmount and delete the delta. |
+| `afs.mount` | `POST /api/v1/afs/sessions/:id/mount` | Mount the merged view; `DELETE` unmounts. |
+| `afs.timeline` | `GET /api/v1/afs/sessions/:id/timeline` | Cursor-paginated provenance + tool calls. |
+
+`discard` is a POST rather than `DELETE /afs/sessions/:id` deliberately: it is a
+destructive operation whose body carries an explicit `confirm` and an optional
+`retainAudit`, and it must be distinguishable in logs from an idle cleanup.
+
+### 3.3 Shapes
+
+**Create.**
+
+```http
+POST /api/v1/afs/sessions
+{
+  "projectRoot": "/workspace/project",
+  "sessionId": "01J...",         // optional: bind to a Coven session
+  "beadId": "coven-vhw",         // optional
+  "name": "vhw-design"           // optional: joinable handle, unique while open
+}
+```
+
+```json
+{
+  "id": "01JAFS...",
+  "name": "vhw-design",
+  "state": "open",
+  "base": { "fingerprint": "sha256:…", "commit": "74d6207", "ingestedAt": "…" },
+  "binding": { "sessionId": "01J…", "familiarId": "…", "beadId": "coven-vhw" },
+  "mount": null,
+  "changes": { "added": 0, "modified": 0, "deleted": 0, "bytes": 0 }
+}
+```
+
+**Mount.** `POST …/mount` returns the mount point and backend; the response
+never includes a listener address a caller could hand to another process.
+
+```json
+{ "mountPoint": "<COVEN_HOME>/afs/mounts/01JAFS…", "backend": "nfs", "readOnly": false }
+```
+
+**Diff.** `GET …/diff` returns the change set; `GET …/diff?path=src/main.rs`
+returns one unified diff, truncated at a documented byte cap with
+`"truncated": true` rather than streaming an unbounded body.
+
+```json
+{
+  "changes": [
+    { "path": "src/main.rs", "change": "modified", "bytes": 1841, "ino": 42, "baseIno": 17, "mode": 33188 },
+    { "path": "docs/new.md",  "change": "added",    "bytes": 210,  "ino": 43, "baseIno": null, "mode": 33188 },
+    { "path": "old.txt",      "change": "deleted",  "bytes": 0,    "ino": null, "baseIno": 9,  "mode": null }
+  ],
+  "truncated": false
+}
+```
+
+**Timeline.** Cursor-paginated on `afs_provenance.seq`, matching the daemon's
+existing `eventCursor: "sequence"` idiom: `?since=<seq>&limit=<n>`, newest-last,
+`nextCursor` echoed in the response.
+
+**Commit.**
+
+```http
+POST /api/v1/afs/sessions/:id/commit
+{ "branch": "afs/vhw-design", "message": "feat: …", "dryRun": false }
+```
+
+```json
+{
+  "branch": "afs/vhw-design",
+  "commit": "9f2c…",
+  "worktree": "/workspace/project/.worktrees/afs-vhw-design",
+  "applied": { "added": 3, "modified": 7, "deleted": 1 },
+  "state": "committed"
+}
+```
+
+### 3.4 Error codes
+
+Dotted codes in the standard envelope (see
+[Error envelope](../../docs/daemon/error-envelope.md)):
+
+| Code | Meaning |
+|---|---|
+| `afs.session_not_found` | Unknown or already-discarded AFS session. |
+| `afs.session_not_open` | Operation requires `state = open`. |
+| `afs.name_in_use` | Another open session holds that joinable name. |
+| `afs.mount_unsupported` | No mount backend on this platform (`afsMount: false`). |
+| `afs.mount_busy` | Already mounted, or the mount point is not empty. |
+| `afs.base_diverged` | Project root moved off the recorded base commit. |
+| `afs.commit_conflict` | Target branch exists with unrelated content. |
+| `afs.path_outside_root` | A delta path would materialize outside the repository root. |
+| `afs.copy_up_too_large` | A single copy-up exceeds the configured byte cap. |
+| `afs.commit_unsigned` | Commit signing is required but unavailable. |
+
+`afs.base_diverged` and `afs.path_outside_root` fail closed: neither is
+retried, downgraded, or partially applied.
+
+---
+
+## 4. Provenance extensions
+
+### 4.1 `afs_session` — binding and lifecycle
+
+One row per delta database.
+
+```sql
+CREATE TABLE IF NOT EXISTS afs_session (
+  id                TEXT PRIMARY KEY,
+  name              TEXT,
+  state             TEXT NOT NULL,          -- open | committing | committed | discarded
+  base_fingerprint  TEXT NOT NULL,
+  base_commit       TEXT,                   -- git commit of the base, when the root is a repo
+  project_root      TEXT NOT NULL,
+  coven_session_id  TEXT,                   -- sessions.id in the coven store
+  familiar_id       TEXT,                   -- sessions.familiar_id
+  bead_id           TEXT,
+  created_at        INTEGER NOT NULL,
+  updated_at        INTEGER NOT NULL
+);
+```
+
+### 4.2 `afs_provenance` — file operations joined to Coven identity
+
+```sql
+CREATE TABLE IF NOT EXISTS afs_provenance (
+  seq               INTEGER PRIMARY KEY AUTOINCREMENT,
+  op                TEXT NOT NULL,          -- write|truncate|mkdir|rmdir|unlink|rename|symlink|hardlink|copy_up
+  path              TEXT NOT NULL,
+  to_path           TEXT,                   -- rename destination
+  ino               INTEGER,                -- delta inode after the op
+  base_ino          INTEGER,                -- fs_origin base inode when copy-up occurred
+  bytes             INTEGER NOT NULL DEFAULT 0,
+  at                INTEGER NOT NULL,       -- unixepoch seconds
+  at_nsec           INTEGER NOT NULL DEFAULT 0,
+  afs_session_id    TEXT NOT NULL,
+  coven_session_id  TEXT,
+  familiar_id       TEXT,
+  bead_id           TEXT,
+  turn              INTEGER,                -- events.rowid cursor at the time of the op
+  tool_call_id      INTEGER REFERENCES tool_calls(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_path ON afs_provenance(path, seq);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_session ON afs_provenance(coven_session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_bead ON afs_provenance(bead_id, seq);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_tool_call ON afs_provenance(tool_call_id);
+```
+
+`tool_call_id` is a real foreign key: `tool_calls` lives in the same delta
+database. `coven_session_id`, `familiar_id`, `bead_id`, and `turn` are
+**by-value** references into the daemon store (`<COVEN_HOME>/coven.db`) — a
+different SQLite file, so no constraint can enforce them. That is deliberate:
+the delta must stay self-describing when copied off the host, and a delta whose
+originating session was pruned must still read.
+
+**Why the identity columns repeat per row instead of living only in
+`afs_session`:** `afs.session.join` exists, so more than one actor can write to
+one delta. The acting session, familiar, bead, and turn are properties of the
+*operation*, not of the delta. `afs_session` records who opened it;
+`afs_provenance` records who did each thing.
+
+`turn` is the session's event cursor (`MAX(events.rowid)` for that session) at
+the moment of the operation — the same cursor session handoff fences on, so a
+timeline entry can be lined up against a transcript position without a second
+clock.
+
+### 4.3 `afs_commit` — materialization record
+
+```sql
+CREATE TABLE IF NOT EXISTS afs_commit (
+  id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+  branch                 TEXT NOT NULL,
+  commit_sha             TEXT,
+  worktree_path          TEXT,
+  provenance_high_water  INTEGER NOT NULL,  -- afs_provenance.seq covered by this commit
+  state                  TEXT NOT NULL,     -- planned | committed | failed
+  created_at             INTEGER NOT NULL
+);
+```
+
+`provenance_high_water` makes a commit answerable: every operation at or below
+that `seq` is represented in that commit, and a later commit on the same delta
+covers the open interval above it.
+
+### 4.4 Unattributed mutations
+
+Writes that arrive without a bound actor — upstream `agentfs` tooling, a manual
+`sqlite3` edit, a mount write from a process the daemon did not launch — produce
+either no provenance row or a row with null identity columns. Diff therefore
+never reads `afs_provenance`; it is computed from `fs_dentry`, `fs_origin`, and
+`fs_whiteout`, which cannot lie about what the filesystem contains. The timeline
+reports its own completeness by comparing the change set against provenance
+coverage and marking uncovered paths `attribution: "unknown"`. A UI that showed
+a clean timeline while the diff carried unexplained files would be worse than
+no timeline.
+
+---
+
+## 5. Commit materialization
+
+Commit turns a delta into an ordinary git branch. It adds no new review
+machinery: the branch enters the existing PR pipeline described in
+[AGENTS.md](../../AGENTS.md).
+
+1. **Quiesce.** `state → committing`; reject writes; unmount if mounted.
+2. **Verify the base.** The project root's HEAD must still be `base_commit`;
+   otherwise `afs.base_diverged`. The delta is preserved, not discarded — the
+   operator rebases the base or commits onto a fresh worktree.
+3. **Create the worktree.** `git worktree add -b <branch> <path> <base_commit>`,
+   following the repo's worktree convention. Branch defaults to
+   `afs/<session-name-or-id>`.
+4. **Apply the change set.** Added and modified paths are written from the
+   delta; whiteouts become removals. Only the executable bit of `mode` is
+   carried across — AFS mode bits are not a git concept.
+5. **Refuse escapes.** Any path that normalizes outside the repository root,
+   any write under `.git/`, and any symlink whose target escapes the root fail
+   the whole commit with `afs.path_outside_root`. Materialization is
+   all-or-nothing; a partially applied delta is never left on a branch.
+6. **Commit, signed.** The repo requires verified commits, so materialization
+   signs (`-S`) using the operator's existing git signing configuration and
+   fails with `afs.commit_unsigned` if signing is unavailable or fails. Coven
+   never disables signing to make a commit land.
+7. **Attribute.** Trailers carry the provenance the branch would otherwise
+   lose: `Coven-Session`, `Coven-Familiar`, `Coven-Bead`, `Coven-Afs-Session`,
+   plus `Co-authored-by:` lines in the numeric-id no-reply form required by
+   AGENTS.md.
+8. **Record.** Insert `afs_commit`; `state → committed`. The delta survives
+   commit — it is the audit record — until an explicit discard.
+
+Commit does not push, open a PR, or run CI. Those stay where they are.
+
+---
+
+## 6. Cave surfaces
+
+Cave reads AFS exclusively through the daemon routes above. It holds no SQLite
+handle on a delta and reimplements no diff or overlay logic; the Rust authority
+boundary applies unchanged.
+
+**Filesystem pane** (per session, behind the `afs` capability):
+
+- **Changes** — the `afs.session.diff` change set as a tree, with per-file
+  added/modified/deleted badges and byte counts. Selecting a file fetches that
+  path's unified diff on demand; the truncation flag renders as an explicit
+  "diff truncated" affordance, never as a silently short diff.
+- **Timeline** — `afs.timeline` merged into one ordered list: file operations
+  and the tool calls that caused them, grouped by turn, each entry linking back
+  to its session event. Rows whose `attribution` is `"unknown"` are marked, not
+  hidden.
+- **Commit** — branch name, the change counts that would be applied, and a
+  `dryRun` preview. Commit is an explicit operator action; Cave never
+  materializes automatically.
+
+Degraded states are first-class. `afs: false` hides the pane; `afsMount: false`
+shows changes and timeline but disables mount controls; `afsCommit: false`
+disables the commit action with the reason from the capability payload.
+
+---
+
+## 7. Operational semantics
+
+**Copy-up cost.** RESEARCH.md flags full-file copy-up as the acceptance risk. A
+configurable per-file cap (`afs.copy_up_max_bytes`) fails the write with
+`afs.copy_up_too_large` rather than silently absorbing a multi-gigabyte artifact
+into a delta. Ingest filters exclude the obvious offenders (`target/`,
+`node_modules/`, `.git/objects/`) from the base by default. The cap's default
+value is set from the `coven-110` mount benchmark, not guessed here.
+
+**Orphan recovery.** A delta whose daemon died stays `open` with a stale mount.
+Startup sweeps `<COVEN_HOME>/afs/sessions/`, unmounts anything mounted by a dead
+pid, and leaves the delta intact — the same posture as
+[orphan recovery](../../docs/daemon/orphan-recovery.md) for sessions. Deltas are
+never auto-discarded; unreviewed work is not garbage.
+
+**Loopback NFS exposure (unresolved).** The macOS backend serves NFSv3 on
+loopback. Any local user can reach a loopback port, so a bare port grants a
+second account on the machine read/write access to a session's files. Mitigation
+before mounts are enabled by default: bind `127.0.0.1` on an ephemeral port per
+session, never a fixed one; refuse any non-loopback bind; and require an
+export-path token that is not derivable from the session id. Whether that is
+sufficient on a shared macOS host must be settled — with an explicit decision
+recorded here — before `afsMount` defaults to on. Until then it ships
+opt-in.
+
+**Enforcement is not free.** As RESEARCH.md notes, the mount alone does not stop
+an agent writing to an absolute path outside it. AFS bounds the blast radius of
+writes that go *through* it; the OS sandbox that forces all writes through the
+mount is separate work and is not claimed by this design.
+
+---
+
+## 8. Open questions
+
+- **Sandbox pairing** (from RESEARCH.md): Linux namespaces are the proven path;
+  macOS needs a validated strategy. Unscoped here.
+- **Windows**: no mount backend upstream or here. SDK-only; ProjFS is the
+  plausible native route and remains unscoped.
+- **Copy-up cap default**: pending `coven-110` benchmark numbers.
+- **Loopback NFS access control**: see §7; blocks mount-on-by-default.
+- **Base ingest filters**: the default exclude set needs to be validated against
+  a real repository checkout plus a `pnpm install`-scale write workload.
+
+## 9. Delivery sequencing
+
+| Step | Bead | State |
+|---|---|---|
+| Storage engine + overlay | `coven-d4p` | PR #658 open |
+| macOS mount + benchmark | `coven-110` | blocked on `coven-d4p` |
+| This design | `coven-vhw` | — |
+| Daemon API + extension tables | not yet filed | needs `coven-d4p` merged |
+| Cave surfaces | not yet filed | needs the daemon API |
+
+Nothing in §3–§6 is implementable before `coven-d4p` merges; this document is
+the contract those follow-ups are held to, not a claim that any of it exists.

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -428,11 +428,11 @@ mount is separate work and is not claimed by this design.
 
 | Step | Bead | State |
 |---|---|---|
-| Storage engine + overlay | `coven-d4p` | PR #658 open |
-| macOS mount + benchmark | `coven-110` | blocked on `coven-d4p` |
+| Storage engine + overlay | `coven-d4p` | merged — PR #658, `e2da654` |
+| macOS mount + benchmark | `coven-110` | unblocked |
 | This design | `coven-vhw` | — |
-| Daemon API + extension tables | not yet filed | needs `coven-d4p` merged |
+| Daemon API + extension tables | not yet filed | ready to file |
 | Cave surfaces | not yet filed | needs the daemon API |
 
-Nothing in §3–§6 is implementable before `coven-d4p` merges; this document is
-the contract those follow-ups are held to, not a claim that any of it exists.
+The storage engine exists; nothing in §3–§6 does. This document is the contract
+those follow-ups are held to, not a claim that any of them are built.

--- a/specs/coven-agent-fs/RESEARCH.md
+++ b/specs/coven-agent-fs/RESEARCH.md
@@ -68,8 +68,8 @@ From the surveyed products (high, per-source): (a) POSIX view so git/grep/existi
 
 1. Bead: spike `coven-afs` — SPEC v0.4 schema in rusqlite + read/write/overlay ops + unit tests (no mount yet).
 2. Bead: mount spike — `nfsserve` on macOS against the spike DB; benchmark a real repo checkout + build.
-3. Design doc in the coven repo: daemon API surface + provenance extension tables + Cave diff/timeline UI.
-4. Decide interop stance: freeze on "SPEC-compatible, coven-extended" and document the extension tables.
+3. Design doc in the coven repo: daemon API surface + provenance extension tables + Cave diff/timeline UI. **Delivered:** [DESIGN.md](./DESIGN.md).
+4. Decide interop stance: freeze on "SPEC-compatible, coven-extended" and document the extension tables. **Frozen:** [DESIGN.md §1](./DESIGN.md).
 
 ## Source ledger
 


### PR DESCRIPTION
## Context

- Summary: adds `specs/coven-agent-fs/DESIGN.md`, the design doc `RESEARCH.md` (merged in #600) called for as next steps 3 and 4. Delivers bead `coven-vhw`.
- Files changed: `specs/coven-agent-fs/DESIGN.md` (new), `specs/coven-agent-fs/RESEARCH.md` (two cross-reference lines marking next steps 3 and 4 delivered).
- Closes: bead `coven-vhw` (no GitHub issue)

## Implementation

- Approach — the doc covers exactly what the bead scoped:
  - **§1 Interop stance, frozen** as three testable rules. E1: no column of a SPEC v0.4 table is ever added, renamed, dropped, or retyped — including the `tool_calls` extension columns the SPEC does sanction, so one rule covers every table. E2: all Coven state lives in additive `afs_*` tables that can be dropped without changing filesystem semantics. E3: both read directions work, so a foreign upstream database is simply one with no provenance yet. Backed by a conformance test rather than an assertion.
  - **§3 Daemon API**: `afs.session.create/list/get/join/diff/commit/discard`, `afs.mount`, `afs.timeline` mapped onto `coven.daemon.v1` routes, with `afs` / `afsMount` / `afsCommit` capability flags, request/response shapes, cursor pagination reusing the existing `eventCursor: "sequence"` idiom, and dotted error codes in the standard envelope.
  - **§4 Provenance extensions**: DDL for `afs_session`, `afs_provenance`, `afs_commit`, joining file operations to session / familiar / bead / turn / tool call. `turn` is the session's `MAX(events.rowid)` cursor — the same one session handoff fences on. Documents why identity columns repeat per operation (`afs.session.join` means the acting identity is a property of the operation, not the delta) and why diff is computed from `fs_dentry`/`fs_origin`/`fs_whiteout` rather than the provenance log.
  - **§5 Commit materialization** into a git worktree and signed branch feeding the existing PR pipeline — all-or-nothing, fails closed on base divergence and path escapes, honors the repo's verified-commit requirement.
  - **§6 Cave surfaces**: Changes / Timeline / Commit panes, read exclusively through daemon routes so the Rust authority boundary holds, with explicit degraded states per capability flag.
- User-visible behavior: none. Documentation only — no code, no shipped API change.
- Compatibility notes: none. The doc explicitly states nothing in §3–§6 is implementable before `coven-d4p` (PR #658) merges.

## Verification

- [x] `cargo fmt --check` — not applicable (no Rust changed); unchanged from `main`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — not applicable (no Rust changed)
- [x] `cargo test --workspace --locked` — not applicable (no Rust changed)
- [x] `python3 scripts/check-secrets.py` — clean (current tree and history)
- [x] Additional manual checks: `python3 scripts/check-api-contract-docs.py` passed; `python3 scripts/check-coven-privacy.py --staged` passed (it initially blocked two example absolute home paths, now `/workspace/project` per the error-envelope doc's convention); `git diff --check` clean; all relative links resolve to existing files.

## Risk and Rollback

- Risk level: none. Documentation only.
- Rollback plan: revert the commit.

## Agent Handoff

- Current state: complete.
- Follow-ups: two implementation beads are named but not yet filed — daemon API + extension tables, and Cave surfaces. Both need `coven-d4p` merged first, so §9 records the sequencing rather than pre-filing blocked work.
- Known gaps, all recorded in the doc rather than silently resolved: the copy-up byte cap default is left to the `coven-110` benchmark; the loopback-NFS exposure (any local user can reach a loopback port) is stated as an unresolved access-control question that gates `afsMount` defaulting to on; macOS sandbox strategy and Windows mounts remain unscoped, as in RESEARCH.md.