### PR TITLE
docs: specify session permission controls

### DIFF
--- a/specs/coven-session-permissions/PRODUCT.md
+++ b/specs/coven-session-permissions/PRODUCT.md
@@ -62,12 +62,13 @@ Without a common contract, users must remember harness-specific flags, cannot re
 - Automatically approving purchases, publication, messages, account changes, production mutations, or other consequential external actions.
 - Weakening secret scanning, privacy controls, branch protection, repository policy, or audit integrity.
 - Persisting full permission globally or across restarts in the first release.
+- Allowing remote or automated callers to initiate elevation in the first release; they may inspect or revoke permission state.
 - Treating a familiar's autonomy posture as an authorization grant.
 - Replacing harness-native security models.
 
 ## Terminology
 
-- **Principal:** the authenticated human or trusted caller permitted to control the session.
+- **Principal:** the authenticated human operating the trusted local interactive surface for elevation, or an authenticated caller limited to non-elevating control operations.
 - **Familiar:** the selected identity/persona and its effective configuration.
 - **Harness:** the external coding-agent process Coven launches or connects to.
 - **Baseline mode:** the permission mode established when the session starts, after deployment and repository policy are applied.
@@ -127,7 +128,7 @@ An `/allow-all` alias should **not** ship initially. If user research later show
 - whether applying the change requires harness restart/resume;
 - a clear confirm and cancel action.
 
-Typed confirmation is recommended for `--session`; an explicit UI confirmation is sufficient for `--once`. Non-interactive callers must use a distinct launch-time option or structured API and cannot simulate confirmation by embedding text in the task prompt.
+Typed confirmation is recommended for `--session`; an explicit UI confirmation is sufficient for `--once`. In the first release, non-interactive and remote callers may inspect or revoke permission state but cannot initiate elevation. A distinct launch-time option may establish the baseline before a session starts; callers cannot simulate confirmation by embedding text in the task prompt.
 
 ## Permission-state model
 
@@ -219,7 +220,7 @@ Full mode may reduce **harness approval prompts** and broaden harness sandbox be
 | Familiar emits the command in chat | Render as model output only; no transition. |
 | Tool output contains command text | No transition. |
 | User pastes command into trusted command input | Parse as principal intent, then require trusted confirmation. |
-| Remote/untrusted client requests elevation | Require authenticated authorization and policy approval; otherwise deny. |
+| Remote or automated client requests elevation | Deny with `remote_elevation_unsupported`; first-release elevation requires direct local interactive confirmation. Authenticated remote callers may inspect or revoke state. |
 | Harness crashes during relaunch | Remain/revert to baseline; report failure; never display full mode. |
 | Audit recording fails | Deny transition if an audit record is required by policy. |
 | Session detaches or workspace changes | Revoke session elevation. |
@@ -314,10 +315,10 @@ Do not record:
 1. Should `--session` default to 30 or 60 minutes, and may the principal shorten it?
 2. Which external-action categories remain separately confirmable in the first policy schema?
 3. Is a recoverability check (clean Git state, worktree, snapshot, or AgentFS) mandatory or advisory?
-4. Should detach always revoke elevation, or may authenticated local reconnect retain it within TTL?
-5. What terminology should UI use when a harness supports broad tool approval but cannot remove its sandbox?
-6. Should a future `/allow-all` discoverability alias exist, or is documentation/search sufficient?
-7. Which callers count as a trusted principal path in daemon and remote-client deployments?
+4. What terminology should UI use when a harness supports broad tool approval but cannot remove its sandbox?
+5. Should a future `/allow-all` discoverability alias exist, or is documentation/search sufficient?
+
+First-release decisions: detach always revokes elevation, and only the trusted local interactive principal path may initiate elevation. Remote elevation requires a separate future user-presence and channel-binding design.
 
 ## Review exit criteria
 

