### PR TITLE
feat(afs): authenticate NFS file handles and gate the export behind a token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,11 +723,14 @@ name = "coven-afs"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "getrandom 0.2.17",
+ "hmac",
  "libc",
  "nfsserve",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/coven-afs/Cargo.toml
+++ b/crates/coven-afs/Cargo.toml
@@ -10,7 +10,15 @@ repository.workspace = true
 [features]
 # Mount backends pull in tokio and an RPC stack; the storage engine does not
 # need them, so exporting a filesystem is opt-in.
-mount = ["dep:nfsserve", "dep:async-trait", "dep:tokio", "dep:libc"]
+mount = [
+    "dep:nfsserve",
+    "dep:async-trait",
+    "dep:tokio",
+    "dep:libc",
+    "dep:hmac",
+    "dep:sha2",
+    "dep:getrandom",
+]
 
 [dependencies]
 rusqlite = { version = "0.40", features = ["bundled"] }
@@ -18,6 +26,12 @@ nfsserve = { version = "0.11", optional = true }
 async-trait = { version = "0.1", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"], optional = true }
 libc = { version = "0.2", optional = true }
+# File-handle authentication (see the Trust section in src/nfs.rs). All three
+# are already in the workspace lock, so the mount feature pulls in no new
+# transitive dependencies.
+hmac = { version = "0.12", optional = true }
+sha2 = { version = "0.10", optional = true }
+getrandom = { version = "0.2", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/crates/coven-afs/examples/afs_serve.rs
+++ b/crates/coven-afs/examples/afs_serve.rs
@@ -65,8 +65,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             started.elapsed().as_secs_f64() * 1000.0
         );
     }
-    let listener = NFSTcpListener::bind(&format!("127.0.0.1:{port}"), AfsNfs::new(fs)).await?;
+    let host = std::env::var("AFS_BIND").unwrap_or_else(|_| "127.0.0.1".into());
+    // Refused in library code rather than by convention: an export reachable
+    // off-box hands the session's files to the network.
+    coven_afs::ensure_loopback(&host)?;
+
+    let export = AfsNfs::new(fs);
+    // DESIGN.md §7 invariant: the export token is never logged, printed, or
+    // displayed — token secrecy is the whole access-control boundary. This
+    // example writes it to a file readable only by the current user rather
+    // than to stdout, so a terminal transcript or CI log never carries it.
+    let token_path = std::env::temp_dir().join(format!("afs-export-{}.token", std::process::id()));
+    write_token(&token_path, export.token())?;
+
+    let listener = NFSTcpListener::bind(&format!("{host}:{port}"), export).await?;
     println!("afs_serve: port={}", listener.get_listen_port());
+    println!(
+        "afs_serve: export token written to {}",
+        token_path.display()
+    );
+    println!(
+        "afs_serve: mount localhost:/$(cat {}) ",
+        token_path.display()
+    );
     listener.handle_forever().await?;
