### PR TITLE
fix(release): ship the AFS mount helper in the macOS packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,13 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
+      # The smoke test packages with --skip-build, so it needs every binary the
+      # payload declares — the same set the release builds. Without this the
+      # macOS packages would be assembled without the AFS export helper, which
+      # is precisely the gap this job exists to catch (coven-g2t).
+      - name: Build the AFS mount export helper (macOS only)
+        if: startsWith(matrix.npm-target, 'macos')
+        run: cargo build --release -p coven-afs --features mount --bins --target ${{ matrix.rust-target }}
       - run: node scripts/test-cli-prepublish.mjs --target=${{ matrix.npm-target }} --skip-build --skip-secrets-scan
         env:
           COVEN_NPM_DRY_RUN_VERSION: 999.0.0

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -209,10 +209,24 @@ jobs:
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
         env:
           COVEN_BUILD_VERSION: v${{ needs.verify-tag.outputs.npm_version }}
+      # The per-mount NFS export process, which the daemon spawns and locates
+      # beside its own executable. macOS only: `afs_mount::backend()` returns
+      # None on other platforms, and the `mount` feature does not compile on
+      # Windows. Without this the package ships one binary and every installed
+      # user gets `afsMount: false` (coven-g2t).
+      - name: Build the AFS mount export helper (macOS only)
+        if: startsWith(matrix.npm-target, 'macos')
+        run: cargo build --release -p coven-afs --features mount --bins --target ${{ matrix.rust-target }}
+        env:
+          COVEN_BUILD_VERSION: v${{ needs.verify-tag.outputs.npm_version }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.0
         with:
           name: coven-${{ matrix.npm-target }}
-          path: target/${{ matrix.rust-target }}/release/${{ matrix.binary }}
+          # Both binaries when the helper was built; the glob matches nothing
+          # extra on platforms that skipped it.
+          path: |
+            target/${{ matrix.rust-target }}/release/${{ matrix.binary }}
+            target/${{ matrix.rust-target }}/release/coven-afs-serve
           if-no-files-found: error
 
   npm-dry-run:

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -17,7 +17,7 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { defaultTargetName, isMainModule, isOidcContext, nativeTargetNamesForPackageSet, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
+import { defaultTargetName, isMainModule, targetHelperBinaryName, isOidcContext, nativeTargetNamesForPackageSet, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 import { parseReleaseTag } from './release-npm-context.mjs';
 import { nativePackageSet } from './release-npm-recovery-contract.mjs';
 import { platformMatrix } from './release-npm-platform-matrix.mjs';
@@ -58,6 +58,22 @@ test('parseReleaseTag rejects malformed and unrelated prerelease tags', () => {
       /stable vX.Y.Z tag or vX.Y.Z-recovery.N/
     );
   }
+});
+
+test('macOS platform packages ship the AFS mount export helper', () => {
+  // v0.3.0 shipped without it and every installed user got `afsMount: false`,
+  // because the daemon locates the helper beside its own executable and it
+  // was never packaged. This asserts the declaration that puts it there.
+  assert.equal(targetHelperBinaryName('macos'), 'coven-afs-serve');
+  assert.equal(targetHelperBinaryName('macos-x64'), 'coven-afs-serve');
+});
+
+test('non-macOS platform packages ship no mount helper', () => {
+  // Deliberate, not incidental: `afs_mount::backend()` returns None off
+  // macOS, and the `mount` feature does not compile on Windows, so shipping
+  // the helper there would be dead weight.
+  assert.equal(targetHelperBinaryName('linux-x64'), undefined);
+  assert.equal(targetHelperBinaryName('windows'), undefined);
 });
 
 test('nativePackageSet accepts only complete historical native package sets', () => {

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -16,14 +16,21 @@ const targets = {
     os: 'darwin',
     cpu: 'arm64',
     rustTarget: 'aarch64-apple-darwin',
-    binaryName: 'coven'
+    binaryName: 'coven',
+    // The per-mount NFS export process. Declared only for macOS because
+    // `afs_mount::backend()` returns None elsewhere, and the `mount` feature
+    // does not compile on Windows at all. Shipping it where nothing can use
+    // it would be dead weight; omitting it on macOS makes `afsMount` false
+    // for every installed user, which is what this fixes.
+    helperBinaryName: 'coven-afs-serve'
   },
   'macos-x64': {
     packageName: '@opencoven/cli-macos-x64',
     os: 'darwin',
     cpu: 'x64',
     rustTarget: 'x86_64-apple-darwin',
-    binaryName: 'coven'
+    binaryName: 'coven',
+    helperBinaryName: 'coven-afs-serve'
   },
   'linux-x64': {
     packageName: '@opencoven/cli-linux-x64',
@@ -86,6 +93,17 @@ function main() {
   if (!wrapperOnly) {
     if (!skipBuild) {
       run('cargo', ['build', '--release', '--package', 'coven-cli', '--target', target.rustTarget]);
+      if (target.helperBinaryName) {
+        // Built here as well as in CI, so a local `--dry-run` produces the
+        // same payload the release does. Without this the helper check below
+        // would fail locally for a reason that has nothing to do with the
+        // package being wrong.
+        run('cargo', [
+          'build', '--release', '-p', 'coven-afs',
+          '--features', 'mount', '--bins',
+          '--target', target.rustTarget
+        ]);
+      }
     }
 
     const binaryPath = path.join(repoRoot, 'target', target.rustTarget, 'release', target.binaryName);
@@ -158,6 +176,18 @@ function writePlatformPackage(targetName, target, binaryPath, version) {
   cpSync(path.join(repoRoot, 'npm', 'coven-platform-template', 'README.md'), path.join(outDir, 'README.md'));
   cpSync(binaryPath, path.join(binDir, target.binaryName));
   chmodSync(path.join(binDir, target.binaryName), 0o755);
+
+  if (target.helperBinaryName) {
+    const helperPath = path.join(path.dirname(binaryPath), target.helperBinaryName);
+    if (!existsSync(helperPath)) {
+      // Loud rather than optional. v0.3.0 shipped without this helper and
+      // every installed user got `afsMount: false`; nothing failed, because
+      // nothing looked.
+      fail(`Declared helper binary not found at ${helperPath}`);
+    }
+    cpSync(helperPath, path.join(binDir, target.helperBinaryName));
+    chmodSync(path.join(binDir, target.helperBinaryName), 0o755);
+  }
   return outDir;
 }
 
@@ -210,6 +240,15 @@ export function releaseVersion(env = process.env, packageVersion = wrapperPackag
 
 export function targetPackageName(targetName) {
   return targets[targetName]?.packageName;
+}
+
+/// The extra binary a platform package ships beside `coven`, or undefined.
+///
+/// Exported so the packaging contract is testable: v0.3.0 shipped without the
+/// AFS export helper and nothing failed, because nothing inspected what went
+/// into the tarball.
+export function targetHelperBinaryName(targetName) {
+  return targets[targetName]?.helperBinaryName;
 }
 
 export function nativeTargetNamesForPackageSet(packageSet = process.env.COVEN_NPM_NATIVE_PACKAGE_SET ?? 'post-intel') {


### PR DESCRIPTION
Closes `coven-g2t`. **v0.3.0 shipped the mount backend as its headline feature
and no installed user can enable it.**

## What's broken

The platform package contains exactly one file:

```
node_modules/@opencoven/cli-macos/bin/
  coven            16094304 bytes
  (no coven-afs-serve)
```

`afs_mount::backend()` locates the export helper beside the running executable,
doesn't find it, and correctly reports no backend. Verified on a clean 0.3.0
install:

```
GET /api/v1/health -> afs=true, afsCommit=true, afsMount=FALSE
```

So the backend works only from a source checkout where someone has run
`cargo build -p coven-afs --features mount --bins`. The release built only
`--package coven-cli`; `coven-afs-serve` is a binary of the `coven-afs` crate
behind its `mount` feature and was never built or packaged.

Not a regression — the packaging was never updated when the backend landed. It
went unnoticed through five release-adjacent PRs because **nothing inspects
what goes into the tarball**.

## The fix

- The release builds the helper for macOS targets and uploads both binaries.
- `publish-npm.mjs` declares `helperBinaryName` for those targets and copies it
  into the payload.
- **A declared-but-unbuilt helper now fails the publish loudly** — the check
  whose absence let v0.3.0 ship silently.
- Local `--dry-run` builds it too, so a dry run produces the same payload the
  release does rather than failing for an unrelated reason.

macOS only, deliberately: `backend()` returns `None` elsewhere and the `mount`
feature doesn't compile on Windows, so shipping it there is dead weight. The
declaration names which targets carry it instead of relying on a glob.

## Verification

Both directions, with stand-in binaries:

- helper missing → `Declared helper binary not found at …/coven-afs-serve`, exit 1
- helper present → npm's own manifest lists `bin/coven` **and**
  `bin/coven-afs-serve` in the macOS tarball

Two unit tests pin which targets declare a helper and which deliberately don't
(69 node tests pass). Full gate set green: `cargo fmt --check`,
`clippy --workspace --all-targets -D warnings`, `test --workspace --locked`,
`check-secrets-test.py`, `check-secrets.py`.

**What this cannot prove locally** is the real macOS runner build. If that step
fails, v0.3.1 burns and we go forward to v0.3.2 — the tag is never recycled.

Cutting `v0.3.1` from this.