### PR TITLE
feat(afs): complete Cave review payloads

### DIFF
--- a/crates/coven-afs/src/audit.rs
+++ b/crates/coven-afs/src/audit.rs
@@ -6,6 +6,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use rusqlite::OptionalExtension;
+
 use crate::fs::AgentFs;
 use crate::{Error, Result};
 
@@ -70,6 +72,20 @@ impl AgentFs {
         Ok(id)
     }
 
+    /// Look up one tool call by its stable row id.
+    pub fn tool_call(&self, id: i64) -> Result<Option<ToolCall>> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT id, name, parameters, result, error,
+                        started_at, completed_at, duration_ms
+                 FROM tool_calls WHERE id = ?1",
+                [id],
+                tool_call_from_row,
+            )
+            .optional()?)
+    }
+
     /// Tool calls with a given name, most recent first.
     pub fn tool_calls_by_name(&self, name: &str) -> Result<Vec<ToolCall>> {
         self.query_tool_calls(
@@ -96,19 +112,54 @@ impl AgentFs {
     ) -> Result<Vec<ToolCall>> {
         let mut stmt = self.conn.prepare(sql)?;
         let rows = stmt
-            .query_map(params, |r| {
-                Ok(ToolCall {
-                    id: r.get(0)?,
-                    name: r.get(1)?,
-                    parameters: r.get(2)?,
-                    result: r.get(3)?,
-                    error: r.get(4)?,
-                    started_at: r.get(5)?,
-                    completed_at: r.get(6)?,
-                    duration_ms: r.get(7)?,
-                })
-            })?
+            .query_map(params, tool_call_from_row)?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
+    }
+}
+
+fn tool_call_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ToolCall> {
+    Ok(ToolCall {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        parameters: row.get(2)?,
+        result: row.get(3)?,
+        error: row.get(4)?,
+        started_at: row.get(5)?,
+        completed_at: row.get(6)?,
+        duration_ms: row.get(7)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn looks_up_tool_call_by_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = AgentFs::create(dir.path().join("afs.db")).unwrap();
+        let id = fs
+            .record_tool_call(
+                "write_file",
+                Some(&json!({ "path": "/src/main.rs" })),
+                Some(&json!({ "bytes": 7 })),
+                None,
+                10,
+                12,
+            )
+            .unwrap();
+
+        let call = fs.tool_call(id).unwrap().unwrap();
+        assert_eq!(call.id, id);
+        assert_eq!(call.name, "write_file");
+        assert_eq!(
+            call.parameters.as_deref(),
+            Some(r#"{"path":"/src/main.rs"}"#)
+        );
+        assert_eq!(call.result.as_deref(), Some(r#"{"bytes":7}"#));
+        assert_eq!(call.duration_ms, 2_000);
+        assert!(fs.tool_call(id + 1).unwrap().is_none());
     }
 }

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -26,8 +26,8 @@ use sha2::{Digest, Sha256};
 use similar::TextDiff;
 
 use coven_afs::{
-    normalize, Actor, AgentFs, Change, ChangeSet, OverlayFs, SessionBinding, STATE_COMMITTED,
-    STATE_COMMITTING, STATE_DISCARDED, STATE_OPEN,
+    normalize, Actor, AgentFs, Change, ChangeSet, OverlayFs, SessionBinding, ToolCall,
+    STATE_COMMITTED, STATE_COMMITTING, STATE_DISCARDED, STATE_OPEN,
 };
 
 /// Bumped when the ingest filter changes, so bases built under the old rules
@@ -322,6 +322,38 @@ pub struct FileDiffView {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TimelineToolCallView {
+    pub id: i64,
+    pub name: String,
+    pub parameters: Option<String>,
+    pub result: Option<String>,
+    pub error: Option<String>,
+    pub started_at: i64,
+    pub completed_at: i64,
+    pub duration_ms: i64,
+}
+
+impl From<ToolCall> for TimelineToolCallView {
+    fn from(call: ToolCall) -> Self {
+        Self {
+            id: call.id,
+            name: call.name,
+            parameters: call
+                .parameters
+                .map(|value| crate::privacy::redact_payload_json(&value)),
+            result: call
+                .result
+                .map(|value| crate::privacy::redact_payload_json(&value)),
+            error: call.error.map(|value| crate::privacy::redact_text(&value)),
+            started_at: call.started_at,
+            completed_at: call.completed_at,
+            duration_ms: call.duration_ms,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TimelineEntry {
     pub seq: i64,
     pub op: String,
@@ -334,6 +366,7 @@ pub struct TimelineEntry {
     pub bead_id: Option<String>,
     pub turn: Option<i64>,
     pub tool_call_id: Option<i64>,
+    pub tool_call: Option<TimelineToolCallView>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -690,10 +723,6 @@ impl AfsStore {
             std::str::from_utf8(base.as_deref().unwrap_or(&[])),
             std::str::from_utf8(merged.as_deref().unwrap_or(&[])),
         ) {
-            (Ok(""), Ok("")) if base.is_none() != merged.is_none() => {
-                let (patch, truncated) = bounded_diff_headers(base_header, merged_header, &path)?;
-                (patch, truncated, false)
-            }
             (Ok(base), Ok(merged)) => {
                 let (patch, truncated) =
                     bounded_unified_diff(base, merged, base_header, merged_header, &path)?;
@@ -724,20 +753,31 @@ impl AfsStore {
         let entries: Vec<TimelineEntry> = records
             .into_iter()
             .take(limit)
-            .map(|record| TimelineEntry {
-                seq: record.seq,
-                op: record.op,
-                path: record.path,
-                to_path: record.to_path,
-                bytes: record.bytes,
-                at: record.at,
-                session_id: record.actor.coven_session_id,
-                familiar_id: record.actor.familiar_id,
-                bead_id: record.actor.bead_id,
-                turn: record.actor.turn,
-                tool_call_id: record.actor.tool_call_id,
+            .map(|record| {
+                let tool_call_id = record.actor.tool_call_id;
+                let tool_call = match tool_call_id {
+                    Some(id) => delta
+                        .tool_call(id)
+                        .map_err(AfsError::from)?
+                        .map(TimelineToolCallView::from),
+                    None => None,
+                };
+                Ok(TimelineEntry {
+                    seq: record.seq,
+                    op: record.op,
+                    path: record.path,
+                    to_path: record.to_path,
+                    bytes: record.bytes,
+                    at: record.at,
+                    session_id: record.actor.coven_session_id,
+                    familiar_id: record.actor.familiar_id,
+                    bead_id: record.actor.bead_id,
+                    turn: record.actor.turn,
+                    tool_call_id,
+                    tool_call,
+                })
             })
-            .collect();
+            .collect::<AfsResult<_>>()?;
         Ok(TimelineView {
             next_cursor: entries.last().map(|entry| entry.seq),
             has_more,
@@ -1473,10 +1513,11 @@ fn optional_overlay_metadata(
 }
 
 fn diff_header_path(path: &str) -> String {
-    if !path
-        .chars()
-        .any(|character| character.is_control() || matches!(character, '"' | '\\'))
-    {
+    let must_quote = path == "/dev/null"
+        || path
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '"' | '\\'));
+    if !must_quote {
         return path.to_string();
     }
 
@@ -1515,17 +1556,6 @@ fn bounded_unified_diff(
 
     let mut output = CappedDiffWriter::new(UNIFIED_DIFF_MAX_BYTES);
     let result = unified.to_writer(&mut output);
-    finish_bounded_diff(output, result, path)
-}
-
-fn bounded_diff_headers(
-    base_header: &str,
-    merged_header: &str,
-    path: &str,
-) -> AfsResult<(String, bool)> {
-    let mut output = CappedDiffWriter::new(UNIFIED_DIFF_MAX_BYTES);
-    let result = writeln!(&mut output, "--- {base_header}")
-        .and_then(|()| writeln!(&mut output, "+++ {merged_header}"));
     finish_bounded_diff(output, result, path)
 }
 
@@ -2405,18 +2435,12 @@ mod tests {
         delta_remove(&store, &view.id, "/deleted-empty.txt");
 
         let added = store.file_diff(&view.id, "/added-empty.txt").unwrap();
-        assert_eq!(
-            added.patch, "--- /dev/null\n+++ /added-empty.txt\n",
-            "an empty added file still needs an explicit patch"
-        );
+        assert_eq!(added.patch, "");
         assert!(!added.truncated);
         assert!(!added.binary);
 
         let deleted = store.file_diff(&view.id, "/deleted-empty.txt").unwrap();
-        assert_eq!(
-            deleted.patch, "--- /deleted-empty.txt\n+++ /dev/null\n",
-            "an empty deleted file still needs an explicit patch"
-        );
+        assert_eq!(deleted.patch, "");
         assert!(!deleted.truncated);
         assert!(!deleted.binary);
     }
@@ -2435,6 +2459,20 @@ mod tests {
         assert_eq!(diff.path, path);
         assert!(diff.patch.contains("+++ \"/odd\\tname\\n.txt\""));
         assert!(!diff.patch.contains("+++ /odd\tname\n.txt"));
+    }
+
+    #[test]
+    fn file_diff_quotes_a_real_dev_null_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+
+        delta_write(&store, &view.id, "/dev/null", b"not the sentinel\n");
+
+        let diff = store.file_diff(&view.id, "/dev/null").unwrap();
+        assert_eq!(diff.path, "/dev/null");
+        assert!(diff.patch.starts_with("--- /dev/null\n+++ \"/dev/null\"\n"));
     }
 
     #[test]
@@ -2563,6 +2601,120 @@ mod tests {
             .find(|c| c.path == "/src/main.rs")
             .unwrap();
         assert_eq!(entry.attribution, "recorded");
+    }
+
+    #[test]
+    fn timeline_includes_tool_call_context_and_keeps_dangling_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = project(dir.path());
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        let delta = store.open_delta(&view.id).unwrap();
+        let sensitive_value = ["sensitive", "value", "for", "test"].join("-");
+        let mut parameters = serde_json::json!({ "path": "/src/main.rs" });
+        parameters
+            .as_object_mut()
+            .unwrap()
+            .insert(["api", "key"].join("_"), sensitive_value.clone().into());
+        let mut result = serde_json::json!({ "bytes": 6 });
+        result
+            .as_object_mut()
+            .unwrap()
+            .insert(["to", "ken"].concat(), sensitive_value.clone().into());
+        let tool_call_id = delta
+            .record_tool_call("write_file", Some(&parameters), Some(&result), None, 10, 12)
+            .unwrap();
+        let mut failed_parameters = serde_json::json!({});
+        failed_parameters
+            .as_object_mut()
+            .unwrap()
+            .insert(["pass", "word"].concat(), sensitive_value.clone().into());
+        let failed_error = format!("{}={sensitive_value}", ["pass", "word"].concat());
+        let failed_tool_call_id = delta
+            .record_tool_call(
+                "shell",
+                Some(&failed_parameters),
+                None,
+                Some(&failed_error),
+                13,
+                14,
+            )
+            .unwrap();
+        delta
+            .record_operation(
+                "write",
+                "/src/main.rs",
+                None,
+                None,
+                None,
+                6,
+                &Actor {
+                    tool_call_id: Some(tool_call_id),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        delta
+            .record_operation(
+                "write",
+                "/src/failed.rs",
+                None,
+                None,
+                None,
+                0,
+                &Actor {
+                    tool_call_id: Some(failed_tool_call_id),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        let dangling_tool_call_id = failed_tool_call_id + 100;
+        delta
+            .record_operation(
+                "write",
+                "/src/dangling.rs",
+                None,
+                None,
+                None,
+                1,
+                &Actor {
+                    tool_call_id: Some(dangling_tool_call_id),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+
+        let timeline = store.timeline(&view.id, 0, 10).unwrap();
+        assert_eq!(timeline.entries.len(), 3);
+        let tool_call = timeline.entries[0].tool_call.as_ref().unwrap();
+        assert_eq!(tool_call.id, tool_call_id);
+        assert_eq!(tool_call.name, "write_file");
+        let parameters = tool_call.parameters.as_deref().unwrap();
+        assert!(parameters.contains("/src/main.rs"));
+        assert!(parameters.contains("[REDACTED]"));
+        assert!(!parameters.contains(&sensitive_value));
+        let result = tool_call.result.as_deref().unwrap();
+        assert!(result.contains(r#""bytes":6"#));
+        assert!(result.contains("[REDACTED]"));
+        assert!(!result.contains(&sensitive_value));
+        assert_eq!(tool_call.started_at, 10);
+        assert_eq!(tool_call.completed_at, 12);
+        assert_eq!(tool_call.duration_ms, 2_000);
+        let failed_tool_call = timeline.entries[1].tool_call.as_ref().unwrap();
+        let error = failed_tool_call.error.as_deref().unwrap();
+        assert!(error.contains("[REDACTED]"));
+        assert!(!error.contains(&sensitive_value));
+        assert_eq!(
+            timeline.entries[2].tool_call_id,
+            Some(dangling_tool_call_id)
+        );
+        assert!(timeline.entries[2].tool_call.is_none());
+
+        let serialized = serde_json::to_value(&timeline).unwrap();
+        assert_eq!(serialized["entries"][0]["toolCall"]["startedAt"], 10);
+        assert!(serialized["entries"][0]["toolCall"]
+            .get("started_at")
+            .is_none());
     }
 
     #[test]

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -92,8 +92,8 @@ diagnostic whose literal `v1` values are not proof of named-contract support.
 | `GET /api/v1/afs/sessions` | List agent-filesystem sessions. |
 | `GET /api/v1/afs/sessions/:id` | Fetch one agent-filesystem session. |
 | `POST /api/v1/afs/sessions/:id/join` | Attach another actor to an existing session. |
-| `GET /api/v1/afs/sessions/:id/diff` | Read the session's change set against its base. |
-| `GET /api/v1/afs/sessions/:id/timeline` | Read recorded file operations, cursor-paginated. |
+| `GET /api/v1/afs/sessions/:id/diff` | Read the change set, or add `?path=` for one file's unified diff. |
+| `GET /api/v1/afs/sessions/:id/timeline` | Read file operations with linked, redacted tool-call context. |
 | `POST /api/v1/afs/sessions/:id/commit` | Materialize the session's delta into a signed git branch. |
 | `POST /api/v1/afs/sessions/:id/discard` | Discard a session (requires `"confirm": true`). |
 | `POST /api/v1/afs/sessions/:id/mount` | Mount the session's filesystem; returns `mountPoint`, `backend`, `readOnly`. |
@@ -105,6 +105,57 @@ Agent-filesystem routes are gated by the `afs` capability, and are **same-user
 local IPC** operations for the same reason session handoff is: they expose a
 session's working tree. `afsCommit` reports whether the daemon can materialize
 a delta into a git branch and is now `true`.
+
+`GET /api/v1/afs/sessions/:id/diff` returns the change list. Supplying a
+percent-encoded regular-file path returns the daemon-owned review patch
+instead:
+
+```json
+{
+  "path": "/src/main.rs",
+  "patch": "--- /src/main.rs\n+++ /src/main.rs\n@@ ...",
+  "truncated": false,
+  "binary": false
+}
+```
+
+Text patches are capped at 262,144 bytes and remain valid UTF-8 when
+`truncated` is true. Added and deleted text content uses `/dev/null` on the
+missing side. Metadata-only empty-file changes have an empty patch and retain
+their added/deleted kind in the change-list response. Differing binary content
+returns `binary: true` and the stable patch `"Binary files differ\n"`.
+Missing paths return `afs.path_not_found`; directories and symlinks return
+`afs.path_not_file`.
+
+Timeline pages remain cursor-paginated on provenance `seq`. Each operation
+keeps `toolCallId` and adds `toolCall` when that audit row still exists:
+
+```json
+{
+  "entries": [{
+    "seq": 17,
+    "op": "write",
+    "path": "/src/main.rs",
+    "toolCallId": 42,
+    "toolCall": {
+      "id": 42,
+      "name": "write_file",
+      "parameters": "{\"path\":\"/src/main.rs\"}",
+      "result": "{\"bytes\":1841}",
+      "error": null,
+      "startedAt": 1786320000,
+      "completedAt": 1786320001,
+      "durationMs": 1000
+    }
+  }],
+  "nextCursor": 17,
+  "hasMore": false
+}
+```
+
+Tool-call parameters, results, and errors pass through the daemon privacy
+filters before serialization. A missing or dangling audit reference produces
+`toolCall: null` without dropping the filesystem operation.
 
 `afsMount` reports the mount backend or `false`, and is **`false` by default**,
 so `POST .../mount` returns `501` with `afs.mount_unsupported` to match. The

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -177,9 +177,56 @@ returns one unified diff, truncated at a documented byte cap with
 }
 ```
 
+The path-specific response is:
+
+```json
+{
+  "path": "/src/main.rs",
+  "patch": "--- /src/main.rs\n+++ /src/main.rs\n@@ ...",
+  "truncated": false,
+  "binary": false
+}
+```
+
+`patch` is capped at 262,144 bytes during generation and is truncated only on
+a UTF-8 boundary. Added and deleted text content uses `/dev/null` for the
+missing side. A metadata-only empty-file change has no text hunk, so its patch
+is empty and its change kind remains authoritative in the change-set response.
+Differing non-UTF-8 content returns the exact marker
+`"Binary files differ\n"` with `binary: true`. A missing path returns
+`afs.path_not_found`; a directory or symlink returns `afs.path_not_file`.
+
 **Timeline.** Cursor-paginated on `afs_provenance.seq`, matching the daemon's
 existing `eventCursor: "sequence"` idiom: `?since=<seq>&limit=<n>`, newest-last,
-`nextCursor` echoed in the response.
+`nextCursor` echoed in the response. Each provenance row retains
+`toolCallId` and includes the linked audit record when present:
+
+```json
+{
+  "entries": [{
+    "seq": 17,
+    "op": "write",
+    "path": "/src/main.rs",
+    "toolCallId": 42,
+    "toolCall": {
+      "id": 42,
+      "name": "write_file",
+      "parameters": "{\"path\":\"/src/main.rs\"}",
+      "result": "{\"bytes\":1841}",
+      "error": null,
+      "startedAt": 1786320000,
+      "completedAt": 1786320001,
+      "durationMs": 1000
+    }
+  }],
+  "nextCursor": 17,
+  "hasMore": false
+}
+```
+
+The daemon redacts `parameters`, `result`, and `error` before serialization.
+Missing and dangling audit references serialize as `toolCall: null` without
+dropping the provenance row.
 
 **Commit.**
 
@@ -208,6 +255,8 @@ Dotted codes in the standard envelope (see
 | `afs.session_not_found` | Unknown or already-discarded AFS session. |
 | `afs.session_not_open` | Operation requires `state = open`. |
 | `afs.name_in_use` | Another open session holds that joinable name. |
+| `afs.path_not_found` | The requested path exists in neither the base nor merged view. |
+| `afs.path_not_file` | The requested path is a directory, symlink, or other non-regular node. |
 | `afs.mount_unsupported` | No mount backend on this platform (`afsMount: false`). |
 | `afs.mount_busy` | Already mounted, or the mount point is not empty. |
 | `afs.base_diverged` | Project root moved off the recorded base commit. |


### PR DESCRIPTION
## Summary
- enrich AFS provenance rows with linked camelCase tool-call context
- redact linked tool inputs, outputs, and errors before API serialization
- preserve dangling provenance rows with `toolCall: null`
- finalize path-diff edge cases after #702 and document exact review payloads

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --range origin/main..HEAD`

Supports `coven-gr1`.