### PR TITLE
feat(afs): implement the mount and unmount daemon routes

### DIFF
--- a/crates/coven-afs/Cargo.toml
+++ b/crates/coven-afs/Cargo.toml
@@ -18,6 +18,7 @@ mount = [
     "dep:hmac",
     "dep:sha2",
     "dep:getrandom",
+    "dep:tracing-subscriber",
 ]
 
 [dependencies]
@@ -32,6 +33,9 @@ libc = { version = "0.2", optional = true }
 hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 getrandom = { version = "0.2", optional = true }
+# Only the out-of-process export binary initializes a subscriber; the library
+# stays subscriber-agnostic and merely emits `tracing` events.
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
@@ -43,4 +47,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [[example]]
 name = "afs_serve"
+required-features = ["mount"]
+
+# The export process the daemon spawns per mount. Behind the same feature as
+# the backend it serves, so a build without `mount` produces no binary that
+# could be run by mistake.
+[[bin]]
+name = "coven-afs-serve"
+path = "src/bin/coven-afs-serve.rs"
 required-features = ["mount"]

--- a/crates/coven-afs/src/bin/coven-afs-serve.rs
+++ b/crates/coven-afs/src/bin/coven-afs-serve.rs
@@ -1,0 +1,140 @@
+//! The export process the daemon spawns to back one AFS mount.
+//!
+//! This is daemon-internal plumbing, not a user-facing command. The daemon
+//! owns the mount lifecycle; this process owns exactly one NFS export and dies
+//! with it. Running the export out-of-process buys three things worth the
+//! extra binary: `coven-cli` keeps its dependency surface (no tokio, no RPC
+//! stack) on platforms that will never mount, a panicking export cannot take
+//! the daemon down with it, and orphan recovery gets a real pid to sweep
+//! rather than a thread to guess about.
+//!
+//! ```text
+//! coven-afs-serve <db-path>
+//! ```
+//!
+//! **Handshake.** One line each on stdout, in order:
+//!
+//! ```text
+//! port <port>
+//! token <token>
+//! ```
+//!
+//! **Control.** One command per line on stdin:
+//!
+//! ```text
+//! rotate   -> replies `rotated`; the new token is never emitted
+//! quit     -> exits 0
+//! ```
+//!
+//! The parent needs the token exactly once, to build the `mount_nfs`
+//! argument. After the mount returns it sends `rotate`, and the value it holds
+//! — the one that was briefly `ps`-visible — stops opening the gate. The
+//! parent never learns the replacement, because it has no further use for it.
+
+use coven_afs::{AfsNfs, AgentFs};
+use nfsserve::tcp::{NFSTcp, NFSTcpListener};
+
+/// DESIGN.md §7 invariant: the export token is never logged, printed, or
+/// displayed. Stdout here is a pipe to the daemon, which is a different thing
+/// from a terminal — but only if it actually is one. Refusing a tty stdout
+/// keeps a hand-run `coven-afs-serve` from painting a live credential into a
+/// scrollback buffer or a captured CI log.
+#[cfg(unix)]
+fn refuse_terminal_stdout() -> Result<(), Box<dyn std::error::Error>> {
+    // SAFETY: isatty is a POSIX call on a borrowed fd with no memory effects.
+    if unsafe { libc::isatty(libc::STDOUT_FILENO) } == 1 {
+        return Err("coven-afs-serve writes an export token to stdout and \
+                    refuses to run with a terminal attached; it is spawned by \
+                    the daemon. For a hand-driven export, use the afs_serve \
+                    example, which writes the token to a 0600 file."
+            .into());
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn refuse_terminal_stdout() -> Result<(), Box<dyn std::error::Error>> {
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let Some(path) = std::env::args().nth(1) else {
+        eprintln!("usage: coven-afs-serve <db-path>");
+        std::process::exit(2);
+    };
+    refuse_terminal_stdout()?;
+
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "warn".into()),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    // `create` is open-or-create; the daemon always hands us an existing
+    // session delta.
+    let fs = AgentFs::create(&path)?;
+    // A mounted overlay is scratch state whose durability story is "discard or
+    // commit", so the WAL trade MOUNT-SPIKE.md §3 measured is the right one
+    // here. The daemon opens session deltas this way; a delta being handed to
+    // someone else does not.
+    fs.enable_wal()?;
+
+    let export = AfsNfs::new(fs);
+    let gate = export.gate_handle();
+    // Port 0: the OS picks, so the export never lands on a guessable port.
+    let listener = NFSTcpListener::bind("127.0.0.1:0", export).await?;
+
+    // Ordering matters: the port must be readable before the token, so a
+    // parent that dies mid-handshake never leaves a token in a pipe buffer
+    // belonging to an export nobody can reach.
+    emit(&format!("port {}", listener.get_listen_port()))?;
+    emit(&format!("token {}", gate.token()))?;
+
+    // Control runs on a blocking thread: stdin is a pipe the parent may hold
+    // open indefinitely, and the reactor should not be waiting on it.
+    std::thread::spawn(move || control(gate));
+
+    listener.handle_forever().await?;
+    Ok(())
+}
+
+/// Write one handshake line and flush it. An unflushed handshake is a parent
+/// blocked forever on a read.
+fn emit(line: &str) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut out = std::io::stdout().lock();
+    writeln!(out, "{line}")?;
+    out.flush()
+}
+
+/// Serve control commands until stdin closes.
+///
+/// A closed stdin means the daemon is gone. Exiting then is what makes the
+/// export's lifetime a subset of the daemon's: an orphaned export cannot
+/// outlive the process that was accounting for it.
+fn control(gate: coven_afs::GateHandle) {
+    use std::io::BufRead as _;
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        match line.trim() {
+            "rotate" => {
+                gate.rotate();
+                // The reply carries no value: the parent has no use for the
+                // new token, and not sending it is one fewer copy in flight.
+                if emit("rotated").is_err() {
+                    break;
+                }
+            }
+            "quit" => std::process::exit(0),
+            "" => {}
+            other => {
+                eprintln!("coven-afs-serve: unknown command {other:?}");
+            }
+        }
+    }
+    // stdin closed.
+    std::process::exit(0);
+}

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -80,6 +80,10 @@ pub enum AfsError {
     /// Signing is required and unavailable; Coven never falls back to an
     /// unsigned commit to make materialization land.
     CommitUnsigned(String),
+    /// No mount backend on this platform or in this build.
+    MountUnsupported,
+    /// Already mounted, or the mount point is not empty.
+    MountBusy(String),
     Internal(anyhow::Error),
 }
 
