### PR TITLE
test: deflake PTY SIGTERM cancellation

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4349,10 +4349,11 @@ while :; do sleep 1; done
 
     #[cfg(unix)]
     #[test]
-    fn native_stream_sigterm_returns_promptly_and_reaps_process_tree() -> Result<()> {
+    fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let temp_dir = tempfile::tempdir()?;
+        let watchdog = Duration::from_secs(30);
         let fake_harness = temp_dir.path().join("long-lived-stream");
         let harness_pid_file = temp_dir.path().join("harness.pid");
         let descendant_pid_file = temp_dir.path().join("descendant.pid");
@@ -4371,7 +4372,7 @@ while :; do sleep 1; done
 
         let signal_dir = temp_dir.path().to_path_buf();
         let signaler = thread::spawn(move || {
-            let deadline = Instant::now() + Duration::from_secs(3);
+            let deadline = Instant::now() + watchdog;
             while Instant::now() < deadline {
                 if signal_dir.join("harness.pid").exists()
                     && signal_dir.join("descendant.pid").exists()
@@ -4385,7 +4386,6 @@ while :; do sleep 1; done
             panic!("native stream fixture did not start before signal deadline");
         });
 
-        let started = Instant::now();
         let error = stream_harness_with_program(
             fake_harness.to_str().unwrap(),
             temp_dir.path(),
@@ -4397,10 +4397,6 @@ while :; do sleep 1; done
         )
         .expect_err("SIGTERM must cancel a native stream");
         signaler.join().expect("signal thread panicked");
-        assert!(
-            started.elapsed() < Duration::from_secs(2),
-            "native stream cancellation was not prompt"
-        );
         assert!(
             format!("{error:#}").contains("streamy native stream cancelled by SIGTERM"),
             "unexpected cancellation error: {error:#}"
@@ -4424,7 +4420,7 @@ while :; do sleep 1; done
             ("descendant", descendant_pid_file),
         ] {
             let pid: libc::pid_t = std::fs::read_to_string(path)?.trim().parse()?;
-            let deadline = Instant::now() + Duration::from_secs(1);
+            let deadline = Instant::now() + watchdog;
             while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
                 thread::sleep(Duration::from_millis(10));
             }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -462,15 +462,18 @@ fn arm_supervised_stream_cancellation_test_signal() {
 }
 
 #[cfg(all(test, unix))]
-fn disarm_supervised_stream_cancellation_test_signal() {
+fn disarm_supervised_stream_cancellation_test_signal() -> Result<()> {
     let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    assert!(
-        !state.handler_active,
-        "supervised-stream cancellation handler remained active after the runner returned"
-    );
+    let handler_active = state.handler_active;
     state.armed_thread = None;
+    if handler_active {
+        anyhow::bail!(
+            "supervised-stream cancellation handler remained active after the runner returned"
+        );
+    }
+    Ok(())
 }
 
 #[cfg(all(test, unix))]
@@ -4490,27 +4493,9 @@ while :; do sleep 1; done
             Ok(result) => result,
             Err(_) => Err(anyhow::anyhow!("native stream signal thread panicked")),
         };
-        disarm_supervised_stream_cancellation_test_signal();
-        signal_result?;
-        let error = stream_result.expect_err("SIGTERM must cancel a native stream");
-        assert!(
-            format!("{error:#}").contains("streamy native stream cancelled by SIGTERM"),
-            "unexpected cancellation error: {error:#}"
-        );
 
-        let _signal_lock = SUPERVISED_STREAM_CANCELLATION_LOCK
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let mut restored: libc::sigaction = unsafe { std::mem::zeroed() };
-        assert_eq!(
-            unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut restored) },
-            0
-        );
-        assert_ne!(
-            restored.sa_sigaction, cancel_supervised_stream as *const () as usize,
-            "native stream runner did not restore the previous SIGTERM handler"
-        );
-
+        // Cleanup must precede every test outcome check so a runner regression
+        // cannot leave either long-lived fixture process behind.
         let mut failures = Vec::new();
         let mut fixtures = Vec::new();
         for (label, path) in [
@@ -4560,6 +4545,19 @@ while :; do sleep 1; done
                         ));
                     }
                 }
+                let waited = unsafe { libc::waitpid(*pid, std::ptr::null_mut(), 0) };
+                if waited == -1 {
+                    let error = std::io::Error::last_os_error();
+                    if !matches!(error.raw_os_error(), Some(libc::ECHILD) | Some(libc::ESRCH)) {
+                        failures.push(format!(
+                            "failed to wait for unreaped {label} {pid} after SIGKILL: {error}"
+                        ));
+                    }
+                } else if waited != *pid {
+                    failures.push(format!(
+                        "waitpid returned unexpected PID {waited} while cleaning up {label} {pid}"
+                    ));
+                }
             }
         }
 
@@ -4578,6 +4576,43 @@ while :; do sleep 1; done
                     "cancelled native stream {label} {pid} survived cleanup"
                 ));
             }
+        }
+
+        if let Err(error) = disarm_supervised_stream_cancellation_test_signal() {
+            failures.push(format!("{error:#}"));
+        }
+        if let Err(error) = signal_result {
+            failures.push(format!("native stream signal thread failed: {error:#}"));
+        }
+        match stream_result {
+            Ok(code) => failures.push(format!(
+                "SIGTERM must cancel a native stream, but it exited successfully with code {code}"
+            )),
+            Err(error)
+                if !format!("{error:#}").contains("streamy native stream cancelled by SIGTERM") =>
+            {
+                failures.push(format!("unexpected cancellation error: {error:#}"));
+            }
+            Err(_) => {}
+        }
+        let handler_restoration = {
+            let _signal_lock = SUPERVISED_STREAM_CANCELLATION_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut restored: libc::sigaction = unsafe { std::mem::zeroed() };
+            if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut restored) } != 0 {
+                Err(std::io::Error::last_os_error())
+                    .context("failed to read restored SIGTERM handler")
+            } else if restored.sa_sigaction == cancel_supervised_stream as *const () as usize {
+                Err(anyhow::anyhow!(
+                    "native stream runner did not restore the previous SIGTERM handler"
+                ))
+            } else {
+                Ok(())
+            }
+        };
+        if let Err(error) = handler_restoration {
+            failures.push(format!("{error:#}"));
         }
         if !failures.is_empty() {
             anyhow::bail!("{}", failures.join("; "));

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -430,91 +430,9 @@ static SUPERVISED_STREAM_CANCELLATION_SIGNAL: AtomicI32 = AtomicI32::new(0);
 #[cfg(unix)]
 static SUPERVISED_STREAM_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
 
-#[cfg(all(test, unix))]
-#[derive(Default)]
-struct SupervisedStreamCancellationTestState {
-    armed_thread: Option<thread::ThreadId>,
-    handler_active: bool,
-}
-
-#[cfg(all(test, unix))]
-static SUPERVISED_STREAM_CANCELLATION_TEST_STATE: Mutex<SupervisedStreamCancellationTestState> =
-    Mutex::new(SupervisedStreamCancellationTestState {
-        armed_thread: None,
-        handler_active: false,
-    });
-
 #[cfg(unix)]
 extern "C" fn cancel_supervised_stream(signal: libc::c_int) {
     SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(signal, Ordering::Relaxed);
-}
-
-#[cfg(all(test, unix))]
-fn arm_supervised_stream_cancellation_test_signal() {
-    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    assert!(
-        state.armed_thread.is_none(),
-        "another supervised-stream cancellation test is already armed"
-    );
-    state.armed_thread = Some(thread::current().id());
-}
-
-#[cfg(all(test, unix))]
-fn disarm_supervised_stream_cancellation_test_signal() -> Result<()> {
-    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let handler_active = state.handler_active;
-    state.armed_thread = None;
-    if handler_active {
-        anyhow::bail!(
-            "supervised-stream cancellation handler remained active after the runner returned"
-        );
-    }
-    Ok(())
-}
-
-#[cfg(all(test, unix))]
-fn activate_supervised_stream_cancellation_test_signal() {
-    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if state.armed_thread == Some(thread::current().id()) {
-        state.handler_active = true;
-    }
-}
-
-#[cfg(all(test, unix))]
-fn deactivate_supervised_stream_cancellation_test_signal() {
-    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if state.armed_thread == Some(thread::current().id()) {
-        state.handler_active = false;
-    }
-}
-
-#[cfg(all(test, unix))]
-fn signal_active_supervised_stream_cancellation_test() -> Result<()> {
-    let state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    if !state.handler_active {
-        anyhow::bail!("native stream SIGTERM handler was not active");
-    }
-    let sent = unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
-    if sent != 0 {
-        return Err(std::io::Error::last_os_error()).context("failed to signal test process");
-    }
-    // Keep the handler installed until it records the signal; otherwise a
-    // pending process-wide SIGTERM could run after the prior handler returns.
-    while SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed) != libc::SIGTERM {
-        thread::yield_now();
-    }
-    drop(state);
-    Ok(())
 }
 
 /// Temporarily converts TERM/INT/HUP into a supervised bridge cancellation.
