### PR TITLE
docs: reconcile Psyche O2 contract boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__/
 # Git worktrees (project-local)
 .worktrees/
 /.fastembed_cache
+/.psyche*

--- a/docs/superpowers/plans/2026-08-08-psyche-o2-documentation-integration.md
+++ b/docs/superpowers/plans/2026-08-08-psyche-o2-documentation-integration.md
@@ -1,0 +1,309 @@
+# Psyche O2 Documentation Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Integrate the proposed O2 execution-binding contract into Psyche
+documentation without claiming that the deferred O3-O7 capabilities exist.
+
+**Architecture:** `O2_CONTRACT_DESIGN.md` is the proposed detailed contract
+for immutable opaque binding and exact-match correlation. The canonical
+runtime, technical, plan, and review documents link to it and classify
+adoption, lookup/fencing, cancellation acknowledgement, artifacts, and recovery
+as distinct O3-O7 phases. No daemon route, database schema, or runtime code is
+changed.
+
+**Tech Stack:** Markdown, Git, repository privacy and secret guards.
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `.gitignore` | Ignore only repository-root local Psyche artifacts. |
+| `specs/psyche/O2_CONTRACT_DESIGN.md` | Proposed, detailed O2 contract and implementation acceptance map. |
+| `specs/psyche/RUNTIME_DESIGN.md` | Canonical product/ownership boundary and phased execution-binding overview. |
+| `specs/psyche/TECH.md` | Canonical technical architecture; references the O2 contract instead of duplicating an O2-O7 composite schema. |
+| `specs/psyche/PLAN.md` | Program sequencing and companion-document index. |
+| `specs/psyche/INTEGRATION_REVIEW.md` | Non-normative review summary that points to the proposed O2 boundary. |
+
+### Task 1: Preserve the O2 proposal and narrow the ignore rule
+
+**Files:**
+- Modify: `.gitignore`
+- Create: `specs/psyche/O2_CONTRACT_DESIGN.md`
+
+- [ ] **Step 1: Narrow the local artifact rule**
+
+Change the final ignore entry from:
+
+```gitignore
+.psyche*
+```
+
+to:
+
+```gitignore
+/.psyche*
+```
+
+This preserves the intended local-root artifact exclusion without hiding
+`.psyche*` files in documentation, fixtures, or nested projects.
+
+- [ ] **Step 2: Retain the proposal’s delivery status**
+
+Keep this header in `specs/psyche/O2_CONTRACT_DESIGN.md`:
+
+```markdown
+**Status:** Design proposed; not yet approved or implemented.
+```
+
+Keep the explicit O2 non-goals: no replay/duplicate-adoption prevention, no
+adoption key, no lookup/fencing, no cancellation acknowledgement, no artifact
+binding, and no crash-safe O2-O6 recovery.
+
+- [ ] **Step 3: Validate the staged scope**
+
+Run:
+
+```bash
+git diff --check
+git check-ignore -v .psyche .psyche-cache/example
+```
+
+Expected: no whitespace errors; both sample root paths report the anchored
+`/.psyche*` rule.
+
+- [ ] **Step 4: Commit the bounded proposal**
+
+```bash
+git add .gitignore specs/psyche/O2_CONTRACT_DESIGN.md
+git commit -m "docs: define proposed Psyche O2 binding contract"
+```
+
+### Task 2: Reconcile the canonical runtime boundary
+
+**Files:**
+- Modify: `specs/psyche/RUNTIME_DESIGN.md`
+
+- [ ] **Step 1: Add the O2 proposal to the canonical companion links**
+
+Add `[O2 contract design](./O2_CONTRACT_DESIGN.md)` beside the existing O1
+contract-design link near the document header. Label it as a proposed
+contract in the surrounding prose.
+
+- [ ] **Step 2: Replace the composite contract-table entry**
+
+Replace the existing `psyche.execution_binding.v1` purpose:
+
+```markdown
+Stable attempt and request IDs, payload digest, Coven adoption resolution,
+event cursor, and terminal correlation.
+```
+
+with a phased summary:
+
+```markdown
+Proposed O2 immutable opaque session binding and exact-match correlation;
+O3-O7 separately add adoption, lookup/fencing, cancellation, artifacts, and
+recovery.
+```
+
+- [ ] **Step 3: Make the Coven-client boundary phase-aware**
+
+Under `### 4.9 Coven client`, retain the product requirement that Psyche
+eventually adopts, follows, cancels, and recovers sessions. Add a sentence
+that those operations require O3-O7 after O2 and are not capabilities of the
+proposed O2 contract. Link to `O2_CONTRACT_DESIGN.md`.
+
+- [ ] **Step 4: Correct the execution-binding capability row**
+
+Replace the table row:
+
+```markdown
+| Coven execution binding | One node dispatches, adopts, follows, cancels, and recovers one real session. |
+```
+
+with two rows:
+
+```markdown
+| Proposed O2 execution binding | Immutable opaque request/session correlation and exact mismatch rejection only. |
+| O3-O7 execution lifecycle | Planned adoption, lookup/fencing, cancellation acknowledgement, artifact binding, and recovery required before real conformance. |
+```
+
+- [ ] **Step 5: Validate links and terminology**
+
+Run:
+
+```bash
+rg -n 'psyche\.execution_binding\.v1|O2|O3-O7' specs/psyche/RUNTIME_DESIGN.md
+```
+
+Expected: every O2 reference says proposed, and the document no longer assigns
+adoption, cursors, cancellation, or terminal recovery directly to O2.
+
+### Task 3: Reconcile the technical architecture without duplicating O2’s wire schema
+
+**Files:**
+- Modify: `specs/psyche/TECH.md`
+
+- [ ] **Step 1: Update the contract inventory**
+
+Replace the `psyche.execution_binding.v1` row with:
+
+```markdown
+| `psyche.execution_binding.v1` | Proposed O2 immutable opaque binding and mismatch correlation; O3-O7 separately own adoption, lookup/fencing, cancellation, artifacts, and recovery. |
+```
+
+- [ ] **Step 2: Replace the composite binding JSON**
+
+Under `### Identity snapshot`, remove the inline
+`psyche.execution_binding.v1` example containing `adoption_state`,
+`event_cursor`, `cancellation_state`, and `terminal_state`. Replace it with
+the following prose:
+
+```markdown
+The proposed O2 binding is specified in
+[O2 contract design](./O2_CONTRACT_DESIGN.md). It carries the immutable opaque
+correlation tuple that Coven persists and exact-compares. Psyche retains its
+own request record and does not treat the O2 binding as an adoption, cursor,
+cancellation, artifact, or recovery record; those are planned O3-O7 state.
+```
+
+- [ ] **Step 3: Reassign every composite-state claim**
+
+At each `TECH.md` reference to `psyche.execution_binding.v1`, make the
+ownership explicit:
+
+```markdown
+O2 stores immutable correlation; O3 owns adoption/uniqueness, O4 owns
+lookup/fencing, O5 owns cancellation acknowledgement, O6 owns artifacts, and
+O7 owns cross-phase recovery.
+```
+
+Apply this to the execution-request narrative, storage-table entry, and any
+error description that currently represents O3-O7 state as a field of the O2
+object. Keep the broader Psyche lifecycle and safety requirements; only stop
+attributing them to O2.
+
+- [ ] **Step 4: Verify no stale composite O2 schema remains**
+
+Run:
+
+```bash
+rg -n 'adoption_state|event_cursor|cancellation_state|terminal_state' specs/psyche/TECH.md
+```
+
+Expected: no result is inside an O2 binding example or described as an O2
+field. References to adoption/cancellation elsewhere remain only as planned
+Psyche lifecycle requirements.
+
+### Task 4: Align the program plan and review dossier
+
+**Files:**
+- Modify: `specs/psyche/PLAN.md`
+- Modify: `specs/psyche/INTEGRATION_REVIEW.md`
+
+- [ ] **Step 1: Add O2 to the program-plan companion index**
+
+Add `[O2 contract design](./O2_CONTRACT_DESIGN.md)` after the O1 link. Add a
+short O2-O7 delivery-boundary note after the O1 candidate paragraph:
+
+```markdown
+O2 is a proposed immutable binding and mismatch-correlation contract. Stable
+adoption, lookup/fencing, cancellation acknowledgement, artifact binding, and
+cross-phase recovery remain separate O3-O7 planned work; W5/G4 still require
+the full classified conformance profile.
+```
+
+- [ ] **Step 2: Make the review dossier point to the proposed contract**
+
+In `INTEGRATION_REVIEW.md`, add the O2 contract to the source-precedence table
+as the detailed proposed contract for immutable binding. Update its
+`psyche.execution_binding.v1` contract row to state:
+
+```markdown
+Proposed O2 immutable attempt/session correlation; O3-O7 own adoption, cursor,
+cancellation, artifact, and recovery state.
+```
+
+Keep the dossier non-normative and preserve `RUNTIME_DESIGN.md` as the
+authoritative product boundary.
+
+- [ ] **Step 3: Validate all companion links**
+
+Run:
+
+```bash
+rg -n 'O2 contract design|O3-O7|psyche\.execution_binding\.v1' \
+  specs/psyche/PLAN.md specs/psyche/INTEGRATION_REVIEW.md
+```
+
+Expected: both documents link to the detailed O2 proposal and assign later
+behavior to O3-O7.
+
+- [ ] **Step 4: Commit the reconciliation**
+
+```bash
+git add specs/psyche/RUNTIME_DESIGN.md specs/psyche/TECH.md \
+  specs/psyche/PLAN.md specs/psyche/INTEGRATION_REVIEW.md
+git commit -m "docs: reconcile Psyche O2 delivery boundaries"
+```
+
+### Task 5: Run documentation safety checks and prepare review
+
+**Files:**
+- Verify: `.gitignore`
+- Verify: `specs/psyche/O2_CONTRACT_DESIGN.md`
+- Verify: `specs/psyche/RUNTIME_DESIGN.md`
+- Verify: `specs/psyche/TECH.md`
+- Verify: `specs/psyche/PLAN.md`
+- Verify: `specs/psyche/INTEGRATION_REVIEW.md`
+
+- [ ] **Step 1: Check the complete documentation diff**
+
+Run:
+
+```bash
+git diff origin/main...HEAD --check
+git diff --cached --check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 2: Run repository guards**
+
+Run:
+
+```bash
+python scripts/check-secrets.py
+git add .gitignore specs/psyche/O2_CONTRACT_DESIGN.md \
+  specs/psyche/RUNTIME_DESIGN.md specs/psyche/TECH.md \
+  specs/psyche/PLAN.md specs/psyche/INTEGRATION_REVIEW.md
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: the secret and privacy guards pass with no exceptions or allowlists.
+
+- [ ] **Step 3: Review the claimed delivery state**
+
+Run:
+
+```bash
+rg -n 'implemented|shipped|complete' specs/psyche/O2_CONTRACT_DESIGN.md \
+  specs/psyche/RUNTIME_DESIGN.md specs/psyche/TECH.md \
+  specs/psyche/PLAN.md specs/psyche/INTEGRATION_REVIEW.md
+```
+
+Expected: no new statement describes O2 or any O3-O7 capability as delivered.
+
+- [ ] **Step 4: Push and open the documentation PR**
+
+```bash
+git push -u origin docs/psyche-o2-contract
+gh pr create --base main --head docs/psyche-o2-contract \
+  --title "docs: reconcile Psyche O2 contract boundary"
+```
+
+The PR description must state that this is documentation-only and that O2 is
+proposed, while O3-O7 remain planned.

