### PR TITLE
feat(afs): serve the merged base+delta view over NFS and enable the mount backend

### DIFF
--- a/crates/coven-afs/src/bin/coven-afs-serve.rs
+++ b/crates/coven-afs/src/bin/coven-afs-serve.rs
@@ -9,8 +9,12 @@
 //! rather than a thread to guess about.
 //!
 //! ```text
-//! coven-afs-serve <db-path>
+//! coven-afs-serve <delta-path> [base-path]
 //! ```
+//!
+//! With a base, the export serves the merged base+delta view a mount is
+//! supposed to show (DESIGN.md §3.2). Without one it serves the delta alone,
+//! which is only useful for a session that has no base.
 //!
 //! **Handshake.** One line each on stdout, in order:
 //!
@@ -31,7 +35,7 @@
 //! — the one that was briefly `ps`-visible — stops opening the gate. The
 //! parent never learns the replacement, because it has no further use for it.
 
-use coven_afs::{AfsNfs, AgentFs};
+use coven_afs::{AfsNfs, AgentFs, OverlayExport, OverlayFs};
 use nfsserve::tcp::{NFSTcp, NFSTcpListener};
 
 /// DESIGN.md §7 invariant: the export token is never logged, printed, or
@@ -59,10 +63,12 @@ fn refuse_terminal_stdout() -> Result<(), Box<dyn std::error::Error>> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let Some(path) = std::env::args().nth(1) else {
-        eprintln!("usage: coven-afs-serve <db-path>");
+    let mut args = std::env::args().skip(1);
+    let Some(path) = args.next() else {
+        eprintln!("usage: coven-afs-serve <delta-path> [base-path]");
         std::process::exit(2);
     };
+    let base = args.next();
     refuse_terminal_stdout()?;
 
     tracing_subscriber::fmt()
@@ -72,16 +78,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_writer(std::io::stderr)
         .init();
 
-    // `create` is open-or-create; the daemon always hands us an existing
-    // session delta.
-    let fs = AgentFs::create(&path)?;
-    // A mounted overlay is scratch state whose durability story is "discard or
-    // commit", so the WAL trade MOUNT-SPIKE.md §3 measured is the right one
-    // here. The daemon opens session deltas this way; a delta being handed to
-    // someone else does not.
-    fs.enable_wal()?;
+    // Two shapes of export, one serving path. Splitting the listener setup
+    // per branch would duplicate the handshake, which is the part that must
+    // not drift.
+    match base {
+        Some(base) => {
+            let overlay = OverlayFs::open(&path, &base)?;
+            // A mounted overlay is scratch state whose durability story is
+            // "discard or commit", so the WAL trade MOUNT-SPIKE.md §3 measured
+            // is the right one. The daemon opens session deltas this way; a
+            // delta being handed to someone else does not.
+            overlay.delta().enable_wal()?;
+            serve(AfsNfs::new(OverlayExport::new(overlay)?)).await
+        }
+        None => {
+            let fs = AgentFs::create(&path)?;
+            fs.enable_wal()?;
+            serve(AfsNfs::new(fs)).await
+        }
+    }
+}
 