+    Ok(())
+}
+
+/// Write the token 0600, so it is not readable by the local accounts the gate
+/// exists to keep out.
+fn write_token(path: &std::path::Path, token: &str) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(token.as_bytes())?;
     Ok(())
 }

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -41,7 +41,7 @@ pub use diff::{Change, ChangeEntry, ChangeSet};
 pub use fs::{AgentFs, Metadata, ROOT_INO, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
 pub use ino::DirEntry;
 #[cfg(feature = "mount")]
-pub use nfs::AfsNfs;
+pub use nfs::{ensure_loopback, export_token, AfsNfs};
 pub use overlay::OverlayFs;
 pub use path::{basename, components, normalize, parent};
 pub use provenance::{

--- a/crates/coven-afs/src/nfs.rs
+++ b/crates/coven-afs/src/nfs.rs
@@ -36,20 +36,136 @@ use std::sync::Mutex;
 
 use async_trait::async_trait;
 use nfsserve::nfs::{
-    fattr3, fileid3, filename3, ftype3, nfspath3, nfsstat3, nfstime3, sattr3, set_atime, set_gid3,
-    set_mode3, set_mtime, set_size3, set_uid3, specdata3,
+    fattr3, fileid3, filename3, ftype3, nfs_fh3, nfspath3, nfsstat3, nfstime3, sattr3, set_atime,
+    set_gid3, set_mode3, set_mtime, set_size3, set_uid3, specdata3,
 };
 use nfsserve::vfs::{DirEntry as NfsDirEntry, NFSFileSystem, ReadDirResult, VFSCapabilities};
 
 use crate::fs::{Metadata, ROOT_INO};
 use crate::{AgentFs, Error};
 
+/// Refuse any bind address that is not loopback.
+///
+/// The export is unauthenticated at the RPC layer, so a non-loopback bind
+/// hands the session's files to the network. This is a hard refusal rather
+/// than a warning: there is no deployment in which it is correct.
+pub fn ensure_loopback(host: &str) -> Result<(), Error> {
+    let host = host.trim();
+    // Order matters: a bare IPv6 address is mostly colons, so trying to strip
+    // a ":port" first turns `::1` into `:`. Parse the whole string as an
+    // address before assuming any colon is a port separator.
+    let candidate = if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return loopback_or_refuse(ip.is_loopback(), host);
+    } else if let Some(rest) = host.strip_prefix('[') {
+        // `[::1]:2049` — the bracketed form exists precisely to disambiguate.
+        rest.split_once(']').map_or(rest, |(inside, _)| inside)
+    } else {
+        // Anything left has at most one colon before a port.
+        host.rsplit_once(':').map_or(host, |(head, _)| head)
+    };
+    let is_loopback = match candidate.parse::<std::net::IpAddr>() {
+        Ok(ip) => ip.is_loopback(),
+        // "localhost" resolves to loopback on every platform we serve, but an
+        // unresolvable name is not something to guess about.
+        Err(_) => candidate.eq_ignore_ascii_case("localhost"),
+    };
+    loopback_or_refuse(is_loopback, host)
+}
+
+fn loopback_or_refuse(is_loopback: bool, host: &str) -> Result<(), Error> {
+    if is_loopback {
+        Ok(())
+    } else {
+        Err(Error::InvalidArgument(format!(
+            "refusing to export on {host}: an AgentFS NFS export must bind loopback only"
+        )))
+    }
+}
+
+/// A random export-path component, 128 bits of OS entropy as hex.
+///
+/// Not derived from the session id: the id appears in logs, in the daemon API,
+/// and in Cave, so deriving from it would publish the token.
+pub fn export_token() -> String {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes).expect("OS entropy is required to export a filesystem");
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Per-export secret that authenticates NFS file handles.
+///
+/// Generated fresh for every export, so handles from a previous server are
+/// rejected automatically — the property nfsserve's startup-time generation
+/// number was reaching for, without the guessability.
+struct HandleKey([u8; 32]);
+
+impl HandleKey {
+    fn random() -> Self {
+        let mut key = [0u8; 32];
+        // A failure here means the OS entropy source is unavailable; there is
+        // no safe weaker fallback, so refuse to serve rather than issue
+        // forgeable handles.
+        getrandom::getrandom(&mut key).expect("OS entropy is required to export a filesystem");
+        Self(key)
+    }
+
+    /// Truncated HMAC-SHA256 over the file id. 128 bits is far beyond what a
+    /// local attacker can brute-force online, and keeps the handle at 24 of
+    /// the 64 bytes NFSv3 allows.
+    fn tag(&self, id: fileid3) -> [u8; 16] {
+        type Mac = hmac::Hmac<sha2::Sha256>;
+        use hmac::Mac as _;
+        let mut mac =
+            <Mac as hmac::Mac>::new_from_slice(&self.0).expect("HMAC accepts any key len");
+        mac.update(&id.to_le_bytes());
+        let full = mac.finalize().into_bytes();
+        let mut tag = [0u8; 16];
+        tag.copy_from_slice(&full[..16]);
+        tag
+    }
+}
+
+/// Compare without leaking where the mismatch was.
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |acc, (l, r)| acc | (l ^ r))
+        == 0
+}
+
+/// The synthetic directory an export is rooted at.
+///
+/// Not a real inode: `fs_inode.ino` is a positive `AUTOINCREMENT`, so the top
+/// of the range can never collide with one.
+const GATE_ROOT: fileid3 = u64::MAX;
+
 /// An [`AgentFs`] exported over NFSv3.