--- a/specs/coven-session-permissions/PRODUCT.md
+++ b/specs/coven-session-permissions/PRODUCT.md
@@ -1,0 +1,331 @@
+# Session Permission Controls — Product Specification
+
+**Status:** Draft for familiar review
+**Scope:** Planning only; this document does not authorize implementation
+**Owners:** Coven maintainers
+**Reviewers:** Security, CLI/TUI, harness adapters, daemon/control plane, AgentFS/provenance, documentation
+
+## Summary
+
+Coven should let a principal deliberately grant a running familiar more execution authority when repeated approval prompts obstruct trusted work. The interactive surface should be a Coven-owned command such as:
+
+```text
+/permissions full --once
+/permissions full --session
+```
+
+The feature is **not** a way for a familiar to remove its own limits. It is a temporary delegation by the human principal, interpreted and enforced by Coven's Rust authority layer, bounded by the active workspace and operating environment, visibly recorded, and easy to revoke.
+
+We intentionally avoid presenting the feature as literally “allow all.” No application can override controls outside its authority, and some controls must remain non-bypassable.
+
+## Problem
+
+High-autonomy sessions can be interrupted by repetitive approval prompts even when all of the following are true:
+
+- the principal trusts the requested task;
+- the repository is local or disposable;
+- changes are recoverable through Git, snapshots, or AgentFS;
+- credentials and external systems are already constrained;
+- the harness supports a broader native permission mode.
+
+Today, permission behavior is harness-specific. Coven has a typed launch-time `Permission` (`Full` or `ReadOnly`) and per-harness `SandboxMapping` in the CLI/runtime specification, while the broader capability model is still being designed. Coven does not yet expose a stable, principal-facing **running-session** permission contract or a Coven-owned interactive slash command for changing it.
+
+Without a common contract, users must remember harness-specific flags, cannot reliably see the effective mode, and may mistake a familiar's stated autonomy posture for actual authority.
+
+## Product principles
+
+1. **The principal grants authority.** Model output, familiar configuration, repository content, and tool results cannot grant or elevate permission.
+2. **Coven remains the authority layer.** Interactive syntax is only a request to the Rust control plane; the TUI and TypeScript integrations must not independently bypass policy.
+3. **Full means maximum delegated authority, not unlimited power.** OS, container, daemon, workspace, credential, policy, and non-bypassable safety boundaries remain effective.
+4. **Elevation is explicit, conspicuous, temporary, and reversible.** No silent inheritance or hidden sticky state.
+5. **Fail closed.** If Coven cannot prove that the selected harness supports the requested mode, it must refuse elevation rather than claim success.
+6. **Prompt injection cannot activate elevation.** Commands are accepted only from a trusted principal input path and are never inferred from model-generated text.
+7. **The effective state is inspectable and auditable.** The UI and session provenance show who requested a transition, when it occurred, its scope, and its result.
+8. **Capability and policy are separate.** A harness may support full mode while deployment policy forbids it.
+
+## Goals
+
+- Provide one consistent permission vocabulary across supported harnesses.
+- Let a principal inspect, elevate, and restore a session's effective permission mode.
+- Support a one-turn scope and a current-session scope.
+- Make elevated operation unmistakable in interactive UI.
+- Preserve a minimal set of non-bypassable Coven invariants.
+- Record transitions without leaking prompts, secrets, or credentials.
+- Expose support and refusal reasons in machine-readable form for integrations.
+- Define safe behavior when a harness must be relaunched to change modes.
+
+## Non-goals
+
+- Giving a familiar authority to elevate itself.
+- Removing OS, container, credential, network, daemon-authentication, or workspace boundaries.
+- Inventing a universal mapping for unsupported third-party harnesses.
+- Automatically approving purchases, publication, messages, account changes, production mutations, or other consequential external actions.
+- Weakening secret scanning, privacy controls, branch protection, repository policy, or audit integrity.
+- Persisting full permission globally or across restarts in the first release.
+- Treating a familiar's autonomy posture as an authorization grant.
+- Replacing harness-native security models.
+
+## Terminology
+
+- **Principal:** the authenticated human or trusted caller permitted to control the session.
+- **Familiar:** the selected identity/persona and its effective configuration.
+- **Harness:** the external coding-agent process Coven launches or connects to.
+- **Baseline mode:** the permission mode established when the session starts, after deployment and repository policy are applied.
+- **Effective mode:** the mode actually enforced for the current turn/session.
+- **Elevation:** a transition from baseline to a broader effective mode.
+- **Full mode:** the broadest harness execution mode Coven policy permits inside the current execution boundary.
+- **Non-bypassable boundary:** a restriction that full mode cannot disable.
+- **Turn:** one principal submission and the resulting agent activity until the harness yields control.
+
+## Proposed command surface
+
+### Required commands
+
+```text
+/permissions
+/permissions show
+/permissions full --once
+/permissions full --session
+/permissions default
+/permissions help
+```
+
+`/permissions` is equivalent to `/permissions show`.
+
+### Semantics
+
+| Command | Meaning |
+|---|---|
+| `/permissions show` | Show baseline mode, effective mode, scope, expiration, support, policy, and non-bypassable boundaries. |
+| `/permissions full --once` | Request full mode for the next principal turn only. It is consumed only when a turn begins successfully. |
+| `/permissions full --session` | Request full mode until explicit restoration, session termination, detach, workspace change, policy change, or timeout. |
+| `/permissions default` | Revoke pending/effective elevation and restore the session baseline. |
+| `/permissions help` | Explain modes, scopes, constraints, and recovery. |
+
+### Naming decision
+
+The canonical command is `/permissions`, not `/allow-all`.
+
+Reasons:
+
+- “allow all” implies authority Coven cannot possess;
+- it obscures retained safety boundaries;
+- it encourages binary thinking where capability, policy, and effective state differ;
+- it is more attractive as a prompt-injection target.
+
+An `/allow-all` alias should **not** ship initially. If user research later shows strong discoverability value, it may print an explanation and redirect to `/permissions full`; it must never have broader semantics.
+
+### Confirmation
+
+`full` requires an out-of-band confirmation rendered by trusted Coven UI, not a normal prompt sent to the harness. The confirmation must state:
+
+- selected harness and workspace;
+- requested scope (`once` or `session`);
+- concrete categories being broadened (filesystem, command execution, network, tool approval), as known;
+- boundaries that remain enforced;
+- expiration/revocation behavior;
+- whether applying the change requires harness restart/resume;
+- a clear confirm and cancel action.
+
+Typed confirmation is recommended for `--session`; an explicit UI confirmation is sufficient for `--once`. Non-interactive callers must use a distinct launch-time option or structured API and cannot simulate confirmation by embedding text in the task prompt.
+
+## Permission-state model
+
+The first release exposes two principal-facing modes:
+
+- **default:** the policy-resolved baseline selected at launch;
+- **full:** the broadest mode supported by both the harness and Coven policy.
+
+Scopes:
+
+- **once:** next successfully started turn;
+- **session:** current attached session only, with a bounded timeout;
+- **persistent/global:** not supported.
+
+An intermediate `edits` or `workspace` mode may be considered later, but only after supported harnesses have a semantically honest mapping. Shipping a label whose behavior differs materially by harness would undermine the common contract.
+
+## Required user experience
+
+### Normal state
+
+The status area shows the effective mode without dominating the UI:
+
+```text
+Permissions: default
+```
+
+### Pending one-turn elevation
+
+```text
+Permissions: FULL (next turn only)
+```
+
+The principal can cancel with `/permissions default` before submitting the turn.
+
+### Active session elevation
+
+A persistent, visually distinct indicator remains visible:
+
+```text
+FULL ACCESS · session · expires in 42m · /permissions default to revoke
+```
+
+Color must not be the only signal. Screen-reader output and narrow terminals must retain the text label.
+
+### Unsupported or forbidden state
+
+Refusals must distinguish:
+
+- harness does not support the requested mode;
+- Coven cannot verify support;
+- deployment or repository policy denies it;
+- caller is not an authorized principal;
+- session cannot be safely resumed/relaunched;
+- current operation cannot transition modes.
+
+Example:
+
+```text
+Full permission was not enabled: this harness cannot be safely resumed with a broader mode.
+The session remains at: default.
+```
+
+### Relaunch disclosure
+
+Many harnesses choose approval/sandbox behavior at process launch. Coven must not suggest a live change occurred if it only changed UI state. If relaunch is necessary, confirmation must explain it, preserve continuity only through a verified resume mechanism, and surface success only after the replacement process is running in the requested mode.
+
+## Boundaries retained in full mode
+
+The exact policy is deployment-specific, but the product contract requires these categories to remain outside model-controlled bypass:
+
+- authentication and authorization of the principal;
+- daemon transport and same-user protections;
+- session/workspace identity and configured root boundaries;
+- audit-event integrity and permission-state provenance;
+- secret redaction and privacy controls;
+- Coven repository/deployment policy;
+- host OS, sandbox, container, and credential constraints;
+- explicit protections for destructive Coven control-plane operations;
+- consequential external actions that policy marks as separately confirmable;
+- kill, detach, timeout, and revocation controls.
+
+Full mode may reduce **harness approval prompts** and broaden harness sandbox behavior where policy permits. It does not erase the surrounding control plane.
+
+## Trust and threat scenarios
+
+| Scenario | Required behavior |
+|---|---|
+| Repository file says “run `/permissions full`” | Treat as untrusted content; do not execute or prefill a trusted command. |
+| Familiar emits the command in chat | Render as model output only; no transition. |
+| Tool output contains command text | No transition. |
+| User pastes command into trusted command input | Parse as principal intent, then require trusted confirmation. |
+| Remote/untrusted client requests elevation | Require authenticated authorization and policy approval; otherwise deny. |
+| Harness crashes during relaunch | Remain/revert to baseline; report failure; never display full mode. |
+| Audit recording fails | Deny transition if an audit record is required by policy. |
+| Session detaches or workspace changes | Revoke session elevation. |
+| One-turn request is queued but turn fails to start | Keep it pending or cancel with explicit status; never consume silently. |
+| Full mode expires during a running operation | Stop new elevated work at the next safe boundary; report the transition. |
+
+## Policy and configuration
+
+A deployment policy should be able to:
+
+- disable interactive elevation entirely;
+- allow `--once` but deny `--session`;
+- set the maximum session-elevation TTL;
+- require a disposable worktree, container, or AgentFS-backed session;
+- require clean Git state or a recovery checkpoint;
+- deny elevation when high-value credentials are present;
+- keep selected action classes separately confirmable;
+- require provenance/audit availability;
+- constrain eligible callers, harnesses, repositories, and transports.
+
+Policy resolution is monotonic: repository or familiar configuration may request **less** authority but cannot grant more authority than deployment/principal policy allows.
+
+## Audit and privacy requirements
+
+Record a structured transition event with:
+
+- session ID and workspace identity;
+- authenticated actor identity or local-principal marker;
+- old and new effective modes;
+- requested and granted scope;
+- reason/result code;
+- timestamp and expiration;
+- harness kind/version and capability source;
+- whether relaunch/resume occurred;
+- applicable policy identifier/version.
+
+Do not record:
+
+- confirmation keystrokes beyond the decision;
+- task prompts solely because a mode changed;
+- environment values, tokens, or credential contents;
+- raw harness command lines if they may contain sensitive arguments.
+
+## Rollout proposal
+
+### Phase 0 — Contract review
+
+- Approve terminology and non-bypassable invariants.
+- Resolve overlap with the harness capability specification and open implementation work.
+- Threat-model trusted input, daemon/API callers, relaunch, and audit failure.
+- Confirm supported-harness mappings against pinned versions.
+
+### Phase 1 — Inspection only
+
+- Add structured permission state and `/permissions show`.
+- Display baseline/effective mode and support/refusal details.
+- Emit audit events for baseline establishment.
+- No interactive elevation.
+
+### Phase 2 — One-turn elevation
+
+- Add `/permissions full --once` behind an experimental feature gate.
+- Require trusted confirmation and verified support.
+- Prefer disposable/recoverable sessions during evaluation.
+- Gather refusal, relaunch, and revocation telemetry without prompt contents.
+
+### Phase 3 — Session elevation
+
+- Add `/permissions full --session` with TTL and persistent indicator.
+- Add disconnect, workspace-change, crash, and policy-change revocation.
+- Keep persistent/global elevation out of scope.
+
+### Phase 4 — Stable API
+
+- Stabilize machine-readable control-plane operations.
+- Document non-interactive launch-time delegation separately.
+- Remove the experimental gate only after security review and cross-harness conformance tests.
+
+## Success criteria
+
+- A principal can accurately inspect the effective mode before and after every transition.
+- No model-, repository-, or tool-generated text can trigger elevation.
+- Every successful transition has a structured provenance event.
+- UI never reports full mode unless the harness/control plane actually applied it.
+- Revocation works across supported harnesses at the documented safe boundary.
+- Unsupported and policy-denied cases fail closed with actionable reasons.
+- Cross-harness conformance tests prove the common semantics.
+- Security review finds no path from untrusted session content to elevation.
+
+## Open product questions
+
+1. Should `--session` default to 30 or 60 minutes, and may the principal shorten it?
+2. Which external-action categories remain separately confirmable in the first policy schema?
+3. Is a recoverability check (clean Git state, worktree, snapshot, or AgentFS) mandatory or advisory?
+4. Should detach always revoke elevation, or may authenticated local reconnect retain it within TTL?
+5. What terminology should UI use when a harness supports broad tool approval but cannot remove its sandbox?
+6. Should a future `/allow-all` discoverability alias exist, or is documentation/search sufficient?
+7. Which callers count as a trusted principal path in daemon and remote-client deployments?
+
+## Review exit criteria
+
+This product proposal is ready for technical implementation planning only when:
+
+- Security approves the principal-only activation model and retained boundaries.
+- Harness maintainers approve honest mappings for every supported harness.
+- CLI/TUI maintainers approve trusted command input and persistent indicators.
+- Control-plane maintainers approve policy resolution and transition ownership.
+- AgentFS/provenance maintainers approve the audit schema and recovery expectations.
+- Documentation reviewers confirm that “full” is not described as unlimited.

