### PR TITLE
docs: cover PRs #680 and #682 in the v0.2.5 release notes

### DIFF
--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -13,10 +13,18 @@ title: "Coven changelog and release notes"
 - **AgentFS-compatible storage foundation.** The experimental `coven-afs`
   crate implements an AgentFS SPEC v0.4-compatible SQLite filesystem, JSON
   key/value storage, an insert-only tool-call audit log, and copy-on-write
-  base/delta overlays. This release provides the storage engine only—there is
-  no FUSE/NFS mount or daemon/Cave surface yet. See
+  base/delta overlays. See
   [PR #658](https://github.com/OpenCoven/coven/pull/658) and
   [PR #678](https://github.com/OpenCoven/coven/pull/678).
+- **Experimental NFSv3 mount backend for `coven-afs`.** Behind the crate's
+  off-by-default `mount` feature, an AgentFS database can be exported over
+  loopback NFSv3 and mounted without root on macOS. There is still no daemon
+  or Cave surface, and mounts are not enabled by default: an agent process
+  could not yet write through the mount on macOS, which is being tracked
+  before the path is recommended. The same change measured the storage
+  engine's throughput and added opt-in write-ahead logging, which takes
+  checkout-shaped writes from 8.84x the host filesystem to 1.29x. See
+  [PR #680](https://github.com/OpenCoven/coven/pull/680).
 
 ### Updates
 
@@ -29,6 +37,12 @@ title: "Coven changelog and release notes"
   [PR #668](https://github.com/OpenCoven/coven/pull/668).
 
 ### Bug fixes
+
+- **Faster session launch.** Session launches no longer spawn `git` to locate
+  the repository maintenance gate when the project root is not inside a
+  repository, restoring launch-to-first-output to its pre-gate baseline
+  (median 117.8 ms to 38.8 ms on a loaded machine). See
+  [PR #682](https://github.com/OpenCoven/coven/pull/682).
 
 - **Explicit, resilient event persistence.** Event commits retry transient
   SQLite busy/locked failures. When queue pressure drops raw output, each


### PR DESCRIPTION
## Context

- Summary: the v0.2.5 notes (#681) were written "through PR #679". Two user-visible changes merged after: #680 and #682. One of them makes an existing sentence false.
- Files changed: `docs/reference/release-notes.md`
- Closes: none — pre-release accuracy fix ahead of tagging v0.2.5.

## Implementation

- The AFS entry said the release provides "the storage engine only—there is no FUSE/NFS mount or daemon/Cave surface yet". #680 added an NFSv3 mount backend, so that sentence would ship as untrue. Rewritten to describe what actually landed, including the parts a reader needs to not over-trust it: the `mount` feature is off by default, there is still no daemon or Cave surface, and an agent process could not yet write through the mount on macOS.
- Added a bug-fix entry for #682 (session-launch git spawn removed; 117.8 ms → 38.8 ms median).
- User-visible behavior: documentation only.

## Verification

- [x] `python3 scripts/check-secrets.py` — clean
- [x] `python3 scripts/check-coven-privacy.py --staged` — clean
- [x] No Rust changed, so fmt/clippy/test are unaffected; the full gate set runs against the release commit before the tag is pushed.

## Risk and Rollback

- Risk level: none. Documentation only.
- Rollback plan: revert.

## Agent Handoff

- Current state: ready. Intended to land immediately before the v0.2.5 tag.
- Follow-ups: none.