### PR TITLE
feat(afs): add NFSv3 mount backend and measure storage throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,11 +722,16 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "coven-afs"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "libc",
+ "nfsserve",
  "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1528,6 +1544,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2809,6 +2835,22 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nfsserve"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1424b6d88c60a091931392970999ea3ceab132d968e6a5545c770fad5b97d7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "byteorder",
+ "filetime",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/coven-afs/Cargo.toml
+++ b/crates/coven-afs/Cargo.toml
@@ -7,11 +7,26 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 
+[features]
+# Mount backends pull in tokio and an RPC stack; the storage engine does not
+# need them, so exporting a filesystem is opt-in.
+mount = ["dep:nfsserve", "dep:async-trait", "dep:tokio", "dep:libc"]
+
 [dependencies]
 rusqlite = { version = "0.40", features = ["bundled"] }
+nfsserve = { version = "0.11", optional = true }
+async-trait = { version = "0.1", optional = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"], optional = true }
+libc = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[[example]]
+name = "afs_serve"
+required-features = ["mount"]

--- a/crates/coven-afs/examples/afs_bench.rs
+++ b/crates/coven-afs/examples/afs_bench.rs
@@ -1,0 +1,352 @@
+//! Storage-layer throughput: coven-afs versus the host filesystem.
+//!
+//! ```text
+//! cargo run --release -p coven-afs --example afs_bench -- [--scale N] [--json <path>]
+//! ```
+//!
+//! Answers the question RESEARCH.md flagged as gating the architecture: what
+//! a repository-checkout-shaped and a `pnpm install`-shaped write workload
+//! cost through SQLite chunks instead of the host filesystem, and what
+//! full-file copy-up costs on first write to a base file.
+//!
+//! This measures the storage engine, not a mount. Numbers here are the floor
+//! any mount backend inherits.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use coven_afs::{AgentFs, OverlayFs};
+
+/// Deterministic filler so runs are comparable. Content must not be constant:
+/// SQLite and the host filesystem both handle incompressible bytes
+/// differently from long runs of one byte.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+
+    fn bytes(&mut self, len: usize) -> Vec<u8> {
+        let mut out = vec![0_u8; len];
+        for slot in out.iter_mut() {
+            *slot = (self.next() & 0xff) as u8;
+        }
+        out
+    }
+}
+
+/// One synthetic tree: paths plus the bytes each file holds.
+fn tree(scale: usize, shape: Shape) -> Vec<(String, Vec<u8>)> {
+    let mut rng = Rng(0x5eed_1234_abcd_0001);
+    let mut files = Vec::with_capacity(scale);
+    for index in 0..scale {
+        let (path, size) = match shape {
+            // Source-checkout shape: a few directory levels, mostly small
+            // text-sized files, an occasional big one.
+            Shape::Checkout => {
+                let dir = index % 32;
+                let sub = (index / 32) % 8;
+                let size = if index % 97 == 0 {
+                    256 * 1024
+                } else {
+                    1024 + (index % 7) * 1024
+                };
+                (format!("/src/mod{dir}/part{sub}/file{index}.rs"), size)
+            }
+            // Dependency-tree shape: very many very small files, deeply nested.
+            Shape::Packages => {
+                let pkg = index % 200;
+                let size = 200 + (index % 5) * 150;
+                (
+                    format!("/node_modules/pkg{pkg}/dist/lib/unit{index}.js"),
+                    size,
+                )
+            }
+        };
+        files.push((path, rng.bytes(size)));
+    }
+    files
+}
+
+#[derive(Clone, Copy)]
+enum Shape {
+    Checkout,
+    Packages,
+}
+
+fn total_bytes(files: &[(String, Vec<u8>)]) -> usize {
+    files.iter().map(|(_, data)| data.len()).sum()
+}
+
+fn millis(duration: Duration) -> f64 {
+    (duration.as_secs_f64() * 1000.0 * 1000.0).round() / 1000.0
+}
+
+fn throughput(bytes: usize, duration: Duration) -> f64 {
+    let mb = bytes as f64 / (1024.0 * 1024.0);
+    ((mb / duration.as_secs_f64()) * 100.0).round() / 100.0
+}
+
+// ---- host filesystem ----------------------------------------------------
+
+fn host_write(root: &Path, files: &[(String, Vec<u8>)]) -> Duration {
+    let start = Instant::now();
+    for (path, data) in files {
+        let full = root.join(path.trim_start_matches('/'));
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        let mut handle = std::fs::File::create(&full).unwrap();
+        handle.write_all(data).unwrap();
+    }
+    start.elapsed()
+}
+
+fn host_read(root: &Path, files: &[(String, Vec<u8>)]) -> Duration {
+    let start = Instant::now();
+    for (path, _) in files {
+        let full = root.join(path.trim_start_matches('/'));
+        let data = std::fs::read(&full).unwrap();
+        std::hint::black_box(data.len());
+    }
+    start.elapsed()
+}
+
+fn host_stat(root: &Path, files: &[(String, Vec<u8>)]) -> Duration {
+    let start = Instant::now();
+    for (path, _) in files {
+        let full = root.join(path.trim_start_matches('/'));
+        std::hint::black_box(std::fs::metadata(&full).unwrap().len());
+    }
+    start.elapsed()
+}
+
+// ---- coven-afs ----------------------------------------------------------
+
+fn afs_write(fs: &mut AgentFs, files: &[(String, Vec<u8>)]) -> Duration {
+    let start = Instant::now();
+    for (path, data) in files {
+        fs.write_file(path, data).unwrap();
+    }
+    start.elapsed()
+}
+
+fn afs_read(fs: &AgentFs, files: &[(String, Vec<u8>)]) -> Duration {
+    let start = Instant::now();
+    for (path, _) in files {
+        std::hint::black_box(fs.read_file(path).unwrap().len());
+    }
+    start.elapsed()
+}
+
+fn afs_stat(fs: &AgentFs, files: &[(String, Vec<u8>)]) -> Duration {
+    let start = Instant::now();
+    for (path, _) in files {
+        std::hint::black_box(fs.stat(path).unwrap().size);
+    }
+    start.elapsed()
+}
+
+/// Chunked writes at increasing offsets, i.e. what a mount client actually
+/// issues for one large file.
+fn afs_chunked_write(fs: &mut AgentFs, path: &str, data: &[u8], chunk: usize) -> Duration {
+    let ino = fs.write_file(path, &[]).unwrap();
+    let start = Instant::now();
+    for (index, piece) in data.chunks(chunk).enumerate() {
+        fs.write_ino_at(ino, (index * chunk) as u64, piece).unwrap();
+    }
+    start.elapsed()
+}
+
+fn host_chunked_write(path: &Path, data: &[u8], chunk: usize) -> Duration {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    let mut handle = std::fs::File::create(path).unwrap();
+    let start = Instant::now();
+    for piece in data.chunks(chunk) {
+        handle.write_all(piece).unwrap();
+    }
+    handle.flush().unwrap();
+    start.elapsed()
+}
+
+fn main() {
+    let mut scale = 2000_usize;
+    let mut json_path: Option<String> = None;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--scale" => scale = args.next().and_then(|v| v.parse().ok()).unwrap_or(scale),
+            "--json" => json_path = args.next(),
+            other => {
+                eprintln!("unknown argument: {other}");
+                std::process::exit(2);
+            }
+        }
+    }
+
+    let temp = tempfile::tempdir().unwrap();
+    let mut report = Vec::new();
+
+    for (label, shape) in [("checkout", Shape::Checkout), ("packages", Shape::Packages)] {
+        let files = tree(scale, shape);
+        let bytes = total_bytes(&files);
+
+        let host_root = temp.path().join(format!("host-{label}"));
+        std::fs::create_dir_all(&host_root).unwrap();
+        let host_w = host_write(&host_root, &files);
+        let host_r = host_read(&host_root, &files);
+        let host_s = host_stat(&host_root, &files);
+
+        let db = temp.path().join(format!("afs-{label}.db"));
+        let mut fs = AgentFs::create(&db).unwrap();
+        let afs_w = afs_write(&mut fs, &files);
+        let afs_r = afs_read(&fs, &files);
+        let afs_s = afs_stat(&fs, &files);
+        drop(fs);
+        let db_bytes = std::fs::metadata(&db).unwrap().len();
+
+        // Same workload with write-ahead logging: the default rollback
+        // journal syncs on every file, which the host path does not do.
+        let wal_db = temp.path().join(format!("afs-wal-{label}.db"));
+        let mut wal_fs = AgentFs::create(&wal_db).unwrap();
+        wal_fs.enable_wal().unwrap();
+        let afs_wal_w = afs_write(&mut wal_fs, &files);
+        let afs_wal_r = afs_read(&wal_fs, &files);
+        drop(wal_fs);
+
+        println!(
+            "{label}: {} files, {:.1} MiB payload",
+            files.len(),
+            bytes as f64 / (1024.0 * 1024.0)
+        );
+        println!(
+            "  write  host {:>9.3} ms ({:>7.2} MiB/s)   afs {:>9.3} ms ({:>7.2} MiB/s)   {:.2}x",
+            millis(host_w),
+            throughput(bytes, host_w),
+            millis(afs_w),
+            throughput(bytes, afs_w),
+            afs_w.as_secs_f64() / host_w.as_secs_f64()
+        );
+        println!(
+            "  write(wal) {:>28} afs {:>9.3} ms ({:>7.2} MiB/s)   {:.2}x",
+            "",
+            millis(afs_wal_w),
+            throughput(bytes, afs_wal_w),
+            afs_wal_w.as_secs_f64() / host_w.as_secs_f64()
+        );
+        println!(
+            "  read   host {:>9.3} ms ({:>7.2} MiB/s)   afs {:>9.3} ms ({:>7.2} MiB/s)   {:.2}x",
+            millis(host_r),
+            throughput(bytes, host_r),
+            millis(afs_r),
+            throughput(bytes, afs_r),
+            afs_r.as_secs_f64() / host_r.as_secs_f64()
+        );
+        println!(
+            "  stat   host {:>9.3} ms                  afs {:>9.3} ms                  {:.2}x",
+            millis(host_s),
+            millis(afs_s),
+            afs_s.as_secs_f64() / host_s.as_secs_f64()
+        );
+        println!(
+            "  on-disk payload {:.1} MiB, afs db {:.1} MiB ({:.2}x)",
+            bytes as f64 / (1024.0 * 1024.0),
+            db_bytes as f64 / (1024.0 * 1024.0),
+            db_bytes as f64 / bytes as f64
+        );
+
+        report.push(format!(
+            r#"    "{label}": {{
+      "files": {}, "payloadBytes": {}, "afsDbBytes": {},
+      "hostWriteMs": {}, "afsWriteMs": {}, "afsWalWriteMs": {}, "afsWalReadMs": {},
+      "hostReadMs": {}, "afsReadMs": {},
+      "hostStatMs": {}, "afsStatMs": {}
+    }}"#,
+            files.len(),
+            bytes,
+            db_bytes,
+            millis(host_w),
+            millis(afs_w),
+            millis(afs_wal_w),
+            millis(afs_wal_r),
+            millis(host_r),
+            millis(afs_r),
+            millis(host_s),
+            millis(afs_s),
+        ));
+    }
+
+    // Large-file chunked write: what an NFS/FUSE client issues for one big
+    // file, and the case where whole-file rewrite semantics would be fatal.
+    let mut rng = Rng(0xfeed_0000_0000_0001);
+    let big = rng.bytes(64 * 1024 * 1024);
+    let chunk = 64 * 1024;
+    let host_big = host_chunked_write(&temp.path().join("big/host.bin"), &big, chunk);
+    let mut fs = AgentFs::create(temp.path().join("big.db")).unwrap();
+    fs.enable_wal().unwrap();
+    let afs_big = afs_chunked_write(&mut fs, "/big.bin", &big, chunk);
+    drop(fs);
+    println!(
+        "large file (wal): 64 MiB in {} KiB writes — host {:.3} ms ({:.2} MiB/s), afs {:.3} ms ({:.2} MiB/s), {:.2}x",
+        chunk / 1024,
+        millis(host_big),
+        throughput(big.len(), host_big),
+        millis(afs_big),
+        throughput(big.len(), afs_big),
+        afs_big.as_secs_f64() / host_big.as_secs_f64()
+    );
+    report.push(format!(
+        r#"    "largeFileChunkedWrite": {{
+      "bytes": {}, "chunkBytes": {}, "hostMs": {}, "afsMs": {}
+    }}"#,
+        big.len(),
+        chunk,
+        millis(host_big),
+        millis(afs_big)
+    ));
+
+    // Copy-up: first write to a file that lives in the read-only base.
+    let base_path = temp.path().join("base.db");
+    let mut base = AgentFs::create(&base_path).unwrap();
+    let mut copy_up_rows = Vec::new();
+    for size_mib in [1_usize, 8, 32] {
+        let payload = rng.bytes(size_mib * 1024 * 1024);
+        base.write_file(&format!("/base{size_mib}.bin"), &payload)
+            .unwrap();
+    }
+    drop(base);
+    for size_mib in [1_usize, 8, 32] {
+        let delta_path = temp.path().join(format!("delta{size_mib}.db"));
+        let mut overlay = OverlayFs::open(&delta_path, &base_path).unwrap();
+        overlay.delta().enable_wal().unwrap();
+        // copy_up is the real cost: a whole-file replace never reads the base,
+        // so measuring write_file here would report ~1 ms and mean nothing.
+        let start = Instant::now();
+        overlay.copy_up(&format!("/base{size_mib}.bin")).unwrap();
+        let elapsed = start.elapsed();
+        println!(
+            "copy-up: first write to a {size_mib} MiB base file took {:.3} ms",
+            millis(elapsed)
+        );
+        copy_up_rows.push(format!(
+            r#"      {{ "baseFileMiB": {size_mib}, "firstWriteMs": {} }}"#,
+            millis(elapsed)
+        ));
+    }
+    report.push(format!(
+        "    \"copyUp\": [\n{}\n    ]",
+        copy_up_rows.join(",\n")
+    ));
+
+    if let Some(path) = json_path {
+        let json = format!(
+            "{{\n  \"scale\": {scale},\n  \"results\": {{\n{}\n  }}\n}}\n",
+            report.join(",\n")
+        );
+        std::fs::write(&path, json).unwrap();
+        println!("wrote {path}");
+    }
+}