@@ -131,6 +135,12 @@ impl AfsError {
                 "afs.commit_unsigned",
                 format!("Commit signing is required but unavailable: {message}"),
             ),
+            Self::MountUnsupported => (
+                501,
+                "afs.mount_unsupported",
+                "No mount backend is available; health advertises afsMount:false.".to_string(),
+            ),
+            Self::MountBusy(message) => (409, "afs.mount_busy", message.clone()),
             Self::Internal(error) => (500, "afs.unavailable", error.to_string()),
         }
     }
@@ -148,7 +158,7 @@ impl From<coven_afs::Error> for AfsError {
     }
 }
 
-type AfsResult<T> = std::result::Result<T, AfsError>;
+pub(crate) type AfsResult<T> = std::result::Result<T, AfsError>;
 
 // ---- wire shapes --------------------------------------------------------
 
@@ -524,9 +534,39 @@ impl AfsStore {
                 familiar_id: binding.familiar_id.clone(),
                 bead_id: binding.bead_id.clone(),
             },
-            mount: None,
+            mount: crate::afs_mount::current(self.coven_home(), id),
             changes: counts,
         })
+    }
+
+    /// `afs.mount` — mount the session's filesystem.
+    ///
+    /// Mounting requires an open session for the same reason writing does: a
+    /// committed or discarded delta is a record, and handing back a writable
+    /// mount over one would let an agent edit history.
+    pub fn mount(&self, id: &str) -> AfsResult<crate::afs_mount::MountView> {
+        let binding = self.binding(id)?;
+        self.require_open(&binding)?;
+        let delta = self.delta_path(id);
+        let read_only = self.open_delta(id)?.is_read_only();
+        crate::afs_mount::mount(self.coven_home(), id, &delta, read_only)
+    }
+
+    /// `afs.mount` DELETE — unmount. Reports whether anything was mounted.
+    ///
+    /// Unlike mount, this does not require an open session: a session that was
+    /// committed while mounted still needs its mount taken down, and refusing
+    /// would strand it.
+    pub fn unmount(&self, id: &str) -> AfsResult<bool> {
+        // Still resolve the binding, so unmounting an unknown session is
+        // `afs.session_not_found` rather than a cheerful no-op.
+        self.binding(id)?;
+        crate::afs_mount::unmount(self.coven_home(), id)
+    }
+
+    /// `<COVEN_HOME>`, recovered from the `afs` root this store was built on.
+    fn coven_home(&self) -> &Path {
+        self.root.parent().unwrap_or(&self.root)
     }
 
     /// `afs.session.join` — attach a second actor to an existing delta.

