### PR TITLE
fix: harden memory recall command guidance

### DIFF
--- a/skills/memory-recall/SKILL.md
+++ b/skills/memory-recall/SKILL.md
@@ -107,7 +107,7 @@ log query text to any destination outside the Coven filesystem.
 Claude Code, CovenCave, bare SSH), does this skill work without modification?*
 
 **✅ Yes.** The skill's only dependencies are (a) the `coven-memory` CLI — a
-Coven-shipped binary and (b) `~/.coven/memory/` — a Coven-owned contract path.
+Coven-shipped binary, and (b) `~/.coven/memory/` — a Coven-owned contract path.
 No shell, runtime-specific hooks, session APIs, or bootstrap injection are
 required.
 FAMILIAR_ROOT resolution follows the schema's flag→env→fail-closed order and is

--- a/skills/memory-recall/SKILL.md
+++ b/skills/memory-recall/SKILL.md
@@ -37,7 +37,7 @@ or mutate anything under `~/.coven/memory` — that is the promotion layer's job
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `query` | string | ✅ | Natural-language question or keyword phrase. |
-| `familiar` | string | ❌ | Store scope filter passed to the crate: `coven` (default; the shared store) or a familiar id for per-familiar stores. |
+| `familiar` | string | ❌ | Store scope filter passed to the crate: `coven` (default; the shared store) or a familiar id for per-familiar stores. Must match `^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`. |
 | `k` | int | ❌ | Max results. Default 5, max 20. |
 | `since` / `until` | ISO date | ❌ | Filter on manifest `timestamp`. |
 | `verified_only` | bool | ❌ | Default `true`. Drop hits whose manifest `sha256` no longer matches the promoted snapshot or whose `attested_via` file is missing. |
@@ -62,10 +62,16 @@ log query text to any destination outside the Coven filesystem.
 
 1. **Precondition.** `~/.coven/memory/manifest.jsonl` exists with ≥1 line, else return
    `{hits: [], count: 0, note: "promotion layer has not run"}` and stop.
-2. **Query the crate.** `coven-memory search --familiar <familiar> "<query>"` (add
-   `--index`/`--db` only if the store lives off the default path). The crate owns
-   ranking (fastembed/nomic-embed-text-v1.5 + TurboVec ANN; schema §11.5 pins
-   embeddings as crate-internal).
+2. **Query the crate.** Treat `query` and `familiar` as untrusted data. Validate
+   `familiar` against `^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$` (default `coven`);
+   reject any other value. Invoke the crate with an argv API, not a shell command
+   string, equivalent to `execve`/`subprocess.run(["coven-memory", "search",
+   "--familiar", familiar, query])`. If a runtime exposes only a shell, pass
+   every dynamic argument through robust single-argument shell escaping (for
+   example POSIX `shlex.quote`) and do not concatenate raw input. Add `--index`/
+   `--db` only if the store lives off the default path. The crate owns ranking
+   (fastembed/nomic-embed-text-v1.5 + TurboVec ANN; schema §11.5 pins embeddings
+   as crate-internal).
 3. **Join against the manifest.** For each hit, find its manifest line by `ulid`.
    Apply `since`/`until` on `timestamp`. Detect supersession: if a later
    `operation: supersede` line names this ulid as `prior_ulid`, annotate
@@ -101,8 +107,9 @@ log query text to any destination outside the Coven filesystem.
 Claude Code, CovenCave, bare SSH), does this skill work without modification?*
 
 **✅ Yes.** The skill's only dependencies are (a) the `coven-memory` CLI — a
-Coven-shipped binary, (b) `~/.coven/memory/` — a Coven-owned contract path, and
-(c) a shell. No runtime-specific hooks, session APIs, or bootstrap injection.
+Coven-shipped binary and (b) `~/.coven/memory/` — a Coven-owned contract path.
+No shell, runtime-specific hooks, session APIs, or bootstrap injection are
+required.
 FAMILIAR_ROOT resolution follows the schema's flag→env→fail-closed order and is
 only needed for optional source opening, never for querying. Session references
 use the portable `session://` class form, never raw runtime session keys.

