### PR TITLE
docs: name the AgentFS mount gates in the release notes

### DIFF
--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -18,13 +18,18 @@ title: "Coven changelog and release notes"
   [PR #678](https://github.com/OpenCoven/coven/pull/678).
 - **Experimental NFSv3 mount backend for `coven-afs`.** Behind the crate's
   off-by-default `mount` feature, an AgentFS database can be exported over
-  loopback NFSv3 and mounted without root on macOS. There is still no daemon
-  or Cave surface, and mounts are not enabled by default: an agent process
-  could not yet write through the mount on macOS, which is being tracked
-  before the path is recommended. The same change measured the storage
-  engine's throughput and added opt-in write-ahead logging, which takes
-  checkout-shaped writes from 8.84x the host filesystem to 1.29x. See
-  [PR #680](https://github.com/OpenCoven/coven/pull/680).
+  loopback NFSv3 and mounted without root on macOS. The same change measured
+  the storage engine's throughput and added opt-in write-ahead logging, which
+  puts agent-shaped writes at 0.81–1.29x the host filesystem: 1.29x for
+  checkout-shaped trees, and 0.81x for `node_modules`-shaped trees, where the
+  database is faster than the host. The export is protocol-correct but remains
+  an engineering spike, and three unresolved gates keep it off by default — an
+  agent process still needs a Full Disk Access / Network Volumes confirmation
+  on macOS (if that fails, the macOS backend has to change), loopback NFS
+  access control is unsettled, and Linux/FUSE is unevaluated. No CLI, daemon,
+  API, or Cave workflow exposes it. See
+  [PR #680](https://github.com/OpenCoven/coven/pull/680) and
+  `specs/coven-agent-fs/MOUNT-SPIKE.md`.
 
 ### Updates
 


### PR DESCRIPTION
## Context

- Summary: tighten the v0.2.5 **Experimental NFSv3 mount backend** bullet so the release notes name the same gates the spec does.
- Files changed: `docs/reference/release-notes.md` (docs only, no code).
- Follow-up to #683 and #685. #683 carried this wording, but its `release-notes.md` edit was dropped when it conflicted with #685 — correctly, since #685 had already restructured the section into two bullets. Only the added precision was lost; this restores it on top of #685's structure.

## What changed

| Gate | Before | After |
|---|---|---|
| macOS blocker | "could not yet write through the mount... being tracked" | Full Disk Access / Network Volumes confirmation, with a backend change as the fallback if it fails |
| Throughput | `8.84x → 1.29x` (checkout shape only) | `0.81–1.29x`, with the shape each ratio belongs to |
| Loopback NFS access control | not mentioned | named as unsettled |
| Linux/FUSE | not mentioned | named as unevaluated |

## Sources

Every claim is taken from files already on `main`:

- `0.81x` / `1.29x` and their shapes — `specs/coven-agent-fs/MOUNT-SPIKE.md` §2 (checkout-shape and package-tree-shape tables)
- Full Disk Access / Network Volumes, and the backend-change fallback — `MOUNT-SPIKE.md` §4
- Linux/FUSE unevaluated — `MOUNT-SPIKE.md` §4
- Loopback NFS access control blocks mount-on-by-default — `specs/coven-agent-fs/DESIGN.md` §7, restated in §8

No behavior change; the gates were already documented in the specs, just not in the release notes.

## Validation

- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `python3 scripts/check-api-contract-docs.py`
- `python3 scripts/check-api-contract-docs-test.py` (42 tests)
- `cargo fmt --check`

`cargo clippy` / `cargo test` not run locally: no Rust source is touched by this diff. CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)