### PR TITLE
perf(daemon): skip the git probe when no repository can exist

### DIFF
--- a/crates/coven-cli/src/maintenance_gate.rs
+++ b/crates/coven-cli/src/maintenance_gate.rs
@@ -106,6 +106,39 @@ pub struct MaintenanceGate {
     common_dir: PathBuf,
 }
 
+/// Whether `project_root` could possibly sit inside a git repository.
+///
+/// Only ever used to skip work: a `false` result means no `.git` entry and no
+/// bare-repository layout exists anywhere from `project_root` up to the
+/// filesystem root, which `git rev-parse` would report as "not a git
+/// repository" too. A `true` result decides nothing — `git` still runs and
+/// still has the final say. Deliberately conservative, because a wrong `false`
+/// would silently disable the maintenance fence:
+///
+/// - a `.git` file (worktree link) counts as much as a `.git` directory;
+/// - a bare repository has no `.git` at all, so its `HEAD` + `objects` layout
+///   counts too;
+/// - `GIT_DIR` / `GIT_COMMON_DIR` can point anywhere, so their presence in the
+///   environment skips this check entirely.
+///
+/// Nothing is cached. A `git init` between two launches is picked up by the
+/// next one.
+fn maybe_in_repository(project_root: &Path) -> bool {
+    if std::env::var_os("GIT_DIR").is_some() || std::env::var_os("GIT_COMMON_DIR").is_some() {
+        return true;
+    }
+    let mut current = Some(project_root);
+    while let Some(directory) = current {
+        if directory.join(".git").exists()
+            || (directory.join("HEAD").exists() && directory.join("objects").is_dir())
+        {
+            return true;
+        }
+        current = directory.parent();
+    }
+    false
+}
+
 impl MaintenanceGate {
     /// Resolve the common directory for `project_root`. This accepts a
     /// worktree root as well as the primary checkout.
@@ -133,6 +166,15 @@ impl MaintenanceGate {
     /// exclusion domain to join; callers use this only for launch paths, never
     /// for claim or owner commands (which require a repository).
     pub fn discover_optional(project_root: &Path) -> Result<Option<Self>> {
+        // Every session launch calls this, and spawning `git` costs more than
+        // the rest of launch-to-first-output put together (~14 ms of the
+        // ~37 ms floor on macOS, measured in bead coven-mwb). A directory with
+        // no repository anywhere above it cannot be a worktree, and that check
+        // is a handful of stats. Anything that might be a repository still
+        // goes to `git`, which stays the authority.
+        if !maybe_in_repository(project_root) {
+            return Ok(None);
+        }
         let output = std::process::Command::new("git")
             .arg("-C")
             .arg(project_root)
@@ -618,6 +660,53 @@ mod tests {
     use std::fs::FileTimes;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
+
+    #[test]
+    fn plain_directory_has_no_gate_and_never_consults_git() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        assert!(!maybe_in_repository(temp.path()));
+        assert!(MaintenanceGate::discover_optional(temp.path())?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn repository_layouts_still_reach_git() -> Result<()> {
+        // Each of these must fall through to `git`, because treating one as a
+        // plain directory would silently drop the maintenance fence.
+        let worktree_dir = tempfile::tempdir()?;
+        std::fs::create_dir(worktree_dir.path().join(".git"))?;
+        assert!(maybe_in_repository(worktree_dir.path()));
+
+        let linked = tempfile::tempdir()?;
+        std::fs::write(
+            linked.path().join(".git"),
+            b"gitdir: /elsewhere/.git/worktrees/w",
+        )?;
+        assert!(maybe_in_repository(linked.path()));
+
+        let nested = tempfile::tempdir()?;
+        std::fs::create_dir(nested.path().join(".git"))?;
+        let deep = nested.path().join("crates/coven-cli/src");
+        std::fs::create_dir_all(&deep)?;
+        assert!(maybe_in_repository(&deep));
+
+        let bare = tempfile::tempdir()?;
+        std::fs::write(bare.path().join("HEAD"), b"ref: refs/heads/main\n")?;
+        std::fs::create_dir(bare.path().join("objects"))?;
+        assert!(maybe_in_repository(bare.path()));
+        Ok(())
+    }
+
+    #[test]
+    fn a_repository_created_after_a_launch_is_seen_by_the_next_one() -> Result<()> {
+        // Nothing is cached, so the fence cannot be disabled for the lifetime
+        // of a daemon by an early miss.
+        let temp = tempfile::tempdir()?;
+        assert!(!maybe_in_repository(temp.path()));
+        std::fs::create_dir(temp.path().join(".git"))?;
+        assert!(maybe_in_repository(temp.path()));
+        Ok(())
+    }
 
     fn assert_contended(error: &anyhow::Error) {
         assert!(error


### PR DESCRIPTION
## Context

- Summary: resolves bead `coven-mwb`. The launch-to-first-output slowdown flagged when closing the perf epic is real, was bisected to `622ed28` (#603), and is fixed here.
- Files changed: `crates/coven-cli/src/maintenance_gate.rs`
- Closes: bead `coven-mwb` (no GitHub issue)

## Implementation

Every session launch calls `MaintenanceGate::discover_optional`, which spawns `git rev-parse --git-common-dir` to find the repository-wide exclusion domain. When the project root is not in a repository, that subprocess is started only to fail — and process spawn dominates launch-to-first-output.

This checks for a repository with a handful of `stat`s before paying for a subprocess. **The check only ever skips work.** A `false` result means no `.git` entry and no bare-repository layout exists anywhere from the project root up to the filesystem root — the same conclusion `git` would reach. Anything that might be a repository still goes to `git`, which remains the authority. Specifically conservative because a wrong `false` would silently disable the maintenance fence:

- a `.git` **file** (worktree link) counts as much as a `.git` directory;
- a **bare** repository has no `.git` at all, so its `HEAD` + `objects/` layout counts too;
- `GIT_DIR` / `GIT_COMMON_DIR` can point anywhere, so their presence skips the fast path entirely;
- **nothing is cached**, so a `git init` between two launches is seen by the next one — an early miss can't disable the fence for a daemon's lifetime.

## How it was found

Reported in `coven-mwb` as `harness_first_output` regressing +71.8% between 2026-07-29 and current main. Two corrections came out of the investigation, both worth stating:

1. **The original number was inflated by machine load.** The same binary re-measured at 61.8 ms median / 49.7 ms min versus the originally reported 77.2 / 67.5. The real step is ~+14 ms on the floor, not ~+32 ms.
2. **My first hypothesis was wrong.** `114f9c8` (#607, bounded event writer) has a `COALESCE_WINDOW` of 12 ms and looked like an obvious culprit from code reading. Measuring across it showed it slightly *improved* the number (56.6 → 51.5 ms). Bisecting found the step is *before* it.

Bisection, all measured in one sitting with the current runner at n=15:

| binary | median | min |
|---|---|---|
| `7a44cdc` (2026-07-29) | 39.0 | 36.5 |
| `a2a3b92` | 34.2 | 33.6 |
| `5117119` | 35.4 | 34.4 |
| `1e7485f` | 35.8 | 35.1 |
| `9225825` | 41.0 | 37.5 |
| **`622ed28` (#603)** | **53.9** | **51.4** |
| `114f9c8` (#607) | 51.5 | 49.8 |
| `74d6207` | 61.8 | 49.7 |

The step at `622ed28` reproduced across two separate measurements (min 50.7 and 51.4).

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — 1833 passed, 2 ignored
- [x] `python3 scripts/check-secrets.py` — clean
- [x] Additional manual checks: privacy guard passed; `git diff --check` clean.

Fixture-backed before/after, interleaved A/B on one machine so load hits both equally, n=15:

| | median | min |
|---|---|---|
| main (`e81e4fa`) | 117.758 ms | 67.864 ms |
| with fix | **38.763 ms** | **34.930 ms** |

That restores the pre-#603 baseline (39.040 / 36.507). The interleaved run happened under load average ~28, which is why both numbers sit above the quiet-machine figures — and it shows the regression *amplifies* under load, since process spawn is what suffers first. That is exactly the condition an agent harness runs in.

Three tests added: a plain directory takes the fast path, every repository layout (`.git` dir, `.git` file, nested subdirectory, bare repo) still reaches `git`, and a repository created after a miss is seen by the next call.

## Risk and Rollback

- Risk level: low, but it touches a safety fence, so the check is deliberately one-directional — it can only skip a probe that would have returned "not a git repository". If it is ever wrong, it is wrong in the direction of doing more work, not less fencing.
- Rollback plan: revert the commit; no state, no schema, no contract change.

## Agent Handoff

- Current state: complete, bisected, fixed, and measured.
- Follow-ups: none required. If the gate ever becomes hot on the repository path too, the remaining `git` spawn is the next thing to look at — caching it was rejected here because a cached negative could silently disable the fence.
- Known gaps: the intermittent `coven-cli` socket-binding test failures I saw under heavy parallel load are pre-existing and unrelated — they appeared identically in a worktree whose diff touched no Rust in this crate. Three consecutive clean workspace runs here.