### PR TITLE
fix: persist attached Copilot session output

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -4,6 +4,10 @@ use std::ffi::{OsStr, OsString};
 use std::io::Read;
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use std::thread;
 use std::time::Duration;
 
@@ -3763,13 +3767,25 @@ fn run_harness_attached(
     launch_mode: harness::HarnessLaunchMode,
     stream_json: bool,
 ) -> Result<pty_runner::PtyRunResult> {
+    run_harness_attached_observed(command, launch_mode, stream_json, None)
+}
+
+fn run_harness_attached_observed(
+    command: &pty_runner::HarnessCommand,
+    launch_mode: harness::HarnessLaunchMode,
+    stream_json: bool,
+    observer: Option<pty_runner::AttachedOutputObserver>,
+) -> Result<pty_runner::PtyRunResult> {
     #[cfg(windows)]
     if launch_mode == harness::HarnessLaunchMode::NonInteractive {
+        if let Some(observer) = observer {
+            return pty_runner::run_piped_attached_observed(command, observer);
+        }
         return pty_runner::run_piped_attached(command, stream_json);
     }
     #[cfg(not(windows))]
     let _ = (launch_mode, stream_json);
-    pty_runner::run_attached(command)
+    pty_runner::run_attached_observed(command, observer)
 }
 
 /// Lock stdout, emit one stream-JSON frame, release. Per-frame locking keeps
@@ -4411,6 +4427,40 @@ fn run_session(
     // Preserve the JSONL-only captured-output contract from #315 on
     // non-Windows platforms. Windows Codex must bypass ConPTY and use the
     // verified ordinary-pipe path so Cave receives a terminal response.
+    let event_writer = if stream_json {
+        None
+    } else {
+        Some(match event_writer::EventWriter::start(coven_home.clone()) {
+            Ok(writer) => writer,
+            Err(error) => {
+                store::update_session_status(
+                    &conn,
+                    &record.id,
+                    FAILED_SESSION_STATUS,
+                    None,
+                    &current_timestamp(),
+                )?;
+                return Err(error).context("failed to start attached session event writer");
+            }
+        })
+    };
+    let output_pressured = Arc::new(AtomicBool::new(false));
+    let output_observer = event_writer.as_ref().map(|event_writer| {
+        let output_writer = event_writer.clone();
+        let output_session_id = record.id.clone();
+        let output_pressured = Arc::clone(&output_pressured);
+        Box::new(move |chunk| {
+            let text = String::from_utf8(chunk)
+                .context("attached PTY observer received invalid UTF-8 output")?;
+            match output_writer.record_output(&output_session_id, text)? {
+                true => Ok(()),
+                false => {
+                    output_pressured.store(true, Ordering::Release);
+                    Ok(())
+                }
+            }
+        }) as pty_runner::AttachedOutputObserver
+    });
     #[cfg(not(windows))]
     let attached = if stream_json {
         let output_session_id = record.id.clone();
@@ -4425,7 +4475,7 @@ fn run_session(
             }),
         )
     } else {
-        run_harness_attached(&command, launch_mode, false)
+        run_harness_attached_observed(&command, launch_mode, false, output_observer)
     };
     #[cfg(windows)]
     let attached = if stream_json {
@@ -4441,11 +4491,21 @@ fn run_session(
             }),
         )
     } else {
-        run_harness_attached(&command, launch_mode, false)
+        run_harness_attached_observed(&command, launch_mode, false, output_observer)
     };
