### PR TITLE
feat(agents): recover the coven-agents crate from an unreferenced stash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "coven-agents"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "coven-cli"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/coven-afs", "crates/coven-cli", "crates/coven-memory", "crates/coven-relay"]
+members = ["crates/coven-afs", "crates/coven-agents", "crates/coven-cli", "crates/coven-memory", "crates/coven-relay"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/coven-agents/Cargo.toml
+++ b/crates/coven-agents/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "coven-agents"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Provider-neutral agent runtime primitives for OpenCoven"
+
+[dependencies]
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/coven-agents/README.md
+++ b/crates/coven-agents/README.md
@@ -1,0 +1,24 @@
+# coven-agents
+
+`coven-agents` is an experimental, provider-neutral Rust run loop for
+OpenCoven. It supplies the orchestration primitives that model adapters,
+applications, and familiar runtimes can share:
+
+- bounded model/tool loops
+- agent handoffs
+- blocking input and output guardrails
+- pluggable session journals
+- metadata-only lifecycle observation
+
+Input guardrails apply to the starting agent, and output guardrails apply to the
+agent that produces the final output. A `SessionStore` must serialize writers
+for each session id or implement optimistic concurrency control.
+
+The crate deliberately does not include an OpenAI client, a daemon command,
+MCP, sandbox execution, voice, or realtime transport. Those are adapters and
+application concerns. Keeping this crate as a workspace leaf also allows it to
+move into its own repository if the API stabilizes.
+
+The implementation was derived from public behavioral documentation and
+OpenCoven's existing runtime requirements, not from another SDK's source code.
+See the design document under `docs/superpowers/specs/`.

--- a/crates/coven-agents/src/agent.rs
+++ b/crates/coven-agents/src/agent.rs
@@ -1,0 +1,127 @@
+use std::{fmt, sync::Arc};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{InputGuardrail, Model, OutputGuardrail, Tool};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AgentId(String);
+
+impl AgentId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AgentId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl From<&str> for AgentId {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for AgentId {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Handoff {
+    pub name: String,
+    pub description: String,
+    pub target: AgentId,
+}
+
+impl Handoff {
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        target: impl Into<AgentId>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            target: target.into(),
+        }
+    }
+}
+
+pub struct Agent<C>
+where
+    C: Sync,
+{
+    pub(crate) id: AgentId,
+    pub(crate) name: String,
+    pub(crate) instructions: String,
+    pub(crate) model: Arc<dyn Model<C>>,
+    pub(crate) tools: Vec<Arc<dyn Tool<C>>>,
+    pub(crate) handoffs: Vec<Handoff>,
+    pub(crate) input_guardrails: Vec<Arc<dyn InputGuardrail<C>>>,
+    pub(crate) output_guardrails: Vec<Arc<dyn OutputGuardrail<C>>>,
+}
+
+impl<C> Agent<C>
+where
+    C: Sync,
+{
+    pub fn new(
+        id: impl Into<AgentId>,
+        name: impl Into<String>,
+        instructions: impl Into<String>,
+        model: Arc<dyn Model<C>>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            instructions: instructions.into(),
+            model,
+            tools: Vec::new(),
+            handoffs: Vec::new(),
+            input_guardrails: Vec::new(),
+            output_guardrails: Vec::new(),
+        }
+    }
+
+    pub fn id(&self) -> &AgentId {
+        &self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn instructions(&self) -> &str {
+        &self.instructions
+    }
+
+    pub fn with_tool(mut self, tool: Arc<dyn Tool<C>>) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    pub fn with_handoff(mut self, handoff: Handoff) -> Self {
+        self.handoffs.push(handoff);
+        self
+    }
+
+    pub fn with_input_guardrail(mut self, guardrail: Arc<dyn InputGuardrail<C>>) -> Self {
+        self.input_guardrails.push(guardrail);
+        self
+    }
+
+    pub fn with_output_guardrail(mut self, guardrail: Arc<dyn OutputGuardrail<C>>) -> Self {
+        self.output_guardrails.push(guardrail);
+        self
+    }
+}

--- a/crates/coven-agents/src/agent.rs
+++ b/crates/coven-agents/src/agent.rs
@@ -2,7 +2,7 @@ use std::{fmt, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{InputGuardrail, Model, OutputGuardrail, Tool};
+use crate::{InputGuardrail, Model, OutputGuardrail, Tool, ToolDefinition};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -57,6 +57,14 @@ impl Handoff {
     }
 }
 
+pub(crate) struct AgentTool<C>
+where
+    C: Sync,
+{
+    pub(crate) tool: Arc<dyn Tool<C>>,
+    pub(crate) definition: ToolDefinition,
+}
+
 pub struct Agent<C>
 where
     C: Sync,
@@ -65,7 +73,7 @@ where
     pub(crate) name: String,
     pub(crate) instructions: String,
     pub(crate) model: Arc<dyn Model<C>>,
-    pub(crate) tools: Vec<Arc<dyn Tool<C>>>,
+    pub(crate) tools: Vec<AgentTool<C>>,
     pub(crate) handoffs: Vec<Handoff>,
     pub(crate) input_guardrails: Vec<Arc<dyn InputGuardrail<C>>>,
     pub(crate) output_guardrails: Vec<Arc<dyn OutputGuardrail<C>>>,
@@ -106,7 +114,8 @@ where
     }
 
     pub fn with_tool(mut self, tool: Arc<dyn Tool<C>>) -> Self {
-        self.tools.push(tool);
+        let definition = tool.definition();
+        self.tools.push(AgentTool { tool, definition });
         self
     }
 

