### PR TITLE
fix(patch): accept every configured harness, not a stale two-id allowlist

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -512,7 +512,10 @@ enum Command {
         issue: Vec<String>,
         #[arg(long, help = "Override the repo path for this run")]
         repo: Option<PathBuf>,
-        #[arg(long, help = "Harness to use: codex, claude, or copilot")]
+        #[arg(
+            long,
+            help = "Harness to use: codex, claude, or copilot, or any adapter recipe you installed (`coven adapter list`). Defaults to the first available of codex, claude, copilot."
+        )]
         harness: Option<String>,
         #[arg(
             long,
@@ -2931,7 +2934,15 @@ fn run_patch(
         }
     };
     let harness_id = match harness {
-        Some(harness) => patch::HarnessId::parse(&harness)?,
+        // The configured-harness set is the authority, exactly as it is for
+        // `coven run`: an unknown id fails here with the data-driven message
+        // that names every configured harness and installable recipe, and the
+        // availability check stays at launch so `--dry-run` still plans
+        // against a harness that is not installed yet.
+        Some(harness) => patch::HarnessId::validated(
+            session_launch::validate_harness(&harness, session_launch::HarnessCheck::Configured)?
+                .id,
+        ),
         None if non_interactive => anyhow::bail!(
             "--harness is required with --non-interactive; add `--harness codex` (or claude, or copilot)"
         ),
@@ -3084,15 +3095,28 @@ fn confirm_yes(prompt: &str) -> Result<bool> {
     Ok(matches!(line.trim(), "y" | "Y" | "yes" | "YES" | "Yes"))
 }
 
+/// Bundled harnesses `coven patch` auto-selects from, in preference order.
+/// Only the publicly supported set is auto-selected; a trusted adapter recipe
+/// still runs a patch, but the operator has to name it with `--harness`.
+const PATCH_DEFAULT_HARNESS_PREFERENCE: [&str; 3] = ["codex", "claude", "copilot"];
+
 fn choose_default_harness() -> Result<patch::HarnessId> {
-    let harnesses = harness::built_in_harnesses();
-    if harnesses.iter().any(|h| h.id == "codex" && h.available) {
-        return Ok(patch::HarnessId::Codex);
-    }
-    if harnesses.iter().any(|h| h.id == "claude" && h.available) {
-        return Ok(patch::HarnessId::ClaudeCode);
-    }
-    anyhow::bail!("no supported harness is available; run `coven doctor` for setup guidance")
+    let harnesses = harness::configured_harnesses()?;
+    pick_patch_default_harness(&harnesses).ok_or_else(|| {
+        anyhow::anyhow!(
+            "no supported harness is available; install {}, then run `coven doctor` for setup guidance",
+            PATCH_DEFAULT_HARNESS_PREFERENCE.join(", ")
+        )
+    })
+}
+
+fn pick_patch_default_harness(harnesses: &[harness::HarnessSummary]) -> Option<patch::HarnessId> {
+    PATCH_DEFAULT_HARNESS_PREFERENCE.iter().find_map(|id| {
+        harnesses
+            .iter()
+            .find(|harness| harness.id == *id && harness.available)
+            .map(|harness| patch::HarnessId::validated(&harness.id))
+    })
 }
 
 fn pick_default_harness(harnesses: &[harness::HarnessSummary]) -> Option<String> {
@@ -7465,6 +7489,87 @@ mod tests {
             pick_default_harness(&harnesses),
             None,
             "None when no harness is available"
+        );
+    }
+
+    #[test]
+    fn patch_default_harness_falls_back_to_copilot() {
+        // Copilot is a bundled supported harness, so a machine that only has
+        // Copilot installed must still get a `coven patch` default instead of
+        // "no supported harness is available".
+        let harnesses = vec![
+            make_harness("codex", false),
+            make_harness("claude", false),
+            make_harness("copilot", true),
+        ];
+        assert_eq!(
+            pick_patch_default_harness(&harnesses).map(|id| id.as_str().to_string()),
+            Some("copilot".to_string()),
+            "copilot must be an auto-selectable patch default"
+        );
+    }
+
+    #[test]
+    fn patch_default_harness_prefers_codex_then_claude_then_copilot() {
+        let all_available = vec![
+            make_harness("codex", true),
+            make_harness("claude", true),
+            make_harness("copilot", true),
+        ];
+        assert_eq!(
+            pick_patch_default_harness(&all_available).map(|id| id.as_str().to_string()),
+            Some("codex".to_string())
+        );
+
+        let no_codex = vec![
+            make_harness("codex", false),
+            make_harness("claude", true),
+            make_harness("copilot", true),
+        ];
+        assert_eq!(
+            pick_patch_default_harness(&no_codex).map(|id| id.as_str().to_string()),
+            Some("claude".to_string())
+        );
+    }
+
+    #[test]
+    fn patch_does_not_auto_select_an_adapter_recipe() {
+        // Adapter recipes stay opt-in: available or not, they are never picked
+        // for the user, only named explicitly with `--harness`.
+        let harnesses = vec![
+            make_harness("codex", false),
+            make_harness("claude", false),
+            make_harness("copilot", false),
+            make_harness("hermes", true),
+        ];
+        assert_eq!(
+            pick_patch_default_harness(&harnesses).map(|id| id.as_str().to_string()),
+            None,
+            "an installed adapter recipe must not become the implicit patch default"
+        );
+    }
+
+    #[test]
+    fn patch_harness_help_matches_the_ids_patch_accepts() {
+        use clap::CommandFactory;
+
+        // The help promised `copilot` while the parser rejected it. Keep the
+        // advertised set and the auto-selected set in one place so they cannot
+        // drift apart again.
+        let mut cmd = Cli::command();
+        let patch = cmd
+            .find_subcommand_mut("patch")
+            .expect("patch subcommand exists");
+        let help = patch.render_long_help().to_string();
+        for id in PATCH_DEFAULT_HARNESS_PREFERENCE {
+            assert!(
+                help.contains(id),
+                "patch --harness help must name `{id}`:\n{help}"
+            );
+        }
+        assert!(
+            help.contains("coven adapter list"),
+            "patch --harness help must point at installed adapter recipes:\n{help}"
         );
     }
 

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -2944,7 +2944,7 @@ fn run_patch(
                 .id,
         ),
         None if non_interactive => anyhow::bail!(
-            "--harness is required with --non-interactive; add `--harness codex` (or claude, or copilot)"
+            "--harness is required with --non-interactive; add `--harness <configured-harness-id>`"
         ),
         None => choose_default_harness()?,
     };

