### PR TITLE
feat(afs): add path-specific unified diffs to the review routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.11.0",
+ "similar",
  "sysinfo",
  "tempfile",
  "textwrap",
@@ -4359,6 +4360,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -48,6 +48,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
 sha2 = "0.11"
+similar = "2"
 toml = "1.1"
 toml_edit = { version = "0.25", features = ["serde"] }
 unicode-normalization = "0.1"

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -674,24 +674,26 @@ impl AfsStore {
         } else {
             None
         };
+        let base_header = if base.is_some() {
+            path.as_str()
+        } else {
+            "/dev/null"
+        };
+        let merged_header = if merged.is_some() {
+            path.as_str()
+        } else {
+            "/dev/null"
+        };
         let patch = match (
             std::str::from_utf8(base.as_deref().unwrap_or(&[])),
             std::str::from_utf8(merged.as_deref().unwrap_or(&[])),
         ) {
             (Ok(""), Ok("")) if base.is_none() != merged.is_none() => {
-                let base_header = if base.is_some() {
-                    path.as_str()
-                } else {
-                    "/dev/null"
-                };
-                let merged_header = if merged.is_some() {
-                    path.as_str()
-                } else {
-                    "/dev/null"
-                };
                 bounded_diff_headers(base_header, merged_header, &path)?
             }
-            (Ok(base), Ok(merged)) => bounded_unified_diff(base, merged, &path, &path, &path)?,
+            (Ok(base), Ok(merged)) => {
+                bounded_unified_diff(base, merged, base_header, merged_header, &path)?
+            }
             _ => ("Binary files differ\n".to_string(), false),
         };
         let binary = patch.0 == "Binary files differ\n";
@@ -2329,6 +2331,7 @@ mod tests {
         assert_eq!(diff.path, "/src/added.txt");
         assert!(!diff.binary);
         assert!(!diff.truncated);
+        assert!(diff.patch.contains("--- /dev/null"));
         assert!(diff.patch.contains("+++ /src/added.txt"));
         assert!(diff.patch.contains("+new line"));
     }
@@ -2348,7 +2351,7 @@ mod tests {
         assert!(!diff.binary);
         assert!(!diff.truncated);
         assert!(diff.patch.contains("--- /notes.txt"));
-        assert!(diff.patch.contains("+++ /notes.txt"));
+        assert!(diff.patch.contains("+++ /dev/null"));
         assert!(diff.patch.contains("-alpha"));
         assert!(diff.patch.contains("-beta"));
     }
@@ -2446,8 +2449,9 @@ mod tests {
         assert!(diff.truncated);
         assert!(diff.patch.len() <= UNIFIED_DIFF_MAX_BYTES);
         assert!(std::str::from_utf8(diff.patch.as_bytes()).is_ok());
-        assert!(diff.patch.contains("--- /src/large.txt"));
-        assert!(diff.patch.starts_with("--- /src/large.txt"));
+        assert!(diff.patch.contains("--- /dev/null"));
+        assert!(diff.patch.contains("+++ /src/large.txt"));
+        assert!(diff.patch.starts_with("--- /dev/null"));
     }
 
     #[test]

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -684,24 +684,29 @@ impl AfsStore {
         } else {
             "/dev/null"
         };
-        let patch = match (
+        let (patch, truncated, binary) = match (
             std::str::from_utf8(base.as_deref().unwrap_or(&[])),
             std::str::from_utf8(merged.as_deref().unwrap_or(&[])),
         ) {
             (Ok(""), Ok("")) if base.is_none() != merged.is_none() => {
-                bounded_diff_headers(base_header, merged_header, &path)?
+                let (patch, truncated) = bounded_diff_headers(base_header, merged_header, &path)?;
+                (patch, truncated, false)
             }
             (Ok(base), Ok(merged)) => {
-                bounded_unified_diff(base, merged, base_header, merged_header, &path)?
+                let (patch, truncated) =
+                    bounded_unified_diff(base, merged, base_header, merged_header, &path)?;
+                (patch, truncated, false)
             }
-            _ => ("Binary files differ\n".to_string(), false),
+            _ if matches!((&base, &merged), (Some(base), Some(merged)) if base == merged) => {
+                (String::new(), false, true)
+            }
+            _ => ("Binary files differ\n".to_string(), false, true),
         };
-        let binary = patch.0 == "Binary files differ\n";
 
         Ok(FileDiffView {
             path,
-            patch: patch.0,
-            truncated: patch.1,
+            patch,
+            truncated,
             binary,
         })
     }