+    if output_pressured.load(Ordering::Acquire) {
+        eprintln!(
+            "coven: event writer is pressured; some raw output for session `{}` was rejected",
+            record.id
+        );
+    }
 
     match attached {
         Ok(result) => {
+            let exit_event = event_writer
+                .as_ref()
+                .map(|event_writer| event_writer.record_exit(&record.id, result.clone()))
+                .transpose();
             store::update_session_status(
                 &conn,
                 &record.id,
@@ -4453,6 +4513,7 @@ fn run_session(
                 result.exit_code,
                 &current_timestamp(),
             )?;
+            exit_event?;
             if stream_json {
                 let is_error = result.exit_code.is_some_and(|c| c != 0);
                 emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
@@ -4482,6 +4543,18 @@ fn run_session(
             Ok(())
         }
         Err(error) => {
+            let exit_event = event_writer
+                .as_ref()
+                .map(|event_writer| {
+                    event_writer.record_exit(
+                        &record.id,
+                        pty_runner::PtyRunResult {
+                            status: FAILED_SESSION_STATUS,
+                            exit_code: None,
+                        },
+                    )
+                })
+                .transpose();
             store::update_session_status(
                 &conn,
                 &record.id,
@@ -4489,6 +4562,11 @@ fn run_session(
                 None,
                 &current_timestamp(),
             )?;
+            if let Err(persistence_error) = exit_event {
+                return Err(persistence_error).context(format!(
+                    "failed to persist terminal event after attached run error: {error:#}"
+                ));
+            }
             if stream_json {
                 emit_stream_event(&stream_json::Event::Result(stream_json::RunResult {
                     subtype: "error_during_execution".into(),

--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -59,6 +59,8 @@ pub struct DetachedPtyObserver {
     pub on_exit: Box<dyn FnOnce(PtyRunResult) + Send + 'static>,
 }
 
+pub type AttachedOutputObserver = Box<dyn FnMut(Vec<u8>) -> Result<()> + Send + 'static>;
+
 #[cfg(windows)]
 const DETACHED_STARTUP_TIMEOUT: Duration = Duration::from_secs(30);
 // Keep the value available to cross-platform source-contract tests while
@@ -3037,9 +3039,12 @@ fn stream_passthrough_args(args: Vec<String>, forward_stdin: bool) -> Vec<String
     filtered
 }
 
-pub fn run_attached(command: &HarnessCommand) -> Result<PtyRunResult> {
+pub fn run_attached_observed(
+    command: &HarnessCommand,
+    observer: Option<AttachedOutputObserver>,
+) -> Result<PtyRunResult> {
     let pty_system = native_pty_system();
-    run_attached_with_pty_system(command, pty_system.as_ref())
+    run_attached_with_pty_system(command, pty_system.as_ref(), observer)
 }
 
 /// Run `command` on a PTY like `run_attached`, but capture the PTY output
@@ -3152,6 +3157,86 @@ pub fn run_piped_attached(
             .map_err(|_| anyhow::anyhow!("stderr forwarding thread panicked"))?
             .context("failed forwarding harness stderr to stdout")?;
     }
+    Ok(PtyRunResult {
+        status: if status.success() {
+            "completed"
+        } else {
+            "failed"
+        },
+        exit_code: status.code(),
+    })
+}
+
+#[cfg(windows)]
+pub fn run_piped_attached_observed(
+    command: &HarnessCommand,
+    observer: AttachedOutputObserver,
+) -> Result<PtyRunResult> {
+    let mut child_command = std::process::Command::new(&command.program);
+    child_command
+        .args(&command.args)
+        .current_dir(&command.cwd)
+        .stdin(if command.stdin_prompt.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    command.apply_environment(&mut child_command);
+    let mut child = child_command.spawn().with_context(|| {
+        format!(
+            "failed to spawn harness `{}` in observed piped mode",
+            command.program()
+        )
+    })?;
+    write_stdin_prompt(&mut child, command.stdin_prompt.as_deref())?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("observed piped harness did not expose stdout")?;
+    let stderr = child
+        .stderr
+        .take()
+        .context("observed piped harness did not expose stderr")?;
+    let observer = Arc::new(Mutex::new(observer));
+
+    let stdout_observer = Arc::clone(&observer);
+    let stdout_forwarder = thread::spawn(move || -> Result<()> {
+        let mut reader = stdout;
+        let stdout = io::stdout();
+        let mut writer = stdout.lock();
+        let callback: AttachedOutputObserver = Box::new(move |chunk| {
+            let mut observer = stdout_observer
+                .lock()
+                .map_err(|_| anyhow::anyhow!("attached output observer lock poisoned"))?;
+            observer(chunk)
+        });
+        copy_attached_output(&mut reader, &mut writer, Some(callback))
+    });
+    let stderr_observer = observer;
+    let stderr_forwarder = thread::spawn(move || -> Result<()> {
+        let mut reader = stderr;
+        let stderr = io::stderr();
+        let mut writer = stderr.lock();
+        let callback: AttachedOutputObserver = Box::new(move |chunk| {
+            let mut observer = stderr_observer
+                .lock()
+                .map_err(|_| anyhow::anyhow!("attached output observer lock poisoned"))?;
+            observer(chunk)
+        });
+        copy_attached_output(&mut reader, &mut writer, Some(callback))
+    });
+
+    let status = child.wait().context("failed waiting for piped harness")?;
+    let stdout_result = stdout_forwarder
+        .join()
+        .map_err(|_| anyhow::anyhow!("stdout forwarding thread panicked"))?;
+    let stderr_result = stderr_forwarder
+        .join()
+        .map_err(|_| anyhow::anyhow!("stderr forwarding thread panicked"))?;
+    stdout_result?;
+    stderr_result?;
     Ok(PtyRunResult {
         status: if status.success() {
             "completed"
@@ -4844,6 +4929,7 @@ impl Drop for PtyResizeWatcher {
 fn run_attached_with_pty_system(
     command: &HarnessCommand,
     pty_system: &(dyn PtySystem + Send),
+    observer: Option<AttachedOutputObserver>,
 ) -> Result<PtyRunResult> {
     let initial_size = attached_terminal_size();
     let pair = pty_system
@@ -4875,8 +4961,7 @@ fn run_attached_with_pty_system(
 
     let output_thread = thread::spawn(move || {
         let mut stdout = io::stdout().lock();
-        io::copy(&mut reader, &mut stdout)?;
-        stdout.flush()
+        copy_attached_output(&mut reader, &mut stdout, observer)
     });
 
     // Only forward stdin to the PTY when it is an interactive terminal. A
@@ -4896,7 +4981,9 @@ fn run_attached_with_pty_system(
     if let Some(watcher) = resize_watcher.as_mut() {
         watcher.stop();
     }
-    let _ = output_thread.join();
+    output_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("attached output thread panicked"))??;
     let exit_code = i32::try_from(exit_status.exit_code()).unwrap_or(i32::MAX);
     let status = if exit_status.success() {
         "completed"
@@ -4908,6 +4995,73 @@ fn run_attached_with_pty_system(
         status,
         exit_code: Some(exit_code),
     })
+}
+
+fn copy_attached_output(
+    reader: &mut dyn Read,
+    writer: &mut dyn Write,
+    mut observer: Option<AttachedOutputObserver>,
+) -> Result<()> {
+    let mut buffer = [0_u8; 8192];
+    let mut observed = Vec::with_capacity(buffer.len());
+    let mut observer_error = None;
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(bytes_read) => {
+                let chunk = &buffer[..bytes_read];
+                writer.write_all(chunk)?;
+                if let Some(callback) = observer.as_deref_mut() {
+                    observed.extend_from_slice(chunk);
+                    if let Err(error) = emit_observed_utf8(&mut observed, callback, false) {
+                        observer_error = Some(error);
+                        observer = None;
+                        observed.clear();
+                    }
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    if let Some(callback) = observer.as_deref_mut() {
+        if let Err(error) = emit_observed_utf8(&mut observed, callback, true) {
+            observer_error = Some(error);
+        }
+    }
+    writer
+        .flush()
+        .context("failed to flush attached harness output")?;
+    match observer_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn emit_observed_utf8(
+    pending: &mut Vec<u8>,
+    observer: &mut (dyn FnMut(Vec<u8>) -> Result<()> + Send + 'static),
+    finish: bool,
+) -> Result<()> {
+    let valid_up_to = match std::str::from_utf8(pending) {
+        Ok(_) => pending.len(),
+        Err(error) => error.valid_up_to(),
+    };
+    if valid_up_to > 0 {
+        observer(pending.drain(..valid_up_to).collect())?;
+    }
+    while pending.len() > 4
+        && std::str::from_utf8(pending)
+            .err()
+            .is_some_and(|error| error.valid_up_to() == 0)
+    {
+        let byte = pending.drain(..1).collect::<Vec<_>>();
+        observer(String::from_utf8_lossy(&byte).into_owned().into_bytes())?;
+    }
+    if finish && !pending.is_empty() {
+        observer(String::from_utf8_lossy(pending).into_owned().into_bytes())?;
+        pending.clear();
+    }
+    Ok(())
 }
 
 struct RawModeGuard {
@@ -8572,6 +8726,48 @@ exit 0
             "🎉",
             "split codepoint must round-trip; the drain owns per-call buffer state"
         );
+    }
+
+    #[test]
+    fn attached_output_mirrors_raw_bytes_and_reassembles_observed_utf8() -> anyhow::Result<()> {
+        let emoji = "🎉".as_bytes();
+        let (head, tail) = emoji.split_at(2);
+        let mut reader = ChunkedReader {
+            chunks: vec![head, tail].into(),
+        };
+        let mut mirrored = Vec::new();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_observer = Arc::clone(&captured);
+        let observer: AttachedOutputObserver = Box::new(move |chunk| {
+            captured_for_observer.lock().unwrap().push(chunk);
+            Ok(())
+        });
+
+        copy_attached_output(&mut reader, &mut mirrored, Some(observer))?;
+
+        assert_eq!(mirrored, emoji);
+        let captured = captured.lock().unwrap();
+        assert_eq!(captured.as_slice(), [emoji]);
+        assert!(captured
+            .iter()
+            .all(|chunk| std::str::from_utf8(chunk).is_ok()));
+        Ok(())
+    }
+
+    #[test]
+    fn attached_output_drains_after_observer_failure_and_returns_the_error() {
+        let mut reader = ChunkedReader {
+            chunks: vec![&b"first"[..], &b"second"[..]].into(),
+        };
+        let mut mirrored = Vec::new();
+        let observer: AttachedOutputObserver =
+            Box::new(|_| anyhow::bail!("simulated ledger failure"));
+
+        let error = copy_attached_output(&mut reader, &mut mirrored, Some(observer))
+            .expect_err("observer failure must surface");
+
+        assert_eq!(mirrored, b"firstsecond");
+        assert!(error.to_string().contains("simulated ledger failure"));
     }
 
     #[test]

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -1078,6 +1078,95 @@ fn piped_run_output_has_no_eof_control_artifact() -> anyhow::Result<()> {
 }
 
 #[test]
+fn attached_copilot_run_persists_output_and_exit_events() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let project = temp_dir.path().join("project");
+    let fake_bin = temp_dir.path().join("bin");
+    fs::create_dir_all(&coven_home)?;
+    fs::create_dir_all(&project)?;
+    fs::create_dir_all(&fake_bin)?;
+    init_git_repo(&project)?;
+    write_fake_copilot(&fake_bin)?;
+    let path = prepend_path(&fake_bin);
+    let coven = coven_bin();
+
+    let run = run_coven_in(
+        &coven,
+        &coven_home,
+        &path,
+        &project,
+        &[],
+        &["run", "copilot", "ledger check"],
+    )?;
+    assert_success("attached copilot run", &run);
+    assert_stdout_contains("attached copilot run", &run, "fake copilot ledger output");
+
+    let sessions = run_coven(&coven, &coven_home, &path, &["sessions", "--json"])?;
+    assert_success("list copilot sessions", &sessions);
+    let sessions = parse_stdout_json("list copilot sessions", &sessions)?;
+    let session_id = sessions["sessions"]
+        .as_array()
+        .context("sessions array")?
+        .iter()
+        .find(|session| session["harness"] == "copilot")
+        .and_then(|session| session["id"].as_str())
+        .context("copilot session id")?;
+
+    let events = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["sessions", "events", session_id, "--json"],
+    )?;
+    assert_success("list copilot session events", &events);
+    let events = parse_stdout_json("list copilot session events", &events)?;
+    let events = events["events"].as_array().context("events array")?;
+    let kinds: Vec<_> = events
+        .iter()
+        .filter_map(|event| event["kind"].as_str())
+        .collect();
+
+    assert_eq!(kinds, ["output", "exit"]);
+    let output_payload: Value = serde_json::from_str(
+        events[0]["payload_json"]
+            .as_str()
+            .context("output payload JSON")?,
+    )?;
+    assert!(
+        output_payload["data"]
+            .as_str()
+            .is_some_and(|data| data.contains("fake copilot ledger output")),
+        "unexpected output payload: {}",
+        output_payload
+    );
+    let exit_payload: Value = serde_json::from_str(
+        events[1]["payload_json"]
+            .as_str()
+            .context("exit payload JSON")?,
+    )?;
+    assert_eq!(exit_payload["status"], "completed");
+    assert_eq!(exit_payload["exitCode"], 0);
+
+    let log = run_coven(
+        &coven,
+        &coven_home,
+        &path,
+        &["sessions", "log", session_id, "--json"],
+    )?;
+    assert_success("read copilot session log", &log);
+    let log = parse_stdout_json("read copilot session log", &log)?;
+    assert!(log
+        .as_array()
+        .context("log lines")?
+        .iter()
+        .any(|line| line["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("fake copilot ledger output"))));
+    Ok(())
+}
+
+#[test]
 fn adapter_install_hermes_writes_trusted_manifest() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -1678,6 +1767,18 @@ printf 'fake codex complete: %s\n' "$*"
     let mut permissions = fs::metadata(&codex)?.permissions();
     permissions.set_mode(0o755);
     fs::set_permissions(&codex, permissions)?;
+    Ok(())
+}
+
+fn write_fake_copilot(fake_bin: &Path) -> anyhow::Result<()> {
+    let copilot = fake_bin.join("copilot");
+    fs::write(
+        &copilot,
+        "#!/bin/sh\nprintf 'fake copilot ledger output\\n'\n",
+    )?;
+    let mut permissions = fs::metadata(&copilot)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&copilot, permissions)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Context

- Summary: Persist ordinary attached Copilot CLI output and terminal status in Coven's session event ledger.
- Files changed: `crates/coven-cli/src/main.rs`, `crates/coven-cli/src/pty_runner.rs`, `crates/coven-cli/tests/smoke.rs`
- Closes #693

## Implementation

- Approach: Tee attached PTY output to the terminal unchanged while forwarding UTF-8-safe chunks to the existing bounded, privacy-aware `EventWriter`; record an ordered exit event after the output drain finishes. The Windows noninteractive pipe path observes stdout and stderr through the same contract.
- User-visible behavior: Completed `coven run copilot ...` sessions now replay through `/log`, `/events`, and `coven attach` instead of appearing empty.
- Compatibility notes: Stream-JSON paths remain unchanged. Output pressure stays non-blocking and visible, persistence errors surface, and terminal session status is updated even if terminal-event persistence fails.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace --locked` — 1,940 unit tests and all changed-surface integration tests passed; the run then hit two unrelated `process_supervisor` failures reproduced on clean `origin/main` (`supervisor_admits_then_preserves_stdout_stderr_and_exit_code`, `supervisor_propagates_target_signal`).
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Fake-Copilot smoke test proves ordered `output`/`exit` events and non-empty `/log`.
- [x] Attached-output UTF-8/error tests and `stream_json_integration` pass.

## Risk and Rollback

- Risk level: Medium. The shared attached-output drain now supports observation, including the Windows noninteractive pipe path.
- Rollback plan: Revert this commit to return attached runs to terminal-only output.

## Agent Handoff

- Current state: Ready for review; targeted checks, clippy, secret scan, privacy guard, and two independent code-review passes are clean.
- Follow-ups: Let hosted Windows CI exercise the Windows-only observed pipe implementation.
- Known gaps: Local Windows cross-compilation is blocked by the host's missing Windows C toolchain; hosted CI is authoritative. The two repository-wide `process_supervisor` failures are pre-existing on `origin/main`.
