### PR TITLE
ci: build and probe the macOS mount backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,37 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo test -p coven-afs --features mount --locked
 
+  afs-mount-macos:
+    name: AFS mount backend (macOS)
+    # macOS is the only platform that advertises a mount backend
+    # (`afsMount: "nfs"`), and the `Rust checks` matrix does not include it.
+    # A separate job rather than a third matrix entry: this needs to build one
+    # crate, not the workspace, and the mount steps in that job are already
+    # conditioned on `runner.os == 'Linux'` for reasons that do not apply here.
+    #
+    # This does not close a *compile* gap. `crates/coven-cli/src/afs_mount.rs`
+    # uses `cfg!(target_os = "macos")` — the macro, so both branches type-check
+    # on Linux — and its helpers are `cfg(unix)`, which Linux covers. What is
+    # missing is Darwin behaviour: the nfsserve stack, the uid/gid mapping in
+    # `nfs.rs`, and the only place `mount_nfs` can actually run.
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - name: Clippy (coven-afs mount feature)
+        run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
+      - name: Test (coven-afs mount feature)
+        run: cargo test -p coven-afs --features mount --locked
+      # Informational. `coven-x77` found that macOS refuses `open()` on network
+      # volumes for processes without privacy consent, and a runner is exactly
+      # such a process — so this may well be refused. Recording which stage
+      # refuses turns a standing guess into an answer; it must never gate a PR.
+      - name: Probe a real mount (informational)
+        continue-on-error: true
+        run: ./scripts/afs-mount-smoke.sh
+
   performance-baseline:
     name: CLI performance baseline
     runs-on: ubuntu-latest

