### PR TITLE
fix: disable insecure NFS mount backend

### DIFF
--- a/crates/coven-cli/src/afs_mount.rs
+++ b/crates/coven-cli/src/afs_mount.rs
@@ -102,8 +102,7 @@ pub fn backend() -> Option<&'static str> {
     None
 }
 
-/// Locate the export helper next to the running daemon. A build that did not
-/// ship it advertises no backend rather than failing at mount time.
+/// Locate the export helper next to the running daemon.
 fn helper_path() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
     let candidate = exe.parent()?.join(HELPER);

--- a/crates/coven-cli/src/afs_mount.rs
+++ b/crates/coven-cli/src/afs_mount.rs
@@ -10,10 +10,11 @@
 //! afs/mounts/<id>/          the mount point itself
 //! ```
 //!
-//! **Available where a backend exists.** The export serves the merged
-//! base+delta view (DESIGN.md §3.2), so a mount shows what a caller asking for
-//! one means. `afsMount` reports `"nfs"` on macOS where the export helper
-//! shipped, and `false` everywhere else.
+//! **Unavailable until the backend has a safe authentication channel.**
+//! `mount_nfs` requires the export path on its command line. Because that path
+//! contains the export credential, enabling the backend would expose access to
+//! other local users through the process list. `afsMount` therefore reports
+//! `false` on every platform.
 //!
 //! What mount availability does *not* claim is that every process can read
 //! through the mount. macOS refuses `open()` on network volumes for processes
@@ -92,15 +93,13 @@ fn exports() -> &'static Mutex<HashMap<String, Export>> {
 
 /// The mount backend for this platform and build, or `None`.
 ///
-/// `None` is the honest answer in two distinct situations and the caller
-/// cannot tell them apart, which is fine: both mean "do not offer to mount".
-/// Linux's FUSE backend is not built yet, so macOS is the only platform that
-/// reports one.
+/// NFS cannot currently pass the export credential to `mount_nfs` without
+/// placing it in a process argument visible to other local users. Rotation
+/// after mounting is insufficient: a process that uses the credential before
+/// rotation can retain an authenticated file handle. Keep the backend disabled
+/// until the credential can be transferred without that disclosure window.
 pub fn backend() -> Option<&'static str> {
-    if !cfg!(target_os = "macos") {
-        return None;
-    }
-    helper_path().is_some().then_some("nfs")
+    None
 }
 
 /// Locate the export helper next to the running daemon. A build that did not
@@ -525,12 +524,9 @@ mod tests {
     const DEAD_PID: u32 = 0;
 
     #[test]
-    fn no_backend_is_advertised_off_macos() {
-        // FUSE is not built. A platform without a backend must report none
-        // rather than offer a mount it cannot perform.
-        if cfg!(target_os = "macos") {
-            return;
-        }
+    fn no_backend_is_advertised() {
+        // The NFS credential would be visible in mount_nfs's process
+        // arguments, and FUSE is not built. Do not advertise either backend.
         assert_eq!(backend(), None);
     }
 

--- a/docs/daemon/socket-api.md
+++ b/docs/daemon/socket-api.md
@@ -157,10 +157,11 @@ Tool-call parameters, results, and errors pass through the daemon privacy
 filters before serialization. A missing or dangling audit reference produces
 `toolCall: null` without dropping the filesystem operation.
 
-`afsMount` reports the mount backend or `false`. It is `"nfs"` on macOS where
-the export helper shipped and `false` elsewhere — the Linux FUSE backend is not
-built. `POST .../mount` returns `501` with `afs.mount_unsupported` wherever no
-backend is reported.
+`afsMount` reports the mount backend or `false`. It is currently `false` on all
+platforms: the macOS NFS backend cannot pass its export credential to
+`mount_nfs` without exposing it in the process list, and the Linux FUSE backend
+is not built. `POST .../mount` returns `501` with `afs.mount_unsupported`
+wherever no backend is reported.
 
 The daemon spawns a per-mount export process serving the merged base+delta
 view, mounts it on loopback, rotates the export token as soon as the mount

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -482,18 +482,20 @@ What ships instead:
   positional argument and offers no stdin, environment, or config alternative
   (`man mount_nfs` has neither an ENVIRONMENT nor a FILES section), so the
   token is `ps`-visible for the duration of that one call. The daemon rotates
-  the gate the moment the mount returns, which makes a scraped value useless.
-  Established mounts are unaffected: the client holds an authenticated file
-  handle, handles are keyed on the file id under a key rotation does not
-  touch, and only a *new* traversal of the gate needs the current token.
+  the gate the moment the mount returns, but a local process can use a scraped
+  value before then and retain the authenticated file handle after rotation.
+  Established mounts are unaffected because handles are keyed on the file id
+  under a key rotation does not touch; only a *new* traversal of the gate needs
+  the current token.
 
 **Decision.** This is sufficient to keep an unprivileged local account out by
 default, and it is *not* sufficient to survive disclosure of the token. An
 attacker can still find the port, learn the export path, and mount the gate —
 they arrive at an empty directory and must produce 128 bits to go further.
 There is no second factor behind the token: NFSv3 `AUTH_UNIX` authenticates
-nothing. Mount therefore remains **opt-in and off by default**; `afsMount`
-advertises a backend only where these mitigations are active.
+nothing. Mount therefore remains **disabled**; `afsMount` advertises no backend
+until the export credential can reach the mount client without a disclosure
+window.
 
 > **Invariant: the export token is never logged, printed, or displayed.**
 > Token secrecy is the entire access-control boundary, so anything that

--- a/specs/coven-agent-fs/DESIGN.md
+++ b/specs/coven-agent-fs/DESIGN.md
@@ -484,8 +484,8 @@ What ships instead:
   token is `ps`-visible for the duration of that one call. The daemon rotates
   the gate the moment the mount returns, but a local process can use a scraped
   value before then and retain the authenticated file handle after rotation.
-  Established mounts are unaffected because handles are keyed on the file id
-  under a key rotation does not touch; only a *new* traversal of the gate needs
+  Established mounts are unaffected because handles are keyed on the file id,
+  which a key rotation does not touch; only a *new* traversal of the gate needs
   the current token.
 
 **Decision.** This is sufficient to keep an unprivileged local account out by


### PR DESCRIPTION
### Motivation

- Close a local-credential exposure: the macOS NFS mount path passed the export token in `mount_nfs` argv while advertising the backend by default, allowing unprivileged local users to scrape a reusable token and obtain persistent file handles.
- Temporarily remove the unsafe attack surface until a mount-time credential transport can be implemented that does not expose the token in process arguments.

### Description

- Stop advertising the mount backend on any platform by making `backend()` return `None`, so health reports `afsMount: false` and mount requests are rejected as unsupported.
- Update documentation to explain the rationale and that token rotation after mount does not invalidate file handles acquired during the argv exposure window.
- Add/adjust a unit test to assert that no backend is advertised.

### Testing

- ✅ Ran `cargo test -p coven-cli afs_mount --locked` and all affected tests passed (15 tests).
- ✅ Ran `cargo fmt --check` and formatting is clean.
- ✅ Ran `python3 scripts/check-secrets.py` and the secret guard passed.
- ✅ Ran `python3 scripts/check-coven-privacy.py --staged` and the privacy guard passed.
- ⚠️ `cargo clippy --workspace --all-targets -- -D warnings` and full `cargo test --workspace --locked` were not completed locally due to dependency compilation time limits but are expected to run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a79528476ac8327b7369174759f2a81)