--- a/crates/coven-agents/src/error.rs
+++ b/crates/coven-agents/src/error.rs
@@ -1,0 +1,92 @@
+use thiserror::Error;
+
+use crate::AgentId;
+
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardrailStage {
+    Input,
+    Output,
+}
+
+impl std::fmt::Display for GuardrailStage {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Input => formatter.write_str("input"),
+            Self::Output => formatter.write_str("output"),
+        }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ConfigError {
+    #[error("at least one agent is required")]
+    NoAgents,
+    #[error("agent id `{0}` is registered more than once")]
+    DuplicateAgent(AgentId),
+    #[error("agent `{agent}` registers tool `{tool}` more than once")]
+    DuplicateTool { agent: AgentId, tool: String },
+    #[error("agent `{agent}` registers handoff `{handoff}` more than once")]
+    DuplicateHandoff { agent: AgentId, handoff: String },
+    #[error("agent `{agent}` handoff `{handoff}` targets unknown agent `{target}`")]
+    UnknownHandoffTarget {
+        agent: AgentId,
+        handoff: String,
+        target: AgentId,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum RunError {
+    #[error("starting agent `{0}` is not registered")]
+    UnknownStartingAgent(AgentId),
+    #[error("runner configuration became invalid: {reason}")]
+    InvalidConfiguration { reason: String },
+    #[error("session id was provided but no session store is configured")]
+    SessionUnavailable,
+    #[error("session {operation} failed")]
+    SessionFailed {
+        operation: &'static str,
+        #[source]
+        source: BoxError,
+    },
+    #[error("model call for agent `{agent}` failed")]
+    ModelFailed {
+        agent: AgentId,
+        #[source]
+        source: BoxError,
+    },
+    #[error("{stage} guardrail `{guardrail}` for agent `{agent}` failed")]
+    GuardrailFailed {
+        agent: AgentId,
+        guardrail: String,
+        stage: GuardrailStage,
+        #[source]
+        source: BoxError,
+    },
+    #[error("{stage} guardrail `{guardrail}` for agent `{agent}` rejected the run: {reason}")]
+    GuardrailRejected {
+        agent: AgentId,
+        guardrail: String,
+        stage: GuardrailStage,
+        reason: String,
+    },
+    #[error("agent `{agent}` requested unknown tool `{tool}`")]
+    UnknownTool { agent: AgentId, tool: String },
+    #[error("tool `{tool}` for agent `{agent}` failed")]
+    ToolFailed {
+        agent: AgentId,
+        tool: String,
+        #[source]
+        source: BoxError,
+    },
+    #[error("agent `{agent}` requested unknown handoff `{handoff}`")]
+    UnknownHandoff { agent: AgentId, handoff: String },
+    #[error("agent `{agent}` returned an invalid model response: {reason}")]
+    InvalidModelResponse { agent: AgentId, reason: String },
+    #[error("run exceeded the maximum of {limit} model turns")]
+    MaxTurnsExceeded { limit: usize },
+    #[error("run exceeded the maximum of {limit} handoffs")]
+    MaxHandoffsExceeded { limit: usize },
+}

--- a/crates/coven-agents/src/guardrail.rs
+++ b/crates/coven-agents/src/guardrail.rs
@@ -1,0 +1,43 @@
+use async_trait::async_trait;
+
+use crate::BoxError;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuardrailVerdict {
+    Allow,
+    Reject { reason: String },
+}
+
+impl GuardrailVerdict {
+    pub fn reject(reason: impl Into<String>) -> Self {
+        Self::Reject {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[async_trait]
+/// Checks the original user input before the starting agent runs.
+///
+/// Input guardrails attached only to handoff targets do not run in this MVP.
+pub trait InputGuardrail<C>: Send + Sync
+where
+    C: Sync,
+{
+    fn name(&self) -> &str;
+
+    async fn check(&self, input: &str, context: &C) -> Result<GuardrailVerdict, BoxError>;
+}
+
+#[async_trait]
+/// Checks the final output produced by the agent that completes the run.
+///
+/// Output guardrails on intermediate agents do not run in this MVP.
+pub trait OutputGuardrail<C>: Send + Sync
+where
+    C: Sync,
+{
+    fn name(&self) -> &str;
+
+    async fn check(&self, output: &str, context: &C) -> Result<GuardrailVerdict, BoxError>;
+}

--- a/crates/coven-agents/src/lib.rs
+++ b/crates/coven-agents/src/lib.rs
@@ -1,0 +1,25 @@
+//! Provider-neutral agent runtime primitives for OpenCoven.
+//!
+//! The crate owns deterministic orchestration, not provider transport,
+//! persistence, sandboxing, or user interface concerns.
+
+mod agent;
+mod error;
+mod guardrail;
+mod model;
+mod observer;
+mod runner;
+mod session;
+mod tool;
+
+pub use agent::{Agent, AgentId, Handoff};
+pub use error::{BoxError, ConfigError, GuardrailStage, RunError};
+pub use guardrail::{GuardrailVerdict, InputGuardrail, OutputGuardrail};
+pub use model::{
+    HandoffCall, HandoffDefinition, Model, ModelAction, ModelRequest, ModelResponse, RunItem,
+    ToolCall,
+};
+pub use observer::{NoopObserver, RunEvent, RunFailureKind, RunObserver};
+pub use runner::{RunOptions, RunResult, Runner};
+pub use session::{InMemorySession, SessionStore};
+pub use tool::{Tool, ToolDefinition};

--- a/crates/coven-agents/src/model.rs
+++ b/crates/coven-agents/src/model.rs
@@ -1,0 +1,115 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{AgentId, BoxError, ToolDefinition};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: Value,
+}
+
+impl ToolCall {
+    pub fn new(id: impl Into<String>, name: impl Into<String>, arguments: Value) -> Self {
+        Self {
+            id: id.into(),
+            name: name.into(),
+            arguments,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandoffCall {
+    pub name: String,
+}
+
+impl HandoffCall {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HandoffDefinition {
+    pub name: String,
+    pub description: String,
+    pub target: AgentId,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ModelAction {
+    ToolCall(ToolCall),
+    Handoff(HandoffCall),
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModelResponse {
+    pub assistant_message: Option<String>,
+    pub actions: Vec<ModelAction>,
+}
+
+impl ModelResponse {
+    pub fn final_output(output: impl Into<String>) -> Self {
+        Self {
+            assistant_message: Some(output.into()),
+            actions: Vec::new(),
+        }
+    }
+
+    pub fn actions(actions: Vec<ModelAction>) -> Self {
+        Self {
+            assistant_message: None,
+            actions,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RunItem {
+    UserMessage {
+        content: String,
+    },
+    AssistantMessage {
+        agent: AgentId,
+        content: String,
+    },
+    ToolCall {
+        agent: AgentId,
+        call: ToolCall,
+    },
+    ToolResult {
+        agent: AgentId,
+        call_id: String,
+        tool: String,
+        output: Value,
+    },
+    Handoff {
+        from: AgentId,
+        to: AgentId,
+        name: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ModelRequest {
+    pub agent_id: AgentId,
+    pub agent_name: String,
+    pub instructions: String,
+    pub items: Vec<RunItem>,
+    pub tools: Vec<ToolDefinition>,
+    pub handoffs: Vec<HandoffDefinition>,
+}
+
+#[async_trait]
+pub trait Model<C>: Send + Sync
+where
+    C: Sync,
+{
+    async fn generate(&self, request: ModelRequest, context: &C)
+        -> Result<ModelResponse, BoxError>;
+}

--- a/crates/coven-agents/src/observer.rs
+++ b/crates/coven-agents/src/observer.rs
@@ -1,0 +1,66 @@
+use crate::{AgentId, GuardrailStage};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunFailureKind {
+    Configuration,
+    Session,
+    InputGuardrail,
+    OutputGuardrail,
+    Model,
+    Tool,
+    Handoff,
+    InvalidResponse,
+    Limit,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunEvent {
+    RunStarted {
+        starting_agent: AgentId,
+    },
+    GuardrailChecked {
+        agent: AgentId,
+        guardrail: String,
+        stage: GuardrailStage,
+        allowed: bool,
+    },
+    ModelRequested {
+        agent: AgentId,
+        turn: usize,
+    },
+    ToolStarted {
+        agent: AgentId,
+        tool: String,
+        call_id: String,
+    },
+    ToolCompleted {
+        agent: AgentId,
+        tool: String,
+        call_id: String,
+    },
+    Handoff {
+        from: AgentId,
+        to: AgentId,
+        name: String,
+    },
+    RunCompleted {
+        final_agent: AgentId,
+        turns: usize,
+        handoffs: usize,
+    },
+    RunFailed {
+        agent: AgentId,
+        kind: RunFailureKind,
+    },
+}
+
+pub trait RunObserver: Send + Sync {
+    fn on_event(&self, event: &RunEvent);
+}
+
+#[derive(Debug, Default)]
+pub struct NoopObserver;
+
+impl RunObserver for NoopObserver {
+    fn on_event(&self, _event: &RunEvent) {}
+}

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -1,0 +1,480 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+use crate::{
+    Agent, AgentId, ConfigError, GuardrailStage, GuardrailVerdict, HandoffDefinition, ModelAction,
+    ModelRequest, NoopObserver, RunError, RunEvent, RunFailureKind, RunItem, RunObserver,
+    SessionStore,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunOptions {
+    pub max_turns: usize,
+    pub max_handoffs: usize,
+    pub session_id: Option<String>,
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self {
+            max_turns: 16,
+            max_handoffs: 8,
+            session_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RunResult {
+    pub final_output: String,
+    pub final_agent: AgentId,
+    pub new_items: Vec<RunItem>,
+    pub turns: usize,
+    pub handoffs: usize,
+}
+
+pub struct Runner<C>
+where
+    C: Sync,
+{
+    agents: BTreeMap<AgentId, Arc<Agent<C>>>,
+    session: Option<Arc<dyn SessionStore>>,
+    observer: Arc<dyn RunObserver>,
+}
+
+impl<C> Runner<C>
+where
+    C: Send + Sync + 'static,
+{
+    pub fn new(agents: impl IntoIterator<Item = Agent<C>>) -> Result<Self, ConfigError> {
+        let mut registered = BTreeMap::new();
+
+        for agent in agents {
+            let id = agent.id.clone();
+            if registered.insert(id.clone(), Arc::new(agent)).is_some() {
+                return Err(ConfigError::DuplicateAgent(id));
+            }
+        }
+
+        if registered.is_empty() {
+            return Err(ConfigError::NoAgents);
+        }
+
+        for agent in registered.values() {
+            let mut tool_names = BTreeSet::new();
+            for tool in &agent.tools {
+                let name = tool.definition().name;
+                if !tool_names.insert(name.clone()) {
+                    return Err(ConfigError::DuplicateTool {
+                        agent: agent.id.clone(),
+                        tool: name,
+                    });
+                }
+            }
+
+            let mut handoff_names = BTreeSet::new();
+            for handoff in &agent.handoffs {
+                if !handoff_names.insert(handoff.name.clone()) {
+                    return Err(ConfigError::DuplicateHandoff {
+                        agent: agent.id.clone(),
+                        handoff: handoff.name.clone(),
+                    });
+                }
+                if !registered.contains_key(&handoff.target) {
+                    return Err(ConfigError::UnknownHandoffTarget {
+                        agent: agent.id.clone(),
+                        handoff: handoff.name.clone(),
+                        target: handoff.target.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(Self {
+            agents: registered,
+            session: None,
+            observer: Arc::new(NoopObserver),
+        })
+    }
+
+    pub fn with_session(mut self, session: Arc<dyn SessionStore>) -> Self {
+        self.session = Some(session);
+        self
+    }
+
+    pub fn with_observer(mut self, observer: Arc<dyn RunObserver>) -> Self {
+        self.observer = observer;
+        self
+    }
+
+    fn fail(&self, agent: &AgentId, kind: RunFailureKind, error: RunError) -> RunError {
+        self.observer.on_event(&RunEvent::RunFailed {
+            agent: agent.clone(),
+            kind,
+        });
+        error
+    }
+
+    pub async fn run(
+        &self,
+        starting_agent: impl Into<AgentId>,
+        input: impl Into<String>,
+        context: &C,
+        options: RunOptions,
+    ) -> Result<RunResult, RunError> {
+        let starting_agent = starting_agent.into();
+        let mut current = self.agents.get(&starting_agent).cloned().ok_or_else(|| {
+            self.fail(
+                &starting_agent,
+                RunFailureKind::Configuration,
+                RunError::UnknownStartingAgent(starting_agent.clone()),
+            )
+        })?;
+        let input = input.into();
+
+        self.observer.on_event(&RunEvent::RunStarted {
+            starting_agent: starting_agent.clone(),
+        });
+
+        for guardrail in &current.input_guardrails {
+            let verdict = guardrail.check(&input, context).await.map_err(|source| {
+                self.fail(
+                    &current.id,
+                    RunFailureKind::InputGuardrail,
+                    RunError::GuardrailFailed {
+                        agent: current.id.clone(),
+                        guardrail: guardrail.name().to_owned(),
+                        stage: GuardrailStage::Input,
+                        source,
+                    },
+                )
+            })?;
+            let allowed = verdict == GuardrailVerdict::Allow;
+            self.observer.on_event(&RunEvent::GuardrailChecked {
+                agent: current.id.clone(),
+                guardrail: guardrail.name().to_owned(),
+                stage: GuardrailStage::Input,
+                allowed,
+            });
+            if let GuardrailVerdict::Reject { reason } = verdict {
+                return Err(self.fail(
+                    &current.id,
+                    RunFailureKind::InputGuardrail,
+                    RunError::GuardrailRejected {
+                        agent: current.id.clone(),
+                        guardrail: guardrail.name().to_owned(),
+                        stage: GuardrailStage::Input,
+                        reason,
+                    },
+                ));
+            }
+        }
+
+        let mut new_items = vec![RunItem::UserMessage {
+            content: input.clone(),
+        }];
+        let mut model_items = match (&options.session_id, &self.session) {
+            (Some(session_id), Some(session)) => {
+                let mut items = session.load(session_id).await.map_err(|source| {
+                    self.fail(
+                        &current.id,
+                        RunFailureKind::Session,
+                        RunError::SessionFailed {
+                            operation: "load",
+                            source,
+                        },
+                    )
+                })?;
+                items.extend(new_items.clone());
+                items
+            }
+            (Some(_), None) => {
+                return Err(self.fail(
+                    &current.id,
+                    RunFailureKind::Session,
+                    RunError::SessionUnavailable,
+                ));
+            }
+            (None, _) => new_items.clone(),
+        };
+        let mut handoff_count = 0;
+
+        for turn in 1..=options.max_turns {
+            self.observer.on_event(&RunEvent::ModelRequested {
+                agent: current.id.clone(),
+                turn,
+            });
+
+            let request = ModelRequest {
+                agent_id: current.id.clone(),
+                agent_name: current.name.clone(),
+                instructions: current.instructions.clone(),
+                items: model_items.clone(),
+                tools: current.tools.iter().map(|tool| tool.definition()).collect(),
+                handoffs: current
+                    .handoffs
+                    .iter()
+                    .map(|handoff| HandoffDefinition {
+                        name: handoff.name.clone(),
+                        description: handoff.description.clone(),
+                        target: handoff.target.clone(),
+                    })
+                    .collect(),
+            };
+            let response = current
+                .model
+                .generate(request, context)
+                .await
+                .map_err(|source| {
+                    self.fail(
+                        &current.id,
+                        RunFailureKind::Model,
+                        RunError::ModelFailed {
+                            agent: current.id.clone(),
+                            source,
+                        },
+                    )
+                })?;
+
+            if let Some(message) = &response.assistant_message {
+                let item = RunItem::AssistantMessage {
+                    agent: current.id.clone(),
+                    content: message.clone(),
+                };
+                new_items.push(item.clone());
+                model_items.push(item);
+            }
+
+            if response.actions.is_empty() {
+                let output = response.assistant_message.ok_or_else(|| {
+                    self.fail(
+                        &current.id,
+                        RunFailureKind::InvalidResponse,
+                        RunError::InvalidModelResponse {
+                            agent: current.id.clone(),
+                            reason: "a response without actions must contain an assistant message"
+                                .to_owned(),
+                        },
+                    )
+                })?;
+
+                for guardrail in &current.output_guardrails {
+                    let verdict = guardrail.check(&output, context).await.map_err(|source| {
+                        self.fail(
+                            &current.id,
+                            RunFailureKind::OutputGuardrail,
+                            RunError::GuardrailFailed {
+                                agent: current.id.clone(),
+                                guardrail: guardrail.name().to_owned(),
+                                stage: GuardrailStage::Output,
+                                source,
+                            },
+                        )
+                    })?;
+                    let allowed = verdict == GuardrailVerdict::Allow;
+                    self.observer.on_event(&RunEvent::GuardrailChecked {
+                        agent: current.id.clone(),
+                        guardrail: guardrail.name().to_owned(),
+                        stage: GuardrailStage::Output,
+                        allowed,
+                    });
+                    if let GuardrailVerdict::Reject { reason } = verdict {
+                        return Err(self.fail(
+                            &current.id,
+                            RunFailureKind::OutputGuardrail,
+                            RunError::GuardrailRejected {
+                                agent: current.id.clone(),
+                                guardrail: guardrail.name().to_owned(),
+                                stage: GuardrailStage::Output,
+                                reason,
+                            },
+                        ));
+                    }
+                }
+
+                if let (Some(session_id), Some(session)) = (&options.session_id, &self.session) {
+                    session
+                        .append(session_id, &new_items)
+                        .await
+                        .map_err(|source| {
+                            self.fail(
+                                &current.id,
+                                RunFailureKind::Session,
+                                RunError::SessionFailed {
+                                    operation: "append",
+                                    source,
+                                },
+                            )
+                        })?;
+                }
+
+                self.observer.on_event(&RunEvent::RunCompleted {
+                    final_agent: current.id.clone(),
+                    turns: turn,
+                    handoffs: handoff_count,
+                });
+                return Ok(RunResult {
+                    final_output: output,
+                    final_agent: current.id.clone(),
+                    new_items,
+                    turns: turn,
+                    handoffs: handoff_count,
+                });
+            }
+
+            let handoff_actions = response
+                .actions
+                .iter()
+                .filter(|action| matches!(action, ModelAction::Handoff(_)))
+                .count();
+            if handoff_actions > 0 {
+                if response.actions.len() != 1 {
+                    return Err(self.fail(
+                        &current.id,
+                        RunFailureKind::InvalidResponse,
+                        RunError::InvalidModelResponse {
+                            agent: current.id.clone(),
+                            reason: "a handoff cannot be combined with other actions".to_owned(),
+                        },
+                    ));
+                }
+                handoff_count += 1;
+                if handoff_count > options.max_handoffs {
+                    return Err(self.fail(
+                        &current.id,
+                        RunFailureKind::Limit,
+                        RunError::MaxHandoffsExceeded {
+                            limit: options.max_handoffs,
+                        },
+                    ));
+                }
+
+                let [ModelAction::Handoff(call)] = response.actions.as_slice() else {
+                    return Err(self.fail(
+                        &current.id,
+                        RunFailureKind::InvalidResponse,
+                        RunError::InvalidModelResponse {
+                            agent: current.id.clone(),
+                            reason: "a handoff must be the only model action".to_owned(),
+                        },
+                    ));
+                };
+                let handoff = current
+                    .handoffs
+                    .iter()
+                    .find(|handoff| handoff.name == call.name)
+                    .ok_or_else(|| {
+                        self.fail(
+                            &current.id,
+                            RunFailureKind::Handoff,
+                            RunError::UnknownHandoff {
+                                agent: current.id.clone(),
+                                handoff: call.name.clone(),
+                            },
+                        )
+                    })?;
+                let target = self.agents.get(&handoff.target).cloned().ok_or_else(|| {
+                    self.fail(
+                        &current.id,
+                        RunFailureKind::Configuration,
+                        RunError::InvalidConfiguration {
+                            reason: format!(
+                                "validated handoff `{}` targets unavailable agent `{}`",
+                                handoff.name, handoff.target
+                            ),
+                        },
+                    )
+                })?;
+                let item = RunItem::Handoff {
+                    from: current.id.clone(),
+                    to: target.id.clone(),
+                    name: handoff.name.clone(),
+                };
+                new_items.push(item.clone());
+                model_items.push(item);
+                self.observer.on_event(&RunEvent::Handoff {
+                    from: current.id.clone(),
+                    to: target.id.clone(),
+                    name: handoff.name.clone(),
+                });
+                current = target;
+                continue;
+            }
+
+            for action in response.actions {
+                let ModelAction::ToolCall(call) = action else {
+                    return Err(self.fail(
+                        &current.id,
+                        RunFailureKind::InvalidResponse,
+                        RunError::InvalidModelResponse {
+                            agent: current.id.clone(),
+                            reason: "handoff action reached the tool execution path".to_owned(),
+                        },
+                    ));
+                };
+                let tool = current
+                    .tools
+                    .iter()
+                    .find(|tool| tool.definition().name == call.name)
+                    .ok_or_else(|| {
+                        self.fail(
+                            &current.id,
+                            RunFailureKind::Tool,
+                            RunError::UnknownTool {
+                                agent: current.id.clone(),
+                                tool: call.name.clone(),
+                            },
+                        )
+                    })?;
+                let call_item = RunItem::ToolCall {
+                    agent: current.id.clone(),
+                    call: call.clone(),
+                };
+                new_items.push(call_item.clone());
+                model_items.push(call_item);
+                self.observer.on_event(&RunEvent::ToolStarted {
+                    agent: current.id.clone(),
+                    tool: call.name.clone(),
+                    call_id: call.id.clone(),
+                });
+                let output = tool
+                    .execute(call.arguments, context)
+                    .await
+                    .map_err(|source| {
+                        self.fail(
+                            &current.id,
+                            RunFailureKind::Tool,
+                            RunError::ToolFailed {
+                                agent: current.id.clone(),
+                                tool: call.name.clone(),
+                                source,
+                            },
+                        )
+                    })?;
+                let result_item = RunItem::ToolResult {
+                    agent: current.id.clone(),
+                    call_id: call.id.clone(),
+                    tool: call.name.clone(),
+                    output,
+                };
+                new_items.push(result_item.clone());
+                model_items.push(result_item);
+                self.observer.on_event(&RunEvent::ToolCompleted {
+                    agent: current.id.clone(),
+                    tool: call.name,
+                    call_id: call.id,
+                });
+            }
+        }
+
+        Err(self.fail(
+            &current.id,
+            RunFailureKind::Limit,
+            RunError::MaxTurnsExceeded {
+                limit: options.max_turns,
+            },
+        ))
+    }
+}

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -65,7 +65,7 @@ where
         for agent in registered.values() {
             let mut tool_names = BTreeSet::new();
             for tool in &agent.tools {
-                let name = tool.definition().name;
+                let name = tool.definition.name.clone();
                 if !tool_names.insert(name.clone()) {
                     return Err(ConfigError::DuplicateTool {
                         agent: agent.id.clone(),
@@ -212,7 +212,11 @@ where
                 agent_name: current.name.clone(),
                 instructions: current.instructions.clone(),
                 items: model_items.clone(),
-                tools: current.tools.iter().map(|tool| tool.definition()).collect(),
+                tools: current
+                    .tools
+                    .iter()
+                    .map(|tool| tool.definition.clone())
+                    .collect(),
                 handoffs: current
                     .handoffs
                     .iter()
@@ -417,7 +421,7 @@ where
                 let tool = current
                     .tools
                     .iter()
-                    .find(|tool| tool.definition().name == call.name)
+                    .find(|tool| tool.definition.name == call.name)
                     .ok_or_else(|| {
                         self.fail(
                             &current.id,
@@ -439,20 +443,21 @@ where
                     tool: call.name.clone(),
                     call_id: call.id.clone(),
                 });
-                let output = tool
-                    .execute(call.arguments, context)
-                    .await
-                    .map_err(|source| {
-                        self.fail(
-                            &current.id,
-                            RunFailureKind::Tool,
-                            RunError::ToolFailed {
-                                agent: current.id.clone(),
-                                tool: call.name.clone(),
-                                source,
-                            },
-                        )
-                    })?;
+                let output =
+                    tool.tool
+                        .execute(call.arguments, context)
+                        .await
+                        .map_err(|source| {
+                            self.fail(
+                                &current.id,
+                                RunFailureKind::Tool,
+                                RunError::ToolFailed {
+                                    agent: current.id.clone(),
+                                    tool: call.name.clone(),
+                                    source,
+                                },
+                            )
+                        })?;
                 let result_item = RunItem::ToolResult {
                     agent: current.id.clone(),
                     call_id: call.id.clone(),

--- a/crates/coven-agents/src/session.rs
+++ b/crates/coven-agents/src/session.rs
@@ -1,0 +1,53 @@
+use std::{
+    collections::BTreeMap,
+    io,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+
+use crate::{BoxError, RunItem};
+
+#[async_trait]
+/// Conversation history storage for completed runs.
+///
+/// The runner performs separate load and append operations. Implementations
+/// must enforce a single writer per session id or provide their own optimistic
+/// concurrency control when concurrent runs can target the same session.
+pub trait SessionStore: Send + Sync {
+    async fn load(&self, session_id: &str) -> Result<Vec<RunItem>, BoxError>;
+
+    async fn append(&self, session_id: &str, items: &[RunItem]) -> Result<(), BoxError>;
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InMemorySession {
+    items: Arc<Mutex<BTreeMap<String, Vec<RunItem>>>>,
+}
+
+impl InMemorySession {
+    pub async fn items(&self, session_id: &str) -> Result<Vec<RunItem>, BoxError> {
+        self.load(session_id).await
+    }
+}
+
+#[async_trait]
+impl SessionStore for InMemorySession {
+    async fn load(&self, session_id: &str) -> Result<Vec<RunItem>, BoxError> {
+        let sessions = self.items.lock().map_err(|_| {
+            Box::new(io::Error::other("in-memory session lock poisoned")) as BoxError
+        })?;
+        Ok(sessions.get(session_id).cloned().unwrap_or_default())
+    }
+
+    async fn append(&self, session_id: &str, items: &[RunItem]) -> Result<(), BoxError> {
+        let mut sessions = self.items.lock().map_err(|_| {
+            Box::new(io::Error::other("in-memory session lock poisoned")) as BoxError
+        })?;
+        sessions
+            .entry(session_id.to_owned())
+            .or_default()
+            .extend_from_slice(items);
+        Ok(())
+    }
+}

--- a/crates/coven-agents/src/tool.rs
+++ b/crates/coven-agents/src/tool.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::BoxError;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+impl ToolDefinition {
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        input_schema: Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            input_schema,
+        }
+    }
+}
+
+#[async_trait]
+pub trait Tool<C>: Send + Sync
+where
+    C: Sync,
+{
+    fn definition(&self) -> ToolDefinition;
+
+    async fn execute(&self, arguments: Value, context: &C) -> Result<Value, BoxError>;
+}

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -86,6 +86,30 @@ impl Tool<()> for AddTool {
     }
 }
 
+struct CountingDefinitionTool {
+    definition_calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool<()> for CountingDefinitionTool {
+    fn definition(&self) -> ToolDefinition {
+        self.definition_calls.fetch_add(1, Ordering::SeqCst);
+        ToolDefinition::new(
+            "counted",
+            "Counts definition calls",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, _arguments: Value, _context: &()) -> Result<Value, BoxError> {
+        Ok(json!({ "ok": true }))
+    }
+}
+
 struct RejectInput;
 
 #[async_trait]
@@ -155,6 +179,33 @@ async fn executes_tools_and_returns_the_final_output() {
         RunItem::ToolResult { output, .. } if output == &json!({ "sum": 5 })
     )));
     assert_eq!(model.requests().len(), 2);
+}
+
+#[tokio::test]
+async fn caches_tool_definitions_across_turns() {
+    let model = Arc::new(QueueModel::new([
+        ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "counted",
+            json!({}),
+        ))]),
+        ModelResponse::final_output("Done."),
+    ]));
+    let definition_calls = Arc::new(AtomicUsize::new(0));
+    let agent = Agent::new("math", "Math", "Use the calculator.", model).with_tool(Arc::new(
+        CountingDefinitionTool {
+            definition_calls: definition_calls.clone(),
+        },
+    ));
+    let runner = Runner::new([agent]).unwrap();
+
+    let result = runner
+        .run("math", "Run the counted tool.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.turns, 2);
+    assert_eq!(definition_calls.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -1,0 +1,388 @@
+use std::{
+    collections::VecDeque,
+    io,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use async_trait::async_trait;
+use coven_agents::{
+    Agent, BoxError, ConfigError, GuardrailStage, GuardrailVerdict, Handoff, HandoffCall,
+    InMemorySession, InputGuardrail, Model, ModelAction, ModelRequest, ModelResponse,
+    OutputGuardrail, RunError, RunEvent, RunFailureKind, RunItem, RunObserver, RunOptions, Runner,
+    SessionStore, Tool, ToolCall, ToolDefinition,
+};
+use serde_json::{json, Value};
+
+#[derive(Default)]
+struct QueueModel {
+    responses: Mutex<VecDeque<ModelResponse>>,
+    requests: Mutex<Vec<ModelRequest>>,
+    calls: AtomicUsize,
+}
+
+impl QueueModel {
+    fn new(responses: impl IntoIterator<Item = ModelResponse>) -> Self {
+        Self {
+            responses: Mutex::new(responses.into_iter().collect()),
+            ..Self::default()
+        }
+    }
+
+    fn requests(&self) -> Vec<ModelRequest> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Model<()> for QueueModel {
+    async fn generate(
+        &self,
+        request: ModelRequest,
+        _context: &(),
+    ) -> Result<ModelResponse, BoxError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.requests.lock().unwrap().push(request);
+        self.responses
+            .lock()
+            .unwrap()
+            .pop_front()
+            .ok_or_else(|| Box::new(io::Error::other("no queued response")) as BoxError)
+    }
+}
+
+struct AddTool;
+
+#[async_trait]
+impl Tool<()> for AddTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "add",
+            "Add two integers",
+            json!({
+                "type": "object",
+                "properties": {
+                    "left": { "type": "integer" },
+                    "right": { "type": "integer" }
+                },
+                "required": ["left", "right"],
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    async fn execute(&self, arguments: Value, _context: &()) -> Result<Value, BoxError> {
+        let left = arguments
+            .get("left")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| Box::new(io::Error::other("missing left")) as BoxError)?;
+        let right = arguments
+            .get("right")
+            .and_then(Value::as_i64)
+            .ok_or_else(|| Box::new(io::Error::other("missing right")) as BoxError)?;
+        Ok(json!({ "sum": left + right }))
+    }
+}
+
+struct RejectInput;
+
+#[async_trait]
+impl InputGuardrail<()> for RejectInput {
+    fn name(&self) -> &str {
+        "reject-input"
+    }
+
+    async fn check(&self, _input: &str, _context: &()) -> Result<GuardrailVerdict, BoxError> {
+        Ok(GuardrailVerdict::reject("blocked by policy"))
+    }
+}
+
+struct RejectOutput;
+
+#[async_trait]
+impl OutputGuardrail<()> for RejectOutput {
+    fn name(&self) -> &str {
+        "reject-output"
+    }
+
+    async fn check(&self, _output: &str, _context: &()) -> Result<GuardrailVerdict, BoxError> {
+        Ok(GuardrailVerdict::reject("output blocked by policy"))
+    }
+}
+
+#[derive(Default)]
+struct RecordingObserver {
+    events: Mutex<Vec<RunEvent>>,
+}
+
+impl RecordingObserver {
+    fn events(&self) -> Vec<RunEvent> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl RunObserver for RecordingObserver {
+    fn on_event(&self, event: &RunEvent) {
+        self.events.lock().unwrap().push(event.clone());
+    }
+}
+
+#[tokio::test]
+async fn executes_tools_and_returns_the_final_output() {
+    let model = Arc::new(QueueModel::new([
+        ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "add",
+            json!({ "left": 2, "right": 3 }),
+        ))]),
+        ModelResponse::final_output("The sum is 5."),
+    ]));
+    let agent = Agent::new("math", "Math", "Use the calculator.", model.clone())
+        .with_tool(Arc::new(AddTool));
+    let runner = Runner::new([agent]).unwrap();
+
+    let result = runner
+        .run("math", "Add 2 and 3.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.final_output, "The sum is 5.");
+    assert_eq!(result.turns, 2);
+    assert!(result.new_items.iter().any(|item| matches!(
+        item,
+        RunItem::ToolResult { output, .. } if output == &json!({ "sum": 5 })
+    )));
+    assert_eq!(model.requests().len(), 2);
+}
+
+#[tokio::test]
+async fn hands_control_to_a_registered_agent() {
+    let triage_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-specialist")),
+    ])]));
+    let specialist_model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "Handled by the specialist.",
+    )]));
+    let triage = Agent::new("triage", "Triage", "Route the request.", triage_model).with_handoff(
+        Handoff::new("to-specialist", "Use for specialist work", "specialist"),
+    );
+    let specialist = Agent::new(
+        "specialist",
+        "Specialist",
+        "Handle specialist work.",
+        specialist_model,
+    );
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([triage, specialist])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let result = runner
+        .run("triage", "Please route this.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.final_agent.as_str(), "specialist");
+    assert_eq!(result.handoffs, 1);
+    assert!(observer.events().iter().any(|event| matches!(
+        event,
+        RunEvent::Handoff { from, to, name }
+            if from.as_str() == "triage"
+                && to.as_str() == "specialist"
+                && name == "to-specialist"
+    )));
+}
+
+#[tokio::test]
+async fn blocking_input_guardrail_prevents_model_execution() {
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "should not run",
+    )]));
+    let agent = Agent::new("safe", "Safe", "Be safe.", model.clone())
+        .with_input_guardrail(Arc::new(RejectInput));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let error = runner
+        .run("safe", "blocked input", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RunError::GuardrailRejected {
+            stage: GuardrailStage::Input,
+            ..
+        }
+    ));
+    assert_eq!(model.calls.load(Ordering::SeqCst), 0);
+    assert!(observer.events().iter().any(|event| matches!(
+        event,
+        RunEvent::RunFailed {
+            kind: RunFailureKind::InputGuardrail,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn session_history_is_loaded_and_successful_items_are_appended() {
+    let session = Arc::new(InMemorySession::default());
+    session
+        .append(
+            "conversation-1",
+            &[RunItem::UserMessage {
+                content: "Earlier message".to_owned(),
+            }],
+        )
+        .await
+        .unwrap();
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "Current answer",
+    )]));
+    let agent = Agent::new("assistant", "Assistant", "Answer.", model.clone());
+    let runner = Runner::new([agent]).unwrap().with_session(session.clone());
+    let options = RunOptions {
+        session_id: Some("conversation-1".to_owned()),
+        ..RunOptions::default()
+    };
+
+    runner
+        .run("assistant", "Current message", &(), options)
+        .await
+        .unwrap();
+
+    let request_items = &model.requests()[0].items;
+    assert_eq!(request_items.len(), 2);
+    assert!(matches!(
+        &request_items[0],
+        RunItem::UserMessage { content } if content == "Earlier message"
+    ));
+    let stored = session.items("conversation-1").await.unwrap();
+    assert_eq!(stored.len(), 3);
+}
+
+#[tokio::test]
+async fn rejected_output_is_not_appended_to_the_session() {
+    let session = Arc::new(InMemorySession::default());
+    let model = Arc::new(QueueModel::new([ModelResponse::final_output(
+        "blocked output",
+    )]));
+    let agent = Agent::new("assistant", "Assistant", "Answer.", model)
+        .with_output_guardrail(Arc::new(RejectOutput));
+    let runner = Runner::new([agent]).unwrap().with_session(session.clone());
+    let options = RunOptions {
+        session_id: Some("conversation-1".to_owned()),
+        ..RunOptions::default()
+    };
+
+    let error = runner
+        .run("assistant", "Current message", &(), options)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RunError::GuardrailRejected {
+            stage: GuardrailStage::Output,
+            ..
+        }
+    ));
+    assert!(session.items("conversation-1").await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn bounded_runner_stops_repeated_tool_turns() {
+    let repeated_call = || {
+        ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
+            "call",
+            "add",
+            json!({ "left": 1, "right": 1 }),
+        ))])
+    };
+    let model = Arc::new(QueueModel::new([repeated_call(), repeated_call()]));
+    let agent = Agent::new("loop", "Loop", "Keep calling.", model).with_tool(Arc::new(AddTool));
+    let runner = Runner::new([agent]).unwrap();
+    let options = RunOptions {
+        max_turns: 2,
+        ..RunOptions::default()
+    };
+
+    let error = runner.run("loop", "Loop.", &(), options).await.unwrap_err();
+
+    assert!(matches!(error, RunError::MaxTurnsExceeded { limit: 2 }));
+}
+
+#[tokio::test]
+async fn bounded_runner_stops_repeated_handoffs() {
+    let first_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-second")),
+    ])]));
+    let second_model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::Handoff(HandoffCall::new("to-first")),
+    ])]));
+    let first = Agent::new("first", "First", "Route.", first_model).with_handoff(Handoff::new(
+        "to-second",
+        "Route to second",
+        "second",
+    ));
+    let second = Agent::new("second", "Second", "Route.", second_model).with_handoff(Handoff::new(
+        "to-first",
+        "Route to first",
+        "first",
+    ));
+    let runner = Runner::new([first, second]).unwrap();
+    let options = RunOptions {
+        max_handoffs: 1,
+        ..RunOptions::default()
+    };
+
+    let error = runner
+        .run("first", "Keep routing.", &(), options)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RunError::MaxHandoffsExceeded { limit: 1 }));
+}
+
+#[tokio::test]
+async fn rejects_empty_model_responses() {
+    let model = Arc::new(QueueModel::new([ModelResponse {
+        assistant_message: None,
+        actions: Vec::new(),
+    }]));
+    let agent = Agent::new("empty", "Empty", "Answer.", model);
+    let runner = Runner::new([agent]).unwrap();
+
+    let error = runner
+        .run("empty", "Answer.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RunError::InvalidModelResponse { .. }));
+}
+
+#[test]
+fn rejects_handoffs_to_unregistered_agents() {
+    let model = Arc::new(QueueModel::default());
+    let agent = Agent::new("triage", "Triage", "Route.", model).with_handoff(Handoff::new(
+        "missing",
+        "Missing target",
+        "not-registered",
+    ));
+
+    let error = Runner::new([agent]).err().unwrap();
+
+    assert_eq!(
+        error,
+        ConfigError::UnknownHandoffTarget {
+            agent: "triage".into(),
+            handoff: "missing".to_owned(),
+            target: "not-registered".into(),
+        }
+    );
+}

--- a/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
+++ b/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
@@ -1,0 +1,132 @@
+# Coven Agents Rust Design
+
+## Decision
+
+Build an independent Rust orchestration core for OpenCoven, but do not attempt a
+feature-for-feature port of the OpenAI Agents SDK.
+
+The useful common denominator is a provider-neutral run loop around agents,
+tools, handoffs, guardrails, sessions, and lifecycle events. OpenAI-specific
+hosted tools, Responses transport, realtime voice, and tracing export belong in
+adapters. OpenCoven's project boundaries, harness sessions, familiar identity,
+memory, and user approvals remain owned by their existing systems.
+
+## Placement
+
+Start as the leaf crate `crates/coven-agents` in the MIT-licensed `coven`
+workspace. It must not depend on `coven-cli`, the daemon, or another workspace
+crate. This validates the API in the ecosystem's Rust authority repository
+without wiring unfinished orchestration into the product. If the crate develops
+independent consumers and release cadence, extract it into a dedicated
+repository before a stable release.
+
+Adding the same code to `coven-code` would couple a reusable SDK to a GPL,
+application-specific coding loop. Adding it to Cave would put authority logic in
+a desktop client. Both are rejected.
+
+## Clean-room boundary
+
+The design is derived from public behavioral documentation and OpenCoven
+requirements. No upstream implementation code is copied or translated. The
+upstream project is MIT-licensed, so this boundary is an architectural and
+provenance choice rather than a license requirement.
+
+Shared generic vocabulary such as agent, runner, tool, handoff, guardrail,
+session, trace, and model is treated as domain terminology. Types and behavior
+are designed for Rust and OpenCoven instead of preserving Python API parity.
+
+## MVP architecture
+
+### Agent catalog
+
+An `Agent<C>` contains a stable id, display name, instructions, a model adapter,
+tools, handoffs, and input/output guardrails. Handoffs reference stable agent
+ids rather than owning recursive agent values, avoiding reference cycles and
+making the graph validate before execution.
+
+### Model adapter
+
+`Model<C>` receives a complete `ModelRequest`: active identity, instructions,
+conversation items, tool definitions, and handoff definitions. It returns an
+optional assistant message plus model actions. Provider adapters own wire-format
+translation.
+
+### Deterministic runner
+
+The runner:
+
+1. validates all ids, tool names, handoff names, and handoff targets;
+2. runs starting-agent input guardrails before any model or tool side effect;
+3. loads optional session history;
+4. calls the active model;
+5. executes tool calls sequentially or changes active agent for one handoff;
+6. repeats within explicit turn and handoff limits;
+7. runs final-agent output guardrails;
+8. appends successful runs to the session;
+9. emits metadata-only lifecycle events.
+
+Sequential tool execution is intentional in the MVP. Parallel execution needs
+an explicit ordering, cancellation, and side-effect policy and should not be
+implied by an implementation detail.
+
+### Extension traits
+
+- `Tool<C>`: JSON-schema description plus asynchronous local execution.
+- `InputGuardrail<C>` and `OutputGuardrail<C>`: blocking checks returning allow
+  or a reasoned rejection.
+- `SessionStore`: load and append conversation items.
+- `RunObserver`: non-failing metadata event sink.
+
+Application context is an immutable `&C`; mutable dependencies use explicit
+interior mutability. This makes sharing across asynchronous tools and model
+adapters visible in their types.
+
+## Error and persistence semantics
+
+Configuration errors are detected before a run. Runtime errors preserve the
+agent, tool, guardrail stage, operation, and source error where applicable.
+Unknown model-requested tools or handoffs fail closed.
+
+Input guardrails are blocking by default. This is safer for a local tool runtime
+because rejected input cannot race with model calls or tool side effects.
+
+The MVP appends to a session only after a final output passes output guardrails.
+Failed or interrupted runs remain observable through the caller and observer,
+but are not written as successful conversation history. Durable resumability
+requires a separate run-state journal and is deferred.
+
+Session load and append are separate operations. Session-store implementations
+must serialize writers per session id or implement optimistic concurrency
+control; the runner does not merge concurrent turns.
+
+Observers receive names, ids, counts, and state transitions, not prompts,
+arguments, outputs, or model reasoning. Sensitive payload capture must be an
+explicit adapter policy.
+
+## Non-goals
+
+- OpenAI or Anthropic HTTP clients
+- compatibility with the Python SDK API
+- voice or realtime pipelines
+- hosted tools
+- MCP integration
+- sandbox lifecycle
+- SQLite persistence
+- human approval interruption/resume
+- retries or automatic replay of side-effecting calls
+- daemon, CLI, Cave, or `coven-code` integration
+
+## Testing
+
+Tests use deterministic fake models and local tools. They cover final output,
+tool round trips, handoffs, guardrail short-circuiting, session history,
+configuration validation, observer metadata, and bounded-loop failures. No
+network credentials or provider APIs are required.
+
+## Follow-up risks
+
+The principal risk is prematurely stabilizing a public API before provider,
+approval, and durable run-state adapters exercise it. Keep the crate
+experimental and workspace-local until at least two real consumers share it.
+The next coherent slice is a typed OpenAI/Anthropic-neutral test adapter or a
+Coven event-ledger adapter, not broad feature parity.


### PR DESCRIPTION
> **Recovered work, not reviewed design.** The code is intact and passes every gate; nobody has assessed whether the design is right. Its author should confirm, amend, or redirect.

## What this is

A provider-neutral agent run loop for OpenCoven — `agent`, `model`, `runner`, `session`, `tool`, `guardrail`, `observer`, `error` — with a 388-line integration suite and its design doc (`2026-08-14-coven-agents-rust-design.md`).

## Why it is arriving this way

It was written on 2026-08-14 and never committed. It existed **only** in the working tree of a stash labelled `!!GitHub_Desktop<fix/banner-contrast>` — a name that reads like editor autosave and gives no hint it held ~1,500 lines of an unreleased crate.

It was one `git stash drop` from being unrecoverable:

- absent from `main`
- absent from every branch and tag
- absent from all four worktrees
- no commit anywhere in the object graph touched `crates/coven-agents`
- no PR, no issue

Its only anchor was the stash's own index commit. It surfaced during a worktree/branch sweep, when the stash was queued for deletion as apparent cleanup residue.

Two near-misses worth recording: the stash's first parent was `fix/banner-contrast`, a superseded logo branch deleted earlier in the same sweep — had the stash gone first, the crate would have gone with it.

## Fidelity

All 13 recovered files are **hash-identical** to the stash. The stash mixed unrelated work, so only the coherent unit was taken:

| Included | Excluded |
| --- | --- |
| `crates/coven-agents/` (12 files) | 6 brainstorm/review artifacts (unrelated) |
| `docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md` | `DESIGN.md` branding edit — superseded by #744, would partially revert it |
| `Cargo.toml` workspace `members` entry | the stash's stale `Cargo.lock` |

`Cargo.lock` here is cargo's own resolution against current `main`, not the stash's copy.

## Validation on current main

- `cargo check -p coven-agents` — clean
- `cargo test -p coven-agents` — **9 passed**, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy -p coven-agents --all-targets -- -D warnings` — clean
- `scripts/check-secrets.py` — no current-tree or history findings

## Note

The source stash was **copied from, not popped**, so it remains intact as a safety net. It can be dropped once this lands.