### PR TITLE
test(afs): verify a mount end to end through the daemon routes

### DIFF
--- a/scripts/afs-mount-e2e.sh
+++ b/scripts/afs-mount-e2e.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Drive a real AFS mount through the daemon routes, end to end.
+#
+# `scripts/afs-mount-smoke.sh` proves the *export* can be mounted; it starts an
+# export by hand and calls `mount_nfs` itself. Nothing has ever exercised the
+# path a caller actually uses: `POST /api/v1/afs/sessions/:id/mount`, where the
+# daemon spawns the export, mounts it, rotates the token, records the mount,
+# and hands back a mount point. `afsMount` advertises `"nfs"` on the strength
+# of in-process tests and that export-level probe alone.
+#
+# This is a manual verification, not a CI gate. It starts a daemon, mounts a
+# session, reads and writes through the mount, unmounts, and checks the daemon
+# agreed at every step. Run it from a terminal on macOS:
+#
+#   ./scripts/afs-mount-e2e.sh
+#
+# Exits non-zero on the first failed expectation, because unlike the probe this
+# one is asserting a contract rather than discovering a platform's behaviour.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+export COVEN_HOME="$WORK/home"
+SOCKET="$COVEN_HOME/coven.sock"
+PROJECT="$WORK/project"
+FAILED=0
+
+cleanup() {
+    # Unmount before stopping the daemon: a live mount whose export dies with
+    # its parent leaves a stale mount point that needs force.
+    if [ -n "${MOUNT_POINT:-}" ]; then
+        umount "$MOUNT_POINT" 2>/dev/null \
+            || diskutil unmount force "$MOUNT_POINT" 2>/dev/null \
+            || true
+    fi
+    "$COVEN" daemon stop >/dev/null 2>&1 || true
+    rm -rf "$WORK" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+step() { printf '\n== %s\n' "$1"; }
+ok()   { printf '   ok    %s\n' "$1"; }
+bad()  { printf '   FAIL  %s\n' "$1"; FAILED=1; }
+api()  { curl -s --unix-socket "$SOCKET" "$@"; }
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "macOS only: no other platform advertises a mount backend"
+    exit 0
+fi
+
+step "build the daemon and the export helper"
+# The daemon locates the helper beside its own executable, so both must land in
+# the same directory — which `cargo build` does for this workspace.
+cargo build -q -p coven-cli || { bad "build coven-cli"; exit 1; }
+cargo build -q -p coven-afs --features mount --bins || { bad "build helper"; exit 1; }
+COVEN="$ROOT/target/debug/coven"
+[ -x "$ROOT/target/debug/coven-afs-serve" ] || { bad "helper missing beside daemon"; exit 1; }
+ok "coven + coven-afs-serve"
+
+step "start a daemon on a throwaway COVEN_HOME"
+mkdir -p "$COVEN_HOME" "$PROJECT"
+git -C "$PROJECT" init -q 2>/dev/null
+printf 'from the base\n' > "$PROJECT/hello.txt"
+git -C "$PROJECT" add -A 2>/dev/null
+git -C "$PROJECT" -c user.email=e2e@example.invalid -c user.name=e2e \
+    commit -qm "base" 2>/dev/null
+"$COVEN" daemon start >/dev/null 2>&1
+for _ in $(seq 1 100); do [ -S "$SOCKET" ] && break; sleep 0.2; done
+[ -S "$SOCKET" ] || { bad "daemon socket never appeared"; exit 1; }
+ok "socket up"
+
+step "the daemon advertises a mount backend"
+BACKEND="$(api http://localhost/api/v1/health | python3 -c "
+import json,sys
+print(json.load(sys.stdin)['capabilities']['afsMount'])" 2>/dev/null)"
+if [ "$BACKEND" = "nfs" ]; then ok "afsMount=nfs"; else
+    bad "afsMount=$BACKEND — nothing to verify"; exit 1
+fi
+
+step "create an AFS session"
+ID="$(api -X POST -H 'Content-Type: application/json' \
+    -d "{\"projectRoot\":\"$PROJECT\"}" http://localhost/api/v1/afs/sessions \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])" 2>/dev/null)"
+[ -n "$ID" ] || { bad "no session id"; exit 1; }
+ok "session $ID"
+
+step "mount it through the route"
+MOUNT_JSON="$(api -X POST -H 'Content-Type: application/json' -d '{}' \
+    "http://localhost/api/v1/afs/sessions/$ID/mount")"
+MOUNT_POINT="$(printf '%s' "$MOUNT_JSON" | python3 -c "
+import json,sys
+d=json.load(sys.stdin); print(d.get('mountPoint',''))" 2>/dev/null)"
+if [ -z "$MOUNT_POINT" ]; then
+    bad "mount refused: $MOUNT_JSON"; exit 1
+fi
+ok "mountPoint $MOUNT_POINT"
+
+# §3.3: the response must never carry a listener address.
+printf '%s' "$MOUNT_JSON" | grep -qiE '"port"|"token"|localhost:' \
+    && bad "the mount response leaked a listener address or token" \
+    || ok "response carries no port or token"
+
+step "the mount is real"
+mount | grep -q "$(basename "$MOUNT_POINT")" \
+    && ok "visible in mount(8)" \
+    || bad "not present in mount(8)"
+
+step "read and write through it"
+ls "$MOUNT_POINT" >/dev/null 2>&1 && ok "readdir" || bad "readdir"
+if [ "$(cat "$MOUNT_POINT/hello.txt" 2>/dev/null)" = "from the base" ]; then
+    # The merged view is the whole point: this file is in the base, and the
+    # delta is empty, so a delta-only export would show nothing.
+    ok "base file readable (merged view)"
+else
+    bad "base file not readable through the mount"
+fi
+printf 'written through the mount\n' > "$MOUNT_POINT/written.txt" 2>/dev/null \
+    && ok "write" || bad "write"
+
+step "the daemon reports the session as mounted"
+SESSION_MOUNT="$(api "http://localhost/api/v1/afs/sessions/$ID" | python3 -c "
+import json,sys; print(json.load(sys.stdin).get('mount') or '')" 2>/dev/null)"
+[ "$SESSION_MOUNT" = "$MOUNT_POINT" ] \
+    && ok "session.mount matches" \
+    || bad "session.mount=$SESSION_MOUNT expected $MOUNT_POINT"
+
+step "the write is visible to the daemon's diff"
+CHANGES="$(api "http://localhost/api/v1/afs/sessions/$ID/diff" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+print(','.join(sorted(c['path'] for c in d.get('changes',[]))))" 2>/dev/null)"
+case "$CHANGES" in
+    *written.txt*) ok "diff sees /written.txt" ;;
+    *) bad "diff did not record the mounted write (changes: ${CHANGES:-none})" ;;
+esac
+
+step "unmount through the route"
+UNMOUNTED="$(api -X DELETE "http://localhost/api/v1/afs/sessions/$ID/mount" | python3 -c "
+import json,sys; print(json.load(sys.stdin).get('unmounted'))" 2>/dev/null)"
+[ "$UNMOUNTED" = "True" ] && ok "unmounted" || bad "unmount reported $UNMOUNTED"
+mount | grep -q "$(basename "$MOUNT_POINT")" \
+    && bad "still mounted after DELETE" \
+    || ok "gone from mount(8)"
+MOUNT_POINT=""
+
+step "unmounting again is idempotent"
+AGAIN="$(api -X DELETE "http://localhost/api/v1/afs/sessions/$ID/mount" \
+    -o /dev/null -w '%{http_code}')"
+[ "$AGAIN" = "200" ] && ok "second DELETE is 200" || bad "second DELETE was $AGAIN"
+
+printf '\n'
+if [ "$FAILED" -eq 0 ]; then
+    echo "end-to-end mount verified through the daemon routes"
+else
+    echo "end-to-end mount FAILED"
+fi
+exit "$FAILED"

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -553,6 +553,14 @@ and nothing in the operating system stops it afterwards. Any future reasoning
 that treats macOS consent as a second factor is reasoning from a finding this
 job disproved.
 