-    let export = AfsNfs::new(fs);
+/// Bind, hand the parent the port and token, and serve until told to stop.
+async fn serve<F: coven_afs::ExportFs>(
+    export: AfsNfs<F>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let gate = export.gate_handle();
     // Port 0: the OS picks, so the export never lands on a guessable port.
     let listener = NFSTcpListener::bind("127.0.0.1:0", export).await?;

--- a/crates/coven-afs/src/ino.rs
+++ b/crates/coven-afs/src/ino.rs
@@ -104,6 +104,21 @@ impl AgentFs {
         Ok(entries)
     }
 
+    /// The name a directory entry has under a given parent.
+    ///
+    /// Used to reconstruct a path from an inode. A hard-linked file has
+    /// several names; this returns the one under the parent asked about.
+    pub fn child_name(&self, parent_ino: i64, ino: i64) -> Result<String> {
+        self.conn
+            .query_row(
+                "SELECT name FROM fs_dentry WHERE parent_ino = ?1 AND ino = ?2",
+                params![parent_ino, ino],
+                |r| r.get(0),
+            )
+            .optional()?
+            .ok_or_else(|| Error::NotFound(format!("dentry for inode {ino}")))
+    }
+
     /// The directory holding an inode, or `None` for the root and for any
     /// inode with no dentry. A hard-linked file has several parents; this
     /// returns the lowest-numbered one, which is enough for resolving `..`.

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -42,7 +42,7 @@ pub use diff::{Change, ChangeEntry, ChangeSet};
 pub use fs::{AgentFs, Metadata, ROOT_INO, S_IFDIR, S_IFLNK, S_IFMT, S_IFREG};
 pub use ino::DirEntry;
 #[cfg(feature = "mount")]
-pub use nfs::{ensure_loopback, export_token, AfsNfs, GateHandle};
+pub use nfs::{ensure_loopback, export_token, AfsNfs, ExportFs, GateHandle};
 pub use overlay::OverlayFs;
 pub use overlay_ino::{OverlayExport, BASE_TAG};
 pub use path::{basename, components, normalize, parent};

--- a/crates/coven-afs/src/lib.rs
+++ b/crates/coven-afs/src/lib.rs
@@ -32,6 +32,7 @@ mod kv;
 #[cfg(feature = "mount")]
 mod nfs;
 mod overlay;
+mod overlay_ino;
 mod path;
 mod provenance;
 mod schema;
@@ -43,6 +44,7 @@ pub use ino::DirEntry;
 #[cfg(feature = "mount")]
 pub use nfs::{ensure_loopback, export_token, AfsNfs, GateHandle};
 pub use overlay::OverlayFs;
+pub use overlay_ino::{OverlayExport, BASE_TAG};
 pub use path::{basename, components, normalize, parent};
 pub use provenance::{
     Actor, CommitRecord, ProvenanceRecord, SessionBinding, EXTENSION_TABLES, STATE_COMMITTED,

--- a/crates/coven-afs/src/nfs.rs
+++ b/crates/coven-afs/src/nfs.rs
@@ -370,6 +370,14 @@ impl ExportFs for AgentFs {
 }
 
 impl ExportFs for crate::OverlayExport {
+    /// Never read-only. `OverlayFs::new` refuses a read-only delta outright,
+    /// so an overlay that exists has a writable one; the base being read-only
+    /// is the point of the overlay rather than a restriction on it.
+    ///
+    /// A read-only *mount* is a separate matter, enforced by the kernel via
+    /// `mount_nfs -o ro`. The export cannot enforce it: NFSv3 has no notion of
+    /// a read-only client, so anything that reached the port with the token
+    /// could write regardless of what the export believed.
     fn is_read_only(&self) -> bool {
         false
     }

--- a/crates/coven-afs/src/nfs.rs
+++ b/crates/coven-afs/src/nfs.rs
@@ -153,8 +153,8 @@ const GATE_ROOT: fileid3 = u64::MAX;
 /// `MOUNTPROC3_EXPORT` dumps the export path to any caller, unauthenticated,
 /// so a token carried there is readable by exactly the attacker it is meant to
 /// stop. Inside the VFS there is no procedure that lists it.
-pub struct AfsNfs {
-    fs: Mutex<AgentFs>,
+pub struct AfsNfs<F: ExportFs = AgentFs> {
+    fs: Mutex<F>,
     read_only: bool,
     uid: u32,
     gid: u32,
@@ -220,10 +220,244 @@ impl GateHandle {
     }
 }
 
-impl AfsNfs {
-    /// Wrap a filesystem for export. A read-only [`AgentFs`] is exported
+/// The inode-addressed operations an NFS export needs from a filesystem.
+///
+/// Implemented by [`AgentFs`], which exports one layer, and by
+/// [`OverlayExport`], which exports a merged base+delta view. The export is
+/// written against this rather than against `AgentFs` because mounting a
+/// session means mounting the merged view (DESIGN.md §3.2); exporting the
+/// delta alone would show only the files a session had already changed.
+///
+/// Every method takes `&mut self`: the overlay caches inode paths as clients
+/// walk down from the root, so operations that look read-only to a caller are
+/// not read-only to the implementation.
+pub trait ExportFs: Send + 'static {
+    fn is_read_only(&self) -> bool;
+    fn root_ino(&self) -> i64;
+    fn lookup_ino(&mut self, parent: i64, name: &str) -> crate::Result<Option<i64>>;
+    fn parent_of(&mut self, ino: i64) -> crate::Result<Option<i64>>;
+    fn stat_ino(&mut self, ino: i64) -> crate::Result<Metadata>;
+    fn setattr_ino(
+        &mut self,
+        ino: i64,
+        mode: Option<u32>,
+        uid: Option<i64>,
+        gid: Option<i64>,
+        atime: Option<(i64, i64)>,
+        mtime: Option<(i64, i64)>,
+    ) -> crate::Result<Metadata>;
+    fn read_ino_at(
+        &mut self,
+        ino: i64,
+        offset: u64,
+        count: usize,
+    ) -> crate::Result<(Vec<u8>, bool)>;
+    fn write_ino_at(&mut self, ino: i64, offset: u64, data: &[u8]) -> crate::Result<Metadata>;
+    fn truncate_ino(&mut self, ino: i64, size: u64) -> crate::Result<Metadata>;
+    fn create_child(
+        &mut self,
+        parent: i64,
+        name: &str,
+        mode: u32,
+    ) -> crate::Result<(i64, Metadata)>;
+    fn mkdir_ino(&mut self, parent: i64, name: &str, mode: u32) -> crate::Result<(i64, Metadata)>;
+    fn symlink_ino(
+        &mut self,
+        parent: i64,
+        name: &str,
+        target: &str,
+    ) -> crate::Result<(i64, Metadata)>;
+    fn readlink_ino(&mut self, ino: i64) -> crate::Result<String>;
+    fn remove_ino(&mut self, parent: i64, name: &str) -> crate::Result<()>;
+    fn rename_ino(
+        &mut self,
+        from_parent: i64,
+        from_name: &str,
+        to_parent: i64,
+        to_name: &str,
+    ) -> crate::Result<()>;
+    fn readdir_ino(
+        &mut self,
+        parent: i64,
+        start_after: i64,
+        limit: usize,
+    ) -> crate::Result<Vec<crate::ino::DirEntry>>;
+}
+
+impl ExportFs for AgentFs {
+    fn is_read_only(&self) -> bool {
+        AgentFs::is_read_only(self)
+    }
+    fn root_ino(&self) -> i64 {
+        ROOT_INO
+    }
+    fn lookup_ino(&mut self, parent: i64, name: &str) -> crate::Result<Option<i64>> {
+        AgentFs::lookup_ino(self, parent, name)
+    }
+    fn parent_of(&mut self, ino: i64) -> crate::Result<Option<i64>> {
+        AgentFs::parent_of(self, ino)
+    }
+    fn stat_ino(&mut self, ino: i64) -> crate::Result<Metadata> {
+        AgentFs::stat_ino(self, ino)
+    }
+    fn setattr_ino(
+        &mut self,
+        ino: i64,
+        mode: Option<u32>,
+        uid: Option<i64>,
+        gid: Option<i64>,
+        atime: Option<(i64, i64)>,
+        mtime: Option<(i64, i64)>,
+    ) -> crate::Result<Metadata> {
+        AgentFs::setattr_ino(self, ino, mode, uid, gid, atime, mtime)
+    }
+    fn read_ino_at(
+        &mut self,
+        ino: i64,
+        offset: u64,
+        count: usize,
+    ) -> crate::Result<(Vec<u8>, bool)> {
+        AgentFs::read_ino_at(self, ino, offset, count)
+    }
+    fn write_ino_at(&mut self, ino: i64, offset: u64, data: &[u8]) -> crate::Result<Metadata> {
+        AgentFs::write_ino_at(self, ino, offset, data)
+    }
+    fn truncate_ino(&mut self, ino: i64, size: u64) -> crate::Result<Metadata> {
+        AgentFs::truncate_ino(self, ino, size)
+    }
+    fn create_child(
+        &mut self,
+        parent: i64,
+        name: &str,
+        mode: u32,
+    ) -> crate::Result<(i64, Metadata)> {
+        AgentFs::create_child(self, parent, name, mode)
+    }
+    fn mkdir_ino(&mut self, parent: i64, name: &str, mode: u32) -> crate::Result<(i64, Metadata)> {
+        AgentFs::mkdir_ino(self, parent, name, mode)
+    }
+    fn symlink_ino(
+        &mut self,
+        parent: i64,
+        name: &str,
+        target: &str,
+    ) -> crate::Result<(i64, Metadata)> {
+        AgentFs::symlink_ino(self, parent, name, target)
+    }
+    fn readlink_ino(&mut self, ino: i64) -> crate::Result<String> {
+        AgentFs::readlink_ino(self, ino)
+    }
+    fn remove_ino(&mut self, parent: i64, name: &str) -> crate::Result<()> {
+        AgentFs::remove_ino(self, parent, name)
+    }
+    fn rename_ino(
+        &mut self,
+        from_parent: i64,
+        from_name: &str,
+        to_parent: i64,
+        to_name: &str,
+    ) -> crate::Result<()> {
+        AgentFs::rename_ino(self, from_parent, from_name, to_parent, to_name)
+    }
+    fn readdir_ino(
+        &mut self,
+        parent: i64,
+        start_after: i64,
+        limit: usize,
+    ) -> crate::Result<Vec<crate::ino::DirEntry>> {
+        AgentFs::readdir_ino(self, parent, start_after, limit)
+    }
+}
+
+impl ExportFs for crate::OverlayExport {
+    fn is_read_only(&self) -> bool {
+        false
+    }
+    fn root_ino(&self) -> i64 {
+        self.root()
+    }
+    fn lookup_ino(&mut self, parent: i64, name: &str) -> crate::Result<Option<i64>> {
+        crate::OverlayExport::lookup_ino(self, parent, name)
+    }
+    fn parent_of(&mut self, ino: i64) -> crate::Result<Option<i64>> {
+        crate::OverlayExport::parent_of(self, ino)
+    }
+    fn stat_ino(&mut self, ino: i64) -> crate::Result<Metadata> {
+        crate::OverlayExport::stat_ino(self, ino)
+    }
+    fn setattr_ino(
+        &mut self,
+        ino: i64,
+        mode: Option<u32>,
+        uid: Option<i64>,
+        gid: Option<i64>,
+        atime: Option<(i64, i64)>,
+        mtime: Option<(i64, i64)>,
+    ) -> crate::Result<Metadata> {
+        crate::OverlayExport::setattr_ino(self, ino, mode, uid, gid, atime, mtime)
+    }
+    fn read_ino_at(
+        &mut self,
+        ino: i64,
+        offset: u64,
+        count: usize,
+    ) -> crate::Result<(Vec<u8>, bool)> {
+        crate::OverlayExport::read_ino_at(self, ino, offset, count)
+    }
+    fn write_ino_at(&mut self, ino: i64, offset: u64, data: &[u8]) -> crate::Result<Metadata> {
+        crate::OverlayExport::write_ino_at(self, ino, offset, data)
+    }
+    fn truncate_ino(&mut self, ino: i64, size: u64) -> crate::Result<Metadata> {
+        crate::OverlayExport::truncate_ino(self, ino, size)
+    }
+    fn create_child(
+        &mut self,
+        parent: i64,
+        name: &str,
+        mode: u32,
+    ) -> crate::Result<(i64, Metadata)> {
+        crate::OverlayExport::create_child(self, parent, name, mode)
+    }
+    fn mkdir_ino(&mut self, parent: i64, name: &str, mode: u32) -> crate::Result<(i64, Metadata)> {
+        crate::OverlayExport::mkdir_ino(self, parent, name, mode)
+    }
+    fn symlink_ino(
+        &mut self,
+        parent: i64,
+        name: &str,
+        target: &str,
+    ) -> crate::Result<(i64, Metadata)> {
+        crate::OverlayExport::symlink_ino(self, parent, name, target)
+    }
+    fn readlink_ino(&mut self, ino: i64) -> crate::Result<String> {
+        crate::OverlayExport::readlink_ino(self, ino)
+    }
+    fn remove_ino(&mut self, parent: i64, name: &str) -> crate::Result<()> {
+        crate::OverlayExport::remove_ino(self, parent, name)
+    }
+    fn rename_ino(
+        &mut self,
+        from_parent: i64,
+        from_name: &str,
+        to_parent: i64,
+        to_name: &str,
+    ) -> crate::Result<()> {
+        crate::OverlayExport::rename_ino(self, from_parent, from_name, to_parent, to_name)
+    }
+    fn readdir_ino(
+        &mut self,
+        parent: i64,
+        start_after: i64,
+        limit: usize,
+    ) -> crate::Result<Vec<crate::ino::DirEntry>> {
+        crate::OverlayExport::readdir_ino(self, parent, start_after, limit)
+    }
+}
+
+impl<F: ExportFs> AfsNfs<F> {
+    /// Wrap a filesystem for export. A read-only filesystem is exported
     /// read-only.
-    pub fn new(fs: AgentFs) -> Self {
+    pub fn new(fs: F) -> Self {
         // SAFETY: getuid/getgid are always-succeeding POSIX calls with no
         // preconditions and no memory effects.
         let (uid, gid) = unsafe { (libc::getuid(), libc::getgid()) };
@@ -295,7 +529,16 @@ impl AfsNfs {
         attr
     }
 
-    fn with<T>(&self, op: impl FnOnce(&mut AgentFs) -> crate::Result<T>) -> Result<T, nfsstat3> {
+    /// The exported filesystem's root inode. `AgentFs` roots at [`ROOT_INO`];
+    /// an overlay roots at whatever it presents as the merged root.
+    fn root_of_export(&self) -> i64 {
+        self.fs
+            .lock()
+            .map(|guard| guard.root_ino())
+            .unwrap_or(ROOT_INO)
+    }
+
+    fn with<T>(&self, op: impl FnOnce(&mut F) -> crate::Result<T>) -> Result<T, nfsstat3> {
         let mut guard = self.fs.lock().map_err(|_| nfsstat3::NFS3ERR_SERVERFAULT)?;
         op(&mut guard).map_err(status)
     }
@@ -358,7 +601,7 @@ fn name_of(name: &filename3) -> Result<String, nfsstat3> {
 
 /// Apply the mutable parts of a `sattr3` to an inode. Size is applied first so
 /// a truncate-on-create carries the requested length.
-fn apply_sattr(fs: &mut AgentFs, ino: i64, attr: &sattr3) -> crate::Result<Metadata> {
+fn apply_sattr<F: ExportFs>(fs: &mut F, ino: i64, attr: &sattr3) -> crate::Result<Metadata> {
     if let set_size3::size(size) = attr.size {
         fs.truncate_ino(ino, size)?;
     }
@@ -392,7 +635,7 @@ fn apply_sattr(fs: &mut AgentFs, ino: i64, attr: &sattr3) -> crate::Result<Metad
 }
 
 #[async_trait]
-impl NFSFileSystem for AfsNfs {
+impl<F: ExportFs> NFSFileSystem for AfsNfs<F> {
     fn capabilities(&self) -> VFSCapabilities {
         if self.read_only {
             VFSCapabilities::ReadOnly
@@ -443,7 +686,7 @@ impl NFSFileSystem for AfsNfs {
             // The only way past the gate. A wrong name is NOENT, exactly as a
             // missing file would be, so probing reveals nothing.
             return if self.gate_name.matches(name.as_bytes()) {
-                Ok(ROOT_INO as u64)
+                Ok(self.root_of_export() as u64)
             } else if name == "." || name == ".." {
                 Ok(GATE_ROOT)
             } else {
@@ -730,6 +973,67 @@ mod tests {
         // The gate answers getattr as a directory so a client can traverse it.
         let attr = export.getattr(gate).await.unwrap();
         assert!(matches!(attr.ftype, ftype3::NF3DIR));
+    }
+
+    /// An overlay export with a base file and an empty delta.
+    fn overlay_export(dir: &std::path::Path) -> AfsNfs<crate::OverlayExport> {
+        let base_path = dir.join("base.db");
+        {
+            let mut base = AgentFs::create(&base_path).unwrap();
+            base.write_file("/from-base.txt", b"base content").unwrap();
+        }
+        let overlay = crate::OverlayFs::open(dir.join("delta.db"), &base_path).unwrap();
+        AfsNfs::new(crate::OverlayExport::new(overlay).unwrap())
+    }
+
+    #[tokio::test]
+    async fn the_export_serves_the_merged_view_not_just_the_delta() {
+        // DESIGN.md §3.2: a mount shows the merged base+delta view. Exporting
+        // the delta alone would show only files the session had already
+        // changed, which for a fresh session is nothing at all.
+        let temp = tempfile::tempdir().unwrap();
+        let export = overlay_export(temp.path());
+        let root = export
+            .path_to_id(format!("/{}", export.token()).as_bytes())
+            .await
+            .expect("the gate opens");
+
+        let listing = export.readdir(root, 0, 64).await.unwrap();
+        assert!(
+            listing
+                .entries
+                .iter()
+                .any(|e| e.name.as_ref() == b"from-base.txt"),
+            "a base-only file must be visible through the mount"
+        );
+
+        let id = export.lookup(root, &name("from-base.txt")).await.unwrap();
+        let (data, _) = export.read(id, 0, 64).await.unwrap();
+        assert_eq!(data, b"base content");
+    }
+
+    #[tokio::test]
+    async fn a_file_handle_survives_the_copy_up_a_write_causes() {
+        // The acceptance criterion for coven-vlw, at the layer that matters:
+        // the client holds an NFS file handle, and the write that moves the
+        // file into the delta must not invalidate it.
+        let temp = tempfile::tempdir().unwrap();
+        let export = overlay_export(temp.path());
+        let root = export
+            .path_to_id(format!("/{}", export.token()).as_bytes())
+            .await
+            .expect("the gate opens");
+
+        let id = export.lookup(root, &name("from-base.txt")).await.unwrap();
+        let handle = export.id_to_fh(id);
+
+        export.write(id, 0, b"rewritten...").await.unwrap();
+
+        // Same handle, resolved the way a server does on every operation.
+        let resolved = export.fh_to_id(&handle).expect("the handle still resolves");
+        assert_eq!(resolved, id);
+        let (data, _) = export.read(resolved, 0, 64).await.unwrap();
+        assert_eq!(data, b"rewritten...");
     }
 
     #[tokio::test]

--- a/crates/coven-afs/src/overlay.rs
+++ b/crates/coven-afs/src/overlay.rs
@@ -53,6 +53,47 @@ impl OverlayFs {
         &self.base
     }
 
+    /// The writable delta layer, mutably. Needed by inode-addressed writes,
+    /// which reach the delta directly once a file has been copied up.
+    pub fn delta_mut(&mut self) -> &mut AgentFs {
+        &mut self.delta
+    }
+
+    /// Every recorded copy-up as `(base_ino, delta_ino)`.
+    ///
+    /// `fs_origin` is keyed by `delta_ino`, so this is the only way to build
+    /// the reverse mapping without indexing a SPEC table (DESIGN.md E1).
+    pub fn origin_pairs(&self) -> Result<Vec<(i64, i64)>> {
+        let mut stmt = self
+            .delta
+            .conn
+            .prepare("SELECT base_ino, delta_ino FROM fs_origin")?;
+        let rows = stmt
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Hide `path` and everything under it from the base layer.
+    ///
+    /// The path-addressed operations do this for themselves; the
+    /// inode-addressed layer needs it directly, because deleting a name that
+    /// exists only in the base is a whiteout rather than a delta removal.
+    pub fn set_whiteout(&self, path: &str) -> Result<()> {
+        self.create_whiteout(&normalize(path))
+    }
+
+    /// Stop hiding `path`. SPEC rule: a whiteout is removed when a new file is
+    /// created at that path.
+    pub fn clear_whiteout(&self, path: &str) -> Result<()> {
+        self.remove_whiteout(&normalize(path))
+    }
+
+    /// Whether the base layer can still contribute entries at `path`.
+    pub fn base_visible(&self, path: &str) -> Result<bool> {
+        self.base_visible_at(&normalize(path))
+    }
+
     // ---- whiteouts ---------------------------------------------------------
 
     /// Whether `path` has a whiteout in the delta layer.

--- a/crates/coven-afs/src/overlay_ino.rs
+++ b/crates/coven-afs/src/overlay_ino.rs
@@ -405,6 +405,87 @@ impl OverlayExport {
         Ok(())
     }
 
+    /// Move a name, materializing whatever the base still owns.
+    ///
+    /// Rename is the operation where the two layers genuinely fight: the base
+    /// is read-only, so a name cannot move out of it. The source is copied
+    /// into the delta first, moved there, and the old name whited out if the
+    /// base would otherwise keep supplying it.
+    pub fn rename_ino(
+        &mut self,
+        from_parent: i64,
+        from_name: &str,
+        to_parent: i64,
+        to_name: &str,
+    ) -> Result<()> {
+        let from_dir_path = self.path_of(from_parent)?;
+        let from_path = Self::child_path(&from_dir_path, from_name);
+        let to_dir_path = self.path_of(to_parent)?;
+        let to_path = Self::child_path(&to_dir_path, to_name);
+        if from_path == to_path {
+            return Ok(());
+        }
+
+        let source = self
+            .lookup_ino(from_parent, from_name)?
+            .ok_or_else(|| Error::NotFound(from_path.clone()))?;
+        if let Layer::Base(base_ino) = self.resolve(source) {
+            let delta_ino = self.materialize_tree(&from_path)?;
+            self.redirect.insert(base_ino, delta_ino);
+        }
+
+        let from_dir = self.ensure_delta_dir(from_parent)?;
+        let to_dir = self.ensure_delta_dir(to_parent)?;
+        self.fs.clear_whiteout(&to_path)?;
+        self.fs
+            .delta_mut()
+            .rename_ino(from_dir, from_name, to_dir, to_name)?;
+
+        // The delta entry moved, but the base's copy of the old name did not.
+        // Without a whiteout the file reappears at its original path, which
+        // reads as the rename having copied rather than moved.
+        let base_keeps_source = match self.base_dir_ino(from_parent, &from_dir_path)? {
+            Some(base_dir) => self.fs.base().lookup_ino(base_dir, from_name)?.is_some(),
+            None => false,
+        };
+        if base_keeps_source {
+            self.fs.set_whiteout(&from_path)?;
+        }
+
+        self.paths.remove(&source);
+        self.remember(source, to_path);
+        Ok(())
+    }
+
+    /// Copy a base subtree into the delta, returning the delta inode.
+    ///
+    /// Only rename needs this. Reads and writes never do: a file copies up
+    /// alone, and a directory keeps serving its children through the merge.
+    /// Moving a directory out of the base is the one case where the delta has
+    /// to own the whole subtree, and the cost is proportional to it.
+    fn materialize_tree(&mut self, path: &str) -> Result<i64> {
+        let meta = self.fs.base().stat(path)?;
+        if meta.is_file() {
+            return self.fs.copy_up(path);
+        }
+        if meta.is_symlink() {
+            let target = self.fs.base().read_link(path)?;
+            return self.fs.delta_mut().symlink(&target, path);
+        }
+        let ino = self.fs.delta_mut().mkdir_p(path)?;
+        for name in self.fs.base().readdir(path)? {
+            let child = Self::child_path(path, &name);
+            if self.fs.has_whiteout(&child)? {
+                continue;
+            }
+            if self.fs.delta().exists(&child)? {
+                continue;
+            }
+            self.materialize_tree(&child)?;
+        }
+        Ok(ino)
+    }
+
     /// Change attributes, copying the file up first if it is still base.
     pub fn setattr_ino(
         &mut self,
@@ -734,6 +815,64 @@ mod tests {
         assert_eq!(meta.mode & 0o777, 0o600);
         // Content survived the copy-up.
         assert_eq!(read_all(&export, id), b"unchanged");
+    }
+
+    #[test]
+    fn renaming_a_base_only_file_moves_it_rather_than_copying_it() {
+        // Without a whiteout on the source, the base keeps supplying the old
+        // name and the file appears at both paths — a copy, not a move.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        export
+            .rename_ino(root, "keep.txt", root, "moved.txt")
+            .unwrap();
+
+        assert_eq!(export.lookup_ino(root, "keep.txt").unwrap(), None);
+        let moved = export
+            .lookup_ino(root, "moved.txt")
+            .unwrap()
+            .expect("moved");
+        assert_eq!(read_all(&export, moved), b"unchanged");
+        let listed = names(&export.readdir_ino(root, 0, 100).unwrap());
+        assert!(listed.contains(&"moved.txt".to_string()));
+        assert!(!listed.contains(&"keep.txt".to_string()), "{listed:?}");
+    }
+
+    #[test]
+    fn renaming_a_base_only_directory_carries_its_children() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        export.rename_ino(root, "dir", root, "moved").unwrap();
+
+        assert_eq!(export.lookup_ino(root, "dir").unwrap(), None);
+        let moved = export.lookup_ino(root, "moved").unwrap().expect("moved");
+        let nested = export
+            .lookup_ino(moved, "nested.txt")
+            .unwrap()
+            .expect("child");
+        assert_eq!(read_all(&export, nested), b"nested");
+    }
+
+    #[test]
+    fn renaming_onto_a_whited_out_name_lifts_the_whiteout() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        export.remove_ino(root, "drop.txt").unwrap();
+
+        export
+            .rename_ino(root, "keep.txt", root, "drop.txt")
+            .unwrap();
+
+        let found = export
+            .lookup_ino(root, "drop.txt")
+            .unwrap()
+            .expect("visible");
+        assert_eq!(read_all(&export, found), b"unchanged");
     }
 
     #[test]

--- a/crates/coven-afs/src/overlay_ino.rs
+++ b/crates/coven-afs/src/overlay_ino.rs
@@ -1,0 +1,752 @@
+//! Inode-addressed access to a copy-on-write overlay.
+//!
+//! [`crate::overlay`] resolves paths; a mount backend cannot use it, for the
+//! reason [`crate::ino`] gives: NFSv3 and FUSE address objects by a 64-bit file
+//! id and a `(parent, name)` pair, never by path. Serving the *merged* view
+//! therefore needs the overlay's delta-then-base rules expressed against inode
+//! numbers, which is what this module is.
+//!
+//! # The identity problem
+//!
+//! Both layers allocate `fs_inode.ino` as an `AUTOINCREMENT` starting at
+//! [`ROOT_INO`], so base inode 5 and delta inode 5 are unrelated files. A
+//! union of the two id spaces collides on almost every id.
+//!
+//! Base inodes are therefore exposed with [`BASE_TAG`] set and delta inodes
+//! exposed as they are. The tag is a high bit rather than an offset because
+//! `readdir_ino` paginates with `WHERE ino > start_after`: a high bit keeps the
+//! merged sequence monotonic, so a cursor still resumes exactly, walking the
+//! delta's entries and then the base's.
+//!
+//! # Handle stability across copy-up
+//!
+//! A client holding a handle to a base-only file must keep it working after
+//! the first write, which moves that file into the delta and gives it a new
+//! delta inode. The exposed id cannot change underneath the client, so a
+//! tagged base id stays the file's identity for the export's lifetime and
+//! resolution redirects it to the delta inode once one exists.
+//!
+//! `fs_origin` records `delta_ino -> base_ino` but is keyed by `delta_ino`, so
+//! the reverse lookup this needs has no index. Rather than touch a SPEC table
+//! (DESIGN.md E1 forbids it), the redirect lives in memory: it is seeded from
+//! `fs_origin` at open and updated on each copy-up. The export owns the only
+//! writer to its delta, so the map cannot go stale beneath it.
+
+use std::collections::HashMap;
+
+use crate::fs::{Metadata, ROOT_INO};
+use crate::ino::DirEntry;
+use crate::overlay::OverlayFs;
+use crate::path::normalize;
+use crate::{AgentFs, Error, Result};
+
+/// Marks an exposed id as belonging to the base layer.
+///
+/// Bit 62: the ids stay positive in `i64`, and no realistic delta allocates
+/// enough inodes to reach it.
+pub const BASE_TAG: i64 = 1 << 62;
+
+/// Which layer an exposed id resolves to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Layer {
+    Delta(i64),
+    Base(i64),
+}
+
+/// An overlay presented as a single inode-addressed filesystem.
+pub struct OverlayExport {
+    fs: OverlayFs,
+    /// `base_ino -> delta_ino` for files that have been copied up. The reverse
+    /// of `fs_origin`, which is keyed the other way.
+    redirect: HashMap<i64, i64>,
+    /// Exposed id to absolute path.
+    ///
+    /// Whiteouts are keyed by path (`fs_whiteout.path`), so merging a
+    /// directory or resolving a name needs its parent's path. Clients walk
+    /// down from the root, so the path is known on the way in and recorded
+    /// here; [`Self::path_of`] falls back to a walk for a handle this process
+    /// has not seen, which is what happens after a restart.
+    paths: HashMap<i64, String>,
+}
+
+impl OverlayExport {
+    /// Wrap an overlay for inode-addressed access.
+    pub fn new(fs: OverlayFs) -> Result<Self> {
+        let redirect = fs.origin_pairs()?.into_iter().collect();
+        let mut paths = HashMap::new();
+        paths.insert(ROOT_INO, "/".to_string());
+        Ok(Self {
+            fs,
+            redirect,
+            paths,
+        })
+    }
+
+    /// The overlay's root. The delta's root is the merged root: a delta always
+    /// exists, and the base's root is reached through it rather than beside it.
+    pub fn root(&self) -> i64 {
+        ROOT_INO
+    }
+
+    /// The underlying overlay.
+    pub fn overlay(&self) -> &OverlayFs {
+        &self.fs
+    }
+
+    /// The underlying overlay, mutably.
+    pub fn overlay_mut(&mut self) -> &mut OverlayFs {
+        &mut self.fs
+    }
+
+    fn resolve(&self, id: i64) -> Layer {
+        if id & BASE_TAG == 0 {
+            return Layer::Delta(id);
+        }
+        let base = id & !BASE_TAG;
+        match self.redirect.get(&base) {
+            Some(delta) => Layer::Delta(*delta),
+            None => Layer::Base(base),
+        }
+    }
+
+    /// The path for an exposed id.
+    ///
+    /// Cheap for anything reached by walking from the root, which is every
+    /// handle a client obtained in this process. The fallback walk exists for
+    /// handles that outlived the cache.
+    fn path_of(&self, id: i64) -> Result<String> {
+        if let Some(path) = self.paths.get(&id) {
+            return Ok(path.clone());
+        }
+        let (fs, ino) = match self.resolve(id) {
+            Layer::Delta(ino) => (self.fs.delta(), ino),
+            Layer::Base(ino) => (self.fs.base(), ino),
+        };
+        walk_to_path(fs, ino)
+    }
+
+    fn remember(&mut self, id: i64, path: String) {
+        self.paths.insert(id, path);
+    }
+
+    /// Join a parent path and a child name.
+    fn child_path(parent: &str, name: &str) -> String {
+        if parent == "/" {
+            format!("/{name}")
+        } else {
+            format!("{parent}/{name}")
+        }
+    }
+
+    /// Resolve one name in a directory, following delta -> whiteout -> base.
+    pub fn lookup_ino(&mut self, parent: i64, name: &str) -> Result<Option<i64>> {
+        let parent_path = self.path_of(parent)?;
+        let child = Self::child_path(&parent_path, name);
+
+        // The delta wins outright: a name present there is the merged answer,
+        // whether it is new or copied up.
+        if let Layer::Delta(dir) = self.resolve(parent) {
+            if let Some(ino) = self.fs.delta().lookup_ino(dir, name)? {
+                self.remember(ino, child);
+                return Ok(Some(ino));
+            }
+        }
+
+        // A whiteout hides the base entry and everything under it.
+        if self.fs.has_whiteout(&child)? {
+            return Ok(None);
+        }
+
+        let Some(base_dir) = self.base_dir_ino(parent, &parent_path)? else {
+            return Ok(None);
+        };
+        let Some(base_ino) = self.fs.base().lookup_ino(base_dir, name)? else {
+            return Ok(None);
+        };
+        // Already copied up under a different delta name? Then the delta entry
+        // above would have matched; reaching here means this is still base.
+        let exposed = base_ino | BASE_TAG;
+        self.remember(exposed, child);
+        Ok(Some(exposed))
+    }
+
+    /// The base-layer inode for a directory, if the base can still contribute
+    /// entries there.
+    fn base_dir_ino(&self, parent: i64, parent_path: &str) -> Result<Option<i64>> {
+        match self.resolve(parent) {
+            Layer::Base(ino) => Ok(Some(ino)),
+            Layer::Delta(_) => {
+                // A directory that exists in the delta may still have base
+                // entries to merge, but only where the base remains visible.
+                if !self.fs.base_visible(parent_path)? {
+                    return Ok(None);
+                }
+                self.fs.base().resolve(parent_path)
+            }
+        }
+    }
+
+    /// Metadata for an exposed id, with `ino` reported as the exposed id so a
+    /// client sees one stable identity rather than the layer's private one.
+    pub fn stat_ino(&self, id: i64) -> Result<Metadata> {
+        let mut meta = match self.resolve(id) {
+            Layer::Delta(ino) => self.fs.delta().stat_ino(ino)?,
+            Layer::Base(ino) => self.fs.base().stat_ino(ino)?,
+        };
+        meta.ino = id;
+        Ok(meta)
+    }
+
+    /// Read from a file by exposed id.
+    pub fn read_ino_at(&self, id: i64, offset: u64, count: usize) -> Result<(Vec<u8>, bool)> {
+        match self.resolve(id) {
+            Layer::Delta(ino) => self.fs.delta().read_ino_at(ino, offset, count),
+            Layer::Base(ino) => self.fs.base().read_ino_at(ino, offset, count),
+        }
+    }
+
+    /// Read a symlink target by exposed id.
+    pub fn readlink_ino(&self, id: i64) -> Result<String> {
+        match self.resolve(id) {
+            Layer::Delta(ino) => self.fs.delta().readlink_ino(ino),
+            Layer::Base(ino) => self.fs.base().readlink_ino(ino),
+        }
+    }
+
+    /// The merged children of a directory: the delta's entries, then the
+    /// base's minus whiteouts and minus anything the delta already covers.
+    ///
+    /// Pagination stays exact because [`BASE_TAG`] keeps the merged sequence
+    /// monotonic — a cursor below the tag is still walking the delta, above it
+    /// the base.
+    pub fn readdir_ino(
+        &mut self,
+        parent: i64,
+        start_after: i64,
+        limit: usize,
+    ) -> Result<Vec<DirEntry>> {
+        let parent_path = self.path_of(parent)?;
+        let mut entries = Vec::new();
+
+        if let Layer::Delta(dir) = self.resolve(parent) {
+            if start_after & BASE_TAG == 0 {
+                for entry in self.fs.delta().readdir_ino(dir, start_after, limit)? {
+                    let child = Self::child_path(&parent_path, &entry.name);
+                    self.remember(entry.meta.ino, child);
+                    entries.push(entry);
+                }
+            }
+            if entries.len() >= limit {
+                return Ok(entries);
+            }
+        }
+
+        let Some(base_dir) = self.base_dir_ino(parent, &parent_path)? else {
+            return Ok(entries);
+        };
+        // Resuming inside the base portion starts after the untagged cursor;
+        // arriving fresh from the delta portion starts at the beginning.
+        let base_cursor = if start_after & BASE_TAG == 0 {
+            0
+        } else {
+            start_after & !BASE_TAG
+        };
+        // Filtering happens after the query, so a batch can be consumed
+        // entirely by whiteouts and delta duplicates. Keep pulling until the
+        // page is full or the base is exhausted: returning a short page — in
+        // the worst case an empty one — reads to a client as end-of-directory,
+        // and it would stop with entries left unseen.
+        let mut cursor = base_cursor;
+        while entries.len() < limit {
+            let batch = self.fs.base().readdir_ino(
+                base_dir,
+                cursor,
+                limit.saturating_sub(entries.len()).max(1),
+            )?;
+            let Some(last) = batch.last() else {
+                break;
+            };
+            cursor = last.meta.ino;
+            for mut entry in batch {
+                let child = Self::child_path(&parent_path, &entry.name);
+                if self.fs.has_whiteout(&child)? {
+                    continue;
+                }
+                // A name the delta already provides was emitted above.
+                if let Layer::Delta(dir) = self.resolve(parent) {
+                    if self.fs.delta().lookup_ino(dir, &entry.name)?.is_some() {
+                        continue;
+                    }
+                }
+                let exposed = entry.meta.ino | BASE_TAG;
+                entry.meta.ino = exposed;
+                self.remember(exposed, child);
+                entries.push(entry);
+            }
+        }
+        Ok(entries)
+    }
+
+    /// Write to a file by exposed id, copying it up from the base first.
+    ///
+    /// The exposed id does not change: the redirect makes the caller's handle
+    /// point at the new delta inode, which is the whole reason the redirect
+    /// exists.
+    pub fn write_ino_at(&mut self, id: i64, offset: u64, data: &[u8]) -> Result<Metadata> {
+        let ino = self.materialize(id)?;
+        let mut meta = self.fs.delta_mut().write_ino_at(ino, offset, data)?;
+        meta.ino = id;
+        Ok(meta)
+    }
+
+    /// Truncate a file by exposed id, copying it up first.
+    pub fn truncate_ino(&mut self, id: i64, size: u64) -> Result<Metadata> {
+        let ino = self.materialize(id)?;
+        let mut meta = self.fs.delta_mut().truncate_ino(ino, size)?;
+        meta.ino = id;
+        Ok(meta)
+    }
+
+    /// The delta inode for a directory, creating the chain if the directory so
+    /// far exists only in the base.
+    ///
+    /// Every creation lands in the delta, so a new file under a base-only
+    /// directory needs that directory to exist there first. Directories are
+    /// made rather than copied: their contents keep coming from the base
+    /// through the merge, which is what keeps this cheap.
+    fn ensure_delta_dir(&mut self, parent: i64) -> Result<i64> {
+        let base_ino = match self.resolve(parent) {
+            Layer::Delta(ino) => return Ok(ino),
+            Layer::Base(ino) => ino,
+        };
+        let path = self.path_of(parent)?;
+        let ino = self.fs.delta_mut().mkdir_p(&path)?;
+        // The directory now exists in both layers, and the caller still holds
+        // the tagged base id. Redirect it the same way a copied-up file is
+        // redirected, or that id keeps resolving to the base and everything
+        // created here is invisible through it.
+        self.redirect.insert(base_ino, ino);
+        self.remember(ino, path.clone());
+        self.remember(base_ino | BASE_TAG, path);
+        Ok(ino)
+    }
+
+    /// Create a regular file.
+    pub fn create_child(&mut self, parent: i64, name: &str, mode: u32) -> Result<(i64, Metadata)> {
+        self.insert(parent, name, |delta, dir| {
+            delta.create_child(dir, name, mode)
+        })
+    }
+
+    /// Create a directory.
+    pub fn mkdir_ino(&mut self, parent: i64, name: &str, mode: u32) -> Result<(i64, Metadata)> {
+        self.insert(parent, name, |delta, dir| delta.mkdir_ino(dir, name, mode))
+    }
+
+    /// Create a symlink.
+    pub fn symlink_ino(
+        &mut self,
+        parent: i64,
+        name: &str,
+        target: &str,
+    ) -> Result<(i64, Metadata)> {
+        self.insert(parent, name, |delta, dir| {
+            delta.symlink_ino(dir, name, target)
+        })
+    }
+
+    /// Shared shape for the three creations: materialize the parent, clear any
+    /// whiteout at the child, create in the delta.
+    fn insert(
+        &mut self,
+        parent: i64,
+        name: &str,
+        create: impl FnOnce(&mut AgentFs, i64) -> Result<(i64, Metadata)>,
+    ) -> Result<(i64, Metadata)> {
+        let parent_path = self.path_of(parent)?;
+        let child = Self::child_path(&parent_path, name);
+        let dir = self.ensure_delta_dir(parent)?;
+        // SPEC rule: creating at a whited-out path lifts the whiteout, so the
+        // new file is visible rather than hidden by its predecessor's deletion.
+        self.fs.clear_whiteout(&child)?;
+        let (ino, meta) = create(self.fs.delta_mut(), dir)?;
+        self.remember(ino, child);
+        Ok((ino, meta))
+    }
+
+    /// Remove a name from a directory.
+    ///
+    /// A delta entry is deleted. A name the base still provides is whited out
+    /// instead — the base is read-only, so hiding is the only removal
+    /// available. A copied-up file needs both.
+    pub fn remove_ino(&mut self, parent: i64, name: &str) -> Result<()> {
+        let parent_path = self.path_of(parent)?;
+        let child = Self::child_path(&parent_path, name);
+
+        let mut removed = false;
+        if let Layer::Delta(dir) = self.resolve(parent) {
+            if self.fs.delta().lookup_ino(dir, name)?.is_some() {
+                self.fs.delta_mut().remove_ino(dir, name)?;
+                removed = true;
+            }
+        }
+
+        // Does the base still contribute this name? If so it reappears after
+        // the delta entry goes, and only a whiteout actually removes it.
+        let base_has = match self.base_dir_ino(parent, &parent_path)? {
+            Some(base_dir) => self.fs.base().lookup_ino(base_dir, name)?.is_some(),
+            None => false,
+        };
+        if base_has {
+            self.fs.set_whiteout(&child)?;
+        } else if !removed {
+            return Err(Error::NotFound(child));
+        }
+        Ok(())
+    }
+
+    /// Change attributes, copying the file up first if it is still base.
+    pub fn setattr_ino(
+        &mut self,
+        id: i64,
+        mode: Option<u32>,
+        uid: Option<i64>,
+        gid: Option<i64>,
+        atime: Option<(i64, i64)>,
+        mtime: Option<(i64, i64)>,
+    ) -> Result<Metadata> {
+        let ino = self.materialize(id)?;
+        let mut meta = self
+            .fs
+            .delta_mut()
+            .setattr_ino(ino, mode, uid, gid, atime, mtime)?;
+        meta.ino = id;
+        Ok(meta)
+    }
+
+    /// The directory holding an exposed id.
+    pub fn parent_of(&self, id: i64) -> Result<Option<i64>> {
+        match self.resolve(id) {
+            Layer::Delta(ino) => self.fs.delta().parent_of(ino),
+            Layer::Base(ino) => Ok(self.fs.base().parent_of(ino)?.map(|parent| {
+                if parent == ROOT_INO {
+                    ROOT_INO
+                } else {
+                    parent | BASE_TAG
+                }
+            })),
+        }
+    }
+
+    /// Ensure an exposed id has a delta inode, copying up if it is still base,
+    /// and return that delta inode.
+    fn materialize(&mut self, id: i64) -> Result<i64> {
+        match self.resolve(id) {
+            Layer::Delta(ino) => Ok(ino),
+            Layer::Base(base_ino) => {
+                let path = self.path_of(id)?;
+                let delta_ino = self.fs.copy_up(&path)?;
+                self.redirect.insert(base_ino, delta_ino);
+                Ok(delta_ino)
+            }
+        }
+    }
+}
+
+/// Reconstruct an absolute path by walking `fs_dentry` upwards.
+///
+/// The cold path behind [`OverlayExport::path_of`]. `ino.rs` avoids this shape
+/// on hot operations for good reason; it is here only for handles the path
+/// cache never saw.
+fn walk_to_path(fs: &AgentFs, ino: i64) -> Result<String> {
+    let mut components = Vec::new();
+    let mut current = ino;
+    while current != ROOT_INO {
+        let Some(parent) = fs.parent_of(current)? else {
+            return Err(Error::NotFound(format!("inode {ino}")));
+        };
+        let name = fs.child_name(parent, current)?;
+        components.push(name);
+        current = parent;
+        // A cycle would hang the export; `fs_dentry` should never contain one,
+        // but an export must not be the thing that proves it.
+        if components.len() > 4096 {
+            return Err(Error::InvalidArgument(format!(
+                "inode {ino} exceeds the maximum path depth"
+            )));
+        }
+    }
+    components.reverse();
+    Ok(normalize(&format!("/{}", components.join("/"))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A base with a small tree, and an empty delta over it.
+    fn export(dir: &std::path::Path) -> OverlayExport {
+        let base_path = dir.join("base.db");
+        {
+            let mut base = AgentFs::create(&base_path).unwrap();
+            base.write_file("/keep.txt", b"unchanged").unwrap();
+            base.write_file("/edit.txt", b"original").unwrap();
+            base.write_file("/drop.txt", b"doomed").unwrap();
+            base.write_file("/dir/nested.txt", b"nested").unwrap();
+        }
+        let overlay = OverlayFs::open(dir.join("delta.db"), &base_path).unwrap();
+        OverlayExport::new(overlay).unwrap()
+    }
+
+    fn read_all(export: &OverlayExport, id: i64) -> Vec<u8> {
+        export.read_ino_at(id, 0, 4096).unwrap().0
+    }
+
+    fn names(entries: &[DirEntry]) -> Vec<String> {
+        let mut names: Vec<String> = entries.iter().map(|e| e.name.clone()).collect();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn a_base_only_file_is_readable_through_the_export() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        let id = export.lookup_ino(root, "keep.txt").unwrap().expect("found");
+        // Nothing is in the delta yet, so this must be a tagged base id.
+        assert_ne!(id & BASE_TAG, 0);
+        assert_eq!(read_all(&export, id), b"unchanged");
+        // The reported ino is the exposed id, not the layer's private one.
+        assert_eq!(export.stat_ino(id).unwrap().ino, id);
+    }
+
+    #[test]
+    fn a_handle_survives_the_copy_up_its_first_write_causes() {
+        // The property the whole design exists for: a client that opened a
+        // base-only file keeps its handle working after writing to it.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        let id = export.lookup_ino(root, "edit.txt").unwrap().expect("found");
+        assert_ne!(id & BASE_TAG, 0);
+        assert_eq!(read_all(&export, id), b"original");
+
+        export.write_ino_at(id, 0, b"rewritten").unwrap();
+
+        // Same handle, no re-lookup.
+        assert_eq!(read_all(&export, id), b"rewritten");
+        assert_eq!(export.stat_ino(id).unwrap().ino, id);
+        // And it now resolves into the delta rather than the base.
+        assert!(matches!(export.resolve(id), Layer::Delta(_)));
+    }
+
+    #[test]
+    fn a_second_lookup_after_copy_up_returns_the_delta_id() {
+        // A fresh lookup legitimately sees the delta entry, so the two ids for
+        // one file coexist. Both must read the copied-up content.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        let base_id = export.lookup_ino(root, "edit.txt").unwrap().unwrap();
+        export.write_ino_at(base_id, 0, b"rewritten").unwrap();
+
+        let delta_id = export.lookup_ino(root, "edit.txt").unwrap().unwrap();
+        assert_eq!(delta_id & BASE_TAG, 0);
+        assert_eq!(read_all(&export, delta_id), b"rewritten");
+        assert_eq!(read_all(&export, base_id), b"rewritten");
+    }
+
+    #[test]
+    fn readdir_merges_both_layers() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        export
+            .overlay_mut()
+            .write_file("/fresh.txt", b"new")
+            .unwrap();
+
+        let entries = export.readdir_ino(root, 0, 100).unwrap();
+        assert_eq!(
+            names(&entries),
+            vec!["dir", "drop.txt", "edit.txt", "fresh.txt", "keep.txt"]
+        );
+    }
+
+    #[test]
+    fn readdir_hides_whiteouts() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        export.overlay_mut().remove_file("/drop.txt").unwrap();
+
+        let entries = export.readdir_ino(root, 0, 100).unwrap();
+        assert!(!names(&entries).contains(&"drop.txt".to_string()));
+        // And the name no longer resolves.
+        assert_eq!(export.lookup_ino(root, "drop.txt").unwrap(), None);
+    }
+
+    #[test]
+    fn readdir_reports_a_copied_up_file_once() {
+        // The delta and the base both hold the name after copy-up; emitting it
+        // twice would make a client see a duplicate directory entry.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        let id = export.lookup_ino(root, "edit.txt").unwrap().unwrap();
+        export.write_ino_at(id, 0, b"rewritten").unwrap();
+
+        let entries = export.readdir_ino(root, 0, 100).unwrap();
+        let hits = entries.iter().filter(|e| e.name == "edit.txt").count();
+        assert_eq!(hits, 1, "{:?}", names(&entries));
+    }
+
+    #[test]
+    fn a_page_filled_entirely_by_whiteouts_still_returns_later_entries() {
+        // Regression: filtering happens after the query, so whiteouts consume
+        // the page budget. Returning the short page reads as end-of-directory
+        // and the client stops with `survivor.txt` unseen.
+        let temp = tempfile::tempdir().unwrap();
+        let base_path = temp.path().join("base.db");
+        {
+            let mut base = AgentFs::create(&base_path).unwrap();
+            for index in 0..8 {
+                base.write_file(&format!("/doomed{index}.txt"), b"x")
+                    .unwrap();
+            }
+            base.write_file("/survivor.txt", b"kept").unwrap();
+        }
+        let overlay = OverlayFs::open(temp.path().join("delta.db"), &base_path).unwrap();
+        let mut export = OverlayExport::new(overlay).unwrap();
+        for index in 0..8 {
+            export
+                .overlay_mut()
+                .remove_file(&format!("/doomed{index}.txt"))
+                .unwrap();
+        }
+
+        // A page of 2 lands entirely inside the whiteouts.
+        let entries = export.readdir_ino(export.root(), 0, 2).unwrap();
+        assert_eq!(names(&entries), vec!["survivor.txt"]);
+    }
+
+    #[test]
+    fn nested_base_directories_are_traversable() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        let dir = export.lookup_ino(root, "dir").unwrap().expect("dir");
+        let nested = export.lookup_ino(dir, "nested.txt").unwrap().expect("file");
+        assert_eq!(read_all(&export, nested), b"nested");
+    }
+
+    #[test]
+    fn creating_under_a_base_only_directory_works() {
+        // The delta has no `/dir` until this point; a creation there has to
+        // make one, while the base's existing children stay visible.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        let dir = export.lookup_ino(root, "dir").unwrap().unwrap();
+        assert_ne!(dir & BASE_TAG, 0, "starts out base-only");
+
+        let (id, _) = export.create_child(dir, "made.txt", 0o644).unwrap();
+        export.write_ino_at(id, 0, b"fresh").unwrap();
+
+        let entries = export.readdir_ino(dir, 0, 100).unwrap();
+        assert_eq!(names(&entries), vec!["made.txt", "nested.txt"]);
+        assert_eq!(read_all(&export, id), b"fresh");
+    }
+
+    #[test]
+    fn removing_a_base_only_name_whites_it_out() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+
+        export.remove_ino(root, "keep.txt").unwrap();
+        assert_eq!(export.lookup_ino(root, "keep.txt").unwrap(), None);
+        assert!(
+            !names(&export.readdir_ino(root, 0, 100).unwrap()).contains(&"keep.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn removing_a_copied_up_file_does_not_resurrect_the_base_copy() {
+        // Deleting only the delta entry would let the base version reappear,
+        // which reads as the delete having silently failed.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        let id = export.lookup_ino(root, "edit.txt").unwrap().unwrap();
+        export.write_ino_at(id, 0, b"rewritten").unwrap();
+
+        export.remove_ino(root, "edit.txt").unwrap();
+        assert_eq!(export.lookup_ino(root, "edit.txt").unwrap(), None);
+    }
+
+    #[test]
+    fn creating_over_a_whiteout_lifts_it() {
+        // SPEC rule: a whiteout is removed when a new file is created at that
+        // path. Without this the replacement stays invisible.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        export.remove_ino(root, "drop.txt").unwrap();
+
+        let (id, _) = export.create_child(root, "drop.txt", 0o644).unwrap();
+        export.write_ino_at(id, 0, b"replacement").unwrap();
+
+        let found = export
+            .lookup_ino(root, "drop.txt")
+            .unwrap()
+            .expect("visible");
+        assert_eq!(read_all(&export, found), b"replacement");
+    }
+
+    #[test]
+    fn removing_a_name_that_exists_nowhere_is_not_found() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        assert!(matches!(
+            export.remove_ino(root, "never.txt"),
+            Err(Error::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn setattr_copies_a_base_file_up_and_keeps_the_handle() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        let id = export.lookup_ino(root, "keep.txt").unwrap().unwrap();
+
+        let meta = export
+            .setattr_ino(id, Some(0o600), None, None, None, None)
+            .unwrap();
+        assert_eq!(meta.ino, id, "the exposed id must not change");
+        assert_eq!(meta.mode & 0o777, 0o600);
+        // Content survived the copy-up.
+        assert_eq!(read_all(&export, id), b"unchanged");
+    }
+
+    #[test]
+    fn a_path_is_recoverable_for_a_handle_the_cache_never_saw() {
+        // Handles outlive the cache across a restart, so the walk fallback has
+        // to produce the same path the cached descent would have.
+        let temp = tempfile::tempdir().unwrap();
+        let mut export = export(temp.path());
+        let root = export.root();
+        let dir = export.lookup_ino(root, "dir").unwrap().unwrap();
+        let nested = export.lookup_ino(dir, "nested.txt").unwrap().unwrap();
+
+        export.paths.clear();
+        assert_eq!(export.path_of(nested).unwrap(), "/dir/nested.txt");
+    }
+}

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -603,7 +603,15 @@ impl AfsStore {
         self.require_open(&binding)?;
         let delta = self.delta_path(id);
         let read_only = self.open_delta(id)?.is_read_only();
-        crate::afs_mount::mount(self.coven_home(), id, &delta, read_only)
+        // The mount shows the merged view, so the export needs both layers
+        // (DESIGN.md §3.2). A session with no base ingested has only a delta
+        // to serve, which is the one case where mounting one layer is right.
+        let base = binding
+            .base_fingerprint
+            .as_deref()
+            .map(|fingerprint| self.base_path(fingerprint))
+            .filter(|path| path.exists());
+        crate::afs_mount::mount(self.coven_home(), id, &delta, base.as_deref(), read_only)
     }
 
     /// `afs.mount` DELETE — unmount. Reports whether anything was mounted.

--- a/crates/coven-cli/src/afs_mount.rs
+++ b/crates/coven-cli/src/afs_mount.rs
@@ -198,7 +198,7 @@ pub fn mount(
     // no future daemon knows to take down.
     write_record(coven_home, &record).map_err(AfsError::Internal)?;
 
-    if let Err(error) = spawn_and_mount(id, delta, base, &point) {
+    if let Err(error) = spawn_and_mount(id, delta, base, &point, read_only) {
         let _ = reclaim(coven_home, &record);
         return Err(AfsError::Internal(error));
     }
@@ -229,7 +229,13 @@ fn prepare_mount_point(point: &Path) -> AfsResult<()> {
 ///
 /// Every failure path tears the export back down. A half-mounted session that
 /// left an NFS server listening would be exactly the orphan §7 is about.
-fn spawn_and_mount(id: &str, delta: &Path, base: Option<&Path>, point: &Path) -> Result<()> {
+fn spawn_and_mount(
+    id: &str,
+    delta: &Path,
+    base: Option<&Path>,
+    point: &Path,
+    read_only: bool,
+) -> Result<()> {
     let helper = helper_path().ok_or_else(|| anyhow!("{HELPER} is not installed"))?;
     let mut command = Command::new(&helper);
     command.arg(delta);
@@ -251,7 +257,7 @@ fn spawn_and_mount(id: &str, delta: &Path, base: Option<&Path>, point: &Path) ->
     let mut export = Export { child, stdin };
     let mut reader = BufReader::new(stdout);
 
-    let outcome = handshake_and_mount(&mut export, &mut reader, point);
+    let outcome = handshake_and_mount(&mut export, &mut reader, point, read_only);
     match outcome {
         Ok(()) => {}
         Err(error) => {
@@ -271,6 +277,7 @@ fn handshake_and_mount(
     export: &mut Export,
     reader: &mut BufReader<std::process::ChildStdout>,
     point: &Path,
+    read_only: bool,
 ) -> Result<()> {
     let port = expect_line(reader, "port")?;
     // Named `gate_name` rather than the obvious thing for the same reason the
@@ -278,7 +285,7 @@ fn handshake_and_mount(
     // that binding being assigned as a hardcoded credential.
     let gate_name = expect_line(reader, "token")?;
 
-    run_mount(&port, &gate_name, point)?;
+    run_mount(&port, &gate_name, point, read_only)?;
 
     // The token was in `mount_nfs`'s argv, so it was `ps`-visible for the
     // length of that call. Rotating now makes anything scraped useless; the
@@ -308,11 +315,25 @@ fn expect_line(reader: &mut BufReader<std::process::ChildStdout>, key: &str) -> 
         .ok_or_else(|| anyhow!("export handshake did not start with {key}"))
 }
 
-fn run_mount(port: &str, gate_name: &str, point: &Path) -> Result<()> {
-    // Unprivileged: MOUNT-SPIKE.md §4 confirmed mount_nfs needs no sudo and no
-    // kext. `soft` keeps a wedged export surfacing as I/O errors instead of
-    // unkillable processes; `nolock` skips the lock manager we do not serve.
-    let options = format!("vers=3,tcp,port={port},mountport={port},nolock,soft");
+/// The `mount_nfs` option string.
+///
+/// Unprivileged: MOUNT-SPIKE.md §4 confirmed `mount_nfs` needs no sudo and no
+/// kext. `soft` keeps a wedged export surfacing as I/O errors instead of
+/// unkillable processes; `nolock` skips the lock manager we do not serve.
+///
+/// `ro` is not cosmetic. The mount response and the record both report
+/// `readOnly`, and a caller told a mount is read-only has been given a promise
+/// the kernel is the only thing that can keep.
+fn mount_options(port: &str, read_only: bool) -> String {
+    let mut options = format!("vers=3,tcp,port={port},mountport={port},nolock,soft");
+    if read_only {
+        options.push_str(",ro");
+    }
+    options
+}
+
+fn run_mount(port: &str, gate_name: &str, point: &Path, read_only: bool) -> Result<()> {
+    let options = mount_options(port, read_only);
     let status = Command::new("mount_nfs")
         .arg("-o")
         .arg(&options)
@@ -639,6 +660,14 @@ mod tests {
             .expect_err("no backend should refuse");
         assert!(matches!(error, AfsError::MountUnsupported));
         Ok(())
+    }
+
+    #[test]
+    fn a_read_only_mount_is_mounted_read_only() {
+        // Reporting readOnly while mounting writable hands the caller a
+        // promise nothing keeps; `ro` is what makes the flag true.
+        assert!(mount_options("2049", true).ends_with(",ro"));
+        assert!(!mount_options("2049", false).contains("ro"));
     }
 
     #[test]

--- a/crates/coven-cli/src/afs_mount.rs
+++ b/crates/coven-cli/src/afs_mount.rs
@@ -10,12 +10,16 @@
 //! afs/mounts/<id>/          the mount point itself
 //! ```
 //!
-//! **Off by default.** `AfsNfs` exports a single [`AgentFs`], not the merged
-//! base+delta view DESIGN.md §3.2 specifies — see bead `coven-vlw`. A mount
-//! today shows only the files a session already changed, which is not what a
-//! caller asking for a mount means. So the backend is advertised, and the
-//! routes work, only under an explicit opt-in; without it `afsMount` is
-//! `false` and `POST …/mount` answers `afs.mount_unsupported`.
+//! **Available where a backend exists.** The export serves the merged
+//! base+delta view (DESIGN.md §3.2), so a mount shows what a caller asking for
+//! one means. `afsMount` reports `"nfs"` on macOS where the export helper
+//! shipped, and `false` everywhere else.
+//!
+//! What mount availability does *not* claim is that every process can read
+//! through the mount. macOS refuses `open()` on network volumes for processes
+//! without the right privacy consent (bead `coven-x77`), which is a property
+//! of the calling process, not of the export. Capabilities advertise
+//! availability and never grant permission.
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
@@ -27,10 +31,6 @@ use anyhow::{anyhow, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::afs::{AfsError, AfsResult};
-
-/// Opt-in switch. Named for what it is: the backend is experimental until
-/// `coven-vlw` gives it a merged view to serve.
-const OPT_IN_ENV: &str = "COVEN_AFS_MOUNT_EXPERIMENTAL";
 
 /// The export process, kept beside the daemon binary.
 const HELPER: &str = "coven-afs-serve";
@@ -92,25 +92,15 @@ fn exports() -> &'static Mutex<HashMap<String, Export>> {
 
 /// The mount backend for this platform and build, or `None`.
 ///
-/// `None` is the honest answer in three distinct situations and the caller
-/// cannot tell them apart, which is fine: all three mean "do not offer to
-/// mount". The opt-in is checked first so that the common path does no
-/// filesystem work.
+/// `None` is the honest answer in two distinct situations and the caller
+/// cannot tell them apart, which is fine: both mean "do not offer to mount".
+/// Linux's FUSE backend is not built yet, so macOS is the only platform that
+/// reports one.
 pub fn backend() -> Option<&'static str> {
-    if !opted_in() {
-        return None;
-    }
     if !cfg!(target_os = "macos") {
         return None;
     }
     helper_path().is_some().then_some("nfs")
-}
-
-fn opted_in() -> bool {
-    matches!(
-        std::env::var(OPT_IN_ENV).as_deref(),
-        Ok("1") | Ok("true") | Ok("yes")
-    )
 }
 
 /// Locate the export helper next to the running daemon. A build that did not
@@ -156,7 +146,13 @@ pub fn current(coven_home: &Path, id: &str) -> Option<String> {
 }
 
 /// `afs.mount` — mount a session's filesystem and return where it landed.
-pub fn mount(coven_home: &Path, id: &str, delta: &Path, read_only: bool) -> AfsResult<MountView> {
+pub fn mount(
+    coven_home: &Path,
+    id: &str,
+    delta: &Path,
+    base: Option<&Path>,
+    read_only: bool,
+) -> AfsResult<MountView> {
     let Some(backend_name) = backend() else {
         return Err(AfsError::MountUnsupported);
     };
@@ -202,7 +198,7 @@ pub fn mount(coven_home: &Path, id: &str, delta: &Path, read_only: bool) -> AfsR
     // no future daemon knows to take down.
     write_record(coven_home, &record).map_err(AfsError::Internal)?;
 
-    if let Err(error) = spawn_and_mount(id, delta, &point) {
+    if let Err(error) = spawn_and_mount(id, delta, base, &point) {
         let _ = reclaim(coven_home, &record);
         return Err(AfsError::Internal(error));
     }
@@ -233,10 +229,17 @@ fn prepare_mount_point(point: &Path) -> AfsResult<()> {
 ///
 /// Every failure path tears the export back down. A half-mounted session that
 /// left an NFS server listening would be exactly the orphan §7 is about.
-fn spawn_and_mount(id: &str, delta: &Path, point: &Path) -> Result<()> {
+fn spawn_and_mount(id: &str, delta: &Path, base: Option<&Path>, point: &Path) -> Result<()> {
     let helper = helper_path().ok_or_else(|| anyhow!("{HELPER} is not installed"))?;
-    let mut child = Command::new(&helper)
-        .arg(delta)
+    let mut command = Command::new(&helper);
+    command.arg(delta);
+    // A second argument makes the export an overlay. Omitting it for a
+    // base-less session is deliberate, not a fallback: there is no merged view
+    // to build.
+    if let Some(base) = base {
+        command.arg(base);
+    }
+    let mut child = command
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -501,11 +504,10 @@ mod tests {
     const DEAD_PID: u32 = 0;
 
     #[test]
-    fn the_backend_is_off_without_the_opt_in() {
-        // The default matters more than the enabled path here: until
-        // coven-vlw lands a merged view, an accidentally-advertised backend
-        // would offer a mount showing only changed files.
-        if std::env::var(OPT_IN_ENV).is_ok() {
+    fn no_backend_is_advertised_off_macos() {
+        // FUSE is not built. A platform without a backend must report none
+        // rather than offer a mount it cannot perform.
+        if cfg!(target_os = "macos") {
             return;
         }
         assert_eq!(backend(), None);
@@ -633,7 +635,7 @@ mod tests {
             return Ok(());
         }
         let temp = tempfile::tempdir()?;
-        let error = mount(temp.path(), "afs-x", &temp.path().join("d.db"), false)
+        let error = mount(temp.path(), "afs-x", &temp.path().join("d.db"), None, false)
             .expect_err("no backend should refuse");
         assert!(matches!(error, AfsError::MountUnsupported));
         Ok(())

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -7031,10 +7031,16 @@ mod tests {
         let temp = tempfile::tempdir()?;
         let response = handle_request("GET", "/api/v1/health", temp.path(), None)?;
         assert!(response.body.contains(r#""afs":true"#));
-        // A client must be able to see that mounting is unavailable rather
-        // than discovering it from a failed request. Commit materialized in
-        // coven-fty, so it now advertises true.
-        assert!(response.body.contains(r#""afsMount":false"#));
+        // A client must be able to see whether mounting is available rather
+        // than discovering it from a failed request. What health reports is
+        // whatever backend detection found — asserting a constant here would
+        // pass or fail on where the test binary happens to sit relative to the
+        // export helper, which is not the contract.
+        let expected = match crate::afs_mount::backend() {
+            Some(backend) => format!(r#""afsMount":"{backend}""#),
+            None => r#""afsMount":false"#.to_string(),
+        };
+        assert!(response.body.contains(&expected), "{}", response.body);
         assert!(response.body.contains(r#""afsCommit":true"#));
         Ok(())
     }
@@ -7100,19 +7106,22 @@ mod tests {
         )?;
         assert_eq!(unconfirmed.status, 400);
 
-        // The mount lifecycle is wired, but no backend is advertised by
-        // default (bead coven-vlw: the export serves a single delta, not the
-        // merged view), so the route refuses through the same envelope the
-        // capability flags predict.
-        let mount = handle_request_with_body(
-            "POST",
-            &format!("/api/v1/afs/sessions/{id}/mount"),
-            temp.path(),
-            None,
-            Some("{}"),
-        )?;
-        assert_eq!(mount.status, 501);
-        assert!(mount.body.contains("afs.mount_unsupported"));
+        // Where no backend exists the route refuses through the same envelope
+        // the capability flags predict. Where one does, this test does not
+        // mount: a real mount belongs in a test that can also unmount, and a
+        // stray NFS mount left behind by a unit test is worse than the
+        // coverage is worth.
+        if crate::afs_mount::backend().is_none() {
+            let mount = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/afs/sessions/{id}/mount"),
+                temp.path(),
+                None,
+                Some("{}"),
+            )?;
+            assert_eq!(mount.status, 501);
+            assert!(mount.body.contains("afs.mount_unsupported"));
+        }
 
         // Unmount is idempotent: asking an unmounted session to unmount is the
         // state the caller wanted, so it succeeds rather than inventing an

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -157,17 +157,22 @@ Tool-call parameters, results, and errors pass through the daemon privacy
 filters before serialization. A missing or dangling audit reference produces
 `toolCall: null` without dropping the filesystem operation.
 
-`afsMount` reports the mount backend or `false`, and is **`false` by default**,
-so `POST .../mount` returns `501` with `afs.mount_unsupported` to match. The
-mount lifecycle is implemented — the daemon spawns a per-mount export process,
-mounts it, rotates the export token, and unmounts orphans left by a dead daemon
-at startup — but the NFS export still serves a session's delta rather than the
-merged base+delta view, so a mount would show only files the session had
-already changed. Setting `COVEN_AFS_MOUNT_EXPERIMENTAL=1` on a macOS daemon
-enables the backend anyway for development. Mounting requires an open session;
-`DELETE` does not, so a session committed while mounted can still be taken
-down, and unmounting something that is not mounted succeeds rather than
-erroring.
+`afsMount` reports the mount backend or `false`. It is `"nfs"` on macOS where
+the export helper shipped and `false` elsewhere — the Linux FUSE backend is not
+built. `POST .../mount` returns `501` with `afs.mount_unsupported` wherever no
+backend is reported.
+
+The daemon spawns a per-mount export process serving the merged base+delta
+view, mounts it on loopback, rotates the export token as soon as the mount
+returns, and unmounts orphans left by a dead daemon at startup. Mounting
+requires an open session; `DELETE` does not, so a session committed while
+mounted can still be taken down, and unmounting something that is not mounted
+succeeds rather than erroring.
+
+A reported backend means the daemon can mount, not that every process can read
+through the mount: macOS refuses `open()` on network volumes for processes
+without the right privacy consent. Capabilities advertise availability and
+never grant permission.
 
 Commit creates a git worktree at the session's `base_commit`, applies the
 change set, and produces a **signed** commit carrying `Coven-Session`,

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -481,11 +481,8 @@ What ships instead:
 - **Token rotation after mount.** `mount_nfs` takes the export path as a
   positional argument and offers no stdin, environment, or config alternative
   (`man mount_nfs` has neither an ENVIRONMENT nor a FILES section), so the
-  token is `ps`-visible for the duration of that one call. Rotating the gate
-  the moment the mount returns makes a scraped value useless. The rotation
-  primitive ships now (`AfsNfs::gate_handle`); the mount route that calls it on
-  every mount is still being built, so until that lands this mitigation is
-  available rather than enforced.
+  token is `ps`-visible for the duration of that one call. The daemon rotates
+  the gate the moment the mount returns, which makes a scraped value useless.
   Established mounts are unaffected: the client holds an authenticated file
   handle, handles are keyed on the file id under a key rotation does not
   touch, and only a *new* traversal of the gate needs the current token.


### PR DESCRIPTION
Closes `coven-vlw`, and with it the reason `afsMount` was pinned to `false`.

DESIGN.md §3.2 says `afs.mount` mounts the **merged view**. `AfsNfs` wrapped a
single `AgentFs`, so a mount showed one layer — and for a fresh session, whose
delta is empty, that is nothing at all.

## The identity problem

`OverlayFs` is path-addressed; NFS is not. It addresses objects by a 64-bit
file id and a `(parent, name)` pair, which is why `ino.rs` exists. Serving the
merged view meant expressing delta-then-base against inode numbers.

Both layers allocate `fs_inode.ino` as `AUTOINCREMENT` from `ROOT_INO`, so base
inode 5 and delta inode 5 are unrelated files and a union collides on nearly
every id. **Base inodes are exposed with a high bit set.** A high bit rather
than an offset because `readdir_ino` paginates on `WHERE ino > start_after`: it
keeps the merged sequence monotonic, so a cursor resumes exactly — delta first,
then base.

**Handle stability across copy-up** is the property the bead exists for. A
client holding a handle to a base-only file must keep it after the write that
moves the file into the delta, so the exposed id never changes and resolution
redirects it once a delta inode exists. `fs_origin` records that link but is
keyed by `delta_ino`, so the reverse lookup has no index. Rather than touch a
SPEC table, the map is held in memory — seeded at open, updated on copy-up. The
export owns the only writer to its delta, so it cannot go stale beneath itself.

**No schema changes.** E1 and E2 are both untouched.

## Shape

`ExportFs` is a trait over the single `with()` choke point every filesystem
call in the export already funnelled through. `AgentFs` implements it for one
layer, `OverlayExport` for the merged view, and `AfsNfs` is generic over it
defaulting to `AgentFs`. `coven-afs-serve` takes an optional base path; both
shapes share one `serve()` so the handshake exists once.

## Enabling the backend

`afsMount` now reports `"nfs"` on macOS where the helper shipped, `false`
elsewhere. `COVEN_AFS_MOUNT_EXPERIMENTAL` is gone — it existed solely because
the export served a single delta.

A reported backend means the daemon can mount, **not** that every process can
read through the mount: macOS refuses `open()` on network volumes without
privacy consent (`coven-x77`). Capabilities advertise availability and never
grant permission.

## Defects found by their own tests

Three, none from review:

- **readdir pagination.** Base entries dropped for whiteouts or delta
  duplicates consumed the page budget, so a page could return short — worst
  case empty — while entries remained, which a client reads as
  end-of-directory. Verified the regression test fails on the unfixed code.
- **Directory materialization.** Creating under a base-only directory made the
  delta directory but registered no redirect, so the caller's tagged id kept
  resolving to the base and everything created through it was invisible.
- **Rename as copy.** Moving a base-only name left the base supplying the old
  one, so the file appeared at both paths.

And two tests that passed for the wrong reason: `health_advertises_the_afs_capability_set`
hardcoded `"afsMount":false` (true only because the test binary sits in
`target/debug/deps` while the helper sits in `target/debug`), and the route
test asserted a 501 unconditionally — on a machine with a backend it would have
performed a real NFS mount inside a unit test and left it mounted.

## Verification

Workspace `cargo test --locked` green (20 binaries), `coven-afs --features
mount` green (57 lib + 27 integration), clippy clean workspace-wide and under
the mount feature, fmt clean, secret scan clean.

Tested at the NFS layer, not only under it: a base-only file appears in
`readdir` through the gate and reads back, and a file handle taken before a
write still resolves after the copy-up it causes.

**Not covered by CI:** there is still no macOS runner, so the platform this
backend targets is never built. The mount-feature legs run on ubuntu only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)