### PR TITLE
fix(api): stop bound launches from disclosing the familiar roster

### DIFF
--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -1995,6 +1995,20 @@ fn launch_session(
         match session_launch::resolve_familiar(coven_home, launch.familiar_id.as_deref()) {
             Ok(familiar_ctx) => familiar_ctx,
             Err(session_launch::FamiliarError::Unknown { familiar_id, error }) => {
+                // A bound launch gets a generic answer: echoing the submitted
+                // id back, plus a resolver message that distinguishes "no such
+                // familiar" from other failures, turns this endpoint into a
+                // familiar-existence oracle for a caller that already proved
+                // only its binding. Unbound launches keep the exact legacy
+                // message and details for backward compatibility.
+                if execution_binding.is_some() {
+                    return api_error(
+                        400,
+                        "unknown_familiar",
+                        "Familiar was not found.",
+                        Some(json!({ "fields": ["familiarId"] })),
+                    );
+                }
                 return api_error(
                     400,
                     "unknown_familiar",
@@ -10107,6 +10121,88 @@ mod tests {
             "parent": null,
             "delegationDigest": null
         })
+    }
+
+    #[test]
+    fn bound_launch_does_not_leak_the_unknown_familiar_id() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        seed_familiars_toml(temp_dir.path())?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "codex",
+            "prompt": "hello coven",
+            "familiarId": "no-such-familiar",
+            "executionBinding": root_binding("no-such-familiar"),
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 400, "{}", response.body);
+        assert!(
+            response.body.contains("unknown_familiar"),
+            "expected unknown familiar error, got: {}",
+            response.body
+        );
+        assert!(
+            !response.body.contains("no-such-familiar"),
+            "a bound launch must not echo the submitted familiar id back, got: {}",
+            response.body
+        );
+        let payload: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(payload["error"]["details"]["fields"], json!(["familiarId"]));
+        assert!(
+            runtime.launches.borrow().is_empty(),
+            "unknown familiar must not launch a runtime"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn unbound_launch_keeps_the_legacy_unknown_familiar_details() -> anyhow::Result<()> {
+        // The redaction is scoped to bound launches; the legacy unbound shape
+        // is relied on by existing clients and must not change with it.
+        let temp_dir = tempfile::tempdir()?;
+        seed_familiars_toml(temp_dir.path())?;
+        let project_root = temp_dir.path().join("repo");
+        std::fs::create_dir_all(&project_root)?;
+        let runtime = RecordingRuntime::default();
+        let body = json!({
+            "projectRoot": project_root,
+            "harness": "claude",
+            "launchMode": "nonInteractive",
+            "prompt": "hi",
+            "familiarId": "no-such-familiar",
+        })
+        .to_string();
+
+        let response = handle_request_with_runtime(
+            "POST",
+            "/sessions",
+            temp_dir.path(),
+            None,
+            Some(&body),
+            &runtime,
+        )?;
+
+        assert_eq!(response.status, 400, "{}", response.body);
+        let payload: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(
+            payload["error"]["details"]["familiarId"], "no-such-familiar",
+            "unbound launches keep echoing the submitted id: {}",
+            response.body
+        );
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A bound launch naming an unknown familiar returns the resolver's raw error:

```json
{"error":{"code":"unknown_familiar",
  "details":{"familiarId":"no-such-familiar"},
  "message":"unknown familiar `no-such-familiar`; expected one of: cody, sage"}}
```

Two problems in one response:

- **The message enumerates every configured familiar id.** A caller holding only an execution binding can read the whole roster from a single rejected launch.
- **`details.familiarId` reflects unvalidated caller input** straight back.

Bound launches now get a generic `"Familiar was not found."` with the offending field named but no value. **Unbound launches are untouched** — they keep the exact legacy message and details, which existing clients depend on.

## Provenance

Recovered from the abandoned `feat/728-psyche-o2-execution-binding` worktree. That branch's other 8 commits are superseded by #732 (same public symbols, main is a strict superset), but this one fix never landed. It was written against a `launch_session` that main has since refactored, so cherry-picking dragged in the old surrounding code — the semantic change is reapplied to main's current implementation instead.

## Validation

- `cargo fmt --check`
- `cargo clippy -p coven-cli --all-targets` — clean
- `cargo test -p coven-cli --bins -- api::tests::bound_launch_does_not_leak api::tests::unbound_launch_keeps_the_legacy api::tests::launch_request_rejects_unknown_familiar api::tests::bound_root_launch_persists` — 4 passed
- **Verified the regression test is real:** removing the guard turns `bound_launch_does_not_leak_the_unknown_familiar_id` red with the roster-leaking body quoted above.
- `scripts/check-secrets.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)