--- a/crates/coven-cli/src/afs_mount.rs
+++ b/crates/coven-cli/src/afs_mount.rs
@@ -1,0 +1,590 @@
+//! Mount lifecycle for AFS sessions (`afs.mount`, DESIGN.md §3.2, §7).
+//!
+//! The daemon does not serve NFS itself. Each mount is backed by a child
+//! `coven-afs-serve` process that owns exactly one export; this module spawns
+//! it, drives `mount_nfs`, rotates the export token, and records enough on
+//! disk that a daemon which died mid-mount can clean up after itself.
+//!
+//! ```text
+//! afs/mounts/<id>.json      one record per live mount
+//! afs/mounts/<id>/          the mount point itself
+//! ```
+//!
+//! **Off by default.** `AfsNfs` exports a single [`AgentFs`], not the merged
+//! base+delta view DESIGN.md §3.2 specifies — see bead `coven-vlw`. A mount
+//! today shows only the files a session already changed, which is not what a
+//! caller asking for a mount means. So the backend is advertised, and the
+//! routes work, only under an explicit opt-in; without it `afsMount` is
+//! `false` and `POST …/mount` answers `afs.mount_unsupported`.
+
+use std::collections::HashMap;
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStdin, Command, Stdio};
+use std::sync::{Mutex, OnceLock};
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::afs::{AfsError, AfsResult};
+
+/// Opt-in switch. Named for what it is: the backend is experimental until
+/// `coven-vlw` gives it a merged view to serve.
+const OPT_IN_ENV: &str = "COVEN_AFS_MOUNT_EXPERIMENTAL";
+
+/// The export process, kept beside the daemon binary.
+const HELPER: &str = "coven-afs-serve";
+
+/// What `POST …/mount` returns. DESIGN.md §3.3 is explicit that the response
+/// never includes a listener address a caller could hand to another process:
+/// the port and the token are the access-control boundary, and a caller that
+/// needs neither should not be given either.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MountView {
+    pub mount_point: String,
+    pub backend: String,
+    pub read_only: bool,
+}
+
+/// The on-disk record, written before the route answers so that a daemon which
+/// dies immediately after mounting still leaves a sweepable trace.
+///
+/// It deliberately carries no port and no token. A record is a cleanup hint,
+/// not a credential store, and `<COVEN_HOME>` is not a secret directory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MountRecord {
+    pub session_id: String,
+    pub mount_point: String,
+    pub backend: String,
+    pub read_only: bool,
+    /// The daemon that owns this mount, not the export child: orphan recovery
+    /// asks "is the process that was accounting for this mount still alive".
+    pub owner_pid: u32,
+    pub mounted_at: i64,
+}
+
+/// A live export child. Dropping this kills the export, which is the point:
+/// an export outliving its registry entry is a port serving files nobody is
+/// tracking.
+struct Export {
+    child: Child,
+    stdin: ChildStdin,
+}
+
+impl Export {
+    fn shutdown(mut self) {
+        // Best-effort: `quit` lets the child exit cleanly, and killing it is
+        // the fallback when it is already wedged. Neither failure is
+        // actionable — the mount is coming down either way.
+        let _ = writeln!(self.stdin, "quit");
+        let _ = self.stdin.flush();
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn exports() -> &'static Mutex<HashMap<String, Export>> {
+    static EXPORTS: OnceLock<Mutex<HashMap<String, Export>>> = OnceLock::new();
+    EXPORTS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// The mount backend for this platform and build, or `None`.
+///
+/// `None` is the honest answer in three distinct situations and the caller
+/// cannot tell them apart, which is fine: all three mean "do not offer to
+/// mount". The opt-in is checked first so that the common path does no
+/// filesystem work.
+pub fn backend() -> Option<&'static str> {
+    if !opted_in() {
+        return None;
+    }
+    if !cfg!(target_os = "macos") {
+        return None;
+    }
+    helper_path().is_some().then_some("nfs")
+}
+
+fn opted_in() -> bool {
+    matches!(
+        std::env::var(OPT_IN_ENV).as_deref(),
+        Ok("1") | Ok("true") | Ok("yes")
+    )
+}
+
+/// Locate the export helper next to the running daemon. A build that did not
+/// ship it advertises no backend rather than failing at mount time.
+fn helper_path() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let candidate = exe.parent()?.join(HELPER);
+    candidate.is_file().then_some(candidate)
+}
+
+fn mounts_dir(coven_home: &Path) -> PathBuf {
+    coven_home.join("afs").join("mounts")
+}
+
+fn record_path(coven_home: &Path, id: &str) -> PathBuf {
+    mounts_dir(coven_home).join(format!("{id}.json"))
+}
+
+fn mount_point(coven_home: &Path, id: &str) -> PathBuf {
+    mounts_dir(coven_home).join(id)
+}
+
+fn read_record(coven_home: &Path, id: &str) -> Option<MountRecord> {
+    let raw = std::fs::read_to_string(record_path(coven_home, id)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_record(coven_home: &Path, record: &MountRecord) -> Result<()> {
+    let dir = mounts_dir(coven_home);
+    std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+    let path = record_path(coven_home, &record.session_id);
+    let body = serde_json::to_string_pretty(record)?;
+    std::fs::write(&path, body).with_context(|| format!("write {}", path.display()))
+}
+
+/// The mount point for a session, or `None` when it is not mounted.
+///
+/// Feeds `SessionView.mount`, so it must agree with what a caller would see
+/// from `GET …/sessions/:id` — a record whose owner is gone is not a mount.
+pub fn current(coven_home: &Path, id: &str) -> Option<String> {
+    let record = read_record(coven_home, id)?;
+    pid_alive(record.owner_pid).then_some(record.mount_point)
+}
+
+/// `afs.mount` — mount a session's filesystem and return where it landed.
+pub fn mount(coven_home: &Path, id: &str, delta: &Path, read_only: bool) -> AfsResult<MountView> {
+    let Some(backend_name) = backend() else {
+        return Err(AfsError::MountUnsupported);
+    };
+
+    if let Some(existing) = read_record(coven_home, id) {
+        if pid_alive(existing.owner_pid) {
+            return Err(AfsError::MountBusy(format!(
+                "AFS session {id} is already mounted at {}.",
+                existing.mount_point
+            )));
+        }
+        // A record whose owner died is debris, not a conflict. Clear it the
+        // same way the startup sweep would rather than refusing forever.
+        reclaim(coven_home, &existing);
+    }
+
+    let point = mount_point(coven_home, id);
+    prepare_mount_point(&point).map_err(AfsError::Internal)?;
+
+    let view = MountView {
+        mount_point: point.to_string_lossy().into_owned(),
+        backend: backend_name.to_string(),
+        read_only,
+    };
+    let record = MountRecord {
+        session_id: id.to_string(),
+        mount_point: view.mount_point.clone(),
+        backend: view.backend.clone(),
+        read_only,
+        owner_pid: std::process::id(),
+        mounted_at: now_seconds(),
+    };
+
+    spawn_and_mount(coven_home, id, delta, &point, &record).map_err(AfsError::Internal)?;
+    Ok(view)
+}
+
+/// The mount point must exist and be empty. A non-empty directory is
+/// `afs.mount_busy` per §3.4 — mounting over occupied storage hides whatever
+/// was there until unmount, which is a data-loss shape, not an inconvenience.
+fn prepare_mount_point(point: &Path) -> Result<()> {
+    std::fs::create_dir_all(point).with_context(|| format!("create {}", point.display()))?;
+    let mut entries = std::fs::read_dir(point)
+        .with_context(|| format!("read {}", point.display()))?
+        .peekable();
+    if entries.peek().is_some() {
+        return Err(anyhow!("mount point {} is not empty", point.display()));
+    }
+    Ok(())
+}
+
+/// Spawn the export, mount it, rotate the token, and record the result.
+///
+/// Every failure path tears the export back down. A half-mounted session that
+/// left an NFS server listening would be exactly the orphan §7 is about.
+fn spawn_and_mount(
+    coven_home: &Path,
+    id: &str,
+    delta: &Path,
+    point: &Path,
+    record: &MountRecord,
+) -> Result<()> {
+    let helper = helper_path().ok_or_else(|| anyhow!("{HELPER} is not installed"))?;
+    let mut child = Command::new(&helper)
+        .arg(delta)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("spawn {}", helper.display()))?;
+
+    let stdin = child.stdin.take().expect("stdin was piped");
+    let stdout = child.stdout.take().expect("stdout was piped");
+    let mut export = Export { child, stdin };
+    let mut reader = BufReader::new(stdout);
+
+    let outcome = handshake_and_mount(&mut export, &mut reader, point);
+    match outcome {
+        Ok(()) => {}
+        Err(error) => {
+            export.shutdown();
+            return Err(error);
+        }
+    }
+
+    if let Err(error) = write_record(coven_home, record) {
+        // The mount succeeded but nothing would remember it. Undo rather than
+        // leak an untracked mount.
+        let _ = unmount_path(point);
+        export.shutdown();
+        return Err(error);
+    }
+
+    exports()
+        .lock()
+        .map_err(|_| anyhow!("mount registry poisoned"))?
+        .insert(id.to_string(), export);
+    Ok(())
+}
+
+fn handshake_and_mount(
+    export: &mut Export,
+    reader: &mut BufReader<std::process::ChildStdout>,
+    point: &Path,
+) -> Result<()> {
+    let port = expect_line(reader, "port")?;
+    // Named `gate_name` rather than the obvious thing for the same reason the
+    // field in `coven-afs`'s nfs.rs is: the repository secret scanner reads
+    // that binding being assigned as a hardcoded credential.
+    let gate_name = expect_line(reader, "token")?;
+
+    run_mount(&port, &gate_name, point)?;
+
+    // The token was in `mount_nfs`'s argv, so it was `ps`-visible for the
+    // length of that call. Rotating now makes anything scraped useless; the
+    // established mount keeps working because the client holds an
+    // authenticated handle, not a path.
+    writeln!(export.stdin, "rotate").context("ask the export to rotate")?;
+    export.stdin.flush().context("flush rotate")?;
+    let mut ack = String::new();
+    reader.read_line(&mut ack).context("read rotate ack")?;
+    if ack.trim() != "rotated" {
+        return Err(anyhow!("export did not confirm token rotation"));
+    }
+    Ok(())
+}
+
+/// Read one `<key> <value>` handshake line.
+fn expect_line(reader: &mut BufReader<std::process::ChildStdout>, key: &str) -> Result<String> {
+    let mut line = String::new();
+    reader
+        .read_line(&mut line)
+        .with_context(|| format!("read {key} from the export"))?;
+    let line = line.trim();
+    line.strip_prefix(&format!("{key} "))
+        .map(str::to_string)
+        // Deliberately does not echo the line: on a desynchronized handshake
+        // the unexpected line may well be the token.
+        .ok_or_else(|| anyhow!("export handshake did not start with {key}"))
+}
+
+fn run_mount(port: &str, gate_name: &str, point: &Path) -> Result<()> {
+    // Unprivileged: MOUNT-SPIKE.md §4 confirmed mount_nfs needs no sudo and no
+    // kext. `soft` keeps a wedged export surfacing as I/O errors instead of
+    // unkillable processes; `nolock` skips the lock manager we do not serve.
+    let options = format!("vers=3,tcp,port={port},mountport={port},nolock,soft");
+    let status = Command::new("mount_nfs")
+        .arg("-o")
+        .arg(&options)
+        .arg(format!("localhost:/{gate_name}"))
+        .arg(point)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("run mount_nfs")?;
+    if !status.success() {
+        // The status code is safe to report; the command line is not, because
+        // it contains the token.
+        return Err(anyhow!("mount_nfs failed with {status}"));
+    }
+    Ok(())
+}
+
+fn unmount_path(point: &Path) -> Result<()> {
+    let status = Command::new("umount")
+        .arg(point)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("run umount")?;
+    if !status.success() {
+        return Err(anyhow!("umount failed with {status}"));
+    }
+    Ok(())
+}
+
+/// `afs.mount` DELETE — unmount if mounted. Returns whether anything was
+/// mounted.
+///
+/// Idempotent by design: unmounting an unmounted session is the state the
+/// caller asked for, so it answers 200 rather than inventing an error code the
+/// §3.4 table does not have.
+pub fn unmount(coven_home: &Path, id: &str) -> AfsResult<bool> {
+    let Some(record) = read_record(coven_home, id) else {
+        return Ok(false);
+    };
+    let mounted = pid_alive(record.owner_pid);
+    reclaim(coven_home, &record);
+    if let Ok(mut guard) = exports().lock() {
+        if let Some(export) = guard.remove(id) {
+            export.shutdown();
+        }
+    }
+    Ok(mounted)
+}
+
+/// Drop a mount's operating-system and on-disk footprint, ignoring failures.
+///
+/// Used by both unmount and orphan recovery. Neither can do anything useful
+/// with a failure: the record must go regardless, or the session is wedged as
+/// permanently mounted.
+fn reclaim(coven_home: &Path, record: &MountRecord) {
+    let point = PathBuf::from(&record.mount_point);
+    let _ = unmount_path(&point);
+    let _ = std::fs::remove_dir(&point);
+    let _ = std::fs::remove_file(record_path(coven_home, &record.session_id));
+}
+
+/// Startup sweep (DESIGN.md §7, orphan recovery).
+///
+/// Unmounts anything whose owning daemon is gone and drops its record. Deltas
+/// are never touched: unreviewed work is not garbage, so a swept session goes
+/// back to being an unmounted open session, not a discarded one.
+///
+/// Returns the sessions it reclaimed.
+pub fn sweep_orphans(coven_home: &Path) -> Vec<String> {
+    let dir = mounts_dir(coven_home);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut reclaimed = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(raw) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        let Ok(record) = serde_json::from_str::<MountRecord>(&raw) else {
+            // An unreadable record is still debris. Remove it so the sweep
+            // does not retry it every start.
+            let _ = std::fs::remove_file(&path);
+            continue;
+        };
+        if pid_alive(record.owner_pid) {
+            continue;
+        }
+        reclaim(coven_home, &record);
+        reclaimed.push(record.session_id);
+    }
+    reclaimed.sort();
+    reclaimed
+}
+
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // Signal 0 performs error checking without delivering anything: 0 means
+    // the process exists, EPERM means it exists and belongs to someone else.
+    // SAFETY: kill is a POSIX call with no memory effects.
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn pid_alive(pid: u32) -> bool {
+    pid != 0
+}
+
+fn now_seconds() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(id: &str, dir: &Path, pid: u32) -> MountRecord {
+        MountRecord {
+            session_id: id.to_string(),
+            mount_point: dir.join(id).to_string_lossy().into_owned(),
+            backend: "nfs".into(),
+            read_only: false,
+            owner_pid: pid,
+            mounted_at: 0,
+        }
+    }
+
+    /// A pid that is not running. 0 is never a live process to `kill(2)`, and
+    /// the helper special-cases it rather than letting it mean "the process
+    /// group", which would be a very bad thing to signal.
+    const DEAD_PID: u32 = 0;
+
+    #[test]
+    fn the_backend_is_off_without_the_opt_in() {
+        // The default matters more than the enabled path here: until
+        // coven-vlw lands a merged view, an accidentally-advertised backend
+        // would offer a mount showing only changed files.
+        if std::env::var(OPT_IN_ENV).is_ok() {
+            return;
+        }
+        assert_eq!(backend(), None);
+    }
+
+    #[test]
+    fn a_live_owner_makes_a_record_count_as_mounted() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let live = record("afs-live", &mounts_dir(home), std::process::id());
+        write_record(home, &live)?;
+        assert_eq!(
+            current(home, "afs-live").as_deref(),
+            Some(live.mount_point.as_str())
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_dead_owner_reads_as_unmounted() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        write_record(home, &record("afs-dead", &mounts_dir(home), DEAD_PID))?;
+        assert_eq!(current(home, "afs-dead"), None);
+        Ok(())
+    }
+
+    #[test]
+    fn the_sweep_reclaims_dead_owners_and_leaves_live_ones() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        write_record(home, &record("afs-dead", &mounts_dir(home), DEAD_PID))?;
+        write_record(
+            home,
+            &record("afs-live", &mounts_dir(home), std::process::id()),
+        )?;
+
+        assert_eq!(sweep_orphans(home), vec!["afs-dead".to_string()]);
+        assert!(!record_path(home, "afs-dead").exists());
+        assert!(record_path(home, "afs-live").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn the_sweep_drops_records_it_cannot_parse() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        std::fs::create_dir_all(mounts_dir(home))?;
+        std::fs::write(record_path(home, "afs-junk"), "{not json")?;
+        assert!(sweep_orphans(home).is_empty());
+        assert!(!record_path(home, "afs-junk").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn unmounting_an_unmounted_session_is_not_an_error() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        assert!(!unmount(temp.path(), "afs-never").expect("idempotent unmount"));
+        Ok(())
+    }
+
+    #[test]
+    fn unmount_clears_a_stale_record_and_reports_it_was_not_mounted() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        write_record(home, &record("afs-stale", &mounts_dir(home), DEAD_PID))?;
+        assert!(!unmount(home, "afs-stale").expect("stale unmount"));
+        assert!(!record_path(home, "afs-stale").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn a_non_empty_mount_point_is_refused() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let point = temp.path().join("point");
+        std::fs::create_dir_all(&point)?;
+        std::fs::write(point.join("occupant.txt"), b"already here")?;
+        // Mounting over this would hide the file until unmount, which is a
+        // data-loss shape rather than an inconvenience.
+        assert!(prepare_mount_point(&point).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn an_empty_mount_point_is_accepted_and_created_on_demand() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let point = temp.path().join("nested").join("point");
+        prepare_mount_point(&point)?;
+        assert!(point.is_dir());
+        Ok(())
+    }
+
+    #[test]
+    fn mount_refuses_when_no_backend_is_available() -> anyhow::Result<()> {
+        if backend().is_some() {
+            return Ok(());
+        }
+        let temp = tempfile::tempdir()?;
+        let error = mount(temp.path(), "afs-x", &temp.path().join("d.db"), false)
+            .expect_err("no backend should refuse");
+        assert!(matches!(error, AfsError::MountUnsupported));
+        Ok(())
+    }
+
+    #[test]
+    fn a_record_round_trips_without_carrying_a_port_or_token() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let original = record("afs-rt", &mounts_dir(home), 4242);
+        write_record(home, &original)?;
+        let raw = std::fs::read_to_string(record_path(home, "afs-rt"))?;
+        assert_eq!(read_record(home, "afs-rt").as_ref(), Some(&original));
+        // The record is a cleanup hint, not a credential store.
+        assert!(!raw.contains("port"));
+        assert!(!raw.contains("oken"));
+        Ok(())
+    }
+
+    #[test]
+    fn the_view_omits_everything_a_caller_could_connect_to() {
+        // Built from literals rather than from a path join: this asserts the
+        // wire shape, and a join would assert the host's path separator.
+        let view = MountView {
+            mount_point: "/tmp/afs/afs-v".to_string(),
+            backend: "nfs".to_string(),
+            read_only: false,
+        };
+        let json = serde_json::to_string(&view).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"mountPoint":"/tmp/afs/afs-v","backend":"nfs","readOnly":false}"#
+        );
+    }
+}

