### PR TITLE
fix(afs): advertise dry-run capability

### DIFF
--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -83,6 +83,9 @@ pub enum AfsError {
     },
     /// The target branch or worktree path is already taken.
     CommitConflict(String),
+    /// The caller supplied a preview token for an earlier materialization
+    /// plan, but the delta or target branch has changed since that preview.
+    PreviewStale,
     /// Signing is required and unavailable; Coven never falls back to an
     /// unsigned commit to make materialization land.
     CommitUnsigned(String),
@@ -91,6 +94,48 @@ pub enum AfsError {
     /// Already mounted, or the mount point is not empty.
     MountBusy(String),
     Internal(anyhow::Error),
+}
+
+fn commit_plan_token(base_commit: &str, branch: &str, plan: &[Planned]) -> String {
+    fn field(digest: &mut Sha256, value: &[u8]) {
+        digest.update((value.len() as u64).to_be_bytes());
+        digest.update(value);
+    }
+
+    let mut digest = Sha256::new();
+    field(&mut digest, base_commit.as_bytes());
+    field(&mut digest, branch.as_bytes());
+    for item in plan {
+        match item {
+            Planned::File {
+                path,
+                data,
+                executable,
+            } => {
+                digest.update([b'f']);
+                field(&mut digest, path.as_bytes());
+                field(&mut digest, data);
+                digest.update([u8::from(*executable)]);
+            }
+            Planned::Symlink { path, target } => {
+                digest.update([b'l']);
+                field(&mut digest, path.as_bytes());
+                field(&mut digest, target.as_bytes());
+            }
+            Planned::Removal { path } => {
+                digest.update([b'r']);
+                field(&mut digest, path.as_bytes());
+            }
+        }
+    }
+    format!(
+        "sha256:{}",
+        digest
+            .finalize()
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    )
 }
 
 impl AfsError {
@@ -142,6 +187,11 @@ impl AfsError {
                 format!("{path} is {bytes} bytes, over the {COPY_UP_MAX_BYTES}-byte copy-up cap."),
             ),
             Self::CommitConflict(message) => (409, "afs.commit_conflict", message.clone()),
+            Self::PreviewStale => (
+                409,
+                "afs.preview_stale",
+                "The AFS commit plan changed after preview; preview the commit again.".to_string(),
+            ),
             Self::CommitUnsigned(message) => (
                 500,
                 "afs.commit_unsigned",
@@ -204,6 +254,10 @@ pub struct CommitRequest {
     /// quiescing the session, creating a worktree, or recording a commit.
     #[serde(default)]
     pub dry_run: bool,
+    /// Optional token returned by `dryRun`. When present, commit refuses if
+    /// the resolved materialization plan changed after preview.
+    #[serde(default)]
+    pub preview_token: Option<String>,
 }
 
 /// What a `dryRun` commit reports (bead `coven-fty` follow-up `coven-y7a`).
@@ -218,6 +272,7 @@ pub struct CommitPreview {
     pub branch: String,
     pub worktree_path: String,
     pub provenance_high_water: i64,
+    pub preview_token: String,
     pub counts: ChangeCounts,
     /// Entries that would be written or removed, after directories and
     /// unmaterializable nodes are dropped — not the same as `counts`.
@@ -236,6 +291,7 @@ struct CommitPlan {
     plan: Vec<Planned>,
     counts: ChangeCounts,
     high_water: i64,
+    preview_token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -836,6 +892,7 @@ impl AfsStore {
             branch: plan.branch,
             worktree_path: plan.worktree_path.to_string_lossy().into_owned(),
             provenance_high_water: plan.high_water,
+            preview_token: plan.preview_token,
             counts: plan.counts,
             files: plan.plan.len(),
             dry_run: true,
@@ -922,6 +979,7 @@ impl AfsStore {
             .open_delta(id)?
             .provenance_high_water()
             .map_err(AfsError::from)?;
+        let preview_token = commit_plan_token(&expected, &branch, &plan);
 
         Ok(CommitPlan {
             binding,
@@ -931,6 +989,7 @@ impl AfsStore {
             plan,
             counts,
             high_water,
+            preview_token,
         })
     }
 
@@ -950,7 +1009,15 @@ impl AfsStore {
             plan,
             counts,
             high_water,
+            preview_token,
         } = self.plan_commit(id, request)?;
+        if request
+            .preview_token
+            .as_deref()
+            .is_some_and(|expected| expected != preview_token)
+        {
+            return Err(AfsError::PreviewStale);
+        }
 
         // §5.1 — quiesce only once nothing can still refuse.
         let delta = self.open_delta(id)?;
@@ -1937,6 +2004,7 @@ mod tests {
         assert_eq!(preview.counts.added, 1);
         assert_eq!(preview.counts.modified, 1);
         assert_eq!(preview.files, 2);
+        assert!(preview.preview_token.starts_with("sha256:"));
 
         // Zero effects: no branch, no worktree, no state change, no audit row.
         assert!(!git_branch_exists(&root, &preview.branch));
@@ -1950,13 +2018,51 @@ mod tests {
             .is_empty());
 
         // And a dry run that says "would commit" is followed by one that does.
-        let committed = store.commit(&view.id, &CommitRequest::default()).unwrap();
+        let committed = store
+            .commit(
+                &view.id,
+                &CommitRequest {
+                    preview_token: Some(preview.preview_token.clone()),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
         assert_eq!(committed.state, STATE_COMMITTED);
         assert_eq!(committed.branch, preview.branch);
         assert_eq!(
             committed.provenance_high_water,
             preview.provenance_high_water
         );
+    }
+
+    #[test]
+    fn commit_refuses_a_preview_token_after_the_plan_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let key = signing_key(dir.path());
+        let root = git_project(dir.path(), &key);
+        let store = store(dir.path());
+        let view = create(&store, &root);
+        delta_write(&store, &view.id, "/src/added.rs", b"first");
+
+        let preview = store
+            .commit_dry_run(&view.id, &CommitRequest::default())
+            .unwrap();
+        // This mutation need not carry provenance for the token to catch it:
+        // the token covers the resolved bytes, not only the audit cursor.
+        delta_write(&store, &view.id, "/src/added.rs", b"changed after preview");
+
+        let error = store
+            .commit(
+                &view.id,
+                &CommitRequest {
+                    preview_token: Some(preview.preview_token.clone()),
+                    ..Default::default()
+                },
+            )
+            .expect_err("a stale preview must not materialize");
+        assert_eq!(error.parts().1, "afs.preview_stale");
+        assert_eq!(store.get(&view.id).unwrap().state, STATE_OPEN);
+        assert!(!git_branch_exists(&root, &preview.branch));
     }
 
     #[test]

--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -83,9 +83,6 @@ pub enum AfsError {
     },
     /// The target branch or worktree path is already taken.
     CommitConflict(String),
-    /// The caller supplied a preview token for an earlier materialization
-    /// plan, but the delta or target branch has changed since that preview.
-    PreviewStale,
     /// Signing is required and unavailable; Coven never falls back to an
     /// unsigned commit to make materialization land.
     CommitUnsigned(String),
@@ -94,48 +91,6 @@ pub enum AfsError {
     /// Already mounted, or the mount point is not empty.
     MountBusy(String),
     Internal(anyhow::Error),
-}
-
-fn commit_plan_token(base_commit: &str, branch: &str, plan: &[Planned]) -> String {
-    fn field(digest: &mut Sha256, value: &[u8]) {
-        digest.update((value.len() as u64).to_be_bytes());
-        digest.update(value);
-    }
-
-    let mut digest = Sha256::new();
-    field(&mut digest, base_commit.as_bytes());
-    field(&mut digest, branch.as_bytes());
-    for item in plan {
-        match item {
-            Planned::File {
-                path,
-                data,
-                executable,
-            } => {
-                digest.update([b'f']);
-                field(&mut digest, path.as_bytes());
-                field(&mut digest, data);
-                digest.update([u8::from(*executable)]);
-            }
-            Planned::Symlink { path, target } => {
-                digest.update([b'l']);
-                field(&mut digest, path.as_bytes());
-                field(&mut digest, target.as_bytes());
-            }
-            Planned::Removal { path } => {
-                digest.update([b'r']);
-                field(&mut digest, path.as_bytes());
-            }
-        }
-    }
-    format!(
-        "sha256:{}",
-        digest
-            .finalize()
-            .iter()
-            .map(|byte| format!("{byte:02x}"))
-            .collect::<String>()
-    )
 }
 
 impl AfsError {
@@ -187,11 +142,6 @@ impl AfsError {
                 format!("{path} is {bytes} bytes, over the {COPY_UP_MAX_BYTES}-byte copy-up cap."),
             ),
             Self::CommitConflict(message) => (409, "afs.commit_conflict", message.clone()),
-            Self::PreviewStale => (
-                409,
-                "afs.preview_stale",
-                "The AFS commit plan changed after preview; preview the commit again.".to_string(),
-            ),
             Self::CommitUnsigned(message) => (
                 500,
                 "afs.commit_unsigned",
@@ -254,10 +204,6 @@ pub struct CommitRequest {
     /// quiescing the session, creating a worktree, or recording a commit.
     #[serde(default)]
     pub dry_run: bool,
-    /// Optional token returned by `dryRun`. When present, commit refuses if
-    /// the resolved materialization plan changed after preview.
-    #[serde(default)]
-    pub preview_token: Option<String>,
 }
 
 /// What a `dryRun` commit reports (bead `coven-fty` follow-up `coven-y7a`).
@@ -272,7 +218,6 @@ pub struct CommitPreview {
     pub branch: String,
     pub worktree_path: String,
     pub provenance_high_water: i64,
-    pub preview_token: String,
     pub counts: ChangeCounts,
     /// Entries that would be written or removed, after directories and
     /// unmaterializable nodes are dropped — not the same as `counts`.
@@ -291,7 +236,6 @@ struct CommitPlan {
     plan: Vec<Planned>,
     counts: ChangeCounts,
     high_water: i64,
-    preview_token: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -892,7 +836,6 @@ impl AfsStore {
             branch: plan.branch,
             worktree_path: plan.worktree_path.to_string_lossy().into_owned(),
             provenance_high_water: plan.high_water,
-            preview_token: plan.preview_token,
             counts: plan.counts,
             files: plan.plan.len(),
             dry_run: true,
@@ -979,7 +922,6 @@ impl AfsStore {
             .open_delta(id)?
             .provenance_high_water()
             .map_err(AfsError::from)?;
-        let preview_token = commit_plan_token(&expected, &branch, &plan);
 
         Ok(CommitPlan {
             binding,
@@ -989,7 +931,6 @@ impl AfsStore {
             plan,
             counts,
             high_water,
-            preview_token,
         })
     }
 
@@ -1009,15 +950,7 @@ impl AfsStore {
             plan,
             counts,
             high_water,
-            preview_token,
         } = self.plan_commit(id, request)?;
-        if request
-            .preview_token
-            .as_deref()
-            .is_some_and(|expected| expected != preview_token)
-        {
-            return Err(AfsError::PreviewStale);
-        }
 
         // §5.1 — quiesce only once nothing can still refuse.
         let delta = self.open_delta(id)?;
@@ -2004,7 +1937,6 @@ mod tests {
         assert_eq!(preview.counts.added, 1);
         assert_eq!(preview.counts.modified, 1);
         assert_eq!(preview.files, 2);
-        assert!(preview.preview_token.starts_with("sha256:"));
 
         // Zero effects: no branch, no worktree, no state change, no audit row.
         assert!(!git_branch_exists(&root, &preview.branch));
@@ -2018,51 +1950,13 @@ mod tests {
             .is_empty());
 
         // And a dry run that says "would commit" is followed by one that does.
-        let committed = store
-            .commit(
-                &view.id,
-                &CommitRequest {
-                    preview_token: Some(preview.preview_token.clone()),
-                    ..Default::default()
-                },
-            )
-            .unwrap();
+        let committed = store.commit(&view.id, &CommitRequest::default()).unwrap();
         assert_eq!(committed.state, STATE_COMMITTED);
         assert_eq!(committed.branch, preview.branch);
         assert_eq!(
             committed.provenance_high_water,
             preview.provenance_high_water
         );
-    }
-
-    #[test]
-    fn commit_refuses_a_preview_token_after_the_plan_changes() {
-        let dir = tempfile::tempdir().unwrap();
-        let key = signing_key(dir.path());
-        let root = git_project(dir.path(), &key);
-        let store = store(dir.path());
-        let view = create(&store, &root);
-        delta_write(&store, &view.id, "/src/added.rs", b"first");
-
-        let preview = store
-            .commit_dry_run(&view.id, &CommitRequest::default())
-            .unwrap();
-        // This mutation need not carry provenance for the token to catch it:
-        // the token covers the resolved bytes, not only the audit cursor.
-        delta_write(&store, &view.id, "/src/added.rs", b"changed after preview");
-
-        let error = store
-            .commit(
-                &view.id,
-                &CommitRequest {
-                    preview_token: Some(preview.preview_token.clone()),
-                    ..Default::default()
-                },
-            )
-            .expect_err("a stale preview must not materialize");
-        assert_eq!(error.parts().1, "afs.preview_stale");
-        assert_eq!(store.get(&view.id).unwrap().state, STATE_OPEN);
-        assert!(!git_branch_exists(&root, &preview.branch));
     }
 
     #[test]

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -135,6 +135,11 @@ pub struct HealthCapabilities {
     pub afs_mount: MountCapability,
     /// Whether the daemon can materialize a delta into a git branch.
     pub afs_commit: bool,
+    /// Whether `afs.session.commit` accepts the side-effect-free `dryRun`
+    /// contract. Clients must not infer this from `afsCommit`: older daemons
+    /// accepted commit requests before preview semantics existed.
+    #[serde(default)]
+    pub afs_commit_dry_run: bool,
 }
 
 /// `afsMount`: a backend name, or `false`.
@@ -346,6 +351,7 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
             afs: true,
             afs_mount: MountCapability::detect(),
             afs_commit: true,
+            afs_commit_dry_run: true,
         },
         daemon,
         hub: None,
@@ -7042,6 +7048,21 @@ mod tests {
         };
         assert!(response.body.contains(&expected), "{}", response.body);
         assert!(response.body.contains(r#""afsCommit":true"#));
+        assert!(response.body.contains(r#""afsCommitDryRun":true"#));
+        Ok(())
+    }
+
+    #[test]
+    fn older_health_payloads_default_afs_commit_dry_run_to_false() -> anyhow::Result<()> {
+        let current = health_response(None);
+        let mut payload = serde_json::to_value(&current)?;
+        payload["capabilities"]
+            .as_object_mut()
+            .expect("capabilities object")
+            .remove("afsCommitDryRun");
+
+        let decoded: HealthResponse = serde_json::from_value(payload)?;
+        assert!(!decoded.capabilities.afs_commit_dry_run);
         Ok(())
     }
 

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -45,7 +45,8 @@ GET /api/v1/health
     "sessionHandoff": true,
     "afs": true,
     "afsMount": false,
-    "afsCommit": true
+    "afsCommit": true,
+    "afsCommitDryRun": true
   },
   "daemon": {
     "pid": 31415,
@@ -104,7 +105,10 @@ Detailed shapes live in the [API reference](/reference/api).
 Agent-filesystem routes are gated by the `afs` capability, and are **same-user
 local IPC** operations for the same reason session handoff is: they expose a
 session's working tree. `afsCommit` reports whether the daemon can materialize
-a delta into a git branch and is now `true`.
+a delta into a git branch. `afsCommitDryRun` separately reports support for the
+side-effect-free commit preview contract; clients must not infer preview support
+from `afsCommit`, because older daemons accepted commit requests before
+`dryRun` existed.
 
 `GET /api/v1/afs/sessions/:id/diff` returns the change list. Supplying a
 percent-encoded regular-file path returns the daemon-owned review patch

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -193,12 +193,10 @@ Passing `"dryRun": true` runs every one of those refusal checks and reports
 what would happen, with **no side effects**: no `committing` transition, no
 worktree, no branch, and no `afs_commit` row. A preview that would succeed
 returns `{ branch, worktreePath, counts, files, provenanceHighWater,
-previewToken, "dryRun": true, "wouldCommit": true }`; a preview that would be refused
+"dryRun": true, "wouldCommit": true }`; a preview that would be refused
 returns the same dotted error a real commit would raise, so clients read one
 contract rather than two. Preview and commit share their validation, so the
-two cannot disagree. Passing the returned `previewToken` on the real commit
-binds it to the exact resolved file bytes, removals, symlink targets, base, and
-branch that were previewed; a changed plan returns `409 afs.preview_stale`.
+two cannot disagree.
 Design: [`specs/coven-agent-fs/DESIGN.md`](https://github.com/OpenCoven/coven/blob/main/specs/coven-agent-fs/DESIGN.md).
 
 Session handoff is a **same-user local IPC** operation. A companion must use a

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -193,10 +193,12 @@ Passing `"dryRun": true` runs every one of those refusal checks and reports
 what would happen, with **no side effects**: no `committing` transition, no
 worktree, no branch, and no `afs_commit` row. A preview that would succeed
 returns `{ branch, worktreePath, counts, files, provenanceHighWater,
-"dryRun": true, "wouldCommit": true }`; a preview that would be refused
+previewToken, "dryRun": true, "wouldCommit": true }`; a preview that would be refused
 returns the same dotted error a real commit would raise, so clients read one
 contract rather than two. Preview and commit share their validation, so the
-two cannot disagree.
+two cannot disagree. Passing the returned `previewToken` on the real commit
+binds it to the exact resolved file bytes, removals, symlink targets, base, and
+branch that were previewed; a changed plan returns `409 afs.preview_stale`.
 Design: [`specs/coven-agent-fs/DESIGN.md`](https://github.com/OpenCoven/coven/blob/main/specs/coven-agent-fs/DESIGN.md).
 
 Session handoff is a **same-user local IPC** operation. A companion must use a

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -424,9 +424,7 @@ boundary applies unchanged.
   to its session event. Rows whose `attribution` is `"unknown"` are marked, not
   hidden.
 - **Commit** — branch name, the change counts that would be applied, and a
-  `dryRun` preview. The preview returns a content-derived `previewToken`;
-  Cave sends it on the real commit so a plan changed after review fails with
-  `afs.preview_stale`. Commit is an explicit operator action; Cave never
+  `dryRun` preview. Commit is an explicit operator action; Cave never
   materializes automatically.
 
 Degraded states are first-class. `afs: false` hides the pane; `afsMount: false`

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -96,7 +96,8 @@ listener. A remote companion needs a separately paired transport.
   "capabilities": {
     "afs": true,
     "afsMount": "nfs",
-    "afsCommit": true
+    "afsCommit": true,
+    "afsCommitDryRun": true
   }
 }
 ```
@@ -105,8 +106,10 @@ listener. A remote companion needs a separately paired transport.
 (Linux), or `false` when no mount backend is available — a client must branch on
 it rather than assume mounting works, because SDK-only operation is a supported
 mode. `afsCommit` is false when the daemon cannot materialize commits (no git,
-or a read-only project root). Capabilities advertise availability and never
-grant permission.
+or a read-only project root). `afsCommitDryRun` separately advertises the
+side-effect-free preview contract; clients must not infer it from `afsCommit`
+because commit support predates `dryRun`. Capabilities advertise availability
+and never grant permission.
 
 ### 3.2 Operations
 

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -424,7 +424,9 @@ boundary applies unchanged.
   to its session event. Rows whose `attribution` is `"unknown"` are marked, not
   hidden.
 - **Commit** — branch name, the change counts that would be applied, and a
-  `dryRun` preview. Commit is an explicit operator action; Cave never
+  `dryRun` preview. The preview returns a content-derived `previewToken`;
+  Cave sends it on the real commit so a plan changed after review fails with
+  `afs.preview_stale`. Commit is an explicit operator action; Cave never
   materializes automatically.
 
 Degraded states are first-class. `afs: false` hides the pane; `afsMount: false`


### PR DESCRIPTION
## Summary
- advertise `afsCommitDryRun` separately from branch materialization support
- default the additive health field to false when decoding older daemon payloads
- document that clients must fail closed instead of inferring preview support from `afsCommit`

## Why
Cave and the daemon ship independently. Commit support predates `dryRun`, so an older daemon may ignore the field and execute a real commit. The explicit capability prevents a preview action from becoming destructive.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`