+On 2026-08-10 the mount was driven end to end through the daemon routes for
+the first time (`scripts/afs-mount-e2e.sh`): `POST …/mount` produced a real
+mount, a base-only file was readable through it, a write through the mount
+appeared in `afs.session.diff`, `GET …/sessions/:id` reported the mount point,
+and `DELETE …/mount` removed it. Until then `afsMount: "nfs"` rested on
+in-process tests and an export-level probe; the route a caller actually uses
+had never been exercised against a kernel client.
+
 **Enforcement is not free.** As RESEARCH.md notes, the mount alone does not stop
 an agent writing to an absolute path outside it. AFS bounds the blast radius of
 writes that go *through* it; the OS sandbox that forces all writes through the


### PR DESCRIPTION
Closes the last real gap in the AFS mount work: **nothing had ever mounted a
session through the daemon routes.**

`afsMount` advertises `"nfs"` (coven-vlw, #704) on the strength of in-process
NFS-layer tests and the export-level probe from #706. Neither exercises the
path a caller actually uses — `POST /api/v1/afs/sessions/:id/mount`, where the
daemon spawns the export, mounts it, rotates the token, records the mount, and
returns a mount point.

## What it verifies

Unlike `afs-mount-smoke.sh`, which *discovers* platform behaviour and reports
verdicts without failing, this asserts a contract and exits non-zero on the
first unmet expectation:

- `afsMount` reports `nfs`, else there is nothing to verify
- `POST …/mount` returns a mount point, and the mount is visible in `mount(8)`
- the response carries **no port or token** — DESIGN.md §3.3
- readdir, read, and write all work through the mount
- **a base-only file is readable** — coven-vlw's merged-view property, against
  a kernel client rather than in-process
- **a write through the mount appears in `afs.session.diff`** — the round trip
  NFS → AgentFS delta → diff route
- `GET …/sessions/:id` reports `mount` matching what the route returned
- `DELETE …/mount` unmounts, and the mount leaves `mount(8)`
- a second `DELETE` is 200, not an error

## First run

Every step passed. DESIGN.md §7 records the result and what it supersedes.

## Why manual, not CI

It starts a daemon and mounts a filesystem — more than a PR check should do on
a shared runner, and the export-level probe in #706 already covers what CI can
reasonably assert. Run it from a terminal on macOS:

```
./scripts/afs-mount-e2e.sh
```

## Verification

`bash -n` clean, secret scan clean, and the script was run end to end on macOS
with no mount or daemon left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
