### PR TITLE
docs: clarify experimental AgentFS NFS status

### DIFF
--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -18,8 +18,9 @@
 //! readable by upstream `agentfs` tooling and vice versa. See
 //! `specs/coven-agent-fs/RESEARCH.md` for the design rationale.
 //!
-//! This spike intentionally excludes any mount layer (FUSE/NFS); it is the
-//! storage engine only.
+//! The optional `mount` feature adds an experimental NFSv3 export for
+//! engineering validation. The bundled example binds only to loopback, but no
+//! mount workflow is exposed by the Coven CLI or daemon yet.
 //!
 //! [AgentFS SPEC v0.4]: https://github.com/tursodatabase/agentfs/blob/main/SPEC.md
 

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -15,7 +15,7 @@ Scope boundaries:
 
 - **In scope:** `coven.daemon.v1` API additions, extension schema, commit
   materialization, Cave read surfaces, interop freeze.
-- **Out of scope:** mount implementation details (spike `coven-110`), sandbox
+- **Out of scope:** productionizing the experimental mount spike, sandbox
   enforcement design, Windows mounts, cloud sync.
 
 ---
@@ -419,20 +419,24 @@ mount is separate work and is not claimed by this design.
   macOS needs a validated strategy. Unscoped here.
 - **Windows**: no mount backend upstream or here. SDK-only; ProjFS is the
   plausible native route and remains unscoped.
-- **Copy-up cap default**: pending `coven-110` benchmark numbers.
+- **Copy-up cap default**: the mount spike supports a cap in the low tens of
+  MiB, but the configurable cap is not implemented yet.
 - **Loopback NFS access control**: see §7; blocks mount-on-by-default.
-- **Base ingest filters**: the default exclude set needs to be validated against
-  a real repository checkout plus a `pnpm install`-scale write workload.
+- **Base ingest filters**: the mount spike validates the workload shape, but
+  the default exclude set still needs an implementation and broader validation.
 
 ## 9. Delivery sequencing
 
 | Step | Bead | State |
 |---|---|---|
 | Storage engine + overlay | `coven-d4p` | merged — PR #658, `e2da654` |
-| macOS mount + benchmark | `coven-110` | unblocked |
+| macOS mount + benchmark | `coven-110` | merged experimental spike — PR #680, conditional on the Full Disk Access confirmation |
 | This design | `coven-vhw` | — |
 | Daemon API + extension tables | not yet filed | ready to file |
 | Cave surfaces | not yet filed | needs the daemon API |
 
-The storage engine exists; nothing in §3–§6 does. This document is the contract
-those follow-ups are held to, not a claim that any of them are built.
+The storage engine and an experimental feature-gated NFSv3 backend exist.
+Nothing in §3–§6 does: daemon API routes, provenance extensions, commit
+materialization, and Cave surfaces remain this document's contract, not a
+claim that they are built. Linux/FUSE remains unstarted, and loopback NFS
+access control still blocks mount-on-by-default.

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -419,8 +419,9 @@ mount is separate work and is not claimed by this design.
   macOS needs a validated strategy. Unscoped here.
 - **Windows**: no mount backend upstream or here. SDK-only; ProjFS is the
   plausible native route and remains unscoped.
-- **Copy-up cap default**: the mount spike supports a cap in the low tens of
-  MiB, but the configurable cap is not implemented yet.
+- **Copy-up cap default**: the mount spike establishes a cap in the low tens
+  of MiB as the policy target, but the configurable cap is not implemented
+  yet.
 - **Loopback NFS access control**: see §7; blocks mount-on-by-default.
 - **Base ingest filters**: the mount spike validates the workload shape, but
   the default exclude set still needs an implementation and broader validation.

--- a/specs/coven-agent-fs/RESEARCH.md
+++ b/specs/coven-agent-fs/RESEARCH.md
@@ -59,7 +59,7 @@ From the surveyed products (high, per-source): (a) POSIX view so git/grep/existi
 
 ## Open questions & conflicts
 
-- **C1**: overlay guide (`fs_block`, whiteout column) vs SPEC (`fs_data`, whiteout table) — resolved and confirmed against the AgentFS CLI and SDK sources in favor of `fs_data`.
+- **C1**: overlay guide (`fs_block`, whiteout column) vs SPEC (`fs_data`, whiteout table) — resolved in favor of `fs_data`, consistent with the SPEC and the `coven-afs` schema.
 - Turso cloud-sync semantics (conflict resolution, audit preservation) unfetched — irrelevant if we build native, relevant if we ever interop.
 - Windows mount story: nothing exists upstream; ProjFS is the plausible native route, unscoped.
 - Linux/FUSE performance remains unmeasured. The macOS NFS spike is

--- a/specs/coven-agent-fs/RESEARCH.md
+++ b/specs/coven-agent-fs/RESEARCH.md
@@ -59,15 +59,23 @@ From the surveyed products (high, per-source): (a) POSIX view so git/grep/existi
 
 ## Open questions & conflicts
 
-- **C1**: overlay guide (`fs_block`, whiteout column) vs SPEC (`fs_data`, whiteout table) — resolved in favor of SPEC, but confirm against CLI source before freezing our schema.
+- **C1**: overlay guide (`fs_block`, whiteout column) vs SPEC (`fs_data`, whiteout table) — resolved and confirmed against the AgentFS CLI and SDK sources in favor of `fs_data`.
 - Turso cloud-sync semantics (conflict resolution, audit preservation) unfetched — irrelevant if we build native, relevant if we ever interop.
 - Windows mount story: nothing exists upstream; ProjFS is the plausible native route, unscoped.
-- Performance of NFS-localhost vs FUSE for big `pnpm install`-scale writes: unmeasured anywhere; needs a spike benchmark.
+- Linux/FUSE performance remains unmeasured. The macOS NFS spike is
+  protocol-correct but needs an agent-process Full Disk Access confirmation
+  before mount-dependent work can proceed.
 
 ## Recommended next steps
 
-1. Bead: spike `coven-afs` — SPEC v0.4 schema in rusqlite + read/write/overlay ops + unit tests (no mount yet).
-2. Bead: mount spike — `nfsserve` on macOS against the spike DB; benchmark a real repo checkout + build.
+1. **Delivered:** `coven-afs` now implements the SPEC v0.4 schema, core
+   operations, copy-on-write overlays, and consistency tests. See
+   [PR #658](https://github.com/OpenCoven/coven/pull/658).
+2. **Delivered as an experimental spike:** a feature-gated `nfsserve` NFSv3
+   export, inode-addressed operations, and the macOS benchmark. The storage
+   verdict is GO with WAL; the mount remains blocked on the Full Disk Access
+   confirmation, loopback access control, and a Linux/FUSE evaluation. See
+   [MOUNT-SPIKE.md](./MOUNT-SPIKE.md).
 3. Design doc in the coven repo: daemon API surface + provenance extension tables + Cave diff/timeline UI. **Delivered:** [DESIGN.md](./DESIGN.md).
 4. Decide interop stance: freeze on "SPEC-compatible, coven-extended" and document the extension tables. **Frozen:** [DESIGN.md §1](./DESIGN.md).
 


### PR DESCRIPTION
## Summary
- document the feature-gated NFSv3 spike in crate and release docs
- distinguish the delivered storage and mount work from unimplemented daemon, provenance, materialization, and Cave work
- record the unresolved macOS confirmation, Linux/FUSE, and loopback access-control gates

## Validation
- `cargo fmt --check`
- `cargo test -p coven-afs --doc --locked`
- `cargo test -p coven-afs --features mount --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`