--- a/crates/coven-afs/examples/afs_serve.rs
+++ b/crates/coven-afs/examples/afs_serve.rs
@@ -1,0 +1,72 @@
+//! Serve an AgentFS database over loopback NFSv3.
+//!
+//! ```text
+//! cargo run -p coven-afs --features mount --example afs_serve -- <db-path> [port]
+//! ```
+//!
+//! Then, on macOS:
+//!
+//! ```text
+//! mount_nfs -o vers=3,tcp,port=<port>,mountport=<port>,nolock,soft \
+//!   localhost:/ <mountpoint>
+//! ```
+//!
+//! Binds 127.0.0.1 only. Loopback NFS is unauthenticated, so anything that can
+//! reach the port owns the export — see the trust note in `src/nfs.rs`.
+
+use coven_afs::{AfsNfs, AgentFs};
+use nfsserve::tcp::{NFSTcp, NFSTcpListener};
+
+/// Ingest a host directory into the filesystem, the "base ingest" step a real
+/// session would run before mounting.
+fn import(fs: &mut AgentFs, root: &std::path::Path, prefix: &str) -> std::io::Result<usize> {
+    let mut count = 0;
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        let child = format!("{}/{}", prefix.trim_end_matches('/'), name);
+        let kind = entry.file_type()?;
+        if kind.is_dir() {
+            count += import(fs, &entry.path(), &child)?;
+        } else if kind.is_file() {
+            let data = std::fs::read(entry.path())?;
+            fs.write_file(&child, &data)
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = std::env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: afs_serve <db-path> [port]");
+        std::process::exit(2);
+    };
+    // Port 0 asks the OS for a free port; the chosen one is printed below so a
+    // caller can mount without a fixed, guessable port.
+    let port: u16 = args.next().unwrap_or_else(|| "0".into()).parse()?;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "warn".into()),
+        )
+        .init();
+
+    let mut fs = AgentFs::create(&path)?;
+    fs.enable_wal()?;
+    if let Ok(source) = std::env::var("AFS_IMPORT") {
+        let started = std::time::Instant::now();
+        let count = import(&mut fs, std::path::Path::new(&source), "")?;
+        println!(
+            "afs_serve: imported {count} files from {source} in {:.3} ms",
+            started.elapsed().as_secs_f64() * 1000.0
+        );
+    }
+    let listener = NFSTcpListener::bind(&format!("127.0.0.1:{port}"), AfsNfs::new(fs)).await?;
+    println!("afs_serve: port={}", listener.get_listen_port());
+    listener.handle_forever().await?;
+    Ok(())
+}

--- a/crates/coven-afs/src/fs.rs
+++ b/crates/coven-afs/src/fs.rs
@@ -125,6 +125,22 @@ impl AgentFs {
         self.read_only
     }
 
