### PR TITLE
fix(afs): reject ASCII case-variants of `.git` during materialization

### DIFF
--- a/crates/coven-cli/src/afs.rs
+++ b/crates/coven-cli/src/afs.rs
@@ -848,7 +848,10 @@ fn reject_escape(normalized: &str) -> AfsResult<()> {
             reason: "it contains a relative component after normalization".to_string(),
         });
     }
-    if components.next() == Some(".git") {
+    if components
+        .next()
+        .is_some_and(|component| component.eq_ignore_ascii_case(".git"))
+    {
         return Err(AfsError::PathOutsideRoot {
             path: normalized.to_string(),
             reason: "writes under .git/ are never materialized".to_string(),
@@ -1806,6 +1809,8 @@ mod tests {
         assert!(reject_escape("/").is_err());
         assert!(reject_escape("/.git/config").is_err());
         assert!(reject_escape("/.git").is_err());
+        assert!(reject_escape("/.GIT/config").is_err());
+        assert!(reject_escape("/.Git").is_err());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Prevent attacker-controlled AFS deltas from overwriting a worktree's `.git` gitfile on case-insensitive filesystems by ensuring the repository-escape guard treats `.git` case-insensitively.

### Description

- Change `reject_escape` in `crates/coven-cli/src/afs.rs` to reject a first path component that equals `.git` using ASCII case-insensitive comparison (`.is_some_and(|c| c.eq_ignore_ascii_case(".git"))`).
- Add regression assertions to the existing unit test to verify mixed- and upper-case variants such as `/.GIT/config` and `/.Git` are rejected.
- Keep existing behavior for the root, relative components, and non-git paths unchanged.

### Testing

- Ran `cargo fmt --check` and it passed.
- Ran `cargo test -p coven-cli escape_rejection_covers_git_and_the_root_itself --locked` and the targeted test passed.
- Ran `python scripts/check-secrets.py` and `python3 scripts/check-coven-privacy.py --staged`, both of which passed for the staged change.
- Attempted full workspace checks (`cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace --locked`); these were blocked by an external fetch failure of a prebuilt dependency (`ort-sys`) in this environment and did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7818d123e08327adfae8bc1c8d4114)