### PR TITLE
feat(afs): serve AFS sessions, provenance, diff, and timeline from the daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "coven-afs",
  "coven-runtime-spec",
  "coven-threads-core",
  "crossterm",

--- a/crates/coven-afs/src/diff.rs
+++ b/crates/coven-afs/src/diff.rs
@@ -1,0 +1,237 @@
+//! Change set between an overlay's delta and its read-only base.
+//!
+//! Computed from `fs_dentry`, `fs_origin`, and `fs_whiteout` — never from
+//! `afs_provenance`. DESIGN.md §4.4 is explicit about why: writes can arrive
+//! without a bound actor (upstream `agentfs` tooling, a manual `sqlite3` edit,
+//! a mount write from a process the daemon did not launch), and those produce
+//! no provenance row. The filesystem tables cannot lie about what the
+//! filesystem contains; the provenance log can be incomplete. A diff derived
+//! from provenance would silently omit exactly the changes nobody can account
+//! for, which are the ones worth seeing.
+
+use crate::fs::Metadata;
+use crate::{AgentFs, OverlayFs, Result};
+
+/// How a path differs from the base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Change {
+    Added,
+    Modified,
+    Deleted,
+}
+
+impl Change {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Added => "added",
+            Self::Modified => "modified",
+            Self::Deleted => "deleted",
+        }
+    }
+}
+
+/// One changed path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChangeEntry {
+    pub path: String,
+    pub change: Change,
+    pub bytes: i64,
+    pub ino: Option<i64>,
+    pub base_ino: Option<i64>,
+    pub mode: Option<u32>,
+}
+
+/// The full change set, with counts callers would otherwise recompute.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ChangeSet {
+    pub entries: Vec<ChangeEntry>,
+    pub added: usize,
+    pub modified: usize,
+    pub deleted: usize,
+    pub bytes: i64,
+}
+
+impl ChangeSet {
+    fn from_entries(mut entries: Vec<ChangeEntry>) -> Self {
+        entries.sort_by(|left, right| left.path.cmp(&right.path));
+        let mut set = Self {
+            added: entries.iter().filter(|e| e.change == Change::Added).count(),
+            modified: entries
+                .iter()
+                .filter(|e| e.change == Change::Modified)
+                .count(),
+            deleted: entries
+                .iter()
+                .filter(|e| e.change == Change::Deleted)
+                .count(),
+            bytes: entries.iter().map(|e| e.bytes).sum(),
+            entries,
+        };
+        set.entries.dedup_by(|a, b| a.path == b.path);
+        set
+    }
+}
+
+/// Walk every path present in a filesystem, depth-first, skipping the root.
+fn walk(fs: &AgentFs, ino: i64, prefix: &str, out: &mut Vec<(String, Metadata)>) -> Result<()> {
+    for entry in fs.readdir_ino(ino, 0, i64::MAX as usize)? {
+        let path = format!("{prefix}/{}", entry.name);
+        let is_dir = entry.meta.is_dir();
+        let child = entry.meta.ino;
+        out.push((path.clone(), entry.meta));
+        if is_dir {
+            walk(fs, child, &path, out)?;
+        }
+    }
+    Ok(())
+}
+
+impl OverlayFs {
+    /// Compute the change set of this overlay against its base.
+    ///
+    /// A path in the delta is `Added` when the base does not have it and
+    /// `Modified` when it does — which is exactly what `fs_origin` records
+    /// after a copy-up, and what a same-path entry in the base means
+    /// otherwise. Whiteouts are `Deleted`. Directories are reported only when
+    /// they are new, because an unchanged directory holding a changed file is
+    /// not itself a change.
+    pub fn change_set(&self) -> Result<ChangeSet> {
+        let mut entries = Vec::new();
+
+        let mut delta_paths = Vec::new();
+        walk(self.delta(), crate::ROOT_INO, "", &mut delta_paths)?;
+        for (path, meta) in delta_paths {
+            let base_ino = self.origin_ino(meta.ino)?;
+            let in_base = self.base().resolve(&path)?;
+            if meta.is_dir() && in_base.is_some() {
+                continue;
+            }
+            let change = if base_ino.is_some() || in_base.is_some() {
+                Change::Modified
+            } else {
+                Change::Added
+            };
+            entries.push(ChangeEntry {
+                path,
+                change,
+                bytes: meta.size,
+                ino: Some(meta.ino),
+                base_ino: base_ino.or(in_base),
+                mode: Some(meta.mode),
+            });
+        }
+
+        let mut stmt = self
+            .delta()
+            .conn
+            .prepare("SELECT path FROM fs_whiteout ORDER BY path ASC")?;
+        for row in stmt.query_map([], |r| r.get::<_, String>(0))? {
+            let path = row?;
+            let base_ino = self.base().resolve(&path)?;
+            entries.push(ChangeEntry {
+                path,
+                change: Change::Deleted,
+                bytes: 0,
+                ino: None,
+                base_ino,
+                mode: None,
+            });
+        }
+
+        Ok(ChangeSet::from_entries(entries))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn overlay(dir: &std::path::Path) -> OverlayFs {
+        let base_path = dir.join("base.db");
+        {
+            let mut base = AgentFs::create(&base_path).unwrap();
+            base.write_file("/keep.txt", b"unchanged").unwrap();
+            base.write_file("/edit.txt", b"original").unwrap();
+            base.write_file("/drop.txt", b"doomed").unwrap();
+            base.write_file("/dir/nested.txt", b"nested").unwrap();
+        }
+        OverlayFs::open(dir.join("delta.db"), &base_path).unwrap()
+    }
+
+    #[test]
+    fn change_set_reports_added_modified_and_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut overlay = overlay(dir.path());
+        overlay.write_file("/new.txt", b"brand new").unwrap();
+        overlay.write_file("/edit.txt", b"changed").unwrap();
+        overlay.remove_file("/drop.txt").unwrap();
+
+        let set = overlay.change_set().unwrap();
+        let by_path = |path: &str| {
+            set.entries
+                .iter()
+                .find(|entry| entry.path == path)
+                .unwrap_or_else(|| panic!("{path} missing from change set"))
+                .change
+        };
+        assert_eq!(by_path("/new.txt"), Change::Added);
+        assert_eq!(by_path("/edit.txt"), Change::Modified);
+        assert_eq!(by_path("/drop.txt"), Change::Deleted);
+        assert!(
+            !set.entries.iter().any(|entry| entry.path == "/keep.txt"),
+            "untouched base files must not appear"
+        );
+        assert_eq!(set.added, 1);
+        assert_eq!(set.modified, 1);
+        assert_eq!(set.deleted, 1);
+    }
+
+    #[test]
+    fn a_write_with_no_provenance_still_appears() {
+        // The case DESIGN.md 4.4 exists for: a mutation nobody recorded must
+        // not be invisible just because the provenance log missed it.
+        let dir = tempfile::tempdir().unwrap();
+        let mut overlay = overlay(dir.path());
+        overlay
+            .write_file("/unattributed.txt", b"who wrote this")
+            .unwrap();
+        assert!(overlay.delta().provenance_since(0, 10).unwrap().is_empty());
+
+        let set = overlay.change_set().unwrap();
+        assert!(set
+            .entries
+            .iter()
+            .any(|entry| entry.path == "/unattributed.txt" && entry.change == Change::Added));
+    }
+
+    #[test]
+    fn unchanged_overlay_reports_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let overlay = overlay(dir.path());
+        let set = overlay.change_set().unwrap();
+        assert!(set.entries.is_empty());
+        assert_eq!(set.bytes, 0);
+    }
+
+    #[test]
+    fn new_directories_are_reported_but_traversed_ones_are_not() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut overlay = overlay(dir.path());
+        overlay
+            .write_file("/dir/added.txt", b"in an existing dir")
+            .unwrap();
+        overlay
+            .write_file("/fresh/deep/file.txt", b"in a new dir")
+            .unwrap();
+
+        let set = overlay.change_set().unwrap();
+        let paths: Vec<&str> = set.entries.iter().map(|e| e.path.as_str()).collect();
+        assert!(paths.contains(&"/dir/added.txt"));
+        assert!(paths.contains(&"/fresh/deep/file.txt"));
+        assert!(
+            !paths.contains(&"/dir"),
+            "a directory that already exists in the base is not itself a change"
+        );
+        assert!(paths.contains(&"/fresh"), "a new directory is a change");
+    }
+}