@@ -669,14 +587,10 @@ impl SupervisedStreamCancellationGuard {
         self.signal_mask
             .unblock_supervisor()
             .context("failed to unblock supervised stream cancellation signals")?;
-        #[cfg(test)]
-        activate_supervised_stream_cancellation_test_signal();
         Ok(self.cancelled_signal())
     }
 
     fn finish(mut self) -> Result<Option<libc::c_int>> {
-        #[cfg(test)]
-        deactivate_supervised_stream_cancellation_test_signal();
         self.signal_mask
             .reblock()
             .context("failed to re-block supervised stream cancellation signals")?;
@@ -710,8 +624,6 @@ impl Drop for SupervisedStreamCancellationGuard {
         if !self.active {
             return;
         }
-        #[cfg(test)]
-        deactivate_supervised_stream_cancellation_test_signal();
         let _ = self.signal_mask.reblock();
         // SAFETY: every entry was captured from a successful sigaction call
         // in install. Restoring it here makes the scope transparent once the
@@ -4436,15 +4348,163 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
-    #[test]
-    fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
+    const NATIVE_STREAM_SIGTERM_TEST_CHILD_DIR: &str = "COVEN_TEST_NATIVE_STREAM_SIGTERM_DIR";
+    #[cfg(unix)]
+    const NATIVE_STREAM_SIGTERM_TEST_WATCHDOG: Duration = Duration::from_secs(30);
+
+    #[cfg(unix)]
+    extern "C" fn retain_native_stream_sigterm_test_signal(_signal: libc::c_int) {}
+
+    #[cfg(unix)]
+    struct NativeStreamSigtermTestSignal {
+        previous: libc::sigaction,
+        active: bool,
+    }
+
+    #[cfg(unix)]
+    impl NativeStreamSigtermTestSignal {
+        fn install() -> Result<Self> {
+            let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+            action.sa_sigaction = retain_native_stream_sigterm_test_signal as *const () as usize;
+            unsafe {
+                libc::sigemptyset(&mut action.sa_mask);
+            }
+            action.sa_flags = 0;
+            let mut previous: libc::sigaction = unsafe { std::mem::zeroed() };
+            if unsafe { libc::sigaction(libc::SIGTERM, &action, &mut previous) } != 0 {
+                return Err(std::io::Error::last_os_error())
+                    .context("installing native stream SIGTERM test handler");
+            }
+            Ok(Self {
+                previous,
+                active: true,
+            })
+        }
+
+        fn is_restored(&self) -> Result<bool> {
+            let mut current: libc::sigaction = unsafe { std::mem::zeroed() };
+            if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut current) } != 0 {
+                return Err(std::io::Error::last_os_error())
+                    .context("reading restored native stream SIGTERM handler");
+            }
+            Ok(current.sa_sigaction
+                == retain_native_stream_sigterm_test_signal as *const () as usize)
+        }
+
+        fn cancellation_handler_is_active() -> Result<bool> {
+            let mut current: libc::sigaction = unsafe { std::mem::zeroed() };
+            if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut current) } != 0 {
+                return Err(std::io::Error::last_os_error())
+                    .context("reading native stream SIGTERM handler");
+            }
+            Ok(current.sa_sigaction == cancel_supervised_stream as *const () as usize)
+        }
+
+        fn restore(&mut self) -> Result<()> {
+            if !self.active {
+                return Ok(());
+            }
+            if unsafe { libc::sigaction(libc::SIGTERM, &self.previous, std::ptr::null_mut()) } != 0
+            {
+                return Err(std::io::Error::last_os_error())
+                    .context("restoring native stream SIGTERM test handler");
+            }
+            self.active = false;
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for NativeStreamSigtermTestSignal {
+        fn drop(&mut self) {
+            if self.active {
+                unsafe {
+                    libc::sigaction(libc::SIGTERM, &self.previous, std::ptr::null_mut());
+                }
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    fn native_stream_sigterm_fixture_pids(
+        fixture_dir: &Path,
+    ) -> (Vec<(&'static str, libc::pid_t)>, Vec<String>) {
+        let mut fixtures = Vec::new();
+        let mut failures = Vec::new();
+        for (label, file_name) in [("harness", "harness.pid"), ("descendant", "descendant.pid")] {
+            let path = fixture_dir.join(file_name);
+            match std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {label} PID file {}", path.display()))
+                .and_then(|contents| {
+                    contents
+                        .trim()
+                        .parse::<libc::pid_t>()
+                        .context("parsing fixture PID")
+                }) {
+                Ok(pid) if pid > 0 => fixtures.push((label, pid)),
+                Ok(pid) => failures.push(format!("{label} fixture recorded invalid PID {pid}")),
+                Err(error) => failures.push(format!("{label} fixture PID unavailable: {error:#}")),
+            }
+        }
+        (fixtures, failures)
+    }
+
+    #[cfg(unix)]
+    fn native_stream_sigterm_fixture_is_reaped(pid: libc::pid_t) -> bool {
+        (unsafe { libc::kill(pid, 0) }) == -1
+            && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    }
+
+    #[cfg(unix)]
+    fn cleanup_native_stream_sigterm_fixtures(fixture_dir: &Path) -> Vec<String> {
+        let (fixtures, mut failures) = native_stream_sigterm_fixture_pids(fixture_dir);
+        let mut reaped = fixtures
+            .iter()
+            .map(|(_, pid)| native_stream_sigterm_fixture_is_reaped(*pid))
+            .collect::<Vec<_>>();
+
+        for ((label, pid), reaped) in fixtures.iter().zip(&mut reaped) {
+            if !*reaped {
+                failures.push(format!(
+                    "cancelled native stream left {label} {pid} unreaped before cleanup"
+                ));
+                if unsafe { libc::kill(*pid, libc::SIGKILL) } == -1 {
+                    let error = std::io::Error::last_os_error();
+                    if error.raw_os_error() == Some(libc::ESRCH) {
+                        *reaped = true;
+                    } else {
+                        failures.push(format!(
+                            "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
+                        ));
+                    }
+                }
+            }
+        }
+
+        let cleanup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+        while reaped.iter().any(|reaped| !reaped) && Instant::now() < cleanup_deadline {
+            for ((_, pid), reaped) in fixtures.iter().zip(&mut reaped) {
+                *reaped = native_stream_sigterm_fixture_is_reaped(*pid);
+            }
+            if reaped.iter().any(|reaped| !reaped) {
+                thread::sleep(Duration::from_millis(10));
+            }
+        }
+        for ((label, pid), reaped) in fixtures.iter().zip(&reaped) {
+            if !reaped {
+                failures.push(format!(
+                    "cancelled native stream {label} {pid} survived cleanup"
+                ));
+            }
+        }
+        failures
+    }
+
+    #[cfg(unix)]
+    fn write_native_stream_sigterm_fixture(fixture_dir: &Path) -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let temp_dir = tempfile::tempdir()?;
-        let watchdog = Duration::from_secs(30);
-        let fake_harness = temp_dir.path().join("long-lived-stream");
-        let harness_pid_file = temp_dir.path().join("harness.pid");
-        let descendant_pid_file = temp_dir.path().join("descendant.pid");
+        let fake_harness = fixture_dir.join("long-lived-stream");
         std::fs::write(
             &fake_harness,
             r#"#!/bin/sh
@@ -4457,130 +4517,68 @@ while :; do sleep 1; done
         let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&fake_harness, permissions)?;
+        Ok(())
+    }
 
-        arm_supervised_stream_cancellation_test_signal();
-        let signal_dir = temp_dir.path().to_path_buf();
+    #[cfg(unix)]
+    fn native_stream_sigterm_child(fixture_dir: &Path) -> Result<()> {
+        let signal_guard = NativeStreamSigtermTestSignal::install()?;
+        let signal_dir = fixture_dir.to_path_buf();
+        let stream_finished = Arc::new(AtomicBool::new(false));
+        let signal_stream_finished = Arc::clone(&stream_finished);
         let signaler = thread::spawn(move || -> Result<()> {
-            let deadline = Instant::now() + watchdog;
-            let fixture_started = loop {
-                if signal_dir.join("harness.pid").exists()
-                    && signal_dir.join("descendant.pid").exists()
-                {
-                    break true;
+            let deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+            while !(signal_dir.join("harness.pid").exists()
+                && signal_dir.join("descendant.pid").exists())
+            {
+                if signal_stream_finished.load(Ordering::Relaxed) {
+                    anyhow::bail!("native stream returned before the fixture started");
                 }
                 if Instant::now() >= deadline {
-                    break false;
+                    anyhow::bail!(
+                        "native stream fixture did not start before the watchdog expired"
+                    );
                 }
                 thread::sleep(Duration::from_millis(10));
-            };
-            signal_active_supervised_stream_cancellation_test()?;
-            if !fixture_started {
-                anyhow::bail!("native stream fixture did not start before the 30-second watchdog");
+            }
+            if signal_stream_finished.load(Ordering::Relaxed) {
+                anyhow::bail!("native stream returned before the fixture could be signalled");
+            }
+            if !NativeStreamSigtermTestSignal::cancellation_handler_is_active()? {
+                anyhow::bail!("native stream SIGTERM handler was not active for the fixture");
+            }
+            let result = unsafe { libc::pthread_kill(libc::pthread_self(), libc::SIGTERM) };
+            if result != 0 {
+                return Err(std::io::Error::from_raw_os_error(result))
+                    .context("sending fixture SIGTERM to the signaler thread");
             }
             Ok(())
         });
 
+        let fake_harness = fixture_dir.join("long-lived-stream");
         let stream_result = stream_harness_with_program(
-            fake_harness.to_str().unwrap(),
-            temp_dir.path(),
+            fake_harness.to_str().expect("fixture path is UTF-8"),
+            fixture_dir,
             Vec::new(),
             false,
             "streamy",
             "ledger-current",
             &mut Vec::new(),
         );
+        stream_finished.store(true, Ordering::Relaxed);
         let signal_result = match signaler.join() {
             Ok(result) => result,
             Err(_) => Err(anyhow::anyhow!("native stream signal thread panicked")),
         };
+        let restoration_result = signal_guard.is_restored();
+        let mut signal_guard = signal_guard;
+        let guard_restore_result = signal_guard.restore();
 
-        // Cleanup must precede every test outcome check so a runner regression
-        // cannot leave either long-lived fixture process behind.
-        let mut failures = Vec::new();
-        let mut fixtures = Vec::new();
-        for (label, path) in [
-            ("harness", harness_pid_file),
-            ("descendant", descendant_pid_file),
-        ] {
-            match std::fs::read_to_string(&path)
-                .with_context(|| format!("reading {label} PID file {}", path.display()))
-                .and_then(|contents| {
-                    contents
-                        .trim()
-                        .parse::<libc::pid_t>()
-                        .context("parsing fixture PID")
-                }) {
-                Ok(pid) if pid > 0 => fixtures.push((label, pid, false)),
-                Ok(pid) => failures.push(format!("{label} fixture recorded invalid PID {pid}")),
-                Err(error) => failures.push(format!("{label} fixture PID unavailable: {error:#}")),
-            }
-        }
-        let is_reaped = |pid: libc::pid_t| {
-            (unsafe { libc::kill(pid, 0) }) == -1
-                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-        };
-        let reaping_deadline = Instant::now() + watchdog;
-        while fixtures.iter().any(|(_, _, reaped)| !reaped) && Instant::now() < reaping_deadline {
-            for (_, pid, reaped) in &mut fixtures {
-                *reaped = is_reaped(*pid);
-            }
-            if fixtures.iter().any(|(_, _, reaped)| !reaped) {
-                thread::sleep(Duration::from_millis(10));
-            }
-        }
-
-        for (label, pid, reaped) in &mut fixtures {
-            if !*reaped {
-                failures.push(format!(
-                    "cancelled native stream left {label} {pid} unreaped before cleanup"
-                ));
-                let killed = unsafe { libc::kill(*pid, libc::SIGKILL) };
-                if killed == -1 {
-                    let error = std::io::Error::last_os_error();
-                    if error.raw_os_error() == Some(libc::ESRCH) {
-                        *reaped = true;
-                    } else {
-                        failures.push(format!(
-                            "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
-                        ));
-                    }
-                }
-                let waited = unsafe { libc::waitpid(*pid, std::ptr::null_mut(), 0) };
-                if waited == -1 {
-                    let error = std::io::Error::last_os_error();
-                    if !matches!(error.raw_os_error(), Some(libc::ECHILD) | Some(libc::ESRCH)) {
-                        failures.push(format!(
-                            "failed to wait for unreaped {label} {pid} after SIGKILL: {error}"
-                        ));
-                    }
-                } else if waited != *pid {
-                    failures.push(format!(
-                        "waitpid returned unexpected PID {waited} while cleaning up {label} {pid}"
-                    ));
-                }
-            }
-        }
-
-        let cleanup_deadline = Instant::now() + watchdog;
-        while fixtures.iter().any(|(_, _, reaped)| !reaped) && Instant::now() < cleanup_deadline {
-            for (_, pid, reaped) in &mut fixtures {
-                *reaped = is_reaped(*pid);
-            }
-            if fixtures.iter().any(|(_, _, reaped)| !reaped) {
-                thread::sleep(Duration::from_millis(10));
-            }
-        }
-        for (label, pid, reaped) in fixtures {
-            if !reaped {
-                failures.push(format!(
-                    "cancelled native stream {label} {pid} survived cleanup"
-                ));
-            }
-        }
-
-        if let Err(error) = disarm_supervised_stream_cancellation_test_signal() {
-            failures.push(format!("{error:#}"));
-        }
+        // Complete fixture cleanup before reporting a runner, signal, or
+        // restoration failure. The parent test repeats this after a watchdog
+        // termination so a malformed child test process cannot strand either
+        // exact fixture PID.
+        let mut failures = cleanup_native_stream_sigterm_fixtures(fixture_dir);
         if let Err(error) = signal_result {
             failures.push(format!("native stream signal thread failed: {error:#}"));
         }
@@ -4595,24 +4593,87 @@ while :; do sleep 1; done
             }
             Err(_) => {}
         }
-        let handler_restoration = {
-            let _signal_lock = SUPERVISED_STREAM_CANCELLATION_LOCK
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
-            let mut restored: libc::sigaction = unsafe { std::mem::zeroed() };
-            if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut restored) } != 0 {
-                Err(std::io::Error::last_os_error())
-                    .context("failed to read restored SIGTERM handler")
-            } else if restored.sa_sigaction == cancel_supervised_stream as *const () as usize {
-                Err(anyhow::anyhow!(
-                    "native stream runner did not restore the previous SIGTERM handler"
-                ))
-            } else {
-                Ok(())
+        match restoration_result {
+            Ok(true) => {}
+            Ok(false) => failures
+                .push("native stream runner did not restore the previous SIGTERM handler".into()),
+            Err(error) => failures.push(format!("{error:#}")),
+        }
+        if let Err(error) = guard_restore_result {
+            failures.push(format!("{error:#}"));
+        }
+        if !failures.is_empty() {
+            anyhow::bail!("{}", failures.join("; "));
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
+        if let Some(fixture_dir) = std::env::var_os(NATIVE_STREAM_SIGTERM_TEST_CHILD_DIR) {
+            return native_stream_sigterm_child(Path::new(&fixture_dir));
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        write_native_stream_sigterm_fixture(temp_dir.path())?;
+        let current_exe =
+            std::env::current_exe().context("resolving native stream SIGTERM test executable")?;
+        let mut child = std::process::Command::new(current_exe)
+            .arg("--exact")
+            .arg("pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree")
+            .arg("--nocapture")
+            .env(NATIVE_STREAM_SIGTERM_TEST_CHILD_DIR, temp_dir.path())
+            .spawn()
+            .context("spawning isolated native stream SIGTERM test")?;
+
+        let mut failures = Vec::new();
+        let deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+        let mut child_status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break Some(status),
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(None) => {
+                    failures.push(
+                        "isolated native stream SIGTERM test exceeded the watchdog; terminating it"
+                            .into(),
+                    );
+                    break None;
+                }
+                Err(error) => {
+                    failures.push(format!(
+                        "polling isolated native stream SIGTERM test: {error}"
+                    ));
+                    break None;
+                }
             }
         };
-        if let Err(error) = handler_restoration {
-            failures.push(format!("{error:#}"));
+        if child_status.is_none() {
+            if let Err(error) = child.kill() {
+                failures.push(format!(
+                    "terminating isolated native stream SIGTERM test: {error}"
+                ));
+            }
+            match child.wait() {
+                Ok(status) => child_status = Some(status),
+                Err(error) => failures.push(format!(
+                    "waiting for terminated native stream SIGTERM test: {error}"
+                )),
+            }
+        }
+
+        // The isolated child may be killed by the watchdog before it can
+        // clean up, so verify and clean both exact fixture PIDs here before
+        // reporting its outcome.
+        failures.extend(cleanup_native_stream_sigterm_fixtures(temp_dir.path()));
+        match child_status {
+            Some(status) if status.success() => {}
+            Some(status) => failures.push(format!(
+                "isolated native stream SIGTERM test exited unsuccessfully: {status}"
+            )),
+            None => failures.push("isolated native stream SIGTERM test had no exit status".into()),
         }
         if !failures.is_empty() {
             anyhow::bail!("{}", failures.join("; "));

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -481,13 +481,19 @@ impl SupervisedStreamCancellationTestObserver {
             return Err(std::io::Error::from_raw_os_error(result))
                 .context("sending fixture SIGTERM to the stream runner thread");
         }
-        // Keep restoration excluded until the target thread has run the
-        // atomic-only handler. Otherwise a queued thread signal could outlive
-        // the cancellation disposition and be delivered to a restored one.
-        while SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed) != libc::SIGTERM {
-            thread::yield_now();
-        }
         Ok(true)
+    }
+
+    fn wait_for_sigterm_delivery(deadline: Instant) -> Result<()> {
+        while SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed) != libc::SIGTERM {
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "fixture SIGTERM was not recorded by the stream cancellation handler before the watchdog expired"
+                );
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        Ok(())
     }
 }
 
@@ -522,7 +528,7 @@ struct SupervisedStreamCancellationGuard {
     signal_mask: SupervisedSignalMask,
     active: bool,
     #[cfg(test)]
-    test_lifecycle_active: bool,
+    test_lifecycle_registered: bool,
 }
 
 #[cfg(unix)]
@@ -647,16 +653,11 @@ impl SupervisedStreamCancellationGuard {
         }
 
         #[cfg(test)]
-        let test_lifecycle_active = {
-            let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+        let test_lifecycle_registered = {
+            let lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
-                lifecycle.active = true;
-                true
-            } else {
-                false
-            }
+            lifecycle.observer.as_ref() == Some(&thread::current().id())
         };
 
         Ok(Self {
@@ -665,7 +666,7 @@ impl SupervisedStreamCancellationGuard {
             signal_mask,
             active: true,
             #[cfg(test)]
-            test_lifecycle_active,
+            test_lifecycle_registered,
         })
     }
 
@@ -678,12 +679,21 @@ impl SupervisedStreamCancellationGuard {
         self.signal_mask
             .unblock_supervisor()
             .context("failed to unblock supervised stream cancellation signals")?;
+        #[cfg(test)]
+        if self.test_lifecycle_registered {
+            let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                lifecycle.active = true;
+            }
+        }
         Ok(self.cancelled_signal())
     }
 
     fn finish(mut self) -> Result<Option<libc::c_int>> {
         #[cfg(test)]
-        let mut test_lifecycle = self.test_lifecycle_active.then(|| {
+        let mut test_lifecycle = self.test_lifecycle_registered.then(|| {
             SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -728,7 +738,7 @@ impl Drop for SupervisedStreamCancellationGuard {
             return;
         }
         #[cfg(test)]
-        let mut test_lifecycle = self.test_lifecycle_active.then(|| {
+        let mut test_lifecycle = self.test_lifecycle_registered.then(|| {
             SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -4512,6 +4522,26 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
+    fn native_stream_sigterm_fixture_process_group(
+        pid: libc::pid_t,
+    ) -> io::Result<Option<libc::pid_t>> {
+        loop {
+            let process_group = unsafe { libc::getpgid(pid) };
+            if process_group >= 0 {
+                return Ok(Some(process_group));
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            if error.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(None);
+            }
+            return Err(error);
+        }
+    }
+
+    #[cfg(unix)]
     fn cleanup_native_stream_sigterm_fixtures(fixture_dir: &Path) -> Vec<String> {
         let mut pids: [Option<libc::pid_t>; 2] = [None; 2];
         let mut pid_errors: [Option<String>; 2] = std::array::from_fn(|_| None);
@@ -4548,7 +4578,7 @@ while :; do sleep 1; done
 
         let mut failures = Vec::new();
         for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
-            let Some(pid) = pids[index] else {
+            if pids[index].is_none() {
                 if let Some(error) = &pid_errors[index] {
                     failures.push(format!(
                         "cancelled native stream could not read {label} PID before the reaping watchdog expired: {error}"
@@ -4558,25 +4588,54 @@ while :; do sleep 1; done
                         "cancelled native stream did not record {label} PID before the reaping watchdog expired"
                     ));
                 }
-                continue;
-            };
-            if reaped[index] {
-                continue;
             }
+        }
 
-            failures.push(format!(
-                "cancelled native stream left {label} {pid} alive after the reaping watchdog; attempting exact-PID cleanup"
-            ));
-            if unsafe { libc::kill(pid, libc::SIGKILL) } == -1 {
-                let error = std::io::Error::last_os_error();
-                if error.raw_os_error() == Some(libc::ESRCH) {
-                    reaped[index] = true;
-                } else {
-                    failures.push(format!(
-                        "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
-                    ));
+        let harness_pid = pids[0];
+        if let Some(harness_pid) = harness_pid {
+            let mut verified_fixture_group = false;
+            for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
+                let Some(pid) = pids[index] else {
+                    continue;
+                };
+                if reaped[index] {
+                    continue;
+                }
+                match native_stream_sigterm_fixture_process_group(pid) {
+                    Ok(Some(process_group)) if process_group == harness_pid => {
+                        verified_fixture_group = true;
+                    }
+                    Ok(Some(process_group)) => failures.push(format!(
+                        "cancelled native stream {label} {pid} reported process group {process_group}, not recorded harness process group {harness_pid}; refusing fixture cleanup"
+                    )),
+                    Ok(None) => reaped[index] = true,
+                    Err(error) => failures.push(format!(
+                        "failed to read process group for still-observed {label} {pid}: {error}"
+                    )),
                 }
             }
+            if verified_fixture_group {
+                // The strict spawn makes the harness PID the leader of a new
+                // session. Killing only a group proven by one of the recorded
+                // fixture identities avoids sending SIGKILL to a recycled PID.
+                if unsafe { libc::killpg(harness_pid, libc::SIGKILL) } == -1 {
+                    let error = std::io::Error::last_os_error();
+                    if error.raw_os_error() != Some(libc::ESRCH) {
+                        failures.push(format!(
+                            "failed to terminate verified fixture process group led by {harness_pid}: {error}"
+                        ));
+                    }
+                }
+            } else {
+                failures.push(format!(
+                    "no still-observed fixture process verified recorded harness process group {harness_pid}; refusing fixture cleanup"
+                ));
+            }
+        } else {
+            failures.push(
+                "cancelled native stream did not record harness PID, so it had not safely advanced to descendant launch and no fixture group could be cleaned"
+                    .into(),
+            );
         }
 
         let cleanup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
@@ -4606,7 +4665,7 @@ while :; do sleep 1; done
             if let Some(pid) = pids[index] {
                 if !reaped[index] {
                     failures.push(format!(
-                        "cancelled native stream {label} {pid} survived exact-PID failure cleanup"
+                        "cancelled native stream {label} {pid} survived verified fixture process-group cleanup"
                     ));
                 }
             }
@@ -4664,6 +4723,9 @@ while :; do sleep 1; done
                 match native_stream_sigterm_fixture_is_ready(&signal_dir) {
                     Ok(true) => {
                         if signal_lifecycle.send_sigterm_if_active(runner_thread)? {
+                            SupervisedStreamCancellationTestObserver::wait_for_sigterm_delivery(
+                                startup_deadline,
+                            )?;
                             return Ok(());
                         }
                         anyhow::bail!(
@@ -4672,26 +4734,54 @@ while :; do sleep 1; done
                     }
                     Ok(false) if Instant::now() < startup_deadline => {}
                     Ok(false) => {
-                        let sent = signal_lifecycle.send_sigterm_if_active(runner_thread)?;
-                        if sent {
-                            anyhow::bail!(
-                                "native stream fixture did not become ready before the startup watchdog expired; sent SIGTERM while its handler was active"
-                            );
+                        match signal_lifecycle.send_sigterm_if_active(runner_thread) {
+                            Ok(true) => {
+                                let delivery =
+                                    SupervisedStreamCancellationTestObserver::wait_for_sigterm_delivery(
+                                        startup_deadline,
+                                    );
+                                anyhow::bail!(
+                                    "native stream fixture did not become ready before the startup watchdog expired; sent SIGTERM while its handler was active{}",
+                                    delivery
+                                        .err()
+                                        .map(|error| format!(
+                                            " but it was not recorded: {error:#}"
+                                        ))
+                                        .unwrap_or_default()
+                                );
+                            }
+                            Ok(false) => anyhow::bail!(
+                                "native stream fixture did not become ready before the startup watchdog expired; handler was inactive and no SIGTERM was sent"
+                            ),
+                            Err(error) => anyhow::bail!(
+                                "native stream fixture did not become ready before the startup watchdog expired; failed to send SIGTERM while its handler was active: {error:#}"
+                            ),
                         }
-                        anyhow::bail!(
-                            "native stream fixture did not become ready before the startup watchdog expired; handler was inactive and no SIGTERM was sent"
-                        );
                     }
                     Err(error) => {
-                        let sent = signal_lifecycle.send_sigterm_if_active(runner_thread)?;
-                        if sent {
-                            anyhow::bail!(
-                                "native stream fixture readiness failed: {error:#}; sent SIGTERM while its handler was active"
-                            );
+                        match signal_lifecycle.send_sigterm_if_active(runner_thread) {
+                            Ok(true) => {
+                                let delivery =
+                                    SupervisedStreamCancellationTestObserver::wait_for_sigterm_delivery(
+                                        startup_deadline,
+                                    );
+                                anyhow::bail!(
+                                    "native stream fixture readiness failed: {error:#}; sent SIGTERM while its handler was active{}",
+                                    delivery
+                                        .err()
+                                        .map(|delivery_error| format!(
+                                            " but it was not recorded: {delivery_error:#}"
+                                        ))
+                                        .unwrap_or_default()
+                                );
+                            }
+                            Ok(false) => anyhow::bail!(
+                                "native stream fixture readiness failed: {error:#}; handler was inactive and no SIGTERM was sent"
+                            ),
+                            Err(send_error) => anyhow::bail!(
+                                "native stream fixture readiness failed: {error:#}; failed to send SIGTERM while its handler was active: {send_error:#}"
+                            ),
                         }
-                        anyhow::bail!(
-                            "native stream fixture readiness failed: {error:#}; handler was inactive and no SIGTERM was sent"
-                        );
                     }
                 }
                 thread::sleep(Duration::from_millis(10));

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4700,6 +4700,7 @@ while :; do sleep 1; done
     struct NativeStreamSigtermCleanupHandle {
         command_path: PathBuf,
         acknowledgement_path: PathBuf,
+        sentinel_readiness_path: PathBuf,
         token: String,
     }
 
@@ -4722,8 +4723,29 @@ while :; do sleep 1; done
         Ok(NativeStreamSigtermCleanupHandle {
             command_path,
             acknowledgement_path: fixture_dir.join("cleanup.ack"),
+            sentinel_readiness_path: fixture_dir.join("cleanup.ready"),
             token: format!("coven-native-stream-sigterm-{}", uuid::Uuid::new_v4()),
         })
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn native_stream_sigterm_fixture_sentinel_is_ready(
+        cleanup: &NativeStreamSigtermCleanupHandle,
+    ) -> Result<bool> {
+        match std::fs::read_to_string(&cleanup.sentinel_readiness_path) {
+            Ok(readiness) if readiness.trim() == cleanup.token => Ok(true),
+            Ok(readiness) if readiness.trim().is_empty() => Ok(false),
+            Ok(_) => anyhow::bail!(
+                "native stream fixture cleanup sentinel readiness did not match its token"
+            ),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error).with_context(|| {
+                format!(
+                    "reading native stream fixture cleanup sentinel readiness {}",
+                    cleanup.sentinel_readiness_path.display()
+                )
+            }),
+        }
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
@@ -4889,6 +4911,7 @@ while :; do sleep 1; done
                 r#"#!/bin/sh
 (
   exec 3<> cleanup.fifo
+  printf '%s\n' "{cleanup_token}" > cleanup.ready
   while IFS= read -r cleanup_command <&3; do
     if [ "$cleanup_command" = "{cleanup_token}" ]; then
       printf '%s\n' "$cleanup_command" > cleanup.ack
@@ -4928,11 +4951,23 @@ while :; do sleep 1; done
                     );
                 }
 
-                match native_stream_sigterm_fixture_identities(&signal_dir) {
-                    Ok(Some(identities)) => {
-                        *signal_fixture_identities
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(identities);
+                let fixture_identities_ready =
+                    match native_stream_sigterm_fixture_identities(&signal_dir) {
+                        Ok(Some(identities)) => {
+                            *signal_fixture_identities
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner()) =
+                                Some(identities);
+                            true
+                        }
+                        Ok(None) => false,
+                        Err(error) => {
+                            last_readiness_error = Some(format!("{error:#}"));
+                            false
+                        }
+                    };
+                match native_stream_sigterm_fixture_sentinel_is_ready(&signal_cleanup) {
+                    Ok(true) if fixture_identities_ready => {
                         match signal_lifecycle.send_sigterm_if_active(runner_thread) {
                             // `send_sigterm_if_active` holds the lifecycle
                             // lock across pthread_kill, excluding restoration.
@@ -4942,7 +4977,7 @@ while :; do sleep 1; done
                             Err(error) => last_delivery_error = Some(format!("{error:#}")),
                         }
                     }
-                    Ok(None) => {}
+                    Ok(_) => {}
                     Err(error) => {
                         last_readiness_error = Some(format!("{error:#}"));
                     }
@@ -4953,15 +4988,27 @@ while :; do sleep 1; done
                     );
                 }
                 if Instant::now() >= startup_deadline {
-                    // This is a failure-only escape hatch. It intentionally
-                    // does not use pthread_kill without both prerequisites;
-                    // the fixture's own FIFO sentinel kills only its group.
-                    let cleanup_result = request_native_stream_sigterm_fixture_cleanup(
-                        &signal_cleanup,
-                        Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
-                    );
+                    // Reuse the owner-verified lifecycle path: its mutex keeps
+                    // handler restoration out of the thread-directed delivery.
+                    let fallback_delivery = match signal_lifecycle
+                        .send_sigterm_if_active(runner_thread)
+                    {
+                        Ok(true) => {
+                            "sent lifecycle-verified SIGTERM cancellation to the stream runner"
+                                .to_string()
+                        }
+                        Ok(false) => {
+                            "did not signal because the cancellation lifecycle was already inactive"
+                                .to_string()
+                        }
+                        Err(error) => {
+                            format!(
+                                "failed to send lifecycle-verified SIGTERM cancellation: {error:#}"
+                            )
+                        }
+                    };
                     anyhow::bail!(
-                        "native stream fixture and cancellation handler did not become ready together before the startup watchdog expired; no SIGTERM was sent{}{}; durable fixture cleanup {}",
+                        "native stream fixture-start failure: the fixture, cleanup sentinel, and cancellation handler did not become ready together before the startup watchdog expired{}{}; fallback {}",
                         last_readiness_error
                             .as_deref()
                             .map(|error| format!("; last readiness error: {error}"))
@@ -4970,10 +5017,7 @@ while :; do sleep 1; done
                             .as_deref()
                             .map(|error| format!("; last delivery error: {error}"))
                             .unwrap_or_default(),
-                        match cleanup_result {
-                            Ok(()) => "was acknowledged".to_string(),
-                            Err(error) => format!("failed: {error:#}"),
-                        }
+                        fallback_delivery,
                     );
                 }
                 thread::sleep(Duration::from_millis(10));

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4700,16 +4700,32 @@ while :; do sleep 1; done
     struct NativeStreamSigtermCleanupHandle {
         command_path: PathBuf,
         acknowledgement_path: PathBuf,
-        sentinel_readiness_path: PathBuf,
         token: String,
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    struct NativeStreamSigtermFixtureCleanup {
+        command: std::fs::File,
+        readiness_path: PathBuf,
+        token: String,
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    struct NativeStreamSigtermCleanupSentinel {
+        shutdown: Arc<AtomicBool>,
+        result: mpsc::Receiver<Result<()>>,
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn create_native_stream_sigterm_cleanup_handle(
         fixture_dir: &Path,
-    ) -> Result<NativeStreamSigtermCleanupHandle> {
+    ) -> Result<(
+        NativeStreamSigtermCleanupHandle,
+        NativeStreamSigtermFixtureCleanup,
+    )> {
         use std::ffi::CString;
         use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::OpenOptionsExt;
 
         let command_path = fixture_dir.join("cleanup.fifo");
         let command_path_c = CString::new(command_path.as_os_str().as_bytes())
@@ -4720,108 +4736,256 @@ while :; do sleep 1; done
             return Err(io::Error::last_os_error())
                 .context("creating native stream fixture cleanup FIFO");
         }
-        Ok(NativeStreamSigtermCleanupHandle {
-            command_path,
-            acknowledgement_path: fixture_dir.join("cleanup.ack"),
-            sentinel_readiness_path: fixture_dir.join("cleanup.ready"),
-            token: format!("coven-native-stream-sigterm-{}", uuid::Uuid::new_v4()),
-        })
+        let marker = format!("coven-native-stream-sigterm-{}", uuid::Uuid::new_v4());
+        let fixture_command_path = fixture_dir.join("fixture-cleanup.fifo");
+        let fixture_command_path_c = CString::new(fixture_command_path.as_os_str().as_bytes())
+            .context("encoding native stream fixture cleanup FIFO path")?;
+        // SAFETY: the temporary fixture directory is unique and the C string
+        // is NUL-terminated for mkfifo.
+        if unsafe { libc::mkfifo(fixture_command_path_c.as_ptr(), 0o600) } != 0 {
+            return Err(io::Error::last_os_error())
+                .context("creating native stream fixture-group cleanup FIFO");
+        }
+        // Retain both ends so the fixture's read-only open cannot deadlock
+        // before the signaler observes its readiness marker. This endpoint
+        // never reads, so only the in-fixture sentinel can consume a command.
+        let fixture_command = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&fixture_command_path)
+            .context("opening native stream fixture-group cleanup FIFO")?;
+        Ok((
+            NativeStreamSigtermCleanupHandle {
+                command_path,
+                acknowledgement_path: fixture_dir.join("cleanup.ack"),
+                token: format!("coven-native-stream-sigterm-{}", uuid::Uuid::new_v4()),
+            },
+            NativeStreamSigtermFixtureCleanup {
+                command: fixture_command,
+                readiness_path: fixture_dir.join("fixture-cleanup.ready"),
+                token: marker,
+            },
+        ))
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn native_stream_sigterm_fixture_sentinel_is_ready(
-        cleanup: &NativeStreamSigtermCleanupHandle,
+        readiness_path: &Path,
+        token: &str,
     ) -> Result<bool> {
-        match std::fs::read_to_string(&cleanup.sentinel_readiness_path) {
-            Ok(readiness) if readiness.trim() == cleanup.token => Ok(true),
+        match std::fs::read_to_string(readiness_path) {
+            Ok(readiness) if readiness.trim() == token => Ok(true),
             Ok(readiness) if readiness.trim().is_empty() => Ok(false),
             Ok(_) => anyhow::bail!(
-                "native stream fixture cleanup sentinel readiness did not match its token"
+                "native stream fixture-group cleanup sentinel readiness did not match its token"
             ),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
             Err(error) => Err(error).with_context(|| {
                 format!(
-                    "reading native stream fixture cleanup sentinel readiness {}",
-                    cleanup.sentinel_readiness_path.display()
+                    "reading native stream fixture-group cleanup sentinel readiness {}",
+                    readiness_path.display()
                 )
             }),
         }
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
-    fn request_native_stream_sigterm_fixture_cleanup(
-        cleanup: &NativeStreamSigtermCleanupHandle,
-        deadline: Instant,
+    fn request_native_stream_sigterm_fixture_group_cleanup(
+        fixture_cleanup: &mut NativeStreamSigtermFixtureCleanup,
     ) -> Result<()> {
+        // This command is consumed only by the fixture's own process-group
+        // member, which uses `kill -KILL 0`; no numeric PID is ever signalled.
+        writeln!(fixture_cleanup.command, "{}", fixture_cleanup.token)
+            .context("writing native stream fixture-group cleanup command")?;
+        fixture_cleanup
+            .command
+            .flush()
+            .context("flushing native stream fixture-group cleanup command")
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn start_native_stream_sigterm_cleanup_sentinel(
+        cleanup: &NativeStreamSigtermCleanupHandle,
+    ) -> Result<NativeStreamSigtermCleanupSentinel> {
         use std::os::unix::fs::OpenOptionsExt;
 
-        // Open both ends so writing before the fixture sentinel has opened
-        // its read end is safe; retain this descriptor until the sentinel
-        // acknowledges the exact, per-test token.
-        let mut command = std::fs::OpenOptions::new()
+        // Keep this reader in the test process, outside the harness session
+        // which `stream_harness_with_program` intentionally kills. Opening a
+        // read-only nonblocking endpoint here also guarantees the command
+        // writer below never relies on a FIFO self-reader.
+        let command = std::fs::OpenOptions::new()
             .read(true)
-            .write(true)
             .custom_flags(libc::O_NONBLOCK)
             .open(&cleanup.command_path)
             .with_context(|| {
                 format!(
-                    "opening native stream fixture cleanup FIFO {}",
+                    "opening native stream cleanup sentinel FIFO {}",
                     cleanup.command_path.display()
                 )
             })?;
-        writeln!(command, "{}", cleanup.token)
-            .context("writing native stream fixture cleanup command")?;
-        command
-            .flush()
-            .context("flushing native stream fixture cleanup command")?;
+        let acknowledgement_path = cleanup.acknowledgement_path.clone();
+        let expected_marker = cleanup.token.clone();
+        let (result_sender, result_receiver) = mpsc::sync_channel(1);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let sentinel_shutdown = Arc::clone(&shutdown);
+        thread::spawn(move || {
+            let result = (|| -> Result<()> {
+                let mut command = command;
+                let mut buffer = Vec::new();
+                let mut chunk = [0_u8; 256];
+                loop {
+                    if sentinel_shutdown.load(Ordering::Relaxed) {
+                        anyhow::bail!(
+                            "native stream cleanup sentinel was stopped before acknowledging its command"
+                        );
+                    }
+                    match command.read(&mut chunk) {
+                        Ok(0) => thread::sleep(Duration::from_millis(10)),
+                        Ok(read) => {
+                            buffer.extend_from_slice(&chunk[..read]);
+                            if let Some(line_end) = buffer.iter().position(|byte| *byte == b'\n') {
+                                let line: Vec<u8> = buffer.drain(..=line_end).collect();
+                                if line[..line.len() - 1] != *expected_marker.as_bytes() {
+                                    anyhow::bail!(
+                                        "native stream cleanup sentinel received an unexpected command"
+                                    );
+                                }
+                                std::fs::write(
+                                    &acknowledgement_path,
+                                    format!("{expected_marker}\n"),
+                                )
+                                .with_context(|| {
+                                    format!(
+                                        "writing native stream fixture cleanup acknowledgement {}",
+                                        acknowledgement_path.display()
+                                    )
+                                })?;
+                                return Ok(());
+                            }
+                            if buffer.len() > expected_marker.len() {
+                                anyhow::bail!(
+                                    "native stream cleanup sentinel received an unterminated command"
+                                );
+                            }
+                        }
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(error) => {
+                            return Err(error)
+                                .context("reading native stream cleanup sentinel FIFO");
+                        }
+                    }
+                }
+            })();
+            let _ = result_sender.send(result);
+        });
+        Ok(NativeStreamSigtermCleanupSentinel {
+            shutdown,
+            result: result_receiver,
+        })
+    }
 
-        loop {
-            match std::fs::read_to_string(&cleanup.acknowledgement_path) {
-                Ok(acknowledgement) if acknowledgement.trim() == cleanup.token => return Ok(()),
-                Ok(acknowledgement) if !acknowledgement.trim().is_empty() => anyhow::bail!(
-                    "native stream fixture cleanup acknowledgement did not match its token"
-                ),
-                Ok(_) => {}
-                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                Err(error) => {
-                    return Err(error).with_context(|| {
-                        format!(
-                            "reading native stream fixture cleanup acknowledgement {}",
-                            cleanup.acknowledgement_path.display()
-                        )
-                    });
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn request_native_stream_sigterm_fixture_cleanup(
+        cleanup: &NativeStreamSigtermCleanupHandle,
+        sentinel: &NativeStreamSigtermCleanupSentinel,
+        deadline: Instant,
+    ) -> Result<()> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // The test-owned sentinel opens its read endpoint before the fixture
+        // launches. A write-only descriptor therefore makes delivery
+        // unambiguous: this caller can never consume its own command.
+        let result = (|| -> Result<()> {
+            let mut command = std::fs::OpenOptions::new()
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(&cleanup.command_path)
+                .with_context(|| {
+                    format!(
+                        "opening native stream fixture cleanup FIFO {}",
+                        cleanup.command_path.display()
+                    )
+                })?;
+            writeln!(command, "{}", cleanup.token)
+                .context("writing native stream fixture cleanup command")?;
+            command
+                .flush()
+                .context("flushing native stream fixture cleanup command")?;
+
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or_default();
+            match sentinel.result.recv_timeout(remaining) {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    return Err(error).context("native stream cleanup sentinel failed");
+                }
+                Err(RecvTimeoutError::Timeout) => {
+                    anyhow::bail!(
+                        "native stream cleanup sentinel did not acknowledge its durable command before the watchdog expired"
+                    );
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    anyhow::bail!(
+                        "native stream cleanup sentinel stopped before acknowledging its command"
+                    );
                 }
             }
-            if Instant::now() >= deadline {
-                anyhow::bail!(
-                    "native stream fixture did not acknowledge its durable cleanup command before the watchdog expired"
-                );
+
+            match std::fs::read_to_string(&cleanup.acknowledgement_path) {
+                Ok(acknowledgement) if acknowledgement.trim() == cleanup.token => Ok(()),
+                Ok(_) => anyhow::bail!(
+                    "native stream fixture cleanup acknowledgement did not match its token"
+                ),
+                Err(error) => Err(error).with_context(|| {
+                    format!(
+                        "reading native stream fixture cleanup acknowledgement {}",
+                        cleanup.acknowledgement_path.display()
+                    )
+                }),
             }
-            thread::sleep(Duration::from_millis(10));
+        })();
+        if result.is_err() {
+            sentinel.shutdown.store(true, Ordering::Relaxed);
         }
+        result
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn cleanup_native_stream_sigterm_fixtures(
         cleanup: &NativeStreamSigtermCleanupHandle,
+        sentinel: &NativeStreamSigtermCleanupSentinel,
+        fixture_cleanup: &mut NativeStreamSigtermFixtureCleanup,
         identities: Option<&[NativeStreamSigtermFixtureIdentity; 2]>,
     ) -> Vec<String> {
+        let mut failures = Vec::new();
+        if let Err(error) = request_native_stream_sigterm_fixture_cleanup(
+            cleanup,
+            sentinel,
+            Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
+        ) {
+            failures.push(format!(
+                "failed to request durable native stream fixture cleanup: {error:#}"
+            ));
+        }
+
         let Some(identities) = identities else {
-            return match request_native_stream_sigterm_fixture_cleanup(
-                cleanup,
-                Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
-            ) {
-                Ok(()) => vec![
-                    "cancelled native stream cleanup was acknowledged, but fixture identities were never captured; refusing to report PID-file absence as reaping"
-                        .into(),
-                ],
-                Err(error) => vec![format!(
-                    "cancelled native stream did not capture durable fixture identities and its cleanup sentinel was unavailable: {error:#}"
-                )],
-            };
+            if let Err(error) = request_native_stream_sigterm_fixture_group_cleanup(fixture_cleanup)
+            {
+                failures.push(format!(
+                    "failed to request fixture-local native stream process-group cleanup: {error:#}"
+                ));
+            }
+            failures.push(
+                "cancelled native stream cleanup was acknowledged, but fixture identities were never captured; refusing to report PID-file absence as reaping"
+                    .into(),
+            );
+            return failures;
         };
 
-        let mut failures = Vec::new();
         match native_stream_sigterm_fixture_states(identities) {
             Ok(states)
                 if states
@@ -4838,12 +5002,9 @@ while :; do sleep 1; done
             }
         }
 
-        if let Err(error) = request_native_stream_sigterm_fixture_cleanup(
-            cleanup,
-            Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
-        ) {
+        if let Err(error) = request_native_stream_sigterm_fixture_group_cleanup(fixture_cleanup) {
             failures.push(format!(
-                "failed to request durable native stream fixture cleanup: {error:#}"
+                "failed to request fixture-local native stream process-group cleanup: {error:#}"
             ));
         }
 
@@ -4904,17 +5065,17 @@ while :; do sleep 1; done
 
         let temp_dir = tempfile::tempdir()?;
         let fake_harness = temp_dir.path().join("long-lived-stream");
-        let cleanup = create_native_stream_sigterm_cleanup_handle(temp_dir.path())?;
+        let (cleanup, mut fixture_cleanup) =
+            create_native_stream_sigterm_cleanup_handle(temp_dir.path())?;
         std::fs::write(
             &fake_harness,
             format!(
                 r#"#!/bin/sh
 (
-  exec 3<> cleanup.fifo
-  printf '%s\n' "{cleanup_token}" > cleanup.ready
+  exec 3< fixture-cleanup.fifo
+  printf '%s\n' "{cleanup_token}" > fixture-cleanup.ready
   while IFS= read -r cleanup_command <&3; do
     if [ "$cleanup_command" = "{cleanup_token}" ]; then
-      printf '%s\n' "$cleanup_command" > cleanup.ack
       kill -KILL 0
     fi
   done
@@ -4924,7 +5085,7 @@ sleep 120 </dev/null >/dev/null 2>&1 &
 printf '%s\n' "$!" > descendant.pid
 while :; do sleep 1; done
 "#,
-                cleanup_token = cleanup.token
+                cleanup_token = fixture_cleanup.token
             ),
         )?;
         let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
@@ -4932,6 +5093,7 @@ while :; do sleep 1; done
         std::fs::set_permissions(&fake_harness, permissions)?;
 
         let lifecycle = Arc::new(SupervisedStreamCancellationTestObserver::arm()?);
+        let cleanup_sentinel = start_native_stream_sigterm_cleanup_sentinel(&cleanup)?;
         let signal_lifecycle = Arc::clone(&lifecycle);
         let runner_thread = unsafe { libc::pthread_self() } as usize;
         let signal_dir = temp_dir.path().to_path_buf();
@@ -4939,7 +5101,8 @@ while :; do sleep 1; done
         let signal_stream_finished = Arc::clone(&stream_finished);
         let fixture_identities = Arc::new(Mutex::new(None));
         let signal_fixture_identities = Arc::clone(&fixture_identities);
-        let signal_cleanup = cleanup.clone();
+        let signal_fixture_cleanup = fixture_cleanup.readiness_path.clone();
+        let signal_cleanup_token = fixture_cleanup.token.clone();
         let signaler = thread::spawn(move || -> Result<()> {
             let startup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
             let mut last_readiness_error = None;
@@ -4966,20 +5129,26 @@ while :; do sleep 1; done
                             false
                         }
                     };
-                match native_stream_sigterm_fixture_sentinel_is_ready(&signal_cleanup) {
-                    Ok(true) if fixture_identities_ready => {
-                        match signal_lifecycle.send_sigterm_if_active(runner_thread) {
-                            // `send_sigterm_if_active` holds the lifecycle
-                            // lock across pthread_kill, excluding restoration.
-                            // The final runner error below proves consumption.
-                            Ok(true) => return Ok(()),
-                            Ok(false) => {}
-                            Err(error) => last_delivery_error = Some(format!("{error:#}")),
-                        }
-                    }
-                    Ok(_) => {}
+
+                let fixture_sentinel_ready = match native_stream_sigterm_fixture_sentinel_is_ready(
+                    &signal_fixture_cleanup,
+                    &signal_cleanup_token,
+                ) {
+                    Ok(ready) => ready,
                     Err(error) => {
                         last_readiness_error = Some(format!("{error:#}"));
+                        false
+                    }
+                };
+
+                if fixture_identities_ready && fixture_sentinel_ready {
+                    match signal_lifecycle.send_sigterm_if_active(runner_thread) {
+                        // `send_sigterm_if_active` holds the lifecycle lock
+                        // across pthread_kill, excluding restoration. The
+                        // final runner error below proves consumption.
+                        Ok(true) => return Ok(()),
+                        Ok(false) => {}
+                        Err(error) => last_delivery_error = Some(format!("{error:#}")),
                     }
                 }
                 if signal_stream_finished.load(Ordering::Relaxed) {
@@ -5044,8 +5213,12 @@ while :; do sleep 1; done
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();
-        let mut failures =
-            cleanup_native_stream_sigterm_fixtures(&cleanup, captured_fixture_identities.as_ref());
+        let mut failures = cleanup_native_stream_sigterm_fixtures(
+            &cleanup,
+            &cleanup_sentinel,
+            &mut fixture_cleanup,
+            captured_fixture_identities.as_ref(),
+        );
         if let Err(error) = signal_result {
             failures.push(format!("native stream signal thread failed: {error:#}"));
         }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -445,6 +445,7 @@ enum SupervisedStreamCancellationTestPhase {
     Registered,
     InstalledMasked,
     ActiveUnmasked,
+    Restoring,
     Finished,
 }
 
@@ -476,13 +477,11 @@ impl SupervisedStreamCancellationTestObserver {
         Ok(Self { owner })
     }
 
-    /// The returned installed/active phase means this call delivered SIGTERM.
+    /// Only an actually unmasked guard accepts a test SIGTERM.
     ///
-    /// The lifecycle mutex covers both this dispatch and the guard's transition
-    /// to `Finished`, which happens before handler restoration. Consequently,
-    /// this test-only helper can queue a signal while the guard is masked or
-    /// deliver one while it is unmasked, but can never signal a restored
-    /// default disposition.
+    /// The lifecycle mutex covers both this dispatch and the guard's physical
+    /// signal-mask and handler transitions. A test signal can therefore never
+    /// be queued for later delivery under a restored disposition.
     fn send_sigterm_if_guarded(
         &self,
         target: usize,
@@ -495,9 +494,10 @@ impl SupervisedStreamCancellationTestObserver {
         }
         match lifecycle.phase {
             SupervisedStreamCancellationTestPhase::Registered
+            | SupervisedStreamCancellationTestPhase::InstalledMasked
+            | SupervisedStreamCancellationTestPhase::Restoring
             | SupervisedStreamCancellationTestPhase::Finished => return Ok(lifecycle.phase),
-            SupervisedStreamCancellationTestPhase::InstalledMasked
-            | SupervisedStreamCancellationTestPhase::ActiveUnmasked => {}
+            SupervisedStreamCancellationTestPhase::ActiveUnmasked => {}
         }
 
         let result = unsafe { libc::pthread_kill(target as libc::pthread_t, libc::SIGTERM) };
@@ -697,20 +697,28 @@ impl SupervisedStreamCancellationGuard {
     }
 
     fn activate(&mut self) -> Result<Option<libc::c_int>> {
+        #[cfg(test)]
+        let mut test_lifecycle = self.test_lifecycle_registered.then(|| {
+            SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        });
+        #[cfg(test)]
+        if let Some(lifecycle) = &test_lifecycle {
+            if lifecycle.observer.as_ref() == Some(&thread::current().id())
+                && lifecycle.phase != SupervisedStreamCancellationTestPhase::InstalledMasked
+            {
+                anyhow::bail!(
+                    "supervised stream cancellation test lifecycle was not installed and masked before activation"
+                );
+            }
+        }
         self.signal_mask
             .unblock_supervisor()
             .context("failed to unblock supervised stream cancellation signals")?;
         #[cfg(test)]
-        if self.test_lifecycle_registered {
-            let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(lifecycle) = &mut test_lifecycle {
             if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
-                if lifecycle.phase != SupervisedStreamCancellationTestPhase::InstalledMasked {
-                    anyhow::bail!(
-                        "supervised stream cancellation test lifecycle was not installed and masked before activation"
-                    );
-                }
                 lifecycle.phase = SupervisedStreamCancellationTestPhase::ActiveUnmasked;
             }
         }
@@ -727,7 +735,7 @@ impl SupervisedStreamCancellationGuard {
         #[cfg(test)]
         if let Some(lifecycle) = &mut test_lifecycle {
             if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
-                lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::Restoring;
             }
         }
         self.signal_mask
@@ -744,14 +752,17 @@ impl SupervisedStreamCancellationGuard {
                 }
             }
         }
-        #[cfg(test)]
-        drop(test_lifecycle);
         SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
         self.active = false;
-
         self.signal_mask
             .restore()
             .context("failed to restore supervised stream signal mask")?;
+        #[cfg(test)]
+        if let Some(lifecycle) = &mut test_lifecycle {
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
+            }
+        }
         if let Some(error) = restore_error {
             return Err(error).context("failed to restore supervised stream cancellation handlers");
         }
@@ -774,7 +785,7 @@ impl Drop for SupervisedStreamCancellationGuard {
         #[cfg(test)]
         if let Some(lifecycle) = &mut test_lifecycle {
             if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
-                lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::Restoring;
             }
         }
         let _ = self.signal_mask.reblock();
@@ -786,10 +797,16 @@ impl Drop for SupervisedStreamCancellationGuard {
                 let _ = libc::sigaction(*signal, previous, std::ptr::null_mut());
             }
         }
-        #[cfg(test)]
-        drop(test_lifecycle);
         SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
         let _ = self.signal_mask.restore();
+        #[cfg(test)]
+        if let Some(lifecycle) = &mut test_lifecycle {
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
+            }
+        }
+        #[cfg(test)]
+        drop(test_lifecycle);
     }
 }
 
@@ -4504,6 +4521,8 @@ while :; do sleep 1; done
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     const NATIVE_STREAM_SIGTERM_TEST_WATCHDOG: Duration = Duration::from_secs(30);
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    const NATIVE_STREAM_SIGTERM_REAPING_GRACE: Duration = Duration::from_secs(1);
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     const NATIVE_STREAM_SIGTERM_FIXTURES: [(&str, &str); 2] =
@@ -4735,6 +4754,31 @@ while :; do sleep 1; done
             native_stream_sigterm_fixture_state(&identities[0])?,
             native_stream_sigterm_fixture_state(&identities[1])?,
         ])
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn await_native_stream_sigterm_fixture_reaping_grace(
+        identities: &[NativeStreamSigtermFixtureIdentity; 2],
+    ) -> io::Result<[NativeStreamSigtermFixtureState; 2]> {
+        let deadline = Instant::now() + NATIVE_STREAM_SIGTERM_REAPING_GRACE;
+        loop {
+            match native_stream_sigterm_fixture_states(identities) {
+                Ok(states) => {
+                    if states
+                        .iter()
+                        .all(|state| *state == NativeStreamSigtermFixtureState::Reaped)
+                        || Instant::now() >= deadline
+                    {
+                        return Ok(states);
+                    }
+                }
+                Err(error) if Instant::now() >= deadline => return Err(error),
+                Err(_) => {}
+            }
+            // This is containment observation after the direct child has been
+            // waited, not a normal-path timing assertion.
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
@@ -5101,13 +5145,15 @@ while :; do sleep 1; done
             return failures;
         };
 
-        let initial_states = match native_stream_sigterm_fixture_states(identities) {
+        let states_after_reaping_grace = match await_native_stream_sigterm_fixture_reaping_grace(
+            identities,
+        ) {
             Ok(states)
                 if states
                     .iter()
                     .all(|state| *state == NativeStreamSigtermFixtureState::Reaped) =>
             {
-                return Vec::new();
+                return failures;
             }
             Ok(states) => {
                 // This is the production assertion. The emergency FIFO can
@@ -5116,11 +5162,11 @@ while :; do sleep 1; done
                     match state {
                         NativeStreamSigtermFixtureState::Reaped => {}
                         NativeStreamSigtermFixtureState::Alive => failures.push(format!(
-                            "SIGTERM production reaping check failed before fixture-local emergency cleanup: {} {} was still alive",
+                            "SIGTERM production reaping check failed after the reaping grace: {} {} was still alive",
                             NATIVE_STREAM_SIGTERM_FIXTURES[index].0, identities[index].pid
                         )),
                         NativeStreamSigtermFixtureState::Reused => failures.push(format!(
-                            "SIGTERM production reaping check failed before fixture-local emergency cleanup: recorded {} PID {} was reused",
+                            "SIGTERM production reaping check failed after the reaping grace: recorded {} PID {} was reused",
                             NATIVE_STREAM_SIGTERM_FIXTURES[index].0, identities[index].pid
                         )),
                     }
@@ -5129,7 +5175,7 @@ while :; do sleep 1; done
             }
             Err(error) => {
                 failures.push(format!(
-                    "could not verify native stream fixture identities before fixture-local emergency cleanup: {error}"
+                    "could not verify native stream fixture identities through the reaping grace before fixture-local emergency cleanup: {error}"
                 ));
                 None
             }
@@ -5149,9 +5195,9 @@ while :; do sleep 1; done
                         .iter()
                         .all(|state| *state == NativeStreamSigtermFixtureState::Reaped) =>
                 {
-                    match initial_states {
-                        Some(initial_states) => {
-                            let initial_context = initial_states
+                    match states_after_reaping_grace {
+                        Some(states_after_reaping_grace) => {
+                            let initial_context = states_after_reaping_grace
                                 .iter()
                                 .enumerate()
                                 .map(|(index, state)| {
@@ -5304,14 +5350,10 @@ while :; do sleep 1; done
 
                 if fixture_identities_ready && fixture_sentinel_ready {
                     match signal_lifecycle.send_sigterm_if_guarded(runner_thread) {
-                        // `stream_harness_with_program` installs the guard
-                        // before spawning this fixture. A pending signal is
-                        // therefore safe in InstalledMasked and cancels as
-                        // soon as activate() unmasks the runner thread.
-                        Ok(
-                            SupervisedStreamCancellationTestPhase::InstalledMasked
-                            | SupervisedStreamCancellationTestPhase::ActiveUnmasked,
-                        ) => {
+                        // Dispatch begins only after
+                        // `stream_harness_with_program` has physically
+                        // unmasked its installed guard.
+                        Ok(SupervisedStreamCancellationTestPhase::ActiveUnmasked) => {
                             if let Some(failure) = startup_failure {
                                 anyhow::bail!(
                                     "{failure}; lifecycle-verified SIGTERM was delivered to contain the stalled fixture startup"
@@ -5319,9 +5361,13 @@ while :; do sleep 1; done
                             }
                             return Ok(());
                         }
-                        Ok(SupervisedStreamCancellationTestPhase::Registered) => {
+                        Ok(
+                            SupervisedStreamCancellationTestPhase::Registered
+                            | SupervisedStreamCancellationTestPhase::InstalledMasked
+                            | SupervisedStreamCancellationTestPhase::Restoring,
+                        ) => {
                             last_delivery_error = Some(
-                                "fixture was ready while the cancellation guard was still registered; waiting for guarded delivery"
+                                "fixture was ready before the cancellation guard was physically active; waiting for guarded delivery"
                                     .into(),
                             );
                         }
@@ -5354,23 +5400,27 @@ while :; do sleep 1; done
                             .map(|error| format!("; last delivery error: {error}"))
                             .unwrap_or_default(),
                     );
-                    // Hold the lifecycle mutex through pthread_kill. If the
-                    // guard remains only Registered, keep the signaler alive:
-                    // returning here would leave a fixture that becomes
-                    // signalable later with no cancellation request.
+                    // The lifecycle mutex stays held through pthread_kill.
+                    // Before actual unmasking, retain the signaler instead of
+                    // queueing a signal that could reach a restored handler.
                     match signal_lifecycle.send_sigterm_if_guarded(runner_thread) {
-                        Ok(
-                            SupervisedStreamCancellationTestPhase::InstalledMasked
-                            | SupervisedStreamCancellationTestPhase::ActiveUnmasked,
-                        ) => {
+                        Ok(SupervisedStreamCancellationTestPhase::ActiveUnmasked) => {
                             anyhow::bail!(
                                 "{failure}; lifecycle-verified SIGTERM was delivered to contain the stalled fixture startup"
                             );
                         }
-                        Ok(SupervisedStreamCancellationTestPhase::Registered) => {
+                        Ok(
+                            SupervisedStreamCancellationTestPhase::Registered
+                            | SupervisedStreamCancellationTestPhase::InstalledMasked,
+                        ) => {
                             startup_failure = Some(format!(
-                                "{failure}; guard remains registered, so SIGTERM is deferred until its disposition is safe"
+                                "{failure}; guard is not yet physically active, so SIGTERM is deferred until its disposition is safe"
                             ));
+                        }
+                        Ok(SupervisedStreamCancellationTestPhase::Restoring) => {
+                            anyhow::bail!(
+                                "{failure}; guard began restoration, so SIGTERM was not sent under a restored disposition"
+                            );
                         }
                         Ok(SupervisedStreamCancellationTestPhase::Finished) => {
                             anyhow::bail!(

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -430,6 +430,80 @@ static SUPERVISED_STREAM_CANCELLATION_SIGNAL: AtomicI32 = AtomicI32::new(0);
 #[cfg(unix)]
 static SUPERVISED_STREAM_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
 
+#[cfg(all(test, unix))]
+// The test signaler and guard restoration share this lock so a test TERM can
+// never race a restored disposition. This observer is not compiled into the
+// production signal path.
+#[derive(Default)]
+struct SupervisedStreamCancellationTestLifecycle {
+    observer: Option<thread::ThreadId>,
+    active: bool,
+}
+
+#[cfg(all(test, unix))]
+static SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE: Mutex<
+    SupervisedStreamCancellationTestLifecycle,
+> = Mutex::new(SupervisedStreamCancellationTestLifecycle {
+    observer: None,
+    active: false,
+});
+
+#[cfg(all(test, unix))]
+struct SupervisedStreamCancellationTestObserver {
+    owner: thread::ThreadId,
+}
+
+#[cfg(all(test, unix))]
+impl SupervisedStreamCancellationTestObserver {
+    fn arm() -> Result<Self> {
+        let owner = thread::current().id();
+        let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if lifecycle.observer.is_some() {
+            anyhow::bail!("a supervised stream cancellation test observer is already active");
+        }
+        lifecycle.observer = Some(owner);
+        lifecycle.active = false;
+        Ok(Self { owner })
+    }
+
+    fn send_sigterm_if_active(&self, target: usize) -> Result<bool> {
+        let lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if lifecycle.observer.as_ref() != Some(&self.owner) || !lifecycle.active {
+            return Ok(false);
+        }
+
+        let result = unsafe { libc::pthread_kill(target as libc::pthread_t, libc::SIGTERM) };
+        if result != 0 {
+            return Err(std::io::Error::from_raw_os_error(result))
+                .context("sending fixture SIGTERM to the stream runner thread");
+        }
+        // Keep restoration excluded until the target thread has run the
+        // atomic-only handler. Otherwise a queued thread signal could outlive
+        // the cancellation disposition and be delivered to a restored one.
+        while SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed) != libc::SIGTERM {
+            thread::yield_now();
+        }
+        Ok(true)
+    }
+}
+
+#[cfg(all(test, unix))]
+impl Drop for SupervisedStreamCancellationTestObserver {
+    fn drop(&mut self) {
+        let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if lifecycle.observer.as_ref() == Some(&self.owner) {
+            lifecycle.active = false;
+            lifecycle.observer = None;
+        }
+    }
+}
+
 #[cfg(unix)]
 extern "C" fn cancel_supervised_stream(signal: libc::c_int) {
     SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(signal, Ordering::Relaxed);
@@ -447,6 +521,8 @@ struct SupervisedStreamCancellationGuard {
     previous_handlers: Vec<(libc::c_int, libc::sigaction)>,
     signal_mask: SupervisedSignalMask,
     active: bool,
+    #[cfg(test)]
+    test_lifecycle_active: bool,
 }
 
 #[cfg(unix)]
@@ -570,11 +646,26 @@ impl SupervisedStreamCancellationGuard {
             }
         }
 
+        #[cfg(test)]
+        let test_lifecycle_active = {
+            let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                lifecycle.active = true;
+                true
+            } else {
+                false
+            }
+        };
+
         Ok(Self {
             _lock: lock,
             previous_handlers,
             signal_mask,
             active: true,
+            #[cfg(test)]
+            test_lifecycle_active,
         })
     }
 
@@ -591,6 +682,16 @@ impl SupervisedStreamCancellationGuard {
     }
 
     fn finish(mut self) -> Result<Option<libc::c_int>> {
+        #[cfg(test)]
+        let mut test_lifecycle = self.test_lifecycle_active.then(|| {
+            SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        });
+        #[cfg(test)]
+        if let Some(lifecycle) = &mut test_lifecycle {
+            lifecycle.active = false;
+        }
         self.signal_mask
             .reblock()
             .context("failed to re-block supervised stream cancellation signals")?;
@@ -605,6 +706,8 @@ impl SupervisedStreamCancellationGuard {
                 }
             }
         }
+        #[cfg(test)]
+        drop(test_lifecycle);
         SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
         self.active = false;
 
@@ -624,6 +727,16 @@ impl Drop for SupervisedStreamCancellationGuard {
         if !self.active {
             return;
         }
+        #[cfg(test)]
+        let mut test_lifecycle = self.test_lifecycle_active.then(|| {
+            SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+        });
+        #[cfg(test)]
+        if let Some(lifecycle) = &mut test_lifecycle {
+            lifecycle.active = false;
+        }
         let _ = self.signal_mask.reblock();
         // SAFETY: every entry was captured from a successful sigaction call
         // in install. Restoring it here makes the scope transparent once the
@@ -633,6 +746,8 @@ impl Drop for SupervisedStreamCancellationGuard {
                 let _ = libc::sigaction(*signal, previous, std::ptr::null_mut());
             }
         }
+        #[cfg(test)]
+        drop(test_lifecycle);
         SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(0, Ordering::Relaxed);
         let _ = self.signal_mask.restore();
     }
@@ -4348,82 +4463,11 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
-    const NATIVE_STREAM_SIGTERM_TEST_CHILD_DIR: &str = "COVEN_TEST_NATIVE_STREAM_SIGTERM_DIR";
-    #[cfg(unix)]
     const NATIVE_STREAM_SIGTERM_TEST_WATCHDOG: Duration = Duration::from_secs(30);
 
     #[cfg(unix)]
-    extern "C" fn retain_native_stream_sigterm_test_signal(_signal: libc::c_int) {}
-
-    #[cfg(unix)]
-    struct NativeStreamSigtermTestSignal {
-        previous: libc::sigaction,
-        active: bool,
-    }
-
-    #[cfg(unix)]
-    impl NativeStreamSigtermTestSignal {
-        fn install() -> Result<Self> {
-            let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
-            action.sa_sigaction = retain_native_stream_sigterm_test_signal as *const () as usize;
-            unsafe {
-                libc::sigemptyset(&mut action.sa_mask);
-            }
-            action.sa_flags = 0;
-            let mut previous: libc::sigaction = unsafe { std::mem::zeroed() };
-            if unsafe { libc::sigaction(libc::SIGTERM, &action, &mut previous) } != 0 {
-                return Err(std::io::Error::last_os_error())
-                    .context("installing native stream SIGTERM test handler");
-            }
-            Ok(Self {
-                previous,
-                active: true,
-            })
-        }
-
-        fn is_restored(&self) -> Result<bool> {
-            let mut current: libc::sigaction = unsafe { std::mem::zeroed() };
-            if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut current) } != 0 {
-                return Err(std::io::Error::last_os_error())
-                    .context("reading restored native stream SIGTERM handler");
-            }
-            Ok(current.sa_sigaction
-                == retain_native_stream_sigterm_test_signal as *const () as usize)
-        }
-
-        fn cancellation_handler_is_active() -> Result<bool> {
-            let mut current: libc::sigaction = unsafe { std::mem::zeroed() };
-            if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut current) } != 0 {
-                return Err(std::io::Error::last_os_error())
-                    .context("reading native stream SIGTERM handler");
-            }
-            Ok(current.sa_sigaction == cancel_supervised_stream as *const () as usize)
-        }
-
-        fn restore(&mut self) -> Result<()> {
-            if !self.active {
-                return Ok(());
-            }
-            if unsafe { libc::sigaction(libc::SIGTERM, &self.previous, std::ptr::null_mut()) } != 0
-            {
-                return Err(std::io::Error::last_os_error())
-                    .context("restoring native stream SIGTERM test handler");
-            }
-            self.active = false;
-            Ok(())
-        }
-    }
-
-    #[cfg(unix)]
-    impl Drop for NativeStreamSigtermTestSignal {
-        fn drop(&mut self) {
-            if self.active {
-                unsafe {
-                    libc::sigaction(libc::SIGTERM, &self.previous, std::ptr::null_mut());
-                }
-            }
-        }
-    }
+    const NATIVE_STREAM_SIGTERM_FIXTURES: [(&str, &str); 2] =
+        [("harness", "harness.pid"), ("descendant", "descendant.pid")];
 
     #[cfg(unix)]
     fn native_stream_sigterm_fixture_pid(
@@ -4433,11 +4477,12 @@ while :; do sleep 1; done
     ) -> Result<Option<libc::pid_t>> {
         let path = fixture_dir.join(file_name);
         match std::fs::read_to_string(&path) {
+            Ok(contents) if contents.trim().is_empty() => Ok(None),
             Ok(contents) => {
                 let pid = contents
                     .trim()
                     .parse::<libc::pid_t>()
-                    .context("parsing fixture PID")?;
+                    .with_context(|| format!("parsing {label} fixture PID"))?;
                 if pid <= 0 {
                     anyhow::bail!("{label} fixture recorded invalid PID {pid}");
                 }
@@ -4451,53 +4496,30 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
+    fn native_stream_sigterm_fixture_is_ready(fixture_dir: &Path) -> Result<bool> {
+        for (label, file_name) in NATIVE_STREAM_SIGTERM_FIXTURES {
+            if native_stream_sigterm_fixture_pid(fixture_dir, label, file_name)?.is_none() {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    #[cfg(unix)]
     fn native_stream_sigterm_fixture_is_reaped(pid: libc::pid_t) -> bool {
         (unsafe { libc::kill(pid, 0) }) == -1
             && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
     }
 
     #[cfg(unix)]
-    fn terminate_native_stream_sigterm_harness_group(fixture_dir: &Path) -> Vec<String> {
-        let pid = match native_stream_sigterm_fixture_pid(fixture_dir, "harness", "harness.pid") {
-            Ok(Some(pid)) => pid,
-            // The fixture writes its harness PID before starting a descendant.
-            // With no PID, there is no process group to target.
-            Ok(None) => return Vec::new(),
-            Err(error) => {
-                return vec![format!(
-                    "reading fixture harness PID for cleanup: {error:#}"
-                )]
-            }
-        };
-
-        // stream_harness_with_program reaches spawn_strict_child_process_tree,
-        // whose Unix setup calls setsid(). The harness PID is therefore the
-        // exact leader of the isolated harness process group.
-        if unsafe { libc::kill(-pid, libc::SIGKILL) } == -1 {
-            let error = std::io::Error::last_os_error();
-            if error.raw_os_error() != Some(libc::ESRCH) {
-                return vec![format!(
-                    "failed to terminate fixture harness process group led by {pid}: {error}"
-                )];
-            }
-        }
-        Vec::new()
-    }
-
-    #[cfg(unix)]
-    fn cleanup_native_stream_sigterm_fixtures(
-        fixture_dir: &Path,
-        require_recorded_pids: bool,
-    ) -> Vec<String> {
-        const FIXTURES: [(&str, &str); 2] =
-            [("harness", "harness.pid"), ("descendant", "descendant.pid")];
-        let mut pids = [None; FIXTURES.len()];
-        let mut pid_errors = [None, None];
-        let mut reaped = [false; FIXTURES.len()];
-        let grace_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+    fn cleanup_native_stream_sigterm_fixtures(fixture_dir: &Path) -> Vec<String> {
+        let mut pids: [Option<libc::pid_t>; 2] = [None; 2];
+        let mut pid_errors: [Option<String>; 2] = std::array::from_fn(|_| None);
+        let mut reaped = [false; 2];
+        let reaping_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
 
         loop {
-            for (index, (label, file_name)) in FIXTURES.iter().enumerate() {
+            for (index, (label, file_name)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
                 if pids[index].is_none() {
                     match native_stream_sigterm_fixture_pid(fixture_dir, label, file_name) {
                         Ok(Some(pid)) => {
@@ -4509,53 +4531,50 @@ while :; do sleep 1; done
                     }
                 }
                 if let Some(pid) = pids[index] {
-                    reaped[index] = native_stream_sigterm_fixture_is_reaped(pid);
+                    if !reaped[index] {
+                        reaped[index] = native_stream_sigterm_fixture_is_reaped(pid);
+                    }
                 }
             }
 
-            let all_recorded = pids.iter().all(Option::is_some);
-            let all_reaped = pids
-                .iter()
-                .enumerate()
-                .all(|(index, pid)| pid.is_none() || reaped[index]);
-            let no_pid_errors = pid_errors.iter().all(Option::is_none);
-            if all_reaped && no_pid_errors && (!require_recorded_pids || all_recorded) {
+            if pids.iter().all(Option::is_some) && reaped.iter().all(|reaped| *reaped) {
                 return Vec::new();
             }
-            if Instant::now() >= grace_deadline {
+            if Instant::now() >= reaping_deadline {
                 break;
             }
             thread::sleep(Duration::from_millis(10));
         }
 
         let mut failures = Vec::new();
-        for (index, (label, _)) in FIXTURES.iter().enumerate() {
+        for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
             let Some(pid) = pids[index] else {
                 if let Some(error) = &pid_errors[index] {
                     failures.push(format!(
-                        "cancelled native stream could not read {label} PID before reaping grace expired: {error}"
+                        "cancelled native stream could not read {label} PID before the reaping watchdog expired: {error}"
                     ));
-                } else if require_recorded_pids {
+                } else {
                     failures.push(format!(
-                        "cancelled native stream did not record {label} PID before reaping grace expired"
+                        "cancelled native stream did not record {label} PID before the reaping watchdog expired"
                     ));
                 }
                 continue;
             };
-            if !reaped[index] {
-                failures.push(format!(
-                    "cancelled native stream left {label} {pid} unreaped after reaping grace; \
-                     attempting exact-PID failure cleanup"
-                ));
-                if unsafe { libc::kill(pid, libc::SIGKILL) } == -1 {
-                    let error = std::io::Error::last_os_error();
-                    if error.raw_os_error() == Some(libc::ESRCH) {
-                        reaped[index] = true;
-                    } else {
-                        failures.push(format!(
-                            "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
-                        ));
-                    }
+            if reaped[index] {
+                continue;
+            }
+
+            failures.push(format!(
+                "cancelled native stream left {label} {pid} alive after the reaping watchdog; attempting exact-PID cleanup"
+            ));
+            if unsafe { libc::kill(pid, libc::SIGKILL) } == -1 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ESRCH) {
+                    reaped[index] = true;
+                } else {
+                    failures.push(format!(
+                        "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
+                    ));
                 }
             }
         }
@@ -4569,7 +4588,9 @@ while :; do sleep 1; done
         {
             for (index, pid) in pids.iter().enumerate() {
                 if let Some(pid) = pid {
-                    reaped[index] = native_stream_sigterm_fixture_is_reaped(*pid);
+                    if !reaped[index] {
+                        reaped[index] = native_stream_sigterm_fixture_is_reaped(*pid);
+                    }
                 }
             }
             if pids
@@ -4580,7 +4601,8 @@ while :; do sleep 1; done
                 thread::sleep(Duration::from_millis(10));
             }
         }
-        for (index, (label, _)) in FIXTURES.iter().enumerate() {
+
+        for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
             if let Some(pid) = pids[index] {
                 if !reaped[index] {
                     failures.push(format!(
@@ -4593,15 +4615,30 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
-    fn write_native_stream_sigterm_fixture(fixture_dir: &Path) -> Result<()> {
+    fn native_stream_sigterm_handler_is_restored() -> Result<bool> {
+        let _lock = SUPERVISED_STREAM_CANCELLATION_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut current: libc::sigaction = unsafe { std::mem::zeroed() };
+        if unsafe { libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut current) } != 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("reading restored native stream SIGTERM handler");
+        }
+        Ok(current.sa_sigaction != cancel_supervised_stream as *const () as usize)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
-        let fake_harness = fixture_dir.join("long-lived-stream");
+        let temp_dir = tempfile::tempdir()?;
+        let fake_harness = temp_dir.path().join("long-lived-stream");
         std::fs::write(
             &fake_harness,
             r#"#!/bin/sh
 printf '%s\n' "$$" > harness.pid
-sleep 120 &
+sleep 120 </dev/null >/dev/null 2>&1 &
 printf '%s\n' "$!" > descendant.pid
 while :; do sleep 1; done
 "#,
@@ -4609,50 +4646,61 @@ while :; do sleep 1; done
         let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
         permissions.set_mode(0o755);
         std::fs::set_permissions(&fake_harness, permissions)?;
-        Ok(())
-    }
 
-    #[cfg(unix)]
-    fn native_stream_sigterm_child(fixture_dir: &Path) -> Result<()> {
-        let signal_guard = NativeStreamSigtermTestSignal::install()?;
+        let lifecycle = Arc::new(SupervisedStreamCancellationTestObserver::arm()?);
+        let signal_lifecycle = Arc::clone(&lifecycle);
         let runner_thread = unsafe { libc::pthread_self() } as usize;
-        let signal_dir = fixture_dir.to_path_buf();
+        let signal_dir = temp_dir.path().to_path_buf();
         let stream_finished = Arc::new(AtomicBool::new(false));
         let signal_stream_finished = Arc::clone(&stream_finished);
         let signaler = thread::spawn(move || -> Result<()> {
-            let deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
-            while !(signal_dir.join("harness.pid").exists()
-                && signal_dir.join("descendant.pid").exists())
-            {
+            let startup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+            loop {
                 if signal_stream_finished.load(Ordering::Relaxed) {
-                    anyhow::bail!("native stream returned before the fixture started");
-                }
-                if Instant::now() >= deadline {
                     anyhow::bail!(
-                        "native stream fixture did not start before the watchdog expired"
+                        "native stream returned before the fixture became ready; no SIGTERM was sent"
                     );
+                }
+                match native_stream_sigterm_fixture_is_ready(&signal_dir) {
+                    Ok(true) => {
+                        if signal_lifecycle.send_sigterm_if_active(runner_thread)? {
+                            return Ok(());
+                        }
+                        anyhow::bail!(
+                            "native stream handler was inactive before the fixture could be signalled; no SIGTERM was sent"
+                        );
+                    }
+                    Ok(false) if Instant::now() < startup_deadline => {}
+                    Ok(false) => {
+                        let sent = signal_lifecycle.send_sigterm_if_active(runner_thread)?;
+                        if sent {
+                            anyhow::bail!(
+                                "native stream fixture did not become ready before the startup watchdog expired; sent SIGTERM while its handler was active"
+                            );
+                        }
+                        anyhow::bail!(
+                            "native stream fixture did not become ready before the startup watchdog expired; handler was inactive and no SIGTERM was sent"
+                        );
+                    }
+                    Err(error) => {
+                        let sent = signal_lifecycle.send_sigterm_if_active(runner_thread)?;
+                        if sent {
+                            anyhow::bail!(
+                                "native stream fixture readiness failed: {error:#}; sent SIGTERM while its handler was active"
+                            );
+                        }
+                        anyhow::bail!(
+                            "native stream fixture readiness failed: {error:#}; handler was inactive and no SIGTERM was sent"
+                        );
+                    }
                 }
                 thread::sleep(Duration::from_millis(10));
             }
-            if signal_stream_finished.load(Ordering::Relaxed) {
-                anyhow::bail!("native stream returned before the fixture could be signalled");
-            }
-            if !NativeStreamSigtermTestSignal::cancellation_handler_is_active()? {
-                anyhow::bail!("native stream SIGTERM handler was not active for the fixture");
-            }
-            let result =
-                unsafe { libc::pthread_kill(runner_thread as libc::pthread_t, libc::SIGTERM) };
-            if result != 0 {
-                return Err(std::io::Error::from_raw_os_error(result))
-                    .context("sending fixture SIGTERM to the stream runner thread");
-            }
-            Ok(())
         });
 
-        let fake_harness = fixture_dir.join("long-lived-stream");
         let stream_result = stream_harness_with_program(
             fake_harness.to_str().expect("fixture path is UTF-8"),
-            fixture_dir,
+            temp_dir.path(),
             Vec::new(),
             false,
             "streamy",
@@ -4664,15 +4712,9 @@ while :; do sleep 1; done
             Ok(result) => result,
             Err(_) => Err(anyhow::anyhow!("native stream signal thread panicked")),
         };
-        let restoration_result = signal_guard.is_restored();
-        let mut signal_guard = signal_guard;
-        let guard_restore_result = signal_guard.restore();
+        let restoration_result = native_stream_sigterm_handler_is_restored();
 
-        // Complete fixture cleanup before reporting a runner, signal, or
-        // restoration failure. The parent test repeats this after a watchdog
-        // termination so a malformed child test process cannot strand either
-        // exact fixture PID.
-        let mut failures = cleanup_native_stream_sigterm_fixtures(fixture_dir, true);
+        let mut failures = cleanup_native_stream_sigterm_fixtures(temp_dir.path());
         if let Err(error) = signal_result {
             failures.push(format!("native stream signal thread failed: {error:#}"));
         }
@@ -4693,100 +4735,7 @@ while :; do sleep 1; done
                 .push("native stream runner did not restore the previous SIGTERM handler".into()),
             Err(error) => failures.push(format!("{error:#}")),
         }
-        if let Err(error) = guard_restore_result {
-            failures.push(format!("{error:#}"));
-        }
-        if !failures.is_empty() {
-            anyhow::bail!("{}", failures.join("; "));
-        }
-        Ok(())
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
-        if let Some(fixture_dir) = std::env::var_os(NATIVE_STREAM_SIGTERM_TEST_CHILD_DIR) {
-            return native_stream_sigterm_child(Path::new(&fixture_dir));
-        }
-
-        let temp_dir = tempfile::tempdir()?;
-        write_native_stream_sigterm_fixture(temp_dir.path())?;
-        let current_exe =
-            std::env::current_exe().context("resolving native stream SIGTERM test executable")?;
-        let mut child = std::process::Command::new(current_exe)
-            .arg("--exact")
-            .arg("pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree")
-            .arg("--nocapture")
-            .env(NATIVE_STREAM_SIGTERM_TEST_CHILD_DIR, temp_dir.path())
-            .spawn()
-            .context("spawning isolated native stream SIGTERM test")?;
-
-        let mut failures = Vec::new();
-        let deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
-        let mut child_status = loop {
-            match child.try_wait() {
-                Ok(Some(status)) => break Some(status),
-                Ok(None) if Instant::now() < deadline => {
-                    thread::sleep(Duration::from_millis(10));
-                }
-                Ok(None) => {
-                    failures.push(
-                        "isolated native stream SIGTERM test exceeded the watchdog; terminating it"
-                            .into(),
-                    );
-                    break None;
-                }
-                Err(error) => {
-                    failures.push(format!(
-                        "polling isolated native stream SIGTERM test: {error}"
-                    ));
-                    break None;
-                }
-            }
-        };
-        if child_status.is_none() {
-            // The harness writes harness.pid before it starts the long-lived
-            // sleep(120) descendant. Kill its isolated process group first so
-            // a watchdog cannot strand a child between that sleep starting
-            // and descendant.pid being written.
-            failures.extend(terminate_native_stream_sigterm_harness_group(
-                temp_dir.path(),
-            ));
-            if let Err(error) = child.kill() {
-                failures.push(format!(
-                    "terminating isolated native stream SIGTERM test: {error}"
-                ));
-            }
-            match child.wait() {
-                Ok(status) => child_status = Some(status),
-                Err(error) => failures.push(format!(
-                    "waiting for terminated native stream SIGTERM test: {error}"
-                )),
-            }
-            // If the harness wrote its PID while the test child was being
-            // terminated, its group still contains every unrecorded
-            // descendant and can be targeted precisely.
-            failures.extend(terminate_native_stream_sigterm_harness_group(
-                temp_dir.path(),
-            ));
-        }
-
-        // The isolated child may be killed by the watchdog before it can
-        // clean up, so verify and clean both exact fixture PIDs here before
-        // reporting its outcome.
-        failures.extend(cleanup_native_stream_sigterm_fixtures(
-            temp_dir.path(),
-            child_status
-                .as_ref()
-                .is_some_and(std::process::ExitStatus::success),
-        ));
-        match child_status {
-            Some(status) if status.success() => {}
-            Some(status) => failures.push(format!(
-                "isolated native stream SIGTERM test exited unsuccessfully: {status}"
-            )),
-            None => failures.push("isolated native stream SIGTERM test had no exit status".into()),
-        }
+        drop(lifecycle);
         if !failures.is_empty() {
             anyhow::bail!("{}", failures.join("; "));
         }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4426,27 +4426,28 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
-    fn native_stream_sigterm_fixture_pids(
+    fn native_stream_sigterm_fixture_pid(
         fixture_dir: &Path,
-    ) -> (Vec<(&'static str, libc::pid_t)>, Vec<String>) {
-        let mut fixtures = Vec::new();
-        let mut failures = Vec::new();
-        for (label, file_name) in [("harness", "harness.pid"), ("descendant", "descendant.pid")] {
-            let path = fixture_dir.join(file_name);
-            match std::fs::read_to_string(&path)
-                .with_context(|| format!("reading {label} PID file {}", path.display()))
-                .and_then(|contents| {
-                    contents
-                        .trim()
-                        .parse::<libc::pid_t>()
-                        .context("parsing fixture PID")
-                }) {
-                Ok(pid) if pid > 0 => fixtures.push((label, pid)),
-                Ok(pid) => failures.push(format!("{label} fixture recorded invalid PID {pid}")),
-                Err(error) => failures.push(format!("{label} fixture PID unavailable: {error:#}")),
+        label: &str,
+        file_name: &str,
+    ) -> Result<Option<libc::pid_t>> {
+        let path = fixture_dir.join(file_name);
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                let pid = contents
+                    .trim()
+                    .parse::<libc::pid_t>()
+                    .context("parsing fixture PID")?;
+                if pid <= 0 {
+                    anyhow::bail!("{label} fixture recorded invalid PID {pid}");
+                }
+                Ok(Some(pid))
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => {
+                Err(error).with_context(|| format!("reading {label} PID file {}", path.display()))
             }
         }
-        (fixtures, failures)
     }
 
     #[cfg(unix)]
@@ -4456,22 +4457,100 @@ while :; do sleep 1; done
     }
 
     #[cfg(unix)]
-    fn cleanup_native_stream_sigterm_fixtures(fixture_dir: &Path) -> Vec<String> {
-        let (fixtures, mut failures) = native_stream_sigterm_fixture_pids(fixture_dir);
-        let mut reaped = fixtures
-            .iter()
-            .map(|(_, pid)| native_stream_sigterm_fixture_is_reaped(*pid))
-            .collect::<Vec<_>>();
+    fn terminate_native_stream_sigterm_harness_group(fixture_dir: &Path) -> Vec<String> {
+        let pid = match native_stream_sigterm_fixture_pid(fixture_dir, "harness", "harness.pid") {
+            Ok(Some(pid)) => pid,
+            // The fixture writes its harness PID before starting a descendant.
+            // With no PID, there is no process group to target.
+            Ok(None) => return Vec::new(),
+            Err(error) => {
+                return vec![format!(
+                    "reading fixture harness PID for cleanup: {error:#}"
+                )]
+            }
+        };
 
-        for ((label, pid), reaped) in fixtures.iter().zip(&mut reaped) {
-            if !*reaped {
+        // stream_harness_with_program reaches spawn_strict_child_process_tree,
+        // whose Unix setup calls setsid(). The harness PID is therefore the
+        // exact leader of the isolated harness process group.
+        if unsafe { libc::kill(-pid, libc::SIGKILL) } == -1 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return vec![format!(
+                    "failed to terminate fixture harness process group led by {pid}: {error}"
+                )];
+            }
+        }
+        Vec::new()
+    }
+
+    #[cfg(unix)]
+    fn cleanup_native_stream_sigterm_fixtures(
+        fixture_dir: &Path,
+        require_recorded_pids: bool,
+    ) -> Vec<String> {
+        const FIXTURES: [(&str, &str); 2] =
+            [("harness", "harness.pid"), ("descendant", "descendant.pid")];
+        let mut pids = [None; FIXTURES.len()];
+        let mut pid_errors = [None, None];
+        let mut reaped = [false; FIXTURES.len()];
+        let grace_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+
+        loop {
+            for (index, (label, file_name)) in FIXTURES.iter().enumerate() {
+                if pids[index].is_none() {
+                    match native_stream_sigterm_fixture_pid(fixture_dir, label, file_name) {
+                        Ok(Some(pid)) => {
+                            pids[index] = Some(pid);
+                            pid_errors[index] = None;
+                        }
+                        Ok(None) => pid_errors[index] = None,
+                        Err(error) => pid_errors[index] = Some(format!("{error:#}")),
+                    }
+                }
+                if let Some(pid) = pids[index] {
+                    reaped[index] = native_stream_sigterm_fixture_is_reaped(pid);
+                }
+            }
+
+            let all_recorded = pids.iter().all(Option::is_some);
+            let all_reaped = pids
+                .iter()
+                .enumerate()
+                .all(|(index, pid)| pid.is_none() || reaped[index]);
+            let no_pid_errors = pid_errors.iter().all(Option::is_none);
+            if all_reaped && no_pid_errors && (!require_recorded_pids || all_recorded) {
+                return Vec::new();
+            }
+            if Instant::now() >= grace_deadline {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut failures = Vec::new();
+        for (index, (label, _)) in FIXTURES.iter().enumerate() {
+            let Some(pid) = pids[index] else {
+                if let Some(error) = &pid_errors[index] {
+                    failures.push(format!(
+                        "cancelled native stream could not read {label} PID before reaping grace expired: {error}"
+                    ));
+                } else if require_recorded_pids {
+                    failures.push(format!(
+                        "cancelled native stream did not record {label} PID before reaping grace expired"
+                    ));
+                }
+                continue;
+            };
+            if !reaped[index] {
                 failures.push(format!(
-                    "cancelled native stream left {label} {pid} unreaped before cleanup"
+                    "cancelled native stream left {label} {pid} unreaped after reaping grace; \
+                     attempting exact-PID failure cleanup"
                 ));
-                if unsafe { libc::kill(*pid, libc::SIGKILL) } == -1 {
+                if unsafe { libc::kill(pid, libc::SIGKILL) } == -1 {
                     let error = std::io::Error::last_os_error();
                     if error.raw_os_error() == Some(libc::ESRCH) {
-                        *reaped = true;
+                        reaped[index] = true;
                     } else {
                         failures.push(format!(
                             "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
@@ -4482,19 +4561,32 @@ while :; do sleep 1; done
         }
 
         let cleanup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
-        while reaped.iter().any(|reaped| !reaped) && Instant::now() < cleanup_deadline {
-            for ((_, pid), reaped) in fixtures.iter().zip(&mut reaped) {
-                *reaped = native_stream_sigterm_fixture_is_reaped(*pid);
+        while pids
+            .iter()
+            .enumerate()
+            .any(|(index, pid)| pid.is_some() && !reaped[index])
+            && Instant::now() < cleanup_deadline
+        {
+            for (index, pid) in pids.iter().enumerate() {
+                if let Some(pid) = pid {
+                    reaped[index] = native_stream_sigterm_fixture_is_reaped(*pid);
+                }
             }
-            if reaped.iter().any(|reaped| !reaped) {
+            if pids
+                .iter()
+                .enumerate()
+                .any(|(index, pid)| pid.is_some() && !reaped[index])
+            {
                 thread::sleep(Duration::from_millis(10));
             }
         }
-        for ((label, pid), reaped) in fixtures.iter().zip(&reaped) {
-            if !reaped {
-                failures.push(format!(
-                    "cancelled native stream {label} {pid} survived cleanup"
-                ));
+        for (index, (label, _)) in FIXTURES.iter().enumerate() {
+            if let Some(pid) = pids[index] {
+                if !reaped[index] {
+                    failures.push(format!(
+                        "cancelled native stream {label} {pid} survived exact-PID failure cleanup"
+                    ));
+                }
             }
         }
         failures
@@ -4523,6 +4615,7 @@ while :; do sleep 1; done
     #[cfg(unix)]
     fn native_stream_sigterm_child(fixture_dir: &Path) -> Result<()> {
         let signal_guard = NativeStreamSigtermTestSignal::install()?;
+        let runner_thread = unsafe { libc::pthread_self() } as usize;
         let signal_dir = fixture_dir.to_path_buf();
         let stream_finished = Arc::new(AtomicBool::new(false));
         let signal_stream_finished = Arc::clone(&stream_finished);
@@ -4547,10 +4640,11 @@ while :; do sleep 1; done
             if !NativeStreamSigtermTestSignal::cancellation_handler_is_active()? {
                 anyhow::bail!("native stream SIGTERM handler was not active for the fixture");
             }
-            let result = unsafe { libc::pthread_kill(libc::pthread_self(), libc::SIGTERM) };
+            let result =
+                unsafe { libc::pthread_kill(runner_thread as libc::pthread_t, libc::SIGTERM) };
             if result != 0 {
                 return Err(std::io::Error::from_raw_os_error(result))
-                    .context("sending fixture SIGTERM to the signaler thread");
+                    .context("sending fixture SIGTERM to the stream runner thread");
             }
             Ok(())
         });
@@ -4578,7 +4672,7 @@ while :; do sleep 1; done
         // restoration failure. The parent test repeats this after a watchdog
         // termination so a malformed child test process cannot strand either
         // exact fixture PID.
-        let mut failures = cleanup_native_stream_sigterm_fixtures(fixture_dir);
+        let mut failures = cleanup_native_stream_sigterm_fixtures(fixture_dir, true);
         if let Err(error) = signal_result {
             failures.push(format!("native stream signal thread failed: {error:#}"));
         }
@@ -4651,6 +4745,13 @@ while :; do sleep 1; done
             }
         };
         if child_status.is_none() {
+            // The harness writes harness.pid before it starts the long-lived
+            // sleep(120) descendant. Kill its isolated process group first so
+            // a watchdog cannot strand a child between that sleep starting
+            // and descendant.pid being written.
+            failures.extend(terminate_native_stream_sigterm_harness_group(
+                temp_dir.path(),
+            ));
             if let Err(error) = child.kill() {
                 failures.push(format!(
                     "terminating isolated native stream SIGTERM test: {error}"
@@ -4662,12 +4763,23 @@ while :; do sleep 1; done
                     "waiting for terminated native stream SIGTERM test: {error}"
                 )),
             }
+            // If the harness wrote its PID while the test child was being
+            // terminated, its group still contains every unrecorded
+            // descendant and can be targeted precisely.
+            failures.extend(terminate_native_stream_sigterm_harness_group(
+                temp_dir.path(),
+            ));
         }
 
         // The isolated child may be killed by the watchdog before it can
         // clean up, so verify and clean both exact fixture PIDs here before
         // reporting its outcome.
-        failures.extend(cleanup_native_stream_sigterm_fixtures(temp_dir.path()));
+        failures.extend(cleanup_native_stream_sigterm_fixtures(
+            temp_dir.path(),
+            child_status
+                .as_ref()
+                .is_some_and(std::process::ExitStatus::success),
+        ));
         match child_status {
             Some(status) if status.success() => {}
             Some(status) => failures.push(format!(

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -434,10 +434,18 @@ static SUPERVISED_STREAM_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
 // The test signaler and guard restoration share this lock so a test TERM can
 // never race a restored disposition. This observer is not compiled into the
 // production signal path.
-#[derive(Default)]
 struct SupervisedStreamCancellationTestLifecycle {
     observer: Option<thread::ThreadId>,
-    active: bool,
+    phase: SupervisedStreamCancellationTestPhase,
+}
+
+#[cfg(all(test, unix))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SupervisedStreamCancellationTestPhase {
+    Registered,
+    InstalledMasked,
+    ActiveUnmasked,
+    Finished,
 }
 
 #[cfg(all(test, unix))]
@@ -445,7 +453,7 @@ static SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE: Mutex<
     SupervisedStreamCancellationTestLifecycle,
 > = Mutex::new(SupervisedStreamCancellationTestLifecycle {
     observer: None,
-    active: false,
+    phase: SupervisedStreamCancellationTestPhase::Finished,
 });
 
 #[cfg(all(test, unix))]
@@ -464,16 +472,32 @@ impl SupervisedStreamCancellationTestObserver {
             anyhow::bail!("a supervised stream cancellation test observer is already active");
         }
         lifecycle.observer = Some(owner);
-        lifecycle.active = false;
+        lifecycle.phase = SupervisedStreamCancellationTestPhase::Registered;
         Ok(Self { owner })
     }
 
-    fn send_sigterm_if_active(&self, target: usize) -> Result<bool> {
+    /// The returned installed/active phase means this call delivered SIGTERM.
+    ///
+    /// The lifecycle mutex covers both this dispatch and the guard's transition
+    /// to `Finished`, which happens before handler restoration. Consequently,
+    /// this test-only helper can queue a signal while the guard is masked or
+    /// deliver one while it is unmasked, but can never signal a restored
+    /// default disposition.
+    fn send_sigterm_if_guarded(
+        &self,
+        target: usize,
+    ) -> Result<SupervisedStreamCancellationTestPhase> {
         let lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if lifecycle.observer.as_ref() != Some(&self.owner) || !lifecycle.active {
-            return Ok(false);
+        if lifecycle.observer.as_ref() != Some(&self.owner) {
+            anyhow::bail!("supervised stream cancellation test observer no longer owns lifecycle");
+        }
+        match lifecycle.phase {
+            SupervisedStreamCancellationTestPhase::Registered
+            | SupervisedStreamCancellationTestPhase::Finished => return Ok(lifecycle.phase),
+            SupervisedStreamCancellationTestPhase::InstalledMasked
+            | SupervisedStreamCancellationTestPhase::ActiveUnmasked => {}
         }
 
         let result = unsafe { libc::pthread_kill(target as libc::pthread_t, libc::SIGTERM) };
@@ -481,7 +505,7 @@ impl SupervisedStreamCancellationTestObserver {
             return Err(std::io::Error::from_raw_os_error(result))
                 .context("sending fixture SIGTERM to the stream runner thread");
         }
-        Ok(true)
+        Ok(lifecycle.phase)
     }
 }
 
@@ -492,7 +516,7 @@ impl Drop for SupervisedStreamCancellationTestObserver {
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         if lifecycle.observer.as_ref() == Some(&self.owner) {
-            lifecycle.active = false;
+            lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
             lifecycle.observer = None;
         }
     }
@@ -642,10 +666,19 @@ impl SupervisedStreamCancellationGuard {
 
         #[cfg(test)]
         let test_lifecycle_registered = {
-            let lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
+            let mut lifecycle = SUPERVISED_STREAM_CANCELLATION_TEST_LIFECYCLE
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-            lifecycle.observer.as_ref() == Some(&thread::current().id())
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                debug_assert_eq!(
+                    lifecycle.phase,
+                    SupervisedStreamCancellationTestPhase::Registered
+                );
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::InstalledMasked;
+                true
+            } else {
+                false
+            }
         };
 
         Ok(Self {
@@ -673,7 +706,12 @@ impl SupervisedStreamCancellationGuard {
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
-                lifecycle.active = true;
+                if lifecycle.phase != SupervisedStreamCancellationTestPhase::InstalledMasked {
+                    anyhow::bail!(
+                        "supervised stream cancellation test lifecycle was not installed and masked before activation"
+                    );
+                }
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::ActiveUnmasked;
             }
         }
         Ok(self.cancelled_signal())
@@ -688,7 +726,9 @@ impl SupervisedStreamCancellationGuard {
         });
         #[cfg(test)]
         if let Some(lifecycle) = &mut test_lifecycle {
-            lifecycle.active = false;
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
+            }
         }
         self.signal_mask
             .reblock()
@@ -733,7 +773,9 @@ impl Drop for SupervisedStreamCancellationGuard {
         });
         #[cfg(test)]
         if let Some(lifecycle) = &mut test_lifecycle {
-            lifecycle.active = false;
+            if lifecycle.observer.as_ref() == Some(&thread::current().id()) {
+                lifecycle.phase = SupervisedStreamCancellationTestPhase::Finished;
+            }
         }
         let _ = self.signal_mask.reblock();
         // SAFETY: every entry was captured from a successful sigaction call
@@ -4713,7 +4755,20 @@ while :; do sleep 1; done
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     struct NativeStreamSigtermCleanupSentinel {
         shutdown: Arc<AtomicBool>,
-        result: mpsc::Receiver<Result<()>>,
+        result: mpsc::Receiver<std::result::Result<(), String>>,
+        outcome: Option<std::result::Result<(), String>>,
+        outcome_observed: bool,
+        reader: Option<thread::JoinHandle<()>>,
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    impl Drop for NativeStreamSigtermCleanupSentinel {
+        fn drop(&mut self) {
+            self.shutdown.store(true, Ordering::Relaxed);
+            if let Some(reader) = self.reader.take() {
+                let _ = reader.join();
+            }
+        }
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
@@ -4829,7 +4884,7 @@ while :; do sleep 1; done
         let (result_sender, result_receiver) = mpsc::sync_channel(1);
         let shutdown = Arc::new(AtomicBool::new(false));
         let sentinel_shutdown = Arc::clone(&shutdown);
-        thread::spawn(move || {
+        let reader = thread::spawn(move || {
             let result = (|| -> Result<()> {
                 let mut command = command;
                 let mut buffer = Vec::new();
@@ -4878,19 +4933,95 @@ while :; do sleep 1; done
                         }
                     }
                 }
-            })();
+            })()
+            .map_err(|error| format!("{error:#}"));
             let _ = result_sender.send(result);
         });
         Ok(NativeStreamSigtermCleanupSentinel {
             shutdown,
             result: result_receiver,
+            outcome: None,
+            outcome_observed: false,
+            reader: Some(reader),
         })
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn await_native_stream_sigterm_cleanup_sentinel(
+        sentinel: &mut NativeStreamSigtermCleanupSentinel,
+        deadline: Instant,
+    ) -> Result<()> {
+        if sentinel.outcome.is_none() {
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or_default();
+            let outcome = match sentinel.result.recv_timeout(remaining) {
+                Ok(outcome) => outcome,
+                Err(RecvTimeoutError::Timeout) => {
+                    anyhow::bail!(
+                        "native stream cleanup sentinel did not acknowledge its durable command before the watchdog expired"
+                    );
+                }
+                Err(RecvTimeoutError::Disconnected) => {
+                    anyhow::bail!(
+                        "native stream cleanup sentinel stopped before acknowledging its command"
+                    );
+                }
+            };
+            sentinel.outcome = Some(outcome);
+        }
+
+        sentinel.outcome_observed = true;
+        match sentinel
+            .outcome
+            .as_ref()
+            .expect("cleanup sentinel outcome is recorded before observation")
+        {
+            Ok(()) => Ok(()),
+            Err(error) => anyhow::bail!("native stream cleanup sentinel failed: {error}"),
+        }
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn finish_native_stream_sigterm_cleanup_sentinel(
+        sentinel: &mut NativeStreamSigtermCleanupSentinel,
+    ) -> Vec<String> {
+        sentinel.shutdown.store(true, Ordering::Relaxed);
+        let mut failures = Vec::new();
+        let Some(reader) = sentinel.reader.take() else {
+            failures.push("native stream cleanup sentinel reader was already joined".into());
+            return failures;
+        };
+        if reader.join().is_err() {
+            failures.push("native stream cleanup sentinel reader panicked".into());
+            return failures;
+        }
+
+        if sentinel.outcome.is_none() {
+            match sentinel.result.try_recv() {
+                Ok(outcome) => sentinel.outcome = Some(outcome),
+                Err(mpsc::TryRecvError::Empty) => failures.push(
+                    "native stream cleanup sentinel reader exited without reporting a result"
+                        .into(),
+                ),
+                Err(mpsc::TryRecvError::Disconnected) => failures.push(
+                    "native stream cleanup sentinel reader disconnected without reporting a result"
+                        .into(),
+                ),
+            }
+        }
+        if let Some(Err(error)) = &sentinel.outcome {
+            if !sentinel.outcome_observed {
+                failures.push(format!("native stream cleanup sentinel failed: {error}"));
+            }
+        }
+        failures
     }
 
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn request_native_stream_sigterm_fixture_cleanup(
         cleanup: &NativeStreamSigtermCleanupHandle,
-        sentinel: &NativeStreamSigtermCleanupSentinel,
+        sentinel: &mut NativeStreamSigtermCleanupSentinel,
         deadline: Instant,
     ) -> Result<()> {
         use std::os::unix::fs::OpenOptionsExt;
@@ -4914,26 +5045,10 @@ while :; do sleep 1; done
             command
                 .flush()
                 .context("flushing native stream fixture cleanup command")?;
-
-            let remaining = deadline
-                .checked_duration_since(Instant::now())
-                .unwrap_or_default();
-            match sentinel.result.recv_timeout(remaining) {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => {
-                    return Err(error).context("native stream cleanup sentinel failed");
-                }
-                Err(RecvTimeoutError::Timeout) => {
-                    anyhow::bail!(
-                        "native stream cleanup sentinel did not acknowledge its durable command before the watchdog expired"
-                    );
-                }
-                Err(RecvTimeoutError::Disconnected) => {
-                    anyhow::bail!(
-                        "native stream cleanup sentinel stopped before acknowledging its command"
-                    );
-                }
-            }
+            // The reader now has the complete token; close the only test-side
+            // writer before waiting for its acknowledgement.
+            drop(command);
+            await_native_stream_sigterm_cleanup_sentinel(sentinel, deadline)?;
 
             match std::fs::read_to_string(&cleanup.acknowledgement_path) {
                 Ok(acknowledgement) if acknowledgement.trim() == cleanup.token => Ok(()),
@@ -4957,7 +5072,7 @@ while :; do sleep 1; done
     #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn cleanup_native_stream_sigterm_fixtures(
         cleanup: &NativeStreamSigtermCleanupHandle,
-        sentinel: &NativeStreamSigtermCleanupSentinel,
+        sentinel: &mut NativeStreamSigtermCleanupSentinel,
         fixture_cleanup: &mut NativeStreamSigtermFixtureCleanup,
         identities: Option<&[NativeStreamSigtermFixtureIdentity; 2]>,
     ) -> Vec<String> {
@@ -4973,20 +5088,20 @@ while :; do sleep 1; done
         }
 
         let Some(identities) = identities else {
+            failures.push(
+                "fixture identities were never captured before emergency cleanup; refusing to report PID-file absence as reaping"
+                    .into(),
+            );
             if let Err(error) = request_native_stream_sigterm_fixture_group_cleanup(fixture_cleanup)
             {
                 failures.push(format!(
                     "failed to request fixture-local native stream process-group cleanup: {error:#}"
                 ));
             }
-            failures.push(
-                "cancelled native stream cleanup was acknowledged, but fixture identities were never captured; refusing to report PID-file absence as reaping"
-                    .into(),
-            );
             return failures;
         };
 
-        match native_stream_sigterm_fixture_states(identities) {
+        let initial_states = match native_stream_sigterm_fixture_states(identities) {
             Ok(states)
                 if states
                     .iter()
@@ -4994,13 +5109,31 @@ while :; do sleep 1; done
             {
                 return Vec::new();
             }
-            Ok(_) => {}
+            Ok(states) => {
+                // This is the production assertion. The emergency FIFO can
+                // only contain a leak; it must never turn one into a pass.
+                for (index, state) in states.iter().enumerate() {
+                    match state {
+                        NativeStreamSigtermFixtureState::Reaped => {}
+                        NativeStreamSigtermFixtureState::Alive => failures.push(format!(
+                            "SIGTERM production reaping check failed before fixture-local emergency cleanup: {} {} was still alive",
+                            NATIVE_STREAM_SIGTERM_FIXTURES[index].0, identities[index].pid
+                        )),
+                        NativeStreamSigtermFixtureState::Reused => failures.push(format!(
+                            "SIGTERM production reaping check failed before fixture-local emergency cleanup: recorded {} PID {} was reused",
+                            NATIVE_STREAM_SIGTERM_FIXTURES[index].0, identities[index].pid
+                        )),
+                    }
+                }
+                Some(states)
+            }
             Err(error) => {
                 failures.push(format!(
-                    "could not verify native stream fixture identities before cleanup: {error}"
+                    "could not verify native stream fixture identities before fixture-local emergency cleanup: {error}"
                 ));
+                None
             }
-        }
+        };
 
         if let Err(error) = request_native_stream_sigterm_fixture_group_cleanup(fixture_cleanup) {
             failures.push(format!(
@@ -5016,6 +5149,29 @@ while :; do sleep 1; done
                         .iter()
                         .all(|state| *state == NativeStreamSigtermFixtureState::Reaped) =>
                 {
+                    match initial_states {
+                        Some(initial_states) => {
+                            let initial_context = initial_states
+                                .iter()
+                                .enumerate()
+                                .map(|(index, state)| {
+                                    format!(
+                                        "{} {} was {state:?}",
+                                        NATIVE_STREAM_SIGTERM_FIXTURES[index].0,
+                                        identities[index].pid
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            failures.push(format!(
+                                "fixture-local emergency cleanup reaped the recorded identities after the failed production check ({initial_context}); post-cleanup inspection does not erase that failure"
+                            ));
+                        }
+                        None => failures.push(
+                            "fixture-local emergency cleanup reaped the recorded identities, but the pre-cleanup identity inspection failed; post-cleanup reaping does not replace that production proof"
+                                .into(),
+                        ),
+                    }
                     return failures;
                 }
                 Ok(states) if Instant::now() >= cleanup_deadline => {
@@ -5037,7 +5193,7 @@ while :; do sleep 1; done
                 Ok(_) => thread::sleep(Duration::from_millis(10)),
                 Err(error) => {
                     failures.push(format!(
-                        "could not verify native stream fixture identities after cleanup: {error}"
+                        "could not verify native stream fixture identities after fixture-local emergency cleanup: {error}"
                     ));
                     return failures;
                 }
@@ -5093,7 +5249,7 @@ while :; do sleep 1; done
         std::fs::set_permissions(&fake_harness, permissions)?;
 
         let lifecycle = Arc::new(SupervisedStreamCancellationTestObserver::arm()?);
-        let cleanup_sentinel = start_native_stream_sigterm_cleanup_sentinel(&cleanup)?;
+        let mut cleanup_sentinel = start_native_stream_sigterm_cleanup_sentinel(&cleanup)?;
         let signal_lifecycle = Arc::clone(&lifecycle);
         let runner_thread = unsafe { libc::pthread_self() } as usize;
         let signal_dir = temp_dir.path().to_path_buf();
@@ -5107,10 +5263,15 @@ while :; do sleep 1; done
             let startup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
             let mut last_readiness_error = None;
             let mut last_delivery_error = None;
+            let mut startup_failure = None;
             loop {
                 if signal_stream_finished.load(Ordering::Relaxed) {
                     anyhow::bail!(
-                        "native stream returned before the fixture and cancellation handler were both ready; no SIGTERM was sent"
+                        "{}native stream returned before the fixture and cancellation handler were both ready; no SIGTERM was sent",
+                        startup_failure
+                            .as_deref()
+                            .map(|failure| format!("{failure}; "))
+                            .unwrap_or_default(),
                     );
                 }
 
@@ -5142,42 +5303,48 @@ while :; do sleep 1; done
                 };
 
                 if fixture_identities_ready && fixture_sentinel_ready {
-                    match signal_lifecycle.send_sigterm_if_active(runner_thread) {
-                        // `send_sigterm_if_active` holds the lifecycle lock
-                        // across pthread_kill, excluding restoration. The
-                        // final runner error below proves consumption.
-                        Ok(true) => return Ok(()),
-                        Ok(false) => {}
+                    match signal_lifecycle.send_sigterm_if_guarded(runner_thread) {
+                        // `stream_harness_with_program` installs the guard
+                        // before spawning this fixture. A pending signal is
+                        // therefore safe in InstalledMasked and cancels as
+                        // soon as activate() unmasks the runner thread.
+                        Ok(
+                            SupervisedStreamCancellationTestPhase::InstalledMasked
+                            | SupervisedStreamCancellationTestPhase::ActiveUnmasked,
+                        ) => {
+                            if let Some(failure) = startup_failure {
+                                anyhow::bail!(
+                                    "{failure}; lifecycle-verified SIGTERM was delivered to contain the stalled fixture startup"
+                                );
+                            }
+                            return Ok(());
+                        }
+                        Ok(SupervisedStreamCancellationTestPhase::Registered) => {
+                            last_delivery_error = Some(
+                                "fixture was ready while the cancellation guard was still registered; waiting for guarded delivery"
+                                    .into(),
+                            );
+                        }
+                        Ok(SupervisedStreamCancellationTestPhase::Finished) => {
+                            anyhow::bail!(
+                                "native stream reached the finished cancellation lifecycle before SIGTERM delivery"
+                            );
+                        }
                         Err(error) => last_delivery_error = Some(format!("{error:#}")),
                     }
                 }
                 if signal_stream_finished.load(Ordering::Relaxed) {
                     anyhow::bail!(
-                        "native stream returned before the fixture and cancellation handler were both ready; no SIGTERM was sent"
+                        "{}native stream returned before the fixture and cancellation handler were both ready; no SIGTERM was sent",
+                        startup_failure
+                            .as_deref()
+                            .map(|failure| format!("{failure}; "))
+                            .unwrap_or_default(),
                     );
                 }
-                if Instant::now() >= startup_deadline {
-                    // Reuse the owner-verified lifecycle path: its mutex keeps
-                    // handler restoration out of the thread-directed delivery.
-                    let fallback_delivery = match signal_lifecycle
-                        .send_sigterm_if_active(runner_thread)
-                    {
-                        Ok(true) => {
-                            "sent lifecycle-verified SIGTERM cancellation to the stream runner"
-                                .to_string()
-                        }
-                        Ok(false) => {
-                            "did not signal because the cancellation lifecycle was already inactive"
-                                .to_string()
-                        }
-                        Err(error) => {
-                            format!(
-                                "failed to send lifecycle-verified SIGTERM cancellation: {error:#}"
-                            )
-                        }
-                    };
-                    anyhow::bail!(
-                        "native stream fixture-start failure: the fixture, cleanup sentinel, and cancellation handler did not become ready together before the startup watchdog expired{}{}; fallback {}",
+                if Instant::now() >= startup_deadline && startup_failure.is_none() {
+                    let failure = format!(
+                        "native stream fixture-start failure: the fixture, cleanup sentinel, and cancellation handler did not become ready together before the startup watchdog expired{}{}",
                         last_readiness_error
                             .as_deref()
                             .map(|error| format!("; last readiness error: {error}"))
@@ -5186,8 +5353,36 @@ while :; do sleep 1; done
                             .as_deref()
                             .map(|error| format!("; last delivery error: {error}"))
                             .unwrap_or_default(),
-                        fallback_delivery,
                     );
+                    // Hold the lifecycle mutex through pthread_kill. If the
+                    // guard remains only Registered, keep the signaler alive:
+                    // returning here would leave a fixture that becomes
+                    // signalable later with no cancellation request.
+                    match signal_lifecycle.send_sigterm_if_guarded(runner_thread) {
+                        Ok(
+                            SupervisedStreamCancellationTestPhase::InstalledMasked
+                            | SupervisedStreamCancellationTestPhase::ActiveUnmasked,
+                        ) => {
+                            anyhow::bail!(
+                                "{failure}; lifecycle-verified SIGTERM was delivered to contain the stalled fixture startup"
+                            );
+                        }
+                        Ok(SupervisedStreamCancellationTestPhase::Registered) => {
+                            startup_failure = Some(format!(
+                                "{failure}; guard remains registered, so SIGTERM is deferred until its disposition is safe"
+                            ));
+                        }
+                        Ok(SupervisedStreamCancellationTestPhase::Finished) => {
+                            anyhow::bail!(
+                                "{failure}; guard was already finished, so SIGTERM was not sent under a restored disposition"
+                            );
+                        }
+                        Err(error) => {
+                            anyhow::bail!(
+                                "{failure}; lifecycle-verified SIGTERM delivery failed: {error:#}"
+                            );
+                        }
+                    }
                 }
                 thread::sleep(Duration::from_millis(10));
             }
@@ -5215,10 +5410,13 @@ while :; do sleep 1; done
             .clone();
         let mut failures = cleanup_native_stream_sigterm_fixtures(
             &cleanup,
-            &cleanup_sentinel,
+            &mut cleanup_sentinel,
             &mut fixture_cleanup,
             captured_fixture_identities.as_ref(),
         );
+        failures.extend(finish_native_stream_sigterm_cleanup_sentinel(
+            &mut cleanup_sentinel,
+        ));
         if let Err(error) = signal_result {
             failures.push(format!("native stream signal thread failed: {error:#}"));
         }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4383,6 +4383,8 @@ while :; do sleep 1; done
                 }
                 thread::sleep(Duration::from_millis(10));
             }
+            let sent = unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
+            assert_eq!(sent, 0, "failed to signal test process");
             panic!("native stream fixture did not start before signal deadline");
         });
 

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -483,18 +483,6 @@ impl SupervisedStreamCancellationTestObserver {
         }
         Ok(true)
     }
-
-    fn wait_for_sigterm_delivery(deadline: Instant) -> Result<()> {
-        while SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed) != libc::SIGTERM {
-            if Instant::now() >= deadline {
-                anyhow::bail!(
-                    "fixture SIGTERM was not recorded by the stream cancellation handler before the watchdog expired"
-                );
-            }
-            thread::sleep(Duration::from_millis(10));
-        }
-        Ok(())
-    }
 }
 
 #[cfg(all(test, unix))]
@@ -4472,14 +4460,145 @@ while :; do sleep 1; done
         Ok(())
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     const NATIVE_STREAM_SIGTERM_TEST_WATCHDOG: Duration = Duration::from_secs(30);
 
-    #[cfg(unix)]
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     const NATIVE_STREAM_SIGTERM_FIXTURES: [(&str, &str); 2] =
         [("harness", "harness.pid"), ("descendant", "descendant.pid")];
 
-    #[cfg(unix)]
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct NativeStreamSigtermFixtureIdentity {
+        pid: libc::pid_t,
+        started_at: NativeStreamSigtermProcessStart,
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum NativeStreamSigtermProcessStart {
+        #[cfg(target_os = "linux")]
+        LinuxClockTick(u64),
+        #[cfg(target_os = "macos")]
+        MacOs { seconds: u64, microseconds: u64 },
+    }
+
+    #[cfg(target_os = "macos")]
+    #[repr(C)]
+    struct NativeStreamSigtermMacOsProcBsdInfo {
+        flags: u32,
+        status: u32,
+        exit_status: u32,
+        pid: u32,
+        parent_pid: u32,
+        uid: libc::uid_t,
+        gid: libc::gid_t,
+        real_uid: libc::uid_t,
+        real_gid: libc::gid_t,
+        saved_uid: libc::uid_t,
+        saved_gid: libc::gid_t,
+        reserved: u32,
+        command: [libc::c_char; 16],
+        name: [libc::c_char; 32],
+        open_files: u32,
+        process_group: u32,
+        job_control_count: u32,
+        controlling_terminal: u32,
+        terminal_process_group: u32,
+        nice: i32,
+        start_seconds: u64,
+        start_microseconds: u64,
+    }
+
+    #[cfg(target_os = "macos")]
+    #[link(name = "proc")]
+    unsafe extern "C" {
+        fn proc_pidinfo(
+            pid: libc::pid_t,
+            flavor: libc::c_int,
+            arg: u64,
+            buffer: *mut libc::c_void,
+            buffer_size: libc::c_int,
+        ) -> libc::c_int;
+    }
+
+    #[cfg(target_os = "linux")]
+    fn native_stream_sigterm_process_start(
+        pid: libc::pid_t,
+    ) -> io::Result<Option<NativeStreamSigtermProcessStart>> {
+        let stat_path = PathBuf::from(format!("/proc/{pid}/stat"));
+        let stat = match std::fs::read_to_string(&stat_path) {
+            Ok(stat) => stat,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error),
+        };
+        let (_, fields) = stat.rsplit_once(") ").ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("malformed process stat record at {}", stat_path.display()),
+            )
+        })?;
+        let start_tick = fields
+            .split_whitespace()
+            // Field 3 begins after the process name; starttime is field 22.
+            .nth(19)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("missing process start time at {}", stat_path.display()),
+                )
+            })?
+            .parse()
+            .map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "parsing process start time at {}: {error}",
+                        stat_path.display()
+                    ),
+                )
+            })?;
+        Ok(Some(NativeStreamSigtermProcessStart::LinuxClockTick(
+            start_tick,
+        )))
+    }
+
+    #[cfg(target_os = "macos")]
+    fn native_stream_sigterm_process_start(
+        pid: libc::pid_t,
+    ) -> io::Result<Option<NativeStreamSigtermProcessStart>> {
+        const PROC_PIDTBSDINFO: libc::c_int = 3;
+        let mut info: NativeStreamSigtermMacOsProcBsdInfo = unsafe { std::mem::zeroed() };
+        // SAFETY: `info` is initialized and passed with its exact C layout and size.
+        let result = unsafe {
+            proc_pidinfo(
+                pid,
+                PROC_PIDTBSDINFO,
+                0,
+                (&mut info as *mut NativeStreamSigtermMacOsProcBsdInfo).cast(),
+                std::mem::size_of::<NativeStreamSigtermMacOsProcBsdInfo>() as libc::c_int,
+            )
+        };
+        if result == std::mem::size_of::<NativeStreamSigtermMacOsProcBsdInfo>() as libc::c_int {
+            return Ok(Some(NativeStreamSigtermProcessStart::MacOs {
+                seconds: info.start_seconds,
+                microseconds: info.start_microseconds,
+            }));
+        }
+        if result == 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(None);
+            }
+            return Err(error);
+        }
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("proc_pidinfo returned {result} bytes for process {pid}"),
+        ))
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn native_stream_sigterm_fixture_pid(
         fixture_dir: &Path,
         label: &str,
@@ -4505,175 +4624,245 @@ while :; do sleep 1; done
         }
     }
 
-    #[cfg(unix)]
-    fn native_stream_sigterm_fixture_is_ready(fixture_dir: &Path) -> Result<bool> {
-        for (label, file_name) in NATIVE_STREAM_SIGTERM_FIXTURES {
-            if native_stream_sigterm_fixture_pid(fixture_dir, label, file_name)?.is_none() {
-                return Ok(false);
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn native_stream_sigterm_fixture_identities(
+        fixture_dir: &Path,
+    ) -> Result<Option<[NativeStreamSigtermFixtureIdentity; 2]>> {
+        let Some(harness_pid) = native_stream_sigterm_fixture_pid(
+            fixture_dir,
+            NATIVE_STREAM_SIGTERM_FIXTURES[0].0,
+            NATIVE_STREAM_SIGTERM_FIXTURES[0].1,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some(descendant_pid) = native_stream_sigterm_fixture_pid(
+            fixture_dir,
+            NATIVE_STREAM_SIGTERM_FIXTURES[1].0,
+            NATIVE_STREAM_SIGTERM_FIXTURES[1].1,
+        )?
+        else {
+            return Ok(None);
+        };
+        let Some(harness_started_at) = native_stream_sigterm_process_start(harness_pid)? else {
+            return Ok(None);
+        };
+        let Some(descendant_started_at) = native_stream_sigterm_process_start(descendant_pid)?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some([
+            NativeStreamSigtermFixtureIdentity {
+                pid: harness_pid,
+                started_at: harness_started_at,
+            },
+            NativeStreamSigtermFixtureIdentity {
+                pid: descendant_pid,
+                started_at: descendant_started_at,
+            },
+        ]))
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum NativeStreamSigtermFixtureState {
+        Reaped,
+        Alive,
+        Reused,
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn native_stream_sigterm_fixture_state(
+        identity: &NativeStreamSigtermFixtureIdentity,
+    ) -> io::Result<NativeStreamSigtermFixtureState> {
+        match native_stream_sigterm_process_start(identity.pid)? {
+            None => Ok(NativeStreamSigtermFixtureState::Reaped),
+            Some(started_at) if started_at == identity.started_at => {
+                Ok(NativeStreamSigtermFixtureState::Alive)
             }
+            Some(_) => Ok(NativeStreamSigtermFixtureState::Reused),
         }
-        Ok(true)
     }
 
-    #[cfg(unix)]
-    fn native_stream_sigterm_fixture_is_reaped(pid: libc::pid_t) -> bool {
-        (unsafe { libc::kill(pid, 0) }) == -1
-            && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn native_stream_sigterm_fixture_states(
+        identities: &[NativeStreamSigtermFixtureIdentity; 2],
+    ) -> io::Result<[NativeStreamSigtermFixtureState; 2]> {
+        Ok([
+            native_stream_sigterm_fixture_state(&identities[0])?,
+            native_stream_sigterm_fixture_state(&identities[1])?,
+        ])
     }
 
-    #[cfg(unix)]
-    fn native_stream_sigterm_fixture_process_group(
-        pid: libc::pid_t,
-    ) -> io::Result<Option<libc::pid_t>> {
-        loop {
-            let process_group = unsafe { libc::getpgid(pid) };
-            if process_group >= 0 {
-                return Ok(Some(process_group));
-            }
-            let error = std::io::Error::last_os_error();
-            if error.kind() == io::ErrorKind::Interrupted {
-                continue;
-            }
-            if error.raw_os_error() == Some(libc::ESRCH) {
-                return Ok(None);
-            }
-            return Err(error);
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    #[derive(Clone)]
+    struct NativeStreamSigtermCleanupHandle {
+        command_path: PathBuf,
+        acknowledgement_path: PathBuf,
+        token: String,
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn create_native_stream_sigterm_cleanup_handle(
+        fixture_dir: &Path,
+    ) -> Result<NativeStreamSigtermCleanupHandle> {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let command_path = fixture_dir.join("cleanup.fifo");
+        let command_path_c = CString::new(command_path.as_os_str().as_bytes())
+            .context("encoding native stream fixture cleanup FIFO path")?;
+        // SAFETY: the temporary fixture directory is unique and the C string
+        // is NUL-terminated for mkfifo.
+        if unsafe { libc::mkfifo(command_path_c.as_ptr(), 0o600) } != 0 {
+            return Err(io::Error::last_os_error())
+                .context("creating native stream fixture cleanup FIFO");
         }
+        Ok(NativeStreamSigtermCleanupHandle {
+            command_path,
+            acknowledgement_path: fixture_dir.join("cleanup.ack"),
+            token: format!("coven-native-stream-sigterm-{}", uuid::Uuid::new_v4()),
+        })
     }
 
-    #[cfg(unix)]
-    fn cleanup_native_stream_sigterm_fixtures(fixture_dir: &Path) -> Vec<String> {
-        let mut pids: [Option<libc::pid_t>; 2] = [None; 2];
-        let mut pid_errors: [Option<String>; 2] = std::array::from_fn(|_| None);
-        let mut reaped = [false; 2];
-        let reaping_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn request_native_stream_sigterm_fixture_cleanup(
+        cleanup: &NativeStreamSigtermCleanupHandle,
+        deadline: Instant,
+    ) -> Result<()> {
+        use std::os::unix::fs::OpenOptionsExt;
+
+        // Open both ends so writing before the fixture sentinel has opened
+        // its read end is safe; retain this descriptor until the sentinel
+        // acknowledges the exact, per-test token.
+        let mut command = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK)
+            .open(&cleanup.command_path)
+            .with_context(|| {
+                format!(
+                    "opening native stream fixture cleanup FIFO {}",
+                    cleanup.command_path.display()
+                )
+            })?;
+        writeln!(command, "{}", cleanup.token)
+            .context("writing native stream fixture cleanup command")?;
+        command
+            .flush()
+            .context("flushing native stream fixture cleanup command")?;
 
         loop {
-            for (index, (label, file_name)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
-                if pids[index].is_none() {
-                    match native_stream_sigterm_fixture_pid(fixture_dir, label, file_name) {
-                        Ok(Some(pid)) => {
-                            pids[index] = Some(pid);
-                            pid_errors[index] = None;
-                        }
-                        Ok(None) => pid_errors[index] = None,
-                        Err(error) => pid_errors[index] = Some(format!("{error:#}")),
-                    }
-                }
-                if let Some(pid) = pids[index] {
-                    if !reaped[index] {
-                        reaped[index] = native_stream_sigterm_fixture_is_reaped(pid);
-                    }
+            match std::fs::read_to_string(&cleanup.acknowledgement_path) {
+                Ok(acknowledgement) if acknowledgement.trim() == cleanup.token => return Ok(()),
+                Ok(acknowledgement) if !acknowledgement.trim().is_empty() => anyhow::bail!(
+                    "native stream fixture cleanup acknowledgement did not match its token"
+                ),
+                Ok(_) => {}
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "reading native stream fixture cleanup acknowledgement {}",
+                            cleanup.acknowledgement_path.display()
+                        )
+                    });
                 }
             }
-
-            if pids.iter().all(Option::is_some) && reaped.iter().all(|reaped| *reaped) {
-                return Vec::new();
-            }
-            if Instant::now() >= reaping_deadline {
-                break;
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "native stream fixture did not acknowledge its durable cleanup command before the watchdog expired"
+                );
             }
             thread::sleep(Duration::from_millis(10));
         }
+    }
+
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
+    fn cleanup_native_stream_sigterm_fixtures(
+        cleanup: &NativeStreamSigtermCleanupHandle,
+        identities: Option<&[NativeStreamSigtermFixtureIdentity; 2]>,
+    ) -> Vec<String> {
+        let Some(identities) = identities else {
+            return match request_native_stream_sigterm_fixture_cleanup(
+                cleanup,
+                Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
+            ) {
+                Ok(()) => vec![
+                    "cancelled native stream cleanup was acknowledged, but fixture identities were never captured; refusing to report PID-file absence as reaping"
+                        .into(),
+                ],
+                Err(error) => vec![format!(
+                    "cancelled native stream did not capture durable fixture identities and its cleanup sentinel was unavailable: {error:#}"
+                )],
+            };
+        };
 
         let mut failures = Vec::new();
-        for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
-            if pids[index].is_none() {
-                if let Some(error) = &pid_errors[index] {
-                    failures.push(format!(
-                        "cancelled native stream could not read {label} PID before the reaping watchdog expired: {error}"
-                    ));
-                } else {
-                    failures.push(format!(
-                        "cancelled native stream did not record {label} PID before the reaping watchdog expired"
-                    ));
-                }
+        match native_stream_sigterm_fixture_states(identities) {
+            Ok(states)
+                if states
+                    .iter()
+                    .all(|state| *state == NativeStreamSigtermFixtureState::Reaped) =>
+            {
+                return Vec::new();
+            }
+            Ok(_) => {}
+            Err(error) => {
+                failures.push(format!(
+                    "could not verify native stream fixture identities before cleanup: {error}"
+                ));
             }
         }
 
-        let harness_pid = pids[0];
-        if let Some(harness_pid) = harness_pid {
-            let mut verified_fixture_group = false;
-            for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
-                let Some(pid) = pids[index] else {
-                    continue;
-                };
-                if reaped[index] {
-                    continue;
-                }
-                match native_stream_sigterm_fixture_process_group(pid) {
-                    Ok(Some(process_group)) if process_group == harness_pid => {
-                        verified_fixture_group = true;
-                    }
-                    Ok(Some(process_group)) => failures.push(format!(
-                        "cancelled native stream {label} {pid} reported process group {process_group}, not recorded harness process group {harness_pid}; refusing fixture cleanup"
-                    )),
-                    Ok(None) => reaped[index] = true,
-                    Err(error) => failures.push(format!(
-                        "failed to read process group for still-observed {label} {pid}: {error}"
-                    )),
-                }
-            }
-            if verified_fixture_group {
-                // The strict spawn makes the harness PID the leader of a new
-                // session. Killing only a group proven by one of the recorded
-                // fixture identities avoids sending SIGKILL to a recycled PID.
-                if unsafe { libc::killpg(harness_pid, libc::SIGKILL) } == -1 {
-                    let error = std::io::Error::last_os_error();
-                    if error.raw_os_error() != Some(libc::ESRCH) {
-                        failures.push(format!(
-                            "failed to terminate verified fixture process group led by {harness_pid}: {error}"
-                        ));
-                    }
-                }
-            } else {
-                failures.push(format!(
-                    "no still-observed fixture process verified recorded harness process group {harness_pid}; refusing fixture cleanup"
-                ));
-            }
-        } else {
-            failures.push(
-                "cancelled native stream did not record harness PID, so it had not safely advanced to descendant launch and no fixture group could be cleaned"
-                    .into(),
-            );
+        if let Err(error) = request_native_stream_sigterm_fixture_cleanup(
+            cleanup,
+            Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
+        ) {
+            failures.push(format!(
+                "failed to request durable native stream fixture cleanup: {error:#}"
+            ));
         }
 
         let cleanup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
-        while pids
-            .iter()
-            .enumerate()
-            .any(|(index, pid)| pid.is_some() && !reaped[index])
-            && Instant::now() < cleanup_deadline
-        {
-            for (index, pid) in pids.iter().enumerate() {
-                if let Some(pid) = pid {
-                    if !reaped[index] {
-                        reaped[index] = native_stream_sigterm_fixture_is_reaped(*pid);
+        loop {
+            match native_stream_sigterm_fixture_states(identities) {
+                Ok(states)
+                    if states
+                        .iter()
+                        .all(|state| *state == NativeStreamSigtermFixtureState::Reaped) =>
+                {
+                    return failures;
+                }
+                Ok(states) if Instant::now() >= cleanup_deadline => {
+                    for (index, state) in states.iter().enumerate() {
+                        match state {
+                            NativeStreamSigtermFixtureState::Reaped => {}
+                            NativeStreamSigtermFixtureState::Alive => failures.push(format!(
+                                "cancelled native stream left {} {} alive after durable cleanup",
+                                NATIVE_STREAM_SIGTERM_FIXTURES[index].0, identities[index].pid
+                            )),
+                            NativeStreamSigtermFixtureState::Reused => failures.push(format!(
+                                "recorded {} PID {} was reused; refusing to report that unrelated process as fixture reaping",
+                                NATIVE_STREAM_SIGTERM_FIXTURES[index].0, identities[index].pid
+                            )),
+                        }
                     }
+                    return failures;
                 }
-            }
-            if pids
-                .iter()
-                .enumerate()
-                .any(|(index, pid)| pid.is_some() && !reaped[index])
-            {
-                thread::sleep(Duration::from_millis(10));
-            }
-        }
-
-        for (index, (label, _)) in NATIVE_STREAM_SIGTERM_FIXTURES.iter().enumerate() {
-            if let Some(pid) = pids[index] {
-                if !reaped[index] {
+                Ok(_) => thread::sleep(Duration::from_millis(10)),
+                Err(error) => {
                     failures.push(format!(
-                        "cancelled native stream {label} {pid} survived verified fixture process-group cleanup"
+                        "could not verify native stream fixture identities after cleanup: {error}"
                     ));
+                    return failures;
                 }
             }
         }
-        failures
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     fn native_stream_sigterm_handler_is_restored() -> Result<bool> {
         let _lock = SUPERVISED_STREAM_CANCELLATION_LOCK
             .lock()
@@ -4686,21 +4875,34 @@ while :; do sleep 1; done
         Ok(current.sa_sigaction != cancel_supervised_stream as *const () as usize)
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, any(target_os = "linux", target_os = "macos")))]
     #[test]
     fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let temp_dir = tempfile::tempdir()?;
         let fake_harness = temp_dir.path().join("long-lived-stream");
+        let cleanup = create_native_stream_sigterm_cleanup_handle(temp_dir.path())?;
         std::fs::write(
             &fake_harness,
-            r#"#!/bin/sh
+            format!(
+                r#"#!/bin/sh
+(
+  exec 3<> cleanup.fifo
+  while IFS= read -r cleanup_command <&3; do
+    if [ "$cleanup_command" = "{cleanup_token}" ]; then
+      printf '%s\n' "$cleanup_command" > cleanup.ack
+      kill -KILL 0
+    fi
+  done
+) &
 printf '%s\n' "$$" > harness.pid
 sleep 120 </dev/null >/dev/null 2>&1 &
 printf '%s\n' "$!" > descendant.pid
 while :; do sleep 1; done
 "#,
+                cleanup_token = cleanup.token
+            ),
         )?;
         let mut permissions = std::fs::metadata(&fake_harness)?.permissions();
         permissions.set_mode(0o755);
@@ -4712,77 +4914,67 @@ while :; do sleep 1; done
         let signal_dir = temp_dir.path().to_path_buf();
         let stream_finished = Arc::new(AtomicBool::new(false));
         let signal_stream_finished = Arc::clone(&stream_finished);
+        let fixture_identities = Arc::new(Mutex::new(None));
+        let signal_fixture_identities = Arc::clone(&fixture_identities);
+        let signal_cleanup = cleanup.clone();
         let signaler = thread::spawn(move || -> Result<()> {
             let startup_deadline = Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG;
+            let mut last_readiness_error = None;
+            let mut last_delivery_error = None;
             loop {
                 if signal_stream_finished.load(Ordering::Relaxed) {
                     anyhow::bail!(
-                        "native stream returned before the fixture became ready; no SIGTERM was sent"
+                        "native stream returned before the fixture and cancellation handler were both ready; no SIGTERM was sent"
                     );
                 }
-                match native_stream_sigterm_fixture_is_ready(&signal_dir) {
-                    Ok(true) => {
-                        if signal_lifecycle.send_sigterm_if_active(runner_thread)? {
-                            SupervisedStreamCancellationTestObserver::wait_for_sigterm_delivery(
-                                startup_deadline,
-                            )?;
-                            return Ok(());
-                        }
-                        anyhow::bail!(
-                            "native stream handler was inactive before the fixture could be signalled; no SIGTERM was sent"
-                        );
-                    }
-                    Ok(false) if Instant::now() < startup_deadline => {}
-                    Ok(false) => {
+
+                match native_stream_sigterm_fixture_identities(&signal_dir) {
+                    Ok(Some(identities)) => {
+                        *signal_fixture_identities
+                            .lock()
+                            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(identities);
                         match signal_lifecycle.send_sigterm_if_active(runner_thread) {
-                            Ok(true) => {
-                                let delivery =
-                                    SupervisedStreamCancellationTestObserver::wait_for_sigterm_delivery(
-                                        startup_deadline,
-                                    );
-                                anyhow::bail!(
-                                    "native stream fixture did not become ready before the startup watchdog expired; sent SIGTERM while its handler was active{}",
-                                    delivery
-                                        .err()
-                                        .map(|error| format!(
-                                            " but it was not recorded: {error:#}"
-                                        ))
-                                        .unwrap_or_default()
-                                );
-                            }
-                            Ok(false) => anyhow::bail!(
-                                "native stream fixture did not become ready before the startup watchdog expired; handler was inactive and no SIGTERM was sent"
-                            ),
-                            Err(error) => anyhow::bail!(
-                                "native stream fixture did not become ready before the startup watchdog expired; failed to send SIGTERM while its handler was active: {error:#}"
-                            ),
+                            // `send_sigterm_if_active` holds the lifecycle
+                            // lock across pthread_kill, excluding restoration.
+                            // The final runner error below proves consumption.
+                            Ok(true) => return Ok(()),
+                            Ok(false) => {}
+                            Err(error) => last_delivery_error = Some(format!("{error:#}")),
                         }
                     }
+                    Ok(None) => {}
                     Err(error) => {
-                        match signal_lifecycle.send_sigterm_if_active(runner_thread) {
-                            Ok(true) => {
-                                let delivery =
-                                    SupervisedStreamCancellationTestObserver::wait_for_sigterm_delivery(
-                                        startup_deadline,
-                                    );
-                                anyhow::bail!(
-                                    "native stream fixture readiness failed: {error:#}; sent SIGTERM while its handler was active{}",
-                                    delivery
-                                        .err()
-                                        .map(|delivery_error| format!(
-                                            " but it was not recorded: {delivery_error:#}"
-                                        ))
-                                        .unwrap_or_default()
-                                );
-                            }
-                            Ok(false) => anyhow::bail!(
-                                "native stream fixture readiness failed: {error:#}; handler was inactive and no SIGTERM was sent"
-                            ),
-                            Err(send_error) => anyhow::bail!(
-                                "native stream fixture readiness failed: {error:#}; failed to send SIGTERM while its handler was active: {send_error:#}"
-                            ),
-                        }
+                        last_readiness_error = Some(format!("{error:#}"));
                     }
+                }
+                if signal_stream_finished.load(Ordering::Relaxed) {
+                    anyhow::bail!(
+                        "native stream returned before the fixture and cancellation handler were both ready; no SIGTERM was sent"
+                    );
+                }
+                if Instant::now() >= startup_deadline {
+                    // This is a failure-only escape hatch. It intentionally
+                    // does not use pthread_kill without both prerequisites;
+                    // the fixture's own FIFO sentinel kills only its group.
+                    let cleanup_result = request_native_stream_sigterm_fixture_cleanup(
+                        &signal_cleanup,
+                        Instant::now() + NATIVE_STREAM_SIGTERM_TEST_WATCHDOG,
+                    );
+                    anyhow::bail!(
+                        "native stream fixture and cancellation handler did not become ready together before the startup watchdog expired; no SIGTERM was sent{}{}; durable fixture cleanup {}",
+                        last_readiness_error
+                            .as_deref()
+                            .map(|error| format!("; last readiness error: {error}"))
+                            .unwrap_or_default(),
+                        last_delivery_error
+                            .as_deref()
+                            .map(|error| format!("; last delivery error: {error}"))
+                            .unwrap_or_default(),
+                        match cleanup_result {
+                            Ok(()) => "was acknowledged".to_string(),
+                            Err(error) => format!("failed: {error:#}"),
+                        }
+                    );
                 }
                 thread::sleep(Duration::from_millis(10));
             }
@@ -4804,7 +4996,12 @@ while :; do sleep 1; done
         };
         let restoration_result = native_stream_sigterm_handler_is_restored();
 
-        let mut failures = cleanup_native_stream_sigterm_fixtures(temp_dir.path());
+        let captured_fixture_identities = fixture_identities
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let mut failures =
+            cleanup_native_stream_sigterm_fixtures(&cleanup, captured_fixture_identities.as_ref());
         if let Err(error) = signal_result {
             failures.push(format!("native stream signal thread failed: {error:#}"));
         }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -430,9 +430,88 @@ static SUPERVISED_STREAM_CANCELLATION_SIGNAL: AtomicI32 = AtomicI32::new(0);
 #[cfg(unix)]
 static SUPERVISED_STREAM_CANCELLATION_LOCK: Mutex<()> = Mutex::new(());
 
+#[cfg(all(test, unix))]
+#[derive(Default)]
+struct SupervisedStreamCancellationTestState {
+    armed_thread: Option<thread::ThreadId>,
+    handler_active: bool,
+}
+
+#[cfg(all(test, unix))]
+static SUPERVISED_STREAM_CANCELLATION_TEST_STATE: Mutex<SupervisedStreamCancellationTestState> =
+    Mutex::new(SupervisedStreamCancellationTestState {
+        armed_thread: None,
+        handler_active: false,
+    });
+
 #[cfg(unix)]
 extern "C" fn cancel_supervised_stream(signal: libc::c_int) {
     SUPERVISED_STREAM_CANCELLATION_SIGNAL.store(signal, Ordering::Relaxed);
+}
+
+#[cfg(all(test, unix))]
+fn arm_supervised_stream_cancellation_test_signal() {
+    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+        state.armed_thread.is_none(),
+        "another supervised-stream cancellation test is already armed"
+    );
+    state.armed_thread = Some(thread::current().id());
+}
+
+#[cfg(all(test, unix))]
+fn disarm_supervised_stream_cancellation_test_signal() {
+    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    assert!(
+        !state.handler_active,
+        "supervised-stream cancellation handler remained active after the runner returned"
+    );
+    state.armed_thread = None;
+}
+
+#[cfg(all(test, unix))]
+fn activate_supervised_stream_cancellation_test_signal() {
+    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if state.armed_thread == Some(thread::current().id()) {
+        state.handler_active = true;
+    }
+}
+
+#[cfg(all(test, unix))]
+fn deactivate_supervised_stream_cancellation_test_signal() {
+    let mut state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if state.armed_thread == Some(thread::current().id()) {
+        state.handler_active = false;
+    }
+}
+
+#[cfg(all(test, unix))]
+fn signal_active_supervised_stream_cancellation_test() -> Result<()> {
+    let state = SUPERVISED_STREAM_CANCELLATION_TEST_STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if !state.handler_active {
+        anyhow::bail!("native stream SIGTERM handler was not active");
+    }
+    let sent = unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
+    if sent != 0 {
+        return Err(std::io::Error::last_os_error()).context("failed to signal test process");
+    }
+    // Keep the handler installed until it records the signal; otherwise a
+    // pending process-wide SIGTERM could run after the prior handler returns.
+    while SUPERVISED_STREAM_CANCELLATION_SIGNAL.load(Ordering::Relaxed) != libc::SIGTERM {
+        thread::yield_now();
+    }
+    drop(state);
+    Ok(())
 }
 
 /// Temporarily converts TERM/INT/HUP into a supervised bridge cancellation.
@@ -587,10 +666,14 @@ impl SupervisedStreamCancellationGuard {
         self.signal_mask
             .unblock_supervisor()
             .context("failed to unblock supervised stream cancellation signals")?;
+        #[cfg(test)]
+        activate_supervised_stream_cancellation_test_signal();
         Ok(self.cancelled_signal())
     }
 
     fn finish(mut self) -> Result<Option<libc::c_int>> {
+        #[cfg(test)]
+        deactivate_supervised_stream_cancellation_test_signal();
         self.signal_mask
             .reblock()
             .context("failed to re-block supervised stream cancellation signals")?;
@@ -624,6 +707,8 @@ impl Drop for SupervisedStreamCancellationGuard {
         if !self.active {
             return;
         }
+        #[cfg(test)]
+        deactivate_supervised_stream_cancellation_test_signal();
         let _ = self.signal_mask.reblock();
         // SAFETY: every entry was captured from a successful sigaction call
         // in install. Restoring it here makes the scope transparent once the
@@ -4370,25 +4455,29 @@ while :; do sleep 1; done
         permissions.set_mode(0o755);
         std::fs::set_permissions(&fake_harness, permissions)?;
 
+        arm_supervised_stream_cancellation_test_signal();
         let signal_dir = temp_dir.path().to_path_buf();
-        let signaler = thread::spawn(move || {
+        let signaler = thread::spawn(move || -> Result<()> {
             let deadline = Instant::now() + watchdog;
-            while Instant::now() < deadline {
+            let fixture_started = loop {
                 if signal_dir.join("harness.pid").exists()
                     && signal_dir.join("descendant.pid").exists()
                 {
-                    let sent = unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
-                    assert_eq!(sent, 0, "failed to signal test process");
-                    return;
+                    break true;
+                }
+                if Instant::now() >= deadline {
+                    break false;
                 }
                 thread::sleep(Duration::from_millis(10));
+            };
+            signal_active_supervised_stream_cancellation_test()?;
+            if !fixture_started {
+                anyhow::bail!("native stream fixture did not start before the 30-second watchdog");
             }
-            let sent = unsafe { libc::kill(libc::getpid(), libc::SIGTERM) };
-            assert_eq!(sent, 0, "failed to signal test process");
-            panic!("native stream fixture did not start before signal deadline");
+            Ok(())
         });
 
-        let error = stream_harness_with_program(
+        let stream_result = stream_harness_with_program(
             fake_harness.to_str().unwrap(),
             temp_dir.path(),
             Vec::new(),
@@ -4396,9 +4485,14 @@ while :; do sleep 1; done
             "streamy",
             "ledger-current",
             &mut Vec::new(),
-        )
-        .expect_err("SIGTERM must cancel a native stream");
-        signaler.join().expect("signal thread panicked");
+        );
+        let signal_result = match signaler.join() {
+            Ok(result) => result,
+            Err(_) => Err(anyhow::anyhow!("native stream signal thread panicked")),
+        };
+        disarm_supervised_stream_cancellation_test_signal();
+        signal_result?;
+        let error = stream_result.expect_err("SIGTERM must cancel a native stream");
         assert!(
             format!("{error:#}").contains("streamy native stream cancelled by SIGTERM"),
             "unexpected cancellation error: {error:#}"
@@ -4417,28 +4511,76 @@ while :; do sleep 1; done
             "native stream runner did not restore the previous SIGTERM handler"
         );
 
+        let mut failures = Vec::new();
+        let mut fixtures = Vec::new();
         for (label, path) in [
             ("harness", harness_pid_file),
             ("descendant", descendant_pid_file),
         ] {
-            let pid: libc::pid_t = std::fs::read_to_string(path)?.trim().parse()?;
-            let deadline = Instant::now() + watchdog;
-            let mut reaped = false;
-            while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
+            match std::fs::read_to_string(&path)
+                .with_context(|| format!("reading {label} PID file {}", path.display()))
+                .and_then(|contents| {
+                    contents
+                        .trim()
+                        .parse::<libc::pid_t>()
+                        .context("parsing fixture PID")
+                }) {
+                Ok(pid) if pid > 0 => fixtures.push((label, pid, false)),
+                Ok(pid) => failures.push(format!("{label} fixture recorded invalid PID {pid}")),
+                Err(error) => failures.push(format!("{label} fixture PID unavailable: {error:#}")),
+            }
+        }
+        let is_reaped = |pid: libc::pid_t| {
+            (unsafe { libc::kill(pid, 0) }) == -1
+                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+        };
+        let reaping_deadline = Instant::now() + watchdog;
+        while fixtures.iter().any(|(_, _, reaped)| !reaped) && Instant::now() < reaping_deadline {
+            for (_, pid, reaped) in &mut fixtures {
+                *reaped = is_reaped(*pid);
+            }
+            if fixtures.iter().any(|(_, _, reaped)| !reaped) {
                 thread::sleep(Duration::from_millis(10));
             }
-            if unsafe { libc::kill(pid, 0) } == -1
-                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
-            {
-                reaped = true;
-            }
-            if !reaped {
-                unsafe {
-                    libc::kill(pid, libc::SIGKILL);
-                    libc::waitpid(pid, std::ptr::null_mut(), 0);
+        }
+
+        for (label, pid, reaped) in &mut fixtures {
+            if !*reaped {
+                failures.push(format!(
+                    "cancelled native stream left {label} {pid} unreaped before cleanup"
+                ));
+                let killed = unsafe { libc::kill(*pid, libc::SIGKILL) };
+                if killed == -1 {
+                    let error = std::io::Error::last_os_error();
+                    if error.raw_os_error() == Some(libc::ESRCH) {
+                        *reaped = true;
+                    } else {
+                        failures.push(format!(
+                            "failed to clean up unreaped {label} {pid} with SIGKILL: {error}"
+                        ));
+                    }
                 }
             }
-            assert!(reaped, "cancelled native stream {label} {pid} survived");
+        }
+
+        let cleanup_deadline = Instant::now() + watchdog;
+        while fixtures.iter().any(|(_, _, reaped)| !reaped) && Instant::now() < cleanup_deadline {
+            for (_, pid, reaped) in &mut fixtures {
+                *reaped = is_reaped(*pid);
+            }
+            if fixtures.iter().any(|(_, _, reaped)| !reaped) {
+                thread::sleep(Duration::from_millis(10));
+            }
+        }
+        for (label, pid, reaped) in fixtures {
+            if !reaped {
+                failures.push(format!(
+                    "cancelled native stream {label} {pid} survived cleanup"
+                ));
+            }
+        }
+        if !failures.is_empty() {
+            anyhow::bail!("{}", failures.join("; "));
         }
         Ok(())
     }

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -4361,7 +4361,7 @@ while :; do sleep 1; done
             &fake_harness,
             r#"#!/bin/sh
 printf '%s\n' "$$" > harness.pid
-sleep 30 &
+sleep 120 &
 printf '%s\n' "$!" > descendant.pid
 while :; do sleep 1; done
 "#,
@@ -4421,18 +4421,22 @@ while :; do sleep 1; done
         ] {
             let pid: libc::pid_t = std::fs::read_to_string(path)?.trim().parse()?;
             let deadline = Instant::now() + watchdog;
+            let mut reaped = false;
             while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
                 thread::sleep(Duration::from_millis(10));
             }
-            assert_eq!(
-                unsafe { libc::kill(pid, 0) },
-                -1,
-                "cancelled native stream {label} {pid} survived"
-            );
-            assert_eq!(
-                std::io::Error::last_os_error().raw_os_error(),
-                Some(libc::ESRCH)
-            );
+            if unsafe { libc::kill(pid, 0) } == -1
+                && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+            {
+                reaped = true;
+            }
+            if !reaped {
+                unsafe {
+                    libc::kill(pid, libc::SIGKILL);
+                    libc::waitpid(pid, std::ptr::null_mut(), 0);
+                }
+            }
+            assert!(reaped, "cancelled native stream {label} {pid} survived");
         }
         Ok(())
     }

--- a/docs/superpowers/plans/2026-08-05-psyche-o1-1-conformance-closure.md
+++ b/docs/superpowers/plans/2026-08-05-psyche-o1-1-conformance-closure.md
@@ -457,7 +457,7 @@ cargo test -p coven-cli pty_runner::tests::nonblocking_wait_without_reaping_does
 cargo test -p coven-cli pty_runner::tests::cancellation_guard_blocks_supervised_signals_for_spawned_helpers -- --exact
 cargo test -p coven-cli pty_runner::tests::native_stream_does_not_wait_for_stdout_inheriting_descendant -- --exact
 cargo test -p coven-cli pty_runner::tests::successful_native_stream_cleans_closed_output_descendant -- --exact
-cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_returns_promptly_and_reaps_process_tree -- --exact
+cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact
 cargo test -p coven-cli pty_runner::tests::codex_json_runner_reaps_a_pipe_holding_descendant_after_wrapper_exit -- --exact
 cargo test -p coven-cli pty_runner::tests::codex_json_runner_reaps_a_closed_pipe_descendant_after_wrapper_exit -- --exact
 cargo test -p coven-cli --test stream_json_integration codex_json_sigterm_reaps_descendants_and_marks_ledger_failed -- --exact

--- a/docs/superpowers/plans/2026-08-05-psyche-o1-1-conformance-closure.md
+++ b/docs/superpowers/plans/2026-08-05-psyche-o1-1-conformance-closure.md
@@ -463,7 +463,7 @@ cargo test -p coven-cli pty_runner::tests::codex_json_runner_reaps_a_closed_pipe
 cargo test -p coven-cli --test stream_json_integration codex_json_sigterm_reaps_descendants_and_marks_ledger_failed -- --exact
 ```
 
-Expected on Unix: every test passes, direct children and descendants are gone, cancellation is prompt, `waitid(...WNOHANG | WNOWAIT)` never reports a live child as exited, and cleanup occurs before reaping.
+Expected on Unix: every test passes, direct children and descendants are gone, cancellation returns the expected error, `waitid(...WNOHANG | WNOWAIT)` never reports a live child as exited, and cleanup occurs before reaping.
 
 - [ ] **Step 2: Run the Windows-compilable containment coverage**
 

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -9,11 +9,16 @@ or destructive PID-file cleanup.
 **Architecture:** The production stream runner is unchanged. The test observer
 holds its test-only lifecycle lock across `pthread_kill`; the runner's expected
 cancellation error is the acknowledgement that matters. The signaler waits
-outside locks until fixture identities and guard activation coexist. A
-pre-created tokenized FIFO lets a fixture-owned sentinel kill its own
-`setsid` group on failure, so the test never kills a group from numeric PID
-files. Linux identities use `/proc/<pid>/stat` start ticks; macOS identities
-use `proc_pidinfo(PROC_PIDTBSDINFO)` start timestamps.
+outside locks until fixture identities and guard activation coexist. On
+fixture-start watchdog expiry, the fallback rechecks the owner-scoped guard
+lifecycle under the lifecycle mutex: if it is still active, it sends a
+thread-directed SIGTERM and then records a fixture-start failure; if it is
+inactive, it records the failure without signalling. The stream returns and
+identity-safe cleanup plus aggregated assertions run. This containment path is
+not normal cancellation or a performance assertion, and it never signals under
+the restored/default handler or changes async handler semantics. Linux
+identities use `/proc/<pid>/stat` start ticks; macOS identities use
+`proc_pidinfo(PROC_PIDTBSDINFO)` start timestamps.
 
 **Tech Stack:** Rust, `libc`, Cargo test runner, POSIX shell test fixture.
 
@@ -67,13 +72,14 @@ lock and retries until the watchdog. Do not poll
 `SUPERVISED_STREAM_CANCELLATION_SIGNAL` after `pthread_kill`: guard finish may
 clear it. The final expected cancellation error is the consumption assertion.
 
-On expiry, request tokenized FIFO cleanup rather than dispatching SIGTERM
-without both readiness and activation. After the runner returns, classify each
-captured PID by its recorded platform start identity. PID reuse is a failure,
-not evidence of reaping. The fixture sentinel is the only failure-path
-SIGKILL issuer and executes `kill -KILL 0` from its own group after
-acknowledging the token. Missing PID files cannot prevent that request because
-the FIFO exists before launch.
+On expiry, if the owner-scoped guard lifecycle is still active, send a
+thread-directed SIGTERM while holding the lifecycle mutex, then record a
+fixture-start failure; if the lifecycle is inactive, record the failure
+without signalling. After the runner returns, classify each captured PID by its
+recorded platform start identity. PID reuse is a failure, not evidence of
+reaping. The fallback is a containment failure path, not normal cancellation or
+a performance assertion, and it never signals under the restored/default
+handler or changes async handler semantics.
 
 - [ ] **Step 3: Format and run the renamed test**
 
@@ -85,7 +91,9 @@ cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_rea
 ```
 
 Expected: formatting passes, and the test proves the cancellation error,
-handler restoration, and durable fixture reaping.
+handler restoration, and durable fixture reaping. Any watchdog fallback is a
+containment failure path that still runs identity-safe cleanup and aggregated
+assertions.
 
 - [ ] **Step 4: Run the targeted test under deliberate CPU load**
 
@@ -123,7 +131,9 @@ PY
 
 Expected: the test passes under load. It may take longer than two seconds,
 which is acceptable because correctness is the cancellation error plus
-process-tree reaping.
+process-tree reaping. If the watchdog fallback is taken, it must do so via the
+owner-scoped lifecycle-mutex path described above, not via FIFO cleanup or
+unconditional SIGTERM.
 
 - [ ] **Step 5: Commit the test fix**
 

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -18,7 +18,15 @@ identity-safe cleanup plus aggregated assertions run. This containment path is
 not normal cancellation or a performance assertion, and it never signals under
 the restored/default handler or changes async handler semantics. Linux
 identities use `/proc/<pid>/stat` start ticks; macOS identities use
-`proc_pidinfo(PROC_PIDTBSDINFO)` start timestamps.
+`proc_pidinfo(PROC_PIDTBSDINFO)` start timestamps. The test-owned FIFO reader
+opens read-only before the fixture starts; its write-only request receives an
+exact-token acknowledgement outside the harness session. That keeps the
+acknowledgement available after correct process-group termination kills every
+fixture child on Linux. Cleanup requests the acknowledgement before checking
+identities and stops the coordinator on a command or acknowledgement failure.
+The coordinator never signals fixture PIDs or process groups. A separate
+fixture-local emergency FIFO preserves the safe `kill -KILL 0` containment
+fallback: only a surviving fixture-group member can consume it.
 
 **Tech Stack:** Rust, `libc`, Cargo test runner, POSIX shell test fixture.
 
@@ -62,14 +70,15 @@ fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
 
     let watchdog = Duration::from_secs(30);
     // Keep the expected cancellation error and restoration assertion. Capture
-    // fixture start identities before signalling, and retain a tokenized FIFO
-    // cleanup sentinel created before the shell fixture starts.
+    // fixture start identities before signalling, and start a tokenized
+    // test-owned FIFO cleanup sentinel before the shell fixture starts.
 ```
 
 The signaler repeatedly captures both fixture identities and calls
 `send_sigterm_if_active` only when capture succeeds. A `false` result means
 the lifecycle is not yet active, not that the test should fail; it releases the
-lock and retries until the watchdog. Do not poll
+lock and retries until the watchdog. After the runner returns, request and
+verify the durable FIFO acknowledgement before checking fixture identities. Do not poll
 `SUPERVISED_STREAM_CANCELLATION_SIGNAL` after `pthread_kill`: guard finish may
 clear it. The final expected cancellation error is the consumption assertion.
 

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -2,9 +2,18 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Make the Unix native-stream SIGTERM test verify cancellation and process-tree reaping without asserting a machine-load-dependent completion time.
+**Goal:** Make the Linux/macOS native-stream SIGTERM test verify cancellation
+and process-tree reaping without an atomic-ack race, pre-activation signalling,
+or destructive PID-file cleanup.
 
-**Architecture:** The production stream runner is unchanged. Its Unix unit test will retain the expected cancellation error, restored signal-handler, and `ESRCH` process-tree assertions, replacing only short fixture/reaping deadlines with a shared watchdog and deleting the 2-second elapsed-time assertion.
+**Architecture:** The production stream runner is unchanged. The test observer
+holds its test-only lifecycle lock across `pthread_kill`; the runner's expected
+cancellation error is the acknowledgement that matters. The signaler waits
+outside locks until fixture identities and guard activation coexist. A
+pre-created tokenized FIFO lets a fixture-owned sentinel kill its own
+`setsid` group on failure, so the test never kills a group from numeric PID
+files. Linux identities use `/proc/<pid>/stat` start ticks; macOS identities
+use `proc_pidinfo(PROC_PIDTBSDINFO)` start timestamps.
 
 **Tech Stack:** Rust, `libc`, Cargo test runner, POSIX shell test fixture.
 
@@ -14,9 +23,10 @@
 
 | File | Responsibility |
 | --- | --- |
-| `crates/coven-cli/src/pty_runner.rs` | Unix native-stream SIGTERM unit test and its behavior assertions. |
+| `crates/coven-cli/src/pty_runner.rs` | Linux/macOS native-stream SIGTERM unit test, durable cleanup protocol, and behavior assertions. |
+| `docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md` | Safety rationale and platform identity contract. |
 
-### Task 1: Replace the timing proxy with behavior checks
+### Task 1: Synchronize delivery and use durable fixture cleanup
 
 **Files:**
 - Modify: `crates/coven-cli/src/pty_runner.rs:4350-4444`
@@ -45,53 +55,25 @@ fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
     let watchdog = Duration::from_secs(30);
-    // Keep the existing fixture, signaler, cancellation-error assertion,
-    // SIGTERM-handler restoration assertion, and harness/descendant loop.
+    // Keep the expected cancellation error and restoration assertion. Capture
+    // fixture start identities before signalling, and retain a tokenized FIFO
+    // cleanup sentinel created before the shell fixture starts.
 ```
 
-In the signaler closure, replace:
+The signaler repeatedly captures both fixture identities and calls
+`send_sigterm_if_active` only when capture succeeds. A `false` result means
+the lifecycle is not yet active, not that the test should fail; it releases the
+lock and retries until the watchdog. Do not poll
+`SUPERVISED_STREAM_CANCELLATION_SIGNAL` after `pthread_kill`: guard finish may
+clear it. The final expected cancellation error is the consumption assertion.
 
-```rust
-let deadline = Instant::now() + Duration::from_secs(3);
-```
-
-with:
-
-```rust
-let deadline = Instant::now() + watchdog;
-```
-
-Delete:
-
-```rust
-let started = Instant::now();
-```
-
-and delete the entire assertion:
-
-```rust
-assert!(
-    started.elapsed() < Duration::from_secs(2),
-    "native stream cancellation was not prompt"
-);
-```
-
-In the final harness/descendant loop, replace:
-
-```rust
-let deadline = Instant::now() + Duration::from_secs(1);
-```
-
-with:
-
-```rust
-let deadline = Instant::now() + watchdog;
-```
-
-Do not change the expected cancellation-error text, signal-handler restoration
-check, `kill(pid, 0) == -1` assertion, or `ESRCH` assertion. The watchdog
-prevents a broken test fixture from hanging; it is not a performance
-requirement.
+On expiry, request tokenized FIFO cleanup rather than dispatching SIGTERM
+without both readiness and activation. After the runner returns, classify each
+captured PID by its recorded platform start identity. PID reuse is a failure,
+not evidence of reaping. The fixture sentinel is the only failure-path
+SIGKILL issuer and executes `kill -KILL 0` from its own group after
+acknowledging the token. Missing PID files cannot prevent that request because
+the FIFO exists before launch.
 
 - [ ] **Step 3: Format and run the renamed test**
 
@@ -102,22 +84,41 @@ cargo fmt --check
 cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
 ```
 
-Expected: formatting passes, and the renamed test passes while still reporting
-the cancellation error and reaping both fixture PIDs.
+Expected: formatting passes, and the test proves the cancellation error,
+handler restoration, and durable fixture reaping.
 
 - [ ] **Step 4: Run the targeted test under deliberate CPU load**
 
-Run the test while 24 exact, locally started spinner PIDs consume CPU; terminate
-only those captured PIDs after the test:
+Run the target under a Python supervisor that starts exactly 24 local spinners
+and terminates only those children:
 
 ```sh
-pids=()
-for _ in $(seq 1 24); do
-  yes > /dev/null &
-  pids+=("$!")
-done
-trap 'for pid in "${pids[@]}"; do kill "$pid" 2>/dev/null || true; done; wait' EXIT
-cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
+python3 - <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+spinners = [
+    subprocess.Popen(["yes"], stdout=subprocess.DEVNULL)
+    for _ in range(24)
+]
+try:
+    sys.exit(subprocess.run([
+        "cargo", "test", "-p", "coven-cli",
+        "pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree",
+        "--", "--exact", "--nocapture",
+    ]).returncode)
+finally:
+    for spinner in spinners:
+        spinner.terminate()
+    for spinner in spinners:
+        try:
+            spinner.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            spinner.kill()
+            spinner.wait()
+PY
 ```
 
 Expected: the test passes under load. It may take longer than two seconds,

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -1,0 +1,177 @@
+# PTY SIGTERM Load-Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Unix native-stream SIGTERM test verify cancellation and process-tree reaping without asserting a machine-load-dependent completion time.
+
+**Architecture:** The production stream runner is unchanged. Its Unix unit test will retain the expected cancellation error, restored signal-handler, and `ESRCH` process-tree assertions, replacing only short fixture/reaping deadlines with a shared watchdog and deleting the 2-second elapsed-time assertion.
+
+**Tech Stack:** Rust, `libc`, Cargo test runner, POSIX shell test fixture.
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `crates/coven-cli/src/pty_runner.rs` | Unix native-stream SIGTERM unit test and its behavior assertions. |
+
+### Task 1: Replace the timing proxy with behavior checks
+
+**Files:**
+- Modify: `crates/coven-cli/src/pty_runner.rs:4350-4444`
+- Test: `crates/coven-cli/src/pty_runner.rs:4350-4444`
+
+- [ ] **Step 1: Run the existing targeted test**
+
+Run:
+
+```sh
+cargo test -p coven-cli native_stream_sigterm_returns_promptly_and_reaps_process_tree -- --exact --nocapture
+```
+
+Expected: PASS on an unloaded machine. The existing body contains
+`started.elapsed() < Duration::from_secs(2)`, which is the load-sensitive
+assertion this task removes.
+
+- [ ] **Step 2: Edit the test body**
+
+Rename the test and replace its short deadlines with the shared local watchdog:
+
+```rust
+#[cfg(unix)]
+#[test]
+fn native_stream_sigterm_cancels_and_reaps_process_tree() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let watchdog = Duration::from_secs(30);
+    // Keep the existing fixture, signaler, cancellation-error assertion,
+    // SIGTERM-handler restoration assertion, and harness/descendant loop.
+```
+
+In the signaler closure, replace:
+
+```rust
+let deadline = Instant::now() + Duration::from_secs(3);
+```
+
+with:
+
+```rust
+let deadline = Instant::now() + watchdog;
+```
+
+Delete:
+
+```rust
+let started = Instant::now();
+```
+
+and delete the entire assertion:
+
+```rust
+assert!(
+    started.elapsed() < Duration::from_secs(2),
+    "native stream cancellation was not prompt"
+);
+```
+
+In the final harness/descendant loop, replace:
+
+```rust
+let deadline = Instant::now() + Duration::from_secs(1);
+```
+
+with:
+
+```rust
+let deadline = Instant::now() + watchdog;
+```
+
+Do not change the expected cancellation-error text, signal-handler restoration
+check, `kill(pid, 0) == -1` assertion, or `ESRCH` assertion. The watchdog
+prevents a broken test fixture from hanging; it is not a performance
+requirement.
+
+- [ ] **Step 3: Format and run the renamed test**
+
+Run:
+
+```sh
+cargo fmt --check
+cargo test -p coven-cli native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
+```
+
+Expected: formatting passes, and the renamed test passes while still reporting
+the cancellation error and reaping both fixture PIDs.
+
+- [ ] **Step 4: Run the targeted test under deliberate CPU load**
+
+Run the test while 24 exact, locally started spinner PIDs consume CPU; terminate
+only those captured PIDs after the test:
+
+```sh
+pids=()
+for _ in $(seq 1 24); do
+  yes > /dev/null &
+  pids+=("$!")
+done
+trap 'for pid in "${pids[@]}"; do kill "$pid" 2>/dev/null || true; done; wait' EXIT
+cargo test -p coven-cli native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
+```
+
+Expected: the test passes under load. It may take longer than two seconds,
+which is acceptable because correctness is the cancellation error plus
+process-tree reaping.
+
+- [ ] **Step 5: Commit the test fix**
+
+```sh
+git add crates/coven-cli/src/pty_runner.rs
+git commit -m "test: remove flaky PTY SIGTERM timing bound" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 2: Verify the package and workspace gates
+
+**Files:**
+- No additional files.
+
+- [ ] **Step 1: Run the CLI package tests**
+
+Run:
+
+```sh
+cargo test -p coven-cli --locked
+```
+
+Expected: all non-ignored `coven-cli` tests pass.
+
+- [ ] **Step 2: Run required workspace checks**
+
+Run:
+
+```sh
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+git add crates/coven-cli/src/pty_runner.rs
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: every command exits successfully. The staged privacy guard examines
+only the PTY test change.
+
+- [ ] **Step 3: Inspect the scoped diff**
+
+Run:
+
+```sh
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+```
+
+Expected: no whitespace errors; the implementation diff changes only
+`crates/coven-cli/src/pty_runner.rs` in addition to the already committed
+design and plan records.

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -27,7 +27,7 @@
 Run:
 
 ```sh
-cargo test -p coven-cli native_stream_sigterm_returns_promptly_and_reaps_process_tree -- --exact --nocapture
+cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
 ```
 
 Expected: PASS on an unloaded machine. The existing body contains

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -99,7 +99,7 @@ Run:
 
 ```sh
 cargo fmt --check
-cargo test -p coven-cli native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
+cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
 ```
 
 Expected: formatting passes, and the renamed test passes while still reporting
@@ -117,7 +117,7 @@ for _ in $(seq 1 24); do
   pids+=("$!")
 done
 trap 'for pid in "${pids[@]}"; do kill "$pid" 2>/dev/null || true; done; wait' EXIT
-cargo test -p coven-cli native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
+cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
 ```
 
 Expected: the test passes under load. It may take longer than two seconds,

--- a/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
+++ b/docs/superpowers/plans/2026-08-09-pty-sigterm-load-resilience.md
@@ -45,9 +45,10 @@ Run:
 cargo test -p coven-cli pty_runner::tests::native_stream_sigterm_cancels_and_reaps_process_tree -- --exact --nocapture
 ```
 
-Expected: PASS on an unloaded machine. The existing body contains
-`started.elapsed() < Duration::from_secs(2)`, which is the load-sensitive
-assertion this task removes.
+Expected: PASS on an unloaded machine. The old
+`started.elapsed() < Duration::from_secs(2)` check is removed; the behavior
+contract is the expected cancellation error, previous SIGTERM handler
+restoration, and harness/descendant process-tree reaping.
 
 - [ ] **Step 2: Edit the test body**
 
@@ -129,11 +130,11 @@ finally:
 PY
 ```
 
-Expected: the test passes under load. It may take longer than two seconds,
-which is acceptable because correctness is the cancellation error plus
-process-tree reaping. If the watchdog fallback is taken, it must do so via the
-owner-scoped lifecycle-mutex path described above, not via FIFO cleanup or
-unconditional SIGTERM.
+Expected: the test passes under load. The 30-second watchdog is containment
+only; correctness is the cancellation error, previous SIGTERM handler
+restoration, and harness/descendant process-tree reaping. If the watchdog
+fallback is taken, it must do so via the owner-scoped lifecycle-mutex path
+described above, not via FIFO cleanup or unconditional SIGTERM.
 
 - [ ] **Step 5: Commit the test fix**
 

--- a/docs/superpowers/specs/2026-08-05-psyche-o1-1-corrective-annex-design.md
+++ b/docs/superpowers/specs/2026-08-05-psyche-o1-1-corrective-annex-design.md
@@ -277,7 +277,7 @@ The implementation evidence must include hermetic tests for:
 ### 8.3 Process ownership
 
 - malformed output terminates and reaps the direct child and descendants;
-- cancellation is observed promptly and returns an error;
+- cancellation returns the expected error;
 - a cancellation recorded before or immediately after spawn cannot escape
   supervision;
 - a direct child that exits while a descendant holds stdout does not hang the

--- a/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
@@ -5,7 +5,7 @@
 
 ## Problem
 
-`native_stream_sigterm_returns_promptly_and_reaps_process_tree` currently
+`native_stream_sigterm_cancels_and_reaps_process_tree` currently
 asserts that cancellation completes in under two seconds. Under heavy machine
 load, SIGTERM delivery and process scheduling can legitimately exceed that
 wall-clock budget even when the stream runner returns the required cancellation

--- a/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
@@ -30,6 +30,19 @@ The test will assert behavior, not host scheduling speed:
   and its seconds/microseconds start timestamp. A later missing PID is reaped
   only when it was first captured under that identity; a different start
   identity is reported as reuse, never as fixture reaping.
+- The durable cleanup coordinator is test-owned rather than a background
+  process in the harness session. It opens the FIFO read-only and nonblocking
+  before the fixture starts; the request side subsequently opens it write-only
+  and nonblocking. It records the exact token in the acknowledgement file and
+  exits. This keeps the acknowledgement available after the production runner
+  correctly kills the harness session/process group—a lifecycle that otherwise
+  kills an in-fixture FIFO reader on Linux. Cleanup always requests this
+  acknowledgement before evaluating reaping; on an error the coordinator is
+  stopped, so its test thread remains bounded. The coordinator never signals a
+  fixture PID or process group. A separate fixture-local emergency FIFO retains
+  the existing `kill -KILL 0` fallback: only a surviving member of the
+  fixture's own process group can consume that command, so it cannot target a
+  recycled PID or an unrelated group.
 
 If PID readiness appears before activation, the signaler keeps bounded polling
 outside lifecycle locks. If the runner finishes first, it records a non-signal

--- a/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
@@ -7,11 +7,11 @@
 
 `native_stream_sigterm_cancels_and_reaps_process_tree` must exercise the
 native-stream cancellation path without creating a signal-disposition race or
-using fixture PID files as unsafe cleanup authority. A previous acknowledgement
-poll observed the production cancellation atomic after `pthread_kill`; guard
-finish legitimately clears that atomic, producing a false watchdog failure.
-Likewise, PID-file readiness can precede guard activation, and numeric PIDs or
-their process-group equality can be reused before failure cleanup runs.
+falling back to unsafe PID-file cleanup. A previous acknowledgement poll
+observed the production cancellation atomic after `pthread_kill`; guard finish
+legitimately clears that atomic, producing a false watchdog failure. Likewise,
+PID-file readiness can precede guard activation, and numeric PIDs or their
+process-group equality can be reused before failure cleanup runs.
 
 ## Decision
 
@@ -30,19 +30,18 @@ The test will assert behavior, not host scheduling speed:
   and its seconds/microseconds start timestamp. A later missing PID is reaped
   only when it was first captured under that identity; a different start
   identity is reported as reuse, never as fixture reaping.
-- Failure cleanup uses a per-test FIFO command and unpredictable token created
-  before launch. The fixture-owned sentinel acknowledges that exact token and
-  calls `kill -KILL 0` from inside its own `setsid` process group. The test
-  therefore never sends a destructive signal to a PID or PGID read from a
-  fixture file. The FIFO stays usable even when the harness or descendant PID
-  file was never published.
 
 If PID readiness appears before activation, the signaler keeps bounded polling
 outside lifecycle locks. If the runner finishes first, it records a non-signal
-failure and lets the main thread perform cleanup. At watchdog expiry, it asks
-the fixture sentinel to end its own group rather than sending SIGTERM without
-both prerequisites. Watchdogs remain diagnostic safeguards, not a normal
-performance promise.
+failure and lets the main thread perform cleanup. If the 30-second
+fixture-start watchdog expires and the owner-scoped guard lifecycle is still
+active, the fallback sends a thread-directed SIGTERM while holding the
+lifecycle mutex, then records a fixture-start failure; if the lifecycle is
+inactive, it records the failure without signalling. The stream then returns
+and identity-safe cleanup plus aggregated assertions run. This is a
+containment failure path, not normal cancellation or a performance assertion;
+it never signals under the restored/default handler and does not alter async
+handler semantics.
 
 ## Scope
 
@@ -59,7 +58,6 @@ unsafe PID cleanup.
 Run the named unit test normally and under Python-supervised load from exactly
 24 locally started `yes` spinners. The test must continue to prove the
 cancellation error, handler restoration, durable fixture reaping, and absence
-of side effects in the production handler. If platform identity inspection or
-the FIFO acknowledgement cannot prove cleanup, the test fails without a
-destructive fallback; this may leave a fixture only in that explicitly reported
-broken-fixture case.
+of side effects in the production handler. If platform identity inspection
+cannot prove cleanup, the test fails without an unsafe fallback; this may leave
+a fixture only in that explicitly reported broken-fixture case.

--- a/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
@@ -5,34 +5,61 @@
 
 ## Problem
 
-`native_stream_sigterm_cancels_and_reaps_process_tree` currently
-asserts that cancellation completes in under two seconds. Under heavy machine
-load, SIGTERM delivery and process scheduling can legitimately exceed that
-wall-clock budget even when the stream runner returns the required cancellation
-error and reaps its child process tree.
+`native_stream_sigterm_cancels_and_reaps_process_tree` must exercise the
+native-stream cancellation path without creating a signal-disposition race or
+using fixture PID files as unsafe cleanup authority. A previous acknowledgement
+poll observed the production cancellation atomic after `pthread_kill`; guard
+finish legitimately clears that atomic, producing a false watchdog failure.
+Likewise, PID-file readiness can precede guard activation, and numeric PIDs or
+their process-group equality can be reused before failure cleanup runs.
 
 ## Decision
 
 The test will assert behavior, not host scheduling speed:
 
-- SIGTERM causes the expected native-stream cancellation error.
+- The test observer holds its lifecycle lock across `pthread_kill`, and only
+  sends after both fixture identities are ready and the observed runner owns an
+  active guard. This makes dispatch while the test-owned cancellation
+  disposition is active synchronous with restoration exclusion; it does not
+  poll or extend the production cancellation atomic.
+- The final expected native-stream cancellation error proves the runner
+  consumed that dispatched SIGTERM.
 - The previous SIGTERM handler is restored.
-- The harness and its descendant no longer exist after cancellation.
+- The fixture records durable process-start identities before signalling. Linux
+  uses `/proc/<pid>/stat` field 22; macOS uses `proc_pidinfo(PROC_PIDTBSDINFO)`
+  and its seconds/microseconds start timestamp. A later missing PID is reaped
+  only when it was first captured under that identity; a different start
+  identity is reported as reuse, never as fixture reaping.
+- Failure cleanup uses a per-test FIFO command and unpredictable token created
+  before launch. The fixture-owned sentinel acknowledges that exact token and
+  calls `kill -KILL 0` from inside its own `setsid` process group. The test
+  therefore never sends a destructive signal to a PID or PGID read from a
+  fixture file. The FIFO stays usable even when the harness or descendant PID
+  file was never published.
 
-The test will retain generously bounded watchdogs only to fail a genuinely
-broken fixture or unreaped process. Those watchdogs are diagnostic safeguards,
-not a promise that normal cancellation completes within a fixed duration.
+If PID readiness appears before activation, the signaler keeps bounded polling
+outside lifecycle locks. If the runner finishes first, it records a non-signal
+failure and lets the main thread perform cleanup. At watchdog expiry, it asks
+the fixture sentinel to end its own group rather than sending SIGTERM without
+both prerequisites. Watchdogs remain diagnostic safeguards, not a normal
+performance promise.
 
 ## Scope
 
-Modify only the Unix PTY runner test in
-`crates/coven-cli/src/pty_runner.rs`. No production cancellation or signal
-handling code changes, timeout tuning in unrelated tests, ignored tests, or CI
-test splitting are included.
+Modify only the Linux/macOS Unix PTY runner test in
+`crates/coven-cli/src/pty_runner.rs` and this test design/plan record. No
+production cancellation or signal-handling code changes, timeout tuning in
+unrelated tests, ignored tests, or CI test splitting are included. Linux and
+macOS are the repository's supported Unix CI platforms; unsupported Unix
+targets do not compile this platform-specific test rather than falling back to
+unsafe PID cleanup.
 
 ## Validation
 
-Run the named unit test repeatedly both normally and under deliberate CPU load.
-The test must continue to prove the cancellation error, handler restoration,
-and process-tree reaping. Run the package and workspace test gates after the
-targeted stress result is clean.
+Run the named unit test normally and under Python-supervised load from exactly
+24 locally started `yes` spinners. The test must continue to prove the
+cancellation error, handler restoration, durable fixture reaping, and absence
+of side effects in the production handler. If platform identity inspection or
+the FIFO acknowledgement cannot prove cleanup, the test fails without a
+destructive fallback; this may leave a fixture only in that explicitly reported
+broken-fixture case.

--- a/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
+++ b/docs/superpowers/specs/2026-08-09-pty-sigterm-load-resilience-design.md
@@ -1,0 +1,38 @@
+# PTY SIGTERM Load-Resilience Design
+
+**Status:** Approved for implementation
+**Bead:** `coven-047`
+
+## Problem
+
+`native_stream_sigterm_returns_promptly_and_reaps_process_tree` currently
+asserts that cancellation completes in under two seconds. Under heavy machine
+load, SIGTERM delivery and process scheduling can legitimately exceed that
+wall-clock budget even when the stream runner returns the required cancellation
+error and reaps its child process tree.
+
+## Decision
+
+The test will assert behavior, not host scheduling speed:
+
+- SIGTERM causes the expected native-stream cancellation error.
+- The previous SIGTERM handler is restored.
+- The harness and its descendant no longer exist after cancellation.
+
+The test will retain generously bounded watchdogs only to fail a genuinely
+broken fixture or unreaped process. Those watchdogs are diagnostic safeguards,
+not a promise that normal cancellation completes within a fixed duration.
+
+## Scope
+
+Modify only the Unix PTY runner test in
+`crates/coven-cli/src/pty_runner.rs`. No production cancellation or signal
+handling code changes, timeout tuning in unrelated tests, ignored tests, or CI
+test splitting are included.
+
+## Validation
+
+Run the named unit test repeatedly both normally and under deliberate CPU load.
+The test must continue to prove the cancellation error, handler restoration,
+and process-tree reaping. Run the package and workspace test gates after the
+targeted stress result is clean.


### PR DESCRIPTION
## Summary
- replace the load-sensitive SIGTERM completion assertion with behavior-based cancellation, handler-restoration, and process-tree-reaping verification
- add test-only lifecycle and fixture cleanup coordination that preserves the async handler
- align the affected engineering design and validation documents with the behavior-only contract

## Validation
- targeted test passed normally and under 24 Python-supervised CPU spinners
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked --exclude coven-cli`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`

`cargo test -p coven-cli --locked` intermittently fails an unchanged `mobile_memory::gateway::tests::mobile_listener_requires_pinned_tls13` test with macOS `EAGAIN`; its exact retry passes. Remote CI is the clean-environment full-suite gate.

Closes coven-047.