--- a/docs/superpowers/specs/2026-08-08-psyche-o2-documentation-integration-design.md
+++ b/docs/superpowers/specs/2026-08-08-psyche-o2-documentation-integration-design.md
@@ -1,0 +1,64 @@
+# Psyche O2 Documentation Integration Design
+
+**Status:** Approved for documentation-only implementation  
+**Issue:** #689  
+**Scope:** Reconcile the proposed O2 execution-binding contract with the
+canonical Psyche documentation. No production API, schema, or runtime behavior
+is implemented by this work.
+
+## Decision
+
+`psyche.execution_binding.v1` is a staged delivery sequence, not one complete
+runtime capability:
+
+| Phase | Responsibility | Status |
+| --- | --- | --- |
+| O2 | Immutable opaque binding, syntax validation, exact-match correlation, and expiry handling | Proposed contract |
+| O3 | Adoption key, uniqueness, and replay/duplicate-adoption handling | Planned |
+| O4 | Adoption lookup, return-or-fence behavior, and binding queries | Planned |
+| O5 | Cancellation acknowledgement or unresolved disposition | Planned |
+| O6 | Content-addressed result and artifact binding | Planned |
+| O7 | Crash-safe persistence and recovery across O2-O6 | Planned |
+
+The O2 contract remains explicit that exact comparison detects
+cross-binding substitution only. It does not prevent replay or duplicate
+adoption. Coven persists and compares opaque data; Psyche retains ownership of
+identity, graph semantics, delegation policy, and orchestration.
+
+## Documentation changes
+
+1. Keep `O2_CONTRACT_DESIGN.md` as the detailed, proposed source for O2's
+   request/response shape, persistence, validation, error outcomes, and test
+   map.
+2. Update `RUNTIME_DESIGN.md` to replace its composite execution-binding
+   wording with the staged O2-O7 boundary and link to the O2 proposal.
+3. Update `TECH.md` to describe the same phased capability in its contract
+   table and schema/persistence narrative; it must no longer imply adoption,
+   cursor, cancellation, or terminal correlation are O2 fields.
+4. Update `PLAN.md` and `INTEGRATION_REVIEW.md` with an O2 companion link and
+   a concise delivery-boundary summary. These documents remain program and
+   review aids, not competing contract specifications.
+5. Change the local-artifact ignore rule from `.psyche*` to `/.psyche*` so it
+   affects only repository-root Psyche artifacts.
+
+No public API reference is changed because O2 is not implemented. The detailed
+O2 file is marked proposed everywhere it is linked.
+
+## Source precedence
+
+`O2_CONTRACT_DESIGN.md` is authoritative only for the proposed O2 contract.
+`RUNTIME_DESIGN.md` remains authoritative for the product and ownership
+boundary, and is amended to point to the staged delivery model. The W1 audit
+continues to define the evidence-based O2-O8 ordering. If a document conflicts
+with the proposed O2 scope, it must describe the deferred behavior as O3-O7
+rather than adding it to O2.
+
+## Validation
+
+- Confirm all affected documents use the same O2-O7 allocation and describe
+  O2 as proposed.
+- Run whitespace, secret, and staged privacy checks.
+- Run the repository's documentation-relevant checks; this documentation-only
+  change does not alter Rust or TypeScript behavior.
+- Review the final diff to ensure no O3-O7 implementation or release claim is
+  introduced.

--- a/docs/superpowers/specs/2026-08-08-psyche-o2-documentation-integration-design.md
+++ b/docs/superpowers/specs/2026-08-08-psyche-o2-documentation-integration-design.md
@@ -1,7 +1,7 @@
 # Psyche O2 Documentation Integration Design
 
-**Status:** Approved for documentation-only implementation  
-**Issue:** #689  
+**Status:** Approved for documentation-only implementation
+**Issue:** #689
 **Scope:** Reconcile the proposed O2 execution-binding contract with the
 canonical Psyche documentation. No production API, schema, or runtime behavior
 is implemented by this work.

--- a/specs/psyche/INTEGRATION_REVIEW.md
+++ b/specs/psyche/INTEGRATION_REVIEW.md
@@ -70,6 +70,7 @@ This review does not request:
 | 2 | [Technical architecture](./TECH.md) | Process model, schemas, persistence, errors, observability, testing, migration, and distribution. |
 | 2 | [Threat model](./THREAT_MODEL.md) | Trust assumptions, threats, controls, residual risks, and security acceptance. |
 | 2 | [Coven prerequisites](./COVEN_PREREQUISITES.md) | Required execution behavior and W1 evidence classifications; not a claim about current Coven. |