@@ -2398,6 +2403,21 @@ mod tests {
         assert!(diff.binary);
         assert!(!diff.truncated);
         assert_eq!(diff.patch, "Binary files differ\n");
+    }
+
+    #[test]
+    fn file_diff_does_not_report_unchanged_binary_files_as_different() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        std::fs::write(root.join("image.bin"), [0xff, 0xfe, 0xfd]).unwrap();
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        let diff = store.file_diff(&view.id, "/image.bin").unwrap();
+        assert_eq!(diff.path, "/image.bin");
+        assert!(diff.binary);
+        assert!(!diff.truncated);
+        assert_eq!(diff.patch, "");
     }
 
     #[test]

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -678,7 +678,20 @@ impl AfsStore {
             std::str::from_utf8(base.as_deref().unwrap_or(&[])),
             std::str::from_utf8(merged.as_deref().unwrap_or(&[])),
         ) {
-            (Ok(base), Ok(merged)) => bounded_unified_diff(base, merged, &path)?,
+            (Ok(""), Ok("")) if base.is_none() != merged.is_none() => {
+                let base_header = if base.is_some() {
+                    path.as_str()
+                } else {
+                    "/dev/null"
+                };
+                let merged_header = if merged.is_some() {
+                    path.as_str()
+                } else {
+                    "/dev/null"
+                };
+                bounded_diff_headers(base_header, merged_header, &path)?
+            }
+            (Ok(base), Ok(merged)) => bounded_unified_diff(base, merged, &path, &path, &path)?,
             _ => ("Binary files differ\n".to_string(), false),
         };
         let binary = patch.0 == "Binary files differ\n";
@@ -1450,20 +1463,45 @@ fn optional_overlay_metadata(
     }
 }
 
