### PR TITLE
fix(test): make the AFS e2e script keep the promise in its own header

### DIFF
--- a/scripts/afs-mount-e2e.sh
+++ b/scripts/afs-mount-e2e.sh
@@ -53,7 +53,8 @@ api()  { curl -s --unix-socket "$SOCKET" "$@"; }
 # so an unresolved comparison silently never matches.
 mounted_at() {
     local resolved
-    resolved="$(cd "$1" 2>/dev/null && pwd -P)" || return 1
+    # `--` so a path beginning with `-` is a path, not an option to cd.
+    resolved="$(cd -- "$1" 2>/dev/null && pwd -P)" || return 1
     mount | grep -qF " on $resolved ("
 }
 

--- a/scripts/afs-mount-e2e.sh
+++ b/scripts/afs-mount-e2e.sh
@@ -23,7 +23,6 @@ WORK="$(mktemp -d)"
 export COVEN_HOME="$WORK/home"
 SOCKET="$COVEN_HOME/coven.sock"
 PROJECT="$WORK/project"
-FAILED=0
 
 cleanup() {
     # Unmount before stopping the daemon: a live mount whose export dies with
@@ -40,8 +39,23 @@ trap cleanup EXIT
 
 step() { printf '\n== %s\n' "$1"; }
 ok()   { printf '   ok    %s\n' "$1"; }
-bad()  { printf '   FAIL  %s\n' "$1"; FAILED=1; }
+# Fail fast, as the header promises. Once an expectation is unmet the rest of
+# the run describes a system already known to be wrong, and cascading failures
+# obscure which one actually broke.
+bad()  { printf '   FAIL  %s\n' "$1"; exit 1; }
 api()  { curl -s --unix-socket "$SOCKET" "$@"; }
+
+# Whether `mount(8)` reports something mounted at exactly this path.
+#
+# Matched as a fixed string against the fully resolved path rather than by
+# grepping the basename: a basename can collide with an unrelated mount, and
+# `mktemp -d` returns a /var path that `mount` reports resolved to /private/var,
+# so an unresolved comparison silently never matches.
+mounted_at() {
+    local resolved
+    resolved="$(cd "$1" 2>/dev/null && pwd -P)" || return 1
+    mount | grep -qF " on $resolved ("
+}
 
 if [ "$(uname -s)" != "Darwin" ]; then
     echo "macOS only: no other platform advertises a mount backend"
@@ -96,12 +110,13 @@ fi
 ok "mountPoint $MOUNT_POINT"
 
 # §3.3: the response must never carry a listener address.
-printf '%s' "$MOUNT_JSON" | grep -qiE '"port"|"token"|localhost:' \
-    && bad "the mount response leaked a listener address or token" \
-    || ok "response carries no port or token"
+if printf '%s' "$MOUNT_JSON" | grep -qiE '"port"|"token"|localhost:'; then
+    bad "the mount response leaked a listener address or token"
+fi
+ok "response carries no port or token"
 
 step "the mount is real"
-mount | grep -q "$(basename "$MOUNT_POINT")" \
+mounted_at "$MOUNT_POINT" \
     && ok "visible in mount(8)" \
     || bad "not present in mount(8)"
 
@@ -138,7 +153,7 @@ step "unmount through the route"
 UNMOUNTED="$(api -X DELETE "http://localhost/api/v1/afs/sessions/$ID/mount" | python3 -c "
 import json,sys; print(json.load(sys.stdin).get('unmounted'))" 2>/dev/null)"
 [ "$UNMOUNTED" = "True" ] && ok "unmounted" || bad "unmount reported $UNMOUNTED"
-mount | grep -q "$(basename "$MOUNT_POINT")" \
+mounted_at "$MOUNT_POINT" \
     && bad "still mounted after DELETE" \
     || ok "gone from mount(8)"
 MOUNT_POINT=""
@@ -148,10 +163,5 @@ AGAIN="$(api -X DELETE "http://localhost/api/v1/afs/sessions/$ID/mount" \
     -o /dev/null -w '%{http_code}')"
 [ "$AGAIN" = "200" ] && ok "second DELETE is 200" || bad "second DELETE was $AGAIN"
 
-printf '\n'
-if [ "$FAILED" -eq 0 ]; then
-    echo "end-to-end mount verified through the daemon routes"
-else
-    echo "end-to-end mount FAILED"
-fi
-exit "$FAILED"
+printf '\nend-to-end mount verified through the daemon routes\n'
+exit 0


### PR DESCRIPTION
Follow-up to #710, which I merged before acting on its review. Both Copilot
points were correct.

## The script did not do what its own header said

The header claims it "exits non-zero on the first failed expectation", and
`bad()` only set a flag — so after an unmet expectation it carried on
describing a system already known to be wrong. Cascading failures obscure
which one actually broke. `bad()` now exits, which also makes the accumulator
tail dead code: reaching the end means every expectation held.

## The mount check could pass on a coincidence

It grepped for the mount point's **basename**, as a regex. That can match an
unrelated mount sharing a basename, and a basename containing regex
metacharacters would match something else again.

`mounted_at` now compares the **fully resolved** path as a fixed string.
Resolved matters: `mktemp -d` returns a `/var` path that `mount(8)` reports
under `/private/var`, so an unresolved comparison silently never matches —
the same defect the smoke script's cleanup had in #706, where it left a live
NFS mount behind.

## Verification

Re-ran end to end on macOS after the change. Every step still passes, and the
mount check now means what it claims rather than passing on a basename
coincidence. No mount or daemon left behind; secret scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
