### PR TITLE
fix: preserve supervisor exits on macOS

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -1326,9 +1326,9 @@ impl ChildProcessTree {
         #[cfg(unix)]
         {
             terminate_unix_process_group(self.pid)?;
-            // Leave the handle retryable when signaling fails for anything
-            // other than ESRCH. `terminate_unix_process_group` treats ESRCH
-            // as success because the desired post-condition already holds.
+            // Leave the handle retryable when signaling fails while live
+            // processes may remain. `terminate_unix_process_group` treats
+            // platform-specific already-exited results as success.
             self.terminated = true;
         }
         #[cfg(windows)]
@@ -1561,7 +1561,11 @@ fn terminate_unix_process_group(pid: u32) -> io::Result<()> {
         return Ok(());
     }
     let error = io::Error::last_os_error();
-    if error.raw_os_error() == Some(libc::ESRCH) {
+    let already_exited = error.raw_os_error() == Some(libc::ESRCH)
+        || (cfg!(target_os = "macos") && error.raw_os_error() == Some(libc::EPERM));
+    if already_exited {
+        // Darwin reports EPERM when the group contains only its unreaped
+        // zombie leader. Live same-owner descendants make kill succeed.
         Ok(())
     } else {
         Err(error)


### PR DESCRIPTION
## Summary
- treat Darwin `killpg(SIGKILL)` `EPERM` as an already-exited process group
- preserve target exit codes and signals when the group contains only its unreaped zombie leader
- retain existing cleanup behavior for live descendants and non-Darwin errors

## Root cause
Darwin returns `EPERM` when a process group contains only an unreaped zombie leader. The supervisor interpreted that idempotent cleanup result as fatal and replaced the target status with software-error exit code 70.

## Validation
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p coven-cli --test process_supervisor --locked -- --nocapture`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`

`cargo test --workspace --locked` cleared the supervisor regressions but exposed unrelated parallel-test flakes in memory migration, daemon locking, and a Codex timeout; each failing test passed when rerun alone.