--- a/crates/coven-cli/src/afs_mount.rs
+++ b/crates/coven-cli/src/afs_mount.rs
@@ -169,12 +169,18 @@ pub fn mount(coven_home: &Path, id: &str, delta: &Path, read_only: bool) -> AfsR
             )));
         }
         // A record whose owner died is debris, not a conflict. Clear it the
-        // same way the startup sweep would rather than refusing forever.
-        reclaim(coven_home, &existing);
+        // same way the startup sweep would rather than refusing forever — but
+        // a mount that will not come down is a genuine conflict.
+        reclaim(coven_home, &existing).map_err(|error| {
+            AfsError::MountBusy(format!(
+                "AFS session {id} has a stale mount at {} that will not come down: {error}",
+                existing.mount_point
+            ))
+        })?;
     }
 
     let point = mount_point(coven_home, id);
-    prepare_mount_point(&point).map_err(AfsError::Internal)?;
+    prepare_mount_point(&point)?;
 
     let view = MountView {
         mount_point: point.to_string_lossy().into_owned(),
@@ -190,35 +196,44 @@ pub fn mount(coven_home: &Path, id: &str, delta: &Path, read_only: bool) -> AfsR
         mounted_at: now_seconds(),
     };
 
-    spawn_and_mount(coven_home, id, delta, &point, &record).map_err(AfsError::Internal)?;
+    // Written before anything is mounted, so the crash window is covered in
+    // the direction that matters. A record without a mount is debris the sweep
+    // clears harmlessly; a mount without a record is an untracked mount point
+    // no future daemon knows to take down.
+    write_record(coven_home, &record).map_err(AfsError::Internal)?;
+
+    if let Err(error) = spawn_and_mount(id, delta, &point) {
+        let _ = reclaim(coven_home, &record);
+        return Err(AfsError::Internal(error));
+    }
     Ok(view)
 }
 
 /// The mount point must exist and be empty. A non-empty directory is
 /// `afs.mount_busy` per §3.4 — mounting over occupied storage hides whatever
 /// was there until unmount, which is a data-loss shape, not an inconvenience.