+///
+/// The export is rooted at a synthetic gate directory rather than the
+/// filesystem root. The gate has exactly one child — a directory named by the
+/// export token — and its `readdir` returns nothing, so reaching the real
+/// filesystem requires knowing the token rather than merely reaching the port.
+///
+/// The token deliberately lives here rather than in the NFS export path:
+/// `MOUNTPROC3_EXPORT` dumps the export path to any caller, unauthenticated,
+/// so a token carried there is readable by exactly the attacker it is meant to
+/// stop. Inside the VFS there is no procedure that lists it.
 pub struct AfsNfs {
     fs: Mutex<AgentFs>,
     read_only: bool,
     uid: u32,
     gid: u32,
+    handle_key: HandleKey,
+    /// The export token — the single name that opens the gate.
+    ///
+    /// Named `gate_name` rather than the obvious thing because the repository
+    /// secret scanner reads a struct field of that name being assigned as a
+    /// hardcoded credential, and `AGENTS.md` requires fixing the content
+    /// rather than allowlisting past it.
+    gate_name: String,
 }
 
 impl AfsNfs {
@@ -64,6 +180,34 @@ impl AfsNfs {
             fs: Mutex::new(fs),
             uid,
             gid,
+            handle_key: HandleKey::random(),
+            gate_name: export_token(),
+        }
+    }
+
+    /// The export token. A client mounts `localhost:/<token>`; anything else
+    /// reaches only the empty gate directory.
+    pub fn token(&self) -> &str {
+        &self.gate_name
+    }
+
+    /// Synthetic attributes for the gate directory.
+    fn gate_attributes(&self) -> fattr3 {
+        let now = nfstime3::default();
+        fattr3 {
+            ftype: ftype3::NF3DIR,
+            mode: 0o500,
+            nlink: 2,
+            uid: self.uid,
+            gid: self.gid,
+            size: 0,
+            used: 0,
+            rdev: specdata3::default(),
+            fsid: 0,
+            fileid: GATE_ROOT,
+            atime: now,
+            mtime: now,
+            ctime: now,
         }
     }
 
@@ -186,12 +330,55 @@ impl NFSFileSystem for AfsNfs {
         }
     }
 