+    /// Switch this database to write-ahead logging with relaxed sync.
+    ///
+    /// Opt-in, because it trades a property the design values: a WAL database
+    /// is three files (`-wal`, `-shm`) while open rather than the single
+    /// portable file AgentFS databases otherwise are. They are checkpointed
+    /// away on clean close. Worth it for a mounted scratch overlay, where
+    /// every file write is its own transaction and the default rollback
+    /// journal costs a full sync each time; not worth it for a database being
+    /// handed to someone else.
+    pub fn enable_wal(&self) -> Result<()> {
+        self.ensure_writable()?;
+        self.conn.pragma_update(None, "journal_mode", "WAL")?;
+        self.conn.pragma_update(None, "synchronous", "NORMAL")?;
+        Ok(())
+    }
+
     fn ensure_writable(&self) -> Result<()> {
         if self.read_only {
             Err(Error::ReadOnly)

--- a/crates/coven-afs/src/ino.rs
+++ b/crates/coven-afs/src/ino.rs
@@ -1,0 +1,655 @@
+//! Inode-addressed operations.
+//!
+//! The path-addressed API in [`crate::fs`] is what callers want; a mount
+//! backend cannot use it. NFSv3 and FUSE both address objects by a 64-bit file
+//! id and a `(parent, name)` pair — they never hand the filesystem a path —
+//! and reconstructing a path from an inode would cost a walk up `fs_dentry` on
+//! every operation.
+//!
+//! These operations are the same SPEC v0.4 semantics as their path-addressed
+//! counterparts, expressed against inode numbers. No new tables and no new
+//! columns: this module is pure query shape.
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::fs::{Metadata, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
+use crate::{now_parts, AgentFs, Error, Result};
+
+/// One directory entry with its metadata, as a mount backend needs it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirEntry {
+    pub name: String,
+    pub meta: Metadata,
+}
+
+const METADATA_COLUMNS: &str = "i.ino, i.mode, i.nlink, i.uid, i.gid, i.size, i.atime, i.mtime,
+     i.ctime, i.rdev, i.atime_nsec, i.mtime_nsec, i.ctime_nsec";
+
+fn metadata_from_row(row: &rusqlite::Row<'_>, offset: usize) -> rusqlite::Result<Metadata> {
+    Ok(Metadata {
+        ino: row.get(offset)?,
+        mode: row.get(offset + 1)?,
+        nlink: row.get(offset + 2)?,
+        uid: row.get(offset + 3)?,
+        gid: row.get(offset + 4)?,
+        size: row.get(offset + 5)?,
+        atime: row.get(offset + 6)?,
+        mtime: row.get(offset + 7)?,
+        ctime: row.get(offset + 8)?,
+        rdev: row.get(offset + 9)?,
+        atime_nsec: row.get(offset + 10)?,
+        mtime_nsec: row.get(offset + 11)?,
+        ctime_nsec: row.get(offset + 12)?,
+    })
+}
+
+impl AgentFs {
+    fn writable(&self) -> Result<()> {
+        if self.is_read_only() {
+            Err(Error::ReadOnly)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn require_dir(&self, ino: i64) -> Result<()> {
+        if self.stat_ino(ino)?.is_dir() {
+            Ok(())
+        } else {
+            Err(Error::NotADirectory(format!("inode {ino}")))
+        }
+    }
+
+    // ---- lookup ----------------------------------------------------------
+
+    /// Resolve one path component inside a directory inode.
+    pub fn lookup_ino(&self, parent_ino: i64, name: &str) -> Result<Option<i64>> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT ino FROM fs_dentry WHERE parent_ino = ?1 AND name = ?2",
+                params![parent_ino, name],
+                |r| r.get(0),
+            )
+            .optional()?)
+    }
+
+    /// List a directory's entries with metadata, ordered by inode.
+    ///
+    /// Ordering by inode rather than name is what makes NFSv3's `start_after`
+    /// pagination exact: resuming is a `WHERE ino > start_after`, not a scan
+    /// for a name whose neighbours may have shifted between calls.
+    pub fn readdir_ino(
+        &self,
+        parent_ino: i64,
+        start_after: i64,
+        limit: usize,
+    ) -> Result<Vec<DirEntry>> {
+        self.require_dir(parent_ino)?;
+        let sql = format!(
+            "SELECT d.name, {METADATA_COLUMNS}
+             FROM fs_dentry d JOIN fs_inode i ON i.ino = d.ino
+             WHERE d.parent_ino = ?1 AND d.ino > ?2
+             ORDER BY d.ino ASC LIMIT ?3"
+        );
+        let mut stmt = self.conn.prepare(&sql)?;
+        let entries = stmt
+            .query_map(params![parent_ino, start_after, limit as i64], |r| {
+                Ok(DirEntry {
+                    name: r.get(0)?,
+                    meta: metadata_from_row(r, 1)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(entries)
+    }
+
+    /// The directory holding an inode, or `None` for the root and for any
+    /// inode with no dentry. A hard-linked file has several parents; this
+    /// returns the lowest-numbered one, which is enough for resolving `..`.
+    pub fn parent_of(&self, ino: i64) -> Result<Option<i64>> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT parent_ino FROM fs_dentry WHERE ino = ?1 ORDER BY parent_ino ASC LIMIT 1",
+                [ino],
+                |r| r.get(0),
+            )
+            .optional()?)
+    }
+
+    /// Number of entries in a directory.
+    pub fn child_count(&self, parent_ino: i64) -> Result<i64> {
+        Ok(self.conn.query_row(
+            "SELECT COUNT(*) FROM fs_dentry WHERE parent_ino = ?1",
+            [parent_ino],
+            |r| r.get(0),
+        )?)
+    }
+
+    // ---- reads -----------------------------------------------------------
+
+    /// Read `count` bytes at `offset` from a file inode.
+    ///
+    /// Returns the bytes and whether the read reached end of file, which is
+    /// the shape both NFSv3 READ and FUSE expect.
+    pub fn read_ino_at(&self, ino: i64, offset: u64, count: usize) -> Result<(Vec<u8>, bool)> {
+        let meta = self.stat_ino(ino)?;
+        if !meta.is_file() {
+            return Err(Error::NotARegularFile(format!("inode {ino}")));
+        }
+        let size = meta.size as u64;
+        if offset >= size || count == 0 {
+            return Ok((Vec::new(), true));
+        }
+        let chunk = self.chunk_size() as u64;
+        let end = (offset + count as u64).min(size);
+        let first = (offset / chunk) as i64;
+        let last = ((end - 1) / chunk) as i64;
+        let mut stmt = self.conn.prepare(
+            "SELECT chunk_index, data FROM fs_data
+             WHERE ino = ?1 AND chunk_index >= ?2 AND chunk_index <= ?3
+             ORDER BY chunk_index ASC",
+        )?;
+        let mut out = vec![0_u8; (end - offset) as usize];
+        for row in stmt.query_map(params![ino, first, last], |r| {
+            Ok((r.get::<_, i64>(0)?, r.get::<_, Vec<u8>>(1)?))
+        })? {
+            let (index, data) = row?;
+            // Where this chunk lands in the output window, clipped at both ends.
+            let chunk_start = index as u64 * chunk;
+            let copy_start = chunk_start.max(offset);
+            let copy_end = (chunk_start + data.len() as u64).min(end);
+            if copy_end <= copy_start {
+                continue;
+            }
+            let dst = (copy_start - offset) as usize;
+            let src = (copy_start - chunk_start) as usize;
+            let len = (copy_end - copy_start) as usize;
+            out[dst..dst + len].copy_from_slice(&data[src..src + len]);
+        }
+        Ok((out, end >= size))
+    }
+
+    /// Read a symlink target by inode.
+    pub fn readlink_ino(&self, ino: i64) -> Result<String> {
+        if !self.stat_ino(ino)?.is_symlink() {
+            return Err(Error::NotASymlink(format!("inode {ino}")));
+        }
+        Ok(self
+            .conn
+            .query_row("SELECT target FROM fs_symlink WHERE ino = ?1", [ino], |r| {
+                r.get(0)
+            })?)
+    }
+
+    // ---- writes ----------------------------------------------------------
+
+    /// Write `data` at `offset` into a file inode, rewriting only the chunks
+    /// the range actually touches.
+    ///
+    /// This is the operation a mount stands or falls on: a client writes a
+    /// file in ~64 KiB chunks, so a whole-file rewrite per write would make
+    /// writing an N-byte file cost O(N²). Holes created by writing past the
+    /// end are materialized as zeroes, because [`AgentFs::read_ino_at`]
+    /// reconstructs a file by chunk index and a missing chunk would otherwise
+    /// silently shorten it.
+    pub fn write_ino_at(&mut self, ino: i64, offset: u64, data: &[u8]) -> Result<Metadata> {
+        self.writable()?;
+        let meta = self.stat_ino(ino)?;
+        if !meta.is_file() {
+            return Err(Error::NotARegularFile(format!("inode {ino}")));
+        }
+        if data.is_empty() {
+            return Ok(meta);
+        }
+        let chunk = self.chunk_size() as u64;
+        let size = meta.size as u64;
+        let end = offset + data.len() as u64;
+        let new_size = size.max(end);
+        let first = offset / chunk;
+        let last = (end - 1) / chunk;
+        let (secs, nsec) = now_parts();
+
+        let tx = self.conn.transaction()?;
+        // Materialize any hole between the old end of file and the write.
+        if offset > size {
+            for index in (size / chunk)..first {
+                let start = index * chunk;
+                let want = (chunk).min(new_size - start) as usize;
+                let existing: Option<Vec<u8>> = tx
+                    .query_row(
+                        "SELECT data FROM fs_data WHERE ino = ?1 AND chunk_index = ?2",
+                        params![ino, index as i64],
+                        |r| r.get(0),
+                    )
+                    .optional()?;
+                let mut buf = existing.unwrap_or_default();
+                if buf.len() < want {
+                    buf.resize(want, 0);
+                    tx.execute(
+                        "INSERT INTO fs_data (ino, chunk_index, data) VALUES (?1, ?2, ?3)
+                         ON CONFLICT(ino, chunk_index) DO UPDATE SET data = excluded.data",
+                        params![ino, index as i64, buf],
+                    )?;
+                }
+            }
+        }
+        for index in first..=last {
+            let start = index * chunk;
+            let existing: Option<Vec<u8>> = tx
+                .query_row(
+                    "SELECT data FROM fs_data WHERE ino = ?1 AND chunk_index = ?2",
+                    params![ino, index as i64],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            let mut buf = existing.unwrap_or_default();
+            let want = chunk.min(new_size - start) as usize;
+            if buf.len() < want {
+                buf.resize(want, 0);
+            }
+            let write_start = offset.max(start);
+            let write_end = end.min(start + chunk);
+            let dst = (write_start - start) as usize;
+            let src = (write_start - offset) as usize;
+            let len = (write_end - write_start) as usize;
+            buf[dst..dst + len].copy_from_slice(&data[src..src + len]);
+            tx.execute(
+                "INSERT INTO fs_data (ino, chunk_index, data) VALUES (?1, ?2, ?3)
+                 ON CONFLICT(ino, chunk_index) DO UPDATE SET data = excluded.data",
+                params![ino, index as i64, buf],
+            )?;
+        }
+        tx.execute(
+            "UPDATE fs_inode SET size = ?1, mtime = ?2, mtime_nsec = ?3,
+                                 ctime = ?2, ctime_nsec = ?3
+             WHERE ino = ?4",
+            params![new_size as i64, secs, nsec, ino],
+        )?;
+        tx.commit()?;
+        self.stat_ino(ino)
+    }
+
+    /// Set a file's length, dropping or zero-extending chunks as needed.
+    pub fn truncate_ino(&mut self, ino: i64, size: u64) -> Result<Metadata> {
+        self.writable()?;
+        let meta = self.stat_ino(ino)?;
+        if !meta.is_file() {
+            return Err(Error::NotARegularFile(format!("inode {ino}")));
+        }
+        let old = meta.size as u64;
+        if size == old {
+            return Ok(meta);
+        }
+        if size > old {
+            // Grow by writing one zero byte at the new end; the hole-filling
+            // path above materializes everything before it.
+            self.write_ino_at(ino, size - 1, &[0])?;
+            return self.stat_ino(ino);
+        }
+        let chunk = self.chunk_size() as u64;
+        let (secs, nsec) = now_parts();
+        let tx = self.conn.transaction()?;
+        if size == 0 {
+            tx.execute("DELETE FROM fs_data WHERE ino = ?1", [ino])?;
+        } else {
+            let last = (size - 1) / chunk;
+            tx.execute(
+                "DELETE FROM fs_data WHERE ino = ?1 AND chunk_index > ?2",
+                params![ino, last as i64],
+            )?;
+            let keep = (size - last * chunk) as usize;
+            let existing: Option<Vec<u8>> = tx
+                .query_row(
+                    "SELECT data FROM fs_data WHERE ino = ?1 AND chunk_index = ?2",
+                    params![ino, last as i64],
+                    |r| r.get(0),
+                )
+                .optional()?;
+            if let Some(mut buf) = existing {
+                if buf.len() > keep {
+                    buf.truncate(keep);
+                    tx.execute(
+                        "UPDATE fs_data SET data = ?3 WHERE ino = ?1 AND chunk_index = ?2",
+                        params![ino, last as i64, buf],
+                    )?;
+                }
+            }
+        }
+        tx.execute(
+            "UPDATE fs_inode SET size = ?1, mtime = ?2, mtime_nsec = ?3,
+                                 ctime = ?2, ctime_nsec = ?3
+             WHERE ino = ?4",
+            params![size as i64, secs, nsec, ino],
+        )?;
+        tx.commit()?;
+        self.stat_ino(ino)
+    }
+
+    /// Update ownership, permission bits, and timestamps. `None` leaves a
+    /// field untouched; `mode` carries permission bits only, never the type.
+    pub fn setattr_ino(
+        &mut self,
+        ino: i64,
+        mode: Option<u32>,
+        uid: Option<i64>,
+        gid: Option<i64>,
+        atime: Option<(i64, i64)>,
+        mtime: Option<(i64, i64)>,
+    ) -> Result<Metadata> {
+        self.writable()?;
+        let meta = self.stat_ino(ino)?;
+        let (secs, nsec) = now_parts();
+        let new_mode = mode.map_or(meta.mode, |bits| (meta.mode & S_IFMT) | (bits & 0o7777));
+        let (atime_s, atime_ns) = atime.unwrap_or((meta.atime, meta.atime_nsec));
+        let (mtime_s, mtime_ns) = mtime.unwrap_or((meta.mtime, meta.mtime_nsec));
+        self.conn.execute(
+            "UPDATE fs_inode SET mode = ?1, uid = ?2, gid = ?3,
+                                 atime = ?4, atime_nsec = ?5,
+                                 mtime = ?6, mtime_nsec = ?7,
+                                 ctime = ?8, ctime_nsec = ?9
+             WHERE ino = ?10",
+            params![
+                new_mode,
+                uid.unwrap_or(meta.uid),
+                gid.unwrap_or(meta.gid),
+                atime_s,
+                atime_ns,
+                mtime_s,
+                mtime_ns,
+                secs,
+                nsec,
+                ino
+            ],
+        )?;
+        self.stat_ino(ino)
+    }
+
+    // ---- namespace -------------------------------------------------------
+
+    fn insert_child(
+        &mut self,
+        parent_ino: i64,
+        name: &str,
+        mode: u32,
+        size: i64,
+        symlink_target: Option<&str>,
+    ) -> Result<(i64, Metadata)> {
+        self.writable()?;
+        self.require_dir(parent_ino)?;
+        if self.lookup_ino(parent_ino, name)?.is_some() {
+            return Err(Error::AlreadyExists(name.to_string()));
+        }
+        let (secs, nsec) = now_parts();
+        let tx = self.conn.transaction()?;
+        let ino: i64 = tx.query_row(
+            "INSERT INTO fs_inode (mode, uid, gid, size, atime, mtime, ctime,
+                                   atime_nsec, mtime_nsec, ctime_nsec)
+             VALUES (?1, 0, 0, ?2, ?3, ?3, ?3, ?4, ?4, ?4)
+             RETURNING ino",
+            params![mode, size, secs, nsec],
+            |r| r.get(0),
+        )?;
+        tx.execute(
+            "INSERT INTO fs_dentry (name, parent_ino, ino) VALUES (?1, ?2, ?3)",
+            params![name, parent_ino, ino],
+        )?;
+        tx.execute(
+            "UPDATE fs_inode SET nlink = nlink + 1 WHERE ino = ?1",
+            [ino],
+        )?;
+        if let Some(target) = symlink_target {
+            tx.execute(
+                "INSERT INTO fs_symlink (ino, target) VALUES (?1, ?2)",
+                params![ino, target],
+            )?;
+        }
+        tx.commit()?;
+        let meta = self.stat_ino(ino)?;
+        Ok((ino, meta))
+    }
+
+    /// Create an empty regular file in a directory.
+    pub fn create_child(
+        &mut self,
+        parent_ino: i64,
+        name: &str,
+        mode: u32,
+    ) -> Result<(i64, Metadata)> {
+        self.insert_child(parent_ino, name, S_IFREG | (mode & 0o7777), 0, None)
+    }
+
+    /// Create a subdirectory.
+    pub fn mkdir_ino(&mut self, parent_ino: i64, name: &str, mode: u32) -> Result<(i64, Metadata)> {
+        self.insert_child(parent_ino, name, S_IFDIR | (mode & 0o7777), 0, None)
+    }
+
+    /// Create a symlink.
+    pub fn symlink_ino(
+        &mut self,
+        parent_ino: i64,
+        name: &str,
+        target: &str,
+    ) -> Result<(i64, Metadata)> {
+        self.insert_child(
+            parent_ino,
+            name,
+            S_IFLNK | 0o777,
+            target.len() as i64,
+            Some(target),
+        )
+    }
+
+    /// Remove a directory entry: an empty directory, or one link to a file or
+    /// symlink (dropping the inode and its data on the last link).
+    pub fn remove_ino(&mut self, parent_ino: i64, name: &str) -> Result<()> {
+        self.writable()?;
+        let ino = self
+            .lookup_ino(parent_ino, name)?
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+        let meta = self.stat_ino(ino)?;
+        if meta.is_dir() && self.child_count(ino)? > 0 {
+            return Err(Error::DirectoryNotEmpty(name.to_string()));
+        }
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "DELETE FROM fs_dentry WHERE parent_ino = ?1 AND name = ?2",
+            params![parent_ino, name],
+        )?;
+        if meta.is_dir() {
+            tx.execute("DELETE FROM fs_inode WHERE ino = ?1", [ino])?;
+        } else {
+            tx.execute(
+                "UPDATE fs_inode SET nlink = nlink - 1 WHERE ino = ?1",
+                [ino],
+            )?;
+            let nlink: i64 =
+                tx.query_row("SELECT nlink FROM fs_inode WHERE ino = ?1", [ino], |r| {
+                    r.get(0)
+                })?;
+            if nlink <= 0 {
+                tx.execute("DELETE FROM fs_inode WHERE ino = ?1", [ino])?;
+                tx.execute("DELETE FROM fs_data WHERE ino = ?1", [ino])?;
+                tx.execute("DELETE FROM fs_symlink WHERE ino = ?1", [ino])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Move an entry between directories, replacing an existing destination.
+    pub fn rename_ino(
+        &mut self,
+        from_parent: i64,
+        from_name: &str,
+        to_parent: i64,
+        to_name: &str,
+    ) -> Result<()> {
+        self.writable()?;
+        let ino = self
+            .lookup_ino(from_parent, from_name)?
+            .ok_or_else(|| Error::NotFound(from_name.to_string()))?;
+        if from_parent == to_parent && from_name == to_name {
+            return Ok(());
+        }
+        self.require_dir(to_parent)?;
+        if let Some(existing) = self.lookup_ino(to_parent, to_name)? {
+            if existing != ino {
+                self.remove_ino(to_parent, to_name)?;
+            }
+        }
+        let (secs, nsec) = now_parts();
+        let tx = self.conn.transaction()?;
+        tx.execute(
+            "UPDATE fs_dentry SET name = ?1, parent_ino = ?2
+             WHERE parent_ino = ?3 AND name = ?4",
+            params![to_name, to_parent, from_parent, from_name],
+        )?;
+        tx.execute(
+            "UPDATE fs_inode SET ctime = ?1, ctime_nsec = ?2 WHERE ino = ?3",
+            params![secs, nsec, ino],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fs() -> AgentFs {
+        AgentFs::in_memory_with_chunk_size(16).unwrap()
+    }
+
+    #[test]
+    fn partial_write_only_rewrites_touched_chunks() {
+        let mut fs = fs();
+        let ino = fs.write_file("/a.bin", &[b'a'; 64]).unwrap();
+        fs.write_ino_at(ino, 20, b"ZZZZ").unwrap();
+        let (data, eof) = fs.read_ino_at(ino, 0, 64).unwrap();
+        let mut want = vec![b'a'; 64];
+        want[20..24].copy_from_slice(b"ZZZZ");
+        assert_eq!(data, want);
+        assert!(eof);
+        assert_eq!(fs.stat_ino(ino).unwrap().size, 64);
+    }
+
+    #[test]
+    fn sequential_chunked_write_reconstructs_the_whole_file() {
+        let mut fs = fs();
+        let (ino, _) = fs.create_child(1, "big.bin", 0o644).unwrap();
+        let payload: Vec<u8> = (0..250_u32).map(|i| (i % 251) as u8).collect();
+        for (index, piece) in payload.chunks(7).enumerate() {
+            fs.write_ino_at(ino, (index * 7) as u64, piece).unwrap();
+        }
+        let (data, _) = fs.read_ino_at(ino, 0, payload.len()).unwrap();
+        assert_eq!(data, payload);
+    }
+
+    #[test]
+    fn writing_past_the_end_zero_fills_the_hole() {
+        let mut fs = fs();
+        let (ino, _) = fs.create_child(1, "sparse.bin", 0o644).unwrap();
+        fs.write_ino_at(ino, 0, b"head").unwrap();
+        fs.write_ino_at(ino, 100, b"tail").unwrap();
+        let (data, _) = fs.read_ino_at(ino, 0, 104).unwrap();
+        assert_eq!(data.len(), 104);
+        assert_eq!(&data[0..4], b"head");
+        assert_eq!(&data[100..104], b"tail");
+        assert!(data[4..100].iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn truncate_shrinks_and_grows() {
+        let mut fs = fs();
+        let ino = fs.write_file("/t.bin", &[b'x'; 100]).unwrap();
+        fs.truncate_ino(ino, 10).unwrap();
+        let (data, _) = fs.read_ino_at(ino, 0, 100).unwrap();
+        assert_eq!(data, vec![b'x'; 10]);
+        fs.truncate_ino(ino, 40).unwrap();
+        let (grown, _) = fs.read_ino_at(ino, 0, 100).unwrap();
+        assert_eq!(grown.len(), 40);
+        assert_eq!(&grown[0..10], &vec![b'x'; 10][..]);
+        assert!(grown[10..].iter().all(|byte| *byte == 0));
+    }
+
+    #[test]
+    fn readdir_paginates_by_inode_without_repeating_entries() {
+        let mut fs = fs();
+        let (dir, _) = fs.mkdir_ino(1, "d", 0o755).unwrap();
+        for index in 0..10 {
+            fs.create_child(dir, &format!("f{index}"), 0o644).unwrap();
+        }
+        let mut seen = Vec::new();
+        let mut cursor = 0;
+        loop {
+            let page = fs.readdir_ino(dir, cursor, 3).unwrap();
+            if page.is_empty() {
+                break;
+            }
+            cursor = page.last().unwrap().meta.ino;
+            seen.extend(page.into_iter().map(|entry| entry.name));
+        }
+        seen.sort();
+        let mut want: Vec<String> = (0..10).map(|index| format!("f{index}")).collect();
+        want.sort();
+        assert_eq!(seen, want);
+    }
+
+    #[test]
+    fn rename_replaces_the_destination_and_remove_frees_data() {
+        let mut fs = fs();
+        let (dir, _) = fs.mkdir_ino(1, "d", 0o755).unwrap();
+        let src = fs.write_file("/d/src", b"source").unwrap();
+        let dst = fs.write_file("/d/dst", b"destination").unwrap();
+        fs.rename_ino(dir, "src", dir, "dst").unwrap();
+        assert_eq!(fs.lookup_ino(dir, "src").unwrap(), None);
+        assert_eq!(fs.lookup_ino(dir, "dst").unwrap(), Some(src));
+        assert!(fs.stat_ino(dst).is_err());
+        assert_eq!(fs.read_file("/d/dst").unwrap(), b"source");
+
+        fs.remove_ino(dir, "dst").unwrap();
+        let orphaned: i64 = fs
+            .conn
+            .query_row("SELECT COUNT(*) FROM fs_data WHERE ino = ?1", [src], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(orphaned, 0);
+        assert!(fs.check_consistency().unwrap().is_empty());
+    }
+
+    #[test]
+    fn non_empty_directory_removal_is_refused() {
+        let mut fs = fs();
+        let (dir, _) = fs.mkdir_ino(1, "d", 0o755).unwrap();
+        fs.create_child(dir, "child", 0o644).unwrap();
+        assert!(matches!(
+            fs.remove_ino(1, "d"),
+            Err(Error::DirectoryNotEmpty(_))
+        ));
+    }
+
+    #[test]
+    fn setattr_preserves_the_file_type_bits() {
+        let mut fs = fs();
+        let (ino, _) = fs.create_child(1, "f", 0o644).unwrap();
+        let meta = fs
+            .setattr_ino(ino, Some(0o600), Some(501), Some(20), None, None)
+            .unwrap();
+        assert!(meta.is_file());
+        assert_eq!(meta.mode & 0o7777, 0o600);
+        assert_eq!(meta.uid, 501);
+        assert_eq!(meta.gid, 20);
+    }
+
+    #[test]
+    fn symlinks_round_trip_by_inode() {
+        let mut fs = fs();
+        let (ino, meta) = fs.symlink_ino(1, "link", "/target/path").unwrap();
+        assert!(meta.is_symlink());
+        assert_eq!(fs.readlink_ino(ino).unwrap(), "/target/path");
+    }
+}

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -25,13 +25,19 @@
 
 mod audit;
 mod fs;
+mod ino;
 mod kv;
+#[cfg(feature = "mount")]
+mod nfs;
 mod overlay;
 mod path;
 mod schema;
 
 pub use audit::ToolCall;
 pub use fs::{AgentFs, Metadata, ROOT_INO, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
+pub use ino::DirEntry;
+#[cfg(feature = "mount")]
+pub use nfs::AfsNfs;
 pub use overlay::OverlayFs;
 pub use path::{basename, components, normalize, parent};
 

--- a/crates/coven-afs/src/nfs.rs
+++ b/crates/coven-afs/src/nfs.rs
@@ -1,0 +1,455 @@
+//! NFSv3 export of an [`AgentFs`] database.
+//!
+//! This is the kext-free macOS mount path: serve NFSv3 on loopback and let
+//! the kernel's native `mount_nfs` client attach it. Linux can use the same
+//! server, though FUSE via `fuser` is the better fit there.
+//!
+//! Feature-gated behind `mount` so the default build stays free of tokio and
+//! the RPC stack — most consumers of this crate want the storage engine, not
+//! a server.
+//!
+//! # Concurrency
+//!
+//! The filesystem sits behind a [`Mutex`], so RPCs serialize. `rusqlite` holds
+//! a single connection and every operation is a short transaction, so this is
+//! correct but not concurrent. It bounds what the benchmark can say about
+//! parallel workloads; see `specs/coven-agent-fs/MOUNT-SPIKE.md`.
+//!
+//! # Ownership mapping
+//!
+//! SPEC v0.4 defaults `fs_inode.uid`/`gid` to 0, so an unmapped export
+//! presents a root-owned tree and the client's own permission check rejects
+//! every write before a single RPC leaves the machine. Inodes stored as
+//! unowned (uid/gid 0) are therefore presented as owned by the serving
+//! process's user. Ownership explicitly set through `setattr` is preserved.
+//! Nothing is written back: this is presentation only, so the database stays
+//! byte-identical to what upstream `agentfs` tooling would produce.
+//!
+//! # Trust
+//!
+//! Loopback NFS has no authentication. Anything that can reach the port can
+//! read and write the export, so a bare port on a shared host is a hole. Bind
+//! only 127.0.0.1, prefer an ephemeral port, and treat this as opt-in until
+//! the access-control question in `DESIGN.md` §7 is settled.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use nfsserve::nfs::{
+    fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, nfstime3, sattr3, set_atime, set_gid3,
+    set_mode3, set_mtime, set_size3, set_uid3, specdata3,
+};
+use nfsserve::vfs::{DirEntry as NfsDirEntry, NFSFileSystem, ReadDirResult, VFSCapabilities};
+
+use crate::fs::{Metadata, ROOT_INO};
+use crate::{AgentFs, Error};
+
+/// An [`AgentFs`] exported over NFSv3.
+pub struct AfsNfs {
+    fs: Mutex<AgentFs>,
+    read_only: bool,
+    uid: u32,
+    gid: u32,
+}
+
+impl AfsNfs {
+    /// Wrap a filesystem for export. A read-only [`AgentFs`] is exported
+    /// read-only.
+    pub fn new(fs: AgentFs) -> Self {
+        // SAFETY: getuid/getgid are always-succeeding POSIX calls with no
+        // preconditions and no memory effects.
+        let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
+        Self {
+            read_only: fs.is_read_only(),
+            fs: Mutex::new(fs),
+            uid,
+            gid,
+        }
+    }
+
+    /// Present unowned inodes as belonging to the serving user; see the
+    /// ownership note at the top of this module.
+    fn attributes(&self, meta: &Metadata) -> fattr3 {
+        let mut attr = attributes(meta);
+        if meta.uid == 0 {
+            attr.uid = self.uid;
+        }
+        if meta.gid == 0 {
+            attr.gid = self.gid;
+        }
+        attr
+    }
+
+    fn with<T>(&self, op: impl FnOnce(&mut AgentFs) -> crate::Result<T>) -> Result<T, nfsstat3> {
+        let mut guard = self.fs.lock().map_err(|_| nfsstat3::NFS3ERR_SERVERFAULT)?;
+        op(&mut guard).map_err(status)
+    }
+}
+
+/// Map a storage error onto the closest NFSv3 status.
+fn status(error: Error) -> nfsstat3 {
+    match error {
+        Error::NotFound(_) => nfsstat3::NFS3ERR_NOENT,
+        Error::AlreadyExists(_) => nfsstat3::NFS3ERR_EXIST,
+        Error::NotADirectory(_) => nfsstat3::NFS3ERR_NOTDIR,
+        Error::IsADirectory(_) => nfsstat3::NFS3ERR_ISDIR,
+        Error::DirectoryNotEmpty(_) => nfsstat3::NFS3ERR_NOTEMPTY,
+        Error::NotARegularFile(_) | Error::NotASymlink(_) | Error::InvalidArgument(_) => {
+            nfsstat3::NFS3ERR_INVAL
+        }
+        Error::ReadOnly => nfsstat3::NFS3ERR_ROFS,
+        Error::Sqlite(_) | Error::Json(_) => nfsstat3::NFS3ERR_IO,
+    }
+}
+
+fn time(seconds: i64, nanoseconds: i64) -> nfstime3 {
+    nfstime3 {
+        seconds: seconds.clamp(0, i64::from(u32::MAX)) as u32,
+        nseconds: nanoseconds.clamp(0, i64::from(u32::MAX)) as u32,
+    }
+}
+
+fn attributes(meta: &Metadata) -> fattr3 {
+    let ftype = if meta.is_dir() {
+        ftype3::NF3DIR
+    } else if meta.is_symlink() {
+        ftype3::NF3LNK
+    } else {
+        ftype3::NF3REG
+    };
+    fattr3 {
+        ftype,
+        mode: meta.mode & 0o7777,
+        nlink: meta.nlink.max(0) as u32,
+        uid: meta.uid.max(0) as u32,
+        gid: meta.gid.max(0) as u32,
+        size: meta.size.max(0) as u64,
+        used: meta.size.max(0) as u64,
+        rdev: specdata3 {
+            specdata1: 0,
+            specdata2: 0,
+        },
+        fsid: 0,
+        fileid: meta.ino as u64,
+        atime: time(meta.atime, meta.atime_nsec),
+        mtime: time(meta.mtime, meta.mtime_nsec),
+        ctime: time(meta.ctime, meta.ctime_nsec),
+    }
+}
+
+fn name_of(name: &filename3) -> Result<String, nfsstat3> {
+    String::from_utf8(name.0.clone()).map_err(|_| nfsstat3::NFS3ERR_INVAL)
+}
+
+/// Apply the mutable parts of a `sattr3` to an inode. Size is applied first so
+/// a truncate-on-create carries the requested length.
+fn apply_sattr(fs: &mut AgentFs, ino: i64, attr: &sattr3) -> crate::Result<Metadata> {
+    if let set_size3::size(size) = attr.size {
+        fs.truncate_ino(ino, size)?;
+    }
+    let mode = match attr.mode {
+        set_mode3::mode(bits) => Some(bits),
+        set_mode3::Void => None,
+    };
+    let uid = match attr.uid {
+        set_uid3::uid(id) => Some(i64::from(id)),
+        set_uid3::Void => None,
+    };
+    let gid = match attr.gid {
+        set_gid3::gid(id) => Some(i64::from(id)),
+        set_gid3::Void => None,
+    };
+    let atime = match attr.atime {
+        set_atime::SET_TO_CLIENT_TIME(stamp) => {
+            Some((i64::from(stamp.seconds), i64::from(stamp.nseconds)))
+        }
+        set_atime::SET_TO_SERVER_TIME => Some(crate::now_parts()),
+        set_atime::DONT_CHANGE => None,
+    };
+    let mtime = match attr.mtime {
+        set_mtime::SET_TO_CLIENT_TIME(stamp) => {
+            Some((i64::from(stamp.seconds), i64::from(stamp.nseconds)))
+        }
+        set_mtime::SET_TO_SERVER_TIME => Some(crate::now_parts()),
+        set_mtime::DONT_CHANGE => None,
+    };
+    fs.setattr_ino(ino, mode, uid, gid, atime, mtime)
+}
+
+#[async_trait]
+impl NFSFileSystem for AfsNfs {
+    fn capabilities(&self) -> VFSCapabilities {
+        if self.read_only {
+            VFSCapabilities::ReadOnly
+        } else {
+            VFSCapabilities::ReadWrite
+        }
+    }
+
+    fn root_dir(&self) -> fileid3 {
+        ROOT_INO as u64
+    }
+
+    async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
+        let name = name_of(filename)?;
+        let dir = dirid as i64;
+        self.with(|fs| match name.as_str() {
+            "." => Ok(dir),
+            ".." => Ok(fs.parent_of(dir)?.unwrap_or(ROOT_INO)),
+            _ => fs
+                .lookup_ino(dir, &name)?
+                .ok_or_else(|| Error::NotFound(name.clone())),
+        })
+        .map(|ino| ino as u64)
+    }
+
+    async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+        self.with(|fs| fs.stat_ino(id as i64))
+            .map(|m| self.attributes(&m))
+    }
+
+    async fn setattr(&self, id: fileid3, setattr: sattr3) -> Result<fattr3, nfsstat3> {
+        self.with(|fs| apply_sattr(fs, id as i64, &setattr))
+            .map(|m| self.attributes(&m))
+    }
+
+    async fn read(
+        &self,
+        id: fileid3,
+        offset: u64,
+        count: u32,
+    ) -> Result<(Vec<u8>, bool), nfsstat3> {
+        self.with(|fs| fs.read_ino_at(id as i64, offset, count as usize))
+    }
+
+    async fn write(&self, id: fileid3, offset: u64, data: &[u8]) -> Result<fattr3, nfsstat3> {
+        self.with(|fs| fs.write_ino_at(id as i64, offset, data))
+            .map(|m| self.attributes(&m))
+    }
+
+    async fn create(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+        attr: sattr3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let name = name_of(filename)?;
+        let dir = dirid as i64;
+        self.with(|fs| {
+            // CREATE is not exclusive: an existing file is opened and
+            // truncated per the requested attributes, not rejected.
+            let ino = match fs.lookup_ino(dir, &name)? {
+                Some(existing) => existing,
+                None => fs.create_child(dir, &name, 0o644)?.0,
+            };
+            let meta = apply_sattr(fs, ino, &attr)?;
+            Ok((ino as u64, meta))
+        })
+        .map(|(id, meta)| (id, self.attributes(&meta)))
+    }
+
+    async fn create_exclusive(
+        &self,
+        dirid: fileid3,
+        filename: &filename3,
+    ) -> Result<fileid3, nfsstat3> {
+        let name = name_of(filename)?;
+        self.with(|fs| {
+            fs.create_child(dirid as i64, &name, 0o644)
+                .map(|(ino, _)| ino)
+        })
+        .map(|ino| ino as u64)
+    }
+
+    async fn mkdir(
+        &self,
+        dirid: fileid3,
+        dirname: &filename3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let name = name_of(dirname)?;
+        self.with(|fs| {
+            let (ino, meta) = fs.mkdir_ino(dirid as i64, &name, 0o755)?;
+            Ok((ino as u64, meta))
+        })
+        .map(|(id, meta)| (id, self.attributes(&meta)))
+    }
+
+    async fn remove(&self, dirid: fileid3, filename: &filename3) -> Result<(), nfsstat3> {
+        let name = name_of(filename)?;
+        self.with(|fs| fs.remove_ino(dirid as i64, &name))
+    }
+
+    async fn rename(
+        &self,
+        from_dirid: fileid3,
+        from_filename: &filename3,
+        to_dirid: fileid3,
+        to_filename: &filename3,
+    ) -> Result<(), nfsstat3> {
+        let from = name_of(from_filename)?;
+        let to = name_of(to_filename)?;
+        self.with(|fs| fs.rename_ino(from_dirid as i64, &from, to_dirid as i64, &to))
+    }
+
+    async fn readdir(
+        &self,
+        dirid: fileid3,
+        start_after: fileid3,
+        max_entries: usize,
+    ) -> Result<ReadDirResult, nfsstat3> {
+        let dir = dirid as i64;
+        let (entries, exhausted) = self.with(|fs| {
+            let page = fs.readdir_ino(dir, start_after as i64, max_entries)?;
+            let exhausted = page.len() < max_entries;
+            Ok((page, exhausted))
+        })?;
+        Ok(ReadDirResult {
+            entries: entries
+                .into_iter()
+                .map(|entry| NfsDirEntry {
+                    fileid: entry.meta.ino as u64,
+                    name: entry.name.into_bytes().into(),
+                    attr: self.attributes(&entry.meta),
+                })
+                .collect(),
+            end: exhausted,
+        })
+    }
+
+    async fn symlink(
+        &self,
+        dirid: fileid3,
+        linkname: &filename3,
+        symlink: &nfspath3,
+        attr: &sattr3,
+    ) -> Result<(fileid3, fattr3), nfsstat3> {
+        let name = name_of(linkname)?;
+        let target = String::from_utf8(symlink.0.clone()).map_err(|_| nfsstat3::NFS3ERR_INVAL)?;
+        let attr = *attr;
+        self.with(|fs| {
+            let (ino, _) = fs.symlink_ino(dirid as i64, &name, &target)?;
+            // A symlink has no size to set; only ownership and times apply.
+            let meta = apply_sattr(
+                fs,
+                ino,
+                &sattr3 {
+                    size: set_size3::Void,
+                    ..attr
+                },
+            )?;
+            Ok((ino as u64, meta))
+        })
+        .map(|(id, meta)| (id, self.attributes(&meta)))
+    }
+
+    async fn readlink(&self, id: fileid3) -> Result<nfspath3, nfsstat3> {
+        self.with(|fs| fs.readlink_ino(id as i64))
+            .map(|target| target.into_bytes().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn export() -> AfsNfs {
+        AfsNfs::new(AgentFs::in_memory().unwrap())
+    }
+
+    fn name(text: &str) -> filename3 {
+        text.as_bytes().to_vec().into()
+    }
+
+    #[tokio::test]
+    async fn create_write_read_round_trips_through_the_vfs() {
+        let export = export();
+        let (id, _) = export
+            .create(1, &name("hello.txt"), sattr3::default())
+            .await
+            .unwrap();
+        export.write(id, 0, b"hello ").await.unwrap();
+        let attr = export.write(id, 6, b"world").await.unwrap();
+        assert_eq!(attr.size, 11);
+        let (data, eof) = export.read(id, 0, 64).await.unwrap();
+        assert_eq!(data, b"hello world");
+        assert!(eof);
+    }
+
+    #[tokio::test]
+    async fn lookup_resolves_dot_and_dotdot() {
+        let export = export();
+        let (dir, _) = export.mkdir(1, &name("sub")).await.unwrap();
+        assert_eq!(export.lookup(dir, &name(".")).await.unwrap(), dir);
+        assert_eq!(export.lookup(dir, &name("..")).await.unwrap(), 1);
+        assert_eq!(export.lookup(1, &name("..")).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn missing_entries_report_noent_not_a_server_fault() {
+        let export = export();
+        assert!(matches!(
+            export.lookup(1, &name("nope")).await.unwrap_err(),
+            nfsstat3::NFS3ERR_NOENT
+        ));
+    }
+
+    #[tokio::test]
+    async fn readdir_pages_and_terminates() {
+        let export = export();
+        for index in 0..5 {
+            export
+                .create(1, &name(&format!("f{index}")), sattr3::default())
+                .await
+                .unwrap();
+        }
+        let first = export.readdir(1, 0, 2).await.unwrap();
+        assert_eq!(first.entries.len(), 2);
+        assert!(!first.end);
+        let cursor = first.entries.last().unwrap().fileid;
+        let rest = export.readdir(1, cursor, 10).await.unwrap();
+        assert_eq!(rest.entries.len(), 3);
+        assert!(rest.end);
+    }
+
+    #[tokio::test]
+    async fn setattr_truncates_and_sets_mode() {
+        let export = export();
+        let (id, _) = export
+            .create(1, &name("t.txt"), sattr3::default())
+            .await
+            .unwrap();
+        export.write(id, 0, b"0123456789").await.unwrap();
+        let attr = export
+            .setattr(
+                id,
+                sattr3 {
+                    size: set_size3::size(4),
+                    mode: set_mode3::mode(0o600),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(attr.size, 4);
+        assert_eq!(attr.mode, 0o600);
+        let (data, _) = export.read(id, 0, 64).await.unwrap();
+        assert_eq!(data, b"0123");
+    }
+
+    #[tokio::test]
+    async fn read_only_export_refuses_writes_with_rofs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ro.db");
+        {
+            let mut fs = AgentFs::create(&path).unwrap();
+            fs.write_file("/a.txt", b"data").unwrap();
+        }
+        let export = AfsNfs::new(AgentFs::open_read_only(&path).unwrap());
+        assert!(matches!(export.capabilities(), VFSCapabilities::ReadOnly));
+        let id = export.lookup(1, &name("a.txt")).await.unwrap();
+        assert!(matches!(
+            export.write(id, 0, b"x").await.unwrap_err(),
+            nfsstat3::NFS3ERR_ROFS
+        ));
+    }
+}

--- a/specs/coven-agent-fs/MOUNT-SPIKE.md
+++ b/specs/coven-agent-fs/MOUNT-SPIKE.md
@@ -1,0 +1,189 @@
+# coven-afs mount spike — results and go/no-go
+
+**Status:** Spike complete · 2026-08-08 · bead `coven-110`
+**Follows:** [RESEARCH.md](./RESEARCH.md) next step 2 · [DESIGN.md](./DESIGN.md) §3, §7
+**Code:** `crates/coven-afs/src/ino.rs`, `src/nfs.rs`, `examples/afs_serve.rs`,
+`examples/afs_bench.rs`
+
+RESEARCH.md called the throughput question unmeasured anywhere and said it
+gates the architecture. This spike measures it, and exercises the kext-free
+macOS mount path end to end.
+
+**Verdict: GO on the storage engine, conditional on write-ahead logging.
+The macOS mount is protocol-correct but blocked from agent processes by a
+platform access control that needs one manual confirmation (§4).**
+
+---
+
+## 1. What was built
+
+- **Inode-addressed operations** (`src/ino.rs`). The existing API is
+  path-addressed; NFS and FUSE both address objects by file id and
+  `(parent, name)`. Adds lookup, readdir with inode-ordered pagination,
+  offset read/write, truncate, setattr, create/mkdir/symlink/remove/rename.
+  No schema change — same SPEC v0.4 tables, different query shape.
+- **`write_ino_at`**, the operation a mount stands or falls on. A client
+  writes a file in ~64 KiB pieces, so rewriting the whole file per write would
+  make an N-byte file cost O(N²). Only the touched chunks are rewritten; holes
+  are zero-filled because reads reconstruct a file by chunk index.
+- **NFSv3 export** (`src/nfs.rs`, feature `mount`) over `nfsserve` 0.11
+  (BSD-3-Clause, HuggingFace — the crate AgentFS itself uses).
+- **`AgentFs::enable_wal`**, opt-in write-ahead logging. §3 explains why this
+  turned out to be the whole ballgame.
+- **Benchmarks** (`examples/afs_bench.rs`) and a serving/import harness
+  (`examples/afs_serve.rs`, `AFS_IMPORT=<dir>`).
+
+## 2. Storage throughput
+
+macOS 15 / arm64, release build, 2000 files per shape, one run.
+`afs (wal)` is the same workload with `enable_wal()`; ratios are against the
+host filesystem, lower is better.
+
+### Checkout shape — 2000 files, 13.0 MiB, source-tree sizes
+
+| Operation | host | afs (default) | afs (wal) |
+|---|---|---|---|
+| write | 241.1 ms (53.8 MiB/s) | 2130.3 ms — **8.84x** | 311.3 ms (41.7 MiB/s) — **1.29x** |
+| read | 180.3 ms (72.0 MiB/s) | 1180.4 ms — **6.55x** | — |
+| stat | 6.0 ms | 56.5 ms — **9.37x** | — |
+
+Database is 15.2 MiB for 13.0 MiB of payload (**1.17x**).
+
+### Package-tree shape — 2000 files, 1.0 MiB, `node_modules` sizes
+
+| Operation | host | afs (default) | afs (wal) |
+|---|---|---|---|
+| write | 244.1 ms | 1669.1 ms — **6.84x** | 197.2 ms — **0.81x** |
+| read | 914.6 ms | 831.6 ms — **0.91x** | — |
+| stat | 6.5 ms | 66.6 ms — **10.29x** | — |
+
+Database is 1.4 MiB for 1.0 MiB of payload (**1.51x**).
+
+With WAL, the `pnpm install`-shaped workload is **faster than the host
+filesystem** on both write (0.81x) and read (0.91x). Thousands of tiny files
+are one SQLite transaction stream instead of thousands of create/write/close
+syscall triples, and that trade favours the database.
+
+### Large file — 64 MiB written in 64 KiB pieces (WAL)
+
+| host | afs |
+|---|---|
+| 49.1 ms (1302 MiB/s) | 359.3 ms (178 MiB/s) — **7.31x** |
+
+178 MiB/s is the chunked write path a mount client drives. Adequate; it is
+also the number to re-check if `chunk_size` is ever tuned away from 4096.
+
+### Copy-up — first write to a file that lives in the read-only base (WAL)
+
+| Base file size | First-write cost |
+|---|---|
+| 1 MiB | 3.3 ms |
+| 8 MiB | 57.1 ms |
+| 32 MiB | 238.0 ms |
+
+Linear, ~135–300 MiB/s. RESEARCH.md's concern is confirmed and bounded:
+irrelevant for source files, painful for large binaries. **This validates the
+`afs.copy_up_max_bytes` cap and the default ingest excludes in DESIGN.md §7.**
+A cap in the low tens of MiB keeps worst-case first-write latency under
+~250 ms; `target/`, `node_modules/`, and `.git/objects/` should stay out of
+the base regardless.
+
+Directory ingest, for scale: 138 files / 4.8 MB imported in 181 ms.
+
+## 3. Write-ahead logging is not optional
+
+The engine as merged uses SQLite's default rollback journal with
+`synchronous=FULL`, so every `write_file` is its own fully-synced
+transaction. That is why the default column reads 6.8–8.8x. The host baseline
+does buffered writes and does not fsync per file — which is also what `git
+checkout` and `pnpm install` actually do, so it is the honest comparison.
+
+Enabling WAL with `synchronous=NORMAL` closes almost all of that gap
+(8.84x → 1.29x; 6.84x → 0.81x). A mounted session overlay is scratch state
+whose durability story is "discard or commit", so relaxed sync is the right
+trade there.
+
+It is **opt-in rather than the default** because WAL costs a property this
+design values: a WAL database is three files while open (`-wal`, `-shm`)
+rather than the single portable file that makes a delta copyable. They are
+checkpointed away on clean close. The daemon should call `enable_wal()` when
+it opens a session delta; a database being handed to someone else should not.
+
+## 4. The macOS mount: correct, and blocked by the platform
+
+What works, verified against a live server with RPC tracing:
+
+- An **unprivileged** `mount_nfs` succeeds — no `sudo`, no kext.
+  `mount` reports `localhost:/ on … (nfs, nodev, nosuid, mounted by buns)`.
+- The kernel client drives the export correctly: MOUNT, LOOKUP, ACCESS,
+  GETATTR, READDIRPLUS and FSSTAT all succeed. ACCESS returns `63` (all
+  rights). `stat` through the mount returns real imported data — correct
+  size, correct owner.
+- Spotlight walks the mounted tree without trouble, which is the clearest
+  proof the export is well-formed.
+
+What does not work: **`open()` from an agent's own shell returns `EPERM`** —
+for files (`cat`) and directories (`ls`) alike — while `stat` on the same path
+succeeds and the server logs no error. Metadata passes, `open` is refused, and
+the refusal happens client-side without an RPC.
+
+That pattern is a macOS privacy/TCC restriction on network volumes for the
+calling process, not an NFS or permission fault:
+
+- it is not privilege — reads and writes fail identically, and the mount
+  itself succeeded unprivileged;
+- it is not ownership — inodes are presented as owned by the serving user
+  (SPEC defaults `uid`/`gid` to 0, which made the client reject everything
+  until `src/nfs.rs` mapped unowned inodes to the serving user; that fix is
+  in and `ls -ldn` now shows the correct owner);
+- it is not the server — the same operations succeed for Spotlight, and
+  ACCESS grants every right.
+
+**One manual confirmation is needed**, from a Terminal that has Full Disk
+Access, because this session's process almost certainly does not:
+
+```sh
+cargo run -p coven-afs --features mount --example afs_serve -- /tmp/afs.db 12049 &
+mkdir -p /tmp/afsmnt
+mount_nfs -o vers=3,tcp,port=12049,mountport=12049,nolock,soft localhost:/ /tmp/afsmnt
+mkdir /tmp/afsmnt/hello && echo written > /tmp/afsmnt/hello/file.txt && cat /tmp/afsmnt/hello/file.txt
+umount -f /tmp/afsmnt
+```
+
+If that writes and reads back, the mount path is fully working and the
+constraint is "the agent process needs Full Disk Access / Network Volumes
+consent" — a deployment requirement to document, not a design problem. If it
+still fails, the macOS mount needs a different backend (FSKit, or a
+privileged helper) and this becomes a blocking finding.
+
+Linux/FUSE was **not** evaluated: this spike ran on macOS, and `fuser` needs a
+Linux host to mean anything. The inode API in §1 is the layer a `fuser`
+backend would bind to, so that work is unblocked but unstarted.
+
+## 5. Go/no-go
+
+**GO on the storage engine.** The throughput question that gated the
+architecture is answered: with WAL, an agent-shaped workload runs at
+0.81–1.29x the host filesystem for whole-file writes, faster than the host for
+dependency-tree shapes, at ~1.2–1.5x on-disk overhead. Copy-up is linear and
+capped by policy. Nothing here argues against the design in DESIGN.md.
+
+**Conditional on the mount.** The NFS export is protocol-correct and mounts
+without privileges, but no agent process has yet written a byte through it on
+this machine. Do not schedule mount-dependent work until §4's confirmation
+runs. The SDK-only path (`afsMount: false` in DESIGN.md §3.1) is unaffected
+and remains the safe default.
+
+**Two limits to remember.** The export serializes all RPCs behind one mutex
+over a single SQLite connection, so nothing here measures parallel clients.
+And loopback NFS is still unauthenticated — DESIGN.md §7's access-control
+question is untouched by this spike and still gates enabling mounts by
+default.
+
+## 6. Reproducing
+
+```sh
+cargo run --release -p coven-afs --example afs_bench -- --scale 2000 --json bench.json
+cargo test -p coven-afs --features mount --locked
+AFS_IMPORT=<dir> cargo run -p coven-afs --features mount --example afs_serve -- <db> <port>
+```


### PR DESCRIPTION
## Context

- Summary: spike for bead `coven-110`. Exposes `coven-afs` over the kext-free macOS NFS mount path and measures the repo-checkout / `pnpm install`-shaped throughput that RESEARCH.md called architecture-gating.
- Files changed: `crates/coven-afs/{Cargo.toml,src/ino.rs,src/nfs.rs,src/fs.rs,src/lib.rs,examples/*}`, `specs/coven-agent-fs/MOUNT-SPIKE.md`
- Closes: bead `coven-110` (no GitHub issue)

## Implementation

- **Inode-addressed operations** (`src/ino.rs`, new). The existing API is path-addressed and no mount backend can use it — NFS and FUSE both address objects by file id and `(parent, name)`, and deriving a path per operation would mean walking `fs_dentry` upward every call. Adds lookup, readdir with inode-ordered pagination, offset read/write, truncate, setattr, create/mkdir/symlink/remove/rename. **No schema change**: same SPEC v0.4 tables, different query shape, so DESIGN.md rule E1 holds.
- **`write_ino_at`** rewrites only the chunks a write actually touches. This is the operation a mount stands or falls on: clients write in ~64 KiB pieces, so a whole-file rewrite per write makes an N-byte file cost O(N²). Writing past the end zero-fills, because reads reconstruct a file by chunk index and a missing chunk would silently shorten it.
- **NFSv3 export** (`src/nfs.rs`, feature `mount`) over `nfsserve` 0.11 — BSD-3-Clause, HuggingFace, the same crate AgentFS uses. Feature-gated so the default build stays free of tokio and an RPC stack.
- **Ownership mapping.** SPEC defaults `fs_inode.uid`/`gid` to 0. An unmapped export therefore presents a root-owned tree and the client rejects every operation locally before a single RPC — this cost real debugging time. Inodes stored unowned are presented as owned by the serving user; ownership set explicitly through `setattr` is preserved. Presentation only, nothing written back, database stays byte-identical to what upstream tooling produces.
- **`AgentFs::enable_wal`**, opt-in. See the numbers below — this is the single most consequential finding. Opt-in rather than default because WAL costs the single-file property a portable delta depends on (`-wal`/`-shm` while open).
- User-visible behavior: none. New crate-internal API plus an opt-in feature; nothing in the shipped CLI or daemon changes.
- Compatibility notes: no schema change, no new tables, no new columns. Default-feature builds gain no dependencies.

## Results

Full write-up in `specs/coven-agent-fs/MOUNT-SPIKE.md`. macOS 15 / arm64, release, 2000 files per shape.

| Workload | host | afs (default) | afs (wal) |
|---|---|---|---|
| checkout write (13 MiB) | 241 ms | 2130 ms — 8.84x | **311 ms — 1.29x** |
| package-tree write (1 MiB) | 244 ms | 1669 ms — 6.84x | **197 ms — 0.81x** |
| package-tree read | 915 ms | 832 ms — 0.91x | — |
| checkout read | 180 ms | 1180 ms — 6.55x | — |
| 64 MiB in 64 KiB writes | 49 ms | — | 359 ms (178 MiB/s) — 7.31x |

Copy-up is linear: 1 MiB → 3.3 ms, 8 MiB → 57 ms, 32 MiB → 238 ms. On-disk overhead 1.17–1.51x.

**Verdict: GO on the storage engine, conditional on WAL.** With WAL an agent-shaped workload runs at 0.81–1.29x the host filesystem, and is *faster* than the host for dependency-tree shapes. Copy-up being linear validates the `afs.copy_up_max_bytes` cap and default ingest excludes already specified in DESIGN.md §7.

**The mount is protocol-correct but unconfirmed for agent use.** An unprivileged `mount_nfs` succeeds (no sudo, no kext) and the kernel client drives the export correctly — MOUNT, LOOKUP, ACCESS (returns 63), GETATTR, READDIRPLUS, FSSTAT all succeed, `stat` through the mount returns real imported data, and Spotlight walks the tree. But `open()` from this session's shell returns `EPERM` for both files and directories while `stat` on the same path succeeds and the server logs no error. That is a macOS privacy/TCC restriction on network volumes for the calling process, not an NFS or permission fault. MOUNT-SPIKE.md §4 has a five-line manual confirmation to run from a Terminal with Full Disk Access; I could not run it from this session.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, and again with `--features mount`
- [x] `cargo test --workspace --locked` — 1818 passed, 2 ignored
- [x] `python3 scripts/check-secrets.py` — clean
- [x] Additional manual checks: `cargo test -p coven-afs --features mount --locked` (19 unit + 26 integration); privacy guard passed on 9 staged files; `git diff --check` clean. 15 new tests (9 inode-layer, 6 NFS VFS) all written against behavior, including chunked-write reconstruction, hole zero-filling, readdir pagination, and read-only export rejecting writes with `ROFS`.
- Note: while benchmarks and NFS servers were running concurrently I saw intermittent failures in 1–3 socket-binding `coven-cli` tests. Three consecutive clean runs afterwards, and this diff touches only `crates/coven-afs/**` and `specs/**`.

## Risk and Rollback

- Risk level: low. Additive; the `mount` feature is off by default, so a default build is unchanged apart from two new public methods on `AgentFs`.
- Rollback plan: revert the commit. No schema, no migration, no persisted state.

## Agent Handoff

- Current state: spike complete, numbers recorded, storage verdict is GO.
- Follow-ups: (1) run MOUNT-SPIKE.md §4's confirmation from a Terminal with Full Disk Access and record the outcome; (2) the daemon should call `enable_wal()` when opening a session delta; (3) set `afs.copy_up_max_bytes` from the copy-up table.
- Known gaps, stated rather than papered over: Linux/FUSE was **not** evaluated — this ran on macOS and `fuser` needs a Linux host; the inode API is the layer that work would bind to. The export serializes all RPCs behind one mutex over a single SQLite connection, so nothing here measures concurrent clients. Loopback NFS remains unauthenticated; DESIGN.md §7's access-control question is untouched and still gates enabling mounts by default.