### PR TITLE
ci: build, lint, and test the coven-afs mount feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace --locked
+      # `coven-afs`'s `mount` feature is opt-in, so every step above compiles
+      # the workspace *without* `crates/coven-afs/src/nfs.rs` — the NFSv3
+      # export, its ownership mapping, and the file-handle authentication that
+      # is the access-control boundary for a mounted session (DESIGN.md §7).
+      # That module went unbuilt by CI from #680 until `coven-aof`, so PRs
+      # changing it received green checks computed without it.
+      #
+      # Linux only: the export calls `libc::getuid`/`getgid`, which do not
+      # exist on Windows — `nfsserve` gates its own `fs_util` the same way.
+      # Excluding Windows is the honest fix; weakening the module to compile
+      # there would trade real coverage for a green badge.
+      - name: Clippy (coven-afs mount feature)
+        if: runner.os == 'Linux'
+        run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
+      - name: Test (coven-afs mount feature)
+        if: runner.os == 'Linux'
+        run: cargo test -p coven-afs --features mount --locked
 
   performance-baseline:
     name: CLI performance baseline


### PR DESCRIPTION
## Context

- Summary: CI has never compiled `crates/coven-afs/src/nfs.rs`. Adds a Linux leg that clippy-checks and tests `coven-afs` with the `mount` feature enabled.
- Files: `.github/workflows/ci.yml` (17 added lines, no code changes)
- Closes bead `coven-aof` (P1). Unblocks `coven-dts`.

## The gap

Three facts combine into it:

1. `crates/coven-afs/Cargo.toml` declares no `default = [...]`, so `mount` is opt-in only.
2. `src/lib.rs` gates the whole NFS module behind `#[cfg(feature = "mount")]`.
3. No workflow passes `--features` or `--all-features` anywhere.

So `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace --locked` both run default-features-only, and roughly 700 lines — the NFSv3 server, the ownership mapping, the keyed file handles, and the VFS token gate from #697 — were never built.

**#680 and #697 both received green checks computed without the code they changed.**

## Demonstrated, not asserted

Appending `fn coven_aof_coverage_probe() -> u32 { "not a u32" }` to `nfs.rs` and running both commands:

| Leg | Result |
|---|---|
| `cargo clippy --workspace --all-targets -- -D warnings` (today's gate) | **exit 0** — passed |
| `cargo clippy -p coven-afs --features mount --all-targets -- -D warnings` (new) | **exit 101** — 2 errors |

The existing gate reports success on a file that does not compile. The probe was removed afterwards and `nfs.rs` is byte-identical to `main` in this branch — the diff is workflow-only.

## Why Linux only

`nfs.rs:177` calls `libc::getuid()`/`getgid()`, which do not exist on Windows; `nfsserve` gates its own `fs_util` with `#[cfg(not(target_os = "windows"))]` for the same reason. The exclusion and its reason are recorded in the workflow comment.

Weakening the module to compile on Windows would trade real coverage for a green badge, so the honest fix is to scope the leg. Note the matrix has no macOS runner, so the platform the mount spike actually targeted still is not built here — worth a follow-up, but adding a macOS leg is a bigger cost decision than this bug.

## Expectations for this PR's own CI

This is the first time these commands run on Linux. If the module does not build there, **that is the bug this bead exists to surface** and the failure is the deliverable, not a regression to patch around. Locally on macOS both commands pass:

- `cargo clippy -p coven-afs --features mount --all-targets -- -D warnings` → 0
- `cargo test -p coven-afs --features mount --locked` → 0, 36 lib + 27 integration

## Verification

- [x] `cargo fmt --check` → 0
- [x] `cargo clippy -p coven-afs --features mount --all-targets -- -D warnings` → 0
- [x] `cargo test -p coven-afs --features mount --locked` → 0
- [x] `python3 scripts/check-secrets.py` → 0
- [x] `python3 scripts/check-coven-privacy.py --staged` → 0
- [x] `git diff --cached --check` → 0
- [x] workflow YAML parses

## Risk and Rollback

- Risk level: low for the repository, and deliberately non-zero for this branch — the leg exists to fail when the module is broken.
- Rollback plan: revert; CI returns to not covering the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)