### PR TITLE
docs: record AFS macOS consent validation

### DIFF
--- a/docs/superpowers/plans/2026-08-09-afs-macos-consent-confirmation.md
+++ b/docs/superpowers/plans/2026-08-09-afs-macos-consent-confirmation.md
@@ -1,0 +1,212 @@
+# AgentFS macOS Consent Confirmation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reconcile source and public AgentFS documentation with the verified macOS Terminal NFS mounted-I/O confirmation while retaining all remaining security and deployment gates.
+
+**Architecture:** Treat the successful Terminal run as evidence about one consent-enabled NFS client, not a new product capability. The source spike record remains the evidence authority; source design and research documents summarize its changed implication; public documentation summarizes the same limit without publishing a supported mount workflow.
+
+**Tech Stack:** Markdown/MDX, GitHub pull requests, Coven documentation guards, Mintlify documentation build.
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `specs/coven-agent-fs/MOUNT-SPIKE.md` | Canonical macOS NFS evidence and mount go/no-go decision. |
+| `specs/coven-agent-fs/DESIGN.md` | Delivery sequencing for the AgentFS product design. |
+| `specs/coven-agent-fs/RESEARCH.md` | Research conclusions and recommended work. |
+| `content/docs/guide/agent-filesystem.mdx` in `OpenCoven/coven-docs` | Public capability, safety boundary, and roadmap status. |
+| `content/docs/guide/architecture.mdx` in `OpenCoven/coven-docs` | Public architecture-level summary. |
+| `content/docs/daemon/security.mdx` in `OpenCoven/coven-docs` | Public security-boundary summary. |
+
+### Task 1: Record the source evidence and revised gate
+
+**Files:**
+- Modify: `specs/coven-agent-fs/MOUNT-SPIKE.md:12-14,142-157,171-175`
+- Modify: `specs/coven-agent-fs/DESIGN.md:431-438`
+- Modify: `specs/coven-agent-fs/RESEARCH.md:63-78`
+
+- [ ] **Step 1: Replace the stale source conclusion with the verified result**
+
+In `MOUNT-SPIKE.md`, state that the NFS mount works for a consent-enabled
+client process and make the evidence auditable:
+
+```markdown
+On 2026-08-09, a human-operated Terminal observed `afs_serve` listening on
+`127.0.0.1:12049`, mounted `localhost:/` at `/private/tmp/afsmnt`, and
+successfully created, wrote, and read back `/private/tmp/afsmnt/hello/file.txt`.
+```
+
+State that the earlier connection-refused run happened before the server was
+listening and the resulting local-directory write is not mount evidence.
+Replace the `Conditional on the mount` paragraph with wording that permits
+mount-dependent engineering validation for consent-enabled clients, but keeps
+`afsMount: false` as the safe default until loopback NFS access control,
+concurrency, recovery, Linux/FUSE, sandboxing, and default-on policy have
+independent decisions.
+
+- [ ] **Step 2: Update the design and research summaries**
+
+In `DESIGN.md`, replace the delivery-table phrase `conditional on the Full Disk
+Access confirmation` with:
+
+```markdown
+merged experimental spike — PR #680; Terminal mounted I/O confirmation passed,
+with per-process network-volume consent required
+```
+
+In `RESEARCH.md`, replace the outstanding-confirmation blocker with language
+that says the manual Terminal confirmation passed, and that automated
+agent/client processes may still require explicit macOS privacy or
+network-volume consent. Keep Linux/FUSE and loopback access-control work open.
+
+- [ ] **Step 3: Inspect the changed source documents**
+
+Run:
+
+```sh
+git diff --check
+rg -n -C 2 'outstanding|needs an agent-process|blocked on the Full Disk|no agent process has yet' \
+  specs/coven-agent-fs/MOUNT-SPIKE.md \
+  specs/coven-agent-fs/DESIGN.md \
+  specs/coven-agent-fs/RESEARCH.md
+```
+
+Expected: `git diff --check` has no output. The search has no stale claim that
+the successful Terminal confirmation is outstanding; it may show historical
+context explaining the original agent-process denial.
+
+- [ ] **Step 4: Commit the source documentation**
+
+```sh
+git add specs/coven-agent-fs/MOUNT-SPIKE.md \
+  specs/coven-agent-fs/DESIGN.md \
+  specs/coven-agent-fs/RESEARCH.md
+git commit -m "docs: record AFS macOS consent validation" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 2: Reconcile the public AgentFS documentation
+
+**Files:**
+- Modify: `content/docs/guide/agent-filesystem.mdx` in `OpenCoven/coven-docs`
+- Modify: `content/docs/guide/architecture.mdx` in `OpenCoven/coven-docs`
+- Modify: `content/docs/daemon/security.mdx` in `OpenCoven/coven-docs`
+
+- [ ] **Step 1: Create a clean public-docs worktree from `origin/main`**
+
+```sh
+docs_repo="$(dirname "$(dirname "$(git rev-parse --git-common-dir)")")/coven-docs"
+git -C "$docs_repo" fetch origin main --quiet
+git -C "$docs_repo" worktree add -b docs/afs-macos-consent-confirmation \
+  /tmp/coven-docs-afs-macos-consent-confirmation origin/main
+cd /tmp/coven-docs-afs-macos-consent-confirmation
+```
+
+Expected: the worktree is clean and tracks the current `origin/main`. Do not
+reuse or change any pre-existing public-docs checkout.
+
+- [ ] **Step 2: Update the public capability and roadmap language**
+
+In `agent-filesystem.mdx`, replace the outstanding Full Disk Access
+confirmation with this bounded result:
+
+```markdown
+A human-operated macOS Terminal successfully mounted the loopback export and
+performed a mounted directory create, file write, and read-back. This validates
+the NFS path for a consent-enabled client; an automated agent or other client
+process may still need explicit macOS network-volume/privacy consent.
+```
+
+Change the roadmap so the macOS confirmation is delivered, while
+concurrent-client behavior, Linux/FUSE, loopback access control, recovery,
+sandboxing, and default-enable decisions remain planned. Retain all statements
+that there is no `coven afs` command, daemon-managed lifecycle, supported mount
+workflow, or sandboxed execution mode.
+
+- [ ] **Step 3: Update architecture and security summaries**
+
+In `architecture.mdx`, replace `the outstanding macOS privacy confirmation`
+with a concise reference to the passed consent-enabled Terminal validation and
+the continuing per-process consent requirement.
+
+In `security.mdx`, replace `the macOS agent-process read/write confirmation is
+still outstanding` with wording that says a human-operated Terminal passed
+mounted I/O, but that a particular automated client can still be blocked by
+macOS privacy policy. Preserve the adjacent warnings that loopback NFS lacks
+application-layer authentication and is not a sandbox or access-control
+boundary.
+
+- [ ] **Step 4: Run public documentation validation**
+
+Run the existing repository commands advertised by `package.json`:
+
+```sh
+pnpm run build
+pnpm run check:links
+git diff --check
+```
+
+Expected: each command exits successfully and `git diff --check` has no output.
+
+- [ ] **Step 5: Commit the public documentation**
+
+```sh
+git add content/docs/guide/agent-filesystem.mdx \
+  content/docs/guide/architecture.mdx \
+  content/docs/daemon/security.mdx
+git commit -m "docs: clarify AFS macOS consent result" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 3: Validate, integrate, and close the bead
+
+**Files:**
+- No additional repository files.
+
+- [ ] **Step 1: Run the source documentation guards**
+
+From the Coven source worktree, run:
+
+```sh
+git diff --check
+python scripts/check-secrets.py
+git add specs/coven-agent-fs/MOUNT-SPIKE.md \
+  specs/coven-agent-fs/DESIGN.md \
+  specs/coven-agent-fs/RESEARCH.md
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: no whitespace errors, no secret findings, and a passing staged
+privacy guard. Do not add unrelated source files.
+
+- [ ] **Step 2: Open source and public documentation pull requests**
+
+Push each scoped branch, open a PR against `main`, and describe the same
+bounded conclusion in both PR bodies: Terminal mounted I/O passed; per-process
+consent and all remaining mount-safety gates are unchanged.
+
+- [ ] **Step 3: Merge only after required checks pass**
+
+Merge both PRs only when their required checks are green. Do not bypass branch
+protection or weaken any documentation, security, or privacy gate to merge.
+
+- [ ] **Step 4: Close `coven-x77` with exact evidence**
+
+After both merges, add this evidence to the bead and close it:
+
+```text
+Verified on macOS 2026-08-09: afs_serve listened on 127.0.0.1:12049;
+mount_nfs mounted localhost:/ at /private/tmp/afsmnt; mounted mkdir, file write,
+and read-back returned "written". The earlier connection-refused attempt
+preceded server readiness and is not mount evidence. Documentation now records
+the per-process network-volume consent requirement and remaining safety gates.
+```
+
+- [ ] **Step 5: Clean the manual test resources if still present**
+
+Inspect the exact mount and server PID before cleanup. If still mounted, run
+`umount -f /tmp/afsmnt`; if PID `26067` is still the test server, run
+`kill 26067`. Do not use process-name-based termination.

--- a/docs/superpowers/specs/2026-08-09-afs-macos-consent-confirmation-design.md
+++ b/docs/superpowers/specs/2026-08-09-afs-macos-consent-confirmation-design.md
@@ -1,0 +1,46 @@
+# AgentFS macOS Consent Confirmation Documentation Design
+
+**Status:** Approved documentation update  
+**Bead:** `coven-x77`
+
+## Evidence
+
+On 2026-08-09, a human-operated Terminal successfully:
+
+1. observed `afs_serve` listening on `127.0.0.1:12049`;
+2. mounted the loopback NFSv3 export at `/tmp/afsmnt`;
+3. created a directory and file through the mounted path; and
+4. read the written content back through the mounted path.
+
+The initial connection-refused attempt occurred before the server finished
+compiling and listening, and its local write is not evidence. The later mounted
+write/read is the accepted confirmation.
+
+## Decision
+
+The macOS NFS path is viable for a client process granted the required
+network-volume access. This resolves the manual confirmation gate from
+`coven-x77`; it does not make the NFS export a supported CLI workflow,
+sandbox, access-control boundary, or default-on feature.
+
+The prior agent-process `EPERM` observation remains relevant: client-process
+privacy/consent is a deployment requirement. Loopback NFS authentication,
+concurrent-client behavior, Linux/FUSE validation, sandbox enforcement, and
+default-on safety remain unresolved.
+
+## Documentation changes
+
+- Update the source mount-spike result, research summary, and AgentFS design
+  sequencing to replace the outstanding confirmation with the verified
+  consent-enabled Terminal result.
+- Update the public AgentFS guide, architecture overview, and security posture
+  so they distinguish passed Terminal validation from the unresolved
+  process-consent and security boundaries.
+- Add the observed command outcome to `coven-x77`, then close it after both
+  source and public documentation PRs merge.
+
+## Validation
+
+Check documentation diffs for whitespace; run source privacy and secret guards;
+build and link-check the public docs site; and verify all changed text retains
+the experimental, feature-gated, non-sandboxed status.

--- a/docs/superpowers/specs/2026-08-09-afs-macos-consent-confirmation-design.md
+++ b/docs/superpowers/specs/2026-08-09-afs-macos-consent-confirmation-design.md
@@ -1,6 +1,6 @@
 # AgentFS macOS Consent Confirmation Documentation Design
 
-**Status:** Approved documentation update  
+**Status:** Approved documentation update
 **Bead:** `coven-x77`
 
 ## Evidence

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -431,7 +431,7 @@ mount is separate work and is not claimed by this design.
 | Step | Bead | State |
 |---|---|---|
 | Storage engine + overlay | `coven-d4p` | merged — PR #658, `e2da654` |
-| macOS mount + benchmark | `coven-110` | merged experimental spike — PR #680, conditional on the Full Disk Access confirmation |
+| macOS mount + benchmark | `coven-110` | merged experimental spike — PR #680, Terminal mounted-I/O confirmation passed; per-process network-volume consent required |
 | This design | `coven-vhw` | — |
 | Daemon API + extension tables | not yet filed | ready to file |
 | Cave surfaces | not yet filed | needs the daemon API |

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -431,7 +431,7 @@ mount is separate work and is not claimed by this design.
 | Step | Bead | State |
 |---|---|---|
 | Storage engine + overlay | `coven-d4p` | merged — PR #658, `e2da654` |
-| macOS mount + benchmark | `coven-110` | merged experimental spike — PR #680, Terminal mounted-I/O confirmation passed; per-process network-volume consent required |
+| macOS mount + benchmark | `coven-110` | merged experimental spike — PR #680, Terminal mounted-I/O confirmation passed; macOS network-volume/privacy access must be assessed per client/harness or deployment |
 | This design | `coven-vhw` | — |
 | Daemon API + extension tables | not yet filed | ready to file |
 | Cave surfaces | not yet filed | needs the daemon API |

--- a/specs/coven-agent-fs/MOUNT-SPIKE.md
+++ b/specs/coven-agent-fs/MOUNT-SPIKE.md
@@ -139,7 +139,7 @@ calling process, not an NFS or permission fault:
 - it is not the server — the same operations succeed for Spotlight, and
   ACCESS grants every right.
 
-The manual confirmation path passed from a consent-enabled, human-operated Terminal/client, with `afs_serve` listening on `127.0.0.1:12049`:
+On 2026-08-09, the manual confirmation path passed from a consent-enabled, human-operated Terminal/client, with `afs_serve` listening on `127.0.0.1:12049`:
 
 ```sh
 cargo run -p coven-afs --features mount --example afs_serve -- /tmp/afs.db 12049 &