--- a/skills/memory-recall/SKILL.md
+++ b/skills/memory-recall/SKILL.md
@@ -68,7 +68,7 @@ log query text to any destination outside the Coven filesystem.
    string, equivalent to `execve`/`subprocess.run(["coven-memory", "search",
    "--familiar", familiar, query])`. If a runtime exposes only a shell, pass
    every dynamic argument through robust single-argument shell escaping (for
-   example POSIX `shlex.quote`) and do not concatenate raw input. Add `--index`/
+   example Python `shlex.quote`) and do not concatenate raw input. Add `--index`/
    `--db` only if the store lives off the default path. The crate owns ranking
    (fastembed/nomic-embed-text-v1.5 + TurboVec ANN; schema §11.5 pins embeddings
    as crate-internal).

--- a/skills/memory-recall/SKILL.md
+++ b/skills/memory-recall/SKILL.md
@@ -37,7 +37,7 @@ or mutate anything under `~/.coven/memory` — that is the promotion layer's job
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `query` | string | ✅ | Natural-language question or keyword phrase. |
-| `familiar` | string | ❌ | Store scope filter passed to the crate: `coven` (default; the shared store) or a familiar id for per-familiar stores. Must match `^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$`. |
+| `familiar` | string | ❌ | Store scope filter passed to the crate: `coven` (default; the shared store) or a familiar id for per-familiar stores. Must match `^[A-Za-z0-9_-]{1,128}$` — the same shape the crate's own `validate_identifier` enforces for `familiar_id`. |
 | `k` | int | ❌ | Max results. Default 5, max 20. |
 | `since` / `until` | ISO date | ❌ | Filter on manifest `timestamp`. |
 | `verified_only` | bool | ❌ | Default `true`. Drop hits whose manifest `sha256` no longer matches the promoted snapshot or whose `attested_via` file is missing. |
@@ -63,12 +63,13 @@ log query text to any destination outside the Coven filesystem.
 1. **Precondition.** `~/.coven/memory/manifest.jsonl` exists with ≥1 line, else return
    `{hits: [], count: 0, note: "promotion layer has not run"}` and stop.
 2. **Query the crate.** Treat `query` and `familiar` as untrusted data. Validate
-   `familiar` against `^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$` (default `coven`);
-   reject any other value. Invoke the crate with an argv API, not a shell command
-   string, equivalent to `execve`/`subprocess.run(["coven-memory", "search",
-   "--familiar", familiar, query])`. If a runtime exposes only a shell, pass
-   every dynamic argument through robust single-argument shell escaping (for
-   example Python `shlex.quote`) and do not concatenate raw input. Add `--index`/
+   `familiar` against `^[A-Za-z0-9_-]{1,128}$` (default `coven`) — the shape the
+   crate's `validate_identifier` already enforces — and reject any other value.
+   Invoke the crate with an argv API, not a shell command string, equivalent to
+   `execve`/`subprocess.run(["coven-memory", "search", "--familiar", familiar,
+   query])`. If a runtime exposes only a shell, pass every dynamic argument
+   through robust single-argument shell escaping (for example Python
+   `shlex.quote`) and do not concatenate raw input. Add `--index`/
    `--db` only if the store lives off the default path. The crate owns ranking
    (fastembed/nomic-embed-text-v1.5 + TurboVec ANN; schema §11.5 pins embeddings
    as crate-internal).


### PR DESCRIPTION
### Motivation
- Close a high-severity command-injection hazard in the memory recall skill where agent-facing guidance recommended shell-interpolated execution of untrusted inputs.
- Ensure recall remains read-only and that `query`/`familiar` cannot cause arbitrary local command execution when agents follow the skill guidance.

### Description
- Constrain the `familiar` input in `skills/memory-recall/SKILL.md` to a safe identifier regex `^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$` to prevent shell metacharacter injection.
- Replace the documented shell-interpolated command template with guidance to invoke the CLI via an argv-style API (e.g. `execve`/`subprocess.run(["coven-memory","search","--familiar", familiar, query])`) and document a robust single-argument shell-escaping fallback (for runtimes that expose only a shell).
- Remove the shell from the skill's runtime dependency list so the skill no longer treats shell evaluation as part of the normal execution contract.
- All changes are confined to `skills/memory-recall/SKILL.md` and preserve existing recall semantics while hardening invocation guidance.

### Testing
- `python scripts/check-secrets.py` completed successfully and found no new secrets.
- `cargo fmt --check` completed successfully.
- `git diff --check` passed with no whitespace or checklist errors.
- `cargo clippy --workspace --all-targets -- -D warnings` was attempted but blocked by an environment proxy error while downloading a prebuilt dependency; linting could not be fully verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63af8c34188327ba631906b530ed7c)