+    /// The gate, not the filesystem root — see the type docs.
     fn root_dir(&self) -> fileid3 {
-        ROOT_INO as u64
+        GATE_ROOT
+    }
+
+    /// Authenticated file handle: `[fileid (8, LE) || HMAC tag (16)]`.
+    ///
+    /// nfsserve's default handle is `[startup time in ms || fileid]`, both of
+    /// which a local attacker can derive — the process start time is readable
+    /// from `ps`, and `fs_inode.ino` is a sequential `AUTOINCREMENT` starting
+    /// at [`ROOT_INO`]. A forged handle needs no MOUNT call, so it bypasses
+    /// export-path checks entirely and reads or writes the whole filesystem.
+    /// Keying the handle is what makes every other access control meaningful.
+    fn id_to_fh(&self, id: fileid3) -> nfs_fh3 {
+        let mut data = Vec::with_capacity(24);
+        data.extend_from_slice(&id.to_le_bytes());
+        data.extend_from_slice(&self.handle_key.tag(id));
+        nfs_fh3 { data }
+    }
+
+    fn fh_to_id(&self, fh: &nfs_fh3) -> Result<fileid3, nfsstat3> {
+        if fh.data.len() != 24 {
+            return Err(nfsstat3::NFS3ERR_BADHANDLE);
+        }
+        let id = fileid3::from_le_bytes(fh.data[0..8].try_into().unwrap());
+        // Handles from a previous export fail here too: the key is per-export,
+        // so a restart invalidates them. Forged and stale are deliberately
+        // indistinguishable — telling them apart would tell an attacker which
+        // file ids exist.
+        if constant_time_eq(&fh.data[8..24], &self.handle_key.tag(id)) {
+            Ok(id)
+        } else {
+            Err(nfsstat3::NFS3ERR_BADHANDLE)
+        }
     }
 
     async fn lookup(&self, dirid: fileid3, filename: &filename3) -> Result<fileid3, nfsstat3> {
         let name = name_of(filename)?;
+        if dirid == GATE_ROOT {
+            // The only way past the gate. A wrong name is NOENT, exactly as a
+            // missing file would be, so probing reveals nothing.
+            return if constant_time_eq(name.as_bytes(), self.gate_name.as_bytes()) {
+                Ok(ROOT_INO as u64)
+            } else if name == "." || name == ".." {
+                Ok(GATE_ROOT)
+            } else {
+                Err(nfsstat3::NFS3ERR_NOENT)
+            };
+        }
         let dir = dirid as i64;
         self.with(|fs| match name.as_str() {
             "." => Ok(dir),
@@ -204,6 +391,9 @@ impl NFSFileSystem for AfsNfs {
     }
 
     async fn getattr(&self, id: fileid3) -> Result<fattr3, nfsstat3> {
+        if id == GATE_ROOT {
+            return Ok(self.gate_attributes());
+        }
         self.with(|fs| fs.stat_ino(id as i64))
             .map(|m| self.attributes(&m))
     }
@@ -297,6 +487,15 @@ impl NFSFileSystem for AfsNfs {
         start_after: fileid3,
         max_entries: usize,
     ) -> Result<ReadDirResult, nfsstat3> {
+        if dirid == GATE_ROOT {
+            // The gate lists nothing. Enumerating it would hand over the token
+            // and defeat the whole arrangement, so an attacker who mounts the
+            // export sees an empty directory and has to guess 128 bits.
+            return Ok(ReadDirResult {
+                entries: Vec::new(),
+                end: true,
+            });
+        }
         let dir = dirid as i64;
         let (entries, exhausted) = self.with(|fs| {
             let page = fs.readdir_ino(dir, start_after as i64, max_entries)?;
@@ -358,6 +557,162 @@ mod tests {
 
     fn name(text: &str) -> filename3 {
         text.as_bytes().to_vec().into()
+    }
+
+    #[test]
+    fn a_file_handle_round_trips_but_a_forged_one_is_refused() {
+        let export = export();
+        let fh = export.id_to_fh(ROOT_INO as u64);
+        assert_eq!(export.fh_to_id(&fh).unwrap(), ROOT_INO as u64);
+
+        // The attack the default handle allows: build one from a guessed file
+        // id. Inodes are a sequential AUTOINCREMENT from ROOT_INO, so this is
+        // the whole search space without the key.
+        for id in 1u64..8 {
+            let mut forged = Vec::with_capacity(24);
+            forged.extend_from_slice(&id.to_le_bytes());
+            forged.extend_from_slice(&[0u8; 16]);
+            assert!(
+                export.fh_to_id(&nfs_fh3 { data: forged }).is_err(),
+                "a handle with a guessed id and no valid tag must be refused"
+            );
+        }
+
+        // Flipping any tag bit invalidates it.
+        let mut tampered = fh.data.clone();
+        tampered[23] ^= 0x01;
+        assert!(export.fh_to_id(&nfs_fh3 { data: tampered }).is_err());
+
+        // Re-pointing a valid tag at a different id fails: the tag covers it.
+        let mut moved = fh.data.clone();
+        moved[0] = 9;
+        assert!(export.fh_to_id(&nfs_fh3 { data: moved }).is_err());
+
+        // Wrong length is refused rather than panicking on the slice.
+        for len in [0usize, 16, 23, 25, 64] {
+            assert!(export
+                .fh_to_id(&nfs_fh3 {
+                    data: vec![0u8; len]
+                })
+                .is_err());
+        }
+    }
+
+    #[test]
+    fn handles_do_not_transfer_between_exports() {
+        // Each export keys independently, so a handle from another server —
+        // or from this one before a restart — is not accepted.
+        let first = export();
+        let second = export();
+        let fh = first.id_to_fh(ROOT_INO as u64);
+        assert!(first.fh_to_id(&fh).is_ok());
+        assert!(
+            second.fh_to_id(&fh).is_err(),
+            "a handle must not be honoured by a different export"
+        );
+    }
+
+    #[test]
+    fn the_handle_tag_covers_the_file_id() {
+        let export = export();
+        // Distinct ids must not share a tag, or one handle would address
+        // another file.
+        let tags: std::collections::HashSet<[u8; 16]> =
+            (1u64..64).map(|id| export.handle_key.tag(id)).collect();
+        assert_eq!(tags.len(), 63);
+    }
+
+    #[tokio::test]
+    async fn the_gate_hides_the_filesystem_behind_the_token() {
+        let export = export();
+        let gate = export.root_dir();
+        assert_ne!(gate, ROOT_INO as u64, "the export must not root at the fs");
+
+        // Put something identifiable in the real filesystem.
+        export
+            .mkdir(ROOT_INO as u64, &name("secret"))
+            .await
+            .unwrap();
+
+        // What an attacker sees after mounting the export: an empty directory.
+        let listed = export.readdir(gate, 0, 64).await.unwrap();
+        assert!(listed.entries.is_empty(), "the gate must list nothing");
+        assert!(listed.end);
+
+        // Guessing gets NOENT — the same answer a missing file gives, so
+        // probing does not distinguish "wrong token" from "no such entry".
+        for guess in ["secret", "a", export.token().trim_end_matches(|_| true)] {
+            assert!(export.lookup(gate, &name(guess)).await.is_err());
+        }
+        let almost = format!("{}0", &export.token()[..export.token().len() - 1]);
+        assert!(export.lookup(gate, &name(&almost)).await.is_err());
+
+        // The token opens it, and the real filesystem is behind it.
+        let root = export.lookup(gate, &name(export.token())).await.unwrap();
+        assert_eq!(root, ROOT_INO as u64);
+        let inside = export.readdir(root, 0, 64).await.unwrap();
+        assert!(
+            inside.entries.iter().any(|e| e.name.as_ref() == b"secret"),
+            "the real root is reachable through the token"
+        );
+
+        // The gate answers getattr as a directory so a client can traverse it.
+        let attr = export.getattr(gate).await.unwrap();
+        assert!(matches!(attr.ftype, ftype3::NF3DIR));
+    }
+
+    #[tokio::test]
+    async fn each_export_gets_its_own_token() {
+        let first = export();
+        let second = export();
+        assert_ne!(first.token(), second.token());
+        // A token from one export is meaningless at another's gate.
+        assert!(second
+            .lookup(second.root_dir(), &name(first.token()))
+            .await
+            .is_err());
+    }
+
+    #[test]
+    fn a_non_loopback_bind_is_refused() {
+        for host in [
+            "127.0.0.1",
+            "127.0.0.1:0",
+            "::1",
+            "[::1]:2049",
+            "localhost",
+            "LOCALHOST:0",
+        ] {
+            assert!(ensure_loopback(host).is_ok(), "{host} is loopback");
+        }
+        // The whole point: an export reachable off-box is never correct.
+        for host in [
+            "0.0.0.0",
+            "0.0.0.0:2049",
+            "192.168.1.10",
+            "[::]:2049",
+            "example.com",
+        ] {
+            assert!(ensure_loopback(host).is_err(), "{host} must be refused");
+        }
+    }
+
+    #[test]
+    fn export_tokens_are_random_and_not_derived() {
+        let tokens: std::collections::HashSet<String> = (0..32).map(|_| export_token()).collect();
+        assert_eq!(tokens.len(), 32, "tokens must not repeat");
+        for token in &tokens {
+            assert_eq!(token.len(), 32, "128 bits as hex");
+            assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+        }
+    }
+
+    #[test]
+    fn constant_time_eq_matches_ordinary_equality() {
+        assert!(constant_time_eq(b"", b""));
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
     }
 
     #[tokio::test]

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -396,15 +396,54 @@ pid, and leaves the delta intact — the same posture as
 [orphan recovery](../../docs/daemon/orphan-recovery.md) for sessions. Deltas are
 never auto-discarded; unreviewed work is not garbage.
 
-**Loopback NFS exposure (unresolved).** The macOS backend serves NFSv3 on
-loopback. Any local user can reach a loopback port, so a bare port grants a
-second account on the machine read/write access to a session's files. Mitigation
-before mounts are enabled by default: bind `127.0.0.1` on an ephemeral port per
-session, never a fixed one; refuse any non-loopback bind; and require an
-export-path token that is not derivable from the session id. Whether that is
-sufficient on a shared macOS host must be settled — with an explicit decision
-recorded here — before `afsMount` defaults to on. Until then it ships
-opt-in.
+**Loopback NFS exposure (decided 2026-08-09, `coven-75e`).** The macOS backend
+serves NFSv3 on loopback. Any local user can reach a loopback port, so a bare
+port grants a second account on the machine read/write access to a session's
+files.
+
+Two findings changed the mitigation set this section originally specified, and
+both are worth recording because each defeats the obvious design:
+
+1. **An export-path token cannot live in the MOUNT protocol.**
+   `MOUNTPROC3_EXPORT` returns the export path to any caller with no
+   authentication, so a token carried there is readable by exactly the
+   attacker it is meant to stop.
+2. **The token was not the weak link.** `nfsserve`'s default file handle is
+   `[server start time in ms ‖ file id]`. The start time is readable from
+   `ps` and `fs_inode.ino` is a sequential `AUTOINCREMENT` from `ROOT_INO`, so
+   handles are forgeable. A forged handle needs no MOUNT call at all, which
+   bypasses every path-based check.
+
+What ships instead:
+
+- **Authenticated file handles.** `[file id ‖ HMAC-SHA256(key, file id)]`
+  truncated to 128 bits, under a 256-bit per-export key from OS entropy. A
+  forged or stale handle is `NFS3ERR_BADHANDLE`; the two are deliberately
+  indistinguishable, because separating them would confirm which file ids
+  exist. The per-export key also gives restart invalidation without a
+  guessable generation number.
+- **A VFS token gate.** The export roots at a synthetic gate directory rather
+  than at the filesystem. Its `readdir` returns nothing and its `lookup`
+  succeeds only on a constant-time match against a 128-bit token, so the token
+  lives where no NFS procedure enumerates it. Clients mount
+  `localhost:/<token>`.
+- **Loopback-only bind**, refused in library code rather than by convention,
+  on an **ephemeral port** per session.
+
+**Decision.** This is sufficient to keep an unprivileged local account out by
+default, and it is *not* sufficient to survive disclosure of the token. An
+attacker can still find the port, learn the export path, and mount the gate —
+they arrive at an empty directory and must produce 128 bits to go further.
+There is no second factor behind the token: NFSv3 `AUTH_UNIX` authenticates
+nothing. Mount therefore remains **opt-in and off by default**; `afsMount`
+advertises a backend only where these mitigations are active.
+
+> **Invariant: the export token is never logged, printed, or displayed.**
+> Token secrecy is the entire access-control boundary, so anything that
+> records it — a log line, an error message, a `ps`-visible mount command, a
+> Cave surface, a bug report attachment — grants full read/write to the
+> session's files. Treat it like a credential, because it is one. Code that
+> needs to show a mount target shows the port and a redacted path.
 
 On 2026-08-09, a human-operated consent-enabled Terminal mounted the
 experimental loopback NFS export and completed mounted create/write/read-back.
@@ -431,7 +470,10 @@ mount is separate work and is not claimed by this design.
 - **Copy-up cap default**: the mount spike establishes a cap in the low tens
   of MiB as the policy target, but the configurable cap is not implemented
   yet.
-- **Loopback NFS access control**: see §7; blocks mount-on-by-default.
+- **Loopback NFS access control**: decided in §7 (`coven-75e`) — authenticated
+  file handles plus a VFS token gate on an ephemeral loopback port. Mount stays
+  opt-in because token secrecy is the whole boundary; enabling it by default
+  needs a second factor, not a stronger token.
 - **Base ingest filters**: the mount spike validates the workload shape, but
   the default exclude set still needs an implementation and broader validation.
 


### PR DESCRIPTION
## Context

- Summary: implements bead `coven-75e` — the `DESIGN.md` §7 access-control gate for loopback AFS mounts, and records the resulting sufficiency decision in §7.
- Files: `crates/coven-afs/src/nfs.rs`, `crates/coven-afs/src/lib.rs`, `crates/coven-afs/Cargo.toml`, `crates/coven-afs/examples/afs_serve.rs`, `specs/coven-agent-fs/DESIGN.md`
- Closes `coven-75e`. Unblocks `coven-dts` (the mount routes), which was split out of this bead so the security change could be reviewed on its own.

## Two findings that changed what §7 specified

§7 originally called for "an export-path token that is not derivable from the session id". Implementing it showed that set does not hold, and both findings are recorded in the spec because each defeats the obvious design independently.

**1. An export-path token cannot live in the MOUNT protocol.** `MOUNTPROC3_EXPORT` (procedure 5, the `showmount -e` equivalent) returns the export path to any caller with no authentication — `mount_handlers.rs:158`. A token carried there is readable by exactly the attacker it is meant to stop.

**2. The token was never the weak link.** `nfsserve` builds file handles as `[server start time in ms ‖ file id]` (`vfs.rs:222`). The start time is readable from `ps`; `fs_inode.ino` is a sequential `AUTOINCREMENT` from `ROOT_INO`. So handles are forgeable — and **a forged handle needs no MOUNT call**, which bypasses every path-based check. Patching out `MOUNTPROC3_EXPORT` would have closed a window nobody needs to use.

## What ships

- **Authenticated file handles** — `[file id ‖ HMAC-SHA256(key, file id)]` truncated to 128 bits, under a 256-bit per-export key from OS entropy. Forged and stale handles are deliberately indistinguishable: separating them would confirm which file ids exist. The per-export key also gives restart invalidation without a guessable generation number.
- **A VFS token gate** — the export roots at a synthetic gate directory instead of the filesystem. Its `readdir` returns nothing; its `lookup` succeeds only on a constant-time match. The token therefore lives where no NFS procedure enumerates it. Clients mount `localhost:/<token>`.
- **Loopback-only bind**, refused in library code rather than by convention, on an **ephemeral port**.

This was chosen over forking `nfsserve` to suppress `MOUNTPROC3_EXPORT`: it gives the same property with no dependency to own, and it does not depend on a future `nfsserve` keeping that procedure suppressed.

## The recorded decision (§7)

Sufficient to keep an unprivileged local account out by default; **not** sufficient to survive disclosure of the token. An attacker can still find the port, learn the export path, and mount the gate — they arrive at an empty directory and must produce 128 bits to go further. There is no second factor: NFSv3 `AUTH_UNIX` authenticates nothing.

Mount stays **opt-in and off by default**. §8's open question is updated to say the real remaining gap precisely: default-on needs *a second factor, not a stronger token*.

§7 now carries an invariant:

> **The export token is never logged, printed, or displayed.** Token secrecy is the entire access-control boundary, so anything that records it — a log line, an error message, a `ps`-visible mount command, a Cave surface, a bug report attachment — grants full read/write.

`afs_serve.rs` follows it: the token is written `0600` and only the port and the file path are printed. `coven-dts` carries a note about the four places these routes could leak it — notably that a token in `mount_nfs` argv is world-readable via `ps`.

## Testing

Five new security tests plus one that caught a real bug in my own code:

- forged handles across the actual sequential inode range, bit-flipped tags, tags re-pointed at another id, and wrong lengths — all `BADHANDLE`
- handles do not transfer between exports
- the gate lists nothing, answers a wrong token with `NOENT` (indistinguishable from a missing file), and opens only on the token
- each export gets its own token
- `ensure_loopback` accepts `127.0.0.1`, `::1`, `[::1]:2049`, `localhost`; refuses `0.0.0.0`, `[::]`, LAN addresses, hostnames

That last test **failed first**: I stripped a `:port` suffix with `rsplit_once(':')`, which mangles bare IPv6 — `::1` became `:` and a legitimate loopback bind was refused. Fail-closed rather than dangerous, but exactly the kind of thing later "fixed" by loosening the check.

## Verification

Every gate below was run with its real exit code captured, not inferred from a pipeline:

- [x] `cargo fmt --check` → 0
- [x] `cargo clippy --workspace --all-targets --features coven-afs/mount -- -D warnings` → 0
- [x] `cargo test --workspace --locked` → 0, 20 suites
- [x] `cargo test -p coven-afs --features mount` → 0, **36 lib + 27 integration**
- [x] `python3 scripts/check-secrets.py` → 0
- [x] `python3 scripts/check-coven-privacy.py --staged` → 0
- [x] `git diff --cached --check`

Note the clippy invocation: the mount code is feature-gated, so a default run lints none of it. Worth checking whether CI's `Rust checks` job enables the feature — if not, this diff's most important code is unlinted in CI, which would be a gap worth fixing separately.

The secret scanner flagged twice, both self-inflicted and both fixed by changing content rather than allowlisting, per `AGENTS.md`: a struct field named `token` reads as a hardcoded credential, and then the doc comment *explaining* the rename contained the same literal pattern.

`hmac`, `sha2`, and `getrandom` were already in the workspace lock, so the `mount` feature gains no new transitive dependencies.

## Risk and Rollback

- Risk level: moderate. Changes how every file handle is minted and where the export roots, so a client-visible protocol change — but mount is off by default and no daemon route exposes it yet (`coven-dts`).
- Rollback plan: revert the commit; handles return to nfsserve's default and the export roots at the filesystem again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)