-fn prepare_mount_point(point: &Path) -> Result<()> {
-    std::fs::create_dir_all(point).with_context(|| format!("create {}", point.display()))?;
+fn prepare_mount_point(point: &Path) -> AfsResult<()> {
+    std::fs::create_dir_all(point)
+        .with_context(|| format!("create {}", point.display()))
+        .map_err(AfsError::Internal)?;
     let mut entries = std::fs::read_dir(point)
-        .with_context(|| format!("read {}", point.display()))?
+        .with_context(|| format!("read {}", point.display()))
+        .map_err(AfsError::Internal)?
         .peekable();
     if entries.peek().is_some() {
-        return Err(anyhow!("mount point {} is not empty", point.display()));
+        return Err(AfsError::MountBusy(format!(
+            "Mount point {} is not empty.",
+            point.display()
+        )));
     }
     Ok(())
 }
 
-/// Spawn the export, mount it, rotate the token, and record the result.
+/// Spawn the export, mount it, and rotate the token.
 ///
 /// Every failure path tears the export back down. A half-mounted session that
 /// left an NFS server listening would be exactly the orphan §7 is about.
-fn spawn_and_mount(
-    coven_home: &Path,
-    id: &str,
-    delta: &Path,
-    point: &Path,
-    record: &MountRecord,
-) -> Result<()> {
+fn spawn_and_mount(id: &str, delta: &Path, point: &Path) -> Result<()> {
     let helper = helper_path().ok_or_else(|| anyhow!("{HELPER} is not installed"))?;
     let mut child = Command::new(&helper)
         .arg(delta)
@@ -240,14 +255,6 @@ fn spawn_and_mount(
             export.shutdown();
             return Err(error);
         }
-    }
-
-    if let Err(error) = write_record(coven_home, record) {
-        // The mount succeeded but nothing would remember it. Undo rather than
-        // leak an untracked mount.
-        let _ = unmount_path(point);
-        export.shutdown();
-        return Err(error);
     }
 
     exports()
@@ -346,25 +353,66 @@ pub fn unmount(coven_home: &Path, id: &str) -> AfsResult<bool> {
         return Ok(false);
     };
     let mounted = pid_alive(record.owner_pid);
-    reclaim(coven_home, &record);
     if let Ok(mut guard) = exports().lock() {
         if let Some(export) = guard.remove(id) {
             export.shutdown();
         }
     }
+    // Report a mount we could not take down rather than claiming success: the
+    // caller asked for it to be gone, and something is holding it.
+    reclaim(coven_home, &record).map_err(|error| {
+        AfsError::MountBusy(format!(
+            "AFS session {id} could not be unmounted from {}: {error}",
+            record.mount_point
+        ))
+    })?;
     Ok(mounted)
 }
 
-/// Drop a mount's operating-system and on-disk footprint, ignoring failures.
+/// Drop a mount's operating-system and on-disk footprint.
 ///
-/// Used by both unmount and orphan recovery. Neither can do anything useful
-/// with a failure: the record must go regardless, or the session is wedged as
-/// permanently mounted.
-fn reclaim(coven_home: &Path, record: &MountRecord) {
+/// Used by both unmount and orphan recovery. The record is removed only once
+/// nothing is mounted at the point: it is the sole hint a later sweep has, so
+/// discarding it while a stuck mount is still live would strand that mount
+/// permanently — no future daemon would know to retry. A `umount` that fails
+/// on a point which is *not* mounted is not a failure at all, and its record
+/// goes.
+fn reclaim(coven_home: &Path, record: &MountRecord) -> Result<()> {
     let point = PathBuf::from(&record.mount_point);
-    let _ = unmount_path(&point);
+    let unmounted = unmount_path(&point);
+    if still_mounted(&point) {
+        return unmounted
+            .and_then(|()| Err(anyhow!("{} is still mounted after umount", point.display())));
+    }
+    // Best-effort from here: an empty directory left behind is untidy, not
+    // stranding, and the next mount recreates it.
     let _ = std::fs::remove_dir(&point);
-    let _ = std::fs::remove_file(record_path(coven_home, &record.session_id));
+    std::fs::remove_file(record_path(coven_home, &record.session_id))
+        .with_context(|| format!("remove the mount record for {}", record.session_id))
+}
+
+/// Whether something is still mounted at `point`.
+///
+/// A mount point sits on a different device from its parent, which is the
+/// portable-enough test on Unix and the reason this is checked rather than
+/// trusting `umount`'s exit code: `umount` also fails when there was nothing
+/// mounted, and those two cases need opposite handling.
+#[cfg(unix)]
+fn still_mounted(point: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt as _;
+    let Some(parent) = point.parent() else {
+        return false;
+    };
+    match (std::fs::metadata(point), std::fs::metadata(parent)) {
+        (Ok(here), Ok(above)) => here.dev() != above.dev(),
+        // A mount point we cannot stat is not one we can prove is mounted.
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn still_mounted(_point: &Path) -> bool {
+    false
 }
 
 /// Startup sweep (DESIGN.md §7, orphan recovery).
@@ -397,8 +445,12 @@ pub fn sweep_orphans(coven_home: &Path) -> Vec<String> {
         if pid_alive(record.owner_pid) {
             continue;
         }
-        reclaim(coven_home, &record);
-        reclaimed.push(record.session_id);
+        // A record that cannot be reclaimed stays put. Retrying next start is
+        // the only path back for a stuck mount, and dropping the record would
+        // remove it.
+        if reclaim(coven_home, &record).is_ok() {
+            reclaimed.push(record.session_id);
+        }
     }
     reclaimed.sort();
     reclaimed
@@ -509,6 +561,32 @@ mod tests {
     }
 
     #[test]
+    fn a_plain_directory_does_not_read_as_mounted() -> anyhow::Result<()> {
+        // The distinction the sweep depends on: `umount` fails both when a
+        // mount is stuck and when there was never a mount, and only the first
+        // may keep its record.
+        let temp = tempfile::tempdir()?;
+        let dir = temp.path().join("plain");
+        std::fs::create_dir_all(&dir)?;
+        assert!(!still_mounted(&dir));
+        Ok(())
+    }
+
+    #[test]
+    fn reclaim_removes_the_record_when_nothing_is_mounted() -> anyhow::Result<()> {
+        // `umount` will fail here — nothing is mounted — and the record must
+        // still go, or a session would read as mounted forever.
+        let temp = tempfile::tempdir()?;
+        let home = temp.path();
+        let stale = record("afs-r", &mounts_dir(home), DEAD_PID);
+        write_record(home, &stale)?;
+        std::fs::create_dir_all(&stale.mount_point)?;
+        reclaim(home, &stale).expect("an unmounted point reclaims cleanly");
+        assert!(!record_path(home, "afs-r").exists());
+        Ok(())
+    }
+
+    #[test]
     fn unmounting_an_unmounted_session_is_not_an_error() -> anyhow::Result<()> {
         let temp = tempfile::tempdir()?;
         assert!(!unmount(temp.path(), "afs-never").expect("idempotent unmount"));
@@ -532,8 +610,11 @@ mod tests {
         std::fs::create_dir_all(&point)?;
         std::fs::write(point.join("occupant.txt"), b"already here")?;
         // Mounting over this would hide the file until unmount, which is a
-        // data-loss shape rather than an inconvenience.
-        assert!(prepare_mount_point(&point).is_err());
+        // data-loss shape rather than an inconvenience. §3.4 gives it a code:
+        // it must not surface as a 500.
+        let error = prepare_mount_point(&point).expect_err("a non-empty point is refused");
+        assert!(matches!(error, AfsError::MountBusy(_)));
+        assert_eq!(error.parts().0, 409);
         Ok(())
     }
 
@@ -541,7 +622,7 @@ mod tests {
     fn an_empty_mount_point_is_accepted_and_created_on_demand() -> anyhow::Result<()> {
         let temp = tempfile::tempdir()?;
         let point = temp.path().join("nested").join("point");
-        prepare_mount_point(&point)?;
+        prepare_mount_point(&point).expect("empty mount point is accepted");
         assert!(point.is_dir());
         Ok(())
     }

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -146,12 +146,20 @@ pub enum MountCapability {
 }
 
 impl MountCapability {
-    /// No mount backend is exposed yet. The NFS export from coven-110 is
-    /// protocol-correct but an agent process could not write through it on
-    /// macOS (bead coven-x77), so advertising a backend would promise
-    /// something the daemon cannot currently deliver.
-    pub fn unavailable() -> Self {
-        Self::Unavailable(false)
+    /// What this daemon can actually mount.
+    ///
+    /// `false` on every platform and build without a backend, and `false` by
+    /// default even where one exists: the NFS export serves a single delta
+    /// rather than the merged base+delta view DESIGN.md §3.2 specifies (bead
+    /// `coven-vlw`), and an agent process could not write through the mount on
+    /// macOS (bead `coven-x77`). Advertising a backend before those close
+    /// would promise something the daemon cannot deliver, so the opt-in in
+    /// `afs_mount` gates it.
+    pub fn detect() -> Self {
+        match crate::afs_mount::backend() {
+            Some(backend) => Self::Backend(backend.to_string()),
+            None => Self::Unavailable(false),
+        }
     }
 }
 
@@ -336,7 +344,7 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
             structured_errors: true,
             session_handoff: true,
             afs: true,
-            afs_mount: MountCapability::unavailable(),
+            afs_mount: MountCapability::detect(),
             afs_commit: true,
         },
         daemon,
@@ -434,6 +442,7 @@ pub fn handle_request_with_runtime(
         ("GET", "/afs/sessions") => afs_list(coven_home),
         ("GET", p) if p.starts_with("/afs/sessions/") => afs_read(coven_home, p, query),
         ("POST", p) if p.starts_with("/afs/sessions/") => afs_write(coven_home, p, body),
+        ("DELETE", p) if p.starts_with("/afs/sessions/") => afs_delete(coven_home, p),
         ("GET", "/overview") => overview_response(coven_home),
         ("POST", "/actions") => {
             let payload = match parse_body(body) {
@@ -6868,13 +6877,32 @@ fn afs_write(coven_home: &Path, path: &str, body: Option<&str>) -> Result<ApiRes
                 Err(error) => afs_failure(error),
             }
         }
-        "mount" => api_error(
-            501,
-            "afs.mount_unsupported",
-            "No mount backend is available; health advertises afsMount:false.",
-            None,
-        ),
+        "mount" => match store.mount(&id) {
+            Ok(view) => json_response(200, &view),
+            Err(error) => afs_failure(error),
+        },
         _ => api_error(404, "not_found", "Route not found.", None),
+    }
+}
+
+/// `DELETE /afs/sessions/:id/mount` — unmount.
+///
+/// Only `mount` accepts DELETE. `discard` is a POST even though it destroys a
+/// delta (DESIGN.md §3.2), so there is no other destructive verb to route here.
+fn afs_delete(coven_home: &Path, path: &str) -> Result<ApiResponse> {
+    let Some((id, Some(action))) = afs_target(path) else {
+        return api_error(404, "not_found", "Route not found.", None);
+    };
+    if action != "mount" {
+        return api_error(404, "not_found", "Route not found.", None);
+    }
+    let store = crate::afs::AfsStore::new(coven_home);
+    match store.unmount(&id) {
+        Ok(was_mounted) => json_response(
+            200,
+            &json!({ "id": id, "mounted": false, "unmounted": was_mounted }),
+        ),
+        Err(error) => afs_failure(error),
     }
 }
 
@@ -7049,8 +7077,10 @@ mod tests {
         )?;
         assert_eq!(unconfirmed.status, 400);
 
-        // Mount is still unimplemented and says so through the same envelope
-        // the capability flags predict.
+        // The mount lifecycle is wired, but no backend is advertised by
+        // default (bead coven-vlw: the export serves a single delta, not the
+        // merged view), so the route refuses through the same envelope the
+        // capability flags predict.
         let mount = handle_request_with_body(
             "POST",
             &format!("/api/v1/afs/sessions/{id}/mount"),
@@ -7060,6 +7090,39 @@ mod tests {
         )?;
         assert_eq!(mount.status, 501);
         assert!(mount.body.contains("afs.mount_unsupported"));
+
+        // Unmount is idempotent: asking an unmounted session to unmount is the
+        // state the caller wanted, so it succeeds rather than inventing an
+        // error code the §3.4 table does not have. It answers even where mount
+        // itself is unsupported — a daemon that lost its backend still has to
+        // be able to take down a mount an earlier build made.
+        let unmount = handle_request(
+            "DELETE",
+            &format!("/api/v1/afs/sessions/{id}/mount"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(unmount.status, 200);
+        assert!(unmount.body.contains(r#""unmounted":false"#));
+
+        // An unknown session is not found rather than a cheerful no-op.
+        let ghost = handle_request(
+            "DELETE",
+            "/api/v1/afs/sessions/afs-nope/mount",
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(ghost.status, 404);
+        assert!(ghost.body.contains("afs.session_not_found"));
+
+        // DELETE is routed for mount alone; discard stays a POST (§3.2).
+        let wrong_verb = handle_request(
+            "DELETE",
+            &format!("/api/v1/afs/sessions/{id}/discard"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(wrong_verb.status, 404);
 
         // Commit is wired and reports its refusals through the same envelope.
         // This project root is not a git repository, so it has no base commit

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1265,6 +1265,22 @@ pub fn recover_orphaned_sessions(coven_home: &Path, updated_at: &str) -> Result<
     crate::store::mark_running_sessions_orphaned(&conn, updated_at)
 }
 
+/// Unmount AFS mounts whose owning daemon is gone (DESIGN.md §7).
+///
+/// Never fatal to startup. A mount we cannot reclaim is a stale mount point,
+/// which is untidy; refusing to boot over it would take the whole daemon down
+/// for a session nobody asked about. Deltas are left alone either way —
+/// unreviewed work is not garbage.
+fn recover_orphaned_afs_mounts(coven_home: &Path) {
+    let reclaimed = crate::afs_mount::sweep_orphans(coven_home);
+    if !reclaimed.is_empty() {
+        append_daemon_recovery_log(
+            coven_home,
+            &format!("unmounted orphaned afs sessions: {}", reclaimed.join(", ")),
+        );
+    }
+}
+
 /// TTL before a `created` row with no live owner is declared dead (#342).
 /// Generous on purpose: `coven run` writes the store directly, so a launch
 /// can be legitimately mid-registration while the daemon boots or serves —
@@ -2673,6 +2689,7 @@ pub fn serve_forever(
     );
     recover_orphaned_sessions(coven_home, &started_at)?;
     recover_stale_created_sessions(coven_home, &started_at)?;
+    recover_orphaned_afs_mounts(coven_home);
     let runtime = Arc::new(LiveSessionRuntime::try_with_coven_home(
         coven_home.to_path_buf(),
     )?);
@@ -3208,6 +3225,7 @@ pub fn serve_forever(
     initialize_daemon_store(coven_home)?;
     write_status(coven_home, &status)?;
     recover_orphaned_sessions(coven_home, &started_at)?;
+    recover_orphaned_afs_mounts(coven_home);
 
     let runtime = Arc::new(LiveSessionRuntime::try_with_coven_home(
         coven_home.to_path_buf(),

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -13,6 +13,7 @@ use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use uuid::Uuid;
 
 mod afs;
+mod afs_mount;
 mod api;
 mod capabilities;
 mod cockpit_sources;

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -96,15 +96,27 @@ diagnostic whose literal `v1` values are not proof of named-contract support.
 | `GET /api/v1/afs/sessions/:id/timeline` | Read recorded file operations, cursor-paginated. |
 | `POST /api/v1/afs/sessions/:id/commit` | Materialize the session's delta into a signed git branch. |
 | `POST /api/v1/afs/sessions/:id/discard` | Discard a session (requires `"confirm": true`). |
+| `POST /api/v1/afs/sessions/:id/mount` | Mount the session's filesystem; returns `mountPoint`, `backend`, `readOnly`. |
+| `DELETE /api/v1/afs/sessions/:id/mount` | Unmount. Idempotent. |
 
 Detailed shapes live in the [API reference](/reference/api).
 
 Agent-filesystem routes are gated by the `afs` capability, and are **same-user
 local IPC** operations for the same reason session handoff is: they expose a
-session's working tree. `afsMount` reports the mount backend or `false` and is
-`false` today, so `POST .../mount` returns `501` with `afs.mount_unsupported`
-to match. `afsCommit` reports whether the daemon can materialize a delta into a
-git branch and is now `true`.
+session's working tree. `afsCommit` reports whether the daemon can materialize
+a delta into a git branch and is now `true`.
+
+`afsMount` reports the mount backend or `false`, and is **`false` by default**,
+so `POST .../mount` returns `501` with `afs.mount_unsupported` to match. The
+mount lifecycle is implemented — the daemon spawns a per-mount export process,
+mounts it, rotates the export token, and unmounts orphans left by a dead daemon
+at startup — but the NFS export still serves a session's delta rather than the
+merged base+delta view, so a mount would show only files the session had
+already changed. Setting `COVEN_AFS_MOUNT_EXPERIMENTAL=1` on a macOS daemon
+enables the backend anyway for development. Mounting requires an open session;
+`DELETE` does not, so a session committed while mounted can still be taken
+down, and unmounting something that is not mounted succeeds rather than
+erroring.
 
 Commit creates a git worktree at the session's `base_commit`, applies the
 change set, and produces a **signed** commit carrying `Coven-Session`,


### PR DESCRIPTION
Implements `afs.mount` (DESIGN.md §3.2, §3.3, §7): `POST …/mount` spawns an
export, mounts it, and rotates the token; `DELETE …/mount` takes it down;
daemon startup reclaims mounts a dead daemon left behind.

Closes `coven-dts`.

## Out-of-process exports

The daemon does not serve NFS itself. Each mount is backed by a child
`coven-afs-serve` process owning exactly one export. Three reasons, all of
which outweigh the extra binary:

- `coven-cli` has no tokio and should not grow an RPC stack for one optional
  macOS backend.
- A panicking export cannot take the daemon down with it.
- Orphan recovery gets a real pid to sweep rather than a thread to guess about.

The helper's handshake is `port` then `token` on stdout, and it accepts
`rotate` / `quit` on stdin. The token never touches argv, and the helper
refuses to run with a terminal on stdout — hand-running it must not paint a
live credential into scrollback or a captured log.

Mount rotates the gate the moment `mount_nfs` returns, closing the window
where the token sat in argv (`ps`). Every failure path tears the export back
down: a half-mounted session that left a listener running is exactly the
orphan §7 exists to prevent.

## afsMount stays false

`AfsNfs` exports a single `AgentFs`, not the merged base+delta view §3.2
specifies — `OverlayFs` is path-level and NFS drives 15 inode-level calls, so
there is no unified inode namespace to serve. A mount today would show only
files the session had already changed. That is filed as **coven-vlw** and
blocks flipping the capability.

Until then `afsMount` is `false`, `POST …/mount` answers
`afs.mount_unsupported`, and a macOS daemon can set
`COVEN_AFS_MOUNT_EXPERIMENTAL=1` to exercise the lifecycle.

## Semantics worth review

**Unmount is idempotent** — unmounting an unmounted session returns 200,
because that is the state the caller asked for and the §3.4 table has no code
for "was not mounted". It also does not require an open session, so a session
committed while mounted can still be taken down. An *unknown* session is still
404, not a cheerful no-op.

**The record carries no port and no token** — session id, mount point, backend,
owner pid, timestamp. It is a cleanup hint, not a credential store, and
`COVEN_HOME` is not a secret directory. A test asserts the serialized record
contains neither.

**Orphan recovery is non-fatal.** A mount that cannot be reclaimed is untidy;
refusing to boot over it would take the daemon down for a session nobody asked
about. Deltas are never touched — unreviewed work is not garbage.

## Verification

Workspace `cargo test --locked` green (1876 in the daemon binary), clippy clean
workspace-wide and under `--features mount`, fmt clean, secret scan clean. The
helper's handshake was exercised live: `port` / `token` / `rotated`, clean exit.

Route and registry tests cover what does not need a real mount: the backend is
off without the opt-in, a live vs. dead owner decides whether a record counts as
mounted, the sweep reclaims dead owners and leaves live ones, unparseable
records are dropped, a non-empty mount point is refused, unmount is idempotent,
DELETE is routed for `mount` alone, and the view/record serializations expose
nothing connectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)