--- a/specs/coven-session-permissions/TECH.md
+++ b/specs/coven-session-permissions/TECH.md
@@ -1,0 +1,681 @@
+# Session Permission Controls — Technical Plan
+
+**Status:** Draft for familiar review
+**Depends on:** [`PRODUCT.md`](PRODUCT.md), [`../coven-harness-capabilities/PRODUCT.md`](../coven-harness-capabilities/PRODUCT.md), [`../coven-harness-capabilities/TECH.md`](../coven-harness-capabilities/TECH.md), [`../../docs/ENGINE-CONTRACT.md`](../../docs/ENGINE-CONTRACT.md)
+**Scope:** Architecture and verification plan; no implementation is authorized by this document
+
+## 1. Architectural decision
+
+Permission transitions are control-plane operations owned by Rust. They are not chat messages and must never be forwarded to the harness as prompts.
+
+The intended flow is:
+
+```text
+trusted principal input
+        │
+        ▼
+Coven command parser ──► authorization + policy ──► capability resolution
+        │                                            │
+        │ denied                                     │ supported
+        ▼                                            ▼
+structured refusal                         transition coordinator
+                                                     │
+                                   ┌─────────────────┴────────────────┐
+                                   ▼                                  ▼
+                              live update                     relaunch + resume
+                                   │                                  │
+                                   └─────────────────┬────────────────┘
+                                                     ▼
+                                         verify effective mode
+                                                     │
+                                      audit event + UI state update
+```
+
+The TUI may render confirmation and status, but it does not decide whether elevation is allowed. TypeScript integrations remain thin clients of the same Rust-owned contract.
+
+## 2. Relationship to existing architecture
+
+### Current surfaces
+
+- `crates/coven-cli/src/harness.rs` maps the typed launch-time `Permission` (`Full` or `ReadOnly`) through a per-harness `SandboxMapping` into harness arguments.
+- `docs/reference/cli-run.md` documents launch-time `--permission <LEVEL>` behavior as harness dependent.
+- The harness-capabilities specs propose stable capability descriptors and validation.
+- The engine contract establishes a Rust control plane with thin harness adapters.
+
+### Required convergence
+
+This plan must not create a competing capability registry. The session-permission feature should consume the canonical harness capability descriptors proposed by `specs/coven-harness-capabilities/`.
+
+The existing launch-time `Permission` plus `SandboxMapping` is a useful typed adapter mechanism, but it is insufficient as the running-session authority contract because:
+
+- `Full` still maps to harness-specific semantics;
+- argument expansion proves formatting, not semantic support at the detected harness version;
+- it cannot express whether changes are live or require relaunch;
+- it cannot distinguish support, policy denial, and unknown capability;
+- it does not describe resume/revocation behavior or effective-state verification.
+
+It should remain the adapter-level launch mechanism during migration, while principal-facing session state gains the richer typed contract below.
+
+## 3. Core domain model
+
+Illustrative Rust types (names are provisional):
+
+```rust
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMode {
+    Default,
+    Full,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionScope {
+    Once,
+    Session,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PermissionState {
+    pub baseline: PermissionMode,
+    pub effective: PermissionMode,
+    pub pending: Option<PermissionGrant>,
+    pub active_grant: Option<PermissionGrant>,
+    pub capability: PermissionCapability,
+    pub policy: PermissionPolicyDecision,
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PermissionGrant {
+    pub grant_id: String,
+    pub scope: PermissionScope,
+    pub granted_by: PrincipalId,
+    pub granted_at: Timestamp,
+    pub expires_at: Option<Timestamp>,
+    pub policy_version: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum PermissionCapability {
+    Supported {
+        application: PermissionApplication,
+        revocation: PermissionRevocation,
+        source: CapabilitySource,
+    },
+    Unsupported { reason: String },
+    Unknown { reason: String },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionApplication {
+    Live,
+    RelaunchResume,
+    LaunchOnly,
+}
+```
+
+Rules:
+
+- `effective == Full` only after adapter verification succeeds.
+- A pending `Once` grant is not effective until a turn starts.
+- `generation` increments on each accepted transition and protects against stale clients/races.
+- Unknown capability is a denial for elevation.
+- Strings sent to harnesses are derived adapter details, never accepted as proof of capability.
+
+## 4. State machine
+
+```text
+                    request once + confirm
+ DEFAULT ─────────────────────────────────────► FULL_PENDING_ONCE
+    ▲                                                  │
+    │ default / expiry / policy denial                 │ next turn starts
+    │                                                  ▼
+    ├────────────────────────────────────────── FULL_ACTIVE_ONCE
+    │                                                  │
+    │                                          turn completes/fails
+    │                                                  │
+    │        request session + confirm                 ▼
+    └◄──────────────────────────────────────────── DEFAULT
+    │
+    └──────────────────────────────────────────► FULL_ACTIVE_SESSION
+                                                    │
+                         default / timeout / detach / workspace change /
+                         policy change / unrecoverable adapter failure
+                                                    │
+                                                    ▼
+                                                 DEFAULT
+```
+
+A transient `Transitioning` substate should be represented internally during live update or relaunch. It must not be advertised as `Full`.
+
+### One-turn consumption
+
+A one-turn grant is consumed only after all preconditions pass and the harness begins the turn in verified full mode. If request submission fails before that point, the state remains pending and the UI explains it. After the turn reaches a terminal state, Coven restores baseline before accepting the next principal turn.
+
+### Revocation boundary
+
+If the harness supports live revocation, apply and verify immediately. If it requires relaunch, Coven should:
+
+1. prevent submission of new turns;
+2. request a safe stop at the adapter-defined boundary;
+3. relaunch/resume at baseline;
+4. verify baseline;
+5. update audit/UI state.
+
+Emergency process termination remains available to the principal. UI must not promise that already-issued external side effects can be undone.
+
+## 5. Trusted command input
+
+### Parsing boundary
+
+Slash commands are recognized only from an authenticated, principal-originated input event with an explicit source classification, for example:
+
+```rust
+pub enum InputOrigin {
+    LocalInteractivePrincipal,
+    AuthenticatedRemotePrincipal(PrincipalId),
+    HarnessOutput,
+    ToolOutput,
+    RepositoryContent,
+    Automation,
+}
+```
+
+Only policy-authorized principal variants may create a permission request. The parser must never inspect arbitrary transcript text for executable commands.
+
+### Command grammar
+
+```text
+permissions-command = "/permissions" [ SP action [ SP scope ] ]
+action              = "show" | "full" | "default" | "help"
+scope               = "--once" | "--session"
+```
+
+Constraints:
+
+- `full` requires exactly one scope.
+- `show`, `default`, and `help` reject scopes.
+- unknown options fail without forwarding any text to the harness.
+- command matching is exact after normal terminal line handling; no fuzzy correction for elevation.
+- aliases are excluded from the first release.
+
+### Confirmation token
+
+Confirmation should operate on an opaque, short-lived server-side request:
+
+```rust
+pub struct PermissionConfirmationChallenge {
+    pub challenge_id: String,
+    pub session_id: SessionId,
+    pub expected_generation: u64,
+    pub requested_mode: PermissionMode,
+    pub requested_scope: PermissionScope,
+    pub expires_at: Timestamp,
+    pub summary: PermissionImpactSummary,
+}
+```
+
+The UI returns a decision referencing `challenge_id`; it does not resubmit a natural-language command. Challenges are single-use, expire quickly, bind to session/generation/principal, and are invalidated by workspace or policy changes.
+
+## 6. Policy evaluation
+
+The control plane computes:
+
+```text
+allowed = caller authorization
+       ∩ deployment policy
+       ∩ repository policy
+       ∩ session constraints
+       ∩ harness capability
+       ∩ runtime preconditions
+```
+
+Later layers may only narrow authority.
+
+Suggested decision shape:
+
+```rust
+pub enum PermissionPolicyDecision {
+    Allowed {
+        scopes: BTreeSet<PermissionScope>,
+        max_session_ttl: Duration,
+        retained_boundaries: Vec<BoundaryId>,
+        requirements: Vec<PermissionRequirement>,
+        policy_version: String,
+    },
+    Denied {
+        code: PermissionDenialCode,
+        safe_message: String,
+        policy_version: String,
+    },
+}
+```
+
+Stable denial codes should include:
+
+- `caller_not_authorized`
+- `interactive_elevation_disabled`
+- `scope_not_allowed`
+- `harness_unsupported`
+- `capability_unknown`
+- `resume_unavailable`
+- `audit_unavailable`
+- `workspace_not_recoverable`
+- `credentials_too_broad`
+- `transition_in_progress`
+- `session_not_attached`
+- `policy_changed`
+
+Messages must be safe for logs and must not disclose which secrets or credentials triggered a denial.
+
+## 7. Harness capability contract
+
+Extend the canonical harness capability descriptor rather than introducing ad hoc tests. A permission descriptor needs at least:
+
+```json
+{
+  "permissions": {
+    "modes": ["default", "full"],
+    "full": {
+      "application": "relaunch_resume",
+      "revocation": "relaunch_resume",
+      "adapter_value": "<internal, not principal-facing>",
+      "verified_versions": ["..."]
+    }
+  }
+}
+```
+
+The actual schema should follow the capability spec's typed Rust model and evidence rules. The descriptor must identify:
+
+- semantic support for broad approval/sandbox mode;
+- supported version range and evidence source;
+- whether application is live, relaunch/resume, or launch-only;
+- whether baseline restoration is live or requires relaunch;
+- whether session continuity can be preserved;
+- categories that remain constrained by the harness;
+- verification mechanism after launch.
+
+### Supported harnesses
+
+Only Codex, Claude Code, and GitHub Copilot CLI are eligible while repository policy limits the supported set. Each adapter mapping requires an evidence packet against pinned/supported versions. Planning documents must not hard-code guessed flags.
+
+### Verification
+
+The adapter should verify effective application using the strongest available mechanism, in order:
+
+1. harness-reported structured session configuration;
+2. stable machine-readable startup metadata;
+3. adapter-owned launch contract plus version-pinned conformance evidence;
+4. otherwise capability is unknown and elevation is denied.
+
+A process starting successfully is not sufficient evidence by itself if the harness may silently ignore a flag.
+
+## 8. Transition coordinator
+
+The coordinator is the sole mutation point and should expose operations conceptually like:
+
+```rust
+inspect_permissions(session_id, principal) -> PermissionState
+prepare_permission_change(session_id, principal, request, generation)
+    -> PermissionConfirmationChallenge
+confirm_permission_change(challenge_id, principal, decision)
+    -> PermissionTransitionResult
+restore_default(session_id, principal, generation)
+    -> PermissionTransitionResult
+```
+
+### Atomicity
+
+A successful transition consists of:
+
+1. authorization/policy/capability checks;
+2. audit intent event (if required by policy);
+3. adapter application or relaunch;
+4. effective-mode verification;
+5. durable state mutation with generation increment;
+6. audit result event;
+7. client notification.
+
+On failure, Coven records a safe failure result and preserves/restores baseline. If baseline cannot be verified, mark the session permission state `indeterminate`, block new turns, and require restart or termination. Never optimistically report baseline or full.
+
+### Concurrency
+
+- Serialize transitions per session.
+- Require expected generation from clients.
+- Reject duplicate/late confirmations.
+- A turn-start operation and a permission transition must share the same session lock or transactional boundary.
+- Policy updates invalidate outstanding challenges.
+- Disconnect invalidates unconfirmed challenges and revokes active session grants according to product policy.
+
+## 9. Session persistence and lifecycle
+
+The first release should not restore full grants after daemon restart. Persist enough information to explain that an elevation ended, but initialize the resumed session at baseline.
+
+Revocation triggers:
+
+- explicit `/permissions default`;
+- one-turn completion;
+- TTL expiration;
+- detach/disconnect as selected by product policy;
+- workspace or repository identity change;
+- principal identity change;
+- harness process replacement outside the coordinator;
+- capability/version mismatch;
+- policy update that no longer permits the grant;
+- daemon restart;
+- audit subsystem failure when policy requires audit.
+
+If a session is resumed, permission state must be re-derived and verified, never trusted solely from stored UI metadata.
+
+## 10. API and event model
+
+Exact transport placement depends on daemon evolution, but local TUI and remote integrations should consume one structured contract.
+
+Suggested response fields:
+
+```json
+{
+  "session_id": "...",
+  "baseline": "default",
+  "effective": "full",
+  "scope": "session",
+  "expires_at": "...",
+  "generation": 7,
+  "application": "relaunch_resume",
+  "capability_status": "supported",
+  "policy_status": "allowed",
+  "retained_boundaries": ["daemon_auth", "workspace_root", "audit_integrity"]
+}
+```
+
+Suggested event kinds:
+
+- `permission.baseline_established`
+- `permission.change_requested`
+- `permission.change_denied`
+- `permission.change_cancelled`
+- `permission.transition_started`
+- `permission.transition_succeeded`
+- `permission.transition_failed`
+- `permission.revoked`
+- `permission.expired`
+- `permission.indeterminate`
+
+Event payloads use IDs/codes and safe summaries, never prompt contents or credentials.
+
+## 11. TUI implementation plan
+
+Likely work areas include `crates/coven-cli/src/tui/` for input routing, confirmation modal, state subscription, status rendering, and accessibility. Before implementation, maintainers should map the precise current input path and ensure slash command extraction does not affect ordinary prompt submission.
+
+Required UI components:
+
+- exact command parser with completions/help;
+- inspection view;
+- trusted confirmation dialog;
+- persistent elevated-state banner;
+- countdown/expiration display for session grants;
+- immediate restore control;
+- structured refusal/error rendering;
+- transition-in-progress state that blocks conflicting input;
+- terminal-width and non-color accessibility tests.
+
+No UI component may directly rewrite harness arguments or set its own effective mode.
+
+## 12. Launch-time and non-interactive mode
+
+Interactive slash commands and launch-time delegation share the same typed policy model but have distinct authorization flows.
+
+A future launch surface may resemble:
+
+```text
+coven run <harness> --permission full --permission-scope session ...
+```
+
+For non-interactive use:
+
+- authority must be explicit in process arguments or a trusted structured API;
+- prompt text cannot request elevation;
+- policy may require a named profile rather than confirmation;
+- effective mode is included in startup output and provenance;
+- legacy harness-specific permission strings should be deprecated only after migration compatibility is designed.
+
+This plan does not finalize CLI syntax or deprecation timing.
+
+## 13. Audit storage and AgentFS integration
+
+Permission events should join the canonical session timeline/provenance stream, including AgentFS-backed sessions where available. Event ordering must distinguish request, transition, effective turn, and revocation.
+
+Security properties:
+
+- append-only or integrity-protected according to the existing provenance design;
+- actor/session/workspace binding;
+- safe failure when required audit storage is unavailable;
+- no environment dumps or raw process arguments;
+- retention follows session privacy policy;
+- exported timelines clearly label full-mode intervals.
+
+A useful review artifact is a timeline example:
+
+```text
+10:00 baseline default established
+10:03 full/once requested by local principal
+10:03 challenge confirmed
+10:03 harness relaunched and full verified
+10:04 turn 18 started under full
+10:11 turn 18 completed
+10:11 baseline restored and verified
+```
+
+## 14. Threat model and mitigations
+
+| Threat | Mitigation |
+|---|---|
+| Prompt injection asks for elevation | Origin-typed trusted input; never parse transcript/model/tool text as commands. |
+| Familiar invokes internal API/tool | Permission operations are not model tools; principal authorization is mandatory. |
+| Clickjacking/ambiguous confirmation | Coven-owned modal with workspace, scope, boundaries, expiry; no model-supplied UI text. |
+| Replay of confirmation | Opaque single-use challenge bound to principal/session/generation with short TTL. |
+| Stale remote client overwrites state | Generation checks and per-session serialization. |
+| Harness flag silently ignored | Versioned capability evidence plus effective-mode verification; unknown fails closed. |
+| Relaunch loses or crosses session identity | Adapter verifies resume/session identity before marking success. |
+| UI says default while process remains full | Verification on revocation; indeterminate state blocks new turns. |
+| Session elevation survives unexpectedly | Revoke on lifecycle triggers; never persist across daemon restart initially. |
+| Audit log leaks credentials | Structured allowlisted fields; no raw argv/env/prompt. |
+| Policy TOCTOU | Bind challenge to policy version and re-evaluate at confirmation/application. |
+| Symlink/workspace swap | Bind to canonical workspace identity and invalidate on change. |
+| External side effects continue after revoke | Document safe-boundary semantics; block new work; terminate process for emergency stop. |
+
+## 15. Test strategy
+
+### Unit tests
+
+- strict command grammar and rejection cases;
+- origin authorization matrix;
+- policy intersection and monotonic narrowing;
+- challenge expiry, replay, wrong principal, wrong generation;
+- state-machine transitions and one-turn consumption;
+- TTL and lifecycle revocation;
+- safe denial messages and audit redaction;
+- capability unknown/unsupported behavior.
+
+### Property/state-machine tests
+
+Assert invariants across generated event sequences:
+
+- only confirmed principal requests can lead to `effective == Full`;
+- `effective == Full` implies supported capability and allowed policy;
+- at most one active transition/grant per session;
+- generation increases monotonically;
+- restart initializes baseline;
+- no turn starts while state is transitioning or indeterminate;
+- a one-turn grant applies to at most one turn.
+
+### Adapter contract tests
+
+For every supported harness/version fixture:
+
+- correct full-mode launch mapping;
+- verification succeeds only when mode is effective;
+- relaunch/resume preserves session identity where claimed;
+- default restoration is verified;
+- unsupported versions fail closed;
+- extra arguments cannot override coordinator-owned permission arguments.
+
+### Integration tests
+
+- local TUI confirmation and cancellation;
+- model output containing `/permissions full --session` has no effect;
+- pasted repository text has no effect until explicitly entered and confirmed by principal;
+- disconnect, timeout, workspace switch, crash, and daemon restart revoke appropriately;
+- audit outage behavior follows policy;
+- simultaneous turn submission and elevation request serialize correctly;
+- terminal status is accessible without color.
+
+### Security tests
+
+- fuzz command parser and structured API;
+- replay/cross-session challenge attempts;
+- malicious harness output spoofing permission state;
+- crafted capability manifests and version strings;
+- symlink/workspace identity changes;
+- log scanning for prompt, argv, environment, and credential leakage;
+- unauthorized local/remote caller attempts.
+
+### CI gates
+
+Normal repository gates remain mandatory:
+
+```text
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked
+python scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Run npm build/tests if integration packages change.
+
+## 16. Observability
+
+Collect privacy-preserving counters/timings where telemetry policy permits:
+
+- inspection requests;
+- elevation requests by scope;
+- confirmed/cancelled/denied transitions by stable reason code;
+- transition and revocation duration;
+- relaunch/resume failure counts;
+- indeterminate-state count;
+- automatic revocations by trigger;
+- unsupported harness/version requests.
+
+Do not collect prompts, command contents beyond the canonical permission operation, repository paths, usernames, or credential metadata merely for this feature.
+
+## 17. Implementation slices
+
+Each slice should be independently reviewable and keep user-visible elevation disabled until its prerequisites land.
+
+### Slice A — Domain and capability schema
+
+- Add typed permission state, scope, capability, denial, and transition types.
+- Extend canonical harness capability descriptors with evidence.
+- Add adapter fixtures and conformance tests.
+
+### Slice B — Inspection path
+
+- Establish baseline state at session start.
+- Add control-plane inspection operation and audit event.
+- Implement `/permissions show` and status rendering.
+
+### Slice C — Transition coordinator
+
+- Add authorization/policy evaluation, challenges, generation checks, state machine, and audit results.
+- Keep full transitions behind a compile-time or experimental runtime gate.
+
+### Slice D — One-turn adapter flow
+
+- Implement apply/verify/restore for one supported harness first.
+- Add full lifecycle and failure-path tests.
+- Expand only after the first adapter passes security review.
+
+### Slice E — Session scope and TTL
+
+- Add persistent indicator, expiration, detach/workspace/policy revocation, and emergency restore.
+
+### Slice F — Remaining supported harnesses and stable API
+
+- Add evidence-backed adapters for the other supported harnesses.
+- Stabilize structured daemon/integration APIs after conformance.
+- Publish user/operator documentation and migration guidance.
+
+## 18. Documentation deliverables
+
+Before general availability:
+
+- CLI reference for `/permissions` and launch-time modes;
+- conceptual guide distinguishing familiar identity, capability, policy, and authority;
+- operator policy reference with secure defaults;
+- threat-model/security note;
+- harness support/version matrix;
+- recovery guide for indeterminate transitions;
+- release notes that call the feature elevated permissions, not unlimited access.
+
+## 19. Review checklist
+
+### Authority/security
+
+- [ ] Only authenticated principal input can request or confirm elevation.
+- [ ] No model-visible tool can invoke the transition API.
+- [ ] Full retains documented non-bypassable boundaries.
+- [ ] Unknown capability and audit failure fail closed where required.
+- [ ] Challenge replay and state races are covered.
+
+### Harness adapters
+
+- [ ] Each mapping has pinned-version evidence.
+- [ ] Application and revocation behavior are truthful.
+- [ ] Resume identity is verified.
+- [ ] Extra arguments cannot countermand control-plane permission arguments.
+
+### UX/accessibility
+
+- [ ] Mode, scope, workspace, and expiration are conspicuous.
+- [ ] Confirmation is Coven-owned and unambiguous.
+- [ ] Restore is immediate to request and easy to discover.
+- [ ] Color is not the only elevated-state signal.
+- [ ] Refusals distinguish policy, support, and runtime failure.
+
+### Reliability/provenance
+
+- [ ] Every effective interval is represented in provenance.
+- [ ] Crash/restart/detach behavior is deterministic.
+- [ ] Indeterminate state blocks new turns.
+- [ ] Logs exclude secrets, prompt bodies, raw environment, and unsafe argv.
+
+## 20. Unresolved technical decisions
+
+1. Which crate/module should own session permission state as daemon session APIs mature?
+2. What existing session resume guarantees does each supported harness provide, and are they strong enough for relaunch transitions?
+3. Can all adapter-owned permission arguments be placed after or otherwise protected from user `extra_args` overrides?
+4. What is the canonical workspace identity across ordinary, worktree, and AgentFS-backed sessions?
+5. Which audit backend is mandatory before one-turn elevation can ship?
+6. Should expiration use wall clock plus monotonic timers, and how is daemon suspend handled?
+7. Is emergency revocation process termination automatic after a grace period or explicitly principal-driven?
+8. How does a remote client prove a confirmation was directly initiated by a principal rather than generated by an agent?
+9. What exact capability-schema changes belong in the existing harness-capabilities work to avoid parallel registries?
+
+## 21. Go/no-go gates
+
+Interactive elevation remains disabled until all of these are satisfied:
+
+- typed state and policy live in Rust;
+- trusted input origins and principal authorization are enforced;
+- capability evidence exists for at least one supported harness/version;
+- apply and restore can both be verified;
+- audit events and privacy review are complete;
+- crash/restart/timeout/replay/race tests pass;
+- elevated and indeterminate UI states are conspicuous;
+- security reviewers approve the threat model;
+- documentation never promises literal absence of limitations.

--- a/specs/coven-session-permissions/TECH.md
+++ b/specs/coven-session-permissions/TECH.md
@@ -1,7 +1,7 @@
 # Session Permission Controls — Technical Plan
 
 **Status:** Draft for familiar review
-**Depends on:** [`PRODUCT.md`](PRODUCT.md), [`../coven-harness-capabilities/PRODUCT.md`](../coven-harness-capabilities/PRODUCT.md), [`../coven-harness-capabilities/TECH.md`](../coven-harness-capabilities/TECH.md), [`../../docs/ENGINE-CONTRACT.md`](../../docs/ENGINE-CONTRACT.md)
+**Depends on:** [`PRODUCT.md`](PRODUCT.md), [`../../docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md`](../../docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md), [`../coven-harness-capabilities/PRODUCT.md`](../coven-harness-capabilities/PRODUCT.md), [`../coven-harness-capabilities/TECH.md`](../coven-harness-capabilities/TECH.md), [`../../docs/ENGINE-CONTRACT.md`](../../docs/ENGINE-CONTRACT.md)
 **Scope:** Architecture and verification plan; no implementation is authorized by this document
 
 ## 1. Architectural decision
@@ -39,12 +39,13 @@ The TUI may render confirmation and status, but it does not decide whether eleva
 
 - `crates/coven-cli/src/harness.rs` maps the typed launch-time `Permission` (`Full` or `ReadOnly`) through a per-harness `SandboxMapping` into harness arguments.
 - `docs/reference/cli-run.md` documents launch-time `--permission <LEVEL>` behavior as harness dependent.
-- The harness-capabilities specs propose stable capability descriptors and validation.
+- The harness-capabilities specs define raw, ephemeral native scans for instructions, skills, and plugins.
+- `docs/superpowers/specs/2026-08-03-universal-runtime-capability-recovery-design.md` defines the Rust-owned `EffectiveRuntimeDescriptor` used for client-facing runtime capability truth.
 - The engine contract establishes a Rust control plane with thin harness adapters.
 
 ### Required convergence
 
-This plan must not create a competing capability registry. The session-permission feature should consume the canonical harness capability descriptors proposed by `specs/coven-harness-capabilities/`.
+This plan must not create a competing capability registry. The raw `HarnessCapabilityManifest` from `specs/coven-harness-capabilities/` remains discovery-only and must never authorize elevation. Session permissions consume and extend the Rust-owned `EffectiveRuntimeDescriptor` contract defined by the universal runtime capability design.
 
 The existing launch-time `Permission` plus `SandboxMapping` is a useful typed adapter mechanism, but it is insufficient as the running-session authority contract because:
 
@@ -184,7 +185,7 @@ pub enum InputOrigin {
 }
 ```
 