-fn bounded_unified_diff(base: &str, merged: &str, path: &str) -> AfsResult<(String, bool)> {
+fn bounded_unified_diff(
+    base: &str,
+    merged: &str,
+    base_header: &str,
+    merged_header: &str,
+    path: &str,
+) -> AfsResult<(String, bool)> {
     let diff = TextDiff::from_lines(base, merged);
     let mut unified = diff.unified_diff();
-    unified.context_radius(3).header(path, path);
+    unified.context_radius(3).header(base_header, merged_header);
 
     let mut output = CappedDiffWriter::new(UNIFIED_DIFF_MAX_BYTES);
-    if let Err(error) = unified.to_writer(&mut output) {
+    let result = unified.to_writer(&mut output);
+    finish_bounded_diff(output, result, path)
+}
+
+fn bounded_diff_headers(
+    base_header: &str,
+    merged_header: &str,
+    path: &str,
+) -> AfsResult<(String, bool)> {
+    let mut output = CappedDiffWriter::new(UNIFIED_DIFF_MAX_BYTES);
+    let result = writeln!(&mut output, "--- {base_header}")
+        .and_then(|()| writeln!(&mut output, "+++ {merged_header}"));
+    finish_bounded_diff(output, result, path)
+}
+
+fn finish_bounded_diff(
+    output: CappedDiffWriter,
+    result: io::Result<()>,
+    path: &str,
+) -> AfsResult<(String, bool)> {
+    if let Err(error) = result {
         if !output.truncated {
             return Err(AfsError::Internal(anyhow::anyhow!(
                 "failed to render unified diff for {path}: {error}"
             )));
         }
     }
-
     let truncated = output.truncated;
     let patch = String::from_utf8(output.bytes).map_err(|error| {
         AfsError::Internal(anyhow::anyhow!(
@@ -2313,6 +2351,34 @@ mod tests {
         assert!(diff.patch.contains("+++ /notes.txt"));
         assert!(diff.patch.contains("-alpha"));
         assert!(diff.patch.contains("-beta"));
+    }
+
+    #[test]
+    fn file_diff_distinguishes_added_and_deleted_empty_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        std::fs::write(root.join("deleted-empty.txt"), b"").unwrap();
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        delta_write(&store, &view.id, "/added-empty.txt", b"");
+        delta_remove(&store, &view.id, "/deleted-empty.txt");
+
+        let added = store.file_diff(&view.id, "/added-empty.txt").unwrap();
+        assert_eq!(
+            added.patch, "--- /dev/null\n+++ /added-empty.txt\n",
+            "an empty added file still needs an explicit patch"
+        );
+        assert!(!added.truncated);
+        assert!(!added.binary);
+
+        let deleted = store.file_diff(&view.id, "/deleted-empty.txt").unwrap();
+        assert_eq!(
+            deleted.patch, "--- /deleted-empty.txt\n+++ /dev/null\n",
+            "an empty deleted file still needs an explicit patch"
+        );
+        assert!(!deleted.truncated);
+        assert!(!deleted.binary);
     }
 
     #[test]

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -21,9 +21,10 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use similar::TextDiff;
 
 use coven_afs::{
-    Actor, AgentFs, Change, ChangeSet, OverlayFs, SessionBinding, STATE_COMMITTED,
+    normalize, Actor, AgentFs, Change, ChangeSet, OverlayFs, SessionBinding, STATE_COMMITTED,
     STATE_COMMITTING, STATE_DISCARDED, STATE_OPEN,
 };
 
@@ -44,6 +45,7 @@ const INGEST_EXCLUDES: &[&str] = &[".git", "target", "node_modules", ".worktrees
 /// 238 ms). 16 MiB keeps a worst-case first write near ~120 ms, which stays
 /// inside a plausible interactive budget; 32 MiB would not.
 pub const COPY_UP_MAX_BYTES: u64 = 16 * 1024 * 1024;
+pub const UNIFIED_DIFF_MAX_BYTES: usize = 256 * 1024;
 
 /// Failures that map onto DESIGN.md §3.4's dotted error codes.
 ///
@@ -53,6 +55,7 @@ pub const COPY_UP_MAX_BYTES: u64 = 16 * 1024 * 1024;
 #[derive(Debug)]
 pub enum AfsError {
     SessionNotFound(String),
+    PathNotFound(String),
     SessionNotOpen {
         id: String,
         state: String,
@@ -96,6 +99,7 @@ impl AfsError {
                 "afs.session_not_found",
                 format!("No AFS session {id}."),
             ),
+            Self::PathNotFound(path) => (404, "afs.path_not_found", format!("No AFS path {path}.")),
             Self::SessionNotOpen { id, state } => (
                 409,
                 "afs.session_not_open",
@@ -297,6 +301,15 @@ pub struct DiffView {
     pub changes: Vec<ChangeView>,
     pub counts: ChangeCounts,
     pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileDiffView {
+    pub path: String,
+    pub patch: String,
+    pub truncated: bool,
+    pub binary: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -624,6 +637,67 @@ impl AfsStore {
             changes,
             counts,
             truncated: false,
+        })
+    }
+
+    /// `afs.session.diff` for a single file path.
+    pub fn file_diff(&self, id: &str, path: &str) -> AfsResult<FileDiffView> {
+        let binding = self.binding(id)?;
+        let overlay = self.open_overlay(id, &binding)?;
+        let path = normalize(path);
+
+        let base = read_optional_agent_file(overlay.base(), &path)?;
+        let merged = read_optional_overlay_file(&overlay, &path)?;
+        if base.is_none() && merged.is_none() {
+            return Err(AfsError::PathNotFound(path));
+        }
+
+        let patch = if let (Some(base), Some(merged)) = (&base, &merged) {
+            match (std::str::from_utf8(base), std::str::from_utf8(merged)) {
+                (Ok(base), Ok(merged)) => {
+                    let patch = TextDiff::from_lines(base, merged)
+                        .unified_diff()
+                        .context_radius(3)
+                        .header(&path, &path)
+                        .to_string();
+                    truncate_utf8(patch, UNIFIED_DIFF_MAX_BYTES)
+                }
+                _ => ("Binary files differ\n".to_string(), false),
+            }
+        } else if let Some(base) = &base {
+            match std::str::from_utf8(base) {
+                Ok(base) => {
+                    let patch = TextDiff::from_lines(base, "")
+                        .unified_diff()
+                        .context_radius(3)
+                        .header(&path, &path)
+                        .to_string();
+                    truncate_utf8(patch, UNIFIED_DIFF_MAX_BYTES)
+                }
+                Err(_) => ("Binary files differ\n".to_string(), false),
+            }
+        } else if let Some(merged) = &merged {
+            match std::str::from_utf8(merged) {
+                Ok(merged) => {
+                    let patch = TextDiff::from_lines("", merged)
+                        .unified_diff()
+                        .context_radius(3)
+                        .header(&path, &path)
+                        .to_string();
+                    truncate_utf8(patch, UNIFIED_DIFF_MAX_BYTES)
+                }
+                Err(_) => ("Binary files differ\n".to_string(), false),
+            }
+        } else {
+            unreachable!("missing path handled above");
+        };
+        let binary = patch.0 == "Binary files differ\n";
+
+        Ok(FileDiffView {
+            path,
+            patch: patch.0,
+            truncated: patch.1,
+            binary,
         })
     }
 
@@ -1367,6 +1441,33 @@ fn cleanup_failed_materialization(project_root: &Path, worktree_path: &Path, bra
         .output();
 }
 
+fn read_optional_agent_file(fs: &AgentFs, path: &str) -> AfsResult<Option<Vec<u8>>> {
+    match fs.read_file(path) {
+        Ok(data) => Ok(Some(data)),
+        Err(coven_afs::Error::NotFound(_)) => Ok(None),
+        Err(error) => Err(AfsError::from(error)),
+    }
+}
+
+fn read_optional_overlay_file(overlay: &OverlayFs, path: &str) -> AfsResult<Option<Vec<u8>>> {
+    match overlay.read_file(path) {
+        Ok(data) => Ok(Some(data)),
+        Err(coven_afs::Error::NotFound(_)) => Ok(None),
+        Err(error) => Err(AfsError::from(error)),
+    }
+}
+
+fn truncate_utf8(value: String, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value, false);
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_string(), true)
+}
+
 // ---- base ingest --------------------------------------------------------
 
 fn git_head(project_root: &Path) -> Option<String> {
@@ -1557,6 +1658,12 @@ mod tests {
     fn delta_write(store: &AfsStore, id: &str, path: &str, data: &[u8]) {
         let mut fs = store.open_delta(id).unwrap();
         fs.write_file(path, data).unwrap();
+    }
+
+    fn delta_remove(store: &AfsStore, id: &str, path: &str) {
+        let binding = store.binding(id).unwrap();
+        let mut overlay = store.open_overlay(id, &binding).unwrap();
+        overlay.remove_file(path).unwrap();
     }
 
     fn delta_symlink(store: &AfsStore, id: &str, target: &str, link: &str) {
@@ -2080,6 +2187,116 @@ mod tests {
             diff.changes.iter().all(|c| c.attribution == "unknown"),
             "writes with no provenance must be visible AND marked unknown"
         );
+    }
+
+    #[test]
+    fn file_diff_reports_a_modified_text_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        std::fs::write(root.join("notes.txt"), "alpha\nbeta\ngamma\n").unwrap();
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        delta_write(
+            &store,
+            &view.id,
+            "/notes.txt",
+            b"alpha\nbeta changed\ngamma\n",
+        );
+
+        let diff = store.file_diff(&view.id, "/notes.txt").unwrap();
+        assert_eq!(diff.path, "/notes.txt");
+        assert!(!diff.binary);
+        assert!(!diff.truncated);
+        assert!(diff.patch.contains("--- /notes.txt"));
+        assert!(diff.patch.contains("+++ /notes.txt"));
+        assert!(diff.patch.contains("-beta"));
+        assert!(diff.patch.contains("+beta changed"));
+    }
+
+    #[test]
+    fn file_diff_reports_an_added_text_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        delta_write(&store, &view.id, "/src/added.txt", b"new line\n");
+
+        let diff = store.file_diff(&view.id, "/src/added.txt").unwrap();
+        assert_eq!(diff.path, "/src/added.txt");
+        assert!(!diff.binary);
+        assert!(!diff.truncated);
+        assert!(diff.patch.contains("+++ /src/added.txt"));
+        assert!(diff.patch.contains("+new line"));
+    }
+
+    #[test]
+    fn file_diff_reports_a_deleted_text_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        std::fs::write(root.join("notes.txt"), "alpha\nbeta\n").unwrap();
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        delta_remove(&store, &view.id, "/notes.txt");
+
+        let diff = store.file_diff(&view.id, "/notes.txt").unwrap();
+        assert_eq!(diff.path, "/notes.txt");
+        assert!(!diff.binary);
+        assert!(!diff.truncated);
+        assert!(diff.patch.contains("--- /notes.txt"));
+        assert!(diff.patch.contains("+++ /notes.txt"));
+        assert!(diff.patch.contains("-alpha"));
+        assert!(diff.patch.contains("-beta"));
+    }
+
+    #[test]
+    fn file_diff_reports_binary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        delta_write(&store, &view.id, "/README.md", &[0xff, 0xfe, 0xfd]);
+
+        let diff = store.file_diff(&view.id, "/README.md").unwrap();
+        assert_eq!(diff.path, "/README.md");
+        assert!(diff.binary);
+        assert!(!diff.truncated);
+        assert_eq!(diff.patch, "Binary files differ\n");
+    }
+
+    #[test]
+    fn file_diff_reports_missing_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        assert!(matches!(
+            store.file_diff(&view.id, "/missing.txt"),
+            Err(AfsError::PathNotFound(path)) if path == "/missing.txt"
+        ));
+    }
+
+    #[test]
+    fn file_diff_truncates_oversized_patches() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        let large = "é\n".repeat(140_000);
+        delta_write(&store, &view.id, "/src/large.txt", large.as_bytes());
+
+        let diff = store.file_diff(&view.id, "/src/large.txt").unwrap();
+        assert_eq!(diff.path, "/src/large.txt");
+        assert!(!diff.binary);
+        assert!(diff.truncated);
+        assert_eq!(diff.patch.len(), UNIFIED_DIFF_MAX_BYTES);
+        assert!(diff.patch.contains("--- /src/large.txt"));
+        assert!(diff.patch.starts_with("--- /src/large.txt"));
     }
 
     #[test]

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -16,6 +16,7 @@
 //! overlay handles across requests would buy contention rather than speed.
 
 use std::collections::HashSet;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -56,6 +57,7 @@ pub const UNIFIED_DIFF_MAX_BYTES: usize = 256 * 1024;
 pub enum AfsError {
     SessionNotFound(String),
     PathNotFound(String),
+    PathNotFile(String),
     SessionNotOpen {
         id: String,
         state: String,
@@ -100,6 +102,11 @@ impl AfsError {
                 format!("No AFS session {id}."),
             ),
             Self::PathNotFound(path) => (404, "afs.path_not_found", format!("No AFS path {path}.")),
+            Self::PathNotFile(path) => (
+                400,
+                "afs.path_not_file",
+                format!("AFS path {path} is not a regular file."),
+            ),
             Self::SessionNotOpen { id, state } => (
                 409,
                 "afs.session_not_open",
@@ -646,50 +653,33 @@ impl AfsStore {
         let overlay = self.open_overlay(id, &binding)?;
         let path = normalize(path);
 
-        let base = read_optional_agent_file(overlay.base(), &path)?;
-        let merged = read_optional_overlay_file(&overlay, &path)?;
-        if base.is_none() && merged.is_none() {
+        let base_meta = optional_agent_metadata(overlay.base(), &path)?;
+        let merged_meta = optional_overlay_metadata(&overlay, &path)?;
+        if base_meta.is_none() && merged_meta.is_none() {
             return Err(AfsError::PathNotFound(path));
         }
+        if base_meta.as_ref().is_some_and(|meta| !meta.is_file())
+            || merged_meta.as_ref().is_some_and(|meta| !meta.is_file())
+        {
+            return Err(AfsError::PathNotFile(path));
+        }
 
-        let patch = if let (Some(base), Some(merged)) = (&base, &merged) {
-            match (std::str::from_utf8(base), std::str::from_utf8(merged)) {
-                (Ok(base), Ok(merged)) => {
-                    let patch = TextDiff::from_lines(base, merged)
-                        .unified_diff()
-                        .context_radius(3)
-                        .header(&path, &path)
-                        .to_string();
-                    truncate_utf8(patch, UNIFIED_DIFF_MAX_BYTES)
-                }
-                _ => ("Binary files differ\n".to_string(), false),
-            }
-        } else if let Some(base) = &base {
-            match std::str::from_utf8(base) {
-                Ok(base) => {
-                    let patch = TextDiff::from_lines(base, "")
-                        .unified_diff()
-                        .context_radius(3)
-                        .header(&path, &path)
-                        .to_string();
-                    truncate_utf8(patch, UNIFIED_DIFF_MAX_BYTES)
-                }
-                Err(_) => ("Binary files differ\n".to_string(), false),
-            }
-        } else if let Some(merged) = &merged {
-            match std::str::from_utf8(merged) {
-                Ok(merged) => {
-                    let patch = TextDiff::from_lines("", merged)
-                        .unified_diff()
-                        .context_radius(3)
-                        .header(&path, &path)
-                        .to_string();
-                    truncate_utf8(patch, UNIFIED_DIFF_MAX_BYTES)
-                }
-                Err(_) => ("Binary files differ\n".to_string(), false),
-            }
+        let base = if base_meta.is_some() {
+            Some(overlay.base().read_file(&path).map_err(AfsError::from)?)
         } else {
-            unreachable!("missing path handled above");
+            None
+        };
+        let merged = if merged_meta.is_some() {
+            Some(overlay.read_file(&path).map_err(AfsError::from)?)
+        } else {
+            None
+        };
+        let patch = match (
+            std::str::from_utf8(base.as_deref().unwrap_or(&[])),
+            std::str::from_utf8(merged.as_deref().unwrap_or(&[])),
+        ) {
+            (Ok(base), Ok(merged)) => bounded_unified_diff(base, merged, &path)?,
+            _ => ("Binary files differ\n".to_string(), false),
         };
         let binary = patch.0 == "Binary files differ\n";
 
@@ -1441,31 +1431,105 @@ fn cleanup_failed_materialization(project_root: &Path, worktree_path: &Path, bra
         .output();
 }
 
-fn read_optional_agent_file(fs: &AgentFs, path: &str) -> AfsResult<Option<Vec<u8>>> {
-    match fs.read_file(path) {
-        Ok(data) => Ok(Some(data)),
+fn optional_agent_metadata(fs: &AgentFs, path: &str) -> AfsResult<Option<coven_afs::Metadata>> {
+    match fs.stat(path) {
+        Ok(metadata) => Ok(Some(metadata)),
         Err(coven_afs::Error::NotFound(_)) => Ok(None),
         Err(error) => Err(AfsError::from(error)),
     }
 }
 
-fn read_optional_overlay_file(overlay: &OverlayFs, path: &str) -> AfsResult<Option<Vec<u8>>> {
-    match overlay.read_file(path) {
-        Ok(data) => Ok(Some(data)),
+fn optional_overlay_metadata(
+    overlay: &OverlayFs,
+    path: &str,
+) -> AfsResult<Option<coven_afs::Metadata>> {
+    match overlay.stat(path) {
+        Ok(metadata) => Ok(Some(metadata)),
         Err(coven_afs::Error::NotFound(_)) => Ok(None),
         Err(error) => Err(AfsError::from(error)),
     }
 }
 
-fn truncate_utf8(value: String, max_bytes: usize) -> (String, bool) {
-    if value.len() <= max_bytes {
-        return (value, false);
+fn bounded_unified_diff(base: &str, merged: &str, path: &str) -> AfsResult<(String, bool)> {
+    let diff = TextDiff::from_lines(base, merged);
+    let mut unified = diff.unified_diff();
+    unified.context_radius(3).header(path, path);
+
+    let mut output = CappedDiffWriter::new(UNIFIED_DIFF_MAX_BYTES);
+    if let Err(error) = unified.to_writer(&mut output) {
+        if !output.truncated {
+            return Err(AfsError::Internal(anyhow::anyhow!(
+                "failed to render unified diff for {path}: {error}"
+            )));
+        }
     }
-    let mut end = max_bytes;
-    while !value.is_char_boundary(end) {
-        end -= 1;
+
+    let truncated = output.truncated;
+    let patch = String::from_utf8(output.bytes).map_err(|error| {
+        AfsError::Internal(anyhow::anyhow!(
+            "unified diff for {path} was not valid UTF-8: {error}"
+        ))
+    })?;
+    Ok((patch, truncated))
+}
+
+struct CappedDiffWriter {
+    bytes: Vec<u8>,
+    max_bytes: usize,
+    truncated: bool,
+}
+
+impl CappedDiffWriter {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(max_bytes),
+            max_bytes,
+            truncated: false,
+        }
     }
-    (value[..end].to_string(), true)
+}
+
+impl Write for CappedDiffWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        if self.bytes.len() == self.max_bytes {
+            self.truncated = true;
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "unified diff output limit reached",
+            ));
+        }
+
+        let remaining = self.max_bytes - self.bytes.len();
+        if buf.len() <= remaining {
+            self.bytes.extend_from_slice(buf);
+            return Ok(buf.len());
+        }
+
+        let text = std::str::from_utf8(buf)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        let mut end = remaining;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        if end == 0 {
+            self.truncated = true;
+            return Err(io::Error::new(
+                io::ErrorKind::WriteZero,
+                "unified diff output limit reached",
+            ));
+        }
+
+        self.bytes.extend_from_slice(&buf[..end]);
+        self.truncated = true;
+        Ok(end)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
 }
 
 // ---- base ingest --------------------------------------------------------
@@ -2281,6 +2345,26 @@ mod tests {
     }
 
     #[test]
+    fn file_diff_rejects_non_regular_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        let mut delta = store.open_delta(&view.id).unwrap();
+        delta.mkdir_p("/fresh").unwrap();
+        delta_symlink(&store, &view.id, "/README.md", "/readme-link");
+
+        for path in ["/fresh", "/readme-link"] {
+            let error = store.file_diff(&view.id, path).unwrap_err();
+            let (status, code, message) = error.parts();
+            assert_eq!(status, 400);
+            assert_eq!(code, "afs.path_not_file");
+            assert!(message.contains(path));
+        }
+    }
+
+    #[test]
     fn file_diff_truncates_oversized_patches() {
         let dir = tempfile::tempdir().unwrap();
         let root = project(dir.path());
@@ -2294,7 +2378,8 @@ mod tests {
         assert_eq!(diff.path, "/src/large.txt");
         assert!(!diff.binary);
         assert!(diff.truncated);
-        assert_eq!(diff.patch.len(), UNIFIED_DIFF_MAX_BYTES);
+        assert!(diff.patch.len() <= UNIFIED_DIFF_MAX_BYTES);
+        assert!(std::str::from_utf8(diff.patch.as_bytes()).is_ok());
         assert!(diff.patch.contains("--- /src/large.txt"));
         assert!(diff.patch.starts_with("--- /src/large.txt"));
     }

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -16,6 +16,7 @@
 //! overlay handles across requests would buy contention rather than speed.
 
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
@@ -674,13 +675,14 @@ impl AfsStore {
         } else {
             None
         };
+        let path_header = diff_header_path(&path);
         let base_header = if base.is_some() {
-            path.as_str()
+            path_header.as_str()
         } else {
             "/dev/null"
         };
         let merged_header = if merged.is_some() {
-            path.as_str()
+            path_header.as_str()
         } else {
             "/dev/null"
         };
@@ -1468,6 +1470,36 @@ fn optional_overlay_metadata(
         Err(coven_afs::Error::NotFound(_)) => Ok(None),
         Err(error) => Err(AfsError::from(error)),
     }
+}
+
+fn diff_header_path(path: &str) -> String {
+    if !path
+        .chars()
+        .any(|character| character.is_control() || matches!(character, '"' | '\\'))
+    {
+        return path.to_string();
+    }
+
+    let mut quoted = String::with_capacity(path.len() + 2);
+    quoted.push('"');
+    for character in path.chars() {
+        match character {
+            '"' => quoted.push_str("\\\""),
+            '\\' => quoted.push_str("\\\\"),
+            '\u{08}' => quoted.push_str("\\b"),
+            '\u{0c}' => quoted.push_str("\\f"),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            character if character.is_control() => {
+                write!(&mut quoted, "\\u{:04x}", character as u32)
+                    .expect("writing to a String cannot fail");
+            }
+            character => quoted.push(character),
+        }
+    }
+    quoted.push('"');
+    quoted
 }
 
 fn bounded_unified_diff(
@@ -2387,6 +2419,22 @@ mod tests {
         );
         assert!(!deleted.truncated);
         assert!(!deleted.binary);
+    }
+
+    #[test]
+    fn file_diff_escapes_control_characters_in_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        let path = "/odd\tname\n.txt";
+
+        delta_write(&store, &view.id, path, b"contents\n");
+
+        let diff = store.file_diff(&view.id, path).unwrap();
+        assert_eq!(diff.path, path);
+        assert!(diff.patch.contains("+++ \"/odd\\tname\\n.txt\""));
+        assert!(!diff.patch.contains("+++ /odd\tname\n.txt"));
     }
 
     #[test]

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -7309,6 +7309,38 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn afs_diff_query_path_directory_returns_structured_client_error() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = afs_project(temp.path());
+        let created = handle_request_with_body(
+            "POST",
+            "/api/v1/afs/sessions",
+            temp.path(),
+            None,
+            Some(&json!({ "projectRoot": root }).to_string()),
+        )?;
+        let session: serde_json::Value = serde_json::from_str(&created.body)?;
+        let id = session["id"].as_str().unwrap().to_string();
+        let mut delta =
+            coven_afs::AgentFs::create(temp.path().join("afs/sessions").join(format!("{id}.db")))?;
+        delta.mkdir_p("/fresh")?;
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("path", "/fresh")
+            .finish();
+
+        let response = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}/diff?{query}"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(response.status, 400);
+        assert!(response.body.contains(r#""code":"afs.path_not_file""#));
+        assert!(response.body.contains("/fresh"));
+        Ok(())
+    }
+
     use crate::project;
 
     #[test]

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -6771,9 +6771,15 @@ fn afs_read(coven_home: &Path, path: &str, query: Option<&str>) -> Result<ApiRes
             Ok(view) => json_response(200, &view),
             Err(error) => afs_failure(error),
         },
-        Some("diff") => match store.diff(&id) {
-            Ok(view) => json_response(200, &view),
-            Err(error) => afs_failure(error),
+        Some("diff") => match query.and_then(|q| decoded_query_param(q, "path")) {
+            Some(path) => match store.file_diff(&id, &path) {
+                Ok(view) => json_response(200, &view),
+                Err(error) => afs_failure(error),
+            },
+            None => match store.diff(&id) {
+                Ok(view) => json_response(200, &view),
+                Err(error) => afs_failure(error),
+            },
         },
         Some("timeline") => {
             let since = query
@@ -6927,6 +6933,11 @@ pub(crate) fn query_param<'a>(query: &'a str, key: &str) -> Option<&'a str> {
     })
 }
 
+pub(crate) fn decoded_query_param(query: &str, key: &str) -> Option<String> {
+    url::form_urlencoded::parse(query.as_bytes())
+        .find_map(|(candidate, value)| (candidate == key).then_some(value.into_owned()))
+}
+
 fn session_action_id<'a>(path: &'a str, suffix: &str) -> &'a str {
     path.trim_start_matches("/sessions/")
         .strip_suffix(suffix)
@@ -7001,6 +7012,18 @@ mod tests {
         std::fs::create_dir_all(root.join("src")).unwrap();
         std::fs::write(root.join("src/main.rs"), b"fn main() {}").unwrap();
         root.to_string_lossy().into_owned()
+    }
+
+    fn afs_overlay_for(coven_home: &Path, session: &serde_json::Value) -> coven_afs::OverlayFs {
+        let id = session["id"].as_str().unwrap();
+        let fingerprint = session["base"]["fingerprint"].as_str().unwrap();
+        coven_afs::OverlayFs::open(
+            coven_home.join("afs/sessions").join(format!("{id}.db")),
+            coven_home
+                .join("afs/bases")
+                .join(format!("{fingerprint}.db")),
+        )
+        .unwrap()
     }
 
     #[test]
@@ -7203,6 +7226,89 @@ mod tests {
         assert_eq!(bad.status, 400);
         Ok(())
     }
+
+    #[test]
+    fn afs_diff_query_path_is_percent_decoded_and_returns_file_diff_view() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = afs_project(temp.path());
+        std::fs::write(
+            Path::new(&root).join("space name.txt"),
+            "alpha\nbeta\ngamma\n",
+        )?;
+        let created = handle_request_with_body(
+            "POST",
+            "/api/v1/afs/sessions",
+            temp.path(),
+            None,
+            Some(&json!({ "projectRoot": root }).to_string()),
+        )?;
+        let session: serde_json::Value = serde_json::from_str(&created.body)?;
+        let id = session["id"].as_str().unwrap().to_string();
+
+        let mut overlay = afs_overlay_for(temp.path(), &session);
+        overlay.write_file("/space name.txt", b"alpha\nbeta changed\ngamma\n")?;
+
+        let change_list = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}/diff"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(change_list.status, 200);
+        let change_list: serde_json::Value = serde_json::from_str(&change_list.body)?;
+        assert!(change_list.get("changes").is_some());
+        assert!(change_list.get("patch").is_none());
+
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("path", "/space name.txt")
+            .finish();
+        let response = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}/diff?{query}"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(response.status, 200);
+        let response: serde_json::Value = serde_json::from_str(&response.body)?;
+        assert_eq!(response["path"], "/space name.txt");
+        assert_eq!(response["binary"], false);
+        assert_eq!(response["truncated"], false);
+        assert!(response["patch"]
+            .as_str()
+            .unwrap()
+            .contains("+beta changed"));
+        Ok(())
+    }
+
+    #[test]
+    fn afs_diff_query_path_missing_returns_structured_not_found() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let root = afs_project(temp.path());
+        let created = handle_request_with_body(
+            "POST",
+            "/api/v1/afs/sessions",
+            temp.path(),
+            None,
+            Some(&json!({ "projectRoot": root }).to_string()),
+        )?;
+        let session: serde_json::Value = serde_json::from_str(&created.body)?;
+        let id = session["id"].as_str().unwrap().to_string();
+        let query = url::form_urlencoded::Serializer::new(String::new())
+            .append_pair("path", "/missing.txt")
+            .finish();
+
+        let response = handle_request(
+            "GET",
+            &format!("/api/v1/afs/sessions/{id}/diff?{query}"),
+            temp.path(),
+            None,
+        )?;
+        assert_eq!(response.status, 404);
+        assert!(response.body.contains(r#""code":"afs.path_not_found""#));
+        assert!(response.body.contains("/missing.txt"));
+        Ok(())
+    }
+
     use crate::project;
 
     #[test]


### PR DESCRIPTION
Implements the `GET …/diff?path=<path>` half of DESIGN.md §3.3: the change set
lists what moved, this returns one file's unified diff, capped at a documented
byte limit with `"truncated": true` rather than streaming an unbounded body.

Part of `coven-gr1` (Cave's AFS diff, timeline, and commit surfaces), which
needs a per-path diff to render a review pane.

## What ships

`AfsStore::file_diff` and `FileDiffView`, plus the route wiring and decoded
`?path=` query handling.

The five commits after the feature are edge cases found while building it, and
each one is a case a review client would otherwise render wrongly:

- **Bounded rendering.** Patches stream into a UTF-8-safe capped writer instead
  of being materialized and truncated afterwards, so a large diff never costs
  the memory of the whole patch, and truncation cannot split a multi-byte
  character. Non-regular diff targets are refused with a structured error.
- **Empty files.** Added and deleted empty files emit explicit headers, so a
  client can tell them apart from unchanged content — without this they are
  indistinguishable from "nothing happened".
- **Null headers.** Every added and deleted text diff uses `/dev/null` for the
  missing side, including truncated patches.
- **Binary detection is independent of change detection.** An unchanged binary
  path returns an empty patch while a genuine binary change keeps its marker.
  Conflating the two reported every binary file as modified.
- **Header escaping.** Control characters, quotes, and backslashes are quoted
  in diff headers while the response still carries the raw path.

11 `file_diff` tests cover each of those, including added-vs-deleted empty
files, control characters in paths, and unchanged binaries.

## Note on provenance

These six commits were authored in a separate worktree and are pushed here
rebased onto current `main` (they predate #700 and #701). The rebase applied
without conflicts; the workspace suite passes on the rebased result, which is
the check that matters given #701 reworked the same two files.

A second branch implementing the same feature exists locally
(`feat/coven-gr1-afs-review-contract-local`, one commit) and is **not** being
merged — it lacks all five of the fixes above. It should be discarded once
that is confirmed.

## Verification

`cargo test --workspace --locked` green (20 test binaries, 11 `file_diff`
tests), clippy clean workspace-wide with `-D warnings`, fmt clean, secret scan
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)