### PR TITLE
fix(doctor): give adapter harnesses a runnable auth hint

### DIFF
--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -3515,12 +3515,19 @@ fn credentials_lines(
 
 /// Return the canonical authentication or local-status command for a harness.
 /// Running this command is not proof that a provider turn will succeed.
-fn auth_setup_hint_for_harness(harness_id: &str) -> &'static str {
+///
+/// Every branch must return a command the user can actually paste: doctor
+/// renders this inside backticks, so prose like "see harness docs" reads as a
+/// command that does not exist. Harnesses outside the bundled set arrive
+/// through an adapter manifest, and `coven adapter doctor <id>` is their
+/// canonical local-status command — it reports readiness and prints the
+/// adapter's own install/authentication hint.
+fn auth_setup_hint_for_harness(harness_id: &str) -> String {
     match harness_id {
-        "codex" => "codex login",
-        "claude" => "claude doctor",
-        "copilot" => "copilot login",
-        _ => "see harness docs",
+        "codex" => "codex login".to_string(),
+        "claude" => "claude doctor".to_string(),
+        "copilot" => "copilot login".to_string(),
+        other => format!("coven adapter doctor {other}"),
     }
 }
 
@@ -7306,6 +7313,39 @@ mod tests {
             !lines[0].contains("[!!]"),
             "non-blocking auth guidance must not look like a blocking failure: {}",
             lines[0]
+        );
+    }
+
+    #[test]
+    fn every_auth_setup_hint_is_a_runnable_command() {
+        // doctor renders this hint inside backticks. Adapter harnesses used to
+        // land on the prose fallback "see harness docs", which reads as a
+        // command that does not exist.
+        assert_eq!(auth_setup_hint_for_harness("codex"), "codex login");
+        assert_eq!(auth_setup_hint_for_harness("claude"), "claude doctor");
+        assert_eq!(auth_setup_hint_for_harness("copilot"), "copilot login");
+        for id in ["grok", "hermes", "opencode", "some-local-adapter"] {
+            let hint = auth_setup_hint_for_harness(id);
+            assert_eq!(hint, format!("coven adapter doctor {id}"));
+            assert!(
+                !hint.contains("see harness docs"),
+                "hint must be runnable, got: {hint}"
+            );
+        }
+    }
+
+    #[test]
+    fn credentials_line_for_an_adapter_harness_offers_adapter_doctor() {
+        let lines = credentials_lines(None, &[make_harness_with_hint("hermes", true, "")]);
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("`coven adapter doctor hermes`")),
+            "got: {lines:#?}"
+        );
+        assert!(
+            !lines.iter().any(|line| line.contains("see harness docs")),
+            "got: {lines:#?}"
         );
     }
 


### PR DESCRIPTION
## What was broken

`coven doctor` renders the auth hint inside backticks, so it reads as a
command. `auth_setup_hint_for_harness` matched the three bundled ids and fell
through to the **prose string** `"see harness docs"` for everything else:

```
Credentials:
  [--] Grok Build — executable available; authentication not verified;
       authenticate or inspect local setup with `see harness docs`; ...
```

Every adapter harness — `grok`, `hermes`, `opencode`, and any local manifest
adapter — told the user to run a command that does not exist. That lands right
after `coven adapter install <recipe>`, so it is one of the first things a new
adapter user sees, and it dead-ends them.

## Fix

`coven adapter doctor <id>` is the canonical local-status command for a
manifest adapter: it reports readiness and prints the adapter's own
install/authentication hint. Return that instead of prose, so **every** branch
of the function yields something the user can paste.

```
  [--] Grok Build — executable available; authentication not verified;
       authenticate or inspect local setup with `coven adapter doctor grok`; ...
```

Confirmed against real `coven doctor` output on a machine with the Grok recipe
installed (before/after above). The bundled hints (`codex login`,
`claude doctor`, `copilot login`) are unchanged.

## Verification

- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --locked` — the only failures were the known local
  flakes tracked in #751 (`cockpit_sources::…logical_restore_state` and a
  `pty_runner` reaper test); both pass in isolation on this branch, and neither
  touches this code path
- `python3 scripts/check-secrets.py`, `python3 scripts/check-coven-privacy.py --staged` — clean

New tests assert that every hint is a runnable command (no prose fallback) and
that an adapter harness's credentials line offers `coven adapter doctor <id>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)