--- a/crates/coven-cli/src/patch.rs
+++ b/crates/coven-cli/src/patch.rs
@@ -54,26 +54,25 @@ impl fmt::Display for VerificationProfile {
     }
 }
 
+/// The harness a patch run launches.
+///
+/// This carries an id the configured-harness set has already accepted; it does
+/// not decide membership itself. `session_launch::validate_harness` is the sole
+/// authority for which harnesses exist, so `coven patch` supports exactly what
+/// `coven run` supports — the bundled set plus any trusted adapter recipe the
+/// operator installed — instead of a second, narrower allowlist that drifts.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum HarnessId {
-    Codex,
-    ClaudeCode,
-}
+pub struct HarnessId(String);
 
 impl HarnessId {
-    pub fn parse(value: &str) -> anyhow::Result<Self> {
-        match value {
-            "codex" => Ok(Self::Codex),
-            "claude" => Ok(Self::ClaudeCode),
-            other => anyhow::bail!("unknown harness `{other}`; expected `codex` or `claude`"),
-        }
+    /// Wrap an id that `session_launch::validate_harness` already resolved
+    /// against the configured harness set.
+    pub fn validated(id: impl Into<String>) -> Self {
+        Self(id.into())
     }
 
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Codex => "codex",
-            Self::ClaudeCode => "claude",
-        }
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -238,7 +237,7 @@ mod tests {
                 untracked_files: vec![],
             },
             issue: issue.to_string(),
-            harness_id: HarnessId::Codex,
+            harness_id: HarnessId::validated("codex"),
             verification_profile: VerificationProfile::Auto,
             non_interactive: false,
             dry_run: false,
@@ -422,11 +421,15 @@ $ <command>\n\
     }
 
     #[test]