--- a/crates/coven-afs/src/diff.rs
+++ b/crates/coven-afs/src/diff.rs
@@ -54,7 +54,8 @@ pub struct ChangeSet {
 impl ChangeSet {
     fn from_entries(mut entries: Vec<ChangeEntry>) -> Self {
         entries.sort_by(|left, right| left.path.cmp(&right.path));
-        let mut set = Self {
+        entries.dedup_by(|a, b| a.path == b.path);
+        Self {
             added: entries.iter().filter(|e| e.change == Change::Added).count(),
             modified: entries
                 .iter()
@@ -66,9 +67,7 @@ impl ChangeSet {
                 .count(),
             bytes: entries.iter().map(|e| e.bytes).sum(),
             entries,
-        };
-        set.entries.dedup_by(|a, b| a.path == b.path);
-        set
+        }
     }
 }
 

--- a/crates/coven-afs/src/fs.rs
+++ b/crates/coven-afs/src/fs.rs
@@ -181,6 +181,25 @@ impl AgentFs {
         Ok(self.resolve(path)?.is_some())
     }
 
+    /// Checkpoint any write-ahead log back into the database file and return
+    /// to a rollback journal.
+    ///
+    /// This is how a WAL database becomes a single portable file again: the
+    /// `-wal`/`-shm` sidecars are removed as part of the mode change, and no
+    /// committed data is lost because the checkpoint happens first. Use it
+    /// before publishing a database that someone else will copy or open.
+    pub fn checkpoint_to_single_file(&self) -> Result<()> {
+        self.ensure_writable()?;
+        self.conn
+            .query_row("PRAGMA wal_checkpoint(TRUNCATE)", [], |_| Ok(()))
+            .or_else(|error| match error {
+                rusqlite::Error::QueryReturnedNoRows => Ok(()),
+                other => Err(other),
+            })?;
+        self.conn.pragma_update(None, "journal_mode", "DELETE")?;
+        Ok(())
+    }
+
     /// Read file metadata (SPEC stat), including the link count.
     pub fn stat(&self, path: &str) -> Result<Metadata> {
         let ino = self

--- a/crates/coven-afs/src/ino.rs
+++ b/crates/coven-afs/src/ino.rs
@@ -118,6 +118,15 @@ impl AgentFs {
             .optional()?)
     }
 
+    /// Number of regular files in the filesystem.
+    pub fn file_count(&self) -> Result<i64> {
+        Ok(self.conn.query_row(
+            "SELECT COUNT(*) FROM fs_inode WHERE mode & ?1 = ?2",
+            params![S_IFMT, S_IFREG],
+            |r| r.get(0),
+        )?)
+    }
+
     /// Number of entries in a directory.
     pub fn child_count(&self, parent_ino: i64) -> Result<i64> {
         Ok(self.conn.query_row(

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -24,6 +24,7 @@
 //! [AgentFS SPEC v0.4]: https://github.com/tursodatabase/agentfs/blob/main/SPEC.md
 
 mod audit;
+mod diff;
 mod fs;
 mod ino;
 mod kv;
@@ -31,15 +32,21 @@ mod kv;
 mod nfs;
 mod overlay;
 mod path;
+mod provenance;
 mod schema;
 
 pub use audit::ToolCall;
+pub use diff::{Change, ChangeEntry, ChangeSet};
 pub use fs::{AgentFs, Metadata, ROOT_INO, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
 pub use ino::DirEntry;
 #[cfg(feature = "mount")]
 pub use nfs::AfsNfs;
 pub use overlay::OverlayFs;
 pub use path::{basename, components, normalize, parent};
+pub use provenance::{
+    Actor, CommitRecord, ProvenanceRecord, SessionBinding, EXTENSION_TABLES, STATE_COMMITTED,
+    STATE_COMMITTING, STATE_DISCARDED, STATE_OPEN,
+};
 
 /// Errors produced by coven-afs operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/coven-afs/src/provenance.rs
+++ b/crates/coven-afs/src/provenance.rs
@@ -1,0 +1,522 @@
+//! Coven's extension tables: session binding, per-operation provenance, and
+//! commit materialization records.
+//!
+//! These are the `afs_*` tables specified in `specs/coven-agent-fs/DESIGN.md`
+//! §4. The interop rules from §1 are enforced here by construction:
+//!
+//! - **E1** — no SPEC v0.4 table is touched. Nothing in this module writes to
+//!   `fs_*`, `kv_store`, or `tool_calls`.
+//! - **E2** — every table is named `afs_*` and carries metadata only. Dropping
+//!   all of them must leave filesystem semantics unchanged, which
+//!   [`drop_extensions`] plus the conformance test prove rather than assert.
+//! - **E3** — tables are created lazily and every column is nullable or
+//!   defaulted, so a database produced by upstream `agentfs` reads as one with
+//!   no provenance yet rather than as an error.
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::{now_parts, AgentFs, Result};
+
+/// DDL for every coven extension table. Idempotent.
+const EXTENSION_DDL: &str = "
+CREATE TABLE IF NOT EXISTS afs_session (
+  id                TEXT PRIMARY KEY,
+  name              TEXT,
+  state             TEXT NOT NULL DEFAULT 'open',
+  base_fingerprint  TEXT,
+  base_commit       TEXT,
+  project_root      TEXT,
+  coven_session_id  TEXT,
+  familiar_id       TEXT,
+  bead_id           TEXT,
+  created_at        INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at        INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE TABLE IF NOT EXISTS afs_provenance (
+  seq               INTEGER PRIMARY KEY AUTOINCREMENT,
+  op                TEXT NOT NULL,
+  path              TEXT NOT NULL,
+  to_path           TEXT,
+  ino               INTEGER,
+  base_ino          INTEGER,
+  bytes             INTEGER NOT NULL DEFAULT 0,
+  at                INTEGER NOT NULL DEFAULT (unixepoch()),
+  at_nsec           INTEGER NOT NULL DEFAULT 0,
+  afs_session_id    TEXT,
+  coven_session_id  TEXT,
+  familiar_id       TEXT,
+  bead_id           TEXT,
+  turn              INTEGER,
+  tool_call_id      INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_path ON afs_provenance(path, seq);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_session ON afs_provenance(coven_session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_bead ON afs_provenance(bead_id, seq);
+CREATE INDEX IF NOT EXISTS idx_afs_provenance_tool_call ON afs_provenance(tool_call_id);
+
+CREATE TABLE IF NOT EXISTS afs_commit (
+  id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+  branch                 TEXT NOT NULL,
+  commit_sha             TEXT,
+  worktree_path          TEXT,
+  provenance_high_water  INTEGER NOT NULL DEFAULT 0,
+  state                  TEXT NOT NULL DEFAULT 'planned',
+  created_at             INTEGER NOT NULL DEFAULT (unixepoch())
+);
+";
+
+/// Every table this module owns. The conformance test drops exactly this list.
+pub const EXTENSION_TABLES: &[&str] = &["afs_provenance", "afs_commit", "afs_session"];
+
+/// Lifecycle state of a session delta.
+pub const STATE_OPEN: &str = "open";
+pub const STATE_COMMITTING: &str = "committing";
+pub const STATE_COMMITTED: &str = "committed";
+pub const STATE_DISCARDED: &str = "discarded";
+
+/// The binding of a delta database to the Coven session that opened it.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SessionBinding {
+    pub id: String,
+    pub name: Option<String>,
+    pub state: String,
+    pub base_fingerprint: Option<String>,
+    pub base_commit: Option<String>,
+    pub project_root: Option<String>,
+    pub coven_session_id: Option<String>,
+    pub familiar_id: Option<String>,
+    pub bead_id: Option<String>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Who performed an operation. Repeated per row rather than held once on
+/// [`SessionBinding`] because `afs.session.join` means more than one actor can
+/// write to one delta: the acting identity is a property of the operation.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Actor {
+    pub afs_session_id: Option<String>,
+    pub coven_session_id: Option<String>,
+    pub familiar_id: Option<String>,
+    pub bead_id: Option<String>,
+    /// The session's event cursor (`MAX(events.rowid)`) when the operation ran.
+    pub turn: Option<i64>,
+    pub tool_call_id: Option<i64>,
+}
+
+/// One recorded file operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvenanceRecord {
+    pub seq: i64,
+    pub op: String,
+    pub path: String,
+    pub to_path: Option<String>,
+    pub ino: Option<i64>,
+    pub base_ino: Option<i64>,
+    pub bytes: i64,
+    pub at: i64,
+    pub at_nsec: i64,
+    pub actor: Actor,
+}
+
+/// A materialization of a delta into a git branch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommitRecord {
+    pub id: i64,
+    pub branch: String,
+    pub commit_sha: Option<String>,
+    pub worktree_path: Option<String>,
+    pub provenance_high_water: i64,
+    pub state: String,
+    pub created_at: i64,
+}
+
+impl AgentFs {
+    /// Create the coven extension tables if they are absent.
+    ///
+    /// Safe to call on a database produced by upstream `agentfs`; that is what
+    /// makes rule E3 hold in the coven-reads-foreign direction.
+    pub fn init_extensions(&self) -> Result<()> {
+        self.conn.execute_batch(EXTENSION_DDL)?;
+        Ok(())
+    }
+
+    /// Whether this database carries coven extensions at all.
+    pub fn has_extensions(&self) -> Result<bool> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'afs_session'",
+            [],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Whether a table exists in this database. Useful for interop checks
+    /// against databases produced elsewhere.
+    pub fn table_exists(&self, name: &str) -> Result<bool> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?1",
+            [name],
+            |r| r.get(0),
+        )?;
+        Ok(count > 0)
+    }
+
+    /// Drop every coven extension table, leaving a database that upstream
+    /// tooling sees as an ordinary AgentFS filesystem.
+    ///
+    /// Exists so rule E2 can be *tested* rather than asserted: the conformance
+    /// test runs the SPEC consistency rules, drops these, and runs them again.
+    pub fn drop_extensions(&self) -> Result<()> {
+        for table in EXTENSION_TABLES {
+            self.conn
+                .execute(&format!("DROP TABLE IF EXISTS {table}"), [])?;
+        }
+        Ok(())
+    }
+
+    /// Record (or replace) this delta's session binding.
+    pub fn bind_session(&self, binding: &SessionBinding) -> Result<()> {
+        self.init_extensions()?;
+        let (secs, _) = now_parts();
+        self.conn.execute(
+            "INSERT INTO afs_session
+               (id, name, state, base_fingerprint, base_commit, project_root,
+                coven_session_id, familiar_id, bead_id, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10)
+             ON CONFLICT(id) DO UPDATE SET
+               name = excluded.name,
+               state = excluded.state,
+               base_fingerprint = excluded.base_fingerprint,
+               base_commit = excluded.base_commit,
+               project_root = excluded.project_root,
+               coven_session_id = excluded.coven_session_id,
+               familiar_id = excluded.familiar_id,
+               bead_id = excluded.bead_id,
+               updated_at = excluded.updated_at",
+            params![
+                binding.id,
+                binding.name,
+                binding.state,
+                binding.base_fingerprint,
+                binding.base_commit,
+                binding.project_root,
+                binding.coven_session_id,
+                binding.familiar_id,
+                binding.bead_id,
+                secs,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Read the session binding, if this database has one.
+    pub fn session_binding(&self) -> Result<Option<SessionBinding>> {
+        if !self.has_extensions()? {
+            return Ok(None);
+        }
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT id, name, state, base_fingerprint, base_commit, project_root,
+                        coven_session_id, familiar_id, bead_id, created_at, updated_at
+                 FROM afs_session ORDER BY created_at ASC LIMIT 1",
+                [],
+                |r| {
+                    Ok(SessionBinding {
+                        id: r.get(0)?,
+                        name: r.get(1)?,
+                        state: r.get(2)?,
+                        base_fingerprint: r.get(3)?,
+                        base_commit: r.get(4)?,
+                        project_root: r.get(5)?,
+                        coven_session_id: r.get(6)?,
+                        familiar_id: r.get(7)?,
+                        bead_id: r.get(8)?,
+                        created_at: r.get(9)?,
+                        updated_at: r.get(10)?,
+                    })
+                },
+            )
+            .optional()?)
+    }
+
+    /// Move the session to a new lifecycle state.
+    pub fn set_session_state(&self, id: &str, state: &str) -> Result<()> {
+        self.init_extensions()?;
+        let (secs, _) = now_parts();
+        self.conn.execute(
+            "UPDATE afs_session SET state = ?2, updated_at = ?3 WHERE id = ?1",
+            params![id, state, secs],
+        )?;
+        Ok(())
+    }
+
+    /// Append one operation to the provenance log. Returns its `seq`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_operation(
+        &self,
+        op: &str,
+        path: &str,
+        to_path: Option<&str>,
+        ino: Option<i64>,
+        base_ino: Option<i64>,
+        bytes: i64,
+        actor: &Actor,
+    ) -> Result<i64> {
+        self.init_extensions()?;
+        let (secs, nsec) = now_parts();
+        self.conn.execute(
+            "INSERT INTO afs_provenance
+               (op, path, to_path, ino, base_ino, bytes, at, at_nsec,
+                afs_session_id, coven_session_id, familiar_id, bead_id, turn, tool_call_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)",
+            params![
+                op,
+                path,
+                to_path,
+                ino,
+                base_ino,
+                bytes,
+                secs,
+                nsec,
+                actor.afs_session_id,
+                actor.coven_session_id,
+                actor.familiar_id,
+                actor.bead_id,
+                actor.turn,
+                actor.tool_call_id,
+            ],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Read provenance after `since`, oldest first, capped at `limit`.
+    ///
+    /// Cursor-paginated on `seq` to match the daemon's existing
+    /// `eventCursor: "sequence"` idiom.
+    pub fn provenance_since(&self, since: i64, limit: usize) -> Result<Vec<ProvenanceRecord>> {
+        if !self.has_extensions()? {
+            return Ok(Vec::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT seq, op, path, to_path, ino, base_ino, bytes, at, at_nsec,
+                    afs_session_id, coven_session_id, familiar_id, bead_id, turn, tool_call_id
+             FROM afs_provenance WHERE seq > ?1 ORDER BY seq ASC LIMIT ?2",
+        )?;
+        let rows = stmt
+            .query_map(params![since, limit as i64], |r| {
+                Ok(ProvenanceRecord {
+                    seq: r.get(0)?,
+                    op: r.get(1)?,
+                    path: r.get(2)?,
+                    to_path: r.get(3)?,
+                    ino: r.get(4)?,
+                    base_ino: r.get(5)?,
+                    bytes: r.get(6)?,
+                    at: r.get(7)?,
+                    at_nsec: r.get(8)?,
+                    actor: Actor {
+                        afs_session_id: r.get(9)?,
+                        coven_session_id: r.get(10)?,
+                        familiar_id: r.get(11)?,
+                        bead_id: r.get(12)?,
+                        turn: r.get(13)?,
+                        tool_call_id: r.get(14)?,
+                    },
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// The set of paths that provenance can account for. Used to mark diff
+    /// entries whose attribution is unknown (DESIGN.md §4.4).
+    pub fn attributed_paths(&self) -> Result<std::collections::HashSet<String>> {
+        let mut out = std::collections::HashSet::new();
+        if !self.has_extensions()? {
+            return Ok(out);
+        }
+        let mut stmt = self
+            .conn
+            .prepare("SELECT path FROM afs_provenance UNION SELECT to_path FROM afs_provenance WHERE to_path IS NOT NULL")?;
+        for row in stmt.query_map([], |r| r.get::<_, String>(0))? {
+            out.insert(row?);
+        }
+        Ok(out)
+    }
+
+    /// Highest recorded provenance sequence, or 0 when there is none.
+    pub fn provenance_high_water(&self) -> Result<i64> {
+        if !self.has_extensions()? {
+            return Ok(0);
+        }
+        Ok(self.conn.query_row(
+            "SELECT COALESCE(MAX(seq), 0) FROM afs_provenance",
+            [],
+            |r| r.get(0),
+        )?)
+    }
+
+    /// Record a materialization attempt. Returns its id.
+    pub fn record_commit(
+        &self,
+        branch: &str,
+        commit_sha: Option<&str>,
+        worktree_path: Option<&str>,
+        state: &str,
+    ) -> Result<i64> {
+        self.init_extensions()?;
+        let high_water = self.provenance_high_water()?;
+        let (secs, _) = now_parts();
+        self.conn.execute(
+            "INSERT INTO afs_commit
+               (branch, commit_sha, worktree_path, provenance_high_water, state, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![branch, commit_sha, worktree_path, high_water, state, secs],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// List materializations, newest first.
+    pub fn commits(&self) -> Result<Vec<CommitRecord>> {
+        if !self.has_extensions()? {
+            return Ok(Vec::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT id, branch, commit_sha, worktree_path, provenance_high_water, state, created_at
+             FROM afs_commit ORDER BY id DESC",
+        )?;
+        let rows = stmt
+            .query_map([], |r| {
+                Ok(CommitRecord {
+                    id: r.get(0)?,
+                    branch: r.get(1)?,
+                    commit_sha: r.get(2)?,
+                    worktree_path: r.get(3)?,
+                    provenance_high_water: r.get(4)?,
+                    state: r.get(5)?,
+                    created_at: r.get(6)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn actor() -> Actor {
+        Actor {
+            afs_session_id: Some("afs-1".into()),
+            coven_session_id: Some("sess-1".into()),
+            familiar_id: Some("sage".into()),
+            bead_id: Some("coven-5kt".into()),
+            turn: Some(42),
+            tool_call_id: None,
+        }
+    }
+
+    #[test]
+    fn foreign_database_without_extensions_reads_as_unbound() {
+        let fs = AgentFs::in_memory().unwrap();
+        // No init_extensions: this is what an upstream agentfs database looks
+        // like. Reads must degrade, not fail (rule E3).
+        assert!(!fs.has_extensions().unwrap());
+        assert_eq!(fs.session_binding().unwrap(), None);
+        assert!(fs.provenance_since(0, 10).unwrap().is_empty());
+        assert_eq!(fs.provenance_high_water().unwrap(), 0);
+        assert!(fs.commits().unwrap().is_empty());
+        assert!(fs.attributed_paths().unwrap().is_empty());
+    }
+
+    #[test]
+    fn binding_round_trips_and_updates_in_place() {
+        let fs = AgentFs::in_memory().unwrap();
+        let mut binding = SessionBinding {
+            id: "afs-1".into(),
+            name: Some("spike".into()),
+            state: STATE_OPEN.into(),
+            bead_id: Some("coven-5kt".into()),
+            ..Default::default()
+        };
+        fs.bind_session(&binding).unwrap();
+        binding.state = STATE_COMMITTED.into();
+        fs.bind_session(&binding).unwrap();
+
+        let stored = fs.session_binding().unwrap().unwrap();
+        assert_eq!(stored.id, "afs-1");
+        assert_eq!(stored.state, STATE_COMMITTED);
+        let count: i64 = fs
+            .conn
+            .query_row("SELECT COUNT(*) FROM afs_session", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1, "binding must update in place, not accumulate");
+    }
+
+    #[test]
+    fn provenance_paginates_on_seq_and_keeps_per_operation_identity() {
+        let fs = AgentFs::in_memory().unwrap();
+        for index in 0..5 {
+            fs.record_operation(
+                "write",
+                &format!("/f{index}"),
+                None,
+                Some(index),
+                None,
+                10,
+                &actor(),
+            )
+            .unwrap();
+        }
+        // A second actor writing to the same delta, as afs.session.join allows.
+        let other = Actor {
+            familiar_id: Some("echo".into()),
+            turn: Some(99),
+            ..actor()
+        };
+        fs.record_operation("write", "/shared", None, Some(9), None, 3, &other)
+            .unwrap();
+
+        let first = fs.provenance_since(0, 3).unwrap();
+        assert_eq!(first.len(), 3);
+        let rest = fs.provenance_since(first.last().unwrap().seq, 10).unwrap();
+        assert_eq!(rest.len(), 3);
+        assert_eq!(rest.last().unwrap().path, "/shared");
+        assert_eq!(
+            rest.last().unwrap().actor.familiar_id.as_deref(),
+            Some("echo")
+        );
+        assert_eq!(rest.last().unwrap().actor.turn, Some(99));
+        assert_eq!(fs.provenance_high_water().unwrap(), 6);
+    }
+
+    #[test]
+    fn commit_records_the_provenance_it_covers() {
+        let fs = AgentFs::in_memory().unwrap();
+        fs.record_operation("write", "/a", None, None, None, 1, &actor())
+            .unwrap();
+        fs.record_operation("write", "/b", None, None, None, 1, &actor())
+            .unwrap();
+        fs.record_commit("afs/spike", Some("abc123"), Some("/tmp/wt"), "committed")
+            .unwrap();
+
+        let commits = fs.commits().unwrap();
+        assert_eq!(commits.len(), 1);
+        assert_eq!(commits[0].provenance_high_water, 2);
+        assert_eq!(commits[0].branch, "afs/spike");
+    }
+
+    #[test]
+    fn attributed_paths_include_rename_destinations() {
+        let fs = AgentFs::in_memory().unwrap();
+        fs.record_operation("rename", "/from", Some("/to"), None, None, 0, &actor())
+            .unwrap();
+        let paths = fs.attributed_paths().unwrap();
+        assert!(paths.contains("/from"));
+        assert!(paths.contains("/to"));
+    }
+}

--- a/crates/coven-afs/tests/spec_consistency.rs
+++ b/crates/coven-afs/tests/spec_consistency.rs
@@ -3,7 +3,10 @@
 //! semantics, whiteout lifecycle, origin tracking, KV, and the tool-call
 //! audit rules.
 
-use coven_afs::{AgentFs, OverlayFs, ROOT_INO, S_IFDIR, S_IFMT, S_IFREG};
+use coven_afs::{
+    Actor, AgentFs, OverlayFs, SessionBinding, EXTENSION_TABLES, ROOT_INO, STATE_OPEN, S_IFDIR,
+    S_IFMT, S_IFREG,
+};
 use serde_json::json;
 
 fn assert_consistent(fs: &AgentFs) {
@@ -382,4 +385,69 @@ fn read_only_open_rejects_mutation_but_allows_reads() {
         ro.record_tool_call("t", None, Some(&json!(1)), None, 1, 2),
         Err(coven_afs::Error::ReadOnly)
     ));
+}
+
+/// Rules E1-E3 from `specs/coven-agent-fs/DESIGN.md` §1, proven rather than
+/// asserted: a coven-extended database satisfies the SPEC consistency rules,
+/// and dropping every `afs_*` table leaves a database that still satisfies
+/// them with its filesystem contents untouched.
+#[test]
+fn coven_extensions_are_droppable_without_changing_filesystem_semantics() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut fs = AgentFs::create(dir.path().join("extended.db")).unwrap();
+    fs.write_file("/src/main.rs", b"fn main() {}").unwrap();
+    fs.write_file("/README.md", b"# project").unwrap();
+    fs.symlink("/src/main.rs", "/link.rs").unwrap();
+    fs.mkdir_p("/empty").unwrap();
+
+    fs.bind_session(&SessionBinding {
+        id: "afs-conformance".into(),
+        state: STATE_OPEN.into(),
+        bead_id: Some("coven-5kt".into()),
+        ..Default::default()
+    })
+    .unwrap();
+    fs.record_operation(
+        "write",
+        "/src/main.rs",
+        None,
+        None,
+        None,
+        12,
+        &Actor {
+            coven_session_id: Some("sess-1".into()),
+            turn: Some(7),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    fs.record_commit("afs/conformance", None, None, "planned")
+        .unwrap();
+
+    assert_consistent(&fs);
+    let before: Vec<(String, Vec<u8>)> = ["/src/main.rs", "/README.md"]
+        .iter()
+        .map(|path| (path.to_string(), fs.read_file(path).unwrap()))
+        .collect();
+
+    fs.drop_extensions().unwrap();
+
+    assert_consistent(&fs);
+    for (path, contents) in before {
+        assert_eq!(fs.read_file(&path).unwrap(), contents, "{path} changed");
+    }
+    assert_eq!(fs.read_link("/link.rs").unwrap(), "/src/main.rs");
+    assert!(fs.exists("/empty").unwrap());
+    assert!(!fs.has_extensions().unwrap());
+    for table in EXTENSION_TABLES {
+        assert!(
+            !fs.table_exists(table).unwrap(),
+            "{table} survived drop_extensions"
+        );
+    }
+
+    // A dropped database still reads through the coven accessors, which is the
+    // upstream-produced-database case from rule E3.
+    assert_eq!(fs.session_binding().unwrap(), None);
+    assert!(fs.provenance_since(0, 10).unwrap().is_empty());
 }

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -11,6 +11,7 @@ name = "coven"
 path = "src/main.rs"
 
 [dependencies]
+coven-afs = { path = "../coven-afs" }
 anyhow = "1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -11,7 +11,7 @@ name = "coven"
 path = "src/main.rs"
 
 [dependencies]
-coven-afs = { path = "../coven-afs" }
+coven-afs = { path = "../coven-afs", version = "0.1.0" }
 anyhow = "1"
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -1,0 +1,902 @@
+//! Daemon-owned AFS sessions: the storage side of `coven.daemon.v1`'s
+//! `afs.*` operations.
+//!
+//! Layout under `<COVEN_HOME>` follows `specs/coven-agent-fs/DESIGN.md` §2:
+//!
+//! ```text
+//! afs/bases/<fingerprint>.db     read-only base snapshots, content-addressed
+//! afs/sessions/<id>.db           writable deltas, one per AFS session
+//! ```
+//!
+//! Bases are shared by every session opened against the same fingerprint, so N
+//! concurrent agents on one repository cost one base plus N small deltas.
+//!
+//! Each operation opens the databases it needs and drops them again. SQLite
+//! opens are cheap and the daemon serves requests independently, so holding
+//! overlay handles across requests would buy contention rather than speed.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use coven_afs::{Actor, AgentFs, Change, OverlayFs, SessionBinding, STATE_DISCARDED, STATE_OPEN};
+
+/// Bumped when the ingest filter changes, so bases built under the old rules
+/// are not silently reused for sessions expecting the new ones.
+const INGEST_FILTER_VERSION: u32 = 1;
+
+/// Directories never ingested into a base. Build output and package trees are
+/// the offenders RESEARCH.md called out: they are enormous, regenerable, and
+/// they are exactly what makes full-file copy-up expensive.
+const INGEST_EXCLUDES: &[&str] = &[".git", "target", "node_modules", ".worktrees"];
+
+/// Largest single file copied into a base, and the largest first-write
+/// copy-up a session will absorb.
+///
+/// Justified by the coven-110 measurements in `MOUNT-SPIKE.md` §2: copy-up is
+/// linear at roughly 135–300 MiB/s (1 MiB → 3.3 ms, 8 MiB → 57 ms, 32 MiB →
+/// 238 ms). 16 MiB keeps a worst-case first write near ~120 ms, which stays
+/// inside a plausible interactive budget; 32 MiB would not.
+pub const COPY_UP_MAX_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Failures that map onto DESIGN.md §3.4's dotted error codes.
+///
+/// Only the codes the implemented operations can actually raise live here.
+/// `afs.copy_up_too_large`, `afs.path_outside_root`, `afs.base_diverged`, and
+/// `afs.commit_conflict` arrive with commit materialization; defining them
+/// before anything can return them would advertise a contract the daemon does
+/// not yet honour.
+#[derive(Debug)]
+pub enum AfsError {
+    SessionNotFound(String),
+    SessionNotOpen { id: String, state: String },
+    NameInUse(String),
+    ConfirmationRequired,
+    Internal(anyhow::Error),
+}
+
+impl AfsError {
+    /// `(status, code, message)` for the standard error envelope.
+    pub fn parts(&self) -> (u16, &'static str, String) {
+        match self {
+            Self::SessionNotFound(id) => (
+                404,
+                "afs.session_not_found",
+                format!("No AFS session {id}."),
+            ),
+            Self::SessionNotOpen { id, state } => (
+                409,
+                "afs.session_not_open",
+                format!("AFS session {id} is {state}; this operation requires an open session."),
+            ),
+            Self::NameInUse(name) => (
+                409,
+                "afs.name_in_use",
+                format!("Another open AFS session already holds the name {name}."),
+            ),
+            Self::ConfirmationRequired => (
+                400,
+                "invalid_request",
+                "Discard requires \"confirm\": true.".to_string(),
+            ),
+            Self::Internal(error) => (500, "afs.unavailable", error.to_string()),
+        }
+    }
+}
+
+impl From<anyhow::Error> for AfsError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Internal(error)
+    }
+}
+
+impl From<coven_afs::Error> for AfsError {
+    fn from(error: coven_afs::Error) -> Self {
+        Self::Internal(anyhow::anyhow!(error))
+    }
+}
+
+type AfsResult<T> = std::result::Result<T, AfsError>;
+
+// ---- wire shapes --------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateRequest {
+    pub project_root: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub familiar_id: Option<String>,
+    #[serde(default)]
+    pub bead_id: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BaseView {
+    pub fingerprint: String,
+    pub commit: Option<String>,
+    pub files: i64,
+    pub skipped: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BindingView {
+    pub session_id: Option<String>,
+    pub familiar_id: Option<String>,
+    pub bead_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeCounts {
+    pub added: usize,
+    pub modified: usize,
+    pub deleted: usize,
+    pub bytes: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionView {
+    pub id: String,
+    pub name: Option<String>,
+    pub state: String,
+    pub base: BaseView,
+    pub binding: BindingView,
+    pub mount: Option<String>,
+    pub changes: ChangeCounts,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChangeView {
+    pub path: String,
+    pub change: String,
+    pub bytes: i64,
+    pub ino: Option<i64>,
+    pub base_ino: Option<i64>,
+    pub mode: Option<u32>,
+    /// `"recorded"` when provenance accounts for this path, `"unknown"` when
+    /// it does not. Never hidden: DESIGN.md §4.4 requires a diff entry nobody
+    /// can explain to be visible as such.
+    pub attribution: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiffView {
+    pub changes: Vec<ChangeView>,
+    pub counts: ChangeCounts,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineEntry {
+    pub seq: i64,
+    pub op: String,
+    pub path: String,
+    pub to_path: Option<String>,
+    pub bytes: i64,
+    pub at: i64,
+    pub session_id: Option<String>,
+    pub familiar_id: Option<String>,
+    pub bead_id: Option<String>,
+    pub turn: Option<i64>,
+    pub tool_call_id: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TimelineView {
+    pub entries: Vec<TimelineEntry>,
+    pub next_cursor: Option<i64>,
+    pub has_more: bool,
+}
+
+// ---- store --------------------------------------------------------------
+
+/// The daemon's AFS session store, rooted at `<COVEN_HOME>/afs`.
+pub struct AfsStore {
+    root: PathBuf,
+}
+
+impl AfsStore {
+    pub fn new(coven_home: &Path) -> Self {
+        Self {
+            root: coven_home.join("afs"),
+        }
+    }
+
+    fn bases_dir(&self) -> PathBuf {
+        self.root.join("bases")
+    }
+
+    fn sessions_dir(&self) -> PathBuf {
+        self.root.join("sessions")
+    }
+
+    fn delta_path(&self, id: &str) -> PathBuf {
+        self.sessions_dir().join(format!("{id}.db"))
+    }
+
+    fn base_path(&self, fingerprint: &str) -> PathBuf {
+        self.bases_dir().join(format!("{fingerprint}.db"))
+    }
+
+    /// Open a session's delta with write-ahead logging enabled.
+    ///
+    /// WAL is not the crate default because it costs the single-file property
+    /// a portable delta depends on. A daemon-owned session delta is scratch
+    /// state whose durability story is "discard or commit", and the coven-110
+    /// benchmarks put whole-file writes at 8.84x the host filesystem without
+    /// it versus 1.29x with it, so the daemon always turns it on.
+    fn open_delta(&self, id: &str) -> AfsResult<AgentFs> {
+        let path = self.delta_path(id);
+        if !path.exists() {
+            return Err(AfsError::SessionNotFound(id.to_string()));
+        }
+        let fs = AgentFs::create(&path).map_err(AfsError::from)?;
+        fs.enable_wal().map_err(AfsError::from)?;
+        Ok(fs)
+    }
+
+    fn open_overlay(&self, id: &str, binding: &SessionBinding) -> AfsResult<OverlayFs> {
+        let fingerprint = binding.base_fingerprint.clone().unwrap_or_default();
+        let overlay = OverlayFs::open(self.delta_path(id), self.base_path(&fingerprint))
+            .map_err(AfsError::from)?;
+        overlay.delta().enable_wal().map_err(AfsError::from)?;
+        Ok(overlay)
+    }
+
+    fn binding(&self, id: &str) -> AfsResult<SessionBinding> {
+        let delta = self.open_delta(id)?;
+        delta
+            .session_binding()
+            .map_err(AfsError::from)?
+            .ok_or_else(|| AfsError::SessionNotFound(id.to_string()))
+    }
+
+    fn require_open(&self, binding: &SessionBinding) -> AfsResult<()> {
+        if binding.state == STATE_OPEN {
+            Ok(())
+        } else {
+            Err(AfsError::SessionNotOpen {
+                id: binding.id.clone(),
+                state: binding.state.clone(),
+            })
+        }
+    }
+
+    /// `afs.session.create`.
+    pub fn create(&self, request: &CreateRequest) -> AfsResult<SessionView> {
+        let project_root = std::fs::canonicalize(&request.project_root)
+            .with_context(|| format!("project root {} is unreadable", request.project_root))
+            .map_err(AfsError::from)?;
+
+        if let Some(name) = &request.name {
+            for existing in self.list()? {
+                if existing.name.as_deref() == Some(name.as_str()) && existing.state == STATE_OPEN {
+                    return Err(AfsError::NameInUse(name.clone()));
+                }
+            }
+        }
+
+        let commit = git_head(&project_root);
+        let fingerprint = base_fingerprint(&project_root, commit.as_deref());
+        std::fs::create_dir_all(self.bases_dir())
+            .and_then(|_| std::fs::create_dir_all(self.sessions_dir()))
+            .context("failed to create the AFS store layout")
+            .map_err(AfsError::from)?;
+
+        let base_path = self.base_path(&fingerprint);
+        let (files, skipped) = if base_path.exists() {
+            base_stats(&base_path).unwrap_or((0, 0))
+        } else {
+            ingest_base(&project_root, &base_path)?
+        };
+
+        let id = format!("afs-{}", uuid::Uuid::new_v4());
+        let delta = AgentFs::create(self.delta_path(&id)).map_err(AfsError::from)?;
+        delta.enable_wal().map_err(AfsError::from)?;
+        let binding = SessionBinding {
+            id: id.clone(),
+            name: request.name.clone(),
+            state: STATE_OPEN.to_string(),
+            base_fingerprint: Some(fingerprint.clone()),
+            base_commit: commit.clone(),
+            project_root: Some(project_root.to_string_lossy().into_owned()),
+            coven_session_id: request.session_id.clone(),
+            familiar_id: request.familiar_id.clone(),
+            bead_id: request.bead_id.clone(),
+            ..Default::default()
+        };
+        delta.bind_session(&binding).map_err(AfsError::from)?;
+        drop(delta);
+
+        Ok(SessionView {
+            id,
+            name: binding.name.clone(),
+            state: STATE_OPEN.to_string(),
+            base: BaseView {
+                fingerprint,
+                commit,
+                files,
+                skipped,
+            },
+            binding: BindingView {
+                session_id: binding.coven_session_id.clone(),
+                familiar_id: binding.familiar_id.clone(),
+                bead_id: binding.bead_id.clone(),
+            },
+            mount: None,
+            changes: ChangeCounts {
+                added: 0,
+                modified: 0,
+                deleted: 0,
+                bytes: 0,
+            },
+        })
+    }
+
+    /// `afs.session.list`.
+    pub fn list(&self) -> AfsResult<Vec<SessionView>> {
+        let dir = self.sessions_dir();
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        let entries = std::fs::read_dir(&dir)
+            .with_context(|| format!("failed to list {}", dir.display()))
+            .map_err(AfsError::from)?;
+        for entry in entries {
+            let entry = entry.context("failed to read an AFS session entry")?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("db") {
+                continue;
+            }
+            let Some(id) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if let Ok(view) = self.get(id) {
+                out.push(view);
+            }
+        }
+        out.sort_by(|left, right| left.id.cmp(&right.id));
+        Ok(out)
+    }
+
+    /// `afs.session.get`.
+    pub fn get(&self, id: &str) -> AfsResult<SessionView> {
+        let binding = self.binding(id)?;
+        let counts = match self.open_overlay(id, &binding) {
+            Ok(overlay) => {
+                let set = overlay.change_set().map_err(AfsError::from)?;
+                ChangeCounts {
+                    added: set.added,
+                    modified: set.modified,
+                    deleted: set.deleted,
+                    bytes: set.bytes,
+                }
+            }
+            // A discarded or base-less session still lists; it just has no
+            // change set to report.
+            Err(_) => ChangeCounts {
+                added: 0,
+                modified: 0,
+                deleted: 0,
+                bytes: 0,
+            },
+        };
+        Ok(SessionView {
+            id: binding.id.clone(),
+            name: binding.name.clone(),
+            state: binding.state.clone(),
+            base: BaseView {
+                fingerprint: binding.base_fingerprint.clone().unwrap_or_default(),
+                commit: binding.base_commit.clone(),
+                files: 0,
+                skipped: 0,
+            },
+            binding: BindingView {
+                session_id: binding.coven_session_id.clone(),
+                familiar_id: binding.familiar_id.clone(),
+                bead_id: binding.bead_id.clone(),
+            },
+            mount: None,
+            changes: counts,
+        })
+    }
+
+    /// `afs.session.join` — attach a second actor to an existing delta.
+    ///
+    /// Recorded as an operation rather than folded into the binding, because
+    /// the acting identity is a property of each operation once more than one
+    /// actor can write (DESIGN.md §4.2).
+    pub fn join(&self, id: &str, actor: &Actor) -> AfsResult<SessionView> {
+        let binding = self.binding(id)?;
+        self.require_open(&binding)?;
+        let delta = self.open_delta(id)?;
+        delta
+            .record_operation("join", "/", None, None, None, 0, actor)
+            .map_err(AfsError::from)?;
+        drop(delta);
+        self.get(id)
+    }
+
+    /// `afs.session.diff`.
+    pub fn diff(&self, id: &str) -> AfsResult<DiffView> {
+        let binding = self.binding(id)?;
+        let overlay = self.open_overlay(id, &binding)?;
+        let set = overlay.change_set().map_err(AfsError::from)?;
+        let attributed: HashSet<String> =
+            overlay.delta().attributed_paths().map_err(AfsError::from)?;
+        let counts = ChangeCounts {
+            added: set.added,
+            modified: set.modified,
+            deleted: set.deleted,
+            bytes: set.bytes,
+        };
+        let changes = set
+            .entries
+            .into_iter()
+            .map(|entry| ChangeView {
+                attribution: if attributed.contains(&entry.path) {
+                    "recorded".to_string()
+                } else {
+                    "unknown".to_string()
+                },
+                path: entry.path,
+                change: match entry.change {
+                    Change::Added => "added",
+                    Change::Modified => "modified",
+                    Change::Deleted => "deleted",
+                }
+                .to_string(),
+                bytes: entry.bytes,
+                ino: entry.ino,
+                base_ino: entry.base_ino,
+                mode: entry.mode,
+            })
+            .collect();
+        Ok(DiffView {
+            changes,
+            counts,
+            truncated: false,
+        })
+    }
+
+    /// `afs.timeline` — cursor-paginated on `afs_provenance.seq`, matching the
+    /// daemon's existing `eventCursor: "sequence"` idiom.
+    pub fn timeline(&self, id: &str, since: i64, limit: usize) -> AfsResult<TimelineView> {
+        let delta = self.open_delta(id)?;
+        let records = delta
+            .provenance_since(since, limit + 1)
+            .map_err(AfsError::from)?;
+        let has_more = records.len() > limit;
+        let entries: Vec<TimelineEntry> = records
+            .into_iter()
+            .take(limit)
+            .map(|record| TimelineEntry {
+                seq: record.seq,
+                op: record.op,
+                path: record.path,
+                to_path: record.to_path,
+                bytes: record.bytes,
+                at: record.at,
+                session_id: record.actor.coven_session_id,
+                familiar_id: record.actor.familiar_id,
+                bead_id: record.actor.bead_id,
+                turn: record.actor.turn,
+                tool_call_id: record.actor.tool_call_id,
+            })
+            .collect();
+        Ok(TimelineView {
+            next_cursor: entries.last().map(|entry| entry.seq),
+            has_more,
+            entries,
+        })
+    }
+
+    /// `afs.session.discard` — unmount and delete the delta.
+    ///
+    /// A POST with an explicit `confirm` rather than a DELETE, because it is
+    /// destructive and must be distinguishable in logs from idle cleanup.
+    /// `retain_audit` keeps the database and marks it discarded instead.
+    pub fn discard(&self, id: &str, confirm: bool, retain_audit: bool) -> AfsResult<()> {
+        if !confirm {
+            return Err(AfsError::ConfirmationRequired);
+        }
+        let binding = self.binding(id)?;
+        if retain_audit {
+            let delta = self.open_delta(id)?;
+            delta
+                .set_session_state(&binding.id, STATE_DISCARDED)
+                .map_err(AfsError::from)?;
+            return Ok(());
+        }
+        for suffix in ["", "-wal", "-shm"] {
+            let path = PathBuf::from(format!("{}{suffix}", self.delta_path(id).display()));
+            if path.exists() {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("failed to remove {}", path.display()))
+                    .map_err(AfsError::from)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---- base ingest --------------------------------------------------------
+
+fn git_head(project_root: &Path) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(project_root)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!commit.is_empty()).then_some(commit)
+}
+
+/// Content identity of a base: the inputs that decide what it holds.
+fn base_fingerprint(project_root: &Path, commit: Option<&str>) -> String {
+    let mut digest = Sha256::new();
+    digest.update(project_root.to_string_lossy().as_bytes());
+    digest.update([0]);
+    digest.update(commit.unwrap_or("no-commit").as_bytes());
+    digest.update([0]);
+    digest.update(INGEST_FILTER_VERSION.to_be_bytes());
+    let digest = digest.finalize();
+    digest
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn base_stats(base_path: &Path) -> Result<(i64, i64)> {
+    let fs = AgentFs::open_read_only(base_path).map_err(|e| anyhow::anyhow!(e))?;
+    let count = fs
+        .file_count()
+        .map_err(|e| anyhow::anyhow!(e))
+        .context("failed to count base files")?;
+    Ok((count, 0))
+}
+
+/// Copy a project root into a fresh base database. Returns `(files, skipped)`.
+fn ingest_base(project_root: &Path, base_path: &Path) -> AfsResult<(i64, i64)> {
+    let staging = base_path.with_extension("partial");
+    let _ = std::fs::remove_file(&staging);
+    let mut fs = AgentFs::create(&staging).map_err(AfsError::from)?;
+    fs.enable_wal().map_err(AfsError::from)?;
+    let mut files = 0_i64;
+    let mut skipped = 0_i64;
+    ingest_dir(&mut fs, project_root, "", &mut files, &mut skipped)?;
+    // A base is copied and opened read-only by every session that shares it,
+    // so publish it as the single file that promise depends on rather than a
+    // database trailing WAL sidecars.
+    fs.checkpoint_to_single_file().map_err(AfsError::from)?;
+    drop(fs);
+    // Publish atomically so a crashed ingest never leaves a half-built base
+    // that a later session would happily reuse.
+    std::fs::rename(&staging, base_path)
+        .with_context(|| format!("failed to publish base {}", base_path.display()))
+        .map_err(AfsError::from)?;
+    Ok((files, skipped))
+}
+
+fn ingest_dir(
+    fs: &mut AgentFs,
+    dir: &Path,
+    prefix: &str,
+    files: &mut i64,
+    skipped: &mut i64,
+) -> AfsResult<()> {
+    let entries = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read {}", dir.display()))
+        .map_err(AfsError::from)?;
+    for entry in entries {
+        let entry = entry.context("failed to read a directory entry")?;
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if INGEST_EXCLUDES.contains(&name.as_str()) {
+            *skipped += 1;
+            continue;
+        }
+        let kind = entry.file_type().context("failed to stat an entry")?;
+        let child = format!("{prefix}/{name}");
+        if kind.is_dir() {
+            ingest_dir(fs, &entry.path(), &child, files, skipped)?;
+        } else if kind.is_file() {
+            let size = entry.metadata().map(|meta| meta.len()).unwrap_or(0);
+            if size > COPY_UP_MAX_BYTES {
+                // Recorded, not silently dropped: a base that quietly omits
+                // files would make a diff look complete when it is not.
+                *skipped += 1;
+                continue;
+            }
+            let data = std::fs::read(entry.path())
+                .with_context(|| format!("failed to read {}", entry.path().display()))
+                .map_err(AfsError::from)?;
+            fs.write_file(&child, &data).map_err(AfsError::from)?;
+            *files += 1;
+        }
+        // Symlinks are skipped: a base is a content snapshot, and a link
+        // pointing outside the root would escape it.
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project(dir: &Path) -> PathBuf {
+        let root = dir.join("project");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::create_dir_all(root.join("target")).unwrap();
+        std::fs::write(root.join("src/main.rs"), b"fn main() {}").unwrap();
+        std::fs::write(root.join("README.md"), b"# project").unwrap();
+        std::fs::write(root.join("target/huge.bin"), b"build output").unwrap();
+        root
+    }
+
+    fn store(dir: &Path) -> AfsStore {
+        AfsStore::new(dir)
+    }
+
+    fn create(store: &AfsStore, root: &Path) -> SessionView {
+        store
+            .create(&CreateRequest {
+                project_root: root.to_string_lossy().into_owned(),
+                bead_id: Some("coven-5kt".into()),
+                ..Default::default()
+            })
+            .unwrap()
+    }
+
+    #[test]
+    fn create_ingests_the_project_and_excludes_build_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        assert_eq!(view.state, STATE_OPEN);
+        assert_eq!(view.base.files, 2, "src/main.rs and README.md only");
+        assert!(view.base.skipped >= 1, "target/ must be excluded");
+        assert_eq!(view.changes.added, 0);
+        assert_eq!(view.binding.bead_id.as_deref(), Some("coven-5kt"));
+    }
+
+    #[test]
+    fn two_sessions_on_one_root_share_a_base() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let first = create(&store, &root);
+        let second = create(&store, &root);
+
+        assert_ne!(first.id, second.id);
+        assert_eq!(first.base.fingerprint, second.base.fingerprint);
+        let bases = std::fs::read_dir(dir.path().join("afs/bases"))
+            .unwrap()
+            .count();
+        assert_eq!(bases, 1, "one base for one project root");
+    }
+
+    #[test]
+    fn diff_reports_changes_and_marks_unattributed_ones() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        // Write through the overlay without recording provenance, which is
+        // what an unbound writer does.
+        {
+            let binding = store.binding(&view.id).unwrap();
+            let mut overlay = store.open_overlay(&view.id, &binding).unwrap();
+            overlay
+                .write_file("/src/main.rs", b"fn main() { changed }")
+                .unwrap();
+            overlay.write_file("/new.txt", b"added").unwrap();
+        }
+
+        let diff = store.diff(&view.id).unwrap();
+        assert_eq!(diff.counts.modified, 1);
+        assert_eq!(diff.counts.added, 1);
+        assert!(
+            diff.changes.iter().all(|c| c.attribution == "unknown"),
+            "writes with no provenance must be visible AND marked unknown"
+        );
+    }
+
+    #[test]
+    fn recorded_operations_appear_on_the_timeline_and_mark_attribution() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        {
+            let binding = store.binding(&view.id).unwrap();
+            let mut overlay = store.open_overlay(&view.id, &binding).unwrap();
+            overlay.write_file("/src/main.rs", b"edited").unwrap();
+            overlay
+                .delta()
+                .record_operation(
+                    "write",
+                    "/src/main.rs",
+                    None,
+                    None,
+                    None,
+                    6,
+                    &Actor {
+                        coven_session_id: Some("sess-1".into()),
+                        turn: Some(3),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+
+        let timeline = store.timeline(&view.id, 0, 10).unwrap();
+        assert_eq!(timeline.entries.len(), 1);
+        assert_eq!(timeline.entries[0].path, "/src/main.rs");
+        assert_eq!(timeline.entries[0].turn, Some(3));
+        assert!(!timeline.has_more);
+
+        let diff = store.diff(&view.id).unwrap();
+        let entry = diff
+            .changes
+            .iter()
+            .find(|c| c.path == "/src/main.rs")
+            .unwrap();
+        assert_eq!(entry.attribution, "recorded");
+    }
+
+    #[test]
+    fn timeline_paginates_on_seq() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        {
+            let delta = store.open_delta(&view.id).unwrap();
+            for index in 0..5 {
+                delta
+                    .record_operation(
+                        "write",
+                        &format!("/f{index}"),
+                        None,
+                        None,
+                        None,
+                        1,
+                        &Actor::default(),
+                    )
+                    .unwrap();
+            }
+        }
+        let first = store.timeline(&view.id, 0, 2).unwrap();
+        assert_eq!(first.entries.len(), 2);
+        assert!(first.has_more);
+        let rest = store
+            .timeline(&view.id, first.next_cursor.unwrap(), 10)
+            .unwrap();
+        assert_eq!(rest.entries.len(), 3);
+        assert!(!rest.has_more);
+    }
+
+    #[test]
+    fn join_records_the_second_actor_per_operation() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        store
+            .join(
+                &view.id,
+                &Actor {
+                    familiar_id: Some("echo".into()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let timeline = store.timeline(&view.id, 0, 10).unwrap();
+        assert_eq!(timeline.entries[0].op, "join");
+        assert_eq!(timeline.entries[0].familiar_id.as_deref(), Some("echo"));
+    }
+
+    #[test]
+    fn discard_requires_confirmation_and_then_removes_the_delta() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        assert!(matches!(
+            store.discard(&view.id, false, false),
+            Err(AfsError::ConfirmationRequired)
+        ));
+        assert!(store.get(&view.id).is_ok());
+
+        store.discard(&view.id, true, false).unwrap();
+        assert!(matches!(
+            store.get(&view.id),
+            Err(AfsError::SessionNotFound(_))
+        ));
+        assert!(store.list().unwrap().is_empty());
+    }
+
+    #[test]
+    fn discard_with_retain_audit_keeps_the_delta_and_marks_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        store.discard(&view.id, true, true).unwrap();
+
+        let kept = store.get(&view.id).unwrap();
+        assert_eq!(kept.state, STATE_DISCARDED);
+    }
+
+    #[test]
+    fn a_name_cannot_be_reused_while_a_session_holds_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let request = CreateRequest {
+            project_root: root.to_string_lossy().into_owned(),
+            name: Some("spike".into()),
+            ..Default::default()
+        };
+        store.create(&request).unwrap();
+        assert!(matches!(
+            store.create(&request),
+            Err(AfsError::NameInUse(name)) if name == "spike"
+        ));
+    }
+
+    #[test]
+    fn operations_on_an_unknown_session_report_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = store(dir.path());
+        for result in [
+            store.get("afs-missing").err(),
+            store.diff("afs-missing").err(),
+            store.timeline("afs-missing", 0, 10).err(),
+        ] {
+            assert!(matches!(result, Some(AfsError::SessionNotFound(_))));
+        }
+        let (status, code, _) = AfsError::SessionNotFound("x".into()).parts();
+        assert_eq!(status, 404);
+        assert_eq!(code, "afs.session_not_found");
+    }
+
+    #[test]
+    fn oversized_files_are_skipped_and_counted_rather_than_dropped_silently() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        std::fs::write(
+            root.join("big.bin"),
+            vec![0_u8; (COPY_UP_MAX_BYTES + 1) as usize],
+        )
+        .unwrap();
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        assert_eq!(view.base.files, 2, "the oversized file is not ingested");
+        assert!(view.base.skipped >= 2, "and it is counted as skipped");
+    }
+}

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -127,6 +127,32 @@ pub struct HealthCapabilities {
     pub event_cursor: String,
     pub structured_errors: bool,
     pub session_handoff: bool,
+    /// Whether the `afs.*` route family is served at all.
+    pub afs: bool,
+    /// Mount backend, or `false` when none is available. A client must branch
+    /// on this rather than assume mounting works: SDK-only operation is a
+    /// supported mode, not a degraded one.
+    pub afs_mount: MountCapability,
+    /// Whether the daemon can materialize a delta into a git branch.
+    pub afs_commit: bool,
+}
+
+/// `afsMount`: a backend name, or `false`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MountCapability {
+    Backend(String),
+    Unavailable(bool),
+}
+
+impl MountCapability {
+    /// No mount backend is exposed yet. The NFS export from coven-110 is
+    /// protocol-correct but an agent process could not write through it on
+    /// macOS (bead coven-x77), so advertising a backend would promise
+    /// something the daemon cannot currently deliver.
+    pub fn unavailable() -> Self {
+        Self::Unavailable(false)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -309,6 +335,12 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
             event_cursor: "sequence".to_string(),
             structured_errors: true,
             session_handoff: true,
+            afs: true,
+            afs_mount: MountCapability::unavailable(),
+            // Commit materialization is specified in DESIGN.md section 5 but
+            // not implemented yet; the capability says so rather than letting
+            // a client discover it from a 404.
+            afs_commit: false,
         },
         daemon,
         hub: None,
@@ -401,6 +433,10 @@ pub fn handle_request_with_runtime(
             &health_response_with_hub(coven_home, daemon, runtime.event_writer_health()),
         ),
         ("GET", "/capabilities") => json_response(200, &control_plane::capabilities()),
+        ("POST", "/afs/sessions") => afs_create(coven_home, body),
+        ("GET", "/afs/sessions") => afs_list(coven_home),
+        ("GET", p) if p.starts_with("/afs/sessions/") => afs_read(coven_home, p, query),
+        ("POST", p) if p.starts_with("/afs/sessions/") => afs_write(coven_home, p, body),
         ("GET", "/overview") => overview_response(coven_home),
         ("POST", "/actions") => {
             let payload = match parse_body(body) {
@@ -6659,6 +6695,172 @@ fn ward_change_json(change: &crate::ward::AppliedChange) -> Value {
     value
 }
 
+// ---- AFS routes ---------------------------------------------------------
+//
+// `afs.session.*`, `afs.timeline`, and `afs.mount` from
+// `specs/coven-agent-fs/DESIGN.md` section 3.2, mapped onto the daemon's REST
+// idiom. Same-user local IPC only: like session handoff, these must never be
+// proxied to a remote listener.
+
+fn afs_failure(error: crate::afs::AfsError) -> Result<ApiResponse> {
+    let (status, code, message) = error.parts();
+    api_error(status, code, &message, None)
+}
+
+/// Split `/afs/sessions/<id>[/<action>]`.
+fn afs_target(path: &str) -> Option<(String, Option<String>)> {
+    let rest = path.strip_prefix("/afs/sessions/")?;
+    let rest = rest.trim_end_matches('/');
+    if rest.is_empty() {
+        return None;
+    }
+    match rest.split_once('/') {
+        Some((id, action)) if !id.is_empty() && !action.is_empty() => {
+            Some((id.to_string(), Some(action.to_string())))
+        }
+        Some(_) => None,
+        None => Some((rest.to_string(), None)),
+    }
+}
+
+fn afs_create(coven_home: &Path, body: Option<&str>) -> Result<ApiResponse> {
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(_) => return api_error(400, "invalid_request", "Malformed request body.", None),
+    };
+    let request: crate::afs::CreateRequest = match serde_json::from_value(payload) {
+        Ok(request) => request,
+        Err(error) => {
+            return api_error(
+                400,
+                "invalid_request",
+                &format!("Invalid AFS session request: {error}"),
+                None,
+            )
+        }
+    };
+    if request.project_root.trim().is_empty() {
+        return api_error(400, "invalid_request", "projectRoot is required.", None);
+    }
+    match crate::afs::AfsStore::new(coven_home).create(&request) {
+        Ok(view) => json_response(201, &view),
+        Err(error) => afs_failure(error),
+    }
+}
+
+fn afs_list(coven_home: &Path) -> Result<ApiResponse> {
+    match crate::afs::AfsStore::new(coven_home).list() {
+        Ok(sessions) => json_response(200, &json!({ "sessions": sessions })),
+        Err(error) => afs_failure(error),
+    }
+}
+
+fn afs_read(coven_home: &Path, path: &str, query: Option<&str>) -> Result<ApiResponse> {
+    let Some((id, action)) = afs_target(path) else {
+        return api_error(404, "not_found", "Route not found.", None);
+    };
+    let store = crate::afs::AfsStore::new(coven_home);
+    match action.as_deref() {
+        None => match store.get(&id) {
+            Ok(view) => json_response(200, &view),
+            Err(error) => afs_failure(error),
+        },
+        Some("diff") => match store.diff(&id) {
+            Ok(view) => json_response(200, &view),
+            Err(error) => afs_failure(error),
+        },
+        Some("timeline") => {
+            let since = query
+                .and_then(|q| query_param(q, "since"))
+                .and_then(|value| value.parse::<i64>().ok())
+                .unwrap_or(0);
+            let limit = match query
+                .and_then(|q| query_param(q, "limit"))
+                .map(|value| value.parse::<usize>())
+            {
+                Some(Ok(limit)) if (1..=1000).contains(&limit) => limit,
+                Some(_) => {
+                    return api_error(
+                        400,
+                        "invalid_request",
+                        "limit must be between 1 and 1000.",
+                        None,
+                    )
+                }
+                None => 100,
+            };
+            match store.timeline(&id, since, limit) {
+                Ok(view) => json_response(200, &view),
+                Err(error) => afs_failure(error),
+            }
+        }
+        Some(_) => api_error(404, "not_found", "Route not found.", None),
+    }
+}
+
+fn afs_write(coven_home: &Path, path: &str, body: Option<&str>) -> Result<ApiResponse> {
+    let Some((id, Some(action))) = afs_target(path) else {
+        return api_error(404, "not_found", "Route not found.", None);
+    };
+    let payload = match parse_body(body) {
+        Ok(payload) => payload,
+        Err(_) => return api_error(400, "invalid_request", "Malformed request body.", None),
+    };
+    let store = crate::afs::AfsStore::new(coven_home);
+    match action.as_str() {
+        "join" => {
+            let actor = coven_afs::Actor {
+                afs_session_id: Some(id.clone()),
+                coven_session_id: payload
+                    .get("sessionId")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned),
+                familiar_id: payload
+                    .get("familiarId")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned),
+                bead_id: payload
+                    .get("beadId")
+                    .and_then(|value| value.as_str())
+                    .map(str::to_owned),
+                turn: payload.get("turn").and_then(|value| value.as_i64()),
+                tool_call_id: None,
+            };
+            match store.join(&id, &actor) {
+                Ok(view) => json_response(200, &view),
+                Err(error) => afs_failure(error),
+            }
+        }
+        "discard" => {
+            let confirm = payload
+                .get("confirm")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false);
+            let retain_audit = payload
+                .get("retainAudit")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false);
+            match store.discard(&id, confirm, retain_audit) {
+                Ok(()) => json_response(200, &json!({ "id": id, "discarded": true })),
+                Err(error) => afs_failure(error),
+            }
+        }
+        "commit" => api_error(
+            501,
+            "afs.commit_unsupported",
+            "Commit materialization is not implemented; health advertises afsCommit:false.",
+            None,
+        ),
+        "mount" => api_error(
+            501,
+            "afs.mount_unsupported",
+            "No mount backend is available; health advertises afsMount:false.",
+            None,
+        ),
+        _ => api_error(404, "not_found", "Route not found.", None),
+    }
+}
+
 pub(crate) fn parse_body(body: Option<&str>) -> Result<Value> {
     match body.filter(|body| !body.trim().is_empty()) {
         Some(body) => serde_json::from_str(body).context("failed to parse request body"),
@@ -6748,6 +6950,153 @@ pub(crate) fn json_response<T: Serialize>(status: u16, body: &T) -> Result<ApiRe
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn afs_project(dir: &Path) -> String {
+        let root = dir.join("project");
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        std::fs::write(root.join("src/main.rs"), b"fn main() {}").unwrap();
+        root.to_string_lossy().into_owned()
+    }
+
+    #[test]
+    fn health_advertises_the_afs_capability_set() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let response = handle_request("GET", "/api/v1/health", temp.path(), None)?;
+        assert!(response.body.contains(r#""afs":true"#));
+        // A client must be able to see that mounting and committing are not
+        // available rather than discovering it from a failed request.
+        assert!(response.body.contains(r#""afsMount":false"#));
+        assert!(response.body.contains(r#""afsCommit":false"#));
+        Ok(())
+    }
+
+    #[test]
+    fn afs_session_create_get_and_list_round_trip() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = afs_project(temp.path());
+        let created = handle_request_with_body(
+            "POST",
+            "/api/v1/afs/sessions",
+            temp.path(),
+            None,
+            Some(&json!({ "projectRoot": root, "beadId": "coven-5kt" }).to_string()),
+        )?;
+        assert_eq!(created.status, 201);
+        let view: serde_json::Value = serde_json::from_str(&created.body)?;
+        let id = view["id"].as_str().unwrap().to_string();
+        assert_eq!(view["state"], "open");
+        assert_eq!(view["binding"]["beadId"], "coven-5kt");
+
+        let fetched = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(fetched.status, 200);
+
+        let listed = handle_request("GET", "/api/v1/afs/sessions", temp.path(), None)?;
+        let listed: serde_json::Value = serde_json::from_str(&listed.body)?;
+        assert_eq!(listed["sessions"].as_array().unwrap().len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn afs_routes_report_structured_errors() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let missing = handle_request("GET", "/api/v1/afs/sessions/afs-nope", temp.path(), None)?;
+        assert_eq!(missing.status, 404);
+        assert!(missing.body.contains(r#""code":"afs.session_not_found""#));
+
+        let root = afs_project(temp.path());
+        let created = handle_request_with_body(
+            "POST",
+            "/api/v1/afs/sessions",
+            temp.path(),
+            None,
+            Some(&json!({ "projectRoot": root }).to_string()),
+        )?;
+        let id = serde_json::from_str::<serde_json::Value>(&created.body)?["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Discard is destructive, so it refuses without an explicit confirm.
+        let unconfirmed = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/afs/sessions/{id}/discard"),
+            temp.path(),
+            None,
+            Some("{}"),
+        )?;
+        assert_eq!(unconfirmed.status, 400);
+
+        // Unimplemented operations say so through the same envelope the
+        // capability flags predict.
+        let commit = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/afs/sessions/{id}/commit"),
+            temp.path(),
+            None,
+            Some("{}"),
+        )?;
+        assert_eq!(commit.status, 501);
+        assert!(commit.body.contains("afs.commit_unsupported"));
+
+        let confirmed = handle_request_with_body(
+            "POST",
+            &format!("/api/v1/afs/sessions/{id}/discard"),
+            temp.path(),
+            None,
+            Some(&json!({ "confirm": true }).to_string()),
+        )?;
+        assert_eq!(confirmed.status, 200);
+        Ok(())
+    }
+
+    #[test]
+    fn afs_timeline_paginates_and_rejects_a_bad_limit() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = afs_project(temp.path());
+        let created = handle_request_with_body(
+            "POST",
+            "/api/v1/afs/sessions",
+            temp.path(),
+            None,
+            Some(&json!({ "projectRoot": root }).to_string()),
+        )?;
+        let id = serde_json::from_str::<serde_json::Value>(&created.body)?["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        handle_request_with_body(
+            "POST",
+            &format!("/api/v1/afs/sessions/{id}/join"),
+            temp.path(),
+            None,
+            Some(&json!({ "familiarId": "echo" }).to_string()),
+        )?;
+
+        let timeline = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}/timeline?since=0&limit=10"),
+            temp.path(),
+            None,
+        )?;
+        let timeline: serde_json::Value = serde_json::from_str(&timeline.body)?;
+        assert_eq!(timeline["entries"][0]["op"], "join");
+        assert_eq!(timeline["entries"][0]["familiarId"], "echo");
+        assert_eq!(timeline["hasMore"], false);
+
+        let bad = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}/timeline?limit=0"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(bad.status, 400);
+        Ok(())
+    }
     use crate::project;
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -12,6 +12,7 @@ use chrono::{SecondsFormat, Utc};
 use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use uuid::Uuid;
 
+mod afs;
 mod api;
 mod capabilities;
 mod cockpit_sources;

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -42,7 +42,10 @@ GET /api/v1/health
     "executorDispatch": true,
     "eventCursor": "sequence",
     "structuredErrors": true,
-    "sessionHandoff": true
+    "sessionHandoff": true,
+    "afs": true,
+    "afsMount": false,
+    "afsCommit": false
   },
   "daemon": {
     "pid": 31415,
@@ -85,8 +88,23 @@ diagnostic whose literal `v1` values are not proof of named-contract support.
 | `POST /api/v1/sessions/:id/handoffs/:handoffId/ack` | Acknowledge a quiesced source. |
 | `POST /api/v1/sessions/:id/handoffs/:handoffId/continuations` | Record continuation import. |
 | `POST /api/v1/store/vacuum` | Rebuild the event FTS index and compact the SQLite store. |
+| `POST /api/v1/afs/sessions` | Create an agent-filesystem session over a project root. |
+| `GET /api/v1/afs/sessions` | List agent-filesystem sessions. |
+| `GET /api/v1/afs/sessions/:id` | Fetch one agent-filesystem session. |
+| `POST /api/v1/afs/sessions/:id/join` | Attach another actor to an existing session. |
+| `GET /api/v1/afs/sessions/:id/diff` | Read the session's change set against its base. |
+| `GET /api/v1/afs/sessions/:id/timeline` | Read recorded file operations, cursor-paginated. |
+| `POST /api/v1/afs/sessions/:id/discard` | Discard a session (requires `"confirm": true`). |
 
 Detailed shapes live in the [API reference](/reference/api).
+
+Agent-filesystem routes are gated by the `afs` capability, and are **same-user
+local IPC** operations for the same reason session handoff is: they expose a
+session's working tree. `afsMount` reports the mount backend or `false`, and
+`afsCommit` reports whether the daemon can materialize a delta into a git
+branch; both are `false` today, and `POST .../mount` and `POST .../commit`
+return `501` with `afs.mount_unsupported` / `afs.commit_unsupported` to match.
+Design: [`specs/coven-agent-fs/DESIGN.md`](https://github.com/OpenCoven/coven/blob/main/specs/coven-agent-fs/DESIGN.md).
 
 Session handoff is a **same-user local IPC** operation. A companion must use a
 separately paired authenticated transport; exposing these endpoints directly


### PR DESCRIPTION
## Context

- Summary: implements the storage and read surfaces of `specs/coven-agent-fs/DESIGN.md` §3–4 for bead `coven-5kt`, now that the engine (`coven-d4p`) and the mount spike (`coven-110`) have landed.
- Files changed: `crates/coven-afs/src/{provenance,diff,fs,ino,lib}.rs`, `crates/coven-afs/tests/spec_consistency.rs`, `crates/coven-cli/src/{afs,api,main}.rs`, `crates/coven-cli/Cargo.toml`, `docs/daemon/socket-api.md`
- Closes: bead `coven-5kt` **partially** — see *Scope* below.

## Implementation

**Extension tables** (`afs_session`, `afs_provenance`, `afs_commit`) created lazily with every column nullable or defaulted, so a database produced by upstream `agentfs` reads as one with no provenance rather than erroring (rule **E3**). Nothing writes to a SPEC table (**E1**).

**Rule E2 is tested, not asserted.** `drop_extensions()` plus a conformance test that runs the SPEC consistency rules, drops every `afs_*` table, and runs them again — verifying file contents, symlinks, and directories are unchanged and that the coven accessors still degrade cleanly afterwards.

**Diff is computed from `fs_dentry` / `fs_origin` / `fs_whiteout`, never from the provenance log** (§4.4). Writes can arrive with no bound actor, so a provenance-derived diff would silently omit exactly the changes nobody can account for. There is a test for precisely that: a write with no provenance row still appears, marked `attribution: "unknown"`.

**Findings from the spike carried forward.** WAL is enabled on every delta open — the coven-110 numbers put whole-file writes at 8.84x the host filesystem without it and 1.29x with it. `COPY_UP_MAX_BYTES` is 16 MiB, justified from the measured copy-up curve (1 MiB → 3.3 ms, 8 MiB → 57 ms, 32 MiB → 238 ms), keeping a worst-case first write near ~120 ms.

Two smaller decisions worth flagging:

- `checkpoint_to_single_file()` was added because publishing a WAL base left `-wal`/`-shm` sidecars in `bases/`, breaking the single-portable-file property a shared base depends on. A test caught it.
- Oversized and excluded files during ingest are **skipped and counted**, not silently dropped — a base that quietly omits files would make a diff look complete when it is not.

## Scope — what is deferred, and why

Seven of nine operations ship: `create`, `list`, `get`, `join`, `diff`, `timeline`, `discard`.

**`commit` and `mount` are deferred.** They return `501` with `afs.commit_unsupported` / `afs.mount_unsupported`, and `health` advertises `afsCommit:false` / `afsMount:false`, so a client learns this from the capability handshake rather than from a failed request. Reasons: mount is blocked on `coven-x77` (an agent process could not write through the NFS mount on macOS), and commit materialization is a git-worktree-plus-signing, all-or-nothing operation that deserves its own change rather than being bolted onto this one. I have not filed the commit bead — say the word and I will, or push it into this PR if you would rather it land together.

Consistent with that, the error enum defines only codes the implemented operations can raise. `afs.copy_up_too_large`, `afs.path_outside_root`, `afs.base_diverged`, and `afs.commit_conflict` arrive with commit; defining them now would advertise a contract the daemon does not honour. Clippy caught two of them sitting unconstructed, which is what prompted the cleanup.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` — 1848 passed, 2 ignored (was 1833)
- [x] `python3 scripts/check-secrets.py` — clean
- [x] Additional manual checks: `python3 scripts/check-api-contract-docs.py` passed; privacy guard passed on 12 staged files; `git diff --check` clean.

15 new tests: 5 provenance (including a foreign database with no extensions reading as unbound), 4 diff (including the unattributed-write case and directory handling), 1 E1–E3 conformance, 11 store-level, 4 route-level covering the capability handshake, structured errors, discard confirmation, and timeline pagination.

## Risk and Rollback

- Risk level: low. Additive routes behind a capability flag; no existing route, schema, or contract changes. `coven-afs` gains no default-feature dependencies.
- Rollback plan: revert the commit.

## Agent Handoff

- Current state: the read and lifecycle surface is complete and tested end to end through `handle_request`.
- Follow-ups: commit materialization (DESIGN.md §5); mount routes once `coven-x77` resolves; `coven-gr1` (Cave surfaces) is unblocked by this and can consume these routes.
- Known gaps: diff has no per-path unified-diff mode yet (`truncated` is always `false` — the field is in the shape so adding it later is additive); the store opens databases per request rather than pooling, which is right for correctness but unmeasured under concurrent load.