### PR TITLE
fix(test): stop the Windows PTY stub from disabling its own timeout

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -3746,19 +3746,24 @@ mod tests {
         Ok(())
     }
 
-    /// Headroom for the fixture to register its descendant, not a measured
-    /// budget.
+    /// Deliberately short, and shorter is safer here.
     ///
-    /// The stub spawns a `cmd.exe` descendant, writes its pid, and only then
-    /// blocks on a CPR reply that never arrives — and all of that has to
-    /// happen before the startup timeout under test fires. Two seconds was
-    /// enough on an idle host and not on a loaded CI runner, where the runner
-    /// killed the stub before the pid file existed and the test failed reading
-    /// it (`coven-047`, `coven-5ua`). The behaviour under test is that a
-    /// startup timeout fails the run and kills the descendant; how long the
-    /// timeout is set to is not part of that claim.
+    /// `spawn_detached_with_observer_and_timeout` races three claimants on one
+    /// `AtomicU8`: meaningful output, child exit, and the timeout thread's
+    /// `compare_exchange(0 -> 2)`. Only the winner acts, so if anything
+    /// printable reaches the PTY first the timeout never fires at all — the
+    /// stub then blocks forever in `expect_reply`, `on_exit` never runs, and
+    /// every watchdog in this test expires.
+    ///
+    /// The stub's descendant is `cmd.exe ... >nul`, which normally emits
+    /// nothing, but any stray printable byte claims the state permanently.
+    /// Lengthening this window widens the opportunity for that, which is what
+    /// an earlier attempt at `coven-5ua` did: raising it to 15s traded the
+    /// pid-file race for a worse failure where the timeout lost the race
+    /// outright. Two seconds is enough because the pid is now polled for
+    /// concurrently rather than read after the kill.
     #[cfg(windows)]
-    const WINDOWS_DETACHED_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
+    const WINDOWS_DETACHED_STARTUP_TIMEOUT: Duration = Duration::from_secs(2);
 
     /// Containment watchdogs. Reaching one means something is hung, not that
     /// the host was slow, so they are generous on purpose.
@@ -3818,7 +3823,20 @@ mod tests {
             Ok(result) => result,
             Err(error) => {
                 let _ = session.killer.kill();
-                return Err(error.into());
+                // Say which race was lost instead of only that a deadline
+                // passed. The startup timeout emits its own message when it
+                // wins; its absence here means something else claimed
+                // `startup_state` first and the timeout never fired, which is
+                // a different defect from slow reaping under load.
+                let observed = String::from_utf8_lossy(&captured.lock().unwrap()).into_owned();
+                let diagnosis = if observed.contains("no meaningful output") {
+                    "startup timeout fired but the child was never reaped"
+                } else {
+                    "startup timeout never fired: another claimant won startup_state"
+                };
+                return Err(anyhow::anyhow!(
+                    "{error}: {diagnosis}; observed output: {observed:?}"
+                ));
             }
         };
         let descendant_pid = descendant_pid.with_context(|| {

--- a/crates/coven-cli/tests/fixtures/windows_detached_pty_stub.rs
+++ b/crates/coven-cli/tests/fixtures/windows_detached_pty_stub.rs
@@ -1,7 +1,7 @@
 #![cfg(windows)]
 
 use std::io::{Read, Write};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::Duration;
 
@@ -54,12 +54,25 @@ fn main() {
     }
 
     let pid_file = args.get(2).expect("timeout mode requires a pid file");
-    set_raw_input_mode().expect("failed to enable raw VT input mode");
+    // Spawn and register the descendant before touching the terminal, so the
+    // pid is on disk as early as possible: the runner kills this process tree
+    // when its startup timeout fires, and a pid written after that is a pid
+    // the test never sees.
+    //
+    // The descendant's stdio goes to null rather than being inherited. This
+    // mode exists to produce *no* meaningful output, and an inherited handle
+    // lets any stray printable byte from `cmd.exe` reach the PTY — which the
+    // runner reads as the harness having started, permanently disabling the
+    // startup timeout under test (`coven-5ua`).
     let mut descendant = Command::new("cmd.exe")
         .args(["/d", "/c", "ping 127.0.0.1 -n 120 >nul"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
         .spawn()
         .unwrap();
     std::fs::write(pid_file, descendant.id().to_string()).unwrap();
+    set_raw_input_mode().expect("failed to enable raw VT input mode");
     output.write_all(b"\x1b[6n").unwrap();
     output.flush().unwrap();
     expect_reply(&mut input, b"\x1b[1;1R", None, "timeout-cpr");


### PR DESCRIPTION
Second attempt at `coven-5ua`. **The first one (#705) regressed into a worse
failure**, and reading the startup path explains both.

## What #705 got wrong

`spawn_detached_with_observer_and_timeout` races three claimants on a single
`AtomicU8` — meaningful output, child exit, and the timeout thread's
`compare_exchange(0 -> 2)`. **Only the winner acts.**
`MeaningfulOutputDetector` treats any printable ASCII byte in Ground state as
meaningful, so one stray byte reaching the PTY claims the state permanently:
the timeout never fires, the stub blocks forever in `expect_reply`, `on_exit`
never runs, and every watchdog in the test expires.

That is exactly the new failure — `Error: timed out waiting on channel` on CI
run 31370145402, against a diff (#706) touching only the workflow, a script,
and docs.

**Raising the startup timeout to 15s gave that stray byte 7.5× longer to win
the race.** Short is safer here, not riskier. I had it backwards.

## What this changes

- **Startup timeout back to 2s.** The pid-file race stays fixed by #705's
  polling, which is what actually addressed it — the pid is caught the instant
  it is written rather than read after the kill. The longer timeout was never
  the load-bearing part.
- **The stray byte loses its source.** The stub's descendant is
  `cmd.exe ... >nul` spawned with *inherited* stdio, so anything it emits lands
  on the PTY. This mode exists to produce no meaningful output, so its stdio now
  goes to null — the fixture now matches what it claims to model. The descendant
  is also spawned and registered before the terminal is touched, so the pid
  reaches disk as early as possible.
- **The failure diagnoses itself.** The startup timeout emits its own message
  when it wins, so its absence proves something else claimed the state. The
  `recv_timeout` path now reports which of the two defects occurred and the
  observed output, instead of only that a deadline passed.

## Verification

fmt clean, clippy clean workspace-wide with `-D warnings`, 51 `pty_runner`
tests pass, secret scan clean.

⚠️ **The changed code is `cfg(windows)` and cannot be type-checked on macOS** —
cross-checking against `x86_64-pc-windows-msvc` fails in the `libsqlite3-sys`
and `ring` build scripts, which need an MSVC-targeting C compiler. CI's Windows
job is the check.

**One green Windows run is not evidence this is fixed** — #705 had one and
regressed on the next PR. The bead stays open until it survives several runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