-    fn parses_harness_ids() -> anyhow::Result<()> {
-        assert_eq!(HarnessId::parse("codex")?, HarnessId::Codex);
-        assert_eq!(HarnessId::parse("claude")?, HarnessId::ClaudeCode);
-        assert!(HarnessId::parse("shell").is_err());
-        Ok(())
+    fn harness_id_carries_any_validated_id_verbatim() {
+        // No second allowlist lives here: whatever the configured-harness set
+        // accepted reaches the plan and the launch unchanged, so a bundled
+        // harness and a trusted adapter recipe travel the same path.
+        for id in ["codex", "claude", "copilot", "hermes"] {
+            let harness = HarnessId::validated(id);
+            assert_eq!(harness.as_str(), id);
+            assert_eq!(harness.to_string(), id);
+        }
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -1917,14 +1917,44 @@ fn run_new_user_start_here() -> Result<()> {
     run_doctor(false)
 }
 
+/// Comma-separated list of harnesses the guided prompt should offer: every
+/// configured harness whose executable is present, with the default first so
+/// pressing enter is obviously the same choice. Falls back to the default id
+/// alone when the harness set cannot be read.
+fn guided_harness_options(default_harness: &str) -> String {
+    let available = crate::harness::configured_harnesses()
+        .map(|harnesses| {
+            harnesses
+                .into_iter()
+                .filter(|harness| harness.available)
+                .map(|harness| harness.id)
+                .collect()
+        })
+        .unwrap_or_default();
+    format_guided_harness_options(default_harness, available)
+}
+
+fn format_guided_harness_options(default_harness: &str, mut ids: Vec<String>) -> String {
+    if !ids.iter().any(|id| id == default_harness) {
+        ids.push(default_harness.to_string());
+    }
+    ids.sort_by_key(|id| (id != default_harness, id.clone()));
+    ids.join(", ")
+}
+
 fn run_guided_harness_session() -> Result<()> {
     let primary_strong = theme::fg(theme::PRIMARY_STRONG);
     let reset = theme::reset();
     println!("{primary_strong}Run an agent in this project{reset}");
     println!("Coven will create a session record, validate the project root, then attach to the harness.\n");
     let default_harness = default_harness_id().unwrap_or_else(|| "codex".to_string());
-    let harness_prompt =
-        format!("Harness [default: {default_harness}; options: codex, claude, copilot]: ");
+    // The options were a fixed "codex, claude, copilot" string, so the default
+    // shown could be a harness the list did not contain, and an installed
+    // adapter recipe never appeared at all. Offer what is actually launchable.
+    let harness_prompt = format!(
+        "Harness [default: {default_harness}; options: {}]: ",
+        guided_harness_options(&default_harness)
+    );
     let harness =
         prompt_for_optional_line(&harness_prompt)?.unwrap_or_else(|| default_harness.to_string());
     let prompt = prompt_for_required_line("Task for the agent: ")?;
@@ -2324,6 +2354,42 @@ pub(crate) fn move_magical_tui_selection(current: usize, direction: MagicalTuiMo
 #[cfg(test)]
 pub(crate) fn render_frame_plain_for_test(selection: usize) -> String {
     render_magical_tui_frame_plain(selection)
+}
+
+#[cfg(test)]
+mod guided_harness_option_tests {
+    use super::format_guided_harness_options;
+
+    fn ids(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn lists_the_default_first_then_the_rest_alphabetically() {
+        assert_eq!(
+            format_guided_harness_options("claude", ids(&["copilot", "codex", "claude"])),
+            "claude, codex, copilot"
+        );
+    }
+
+    #[test]
+    fn includes_installed_adapter_recipes() {
+        assert_eq!(
+            format_guided_harness_options("codex", ids(&["codex", "hermes"])),
+            "codex, hermes",
+            "an installed recipe is launchable, so the prompt must offer it"
+        );
+    }
+
+    #[test]
+    fn always_contains_the_default_it_advertises() {
+        // The prompt used to print a fixed option list that could omit the
+        // very default it told the user to accept.
+        assert_eq!(
+            format_guided_harness_options(crate::engine::ENGINE_HARNESS_ID, Vec::new()),
+            crate::engine::ENGINE_HARNESS_ID
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/reference/cli-patch.md
+++ b/docs/reference/cli-patch.md
@@ -28,6 +28,17 @@ When a non-dry-run patch session launches, Coven records the canonical OpenClaw 
 
 If the stored path becomes invalid, pass a fresh `--repo <path>` to replace it.
 
+## Harness selection
+
+`--harness` accepts the same ids as `coven run`: the bundled harnesses `codex`,
+`claude`, and `copilot`, plus any adapter recipe installed on this machine (see
+`coven adapter list`). An unknown id reports the configured harnesses and the
+installable recipes instead of failing with a shorter, stale list.
+
+Without `--harness`, Coven picks the first *available* bundled harness in the
+order `codex`, `claude`, `copilot`. Adapter recipes are never auto-selected —
+name one explicitly to use it.
+
 ## Safety
 
 The OpenClaw patch flow does not commit or push. It records a Coven session, launches the selected harness in the chosen repo, runs verification after the harness exits, and reports changed files plus verification status.

--- a/docs/reference/cli-patch.md
+++ b/docs/reference/cli-patch.md
@@ -31,9 +31,10 @@ If the stored path becomes invalid, pass a fresh `--repo <path>` to replace it.
 ## Harness selection
 
 `--harness` accepts the same ids as `coven run`: the bundled harnesses `codex`,
-`claude`, and `copilot`, plus any adapter recipe installed on this machine (see
-`coven adapter list`). An unknown id reports the configured harnesses and the
-installable recipes instead of failing with a shorter, stale list.
+`claude`, `copilot`, and `coven-code`, plus any adapter recipe installed on this
+machine (see `coven adapter list`). An unknown id reports the configured
+harnesses and the installable recipes instead of failing with a shorter, stale
+list.
 
 Without `--harness`, Coven picks the first *available* bundled harness in the
 order `codex`, `claude`, `copilot`. Adapter recipes are never auto-selected —


### PR DESCRIPTION
## What was broken

`coven patch --harness` advertised `codex, claude, or copilot`, and the
non-interactive error hint repeated that list. But `patch::HarnessId::parse`
was a **second, narrower allowlist** that only knew `codex` and `claude`:

```
$ coven patch openclaw "..." --harness copilot --dry-run
Error: unknown harness `copilot`; expected `codex` or `claude`
```

`choose_default_harness` had the same gap, so a machine with only Copilot
installed got *"no supported harness is available"* from `coven patch` while
`coven run copilot` worked fine. Installed adapter recipes (hermes, opencode,
grok) were rejected by `coven patch` for the same reason.

## Fix

`session_launch::validate_harness` is already the authority for which
harnesses exist, and `launch_patch_session` already calls it. This removes the
duplicate allowlist rather than widening it: `HarnessId` becomes a newtype
carrying an id that authority accepted, so `coven patch` supports exactly what
`coven run` supports.

```
$ coven patch openclaw "..." --harness copilot --dry-run
Coven will patch openclaw at ... using harness `copilot` with verification `auto`.

$ coven patch openclaw "..." --harness bogus --dry-run
Error: unsupported harness `bogus`. Configured harnesses: codex, claude,
coven-code, copilot, grok. Known installable adapter recipes: grok, hermes,
opencode. ...
```

Deliberately unchanged:

- **Auto-selection stays narrow.** Only the publicly supported `codex`,
  `claude`, `copilot` are picked for the user; an installed adapter recipe
  must be named explicitly. Per `AGENTS.md`, this does not widen the public
  supported set.
- **Availability is still checked at launch**, so `--dry-run` keeps planning
  against a harness that is not installed yet.

## Also: the guided harness prompt

The same drift had reached `run_guided_harness_session`, which printed a fixed
`options: codex, claude, copilot` string. That list could omit the very
default it told the user to accept (`coven-code`) and never showed an
installed recipe. It now lists the harnesses that are actually launchable,
default first.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --locked` — green
- `python3 scripts/check-secrets.py`, `python3 scripts/check-coven-privacy.py --staged` — clean
- `node --test scripts/cli-docs-test.mjs scripts/onboarding-docs-test.mjs` — green
- Behavior confirmed against a real checkout, before and after (transcripts above)

New regression tests: Copilot is auto-selectable; adapter recipes are never
auto-selected; the `--harness` help and the auto-selected set are asserted
against one shared constant so they cannot drift apart again; the guided
prompt always contains the default it advertises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)