--- a/specs/coven-agent-fs/MOUNT-SPIKE.md
+++ b/specs/coven-agent-fs/MOUNT-SPIKE.md
@@ -139,7 +139,7 @@ calling process, not an NFS or permission fault:
 - it is not the server — the same operations succeed for Spotlight, and
   ACCESS grants every right.
 
-The manual confirmation path passed from a human-operated Terminal/client:
+The manual confirmation path passed from a consent-enabled, human-operated Terminal/client, with `afs_serve` listening on `127.0.0.1:12049`:
 
 ```sh
 cargo run -p coven-afs --features mount --example afs_serve -- /tmp/afs.db 12049 &

--- a/specs/coven-agent-fs/MOUNT-SPIKE.md
+++ b/specs/coven-agent-fs/MOUNT-SPIKE.md
@@ -10,8 +10,8 @@ gates the architecture. This spike measures it, and exercises the kext-free
 macOS mount path end to end.
 
 **Verdict: GO on the storage engine, conditional on write-ahead logging.
-The macOS mount is protocol-correct but blocked from agent processes by a
-platform access control that needs one manual confirmation (§4).**
+The macOS loopback NFS path is validated for a consent-enabled,
+human-operated Terminal/client.**
 
 ---
 
@@ -109,7 +109,7 @@ rather than the single portable file that makes a delta copyable. They are
 checkpointed away on clean close. The daemon should call `enable_wal()` when
 it opens a session delta; a database being handed to someone else should not.
 
-## 4. The macOS mount: correct, and blocked by the platform
+## 4. The macOS mount: correct, and now manually confirmed
 
 What works, verified against a live server with RPC tracing:
 
@@ -122,7 +122,7 @@ What works, verified against a live server with RPC tracing:
 - Spotlight walks the mounted tree without trouble, which is the clearest
   proof the export is well-formed.
 
-What does not work: **`open()` from an agent's own shell returns `EPERM`** —
+What does not work for an automated agent shell: **`open()` returns `EPERM`** —
 for files (`cat`) and directories (`ls`) alike — while `stat` on the same path
 succeeds and the server logs no error. Metadata passes, `open` is refused, and
 the refusal happens client-side without an RPC.
@@ -139,8 +139,7 @@ calling process, not an NFS or permission fault:
 - it is not the server — the same operations succeed for Spotlight, and
   ACCESS grants every right.
 
-**One manual confirmation is needed**, from a Terminal that has Full Disk
-Access, because this session's process almost certainly does not:
+The manual confirmation path passed from a human-operated Terminal/client:
 
 ```sh
 cargo run -p coven-afs --features mount --example afs_serve -- /tmp/afs.db 12049 &