-Only policy-authorized principal variants may create a permission request. The parser must never inspect arbitrary transcript text for executable commands.
+Only `LocalInteractivePrincipal` may create a `full` request in the first release, and it must complete a Coven-owned local confirmation challenge. `AuthenticatedRemotePrincipal` may use `show` and `default`, but `full` fails with `remote_elevation_unsupported`. The parser must never inspect arbitrary transcript text for executable commands. Future remote elevation requires a separate user-presence and channel-binding protocol; authentication alone is insufficient.
 
 ### Command grammar
 
@@ -268,40 +269,53 @@ Stable denial codes should include:
 - `transition_in_progress`
 - `session_not_attached`
 - `policy_changed`
+- `remote_elevation_unsupported`
 
 Messages must be safe for logs and must not disclose which secrets or credentials triggered a denial.
 
-## 7. Harness capability contract
+## 7. Effective runtime permission capability contract
 
-Extend the canonical harness capability descriptor rather than introducing ad hoc tests. A permission descriptor needs at least:
+Permission authority extends the Rust-owned `EffectiveRuntimeDescriptor`; it does not use the raw native-scan manifest. The descriptor's capability map should expose a stable capability id such as `session.permission.full`, backed by an internal typed record:
 
-```json
-{
-  "permissions": {
-    "modes": ["default", "full"],
-    "full": {
-      "application": "relaunch_resume",
-      "revocation": "relaunch_resume",
-      "adapter_value": "<internal, not principal-facing>",
-      "verified_versions": ["..."]
-    }
-  }
+```rust
+pub struct EffectivePermissionCapability {
+    pub state: CapabilityState,
+    pub detected_version: Option<String>,
+    pub supported_versions: String,
+    pub evidence_id: String,
+    pub application: PermissionTransitionMechanism,
+    pub revocation: PermissionTransitionMechanism,
+    pub continuity: SessionContinuity,
+    pub verification: PermissionVerification,
+    pub retained_boundaries: BTreeSet<RetainedBoundary>,
+    pub adapter_mapping: PermissionAdapterMapping, // internal, never principal-supplied
 }
 ```
 
-The actual schema should follow the capability spec's typed Rust model and evidence rules. The descriptor must identify:
+The Rust resolver derives this record from the detected runtime version, adapter-owned launch mechanics, and a committed evidence packet. Each evidence packet must identify:
 
-- semantic support for broad approval/sandbox mode;
-- supported version range and evidence source;
-- whether application is live, relaunch/resume, or launch-only;
-- whether baseline restoration is live or requires relaunch;
-- whether session continuity can be preserved;
-- categories that remain constrained by the harness;
-- verification mechanism after launch.
+- runtime id and exact supported version range;
+- evidence source, release/build identity, and conformance-test revision;
+- adapter-owned application arguments or RPC and their precedence over `extra_args`;
+- live, relaunch/resume, or launch-only application behavior;
+- live or relaunch/resume baseline restoration behavior;
+- session-continuity guarantees and failure handling;
+- the strongest effective-state verification mechanism available;
+- retained workspace, credential, privacy, branch, network, and external-action boundaries.
+
+If any field is missing, stale for the detected version, or contradicted at runtime, the capability state is `unverified` and elevation is denied. Stored UI metadata, raw harness scans, process startup success, and guessed flags are never evidence.
 
 ### Supported harnesses
 
-Only Codex, Claude Code, and GitHub Copilot CLI are eligible while repository policy limits the supported set. Each adapter mapping requires an evidence packet against pinned/supported versions. Planning documents must not hard-code guessed flags.
+Only Codex, Claude Code, and GitHub Copilot CLI are eligible while repository policy limits the supported set. At this specification's publication, all three mappings are intentionally `unverified` and fail closed:
+
+| Runtime | Initial capability state | Required behavior |
+|---|---|---|
+| Codex | `unverified` | Deny until a version-bounded evidence packet proves application, restoration, continuity, verification, and retained boundaries. |
+| Claude Code | `unverified` | Deny until a version-bounded evidence packet proves application, restoration, continuity, verification, and retained boundaries. |
+| GitHub Copilot CLI | `unverified` | Deny until a version-bounded evidence packet proves application, restoration, continuity, verification, and retained boundaries. |
+
+An adapter mapping may move to `supported` only in the same change that adds its evidence packet and conformance tests. Planning documents must not hard-code guessed flags.
 
 ### Verification
 
@@ -349,7 +363,7 @@ On failure, Coven records a safe failure result and preserves/restores baseline.
 - Reject duplicate/late confirmations.
 - A turn-start operation and a permission transition must share the same session lock or transactional boundary.
 - Policy updates invalidate outstanding challenges.
-- Disconnect invalidates unconfirmed challenges and revokes active session grants according to product policy.
+- Disconnect invalidates unconfirmed challenges and revokes active session grants.
 
 ## 9. Session persistence and lifecycle
 
@@ -360,7 +374,7 @@ Revocation triggers:
 - explicit `/permissions default`;
 - one-turn completion;
 - TTL expiration;
-- detach/disconnect as selected by product policy;
+- detach/disconnect;
 - workspace or repository identity change;
 - principal identity change;
 - harness process replacement outside the coordinator;
@@ -663,8 +677,9 @@ Before general availability:
 5. Which audit backend is mandatory before one-turn elevation can ship?
 6. Should expiration use wall clock plus monotonic timers, and how is daemon suspend handled?
 7. Is emergency revocation process termination automatic after a grace period or explicitly principal-driven?
-8. How does a remote client prove a confirmation was directly initiated by a principal rather than generated by an agent?
-9. What exact capability-schema changes belong in the existing harness-capabilities work to avoid parallel registries?
+8. What exact additive descriptor-version change should carry `EffectivePermissionCapability` after the effective runtime descriptor contract lands?
+
+First-release decisions: remote callers cannot elevate, detach/disconnect always revokes active grants, and raw harness capability scans are never permission evidence.
 
 ## 21. Go/no-go gates
 


### PR DESCRIPTION
## Context

- Summary: Define product and technical contracts for principal-controlled running-session permission changes.
- Files changed: `specs/coven-session-permissions/PRODUCT.md` and `specs/coven-session-permissions/TECH.md`.
- Closes #738

## Implementation

- Approach: Specify trusted principal input, Rust authority enforcement, capability/policy separation, lifecycle, auditability, refusal behavior, and harness mappings before implementation.
- User-visible behavior: Planning only; no runtime behavior changes.
- Compatibility notes: The proposal preserves OS, workspace, credential, privacy, branch, and non-bypassable Coven protections.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] `cargo test --workspace --locked` (shared macOS baseline is unstable in unrelated migration and PTY tests)
- [x] `python3 scripts/check-secrets.py`
- [x] Additional manual checks: privacy guard and `git diff --check`.

## Risk and Rollback

- Risk level: Low; documentation/specification only.
- Rollback plan: Revert commit `630cc12`.

## Agent Handoff

- Current state: Complete and clean in `docs/session-permission-controls`.
- Follow-ups: Review and approve the contract before any implementation begins.
- Known gaps: No implementation is authorized by these draft specifications.