+| 2 | [O2 contract design](./O2_CONTRACT_DESIGN.md) | Proposed immutable opaque binding and mismatch-correlation contract; O3-O7 remain planned companion work. |
 | 2 | [Telegram parity ledger](./TELEGRAM_PARITY.md) | Adapter feature scope and required evidence. |
 | 2 | [Program plan](./PLAN.md) | W0-W11 dependency graph, G0-G12 gates, and delivery discipline. |
 | 3 | This dossier | Integrated summary and maintainer checklist only. |
@@ -415,7 +416,7 @@ runtime and technical specifications.
 | `psyche.delegation.v1` | Immutable non-widening child authority | Parent/child, project, action, budget, evidence, surface limits |
 | `psyche.budget.v1` | Reservation, consumption, release, and evidence | Graph/node/attempt, resource class, enforcement strength, idempotency |
 | `psyche.approval.v1` | Domain-specific approval decision | Owning authority, principal, actor, action digest, expiry, decision |
-| `psyche.execution_binding.v1` | Psyche attempt to Coven session correlation | Graph, node, attempt, session, identity, project, request digest, cursor |
+| `psyche.execution_binding.v1` | Proposed O2 immutable attempt/session correlation | O3-O7 own adoption, lookup/fencing, cancellation, artifact, and recovery state |
 | `psyche.evidence.v1` | Sealed content-addressed evidence set | Producer, graph/node/attempt/session, artifacts, digests, policy |
 | `psyche.verdict.v1` | Verification result and provenance | Evidence set, reviewer, policy, decision, confidence/escalation |
 | `psyche.recovery.v1` | Durable reconciliation or operator recovery | Subject, prior state, authority evidence, action, outcome, actor |