@@ -150,11 +149,17 @@ mkdir /tmp/afsmnt/hello && echo written > /tmp/afsmnt/hello/file.txt && cat /tmp
 umount -f /tmp/afsmnt
 ```
 
-If that writes and reads back, the mount path is fully working and the
-constraint is "the agent process needs Full Disk Access / Network Volumes
-consent" — a deployment requirement to document, not a design problem. If it
-still fails, the macOS mount needs a different backend (FSKit, or a
-privileged helper) and this becomes a blocking finding.
+The `mount_nfs` client mounted `localhost:/` at `/private/tmp/afsmnt` and
+`mount` reported NFS with `nodev` and `nosuid`. `mkdir /tmp/afsmnt/hello`, the
+write to `file.txt`, and the read-back of `written` all succeeded. The earlier
+`Connection refused` was just startup timing: Cargo/server startup had not
+completed yet. The later local write happened while unmounted and is not NFS
+evidence.
+
+This is consistent with a per-process macOS privacy/TCC requirement such as
+Network Volumes or Full Disk Access for the client or agent process. Do not
+read that as universal sufficiency in every deployment context; treat it as a
+process-consent requirement to document and re-check per harness.
 
 Linux/FUSE was **not** evaluated: this spike ran on macOS, and `fuser` needs a
 Linux host to mean anything. The inode API in §1 is the layer a `fuser`
@@ -168,17 +173,20 @@ architecture is answered: with WAL, an agent-shaped workload runs at
 dependency-tree shapes, at ~1.2–1.5x on-disk overhead. Copy-up is linear and
 capped by policy. Nothing here argues against the design in DESIGN.md.
 
-**Conditional on the mount.** The NFS export is protocol-correct and mounts
-without privileges, but no agent process has yet written a byte through it on
-this machine. Do not schedule mount-dependent work until §4's confirmation
-runs. The SDK-only path (`afsMount: false` in DESIGN.md §3.1) is unaffected
-and remains the safe default.
+**Consent-enabled mount validation may proceed.** The NFS export is
+protocol-correct and the human-operated Terminal/client path now has a manual
+write/read confirmation. Keep the SDK-only path (`afsMount: false` in
+DESIGN.md §3.1) as the safe default until the remaining gates below close.
 
 **Two limits to remember.** The export serializes all RPCs behind one mutex
 over a single SQLite connection, so nothing here measures parallel clients.
 And loopback NFS is still unauthenticated — DESIGN.md §7's access-control
 question is untouched by this spike and still gates enabling mounts by
 default.
+
+**Remaining gates.** Unauthenticated loopback access control, one SQLite
+connection/mutex and untested parallel clients, recovery/default-enable
+policy, sandboxing, and Linux/FUSE remain unresolved.
 
 ## 6. Reproducing
 

--- a/specs/coven-agent-fs/RESEARCH.md
+++ b/specs/coven-agent-fs/RESEARCH.md
@@ -63,8 +63,10 @@ From the surveyed products (high, per-source): (a) POSIX view so git/grep/existi
 - Turso cloud-sync semantics (conflict resolution, audit preservation) unfetched — irrelevant if we build native, relevant if we ever interop.
 - Windows mount story: nothing exists upstream; ProjFS is the plausible native route, unscoped.
 - Linux/FUSE performance remains unmeasured. The macOS NFS spike is
-  protocol-correct but needs an agent-process Full Disk Access confirmation
-  before mount-dependent work can proceed.
+  protocol-correct; the human-operated Terminal mounted-I/O confirmation
+  passed, and per-process network-volume / Full Disk Access consent remains a
+  deployment requirement to re-check for the client or agent process before
+  using it broadly.
 
 ## Recommended next steps
 
@@ -73,8 +75,9 @@ From the surveyed products (high, per-source): (a) POSIX view so git/grep/existi
    [PR #658](https://github.com/OpenCoven/coven/pull/658).
 2. **Delivered as an experimental spike:** a feature-gated `nfsserve` NFSv3
    export, inode-addressed operations, and the macOS benchmark. The storage
-   verdict is GO with WAL; the mount remains blocked on the Full Disk Access
-   confirmation, loopback access control, and a Linux/FUSE evaluation. See
+   verdict is GO with WAL; the mount has passed the human-operated Terminal
+   mounted-I/O confirmation, but loopback access control, per-process
+   network-volume consent, and a Linux/FUSE evaluation remain open. See
    [MOUNT-SPIKE.md](./MOUNT-SPIKE.md).
 3. Design doc in the coven repo: daemon API surface + provenance extension tables + Cave diff/timeline UI. **Delivered:** [DESIGN.md](./DESIGN.md).
 4. Decide interop stance: freeze on "SPEC-compatible, coven-extended" and document the extension tables. **Frozen:** [DESIGN.md §1](./DESIGN.md).


### PR DESCRIPTION
## Summary
- records the 2026-08-09 consent-enabled Terminal NFS mount/write/read confirmation
- replaces the stale outstanding confirmation gate with client-specific macOS privacy/network-volume assessment
- preserves the experimental/default-off, no-auth, no-sandbox, concurrency, recovery, and Linux/FUSE boundaries

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- `git diff --check origin/main...HEAD`