### PR TITLE
feat(afs): rotate the NFS export token after mount

### DIFF
--- a/crates/coven-afs/examples/afs_serve.rs
+++ b/crates/coven-afs/examples/afs_serve.rs
@@ -76,7 +76,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // example writes it to a file readable only by the current user rather
     // than to stdout, so a terminal transcript or CI log never carries it.
     let token_path = std::env::temp_dir().join(format!("afs-export-{}.token", std::process::id()));
-    write_token(&token_path, export.token())?;
+    write_token(&token_path, &export.token())?;
+
+    // `mount_nfs` puts the export path in argv, so the token is `ps`-visible
+    // for the length of that call. Rotating afterwards makes a scraped value
+    // useless. The delay is a stand-in for the daemon's mount route, which
+    // rotates the moment the mount returns.
+    let gate = export.gate_handle();
+    if let Ok(after) = std::env::var("AFS_ROTATE_AFTER") {
+        let seconds: u64 = after.parse()?;
+        let path = token_path.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_secs(seconds));
+            let next = gate.rotate();
+            if let Err(error) = write_token(&path, &next) {
+                eprintln!("afs_serve: rotate wrote no token file: {error}");
+                return;
+            }
+            println!("afs_serve: token rotated; {} refreshed", path.display());
+        });
+    }
 
     let listener = NFSTcpListener::bind(&format!("{host}:{port}"), export).await?;
     println!("afs_serve: port={}", listener.get_listen_port());

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -41,7 +41,7 @@ pub use diff::{Change, ChangeEntry, ChangeSet};
 pub use fs::{AgentFs, Metadata, ROOT_INO, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
 pub use ino::DirEntry;
 #[cfg(feature = "mount")]
-pub use nfs::{ensure_loopback, export_token, AfsNfs};
+pub use nfs::{ensure_loopback, export_token, AfsNfs, GateHandle};
 pub use overlay::OverlayFs;
 pub use path::{basename, components, normalize, parent};
 pub use provenance::{

--- a/crates/coven-afs/src/nfs.rs
+++ b/crates/coven-afs/src/nfs.rs
@@ -194,6 +194,20 @@ impl GateHandle {
             .clone()
     }
 
+    /// Constant-time comparison of `candidate` against the current token,
+    /// performed under the read guard.
+    ///
+    /// This is what the gate `lookup` uses. It deliberately avoids
+    /// [`Self::token`]: cloning would spill another copy of a live credential
+    /// onto the heap on every probe, and freed heap is not zeroed.
+    fn matches(&self, candidate: &[u8]) -> bool {
+        let guard = self
+            .inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        constant_time_eq(candidate, guard.as_bytes())
+    }
+
     /// Replace the token, returning the new one.
     pub fn rotate(&self) -> String {
         let next = export_token();
@@ -428,7 +442,7 @@ impl NFSFileSystem for AfsNfs {
         if dirid == GATE_ROOT {
             // The only way past the gate. A wrong name is NOENT, exactly as a
             // missing file would be, so probing reveals nothing.
-            return if constant_time_eq(name.as_bytes(), self.gate_name.token().as_bytes()) {
+            return if self.gate_name.matches(name.as_bytes()) {
                 Ok(ROOT_INO as u64)
             } else if name == "." || name == ".." {
                 Ok(GATE_ROOT)

--- a/crates/coven-afs/src/nfs.rs
+++ b/crates/coven-afs/src/nfs.rs
@@ -165,7 +165,45 @@ pub struct AfsNfs {
     /// secret scanner reads a struct field of that name being assigned as a
     /// hardcoded credential, and `AGENTS.md` requires fixing the content
     /// rather than allowlisting past it.
-    gate_name: String,
+    gate_name: GateHandle,
+}
+
+/// A rotation handle for an export's token, clonable and detachable from the
+/// export itself.
+///
+/// `NFSTcpListener::bind` takes the export by value, so whoever wants to rotate
+/// after a mount completes — the daemon's mount route, or the example below —
+/// has to hold this rather than the [`AfsNfs`].
+#[derive(Clone)]
+pub struct GateHandle {
+    inner: std::sync::Arc<std::sync::RwLock<String>>,
+}
+
+impl GateHandle {
+    fn new(token: String) -> Self {
+        Self {
+            inner: std::sync::Arc::new(std::sync::RwLock::new(token)),
+        }
+    }
+
+    /// The current token.
+    pub fn token(&self) -> String {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    /// Replace the token, returning the new one.
+    pub fn rotate(&self) -> String {
+        let next = export_token();
+        let mut guard = self
+            .inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = next.clone();
+        next
+    }
 }
 
 impl AfsNfs {
@@ -181,14 +219,33 @@ impl AfsNfs {
             uid,
             gid,
             handle_key: HandleKey::random(),
-            gate_name: export_token(),
+            gate_name: GateHandle::new(export_token()),
         }
     }
 
     /// The export token. A client mounts `localhost:/<token>`; anything else
     /// reaches only the empty gate directory.
-    pub fn token(&self) -> &str {
-        &self.gate_name
+    pub fn token(&self) -> String {
+        self.gate_name.token()
+    }
+
+    /// A rotation handle that outlives moving this export into a listener.
+    pub fn gate_handle(&self) -> GateHandle {
+        self.gate_name.clone()
+    }
+
+    /// Replace the token, returning the new one.
+    ///
+    /// `mount_nfs` takes the export path as a positional argument and offers
+    /// no stdin, environment, or config alternative, so the token is visible
+    /// in `ps` for the duration of that call. Rotating immediately after the
+    /// mount completes makes the value anyone could have scraped useless.
+    ///
+    /// An established mount is unaffected: the client holds an authenticated
+    /// file handle, and handles are keyed on the file id under a key this does
+    /// not touch. Only a *new* traversal of the gate needs the current token.
+    pub fn rotate_gate(&self) -> String {
+        self.gate_name.rotate()
     }
 
     /// Synthetic attributes for the gate directory.
@@ -371,7 +428,7 @@ impl NFSFileSystem for AfsNfs {
         if dirid == GATE_ROOT {
             // The only way past the gate. A wrong name is NOENT, exactly as a
             // missing file would be, so probing reveals nothing.
-            return if constant_time_eq(name.as_bytes(), self.gate_name.as_bytes()) {
+            return if constant_time_eq(name.as_bytes(), self.gate_name.token().as_bytes()) {
                 Ok(ROOT_INO as u64)
             } else if name == "." || name == ".." {
                 Ok(GATE_ROOT)
@@ -641,14 +698,14 @@ mod tests {
 
         // Guessing gets NOENT — the same answer a missing file gives, so
         // probing does not distinguish "wrong token" from "no such entry".
-        for guess in ["secret", "a", export.token().trim_end_matches(|_| true)] {
+        for guess in ["secret", "a", ""] {
             assert!(export.lookup(gate, &name(guess)).await.is_err());
         }
         let almost = format!("{}0", &export.token()[..export.token().len() - 1]);
         assert!(export.lookup(gate, &name(&almost)).await.is_err());
 
         // The token opens it, and the real filesystem is behind it.
-        let root = export.lookup(gate, &name(export.token())).await.unwrap();
+        let root = export.lookup(gate, &name(&export.token())).await.unwrap();
         assert_eq!(root, ROOT_INO as u64);
         let inside = export.readdir(root, 0, 64).await.unwrap();
         assert!(
@@ -662,13 +719,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rotating_the_token_keeps_an_established_mount_working() {
+        // The `ps` window: `mount_nfs` takes the export path as a positional
+        // argument, so the token is world-readable while that call runs.
+        // Rotating straight afterwards is only safe if a mount that already
+        // resolved keeps working — this is that claim, tested.
+        let export = export();
+        let first = export.token();
+
+        // What MOUNT does: resolve `/<token>` to a file handle. `path_to_id`
+        // is the same walk `mountproc3_mnt` performs.
+        let mounted_id = export
+            .path_to_id(format!("/{first}").as_bytes())
+            .await
+            .expect("the export path resolves at mount time");
+        let mounted_fh = export.id_to_fh(mounted_id);
+        export.mkdir(mounted_id, &name("work")).await.unwrap();
+
+        let second = export.rotate_gate();
+        assert_ne!(first, second);
+
+        // The established mount holds a handle, not a path. It keeps working:
+        // handles are keyed on the file id, and rotation does not touch the
+        // key.
+        assert_eq!(export.fh_to_id(&mounted_fh).unwrap(), mounted_id);
+        let listing = export.readdir(mounted_id, 0, 64).await.unwrap();
+        assert!(listing.entries.iter().any(|e| e.name.as_ref() == b"work"));
+        export.mkdir(mounted_id, &name("after")).await.unwrap();
+
+        // But the scraped token is dead: a NEW traversal with it fails.
+        assert!(
+            export
+                .path_to_id(format!("/{first}").as_bytes())
+                .await
+                .is_err(),
+            "the token visible in ps must stop working once rotated"
+        );
+        // And the current one works.
+        assert_eq!(
+            export
+                .path_to_id(format!("/{second}").as_bytes())
+                .await
+                .unwrap(),
+            mounted_id
+        );
+    }
+
+    #[tokio::test]
     async fn each_export_gets_its_own_token() {
         let first = export();
         let second = export();
         assert_ne!(first.token(), second.token());
         // A token from one export is meaningless at another's gate.
         assert!(second
-            .lookup(second.root_dir(), &name(first.token()))
+            .lookup(second.root_dir(), &name(&first.token()))
             .await
             .is_err());
     }

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -432,8 +432,11 @@ What ships instead:
 - **Token rotation after mount.** `mount_nfs` takes the export path as a
   positional argument and offers no stdin, environment, or config alternative
   (`man mount_nfs` has neither an ENVIRONMENT nor a FILES section), so the
-  token is `ps`-visible for the duration of that one call. The daemon rotates
-  the gate the moment the mount returns, which makes a scraped value useless.
+  token is `ps`-visible for the duration of that one call. Rotating the gate
+  the moment the mount returns makes a scraped value useless. The rotation
+  primitive ships now (`AfsNfs::gate_handle`); the mount route that calls it on
+  every mount is still being built, so until that lands this mitigation is
+  available rather than enforced.
   Established mounts are unaffected: the client holds an authenticated file
   handle, handles are keyed on the file id under a key rotation does not
   touch, and only a *new* traversal of the gate needs the current token.

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -429,6 +429,14 @@ What ships instead:
   `localhost:/<token>`.
 - **Loopback-only bind**, refused in library code rather than by convention,
   on an **ephemeral port** per session.
+- **Token rotation after mount.** `mount_nfs` takes the export path as a
+  positional argument and offers no stdin, environment, or config alternative
+  (`man mount_nfs` has neither an ENVIRONMENT nor a FILES section), so the
+  token is `ps`-visible for the duration of that one call. The daemon rotates
+  the gate the moment the mount returns, which makes a scraped value useless.
+  Established mounts are unaffected: the client holds an authenticated file
+  handle, handles are keyed on the file id under a key rotation does not
+  touch, and only a *new* traversal of the gate needs the current token.
 
 **Decision.** This is sufficient to keep an unprivileged local account out by
 default, and it is *not* sufficient to survive disclosure of the token. An
@@ -453,6 +461,15 @@ client/harness or deployment; this does not claim universal requirement, and
 it does not say Full Disk Access guarantees access. This result does not
 change default-off status or resolve loopback NFS access control, sandboxing,
 recovery, concurrency, or Linux/FUSE gates.
+
+Also on 2026-08-09, the same human-operated Terminal confirmed rotation on a
+live mount: with the export rotated out from under an established mount, reads,
+directory listings, and writes through that mount continued to work, while a
+fresh `mount_nfs` with the pre-rotation token was refused and one with the
+current token succeeded. macOS's NFSv3 client does not re-resolve the export
+path after mount. The server-side half of that property — a captured handle
+outliving rotation — is covered by a unit test, so a regression fails CI rather
+than waiting on a manual check.
 
 **Enforcement is not free.** As RESEARCH.md notes, the mount alone does not stop
 an agent writing to an absolute path outside it. AFS bounds the blast radius of


### PR DESCRIPTION
`mount_nfs` takes the export path as a positional argument and offers no stdin,
environment, or config alternative — `man mount_nfs` has neither an ENVIRONMENT
nor a FILES section. The gate token is therefore visible in `ps` for the length
of that one call. Rotating the gate immediately after the mount returns makes a
scraped value useless.

An established mount is unaffected. The client holds an authenticated file
handle, and handles are keyed on the file id under an HMAC key rotation does not
touch, so only a *new* traversal of the gate needs the current token.

## Verification

The server-side property is pinned by a unit test
(`rotating_the_token_keeps_an_established_mount_working`): it reproduces MOUNT
via the same `path_to_id` walk `mountproc3_mnt` performs, captures the handle,
rotates, then asserts the handle still resolves and reads and writes still
succeed, that the old token no longer opens the gate, and that the new one does.

The client half can't be settled from a test, so it was checked by hand on
2026-08-09 from a consent-enabled Terminal: with the export rotated out from
under a live mount, reads, directory listings, and writes through that mount
continued to work, while a fresh `mount_nfs` with the pre-rotation token was
refused and one with the current token succeeded. macOS's NFSv3 client does not
re-resolve the export path after mount. DESIGN.md §7 records that alongside the
existing dated mount finding.

## Shape

`NFSTcpListener::bind` takes the export by value, so rotation needs a handle
that outlives the move. `AfsNfs::gate_handle()` returns a clonable `GateHandle`;
the daemon's mount route will hold one. The `afs_serve` example arms rotation
from `AFS_ROTATE_AFTER=<seconds>` purely so the behaviour stays reproducible by
hand — it is a stand-in for the mount route, not a shipping interface.

The never-log invariant still holds: the example writes the rotated token back
to its 0600 file and prints only the path.

Refs: coven-dts

🤖 Generated with [Claude Code](https://claude.com/claude-code)