--- a/scripts/afs-mount-smoke.sh
+++ b/scripts/afs-mount-smoke.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Probe whether this macOS host can mount an AFS export and read through it.
+#
+# Informational, never a gate. `coven-x77` and MOUNT-SPIKE.md §4 established
+# that macOS refuses `open()` on network volumes for processes without privacy
+# consent, and a CI runner is exactly such an unconsented process. The point of
+# running this anyway is to replace a guess with a recorded answer: mounting
+# unprivileged is known to work from a consented Terminal, and nobody has ever
+# checked what an unconsented one gets.
+#
+# Prints a verdict for each stage and always exits 0. The workflow step that
+# calls it is `continue-on-error` as well, so a refusal here is evidence rather
+# than a broken build.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+MOUNT_POINT="$WORK/mnt"
+SOURCE="$WORK/src"
+SERVE_LOG="$WORK/serve.log"
+SERVER_PID=""
+
+cleanup() {
+    # Unconditional rather than guarded on a `mount` grep: `mktemp -d` hands
+    # back a path under /var, which `mount` reports resolved to /private/var,
+    # so matching the literal path silently skips the unmount and leaves a live
+    # NFS mount behind. Failing to unmount something that was never mounted is
+    # harmless; the reverse is not.
+    umount "$MOUNT_POINT" 2>/dev/null \
+        || diskutil unmount force "$MOUNT_POINT" 2>/dev/null \
+        || true
+    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null
+    # The unmount is not always visible to the next syscall, so a busy
+    # directory here is expected rather than a leak.
+    rm -rf "$WORK" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+verdict() { printf '%-28s %s\n' "$1" "$2"; }
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    verdict "platform" "SKIP (not Darwin)"
+    exit 0
+fi
+
+mkdir -p "$SOURCE" "$MOUNT_POINT"
+printf 'mounted read-back works\n' > "$SOURCE/hello.txt"
+
+cargo build -q -p coven-afs --features mount --example afs_serve || {
+    verdict "build" "FAIL"
+    exit 0
+}
+verdict "build" "ok"
+
+EXAMPLE="$ROOT/target/debug/examples/afs_serve"
+AFS_IMPORT="$SOURCE" "$EXAMPLE" "$WORK/smoke.db" 0 > "$SERVE_LOG" 2>&1 &
+SERVER_PID=$!
+
+# The export prints its port once bound. Waiting on that line rather than
+# sleeping keeps the probe honest about which stage failed.
+PORT=""
+for _ in $(seq 1 100); do
+    PORT="$(sed -n 's/^afs_serve: port=\([0-9]*\)$/\1/p' "$SERVE_LOG" | head -1)"
+    [ -n "$PORT" ] && break
+    kill -0 "$SERVER_PID" 2>/dev/null || break
+    sleep 0.2
+done
+if [ -z "$PORT" ]; then
+    verdict "export bound" "FAIL"
+    sed 's/^/    /' "$SERVE_LOG"
+    exit 0
+fi
+verdict "export bound" "ok (port $PORT)"
+
+TOKEN_FILE="$(sed -n 's/^afs_serve: export token written to \(.*\)$/\1/p' "$SERVE_LOG" | head -1)"
+if [ ! -r "$TOKEN_FILE" ]; then
+    verdict "token file" "FAIL"
+    exit 0
+fi
+
+# The token reaches `mount_nfs` in argv because it offers no alternative; the
+# daemon's answer is to rotate immediately afterwards. Here the export dies
+# with the probe, so the exposure ends with it.
+if mount_nfs -o "vers=3,tcp,port=$PORT,mountport=$PORT,nolock,soft" \
+    "localhost:/$(cat "$TOKEN_FILE")" "$MOUNT_POINT" 2>"$WORK/mount.err"; then
+    verdict "mount_nfs" "ok"
+else
+    verdict "mount_nfs" "REFUSED"
+    sed 's/^/    /' "$WORK/mount.err"
+    exit 0
+fi
+
+# The two halves fail separately under TCC: metadata passes while `open()` is
+# refused, which is the signature MOUNT-SPIKE.md recorded.
+if ls -la "$MOUNT_POINT" > "$WORK/ls.out" 2>"$WORK/ls.err"; then
+    verdict "readdir through mount" "ok"
+else
+    verdict "readdir through mount" "REFUSED"
+    sed 's/^/    /' "$WORK/ls.err"
+fi
+
+if cat "$MOUNT_POINT/hello.txt" > "$WORK/cat.out" 2>"$WORK/cat.err"; then
+    verdict "read through mount" "ok"
+else
+    verdict "read through mount" "REFUSED (TCC signature)"
+    sed 's/^/    /' "$WORK/cat.err"
+fi
+
+if printf 'written by CI\n' > "$MOUNT_POINT/written.txt" 2>"$WORK/write.err"; then
+    verdict "write through mount" "ok"
+else
+    verdict "write through mount" "REFUSED"
+    sed 's/^/    /' "$WORK/write.err"
+fi
+
+exit 0

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -520,6 +520,17 @@ path after mount. The server-side half of that property — a captured handle
 outliving rotation — is covered by a unit test, so a regression fails CI rather
 than waiting on a manual check.
 
+On 2026-08-10, the `scripts/afs-mount-smoke.sh` probe run from an automated
+agent shell on a maintainer's machine completed every stage: mount, readdir,
+read, and write through the mount. That is the operation MOUNT-SPIKE.md §4
+recorded as `EPERM` for an automated agent shell, so it does **not** overturn
+that finding — the likelier reading is that consent is a property of the
+process tree, and this shell inherited a terminal that had since been granted
+it. What it does establish is that nothing about being automated is
+disqualifying on its own. The genuinely unconsented data point comes from the
+`AFS mount backend (macOS)` CI job, which runs the same probe on a runner and
+reports its verdict without gating the build.
+
 **Enforcement is not free.** As RESEARCH.md notes, the mount alone does not stop
 an agent writing to an absolute path outside it. AFS bounds the blast radius of
 writes that go *through* it; the OS sandbox that forces all writes through the

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -527,9 +527,21 @@ recorded as `EPERM` for an automated agent shell, so it does **not** overturn
 that finding — the likelier reading is that consent is a property of the
 process tree, and this shell inherited a terminal that had since been granted
 it. What it does establish is that nothing about being automated is
-disqualifying on its own. The genuinely unconsented data point comes from the
-`AFS mount backend (macOS)` CI job, which runs the same probe on a runner and
-reports its verdict without gating the build.
+disqualifying on its own.
+
+The genuinely unconsented data point arrived the same day from the `AFS mount
+backend (macOS)` CI job, on a stock GitHub runner with no consent granted to
+anything: **every stage passed — mount, readdir, read, and write.** So the
+`EPERM` MOUNT-SPIKE.md §4 recorded was specific to that harness or that macOS
+version; it is not a blanket privacy restriction on network volumes, and it is
+not a barrier a design may lean on.
+
+That matters for §7's threat model rather than for convenience. The mitigation
+list here is the whole of the access control: an unprivileged local process
+that reaches the port and knows the token reads and writes the session's files,
+and nothing in the operating system stops it afterwards. Any future reasoning
+that treats macOS consent as a second factor is reasoning from a finding this
+job disproved.
 
 **Enforcement is not free.** As RESEARCH.md notes, the mount alone does not stop
 an agent writing to an absolute path outside it. AFS bounds the blast radius of


### PR DESCRIPTION
Closes `coven-410`. Adds an `AFS mount backend (macOS)` job running
`cargo clippy` and `cargo test` for `-p coven-afs --features mount`, plus an
informational probe that attempts a real mount.

## Correcting the bead's premise

I filed `coven-410` claiming CI never builds the platform this backend targets.
**That was largely wrong**, and the workflow comment says so rather than letting
the job's existence imply otherwise:

- `afs_mount.rs` uses `cfg!(target_os = "macos")` — the *macro*, so both
  branches type-check on Linux.
- `run_mount` and `unmount_path` are not platform-gated at all.
- `still_mounted` and `pid_alive` are `cfg(unix)`, which Linux covers.
- `coven-afs`'s mount feature has **zero** `#[cfg(target_os = "macos")]` items.

What was actually missing is Darwin *behaviour*: the nfsserve stack, the
uid/gid mapping in `nfs.rs`, and the only place `mount_nfs` can run.

## Why a separate job

It builds one crate rather than the workspace, and the existing mount steps
inside `Rust checks` are conditioned on `runner.os == 'Linux'` for reasons that
do not apply here. Folding macOS into that matrix would have meant reworking
those conditions on a job that also builds everything else.

## The probe

`scripts/afs-mount-smoke.sh` is `continue-on-error` and always exits 0 —
evidence, not a gate. It reports a verdict per stage (export bound → `mount_nfs`
→ readdir → read → write) because TCC's signature from MOUNT-SPIKE.md is
*metadata passing while `open()` is refused*; a single pass/fail would blur
"mount refused" and "read refused", which are entirely different findings.

**Run locally from an automated agent shell, it passed every stage** — including
the read that MOUNT-SPIKE.md §4 recorded as `EPERM`. That does not overturn
`coven-x77`. The likelier reading is that consent is a property of the process
tree and this shell inherited a terminal that had since been granted it. The
genuinely unconsented data point is what the CI job produces. DESIGN.md §7
records both readings rather than the flattering one.

**So the interesting output of this PR is the probe's verdict on the runner.**
Worth reading that step's log before merging.

## Cleanup bug found while testing

The probe's first version guarded its unmount on `mount | grep " $MOUNT_POINT "`.
`mktemp -d` returns a path under `/var`, which `mount` reports resolved to
`/private/var`, so the match silently failed and left a live NFS mount behind. It
now unmounts unconditionally — failing to unmount something never mounted is
harmless; the reverse is not.

## Verification

fmt clean, secret scan clean, `bash -n` clean, and the probe was run twice
locally end to end with no mount left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
