### PR TITLE
fix(windows): hide noninteractive harness processes

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -21,8 +21,8 @@ use crate::{
     daemon::DaemonStatus,
     encrypted_artifacts::SensitiveArtifactStore,
     handoff::{HandoffPacketV1, WorkspaceSnapshot},
-    harness::{ConversationHint, HarnessLaunchMode},
-    privacy, session_launch, store, ward,
+    harness::{ConversationHint, HarnessLaunchMode, LaunchPolicy},
+    privacy, project, session_launch, store, ward,
 };
 
 const MAX_EVENTS_LIMIT: i64 = 1_000;
@@ -127,6 +127,10 @@ pub struct HealthCapabilities {
     pub event_cursor: String,
     pub structured_errors: bool,
     pub session_handoff: bool,
+    /// Whether `POST /sessions` accepts the exact, fail-closed
+    /// `launchPolicy` contract documented for unattended Codex work.
+    #[serde(default)]
+    pub session_launch_policy: bool,
     /// Whether the `afs.*` route family is served at all.
     pub afs: bool,
     /// Mount backend, or `false` when none is available. A client must branch
@@ -239,6 +243,7 @@ pub struct SessionLaunch {
     /// transform for the underlying CLI.
     pub model: Option<String>,
     pub launch_mode: HarnessLaunchMode,
+    pub launch_policy: Option<LaunchPolicy>,
     pub prompt: String,
     pub title: String,
     pub conversation: Option<ConversationHint>,
@@ -333,7 +338,29 @@ impl SessionRuntime for NoopSessionRuntime {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RequestAuthority {
+    /// Filesystem-permission-protected Unix socket or owner-only Windows pipe.
+    OwnerLocalIpc,
+    /// Optional loopback TCP listener. Host/Origin checks reduce browser risk,
+    /// but they do not prove that the caller owns the daemon process.
+    Tcp,
+}
+
+impl RequestAuthority {
+    fn allows_session_launch_policy(self) -> bool {
+        matches!(self, Self::OwnerLocalIpc)
+    }
+}
+
 pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
+    health_response_for_authority(daemon, RequestAuthority::OwnerLocalIpc)
+}
+
+pub(crate) fn health_response_for_authority(
+    daemon: Option<DaemonStatus>,
+    authority: RequestAuthority,
+) -> HealthResponse {
     HealthResponse {
         ok: true,
         api_version: COVEN_API_NAMED_VERSION.to_string(),
@@ -348,6 +375,7 @@ pub fn health_response(daemon: Option<DaemonStatus>) -> HealthResponse {
             event_cursor: "sequence".to_string(),
             structured_errors: true,
             session_handoff: true,
+            session_launch_policy: authority.allows_session_launch_policy(),
             afs: true,
             afs_mount: MountCapability::detect(),
             afs_commit: true,
@@ -364,8 +392,9 @@ fn health_response_with_hub(
     coven_home: &Path,
     daemon: Option<DaemonStatus>,
     event_writer: Option<crate::event_writer::EventWriterHealth>,
+    authority: RequestAuthority,
 ) -> HealthResponse {
-    let mut response = health_response(daemon);
+    let mut response = health_response_for_authority(daemon, authority);
     if let Ok(summary) = crate::hub::hub_health_summary(coven_home) {
         response.hub = serde_json::from_value(summary).ok();
     }
@@ -413,6 +442,26 @@ pub fn handle_request_with_runtime(
     body: Option<&str>,
     runtime: &dyn SessionRuntime,
 ) -> Result<ApiResponse> {
+    handle_request_with_runtime_and_authority(
+        method,
+        path,
+        coven_home,
+        daemon,
+        body,
+        runtime,
+        RequestAuthority::OwnerLocalIpc,
+    )
+}
+
+pub(crate) fn handle_request_with_runtime_and_authority(
+    method: &str,
+    path: &str,
+    coven_home: &Path,
+    daemon: Option<DaemonStatus>,
+    body: Option<&str>,
+    runtime: &dyn SessionRuntime,
+    authority: RequestAuthority,
+) -> Result<ApiResponse> {
     let (route, query) = split_path_query(path);
     let route = match normalize_api_route(route) {
         ApiRoute::Route(route) => route,
@@ -441,7 +490,7 @@ pub fn handle_request_with_runtime(
         ),
         ("GET", "/health") => json_response(
             200,
-            &health_response_with_hub(coven_home, daemon, runtime.event_writer_health()),
+            &health_response_with_hub(coven_home, daemon, runtime.event_writer_health(), authority),
         ),
         ("GET", "/capabilities") => json_response(200, &control_plane::capabilities()),
         ("POST", "/afs/sessions") => afs_create(coven_home, body),
@@ -791,7 +840,7 @@ pub fn handle_request_with_runtime(
             get_scheduler_loop_state(coven_home, loop_id)
         }
         ("GET", "/sessions") => list_sessions_response(coven_home, query),
-        ("POST", "/sessions") => launch_session(coven_home, body, runtime),
+        ("POST", "/sessions") => launch_session(coven_home, body, runtime, authority),
         ("POST", "/sessions/external") => register_external_session(coven_home, body),
         ("POST", path) if path.starts_with("/sessions/") && path.ends_with("/complete") => {
             let session_id = session_action_id(path, "/complete");
@@ -1856,6 +1905,7 @@ fn launch_session(
     coven_home: &Path,
     body: Option<&str>,
     runtime: &dyn SessionRuntime,
+    authority: RequestAuthority,
 ) -> Result<ApiResponse> {
     // Client-side validation errors (malformed JSON, bad fields,
     // unsupported launchMode, malformed `conversation` object, …) must
@@ -1868,6 +1918,14 @@ fn launch_session(
             return api_error(400, "invalid_request", &error.to_string(), None);
         }
     };
+    if payload.get("launchPolicy").is_some() && !authority.allows_session_launch_policy() {
+        return api_error(
+            403,
+            "forbidden",
+            "launchPolicy is accepted only over the owner-gated local IPC transport.",
+            None,
+        );
+    }
     let mut launch = match session_launch_from_payload(payload) {
         Ok(launch) => launch,
         Err(error) => {
@@ -1943,7 +2001,17 @@ fn launch_session(
         // missing auth, child closed stdin during stream-mode init):
         // mark the session row failed and return a structured response
         // so the client surfaces the cause and the daemon stays up.
-        store::update_session_status(&conn, &record.id, "failed", None, &current_timestamp())?;
+        // Cancellation can win while a large launch-time stdin prompt is
+        // still being delivered. Preserve that terminal decision: only a row
+        // that is still owned by the failing launch may transition to failed.
+        let _ = store::update_session_status_if_current(
+            &conn,
+            &record.id,
+            "running",
+            "failed",
+            None,
+            &current_timestamp(),
+        )?;
         return api_error(
             500,
             "launch_failed",
@@ -2423,6 +2491,7 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
     // binary is surfaced by the runtime as a structured launch failure.
     session_launch::validate_harness(&harness, session_launch::HarnessCheck::Configured)?;
     let launch_mode = launch_mode_from_payload(&payload)?;
+    let launch_policy = launch_policy_from_payload(&payload, &harness, launch_mode)?;
     let model = payload
         .get("model")
         .and_then(Value::as_str)
@@ -2464,6 +2533,7 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         harness,
         model,
         launch_mode,
+        launch_policy,
         prompt,
         title,
         conversation,
@@ -2471,6 +2541,66 @@ fn session_launch_from_payload(payload: Value) -> Result<SessionLaunch> {
         familiar_id,
         caller_familiar_id,
     })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LaunchPolicyPayload {
+    approval: String,
+    sandbox: String,
+    #[serde(default)]
+    add_dirs: Vec<String>,
+}
+
+fn launch_policy_from_payload(
+    payload: &Value,
+    harness: &str,
+    launch_mode: HarnessLaunchMode,
+) -> Result<Option<LaunchPolicy>> {
+    let Some(value) = payload.get("launchPolicy") else {
+        return Ok(None);
+    };
+    let requested: LaunchPolicyPayload = serde_json::from_value(value.clone()).context(
+        "launchPolicy must be an object with approval, sandbox, and optional addDirs fields",
+    )?;
+    anyhow::ensure!(
+        requested.approval == "never",
+        "launchPolicy.approval must be exactly `never`"
+    );
+    anyhow::ensure!(
+        requested.sandbox == "workspace-write",
+        "launchPolicy.sandbox must be exactly `workspace-write`"
+    );
+    anyhow::ensure!(
+        harness == "codex" && launch_mode == HarnessLaunchMode::NonInteractive,
+        "launchPolicy is supported only for Codex nonInteractive launches"
+    );
+
+    let mut seen = HashSet::new();
+    let mut add_dirs = Vec::with_capacity(requested.add_dirs.len());
+    for (index, raw_dir) in requested.add_dirs.into_iter().enumerate() {
+        anyhow::ensure!(
+            !raw_dir.is_empty() && raw_dir.trim() == raw_dir,
+            "launchPolicy.addDirs[{index}] must be a non-empty path without surrounding whitespace"
+        );
+        let requested_path = Path::new(&raw_dir);
+        anyhow::ensure!(
+            requested_path.is_absolute(),
+            "launchPolicy.addDirs[{index}] must be an absolute path"
+        );
+        let resolved = project::canonical_project_root(requested_path).with_context(|| {
+            format!("launchPolicy.addDirs[{index}] must resolve to an existing directory")
+        })?;
+        anyhow::ensure!(
+            resolved.is_dir(),
+            "launchPolicy.addDirs[{index}] must resolve to an existing directory"
+        );
+        if seen.insert(resolved.clone()) {
+            add_dirs.push(resolved.to_string_lossy().into_owned());
+        }
+    }
+
+    Ok(Some(LaunchPolicy::unattended_workspace_write(add_dirs)))
 }
 
 fn launch_mode_from_payload(payload: &Value) -> Result<HarnessLaunchMode> {
@@ -7049,6 +7179,7 @@ mod tests {
         assert!(response.body.contains(&expected), "{}", response.body);
         assert!(response.body.contains(r#""afsCommit":true"#));
         assert!(response.body.contains(r#""afsCommitDryRun":true"#));
+        assert!(response.body.contains(r#""sessionLaunchPolicy":true"#));
         Ok(())
     }
 
@@ -7060,9 +7191,14 @@ mod tests {
             .as_object_mut()
             .expect("capabilities object")
             .remove("afsCommitDryRun");
+        payload["capabilities"]
+            .as_object_mut()
+            .expect("capabilities object")
+            .remove("sessionLaunchPolicy");
 
         let decoded: HealthResponse = serde_json::from_value(payload)?;
         assert!(!decoded.capabilities.afs_commit_dry_run);
+        assert!(!decoded.capabilities.session_launch_policy);
         Ok(())
     }
 
@@ -7481,6 +7617,7 @@ mod tests {
         assert!(response.capabilities.executor_dispatch);
         assert_eq!(response.capabilities.event_cursor, "sequence");
         assert!(response.capabilities.structured_errors);
+        assert!(response.capabilities.session_launch_policy);
         assert_eq!(response.daemon, None);
         assert_eq!(response.hub, None);
         assert_eq!(response.event_writer, None);
@@ -7682,6 +7819,7 @@ mod tests {
         let body: serde_json::Value = serde_json::from_str(&response.body)?;
 
         assert_eq!(body["capabilities"]["sessionHandoff"], true);
+        assert_eq!(body["capabilities"]["sessionLaunchPolicy"], true);
         assert_eq!(body["eventWriter"]["queuedEvents"], 3);
         assert_eq!(body["eventWriter"]["queuedBytes"], 4096);
         assert_eq!(body["storage"]["writerBacklogEvents"], 3);
@@ -7769,6 +7907,7 @@ mod tests {
         assert_eq!(body["capabilities"]["eventCursor"], "sequence");
         assert_eq!(body["capabilities"]["structuredErrors"], true);
         assert_eq!(body["capabilities"]["sessionHandoff"], true);
+        assert_eq!(body["capabilities"]["sessionLaunchPolicy"], true);
         Ok(())
     }
 
@@ -8937,6 +9076,130 @@ mod tests {
             HarnessLaunchMode::NonInteractive
         );
         assert!(runtime.launches.borrow()[0].model.is_none());
+        assert!(runtime.launches.borrow()[0].launch_policy.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn launch_policy_request_accepts_exact_workspace_write_and_canonicalizes_dirs(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        let artifacts = project_root.join("artifacts");
+        let mission_workspace = temp_dir.path().join("mission-workspace");
+        std::fs::create_dir_all(&artifacts)?;
+        std::fs::create_dir_all(&mission_workspace)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "launchMode": "nonInteractive",
+            "launchPolicy": {
+                "approval": "never",
+                "sandbox": "workspace-write",
+                "addDirs": [artifacts, mission_workspace, artifacts]
+            },
+            "prompt": "write artifacts/primary.md"
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 201, "{}", response.body);
+        let launch = &runtime.launches.borrow()[0];
+        assert_eq!(
+            launch.launch_policy,
+            Some(LaunchPolicy::unattended_workspace_write(vec![
+                project::canonical_project_root(&artifacts)?
+                    .to_string_lossy()
+                    .into_owned(),
+                project::canonical_project_root(&mission_workspace)?
+                    .to_string_lossy()
+                    .into_owned(),
+            ]))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn launch_policy_rejects_unknown_and_unsupported_authority() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        let file = project_root.join("not-a-directory.txt");
+        std::fs::create_dir_all(&project_root)?;
+        std::fs::write(&file, "fixture")?;
+        let invalid_policies = [
+            json!({"approval":"on-request","sandbox":"workspace-write"}),
+            json!({"approval":"never","sandbox":"danger-full-access"}),
+            json!({"approval":"never","sandbox":"workspace-write","extra":true}),
+            json!({"approval":"never","sandbox":"workspace-write","addDirs":["relative/path"]}),
+            json!({"approval":"never","sandbox":"workspace-write","addDirs":[file]}),
+            json!({"approval":"never","sandbox":"workspace-write","addDirs":[" "]}),
+        ];
+
+        for launch_policy in invalid_policies {
+            let runtime = RecordingRuntime::default();
+            let body = json!({
+                "projectRoot": project_root,
+                "harness": "codex",
+                "launchMode": "nonInteractive",
+                "launchPolicy": launch_policy,
+                "prompt": "write an artifact"
+            })
+            .to_string();
+            let response = handle_request_with_runtime(
+                "POST",
+                "/sessions",
+                temp_dir.path(),
+                None,
+                Some(&body),
+                &runtime,
+            )?;
+            assert_eq!(response.status, 400, "{}", response.body);
+            assert!(
+                response.body.contains("invalid_request"),
+                "{}",
+                response.body
+            );
+            assert!(runtime.launches.borrow().is_empty());
+        }
+
+        for (harness, launch_mode) in [("claude", "nonInteractive"), ("codex", "interactive")] {
+            let runtime = RecordingRuntime::default();
+            let body = json!({
+                "projectRoot": project_root,
+                "harness": harness,
+                "launchMode": launch_mode,
+                "launchPolicy": {"approval":"never","sandbox":"workspace-write"},
+                "prompt": "write an artifact"
+            })
+            .to_string();
+            let response = handle_request_with_runtime(
+                "POST",
+                "/sessions",
+                temp_dir.path(),
+                None,
+                Some(&body),
+                &runtime,
+            )?;
+            assert_eq!(response.status, 400, "{}", response.body);
+            assert!(
+                response.body.contains("Codex nonInteractive"),
+                "{}",
+                response.body
+            );
+            assert!(runtime.launches.borrow().is_empty());
+        }
+
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        assert!(store::list_sessions(&conn)?.is_empty());
         Ok(())
     }
 
@@ -9311,6 +9574,45 @@ mod tests {
             response.body
         );
         assert!(sessions.body.contains(r#""status":"failed""#));
+        Ok(())
+    }
+
+    #[test]
+    fn launch_failure_does_not_overwrite_a_concurrent_killed_status() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let launched_id = std::sync::Arc::new(Mutex::new(None));
+        let runtime = CancelWinningLaunchRuntime {
+            coven_home: temp_dir.path().to_path_buf(),
+            launched_id: std::sync::Arc::clone(&launched_id),
+        };
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "launchMode": "nonInteractive",
+            "prompt": "large prompt"
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+        assert_eq!(response.status, 500);
+        let launched_id = launched_id
+            .lock()
+            .unwrap()
+            .clone()
+            .context("runtime observed generated launch id")?;
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        let session =
+            store::get_session(&conn, &launched_id)?.context("launch row remains present")?;
+        assert_eq!(session.status, "killed");
         Ok(())
     }
 
@@ -9921,6 +10223,28 @@ mod tests {
     impl SessionRuntime for FailingLaunchRuntime {
         fn launch_session(&self, _launch: &SessionLaunch) -> Result<()> {
             anyhow::bail!("launch failed")
+        }
+
+        fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+            Ok(())
+        }
+
+        fn kill_session(&self, _session_id: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    struct CancelWinningLaunchRuntime {
+        coven_home: PathBuf,
+        launched_id: std::sync::Arc<Mutex<Option<String>>>,
+    }
+
+    impl SessionRuntime for CancelWinningLaunchRuntime {
+        fn launch_session(&self, launch: &SessionLaunch) -> Result<()> {
+            *self.launched_id.lock().unwrap() = Some(launch.id.clone());
+            let conn = store::open_store(&store_path(&self.coven_home))?;
+            store::update_session_status(&conn, &launch.id, "killed", None, &current_timestamp())?;
+            anyhow::bail!("launch prompt delivery observed cancellation")
         }
 
         fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -1,12 +1,12 @@
 use std::collections::HashMap;
 use std::io::Write;
 #[cfg(unix)]
-use std::net::{SocketAddr, TcpListener, ToSocketAddrs};
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    Arc, Mutex, Weak,
+    Arc, Condvar, Mutex, Weak,
 };
 use std::time::{Duration, Instant};
 
@@ -58,6 +58,18 @@ pub struct DaemonSpawnSpec {
 
 pub trait RuntimeKiller: Send {
     fn kill(&mut self) -> Result<()>;
+
+    /// Begin daemon-shutdown cancellation without waiting for this one child.
+    /// The default preserves existing PTY behavior; strict piped trees split
+    /// signaling from their quiescence proof so N live sessions do not each
+    /// consume the daemon's bounded stop budget serially.
+    fn signal_shutdown(&mut self) -> Result<()> {
+        self.kill()
+    }
+
+    fn wait_for_shutdown_quiescence(&mut self, _timeout: Duration) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// Sentinel error returned by `LiveSessionRuntime::send_input` and
@@ -87,6 +99,213 @@ pub struct LiveSessionRuntime {
     coven_home: Option<PathBuf>,
     event_writer: Option<crate::event_writer::EventWriter>,
     sessions: Arc<Mutex<HashMap<String, LiveSessionHandle>>>,
+    shutting_down: AtomicBool,
+    launch_gate: Arc<LiveLaunchGate>,
+}
+
+#[derive(Default)]
+struct LiveLaunchGate {
+    state: Mutex<LiveLaunchGateState>,
+    drained: Condvar,
+}
+
+#[derive(Default)]
+struct LiveLaunchGateState {
+    closed: bool,
+    next_id: u64,
+    in_flight: HashMap<u64, Option<SharedLaunchKiller>>,
+}
+
+struct LiveLaunchAdmission {
+    gate: Arc<LiveLaunchGate>,
+    id: u64,
+    active: bool,
+}
+
+#[derive(Clone)]
+struct SharedLaunchKiller {
+    killer: Arc<Mutex<Box<dyn RuntimeKiller>>>,
+}
+
+impl RuntimeKiller for SharedLaunchKiller {
+    fn kill(&mut self) -> Result<()> {
+        match self.killer.lock() {
+            Ok(mut killer) => killer.kill(),
+            Err(poisoned) => poisoned.into_inner().kill(),
+        }
+    }
+
+    fn signal_shutdown(&mut self) -> Result<()> {
+        match self.killer.lock() {
+            Ok(mut killer) => killer.signal_shutdown(),
+            Err(poisoned) => poisoned.into_inner().signal_shutdown(),
+        }
+    }
+
+    fn wait_for_shutdown_quiescence(&mut self, timeout: Duration) -> Result<()> {
+        match self.killer.lock() {
+            Ok(mut killer) => killer.wait_for_shutdown_quiescence(timeout),
+            Err(poisoned) => poisoned.into_inner().wait_for_shutdown_quiescence(timeout),
+        }
+    }
+}
+
+impl LiveLaunchGate {
+    fn begin(self: &Arc<Self>) -> Result<LiveLaunchAdmission> {
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        anyhow::ensure!(
+            !state.closed,
+            "daemon is shutting down; refusing to launch a new live session"
+        );
+        let id = state.next_id;
+        state.next_id = state.next_id.wrapping_add(1);
+        state.in_flight.insert(id, None);
+        Ok(LiveLaunchAdmission {
+            gate: Arc::clone(self),
+            id,
+            active: true,
+        })
+    }
+
+    fn close_and_wait(&self) -> Result<()> {
+        const ADMISSION_DRAIN_BUDGET: Duration = Duration::from_millis(500);
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        state.closed = true;
+        // A published entry owns an exact tree and is signaled immediately.
+        // An unpublished entry never holds this mutex across OS spawn: if its
+        // closure resumes, `publish` observes the closed gate and terminates
+        // that exact tree before returning it. Piped Unix launches also carry
+        // an out-of-process owner-pipe guardian across this pre-publication
+        // window; Windows strict launches carry a KILL_ON_JOB_CLOSE handle as
+        // soon as their suspended CreateProcess call returns.
+        let mut provisional = state
+            .in_flight
+            .values()
+            .filter_map(Clone::clone)
+            .collect::<Vec<_>>();
+        drop(state);
+        let mut failures = Vec::new();
+        for killer in &mut provisional {
+            if let Err(error) = killer.signal_shutdown() {
+                failures.push(format!("{error:#}"));
+            }
+        }
+
+        let deadline = Instant::now() + ADMISSION_DRAIN_BUDGET;
+        let mut state = match self.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        while !state.in_flight.is_empty() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let waited = self.drained.wait_timeout(state, remaining);
+            state = match waited {
+                Ok((state, _)) => state,
+                Err(poisoned) => poisoned.into_inner().0,
+            };
+        }
+        anyhow::ensure!(
+            failures.is_empty(),
+            "failed to terminate {} provisional launch process tree(s): {}",
+            failures.len(),
+            failures.join("; ")
+        );
+        Ok(())
+    }
+}
+
+impl LiveLaunchAdmission {
+    fn spawn_owned<T>(
+        &self,
+        spawn: impl FnOnce(&mut dyn FnMut(Box<dyn RuntimeKiller>) -> Result<()>) -> Result<T>,
+    ) -> Result<(T, SharedLaunchKiller)> {
+        let mut published = None;
+        let mut publish = |killer: Box<dyn RuntimeKiller>| -> Result<()> {
+            anyhow::ensure!(
+                published.is_none(),
+                "live launch killer was published twice"
+            );
+            let mut shared = SharedLaunchKiller {
+                killer: Arc::new(Mutex::new(killer)),
+            };
+            let mut state = match self.gate.state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            let accepted = self.active && !state.closed;
+            if accepted {
+                let slot = state.in_flight.get_mut(&self.id).ok_or_else(|| {
+                    anyhow::anyhow!("live launch admission disappeared before spawn ownership")
+                })?;
+                *slot = Some(shared.clone());
+            }
+            drop(state);
+            if !accepted {
+                let cleanup = shared.signal_shutdown().err();
+                return match cleanup {
+                    Some(error) => Err(anyhow::anyhow!(
+                        "daemon is shutting down; rejected spawned session cleanup failed: {error:#}"
+                    )),
+                    None => Err(anyhow::anyhow!(
+                        "daemon is shutting down; refusing to spawn a new live session"
+                    )),
+                };
+            }
+            published = Some(shared);
+            Ok(())
+        };
+        let value = match spawn(&mut publish) {
+            Ok(value) => value,
+            Err(error) => {
+                if let Some(mut killer) = published.take() {
+                    let cleanup = killer.signal_shutdown().err();
+                    return match cleanup {
+                        Some(cleanup) => Err(anyhow::anyhow!(
+                            "{error:#}; failed to terminate rejected spawned session: {cleanup:#}"
+                        )),
+                        None => Err(error),
+                    };
+                }
+                return Err(error);
+            }
+        };
+        let killer = published.context("spawn returned without publishing exact ownership")?;
+        Ok((value, killer))
+    }
+
+    fn release(mut self) {
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut state = match self.gate.state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        state.in_flight.remove(&self.id);
+        self.active = false;
+        if state.in_flight.is_empty() {
+            self.gate.drained.notify_all();
+        }
+    }
+}
+
+impl Drop for LiveLaunchAdmission {
+    fn drop(&mut self) {
+        self.finish();
+    }
 }
 
 /// What kind of underlying process is bound to a registered live session.
@@ -194,7 +413,13 @@ impl LiveSessionRuntime {
             coven_home: Some(coven_home),
             event_writer: Some(event_writer),
             sessions: Arc::default(),
+            shutting_down: AtomicBool::new(false),
+            launch_gate: Arc::default(),
         })
+    }
+
+    fn begin_launch(&self) -> Result<LiveLaunchAdmission> {
+        self.launch_gate.begin()
     }
 
     #[allow(dead_code)]
@@ -228,13 +453,40 @@ impl LiveSessionRuntime {
         session_id: String,
         kind: LiveSessionKind,
         input: Box<dyn Write + Send>,
-        killer: Box<dyn RuntimeKiller>,
+        mut killer: Box<dyn RuntimeKiller>,
+        registration: Arc<LiveSessionRegistration>,
+    ) -> Result<()> {
+        if self.shutting_down.load(Ordering::Acquire) {
+            return reject_registration_during_shutdown(killer.as_mut());
+        }
+        self.register_kind_after_initial_shutdown_check(
+            session_id,
+            kind,
+            input,
+            killer,
+            registration,
+        )
+    }
+
+    fn register_kind_after_initial_shutdown_check(
+        &self,
+        session_id: String,
+        kind: LiveSessionKind,
+        input: Box<dyn Write + Send>,
+        mut killer: Box<dyn RuntimeKiller>,
         registration: Arc<LiveSessionRegistration>,
     ) -> Result<()> {
         let mut sessions = self
             .sessions
             .lock()
             .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
+        if self.shutting_down.load(Ordering::Acquire) {
+            // The launch may have passed the first admission check and spawned
+            // while shutdown was waiting for this registry lock. Never run a
+            // potentially blocking process-tree kill while holding that lock.
+            drop(sessions);
+            return reject_registration_during_shutdown(killer.as_mut());
+        }
         let replaced = sessions.insert(
             session_id.clone(),
             LiveSessionHandle {
@@ -256,6 +508,67 @@ impl LiveSessionRuntime {
         drop(sessions);
         drop(replaced);
         drop(removed);
+        Ok(())
+    }
+
+    /// Stop admitting sessions, remove every owned handle, and explicitly
+    /// terminate each process tree. Dropping the handles remains a containment
+    /// backstop (notably KILL_ON_JOB_CLOSE on Windows), while this method gives
+    /// graceful daemon shutdown a checked, observable cancellation path.
+    fn shutdown_all(&self) -> Result<()> {
+        self.shutting_down.store(true, Ordering::Release);
+        // No prompt bytes are delivered while an admission remains in this
+        // gate. Closing it makes every pre-registration launcher either fail
+        // registration and kill its exact tree or finish registering that tree
+        // before shutdown drains the live map. This is also the barrier that
+        // keeps a detached Unix request thread from losing a locally owned
+        // setsid child when the daemon process exits.
+        let admission_failure = self.launch_gate.close_and_wait().err();
+        let handles = {
+            let mut sessions = match self.sessions.lock() {
+                Ok(sessions) => sessions,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            sessions
+                .drain()
+                .map(|(_, handle)| handle)
+                .collect::<Vec<_>>()
+        };
+        let mut failures = Vec::new();
+        if let Some(error) = admission_failure {
+            failures.push(format!("{error:#}"));
+        }
+        for handle in &handles {
+            let result = match handle.killer.lock() {
+                Ok(mut killer) => killer.signal_shutdown(),
+                Err(poisoned) => poisoned.into_inner().signal_shutdown(),
+            };
+            if let Err(error) = result {
+                failures.push(format!("{error:#}"));
+            }
+        }
+        // All trees have been signaled before any wait begins. Share one
+        // deadline across the set so shutdown remains bounded instead of
+        // multiplying the wait budget by the number of live sessions.
+        let quiescence_deadline = Instant::now() + Duration::from_secs(1);
+        for handle in handles {
+            let remaining = quiescence_deadline.saturating_duration_since(Instant::now());
+            let result = match handle.killer.lock() {
+                Ok(mut killer) => killer.wait_for_shutdown_quiescence(remaining),
+                Err(poisoned) => poisoned
+                    .into_inner()
+                    .wait_for_shutdown_quiescence(remaining),
+            };
+            if let Err(error) = result {
+                failures.push(format!("{error:#}"));
+            }
+        }
+        anyhow::ensure!(
+            failures.is_empty(),
+            "failed to terminate {} live session process tree(s): {}",
+            failures.len(),
+            failures.join("; ")
+        );
         Ok(())
     }
 
@@ -288,6 +601,16 @@ impl LiveSessionRuntime {
             output_observer_with_cleanup(self.event_writer.clone(), session_id, Some(cleanup)),
             registration,
         )
+    }
+}
+
+fn reject_registration_during_shutdown(killer: &mut dyn RuntimeKiller) -> Result<()> {
+    const REJECTION: &str = "daemon is shutting down; refusing to register a new live session";
+    match killer.kill() {
+        Ok(()) => anyhow::bail!(REJECTION),
+        Err(error) => anyhow::bail!(
+            "{REJECTION}; failed to terminate the rejected session process tree: {error:#}"
+        ),
     }
 }
 
@@ -505,6 +828,10 @@ impl LiveSessionRuntime {
         launch: &SessionLaunch,
         writer: Option<crate::maintenance_gate::WriterLease>,
     ) -> Result<()> {
+        anyhow::ensure!(
+            !self.shutting_down.load(Ordering::Acquire),
+            "daemon is shutting down; refusing to launch a new session"
+        );
         let familiar_ctx = match (&self.coven_home, launch.familiar_id.as_deref()) {
             (Some(home), familiar_id) => {
                 crate::familiar_identity::resolve_optional(home, familiar_id)?
@@ -514,21 +841,42 @@ impl LiveSessionRuntime {
             }
             (None, None) => None,
         };
-        let command = pty_runner::build_harness_command_with_conversation(
-            &launch.harness,
-            &launch.prompt,
-            Path::new(&launch.cwd),
-            launch.launch_mode,
-            launch.conversation.as_ref(),
-            familiar_ctx.as_ref(),
-            crate::harness::HarnessLaunchOptions {
-                model: launch.model.as_deref(),
-                ..Default::default()
-            },
-        )?;
+        let launch_options = crate::harness::HarnessLaunchOptions {
+            model: launch.model.as_deref(),
+            launch_policy: launch.launch_policy.as_ref(),
+            ..Default::default()
+        };
+        let command = if launch.harness == "codex"
+            && launch.launch_mode == crate::harness::HarnessLaunchMode::NonInteractive
+        {
+            pty_runner::build_piped_harness_command_with_conversation(
+                &launch.harness,
+                &launch.prompt,
+                Path::new(&launch.cwd),
+                launch.launch_mode,
+                launch.conversation.as_ref(),
+                familiar_ctx.as_ref(),
+                launch_options,
+            )?
+        } else {
+            pty_runner::build_harness_command_with_conversation(
+                &launch.harness,
+                &launch.prompt,
+                Path::new(&launch.cwd),
+                launch.launch_mode,
+                launch.conversation.as_ref(),
+                familiar_ctx.as_ref(),
+                launch_options,
+            )?
+        };
         let (observer, registration) =
             self.observer_for_session_with_writer(launch.id.clone(), writer);
         let observer = Some(observer);
+        // Hold admission from before the OS spawn until the exact process-tree
+        // handle is in the live registry. Shutdown closes and drains this gate,
+        // so a detached request handler cannot lose a pre-registration Unix
+        // process group when the daemon exits.
+        let launch_admission = self.begin_launch()?;
 
         if launch.launch_mode == crate::harness::HarnessLaunchMode::Stream {
             // Defense in depth: only allow Stream mode for harnesses that
@@ -543,52 +891,74 @@ impl LiveSessionRuntime {
                     launch.harness
                 );
             }
-            let piped = pty_runner::spawn_piped_with_observer(&command, observer, true)?;
-            let mut killer_box = piped_killer(piped.pid);
-            let mut input = piped.input;
-            // Send the launch's prompt as the first stream-json user
-            // message so the chat doesn't need a separate send call right
-            // after launch. A write failure here means the child already
-            // exited (e.g. auth missing) — treat that as a hard launch
-            // error: kill what's left of the child and surface it to the
-            // caller so the session row is marked failed instead of
-            // pretending we delivered the prompt.
+            let (piped, _provisional_killer) = launch_admission.spawn_owned(|publish| {
+                let piped = pty_runner::spawn_piped_with_observer(&command, observer, true)?;
+                let killer: Box<dyn RuntimeKiller> = Box::new(piped.cancellation_handle());
+                publish(killer)?;
+                Ok(piped)
+            })?;
+            piped.activate(|input, process_tree| {
+                self.register_kind_with_registration(
+                    launch.id.clone(),
+                    LiveSessionKind::Stream,
+                    input,
+                    Box::new(process_tree),
+                    registration,
+                )?;
+                launch_admission.release();
+                Ok(())
+            })?;
+            // Register cancellation ownership before sending the launch's
+            // first stream-json user message. A child that stops reading can
+            // still block this per-session input lock, but daemon shutdown or
+            // /kill owns an independent strict process-tree handle and can
+            // interrupt the write without waiting for that lock.
             if !launch.prompt.is_empty() {
-                if let Err(error) = write_stream_message(input.as_mut(), &launch.prompt) {
-                    let _ = killer_box.kill();
-                    return Err(error).with_context(|| {
-                        format!(
-                            "stream-mode launch of `{}` failed: child closed stdin before the initial message landed (auth/setup error?)",
-                            launch.harness
-                        )
-                    });
+                if let Err(error) = SessionRuntime::send_input(
+                    self,
+                    &launch.id,
+                    &json!({ "data": launch.prompt.as_str() }),
+                ) {
+                    let cleanup = SessionRuntime::kill_session(self, &launch.id).err();
+                    let primary = error.context(format!(
+                        "stream-mode launch of `{}` failed: child closed stdin before the initial message landed (auth/setup error?)",
+                        launch.harness
+                    ));
+                    return match cleanup {
+                        Some(cleanup) => Err(anyhow::anyhow!(
+                            "{primary:#}; failed to terminate the rejected stream launch: {cleanup:#}"
+                        )),
+                        None => Err(primary),
+                    };
                 }
             }
-            return self.register_kind_with_registration(
-                launch.id.clone(),
-                LiveSessionKind::Stream,
-                input,
-                killer_box,
-                registration,
-            );
+            return Ok(());
         }
 
-        // ConPTY can terminate one-shot `codex exec` children immediately on
-        // Windows (observed as u32::MAX with no output). These sessions do not
-        // need a terminal: the prompt is already in argv and stdout/stderr are
-        // machine-drained. Ordinary pipes match direct `codex exec`, preserve
-        // output observation, and let the child reach a real exit status.
-        #[cfg(windows)]
-        if launch.launch_mode == crate::harness::HarnessLaunchMode::NonInteractive {
-            let piped = pty_runner::spawn_piped_with_observer(&command, observer, false)?;
-            let killer = piped_killer(piped.pid);
-            return self.register_kind_with_registration(
-                launch.id.clone(),
-                LiveSessionKind::Pty,
-                piped.input,
-                killer,
-                registration,
-            );
+        // Noninteractive Codex is a machine-owned one-shot on every platform:
+        // ordinary pipes carry its complete prompt on stdin and keep argv
+        // bounded. Windows additionally routes every noninteractive harness
+        // here because ConPTY can terminate those children immediately.
+        if launch.launch_mode == crate::harness::HarnessLaunchMode::NonInteractive
+            && (cfg!(windows) || launch.harness == "codex")
+        {
+            let (piped, _provisional_killer) = launch_admission.spawn_owned(|publish| {
+                let piped = pty_runner::spawn_piped_with_observer(&command, observer, false)?;
+                let killer: Box<dyn RuntimeKiller> = Box::new(piped.cancellation_handle());
+                publish(killer)?;
+                Ok(piped)
+            })?;
+            return piped.activate(|input, process_tree| {
+                self.register_kind_with_registration(
+                    launch.id.clone(),
+                    LiveSessionKind::Pty,
+                    input,
+                    Box::new(process_tree),
+                    registration,
+                )?;
+                launch_admission.release();
+                Ok(())
+            });
         }
 
         // Interactive claude launches hit the workspace trust dialog (not
@@ -601,14 +971,21 @@ impl LiveSessionRuntime {
             ensure_claude_trusts_dir(&launch.cwd);
         }
 
-        let detached = pty_runner::spawn_detached_with_observer(&command, observer)?;
+        let (input, provisional_killer) = launch_admission.spawn_owned(|publish| {
+            let detached = pty_runner::spawn_detached_with_observer(&command, observer)?;
+            let killer: Box<dyn RuntimeKiller> = Box::new(detached.killer);
+            publish(killer)?;
+            Ok(detached.input)
+        })?;
         self.register_kind_with_registration(
             launch.id.clone(),
             LiveSessionKind::Pty,
-            detached.input,
-            Box::new(detached.killer),
+            input,
+            Box::new(provisional_killer),
             registration,
-        )
+        )?;
+        launch_admission.release();
+        Ok(())
     }
 
     fn send_input(&self, session_id: &str, payload: &Value) -> Result<()> {
@@ -669,44 +1046,42 @@ impl LiveSessionRuntime {
                 })
             })?
         };
-        let mut killer = handle
-            .killer
-            .lock()
-            .map_err(|_| anyhow::anyhow!("live session killer lock poisoned"))?;
-        killer.kill()
+        let kill_result = {
+            let mut killer = handle
+                .killer
+                .lock()
+                .map_err(|_| anyhow::anyhow!("live session killer lock poisoned"))?;
+            killer.kill()
+        };
+        if let Err(error) = kill_result {
+            // A quiescence timeout does not prove the strict owner is safe to
+            // discard. Retain the exact input/killer handle for a retry unless
+            // the exit callback already proved the process gone or daemon
+            // shutdown has taken over containment.
+            if !handle.registration.exited.load(Ordering::Acquire)
+                && !self.shutting_down.load(Ordering::Acquire)
+            {
+                let mut sessions = self
+                    .sessions
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("live session registry lock poisoned"))?;
+                if !handle.registration.exited.load(Ordering::Acquire)
+                    && !self.shutting_down.load(Ordering::Acquire)
+                    && !sessions.contains_key(session_id)
+                {
+                    sessions.insert(session_id.to_string(), handle);
+                }
+            }
+            return Err(error);
+        }
+        Ok(())
     }
 }
 
-fn piped_killer(pid: u32) -> Box<dyn RuntimeKiller> {
-    #[cfg(windows)]
-    let job_handle = {
-        use windows_sys::Win32::{
-            Foundation::INVALID_HANDLE_VALUE,
-            System::{
-                JobObjects::{AssignProcessToJobObject, CreateJobObjectW},
-                Threading::{OpenProcess, PROCESS_ALL_ACCESS},
-            },
-        };
-        // SAFETY: Windows API calls; handles are owned by PipedKiller.
-        unsafe {
-            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
-            if job != INVALID_HANDLE_VALUE && job != 0 as _ {
-                let ph = OpenProcess(PROCESS_ALL_ACCESS, 0, pid);
-                if ph != INVALID_HANDLE_VALUE && ph != 0 as _ {
-                    AssignProcessToJobObject(job, ph);
-                    windows_sys::Win32::Foundation::CloseHandle(ph);
-                }
-                Some(job)
-            } else {
-                None
-            }
-        }
-    };
-    Box::new(PipedKiller {
-        pid,
-        #[cfg(windows)]
-        job_handle,
-    })
+impl Drop for LiveSessionRuntime {
+    fn drop(&mut self) {
+        let _ = self.shutdown_all();
+    }
 }
 
 /// Wrap raw user text in claude's stream-json user-message envelope and
@@ -735,102 +1110,27 @@ fn write_stream_message(input: &mut dyn Write, text: &str) -> Result<()> {
     Ok(())
 }
 
-/// Killer for a non-PTY piped child (stream-mode harness sessions).
-/// `pty_runner::spawn_piped_with_observer` returns just the child's PID
-/// because the `Child` handle itself lives inside the wait/drain thread —
-/// sharing it through a `Mutex` would deadlock when `wait()` blocks while
-/// `kill()` waits for the same lock.
-///
-/// The spawn path puts the child in its own session/process group via
-/// `setsid()` (pre_exec), so we can signal the entire group with one
-/// syscall — that picks up subprocesses the harness may have spawned
-/// (skills, MCP servers, shells, …) which would otherwise survive as
-/// orphans. We send SIGKILL (not SIGTERM) because the daemon kill path
-/// is reached from explicit user intent (`/kill`, `/clear`, chat exit)
-/// where the right behavior is "stop immediately"; SIGTERM would let a
-/// harness that ignores it linger past the user's request.
-struct PipedKiller {
-    pid: u32,
-    /// On Windows, a Job Object handle that owns the child process tree.
-    /// Calling TerminateJobObject on it kills the child and all descendants.
-    #[cfg(windows)]
-    job_handle: Option<windows_sys::Win32::Foundation::HANDLE>,
-}
-
-#[cfg(windows)]
-unsafe impl Send for PipedKiller {}
-
-#[cfg(windows)]
-impl Drop for PipedKiller {
-    fn drop(&mut self) {
-        if let Some(h) = self.job_handle.take() {
-            // SAFETY: h is a valid handle owned by this struct.
-            unsafe { windows_sys::Win32::Foundation::CloseHandle(h) };
-        }
+impl RuntimeKiller for pty_runner::StrictChildProcessTree {
+    fn kill(&mut self) -> Result<()> {
+        self.terminate_tree()
+            .context("failed to terminate contained piped harness process tree")
     }
 }
 
-impl RuntimeKiller for PipedKiller {
-    #[cfg(unix)]
+impl RuntimeKiller for pty_runner::SharedStrictChildProcessTree {
     fn kill(&mut self) -> Result<()> {
-        let pid = self.pid as libc::pid_t;
-        // Negative argument signals the process group (pgid == pid
-        // since the child called setsid). SIGKILL can't be ignored.
-        let rc = unsafe { libc::kill(-pid, libc::SIGKILL) };
-        if rc != 0 {
-            let error = std::io::Error::last_os_error();
-            // ESRCH means the group is already gone — fine, that's
-            // the post-condition we want.
-            if error.raw_os_error() != Some(libc::ESRCH) {
-                return Err(error).with_context(|| {
-                    format!("failed to SIGKILL stream harness process group {pid}")
-                });
-            }
-        }
-        Ok(())
+        self.terminate_and_wait(Duration::from_secs(1))
+            .context("failed to terminate and quiesce contained piped harness process tree")
     }
 
-    #[cfg(windows)]
-    fn kill(&mut self) -> Result<()> {
-        use windows_sys::Win32::{
-            Foundation::INVALID_HANDLE_VALUE,
-            System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE},
-        };
-        // Prefer Job Object kill (terminates the whole child tree).
-        if let Some(h) = self.job_handle.take() {
-            // SAFETY: h is a valid job handle; exit code 1 is conventional.
-            let rc = unsafe { windows_sys::Win32::System::JobObjects::TerminateJobObject(h, 1) };
-            unsafe { windows_sys::Win32::Foundation::CloseHandle(h) };
-            if rc == 0 {
-                // Fall back to direct TerminateProcess on the root pid.
-                unsafe {
-                    let ph = OpenProcess(PROCESS_TERMINATE, 0, self.pid);
-                    if ph != INVALID_HANDLE_VALUE && ph != 0 as _ {
-                        TerminateProcess(ph, 1);
-                        windows_sys::Win32::Foundation::CloseHandle(ph);
-                    }
-                }
-            }
-            return Ok(());
-        }
-        // No job object — fall back to TerminateProcess on the root pid.
-        unsafe {
-            let ph = OpenProcess(PROCESS_TERMINATE, 0, self.pid);
-            if ph == INVALID_HANDLE_VALUE || ph == 0 as _ {
-                return Ok(()); // Already gone.
-            }
-            TerminateProcess(ph, 1);
-            windows_sys::Win32::Foundation::CloseHandle(ph);
-        }
-        Ok(())
+    fn signal_shutdown(&mut self) -> Result<()> {
+        self.terminate_tree()
+            .context("failed to terminate contained piped harness process tree")
     }
 
-    #[cfg(not(any(unix, windows)))]
-    fn kill(&mut self) -> Result<()> {
-        anyhow::bail!(
-            "stream-mode harness kill not implemented on this platform (pid {})",
-            self.pid
-        )
+    fn wait_for_shutdown_quiescence(&mut self, timeout: Duration) -> Result<()> {
+        pty_runner::SharedStrictChildProcessTree::wait_for_shutdown_quiescence(self, timeout)
+            .context("contained piped harness process tree did not finish shutdown cleanup")
     }
 }
 
@@ -1059,6 +1359,7 @@ pub fn start_background_server(
 ) -> Result<DaemonStatus> {
     let spec = background_server_spec(current_exe, coven_home);
     ensure_private_coven_home(coven_home)?;
+    prevent_background_server_stdio_handle_leaks()?;
     let child = background_server_command(&spec)
         .spawn()
         .with_context(|| format!("failed to start Coven daemon {}", spec.program.display()))?;
@@ -1069,6 +1370,47 @@ pub fn start_background_server(
     };
     write_status(coven_home, &status)?;
     Ok(status)
+}
+
+#[cfg(windows)]
+fn prevent_background_server_stdio_handle_leaks() -> Result<()> {
+    use windows_sys::Win32::{
+        Foundation::{SetHandleInformation, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE},
+        System::Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE},
+    };
+
+    // `CreateProcessW(..., bInheritHandles=TRUE, ...)` inherits every handle
+    // still marked inheritable in the launcher, not only the null std handles
+    // Rust creates for the detached `daemon serve` child. When `daemon start`
+    // itself was launched with captured stdout/stderr, those inherited capture
+    // handles otherwise stay open for the daemon's lifetime and the caller
+    // never observes pipe EOF/Child `close` after the launcher exits.
+    //
+    // Clearing HANDLE_FLAG_INHERIT does not close these handles or prevent the
+    // launcher from writing its normal diagnostics. Rust creates inheritable
+    // duplicates for any later child whose stdio is intentionally inherited;
+    // the daemon child below receives its own null std handles.
+    for (label, stream) in [
+        ("stdin", STD_INPUT_HANDLE),
+        ("stdout", STD_OUTPUT_HANDLE),
+        ("stderr", STD_ERROR_HANDLE),
+    ] {
+        let handle = unsafe { GetStdHandle(stream) };
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+            continue;
+        }
+        if unsafe { SetHandleInformation(handle, HANDLE_FLAG_INHERIT, 0) } == 0 {
+            return Err(std::io::Error::last_os_error()).with_context(|| {
+                format!("failed to prevent inherited {label} from leaking into Coven daemon")
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn prevent_background_server_stdio_handle_leaks() -> Result<()> {
+    Ok(())
 }
 
 fn background_server_command(spec: &DaemonSpawnSpec) -> Command {
@@ -1956,9 +2298,9 @@ fn daemon_status_from_health_socket(socket: &str) -> Result<Option<DaemonStatus>
     }
 }
 
-// `bind_tcp_listener` and `serve_next_tcp_connection` expose the TCP transport
-// so it can be unit-tested in isolation; `serve_forever` wires them into the
-// daemon's accept loop alongside the Unix socket listener.
+// `bind_tcp_listener` plus the accepted-stream handler expose the TCP transport
+// so it can be tested in isolation; `serve_forever` wires them into the daemon's
+// accept loop alongside the Unix socket listener.
 //
 // TCP gets read/write timeouts and a Content-Length cap because — unlike the
 // Unix socket — a misbehaving network client can otherwise hold the API
@@ -2042,6 +2384,7 @@ fn is_client_disconnect(error: &anyhow::Error) -> bool {
 }
 
 #[cfg(unix)]
+#[cfg(test)]
 pub fn serve_next_tcp_connection(
     listener: &TcpListener,
     coven_home: &Path,
@@ -2052,6 +2395,23 @@ pub fn serve_next_tcp_connection(
     let (stream, _) = listener
         .accept()
         .context("failed to accept TCP API connection")?;
+    serve_accepted_tcp_connection(stream, coven_home, status, runtime, allowed_hosts)
+}
+
+#[cfg(unix)]
+fn serve_accepted_tcp_connection(
+    stream: TcpStream,
+    coven_home: &Path,
+    status: Option<DaemonStatus>,
+    runtime: &dyn SessionRuntime,
+    allowed_hosts: &[String],
+) -> Result<()> {
+    // Production may place the listener in nonblocking mode so its auxiliary
+    // accept thread can observe daemon shutdown. Accepted sockets must retain
+    // the ordinary bounded blocking request semantics.
+    stream
+        .set_nonblocking(false)
+        .context("failed to configure accepted TCP API connection")?;
     stream
         .set_read_timeout(Some(TCP_IO_TIMEOUT))
         .context("failed to set TCP read timeout")?;
@@ -2343,8 +2703,9 @@ fn record_store_maintenance_failure_with_free_disk_check(
 /// exits via any path that runs destructors — normal return, `Err` propagation,
 /// or panic unwinding. This is what prevents orphaned `~/.coven/coven.sock`
 /// files from appearing when the daemon crashes (see OpenCoven/coven#197).
-/// SIGKILL and `_exit` bypass Drop; the explicit signal handler covers SIGTERM
-/// / SIGINT / SIGHUP.
+/// SIGKILL bypasses Drop. SIGTERM / SIGINT / SIGHUP only set a signal-safe
+/// flag; the accept loop then drains live process ownership before this guard
+/// removes endpoint metadata during normal unwinding.
 #[cfg(unix)]
 struct ShutdownGuard {
     socket_path: PathBuf,
@@ -2371,20 +2732,28 @@ fn daemon_status_file_pid(status_path: &Path) -> Option<u32> {
 }
 
 #[cfg(unix)]
+static DAEMON_TERMINATION_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(unix)]
 extern "C" fn handle_termination_signal(sig: libc::c_int) {
-    // Only async-signal-safe calls below. Anything that might allocate or take
-    // a lock is forbidden. The ownership-aware ShutdownGuard handles normal
-    // unwinding cleanup; signal exits leave stale metadata for the next
-    // status/start command to validate and clear.
-    let msg: &[u8] = b"coven daemon: received termination signal, exiting\n";
+    // Only async-signal-safe work belongs here. AtomicBool uses a lock-free
+    // primitive on Coven's supported Unix targets and write(2) is signal-safe.
+    // No allocation, lock, or destructor runs in the handler itself.
+    DAEMON_TERMINATION_REQUESTED.store(true, Ordering::Release);
+    let msg: &[u8] = b"coven daemon: received termination signal, shutting down\n";
     unsafe {
         libc::write(
             libc::STDERR_FILENO,
             msg.as_ptr() as *const libc::c_void,
             msg.len(),
         );
-        libc::_exit(128 + sig);
     }
+    let _ = sig;
+}
+
+#[cfg(unix)]
+fn daemon_termination_requested() -> bool {
+    DAEMON_TERMINATION_REQUESTED.load(Ordering::Acquire)
 }
 
 #[cfg(unix)]
@@ -2394,6 +2763,7 @@ fn install_termination_signal_handlers(socket_path: &Path, status_path: &Path) -
     let _status_cstr = CString::new(status_path.as_os_str().as_bytes())
         .context("daemon status path contained an interior NUL")?;
 
+    DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
     for sig in [libc::SIGTERM, libc::SIGINT, libc::SIGHUP] {
         // SAFETY: sigaction is the documented POSIX API for installing signal
         // handlers; we pass a zero-initialized struct, our handler pointer,
@@ -2402,10 +2772,8 @@ fn install_termination_signal_handlers(socket_path: &Path, status_path: &Path) -
             let mut sa: libc::sigaction = std::mem::zeroed();
             sa.sa_sigaction = handle_termination_signal as *const () as usize;
             libc::sigemptyset(&mut sa.sa_mask);
-            // Intentionally no SA_RESTART: we want blocking syscalls (accept)
-            // to return EINTR so the loop can exit promptly. The handler
-            // itself calls _exit, so EINTR handling in the loop is academic,
-            // but the principle is right.
+            // Intentionally no SA_RESTART: accept must return EINTR so the
+            // ordinary daemon loop can observe the flag and run cleanup.
             sa.sa_flags = 0;
             if libc::sigaction(sig, &sa, std::ptr::null_mut()) != 0 {
                 return Err(std::io::Error::last_os_error())
@@ -2671,6 +3039,14 @@ pub fn serve_forever(
     // guard would delete the incumbent's status file and unlink its live socket on
     // our way out — re-orphaning the very daemon we declined to replace.
     let unix_listener = bind_api_socket(coven_home)?;
+    // A process-directed signal may be delivered to any daemon thread, not
+    // necessarily the one blocked in accept(2). Nonblocking accept gives the
+    // main loop a bounded opportunity to observe the signal-safe flag even in
+    // that case; the explicit EINTR branch below remains the prompt path when
+    // the accepting thread receives the signal itself.
+    unix_listener
+        .set_nonblocking(true)
+        .context("failed to configure interruptible Unix API listener")?;
     write_status(coven_home, &status)?;
     let _shutdown_guard = ShutdownGuard {
         socket_path: socket_path.clone(),
@@ -2696,36 +3072,87 @@ pub fn serve_forever(
     start_threads_proposal_scheduler(coven_home)?;
     start_store_maintenance_scheduler(coven_home)?;
 
-    if let Some(addr) = tcp_addr {
+    let (tcp_thread, active_tcp_connection) = if let Some(addr) = tcp_addr {
         let tcp_listener = bind_tcp_listener(addr)?;
+        tcp_listener
+            .set_nonblocking(true)
+            .context("failed to configure interruptible TCP API listener")?;
         let tcp_home = coven_home.to_path_buf();
         let tcp_status = status.clone();
         let tcp_runtime = Arc::clone(&runtime);
         let tcp_allowed_hosts: Vec<String> = allowed_hosts.to_vec();
+        let active_tcp_connection = Arc::new(Mutex::new(None::<TcpStream>));
+        let active_tcp_for_thread = Arc::clone(&active_tcp_connection);
         // TCP accept errors are logged and the loop continues — misbehaving
         // network clients should not bring down the daemon. The Unix loop
         // below uses the same strategy: a single malformed local request must
         // not orphan the socket file (see #197).
-        std::thread::Builder::new()
-            .name("coven-tcp-api".into())
-            .spawn(move || loop {
-                if let Err(error) = serve_next_tcp_connection(
-                    &tcp_listener,
-                    &tcp_home,
-                    Some(tcp_status.clone()),
-                    tcp_runtime.as_ref(),
-                    &tcp_allowed_hosts,
-                ) {
-                    // A client hanging up mid-response is expected under SSE +
-                    // polling load; don't log it or throttle the accept loop.
-                    if !is_client_disconnect(&error) {
-                        eprintln!("coven daemon: TCP connection error: {error:#}");
-                        std::thread::sleep(std::time::Duration::from_millis(100));
+        let thread = Some(
+            std::thread::Builder::new()
+                .name("coven-tcp-api".into())
+                .spawn(move || {
+                    while !daemon_termination_requested() {
+                        let stream = match tcp_listener.accept() {
+                            Ok((stream, _)) => stream,
+                            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                                std::thread::sleep(std::time::Duration::from_millis(25));
+                                continue;
+                            }
+                            Err(error) => {
+                                eprintln!("coven daemon: TCP connection error: {error:#}");
+                                std::thread::sleep(std::time::Duration::from_millis(100));
+                                continue;
+                            }
+                        };
+                        if daemon_termination_requested() {
+                            let _ = stream.shutdown(std::net::Shutdown::Both);
+                            break;
+                        }
+                        let cancellation = match stream.try_clone() {
+                            Ok(cancellation) => cancellation,
+                            Err(error) => {
+                                eprintln!(
+                                    "coven daemon: failed to retain TCP shutdown handle: {error:#}"
+                                );
+                                let _ = stream.shutdown(std::net::Shutdown::Both);
+                                continue;
+                            }
+                        };
+                        match active_tcp_for_thread.lock() {
+                            Ok(mut active) => *active = Some(cancellation),
+                            Err(poisoned) => *poisoned.into_inner() = Some(cancellation),
+                        }
+                        let result = serve_accepted_tcp_connection(
+                            stream,
+                            &tcp_home,
+                            Some(tcp_status.clone()),
+                            tcp_runtime.as_ref(),
+                            &tcp_allowed_hosts,
+                        );
+                        match active_tcp_for_thread.lock() {
+                            Ok(mut active) => {
+                                active.take();
+                            }
+                            Err(poisoned) => {
+                                poisoned.into_inner().take();
+                            }
+                        }
+                        if let Err(error) = result {
+                            // A client hanging up mid-response is expected under SSE +
+                            // polling load; don't log or throttle that path.
+                            if !is_client_disconnect(&error) {
+                                eprintln!("coven daemon: TCP connection error: {error:#}");
+                                std::thread::sleep(std::time::Duration::from_millis(100));
+                            }
+                        }
                     }
-                }
-            })
-            .context("failed to spawn TCP API thread")?;
-    }
+                })
+                .context("failed to spawn TCP API thread")?,
+        );
+        (thread, Some(active_tcp_connection))
+    } else {
+        (None, None)
+    };
 
     // Handle each accepted connection on its own thread. The Unix accept loop
     // used to be serial — accept, then run the handler to completion before
@@ -2745,8 +3172,21 @@ pub fn serve_forever(
     let inflight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     use std::sync::atomic::Ordering;
     loop {
+        if daemon_termination_requested() {
+            break;
+        }
         let (stream, _) = match unix_listener.accept() {
             Ok(pair) => pair,
+            Err(error)
+                if error.kind() == std::io::ErrorKind::Interrupted
+                    && daemon_termination_requested() =>
+            {
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(std::time::Duration::from_millis(25));
+                continue;
+            }
             Err(error) => {
                 eprintln!("coven daemon: unix accept error: {error:#}");
                 append_daemon_recovery_log(coven_home, &format!("unix accept error: {error:#}"));
@@ -2806,6 +3246,53 @@ pub fn serve_forever(
                 &format!("failed to spawn unix handler thread: {error:#}"),
             );
         }
+    }
+
+    // Close admission and terminate process trees before waiting on any
+    // transport worker. In particular, a TCP client may have sent only part of
+    // a request and be sitting inside a 30-second socket read; the documented
+    // daemon-stop budget is two seconds, so shutdown must not wait for that
+    // client before it kills live sessions.
+    let runtime_shutdown = runtime
+        .shutdown_all()
+        .context("failed to terminate live sessions during daemon shutdown");
+    let tcp_shutdown = if let Some(tcp_thread) = tcp_thread {
+        let deadline = Instant::now() + Duration::from_millis(250);
+        while !tcp_thread.is_finished() && Instant::now() < deadline {
+            if let Some(active) = active_tcp_connection.as_ref() {
+                cancel_active_tcp_connection(active);
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        if tcp_thread.is_finished() {
+            tcp_thread
+                .join()
+                .map_err(|_| anyhow::anyhow!("TCP API thread panicked during daemon shutdown"))
+        } else {
+            // Dropping JoinHandle detaches only this already-cancelled worker.
+            // The daemon process exits immediately after serve_forever returns,
+            // so it cannot outlive the process or retain live-session ownership.
+            eprintln!(
+                "coven daemon: TCP API worker did not stop within 250 ms; detaching for process exit"
+            );
+            Ok(())
+        }
+    } else {
+        Ok(())
+    };
+    runtime_shutdown?;
+    tcp_shutdown?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn cancel_active_tcp_connection(active: &Mutex<Option<TcpStream>>) {
+    let stream = match active.lock() {
+        Ok(mut active) => active.take(),
+        Err(poisoned) => poisoned.into_inner().take(),
+    };
+    if let Some(stream) = stream {
+        let _ = stream.shutdown(std::net::Shutdown::Both);
     }
 }
 
@@ -2872,13 +3359,18 @@ where
         None
     };
     let response = match local_control.unwrap_or_else(|| {
-        crate::api::handle_request_with_runtime(
+        let authority = match guard {
+            HostGuard::Disabled => crate::api::RequestAuthority::OwnerLocalIpc,
+            HostGuard::Loopback { .. } => crate::api::RequestAuthority::Tcp,
+        };
+        crate::api::handle_request_with_runtime_and_authority(
             method,
             path,
             coven_home,
             status,
             body.as_deref(),
             runtime,
+            authority,
         )
     }) {
         Ok(response) => response,
@@ -3045,6 +3537,9 @@ fn serve_accepted_connection(
     status: Option<DaemonStatus>,
     runtime: &dyn SessionRuntime,
 ) -> Result<()> {
+    stream
+        .set_nonblocking(false)
+        .context("failed to configure accepted Unix API connection")?;
     // Best-effort I/O timeouts so a stalled client doesn't pin the handler
     // thread forever. These are an optimization, not a precondition: on macOS
     // setsockopt(SO_RCVTIMEO) returns EINVAL (os error 22) for some accepted
@@ -3076,6 +3571,7 @@ fn http_reason_phrase(status: u16) -> &'static str {
         201 => "Created",
         202 => "Accepted",
         400 => "Bad Request",
+        403 => "Forbidden",
         404 => "Not Found",
         409 => "Conflict",
         413 => "Payload Too Large",
@@ -3182,12 +3678,111 @@ pub(crate) fn windows_pipe_path(coven_home: &Path) -> PathBuf {
     PathBuf::from(r"\\.\pipe").join(daemon_windows_pipe_name(coven_home))
 }
 
+/// Put the Windows daemon itself in a process-lifetime kill-on-close Job.
+///
+/// Children inherit every non-breakaway parent Job at CreateProcess time.
+/// This supplies birth-time containment for the narrow interval before a
+/// suspended noninteractive child is assigned to its per-session Job. The
+/// handle is intentionally retained by the process until kernel teardown; an
+/// abrupt `TerminateProcess` from `daemon stop` then closes it and kills every
+/// inherited descendant, while the per-session Job remains the checked,
+/// explicit cancellation owner during normal operation.
+///
+/// This Job is a required startup invariant, not an optional backstop. The
+/// per-session Job becomes the normal owner only after attachment, so running
+/// without the daemon Job would reopen a birth-to-attachment interval where an
+/// abrupt daemon exit could orphan the suspended child. Creation,
+/// configuration, or assignment failure therefore aborts daemon startup
+/// instead of continuing with degraded containment.
+#[cfg(windows)]
+fn install_daemon_lifetime_job() -> Result<()> {
+    use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+
+    install_daemon_lifetime_job_with(|job, process| {
+        // SAFETY: both handles are supplied by the checked installer below.
+        if unsafe { AssignProcessToJobObject(job, process) } == 0 {
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    })
+}
+
+#[cfg(windows)]
+fn install_daemon_lifetime_job_with(
+    assign_process: impl FnOnce(
+        windows_sys::Win32::Foundation::HANDLE,
+        windows_sys::Win32::Foundation::HANDLE,
+    ) -> std::io::Result<()>,
+) -> Result<()> {
+    use std::mem::size_of;
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
+        System::{
+            JobObjects::{
+                CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            },
+            Threading::GetCurrentProcess,
+        },
+    };
+
+    unsafe {
+        let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+        anyhow::ensure!(
+            job != INVALID_HANDLE_VALUE && !job.is_null(),
+            "failed to create daemon lifetime Job: {}",
+            std::io::Error::last_os_error()
+        );
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        if SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &limits as *const _ as *const std::ffi::c_void,
+            size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+        ) == 0
+        {
+            let error = std::io::Error::last_os_error();
+            CloseHandle(job);
+            return Err(error).context("failed to configure daemon lifetime Job");
+        }
+        if let Err(error) = assign_process(job, GetCurrentProcess()) {
+            CloseHandle(job);
+            return Err(error).context(
+                "failed to assign Coven daemon to its lifetime Job; the parent Job must permit modern nested jobs",
+            );
+        }
+        // HANDLE is Copy and has no Rust destructor. Deliberately do not call
+        // CloseHandle: kernel process teardown is the lifetime boundary this
+        // Job is designed to enforce.
+    }
+    Ok(())
+}
+
 #[cfg(windows)]
 pub fn serve_forever(
     coven_home: &Path,
     started_at: String,
     tcp_addr: Option<&str>,
     allowed_hosts: &[String],
+) -> Result<()> {
+    serve_forever_with_lifetime_job_installer(
+        coven_home,
+        started_at,
+        tcp_addr,
+        allowed_hosts,
+        install_daemon_lifetime_job,
+    )
+}
+
+#[cfg(windows)]
+fn serve_forever_with_lifetime_job_installer(
+    coven_home: &Path,
+    started_at: String,
+    tcp_addr: Option<&str>,
+    allowed_hosts: &[String],
+    install_lifetime_job: impl FnOnce() -> Result<()>,
 ) -> Result<()> {
     use interprocess::{
         local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
@@ -3202,6 +3797,7 @@ pub fn serve_forever(
     let _ = allowed_hosts; // only meaningful on the (Unix) TCP transport
 
     let _serve_lock = acquire_serve_lock(coven_home)?;
+    install_lifetime_job()?;
     let status = DaemonStatus {
         pid: std::process::id(),
         started_at: started_at.clone(),
@@ -3336,6 +3932,52 @@ mod tests {
         assert_eq!(status["hubId"], hub_id);
         assert_eq!(status["nodesTotal"], 0);
         assert_eq!(status["nodesAvailable"], 0);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn termination_signal_requests_graceful_cleanup_instead_of_immediate_exit() {
+        DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
+        handle_termination_signal(libc::SIGTERM);
+        assert!(daemon_termination_requested());
+        DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_daemon_startup_fails_closed_when_lifetime_job_assignment_fails() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let error = serve_forever_with_lifetime_job_installer(
+            temp_dir.path(),
+            "2026-08-11T00:00:00Z".to_string(),
+            None,
+            &[],
+            || {
+                install_daemon_lifetime_job_with(|_, _| {
+                    Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "injected assignment refusal",
+                    ))
+                })
+            },
+        )
+        .expect_err("daemon startup must reject a missing lifetime Job");
+
+        let diagnostic = format!("{error:#}");
+        assert!(
+            diagnostic.contains("failed to assign Coven daemon to its lifetime Job"),
+            "{diagnostic}"
+        );
+        assert!(
+            diagnostic.contains("injected assignment refusal"),
+            "{diagnostic}"
+        );
+        assert_eq!(
+            read_status(temp_dir.path())?,
+            None,
+            "failed lifetime Job assignment published daemon readiness"
+        );
         Ok(())
     }
 
@@ -3833,6 +4475,7 @@ mod tests {
             harness: "codex".to_string(),
             model: None,
             launch_mode: crate::harness::HarnessLaunchMode::Stream,
+            launch_policy: None,
             prompt: "hello".to_string(),
             title: "stream codex (should be rejected)".to_string(),
             conversation: None,
@@ -4109,6 +4752,643 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn runtime_shutdown_kills_all_handles_and_refuses_new_registrations() -> Result<()> {
+        let runtime = LiveSessionRuntime::default();
+        let first = Arc::new(Mutex::new(false));
+        let second = Arc::new(Mutex::new(false));
+        for (id, killed) in [
+            ("first", Arc::clone(&first)),
+            ("second", Arc::clone(&second)),
+        ] {
+            runtime.register(
+                id.to_string(),
+                Box::new(SharedBuffer::default()),
+                Box::new(RecordingKiller { killed }),
+            )?;
+        }
+
+        runtime.shutdown_all()?;
+
+        assert!(*first.lock().unwrap());
+        assert!(*second.lock().unwrap());
+        let late_killed = Arc::new(Mutex::new(false));
+        let late = runtime
+            .register(
+                "late".to_string(),
+                Box::new(SharedBuffer::default()),
+                Box::new(RecordingKiller {
+                    killed: Arc::clone(&late_killed),
+                }),
+            )
+            .expect_err("shutdown must close admission");
+        assert!(late.to_string().contains("shutting down"), "{late:#}");
+        assert!(
+            *late_killed.lock().unwrap(),
+            "pre-lock shutdown rejection must explicitly invoke the supplied PTY killer"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn post_lock_shutdown_rejection_kills_without_holding_registry_lock() -> Result<()> {
+        let runtime = LiveSessionRuntime::default();
+        runtime.shutting_down.store(true, Ordering::Release);
+        let killed = Arc::new(Mutex::new(false));
+        let registry_was_unlocked = Arc::new(Mutex::new(false));
+        let error = runtime
+            .register_kind_after_initial_shutdown_check(
+                "late-after-check".to_string(),
+                LiveSessionKind::Pty,
+                Box::new(SharedBuffer::default()),
+                Box::new(RegistryObservingKiller {
+                    sessions: Arc::downgrade(&runtime.sessions),
+                    killed: Arc::clone(&killed),
+                    registry_was_unlocked: Arc::clone(&registry_was_unlocked),
+                    fail_message: None,
+                }),
+                Arc::new(LiveSessionRegistration::new(None)),
+            )
+            .expect_err("shutdown observed under the registry lock must reject admission");
+
+        assert!(error.to_string().contains("shutting down"), "{error:#}");
+        assert!(*killed.lock().unwrap());
+        assert!(
+            *registry_was_unlocked.lock().unwrap(),
+            "late-registration cleanup ran while holding the registry lock"
+        );
+        assert!(runtime.sessions.lock().unwrap().is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn late_registration_reports_shutdown_and_cleanup_failure() -> Result<()> {
+        let runtime = LiveSessionRuntime::default();
+        runtime.shutting_down.store(true, Ordering::Release);
+        let error = runtime
+            .register(
+                "late-cleanup-failure".to_string(),
+                Box::new(SharedBuffer::default()),
+                Box::new(FailingKiller("synthetic cleanup failure")),
+            )
+            .expect_err("late registration must fail closed when cleanup also fails");
+        let diagnostic = format!("{error:#}");
+        assert!(diagnostic.contains("shutting down"), "{diagnostic}");
+        assert!(
+            diagnostic.contains("failed to terminate the rejected session process tree"),
+            "{diagnostic}"
+        );
+        assert!(
+            diagnostic.contains("synthetic cleanup failure"),
+            "{diagnostic}"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn daemon_shutdown_descendant_fixture(
+        build_dir: &Path,
+        pid_file: &Path,
+    ) -> pty_runner::HarnessCommand {
+        pty_runner::HarnessCommand::fixture(
+            "/bin/sh",
+            vec![
+                "-c".to_string(),
+                "sleep 120 </dev/null >/dev/null 2>&1 & echo $! > \"$1\"; wait".to_string(),
+                "daemon-shutdown-descendant".to_string(),
+                pid_file.to_string_lossy().into_owned(),
+            ],
+            build_dir.to_path_buf(),
+        )
+    }
+
+    #[cfg(windows)]
+    fn daemon_shutdown_descendant_fixture(
+        build_dir: &Path,
+        pid_file: &Path,
+    ) -> pty_runner::HarnessCommand {
+        let probe = pty_runner::windows_console_probe_command(build_dir)
+            .expect("compile native Windows process probe");
+        pty_runner::HarnessCommand::fixture(
+            probe.program().to_string(),
+            vec![
+                "--spawn-descendant".to_string(),
+                pid_file.to_string_lossy().into_owned(),
+            ],
+            probe.cwd().to_path_buf(),
+        )
+    }
+
+    #[cfg(any(unix, windows))]
+    fn await_daemon_shutdown_descendant_pid(pid_file: &Path) -> Result<u32> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(raw) = std::fs::read_to_string(pid_file) {
+                if let Ok(pid) = raw.trim().parse::<u32>() {
+                    return Ok(pid);
+                }
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "piped fixture did not publish its descendant pid"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[cfg(unix)]
+    fn await_daemon_shutdown_descendant_exit(pid: u32, context: &str) -> Result<()> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+            if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+                return Ok(());
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "{context} left descendant {pid} running"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[cfg(windows)]
+    fn await_daemon_shutdown_descendant_exit(pid: u32, context: &str) -> Result<()> {
+        anyhow::ensure!(
+            wait_for_windows_process_exit(pid, Duration::from_secs(10)),
+            "{context} left descendant {pid} running"
+        );
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn dropping_runtime_terminates_registered_piped_process_tree() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("descendant.pid");
+        let command = daemon_shutdown_descendant_fixture(temp_dir.path(), &pid_file);
+        let (exit_tx, exit_rx) = std::sync::mpsc::channel();
+        let observer = pty_runner::DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+        let descendant_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
+        let runtime = LiveSessionRuntime::default();
+        piped.activate(|input, process_tree| {
+            runtime.register("piped".to_string(), input, Box::new(process_tree))
+        })?;
+
+        drop(runtime);
+        let result = exit_rx
+            .try_recv()
+            .context("runtime drop returned before the piped exit callback completed")?;
+        assert_eq!(result.status, "failed", "{result:?}");
+        await_daemon_shutdown_descendant_exit(descendant_pid, "runtime drop")?;
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn shutdown_admission_failure_drops_already_spawned_piped_process_tree() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("descendant.pid");
+        let mut command = daemon_shutdown_descendant_fixture(temp_dir.path(), &pid_file);
+        command.set_stdin_prompt_for_test(vec![b'x'; 1024 * 1024]);
+        let (exit_tx, exit_rx) = std::sync::mpsc::channel();
+        let observer = pty_runner::DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+        let descendant_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
+        let runtime = LiveSessionRuntime::default();
+        runtime.shutdown_all()?;
+
+        let error = piped
+            .activate(|input, process_tree| {
+                runtime.register("late-piped".to_string(), input, Box::new(process_tree))
+            })
+            .expect_err("shutdown admission must reject a late spawned tree");
+        assert!(error.to_string().contains("shutting down"), "{error:#}");
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        assert_eq!(result.status, "failed", "{result:?}");
+        await_daemon_shutdown_descendant_exit(descendant_pid, "rejected registration")?;
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn runtime_kill_interrupts_in_flight_piped_prompt_within_stop_budget() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("never-read.pid");
+        let command = pty_runner::piped_prompt_probe_command(
+            temp_dir.path(),
+            "never-read",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (exit_tx, exit_rx) = std::sync::mpsc::channel();
+        let observer = pty_runner::DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+        let child_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
+        let runtime = Arc::new(LiveSessionRuntime::default());
+        let activation_runtime = Arc::clone(&runtime);
+        let (activation_tx, activation_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = piped.activate(|input, process_tree| {
+                activation_runtime.register(
+                    "blocked-prompt".to_string(),
+                    input,
+                    Box::new(process_tree),
+                )
+            });
+            let _ = activation_tx.send(result);
+        });
+        let registration_deadline = Instant::now() + Duration::from_secs(2);
+        while !runtime
+            .sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains_key("blocked-prompt")
+        {
+            anyhow::ensure!(
+                Instant::now() < registration_deadline,
+                "piped prompt was not registered before its writer blocked"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+
+        let started = Instant::now();
+        SessionRuntime::kill_session(runtime.as_ref(), "blocked-prompt")?;
+        assert!(started.elapsed() < Duration::from_secs(2));
+        let activation = activation_rx.recv_timeout(Duration::from_secs(2))?;
+        let error = activation.expect_err("cancellation must interrupt prompt delivery");
+        let diagnostic = format!("{error:#}");
+        assert!(
+            diagnostic.contains("terminated") || diagnostic.contains("failed writing"),
+            "{diagnostic}"
+        );
+        let exit = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        assert_eq!(exit.status, "failed", "{exit:?}");
+        await_daemon_shutdown_descendant_exit(child_pid, "prompt cancellation")?;
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn concurrent_api_kill_during_prompt_delivery_preserves_killed_status() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+        let pid_file = temp_dir.path().join("api-cancel-never-read.pid");
+        let command = pty_runner::piped_prompt_probe_command(
+            temp_dir.path(),
+            "never-read",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (launched_tx, launched_rx) = std::sync::mpsc::channel();
+        let runtime = Arc::new(PromptCancellationApiRuntime {
+            inner: LiveSessionRuntime::with_coven_home(temp_dir.path().to_path_buf()),
+            command: Mutex::new(Some(command)),
+            launched: Mutex::new(Some(launched_tx)),
+            await_root_exit_before_activate: None,
+        });
+        let body = serde_json::json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "launchMode": "nonInteractive",
+            "prompt": "cancel this blocked delivery"
+        })
+        .to_string();
+        let launch_runtime = Arc::clone(&runtime);
+        let launch_home = temp_dir.path().to_path_buf();
+        let (response_tx, response_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let response = crate::api::handle_request_with_runtime(
+                "POST",
+                "/sessions",
+                &launch_home,
+                None,
+                Some(&body),
+                launch_runtime.as_ref(),
+            );
+            let _ = response_tx.send(response);
+        });
+
+        let session_id = launched_rx.recv_timeout(Duration::from_secs(2))?;
+        let child_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
+        let registration_deadline = Instant::now() + Duration::from_secs(2);
+        while !runtime
+            .inner
+            .sessions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .contains_key(&session_id)
+        {
+            anyhow::ensure!(
+                Instant::now() < registration_deadline,
+                "API launch did not register before prompt delivery blocked"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let kill = crate::api::handle_request_with_runtime(
+            "POST",
+            &format!("/sessions/{session_id}/kill"),
+            temp_dir.path(),
+            None,
+            None,
+            runtime.as_ref(),
+        )?;
+        assert_eq!(kill.status, 202, "{}", kill.body);
+        let launch = response_rx.recv_timeout(Duration::from_secs(2))??;
+        assert_eq!(launch.status, 500, "{}", launch.body);
+        let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME))?;
+        let row = crate::store::get_session(&conn, &session_id)?
+            .context("cancelled API launch row remains present")?;
+        assert_eq!(row.status, "killed");
+        await_daemon_shutdown_descendant_exit(child_pid, "concurrent API cancellation")?;
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn api_prompt_delivery_failure_wins_over_successful_root_exit() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+        let pid_file = temp_dir.path().join("api-exit-zero-closed-stdin.pid");
+        let command = pty_runner::piped_prompt_probe_command(
+            temp_dir.path(),
+            "exit-zero-close-stdin",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (launched_tx, launched_rx) = std::sync::mpsc::channel();
+        let runtime = PromptCancellationApiRuntime {
+            inner: LiveSessionRuntime::with_coven_home(temp_dir.path().to_path_buf()),
+            command: Mutex::new(Some(command)),
+            launched: Mutex::new(Some(launched_tx)),
+            await_root_exit_before_activate: Some(pid_file.clone()),
+        };
+        let body = serde_json::json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "launchMode": "nonInteractive",
+            "prompt": "this prompt is replaced by the pipe-capacity fixture payload"
+        })
+        .to_string();
+
+        let response = crate::api::handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+        assert_eq!(response.status, 500, "{}", response.body);
+        assert!(response.body.contains("launch_failed"), "{}", response.body);
+        let session_id = launched_rx.recv_timeout(Duration::from_secs(2))?;
+        let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME))?;
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let (row, exit_payload) = loop {
+            let row = crate::store::get_session(&conn, &session_id)?
+                .context("failed API launch row remains present")?;
+            let exit_payload = crate::store::list_events(&conn, &session_id)?
+                .into_iter()
+                .find(|event| event.kind == "exit")
+                .map(|event| event.payload_json);
+            if let Some(exit_payload) = exit_payload {
+                break (row, exit_payload);
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "failed API launch never persisted its exit event"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        };
+
+        assert_eq!(row.status, "failed", "{row:?}");
+        let exit_payload: Value = serde_json::from_str(&exit_payload)?;
+        assert_eq!(exit_payload["status"], "failed", "{exit_payload}");
+        assert_eq!(exit_payload["exitCode"], 0, "{exit_payload}");
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_kill_returns_only_after_descendant_output_is_quiescent() -> Result<()> {
+        use std::sync::atomic::AtomicUsize;
+
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("output-descendant.pid");
+        let command = pty_runner::piped_prompt_probe_command(
+            temp_dir.path(),
+            "descendant-output",
+            &pid_file.to_string_lossy(),
+            None,
+            Vec::new(),
+        )?;
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observer_count = Arc::clone(&observed);
+        let observer = pty_runner::DetachedPtyObserver {
+            on_output: Box::new(move |chunk| {
+                observer_count.fetch_add(chunk.len(), Ordering::AcqRel);
+            }),
+            on_exit: Box::new(|_| {}),
+        };
+        let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+        let descendant_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
+        let runtime = LiveSessionRuntime::default();
+        piped.activate(|input, process_tree| {
+            runtime.register(
+                "output-descendant".to_string(),
+                input,
+                Box::new(process_tree),
+            )
+        })?;
+
+        let output_deadline = Instant::now() + Duration::from_secs(2);
+        while observed.load(Ordering::Acquire) == 0 {
+            anyhow::ensure!(
+                Instant::now() < output_deadline,
+                "output descendant did not emit its readiness output"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let started = Instant::now();
+        SessionRuntime::kill_session(&runtime, "output-descendant")?;
+        assert!(started.elapsed() < Duration::from_secs(2));
+        let count_at_return = observed.load(Ordering::Acquire);
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(
+            observed.load(Ordering::Acquire),
+            count_at_return,
+            "descendant output was observed after cancellation returned"
+        );
+        await_daemon_shutdown_descendant_exit(descendant_pid, "quiescent cancellation")?;
+
+        let already_gone = SessionRuntime::kill_session(&runtime, "output-descendant")
+            .expect_err("a completed cancellation must be idempotently not-live");
+        assert!(already_gone.downcast_ref::<NotLiveError>().is_some());
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn shutdown_bounds_pre_registration_launch_and_kills_its_exact_tree() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("pre-registration.pid");
+        let command = pty_runner::piped_prompt_probe_command(
+            temp_dir.path(),
+            "never-read",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (exit_tx, exit_rx) = std::sync::mpsc::channel();
+        let observer = pty_runner::DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let runtime = Arc::new(LiveSessionRuntime::default());
+        let admission = runtime.begin_launch()?;
+        let (piped, _provisional_killer) = admission.spawn_owned(|publish| {
+            let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+            let killer: Box<dyn RuntimeKiller> = Box::new(piped.cancellation_handle());
+            publish(killer)?;
+            Ok(piped)
+        })?;
+        let child_pid = await_daemon_shutdown_descendant_pid(&pid_file)?;
+        let activation_runtime = Arc::clone(&runtime);
+        let (at_registration_tx, at_registration_rx) = std::sync::mpsc::channel();
+        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+        let (activation_tx, activation_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result = piped.activate(|input, process_tree| {
+                let _ = at_registration_tx.send(());
+                let _ = continue_rx.recv();
+                let registered = activation_runtime.register(
+                    "pre-registration".to_string(),
+                    input,
+                    Box::new(process_tree),
+                );
+                admission.release();
+                registered
+            });
+            let _ = activation_tx.send(result);
+        });
+        at_registration_rx.recv_timeout(Duration::from_secs(2))?;
+
+        let shutdown_runtime = Arc::clone(&runtime);
+        let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = shutdown_tx.send(shutdown_runtime.shutdown_all());
+        });
+        shutdown_rx.recv_timeout(Duration::from_secs(2))??;
+        await_daemon_shutdown_descendant_exit(child_pid, "bounded pre-registration shutdown")?;
+        continue_tx.send(())?;
+        let activation = activation_rx.recv_timeout(Duration::from_secs(2))?;
+        let error = activation.expect_err("closed admission must reject the pending launch");
+        assert!(error.to_string().contains("shutting down"), "{error:#}");
+        let exit = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        assert_eq!(exit.status, "failed", "{exit:?}");
+        Ok(())
+    }
+
+    #[test]
+    fn shutdown_budget_does_not_wait_for_spawn_closure_after_ownership_publication() -> Result<()> {
+        let runtime = Arc::new(LiveSessionRuntime::default());
+        let admission = runtime.begin_launch()?;
+        let killed = Arc::new(Mutex::new(false));
+        let (published_tx, published_rx) = std::sync::mpsc::channel();
+        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+        let killed_in_spawn = Arc::clone(&killed);
+        let spawn_thread = std::thread::spawn(move || {
+            admission.spawn_owned(|publish| {
+                publish(Box::new(RecordingKiller {
+                    killed: killed_in_spawn,
+                }))?;
+                let _ = published_tx.send(());
+                let _ = continue_rx.recv();
+                Ok(())
+            })
+        });
+        published_rx.recv_timeout(Duration::from_secs(1))?;
+
+        let started = Instant::now();
+        runtime.shutdown_all()?;
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "shutdown exceeded its external stop budget"
+        );
+        assert!(*killed.lock().unwrap());
+        continue_tx.send(())?;
+        let _ = spawn_thread.join().expect("spawn closure thread")?;
+        Ok(())
+    }
+
+    #[test]
+    fn shutdown_budget_closes_gate_while_spawn_closure_is_stalled_before_publication() -> Result<()>
+    {
+        let runtime = Arc::new(LiveSessionRuntime::default());
+        let admission = runtime.begin_launch()?;
+        let killed = Arc::new(Mutex::new(false));
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+        let killed_in_spawn = Arc::clone(&killed);
+        let spawn_thread = std::thread::spawn(move || {
+            admission.spawn_owned(|publish| {
+                let _ = entered_tx.send(());
+                let _ = continue_rx.recv();
+                publish(Box::new(RecordingKiller {
+                    killed: killed_in_spawn,
+                }))?;
+                Ok(())
+            })
+        });
+        entered_rx.recv_timeout(Duration::from_secs(1))?;
+
+        let started = Instant::now();
+        runtime.shutdown_all()?;
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "shutdown waited on a pre-publication spawn closure"
+        );
+        assert!(!*killed.lock().unwrap());
+
+        continue_tx.send(())?;
+        let error = match spawn_thread.join().expect("spawn closure thread") {
+            Ok(_) => anyhow::bail!("a closed launch gate accepted late ownership publication"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("shutting down"), "{error:#}");
+        assert!(
+            *killed.lock().unwrap(),
+            "late publication did not invoke the exact supplied killer"
+        );
+        Ok(())
+    }
+
     #[derive(Clone, Default)]
     struct SharedBuffer {
         data: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
@@ -4140,6 +5420,131 @@ mod tests {
         fn kill(&mut self) -> Result<()> {
             *self.killed.lock().unwrap() = true;
             Ok(())
+        }
+    }
+
+    struct RegistryObservingKiller {
+        sessions: Weak<Mutex<HashMap<String, LiveSessionHandle>>>,
+        killed: Arc<Mutex<bool>>,
+        registry_was_unlocked: Arc<Mutex<bool>>,
+        fail_message: Option<&'static str>,
+    }
+
+    impl RuntimeKiller for RegistryObservingKiller {
+        fn kill(&mut self) -> Result<()> {
+            *self.killed.lock().unwrap() = true;
+            let unlocked = self
+                .sessions
+                .upgrade()
+                .is_some_and(|sessions| sessions.try_lock().is_ok());
+            *self.registry_was_unlocked.lock().unwrap() = unlocked;
+            if let Some(message) = self.fail_message {
+                anyhow::bail!(message);
+            }
+            Ok(())
+        }
+    }
+
+    struct FailingKiller(&'static str);
+
+    impl RuntimeKiller for FailingKiller {
+        fn kill(&mut self) -> Result<()> {
+            anyhow::bail!(self.0)
+        }
+    }
+
+    struct CountingFailingKiller {
+        attempts: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl RuntimeKiller for CountingFailingKiller {
+        fn kill(&mut self) -> Result<()> {
+            self.attempts.fetch_add(1, Ordering::AcqRel);
+            anyhow::bail!("quiescence proof timed out")
+        }
+    }
+
+    #[cfg(any(unix, windows))]
+    struct PromptCancellationApiRuntime {
+        inner: LiveSessionRuntime,
+        command: Mutex<Option<pty_runner::HarnessCommand>>,
+        launched: Mutex<Option<std::sync::mpsc::Sender<String>>>,
+        await_root_exit_before_activate: Option<PathBuf>,
+    }
+
+    #[cfg(any(unix, windows))]
+    impl SessionRuntime for PromptCancellationApiRuntime {
+        fn launch_session(&self, launch: &crate::api::SessionLaunch) -> Result<()> {
+            if let Some(sender) = self.launched.lock().unwrap().take() {
+                let _ = sender.send(launch.id.clone());
+            }
+            let command = self
+                .command
+                .lock()
+                .unwrap()
+                .take()
+                .context("prompt-cancellation fixture command was already consumed")?;
+            let (observer, registration) = self.inner.observer_for_session(launch.id.clone());
+            let piped = pty_runner::spawn_piped_with_observer(&command, Some(observer), false)?;
+            if let Some(pid_file) = &self.await_root_exit_before_activate {
+                let pid = await_daemon_shutdown_descendant_pid(pid_file)?;
+                await_daemon_shutdown_descendant_exit(pid, "successful pre-delivery root exit")?;
+            }
+            piped.activate(|input, process_tree| {
+                self.inner.register_kind_with_registration(
+                    launch.id.clone(),
+                    LiveSessionKind::Pty,
+                    input,
+                    Box::new(process_tree),
+                    registration,
+                )
+            })
+        }
+
+        fn send_input(&self, session_id: &str, payload: &Value) -> Result<()> {
+            SessionRuntime::send_input(&self.inner, session_id, payload)
+        }
+
+        fn kill_session(&self, session_id: &str) -> Result<()> {
+            SessionRuntime::kill_session(&self.inner, session_id)
+        }
+
+        fn with_session_event_boundary(
+            &self,
+            session_id: &str,
+            kind: &str,
+            payload: &Value,
+            action: &mut dyn FnMut() -> crate::api::SessionEventBoundaryResult,
+        ) -> Option<crate::api::SessionEventBoundaryResult> {
+            SessionRuntime::with_session_event_boundary(
+                &self.inner,
+                session_id,
+                kind,
+                payload,
+                action,
+            )
+        }
+
+        fn record_session_event(
+            &self,
+            session_id: &str,
+            kind: &str,
+            payload: &Value,
+        ) -> Option<Result<()>> {
+            SessionRuntime::record_session_event(&self.inner, session_id, kind, payload)
+        }
+
+        fn can_record_session_event(
+            &self,
+            session_id: &str,
+            kind: &str,
+            payload: &Value,
+        ) -> Option<Result<bool>> {
+            SessionRuntime::can_record_session_event(&self.inner, session_id, kind, payload)
+        }
+
+        fn event_writer_health(&self) -> Option<crate::event_writer::EventWriterHealth> {
+            SessionRuntime::event_writer_health(&self.inner)
         }
     }
 
@@ -4326,6 +5731,32 @@ mod tests {
     }
 
     #[test]
+    fn failed_kill_retains_exact_handle_for_retry() {
+        let runtime = LiveSessionRuntime::default();
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        runtime
+            .register(
+                "retry-kill".to_string(),
+                Box::new(SharedBuffer::default()),
+                Box::new(CountingFailingKiller {
+                    attempts: Arc::clone(&attempts),
+                }),
+            )
+            .unwrap();
+
+        for expected_attempts in 1..=2 {
+            let error = SessionRuntime::kill_session(&runtime, "retry-kill")
+                .expect_err("failing quiescence proof remains retryable");
+            assert!(error.to_string().contains("quiescence proof"));
+            assert_eq!(attempts.load(Ordering::Acquire), expected_attempts);
+            assert!(
+                runtime.sessions.lock().unwrap().contains_key("retry-kill"),
+                "failed kill discarded the exact ownership handle"
+            );
+        }
+    }
+
+    #[test]
     fn kill_event_commits_before_concurrent_exit() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let conn = crate::store::open_store(&temp_dir.path().join(crate::STORE_FILE_NAME))?;
@@ -4402,7 +5833,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn handle_http_stream_processes_health_request() {
+    fn owner_local_ipc_health_advertises_session_launch_policy() {
         use crate::api::NoopSessionRuntime;
         use std::io::Cursor;
         let temp = tempfile::tempdir().expect("tempdir");
@@ -4424,6 +5855,10 @@ mod tests {
         let response = String::from_utf8(output).expect("utf8");
         assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
         assert!(response.contains("\"apiVersion\""), "got: {response}");
+        assert!(
+            response.contains(r#""sessionLaunchPolicy":true"#),
+            "got: {response}"
+        );
     }
 
     #[cfg(unix)]
@@ -4705,7 +6140,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn bind_tcp_listener_serves_health_over_tcp() {
+    fn tcp_health_does_not_advertise_owner_only_session_launch_policy() {
         use crate::api::NoopSessionRuntime;
         use std::io::{Read, Write};
         use std::net::TcpStream;
@@ -4736,6 +6171,84 @@ mod tests {
 
         assert!(response.starts_with("HTTP/1.1 200 OK"), "got: {response}");
         assert!(response.contains("\"apiVersion\""), "got: {response}");
+        assert!(
+            response.contains(r#""sessionLaunchPolicy":false"#),
+            "got: {response}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn tcp_rejects_launch_policy_before_session_row_or_runtime_launch() -> Result<()> {
+        use std::io::{Read, Write};
+        use std::net::TcpStream;
+        use std::sync::atomic::AtomicBool;
+        use std::thread;
+
+        struct LaunchDetectingRuntime(Arc<AtomicBool>);
+        impl SessionRuntime for LaunchDetectingRuntime {
+            fn launch_session(&self, _launch: &crate::api::SessionLaunch) -> Result<()> {
+                self.0.store(true, Ordering::Release);
+                Ok(())
+            }
+
+            fn send_input(&self, _session_id: &str, _payload: &Value) -> Result<()> {
+                Ok(())
+            }
+
+            fn kill_session(&self, _session_id: &str) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let temp = tempfile::tempdir()?;
+        ensure_private_coven_home(temp.path())?;
+        let project_root = temp.path().join("project");
+        std::fs::create_dir_all(&project_root)?;
+        let body = serde_json::json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "launchMode": "nonInteractive",
+            "launchPolicy": {
+                "approval": "never",
+                "sandbox": "workspace-write",
+                "addDirs": []
+            },
+            "prompt": "write artifacts/primary.md"
+        })
+        .to_string();
+        let request = format!(
+            "POST /api/v1/sessions HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let listener = bind_tcp_listener("127.0.0.1:0")?;
+        let addr = listener.local_addr()?;
+        let coven_home = temp.path().to_path_buf();
+        let launched = Arc::new(AtomicBool::new(false));
+        let launched_for_server = Arc::clone(&launched);
+        let server = thread::spawn(move || {
+            let runtime = LaunchDetectingRuntime(launched_for_server);
+            serve_next_tcp_connection(&listener, &coven_home, None, &runtime, &[])
+        });
+
+        let mut client = TcpStream::connect(addr)?;
+        client.set_read_timeout(Some(Duration::from_secs(5)))?;
+        client.write_all(request.as_bytes())?;
+        let mut response = String::new();
+        client.read_to_string(&mut response)?;
+        server.join().expect("server thread")?;
+
+        assert!(
+            response.starts_with("HTTP/1.1 403 Forbidden"),
+            "got: {response}"
+        );
+        assert!(response.contains(r#""code":"forbidden""#), "{response}");
+        assert!(response.contains("owner-gated local IPC"), "{response}");
+        assert!(!launched.load(Ordering::Acquire));
+        let conn = crate::store::open_store(&temp.path().join(crate::STORE_FILE_NAME))?;
+        assert!(crate::store::list_sessions(&conn)?.is_empty());
+        Ok(())
     }
 
     #[cfg(unix)]

--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -56,6 +56,23 @@ pub enum HarnessLaunchMode {
     Stream,
 }
 
+/// Exact, daemon-authorized launch policy for unattended Codex work.
+///
+/// This is deliberately not a general-purpose permission enum. The local API
+/// accepts only this one policy today, and the harness builder independently
+/// enforces its Codex/non-interactive boundary so another caller cannot use it
+/// to broaden an interactive or unsupported launch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LaunchPolicy {
+    pub add_dirs: Vec<String>,
+}
+
+impl LaunchPolicy {
+    pub fn unattended_workspace_write(add_dirs: Vec<String>) -> Self {
+        Self { add_dirs }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HarnessSpeed {
     Fast,
@@ -134,6 +151,11 @@ pub struct HarnessLaunchOptions<'a> {
     /// harnesses that declare none make the flag a warned no-op. Blank
     /// entries are skipped. A shared slice keeps the struct `Copy`.
     pub add_dirs: &'a [String],
+    /// Explicit daemon-authorized unattended policy. This is separate from
+    /// the interactive composer's `permission` option: it always maps to
+    /// Codex approval-never plus workspace-write, and is rejected for every
+    /// other harness or launch mode.
+    pub launch_policy: Option<&'a LaunchPolicy>,
 }
 
 impl<'a> HarnessLaunchOptions<'a> {
@@ -1911,6 +1933,7 @@ fn command_parts_with_specs(
     // ahead of the prompt positional, mirroring model selection. Harnesses
     // that declare no add-dir mechanism yield no args (the run layer warns).
     let add_dir_args: Vec<String> = spec.add_dir_args(options.add_dirs);
+    let launch_policy_args = launch_policy_args(harness_id, mode, options)?;
     let launch_option_args = launch_option_args(harness_id, options);
 
     // Resolve effective prompt: inject familiar identity preamble when present.
@@ -1935,16 +1958,22 @@ fn command_parts_with_specs(
                 args.insert(0, flag.to_string());
             }
             return Ok((
-                program,
+                program.clone(),
                 with_claude_permission_flags_enabled(
                     harness_id,
-                    sanitize_argv_for_platform(prepend_launch_args(
-                        &model_args,
-                        &sandbox_args,
-                        &add_dir_args,
-                        &launch_option_args,
-                        args,
-                    )),
+                    sanitize_argv_for_program(
+                        harness_id,
+                        mode,
+                        &program,
+                        prepend_launch_args(
+                            &model_args,
+                            &sandbox_args,
+                            &add_dir_args,
+                            &launch_policy_args,
+                            &launch_option_args,
+                            args,
+                        ),
+                    ),
                     claude_bypass_enabled,
                 ),
             ));
@@ -1955,16 +1984,22 @@ fn command_parts_with_specs(
             add_codex_exec_json_flag(&spec, &mut args)?;
         }
         return Ok((
-            program,
+            program.clone(),
             with_claude_permission_flags_enabled(
                 harness_id,
-                sanitize_argv_for_platform(prepend_launch_args(
-                    &model_args,
-                    &sandbox_args,
-                    &add_dir_args,
-                    &launch_option_args,
-                    args,
-                )),
+                sanitize_argv_for_program(
+                    harness_id,
+                    mode,
+                    &program,
+                    prepend_launch_args(
+                        &model_args,
+                        &sandbox_args,
+                        &add_dir_args,
+                        &launch_policy_args,
+                        &launch_option_args,
+                        args,
+                    ),
+                ),
                 claude_bypass_enabled,
             ),
         ));
@@ -1980,23 +2015,29 @@ fn command_parts_with_specs(
                 args.insert(0, f.identity_preamble());
                 args.insert(0, flag.to_string());
             }
-            let args = sanitize_argv_for_platform(prepend_launch_args(
-                &model_args,
-                &sandbox_args,
-                &add_dir_args,
-                &launch_option_args,
-                // The prompt rides behind the harness's prompt flag when it
-                // declares one (continuity launches are always
-                // non-interactive, so the shared `prompt_flag` applies), or
-                // behind `--` for positional-prompt harnesses — user data
-                // must not parse as harness flags either way.
-                args.into_iter()
-                    .chain(match spec.prompt_flag.as_deref() {
-                        Some(flag) => vec![format!("{flag}={effective_prompt}")],
-                        None => vec!["--".to_string(), effective_prompt],
-                    })
-                    .collect(),
-            ));
+            let args = sanitize_argv_for_program(
+                harness_id,
+                mode,
+                &program,
+                prepend_launch_args(
+                    &model_args,
+                    &sandbox_args,
+                    &add_dir_args,
+                    &launch_policy_args,
+                    &launch_option_args,
+                    // The prompt rides behind the harness's prompt flag when it
+                    // declares one (continuity launches are always
+                    // non-interactive, so the shared `prompt_flag` applies), or
+                    // behind `--` for positional-prompt harnesses — user data
+                    // must not parse as harness flags either way.
+                    args.into_iter()
+                        .chain(match spec.prompt_flag.as_deref() {
+                            Some(flag) => vec![format!("{flag}={effective_prompt}")],
+                            None => vec!["--".to_string(), effective_prompt],
+                        })
+                        .collect(),
+                ),
+            );
             return Ok((
                 program,
                 with_claude_permission_flags_enabled(harness_id, args, claude_bypass_enabled),
@@ -2015,16 +2056,22 @@ fn command_parts_with_specs(
         args.insert(0, flag.to_string());
     }
     Ok((
-        program,
+        program.clone(),
         with_claude_permission_flags_enabled(
             harness_id,
-            sanitize_argv_for_platform(prepend_launch_args(
-                &model_args,
-                &sandbox_args,
-                &add_dir_args,
-                &launch_option_args,
-                args,
-            )),
+            sanitize_argv_for_program(
+                harness_id,
+                mode,
+                &program,
+                prepend_launch_args(
+                    &model_args,
+                    &sandbox_args,
+                    &add_dir_args,
+                    &launch_policy_args,
+                    &launch_option_args,
+                    args,
+                ),
+            ),
             claude_bypass_enabled,
         ),
     ))
@@ -2065,6 +2112,55 @@ fn launch_option_args(harness_id: &str, options: HarnessLaunchOptions<'_>) -> Ve
         .unwrap_or_default()
 }
 
+fn launch_policy_args(
+    harness_id: &str,
+    mode: HarnessLaunchMode,
+    options: HarnessLaunchOptions<'_>,
+) -> Result<Vec<String>> {
+    let Some(policy) = options.launch_policy else {
+        return Ok(Vec::new());
+    };
+    if harness_id != "codex" || mode != HarnessLaunchMode::NonInteractive {
+        anyhow::bail!("launchPolicy is supported only for Codex nonInteractive launches");
+    }
+    if options.permission.is_some() || !options.add_dirs.is_empty() {
+        anyhow::bail!(
+            "launchPolicy cannot be combined with separate permission or add-dir options"
+        );
+    }
+
+    // Keep the public flag for Codex versions that honor it directly, but also
+    // pin the config value as a highest-precedence session override. Codex
+    // 0.146.1 parses the root `--ask-for-approval` flag without inheriting it
+    // into `exec`; its headless default can then be discarded when AutoReview
+    // is configured, allowing an untrusted project to select `untrusted`.
+    // The explicit config override survives that AutoReview rebuild.
+    let mut args = vec![
+        "--ask-for-approval".to_string(),
+        "never".to_string(),
+        "-c".to_string(),
+        r#"approval_policy="never""#.to_string(),
+        "--sandbox".to_string(),
+        "workspace-write".to_string(),
+    ];
+    // Codex 0.146.1 safely downgrades `workspace-write` to `read-only` on
+    // native Windows unless a supported Windows sandbox backend is selected.
+    // The unelevated restricted-token backend is the least-privileged backend
+    // that enforces workspace-write there. Keep this explicit override inside
+    // the already Windows/Codex/noninteractive-only launchPolicy boundary;
+    // Codex reports backend setup failures through the preserved stderr/exit
+    // path instead of silently running without a sandbox.
+    if cfg!(windows) {
+        args.push("-c".to_string());
+        args.push(r#"windows.sandbox="unelevated""#.to_string());
+    }
+    for dir in &policy.add_dirs {
+        args.push("--add-dir".to_string());
+        args.push(dir.clone());
+    }
+    Ok(args)
+}
+
 /// Prepend resolved launch argv tokens ahead of `args` (which ends with the
 /// prompt positional). Keeps Coven-managed options before the prompt, matching
 /// how Cave emits run flags.
@@ -2072,22 +2168,30 @@ fn prepend_launch_args(
     model_args: &[String],
     sandbox_args: &[String],
     add_dir_args: &[String],
+    policy_args: &[String],
     option_args: &[String],
     args: Vec<String>,
 ) -> Vec<String> {
     if model_args.is_empty()
         && sandbox_args.is_empty()
         && add_dir_args.is_empty()
+        && policy_args.is_empty()
         && option_args.is_empty()
     {
         return args;
     }
     let mut out = Vec::with_capacity(
-        model_args.len() + sandbox_args.len() + add_dir_args.len() + option_args.len() + args.len(),
+        model_args.len()
+            + sandbox_args.len()
+            + add_dir_args.len()
+            + policy_args.len()
+            + option_args.len()
+            + args.len(),
     );
     out.extend_from_slice(model_args);
     out.extend_from_slice(sandbox_args);
     out.extend_from_slice(add_dir_args);
+    out.extend_from_slice(policy_args);
     out.extend_from_slice(option_args);
     out.extend(args);
     out
@@ -2098,44 +2202,60 @@ fn prepend_launch_args(
 /// messages and stdout is a stream of newline-delimited JSON events.
 /// Returns `None` for harnesses that don't support stream mode so the
 /// caller can fall back to a one-shot launch.
-/// On Windows, harness executables often resolve to `.cmd` shims that are
-/// invoked through `cmd.exe`. cmd.exe interprets metacharacters like
-/// `& | < > ^ % ! "` in arguments even inside double-quoted strings in some
-/// invocation paths. Neutralize them by caret-escaping the dangerous
-/// characters and wrapping affected arguments in quotes so `.cmd` shims that
-/// re-expand `%*` keep the value as data during a second `cmd.exe` parse.
-///
-/// On non-Windows platforms this is a no-op: the OS exec model passes
-/// argv entries as null-terminated byte arrays without shell parsing.
+/// Preserve the established quoting contract only where a Windows batch shim
+/// actually causes argv to cross a second cmd.exe parse. Native executables
+/// always receive exact values. Security-sensitive noninteractive Codex npm
+/// shims also keep exact argv here because the command builder subsequently
+/// resolves them to their validated native executable before spawn. Interactive
+/// and stream Codex retain their existing shim/PTY behavior.
 #[cfg(windows)]
-pub(crate) fn sanitize_argv_for_platform(args: Vec<String>) -> Vec<String> {
+pub(crate) fn sanitize_argv_for_program(
+    harness_id: &str,
+    mode: HarnessLaunchMode,
+    program: &str,
+    args: Vec<String>,
+) -> Vec<String> {
+    let is_batch = Path::new(program)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        });
+    if !is_batch || (harness_id == "codex" && mode == HarnessLaunchMode::NonInteractive) {
+        return args;
+    }
     args.into_iter()
         .map(|arg| escape_cmd_shim_metacharacters(&arg))
         .collect()
 }
 
 #[cfg(not(windows))]
-pub(crate) fn sanitize_argv_for_platform(args: Vec<String>) -> Vec<String> {
+pub(crate) fn sanitize_argv_for_program(
+    _harness_id: &str,
+    _mode: HarnessLaunchMode,
+    _program: &str,
+    args: Vec<String>,
+) -> Vec<String> {
     args
 }
 
-#[cfg(any(windows, test))]
+#[cfg(windows)]
 fn escape_cmd_shim_metacharacters(arg: &str) -> String {
-    // Characters that cmd.exe treats as special when a `.cmd` shim causes argv
-    // to be re-parsed. The caller still passes a single argv entry; this only
-    // neutralizes characters within that entry.
     const CMD_METACHARACTERS: &[char] = &['&', '|', '<', '>', '^', '%', '!', '"'];
-    if !arg.chars().any(|c| CMD_METACHARACTERS.contains(&c)) {
+    if !arg
+        .chars()
+        .any(|character| CMD_METACHARACTERS.contains(&character))
+    {
         return arg.to_string();
     }
 
     let mut escaped = String::with_capacity((arg.len() * 2) + 2);
     escaped.push('"');
-    for ch in arg.chars() {
-        if CMD_METACHARACTERS.contains(&ch) {
+    for character in arg.chars() {
+        if CMD_METACHARACTERS.contains(&character) {
             escaped.push('^');
         }
-        escaped.push(ch);
+        escaped.push(character);
     }
     escaped.push('"');
     escaped
@@ -2533,15 +2653,34 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(windows)]
     #[test]
-    fn cmd_shim_metacharacters_are_caret_escaped_and_wrapped() {
-        assert_eq!(escape_cmd_shim_metacharacters("safe prompt"), "safe prompt");
-
-        let escaped = escape_cmd_shim_metacharacters(r#"a&b|c<d>e^f%g!h"i"#);
-
-        assert_eq!(escaped, r#""a^&b^|c^<d^>e^^f^%g^!h^"i""#);
-        assert!(escaped.starts_with('"'));
-        assert!(escaped.ends_with('"'));
+    fn windows_launch_argv_escaping_is_scoped_to_batch_modes_that_retain_the_shim() {
+        let external_dir = r#"C:\Research & Evidence\資料 ^ 100%!"#;
+        let native = sanitize_argv_for_program(
+            "codex",
+            HarnessLaunchMode::Interactive,
+            r"C:\Tools\codex.exe",
+            vec![external_dir.to_string()],
+        );
+        assert_eq!(native, [external_dir]);
+        let noninteractive_batch = sanitize_argv_for_program(
+            "codex",
+            HarnessLaunchMode::NonInteractive,
+            r"C:\Tools\codex.cmd",
+            vec![external_dir.to_string()],
+        );
+        assert_eq!(noninteractive_batch, [external_dir]);
+        let interactive_batch = sanitize_argv_for_program(
+            "codex",
+            HarnessLaunchMode::Interactive,
+            r"C:\Tools\codex.cmd",
+            vec![external_dir.to_string()],
+        );
+        assert_eq!(
+            interactive_batch,
+            [escape_cmd_shim_metacharacters(external_dir)]
+        );
     }
 
     #[test]
@@ -5472,6 +5611,131 @@ mod tests {
         let prompt_pos = args.iter().position(|a| a == "fix tests").unwrap();
         assert!(sandbox_pos < prompt_pos, "{args:?}");
         Ok(())
+    }
+
+    #[test]
+    fn codex_noninteractive_launch_policy_emits_exact_supported_argv() -> anyhow::Result<()> {
+        let policy = LaunchPolicy::unattended_workspace_write(vec![
+            "/repo/artifacts".to_string(),
+            "/repo/cache".to_string(),
+        ]);
+        let (_, args) = command_parts_with_built_ins(
+            "codex",
+            "write the artifact",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                launch_policy: Some(&policy),
+                ..Default::default()
+            },
+        )?;
+
+        let mut expected = vec![
+            "--ask-for-approval",
+            "never",
+            "-c",
+            r#"approval_policy="never""#,
+            "--sandbox",
+            "workspace-write",
+        ];
+        if cfg!(windows) {
+            expected.extend(["-c", r#"windows.sandbox="unelevated""#]);
+        }
+        expected.extend([
+            "--add-dir",
+            "/repo/artifacts",
+            "--add-dir",
+            "/repo/cache",
+            "exec",
+            "--skip-git-repo-check",
+            "--color",
+            "never",
+            "--",
+            "write the artifact",
+        ]);
+        assert_eq!(args, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn windows_codex_preserves_external_launch_policy_dir_exactly_before_native_resolution(
+    ) -> anyhow::Result<()> {
+        let external_dir = r#"C:\Research & Evidence\資料 ^ 100%!"#.to_string();
+        let policy = LaunchPolicy::unattended_workspace_write(vec![external_dir.clone()]);
+        for resolved_program in [r"C:\Tools\codex.exe", r"C:\Tools\codex.cmd"] {
+            let (program, args) = command_parts_with_specs(
+                &built_in_harness_specs(),
+                "codex",
+                "write the artifact",
+                HarnessLaunchMode::NonInteractive,
+                None,
+                None,
+                HarnessLaunchOptions {
+                    launch_policy: Some(&policy),
+                    ..Default::default()
+                },
+                false,
+                false,
+                |_| resolved_program.to_string(),
+            )?;
+            let windows_args = sanitize_argv_for_program(
+                "codex",
+                HarnessLaunchMode::NonInteractive,
+                &program,
+                args,
+            );
+            let add_dir = windows_args
+                .windows(2)
+                .find(|pair| pair[0] == "--add-dir")
+                .expect("launch policy emits --add-dir");
+            assert_eq!(add_dir[1], external_dir, "{program}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn launch_policy_rejects_unsupported_harnesses_modes_and_mixed_grants() {
+        let policy = LaunchPolicy::unattended_workspace_write(Vec::new());
+        for (harness, mode) in [
+            ("claude", HarnessLaunchMode::NonInteractive),
+            ("codex", HarnessLaunchMode::Interactive),
+            ("codex", HarnessLaunchMode::Stream),
+        ] {
+            let error = command_parts_with_built_ins(
+                harness,
+                "hello",
+                mode,
+                None,
+                None,
+                HarnessLaunchOptions {
+                    launch_policy: Some(&policy),
+                    ..Default::default()
+                },
+            )
+            .unwrap_err();
+            assert!(
+                error.to_string().contains("Codex nonInteractive"),
+                "{error}"
+            );
+        }
+
+        let mixed_dir = vec!["/unvalidated".to_string()];
+        let error = command_parts_with_built_ins(
+            "codex",
+            "hello",
+            HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            HarnessLaunchOptions {
+                permission: Some(Permission::ReadOnly),
+                add_dirs: &mixed_dir,
+                launch_policy: Some(&policy),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot be combined"), "{error}");
     }
 
     #[test]

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -227,6 +227,11 @@ enum Command {
         #[command(subcommand)]
         command: DaemonCommand,
     },
+    #[command(hide = true, name = "process-supervisor")]
+    ProcessSupervisor {
+        #[arg(long, value_name = "PROTOCOL")]
+        protocol: String,
+    },
     #[command(about = "Inspect and decide Ward proposals or migrate configuration")]
     Ward {
         #[command(subcommand)]
@@ -1105,6 +1110,16 @@ fn main() -> Result<()> {
     ) {
         return run_cli(cli);
     }
+    // The process supervisor is a native provider primitive, not a normal
+    // stateful Coven command. It must establish target containment before any
+    // settings/state initialization can create threads or block on a profile
+    // lock. Its first stderr line is the machine-readable admission result.
+    if let Some(Command::ProcessSupervisor { protocol }) = &cli.command {
+        if pty_runner::run_process_supervisor(protocol).is_err() {
+            std::process::exit(70);
+        }
+        unreachable!("process supervisor exits with its target status");
+    }
 
     let loaded =
         settings::user_settings_path().as_deref().and_then(|path| {
@@ -1191,6 +1206,9 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Adapter { command }) => run_adapter_command(command),
         Some(Command::Engine { command }) => run_engine_command(command),
         Some(Command::Daemon { command }) => run_daemon_command(command),
+        Some(Command::ProcessSupervisor { .. }) => {
+            unreachable!("process supervisor runs before state initialization")
+        }
         Some(Command::Ward { command }) => run_ward_command(command),
         Some(Command::Executor { command }) => run_executor_command(command),
         Some(Command::Run {
@@ -3964,6 +3982,7 @@ fn run_session(
         speed: requested_speed,
         permission: requested_permission,
         add_dirs: &requested_add_dirs,
+        launch_policy: None,
     };
 
     let effective_prompt = match (&familiar_ctx, spec.as_ref()) {

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -17,6 +17,9 @@ use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, size as terminal_cell_size, window_size,
 };
 use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, PtySize, PtySystem};
+use serde::Deserialize;
+
+type HarnessEnvironmentOverrides = Vec<(String, Option<String>)>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HarnessCommand {
@@ -24,6 +27,7 @@ pub struct HarnessCommand {
     args: Vec<String>,
     cwd: PathBuf,
     stdin_prompt: Option<Vec<u8>>,
+    env_overrides: HarnessEnvironmentOverrides,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -57,6 +61,14 @@ pub struct DetachedPtyObserver {
 
 #[cfg(windows)]
 const DETACHED_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
+// Keep the value available to cross-platform source-contract tests while
+// taking the production value from the Windows SDK. Centralizing the
+// combination prevents a headless spawn path from silently dropping it when
+// another flag (notably `CREATE_SUSPENDED`) is also required.
+#[cfg(windows)]
+const WINDOWS_CREATE_NO_WINDOW: u32 = windows_sys::Win32::System::Threading::CREATE_NO_WINDOW;
+#[cfg(all(test, not(windows)))]
+const WINDOWS_CREATE_NO_WINDOW: u32 = 0x0800_0000;
 const PTY_WRITE_QUEUE_CAPACITY: usize = 16;
 enum PtyWriteRequest {
     Write {
@@ -236,11 +248,46 @@ impl HarnessCommand {
         &self.cwd
     }
 
+    #[cfg(test)]
+    pub(crate) fn fixture(program: impl Into<String>, args: Vec<String>, cwd: PathBuf) -> Self {
+        Self {
+            program: program.into(),
+            args,
+            cwd,
+            stdin_prompt: None,
+            env_overrides: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_stdin_prompt_for_test(&mut self, prompt: Vec<u8>) {
+        self.stdin_prompt = Some(prompt);
+    }
+
     fn to_command_builder(&self) -> CommandBuilder {
         let mut builder = CommandBuilder::new(&self.program);
         builder.args(&self.args);
         builder.cwd(self.cwd.as_os_str());
+        for (name, value) in &self.env_overrides {
+            match value {
+                Some(value) => builder.env(name, value),
+                None => builder.env_remove(name),
+            }
+        }
         builder
+    }
+
+    fn apply_environment(&self, command: &mut std::process::Command) {
+        for (name, value) in &self.env_overrides {
+            match value {
+                Some(value) => {
+                    command.env(name, value);
+                }
+                None => {
+                    command.env_remove(name);
+                }
+            }
+        }
     }
 }
 
@@ -280,6 +327,34 @@ pub fn build_harness_command_with_conversation(
         familiar,
         options,
         false,
+        false,
+    )
+}
+
+/// Build a daemon-owned noninteractive command whose Codex prompt is carried
+/// on stdin on every platform. Ordinary interactive/attached CLI construction
+/// keeps its existing argv/PTY behavior; this contract is for the piped daemon
+/// runner that owns stdin and can close it after the complete prompt lands.
+#[allow(clippy::too_many_arguments)]
+pub fn build_piped_harness_command_with_conversation(
+    harness_id: &str,
+    prompt: &str,
+    cwd: &Path,
+    mode: crate::harness::HarnessLaunchMode,
+    conversation: Option<&crate::harness::ConversationHint>,
+    familiar: Option<&crate::harness::FamiliarContext>,
+    options: crate::harness::HarnessLaunchOptions<'_>,
+) -> Result<HarnessCommand> {
+    build_harness_command_with_conversation_inner(
+        harness_id,
+        prompt,
+        cwd,
+        mode,
+        conversation,
+        familiar,
+        options,
+        false,
+        true,
     )
 }
 
@@ -306,6 +381,7 @@ pub fn build_codex_json_harness_command_with_conversation(
         familiar,
         options,
         true,
+        false,
     )
 }
 
@@ -319,6 +395,7 @@ fn build_harness_command_with_conversation_inner(
     familiar: Option<&crate::harness::FamiliarContext>,
     options: crate::harness::HarnessLaunchOptions<'_>,
     codex_json: bool,
+    force_codex_stdin: bool,
 ) -> Result<HarnessCommand> {
     let (program, mut args) = if codex_json {
         crate::harness::command_parts_for_codex_json_with_conversation(
@@ -350,35 +427,331 @@ fn build_harness_command_with_conversation_inner(
     } else {
         prompt
     };
-    let stdin_prompt = move_windows_codex_prompt_to_stdin(
+    let stdin_prompt = move_codex_prompt_to_stdin(
         harness_id,
         mode,
         stdin_prompt_text,
         &mut args,
-        cfg!(windows),
+        cfg!(windows) || force_codex_stdin,
     );
+    let (program, env_overrides) = prepare_harness_program(harness_id, mode, program)?;
 
     Ok(HarnessCommand {
-        program: program.to_string(),
+        program,
         args,
         cwd: cwd.to_path_buf(),
         stdin_prompt,
+        env_overrides,
     })
 }
 
-/// Windows may resolve an npm-installed Codex harness to `codex.CMD`. Rust
-/// launches batch files through `cmd.exe` and deliberately rejects multiline
-/// or otherwise unsafe batch arguments. Codex supports `-` as the prompt
-/// positional, reading the real prompt from stdin, so keep user-controlled
-/// prompt text out of the batch command line entirely.
-fn move_windows_codex_prompt_to_stdin(
+#[cfg(not(windows))]
+fn prepare_harness_program(
+    _harness_id: &str,
+    _mode: crate::harness::HarnessLaunchMode,
+    program: String,
+) -> Result<(String, HarnessEnvironmentOverrides)> {
+    Ok((program, Vec::new()))
+}
+
+#[cfg(windows)]
+fn prepare_harness_program(
+    harness_id: &str,
+    mode: crate::harness::HarnessLaunchMode,
+    program: String,
+) -> Result<(String, HarnessEnvironmentOverrides)> {
+    if harness_id != "codex"
+        || mode != crate::harness::HarnessLaunchMode::NonInteractive
+        || !windows_program_is_batch_shim(&program)
+    {
+        return Ok((program, Vec::new()));
+    }
+    let launch = resolve_official_codex_npm_shim(Path::new(&program)).with_context(|| {
+        format!(
+            "Windows Codex resolved to npm shim `{program}`, but Coven could not validate its native @openai/codex executable; reinstall @openai/codex and retry"
+        )
+    })?;
+    Ok((
+        launch.program.to_string_lossy().into_owned(),
+        launch.env_overrides,
+    ))
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+struct WindowsCodexNpmLaunch {
+    program: PathBuf,
+    env_overrides: HarnessEnvironmentOverrides,
+}
+
+#[cfg(any(windows, test))]
+fn windows_program_is_batch_shim(program: &str) -> bool {
+    Path::new(program)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("cmd") || extension.eq_ignore_ascii_case("bat")
+        })
+}
+
+#[cfg(windows)]
+fn resolve_official_codex_npm_shim(shim_path: &Path) -> Result<WindowsCodexNpmLaunch> {
+    #[cfg(target_arch = "x86_64")]
+    const TARGET_PACKAGE: &str = "@openai/codex-win32-x64";
+    #[cfg(target_arch = "x86_64")]
+    const TARGET_TRIPLE: &str = "x86_64-pc-windows-msvc";
+    #[cfg(target_arch = "x86_64")]
+    const TARGET_CPU: &str = "x64";
+    #[cfg(target_arch = "aarch64")]
+    const TARGET_PACKAGE: &str = "@openai/codex-win32-arm64";
+    #[cfg(target_arch = "aarch64")]
+    const TARGET_TRIPLE: &str = "aarch64-pc-windows-msvc";
+    #[cfg(target_arch = "aarch64")]
+    const TARGET_CPU: &str = "arm64";
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    compile_error!("the official Codex npm package supports Windows x64 and arm64 only");
+
+    resolve_official_codex_npm_shim_for_target(shim_path, TARGET_PACKAGE, TARGET_TRIPLE, TARGET_CPU)
+}
+
+#[cfg(any(windows, test))]
+fn resolve_official_codex_npm_shim_for_target(
+    shim_path: &Path,
+    target_package: &str,
+    target_triple: &str,
+    target_cpu: &str,
+) -> Result<WindowsCodexNpmLaunch> {
+    let entry = windows_npm_shim_entry(shim_path)?;
+    let entry = std::fs::canonicalize(&entry)
+        .with_context(|| format!("failed canonicalizing `{}`", entry.display()))?;
+    anyhow::ensure!(
+        entry.file_name().and_then(|name| name.to_str()) == Some("codex.js")
+            && entry
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                == Some("bin"),
+        "npm shim does not target the official @openai/codex bin/codex.js entry"
+    );
+    let package_root = entry
+        .parent()
+        .and_then(Path::parent)
+        .context("official Codex npm entry has no package root")?;
+    let package_json = read_json_file(&package_root.join("package.json"))?;
+    anyhow::ensure!(
+        package_json.get("name").and_then(serde_json::Value::as_str) == Some("@openai/codex"),
+        "npm shim target package is not @openai/codex"
+    );
+    let declared_entry = package_json
+        .get("bin")
+        .and_then(|bin| bin.get("codex"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .replace('\\', "/");
+    anyhow::ensure!(
+        declared_entry == "bin/codex.js",
+        "@openai/codex package does not declare the expected codex entry"
+    );
+    anyhow::ensure!(
+        package_json
+            .get("optionalDependencies")
+            .and_then(|dependencies| dependencies.get(target_package))
+            .and_then(serde_json::Value::as_str)
+            .is_some(),
+        "@openai/codex does not declare native package {target_package}"
+    );
+
+    let mut target_roots = Vec::new();
+    for ancestor in package_root.ancestors() {
+        target_roots.push(
+            ancestor
+                .join("node_modules")
+                .join("@openai")
+                .join(target_package.trim_start_matches("@openai/")),
+        );
+    }
+    let mut native = None;
+    for target_root in target_roots {
+        let target_metadata = target_root.join("package.json");
+        if !target_metadata.is_file() {
+            continue;
+        }
+        let target_json = read_json_file(&target_metadata)?;
+        let supports_windows = target_json
+            .get("os")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|values| values.iter().any(|value| value.as_str() == Some("win32")));
+        let supports_cpu = target_json
+            .get("cpu")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|values| {
+                values
+                    .iter()
+                    .any(|value| value.as_str() == Some(target_cpu))
+            });
+        if target_json.get("name").and_then(serde_json::Value::as_str) != Some("@openai/codex")
+            || !supports_windows
+            || !supports_cpu
+        {
+            continue;
+        }
+        let candidate = target_root
+            .join("vendor")
+            .join(target_triple)
+            .join("bin")
+            .join("codex.exe");
+        if candidate.is_file() {
+            let canonical_root = std::fs::canonicalize(&target_root)?;
+            let canonical_candidate = std::fs::canonicalize(&candidate)?;
+            anyhow::ensure!(
+                canonical_candidate.starts_with(&canonical_root),
+                "native Codex executable escapes its validated package root"
+            );
+            native = Some(canonical_candidate);
+            break;
+        }
+    }
+    let native = native.with_context(|| {
+        format!(
+            "native optional dependency {target_package} is missing its {target_triple} executable"
+        )
+    })?;
+    let canonical_package_root = std::fs::canonicalize(package_root)?;
+    let manager = codex_package_manager(&canonical_package_root);
+    let mut env_overrides = [
+        "CODEX_MANAGED_BY_NPM",
+        "CODEX_MANAGED_BY_BUN",
+        "CODEX_MANAGED_BY_PNPM",
+    ]
+    .into_iter()
+    .map(|name| (name.to_string(), None))
+    .collect::<Vec<_>>();
+    env_overrides.push((
+        "CODEX_MANAGED_PACKAGE_ROOT".to_string(),
+        Some(canonical_package_root.to_string_lossy().into_owned()),
+    ));
+    env_overrides.push((format!("CODEX_MANAGED_BY_{manager}"), Some("1".to_string())));
+    Ok(WindowsCodexNpmLaunch {
+        program: native,
+        env_overrides,
+    })
+}
+
+#[cfg(any(windows, test))]
+fn windows_npm_shim_entry(shim_path: &Path) -> Result<PathBuf> {
+    let bin_dir = shim_path
+        .parent()
+        .context("Windows npm shim has no parent directory")?;
+    let shim = std::fs::read_to_string(shim_path)
+        .with_context(|| format!("failed reading npm shim `{}`", shim_path.display()))?;
+    for line in shim.lines() {
+        let trimmed = line.trim_start();
+        let lowercase = trimmed.to_ascii_lowercase();
+        if lowercase.starts_with("if exist")
+            || lowercase.starts_with("@if exist")
+            || lowercase.starts_with("set")
+            || lowercase.starts_with("@set")
+            || lowercase.starts_with("call")
+            || lowercase.starts_with("@call")
+            || lowercase.starts_with("rem")
+            || lowercase.starts_with("@rem")
+            || trimmed.starts_with("::")
+            || trimmed.starts_with(':')
+        {
+            continue;
+        }
+        let quoted = line.split('"').skip(1).step_by(2).collect::<Vec<_>>();
+        for target in quoted.into_iter().rev() {
+            let lowercase = target.to_ascii_lowercase();
+            let relative = lowercase
+                .strip_prefix("%dp0%\\")
+                .map(|_| &target[6..])
+                .or_else(|| lowercase.strip_prefix("%~dp0\\").map(|_| &target[6..]))
+                .or_else(|| lowercase.strip_prefix("%dp0%/").map(|_| &target[6..]))
+                .or_else(|| lowercase.strip_prefix("%~dp0/").map(|_| &target[6..]));
+            let Some(relative) = relative else {
+                continue;
+            };
+            if relative.contains('%') {
+                continue;
+            }
+            let relative = relative.replace(['\\', '/'], std::path::MAIN_SEPARATOR_STR);
+            let candidate = bin_dir.join(relative);
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+    anyhow::bail!(
+        "npm shim `{}` does not contain a safe existing package entry",
+        shim_path.display()
+    )
+}
+
+#[cfg(any(windows, test))]
+fn read_json_file(path: &Path) -> Result<serde_json::Value> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed reading package metadata `{}`", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("invalid package metadata `{}`", path.display()))
+}
+
+#[cfg(any(windows, test))]
+fn codex_package_manager(package_root: &Path) -> &'static str {
+    let user_agent = std::env::var("npm_config_user_agent")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let exec_path = std::env::var("npm_execpath")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    codex_package_manager_with_env(package_root, &user_agent, &exec_path)
+}
+
+#[cfg(any(windows, test))]
+fn codex_package_manager_with_env(
+    package_root: &Path,
+    user_agent: &str,
+    exec_path: &str,
+) -> &'static str {
+    let rendered = package_root.to_string_lossy().to_ascii_lowercase();
+    if codex_package_is_pnpm_owned(package_root)
+        || rendered.contains(".pnpm")
+        || user_agent.contains("pnpm/")
+        || exec_path.contains("pnpm")
+    {
+        "PNPM"
+    } else if rendered.contains(".bun") || user_agent.contains("bun/") || exec_path.contains("bun")
+    {
+        "BUN"
+    } else {
+        "NPM"
+    }
+}
+
+#[cfg(any(windows, test))]
+fn codex_package_is_pnpm_owned(package_root: &Path) -> bool {
+    package_root.ancestors().any(|ancestor| {
+        let node_modules = ancestor.join("node_modules");
+        if !node_modules.join(".modules.yaml").is_file() {
+            return false;
+        }
+        std::fs::canonicalize(node_modules.join("@openai").join("codex"))
+            .is_ok_and(|candidate| candidate == package_root)
+    })
+}
+
+/// Codex supports `-` as the prompt positional, reading the complete prompt
+/// from stdin. Windows always needs this because npm shims pass through
+/// cmd.exe; daemon-owned piped Codex launches request it on every platform so
+/// compiled Research prompts never become one oversized argv value.
+fn move_codex_prompt_to_stdin(
     harness_id: &str,
     mode: crate::harness::HarnessLaunchMode,
     prompt: &str,
     args: &mut [String],
-    is_windows: bool,
+    use_stdin: bool,
 ) -> Option<Vec<u8>> {
-    if !is_windows
+    if !use_stdin
         || harness_id != "codex"
         || mode != crate::harness::HarnessLaunchMode::NonInteractive
     {
@@ -921,43 +1294,68 @@ struct CodexJsonState {
 /// direct launcher, so a plain `Child::kill()` is not enough to guarantee pipe
 /// EOF or descendant cleanup.
 pub(crate) struct ChildProcessTree {
+    #[cfg(unix)]
     pid: u32,
     terminated: bool,
     #[cfg(windows)]
     job_handle: Option<windows_sys::Win32::Foundation::HANDLE>,
 }
 
+// The Job Object handle is exclusively owned by `ChildProcessTree` and the
+// Win32 job APIs used by its methods are thread-safe. Moving that ownership to
+// the daemon's cancellation registry is therefore safe.
+#[cfg(windows)]
+unsafe impl Send for ChildProcessTree {}
+
 impl ChildProcessTree {
+    #[cfg(unix)]
     pub(crate) fn attach(child: &std::process::Child) -> Self {
         let pid = child.id();
-        #[cfg(windows)]
-        let job_handle = child_job_object_for_process(child);
         Self {
             pid,
             terminated: false,
-            #[cfg(windows)]
-            job_handle,
         }
     }
 
-    fn terminate_impl(&mut self, child: &mut std::process::Child) {
+    fn terminate_tree(&mut self) -> io::Result<()> {
         if self.terminated {
-            return;
+            return Ok(());
         }
-        self.terminated = true;
         #[cfg(unix)]
         {
-            terminate_unix_process_group(self.pid);
+            terminate_unix_process_group(self.pid)?;
+            // Leave the handle retryable when signaling fails for anything
+            // other than ESRCH. `terminate_unix_process_group` treats ESRCH
+            // as success because the desired post-condition already holds.
+            self.terminated = true;
         }
         #[cfg(windows)]
         {
             if let Some(job) = self.job_handle.take() {
-                unsafe {
-                    windows_sys::Win32::System::JobObjects::TerminateJobObject(job, 1);
-                    windows_sys::Win32::Foundation::CloseHandle(job);
+                let terminated =
+                    unsafe { windows_sys::Win32::System::JobObjects::TerminateJobObject(job, 1) };
+                let error = (terminated == 0).then(io::Error::last_os_error);
+                unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+                // Closing the KILL_ON_JOB_CLOSE handle is the kernel-enforced
+                // backstop even when the explicit termination call reports an
+                // error, so no retryable ownership remains after this point.
+                self.terminated = true;
+                if let Some(error) = error {
+                    return Err(error);
                 }
+            } else {
+                self.terminated = true;
             }
         }
+        #[cfg(not(any(unix, windows)))]
+        {
+            self.terminated = true;
+        }
+        Ok(())
+    }
+
+    fn terminate_impl(&mut self, child: &mut std::process::Child) {
+        let _ = self.terminate_tree();
         let _ = child.kill();
     }
 }
@@ -982,7 +1380,6 @@ impl StrictChildProcessTree {
                 return None;
             }
             Some(Self(ChildProcessTree {
-                pid: child.id(),
                 terminated: false,
                 job_handle: Some(job_handle),
             }))
@@ -997,13 +1394,176 @@ impl StrictChildProcessTree {
     pub(crate) fn terminate(&mut self, child: &mut std::process::Child) {
         self.0.terminate_impl(child);
     }
+
+    /// Terminate the contained tree without borrowing the root `Child`.
+    ///
+    /// Detached piped sessions move the `Child` into their wait thread, while
+    /// the daemon retains this containment handle for cancellation. Windows
+    /// terminates the pre-attached Job Object; Unix signals the pre-created
+    /// process group. Both operations are idempotent when the tree exited.
+    pub(crate) fn terminate_tree(&mut self) -> io::Result<()> {
+        self.0.terminate_tree()
+    }
+
+    #[cfg(all(windows, test))]
+    fn close_job_handle_without_explicit_termination_for_test(&mut self) {
+        if let Some(job) = self.0.job_handle.take() {
+            // Model the handle closure the kernel performs when coven.exe is
+            // terminated too abruptly to run Drop. The configured
+            // KILL_ON_JOB_CLOSE limit must still tear down every descendant.
+            unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+        }
+        self.0.terminated = true;
+    }
+}
+
+/// Cloneable ownership of one strict process-tree containment handle.
+///
+/// A piped prompt writer and the daemon registry must be able to observe and
+/// terminate the same tree without duplicating pid-based containment. The
+/// underlying Job Object/process-group handle remains singular and every
+/// operation is serialized through this shared owner.
+#[derive(Clone)]
+pub(crate) struct SharedStrictChildProcessTree {
+    process_tree: Arc<Mutex<StrictChildProcessTree>>,
+    #[cfg(unix)]
+    guardian: Arc<Mutex<ProcessSupervisorGuardian>>,
+    child_wait_state: Arc<AtomicU8>,
+    exit_callback_complete: Arc<AtomicBool>,
+}
+
+impl SharedStrictChildProcessTree {
+    #[cfg(unix)]
+    fn new(
+        process_tree: StrictChildProcessTree,
+        guardian: ProcessSupervisorGuardian,
+        child_wait_state: Arc<AtomicU8>,
+        exit_callback_complete: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            process_tree: Arc::new(Mutex::new(process_tree)),
+            guardian: Arc::new(Mutex::new(guardian)),
+            child_wait_state,
+            exit_callback_complete,
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn new(
+        process_tree: StrictChildProcessTree,
+        child_wait_state: Arc<AtomicU8>,
+        exit_callback_complete: Arc<AtomicBool>,
+    ) -> Self {
+        Self {
+            process_tree: Arc::new(Mutex::new(process_tree)),
+            child_wait_state,
+            exit_callback_complete,
+        }
+    }
+
+    pub(crate) fn terminate_tree(&self) -> io::Result<()> {
+        let termination = match self.process_tree.lock() {
+            Ok(mut process_tree) => process_tree.terminate_tree(),
+            Err(poisoned) => poisoned.into_inner().terminate_tree(),
+        };
+        #[cfg(unix)]
+        match self.guardian.lock() {
+            Ok(mut guardian) => guardian.finish(),
+            Err(poisoned) => poisoned.into_inner().finish(),
+        }
+        termination
+    }
+
+    pub(crate) fn terminate_and_wait(&self, timeout: Duration) -> Result<()> {
+        let termination = self.terminate_tree().err();
+        let wait_state = wait_for_piped_child_reap(&self.child_wait_state, timeout);
+        match (termination, wait_state) {
+            (None, PIPED_CHILD_REAPED) => Ok(()),
+            (Some(error), PIPED_CHILD_REAPED) => Err(anyhow::Error::new(error).context(
+                "process-tree termination reported an error after the child became quiescent",
+            )),
+            (termination, PIPED_CHILD_WAIT_FAILED) => match termination {
+                Some(error) => anyhow::bail!(
+                    "process-tree termination failed ({error}) and the direct child wait failed"
+                ),
+                None => anyhow::bail!(
+                    "the direct child wait failed after process-tree termination"
+                ),
+            },
+            (termination, _) => match termination {
+                Some(error) => anyhow::bail!(
+                    "process-tree termination failed ({error}) and the child did not become quiescent within {} ms",
+                    timeout.as_millis()
+                ),
+                None => anyhow::bail!(
+                    "the child did not become quiescent within {} ms after process-tree termination",
+                    timeout.as_millis()
+                ),
+            },
+        }
+    }
+
+    pub(crate) fn wait_for_quiescence(&self, timeout: Duration) -> Result<()> {
+        match wait_for_piped_child_reap(&self.child_wait_state, timeout) {
+            PIPED_CHILD_REAPED => Ok(()),
+            PIPED_CHILD_WAIT_FAILED => {
+                anyhow::bail!("the direct child wait or output drain failed")
+            }
+            _ => anyhow::bail!(
+                "the child did not become quiescent within {} ms",
+                timeout.as_millis()
+            ),
+        }
+    }
+
+    pub(crate) fn wait_for_shutdown_quiescence(&self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        self.wait_for_quiescence(timeout)?;
+        while !self.exit_callback_complete.load(Ordering::Acquire) {
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "the piped child exit callback did not complete within {} ms",
+                timeout.as_millis()
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+        Ok(())
+    }
+
+    fn is_terminated(&self) -> bool {
+        match self.process_tree.lock() {
+            Ok(process_tree) => process_tree.0.terminated,
+            Err(poisoned) => poisoned.into_inner().0.terminated,
+        }
+    }
+
+    #[cfg(all(windows, test))]
+    fn close_job_handle_without_explicit_termination_for_test(&self) {
+        match self.process_tree.lock() {
+            Ok(mut process_tree) => {
+                process_tree.close_job_handle_without_explicit_termination_for_test()
+            }
+            Err(poisoned) => poisoned
+                .into_inner()
+                .close_job_handle_without_explicit_termination_for_test(),
+        }
+    }
 }
 
 #[cfg(unix)]
-fn terminate_unix_process_group(pid: u32) {
+fn terminate_unix_process_group(pid: u32) -> io::Result<()> {
     // The launch config puts the child at the head of a new session, so the
     // negative pid reaches its wrapper and every descendant.
-    let _ = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+    let result = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+    if result == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
 }
 
 #[cfg(unix)]
@@ -1031,8 +1591,8 @@ fn poll_child_exit_without_reaping(child: &std::process::Child) -> io::Result<bo
     }
 }
 
-#[cfg(all(unix, test))]
 fn wait_for_child_exit_without_reaping(child: &std::process::Child) -> io::Result<()> {
+    #[cfg(unix)]
     loop {
         let mut info: libc::siginfo_t = unsafe { std::mem::zeroed() };
         let result = unsafe {
@@ -1051,6 +1611,26 @@ fn wait_for_child_exit_without_reaping(child: &std::process::Child) -> io::Resul
             return Err(error);
         }
     }
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0};
+        use windows_sys::Win32::System::Threading::WaitForSingleObject;
+
+        let result = unsafe { WaitForSingleObject(child.as_raw_handle() as _, u32::MAX) };
+        match result {
+            WAIT_OBJECT_0 => Ok(()),
+            WAIT_FAILED => Err(io::Error::last_os_error()),
+            other => Err(io::Error::other(format!(
+                "unexpected process wait result {other}"
+            ))),
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = child;
+        Ok(())
+    }
 }
 
 #[cfg(unix)]
@@ -1060,7 +1640,7 @@ impl Drop for ChildProcessTree {
             // A wrapper can exit after detaching a descendant that has already
             // closed stdout/stderr. There is then no pipe timeout to trigger
             // terminate(), but this one-shot runner still owns that group.
-            terminate_unix_process_group(self.pid);
+            let _ = terminate_unix_process_group(self.pid);
         }
     }
 }
@@ -1069,9 +1649,14 @@ impl Drop for ChildProcessTree {
 impl Drop for ChildProcessTree {
     fn drop(&mut self) {
         if let Some(job) = self.job_handle.take() {
-            // The job is configured with KILL_ON_JOB_CLOSE, so an abrupt
-            // coven.exe exit also cleans up npm/Node/Codex descendants.
-            unsafe { windows_sys::Win32::Foundation::CloseHandle(job) };
+            // Use the same non-zero cancellation code as explicit kill when
+            // Rust drops a live handle. KILL_ON_JOB_CLOSE remains the kernel
+            // backstop when coven.exe itself terminates too abruptly to run
+            // this destructor.
+            unsafe {
+                windows_sys::Win32::System::JobObjects::TerminateJobObject(job, 1);
+                windows_sys::Win32::Foundation::CloseHandle(job);
+            }
         }
     }
 }
@@ -1170,21 +1755,34 @@ fn resume_suspended_child(child: &std::process::Child) -> bool {
     previous_suspend_count == 1
 }
 
-fn configure_child_process_tree_command(_command: &mut std::process::Command) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            _command.pre_exec(|| {
-                // Isolate this turn in a fresh process group. A timeout can
-                // then kill the npm/Node/native Codex tree in one signal.
-                if libc::setsid() == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
+#[cfg(unix)]
+fn configure_child_process_tree_command(command: &mut std::process::Command) {
+    use std::os::unix::process::CommandExt;
+    unsafe {
+        command.pre_exec(|| {
+            // Isolate this turn in a fresh process group. A timeout can then
+            // kill the npm/Node/native Codex tree in one signal.
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
     }
+}
+
+#[cfg(any(windows, test))]
+fn windows_noninteractive_creation_flags(additional_flags: u32) -> u32 {
+    additional_flags | WINDOWS_CREATE_NO_WINDOW
+}
+
+#[cfg(windows)]
+fn configure_windows_noninteractive_command(
+    command: &mut std::process::Command,
+    additional_flags: u32,
+) {
+    use std::os::windows::process::CommandExt;
+
+    command.creation_flags(windows_noninteractive_creation_flags(additional_flags));
 }
 
 /// Spawn a process tree that cannot execute before Coven owns its descendants.
@@ -1198,13 +1796,24 @@ pub(crate) fn spawn_strict_child_process_tree(
     configure_child_process_tree_command(command);
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
         use windows_sys::Win32::System::Threading::CREATE_SUSPENDED;
 
-        command.creation_flags(CREATE_SUSPENDED);
+        configure_windows_noninteractive_command(command, CREATE_SUSPENDED);
     }
 
+    spawn_configured_strict_child_process_tree(command)
+}
+
+fn spawn_configured_strict_child_process_tree(
+    command: &mut std::process::Command,
+) -> std::io::Result<(std::process::Child, StrictChildProcessTree)> {
     let mut child = command.spawn()?;
+    #[cfg(all(windows, debug_assertions))]
+    if let Err(error) = wait_at_windows_strict_preattach_test_barrier(child.id()) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
     match StrictChildProcessTree::attach(&child) {
         Some(tree) => Ok((child, tree)),
         None => {
@@ -1215,6 +1824,657 @@ pub(crate) fn spawn_strict_child_process_tree(
             ))
         }
     }
+}
+
+#[cfg(all(windows, debug_assertions))]
+fn wait_at_windows_strict_preattach_test_barrier(child_pid: u32) -> io::Result<()> {
+    let Some(barrier_dir) = std::env::var_os("COVEN_TEST_WINDOWS_STRICT_PREATTACH_BARRIER_DIR")
+    else {
+        return Ok(());
+    };
+    let barrier_dir = PathBuf::from(barrier_dir);
+    std::fs::create_dir_all(&barrier_dir)?;
+    std::fs::write(barrier_dir.join("pid"), child_pid.to_string())?;
+    std::fs::write(barrier_dir.join("ready"), b"ready\n")?;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !barrier_dir.join("release").exists() {
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out at Windows strict pre-attachment test barrier",
+            ));
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    Ok(())
+}
+
+pub(crate) const PROCESS_SUPERVISOR_PROTOCOL: &str = "coven.process-supervisor.v1";
+const PROCESS_SUPERVISOR_CONTROL_PREFIX: &str = "COVEN_PROCESS_SUPERVISOR_V1 ";
+const PROCESS_SUPERVISOR_MAX_REQUEST_BYTES: usize = 256 * 1024;
+const PROCESS_SUPERVISOR_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ProcessSupervisorRequest {
+    version: u8,
+    program: String,
+    args: Vec<String>,
+    cwd: String,
+}
+
+fn read_process_supervisor_request(reader: &mut dyn BufRead) -> Result<ProcessSupervisorRequest> {
+    let mut line = Vec::new();
+    reader
+        .take((PROCESS_SUPERVISOR_MAX_REQUEST_BYTES + 1) as u64)
+        .read_until(b'\n', &mut line)
+        .context("failed reading the process-supervisor launch frame")?;
+    anyhow::ensure!(
+        !line.is_empty(),
+        "process-supervisor launch frame is missing"
+    );
+    anyhow::ensure!(
+        line.len() <= PROCESS_SUPERVISOR_MAX_REQUEST_BYTES,
+        "process-supervisor launch frame exceeds {PROCESS_SUPERVISOR_MAX_REQUEST_BYTES} bytes"
+    );
+    anyhow::ensure!(
+        line.last() == Some(&b'\n'),
+        "process-supervisor launch frame must end with LF"
+    );
+    line.pop();
+    let request: ProcessSupervisorRequest =
+        serde_json::from_slice(&line).context("invalid process-supervisor launch JSON")?;
+    anyhow::ensure!(
+        request.version == 1,
+        "unsupported process-supervisor version"
+    );
+    anyhow::ensure!(
+        !request.program.contains('\0')
+            && !request.cwd.contains('\0')
+            && request.args.iter().all(|arg| !arg.contains('\0')),
+        "process-supervisor launch values must not contain NUL"
+    );
+    let program = Path::new(&request.program);
+    let cwd = Path::new(&request.cwd);
+    anyhow::ensure!(
+        program.is_absolute(),
+        "process-supervisor program must be absolute"
+    );
+    anyhow::ensure!(cwd.is_absolute(), "process-supervisor cwd must be absolute");
+    anyhow::ensure!(
+        cwd.is_dir(),
+        "process-supervisor cwd must be an existing directory"
+    );
+    Ok(request)
+}
+
+fn write_process_supervisor_control(event: serde_json::Value) -> Result<()> {
+    let mut stderr = io::stderr().lock();
+    write!(stderr, "{PROCESS_SUPERVISOR_CONTROL_PREFIX}")?;
+    serde_json::to_writer(&mut stderr, &event)?;
+    writeln!(stderr)?;
+    stderr.flush()?;
+    Ok(())
+}
+
+#[cfg(unix)]
+struct ProcessSupervisorGuardian {
+    owner_write: libc::c_int,
+    setup_pid_write: libc::c_int,
+    setup_ack_read: libc::c_int,
+    pid: libc::pid_t,
+    finished: bool,
+}
+
+#[cfg(unix)]
+fn cloexec_pipe() -> io::Result<[libc::c_int; 2]> {
+    let mut fds = [-1, -1];
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    for fd in fds {
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+        if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) } == -1
+        {
+            let error = io::Error::last_os_error();
+            unsafe {
+                libc::close(fds[0]);
+                libc::close(fds[1]);
+            }
+            return Err(error);
+        }
+    }
+    Ok(fds)
+}
+
+#[cfg(unix)]
+unsafe fn guardian_read_exact(fd: libc::c_int, bytes: &mut [u8]) -> bool {
+    let mut offset = 0;
+    while offset != bytes.len() {
+        let count = unsafe {
+            libc::read(
+                fd,
+                bytes[offset..].as_mut_ptr().cast(),
+                bytes.len() - offset,
+            )
+        };
+        if count > 0 {
+            offset += count as usize;
+        } else if count == -1 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(unix)]
+unsafe fn guardian_write_all(fd: libc::c_int, bytes: &[u8]) -> bool {
+    let mut offset = 0;
+    while offset != bytes.len() {
+        let count =
+            unsafe { libc::write(fd, bytes[offset..].as_ptr().cast(), bytes.len() - offset) };
+        if count > 0 {
+            offset += count as usize;
+        } else if count == -1 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(unix)]
+unsafe fn guardian_remap_and_close_unrelated_fds(
+    owner_read: libc::c_int,
+    pid_read: libc::c_int,
+    ack_write: libc::c_int,
+    max_fd: libc::c_int,
+) -> Option<(libc::c_int, libc::c_int, libc::c_int)> {
+    // A guardian is forked from a multithreaded daemon and intentionally does
+    // not exec. Without this close sweep it would retain accepted API sockets,
+    // store locks, and listeners after the request handler dropped them. First
+    // duplicate the three protocol fds out of the fixed range so dup2 cannot
+    // overwrite a still-needed source, then keep only 3/4/5.
+    let owner_temp = unsafe { libc::fcntl(owner_read, libc::F_DUPFD_CLOEXEC, 64) };
+    let pid_temp = unsafe { libc::fcntl(pid_read, libc::F_DUPFD_CLOEXEC, 64) };
+    let ack_temp = unsafe { libc::fcntl(ack_write, libc::F_DUPFD_CLOEXEC, 64) };
+    if owner_temp < 0 || pid_temp < 0 || ack_temp < 0 {
+        return None;
+    }
+    if unsafe { libc::dup2(owner_temp, 3) } < 0
+        || unsafe { libc::dup2(pid_temp, 4) } < 0
+        || unsafe { libc::dup2(ack_temp, 5) } < 0
+    {
+        return None;
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        let closed = unsafe { libc::syscall(libc::SYS_close_range, 6_u32, u32::MAX, 0_u32) } == 0;
+        if !closed {
+            for fd in 6..max_fd {
+                unsafe { libc::close(fd) };
+            }
+        }
+    }
+    #[cfg(any(
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    unsafe {
+        libc::closefrom(6);
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    )))]
+    for fd in 6..max_fd {
+        unsafe { libc::close(fd) };
+    }
+    for fd in 0..3 {
+        unsafe { libc::close(fd) };
+    }
+    Some((3, 4, 5))
+}
+
+#[cfg(unix)]
+impl ProcessSupervisorGuardian {
+    fn install(command: &mut std::process::Command) -> Result<Self> {
+        use std::os::unix::process::CommandExt;
+
+        let owner = cloexec_pipe().context("failed creating supervisor owner pipe")?;
+        let pid_channel = match cloexec_pipe() {
+            Ok(pipe) => pipe,
+            Err(error) => {
+                unsafe {
+                    libc::close(owner[0]);
+                    libc::close(owner[1]);
+                }
+                return Err(error).context("failed creating supervisor pid channel");
+            }
+        };
+        let ack_channel = match cloexec_pipe() {
+            Ok(pipe) => pipe,
+            Err(error) => {
+                unsafe {
+                    for fd in [owner[0], owner[1], pid_channel[0], pid_channel[1]] {
+                        libc::close(fd);
+                    }
+                }
+                return Err(error).context("failed creating supervisor acknowledgement channel");
+            }
+        };
+
+        let max_fd = unsafe { libc::sysconf(libc::_SC_OPEN_MAX) }
+            .clamp(64, libc::c_int::MAX as libc::c_long) as libc::c_int;
+        let guardian_pid = unsafe { libc::fork() };
+        if guardian_pid == -1 {
+            let error = io::Error::last_os_error();
+            unsafe {
+                for fd in [
+                    owner[0],
+                    owner[1],
+                    pid_channel[0],
+                    pid_channel[1],
+                    ack_channel[0],
+                    ack_channel[1],
+                ] {
+                    libc::close(fd);
+                }
+            }
+            return Err(error).context("failed starting process-supervisor guardian");
+        }
+        if guardian_pid == 0 {
+            unsafe {
+                // The owning desktop may use one final group-directed SIGKILL
+                // as its crash/shutdown backstop. If the guardian remained in
+                // the supervisor's process group, that signal could kill both
+                // owners at once while the separately-sessioned target tree
+                // survived. A private session keeps the guardian alive long
+                // enough to observe owner-pipe EOF and kill the target PGID.
+                if libc::setsid() == -1 {
+                    libc::_exit(71);
+                }
+                libc::close(owner[1]);
+                libc::close(pid_channel[1]);
+                libc::close(ack_channel[0]);
+                let Some((owner_read, pid_read, ack_write)) =
+                    guardian_remap_and_close_unrelated_fds(
+                        owner[0],
+                        pid_channel[0],
+                        ack_channel[1],
+                        max_fd,
+                    )
+                else {
+                    libc::_exit(71);
+                };
+                let mut pid_bytes = [0_u8; std::mem::size_of::<libc::pid_t>()];
+                if guardian_read_exact(pid_read, &mut pid_bytes) {
+                    let target_pid = libc::pid_t::from_ne_bytes(pid_bytes);
+                    let _ = guardian_write_all(ack_write, &[1]);
+                    libc::close(pid_read);
+                    libc::close(ack_write);
+                    let mut byte = [0_u8; 1];
+                    loop {
+                        let count = libc::read(owner_read, byte.as_mut_ptr().cast(), 1);
+                        if count == 1 && byte == *b"D" {
+                            // The parent observed a spawn/exec failure. Rust's
+                            // Command implementation may already have reaped
+                            // that failed child, so signaling the numeric PGID
+                            // here would introduce a stale-id race.
+                            break;
+                        }
+                        if count == 1 && byte == *b"K" {
+                            let _ = libc::kill(-target_pid, libc::SIGKILL);
+                            break;
+                        }
+                        if count == 0 {
+                            // Owner EOF means the supervisor/daemon died
+                            // before it could perform orderly cleanup.
+                            let _ = libc::kill(-target_pid, libc::SIGKILL);
+                            break;
+                        }
+                        if count == -1
+                            && io::Error::last_os_error().kind() != io::ErrorKind::Interrupted
+                        {
+                            let _ = libc::kill(-target_pid, libc::SIGKILL);
+                            break;
+                        }
+                        if count == 1 {
+                            // Fail closed on an unknown owner command.
+                            let _ = libc::kill(-target_pid, libc::SIGKILL);
+                            break;
+                        }
+                    }
+                }
+                libc::_exit(0);
+            }
+        }
+
+        unsafe {
+            libc::close(owner[0]);
+            libc::close(pid_channel[0]);
+            libc::close(ack_channel[1]);
+        }
+        let owner_write = owner[1];
+        let setup_pid_write = pid_channel[1];
+        let setup_ack_read = ack_channel[0];
+        unsafe {
+            command.pre_exec(move || {
+                libc::close(owner_write);
+                let pid = libc::getpid().to_ne_bytes();
+                if !guardian_write_all(setup_pid_write, &pid) {
+                    return Err(io::Error::last_os_error());
+                }
+                libc::close(setup_pid_write);
+                let mut ack = [0_u8; 1];
+                if !guardian_read_exact(setup_ack_read, &mut ack) || ack != [1] {
+                    return Err(io::Error::other(
+                        "process-supervisor guardian did not acknowledge containment",
+                    ));
+                }
+                libc::close(setup_ack_read);
+                Ok(())
+            });
+        }
+        Ok(Self {
+            owner_write,
+            setup_pid_write,
+            setup_ack_read,
+            pid: guardian_pid,
+            finished: false,
+        })
+    }
+
+    fn spawn_finished(&mut self) {
+        unsafe {
+            if self.setup_pid_write >= 0 {
+                libc::close(self.setup_pid_write);
+                self.setup_pid_write = -1;
+            }
+            if self.setup_ack_read >= 0 {
+                libc::close(self.setup_ack_read);
+                self.setup_ack_read = -1;
+            }
+        }
+    }
+
+    fn finish_with_command(&mut self, command: u8) {
+        if self.finished {
+            return;
+        }
+        self.spawn_finished();
+        unsafe {
+            if self.owner_write >= 0 {
+                let _ = guardian_write_all(self.owner_write, &[command]);
+                libc::close(self.owner_write);
+                self.owner_write = -1;
+            }
+            loop {
+                let result = libc::waitpid(self.pid, std::ptr::null_mut(), 0);
+                if result == self.pid
+                    || (result == -1
+                        && io::Error::last_os_error().kind() != io::ErrorKind::Interrupted)
+                {
+                    break;
+                }
+            }
+        }
+        self.finished = true;
+    }
+
+    fn finish(&mut self) {
+        self.finish_with_command(b'K');
+    }
+
+    fn disarm(&mut self) {
+        self.finish_with_command(b'D');
+    }
+}
+
+#[cfg(unix)]
+impl Drop for ProcessSupervisorGuardian {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+#[cfg(unix)]
+type SpawnedProcessSupervisorTarget = (
+    std::process::Child,
+    StrictChildProcessTree,
+    ProcessSupervisorGuardian,
+);
+#[cfg(not(unix))]
+type SpawnedProcessSupervisorTarget = (std::process::Child, StrictChildProcessTree);
+
+fn spawn_process_supervisor_target(
+    request: &ProcessSupervisorRequest,
+) -> Result<SpawnedProcessSupervisorTarget> {
+    let mut command = std::process::Command::new(&request.program);
+    command
+        .args(&request.args)
+        .current_dir(&request.cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    #[cfg(unix)]
+    {
+        configure_child_process_tree_command(&mut command);
+        let mut guardian = ProcessSupervisorGuardian::install(&mut command)?;
+        let spawned = spawn_configured_strict_child_process_tree(&mut command);
+        guardian.spawn_finished();
+        let (child, process_tree) = match spawned {
+            Ok(spawned) => spawned,
+            Err(error) => {
+                guardian.disarm();
+                return Err(error.into());
+            }
+        };
+        Ok((child, process_tree, guardian))
+    }
+    #[cfg(not(unix))]
+    {
+        let (child, process_tree) = spawn_strict_child_process_tree(&mut command)?;
+        Ok((child, process_tree))
+    }
+}
+
+fn process_supervisor_child_exited(child: &mut std::process::Child) -> io::Result<bool> {
+    #[cfg(unix)]
+    {
+        poll_child_exit_without_reaping(child)
+    }
+    #[cfg(not(unix))]
+    {
+        child.try_wait().map(|status| status.is_some())
+    }
+}
+
+#[cfg(unix)]
+fn exit_like_process_supervisor_child(
+    status: std::process::ExitStatus,
+    cancellation_signal: Option<i32>,
+) -> ! {
+    use std::os::unix::process::ExitStatusExt;
+
+    if let Some(signal) = cancellation_signal.or_else(|| status.signal()) {
+        unsafe {
+            libc::signal(signal, libc::SIG_DFL);
+            libc::raise(signal);
+        }
+        std::process::exit(128 + signal);
+    }
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+#[cfg(not(unix))]
+fn exit_like_process_supervisor_child(
+    status: std::process::ExitStatus,
+    _cancellation_signal: Option<i32>,
+) -> ! {
+    std::process::exit(status.code().unwrap_or(1));
+}
+
+/// Hidden, versioned exact-handle process owner used by desktop clients.
+///
+/// The first stdin line is a bounded launch request. Keeping stdin open is the
+/// ownership lease: EOF cancels the strict target tree. On Windows an abrupt
+/// supervisor death closes its kill-on-close Job. On Unix a pre-exec guardian
+/// learns the reserved process-group id before the target can exec, then kills
+/// that group if even SIGKILL closes the supervisor's owner pipe.
+pub(crate) fn run_process_supervisor(protocol: &str) -> Result<()> {
+    if protocol != PROCESS_SUPERVISOR_PROTOCOL {
+        let _ = write_process_supervisor_control(serde_json::json!({
+            "event": "error",
+            "code": "unsupported_protocol",
+            "message": "unsupported process-supervisor protocol",
+        }));
+        anyhow::bail!("unsupported process-supervisor protocol");
+    }
+    let request = {
+        let stdin = io::stdin();
+        let mut stdin = stdin.lock();
+        match read_process_supervisor_request(&mut stdin) {
+            Ok(request) => request,
+            Err(error) => {
+                let _ = write_process_supervisor_control(serde_json::json!({
+                    "event": "error",
+                    "code": "invalid_request",
+                    "message": "invalid process-supervisor launch request",
+                }));
+                return Err(error);
+            }
+        }
+    };
+
+    #[cfg(unix)]
+    let (mut child, mut process_tree, mut guardian) =
+        match spawn_process_supervisor_target(&request) {
+            Ok(spawned) => spawned,
+            Err(error) => {
+                let _ = write_process_supervisor_control(serde_json::json!({
+                    "event": "error",
+                    "code": "spawn_failed",
+                    "message": "the supervised target could not be started",
+                }));
+                return Err(error);
+            }
+        };
+    #[cfg(not(unix))]
+    let (mut child, mut process_tree) = match spawn_process_supervisor_target(&request) {
+        Ok(spawned) => spawned,
+        Err(error) => {
+            let _ = write_process_supervisor_control(serde_json::json!({
+                "event": "error",
+                "code": "spawn_failed",
+                "message": "the supervised target could not be started",
+            }));
+            return Err(error);
+        }
+    };
+
+    let mut child_stdout = child
+        .stdout
+        .take()
+        .context("supervised target did not expose stdout")?;
+    let mut child_stderr = child
+        .stderr
+        .take()
+        .context("supervised target did not expose stderr")?;
+    let mut cancellation = SupervisedStreamCancellationGuard::install("process supervisor")?;
+    write_process_supervisor_control(serde_json::json!({
+        "event": "ready",
+        "protocol": PROCESS_SUPERVISOR_PROTOCOL,
+    }))?;
+
+    let stdout_thread = thread::spawn(move || -> io::Result<()> {
+        let mut stdout = io::stdout().lock();
+        io::copy(&mut child_stdout, &mut stdout)?;
+        stdout.flush()
+    });
+    let stderr_thread = thread::spawn(move || -> io::Result<()> {
+        let mut stderr = io::stderr().lock();
+        io::copy(&mut child_stderr, &mut stderr)?;
+        stderr.flush()
+    });
+    let (owner_tx, owner_rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut stdin = io::stdin().lock();
+        let mut byte = [0_u8; 1];
+        let outcome = loop {
+            match stdin.read(&mut byte) {
+                Ok(0) => break Ok(()),
+                Ok(_) => {
+                    break Err(anyhow::anyhow!(
+                        "unexpected bytes after process-supervisor launch frame"
+                    ));
+                }
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => break Err(anyhow::Error::new(error)),
+            }
+        };
+        let _ = owner_tx.send(outcome);
+    });
+
+    let pending_signal = cancellation.activate()?;
+    let mut cancellation_signal = pending_signal;
+    let mut owner_cancelled = pending_signal.is_some();
+    while !owner_cancelled && !process_supervisor_child_exited(&mut child)? {
+        if let Some(signal) = cancellation.cancelled_signal() {
+            cancellation_signal = Some(signal);
+            owner_cancelled = true;
+            break;
+        }
+        match owner_rx.try_recv() {
+            Ok(Ok(())) => owner_cancelled = true,
+            Ok(Err(error)) => {
+                eprintln!("coven process supervisor: {error:#}");
+                owner_cancelled = true;
+            }
+            Err(mpsc::TryRecvError::Disconnected) => owner_cancelled = true,
+            Err(mpsc::TryRecvError::Empty) => {}
+        }
+        if !owner_cancelled {
+            thread::sleep(PROCESS_SUPERVISOR_POLL_INTERVAL);
+        }
+    }
+
+    let termination_error = process_tree.terminate_tree().err();
+    // The Unix guardian intentionally performs one final group kill when its
+    // owner pipe closes. Reap it while the target group leader is still an
+    // unreaped child, so the numeric PGID cannot be recycled underneath that
+    // fail-safe signal.
+    #[cfg(unix)]
+    guardian.finish();
+    let status = child
+        .wait()
+        .context("failed reaping the supervised target")?;
+    let observed_signal = cancellation.finish()?.or(cancellation_signal);
+    if let Some(error) = termination_error {
+        return Err(anyhow::Error::new(error)
+            .context("failed terminating the supervised target process tree"));
+    }
+
+    if !owner_cancelled {
+        stdout_thread
+            .join()
+            .map_err(|_| anyhow::anyhow!("supervised stdout pump panicked"))??;
+        stderr_thread
+            .join()
+            .map_err(|_| anyhow::anyhow!("supervised stderr pump panicked"))??;
+    }
+    exit_like_process_supervisor_child(status, observed_signal)
 }
 
 /// Run one non-interactive Codex turn through its supported JSONL protocol.
@@ -1289,6 +2549,7 @@ where
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    command.apply_environment(&mut child_command);
     let mut cancellation = SupervisedStreamCancellationGuard::install("Codex")?;
     if let Some(error) = supervised_stream_cancellation_error(&cancellation, "Codex turn") {
         anyhow::bail!(error);
@@ -1740,12 +3001,23 @@ pub fn build_stream_harness_command_with_conversation(
     )?;
     let mut args = stream_passthrough_args(args, forward_stdin);
     args.extend(["--".to_string(), prompt.to_string()]);
-    let args = crate::harness::sanitize_argv_for_platform(args);
+    let args = crate::harness::sanitize_argv_for_program(
+        harness_id,
+        crate::harness::HarnessLaunchMode::Stream,
+        &program,
+        args,
+    );
+    let (program, env_overrides) = prepare_harness_program(
+        harness_id,
+        crate::harness::HarnessLaunchMode::Stream,
+        program,
+    )?;
     Ok(HarnessCommand {
         program,
         args,
         cwd: cwd.to_path_buf(),
         stdin_prompt: None,
+        env_overrides,
     })
 }
 
@@ -1829,7 +3101,8 @@ pub fn run_piped_attached(
     command: &HarnessCommand,
     merge_stderr_to_stdout: bool,
 ) -> Result<PtyRunResult> {
-    let mut child = std::process::Command::new(&command.program)
+    let mut child_command = std::process::Command::new(&command.program);
+    child_command
         .args(&command.args)
         .current_dir(&command.cwd)
         .stdin(if command.stdin_prompt.is_some() {
@@ -1849,14 +3122,14 @@ pub fn run_piped_attached(
             Stdio::piped()
         } else {
             Stdio::inherit()
-        })
-        .spawn()
-        .with_context(|| {
-            format!(
-                "failed to spawn harness `{}` in piped mode",
-                command.program()
-            )
-        })?;
+        });
+    command.apply_environment(&mut child_command);
+    let mut child = child_command.spawn().with_context(|| {
+        format!(
+            "failed to spawn harness `{}` in piped mode",
+            command.program()
+        )
+    })?;
     write_stdin_prompt(&mut child, command.stdin_prompt.as_deref())?;
 
     // Codex on Windows writes its complete `exec` transcript (including the
@@ -1898,7 +3171,8 @@ pub fn run_piped_attached_captured(
     command: &HarnessCommand,
     mut on_output: Box<dyn FnMut(Vec<u8>) + Send + 'static>,
 ) -> Result<PtyRunResult> {
-    let mut child = std::process::Command::new(&command.program)
+    let mut child_command = std::process::Command::new(&command.program);
+    child_command
         .args(&command.args)
         .current_dir(&command.cwd)
         .stdin(if command.stdin_prompt.is_some() {
@@ -1907,14 +3181,14 @@ pub fn run_piped_attached_captured(
             Stdio::inherit()
         })
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
-        .spawn()
-        .with_context(|| {
-            format!(
-                "failed to spawn harness `{}` in captured piped mode",
-                command.program()
-            )
-        })?;
+        .stderr(Stdio::piped());
+    command.apply_environment(&mut child_command);
+    let mut child = child_command.spawn().with_context(|| {
+        format!(
+            "failed to spawn harness `{}` in captured piped mode",
+            command.program()
+        )
+    })?;
     write_stdin_prompt(&mut child, command.stdin_prompt.as_deref())?;
     let mut stderr = child
         .stderr
@@ -1944,10 +3218,11 @@ pub fn stream_harness<W: Write>(
     ledger_session_id: &str,
     out: &mut W,
 ) -> Result<i32> {
-    stream_harness_with_program(
+    stream_harness_with_program_and_env(
         &command.program,
         &command.cwd,
         command.args.clone(),
+        &command.env_overrides,
         forward_stdin,
         harness_id,
         ledger_session_id,
@@ -2081,10 +3356,34 @@ fn normalize_native_stream_line<W: Write>(
         .with_context(|| format!("flushing {harness_id} stdout"))
 }
 
+#[cfg(test)]
 fn stream_harness_with_program<W: Write>(
     program: &str,
     cwd: &Path,
     args: Vec<String>,
+    forward_stdin: bool,
+    harness_id: &str,
+    ledger_session_id: &str,
+    out: &mut W,
+) -> Result<i32> {
+    stream_harness_with_program_and_env(
+        program,
+        cwd,
+        args,
+        &[],
+        forward_stdin,
+        harness_id,
+        ledger_session_id,
+        out,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn stream_harness_with_program_and_env<W: Write>(
+    program: &str,
+    cwd: &Path,
+    args: Vec<String>,
+    env_overrides: &[(String, Option<String>)],
     forward_stdin: bool,
     harness_id: &str,
     ledger_session_id: &str,
@@ -2101,6 +3400,16 @@ fn stream_harness_with_program<W: Write>(
         })
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit());
+    for (name, value) in env_overrides {
+        match value {
+            Some(value) => {
+                command.env(name, value);
+            }
+            None => {
+                command.env_remove(name);
+            }
+        }
+    }
     let cancellation_context = format!("{harness_id} native stream");
     let mut cancellation = SupervisedStreamCancellationGuard::install(&cancellation_context)?;
     if let Some(signal) = cancellation.cancelled_signal() {
@@ -2362,14 +3671,278 @@ pub fn spawn_detached(command: &HarnessCommand) -> Result<DetachedPtySession> {
     spawn_detached_with_observer(command, None)
 }
 
-/// Handle returned by `spawn_piped_with_observer`. The child handle itself
-/// is owned by the internal wait thread (so `wait()` can block without
-/// blocking the killer); the caller gets a writable stdin and the PID so
-/// it can signal termination via `libc::kill` instead of needing exclusive
-/// access to the `Child`.
+/// Handle returned by `spawn_piped_with_observer`. The child handle itself is
+/// owned by the internal wait thread (so `wait()` can block without blocking
+/// cancellation); the caller gets writable stdin plus the strict process-tree
+/// handle that was established before the Windows child started executing.
 pub struct PipedSession {
-    pub input: Box<dyn Write + Send>,
-    pub pid: u32,
+    input: Box<dyn Write + Send>,
+    process_tree: SharedStrictChildProcessTree,
+    prompt_delivery: Option<PipedPromptDelivery>,
+}
+
+const PIPED_PROMPT_DELIVERY_TIMEOUT: Duration = Duration::from_secs(30);
+const PIPED_PROMPT_DELIVERY_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const PIPED_PROMPT_REAP_TIMEOUT: Duration = Duration::from_secs(1);
+const PIPED_CHILD_WAIT_PENDING: u8 = 0;
+const PIPED_CHILD_REAPED: u8 = 1;
+const PIPED_CHILD_WAIT_FAILED: u8 = 2;
+
+struct PipedPromptDelivery {
+    stdin: Option<std::process::ChildStdin>,
+    prompt: Option<Vec<u8>>,
+    outcome: Arc<PipedPromptOutcome>,
+}
+
+struct PipedPromptOutcome {
+    delivered: Mutex<Option<bool>>,
+    ready: Condvar,
+}
+
+impl PipedPromptOutcome {
+    fn new(delivered: Option<bool>) -> Self {
+        Self {
+            delivered: Mutex::new(delivered),
+            ready: Condvar::new(),
+        }
+    }
+
+    fn finish(&self, delivered: bool) {
+        let mut state = self
+            .delivered
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if state.is_none() {
+            *state = Some(delivered);
+            self.ready.notify_all();
+        }
+    }
+
+    fn wait(&self) -> bool {
+        let mut state = self
+            .delivered
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        while state.is_none() {
+            state = self
+                .ready
+                .wait(state)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        }
+        state.unwrap_or(false)
+    }
+}
+
+impl PipedSession {
+    pub(crate) fn cancellation_handle(&self) -> SharedStrictChildProcessTree {
+        self.process_tree.clone()
+    }
+
+    /// Transfer cancellation ownership before delivering a one-shot prompt.
+    ///
+    /// `register` must retain the supplied process-tree handle whenever it
+    /// returns success. This ordering is deliberate: a large prompt may block
+    /// in an OS pipe, so daemon cancellation and shutdown must own the child
+    /// before prompt delivery starts.
+    pub(crate) fn activate<R>(
+        self,
+        register: impl FnOnce(Box<dyn Write + Send>, SharedStrictChildProcessTree) -> Result<R>,
+    ) -> Result<R> {
+        self.activate_with_prompt_timeout(PIPED_PROMPT_DELIVERY_TIMEOUT, register)
+    }
+
+    fn activate_with_prompt_timeout<R>(
+        self,
+        prompt_timeout: Duration,
+        register: impl FnOnce(Box<dyn Write + Send>, SharedStrictChildProcessTree) -> Result<R>,
+    ) -> Result<R> {
+        let Self {
+            input,
+            process_tree,
+            prompt_delivery,
+        } = self;
+        let cleanup_tree = process_tree.clone();
+        let registered = match register(input, process_tree) {
+            Ok(registered) => registered,
+            Err(error) => {
+                drop(prompt_delivery);
+                return Err(cleanup_piped_launch_failure(error, &cleanup_tree));
+            }
+        };
+
+        if let Some(delivery) = prompt_delivery {
+            delivery.deliver(prompt_timeout, &cleanup_tree)?;
+        }
+        Ok(registered)
+    }
+}
+
+impl PipedPromptDelivery {
+    fn deliver(
+        mut self,
+        timeout: Duration,
+        process_tree: &SharedStrictChildProcessTree,
+    ) -> Result<()> {
+        let outcome = Arc::clone(&self.outcome);
+        let stdin = self
+            .stdin
+            .take()
+            .context("piped prompt stdin was already consumed")?;
+        let prompt = self
+            .prompt
+            .take()
+            .context("piped prompt bytes were already consumed")?;
+        let result = deliver_piped_prompt(stdin, prompt, timeout, process_tree);
+        outcome.finish(result.is_ok());
+        result
+    }
+}
+
+impl Drop for PipedPromptDelivery {
+    fn drop(&mut self) {
+        // Registration rejection or caller abandonment means the launch-time
+        // prompt did not land. Wake the exit thread so it can persist a failed
+        // terminal result instead of trusting an unrelated root exit code.
+        self.outcome.finish(false);
+    }
+}
+
+fn deliver_piped_prompt(
+    stdin: std::process::ChildStdin,
+    prompt: Vec<u8>,
+    timeout: Duration,
+    process_tree: &SharedStrictChildProcessTree,
+) -> Result<()> {
+    if process_tree.is_terminated() {
+        return Err(cleanup_piped_launch_failure(
+            anyhow::anyhow!(
+                "harness process tree was terminated before its stdin prompt could be delivered"
+            ),
+            process_tree,
+        ));
+    }
+
+    let (completed_tx, completed_rx) = mpsc::sync_channel(1);
+    let writer = thread::Builder::new()
+        .name("coven-piped-prompt".into())
+        .spawn(move || {
+            let mut stdin = stdin;
+            let result = stdin
+                .write_all(&prompt)
+                .and_then(|_| stdin.flush())
+                .map_err(|error| {
+                    anyhow::Error::new(error).context("failed writing harness prompt to stdin")
+                });
+            // Dropping stdin after the exact write publishes EOF so a
+            // one-shot harness can begin processing the complete prompt.
+            drop(stdin);
+            let _ = completed_tx.send(result);
+        });
+    let writer = match writer {
+        Ok(writer) => writer,
+        Err(error) => {
+            return Err(cleanup_piped_launch_failure(
+                anyhow::Error::new(error)
+                    .context("failed to start bounded harness prompt delivery"),
+                process_tree,
+            ));
+        }
+    };
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            drop(writer);
+            return Err(cleanup_piped_launch_failure(
+                anyhow::anyhow!(
+                    "timed out after {} ms while writing harness prompt to stdin",
+                    timeout.as_millis()
+                ),
+                process_tree,
+            ));
+        }
+        let wait = remaining.min(PIPED_PROMPT_DELIVERY_POLL_INTERVAL);
+        match completed_rx.recv_timeout(wait) {
+            Ok(Ok(())) => {
+                if writer.join().is_err() {
+                    return Err(cleanup_piped_launch_failure(
+                        anyhow::anyhow!("harness prompt writer panicked after delivery"),
+                        process_tree,
+                    ));
+                }
+                return Ok(());
+            }
+            Ok(Err(error)) => {
+                let _ = writer.join();
+                return Err(cleanup_piped_launch_failure(error, process_tree));
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = writer.join();
+                return Err(cleanup_piped_launch_failure(
+                    anyhow::anyhow!("harness prompt writer stopped without reporting delivery"),
+                    process_tree,
+                ));
+            }
+            Err(RecvTimeoutError::Timeout) if process_tree.is_terminated() => {
+                drop(writer);
+                return Err(cleanup_piped_launch_failure(
+                    anyhow::anyhow!(
+                        "harness process tree was terminated while writing its stdin prompt"
+                    ),
+                    process_tree,
+                ));
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+        }
+    }
+}
+
+fn cleanup_piped_launch_failure(
+    primary: anyhow::Error,
+    process_tree: &SharedStrictChildProcessTree,
+) -> anyhow::Error {
+    match process_tree.terminate_and_wait(PIPED_PROMPT_REAP_TIMEOUT) {
+        Ok(()) => primary,
+        Err(cleanup) => anyhow::anyhow!("{primary:#}; cleanup failure: {cleanup:#}"),
+    }
+}
+
+fn wait_for_piped_child_reap(wait_state: &AtomicU8, timeout: Duration) -> u8 {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let state = wait_state.load(Ordering::Acquire);
+        if state != PIPED_CHILD_WAIT_PENDING || Instant::now() >= deadline {
+            return state;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+#[cfg(debug_assertions)]
+fn wait_at_piped_prepublication_test_barrier() -> Result<()> {
+    let Some(barrier_dir) = std::env::var_os("COVEN_TEST_PIPED_PREPUBLICATION_BARRIER_DIR") else {
+        return Ok(());
+    };
+    let barrier_dir = PathBuf::from(barrier_dir);
+    std::fs::create_dir_all(&barrier_dir)
+        .context("failed creating piped pre-publication test barrier")?;
+    std::fs::write(barrier_dir.join("ready"), b"ready\n")
+        .context("failed publishing piped pre-publication test barrier")?;
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while !barrier_dir.join("release").exists() {
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "timed out at piped pre-publication test barrier"
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
+    Ok(())
+}
+
+#[cfg(not(debug_assertions))]
+fn wait_at_piped_prepublication_test_barrier() -> Result<()> {
+    Ok(())
 }
 
 /// Spawn `command` as a plain piped child process (no PTY) and stream its
@@ -2396,59 +3969,90 @@ pub fn spawn_piped_with_observer(
     std_command.stdin(Stdio::piped());
     std_command.stdout(Stdio::piped());
     std_command.stderr(Stdio::piped());
-    // Put the child in its own session/process group so the daemon can
-    // signal it (and any subprocesses it spawns — skills, MCP servers,
-    // shells) as a single unit via `kill(-pid, …)` from `PipedKiller`.
-    // Without this, signals to the pid only reach the immediate child
-    // and leave grandchildren as orphans.
+    command.apply_environment(&mut std_command);
+    // Reuse strict containment. On Windows the console-subsystem child starts
+    // suspended and hidden, enters a KILL_ON_JOB_CLOSE job before its first
+    // instruction, and only then resumes. Unix additionally installs an
+    // independent guardian before fork/exec; daemon-process death closes its
+    // owner pipe and kills the new process group even if shutdown raced before
+    // the request handler could publish its in-process cancellation handle.
     #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            std_command.pre_exec(|| {
-                // setsid() makes the calling process the session leader
-                // of a new session AND the leader of a new process
-                // group with no controlling terminal. Returns -1 on
-                // failure (we propagate as io::Error to abort the spawn).
-                if libc::setsid() == -1 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
+    let (mut child, mut process_tree, mut guardian) = {
+        configure_child_process_tree_command(&mut std_command);
+        let mut guardian = ProcessSupervisorGuardian::install(&mut std_command)?;
+        let spawned = spawn_configured_strict_child_process_tree(&mut std_command);
+        guardian.spawn_finished();
+        match spawned {
+            Ok((child, process_tree)) => (child, process_tree, guardian),
+            Err(error) => {
+                guardian.disarm();
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to spawn harness `{}` in piped mode",
+                        command.program
+                    )
+                });
+            }
         }
-    }
-
-    let mut child = std_command.spawn().with_context(|| {
-        format!(
-            "failed to spawn harness `{}` in piped mode",
-            command.program
-        )
-    })?;
-
-    let pid = child.id();
-    let mut stdin = child
-        .stdin
-        .take()
-        .context("failed to take child stdin in piped mode")?;
-    let stdin: Box<dyn Write + Send> = if let Some(prompt) = command.stdin_prompt.as_deref() {
-        if let Err(error) = stdin.write_all(prompt).and_then(|_| stdin.flush()) {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(error).context("failed writing harness prompt to stdin");
-        }
-        drop(stdin);
-        Box::new(io::sink())
-    } else {
-        Box::new(stdin)
     };
-    let stdout = child
-        .stdout
-        .take()
-        .context("failed to take child stdout in piped mode")?;
-    let stderr = child
-        .stderr
-        .take()
-        .context("failed to take child stderr in piped mode")?;
+    #[cfg(not(unix))]
+    let (mut child, mut process_tree) = spawn_strict_child_process_tree(&mut std_command)
+        .with_context(|| {
+            format!(
+                "failed to spawn harness `{}` in piped mode",
+                command.program
+            )
+        })?;
+
+    let stdin = match child.stdin.take() {
+        Some(stdin) => stdin,
+        None => {
+            process_tree.terminate(&mut child);
+            #[cfg(unix)]
+            guardian.finish();
+            let _ = child.wait();
+            anyhow::bail!("failed to take child stdin in piped mode");
+        }
+    };
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            drop(stdin);
+            process_tree.terminate(&mut child);
+            #[cfg(unix)]
+            guardian.finish();
+            let _ = child.wait();
+            anyhow::bail!("failed to take child stdout in piped mode");
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            drop(stdin);
+            drop(stdout);
+            process_tree.terminate(&mut child);
+            #[cfg(unix)]
+            guardian.finish();
+            let _ = child.wait();
+            anyhow::bail!("failed to take child stderr in piped mode");
+        }
+    };
+    let prompt_outcome = Arc::new(PipedPromptOutcome::new(
+        command.stdin_prompt.is_none().then_some(true),
+    ));
+    let (stdin, prompt_delivery): (Box<dyn Write + Send>, Option<PipedPromptDelivery>) =
+        if let Some(prompt) = command.stdin_prompt.clone() {
+            (
+                Box::new(io::sink()),
+                Some(PipedPromptDelivery {
+                    stdin: Some(stdin),
+                    prompt: Some(prompt),
+                    outcome: Arc::clone(&prompt_outcome),
+                }),
+            )
+        } else {
+            (Box::new(stdin), None)
+        };
 
     // Share the on_output callback between the stdout and stderr drain
     // threads — both want to feed the same observer pipeline. `on_exit` is
@@ -2468,7 +4072,7 @@ pub fn spawn_piped_with_observer(
     // the stream at the first decode error — which `BufRead::lines()`
     // would do.
     let stderr_callback = Arc::clone(&on_output_shared);
-    thread::spawn(move || {
+    let stderr_thread = thread::spawn(move || {
         let mut reader = BufReader::new(stderr);
         let mut buf: Vec<u8> = Vec::with_capacity(256);
         loop {
@@ -2503,11 +4107,36 @@ pub fn spawn_piped_with_observer(
         }
     });
 
-    // Stdout drain + wait. The wait thread OWNS `child`; the killer never
-    // touches the `Child` handle, only the PID. That removes the previous
-    // deadlock risk where `wait()` and `kill()` raced on a shared mutex.
+    // Start both output drains before this function returns and therefore
+    // before `PipedSession::activate` can begin prompt delivery. This avoids
+    // the classic duplex pipe deadlock where the parent fills stdin while the
+    // child fills stdout before either side reads.
+    //
+    // The wait thread owns `child`; cancellation uses the independently owned
+    // process-group/Job Object handle, so it never needs to lock the `Child`
+    // around a blocking wait.
+    let child_wait_state = Arc::new(AtomicU8::new(PIPED_CHILD_WAIT_PENDING));
+    let wait_state = Arc::clone(&child_wait_state);
+    let exit_callback_complete = Arc::new(AtomicBool::new(false));
+    let callback_complete = Arc::clone(&exit_callback_complete);
+    #[cfg(unix)]
+    let process_tree = SharedStrictChildProcessTree::new(
+        process_tree,
+        guardian,
+        Arc::clone(&child_wait_state),
+        Arc::clone(&exit_callback_complete),
+    );
+    #[cfg(not(unix))]
+    let process_tree = SharedStrictChildProcessTree::new(
+        process_tree,
+        Arc::clone(&child_wait_state),
+        Arc::clone(&exit_callback_complete),
+    );
+    let wait_process_tree = Arc::downgrade(&process_tree.process_tree);
+    #[cfg(unix)]
+    let wait_guardian = Arc::downgrade(&process_tree.guardian);
     let stdout_callback = Arc::clone(&on_output_shared);
-    thread::spawn(move || {
+    let stdout_thread = thread::spawn(move || {
         let mut reader = stdout;
         let mut bridge: Box<dyn FnMut(Vec<u8>) + Send + 'static> = Box::new(move |chunk| {
             if let Ok(mut cb) = stdout_callback.lock() {
@@ -2515,24 +4144,95 @@ pub fn spawn_piped_with_observer(
             }
         });
         drain_detached_output(&mut reader, Some(&mut bridge));
-        let result = match child.wait() {
-            Ok(status) => PtyRunResult {
-                status: if status.success() {
-                    "completed"
-                } else {
-                    "failed"
+    });
+    thread::spawn(move || {
+        // Observe root exit concurrently with both pipe drains, without
+        // reaping it. A wrapper can exit while a descendant keeps stdout or
+        // stderr open forever; waiting for EOF first would never reach tree
+        // cleanup. WNOWAIT (or the stable Windows process handle) reserves the
+        // root identity until its entire containment unit is terminated.
+        let pre_reap_wait_failed = wait_for_child_exit_without_reaping(&child).is_err();
+        let containment_cleanup_failed =
+            wait_process_tree
+                .upgrade()
+                .is_some_and(|process_tree| match process_tree.lock() {
+                    Ok(mut process_tree) => process_tree.terminate_tree().is_err(),
+                    Err(poisoned) => poisoned.into_inner().terminate_tree().is_err(),
+                });
+        // Close and reap the independent Unix guardian while the direct child
+        // remains WNOWAIT-reserved. Its final group signal can therefore never
+        // target a recycled numeric PGID.
+        #[cfg(unix)]
+        if let Some(guardian) = wait_guardian.upgrade() {
+            match guardian.lock() {
+                Ok(mut guardian) => guardian.finish(),
+                Err(poisoned) => poisoned.into_inner().finish(),
+            }
+        }
+        // Tree termination closes every inherited output pipe. Join both
+        // drains before publishing quiescence so no observer callback can run
+        // after `/kill` or shutdown reports completion.
+        let stdout_drain_failed = stdout_thread.join().is_err();
+        let stderr_drain_failed = stderr_thread.join().is_err();
+        let (mut result, mut state) = match child.wait() {
+            Ok(status) => (
+                PtyRunResult {
+                    status: if status.success() {
+                        "completed"
+                    } else {
+                        "failed"
+                    },
+                    exit_code: status.code(),
                 },
-                exit_code: status.code(),
-            },
-            Err(_) => PtyRunResult {
-                status: "failed",
-                exit_code: None,
-            },
+                PIPED_CHILD_REAPED,
+            ),
+            Err(_) => (
+                PtyRunResult {
+                    status: "failed",
+                    exit_code: None,
+                },
+                PIPED_CHILD_WAIT_FAILED,
+            ),
         };
+        // A successful cancellation response is a quiescence boundary for
+        // consumers such as Cave: do not publish completion until both pipe
+        // drains have reached EOF. Otherwise a descendant that inherited
+        // stderr could still append output after `/kill` returned.
+        if stdout_drain_failed
+            || stderr_drain_failed
+            || pre_reap_wait_failed
+            || containment_cleanup_failed
+        {
+            state = PIPED_CHILD_WAIT_FAILED;
+        }
+        wait_state.store(state, Ordering::Release);
+        // Prompt-delivery cleanup may itself wait for the reaped/quiescent
+        // state above, so publish that barrier first. Do not publish on_exit,
+        // however, until delivery has a terminal outcome: a root can exit 0
+        // after closing stdin while the required prompt write fails with
+        // EPIPE. In that race the launch and durable exit event must both be
+        // failed, never completed.
+        if !prompt_outcome.wait() {
+            result.status = "failed";
+        }
         on_exit(result);
+        callback_complete.store(true, Ordering::Release);
     });
 
-    Ok(PipedSession { input: stdin, pid })
+    // Integration-only barrier used to prove that daemon termination remains
+    // bounded when a request thread has spawned a strict child but has not yet
+    // returned the cancellation handle to LiveSessionRuntime. On Unix, the
+    // guardian owner pipe is the process-death backstop for this exact window;
+    // on Windows, the already-attached Job Object is.
+    if let Err(error) = wait_at_piped_prepublication_test_barrier() {
+        return Err(cleanup_piped_launch_failure(error, &process_tree));
+    }
+
+    Ok(PipedSession {
+        input: stdin,
+        process_tree,
+        prompt_delivery,
+    })
 }
 
 pub fn spawn_detached_with_observer(
@@ -2690,6 +4390,72 @@ pub(crate) fn windows_detached_stub_command(
         args,
         cwd: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
         stdin_prompt: None,
+        env_overrides: Vec::new(),
+    })
+}
+
+#[cfg(all(test, windows))]
+pub(crate) fn windows_console_probe_command(build_dir: &Path) -> Result<HarnessCommand> {
+    let source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/windows_console_probe.rs");
+    let executable = build_dir.join("windows-console-probe.exe");
+    let compile = std::process::Command::new("rustc.exe")
+        .args(["--edition=2021", "-o"])
+        .arg(&executable)
+        .arg(&source)
+        .output()
+        .context("failed to compile native Windows console probe")?;
+    anyhow::ensure!(
+        compile.status.success(),
+        "native Windows console probe failed to compile: {}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    Ok(HarnessCommand {
+        program: executable.to_string_lossy().into_owned(),
+        args: Vec::new(),
+        cwd: PathBuf::from(env!("CARGO_MANIFEST_DIR")),
+        stdin_prompt: None,
+        env_overrides: Vec::new(),
+    })
+}
+
+#[cfg(all(test, any(unix, windows)))]
+pub(crate) fn piped_prompt_probe_command(
+    build_dir: &Path,
+    mode: &str,
+    first: &str,
+    second: Option<&Path>,
+    prompt: Vec<u8>,
+) -> Result<HarnessCommand> {
+    let source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/piped_prompt_probe.rs");
+    let executable = build_dir.join(if cfg!(windows) {
+        "piped-prompt-probe.exe"
+    } else {
+        "piped-prompt-probe"
+    });
+    let rustc = if cfg!(windows) { "rustc.exe" } else { "rustc" };
+    let compile = std::process::Command::new(rustc)
+        .args(["--edition=2021", "-o"])
+        .arg(&executable)
+        .arg(&source)
+        .output()
+        .context("failed to compile native piped-prompt probe")?;
+    anyhow::ensure!(
+        compile.status.success(),
+        "native piped-prompt probe failed to compile: {}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let mut args = vec![mode.to_string(), first.to_string()];
+    if let Some(second) = second {
+        args.push(second.to_string_lossy().into_owned());
+    }
+    Ok(HarnessCommand {
+        program: executable.to_string_lossy().into_owned(),
+        args,
+        cwd: build_dir.to_path_buf(),
+        stdin_prompt: (!prompt.is_empty()).then_some(prompt),
+        env_overrides: Vec::new(),
     })
 }
 
@@ -3250,6 +5016,889 @@ mod tests {
         }
     }
 
+    #[test]
+    fn windows_noninteractive_flags_preserve_other_creation_flags() {
+        const CREATE_SUSPENDED_VALUE: u32 = 0x0000_0004;
+        assert_eq!(
+            windows_noninteractive_creation_flags(0),
+            WINDOWS_CREATE_NO_WINDOW
+        );
+        assert_eq!(
+            windows_noninteractive_creation_flags(CREATE_SUSPENDED_VALUE),
+            WINDOWS_CREATE_NO_WINDOW | CREATE_SUSPENDED_VALUE
+        );
+    }
+
+    #[test]
+    fn official_windows_codex_npm_shim_resolves_validated_native_package() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let shim = temp_dir.path().join("codex.cmd");
+        let package_root = temp_dir
+            .path()
+            .join("node_modules")
+            .join("@openai")
+            .join("codex");
+        let entry = package_root.join("bin").join("codex.js");
+        let native_root = package_root
+            .join("node_modules")
+            .join("@openai")
+            .join("codex-win32-x64");
+        let native = native_root
+            .join("vendor")
+            .join("x86_64-pc-windows-msvc")
+            .join("bin")
+            .join("codex.exe");
+        std::fs::create_dir_all(entry.parent().unwrap())?;
+        std::fs::create_dir_all(native.parent().unwrap())?;
+        std::fs::write(
+            temp_dir.path().join("node_modules").join(".modules.yaml"),
+            b"fixture\n",
+        )?;
+        std::fs::write(&entry, "// official entry fixture\n")?;
+        std::fs::write(&native, b"native fixture")?;
+        std::fs::write(
+            package_root.join("package.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "name": "@openai/codex",
+                "bin": { "codex": "bin/codex.js" },
+                "optionalDependencies": {
+                    "@openai/codex-win32-x64": "npm:@openai/codex@0.0.0-win32-x64"
+                }
+            }))?,
+        )?;
+        std::fs::write(
+            native_root.join("package.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "name": "@openai/codex",
+                "os": ["win32"],
+                "cpu": ["x64"]
+            }))?,
+        )?;
+        std::fs::write(
+            &shim,
+            "@ECHO off\r\nendLocal & \"%_prog%\" \"%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js\" %*\r\n",
+        )?;
+
+        let launch = resolve_official_codex_npm_shim_for_target(
+            &shim,
+            "@openai/codex-win32-x64",
+            "x86_64-pc-windows-msvc",
+            "x64",
+        )?;
+        assert_eq!(launch.program, std::fs::canonicalize(native)?);
+        assert!(launch.env_overrides.contains(&(
+            "CODEX_MANAGED_PACKAGE_ROOT".to_string(),
+            Some(
+                std::fs::canonicalize(package_root)?
+                    .to_string_lossy()
+                    .into_owned()
+            )
+        )));
+        assert_eq!(
+            launch
+                .env_overrides
+                .iter()
+                .filter(|(name, value)| name.starts_with("CODEX_MANAGED_BY_")
+                    && value.as_deref() == Some("1"))
+                .count(),
+            1
+        );
+        assert!(launch
+            .env_overrides
+            .contains(&("CODEX_MANAGED_BY_PNPM".to_string(), Some("1".to_string()))));
+        Ok(())
+    }
+
+    #[test]
+    fn unofficial_windows_codex_batch_shim_fails_closed() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let shim = temp_dir.path().join("codex.cmd");
+        assert!(windows_program_is_batch_shim(&shim.to_string_lossy()));
+        std::fs::write(&shim, "@echo off\r\necho not-codex %*\r\n")?;
+        let error = resolve_official_codex_npm_shim_for_target(
+            &shim,
+            "@openai/codex-win32-x64",
+            "x86_64-pc-windows-msvc",
+            "x64",
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not contain a safe existing package entry"),
+            "{error:#}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn codex_managed_package_markers_match_supported_package_managers() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let npm_root = temp_dir.path().join("npm/node_modules/@openai/codex");
+        let bun_root = temp_dir
+            .path()
+            .join(".bun/install/global/node_modules/@openai/codex");
+        std::fs::create_dir_all(&npm_root)?;
+        std::fs::create_dir_all(&bun_root)?;
+        assert_eq!(
+            codex_package_manager_with_env(&npm_root, "npm/10", "npm-cli.js"),
+            "NPM"
+        );
+        assert_eq!(
+            codex_package_manager_with_env(&npm_root, "pnpm/10", "pnpm.cjs"),
+            "PNPM"
+        );
+        assert_eq!(codex_package_manager_with_env(&bun_root, "", ""), "BUN");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unattended_launch_policy_piped_fixture_creates_primary_artifact() -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        let project_root = temp_dir.path().join("project");
+        let allowed_dir = project_root.join("artifacts");
+        std::fs::create_dir_all(&allowed_dir)?;
+        let allowed_dir_text = allowed_dir.to_string_lossy().into_owned();
+        let fake_codex = temp_dir.path().join("fake-codex");
+        std::fs::write(
+            &fake_codex,
+            "#!/bin/sh\nprintf '%s\\n' \"$@\" > received-args.txt\ncat > received-prompt.txt\nprintf 'fixture artifact\\n' > artifacts/primary.md\nprintf 'artifact written\\n'\n",
+        )?;
+        let mut permissions = std::fs::metadata(&fake_codex)?.permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&fake_codex, permissions)?;
+
+        let policy =
+            crate::harness::LaunchPolicy::unattended_workspace_write(
+                vec![allowed_dir_text.clone()],
+            );
+        let mut command = build_piped_harness_command_with_conversation(
+            "codex",
+            "write artifacts/primary.md",
+            &project_root,
+            crate::harness::HarnessLaunchMode::NonInteractive,
+            None,
+            None,
+            crate::harness::HarnessLaunchOptions {
+                launch_policy: Some(&policy),
+                ..Default::default()
+            },
+        )?;
+        command.program = fake_codex.to_string_lossy().into_owned();
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+
+        assert_eq!(result.status, "completed", "{result:?}");
+        assert_eq!(
+            std::fs::read_to_string(allowed_dir.join("primary.md"))?,
+            "fixture artifact\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(project_root.join("received-args.txt"))?,
+            [
+                "--ask-for-approval",
+                "never",
+                "-c",
+                r#"approval_policy="never""#,
+                "--sandbox",
+                "workspace-write",
+                "--add-dir",
+                allowed_dir_text.as_str(),
+                "exec",
+                "--skip-git-repo-check",
+                "--color",
+                "never",
+                "--",
+                "-",
+                "",
+            ]
+            .join("\n")
+        );
+        assert_eq!(
+            std::fs::read_to_string(project_root.join("received-prompt.txt"))?,
+            "write artifacts/primary.md"
+        );
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_prompt_delivery_failure_terminates_after_registration() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("closed-stdin.pid");
+        let command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "close-stdin",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let child_pid = await_piped_descendant_pid(&pid_file)?;
+        let registered = Arc::new(AtomicBool::new(false));
+        let registered_in_callback = Arc::clone(&registered);
+        let error = match session.activate(|_input, process_tree| {
+            registered_in_callback.store(true, Ordering::Release);
+            Ok(process_tree)
+        }) {
+            Ok(_) => anyhow::bail!("a closed stdin unexpectedly accepted the prompt"),
+            Err(error) => error,
+        };
+        assert!(registered.load(Ordering::Acquire));
+        assert!(
+            format!("{error:#}").contains("failed writing harness prompt to stdin"),
+            "unexpected error: {error:#}"
+        );
+        let result = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        assert_eq!(result.status, "failed", "{result:?}");
+        assert!(
+            wait_for_piped_process_exit(child_pid, Duration::from_secs(2)),
+            "failed prompt delivery left child {child_pid} running"
+        );
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_prompt_failure_overrides_successful_root_exit() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("exit-zero-closed-stdin.pid");
+        let command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "exit-zero-close-stdin",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let child_pid = await_piped_descendant_pid(&pid_file)?;
+        assert!(
+            wait_for_piped_process_exit(child_pid, Duration::from_secs(10)),
+            "successful root did not exit before prompt delivery"
+        );
+        let error = match session.activate(|_input, process_tree| Ok(process_tree)) {
+            Ok(_) => anyhow::bail!("a closed stdin unexpectedly accepted the large prompt"),
+            Err(error) => error,
+        };
+        let diagnostic = format!("{error:#}");
+        assert!(
+            diagnostic.contains("failed writing harness prompt to stdin")
+                || diagnostic.contains("terminated before its stdin prompt could be delivered"),
+            "{diagnostic}"
+        );
+        let result = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        assert_eq!(result.status, "failed", "{result:?}");
+        assert_eq!(
+            result.exit_code,
+            Some(0),
+            "root exit remains diagnostic but cannot override prompt failure"
+        );
+        assert!(wait_for_piped_process_exit(
+            child_pid,
+            Duration::from_secs(2)
+        ));
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_prompt_and_pre_read_output_exceeding_pipe_capacity_complete_exactly(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let receipt = temp_dir.path().join("received-prompt.bin");
+        let prompt = (0..1024 * 1024)
+            .map(|index| (index % 251) as u8)
+            .collect::<Vec<_>>();
+        let output_bytes = 1024 * 1024;
+        let command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "duplex",
+            &output_bytes.to_string(),
+            Some(&receipt),
+            prompt.clone(),
+        )?;
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_output = Arc::clone(&captured);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(move |chunk| {
+                captured_for_output.lock().unwrap().extend(chunk);
+            }),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session
+            .activate_with_prompt_timeout(Duration::from_secs(8), |_input, process_tree| {
+                Ok(process_tree)
+            })?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+
+        assert_eq!(result.status, "completed", "{result:?}");
+        assert_eq!(result.exit_code, Some(0), "{result:?}");
+        let output = captured.lock().unwrap();
+        assert_eq!(output.len(), output_bytes);
+        assert!(output.iter().all(|byte| *byte == b'o'));
+        assert_eq!(std::fs::read(receipt)?, prompt);
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_root_exit_reaps_closed_pipe_descendant_before_completion() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("closed-pipe-descendant.pid");
+        let command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "root-exit-closed-descendant",
+            &pid_file.to_string_lossy(),
+            None,
+            Vec::new(),
+        )?;
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let descendant_pid = await_piped_descendant_pid(&pid_file)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        assert_eq!(result.status, "completed", "{result:?}");
+        assert_eq!(result.exit_code, Some(0), "{result:?}");
+        assert!(
+            wait_for_piped_process_exit(descendant_pid, Duration::from_secs(2)),
+            "successful root exit left closed-pipe descendant {descendant_pid} running"
+        );
+        drop(process_tree);
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_root_exit_terminates_inherited_output_descendant_and_preserves_exit(
+    ) -> anyhow::Result<()> {
+        use std::sync::atomic::AtomicUsize;
+
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("inherited-output-descendant.pid");
+        let command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "root-exit-output-descendant",
+            &pid_file.to_string_lossy(),
+            None,
+            Vec::new(),
+        )?;
+        let observed = Arc::new(AtomicUsize::new(0));
+        let observed_output = Arc::clone(&observed);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(move |chunk| {
+                observed_output.fetch_add(chunk.len(), Ordering::AcqRel);
+            }),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let descendant_pid = await_piped_descendant_pid(&pid_file)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        let count_at_exit = observed.load(Ordering::Acquire);
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(observed.load(Ordering::Acquire), count_at_exit);
+        drop(process_tree);
+
+        assert_eq!(result.status, "completed", "{result:?}");
+        assert_eq!(result.exit_code, Some(0), "{result:?}");
+        assert!(
+            count_at_exit > 0,
+            "descendant never exercised inherited output"
+        );
+        assert!(
+            wait_for_piped_process_exit(descendant_pid, Duration::from_secs(2)),
+            "natural root exit left inherited-output descendant {descendant_pid} running"
+        );
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_prompt_timeout_terminates_and_reaps_a_child_that_never_reads() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("never-read.pid");
+        let command = piped_prompt_probe_command(
+            temp_dir.path(),
+            "never-read",
+            &pid_file.to_string_lossy(),
+            None,
+            vec![b'x'; 1024 * 1024],
+        )?;
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let child_pid = await_piped_descendant_pid(&pid_file)?;
+        let started = Instant::now();
+        let error = match session
+            .activate_with_prompt_timeout(Duration::from_millis(100), |_input, process_tree| {
+                Ok(process_tree)
+            }) {
+            Ok(_) => anyhow::bail!("a never-reading child accepted the complete prompt"),
+            Err(error) => error,
+        };
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(format!("{error:#}").contains("timed out"), "{error:#}");
+        let result = exit_rx.recv_timeout(Duration::from_secs(2))?;
+        assert_eq!(result.status, "failed", "{result:?}");
+        assert!(
+            wait_for_piped_process_exit(child_pid, Duration::from_secs(2)),
+            "prompt timeout left child {child_pid} running"
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_piped_child_runs_without_a_console_window() -> anyhow::Result<()> {
+        use std::os::windows::process::CommandExt;
+        use windows_sys::Win32::System::Threading::CREATE_NEW_CONSOLE;
+
+        let temp_dir = tempfile::tempdir()?;
+        let command = windows_console_probe_command(temp_dir.path())?;
+        let mut control = std::process::Command::new(command.program());
+        control
+            .current_dir(command.cwd())
+            .creation_flags(CREATE_NEW_CONSOLE);
+        let control_output = control.output()?;
+        assert!(
+            control_output.status.success(),
+            "{:?}",
+            control_output.status
+        );
+        assert_eq!(
+            String::from_utf8(control_output.stdout)?.trim(),
+            "console=present",
+            "the console-subsystem fixture must positively observe an explicitly allocated console before it can prove production suppression"
+        );
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_output = Arc::clone(&captured);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(move |chunk| {
+                captured_for_output.lock().unwrap().extend(chunk);
+            }),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+        let output = String::from_utf8(captured.lock().unwrap().clone())?;
+
+        assert_eq!(result.status, "completed", "{result:?}; {output:?}");
+        assert_eq!(result.exit_code, Some(0), "{result:?}; {output:?}");
+        assert_eq!(output.trim(), "console=absent");
+        Ok(())
+    }
+
+    #[cfg(all(windows, target_arch = "x86_64"))]
+    #[test]
+    fn windows_official_codex_shim_launches_native_with_exact_argv_and_no_console(
+    ) -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let compiled_probe = windows_console_probe_command(temp_dir.path())?;
+        let shim = temp_dir.path().join("codex.cmd");
+        let package_root = temp_dir
+            .path()
+            .join("node_modules")
+            .join("@openai")
+            .join("codex");
+        let entry = package_root.join("bin").join("codex.js");
+        let native_root = package_root
+            .join("node_modules")
+            .join("@openai")
+            .join("codex-win32-x64");
+        let native = native_root
+            .join("vendor")
+            .join("x86_64-pc-windows-msvc")
+            .join("bin")
+            .join("codex.exe");
+        std::fs::create_dir_all(entry.parent().unwrap())?;
+        std::fs::create_dir_all(native.parent().unwrap())?;
+        std::fs::write(&entry, "// official entry fixture\n")?;
+        std::fs::copy(compiled_probe.program(), &native)?;
+        std::fs::write(
+            package_root.join("package.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "name": "@openai/codex",
+                "bin": { "codex": "bin/codex.js" },
+                "optionalDependencies": {
+                    "@openai/codex-win32-x64": "npm:@openai/codex@0.0.0-win32-x64"
+                }
+            }))?,
+        )?;
+        std::fs::write(
+            native_root.join("package.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "name": "@openai/codex",
+                "os": ["win32"],
+                "cpu": ["x64"]
+            }))?,
+        )?;
+        std::fs::write(
+            &shim,
+            "@ECHO off\r\nendLocal & \"%_prog%\" \"%dp0%\\node_modules\\@openai\\codex\\bin\\codex.js\" %*\r\n",
+        )?;
+        let shim_text = shim.to_string_lossy().into_owned();
+        let (interactive_program, interactive_env_overrides) = prepare_harness_program(
+            "codex",
+            crate::harness::HarnessLaunchMode::Interactive,
+            shim_text.clone(),
+        )?;
+        assert_eq!(interactive_program, shim_text);
+        assert!(
+            interactive_env_overrides.is_empty(),
+            "interactive PTY launches must retain the official wrapper and its existing environment"
+        );
+
+        let (program, env_overrides) = prepare_harness_program(
+            "codex",
+            crate::harness::HarnessLaunchMode::NonInteractive,
+            shim_text,
+        )?;
+        assert_eq!(PathBuf::from(&program), std::fs::canonicalize(&native)?);
+        assert!(!windows_program_is_batch_shim(&program));
+
+        let argv_file = temp_dir.path().join("argv.bin");
+        let env_file = temp_dir.path().join("managed-env.txt");
+        let external_dir = r#"C:\Research & Evidence\資料 ^ 100%!"#.to_string();
+        let exact_args = vec![
+            "--ask-for-approval".to_string(),
+            "never".to_string(),
+            "-c".to_string(),
+            r#"approval_policy="never""#.to_string(),
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+            "-c".to_string(),
+            r#"windows.sandbox="unelevated""#.to_string(),
+            "--add-dir".to_string(),
+            external_dir.clone(),
+            "exec".to_string(),
+            "--skip-git-repo-check".to_string(),
+            "--color".to_string(),
+            "never".to_string(),
+            "--".to_string(),
+            "-".to_string(),
+        ];
+        let mut fixture_args = vec![
+            "--record-argv-env".to_string(),
+            argv_file.to_string_lossy().into_owned(),
+            env_file.to_string_lossy().into_owned(),
+        ];
+        fixture_args.extend(exact_args.clone());
+        let command = HarnessCommand {
+            program,
+            args: fixture_args,
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+            env_overrides,
+        };
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_output = Arc::clone(&captured);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let session = spawn_piped_with_observer(
+            &command,
+            Some(DetachedPtyObserver {
+                on_output: Box::new(move |chunk| {
+                    captured_for_output.lock().unwrap().extend(chunk);
+                }),
+                on_exit: Box::new(move |result| {
+                    let _ = exit_tx.send(result);
+                }),
+            }),
+            false,
+        )?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+
+        assert_eq!(result.status, "completed", "{result:?}");
+        assert_eq!(result.exit_code, Some(0), "{result:?}");
+        assert_eq!(
+            String::from_utf8(captured.lock().unwrap().clone())?.trim(),
+            "console=absent"
+        );
+        assert_eq!(
+            std::fs::read_to_string(argv_file)?,
+            exact_args.join("\0"),
+            "native Codex argv changed after npm-shim resolution"
+        );
+        let managed_env = std::fs::read_to_string(env_file)?;
+        assert!(
+            managed_env.contains(&format!(
+                "package_root={}",
+                std::fs::canonicalize(package_root)?.display()
+            )),
+            "{managed_env}"
+        );
+        assert!(
+            managed_env.contains("managers=CODEX_MANAGED_BY_"),
+            "{managed_env}"
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_strict_child_combines_no_window_with_suspended_containment() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let probe = windows_console_probe_command(temp_dir.path())?;
+        let mut command = std::process::Command::new(probe.program());
+        command.current_dir(probe.cwd());
+        command.stdout(Stdio::piped());
+        command.stderr(Stdio::piped());
+
+        let (child, process_tree) = spawn_strict_child_process_tree(&mut command)?;
+        let output = child.wait_with_output()?;
+        drop(process_tree);
+
+        assert!(output.status.success(), "{:?}", output.status);
+        assert_eq!(String::from_utf8(output.stdout)?.trim(), "console=absent");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn piped_descendant_fixture(build_dir: &Path, pid_file: &Path) -> HarnessCommand {
+        HarnessCommand::fixture(
+            "/bin/sh",
+            vec![
+                "-c".to_string(),
+                "sleep 120 </dev/null >/dev/null 2>&1 & echo $! > \"$1\"; wait".to_string(),
+                "piped-descendant".to_string(),
+                pid_file.to_string_lossy().into_owned(),
+            ],
+            build_dir.to_path_buf(),
+        )
+    }
+
+    #[cfg(windows)]
+    fn piped_descendant_fixture(build_dir: &Path, pid_file: &Path) -> HarnessCommand {
+        let mut command = windows_console_probe_command(build_dir).expect("compile Windows probe");
+        command.args = vec![
+            "--spawn-descendant".to_string(),
+            pid_file.to_string_lossy().into_owned(),
+        ];
+        command
+    }
+
+    #[cfg(unix)]
+    fn piped_nonzero_fixture(build_dir: &Path) -> HarnessCommand {
+        HarnessCommand::fixture(
+            "/bin/sh",
+            vec!["-c".to_string(), "exit 23".to_string()],
+            build_dir.to_path_buf(),
+        )
+    }
+
+    #[cfg(windows)]
+    fn piped_nonzero_fixture(build_dir: &Path) -> HarnessCommand {
+        let mut command = windows_console_probe_command(build_dir).expect("compile Windows probe");
+        command.args = vec!["--exit-code".to_string(), "23".to_string()];
+        command
+    }
+
+    #[cfg(any(unix, windows))]
+    fn await_piped_descendant_pid(pid_file: &Path) -> anyhow::Result<u32> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Ok(raw) = std::fs::read_to_string(pid_file) {
+                if let Ok(pid) = raw.trim().parse::<u32>() {
+                    return Ok(pid);
+                }
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "piped fixture did not publish its descendant pid"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[cfg(unix)]
+    fn wait_for_piped_process_exit(pid: u32, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+            if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[cfg(windows)]
+    fn wait_for_piped_process_exit(pid: u32, timeout: Duration) -> bool {
+        wait_for_windows_process_exit(pid, timeout)
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_child_propagates_nonzero_exit_status() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let command = piped_nonzero_fixture(temp_dir.path());
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+
+        assert_eq!(result.status, "failed", "{result:?}");
+        assert_eq!(result.exit_code, Some(23), "{result:?}");
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn piped_process_tree_explicit_cancel_kills_descendant() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("descendant.pid");
+        let command = piped_descendant_fixture(temp_dir.path(), &pid_file);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let descendant_pid = await_piped_descendant_pid(&pid_file)?;
+
+        process_tree.terminate_tree()?;
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+
+        assert_eq!(result.status, "failed", "{result:?}");
+        assert!(
+            wait_for_piped_process_exit(descendant_pid, Duration::from_secs(10)),
+            "explicit cancellation left descendant {descendant_pid} running"
+        );
+        Ok(())
+    }
+
+    #[cfg(any(unix, windows))]
+    #[test]
+    fn dropping_piped_process_tree_handle_kills_descendant() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("descendant.pid");
+        let command = piped_descendant_fixture(temp_dir.path(), &pid_file);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let descendant_pid = await_piped_descendant_pid(&pid_file)?;
+
+        drop(process_tree);
+        let result = exit_rx.recv_timeout(Duration::from_secs(10))?;
+
+        assert_eq!(result.status, "failed", "{result:?}");
+        assert!(
+            wait_for_piped_process_exit(descendant_pid, Duration::from_secs(10)),
+            "dropping containment left descendant {descendant_pid} running"
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_kill_on_job_close_backstop_kills_descendant() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let pid_file = temp_dir.path().join("descendant.pid");
+        let command = piped_descendant_fixture(temp_dir.path(), &pid_file);
+        let (exit_tx, exit_rx) = mpsc::channel();
+        let observer = DetachedPtyObserver {
+            on_output: Box::new(|_| {}),
+            on_exit: Box::new(move |result| {
+                let _ = exit_tx.send(result);
+            }),
+        };
+        let session = spawn_piped_with_observer(&command, Some(observer), false)?;
+        let process_tree = session.activate(|_input, process_tree| Ok(process_tree))?;
+        let descendant_pid = await_piped_descendant_pid(&pid_file)?;
+
+        process_tree.close_job_handle_without_explicit_termination_for_test();
+        let _ = exit_rx.recv_timeout(Duration::from_secs(10))?;
+        drop(process_tree);
+
+        assert!(
+            wait_for_piped_process_exit(descendant_pid, Duration::from_secs(10)),
+            "KILL_ON_JOB_CLOSE backstop left descendant {descendant_pid} running"
+        );
+        Ok(())
+    }
+
     #[derive(Clone)]
     struct RecordingResizeTarget {
         sizes: Arc<Mutex<Vec<PtySize>>>,
@@ -3678,6 +6327,7 @@ mod tests {
             args: vec![],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: None,
+            env_overrides: Vec::new(),
         };
 
         let mut session = spawn_detached(&command)?;
@@ -3694,11 +6344,10 @@ mod tests {
     }
 
     #[cfg(windows)]
-    #[test]
-    fn windows_detached_pty_stub_completes_after_terminal_replies() -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?;
-        let trace_file = temp_dir.path().join("query-trace.txt");
-        let command = windows_detached_stub_command(temp_dir.path(), "queries", Some(&trace_file))?;
+    fn assert_windows_detached_pty_queries(
+        command: &HarnessCommand,
+        trace_file: &Path,
+    ) -> anyhow::Result<()> {
         let captured = Arc::new(Mutex::new(Vec::new()));
         let captured_for_output = Arc::clone(&captured);
         let (exit_tx, exit_rx) = mpsc::channel();
@@ -3714,9 +6363,13 @@ mod tests {
         let mut session = spawn_detached_with_observer_and_timeout(
             &command,
             Some(observer),
-            Some(Duration::from_secs(5)),
+            // Native CI can schedule ConPTY terminal replies several seconds
+            // apart under load. This path must complete all four query/reply
+            // exchanges before it emits meaningful output, so keep the proof
+            // bounded without racing a healthy interactive child.
+            Some(Duration::from_secs(15)),
         )?;
-        let result = match exit_rx.recv_timeout(Duration::from_secs(10)) {
+        let result = match exit_rx.recv_timeout(Duration::from_secs(20)) {
             Ok(result) => result,
             Err(error) => {
                 let _ = session.killer.kill();
@@ -3744,6 +6397,62 @@ mod tests {
             assert!(trace.lines().any(|line| line == stage), "{trace:?}");
         }
         Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_detached_pty_stub_completes_after_terminal_replies() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let trace_file = temp_dir.path().join("query-trace.txt");
+        let command = windows_detached_stub_command(temp_dir.path(), "queries", Some(&trace_file))?;
+
+        assert_windows_detached_pty_queries(&command, &trace_file)
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_interactive_codex_batch_shim_remains_pty_interactive() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let trace_file = temp_dir.path().join("query-trace.txt");
+        // Compile the same console/PTY fixture used by the direct executable
+        // regression, then put an npm-style batch boundary in front of it.
+        let _native = windows_detached_stub_command(temp_dir.path(), "queries", Some(&trace_file))?;
+        let shim = temp_dir.path().join("codex.cmd");
+        std::fs::write(
+            &shim,
+            concat!(
+                "@echo off\r\n",
+                "\"%~dp0windows-detached-pty-stub.exe\" queries ",
+                "\"%~dp0query-trace.txt\" %*\r\n"
+            ),
+        )?;
+
+        let shim = shim.to_string_lossy().into_owned();
+        let (program, env_overrides) = prepare_harness_program(
+            "codex",
+            crate::harness::HarnessLaunchMode::Interactive,
+            shim.clone(),
+        )?;
+        assert_eq!(program, shim, "interactive Codex must retain its npm shim");
+        assert!(
+            env_overrides.is_empty(),
+            "interactive Codex must not receive native-package overrides"
+        );
+        let args = crate::harness::sanitize_argv_for_program(
+            "codex",
+            crate::harness::HarnessLaunchMode::Interactive,
+            &program,
+            vec!["--".to_string(), "interactive PTY smoke".to_string()],
+        );
+        let command = HarnessCommand {
+            program,
+            args,
+            cwd: temp_dir.path().to_path_buf(),
+            stdin_prompt: None,
+            env_overrides,
+        };
+
+        assert_windows_detached_pty_queries(&command, &trace_file)
     }
 
     /// Deliberately short, and shorter is safer here.
@@ -3926,6 +6635,7 @@ printf '%s\n' '{"type":"turn.completed"}'
             ],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: None,
+            env_overrides: Vec::new(),
         };
         let mut assistant = Vec::new();
 
@@ -3974,6 +6684,7 @@ exec sleep 10
             ],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: None,
+            env_overrides: Vec::new(),
         };
 
         // The activity budget must outlive shell startup so the script can
@@ -4023,6 +6734,7 @@ exec sleep 10
             // Far larger than an anonymous-pipe buffer. A synchronous write
             // would block indefinitely because the fake harness never reads.
             stdin_prompt: Some(vec![b'x'; 1024 * 1024]),
+            env_overrides: Vec::new(),
         };
 
         let started = Instant::now();
@@ -4067,6 +6779,7 @@ exit 0
             ],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: None,
+            env_overrides: Vec::new(),
         };
 
         let started = Instant::now();
@@ -4135,6 +6848,7 @@ exit 23
             ],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: None,
+            env_overrides: Vec::new(),
         };
         let mut assistant = Vec::new();
 
@@ -4200,6 +6914,7 @@ exit 0
             ],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: None,
+            env_overrides: Vec::new(),
         };
 
         let outcome = stream_codex_json_with_timeout(&command, Duration::from_secs(1), |_| Ok(()))?;
@@ -6028,15 +8743,12 @@ exit 0
         .unwrap();
 
         assert_eq!(command.program(), "claude");
-        #[cfg(windows)]
-        assert_eq!(command.args(), &["--", "\"explain ^&^& exit\""]);
-        #[cfg(not(windows))]
         assert_eq!(command.args(), &["--", "explain && exit"]);
         assert_eq!(command.cwd(), cwd);
     }
 
     #[test]
-    fn windows_codex_noninteractive_prompt_uses_stdin() {
+    fn codex_noninteractive_prompt_uses_stdin_when_requested() {
         let prompt = "first line\nsecond & line with %PATH%";
         let mut args = vec![
             "exec".to_string(),
@@ -6046,7 +8758,7 @@ exit 0
             prompt.to_string(),
         ];
 
-        let stdin_prompt = move_windows_codex_prompt_to_stdin(
+        let stdin_prompt = move_codex_prompt_to_stdin(
             "codex",
             crate::harness::HarnessLaunchMode::NonInteractive,
             prompt,
@@ -6081,18 +8793,18 @@ exit 0
         Ok(())
     }
 
-    #[cfg(windows)]
     #[test]
-    fn windows_codex_stdin_prompt_keeps_familiar_identity() -> anyhow::Result<()> {
+    fn piped_codex_stdin_prompt_keeps_identity_unicode_and_large_input() -> anyhow::Result<()> {
         let familiar = crate::harness::FamiliarContext {
             id: "codex-local".to_string(),
             display_name: "Codex Local".to_string(),
             role: None,
         };
-        let command = build_harness_command_with_conversation(
+        let prompt = format!("diagnose the failure 🔮\n{}", "evidence ".repeat(12_000));
+        let command = build_piped_harness_command_with_conversation(
             "codex",
-            "diagnose the failure",
-            Path::new("C:\\project"),
+            &prompt,
+            Path::new("/project"),
             crate::harness::HarnessLaunchMode::NonInteractive,
             None,
             Some(&familiar),
@@ -6101,7 +8813,12 @@ exit 0
 
         let prompt = String::from_utf8(command.stdin_prompt.expect("prompt should use stdin"))?;
         assert!(prompt.starts_with(&familiar.identity_preamble()));
-        assert!(prompt.ends_with("diagnose the failure"));
+        assert!(prompt.ends_with("evidence "));
+        assert!(prompt.contains("diagnose the failure 🔮"));
+        assert!(
+            prompt.len() > 100_000,
+            "fixture exceeds ordinary argv safety margins"
+        );
         assert_eq!(command.args.last().map(String::as_str), Some("-"));
         Ok(())
     }
@@ -6114,8 +8831,7 @@ exit 0
             ("codex", crate::harness::HarnessLaunchMode::Interactive),
         ] {
             let mut args = vec!["--".to_string(), prompt.to_string()];
-            let stdin_prompt =
-                move_windows_codex_prompt_to_stdin(harness, mode, prompt, &mut args, true);
+            let stdin_prompt = move_codex_prompt_to_stdin(harness, mode, prompt, &mut args, true);
             assert!(stdin_prompt.is_none());
             assert_eq!(args.last().map(String::as_str), Some(prompt));
         }
@@ -6135,6 +8851,7 @@ exit 0
             args: vec!["exec".to_string(), "--".to_string(), "-".to_string()],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: Some(b"hello from stdin\nsecond & unsafe-looking line".to_vec()),
+            env_overrides: Vec::new(),
         };
         let captured = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
         let callback_output = captured.clone();
@@ -6183,6 +8900,7 @@ exit 0
             ],
             cwd: temp_dir.path().to_path_buf(),
             stdin_prompt: Some(b"first line\nsecond line\n".to_vec()),
+            env_overrides: Vec::new(),
         };
         let mut assistant = Vec::new();
 
@@ -6260,6 +8978,7 @@ exit 0
             // the anonymous-pipe buffer, proving the activity deadline also
             // covers a blocked prompt writer rather than only stdout reads.
             stdin_prompt: Some(vec![b'x'; 1024 * 1024]),
+            env_overrides: Vec::new(),
         };
 
         let started = Instant::now();

--- a/crates/coven-cli/tests/fixtures/piped_prompt_probe.rs
+++ b/crates/coven-cli/tests/fixtures/piped_prompt_probe.rs
@@ -1,0 +1,148 @@
+use std::env;
+use std::fs;
+use std::io::{self, Read, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+#[cfg(unix)]
+extern "C" {
+    fn close(fd: i32) -> i32;
+}
+
+#[cfg(windows)]
+#[link(name = "Kernel32")]
+extern "system" {
+    fn GetStdHandle(kind: u32) -> *mut core::ffi::c_void;
+    fn CloseHandle(handle: *mut core::ffi::c_void) -> i32;
+}
+
+fn close_stdin() {
+    #[cfg(unix)]
+    unsafe {
+        let _ = close(0);
+    }
+    #[cfg(windows)]
+    unsafe {
+        const STD_INPUT_HANDLE: u32 = (-10_i32) as u32;
+        let handle = GetStdHandle(STD_INPUT_HANDLE);
+        if !handle.is_null() && handle as isize != -1 {
+            let _ = CloseHandle(handle);
+        }
+    }
+}
+
+fn required_arg(name: &str) -> String {
+    env::args()
+        .nth(match name {
+            "mode" => 1,
+            "first" => 2,
+            "second" => 3,
+            _ => unreachable!(),
+        })
+        .unwrap_or_else(|| panic!("missing {name}"))
+}
+
+fn main() {
+    match required_arg("mode").as_str() {
+        "duplex" => {
+            let output_bytes = required_arg("first")
+                .parse::<usize>()
+                .expect("output byte count");
+            let receipt = required_arg("second");
+            // Fail a regressed parent-side duplex deadlock in bounded time.
+            // The repaired launcher finishes comfortably before this guard.
+            thread::spawn(|| {
+                thread::sleep(Duration::from_secs(10));
+                std::process::exit(124);
+            });
+
+            let chunk = vec![b'o'; 8192];
+            let mut stdout = io::stdout().lock();
+            let mut remaining = output_bytes;
+            while remaining != 0 {
+                let count = remaining.min(chunk.len());
+                stdout.write_all(&chunk[..count]).expect("write stdout");
+                remaining -= count;
+            }
+            stdout.flush().expect("flush stdout");
+
+            let mut prompt = Vec::new();
+            io::stdin()
+                .read_to_end(&mut prompt)
+                .expect("read complete prompt");
+            fs::write(receipt, prompt).expect("write prompt receipt");
+        }
+        "never-read" => {
+            let pid_file = required_arg("first");
+            fs::write(pid_file, std::process::id().to_string()).expect("write pid");
+            println!("ready");
+            io::stdout().flush().expect("flush ready marker");
+            thread::sleep(Duration::from_secs(120));
+        }
+        "close-stdin" => {
+            let pid_file = required_arg("first");
+            close_stdin();
+            fs::write(pid_file, std::process::id().to_string()).expect("write pid");
+            thread::sleep(Duration::from_secs(120));
+        }
+        "exit-zero-close-stdin" => {
+            let pid_file = required_arg("first");
+            close_stdin();
+            fs::write(pid_file, std::process::id().to_string()).expect("write pid");
+            // Exit successfully without consuming any prompt bytes. The
+            // launcher must treat the failed required transport as terminal
+            // failure rather than trusting this unrelated exit code.
+        }
+        "descendant-output" => {
+            let pid_file = required_arg("first");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("output-child")
+                .stdin(Stdio::null())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("spawn output descendant");
+            fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+            // The descendant intentionally owns both inherited output pipes;
+            // cancellation is complete only once its containing Job/process
+            // group is gone and both parent-side drains have reached EOF.
+            thread::sleep(Duration::from_secs(120));
+        }
+        "root-exit-output-descendant" => {
+            let pid_file = required_arg("first");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("output-child")
+                .stdin(Stdio::null())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .spawn()
+                .expect("spawn inherited-output descendant");
+            fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+            // Let the descendant prove both inherited pipes are live before
+            // the group leader exits successfully.
+            thread::sleep(Duration::from_millis(50));
+        }
+        "root-exit-closed-descendant" => {
+            let pid_file = required_arg("first");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("output-child")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn closed-pipe descendant");
+            fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+            // Exit successfully while the descendant remains alive and has
+            // already closed every pipe observed by the supervisor.
+        }
+        "output-child" => loop {
+            io::stdout().write_all(b"stdout-tick\n").expect("stdout tick");
+            io::stdout().flush().expect("flush stdout tick");
+            io::stderr().write_all(b"stderr-tick\n").expect("stderr tick");
+            io::stderr().flush().expect("flush stderr tick");
+            thread::sleep(Duration::from_millis(5));
+        },
+        mode => panic!("unsupported probe mode {mode}"),
+    }
+}

--- a/crates/coven-cli/tests/fixtures/process_supervisor_probe.rs
+++ b/crates/coven-cli/tests/fixtures/process_supervisor_probe.rs
@@ -1,0 +1,63 @@
+use std::env;
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+fn arg(index: usize, name: &str) -> String {
+    env::args().nth(index).unwrap_or_else(|| panic!("missing {name}"))
+}
+
+fn main() {
+    match arg(1, "mode").as_str() {
+        "output-exit" => {
+            let code = arg(2, "exit code").parse::<i32>().expect("exit code");
+            print!("supervised-stdout");
+            io::stdout().flush().expect("flush stdout");
+            eprint!("supervised-stderr");
+            io::stderr().flush().expect("flush stderr");
+            std::process::exit(code);
+        }
+        "descendant" => {
+            let pid_file = arg(2, "pid file");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("worker")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn descendant");
+            std::fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+            thread::sleep(Duration::from_secs(120));
+        }
+        "descendant-with-root" => {
+            let root_pid_file = arg(2, "root pid file");
+            let descendant_pid_file = arg(3, "descendant pid file");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("worker")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn descendant");
+            std::fs::write(root_pid_file, std::process::id().to_string())
+                .expect("write root pid");
+            std::fs::write(descendant_pid_file, child.id().to_string())
+                .expect("write descendant pid");
+            thread::sleep(Duration::from_secs(120));
+        }
+        "root-exit-descendant" => {
+            let pid_file = arg(2, "pid file");
+            let child = Command::new(env::current_exe().expect("current executable"))
+                .arg("worker")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("spawn descendant");
+            std::fs::write(pid_file, child.id().to_string()).expect("write descendant pid");
+        }
+        "worker" => thread::sleep(Duration::from_secs(120)),
+        mode => panic!("unsupported mode {mode}"),
+    }
+}

--- a/crates/coven-cli/tests/fixtures/windows_codex_json_probe.rs
+++ b/crates/coven-cli/tests/fixtures/windows_codex_json_probe.rs
@@ -1,0 +1,35 @@
+#![cfg(windows)]
+
+use std::io::{Read, Write};
+use std::time::Duration;
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    std::fs::write("args.txt", args.join(" ")).expect("failed to record Codex argv");
+
+    let mut prompt = String::new();
+    std::io::stdin()
+        .read_to_string(&mut prompt)
+        .expect("failed to read Codex prompt");
+    std::fs::write("stdin.txt", prompt).expect("failed to record Codex stdin");
+
+    if std::env::var_os("COVEN_TEST_CODEX_PROBE_SILENT").is_some() {
+        std::thread::sleep(Duration::from_secs(60));
+        return;
+    }
+
+    let mut stdout = std::io::stdout().lock();
+    writeln!(
+        stdout,
+        r#"{{"type":"thread.started","thread_id":"thread-789"}}"#
+    )
+    .unwrap();
+    writeln!(stdout, r#"{{"type":"turn.started"}}"#).unwrap();
+    writeln!(
+        stdout,
+        r#"{{"type":"item.completed","item":{{"id":"item-1","type":"agent_message","text":"reply for Cave"}}}}"#
+    )
+    .unwrap();
+    writeln!(stdout, r#"{{"type":"turn.completed"}}"#).unwrap();
+    stdout.flush().unwrap();
+}

--- a/crates/coven-cli/tests/fixtures/windows_console_probe.rs
+++ b/crates/coven-cli/tests/fixtures/windows_console_probe.rs
@@ -1,0 +1,254 @@
+//! Native Windows console-subsystem probe.
+//!
+//! This file is compiled directly with `rustc.exe` by Windows-only Rust and
+//! npm wrapper tests. It intentionally remains a console-subsystem binary:
+//! `GetConsoleWindow` can then distinguish an ordinary inherited/allocated
+//! console from a child created with `CREATE_NO_WINDOW`. Optional modes also
+//! provide a long-lived descendant and an exact exit code for native process-
+//! containment regressions without relying on PowerShell or a shell shim.
+
+use std::io::{Read, Write};
+use std::os::windows::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[link(name = "Kernel32")]
+extern "system" {
+    fn GetConsoleWindow() -> *mut core::ffi::c_void;
+    fn FreeConsole() -> i32;
+    fn AttachConsole(process_id: u32) -> i32;
+    fn SetConsoleCtrlHandler(
+        handler: Option<unsafe extern "system" fn(u32) -> i32>,
+        add: i32,
+    ) -> i32;
+    fn GenerateConsoleCtrlEvent(event: u32, process_group_id: u32) -> i32;
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    match args.next().as_deref() {
+        Some("--launch-new-console") => {
+            const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+            let program = args
+                .next()
+                .expect("--launch-new-console requires a program");
+            let output = Command::new(program)
+                .args(args)
+                .creation_flags(CREATE_NEW_CONSOLE)
+                .output()
+                .expect("failed to launch positive-control console child");
+            std::io::stdout()
+                .write_all(&output.stdout)
+                .expect("failed forwarding positive-control stdout");
+            std::io::stderr()
+                .write_all(&output.stderr)
+                .expect("failed forwarding positive-control stderr");
+            std::process::exit(output.status.code().unwrap_or(1));
+        }
+        Some("--launch-new-console-ctrl-c") => {
+            const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+            const CTRL_C_EVENT: u32 = 0;
+            let ready_file = args
+                .next()
+                .expect("--launch-new-console-ctrl-c requires a ready file");
+            let program = args
+                .next()
+                .expect("--launch-new-console-ctrl-c requires a program");
+            let mut child = Command::new(program)
+                .args(args)
+                .creation_flags(CREATE_NEW_CONSOLE)
+                .spawn()
+                .expect("failed to launch console-control target");
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            while !std::path::Path::new(&ready_file).exists() {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("console-control target did not publish readiness");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            unsafe {
+                let _ = FreeConsole();
+                assert_ne!(
+                    AttachConsole(child.id()),
+                    0,
+                    "failed to attach to positive-control console"
+                );
+                assert_ne!(
+                    SetConsoleCtrlHandler(None, 1),
+                    0,
+                    "failed to ignore the helper's own Ctrl-C event"
+                );
+                assert_ne!(
+                    GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0),
+                    0,
+                    "failed to generate Ctrl-C for the wrapper process group"
+                );
+                let _ = FreeConsole();
+            }
+            let deadline = std::time::Instant::now() + Duration::from_secs(5);
+            let status = loop {
+                if let Some(status) = child.try_wait().expect("failed waiting for Ctrl-C target") {
+                    break status;
+                }
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!("console-control target did not exit after Ctrl-C");
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            };
+            println!("ctrl-c-exit={}", status.code().unwrap_or(-1));
+            std::process::exit(0);
+        }
+        Some("--spawn-descendant") => {
+            let pid_file = args.next().expect("--spawn-descendant requires a pid file");
+            let child = Command::new("ping.exe")
+                .args(["-n", "120", "127.0.0.1"])
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("failed to spawn descendant fixture");
+            std::fs::write(pid_file, child.id().to_string())
+                .expect("failed to write descendant pid");
+            println!("descendant={}", child.id());
+            std::io::stdout().flush().expect("failed to flush fixture output");
+            loop {
+                std::thread::sleep(Duration::from_secs(60));
+            }
+        }
+        Some("--ctrl-c-ready") => {
+            let ready_file = args.next().expect("--ctrl-c-ready requires a ready file");
+            let pid_file = args.next().expect("--ctrl-c-ready requires a pid file");
+            // Ignore the console broadcast in the native fixture itself. The
+            // Node wrapper must receive Ctrl-C and explicitly terminate this
+            // child, proving forwarding rather than shared-console delivery.
+            unsafe {
+                assert_ne!(
+                    SetConsoleCtrlHandler(None, 1),
+                    0,
+                    "failed to make native Ctrl-C fixture ignore broadcasts"
+                );
+            }
+            std::fs::write(pid_file, std::process::id().to_string())
+                .expect("failed to write Ctrl-C fixture pid");
+            std::fs::write(ready_file, b"ready\n")
+                .expect("failed to write Ctrl-C fixture readiness");
+            loop {
+                std::thread::sleep(Duration::from_secs(60));
+            }
+        }
+        Some("--exit-code") => {
+            let code = args
+                .next()
+                .expect("--exit-code requires a value")
+                .parse::<i32>()
+                .expect("exit code must be an integer");
+            std::process::exit(code);
+        }
+        Some("--echo-stdio-exit") => {
+            let code = args
+                .next()
+                .expect("--echo-stdio-exit requires an exit code")
+                .parse::<i32>()
+                .expect("exit code must be an integer");
+            let state = if unsafe { GetConsoleWindow() }.is_null() {
+                "console=absent"
+            } else {
+                "console=present"
+            };
+            let mut input = Vec::new();
+            std::io::stdin()
+                .read_to_end(&mut input)
+                .expect("failed reading forwarded stdin");
+            println!("{state}");
+            std::io::stdout()
+                .write_all(&input)
+                .expect("failed writing forwarded stdout");
+            std::io::stdout()
+                .flush()
+                .expect("failed flushing forwarded stdout");
+            eprintln!("stderr=forwarded");
+            std::process::exit(code);
+        }
+        Some("--spam-stdout") => {
+            let chunk = vec![b'x'; 64 * 1024];
+            let mut stdout = std::io::stdout().lock();
+            loop {
+                if stdout.write_all(&chunk).is_err() || stdout.flush().is_err() {
+                    break;
+                }
+            }
+        }
+        Some("--print-env") => {
+            let name = args.next().expect("--print-env requires a name");
+            let present = std::env::vars()
+                .any(|(key, _)| key.eq_ignore_ascii_case(&name));
+            println!("env={}", if present { "present" } else { "absent" });
+        }
+        Some("--record-argv-env") => {
+            let argv_file = args
+                .next()
+                .expect("--record-argv-env requires an argv file");
+            let env_file = args
+                .next()
+                .expect("--record-argv-env requires an env file");
+            let remaining = args.collect::<Vec<_>>();
+            std::fs::write(argv_file, remaining.join("\0")).expect("failed recording argv");
+            let package_root = std::env::var("CODEX_MANAGED_PACKAGE_ROOT")
+                .unwrap_or_else(|_| "<absent>".to_string());
+            let managers = [
+                "CODEX_MANAGED_BY_NPM",
+                "CODEX_MANAGED_BY_BUN",
+                "CODEX_MANAGED_BY_PNPM",
+            ]
+            .into_iter()
+            .filter(|name| std::env::var(name).as_deref() == Ok("1"))
+            .collect::<Vec<_>>()
+            .join(",");
+            std::fs::write(
+                env_file,
+                format!("package_root={package_root}\nmanagers={managers}\n"),
+            )
+            .expect("failed recording managed-package environment");
+            let state = if unsafe { GetConsoleWindow() }.is_null() {
+                "console=absent"
+            } else {
+                "console=present"
+            };
+            println!("{state}");
+            return;
+        }
+        Some(other) => {
+            if let Some(pid_file) = std::env::var_os("COVEN_TEST_WINDOWS_CODEX_DESCENDANT_PID_FILE")
+            {
+                let child = Command::new("ping.exe")
+                    .args(["-n", "120", "127.0.0.1"])
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
+                    .spawn()
+                    .expect("failed to spawn Codex-style descendant fixture");
+                std::fs::write(pid_file, child.id().to_string())
+                    .expect("failed to write Codex-style descendant pid");
+                println!("codex-descendant={}", child.id());
+                std::io::stdout()
+                    .flush()
+                    .expect("failed to flush Codex-style fixture output");
+                loop {
+                    std::thread::sleep(Duration::from_secs(60));
+                }
+            }
+            panic!("unknown fixture mode: {other}");
+        }
+        None => {}
+    }
+    let state = if unsafe { GetConsoleWindow() }.is_null() {
+        "console=absent"
+    } else {
+        "console=present"
+    };
+    println!("{state}");
+}

--- a/crates/coven-cli/tests/process_supervisor.rs
+++ b/crates/coven-cli/tests/process_supervisor.rs
@@ -1,0 +1,330 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+const PROTOCOL: &str = "coven.process-supervisor.v1";
+const CONTROL_PREFIX: &str = "COVEN_PROCESS_SUPERVISOR_V1 ";
+
+struct ActiveSupervisor {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    stdout: ChildStdout,
+    stderr: BufReader<ChildStderr>,
+}
+
+fn compile_probe(build_dir: &Path) -> Result<PathBuf> {
+    let source = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/process_supervisor_probe.rs");
+    let executable = build_dir.join(if cfg!(windows) {
+        "process-supervisor-probe.exe"
+    } else {
+        "process-supervisor-probe"
+    });
+    let rustc = if cfg!(windows) { "rustc.exe" } else { "rustc" };
+    let output = Command::new(rustc)
+        .args(["--edition=2021", "-o"])
+        .arg(&executable)
+        .arg(source)
+        .output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "failed compiling process-supervisor probe: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(executable)
+}
+
+fn process_supervisor_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_coven"));
+    command.args(["process-supervisor", "--protocol", PROTOCOL]);
+    command
+}
+
+fn launch_supervisor(program: &Path, args: &[String], cwd: &Path) -> Result<ActiveSupervisor> {
+    launch_supervisor_with_command(process_supervisor_command(), program, args, cwd)
+}
+
+fn launch_supervisor_with_command(
+    mut command: Command,
+    program: &Path,
+    args: &[String],
+    cwd: &Path,
+) -> Result<ActiveSupervisor> {
+    let mut child = command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut stdin = child.stdin.take().context("supervisor stdin")?;
+    let request = serde_json::json!({
+        "version": 1,
+        "program": program,
+        "args": args,
+        "cwd": cwd,
+    });
+    serde_json::to_writer(&mut stdin, &request)?;
+    stdin.write_all(b"\n")?;
+    stdin.flush()?;
+
+    let stdout = child.stdout.take().context("supervisor stdout")?;
+    let stderr = child.stderr.take().context("supervisor stderr")?;
+    let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut stderr = BufReader::new(stderr);
+        let mut control = String::new();
+        let result = stderr.read_line(&mut control).map(|_| (stderr, control));
+        let _ = ready_tx.send(result);
+    });
+    let (stderr, control) = match ready_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(result) => result?,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(anyhow::Error::new(error).context("supervisor did not publish ready"));
+        }
+    };
+    assert!(control.starts_with(CONTROL_PREFIX), "{control:?}");
+    let event: serde_json::Value = serde_json::from_str(&control[CONTROL_PREFIX.len()..])?;
+    assert_eq!(event["event"], "ready", "{event}");
+    assert_eq!(event["protocol"], PROTOCOL, "{event}");
+    Ok(ActiveSupervisor {
+        child,
+        stdin: Some(stdin),
+        stdout,
+        stderr,
+    })
+}
+
+fn wait_bounded(child: &mut Child, timeout: Duration) -> Result<ExitStatus> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        anyhow::ensure!(Instant::now() < deadline, "supervisor did not exit in time");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn wait_for_pid(path: &Path) -> Result<u32> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(raw) = std::fs::read_to_string(path) {
+            if let Ok(pid) = raw.trim().parse::<u32>() {
+                return Ok(pid);
+            }
+        }
+        anyhow::ensure!(Instant::now() < deadline, "fixture did not publish a pid");
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+fn process_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION};
+    const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
+    let handle = unsafe {
+        OpenProcess(
+            SYNCHRONIZE_ACCESS | PROCESS_QUERY_LIMITED_INFORMATION,
+            0,
+            pid,
+        )
+    };
+    if handle.is_null() {
+        return false;
+    }
+    unsafe { CloseHandle(handle) };
+    true
+}
+
+fn wait_for_process_exit(pid: u32) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while process_is_alive(pid) {
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "supervisor left descendant {pid} alive"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}
+
+#[test]
+fn supervisor_admits_then_preserves_stdout_stderr_and_exit_code() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let probe = compile_probe(temp.path())?;
+    let mut active = launch_supervisor(
+        &probe,
+        &["output-exit".to_string(), "23".to_string()],
+        temp.path(),
+    )?;
+
+    let status = wait_bounded(&mut active.child, Duration::from_secs(5))?;
+    assert_eq!(status.code(), Some(23));
+    let mut stdout = String::new();
+    active.stdout.read_to_string(&mut stdout)?;
+    let mut stderr = String::new();
+    active.stderr.read_to_string(&mut stderr)?;
+    assert_eq!(stdout, "supervised-stdout");
+    assert_eq!(stderr, "supervised-stderr");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn supervisor_propagates_target_signal() -> Result<()> {
+    use std::os::unix::process::ExitStatusExt;
+
+    let temp = tempfile::tempdir()?;
+    let mut active = launch_supervisor(
+        Path::new("/bin/sh"),
+        &["-c".to_string(), "kill -TERM $$".to_string()],
+        temp.path(),
+    )?;
+
+    let status = wait_bounded(&mut active.child, Duration::from_secs(5))?;
+    assert_eq!(status.signal(), Some(libc::SIGTERM), "{status:?}");
+    Ok(())
+}
+
+#[test]
+fn supervisor_owner_eof_terminates_and_reaps_descendants() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let probe = compile_probe(temp.path())?;
+    let pid_file = temp.path().join("descendant.pid");
+    let mut active = launch_supervisor(
+        &probe,
+        &[
+            "descendant".to_string(),
+            pid_file.to_string_lossy().into_owned(),
+        ],
+        temp.path(),
+    )?;
+    let descendant = wait_for_pid(&pid_file)?;
+
+    drop(active.stdin.take());
+    let status = wait_bounded(&mut active.child, Duration::from_secs(5))?;
+    assert!(!status.success());
+    wait_for_process_exit(descendant)
+}
+
+#[test]
+fn supervisor_root_exit_cleans_closed_pipe_descendants() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let probe = compile_probe(temp.path())?;
+    let pid_file = temp.path().join("root-exit-descendant.pid");
+    let mut active = launch_supervisor(
+        &probe,
+        &[
+            "root-exit-descendant".to_string(),
+            pid_file.to_string_lossy().into_owned(),
+        ],
+        temp.path(),
+    )?;
+    let descendant = wait_for_pid(&pid_file)?;
+
+    let status = wait_bounded(&mut active.child, Duration::from_secs(5))?;
+    assert_eq!(status.code(), Some(0));
+    wait_for_process_exit(descendant)
+}
+
+#[test]
+fn abrupt_supervisor_termination_retains_no_descendant() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let probe = compile_probe(temp.path())?;
+    let pid_file = temp.path().join("abrupt-descendant.pid");
+    let mut active = launch_supervisor(
+        &probe,
+        &[
+            "descendant".to_string(),
+            pid_file.to_string_lossy().into_owned(),
+        ],
+        temp.path(),
+    )?;
+    let descendant = wait_for_pid(&pid_file)?;
+
+    active.child.kill()?;
+    drop(active.stdin.take());
+    let _ = wait_bounded(&mut active.child, Duration::from_secs(5))?;
+    wait_for_process_exit(descendant)
+}
+
+#[cfg(unix)]
+#[test]
+fn abrupt_supervisor_process_group_termination_retains_no_target_tree() -> Result<()> {
+    use std::os::unix::process::{CommandExt, ExitStatusExt};
+
+    let temp = tempfile::tempdir()?;
+    let probe = compile_probe(temp.path())?;
+    let root_pid_file = temp.path().join("group-kill-root.pid");
+    let descendant_pid_file = temp.path().join("group-kill-descendant.pid");
+    let mut command = process_supervisor_command();
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut active = launch_supervisor_with_command(
+        command,
+        &probe,
+        &[
+            "descendant-with-root".to_string(),
+            root_pid_file.to_string_lossy().into_owned(),
+            descendant_pid_file.to_string_lossy().into_owned(),
+        ],
+        temp.path(),
+    )?;
+    let target_root = wait_for_pid(&root_pid_file)?;
+    let descendant = wait_for_pid(&descendant_pid_file)?;
+    let supervisor_group = active.child.id() as libc::pid_t;
+
+    let killed = unsafe { libc::kill(-supervisor_group, libc::SIGKILL) };
+    anyhow::ensure!(
+        killed == 0,
+        "failed killing isolated supervisor process group: {}",
+        std::io::Error::last_os_error()
+    );
+    drop(active.stdin.take());
+    let status = wait_bounded(&mut active.child, Duration::from_secs(5))?;
+    assert_eq!(status.signal(), Some(libc::SIGKILL), "{status:?}");
+    wait_for_process_exit(target_root)?;
+    wait_for_process_exit(descendant)
+}
+
+#[test]
+fn invalid_supervisor_request_fails_before_ready() -> Result<()> {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["process-supervisor", "--protocol", PROTOCOL])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    child.stdin.take().unwrap().write_all(b"{}\n")?;
+    let output = child.wait_with_output()?;
+    assert_eq!(output.status.code(), Some(70));
+    assert_eq!(output.stdout, b"");
+    let first = String::from_utf8(output.stderr)?;
+    assert!(first.starts_with(CONTROL_PREFIX), "{first:?}");
+    let event: serde_json::Value = serde_json::from_str(
+        first
+            .strip_prefix(CONTROL_PREFIX)
+            .expect("control prefix")
+            .trim_end(),
+    )?;
+    assert_eq!(event["event"], "error");
+    assert_eq!(event["code"], "invalid_request");
+    Ok(())
+}

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -3,7 +3,7 @@
 use std::ffi::OsString;
 use std::fs;
 use std::io::{Read, Write};
-use std::net::Shutdown;
+use std::net::{Shutdown, TcpListener, TcpStream};
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::path::{Path, PathBuf};
@@ -143,6 +143,223 @@ fn daemon_start_is_idempotent_when_daemon_is_already_running() -> anyhow::Result
         second_pid, first_pid,
         "daemon start should reuse the verified running daemon instead of spawning another serve process"
     );
+    Ok(())
+}
+
+#[test]
+fn daemon_stop_terminates_live_piped_session_descendants() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let project_root = temp_dir.path().join("project");
+    let fake_bin = temp_dir.path().join("bin");
+    let descendant_pid_file = temp_dir.path().join("descendant.pid");
+    fs::create_dir_all(&project_root)?;
+    fs::create_dir_all(&fake_bin)?;
+    write_shutdown_fake_codex(&fake_bin, &descendant_pid_file)?;
+    let path = prepend_path(&fake_bin);
+    let coven = coven_bin();
+    let _daemon_guard = DaemonGuard {
+        coven: coven.clone(),
+        coven_home: coven_home.clone(),
+        path: path.clone(),
+    };
+
+    let start = run_coven(&coven, &coven_home, &path, &["daemon", "start"])?;
+    assert_success("daemon start for shutdown containment", &start);
+    wait_for_daemon_health(&coven_home)?;
+    let body = json!({
+        "projectRoot": project_root,
+        "harness": "codex",
+        "launchMode": "nonInteractive",
+        "prompt": "hold for daemon shutdown",
+        "title": "Shutdown containment"
+    })
+    .to_string();
+    let (status, response) = unix_http_request(&coven_home, "POST", "/sessions", Some(&body))?;
+    assert_eq!(status, 201, "unexpected launch response: {response}");
+
+    wait_until("piped descendant pid", || Ok(descendant_pid_file.exists()))?;
+    let descendant_pid = fs::read_to_string(&descendant_pid_file)?
+        .trim()
+        .parse::<u32>()?;
+    assert!(
+        pid_is_alive(descendant_pid),
+        "fixture descendant should be live before daemon stop"
+    );
+
+    let stop = run_coven(&coven, &coven_home, &path, &["daemon", "stop"])?;
+    assert_success("daemon stop with live piped child", &stop);
+    wait_until("piped descendant termination after daemon stop", || {
+        Ok(!pid_is_alive(descendant_pid))
+    })?;
+    assert!(
+        !coven_home.join("coven.sock").exists(),
+        "graceful shutdown should remove its Unix socket"
+    );
+    assert!(
+        !coven_home.join("daemon.json").exists(),
+        "graceful shutdown should remove its status file"
+    );
+    Ok(())
+}
+
+#[test]
+fn daemon_stop_kills_piped_tree_stalled_before_runtime_publication() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let project_root = temp_dir.path().join("project");
+    let fake_bin = temp_dir.path().join("bin");
+    let barrier_dir = temp_dir.path().join("prepublication-barrier");
+    let descendant_pid_file = temp_dir.path().join("prepublication-descendant.pid");
+    fs::create_dir_all(&project_root)?;
+    fs::create_dir_all(&fake_bin)?;
+    write_shutdown_fake_codex(&fake_bin, &descendant_pid_file)?;
+    let path = prepend_path(&fake_bin);
+    let coven = coven_bin();
+    let _daemon_guard = DaemonGuard {
+        coven: coven.clone(),
+        coven_home: coven_home.clone(),
+        path: path.clone(),
+    };
+
+    let start = Command::new(&coven)
+        .args(["daemon", "start"])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .env("COVEN_TEST_PIPED_PREPUBLICATION_BARRIER_DIR", &barrier_dir)
+        .output()?;
+    assert_success("daemon start for pre-publication containment", &start);
+    wait_for_daemon_health(&coven_home)?;
+
+    let body = json!({
+        "projectRoot": project_root,
+        "harness": "codex",
+        "launchMode": "nonInteractive",
+        "prompt": "hold before runtime ownership publication",
+        "title": "Pre-publication shutdown containment"
+    })
+    .to_string();
+    let request = format!(
+        "POST /sessions HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    );
+    let mut launch_stream = UnixStream::connect(coven_home.join("coven.sock"))?;
+    launch_stream.write_all(request.as_bytes())?;
+    launch_stream.shutdown(Shutdown::Write)?;
+
+    wait_until("piped pre-publication barrier", || {
+        Ok(barrier_dir.join("ready").exists())
+    })?;
+    wait_until("pre-publication descendant pid", || {
+        Ok(descendant_pid_file.exists())
+    })?;
+    let descendant_pid = fs::read_to_string(&descendant_pid_file)?
+        .trim()
+        .parse::<u32>()?;
+    assert!(
+        pid_is_alive(descendant_pid),
+        "fixture descendant should be live in the pre-publication window"
+    );
+
+    let started = Instant::now();
+    let stop = run_coven(&coven, &coven_home, &path, &["daemon", "stop"])?;
+    let elapsed = started.elapsed();
+    assert_success("daemon stop during pre-publication launch", &stop);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "daemon stop exceeded its documented two-second deadline: {elapsed:?}"
+    );
+    wait_until("pre-publication descendant guardian cleanup", || {
+        Ok(!pid_is_alive(descendant_pid))
+    })?;
+    drop(launch_stream);
+    Ok(())
+}
+
+#[test]
+fn stalled_tcp_request_cannot_exhaust_daemon_stop_deadline() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+    let port_reservation = TcpListener::bind("127.0.0.1:0")?;
+    let tcp_addr = port_reservation.local_addr()?.to_string();
+    drop(port_reservation);
+    let _daemon_guard = DaemonGuard {
+        coven: coven.clone(),
+        coven_home: coven_home.clone(),
+        path: path.clone(),
+    };
+    let mut daemon = Command::new(&coven)
+        .args(["daemon", "serve", "--tcp", &tcp_addr])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    wait_for_daemon_health(&coven_home)?;
+
+    let mut stalled = TcpStream::connect(&tcp_addr)?;
+    stalled.write_all(
+        b"POST /api/v1/sessions HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: 4096\r\n\r\n{",
+    )?;
+    stalled.flush()?;
+    // The TCP worker polls accept every 25 ms. Leave ample time for it to
+    // accept this request and block waiting for the deliberately absent body.
+    thread::sleep(Duration::from_millis(250));
+
+    let started = Instant::now();
+    // `serve` is our direct child in this test. Reap it concurrently with the
+    // separate `daemon stop` command; otherwise that command's kill(0) probe
+    // correctly observes our unreaped zombie as an extant pid and times out.
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel();
+    let stop_coven = coven.clone();
+    let stop_home = coven_home.clone();
+    let stop_path = path.clone();
+    thread::spawn(move || {
+        let _ = stop_tx.send(run_coven(
+            &stop_coven,
+            &stop_home,
+            &stop_path,
+            &["daemon", "stop"],
+        ));
+    });
+    let daemon_deadline = Instant::now() + Duration::from_secs(2);
+    let daemon_status = loop {
+        if let Some(status) = daemon.try_wait()? {
+            break Some(status);
+        }
+        if Instant::now() >= daemon_deadline {
+            break None;
+        }
+        thread::sleep(Duration::from_millis(10));
+    };
+    let stop = stop_rx.recv_timeout(Duration::from_secs(3))??;
+    let elapsed = started.elapsed();
+    if daemon_status.is_none() {
+        let _ = daemon.kill();
+        let _ = daemon.wait();
+    }
+    assert_success("daemon stop with stalled TCP request", &stop);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "daemon stop exceeded its documented two-second deadline: {elapsed:?}"
+    );
+    let daemon_status = daemon_status.expect("successful daemon stop must reap the serve process");
+    assert!(
+        daemon_status.success(),
+        "foreground daemon exited with {daemon_status}"
+    );
+    assert!(
+        !coven_home.join("coven.sock").exists(),
+        "bounded graceful shutdown should remove its Unix socket"
+    );
+    assert!(
+        !coven_home.join("daemon.json").exists(),
+        "bounded graceful shutdown should remove its status file"
+    );
+    drop(stalled);
     Ok(())
 }
 
@@ -1457,6 +1674,21 @@ if [ "$*" = "hold-for-kill" ]; then
 fi
 printf 'fake codex complete: %s\n' "$*"
 "#,
+    )?;
+    let mut permissions = fs::metadata(&codex)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&codex, permissions)?;
+    Ok(())
+}
+
+fn write_shutdown_fake_codex(fake_bin: &Path, pid_file: &Path) -> anyhow::Result<()> {
+    let codex = fake_bin.join("codex");
+    fs::write(
+        &codex,
+        format!(
+            "#!/bin/sh\nsleep 300 </dev/null >/dev/null 2>&1 &\nprintf '%s\\n' \"$!\" > '{}'\nprintf 'fake codex ready for daemon shutdown\\n'\nwait\n",
+            pid_file.display()
+        ),
     )?;
     let mut permissions = fs::metadata(&codex)?.permissions();
     permissions.set_mode(0o755);

--- a/crates/coven-cli/tests/stream_json_integration.rs
+++ b/crates/coven-cli/tests/stream_json_integration.rs
@@ -1028,14 +1028,83 @@ while :; do sleep 1; done
     );
 }
 
-/// End-to-end Windows regression: an npm-style `codex.cmd` must receive a
-/// multiline prompt through stdin (not ConPTY/cmd argv), and the Coven CLI
-/// must surface the Codex JSON response as an `assistant` frame. The second
-/// invocation proves Cave can keep using the stable Coven ledger id while
-/// Coven resumes the native Codex thread internally.
+#[cfg(windows)]
+fn install_official_windows_codex_fixture(root: &std::path::Path) -> std::path::PathBuf {
+    use std::fs;
+
+    let fake_bin = root.join("bin");
+    let package_root = root.join("node_modules").join("@openai").join("codex");
+    let entry = package_root.join("bin").join("codex.js");
+    let native_root = root
+        .join("node_modules")
+        .join("@openai")
+        .join("codex-win32-x64");
+    let native = native_root
+        .join("vendor")
+        .join("x86_64-pc-windows-msvc")
+        .join("bin")
+        .join("codex.exe");
+    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
+    fs::create_dir_all(entry.parent().unwrap()).expect("failed to create Codex package bin");
+    fs::create_dir_all(native.parent().unwrap()).expect("failed to create native package bin");
+    fs::write(&entry, "// official Codex entry fixture\n")
+        .expect("failed to write Codex entry fixture");
+    fs::write(
+        package_root.join("package.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "name": "@openai/codex",
+            "bin": { "codex": "bin/codex.js" },
+            "optionalDependencies": {
+                "@openai/codex-win32-x64": "npm:@openai/codex@0.0.0-win32-x64"
+            }
+        }))
+        .unwrap(),
+    )
+    .expect("failed to write Codex package metadata");
+    fs::write(
+        native_root.join("package.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "name": "@openai/codex",
+            "os": ["win32"],
+            "cpu": ["x64"]
+        }))
+        .unwrap(),
+    )
+    .expect("failed to write native package metadata");
+    fs::write(
+        fake_bin.join("codex.cmd"),
+        concat!(
+            "@echo off\r\n",
+            "\"%~dp0\\..\\node_modules\\@openai\\codex\\bin\\codex.js\" %*\r\n"
+        ),
+    )
+    .expect("failed to write official Codex shim fixture");
+
+    let fixture = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/windows_codex_json_probe.rs");
+    let compile = Command::new("rustc.exe")
+        .args(["--edition=2021", "-o"])
+        .arg(&native)
+        .arg(&fixture)
+        .output()
+        .expect("failed to compile native Codex JSON probe");
+    assert!(
+        compile.status.success(),
+        "native Codex JSON probe failed to compile: {}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    fake_bin
+}
+
+/// End-to-end Windows regression: an official npm `codex.cmd` is validated
+/// and resolved to its native executable before launch. The native executable
+/// must receive a multiline prompt through stdin (not cmd argv), and Coven
+/// must surface its JSON response as an `assistant` frame. The second run
+/// proves Cave can keep using the stable Coven ledger id while Coven resumes
+/// the native Codex thread internally.
 #[cfg(windows)]
 #[test]
-fn windows_codex_cmd_stream_json_emits_assistant_and_resumes_native_thread() {
+fn windows_official_codex_stream_json_emits_assistant_and_resumes_native_thread() {
     use std::fs;
 
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
@@ -1053,25 +1122,7 @@ description = "Windows Codex regression fixture"
     .expect("failed to write familiar fixture");
     let project_root = temp_dir.path().join("project");
     fs::create_dir_all(&project_root).expect("failed to create project root");
-    let fake_bin = temp_dir.path().join("bin");
-    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
-    let fake_codex = fake_bin.join("codex.cmd");
-    fs::write(
-        &fake_codex,
-        concat!(
-            "@echo off\r\n",
-            // findstr copies stdin without PowerShell's multi-second cold
-            // start, which flaked the sibling pty_runner test (issue #407).
-            "\"%SystemRoot%\\System32\\findstr.exe\" \"^\" > stdin.txt\r\n",
-            "echo %* > args.txt\r\n",
-            "echo {\"type\":\"thread.started\",\"thread_id\":\"thread-789\"}\r\n",
-            "echo {\"type\":\"turn.started\"}\r\n",
-            "echo {\"type\":\"item.completed\",\"item\":{\"id\":\"item-1\",\"type\":\"agent_message\",\"text\":\"reply for Cave\"}}\r\n",
-            "echo {\"type\":\"turn.completed\"}\r\n",
-            "exit /b 0\r\n"
-        ),
-    )
-    .expect("failed to write fake codex cmd");
+    let fake_bin = install_official_windows_codex_fixture(temp_dir.path());
 
     let mut paths = vec![fake_bin.clone()];
     if let Some(existing) = std::env::var_os("PATH") {
@@ -1195,7 +1246,7 @@ description = "Windows Codex regression fixture"
 /// override keeps this integration regression bounded.
 #[cfg(windows)]
 #[test]
-fn windows_silent_codex_cmd_emits_terminal_error_and_marks_session_failed() {
+fn windows_silent_official_codex_emits_terminal_error_and_marks_session_failed() {
     use std::fs;
 
     let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
@@ -1203,13 +1254,7 @@ fn windows_silent_codex_cmd_emits_terminal_error_and_marks_session_failed() {
     fs::create_dir_all(&coven_home).expect("failed to create coven home");
     let project_root = temp_dir.path().join("project");
     fs::create_dir_all(&project_root).expect("failed to create project root");
-    let fake_bin = temp_dir.path().join("bin");
-    fs::create_dir_all(&fake_bin).expect("failed to create fake bin dir");
-    fs::write(
-        fake_bin.join("codex.cmd"),
-        "@echo off\r\n:spin\r\ngoto spin\r\n",
-    )
-    .expect("failed to write silent codex cmd");
+    let fake_bin = install_official_windows_codex_fixture(temp_dir.path());
 
     let mut paths = vec![fake_bin];
     if let Some(existing) = std::env::var_os("PATH") {
@@ -1223,6 +1268,7 @@ fn windows_silent_codex_cmd_emits_terminal_error_and_marks_session_failed() {
         .env("COVEN_HOME", &coven_home)
         .env("PATH", &path)
         .env("PATHEXT", ".CMD")
+        .env("COVEN_TEST_CODEX_PROBE_SILENT", "1")
         .env("COVEN_TEST_CODEX_JSON_IDLE_TIMEOUT_MS", "150")
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/crates/coven-cli/tests/windows_daemon_lifecycle.rs
+++ b/crates/coven-cli/tests/windows_daemon_lifecycle.rs
@@ -1,0 +1,451 @@
+#![cfg(windows)]
+
+use std::ffi::OsString;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use interprocess::{
+    local_socket::{prelude::*, ConnectOptions, GenericNamespaced},
+    ConnectWaitMode,
+};
+
+struct DaemonGuard {
+    coven_home: PathBuf,
+}
+
+struct ExactProcessHandle(windows_sys::Win32::Foundation::HANDLE);
+
+impl ExactProcessHandle {
+    fn duplicate(child: &std::process::Child) -> Result<Self> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::{
+            Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS},
+            System::Threading::GetCurrentProcess,
+        };
+
+        let current = unsafe { GetCurrentProcess() };
+        let mut duplicated = std::ptr::null_mut();
+        let ok = unsafe {
+            DuplicateHandle(
+                current,
+                child.as_raw_handle(),
+                current,
+                &mut duplicated,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            )
+        };
+        anyhow::ensure!(
+            ok != 0 && !duplicated.is_null(),
+            "failed duplicating exact launcher process handle: {}",
+            std::io::Error::last_os_error()
+        );
+        Ok(Self(duplicated))
+    }
+
+    fn terminate(&self) {
+        use windows_sys::Win32::System::Threading::TerminateProcess;
+        unsafe {
+            let _ = TerminateProcess(self.0, 1);
+        }
+    }
+
+    fn wait_for_exit(&self, timeout: Duration) -> Result<bool> {
+        use windows_sys::Win32::{
+            Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+            System::Threading::WaitForSingleObject,
+        };
+
+        let milliseconds = timeout.as_millis().min(u32::MAX as u128) as u32;
+        match unsafe { WaitForSingleObject(self.0, milliseconds) } {
+            WAIT_OBJECT_0 => Ok(true),
+            WAIT_TIMEOUT => Ok(false),
+            WAIT_FAILED => Err(std::io::Error::last_os_error())
+                .context("failed waiting for exact launcher process handle"),
+            result => anyhow::bail!("unexpected launcher process wait result {result}"),
+        }
+    }
+}
+
+impl Drop for ExactProcessHandle {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+impl Drop for DaemonGuard {
+    fn drop(&mut self) {
+        terminate_recorded_daemon(&self.coven_home);
+    }
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed: status={}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn terminate_process(pid: u32) {
+    use windows_sys::Win32::{
+        Foundation::CloseHandle,
+        System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE},
+    };
+    let process = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+    if !process.is_null() {
+        unsafe {
+            let _ = TerminateProcess(process, 1);
+            CloseHandle(process);
+        }
+    }
+}
+
+fn terminate_recorded_daemon(coven_home: &Path) {
+    let Ok(status) = std::fs::read(coven_home.join("daemon.json")) else {
+        return;
+    };
+    let Ok(status) = serde_json::from_slice::<serde_json::Value>(&status) else {
+        return;
+    };
+    let Some(pid) = status["pid"]
+        .as_u64()
+        .and_then(|pid| u32::try_from(pid).ok())
+    else {
+        return;
+    };
+    terminate_process(pid);
+}
+
+fn captured_output_with_timeout(
+    label: &str,
+    command: &mut Command,
+    coven_home: &Path,
+) -> Result<Output> {
+    const LAUNCHER_EXIT_TIMEOUT: Duration = Duration::from_secs(15);
+    const CAPTURE_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
+    const LAUNCHER_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let child = command
+        .spawn()
+        .with_context(|| format!("failed spawning {label}"))?;
+    let launcher = ExactProcessHandle::duplicate(&child)?;
+    let (result_tx, result_rx) = mpsc::sync_channel(1);
+    std::thread::spawn(move || {
+        let _ = result_tx.send(child.wait_with_output());
+    });
+
+    let launcher_deadline = Instant::now() + LAUNCHER_EXIT_TIMEOUT;
+    loop {
+        let poll = launcher_deadline
+            .saturating_duration_since(Instant::now())
+            .min(LAUNCHER_POLL_INTERVAL);
+        match result_rx.recv_timeout(poll) {
+            Ok(result) => return result.with_context(|| format!("failed waiting for {label}")),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                anyhow::bail!("{label} output waiter disconnected")
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) if launcher.wait_for_exit(Duration::ZERO)? => {
+                // The exact launcher has exited, so any remaining pipe owner
+                // is a descendant. Keep this post-exit deadline strict: a
+                // detached daemon inheriting either capture handle is the
+                // regression this fixture exists to detect.
+                return match result_rx.recv_timeout(CAPTURE_CLOSE_TIMEOUT) {
+                    Ok(result) => result.with_context(|| format!("failed waiting for {label}")),
+                    Err(mpsc::RecvTimeoutError::Disconnected) => {
+                        anyhow::bail!("{label} output waiter disconnected")
+                    }
+                    Err(mpsc::RecvTimeoutError::Timeout) => {
+                        terminate_recorded_daemon(coven_home);
+                        let _ = result_rx.recv_timeout(CAPTURE_CLOSE_TIMEOUT);
+                        anyhow::bail!(
+                            "{label} launcher exited but captured stdout/stderr did not close within two seconds; the detached daemon likely inherited a launcher capture handle"
+                        )
+                    }
+                };
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) if Instant::now() >= launcher_deadline => {
+                terminate_recorded_daemon(coven_home);
+                launcher.terminate();
+                let _ = result_rx.recv_timeout(CAPTURE_CLOSE_TIMEOUT);
+                anyhow::bail!("{label} launcher did not exit within fifteen seconds")
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+    }
+}
+
+fn wait_until(label: &str, mut predicate: impl FnMut() -> Result<bool>) -> Result<()> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut last_error = None;
+    while Instant::now() < deadline {
+        match predicate() {
+            Ok(true) => return Ok(()),
+            Ok(false) => {}
+            Err(error) => last_error = Some(error),
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    if let Some(error) = last_error {
+        anyhow::bail!("timed out waiting for {label}; last error: {error:#}");
+    }
+    anyhow::bail!("timed out waiting for {label}")
+}
+
+fn process_is_alive(pid: u32) -> bool {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, WAIT_TIMEOUT},
+        System::Threading::{OpenProcess, WaitForSingleObject},
+    };
+
+    const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
+    let handle = unsafe { OpenProcess(SYNCHRONIZE_ACCESS, 0, pid) };
+    if handle.is_null() {
+        return false;
+    }
+    let result = unsafe { WaitForSingleObject(handle, 0) };
+    unsafe { CloseHandle(handle) };
+    result == WAIT_TIMEOUT
+}
+
+fn prepend_path(dir: &Path) -> OsString {
+    let mut paths = vec![dir.to_path_buf()];
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+    std::env::join_paths(paths).expect("test PATH must be joinable")
+}
+
+fn compile_windows_probe(output: &Path) -> Result<()> {
+    let source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/windows_console_probe.rs");
+    let compile = Command::new("rustc.exe")
+        .args(["--edition=2021", "-o"])
+        .arg(output)
+        .arg(source)
+        .output()?;
+    assert_success("compile Windows daemon containment fixture", &compile);
+    Ok(())
+}
+
+fn prepare_npm_wrapper_fixture(root: &Path) -> Result<PathBuf> {
+    let wrapper_dir = root.join("wrapper");
+    let wrapper_bin_dir = wrapper_dir.join("bin");
+    let wrapper = wrapper_bin_dir.join("coven.js");
+    let native_dir = wrapper_dir
+        .join("node_modules")
+        .join("@opencoven")
+        .join("cli-windows");
+    let native_bin_dir = native_dir.join("bin");
+    std::fs::create_dir_all(&wrapper_bin_dir)?;
+    std::fs::create_dir_all(&native_bin_dir)?;
+    std::fs::write(
+        wrapper_dir.join("package.json"),
+        r#"{"name":"@opencoven/cli-test","type":"module"}"#,
+    )?;
+    std::fs::write(
+        native_dir.join("package.json"),
+        r#"{"name":"@opencoven/cli-windows","version":"0.0.0"}"#,
+    )?;
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .context("coven-cli manifest has no repository root")?
+        .to_path_buf();
+    std::fs::copy(repo_root.join("npm/coven/bin/coven.js"), &wrapper)?;
+    std::fs::copy(
+        env!("CARGO_BIN_EXE_coven"),
+        native_bin_dir.join("coven.exe"),
+    )?;
+    Ok(wrapper)
+}
+
+fn wait_for_daemon_status(coven_home: &Path, path: &OsString) -> Result<serde_json::Value> {
+    let status_path = coven_home.join("daemon.json");
+    wait_until("Windows daemon health", || {
+        if !status_path.exists() {
+            return Ok(false);
+        }
+        let status = Command::new(env!("CARGO_BIN_EXE_coven"))
+            .args(["daemon", "status"])
+            .env("COVEN_HOME", coven_home)
+            .env("PATH", path)
+            .output()?;
+        Ok(status.status.success())
+    })?;
+    Ok(serde_json::from_slice(&std::fs::read(status_path)?)?)
+}
+
+fn send_launch_request(
+    status: &serde_json::Value,
+    project: &Path,
+    prompt: &str,
+) -> Result<interprocess::local_socket::Stream> {
+    let pipe_name = status["socket"]
+        .as_str()
+        .context("daemon status omitted Windows pipe name")?;
+    let name = pipe_name
+        .to_ns_name::<GenericNamespaced>()
+        .context("invalid Windows daemon pipe name")?;
+    let mut stream = ConnectOptions::new()
+        .name(name)
+        .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(2)))
+        .connect_sync()?;
+    let body = serde_json::json!({
+        "projectRoot": project,
+        "harness": "codex",
+        "launchMode": "nonInteractive",
+        "prompt": prompt
+    })
+    .to_string();
+    write!(
+        stream,
+        "POST /sessions HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    )?;
+    stream.flush()?;
+    Ok(stream)
+}
+
+#[test]
+fn abrupt_daemon_stop_kills_child_stalled_before_per_session_job_attachment() -> Result<()> {
+    eprintln!("[windows-daemon-lifecycle] preparing fixture");
+    let temp = tempfile::tempdir()?;
+    let coven_home = temp.path().join("coven-home");
+    let project = temp.path().join("project");
+    let fake_bin = temp.path().join("bin");
+    let barrier = temp.path().join("strict-preattach");
+    std::fs::create_dir_all(&project)?;
+    std::fs::create_dir_all(&fake_bin)?;
+
+    let fake_codex = fake_bin.join("codex.exe");
+    compile_windows_probe(&fake_codex)?;
+    eprintln!("[windows-daemon-lifecycle] fixture compiled");
+
+    let path = prepend_path(&fake_bin);
+    let _guard = DaemonGuard {
+        coven_home: coven_home.clone(),
+    };
+    let mut start = Command::new(env!("CARGO_BIN_EXE_coven"));
+    start
+        .args(["daemon", "start"])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .env("COVEN_TEST_WINDOWS_STRICT_PREATTACH_BARRIER_DIR", &barrier);
+    let start = captured_output_with_timeout(
+        "captured native Windows daemon start",
+        &mut start,
+        &coven_home,
+    )?;
+    assert_success("start Windows daemon with lifetime Job", &start);
+    eprintln!("[windows-daemon-lifecycle] daemon start returned");
+
+    let status = wait_for_daemon_status(&coven_home, &path)?;
+    eprintln!("[windows-daemon-lifecycle] daemon health confirmed");
+    let launch_stream =
+        send_launch_request(&status, &project, "stall before per-session Job attachment")?;
+    eprintln!("[windows-daemon-lifecycle] launch request sent");
+
+    wait_until("strict pre-attachment barrier", || {
+        Ok(barrier.join("ready").exists())
+    })?;
+    eprintln!("[windows-daemon-lifecycle] strict pre-attachment barrier reached");
+    let child_pid = std::fs::read_to_string(barrier.join("pid"))?
+        .trim()
+        .parse::<u32>()?;
+    assert!(
+        process_is_alive(child_pid),
+        "suspended fixture child was not alive at the pre-attachment barrier"
+    );
+
+    let started = Instant::now();
+    let stop = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["daemon", "stop"])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()?;
+    assert_success("abrupt Windows daemon stop", &stop);
+    eprintln!("[windows-daemon-lifecycle] daemon stop returned");
+    assert!(
+        started.elapsed() < Duration::from_secs(2),
+        "Windows daemon stop exceeded its documented two-second contract"
+    );
+    wait_until("inherited daemon Job child termination", || {
+        Ok(!process_is_alive(child_pid))
+    })?;
+    drop(launch_stream);
+    Ok(())
+}
+
+#[test]
+fn abrupt_daemon_stop_kills_live_piped_descendants() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let coven_home = temp.path().join("coven-home");
+    let project = temp.path().join("project");
+    let fake_bin = temp.path().join("bin");
+    let descendant_pid_file = temp.path().join("daemon-descendant.pid");
+    std::fs::create_dir_all(&project)?;
+    std::fs::create_dir_all(&fake_bin)?;
+    compile_windows_probe(&fake_bin.join("codex.exe"))?;
+    let wrapper = prepare_npm_wrapper_fixture(temp.path())?;
+
+    let path = prepend_path(&fake_bin);
+    let _guard = DaemonGuard {
+        coven_home: coven_home.clone(),
+    };
+    let mut start = Command::new("node.exe");
+    start
+        .arg(&wrapper)
+        .args(["daemon", "start"])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .env("COVEN_WINDOWS_HIDE_NATIVE_WINDOW", "1")
+        .env(
+            "COVEN_TEST_WINDOWS_CODEX_DESCENDANT_PID_FILE",
+            &descendant_pid_file,
+        );
+    let start = captured_output_with_timeout(
+        "captured hidden npm-wrapper Windows daemon start",
+        &mut start,
+        &coven_home,
+    )?;
+    assert_success("start Windows daemon descendant fixture", &start);
+    let status = wait_for_daemon_status(&coven_home, &path)?;
+    let launch_stream = send_launch_request(&status, &project, "hold descendant for stop")?;
+
+    wait_until("Windows daemon descendant pid", || {
+        Ok(descendant_pid_file.exists())
+    })?;
+    let descendant_pid = std::fs::read_to_string(&descendant_pid_file)?
+        .trim()
+        .parse::<u32>()?;
+    assert!(process_is_alive(descendant_pid));
+
+    let started = Instant::now();
+    let stop = Command::new(env!("CARGO_BIN_EXE_coven"))
+        .args(["daemon", "stop"])
+        .env("COVEN_HOME", &coven_home)
+        .env("PATH", &path)
+        .output()?;
+    assert_success("abrupt Windows daemon stop with descendant", &stop);
+    assert!(started.elapsed() < Duration::from_secs(2));
+    wait_until("Windows daemon descendant termination", || {
+        Ok(!process_is_alive(descendant_pid))
+    })?;
+    drop(launch_stream);
+    Ok(())
+}

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -57,7 +57,12 @@ proof of `coven.daemon.v1` support.
     "executorDispatch": true,
     "eventCursor": "sequence",
     "structuredErrors": true,
-    "sessionHandoff": true
+    "sessionHandoff": true,
+    "sessionLaunchPolicy": true,
+    "afs": true,
+    "afsMount": false,
+    "afsCommit": true,
+    "afsCommitDryRun": true
   },
   "daemon": {
     "pid": 12345,
@@ -113,6 +118,11 @@ durability.
 | `eventCursor`     | string  | Cursor type supported; `"sequence"` means `afterSeq` is stable.  |
 | `structuredErrors`| boolean | All errors use the `{ error: { code, message, details } }` shape.|
 | `sessionHandoff` | boolean | Durable generation-fenced session handoff routes are available. |
+| `sessionLaunchPolicy` | boolean | Owner-gated local IPC accepts the exact unattended Codex launch policy. Always `false` over TCP. |
+| `afs` | boolean | The AFS route family is available. |
+| `afsMount` | string or `false` | Active mount backend, or `false` when mount-backed access is unavailable. |
+| `afsCommit` | boolean | AFS deltas can be materialized into a Git branch. |
+| `afsCommitDryRun` | boolean | AFS commit accepts the side-effect-free `dryRun` contract. |
 
 ## Structured error envelope
 
@@ -161,6 +171,7 @@ All API errors use the following stable envelope. Clients must branch on `error.
 |------------------------|-------------|--------------------------------------------------|
 | `not_found`            | 404         | Generic route not found.                         |
 | `invalid_request`      | 400 or 404  | Malformed request, unknown harness id, missing required field, or unsupported API version. |
+| `forbidden`            | 403         | The request asks TCP to exercise an owner-local-IPC-only capability such as `launchPolicy`. |
 | `session_not_found`    | 404         | Session id does not exist.                       |
 | `harness_not_found`    | 404         | `GET /capabilities/:harnessId`: harness id is not a known capability scan target. |
 | `session_not_live`     | 409         | Session exists but is not running.               |
@@ -444,11 +455,35 @@ the daemon forwards the provider-qualified id through the selected harness
 adapter's declared `strip_provider` or `preserve` transform. Clients that omit
 it retain the harness's own default model.
 
+Clients must observe `capabilities.sessionLaunchPolicy === true` before sending
+`launchPolicy`. The only supported policy is an exact, explicit Codex
+`nonInteractive` contract: approval `never`, sandbox `workspace-write`, and
+optional absolute additional directories. Every `addDirs` entry must be a
+non-empty, existing directory; entries are canonicalized and deduplicated
+before they reach Codex. This supports an explicitly granted mission workspace
+outside the research context root without granting any implicit parent or
+sibling path. Unknown fields or values, other harnesses or modes, relative,
+missing, or non-directory paths fail with `400 invalid_request` before a
+session row or process is created. Omitting `launchPolicy` preserves the
+harness default.
+This policy is owner-local-IPC-only: health advertises
+`sessionLaunchPolicy: false` over TCP, and a TCP request that nevertheless
+includes the field fails with `403 forbidden` before a session row or process
+is created. Host and Origin allowlists do not grant this authority.
+Capabilities advertise availability; the owner-gated local IPC boundary,
+exact requested write set, and Rust validation remain the authority boundary.
+
 ```json
 {
   "projectRoot": "/repo",
   "harness": "codex",
   "model": "openai/gpt-5.6-sol",
+  "launchMode": "nonInteractive",
+  "launchPolicy": {
+    "approval": "never",
+    "sandbox": "workspace-write",
+    "addDirs": []
+  },
   "prompt": "Fix the tests"
 }
 ```
@@ -1226,7 +1261,9 @@ Shared non-success responses use the structured error envelope:
 3. Verify `capabilities.sessions === true` before session requests and
    `capabilities.events === true` before event requests.
 4. Check `capabilities.eventCursor === "sequence"` before using `afterSeq` pagination.
-5. Only then depend on the documented `v1` sessions/events shapes.
+5. Check `capabilities.sessionLaunchPolicy === true` before sending
+   `launchPolicy`; a missing, false, or malformed value means unsupported.
+6. Only then depend on the documented `v1` sessions/events shapes.
 
 ## Scope boundary
 

--- a/docs/daemon/capabilities-handshake.md
+++ b/docs/daemon/capabilities-handshake.md
@@ -15,6 +15,16 @@ Treat a missing, false, or malformed required capability as unsupported and
 fail before sending the dependent request. Clients should ignore unknown
 additive capabilities.
 
+For example, a client must require `capabilities.sessionLaunchPolicy === true`
+before adding `launchPolicy` to `POST /api/v1/sessions`. The capability says
+the daemon understands that request shape; it does not grant filesystem
+authority. The daemon still validates the exact policy and accepts only
+absolute, existing, canonical additional directories in the explicit write
+set, including an explicitly named external mission workspace when needed.
+This capability is `true` only on the owner-gated local IPC transport. TCP
+health reports it as `false`, and TCP rejects the field even when Host and
+Origin pass their separate loopback/allowlist checks.
+
 `GET /api/v1/api-version` is a legacy route-family diagnostic. Its literal
 `apiVersion: "v1"` and `supportedApiVersions: ["v1"]` values describe the
 `/api/v1/*` namespace. New clients must not use it as proof of

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -43,6 +43,7 @@ GET /api/v1/health
     "eventCursor": "sequence",
     "structuredErrors": true,
     "sessionHandoff": true,
+    "sessionLaunchPolicy": true,
     "afs": true,
     "afsMount": false,
     "afsCommit": true,
@@ -55,6 +56,18 @@ GET /api/v1/health
   }
 }
 ```
+
+This example contains all 14 health capability fields: `sessions`, `events`,
+`travel`, `scheduler`, `hub`, `executorDispatch`, `eventCursor`,
+`structuredErrors`, `sessionHandoff`, `sessionLaunchPolicy`, `afs`, `afsMount`,
+`afsCommit`, and `afsCommitDryRun`.
+
+`sessionLaunchPolicy` is `true` only on owner-gated local IPC. TCP health
+reports it as `false`, and TCP returns `403 forbidden` for any session request
+containing `launchPolicy`, regardless of accepted Host or Origin headers.
+Owner-local clients may use the exact Codex `nonInteractive` policy with
+approval `never`, sandbox `workspace-write`, and explicit absolute existing
+`addDirs`, including a named external mission workspace.
 
 `daemon` is `null` when daemon metadata is unavailable. When present,
 `daemon.socket` reports the active local IPC endpoint. A `hub` summary may also
@@ -75,7 +88,7 @@ diagnostic whose literal `v1` values are not proof of named-contract support.
 | `GET /api/v1/capabilities` | Discover routable capabilities and owning adapters. |
 | `POST /api/v1/actions` | Send a known intent through the control plane. |
 | `GET /api/v1/sessions` | List sessions. |
-| `POST /api/v1/sessions` | Launch a session. |
+| `POST /api/v1/sessions` | Launch a session. `launchPolicy` requires owner-gated local IPC and `sessionLaunchPolicy: true`; TCP rejects the field. |
 | `GET /api/v1/sessions/:id` | Fetch one session. |
 | `GET /api/v1/events?sessionId=...` | Read session events. |
 | `GET /api/v1/memory` | List familiar memory summaries with opaque ids. |

--- a/docs/reference/api-contract.md
+++ b/docs/reference/api-contract.md
@@ -71,7 +71,12 @@ GET /api/v1/health
     "executorDispatch": true,
     "eventCursor": "sequence",
     "structuredErrors": true,
-    "sessionHandoff": true
+    "sessionHandoff": true,
+    "sessionLaunchPolicy": true,
+    "afs": true,
+    "afsMount": false,
+    "afsCommit": true,
+    "afsCommitDryRun": true
   },
   "daemon": { "pid": 12345, "startedAt": "2026-07-14T12:00:00Z", "socket": "<local IPC endpoint>" },
   "eventWriter": {
@@ -86,6 +91,18 @@ GET /api/v1/health
   }
 }
 ```
+
+The health `capabilities` object contains all 14 fields: `sessions`, `events`,
+`travel`, `scheduler`, `hub`, `executorDispatch`, `eventCursor`,
+`structuredErrors`, `sessionHandoff`, `sessionLaunchPolicy`, `afs`, `afsMount`,
+`afsCommit`, and `afsCommitDryRun`.
+
+`sessionLaunchPolicy` is `true` only over owner-gated local IPC. TCP health
+always reports it as `false`, and TCP rejects any `POST /api/v1/sessions`
+payload containing `launchPolicy` with `403 forbidden`; passing Host or Origin
+checks does not elevate TCP authority. The initial exact policy supports Codex
+`nonInteractive` approval `never`, sandbox `workspace-write`, and explicit
+absolute existing `addDirs`, including a named external mission workspace.
 
 When present, `eventWriter.state` is `healthy`, `pressured`, or `failed`.
 Pressure reports explicitly rejected raw output; lifecycle and terminal events

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -28,7 +28,7 @@ flowchart LR
   Root --> Hub["/hub"]
 ```
 
-All error responses use the structured envelope documented in the [API contract](/API-CONTRACT#structured-error-envelope): `{ "error": { "code", "message", "details" } }`. Unknown routes, action ids, and API versions fail closed. Clients negotiate the named `coven.daemon.v1` contract with `GET /api/v1/health`, then check every capability required by the operation. Boolean operation-group flags (`sessions`, `events`, `travel`, `scheduler`, `hub`, `executorDispatch`, `sessionHandoff`) are advertised in the health `capabilities` block — treat a group as unavailable unless health advertises it. Capabilities advertise availability and never grant permission.
+All error responses use the structured envelope documented in the [API contract](/API-CONTRACT#structured-error-envelope): `{ "error": { "code", "message", "details" } }`. Unknown routes, action ids, and API versions fail closed. Clients negotiate the named `coven.daemon.v1` contract with `GET /api/v1/health`, then check every capability required by the operation. Boolean operation-group flags (`sessions`, `events`, `travel`, `scheduler`, `hub`, `executorDispatch`, `sessionHandoff`, `sessionLaunchPolicy`, `afs`, `afsCommit`, `afsCommitDryRun`) are advertised in the health `capabilities` block — treat a group as unavailable unless health advertises it. Capabilities advertise availability and never grant permission.
 
 ## Contract and discovery
 
@@ -41,9 +41,13 @@ All error responses use the structured envelope documented in the [API contract]
 | GET | `/api/v1/capabilities/:harness` | One harness's capability manifest (`?refresh=1` re-scans). | manifest object · `404 harness_not_found` |
 | POST | `/api/v1/actions` | Route a known control-plane action id (intent envelope). | `{ ok, accepted, status, event }` · `400 invalid_request` |
 
-The health `capabilities` object currently contains all nine fields:
+The health `capabilities` object currently contains all 14 fields:
 `sessions`, `events`, `travel`, `scheduler`, `hub`, `executorDispatch`,
-`eventCursor`, `structuredErrors`, and `sessionHandoff`. `daemon` is either `null` or
+`eventCursor`, `structuredErrors`, `sessionHandoff`, `sessionLaunchPolicy`,
+`afs`, `afsMount`, `afsCommit`, and `afsCommitDryRun`. The
+`sessionLaunchPolicy` field is `true` only over owner-gated local IPC and is
+always `false` over TCP; Host and Origin allowlists do not elevate TCP
+authority. `daemon` is either `null` or
 `{ pid, startedAt, socket }`, where the socket is under
 the active local IPC endpoint; the optional `hub` field is a control-plane
 summary.
@@ -64,7 +68,7 @@ snapshot reported by `eventWriter`.
 | Method | Path | Purpose | Body / query | Success | Errors |
 |---|---|---|---|---|---|
 | GET | `/api/v1/sessions` | List sessions. | — | `SessionRecord[]` | — |
-| POST | `/api/v1/sessions` | Launch a project-scoped harness session. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request`, `500 launch_failed` |
+| POST | `/api/v1/sessions` | Launch a project-scoped harness session. `launchPolicy` requires `capabilities.sessionLaunchPolicy === true`; its initial exact contract is `{ approval: "never", sandbox: "workspace-write", addDirs?: string[] }` for Codex `nonInteractive`, with every additional directory absolute, existing, canonicalized, and explicitly listed (including an external mission workspace when named). The field is owner-local-IPC-only; TCP returns `403 forbidden`. | `{ projectRoot, cwd?, harness, prompt, title?, launchMode?, launchPolicy?, conversation?, conversationId? }` | `SessionRecord` | `400 invalid_request`, `403 forbidden`, `500 launch_failed` |
 | POST | `/api/v1/sessions/external` | Register (or idempotently re-register) an externally launched session. | session descriptor | `201` new / `200` existing | `400`, `409 session_id_conflict` |
 | GET | `/api/v1/sessions/:id` | Fetch one session. | — | `SessionRecord` | `404 session_not_found` |
 | POST | `/api/v1/sessions/:id/complete` | Mark an external session completed. | `{ exitCode?, ... }` | updated record | `404 session_not_found`, `422 not_external_session` |
@@ -241,7 +245,7 @@ Full hub request/response shapes live in the [API contract](/API-CONTRACT).
 GET /api/v1/health
 ```
 
-The response provides the active named `apiVersion`, all nine health
+The response provides the active named `apiVersion`, all 14 health
 `capabilities` fields, and optional daemon metadata (`pid`, `startedAt`, and
 `socket`) plus the optional hub summary. Treat a dependent operation as
 unavailable until its required capability fields have been checked.

--- a/docs/reference/release-notes.md
+++ b/docs/reference/release-notes.md
@@ -79,6 +79,25 @@ title: "Coven changelog and release notes"
   [PR #714](https://github.com/OpenCoven/coven/pull/714),
   [PR #715](https://github.com/OpenCoven/coven/pull/715) and
   [PR #721](https://github.com/OpenCoven/coven/pull/721).
+- **Windows noninteractive sessions stay headless.** Piped and strictly
+  contained harness children now share one `CREATE_NO_WINDOW` policy without
+  changing interactive PTY sessions, and desktop clients can explicitly ask
+  the npm wrapper to hide its native child. The local daemon also advertises
+  and validates an exact Codex `nonInteractive` workspace-write launch policy,
+  restricting optional write roots to explicitly listed canonical directories;
+  on native Windows that policy explicitly selects Codex's unelevated
+  restricted-token backend so `workspace-write` is not downgraded to
+  `read-only`. Approval `never` is also pinned as a highest-precedence Codex
+  session config override so an enabled AutoReview policy cannot replace it
+  with the untrusted-project default.
+  Daemon-owned Codex prompts now travel losslessly over stdin on every platform
+  instead of becoming one potentially oversized command-line argument.
+  Windows daemon startup also treats its process-lifetime Job as mandatory:
+  if that Job cannot be created, configured or assigned, startup fails closed
+  rather than reopening the child birth-to-attachment containment gap. See
+  [issues #712](https://github.com/OpenCoven/coven/issues/712) and
+  [#713](https://github.com/OpenCoven/coven/issues/713).
+
 - **Faster session launch.** Session launches no longer spawn `git` to locate
   the repository maintenance gate when the project root is not inside a
   repository, restoring launch-to-first-output to its pre-gate baseline

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -34,3 +34,44 @@ Current early-adopter packages target:
 - `@opencoven/cli-windows` for Windows x64
 
 Alpine Linux is not supported.
+
+## Desktop no-window launch on Windows
+
+An embedding desktop client that intentionally owns no terminal may set
+`COVEN_WINDOWS_HIDE_NATIVE_WINDOW=1` when it starts this npm wrapper. On
+Windows x64 the wrapper then launches `coven.exe` with Node's `windowsHide`
+option and pipe-backed, backpressure-aware forwarding for stdin, stdout, and
+stderr. Avoiding inherited stdio handles is required for `CREATE_NO_WINDOW` to
+take effect. Other values and ordinary CLI launches retain the default visible
+or inherited console, direct stdio, and Ctrl-C behavior. This signal affects
+only the wrapper-to-native boundary; Coven independently suppresses console
+windows for noninteractive harness children.
+
+Desktop integrations that need an exact native process handle may run the npm
+wrapper with the sole argument `--print-native-binary-path`. On success it
+prints exactly one absolute native Coven binary path plus `\n` and exits 0
+without launching Coven. The flag cannot be combined with another argument;
+resolution or validation failures write a diagnostic to stderr and exit 1.
+Callers can then spawn that path directly with `coven process-supervisor
+--protocol coven.process-supervisor.v1`, avoiding a JavaScript-wrapper process
+between their owned child handle and Coven's OS process-tree containment.
+
+`process-supervisor` is a narrow desktop-integration contract, not an ordinary
+interactive CLI. Its stdin must begin with exactly one LF-terminated JSON frame:
+
+```json
+{"version":1,"program":"/absolute/path/to/program","args":["arg"],"cwd":"/absolute/existing/directory"}
+```
+
+The complete frame, including its LF, is limited to 256 KiB. Unknown fields,
+NUL bytes, non-absolute `program` or `cwd` values, and a nonexistent `cwd` are
+rejected before launch. The first stderr line is always prefixed with
+`COVEN_PROCESS_SUPERVISOR_V1 ` and contains either a JSON `ready` event or an
+`error` event (`unsupported_protocol`, `invalid_request`, or `spawn_failed`).
+After `ready`, target stdout and stderr are forwarded unchanged and the
+supervisor mirrors the target's exit result. Keep supervisor stdin open as the
+ownership lease; EOF or an owner termination signal cancels and reaps the
+complete target process tree. The target does not receive this control stdin.
+On Windows, clients must use the native-path discovery contract above and own
+the resulting native supervisor process directly; placing the npm wrapper
+between the client and supervisor would weaken exact-handle ownership.

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -2,6 +2,7 @@
 import { spawn } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { constants as osConstants } from 'node:os';
+import path from 'node:path';
 
 const require = createRequire(import.meta.url);
 
@@ -16,6 +17,8 @@ const binaryName = process.platform === 'win32' ? 'coven.exe' : 'coven';
 const platformKey = `${process.platform}-${process.arch}`;
 const packageName = PLATFORM_PACKAGES[platformKey];
 const MEMORY_DASHBOARD_MIN_NODE_MAJOR = 24;
+const WINDOWS_HIDE_NATIVE_WINDOW_ENV = 'COVEN_WINDOWS_HIDE_NATIVE_WINDOW';
+const PRINT_NATIVE_BINARY_PATH_ARG = '--print-native-binary-path';
 
 function resolveBinary() {
   if (!packageName) {
@@ -73,7 +76,36 @@ try {
 // line. (The wrapper previously short-circuited --version to its own
 // package.json version, which shadowed that output for npm installs.)
 const args = process.argv.slice(2);
+if (args.includes(PRINT_NATIVE_BINARY_PATH_ARG)) {
+  if (args.length !== 1) {
+    console.error(`${PRINT_NATIVE_BINARY_PATH_ARG} cannot be combined with other arguments.`);
+    process.exit(1);
+  }
+  if (!path.isAbsolute(binary) || /[\r\n]/.test(binary)) {
+    console.error('Resolved native Coven binary path is not a safe absolute path.');
+    process.exit(1);
+  }
+  process.stdout.write(`${binary}\n`);
+  process.exit(0);
+}
 const childEnv = { ...process.env };
+// Desktop clients that intentionally own no console can opt into a hidden
+// native child. Keep ordinary CLI launches unchanged so inherited output,
+// terminal attachment, and Ctrl-C behavior retain their existing semantics.
+const hideNativeWindowSignal = Object.entries(process.env).find(
+  ([name]) => name.toUpperCase() === WINDOWS_HIDE_NATIVE_WINDOW_ENV
+);
+const hideNativeWindow =
+  process.platform === 'win32' && hideNativeWindowSignal?.[1] === '1';
+// This is a wrapper-boundary instruction, not ambient Coven configuration.
+// Consume every casing of the name (Windows environment lookup is
+// case-insensitive) so the native CLI and launched harnesses cannot inherit
+// it and accidentally hide an unrelated nested wrapper invocation.
+for (const name of Object.keys(childEnv)) {
+  if (name.toUpperCase() === WINDOWS_HIDE_NATIVE_WINDOW_ENV) {
+    delete childEnv[name];
+  }
+}
 const opensMemoryDashboard = isMemoryOpenInvocation(args);
 const requestsHelp = args.some((arg) => arg === '--help' || arg === '-h');
 if (
@@ -97,11 +129,52 @@ if (opensMemoryDashboard) {
   }
 }
 
+// libuv can apply CREATE_NO_WINDOW only when none of the child's stdio entries
+// inherit Windows handles. The opt-in desktop path therefore uses pipes and
+// transparently forwards them; ordinary terminal-owned CLI launches retain
+// direct inherited stdio and their existing console/Ctrl-C behavior.
 const child = spawn(binary, args, {
-  stdio: 'inherit',
-  windowsHide: false,
+  stdio: hideNativeWindow ? ['pipe', 'pipe', 'pipe'] : 'inherit',
+  windowsHide: hideNativeWindow,
   env: childEnv
 });
+
+let forwardingError = null;
+if (hideNativeWindow) {
+  const failForwarding = (label, error) => {
+    if (
+      label === 'stdin' &&
+      (error?.code === 'EPIPE' || error?.code === 'ERR_STREAM_DESTROYED')
+    ) {
+      // A target may intentionally close stdin before it exits. This is not a
+      // wrapper transport failure; its own exit status remains authoritative.
+      return;
+    }
+    if (!forwardingError) {
+      forwardingError = new Error(`${label} forwarding failed: ${error.message}`);
+      process.exitCode = 1;
+      try {
+        process.stderr.write(`Coven wrapper: ${forwardingError.message}\n`);
+      } catch {
+        // The stderr destination itself may be the failed stream.
+      }
+      if (!child.killed) {
+        child.kill('SIGTERM');
+      }
+    }
+  };
+
+  child.stdin.on('error', (error) => failForwarding('stdin', error));
+  child.stdout.on('error', (error) => failForwarding('stdout source', error));
+  child.stderr.on('error', (error) => failForwarding('stderr source', error));
+  process.stdout.on('error', (error) => failForwarding('stdout', error));
+  process.stderr.on('error', (error) => failForwarding('stderr', error));
+  process.stdin.on('error', (error) => failForwarding('stdin source', error));
+
+  process.stdin.pipe(child.stdin);
+  child.stdout.pipe(process.stdout, { end: false });
+  child.stderr.pipe(process.stderr, { end: false });
+}
 
 for (const signal of ['SIGINT', 'SIGTERM']) {
   process.on(signal, () => {
@@ -116,15 +189,30 @@ child.on('error', (error) => {
   process.exit(1);
 });
 
-child.on('exit', (code, signal) => {
+child.on(hideNativeWindow ? 'close' : 'exit', (code, signal) => {
+  if (hideNativeWindow) {
+    process.stdin.unpipe(child.stdin);
+    process.stdin.pause();
+  }
+  if (forwardingError) {
+    process.exitCode = 1;
+    return;
+  }
   if (signal) {
     if (process.platform === 'win32') {
       const signalNumber = osConstants.signals[signal];
-      process.exit(signalNumber === undefined ? 1 : 128 + signalNumber);
+      process.exitCode = signalNumber === undefined ? 1 : 128 + signalNumber;
+      return;
     }
     process.removeAllListeners(signal);
     process.kill(process.pid, signal);
     return;
   }
-  process.exit(code ?? 1);
+  // Setting exitCode (rather than forcing process.exit) lets pipe-backed
+  // stdout/stderr finish flushing without truncating the native CLI output.
+  if (hideNativeWindow) {
+    process.exitCode = code ?? 1;
+  } else {
+    process.exit(code ?? 1);
+  }
 });

--- a/scripts/benchmark-cli.mjs
+++ b/scripts/benchmark-cli.mjs
@@ -357,9 +357,21 @@ export async function stopLiveSession({
     method: 'POST',
     path: `/api/v1/sessions/${sessionId}/kill`
   });
-  if (response.statusCode !== 202) {
-    throw new Error(`live fixture stop returned ${response.statusCode}`);
+  if (response.statusCode === 202) {
+    return;
   }
+  if (response.statusCode === 409) {
+    try {
+      const body = JSON.parse(response.body);
+      if (body?.error?.code === 'session_not_live') {
+        return;
+      }
+    } catch {
+      // Fall through to the status error below. A generic conflict is not
+      // evidence that the benchmark fixture has already stopped.
+    }
+  }
+  throw new Error(`live fixture stop returned ${response.statusCode}`);
 }
 
 export async function prepareEventTail({
@@ -426,7 +438,10 @@ export async function createHarnessFixture(fixtureRoot, environment = process.en
   const binDir = join(fixtureRoot, 'bin');
   await mkdir(binDir, { recursive: true });
   const executable = join(binDir, 'codex');
-  await writeFile(executable, '#!/bin/sh\nprintf "benchmark output\\n"\n', { mode: 0o700 });
+  // A successful noninteractive harness must accept its complete prompt before
+  // exiting. Draining stdin keeps this benchmark on the successful-launch path
+  // instead of racing the daemon's fail-closed prompt-delivery boundary.
+  await writeFile(executable, '#!/bin/sh\ncat >/dev/null\nprintf "benchmark output\\n"\n', { mode: 0o700 });
   await chmod(executable, 0o700);
   return { ...environment, PATH: `${binDir}:${environment.PATH ?? ''}` };
 }
@@ -435,7 +450,11 @@ export async function createInputHarnessFixture(fixtureRoot, environment = proce
   const binDir = join(fixtureRoot, 'event-bin');
   await mkdir(binDir, { recursive: true });
   const executable = join(binDir, 'codex');
-  await writeFile(executable, '#!/bin/sh\nwhile IFS= read -r line; do :; done\n', { mode: 0o700 });
+  await writeFile(
+    executable,
+    '#!/bin/sh\ncat >/dev/null\nwhile :; do sleep 1; done\n',
+    { mode: 0o700 }
+  );
   await chmod(executable, 0o700);
   return { ...environment, PATH: `${binDir}:${environment.PATH ?? ''}` };
 }

--- a/scripts/benchmark-cli.test.mjs
+++ b/scripts/benchmark-cli.test.mjs
@@ -1020,6 +1020,31 @@ test('stopLiveSession sends the public kill request', async () => {
   });
 });
 
+test('stopLiveSession accepts the typed already-gone kill boundary', async () => {
+  await stopLiveSession({
+    socketPath: '/fixture/coven.sock',
+    sessionId: 'session-1',
+    request: async () => ({
+      statusCode: 409,
+      body: JSON.stringify({ error: { code: 'session_not_live' } })
+    })
+  });
+});
+
+test('stopLiveSession rejects an unrelated conflict', async () => {
+  await assert.rejects(
+    stopLiveSession({
+      socketPath: '/fixture/coven.sock',
+      sessionId: 'session-1',
+      request: async () => ({
+        statusCode: 409,
+        body: JSON.stringify({ error: { code: 'session_handoff_active' } })
+      })
+    }),
+    /live fixture stop returned 409/
+  );
+});
+
 test('waitForOutputEvent resolves only after an output event is recorded', async () => {
   const paths = [];
   let reads = 0;

--- a/scripts/check-api-contract-docs-test.py
+++ b/scripts/check-api-contract-docs-test.py
@@ -64,6 +64,84 @@ Archive visibility is stored separately in `archived_at`.
     def test_accepts_canonical_handshake_and_lifecycle(self) -> None:
         self.assertEqual(module.validate_documents(self.canonical_documents()), [])
 
+    def test_current_launch_policy_transport_and_capability_docs_are_guarded(self) -> None:
+        documents = {
+            path: (module.ROOT / path).read_text(encoding="utf-8")
+            for path in module.SESSION_LAUNCH_POLICY_DOCS
+        }
+        self.assertEqual(module.validate_session_launch_policy_docs(documents), [])
+
+    def test_launch_policy_docs_reject_a_missing_tcp_authority_boundary(self) -> None:
+        documents = {
+            path: (module.ROOT / path).read_text(encoding="utf-8")
+            for path in module.SESSION_LAUNCH_POLICY_DOCS
+        }
+        path = "docs/daemon/capabilities-handshake.md"
+        documents[path] = documents[path].replace("TCP", "remote transport")
+        errors = module.validate_session_launch_policy_docs(documents)
+        self.assertIn(f"{path}: launchPolicy transport boundary is missing", errors)
+
+    def test_every_public_health_example_has_the_exact_capability_set(self) -> None:
+        documents = {
+            path: (module.ROOT / path).read_text(encoding="utf-8")
+            for path in module.SESSION_LAUNCH_POLICY_DOCS
+        }
+        for path in module.HEALTH_CAPABILITY_EXAMPLE_DOCS:
+            with self.subTest(path=path):
+                changed = dict(documents)
+                changed[path] = changed[path].replace(
+                    '"sessionLaunchPolicy": true,', "", 1
+                )
+                errors = module.validate_session_launch_policy_docs(changed)
+                self.assertIn(
+                    f"{path}: health example missing sessionLaunchPolicy", errors
+                )
+
+    def test_every_public_health_count_is_guarded(self) -> None:
+        documents = {
+            path: (module.ROOT / path).read_text(encoding="utf-8")
+            for path in module.SESSION_LAUNCH_POLICY_DOCS
+        }
+        for path in module.HEALTH_CAPABILITY_COUNT_DOCS:
+            with self.subTest(path=path):
+                changed = dict(documents)
+                changed[path] = changed[path].replace("all 14", "all nine", 1)
+                errors = module.validate_session_launch_policy_docs(changed)
+                self.assertIn(
+                    f"{path}: health capability field count is stale", errors
+                )
+
+    def test_every_public_capability_list_is_guarded(self) -> None:
+        documents = {
+            path: (module.ROOT / path).read_text(encoding="utf-8")
+            for path in module.SESSION_LAUNCH_POLICY_DOCS
+        }
+        for path in module.HEALTH_CAPABILITY_LIST_DOCS:
+            with self.subTest(path=path):
+                changed = dict(documents)
+                changed[path] = changed[path].replace(
+                    "`sessionLaunchPolicy`", "`removedCapability`"
+                )
+                errors = module.validate_session_launch_policy_docs(changed)
+                self.assertIn(
+                    f"{path}: capability list missing sessionLaunchPolicy", errors
+                )
+
+    def test_every_public_transport_statement_is_guarded(self) -> None:
+        documents = {
+            path: (module.ROOT / path).read_text(encoding="utf-8")
+            for path in module.SESSION_LAUNCH_POLICY_DOCS
+        }
+        for path in module.SESSION_LAUNCH_POLICY_DOCS:
+            with self.subTest(path=path):
+                changed = dict(documents)
+                changed[path] = changed[path].replace("TCP", "remote transport")
+                changed[path] = changed[path].replace("tcp", "remote transport")
+                errors = module.validate_session_launch_policy_docs(changed)
+                self.assertIn(
+                    f"{path}: launchPolicy transport boundary is missing", errors
+                )
+
     def test_guards_public_contract_guides(self) -> None:
         for path in self.PUBLIC_CONTRACT_DOCS:
             with self.subTest(path=path):

--- a/scripts/check-api-contract-docs.py
+++ b/scripts/check-api-contract-docs.py
@@ -114,6 +114,45 @@ PIPELESS_TABLE_BLOCK = re.compile(
     r"\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+(?:\n|$)"
 )
 STRUCTURAL_ROW_MARKER = "COVEN_DOC_STRUCTURAL_ROW"
+HEALTH_CAPABILITY_FIELDS = (
+    "sessions",
+    "events",
+    "travel",
+    "scheduler",
+    "hub",
+    "executorDispatch",
+    "eventCursor",
+    "structuredErrors",
+    "sessionHandoff",
+    "sessionLaunchPolicy",
+    "afs",
+    "afsMount",
+    "afsCommit",
+    "afsCommitDryRun",
+)
+SESSION_LAUNCH_POLICY_DOCS = (
+    "docs/API-CONTRACT.md",
+    "docs/reference/api.md",
+    "docs/reference/api-contract.md",
+    "docs/daemon/socket-api.md",
+    "docs/daemon/capabilities-handshake.md",
+)
+HEALTH_CAPABILITY_EXAMPLE_DOCS = (
+    "docs/API-CONTRACT.md",
+    "docs/reference/api-contract.md",
+    "docs/daemon/socket-api.md",
+)
+HEALTH_CAPABILITY_LIST_DOCS = (
+    "docs/API-CONTRACT.md",
+    "docs/reference/api.md",
+    "docs/reference/api-contract.md",
+    "docs/daemon/socket-api.md",
+)
+HEALTH_CAPABILITY_COUNT_DOCS = (
+    "docs/reference/api.md",
+    "docs/reference/api-contract.md",
+    "docs/daemon/socket-api.md",
+)
 
 
 def legacy_route_explained(text: str) -> bool:
@@ -356,6 +395,36 @@ def validate_documents(documents: dict[str, str]) -> list[str]:
     return errors
 
 
+def validate_session_launch_policy_docs(documents: dict[str, str]) -> list[str]:
+    """Pin the transport and field-list parts of the privileged launch contract."""
+    errors: list[str] = []
+    for path in SESSION_LAUNCH_POLICY_DOCS:
+        text = documents[path]
+        lowered = text.lower()
+        if "sessionLaunchPolicy" not in text:
+            errors.append(f"{path}: sessionLaunchPolicy capability is missing")
+        if "tcp" not in lowered or not re.search(
+            r"owner[-\s]+(?:gated[-\s]+)?local[-\s]+ipc", lowered
+        ):
+            errors.append(f"{path}: launchPolicy transport boundary is missing")
+
+    for path in HEALTH_CAPABILITY_EXAMPLE_DOCS:
+        for field in HEALTH_CAPABILITY_FIELDS:
+            if f'"{field}"' not in documents[path]:
+                errors.append(f"{path}: health example missing {field}")
+
+    for path in HEALTH_CAPABILITY_LIST_DOCS:
+        for field in HEALTH_CAPABILITY_FIELDS:
+            if f"`{field}`" not in documents[path]:
+                errors.append(f"{path}: capability list missing {field}")
+
+    expected_count = len(HEALTH_CAPABILITY_FIELDS)
+    for path in HEALTH_CAPABILITY_COUNT_DOCS:
+        if not re.search(rf"\ball {expected_count}\b[^.\n]*\bfields\b", documents[path]):
+            errors.append(f"{path}: health capability field count is stale")
+    return errors
+
+
 def main() -> int:
     paths = tuple(dict.fromkeys(CONTRACT_DOCS + LIFECYCLE_DOCS + HEALTH_GUIDANCE_DOCS))
     documents: dict[str, str] = {}
@@ -369,6 +438,7 @@ def main() -> int:
             )
             return 1
     errors = validate_documents(documents)
+    errors.extend(validate_session_launch_policy_docs(documents))
 
     for error in errors:
         print(error, file=sys.stderr)

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -508,6 +508,324 @@ test('wrapper binary maps windows x64 to windows native package and exe binary',
   assert.match(bin, /process\.platform === 'win32' \? 'coven\.exe' : 'coven'/);
 });
 
+test('wrapper no-window mode is an explicit exact-value opt-in', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const bin = readFileSync(binPath, 'utf8');
+  assert.match(bin, /COVEN_WINDOWS_HIDE_NATIVE_WINDOW/);
+  assert.match(
+    bin,
+    /hideNativeWindowSignal\?\.\[1\] === '1'/,
+    'values other than the documented literal 1 must preserve ordinary CLI behavior'
+  );
+  assert.match(bin, /name\.toUpperCase\(\) === WINDOWS_HIDE_NATIVE_WINDOW_ENV/);
+  assert.match(bin, /delete childEnv\[name\]/);
+  assert.match(bin, /hideNativeWindow \? \['pipe', 'pipe', 'pipe'\] : 'inherit'/);
+  assert.match(bin, /windowsHide: hideNativeWindow/);
+});
+
+test('wrapper exposes a strict native-binary path discovery contract', () => {
+  const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
+  const bin = readFileSync(binPath, 'utf8');
+  assert.match(bin, /--print-native-binary-path/);
+  assert.match(bin, /args\.length !== 1/);
+  assert.match(bin, /path\.isAbsolute\(binary\)/);
+  assert.match(bin, /process\.stdout\.write\(`\$\{binary\}\\n`\)/);
+});
+
+test('wrapper docs publish the complete native process-supervisor v1 contract', () => {
+  const readme = readFileSync(
+    new URL(['..', 'npm', 'coven', 'README.md'].join('/'), import.meta.url),
+    'utf8'
+  );
+  assert.match(readme, /coven process-supervisor\s+--protocol coven\.process-supervisor\.v1/);
+  assert.match(
+    readme,
+    /\{"version":1,"program":"\/absolute\/path\/to\/program","args":\["arg"\],"cwd":"\/absolute\/existing\/directory"\}/
+  );
+  assert.match(readme, /limited to 256 KiB/);
+  assert.match(readme, /COVEN_PROCESS_SUPERVISOR_V1/);
+  assert.match(readme, /Keep supervisor stdin open as the\s+ownership lease/);
+  assert.match(readme, /target stdout and stderr are forwarded unchanged/);
+  assert.match(readme, /native supervisor process directly/);
+});
+
+test(
+  'wrapper path discovery prints the exact native executable without launching it',
+  { skip: !SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`] },
+  () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'coven-wrapper-native-path-'));
+    try {
+      const wrapperDir = path.join(fixture, 'wrapper');
+      const wrapperBinDir = path.join(wrapperDir, 'bin');
+      const wrapperPath = path.join(wrapperBinDir, 'coven.js');
+      mkdirSync(wrapperBinDir, { recursive: true });
+      writeFileSync(
+        path.join(wrapperDir, 'package.json'),
+        JSON.stringify({ name: '@opencoven/cli-test', type: 'module' })
+      );
+      copyFileSync(
+        fileURLToPath(new URL('../npm/coven/bin/coven.js', import.meta.url)),
+        wrapperPath
+      );
+      const [packageName, binaryName] =
+        SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`];
+      const nativeDir = path.join(wrapperDir, 'node_modules', ...packageName.split('/'));
+      const nativeBinDir = path.join(nativeDir, 'bin');
+      const nativePath = path.join(nativeBinDir, binaryName);
+      mkdirSync(nativeBinDir, { recursive: true });
+      writeFileSync(
+        path.join(nativeDir, 'package.json'),
+        JSON.stringify({ name: packageName, version: '0.0.0' })
+      );
+      symlinkSync(process.execPath, nativePath);
+
+      const result = spawnSync(
+        process.execPath,
+        [wrapperPath, '--print-native-binary-path'],
+        { encoding: 'utf8' }
+      );
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(result.stderr, '');
+      assert.equal(result.stdout, `${realpathSync(nativePath)}\n`);
+
+      const mixed = spawnSync(
+        process.execPath,
+        [wrapperPath, '--print-native-binary-path', '--version'],
+        { encoding: 'utf8' }
+      );
+      assert.equal(mixed.status, 1);
+      assert.equal(mixed.stdout, '');
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  }
+);
+
+test(
+  'Windows wrapper opt-in launches its console-subsystem native child without a console',
+  { skip: process.platform !== 'win32', timeout: 30_000 },
+  async () => {
+    const fixture = mkdtempSync(path.join(tmpdir(), 'coven-wrapper-console-'));
+    try {
+      const wrapperDir = path.join(fixture, 'wrapper');
+      const wrapperBinDir = path.join(wrapperDir, 'bin');
+      const wrapperPath = path.join(wrapperBinDir, 'coven.js');
+      const nativeDir = path.join(
+        wrapperDir,
+        'node_modules',
+        '@opencoven',
+        'cli-windows'
+      );
+      const nativeBinDir = path.join(nativeDir, 'bin');
+      const nativePath = path.join(nativeBinDir, 'coven.exe');
+      mkdirSync(wrapperBinDir, { recursive: true });
+      mkdirSync(nativeBinDir, { recursive: true });
+      writeFileSync(
+        path.join(wrapperDir, 'package.json'),
+        JSON.stringify({ name: '@opencoven/cli-test', type: 'module' })
+      );
+      writeFileSync(
+        path.join(nativeDir, 'package.json'),
+        JSON.stringify({ name: '@opencoven/cli-windows', version: '0.0.0' })
+      );
+      copyFileSync(
+        fileURLToPath(new URL('../npm/coven/bin/coven.js', import.meta.url)),
+        wrapperPath
+      );
+      const source = fileURLToPath(
+        new URL(
+          '../crates/coven-cli/tests/fixtures/windows_console_probe.rs',
+          import.meta.url
+        )
+      );
+      const compile = spawnSync(
+        'rustc.exe',
+        ['--edition=2021', '-o', nativePath, source],
+        { encoding: 'utf8' }
+      );
+      assert.equal(compile.status, 0, compile.stderr);
+
+      const nativePathResult = spawnSync(
+        process.execPath,
+        [wrapperPath, '--print-native-binary-path'],
+        { encoding: 'utf8' }
+      );
+      assert.equal(nativePathResult.status, 0, nativePathResult.stderr);
+      assert.equal(nativePathResult.stdout, `${nativePath}\n`);
+
+      const ordinaryEnv = { ...process.env };
+      delete ordinaryEnv.COVEN_WINDOWS_HIDE_NATIVE_WINDOW;
+      const ordinary = spawnSync(process.execPath, [wrapperPath], {
+        encoding: 'utf8',
+        env: ordinaryEnv
+      });
+      assert.equal(ordinary.status, 0, ordinary.stderr);
+      assert.match(
+        ordinary.stdout,
+        /console=(?:present|absent)/,
+        'the native console-subsystem probe must run even when the CI parent is already headless'
+      );
+      const allocatedOrdinary = spawnSync(
+        nativePath,
+        ['--launch-new-console', process.execPath, wrapperPath],
+        { encoding: 'utf8', env: ordinaryEnv }
+      );
+      assert.equal(allocatedOrdinary.status, 0, allocatedOrdinary.stderr);
+      assert.match(
+        allocatedOrdinary.stdout,
+        /console=present/,
+        'the same wrapper/native probe must observe the explicitly allocated positive-control console'
+      );
+
+      const nonOptIn = spawnSync(process.execPath, [wrapperPath], {
+        encoding: 'utf8',
+        env: {
+          ...ordinaryEnv,
+          COVEN_WINDOWS_HIDE_NATIVE_WINDOW: 'true'
+        }
+      });
+      assert.equal(nonOptIn.status, 0, nonOptIn.stderr);
+      assert.equal(
+        nonOptIn.stdout,
+        ordinary.stdout,
+        'values other than literal 1 must preserve the parent console state'
+      );
+
+      const nonOptInEnv = spawnSync(
+        process.execPath,
+        [wrapperPath, '--print-env', 'coven_windows_hide_native_window'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...ordinaryEnv,
+            Coven_Windows_Hide_Native_Window: 'true'
+          }
+        }
+      );
+      assert.equal(nonOptInEnv.status, 0, nonOptInEnv.stderr);
+      assert.match(nonOptInEnv.stdout, /env=absent/);
+
+      const hidden = spawnSync(process.execPath, [wrapperPath], {
+        encoding: 'utf8',
+        env: {
+          ...ordinaryEnv,
+          COVEN_WINDOWS_HIDE_NATIVE_WINDOW: '1'
+        }
+      });
+      assert.equal(hidden.status, 0, hidden.stderr);
+      assert.match(hidden.stdout, /console=absent/);
+      const allocatedHidden = spawnSync(
+        nativePath,
+        ['--launch-new-console', process.execPath, wrapperPath],
+        {
+          encoding: 'utf8',
+          env: {
+            ...ordinaryEnv,
+            COVEN_WINDOWS_HIDE_NATIVE_WINDOW: '1'
+          }
+        }
+      );
+      assert.equal(allocatedHidden.status, 0, allocatedHidden.stderr);
+      assert.match(
+        allocatedHidden.stdout,
+        /console=absent/,
+        'wrapper opt-in must suppress the native console even when its Node parent owns an allocated console'
+      );
+
+      const forwardedInput = 'stdin-forwarding-資料-&!^%\n'.repeat(4096);
+      const hiddenForwarding = spawnSync(
+        process.execPath,
+        [wrapperPath, '--echo-stdio-exit', '23'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...ordinaryEnv,
+            COVEN_WINDOWS_HIDE_NATIVE_WINDOW: '1'
+          },
+          input: forwardedInput,
+          maxBuffer: 2 * 1024 * 1024
+        }
+      );
+      assert.equal(hiddenForwarding.status, 23, hiddenForwarding.stderr);
+      assert.equal(
+        hiddenForwarding.stdout,
+        `console=absent\n${forwardedInput}`,
+        'hidden wrapper must preserve pipe-backed stdin and stdout exactly'
+      );
+      assert.equal(
+        hiddenForwarding.stderr,
+        'stderr=forwarded\n',
+        'hidden wrapper must preserve pipe-backed stderr exactly'
+      );
+
+      const brokenDestination = spawn(
+        process.execPath,
+        [wrapperPath, '--spam-stdout'],
+        {
+          env: {
+            ...ordinaryEnv,
+            COVEN_WINDOWS_HIDE_NATIVE_WINDOW: '1'
+          },
+          stdio: ['ignore', 'pipe', 'pipe']
+        }
+      );
+      brokenDestination.stderr.resume();
+      await once(brokenDestination.stdout, 'data');
+      brokenDestination.stdout.destroy();
+      const [brokenCode] = await once(brokenDestination, 'close');
+      assert.equal(
+        brokenCode,
+        1,
+        'a broken forwarded output destination must fail closed instead of reporting native success'
+      );
+
+      const hiddenEnv = spawnSync(
+        process.execPath,
+        [wrapperPath, '--print-env', 'COVEN_WINDOWS_HIDE_NATIVE_WINDOW'],
+        {
+          encoding: 'utf8',
+          env: {
+            ...ordinaryEnv,
+            COVEN_WINDOWS_HIDE_NATIVE_WINDOW: '1'
+          }
+        }
+      );
+      assert.equal(hiddenEnv.status, 0, hiddenEnv.stderr);
+      assert.match(hiddenEnv.stdout, /env=absent/);
+
+      const ctrlReady = path.join(fixture, 'ctrl-c-ready');
+      const ctrlPid = path.join(fixture, 'ctrl-c-native.pid');
+      const ctrlC = spawnSync(
+        nativePath,
+        [
+          '--launch-new-console-ctrl-c',
+          ctrlReady,
+          process.execPath,
+          wrapperPath,
+          '--ctrl-c-ready',
+          ctrlReady,
+          ctrlPid
+        ],
+        { encoding: 'utf8', env: ordinaryEnv }
+      );
+      assert.equal(ctrlC.status, 0, ctrlC.stderr);
+      assert.match(
+        ctrlC.stdout,
+        /ctrl-c-exit=130/,
+        'ordinary wrapper did not preserve forwarded Ctrl-C as exit code 130'
+      );
+      const ctrlNativePid = Number.parseInt(readFileSync(ctrlPid, 'utf8'), 10);
+      assert.throws(
+        () => process.kill(ctrlNativePid, 0),
+        /ESRCH/,
+        'ordinary wrapper Ctrl-C left its native child running'
+      );
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  }
+);
+
 test('wrapper includes conventional Windows signal fallback', () => {
   const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
   const bin = readFileSync(binPath, 'utf8');


### PR DESCRIPTION
## Context

- Summary: Repair the Windows Research Desk process boundary end to end: hide daemon-backed noninteractive harnesses, contain and reap their full process trees, make prompt delivery bounded and cancellable, and expose an exact native supervisor contract for desktop clients.
- Root cause: Cave PR #4413 repaired Node-side child spawning, but Research Desk's local Codex familiar enters Coven with `launchMode: "nonInteractive"`. Coven's Rust `spawn_piped_with_observer` path did not apply `CREATE_NO_WINDOW`; the npm wrapper also used inherited stdio, for which Node/libuv cannot combine `windowsHide` with `CREATE_NO_WINDOW`. Process registration, prompt delivery, and post-spawn Job assignment left additional cancellation and shutdown races.
- Native follow-up root causes: Codex 0.146.1 downgrades requested `workspace-write` to `read-only` on native Windows when `windows.sandbox` is disabled. It also parses root `--ask-for-approval never` without inheriting that field into `exec`; when AutoReview becomes effective, `exec` rebuilds without its synthetic headless default and an untrusted project can select approval `untrusted`. Coven now pins both `-c windows.sandbox="unelevated"` and the session-level `-c approval_policy="never"` inside its validated Windows Codex `nonInteractive` `launchPolicy` boundary.
- Files changed: Rust daemon/API/harness/process-runner code and native fixtures; the npm wrapper and its tests; daemon/API/supervisor documentation and release notes.
- Closes #712
- Closes #713

## Implementation

- Centralizes strict noninteractive containment. Windows children start suspended and hidden, enter `KILL_ON_JOB_CLOSE` containment before resume, and inherit a daemon-lifetime Job from process creation; Unix children keep their process-group behavior and now shut down gracefully through bounded runtime cleanup.
- Makes explicit kill a quiescence boundary: descendants are terminated and reaped, stdout/stderr drains and exit callbacks complete in order, failed kills retain exact ownership for retry, and concurrent cancel cannot be overwritten by a later launch failure.
- Starts output drains before bounded prompt delivery, registers exact ownership before writing, moves full Codex prompts to stdin, and fails deterministically when delivery or admission fails. Large duplex, never-read, closed-stdin, root-exit, cancellation, timeout, and daemon-stop races have executable regressions.
- Adds `RequestAuthority::{OwnerLocalIpc,Tcp}`. Existing public/internal handlers remain owner-local by default; the daemon HTTP transport supplies authority explicitly. `launchPolicy` is available only over owner-gated Unix socket/Windows pipe transport, TCP health advertises `sessionLaunchPolicy: false`, and TCP POSTs containing it are rejected before session creation or spawn. Canonical existing `addDirs` outside `projectRoot` remain valid grants and are forwarded exactly.
- Resolves official Windows Codex npm shims to the validated architecture-specific native executable for noninteractive launches, preserving managed-package markers and exact Unicode/metacharacter argv without `cmd.exe`. Interactive PTY/stream modes retain the shim; a real `codex.cmd` ConPTY fixture proves terminal query/reply behavior is unchanged.
- Selects Codex's supported Windows unelevated restricted-token sandbox backend only for the exact daemon-authorized noninteractive workspace-write policy. The adapter also pins `approval_policy="never"` as an explicit Codex session config override so AutoReview cannot replace the requested policy during `exec` configuration. Interactive/user-owned sessions, stream sessions, non-Codex harnesses, and non-Windows platforms receive no backend override. Backend failures retain Codex stderr/exit evidence and never trigger a shell or unsandboxed fallback.
- Adds hidden `coven process-supervisor --protocol coven.process-supervisor.v1` plus wrapper-only `--print-native-binary-path`. The JSONL admission frame, stdin ownership lease, ready/error record, output forwarding, exit propagation, parent-death behavior, frame cap, and absolute-path checks are documented and tested. No shell, string evaluation, or PID/taskkill fallback is introduced.
- Changes the wrapper no-window opt-in to pipe-backed transparent forwarding so libuv can apply `CREATE_NO_WINDOW`; consumes the opt-in environment key before native spawn and leaves ordinary interactive wrapper behavior unchanged.

### User-visible behavior

- Detached Windows Research/Codex sessions no longer allocate a visible console window.
- The Windows Codex Research policy now remains effectively `workspace-write` instead of being silently reduced to `read-only` by a disabled native sandbox backend.
- Cancellation, timeout, app/daemon shutdown, and direct desktop-client process ownership stop the complete descendant tree before reporting completion.
- Oversized Research prompts no longer ride in one Windows command line, and missing primary artifacts remain a distinct fail-closed application condition.

### Compatibility notes

- Interactive PTY behavior is unchanged and has a native `codex.cmd`/ConPTY regression.
- macOS/Linux do not receive Windows creation flags or the Windows Codex backend override. Both Apple targets compile; native macOS runtime access was unavailable and is not claimed.
- Windows daemon startup deliberately fails closed if its daemon-lifetime Job cannot be created, configured, or assigned. Allowing degraded startup would reopen the pre-session Job-assignment escape window this repair closes.
- The supervisor is an internal desktop-integration contract; ordinary CLI invocation remains unchanged.

## Verification

- [x] `cargo fmt --check`
- [x] Focused `launch_policy` tests: 9 passed; process-supervisor integration: 7 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked` (Linux: 1,940 CLI unit tests passed, 2 ignored; every workspace/integration suite passed)
- [x] Combined Node wrapper/release/benchmark guardrails: 173 passed, 1 Windows-only skip on Linux
- [x] `COVEN_NPM_DRY_RUN_VERSION=999.0.0 node scripts/test-cli-prepublish.mjs --target=linux-x64 --skip-secrets-scan` (all four package build/pack/install/daemon-lifecycle checks passed; dry-run only)
- [x] `python3 scripts/check-api-contract-docs-test.py` (48 passed) and `python3 scripts/check-api-contract-docs.py`
- [x] `python3 scripts/check-secrets-test.py` (87 passed) and `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy-test.py` (33 passed) and `python3 scripts/check-coven-privacy.py --range origin/main...HEAD`
- [x] `git diff --check origin/main...HEAD`
- [x] Apple compile-only: `cargo check -p coven-cli --locked --target x86_64-apple-darwin` and `--target aarch64-apple-darwin` via Zig cross linker

### Native Windows

- Exact head `4cd2de46c801c74b50d32a84fdbaeaca4de523fb` rebuilt cleanly on native Windows: `coven.exe` is 32,505,856 bytes with SHA-256 `7216fa34e5b30531c6eb51ce92915a6d87070358251543b1bc766d5a39171e16`. Two identical owner-local `launchPolicy` sessions with AutoReview enabled both persisted effective approval `never` plus sandbox `workspace-write`, completed with exit 0, and wrote the exact 25-byte sentinel; the second-session regression that previously became `untrusted` is closed.
- `cargo test -p coven-cli --locked --bin coven windows -- --nocapture --test-threads=1`: 34 passed, including the allocated-console positive control, hidden piped child, direct official Codex native argv/no-console path, strict Job flags, Job-close descendant backstop, and real interactive `codex.cmd` ConPTY flow.
- `cargo test -p coven-cli --locked --test stream_json_integration windows_ -- --nocapture --test-threads=1`: 2 passed (official shim-to-native stream/resume and silent timeout durability).
- `cargo test -p coven-cli --locked --test process_supervisor --test windows_daemon_lifecycle -- --nocapture --test-threads=1`: supervisor 5/5; captured native/wrapper daemon start and abrupt shutdown 2/2.
- Windows Node `--test scripts/publish-npm-test.mjs`: 69 passed, 0 failed, 3 platform-inapplicable skips; the opt-in wrapper positive-control test covered hidden console, stdin/stdout/stderr forwarding, exit, broken destination, and Ctrl-C behavior.
- Coordinated Cave provider contract suite against the native binary: 30/30, including owner EOF, descendant quiescence, and abrupt owner death.
- Native Codex 0.146.1 discriminator, isolated to fresh session/rollout IDs and the intended cwd: both policy flag orderings without a selected Windows backend reported approval `never`, sandbox `read-only`, and wrote no sentinel; adding only `-c windows.sandbox="unelevated"` reported sandbox `workspace-write` and wrote the exact sentinel. This is direct platform evidence for the targeted override now emitted by Coven.

### CI

- Current exact head: `4cd2de46c801c74b50d32a84fdbaeaca4de523fb`.
- Exact-head CI: [run 31449780875](https://github.com/OpenCoven/coven/actions/runs/31449780875) completed successfully; all 13 CI jobs passed on the exact signed head.
- Ancillary policy workflow: [Dependabot auto-merge run 31437332441](https://github.com/OpenCoven/coven/actions/runs/31437332441) (expected skipped for a non-Dependabot PR).

## Risk and Rollback

- Risk level: high, because this changes process ownership and shutdown ordering across daemon, wrapper, and desktop-client boundaries. The implementation keeps platform policy centralized and adds native fixtures at every affected boundary.
- Rollback plan: revert the single signed commit. Existing clients default to the unchanged owner-local handler contract; no storage migration or release artifact is involved.
- Observed performance boundary: the native unelevated Codex sandbox was functionally correct, but simple PowerShell tool calls took minutes during one real Research run. That latency is recorded as a separate native/runtime limitation; this PR does not claim to repair it.

## Agent Handoff

- Current state: one SSH-signed, DCO-compliant commit based directly on current `origin/main`; an independent provider audit of the Windows backend repair reported no blockers before publication.
- Cross-repository dependencies: coordinated Coven Cave lifecycle PR [OpenCoven/coven-cave#4524](https://github.com/OpenCoven/coven-cave/pull/4524); companion Cave launch-hardening PR [OpenCoven/coven-cave#4531](https://github.com/OpenCoven/coven-cave/pull/4531); approval-policy verification follow-up [OpenCoven/coven-cave#4537](https://github.com/OpenCoven/coven-cave/pull/4537), squash-merged externally at verified Cave `main` `429a28dd` with a tree equal to audited head `040a28c`.
- Known gaps: no native macOS runtime machine was available. Apple compile proof is recorded above; Windows native process/console and effective sandbox behavior are covered directly. The PowerShell latency boundary above remains explicit.
- No merge, package publication, tag, or release occurred as part of this work.