--- a/specs/psyche/O2_CONTRACT_DESIGN.md
+++ b/specs/psyche/O2_CONTRACT_DESIGN.md
@@ -1,0 +1,635 @@
+# Psyche O2 Coven Contract Design
+
+**Status:** Design proposed; not yet approved or implemented.
+
+**Depends on:** O1, merged (issue #567, Bead `coven-psy-o1`).
+
+**Scope:** O2 only, per `specs/psyche/COVEN_W1_AUDIT.md` §8: the opaque
+canonical execution-binding tuple that resolves C-S3, C-M1, and the O2 exact-
+binding portion of C-M9. This document does not authorize production changes
+until review passes and a test-first child plan is approved.
+
+## 1. Purpose
+
+Psyche needs the daemon to bind every session to an immutable, opaque
+identity tuple that Psyche defines and Coven never interprets. Today
+`familiar_id` and `project_root` are mutable-adjacent, roster-level hints with
+no snapshot, graph, attempt, parent, or delegation identity. Without this, a
+mismatched request — one whose bound fields do not match the session it is
+sent against — can attach to the wrong Psyche attempt, and multi-agent
+delegation (`callerFamiliarId`) has no immutable, opaque correlation to the
+session it displays.
+
+O2 freezes exactly one thing: Coven persists a Psyche-defined opaque
+`psyche.execution_binding.v1` tuple at session creation, validates its syntax
+and expiry, and exact-compares it on every subsequent bound mutating request
+(input, kill) that must prove the binding, while plain reads return the
+stored tuple without requiring proof. This exact-match comparison is a
+mismatch-correlation guarantee only: it detects cross-binding substitution,
+i.e. a proof drawn from, or matching, a different attempt's tuple. O2
+deliberately permits two sessions to be launched with byte-identical
+`executionBinding` objects (§9), so a valid proof presented more than once
+against its own matching session — a replay, or a duplicate adoption of the
+same binding — is indistinguishable from a legitimate request under this
+design. O2 defines no adoption key, request nonce, or single-use/uniqueness
+semantics, so replay prevention and duplicate-adoption prevention are **not**
+resolved by O2 and remain an O3 guarantee. Coven owns storage, syntax
+validation, and comparison; it does not own graph meaning, familiar
+authority, delegation authorization, replay/duplicate prevention, or
+uniqueness (that is O3).
+
+## 2. Proposed decision
+
+### 2.1 Contract identity and field naming
+
+The named contract is `psyche.execution_binding.v1`. Requests carry it under
+the camelCase field `executionBinding`, matching current request
+conventions. The persisted `SessionRecord` response exposes it under the
+snake_case field `execution_binding`, matching current response conventions.
+The binding object itself always carries its own `contract` field so a stored
+or returned object is self-describing without depending on the wrapper field
+name. The health capability array (§6) is named `executionBindingContracts`,
+distinct from the request/response field name, so it cannot collide by name
+or type with the `executionBinding` object itself.
+
+### 2.2 JSON shape
+
+Launch request:
+
+```json
+{
+  "familiarId": "opaque-string",
+  "callerFamiliarId": "opaque-string-or-absent",
+  "executionBinding": {
+    "contract": "psyche.execution_binding.v1",
+    "principalRef": "opaque-string",
+    "familiarId": "opaque-string",
+    "familiarSnapshotDigest": "sha256:<64 lowercase hex>",
+    "projectDigest": "sha256:<64 lowercase hex>",
+    "graphId": "opaque-string",
+    "nodeId": "opaque-string",
+    "attemptId": "opaque-string",
+    "requestDigest": "sha256:<64 lowercase hex>",
+    "policyRevision": "opaque-string",
+    "expiresAt": "YYYY-MM-DDTHH:MM:SSZ",
+    "parent": null,
+    "delegationDigest": null
+  }
+}
+```
+
+For a child (delegated) binding, `parent` is a complete object and
+`delegationDigest` is a digest, never null:
+
+```json
+"parent": {
+  "sessionId": "opaque-string",
+  "graphId": "opaque-string",
+  "nodeId": "opaque-string",
+  "attemptId": "opaque-string"
+},
+"delegationDigest": "sha256:<64 lowercase hex>"
+```
+
+`GET /api/v1/sessions/:id` and any session-listing route return the same typed
+field values under `execution_binding`. Matching current `SessionRecord`
+convention, an unbound session serializes `execution_binding: null`; it is
+never omitted from the payload. A bound session serializes the full typed
+object. O2 introduces no adoption key, request ID, or uniqueness field; that
+is O3's responsibility.
+
+### 2.3 Field semantics (Coven's view only)
+
+Every field is opaque to Coven except for syntax, contract identity, and
+expiry, which Coven validates. Coven never interprets principal, familiar,
+graph, node, attempt, policy, or delegation meaning — it only stores,
+syntax-checks, and exact-compares.
+
+| Field | Nullable | Coven's obligation |
+|---|---:|---|
+| `contract` | No | Must equal `psyche.execution_binding.v1`; reject unknown values before insertion. |
+| `principalRef` | No | Opaque ref syntax; store and exact-compare. |
+| `familiarId` | No | Opaque ref syntax; must exact-match the canonical id resolved from top-level `familiarId` at launch (§2.4). |
+| `familiarSnapshotDigest` | No | Digest syntax; store and exact-compare. |
+| `projectDigest` | No | Digest syntax; store and exact-compare; independent of Coven-canonical `project_root` (§2.4). |
+| `graphId` | No | Opaque ID syntax; store and exact-compare. |
+| `nodeId` | No | Opaque ID syntax; store and exact-compare. |
+| `attemptId` | No | Opaque ID syntax; store and exact-compare. |
+| `requestDigest` | No | Digest syntax; store and exact-compare on bound input/kill. O2 performs no uniqueness or conflict detection over this field (O3). |
+| `policyRevision` | No | Opaque revision syntax; store and exact-compare; Coven never evaluates policy. |
+| `expiresAt` | No | Canonical UTC RFC3339 seconds; Coven checks only that it is syntactically valid and, at launch and for bound input (§5), that it has not already elapsed. Launch normatively rejects an `executionBinding` whose `expiresAt` is already in the past when the launch is processed. |
+| `parent` | Yes | Null for a root binding; a complete four-field object for a child binding. Coven checks existence and exact-match against the referenced parent session's stored fields (§2.4); it never infers graph topology. |
+| `delegationDigest` | Yes | Null for a root binding; a digest for a child binding. Store and exact-compare; Coven never authorizes delegation. |
+
+### 2.4 Launch correlation rules
+
+- The top-level, Coven-resolved canonical `projectRoot` remains Coven
+  authority and is persisted unchanged as `project_root`, exactly as today.
+- `executionBinding.projectDigest` is Psyche-owned, independently persisted,
+  and is never derived from or checked against `project_root`.
+- A bound launch requires top-level `familiarId`. Coven runs its existing
+  `resolve_familiar` resolution on that alias exactly as it does today, and
+  `executionBinding.familiarId` must exact-match the resolved
+  `FamiliarContext.id`, not merely the raw alias supplied. That same
+  canonical id is what Coven persists in `SessionRecord.familiar_id`. This
+  equality check correlates Psyche's opaque snapshot reference to the
+  familiar Coven will actually inject into the session; it does not make
+  Coven the source of familiar identity or snapshot content, which remain
+  Psyche's. A mismatch is rejected before session creation.
+- **Root binding:** `parent` must be `null`, `delegationDigest` must be
+  `null`, and `callerFamiliarId` must be absent. Any of these being present
+  is rejected. Unbound launches are unaffected: their existing
+  `callerFamiliarId` display behavior is unchanged by O2.
+- **Child binding:** `parent` must be a complete object and `delegationDigest`
+  must be present. `callerFamiliarId` is required at the top level and is
+  correlation metadata only — it identifies which stored parent session's
+  fields Coven must exact-match, and Coven performs no delegation
+  authorization decision from it. The session named by `parent.sessionId`
+  must exist and itself carry a stored, non-null `execution_binding`. That
+  parent's stored `familiar_id` must exact-match the request's
+  `callerFamiliarId`, and the parent's stored `graphId`, `nodeId`, and
+  `attemptId` must exact-match the request's `parent.graphId`,
+  `parent.nodeId`, and `parent.attemptId` respectively.
+- Coven performs only existence and equality checks for parent correlation
+  and delegation. It never authorizes delegation policy or infers graph
+  topology beyond the single parent reference given.
+
+## 3. Shape validation
+
+| Value class | Applies to | Rule |
+|---|---|---|
+| Opaque ref/ID/policy-revision | `principalRef`, `familiarId` (both locations), `graphId`, `nodeId`, `attemptId`, `policyRevision`, `parent.sessionId`, `parent.graphId`, `parent.nodeId`, `parent.attemptId` | 1 to 255 ASCII bytes, matching `[A-Za-z0-9._:/-]` only. |
+| Digest | `familiarSnapshotDigest`, `projectDigest`, `requestDigest`, `delegationDigest` (when present) | Exactly `sha256:` followed by 64 lowercase hexadecimal characters. |
+| Timestamp | `expiresAt` | Canonical UTC RFC3339 seconds: `YYYY-MM-DDTHH:MM:SSZ`. No fractional seconds, no non-`Z` offsets. |
+| Contract | `contract` | Must equal `psyche.execution_binding.v1` exactly. |
+
+Coven validates only syntax, contract identity, and expiry as defined here.
+It never validates or interprets the semantic meaning of any field's content.
+
+### 3.1 Exact-object membership and no normalization
+
+The `executionBinding` object and its nested `parent` object are each parsed
+as an exact, closed set of members — there is no open/extensible schema at
+either level:
+
+- `executionBinding` must contain exactly the members listed in §2.2/§2.3
+  (`contract`, `principalRef`, `familiarId`, `familiarSnapshotDigest`,
+  `projectDigest`, `graphId`, `nodeId`, `attemptId`, `requestDigest`,
+  `policyRevision`, `expiresAt`, `parent`, `delegationDigest`) — no more, no
+  fewer required members, and no additional ones.
+- The nested `parent` object, when non-null, must contain exactly the four
+  members listed in §2.2 (`sessionId`, `graphId`, `nodeId`, `attemptId`) — no
+  more, no fewer, and no additional ones.
+- Any member key present in either object that is not in that object's exact
+  field set — at any nesting depth, including inside `parent` — is rejected
+  with `execution_binding_invalid` before any other validation in §2.4 or
+  this section runs. This applies identically at launch and to the binding
+  proof on bound input/kill.
+- Coven performs **no normalization** of accepted field values beyond the
+  syntax rules in this section: no trimming of leading/trailing bytes, no
+  case folding, no Unicode normalization (e.g. NFC/NFKC), and no other
+  reformatting. A value is validated against the applicable rule in the
+  table above and then stored and compared exactly as received, byte for
+  byte. A value that only matches after such normalization is not a match —
+  it is a syntax failure (`execution_binding_invalid`) if it fails the raw
+  syntax check, or a mismatch (`execution_binding_mismatch`) on bound
+  input/kill if it is syntactically valid but byte-differs from the stored
+  value.
+
+## 4. Persistence and API behavior
+
+- The immutable tuple is the complete `executionBinding` object plus the
+  session row's own Coven-canonical `project_root` and assigned session id.
+  These are the only Coven-authoritative values combined with the Psyche
+  tuple; nothing else is added to it.
+- Values are serialized in a deterministic field order matching §2.2 after
+  passing the exact-membership and syntax rules in §3/§3.1 unchanged (no
+  normalization, per §3.1). Coven makes no promise to preserve the caller's
+  original JSON member order or whitespace.
+- The binding is persisted atomically with session-row creation in a
+  nullable `execution_binding_json TEXT` column on the session row. O2 does
+  not introduce a separate binding table.
+- A `NULL` stored `execution_binding_json` value is the only representation
+  of an unbound session and serializes as `execution_binding: null`. If a
+  non-null stored value fails to parse as valid JSON, or its `contract` field
+  does not equal `psyche.execution_binding.v1`, reading that row is a store
+  error. It is never silently treated as an unbound session.
+- No route may update any field of an existing session's `execution_binding`
+  after creation.
+- `GET /api/v1/sessions/:id` and any listing route return the same typed
+  `execution_binding` field values (or `null` for an unbound session)
+  unchanged by archive state, cursor position, or lifecycle status.
+
+## 5. Bound operation requirements
+
+`POST /api/v1/sessions/:id/input` on a bound session requires the complete,
+exact `executionBinding` object alongside the existing `data` payload:
+
+```json
+{
+  "data": "existing input payload, unchanged shape",
+  "executionBinding": { "...": "complete object, matching §2.2" }
+}
+```
+
+`POST /api/v1/sessions/:id/kill` on a bound session, which today carries no
+body, gains a JSON body carrying only the binding:
+
+```json
+{
+  "executionBinding": { "...": "complete object, matching §2.2" }
+}
+```
+
+For both routes, missing or incomplete proof fails closed
+(`execution_binding_required`); a present but non-matching proof fails closed
+(`execution_binding_mismatch`). Input additionally rejects an expired binding
+(`execution_binding_expired`, see §7); input never proceeds against an
+expired binding. **Explicit exception:** kill may proceed after the binding's
+`expiresAt` has elapsed, because kill only narrows authority (stops a running
+attempt) and preserves operator safety. Kill still requires an exact match on
+every other field.
+
+Read/list/events endpoints (`GET /api/v1/sessions/:id`,
+`GET /api/v1/sessions`, event/cursor reads) remain plain session-id reads;
+they require no binding proof and simply return the immutable
+`execution_binding` field already stored, per §2.2/§4. O2 defines
+correlation, not authentication — read access is unchanged from today.
+
+O2 adds no artifact-lookup route and no lookup-by-binding route. Lookup
+remains by daemon session id only.
+
+### 5.1 Operation precedence
+
+**Launch** (`POST /api/v1/sessions`):
+
+1. Existing JSON body parsing, `projectRoot`/`cwd` resolution, and harness
+   validation, unchanged from today.
+2. Execution-binding contract identity, shape (§3), expiry, and root/child
+   cross-field validation (§2.4), if `executionBinding` is present.
+3. Existing familiar resolution (`resolve_familiar`), unchanged from today.
+4. Canonical familiar-equality check (§2.4) and, for a child binding, parent
+   lookup and exact correlation (§2.4).
+5. Existing maintenance-gate check, unchanged from today.
+6. Atomic session-row insert, including `execution_binding_json` if present.
+
+No session row is created, and no existing session state is mutated, unless
+every step through 5 succeeds.
+
+**Input and kill** (`POST /api/v1/sessions/:id/input`,
+`POST /api/v1/sessions/:id/kill`):
+
+1. Existing session lookup by id (`session_not_found` if absent), unchanged
+   from today.
+2. If the session is bound, require and parse the request's
+   `executionBinding` (`execution_binding_required` if missing/incomplete,
+   `execution_binding_invalid` if malformed, or
+   `execution_binding_unsupported` if its contract is unknown).
+3. Exact comparison of the parsed binding against the stored binding
+   (`execution_binding_mismatch` on any field difference).
+4. For input only, expiry check (`execution_binding_expired`); kill has no
+   expiry check per its explicit exception above.
+5. Existing external-runtime/liveness checks, unchanged from today.
+6. The runtime action itself (deliver input, or send kill). Per §5.2,
+   `executionBinding` is stripped from the request body before this step: it
+   is never passed to `SessionRuntime::send_input`/`SessionRuntime::kill_session`
+   and never written into the recorded input/kill event.
+
+For an unbound session, steps 2-4 are skipped entirely and existing
+precedence and behavior (steps 1, 5, 6) are unchanged. No runtime action
+occurs unless every required prior step succeeds.
+
+### 5.2 Bound metadata isolation
+
+`executionBinding` is proof metadata consumed entirely by the API layer; it
+must never leak into the harness/runtime input or into an ordinary input
+event. Concretely, once step 4 (or step 3, for kill) of §5.1 succeeds, the
+request handler strips `executionBinding` out of the parsed body before doing
+anything else with it:
+
+- **Input:** only the existing `data` field — the pre-O2 request/runtime
+  shape — is passed to `SessionRuntime::send_input`. `executionBinding` is
+  never forwarded to the harness/runtime. The event recorded for the request
+  (the existing input event) is likewise built from `data` only; it is the
+  pre-O2 event shape and never contains `executionBinding` or any of its
+  fields.
+- **Kill:** the binding proof exists solely to satisfy §5.1's exact-match
+  and (non-)expiry checks. It is never passed to
+  `SessionRuntime::kill_session`, which continues to take only the session
+  id, and it is never written into the kill event, which remains the pre-O2
+  shape (a bare status marker, no binding fields).
+- This isolation holds regardless of whether the request succeeds or is
+  rejected earlier in §5.1 — `executionBinding` is never given to the
+  runtime or recorded in an event on any code path, including error paths.
+
+## 6. Health negotiation
+
+Health capability discovery is additive:
+
+```json
+{
+  "capabilities": {
+    "executionBindingContracts": ["psyche.execution_binding.v1"]
+  }
+}
+```
+
+A client requiring execution binding must confirm
+`"psyche.execution_binding.v1"` is present in `capabilities.executionBindingContracts`
+before sending a bound launch. An unknown or missing required contract value
+fails before any dependent request, per the existing O1 fail-closed rule —
+O2 adds no new negotiation mechanism beyond this array entry.
+
+Legacy and unbound sessions remain fully compatible: a launch that omits
+`executionBinding` behaves exactly as it does today. Externally registered
+(non-Coven-owned) sessions must reject any `executionBinding` supplied at
+registration time, because Coven does not supervise that runtime and cannot
+honor bound-operation guarantees for it.
+
+## 7. Error matrix
+
+| Code | Status | Condition |
+|---|---:|---|
+| `execution_binding_invalid` | 400 | Malformed, missing a required field, contains an unknown/extra member in `executionBinding` or its nested `parent` object (§3.1), or fails a cross-field rule (§2.4) at launch; malformed binding proof (including an unknown/extra member) on bound input/kill; or an externally registered session's registration request supplies `executionBinding` at all (§6). |
+| `execution_binding_unsupported` | 400 | `contract` is not `psyche.execution_binding.v1`. |
+| `execution_binding_required` | 400 | Bound input or kill omits or supplies incomplete binding proof. |
+| `execution_binding_expired` | 409 | Launch or input references a binding whose `expiresAt` has elapsed. |
+| `execution_binding_mismatch` | 409 | Any exact-match check fails, including parent correlation mismatch, or a request attempts to mutate an existing stored binding. This includes a child launch whose `parent.sessionId` exists but carries a `null` stored `execution_binding` — details name only `parent.sessionId` in that case, since no stored binding fields exist to compare. |
+| `session_not_found` | 404 | The current session, or a child launch's referenced `parent.sessionId`, does not exist at all. Unchanged from existing behavior. |
+
+Error `details` may name only the mismatched field path (e.g.
+`executionBinding.graphId`, `parent.attemptId`); they must never include
+field values or digests. No broader taxonomy is introduced — O2 does not
+attempt the full O8 denial catalogue.
+
+## 8. Future file/test map
+
+| File | Change |
+|---|---|
+| `crates/coven-cli/src/store.rs` | Add `execution_binding_json` nullable column and (de)serialization; parent-lookup helper for stored binding fields. |
+| `crates/coven-cli/src/api.rs` | Parse `executionBinding`/`callerFamiliarId` on launch with exact-object (closed-set) member checking at both the `executionBinding` and nested `parent` levels (§3.1); validate syntax, contract, root/child cross-field rules, and parent correlation with no value normalization; enforce bound-operation checks on input/kill, stripping `executionBinding` before it reaches `SessionRuntime::send_input`/`SessionRuntime::kill_session` or any recorded event (§5.2); add `capabilities.executionBindingContracts` to health. |
+| `docs/API-CONTRACT.md` | Document `executionBinding`/`execution_binding`, the `psyche.execution_binding.v1` shape, the exact-object/no-normalization rule (§3.1), validation rules, the kill-after-expiry exception, and the input/kill metadata-isolation rule (§5.2). |
+| `packages/openclaw-coven/src/client.ts` | Add typed `executionBinding` request/response support and capability check parity with the Rust validation, including rejecting unknown members client-side before send. |
+
+Tests to add in the existing test modules of `store.rs` and `api.rs` (and
+`client.ts` tests where applicable). Launch cannot test arbitrary semantic
+mismatch of opaque fields such as `principalRef` or `projectDigest` against
+some pre-existing expected value, because Coven has no external expectation
+to compare against at creation time — launch tests therefore cover only
+syntax, canonical familiar equality, parent correlation, and the root/child
+cross-field rules. Per-field mismatch and substitution tests, which require
+an already-stored binding to compare against, belong to bound input and kill:
+
+Launch:
+
+- accepts a complete, valid root binding and persists it, and a subsequent
+  read returns the same typed field values;
+- accepts a complete, valid child binding referencing an existing bound
+  parent;
+- rejects an unknown `contract` value (`execution_binding_unsupported`);
+- rejects invalid characters, invalid length (0 or >255), a malformed
+  digest, and a malformed `expiresAt` for each applicable field
+  (`execution_binding_invalid`);
+- rejects an `executionBinding` object containing any unknown/extra
+  top-level member (e.g. an unexpected sibling of `contract`)
+  (`execution_binding_invalid`);
+- rejects a `parent` object containing any unknown/extra member (e.g. an
+  unexpected sibling of `sessionId`/`graphId`/`nodeId`/`attemptId`)
+  (`execution_binding_invalid`);
+- accepts an `executionBinding` object (and, for a child binding, a `parent`
+  object) containing exactly the defined members at each level, as a
+  positive control paired with the two unknown-member rejection tests above;
+- persists and returns opaque ref/ID field values (e.g. `graphId`,
+  `attemptId`) containing mixed-case ASCII letters unchanged, and a
+  subsequent bound-input/kill request differing only in letter case from the
+  stored value is rejected as `execution_binding_mismatch`, proving no case
+  folding is applied (§3.1);
+- rejects an already-expired `expiresAt` (`execution_binding_expired`);
+- rejects a top-level `familiarId` whose `resolve_familiar`-resolved
+  `FamiliarContext.id` does not exact-match `executionBinding.familiarId`
+  (`execution_binding_mismatch`);
+- rejects a root binding carrying non-null `parent`, non-null
+  `delegationDigest`, or a present `callerFamiliarId`;
+- rejects a child binding carrying null `parent`, null `delegationDigest`,
+  or a missing `callerFamiliarId`;
+- rejects a child binding whose `parent.sessionId` does not exist at all
+  (`session_not_found`);
+- rejects a child binding whose `parent.sessionId` exists but carries a
+  `null` stored `execution_binding`, with details naming only
+  `parent.sessionId` (`execution_binding_mismatch`);
+- rejects a child binding whose parent's stored `familiar_id`, `graphId`,
+  `nodeId`, or `attemptId` does not match the request's
+  `callerFamiliarId`/`parent.*` fields (one test per field,
+  `execution_binding_mismatch`);
+- an invalid or mismatched launch performs no row insertion and mutates no
+  existing session (atomic rollback/no partial row);
+- a stored binding round-trips deterministically across a daemon restart
+  (same typed field values, byte-exact and unnormalized per §3.1, on read,
+  independent of original caller whitespace/member order);
+- a launch omitting `executionBinding` behaves identically to current legacy
+  behavior, and its `execution_binding` reads back as `null` (no regression);
+- external session registration supplying `executionBinding` is rejected
+  with `execution_binding_invalid`;
+- `GET /api/v1/health` advertises `capabilities.executionBindingContracts`
+  and clients (Rust first-party and `client.ts`) negotiate it consistently
+  with docs;
+- two sessions may be launched with byte-identical `executionBinding`
+  objects and both succeed, proving O2 introduces no uniqueness/adoption
+  behavior.
+
+Bound input and kill:
+
+- input rejects an expired binding (`execution_binding_expired`); kill
+  succeeds with an exact binding whose `expiresAt` has elapsed (the explicit
+  exception), while still requiring an exact match on all other fields;
+- input and kill each reject a missing or incomplete `executionBinding`
+  (`execution_binding_required`);
+- input and kill each reject an unknown `contract` with
+  `execution_binding_unsupported`;
+- input and kill each reject a proof `executionBinding` object containing
+  any unknown/extra top-level member, and each reject a proof whose `parent`
+  object (child bindings only) contains any unknown/extra member — both
+  cases produce `execution_binding_invalid` (§3.1);
+- input and kill each reject a mismatch on every other individual field —
+  cross-project, cross-familiar, cross-graph, cross-node, cross-attempt,
+  cross-delegation, cross-request-digest, cross-policy-revision,
+  cross-expiry, and cross-parent (`parent.sessionId`/`graphId`/`nodeId`/
+  `attemptId`) substitution — supplying a syntactically valid binding that
+  does not match the stored one, one test per substituted field
+  (`execution_binding_mismatch`), with details naming only the mismatched
+  field path;
+- input and kill each reject an attempt to submit a binding that would
+  mutate the stored binding rather than merely prove it;
+- a successful bound input call records an input event and calls
+  `SessionRuntime::send_input` with a payload equal to (or a strict subset
+  of, containing only) `data`, asserting the recorded event and the
+  `send_input` payload each contain no `executionBinding` key (§5.2);
+- a successful bound kill call records a kill event and calls
+  `SessionRuntime::kill_session` with only the session id, asserting the
+  recorded kill event contains no `executionBinding` key and the
+  `kill_session` call signature carries no binding argument (§5.2).
+
+### 8.1 Metadata isolation acceptance evidence
+
+The tests in the last two bullets above are the acceptance evidence for
+§5.2: they must inspect the actual argument passed to
+`SessionRuntime::send_input`/`SessionRuntime::kill_session` and the actual
+persisted event row, not merely the HTTP response, since a leak would be
+invisible in the response body.
+
+## 9. O3 handoff
+
+O2 defines the exact stored `psyche.execution_binding.v1` identity and its
+`requestDigest` field but creates no uniqueness or adoption semantics over
+them. O2 must accept two sessions launched with identical, otherwise-valid
+`executionBinding` objects, including identical `requestDigest` values,
+because no conflict or adoption rule exists yet. Consequently, O2 has no way
+to distinguish a legitimately repeated proof from a replay or a duplicate
+adoption of the same binding — mismatch detection is the only guarantee O2
+makes, and replay/duplicate-adoption prevention is explicitly O3's
+guarantee, not O2's, per §1. O3 is responsible for defining the adoption-key
+schema (which fields, if any, become a uniqueness scope), the
+collision/conflict outcome, replay/duplicate-adoption rejection, and any
+lookup-by-adoption-key behavior. O2 does not anticipate or partially
+implement that decision.
+
+## 10. Relationship to `RUNTIME_DESIGN`
+
+This O2 design freezes only the immutable launch/correlation core of
+`psyche.execution_binding.v1` as specified in §§2-7: the request/response
+field names, the exact v1 object, shape validation, launch correlation, the
+bound-operation and precedence rules, and the six O2 error codes. The current
+`RUNTIME_DESIGN.md` table's references to adoption resolution, event-cursor
+correlation, and terminal-state correlation under the same contract name
+describe later companion state and contracts owned by O3 (adoption), O4/O5
+(lookup, fencing, cancellation acknowledgement), and O7 (crash-safe
+recovery) — they are not fields of the immutable O2 object defined here and
+must not be implemented as part of O2. `RUNTIME_DESIGN.md` wording that
+implies those later fields already belong to the O2 object must be corrected
+to reflect this boundary once this design is approved. This document does
+not itself edit `RUNTIME_DESIGN.md` or add any of those fields.
+
+## 11. Acceptance checklist
+
+- [ ] Contract name, request field, response field, and inner `contract`
+      value exactly match §2.1.
+- [ ] The v1 object contains exactly the fields listed in §2.2/§2.3, with no
+      added adoption key, request ID, or extra field.
+- [ ] Shape validation matches §3 exactly (byte length, character class,
+      digest format, timestamp format).
+- [ ] `executionBinding` and its nested `parent` object each reject any
+      unknown/extra member with `execution_binding_invalid` at both launch
+      and bound input/kill (§3.1); accepted values are stored/compared byte
+      for byte with no trimming, case folding, or Unicode normalization
+      (§3.1); positive (exact-fields-only) and negative (unknown-member)
+      tests exist at both object levels, per §8.
+- [ ] `project_root`/`projectDigest` separation and canonical familiar
+      equality (`resolve_familiar`/`FamiliarContext.id` versus
+      `executionBinding.familiarId`) are enforced per §2.4.
+- [ ] Root/child cross-field rules (`parent`, `delegationDigest`,
+      `callerFamiliarId`) are enforced exactly as specified.
+- [ ] Parent correlation performs existence + exact-match only, never
+      topology inference or delegation authorization.
+- [ ] Binding persists atomically in `execution_binding_json`, is immutable
+      after creation, and survives restart with deterministic serialization.
+- [ ] Unbound sessions serialize `execution_binding: null`, never omitted;
+      bound sessions serialize the full typed object.
+- [ ] Invalid stored JSON/contract is a store error, never silently unbound.
+- [ ] Bound input/kill require complete exact-match proof, following the
+      precedence in §5.1; input rejects expiry; kill's expiry exception is
+      implemented and tested.
+- [ ] `executionBinding` is stripped before the runtime call and before event
+      recording on both input and kill (§5.2): `SessionRuntime::send_input`
+      receives only `data`, the recorded input event contains only `data`,
+      `SessionRuntime::kill_session` receives no binding argument, and the
+      kill event carries no binding fields — verified by inspecting the
+      actual runtime call and stored event, not just the HTTP response
+      (§8.1).
+- [ ] Read/list/events endpoints remain unauthenticated by binding and
+      unchanged in access behavior.
+- [ ] Health advertises `capabilities.executionBindingContracts` additively.
+- [ ] External session registration rejects `executionBinding` with
+      `execution_binding_invalid`.
+- [ ] All six error codes in §7 are implemented with field-path-only details,
+      including the parent-exists-but-unbound and external-registration
+      mappings.
+- [ ] All tests in §8 (including §8.1) are present and passing.
+- [ ] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
+      `cargo test --workspace --locked`, `python scripts/check-secrets.py`,
+      `python3 scripts/check-coven-privacy.py --staged`,
+      `npm --prefix packages/openclaw-coven run typecheck`, and
+      `npm --prefix packages/openclaw-coven test` all pass.
+- [ ] `docs/API-CONTRACT.md` updated in the same PR as the implementation.
+- [ ] Two identical bindings on separate sessions succeed, proving no O3
+      behavior was introduced; the design's Purpose/self-review make clear
+      this also means replay and duplicate-adoption prevention are not
+      claimed by O2 (§1, §9, §13).
+- [ ] `RUNTIME_DESIGN.md` wording is corrected per §10 once this design is
+      approved, without adding O3-O7 fields to the O2 object.
+
+## 12. Non-goals
+
+- O2 does not implement adoption-key uniqueness, conflict detection, or
+  one-attempt/one-session enforcement (O3; see §9).
+- O2 does not detect or prevent replay of a valid proof, or duplicate
+  adoption of an identical binding across sessions — O2's exact-match
+  comparison is mismatch-correlation only, not a replay/uniqueness guarantee
+  (O3; see §1, §9).
+- O2 does not add lookup-by-binding or return-or-fence semantics (O4).
+- O2 does not define cancellation acknowledgement (O5).
+- O2 does not define content-addressed result/artifact binding (O6).
+- O2 does not add crash-matrix recovery proofs beyond deterministic
+  persistence and restart round-trip (O7 covers the full recovery
+  guarantee).
+- O2 does not interpret `graphId`/`nodeId`/`attemptId` topology, enforce
+  descendant completion, or authorize delegation policy — those remain
+  Psyche authority (C-M4 stays rejected as a Coven aggregate).
+- O2 does not change `docs/SESSION-LIFECYCLE.md` behavior; lifecycle status
+  is unaffected by binding.
+- O2 does not introduce a broad structured-denial taxonomy; only the six
+  codes in §7 are in scope (full O8 catalogue is out of scope).
+- O2 does not implement, and does not require editing now, the adoption
+  resolution, event-cursor, or terminal-correlation companion state
+  described in §10.
+
+## 13. Self-review against audit scope
+
+- **C-S3 (familiar snapshot and attempt binding):** Covered by this design.
+  It specifies binding an opaque, Psyche-defined
+  `familiarSnapshotDigest`/`graphId`/`nodeId`/`attemptId`/`requestDigest`
+  tuple to the authoritative session record, with canonical familiar
+  correlation via `resolve_familiar`/`FamiliarContext.id`, and rejecting
+  mismatch, without Coven interpreting familiar or graph policy (§2.3, §2.4,
+  §7).
+- **C-M1 (parent graph/child node/attempt correlation):** Covered by this
+  design for exact-binding correlation. The `parent` object plus
+  `delegationDigest` give an opaque graph/node/attempt/parent correlation
+  tuple that Coven is specified to store and exact-compare (§2.2, §2.4),
+  without Coven owning graph meaning or descendant enumeration (§12,
+  consistent with C-M4 remaining rejected as a Coven aggregate).
+- **C-M9, O2 portion only (exact opaque binding rejection):** Covered by
+  this design, and *only* for the cross-binding-substitution/mismatch
+  portion of C-M9. Every specified field mismatch, including
+  `delegationDigest`, is defined to produce `execution_binding_mismatch`,
+  with Coven comparing the bound delegation digest without interpreting
+  delegation authorization (§2.3, §2.4, §7). This design does **not** cover,
+  and does not claim to cover, replay of a valid proof or duplicate adoption
+  of an identical binding — those require the O3 uniqueness/adoption
+  semantics (§1, §9) and are explicitly out of scope here. The broader C-M9
+  O8 denial-taxonomy portion is also intentionally left out of scope (§12).
+
+No O3-O8 behavior, uniqueness semantics, replay/duplicate-adoption
+prevention, or production child dispatch is represented as complete by this
+document.
+
+## 14. Gates and completion evidence
+
+This design consumes the approved O1 result. O2 is complete only when:
+
+1. this written design is approved;
+2. an exact-file, test-first child implementation plan is approved;
+3. the scoped implementation and documentation land through a green PR;
+4. an issue and Bead recording this work are opened and record merge and
+   verification evidence; and
+5. no O3-O8 behavior or production child dispatch is represented as
+   complete.

--- a/specs/psyche/PLAN.md
+++ b/specs/psyche/PLAN.md
@@ -13,6 +13,12 @@ O1 remains incomplete until the reviewed PR merges and issue #567 plus Bead
 vocabulary and C-S8 documentation; C-S3-C-S6 and C-S9-C-S12 remain planned,
 and G4/G6 remain blocked.
 
+**O2 proposal:** [O2 contract design](./O2_CONTRACT_DESIGN.md) defines
+immutable opaque binding and mismatch correlation only. Stable adoption,
+lookup/fencing, cancellation acknowledgement, artifact binding, and
+cross-phase recovery remain separate O3-O7 planned work; W5/G4 still require
+the full classified conformance profile.
+
 **Goal:** Build Psyche as the clean-room, local-first, surface-neutral familiar
 runtime for a Coven, with durable intent and orchestration, evidence-first
 verification, Telegram as the first production adapter, and Coven as the
@@ -20,7 +26,7 @@ independent bounded execution substrate.
 
 **Canonical decision:** [Familiar runtime design](./RUNTIME_DESIGN.md)
 
-**Companions:** [W1 Coven audit](./COVEN_W1_AUDIT.md), [O1 contract design](./O1_CONTRACT_DESIGN.md), [Decision dossier](./DECISION_DOSSIER.md), [Product specification](./PRODUCT.md), [Technical architecture](./TECH.md), [Threat model](./THREAT_MODEL.md), [Telegram parity ledger](./TELEGRAM_PARITY.md), [Coven prerequisites](./COVEN_PREREQUISITES.md)
+**Companions:** [W1 Coven audit](./COVEN_W1_AUDIT.md), [O1 contract design](./O1_CONTRACT_DESIGN.md), [O2 contract design](./O2_CONTRACT_DESIGN.md), [Decision dossier](./DECISION_DOSSIER.md), [Product specification](./PRODUCT.md), [Technical architecture](./TECH.md), [Threat model](./THREAT_MODEL.md), [Telegram parity ledger](./TELEGRAM_PARITY.md), [Coven prerequisites](./COVEN_PREREQUISITES.md)
 
 ## 1. Fixed program decisions
 

--- a/specs/psyche/RUNTIME_DESIGN.md
+++ b/specs/psyche/RUNTIME_DESIGN.md
@@ -17,7 +17,7 @@
 [Technical architecture](./TECH.md),
 [Threat model](./THREAT_MODEL.md),
 [Telegram parity](./TELEGRAM_PARITY.md),
-[Coven prerequisites](./COVEN_PREREQUISITES.md), and
+[Coven prerequisites](./COVEN_PREREQUISITES.md),
 [Program plan](./PLAN.md), and
 [O2 contract design](./O2_CONTRACT_DESIGN.md)
 

--- a/specs/psyche/RUNTIME_DESIGN.md
+++ b/specs/psyche/RUNTIME_DESIGN.md
@@ -18,7 +18,8 @@
 [Threat model](./THREAT_MODEL.md),
 [Telegram parity](./TELEGRAM_PARITY.md),
 [Coven prerequisites](./COVEN_PREREQUISITES.md), and
-[Program plan](./PLAN.md)
+[Program plan](./PLAN.md), and
+[O2 contract design](./O2_CONTRACT_DESIGN.md)
 
 > This document defines the approved product and architecture direction. W0
 > reconciles the companion documents to this surface-neutral boundary while
@@ -333,6 +334,12 @@ The client:
 - fences unknown adoption or termination outcomes; and
 - exposes no local success fallback.
 
+This describes the full execution lifecycle Psyche requires. The
+[proposed O2 contract](./O2_CONTRACT_DESIGN.md) covers only immutable opaque
+binding and exact-match correlation. O3 through O7 separately own adoption and
+uniqueness, lookup and fencing, cancellation acknowledgement, artifact
+binding, and cross-phase recovery.
+
 ### 4.10 Operations core
 
 The operations core provides:
@@ -361,7 +368,7 @@ The initial surface-neutral contract set is:
 | `psyche.delegation.v1` | Parent-child relationship, delegated authority, acceptance criteria, and cancellation policy. |
 | `psyche.budget.v1` | Reserved, consumed, and released accounting by resource class. |
 | `psyche.approval.v1` | Psyche orchestration approval request, provenance, decision, and expiry. |
-| `psyche.execution_binding.v1` | Stable attempt and request IDs, payload digest, Coven adoption resolution, event cursor, and terminal correlation. |
+| `psyche.execution_binding.v1` | Proposed O2 immutable opaque session binding and exact-match correlation; O3-O7 separately add adoption, lookup/fencing, cancellation, artifacts, and recovery. |
 | `psyche.evidence.v1` | Immutable test, artifact, trajectory, verifier, or human evidence reference. |
 | `psyche.verdict.v1` | Verification policy, evidence set, independent verifier, confidence class, and decision. |
 | `psyche.recovery.v1` | Lease, ambiguity, fence, reconciliation, and operator resolution state. |
@@ -694,7 +701,8 @@ Comprehensive orchestration is delivered through separate plans:
 | Identity kernel | Surface-neutral snapshots, revisions, contradiction checks, and session bindings. |
 | Intent ledger | Immutable normalized intents with provenance, supersession, and replay protection. |
 | Graph store and state machine | Durable nodes, dependencies, leases, budgets, cancellation, and recovery without real harnesses. |
-| Coven execution binding | One node dispatches, adopts, follows, cancels, and recovers one real session. |
+| Proposed O2 execution binding | Immutable opaque request/session correlation and exact mismatch rejection only. |
+| O3-O7 execution lifecycle | Planned adoption, lookup/fencing, cancellation acknowledgement, artifact binding, and recovery required before real conformance. |
 | Multi-agent execution | Parent-child correlation, bounded delegation, propagation, result adoption, and orphan fencing. |
 | Capability router | Reviewed capability matching with negative tests for metadata poisoning and unsupported contracts. |
 | Context and memory coordinator | Bounded provenance-aware context and explicit memory operations. |

--- a/specs/psyche/TECH.md
+++ b/specs/psyche/TECH.md
@@ -240,7 +240,7 @@ The W0 surface-neutral contract set is:
 | `psyche.delegation.v1` | Parent-child scope, non-widening constraints, budget, evidence access, and cancellation policy. |
 | `psyche.budget.v1` | Reserved, consumed, and released accounting by enforceable resource class. |
 | `psyche.approval.v1` | Psyche orchestration approval request, provenance, decision, and expiry. |
-| `psyche.execution_binding.v1` | Graph attempt, stable request digest, Coven adoption state, event cursor, cancellation, and terminal correlation. |
+| `psyche.execution_binding.v1` | Proposed O2 immutable opaque binding and mismatch correlation; O3-O7 separately own adoption, lookup/fencing, cancellation, artifacts, and recovery. |
 | `psyche.evidence.v1` | Immutable check, artifact, trajectory, verifier, or human evidence reference. |
 | `psyche.verdict.v1` | Verification policy, sealed evidence set, independent verifier, confidence class, and decision. |
 | `psyche.recovery.v1` | Lease, ambiguity, fence, reconciliation, and operator disposition. |
@@ -529,25 +529,13 @@ stores digests, provenance, and identifiers, not a second mutable identity.
 Psyche reads validated handles and verifies digests before graph admission and
 again before execution request construction.
 
-If W1 proves a compatible Coven snapshot-validation contract, Psyche records
-its result in `psyche.execution_binding.v1`:
-
-```json
-{
-  "schema_version": "psyche.execution_binding.v1",
-  "attempt_id": "att_01J...",
-  "familiar_snapshot_id": "ids_01J...",
-  "project_id": "project:sha256:...",
-  "request_id": "req_01J...",
-  "request_digest": "sha256:...",
-  "coven_contract_version": "classified-by-w1",
-  "coven_session_id": null,
-  "adoption_state": "not_submitted",
-  "event_cursor": null,
-  "cancellation_state": "not_requested",
-  "terminal_state": null
-}
-```
+The [proposed O2 contract](./O2_CONTRACT_DESIGN.md) defines the immutable
+opaque binding that Coven persists and exact-compares after W1 proves a
+compatible snapshot-validation contract. Psyche retains its own execution
+request record. O2 is not an adoption, cursor, cancellation, artifact, or
+recovery record: O3 owns adoption and uniqueness, O4 lookup and fencing, O5
+cancellation acknowledgement, O6 artifact binding, and O7 cross-phase
+recovery.
 
 This binding does not make Coven the identity source. It records whether Coven
 accepted the exact Psyche snapshot for one execution request. Missing inputs,
@@ -632,8 +620,8 @@ The execution payload contains a typed task and bounded context manifest. It
 does not contain a competing persona, hidden permission grant, surface secret,
 or untrusted text represented as system instruction. `operation` is `launch`
 or `input`; input also names the adopted session. Psyche persists the exact
-request and digest before submission, then records adoption and event progress
-in `psyche.execution_binding.v1`.
+request and digest before submission. The O2 binding records immutable opaque
+correlation only; adoption and event progress are planned O3 and O4 state.
 
 ### Surface policy request and decision
 
@@ -1118,8 +1106,8 @@ resources. Coven does not authorize Telegram or another surface effect.
 2. Resolve required media or evidence references through only the protected-
    resource contracts that W1 and G4 prove. Missing support blocks that node;
    Psyche never writes directly into a Coven-owned store.
-3. Build and persist the exact `psyche.execution_request.v1` and
-   `psyche.execution_binding.v1` with `adoption_state = not_submitted`.
+3. Build and persist the exact `psyche.execution_request.v1` and the proposed
+   O2 `psyche.execution_binding.v1` immutable correlation tuple.
 4. Submit through the W1-classified session-create or input contract using one
    stable request ID and digest. Surface policy does not participate in Coven
    execution admission.
@@ -1607,7 +1595,7 @@ an exclusive startup lock.
 | `attempts` | One node execution attempt and its immutable request binding. |
 | `delegations` | Non-widening parent-child envelope and cancellation policy. |
 | `budgets` | Idempotent reserve/consume/release accounting by resource class. |
-| `execution_bindings` | Request digest, Coven adoption, session, event cursor, cancellation, terminal state, and ambiguity. |
+| `execution_bindings` | Proposed O2 immutable opaque binding; O3-O7 separately add adoption, session lookup/fencing, cancellation, artifact, and recovery state. |
 | `evidence_sets` | Sealed content-addressed evidence inventory per node attempt. |
 | `verdicts` | Policy, deterministic/human/independent-verifier provenance, confidence class, and decision. |
 | `recovery_records` | Lease, fence, unknown state, reconciliation attempts, and operator disposition. |
@@ -1669,7 +1657,7 @@ Stable v1 error codes:
 | `coven_version_unsupported` | No | Daemon API version is not exactly supported. |
 | `coven_capability_missing` | No | A required capability is not advertised. |
 | `coven_policy_denied` | No | Coven rejected the intent. |
-| `coven_execution_binding_invalid` | No | Execution admission or result does not match every request binding. |
+| `coven_execution_binding_invalid` | No | An O2 binding or later-phase execution record does not match required opaque correlation. |
 | `coven_binding_mismatch` | No | Returned project or familiar binding differs. |
 | `coven_artifact_rejected` | Depends on Coven code | Coven rejected media metadata, bytes, binding, or lifetime. |
 | `coven_intent_conflict` | No | A client intent ID was reused with another request digest. |


### PR DESCRIPTION
Closes #689

## Summary
- add the proposed, documentation-only O2 immutable execution-binding contract
- reconcile runtime, technical, plan, and review documentation so adoption, lookup/fencing, cancellation acknowledgement, artifacts, and recovery remain planned O3-O7 work
- restrict local Psyche artifact ignores to the repository root

## Delivery boundary
O2 is proposed and unimplemented. This PR adds no daemon API, schema migration, runtime behavior, or production child-dispatch claim.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`