### PR TITLE
fix: require main ancestry for npm recovery tags

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -117,12 +117,12 @@ jobs:
             exit 1
           fi
           printf '%s\n' "$verify_output"
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$TAGGED_COMMIT_SHA" origin/main; then
+            echo "::error::Refusing release: tagged commit $TAGGED_COMMIT_SHA is not contained in origin/main."
+            exit 1
+          fi
           if [ "$RELEASE_MODE" != "recovery" ]; then
-            git fetch --no-tags origin main
-            if ! git merge-base --is-ancestor "$TAGGED_COMMIT_SHA" origin/main; then
-              echo "::error::Refusing release: tagged commit $TAGGED_COMMIT_SHA is not contained in origin/main."
-              exit 1
-            fi
             exit 0
           fi
           if ! BASE_TAG_OBJECT_SHA=$(git rev-parse "$RELEASE_TAG^{tag}" 2>/dev/null); then

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -777,6 +777,11 @@ test('release workflow fail-closes signed recovery tags', () => {
   );
   assert.match(
     workflow,
+    /git fetch --no-tags origin main[\s\S]*git merge-base --is-ancestor "\$TAGGED_COMMIT_SHA" origin\/main[\s\S]*if \[ "\$RELEASE_MODE" != "recovery" \]/,
+    'all release tags, including recovery tags, must be contained in origin/main before mode-specific validation'
+  );
+  assert.match(
+    workflow,
     /git verify-tag "\$RELEASE_TAG"/,
     'recovery must locally verify the original stable release tag'
   );


### PR DESCRIPTION
### Motivation
- Prevent recovery release tags from bypassing the protected `origin/main` containment gate and thereby from running arbitrary release/publish scripts that can publish npm artifacts with OIDC privileges.
- Close a supply-chain authorization weakness where recovery tags could change executable release code such as `scripts/publish-npm.mjs` without the tag being merged to `origin/main`.

### Description
- Move the `git merge-base --is-ancestor "$TAGGED_COMMIT_SHA" origin/main` check earlier in `./.github/workflows/release-npm.yml` so the ancestry check runs for all signed release tags before branching into normal vs recovery validation.
- Remove the duplicate, mode-specific `origin/main` check to avoid a recovery-mode bypass and keep mode-specific checks only after the universal ancestry validation.
- Add a regression assertion to `scripts/publish-npm-test.mjs` that the workflow contains the `git fetch` + `git merge-base` ancestry check before the `if [ "$RELEASE_MODE" != "recovery" ]` branch to prevent future regressions.

### Testing
- Ran the Node test suite with `node --test scripts/publish-npm-test.mjs`, which passed (`65` tests passed, `0` failed).
- Ran `cargo fmt --check`, `python scripts/check-secrets.py`, and `python3 scripts/check-coven-privacy.py --staged`, all of which completed successfully for the staged changes.
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace --locked` were blocked by an external prebuilt-binaries download failure for `ort-sys` (proxy returned `403`), preventing full Rust CI in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72a9bbedb08327b8b778309707a82f)