### PR TITLE
wip(hub): append-only spoke result ledger

### DIFF
--- a/crates/coven-cli/src/hub.rs
+++ b/crates/coven-cli/src/hub.rs
@@ -20,6 +20,7 @@ use anyhow::{bail, Context, Result};
 use rusqlite::{Connection, OptionalExtension, Transaction, TransactionBehavior};
 use serde::Deserialize;
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{
@@ -786,7 +787,7 @@ pub fn dispatch_to_node(
     if request.command.is_empty() {
         return api_error(400, "invalid_request", "command must not be empty.", None);
     }
-    let conn = store::open_store(&store_path(coven_home))?;
+    let mut conn = store::open_store(&store_path(coven_home))?;
     let Some(mut node) = store::get_node(&conn, node_id)? else {
         return api_error(
             404,
@@ -837,7 +838,7 @@ pub fn dispatch_to_node(
     let job_json = serde_json::to_string(&job).context("failed to serialize job spec")?;
     let now = current_timestamp();
     // Persist before dispatching so a hub crash mid-dispatch leaves evidence.
-    store::upsert_executor_dispatch(
+    store::insert_executor_dispatch_if_absent(
         &conn,
         &store::ExecutorDispatchRecord {
             job_id: job_id.clone(),
@@ -851,50 +852,11 @@ pub fn dispatch_to_node(
     )?;
 
     let envelope = executor_node::dispatch_job(transport.as_ref(), &job);
-    let envelope_json =
-        serde_json::to_string(&envelope).context("failed to serialize result envelope")?;
     let finished = current_timestamp();
-    store::upsert_executor_dispatch(
-        &conn,
-        &store::ExecutorDispatchRecord {
-            job_id: job_id.clone(),
-            node_id: node_id.to_string(),
-            status: envelope.status.clone(),
-            job_json,
-            envelope_json: Some(envelope_json),
-            created_at: now.clone(),
-            updated_at: finished.clone(),
-        },
-    )?;
-
-    // Advance a matching hub-queue job from the envelope. A transport error
-    // leaves the job assigned/held so no work is lost.
-    if store::get_hub_job(&conn, &job_id)?.is_some() {
-        let hub_state = match envelope.status.as_str() {
-            executor_node::RESULT_STATUS_COMPLETED => Some("completed"),
-            executor_node::RESULT_STATUS_FAILED
-            | executor_node::RESULT_STATUS_TIMEOUT
-            | executor_node::RESULT_STATUS_REJECTED => Some("failed"),
-            _ => None,
-        };
-        if let Some(state) = hub_state {
-            store::update_hub_job_state(&conn, &job_id, state, Some(node_id), &finished)?;
-        }
-    }
-
-    // A dispatch doubles as an availability observation.
     let unreachable = envelope.status == executor_node::RESULT_STATUS_TRANSPORT_ERROR;
-    node.available = !unreachable;
-    node.last_health_at = finished.clone();
-    node.last_error = if unreachable {
-        envelope.error.clone()
-    } else {
-        None
-    };
-    node.updated_at = finished.clone();
-    store::upsert_node(&conn, &node)?;
-    transition_jobs_for_availability(&conn, node_id, !unreachable, &finished)?;
-    sync_executor_queue(&conn, node_id, &finished)?;
+    persist_dispatch_result(
+        &mut conn, &mut node, &job, &job_json, &envelope, &now, &finished,
+    )?;
 
     if unreachable {
         return api_error(
@@ -919,6 +881,101 @@ pub fn dispatch_to_node(
     )
 }
 
+fn persist_dispatch_result(
+    conn: &mut Connection,
+    node: &mut store::NodeRecord,
+    job: &executor_node::ExecutorJob,
+    job_json: &str,
+    envelope: &executor_node::ExecutorResultEnvelope,
+    created_at: &str,
+    finished_at: &str,
+) -> Result<()> {
+    let envelope_json =
+        serde_json::to_string(envelope).context("failed to serialize result envelope")?;
+    let envelope_id = result_envelope_id(&node.node_id, &envelope_json);
+    let unreachable = envelope.status == executor_node::RESULT_STATUS_TRANSPORT_ERROR;
+    let mut observed_node = node.clone();
+    observed_node.available = !unreachable;
+    observed_node.last_health_at = finished_at.to_string();
+    observed_node.last_error = if unreachable {
+        envelope.error.clone()
+    } else {
+        None
+    };
+    observed_node.updated_at = finished_at.to_string();
+
+    let tx = conn
+        .transaction()
+        .context("failed to begin executor result transaction")?;
+    let inserted = store::append_executor_result_envelope(
+        &tx,
+        &store::ExecutorResultEnvelopeRecord {
+            envelope_id,
+            job_id: job.job_id.clone(),
+            node_id: node.node_id.clone(),
+            envelope_json: envelope_json.clone(),
+            recorded_at: finished_at.to_string(),
+        },
+    )?;
+    if !inserted {
+        tx.commit()
+            .context("failed to commit replayed executor result transaction")?;
+        return Ok(());
+    }
+    store::upsert_executor_dispatch(
+        &tx,
+        &store::ExecutorDispatchRecord {
+            job_id: job.job_id.clone(),
+            node_id: node.node_id.clone(),
+            status: envelope.status.clone(),
+            job_json: job_json.to_string(),
+            envelope_json: Some(envelope_json),
+            created_at: created_at.to_string(),
+            updated_at: finished_at.to_string(),
+        },
+    )?;
+
+    // A transport error leaves the job assigned or held so hub-owned work is
+    // never lost. Replaying a terminal envelope repeats this idempotent update.
+    if store::get_hub_job(&tx, &job.job_id)?.is_some() {
+        let hub_state = match envelope.status.as_str() {
+            executor_node::RESULT_STATUS_COMPLETED => Some("completed"),
+            executor_node::RESULT_STATUS_FAILED
+            | executor_node::RESULT_STATUS_TIMEOUT
+            | executor_node::RESULT_STATUS_REJECTED => Some("failed"),
+            _ => None,
+        };
+        if let Some(state) = hub_state {
+            store::update_hub_job_state(&tx, &job.job_id, state, Some(&node.node_id), finished_at)?;
+        }
+    }
+
+    store::upsert_node(&tx, &observed_node)?;
+    transition_jobs_for_availability(&tx, &node.node_id, !unreachable, finished_at)?;
+    sync_executor_queue(&tx, &node.node_id, finished_at)?;
+    tx.commit()
+        .context("failed to commit executor result transaction")?;
+    *node = observed_node;
+    Ok(())
+}
+
+fn result_envelope_id(node_id: &str, envelope_json: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(node_id.as_bytes());
+    digest.update([0]);
+    digest.update(envelope_json.as_bytes());
+    let hash = digest.finalize();
+    let mut id = String::with_capacity("sha256:".len() + hash.len() * 2);
+    id.push_str("sha256:");
+    for byte in hash {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let byte = usize::from(byte);
+        id.push(HEX[byte >> 4] as char);
+        id.push(HEX[byte & 0x0f] as char);
+    }
+    id
+}
+
 pub fn get_dispatch(coven_home: &Path, job_id: &str) -> Result<ApiResponse> {
     let conn = store::open_store(&store_path(coven_home))?;
     let Some(record) = store::get_executor_dispatch(&conn, job_id)? else {
@@ -936,6 +993,20 @@ pub fn get_dispatch(coven_home: &Path, job_id: &str) -> Result<ApiResponse> {
         }
         None => Value::Null,
     };
+    let result_envelopes = store::list_executor_result_envelopes(&conn, job_id)?
+        .into_iter()
+        .map(|result| {
+            let envelope: Value = serde_json::from_str(&result.envelope_json)
+                .context("failed to parse append-only result envelope")?;
+            Ok(json!({
+                "envelopeId": result.envelope_id,
+                "jobId": result.job_id,
+                "nodeId": result.node_id,
+                "envelope": envelope,
+                "recordedAt": result.recorded_at,
+            }))
+        })
+        .collect::<Result<Vec<_>>>()?;
     json_response(
         200,
         &json!({
@@ -944,6 +1015,7 @@ pub fn get_dispatch(coven_home: &Path, job_id: &str) -> Result<ApiResponse> {
             "status": record.status,
             "job": job,
             "envelope": envelope,
+            "resultEnvelopes": result_envelopes,
             "createdAt": record.created_at,
             "updatedAt": record.updated_at,
         }),
@@ -2070,6 +2142,188 @@ exit 2
         assert_eq!(job["job"]["protocolVersion"], "coven.executor.v1");
         assert!(job["job"]["hubId"].as_str().unwrap().starts_with("hub_"));
         assert_eq!(job["job"]["context"]["workspaceId"], "workspace-1");
+        assert_eq!(job["resultEnvelopes"].as_array().unwrap().len(), 1);
+        assert_eq!(job["resultEnvelopes"][0]["envelope"], job["envelope"]);
+        assert!(job["resultEnvelopes"][0]["envelopeId"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn replaying_result_envelope_is_idempotent() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let script = write_fake_executor_script(temp.path())?;
+        register_dispatchable_node(
+            &temp,
+            "node_compute",
+            "compute_executor",
+            &script.to_string_lossy(),
+            r#"["shell","gpu"]"#,
+        )?;
+        let request = r#"{
+            "jobId":"job_replayed",
+            "command":["echo","hello"],
+            "requiredCapabilities":["gpu"]
+        }"#;
+
+        let (first_status, first) =
+            post(&temp, "/api/v1/hub/nodes/node_compute/dispatch", request)?;
+        let (replay_status, replay) =
+            post(&temp, "/api/v1/hub/nodes/node_compute/dispatch", request)?;
+
+        assert_eq!(first_status, 200);
+        assert_eq!(replay_status, 200);
+        assert_eq!(first["envelope"], replay["envelope"]);
+        let (_, dispatch) = get(&temp, "/api/v1/hub/dispatches/job_replayed")?;
+        assert_eq!(dispatch["status"], "completed");
+        assert_eq!(dispatch["resultEnvelopes"].as_array().unwrap().len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn replaying_older_results_does_not_regress_newer_hub_state() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let mut conn = crate::store::open_store(&super::store_path(temp.path()))?;
+        let mut node = crate::store::NodeRecord {
+            node_id: "node_replay".to_string(),
+            role: "compute_executor".to_string(),
+            transport: "local".to_string(),
+            transport_config_json: None,
+            capabilities_json: r#"["shell"]"#.to_string(),
+            available: true,
+            queue_pressure: 0,
+            last_health_at: "2026-08-09T00:00:00Z".to_string(),
+            last_error: None,
+            registered_at: "2026-08-09T00:00:00Z".to_string(),
+            updated_at: "2026-08-09T00:00:00Z".to_string(),
+        };
+        crate::store::upsert_node(&conn, &node)?;
+        let job = crate::executor_node::ExecutorJob {
+            protocol_version: crate::executor_node::EXECUTOR_PROTOCOL_VERSION.to_string(),
+            job_id: "job_replay_order".to_string(),
+            hub_id: Some("hub_test".to_string()),
+            required_capabilities: vec!["shell".to_string()],
+            command: vec!["echo".to_string(), "hello".to_string()],
+            cwd: None,
+            env: std::collections::BTreeMap::new(),
+            stdin: None,
+            timeout_seconds: Some(30),
+            context: None,
+        };
+        let job_json = serde_json::to_string(&job)?;
+        crate::store::upsert_hub_job(
+            &conn,
+            &crate::store::HubJobRecord {
+                job_id: job.job_id.clone(),
+                state: "assigned".to_string(),
+                priority: 0,
+                required_capabilities_json: r#"["shell"]"#.to_string(),
+                assigned_node_id: Some(node.node_id.clone()),
+                loop_id: None,
+                payload_json: "{}".to_string(),
+                created_at: "2026-08-09T00:00:00Z".to_string(),
+                updated_at: "2026-08-09T00:00:00Z".to_string(),
+            },
+        )?;
+        let failed = crate::executor_node::ExecutorResultEnvelope {
+            protocol_version: crate::executor_node::EXECUTOR_PROTOCOL_VERSION.to_string(),
+            job_id: job.job_id.clone(),
+            status: crate::executor_node::RESULT_STATUS_FAILED.to_string(),
+            exit_code: Some(1),
+            stdout: String::new(),
+            stderr: "failed".to_string(),
+            started_at: "2026-08-09T00:00:01Z".to_string(),
+            finished_at: "2026-08-09T00:00:02Z".to_string(),
+            duration_ms: 1_000,
+            error: None,
+        };
+        let transport_error = crate::executor_node::ExecutorResultEnvelope {
+            protocol_version: crate::executor_node::EXECUTOR_PROTOCOL_VERSION.to_string(),
+            job_id: job.job_id.clone(),
+            status: crate::executor_node::RESULT_STATUS_TRANSPORT_ERROR.to_string(),
+            exit_code: None,
+            stdout: String::new(),
+            stderr: String::new(),
+            started_at: "2026-08-09T00:00:03Z".to_string(),
+            finished_at: "2026-08-09T00:00:04Z".to_string(),
+            duration_ms: 1_000,
+            error: Some("connection refused".to_string()),
+        };
+        let completed = crate::executor_node::ExecutorResultEnvelope {
+            protocol_version: crate::executor_node::EXECUTOR_PROTOCOL_VERSION.to_string(),
+            job_id: job.job_id.clone(),
+            status: crate::executor_node::RESULT_STATUS_COMPLETED.to_string(),
+            exit_code: Some(0),
+            stdout: "done".to_string(),
+            stderr: String::new(),
+            started_at: "2026-08-09T00:00:05Z".to_string(),
+            finished_at: "2026-08-09T00:00:06Z".to_string(),
+            duration_ms: 1_000,
+            error: None,
+        };
+
+        super::persist_dispatch_result(
+            &mut conn,
+            &mut node,
+            &job,
+            &job_json,
+            &failed,
+            "2026-08-09T00:00:01Z",
+            "2026-08-09T00:00:02Z",
+        )?;
+        super::persist_dispatch_result(
+            &mut conn,
+            &mut node,
+            &job,
+            &job_json,
+            &transport_error,
+            "2026-08-09T00:00:03Z",
+            "2026-08-09T00:00:04Z",
+        )?;
+        super::persist_dispatch_result(
+            &mut conn,
+            &mut node,
+            &job,
+            &job_json,
+            &completed,
+            "2026-08-09T00:00:05Z",
+            "2026-08-09T00:00:06Z",
+        )?;
+        super::persist_dispatch_result(
+            &mut conn,
+            &mut node,
+            &job,
+            &job_json,
+            &failed,
+            "2026-08-09T00:00:01Z",
+            "2026-08-09T00:00:02Z",
+        )?;
+        super::persist_dispatch_result(
+            &mut conn,
+            &mut node,
+            &job,
+            &job_json,
+            &transport_error,
+            "2026-08-09T00:00:03Z",
+            "2026-08-09T00:00:04Z",
+        )?;
+
+        let dispatch =
+            crate::store::get_executor_dispatch(&conn, &job.job_id)?.expect("dispatch persists");
+        let hub_job = crate::store::get_hub_job(&conn, &job.job_id)?.expect("hub job persists");
+        let stored_node =
+            crate::store::get_node(&conn, &node.node_id)?.expect("node state persists");
+        assert_eq!(dispatch.status, "completed");
+        assert_eq!(hub_job.state, "completed");
+        assert!(stored_node.available);
+        assert!(stored_node.last_error.is_none());
+        assert_eq!(
+            crate::store::list_executor_result_envelopes(&conn, &job.job_id)?.len(),
+            3
+        );
         Ok(())
     }
 

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -289,6 +289,15 @@ pub struct ExecutorDispatchRecord {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutorResultEnvelopeRecord {
+    pub envelope_id: String,
+    pub job_id: String,
+    pub node_id: String,
+    pub envelope_json: String,
+    pub recorded_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct HubJobRecord {
     pub job_id: String,
     pub state: String,
@@ -732,6 +741,34 @@ fn initialize_store_schema(conn: &Connection) -> Result<()> {
 
         CREATE INDEX IF NOT EXISTS idx_executor_dispatches_node
             ON executor_dispatches(node_id, updated_at DESC);
+
+        CREATE TABLE IF NOT EXISTS executor_result_envelopes (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            envelope_id TEXT UNIQUE NOT NULL,
+            job_id TEXT NOT NULL,
+            node_id TEXT NOT NULL,
+            envelope_json TEXT NOT NULL,
+            recorded_at TEXT NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_executor_result_envelopes_job
+            ON executor_result_envelopes(job_id, sequence);
+
+        INSERT OR IGNORE INTO executor_result_envelopes (
+            envelope_id,
+            job_id,
+            node_id,
+            envelope_json,
+            recorded_at
+        )
+        SELECT
+            'legacy:' || job_id,
+            job_id,
+            node_id,
+            envelope_json,
+            updated_at
+        FROM executor_dispatches
+        WHERE envelope_json IS NOT NULL;
 
         CREATE TABLE IF NOT EXISTS hub_jobs (
             job_id TEXT PRIMARY KEY NOT NULL,
@@ -1695,6 +1732,36 @@ pub fn upsert_executor_dispatch(conn: &Connection, record: &ExecutorDispatchReco
     Ok(())
 }
 
+pub fn insert_executor_dispatch_if_absent(
+    conn: &Connection,
+    record: &ExecutorDispatchRecord,
+) -> Result<bool> {
+    let affected = conn
+        .execute(
+            "INSERT INTO executor_dispatches (
+                job_id,
+                node_id,
+                status,
+                job_json,
+                envelope_json,
+                created_at,
+                updated_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+            ON CONFLICT(job_id) DO NOTHING",
+            params![
+                &record.job_id,
+                &record.node_id,
+                &record.status,
+                &record.job_json,
+                &record.envelope_json,
+                &record.created_at,
+                &record.updated_at,
+            ],
+        )
+        .with_context(|| format!("failed to insert executor dispatch {}", record.job_id))?;
+    Ok(affected == 1)
+}
+
 pub fn get_executor_dispatch(
     conn: &Connection,
     job_id: &str,
@@ -1719,6 +1786,69 @@ pub fn get_executor_dispatch(
     )
     .optional()
     .with_context(|| format!("failed to read executor dispatch {job_id}"))
+}
+
+pub fn append_executor_result_envelope(
+    conn: &Connection,
+    record: &ExecutorResultEnvelopeRecord,
+) -> Result<bool> {
+    let affected = conn
+        .execute(
+            "INSERT INTO executor_result_envelopes (
+                envelope_id,
+                job_id,
+                node_id,
+                envelope_json,
+                recorded_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5)
+            ON CONFLICT(envelope_id) DO NOTHING",
+            params![
+                &record.envelope_id,
+                &record.job_id,
+                &record.node_id,
+                &record.envelope_json,
+                &record.recorded_at,
+            ],
+        )
+        .with_context(|| {
+            format!(
+                "failed to append executor result envelope {}",
+                record.envelope_id
+            )
+        })?;
+    Ok(affected == 1)
+}
+
+pub fn list_executor_result_envelopes(
+    conn: &Connection,
+    job_id: &str,
+) -> Result<Vec<ExecutorResultEnvelopeRecord>> {
+    let mut statement = conn
+        .prepare(
+            "SELECT envelope_id, job_id, node_id, envelope_json, recorded_at
+             FROM executor_result_envelopes
+             WHERE job_id = ?1
+             ORDER BY sequence",
+        )
+        .with_context(|| format!("failed to prepare executor result envelope list {job_id}"))?;
+    let rows = statement
+        .query_map(params![job_id], |row| {
+            Ok(ExecutorResultEnvelopeRecord {
+                envelope_id: row.get(0)?,
+                job_id: row.get(1)?,
+                node_id: row.get(2)?,
+                envelope_json: row.get(3)?,
+                recorded_at: row.get(4)?,
+            })
+        })
+        .with_context(|| format!("failed to list executor result envelopes {job_id}"))?;
+    let mut records = Vec::new();
+    for row in rows {
+        records.push(
+            row.with_context(|| format!("failed to read executor result envelope {job_id}"))?,
+        );
+    }
+    Ok(records)
 }
 
 pub fn upsert_hub_job(conn: &Connection, record: &HubJobRecord) -> Result<()> {
@@ -4617,6 +4747,78 @@ END;
         );
         assert_eq!(record.created_at, "2026-07-06T00:00:00Z");
         assert!(get_executor_dispatch(&reopened, "job-missing")?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn executor_result_envelopes_are_append_only_and_replay_safe() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("coven.db");
+        let conn = open_store(&path)?;
+        let first = ExecutorResultEnvelopeRecord {
+            envelope_id: "sha256:first".to_string(),
+            job_id: "job-1".to_string(),
+            node_id: "node-gpu".to_string(),
+            envelope_json: r#"{"jobId":"job-1","status":"completed"}"#.to_string(),
+            recorded_at: "2026-08-09T00:00:00Z".to_string(),
+        };
+        let second = ExecutorResultEnvelopeRecord {
+            envelope_id: "sha256:second".to_string(),
+            job_id: "job-1".to_string(),
+            node_id: "node-gpu".to_string(),
+            envelope_json: r#"{"jobId":"job-1","status":"failed"}"#.to_string(),
+            recorded_at: "2026-08-09T00:01:00Z".to_string(),
+        };
+
+        assert!(append_executor_result_envelope(&conn, &first)?);
+        assert!(!append_executor_result_envelope(&conn, &first)?);
+        assert!(append_executor_result_envelope(&conn, &second)?);
+        drop(conn);
+
+        let reopened = open_store(&path)?;
+        assert_eq!(
+            list_executor_result_envelopes(&reopened, "job-1")?,
+            vec![first, second]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn executor_result_envelopes_backfill_legacy_dispatch_results() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("legacy.db");
+        let legacy = Connection::open(&path)?;
+        legacy.execute_batch(
+            "CREATE TABLE executor_dispatches (
+                job_id TEXT PRIMARY KEY NOT NULL,
+                node_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                job_json TEXT NOT NULL,
+                envelope_json TEXT,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            INSERT INTO executor_dispatches (
+                job_id, node_id, status, job_json, envelope_json, created_at, updated_at
+            ) VALUES (
+                'job-legacy',
+                'node-legacy',
+                'completed',
+                '{\"jobId\":\"job-legacy\"}',
+                '{\"jobId\":\"job-legacy\",\"status\":\"completed\"}',
+                '2026-07-06T00:00:00Z',
+                '2026-07-06T00:01:00Z'
+            );",
+        )?;
+        drop(legacy);
+
+        let conn = open_store(&path)?;
+        let records = list_executor_result_envelopes(&conn, "job-legacy")?;
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].envelope_id, "legacy:job-legacy");
+        assert_eq!(records[0].node_id, "node-legacy");
+        assert_eq!(records[0].recorded_at, "2026-07-06T00:01:00Z");
         Ok(())
     }
 

--- a/docs/superpowers/plans/2026-08-09-spoke-result-ledger.md
+++ b/docs/superpowers/plans/2026-08-09-spoke-result-ledger.md
@@ -1,0 +1,241 @@
+# Spoke Result Ledger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make hub-captured spoke result envelopes append-only and idempotent to replay without changing the existing SSH dispatcher contract.
+
+**Architecture:** Add an immutable SQLite result ledger keyed by a deterministic digest of node identity plus canonical envelope JSON. Keep the existing per-job dispatch row as a latest-state projection, and persist the ledger append plus all result-derived hub state in one transaction.
+
+**Tech Stack:** Rust 2021, rusqlite, serde/serde_json, sha2, Coven daemon API.
+
+---
+
+### Task 1: Add the immutable result ledger
+
+**Files:**
+- Modify: `crates/coven-cli/src/store.rs:274-283`
+- Modify: `crates/coven-cli/src/store.rs:716-727`
+- Modify: `crates/coven-cli/src/store.rs:1647-1702`
+- Test: `crates/coven-cli/src/store.rs:4531-4564`
+
+- [ ] **Step 1: Write failing store tests**
+
+Add tests that append one `ExecutorResultEnvelopeRecord` twice and assert the
+second append returns `false`, then append a different envelope for the same job
+and assert both rows are returned in insertion order. Reopen the database before
+the final assertions to prove durability.
+
+```rust
+assert!(append_executor_result_envelope(&conn, &first)?);
+assert!(!append_executor_result_envelope(&conn, &first)?);
+assert!(append_executor_result_envelope(&conn, &second)?);
+drop(conn);
+let reopened = open_store(&path)?;
+assert_eq!(list_executor_result_envelopes(&reopened, "job-1")?, vec![first, second]);
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p coven-cli store::tests::executor_result_envelopes_are_append_only_and_replay_safe
+```
+
+Expected: compilation fails because the record and functions do not exist.
+
+- [ ] **Step 3: Add schema, record type, and store functions**
+
+Create `ExecutorResultEnvelopeRecord`, the append-only
+`executor_result_envelopes` table, and an index on `(job_id, sequence)`.
+Implement insertion with `INSERT OR IGNORE` and return `affected == 1`.
+Implement ordered retrieval by job ID. Backfill existing non-null latest
+envelopes with deterministic `legacy:<job_id>` IDs:
+
+```sql
+INSERT OR IGNORE INTO executor_result_envelopes (
+    envelope_id, job_id, node_id, envelope_json, recorded_at
+)
+SELECT 'legacy:' || job_id, job_id, node_id, envelope_json, updated_at
+FROM executor_dispatches
+WHERE envelope_json IS NOT NULL;
+```
+
+- [ ] **Step 4: Run focused store tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli store::tests::executor_result_envelopes
+```
+
+Expected: all matching tests pass.
+
+### Task 2: Persist result-derived hub state atomically
+
+**Files:**
+- Modify: `crates/coven-cli/src/hub.rs:768-920`
+- Test: `crates/coven-cli/src/hub.rs:1953-2072`
+
+- [ ] **Step 1: Write a failing hub replay test**
+
+Extract result persistence behind a helper and call it twice with the same
+envelope. Assert one ledger row exists, the latest dispatch projection remains
+terminal, and a matching hub job remains in the same terminal state.
+
+```rust
+persist_dispatch_result(&mut conn, &node, &job, &envelope, &created_at, &finished_at)?;
+persist_dispatch_result(&mut conn, &node, &job, &envelope, &created_at, &finished_at)?;
+assert_eq!(store::list_executor_result_envelopes(&conn, &job.job_id)?.len(), 1);
+assert_eq!(store::get_hub_job(&conn, &job.job_id)?.unwrap().state, "completed");
+```
+
+- [ ] **Step 2: Run the focused hub test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p coven-cli hub::tests::replaying_result_envelope_is_idempotent
+```
+
+Expected: compilation fails because `persist_dispatch_result` does not exist.
+
+- [ ] **Step 3: Implement deterministic envelope IDs**
+
+Serialize the typed envelope once and hash the node ID, a zero separator, and
+the JSON bytes with SHA-256. Encode the digest as lowercase hex:
+
+```rust
+let mut digest = Sha256::new();
+digest.update(node_id.as_bytes());
+digest.update([0]);
+digest.update(envelope_json.as_bytes());
+let envelope_id = format!("sha256:{}", hex_digest(digest.finalize()));
+```
+
+- [ ] **Step 4: Implement transactional persistence**
+
+Move post-dispatch writes into `persist_dispatch_result`. Start one rusqlite
+transaction, append the immutable envelope, update `executor_dispatches`, apply
+the terminal hub-job state, update node availability/error, transition held
+jobs, and synchronize the executor subqueue before committing. Duplicate
+envelopes return before projection updates, so an older replay cannot overwrite
+newer hub state.
+
+- [ ] **Step 5: Run focused hub and executor tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli hub::tests::replaying_result_envelope_is_idempotent
+cargo test -p coven-cli --test executor_protocol
+```
+
+Expected: both commands pass.
+
+### Task 3: Expose immutable result history
+
+**Files:**
+- Modify: `crates/coven-cli/src/hub.rs:922-951`
+- Modify: `specs/coven-multi-host-daemon/TECH.md:302-329`
+- Test: `crates/coven-cli/src/hub.rs:2023-2072`
+
+- [ ] **Step 1: Extend the hub dispatch test**
+
+After a successful fake-executor dispatch, assert the response from
+`GET /api/v1/hub/dispatches/:jobId` includes one ledger entry with a stable
+`envelopeId` and the same envelope as the compatibility projection.
+
+```rust
+assert_eq!(job["resultEnvelopes"].as_array().unwrap().len(), 1);
+assert_eq!(job["resultEnvelopes"][0]["envelope"], job["envelope"]);
+assert!(job["resultEnvelopes"][0]["envelopeId"]
+    .as_str()
+    .unwrap()
+    .starts_with("sha256:"));
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run:
+
+```bash
+cargo test -p coven-cli hub::tests::hub_polls_and_dispatches_outbound_and_records_executor_state
+```
+
+Expected: assertion fails because `resultEnvelopes` is absent.
+
+- [ ] **Step 3: Add result history to the response**
+
+Load the ordered ledger rows, parse each envelope JSON, and serialize them as:
+
+```json
+{
+  "envelopeId": "sha256:...",
+  "jobId": "job_...",
+  "nodeId": "node_...",
+  "envelope": {},
+  "recordedAt": "..."
+}
+```
+
+Update the multi-host technical spec to identify this collection as the
+append-only, replay-safe authority while `envelope` remains the latest
+projection.
+
+- [ ] **Step 4: Run targeted protocol tests**
+
+Run:
+
+```bash
+cargo test -p coven-cli hub::tests
+cargo test -p coven-cli store::tests::executor_result_envelopes
+cargo test -p coven-cli --test executor_protocol
+```
+
+Expected: all tests pass.
+
+### Task 4: Validate repository gates
+
+**Files:**
+- Verify all modified files.
+
+- [ ] **Step 1: Format and lint**
+
+Run:
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: both commands exit successfully with no warnings.
+
+- [ ] **Step 2: Run the workspace tests**
+
+Run:
+
+```bash
+cargo test --workspace --locked
+```
+
+Expected: all workspace tests pass.
+
+- [ ] **Step 3: Run safety checks**
+
+Run:
+
+```bash
+python scripts/check-secrets.py
+git add crates/coven-cli/src/store.rs crates/coven-cli/src/hub.rs specs/coven-multi-host-daemon/TECH.md docs/superpowers/specs/2026-08-09-spoke-result-ledger-design.md docs/superpowers/plans/2026-08-09-spoke-result-ledger.md
+python3 scripts/check-coven-privacy.py --staged
+```
+
+Expected: both scripts report no violations.
+
+- [ ] **Step 4: Commit the completed change**
+
+```bash
+git commit -s -m "fix: make spoke result envelopes append-only" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```

--- a/docs/superpowers/specs/2026-08-09-spoke-result-ledger-design.md
+++ b/docs/superpowers/specs/2026-08-09-spoke-result-ledger-design.md
@@ -1,0 +1,69 @@
+# Spoke Result Ledger Design
+
+## Context
+
+Issue #267 already provides the shared `coven.executor.v1` protocol, outbound
+SSH/local dispatch, hub-initiated health polls, normalized result envelopes,
+and durable latest-state dispatch records. The migrated Phase 1B acceptance
+criteria additionally require result envelopes to be append-only and safe to
+replay. The current `executor_dispatches` row is keyed by `job_id` and updates
+`envelope_json` in place, so it is a useful projection but not an immutable
+history.
+
+## Decision
+
+Keep `executor_dispatches` as the backward-compatible latest-state projection
+and add `executor_result_envelopes` as the authoritative append-only ledger.
+Each ledger entry contains:
+
+- a deterministic envelope ID derived from the node ID and canonical serialized
+  envelope;
+- the job and node IDs;
+- the exact normalized envelope JSON; and
+- the hub recording timestamp.
+
+The deterministic ID makes replay idempotent: inserting the same envelope for
+the same node is a complete no-op, including its derived projections, while a
+different attempt or result remains a distinct entry. Rows are inserted with
+conflict-ignore semantics and are never updated or deleted by the spoke
+protocol.
+
+## Persistence Flow
+
+The hub writes the pre-dispatch projection before starting transport, preserving
+evidence if the hub exits during SSH execution. Once a normalized envelope is
+available, one SQLite transaction:
+
+1. appends the envelope to the immutable ledger;
+2. updates the latest-state dispatch projection;
+3. advances a matching hub job when the result is terminal;
+4. updates node availability and its last error; and
+5. holds or resumes assigned jobs and refreshes the persistent node subqueue.
+
+Replaying an envelope does not append a duplicate ledger entry or reapply older
+state over newer projections. Existing databases backfill each non-null legacy
+`executor_dispatches.envelope_json` as one `legacy:<job_id>` ledger row during
+store initialization.
+
+## API Compatibility
+
+`GET /api/v1/hub/dispatches/:jobId` retains its existing `envelope` field and
+adds `resultEnvelopes`, ordered by append sequence. Existing clients continue to
+read the latest projection; audit and recovery clients can replay the immutable
+history.
+
+## Failure Semantics
+
+Transport failures remain normalized as `transport_error` envelopes and are
+appended like successful results. A failed poll or dispatch marks the node
+unavailable without deleting or reassigning hub work. SQLite transaction
+failure returns an error and leaves the pre-dispatch evidence intact; it cannot
+partially append a result while omitting its hub-state projection.
+
+## Verification
+
+Store tests cover persistence across reopen, duplicate replay, distinct
+envelopes for one job, and legacy backfill. Hub tests cover result history in
+the dispatch API, replay idempotency, and unchanged node/job failure behavior.
+The existing executor protocol integration tests continue to cover stateless
+probe and run-job behavior.

--- a/specs/coven-multi-host-daemon/TECH.md
+++ b/specs/coven-multi-host-daemon/TECH.md
@@ -310,11 +310,17 @@ always see one shape).
   records capabilities, availability, and last error; availability
   transitions hold/resume the node's persistent subqueue.
 - `POST /api/v1/hub/nodes/:nodeId/dispatch` — hub dispatches a job outbound,
-  persists the dispatch record plus normalized envelope, treats the
-  attempt as an availability observation, and advances a matching
-  hub-queue job from the envelope.
+  appends the normalized envelope to an immutable result ledger, updates the
+  latest-state dispatch projection, treats the attempt as an availability
+  observation, and advances a matching hub-queue job from the envelope.
 - `GET /api/v1/hub/dispatches/:jobId` — durable dispatch record (job spec,
-  envelope, status).
+  latest envelope/status projection, and ordered `resultEnvelopes` ledger).
+
+Result ledger entries use deterministic envelope IDs derived from the executor
+node and canonical envelope JSON. Replaying the same envelope is idempotent:
+the append and its derived projection updates are ignored, so an older replay
+cannot replace newer hub state. Different attempts remain distinct, and ledger
+rows are never updated by the spoke protocol.
 
 Acceptance coverage for #267:
 
@@ -323,6 +329,7 @@ Acceptance coverage for #267:
 - job specs carry full context so executor nodes need no local durable
   authority;
 - executors return stdout/stderr/result metadata in a normalized envelope;
+- normalized result envelopes are append-only and safe to replay;
 - the hub records executor capability metadata and last-known
   availability; and
 - stationary and compute roles share the base protocol while advertising


### PR DESCRIPTION
> **Ready for review — but read *Status* first.** All four repository gates pass and the committed tests execute cleanly. The design itself is still incomplete: **0 of 17 plan steps are done**, and the commit was a safety-net snapshot taken by a session that did not author the work. Review it as a direction to confirm or redirect, not as a finished change.

## Context

Refs #267 (closed). Phase 1B landed the `coven.executor.v1` protocol, outbound SSH/local dispatch, health polls, and normalized result envelopes. One migrated acceptance criterion is still open: **result envelopes must be append-only and safe to replay.**

`executor_dispatches` is keyed by `job_id` and updates `envelope_json` in place, so it is a useful latest-state projection but not an immutable history — a replayed or superseded envelope overwrites its predecessor.

## Approach

Keep `executor_dispatches` as the backward-compatible projection and add `executor_result_envelopes` as the authoritative append-only ledger. Each entry holds a deterministic envelope ID derived from the node ID and canonical serialized envelope, the job/node IDs, the exact normalized envelope JSON, and the hub recording timestamp.

The deterministic ID makes replay idempotent: re-inserting the same envelope for the same node is a complete no-op including derived projections, while a different attempt or result stays a distinct entry. Rows use conflict-ignore semantics and are never updated or deleted by the spoke protocol.

## Status — what is actually true of this branch

| | |
| --- | --- |
| Plan steps complete | **0 of 17** across 4 tasks |
| `cargo check -p coven-cli` | passes (0 errors, 0 warnings) |
| `cargo fmt` / `clippy` / `cargo test` | **never run** |
| Tests added | 5 `#[test]` in `store.rs` / `hub.rs`, **not executed** |
| Authorship | not written by the session that committed it |

The commit is a safety-net snapshot: ~511 lines of code and 310 lines of design docs existed only in an uncommitted working tree whose worktree claim had expired, so any checkout, stash, or removal would have destroyed them. Its message is explicit that whoever owns this should *"amend, reset, or rewrite freely."*

## What I did here

Rebased onto `main` (was 46 behind, now 0) and pushed. No conflicts — only `store.rs` had moved, and the ledger additions did not collide with #732's `execution_binding` work. Content preserved byte-identically: 821 insertions / 48 deletions across 5 files before and after. `cargo check` re-run to confirm the rebase did not degrade the recorded state.

Pre-rebase tip `059ddc0` is preserved as branch `backup/267-pre-rebase-20260815` and tag `backup-267-pre-rebase`.

## Next steps for whoever picks this up

1. Work the 17 plan steps in `docs/superpowers/plans/2026-08-09-spoke-result-ledger.md`.
2. Run the gates that were never run — `cargo fmt --check`, `clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --locked`, `scripts/check-secrets.py`.
3. Execute the 5 committed tests; they have never run.
4. Decide whether a fresh issue should track this, since #267 is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Gate results (added after the draft was opened)

All four gates were run. **Nothing fails because of this branch.**

| Gate | Result |
| --- | --- |
| `cargo fmt --check` | **pass** (exit 0) |
| `cargo clippy -p coven-cli --all-targets -- -D warnings` | **pass** (exit 0, 0 warnings) |
| `scripts/check-secrets.py` | **pass** — no current-tree or history findings |
| `cargo test --workspace --locked` | 2058 passed, 3 failed — all pre-existing, see below |

### The 3 test failures are not this branch

`pty_runner::tests::pty_resize_watcher_updates_real_child_geometry` and
`pty_runner::tests::spawn_detached_starts_pty_and_returns_input_and_kill_handles`
fail **identically on `main`** when run serially — 1 passed / 2 failed on both. Pre-existing local macOS environment failures; CI is green on `main`.

`pty_runner::tests::codex_json_runner_reaps_a_pipe_holding_descendant_after_wrapper_exit`
passes serially on both `main` and this branch, and only fails under parallel load. Flaky, same family as the flake seen on #733.

### A trap worth recording for anyone testing this branch

A first run reported 3 *different* failures, all in `memory_import::tests`, which pass on `main`. That looked like a real regression. It is not — the error is:

```
Error: path must be shorter than SUN_LEN
```

Those tests bind a Unix domain socket, and the socket path is derived from the working directory. The worktree path is 68 characters versus 44 for the main checkout, which pushes it past the ~104-char `sun_path` limit. **The same commit passes all 3 from a 9-character path.**

So: test this branch from a short checkout path, or `memory_import` will fail for reasons that have nothing to do with the code.

### Status correction

The *Status* table above says fmt/clippy/tests were never run and the 5 committed tests never executed. That is no longer true — they now run and pass. What remains accurate: **0 of 17 plan steps are complete**, and the design is unfinished by its author's own account.


