### PR TITLE
feat(client): add owner-validated daemon client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "coven-afs",
+ "coven-client",
  "coven-runtime-spec",
  "coven-threads-core",
  "crossterm",
@@ -814,6 +815,19 @@ dependencies = [
  "widestring",
  "windows-sys 0.61.2",
  "zeroize",
+]
+
+[[package]]
+name = "coven-client"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "socket2",
+ "thiserror 2.0.18",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/coven-afs", "crates/coven-agents", "crates/coven-cli", "crates/coven-memory", "crates/coven-relay"]
+members = ["crates/coven-afs", "crates/coven-agents", "crates/coven-cli", "crates/coven-client", "crates/coven-memory", "crates/coven-relay"]
 resolver = "2"
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -311,8 +311,10 @@ curl --unix-socket ~/.coven/coven.sock http://localhost/api/v1/health
 
 1. Call `GET /api/v1/health`
 2. Verify `apiVersion === "coven.daemon.v1"` and `capabilities.structuredErrors === true`
-3. Check `capabilities.eventCursor === "sequence"` before using `afterSeq` pagination
-4. Only then depend on the documented `v1` sessions/events shapes
+3. Check `capabilities.sessions === true` before using session endpoints and
+   `capabilities.events === true` before reading events
+4. Check `capabilities.eventCursor === "sequence"` before using `afterSeq` pagination
+5. Only then depend on the documented `v1` sessions/events shapes
 
 All API errors use a structured `{ "error": { "code", "message", "details" } }` envelope. Branch on `error.code`, never on `error.message`.
 

--- a/crates/coven-cli/Cargo.toml
+++ b/crates/coven-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 coven-afs = { path = "../coven-afs", version = "0.1.0" }
+coven-client = { path = "../coven-client", version = "0.1.0" }
 anyhow = "1"
 base64 = "0.23"
 chrono = { version = "0.4", features = ["serde"] }
@@ -43,6 +44,8 @@ rustls-pki-types = "1"
 rcgen = { version = "0.14", features = ["crypto", "pem", "ring"] }
 p256 = { version = "0.13", features = ["ecdsa", "pem", "pkcs8"] }
 qrcode = { version = "0.14", default-features = false }
+# Event replay uses SQLite 3.43+'s metadata-only octet_length() path before
+# loading payloads. Keep SQLite bundled so the locked library version provides it.
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -72,7 +75,7 @@ rustix = { version = "1", features = ["fs"] }
 [target.'cfg(windows)'.dependencies]
 interprocess = "2"
 widestring = "1"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_SystemInformation"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Threading", "Win32_System_JobObjects", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/coven-cli/src/api.rs
+++ b/crates/coven-cli/src/api.rs
@@ -26,6 +26,8 @@ use crate::{
 };
 
 const MAX_EVENTS_LIMIT: i64 = 1_000;
+const EVENT_CANDIDATE_BATCH_LIMIT: usize = 16;
+const MAX_EVENT_CANDIDATE_BYTES: usize = coven_client::MAX_RESPONSE_BODY_BYTES;
 pub const COVEN_API_ROUTE_VERSION: &str = "v1";
 pub const COVEN_API_NAMED_VERSION: &str = "coven.daemon.v1";
 pub const COVEN_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -958,7 +960,7 @@ pub(crate) fn handle_request_with_runtime_and_authority(
             get_session_artifact(coven_home, path, q)
         }
         ("GET", path) if path.starts_with("/sessions/") => {
-            let session_id = path.trim_start_matches("/sessions/");
+            let session_id = path.strip_prefix("/sessions/").unwrap_or(path);
             let conn = store::open_store(&store_path(coven_home))?;
             match store::get_session(&conn, session_id)? {
                 Some(session) => json_response(200, &session),
@@ -4583,7 +4585,7 @@ fn list_session_events(coven_home: &Path, session_id: &str, query: &str) -> Resu
         None => None,
     };
 
-    let conn = store::open_store(&store_path(coven_home))?;
+    let mut conn = store::open_store(&store_path(coven_home))?;
     if store::get_session(&conn, session_id)?.is_none() {
         return api_error(
             404,
@@ -4593,27 +4595,236 @@ fn list_session_events(coven_home: &Path, session_id: &str, query: &str) -> Resu
         );
     }
 
+    let requested_limit = limit.unwrap_or(MAX_EVENTS_LIMIT);
     let opts = store::EventsQueryOptions {
         after_seq,
         after_event_id,
-        limit,
+        limit: None,
     };
-
-    let events = store::list_events_with_options(&conn, session_id, &opts)?;
-    let next_cursor = events.last().map(|e| EventCursor { after_seq: e.seq });
-    let has_more = if let Some(lim) = limit {
-        events.len() as i64 == lim
-    } else {
-        false
-    };
-
-    json_response(
-        200,
-        &EventsResponse {
-            events,
-            next_cursor,
-            has_more,
+    let transaction = conn
+        .transaction()
+        .context("failed to start bounded event page read")?;
+    let initial_after_rowid = store::resolve_event_after_rowid(&transaction, session_id, &opts)?;
+    let (response, _) = bounded_events_response_from_source(
+        requested_limit as usize,
+        initial_after_rowid,
+        |after_rowid, candidate_limit| {
+            store::list_event_candidates(&transaction, session_id, after_rowid, candidate_limit)
         },
+        |seq| store::get_event_by_seq(&transaction, session_id, seq),
+    )?;
+    transaction
+        .commit()
+        .context("failed to finish bounded event page read")?;
+    Ok(response)
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct BoundedEventsResponseStats {
+    candidate_batches: usize,
+    candidates_examined: usize,
+    events_loaded: usize,
+    peak_candidate_batch: usize,
+    peak_loaded_event_bytes: usize,
+}
+
+fn bounded_events_response_from_source<FCandidates, FLoad>(
+    requested_limit: usize,
+    initial_after_rowid: Option<i64>,
+    mut candidates_after: FCandidates,
+    mut load_event: FLoad,
+) -> Result<(ApiResponse, BoundedEventsResponseStats)>
+where
+    FCandidates: FnMut(Option<i64>, usize) -> Result<store::EventCandidatePage>,
+    FLoad: FnMut(i64) -> Result<Option<store::EventRecord>>,
+{
+    const EVENTS_PREFIX: &str = r#"{"events":["#;
+
+    let max_body_bytes = coven_client::MAX_RESPONSE_BODY_BYTES.saturating_sub(1);
+    let mut stats = BoundedEventsResponseStats::default();
+    let mut events_json = String::new();
+    let mut accepted = 0_usize;
+    let mut scan_after = initial_after_rowid;
+    let mut last_seq = None;
+    let mut has_more = false;
+
+    'candidate_pages: loop {
+        let remaining_with_probe = requested_limit.saturating_sub(accepted).saturating_add(1);
+        let candidate_limit = remaining_with_probe.clamp(1, EVENT_CANDIDATE_BATCH_LIMIT);
+        let page = candidates_after(scan_after, candidate_limit)?;
+        stats.candidate_batches = stats.candidate_batches.saturating_add(1);
+        stats.peak_candidate_batch = stats.peak_candidate_batch.max(page.candidates.len());
+        if page.candidates.is_empty() {
+            break;
+        }
+        let source_exhausted = page.candidates.len() < candidate_limit;
+
+        for candidate in page.candidates {
+            stats.candidates_examined = stats.candidates_examined.saturating_add(1);
+            if accepted >= requested_limit {
+                has_more = true;
+                break 'candidate_pages;
+            }
+            if candidate.allocation_bytes > MAX_EVENT_CANDIDATE_BYTES {
+                if accepted == 0 {
+                    return Ok((oversized_event_response(&candidate)?, stats));
+                }
+                has_more = true;
+                break 'candidate_pages;
+            }
+
+            let separator_bytes = usize::from(accepted > 0);
+            let fixed_bytes = EVENTS_PREFIX
+                .len()
+                .saturating_add(events_json.len())
+                .saturating_add(separator_bytes)
+                .saturating_add(events_response_tail(Some(candidate.seq), false).len());
+            let event_json_budget = max_body_bytes.saturating_sub(fixed_bytes);
+            if candidate
+                .encoded_lower_bound_bytes
+                .is_some_and(|lower_bound| lower_bound > event_json_budget)
+            {
+                if accepted == 0 {
+                    return Ok((oversized_event_response(&candidate)?, stats));
+                }
+                has_more = true;
+                break 'candidate_pages;
+            }
+
+            let event = load_event(candidate.seq)?.with_context(|| {
+                format!(
+                    "event {} disappeared from the bounded event read snapshot",
+                    candidate.seq
+                )
+            })?;
+            let loaded_bytes = event_record_allocation_bytes(&event)?;
+            stats.events_loaded = stats.events_loaded.saturating_add(1);
+            stats.peak_loaded_event_bytes = stats.peak_loaded_event_bytes.max(loaded_bytes);
+            if loaded_bytes > MAX_EVENT_CANDIDATE_BYTES {
+                if accepted == 0 {
+                    return Ok((oversized_event_response(&candidate)?, stats));
+                }
+                has_more = true;
+                break 'candidate_pages;
+            }
+            let Some(encoded_event) = serialize_event_with_limit(&event, event_json_budget)? else {
+                if accepted == 0 {
+                    return Ok((oversized_event_response(&candidate)?, stats));
+                }
+                has_more = true;
+                break 'candidate_pages;
+            };
+            if accepted > 0 {
+                events_json.push(',');
+            }
+            events_json.push_str(&encoded_event);
+            accepted += 1;
+            last_seq = Some(candidate.seq);
+            scan_after = Some(candidate.seq);
+        }
+
+        if source_exhausted {
+            break;
+        }
+    }
+
+    let mut body = String::with_capacity(
+        EVENTS_PREFIX.len() + events_json.len() + events_response_tail(last_seq, has_more).len(),
+    );
+    body.push_str(EVENTS_PREFIX);
+    body.push_str(&events_json);
+    body.push_str(&events_response_tail(last_seq, has_more));
+    debug_assert!(body.len() < coven_client::MAX_RESPONSE_BODY_BYTES);
+    Ok((
+        ApiResponse {
+            status: 200,
+            content_type: "application/json",
+            body,
+        },
+        stats,
+    ))
+}
+
+fn events_response_tail(last_seq: Option<i64>, has_more: bool) -> String {
+    match last_seq {
+        Some(seq) => format!(r#"],"nextCursor":{{"afterSeq":{seq}}},"hasMore":{has_more}}}"#),
+        None => format!(r#"],"nextCursor":null,"hasMore":{has_more}}}"#),
+    }
+}
+
+fn event_record_allocation_bytes(event: &store::EventRecord) -> Result<usize> {
+    [
+        event.id.len(),
+        event.session_id.len(),
+        event.kind.len(),
+        event.payload_json.len(),
+        event.created_at.len(),
+    ]
+    .into_iter()
+    .try_fold(0_usize, |total, field| {
+        total
+            .checked_add(field)
+            .context("loaded event allocation size overflowed")
+    })
+}
+
+struct LimitedJsonWriter {
+    bytes: Vec<u8>,
+    limit: usize,
+    exceeded: bool,
+}
+
+impl LimitedJsonWriter {
+    fn new(limit: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(limit.min(64 * 1024)),
+            limit,
+            exceeded: false,
+        }
+    }
+}
+
+impl Write for LimitedJsonWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if bytes.len() > self.limit.saturating_sub(self.bytes.len()) {
+            self.exceeded = true;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "event exceeded encoded response budget",
+            ));
+        }
+        self.bytes.extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialize_event_with_limit(event: &store::EventRecord, limit: usize) -> Result<Option<String>> {
+    let mut writer = LimitedJsonWriter::new(limit);
+    if let Err(error) = serde_json::to_writer(&mut writer, event) {
+        if writer.exceeded {
+            return Ok(None);
+        }
+        return Err(error).context("failed to serialize events API response");
+    }
+    String::from_utf8(writer.bytes)
+        .map(Some)
+        .context("serialized event response was not UTF-8")
+}
+
+fn oversized_event_response(candidate: &store::EventCandidate) -> Result<ApiResponse> {
+    let details = match candidate.event_id.as_deref() {
+        Some(event_id) => json!({ "eventId": event_id, "seq": candidate.seq }),
+        None => json!({ "seq": candidate.seq }),
+    };
+    api_error(
+        413,
+        "event_response_too_large",
+        "The next event is too large for the daemon transport response limit.",
+        Some(details),
     )
 }
 
@@ -8533,8 +8744,8 @@ pub(crate) fn decoded_query_param(query: &str, key: &str) -> Option<String> {
 }
 
 fn session_action_id<'a>(path: &'a str, suffix: &str) -> &'a str {
-    path.trim_start_matches("/sessions/")
-        .strip_suffix(suffix)
+    path.strip_prefix("/sessions/")
+        .and_then(|rest| rest.strip_suffix(suffix))
         .unwrap_or_default()
 }
 
@@ -8713,6 +8924,68 @@ mod tests {
                 .join(format!("{fingerprint}.db")),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn session_action_routes_preserve_the_raw_v1_remainder() {
+        assert_eq!(
+            session_action_id("/sessions/engine/42/input", "/input"),
+            "engine/42"
+        );
+        assert_eq!(
+            session_action_id("/sessions/engine%2F42/kill", "/kill"),
+            "engine%2F42"
+        );
+    }
+
+    #[test]
+    fn nested_session_routes_preserve_raw_v1_components() {
+        let (session_id, handoff_id) =
+            handoff_route_parts("/sessions/engine/42/handoffs/handoff%2Fid/claim", "/claim")
+                .expect("structurally valid handoff route");
+        assert_eq!(session_id, "engine/42");
+        assert_eq!(handoff_id, "handoff%2Fid");
+    }
+
+    /// An opaque id that itself begins with `/sessions/` (e.g. because a
+    /// caller doubled the collection prefix) must survive as one structural
+    /// removal, not collapse through repeated matches of the same prefix.
+    /// `trim_start_matches` strips *every* leading occurrence of the pattern,
+    /// so `"/sessions//sessions/victim/input"` would previously resolve to
+    /// the unrelated id `"victim"` instead of the literal `"/sessions/victim"`.
+    #[test]
+    fn session_action_routes_do_not_collapse_a_repeated_sessions_prefix() {
+        assert_eq!(
+            session_action_id("/sessions//sessions/victim/input", "/input"),
+            "/sessions/victim"
+        );
+        assert_eq!(
+            session_action_id("/sessions//sessions/victim/kill", "/kill"),
+            "/sessions/victim"
+        );
+        assert_eq!(
+            session_action_id("/sessions//sessions/victim/complete", "/complete"),
+            "/sessions/victim"
+        );
+        assert_eq!(
+            session_action_id("/sessions//sessions/victim/events", "/events"),
+            "/sessions/victim"
+        );
+        assert_eq!(
+            session_action_id("/sessions//sessions/victim/handoffs", "/handoffs"),
+            "/sessions/victim"
+        );
+    }
+
+    #[test]
+    fn nested_session_routes_do_not_collapse_a_repeated_sessions_prefix() {
+        let (session_id, handoff_id) = handoff_route_parts(
+            "/sessions//sessions/victim/handoffs/handoff-id/claim",
+            "/claim",
+        )
+        .expect("structurally valid handoff route");
+        assert_eq!(session_id, "/sessions/victim");
+        assert_eq!(handoff_id, "handoff-id");
     }
 
     #[test]
@@ -9220,6 +9493,7 @@ mod tests {
                 .join("coven.sock")
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
 
         let response = handle_request("GET", "/health", temp_dir.path(), Some(daemon))?;
@@ -15575,6 +15849,140 @@ mod tests {
         Ok(())
     }
 
+    /// Regression coverage for the `/sessions/` route-prefix bug: an opaque
+    /// session id that itself begins with `/sessions/` (e.g. a caller that
+    /// doubles the collection prefix, or a raw v1 id chosen adversarially)
+    /// must be treated as one structural id, never re-stripped down to a
+    /// shorter, unrelated, and possibly real session id. A real session
+    /// named "victim" is seeded so a retargeting bug would otherwise let
+    /// these requests silently act on it instead of 404ing.
+    #[test]
+    fn session_routes_do_not_retarget_a_real_session_via_repeated_prefix() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "victim")?;
+        let wrapped_id = "/sessions/victim";
+        let expected_detail = json!({ "sessionId": wrapped_id }).to_string();
+        let expected_fragment = &expected_detail[1..expected_detail.len() - 1];
+
+        // GET detail
+        let detail = handle_request("GET", "/sessions//sessions/victim", temp_dir.path(), None)?;
+        assert_eq!(detail.status, 404);
+        assert!(detail.body.contains(r#""code":"session_not_found""#));
+        assert!(detail.body.contains(expected_fragment));
+        assert!(!detail.body.contains(r#""title":"hello from coven""#));
+
+        // POST input
+        let input = handle_request_with_body(
+            "POST",
+            "/sessions//sessions/victim/input",
+            temp_dir.path(),
+            None,
+            Some(r#"{ "data": "ls\n" }"#),
+        )?;
+        assert_eq!(input.status, 404);
+        assert!(input.body.contains(r#""code":"session_not_found""#));
+        assert!(input.body.contains(expected_fragment));
+
+        // POST kill
+        let kill = handle_request(
+            "POST",
+            "/sessions//sessions/victim/kill",
+            temp_dir.path(),
+            None,
+        )?;
+        assert_eq!(kill.status, 404);
+        assert!(kill.body.contains(r#""code":"session_not_found""#));
+        assert!(kill.body.contains(expected_fragment));
+
+        // POST complete
+        let complete = handle_request(
+            "POST",
+            "/sessions//sessions/victim/complete",
+            temp_dir.path(),
+            None,
+        )?;
+        assert_eq!(complete.status, 404);
+        assert!(complete.body.contains(r#""code":"session_not_found""#));
+        assert!(complete.body.contains(expected_fragment));
+
+        // GET events
+        let events = handle_request(
+            "GET",
+            "/sessions//sessions/victim/events",
+            temp_dir.path(),
+            None,
+        )?;
+        assert_eq!(events.status, 404);
+        assert!(events.body.contains(r#""code":"session_not_found""#));
+        assert!(events.body.contains(expected_fragment));
+
+        // GET handoffs (list)
+        let handoffs = handle_request(
+            "GET",
+            "/sessions//sessions/victim/handoffs",
+            temp_dir.path(),
+            None,
+        )?;
+        assert_eq!(handoffs.status, 404);
+        assert!(handoffs.body.contains(r#""code":"session_not_found""#));
+        assert!(handoffs.body.contains(expected_fragment));
+
+        // POST handoff claim (nested route). A well-formed request body is
+        // required to get past request validation to the not-found check.
+        let claim = handle_request_with_body(
+            "POST",
+            "/sessions//sessions/victim/handoffs/some-handoff/claim",
+            temp_dir.path(),
+            None,
+            Some(
+                &json!({
+                    "expectedGeneration": 1,
+                    "claimant": "tester",
+                    "idempotencyKey": "key-1",
+                    "destinationWorkspace": {
+                        "repositoryId": null,
+                        "commit": null,
+                        "branch": null,
+                        "dirty": false,
+                        "touchedFiles": [],
+                        "portable": true,
+                    }
+                })
+                .to_string(),
+            ),
+        )?;
+        assert_eq!(claim.status, 404);
+        assert!(claim.body.contains(r#""code":"handoff_not_found""#));
+
+        // GET artifact (nested route). Raw artifact persistence is disabled
+        // by default, so this fails closed on that gate before the session
+        // lookup — but the id in the failure details must still be the
+        // preserved, unretargeted wrapped id.
+        let artifact = handle_request(
+            "GET",
+            "/sessions//sessions/victim/artifacts/some-artifact?raw=1",
+            temp_dir.path(),
+            None,
+        )?;
+        assert_eq!(artifact.status, 403);
+        assert!(artifact.body.contains(r#""code":"raw_artifacts_disabled""#));
+        assert!(artifact.body.contains(expected_fragment));
+
+        Ok(())
+    }
+
+    /// A leading slash embedded in the raw remainder (i.e. the id begins
+    /// with `/`) must also survive intact rather than being consumed by a
+    /// prefix-trim pass.
+    #[test]
+    fn session_detail_preserves_a_leading_slash_in_the_raw_remainder() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let response = handle_request("GET", "/sessions//leading-slash-id", temp_dir.path(), None)?;
+        assert_eq!(response.status, 404);
+        assert!(response.body.contains(r#""sessionId":"/leading-slash-id""#));
+        Ok(())
+    }
+
     fn assert_direct_event_truncation_episodes(
         coven_home: &std::path::Path,
         session_id: &str,
@@ -16036,6 +16444,213 @@ mod tests {
     }
 
     #[test]
+    fn raw_external_session_ids_round_trip_through_nested_session_routes() -> anyhow::Result<()> {
+        let (temp, workspace) = portable_handoff_fixture()?;
+        std::fs::write(
+            temp.path().join("privacy.toml"),
+            "persist_raw_artifacts = true\n",
+        )?;
+        let cases = ["engine/42", "engine%2F42"];
+
+        for (index, session_id) in cases.into_iter().enumerate() {
+            let registration = json!({
+                "id": session_id,
+                "projectRoot": temp.path().join("repo").to_string_lossy(),
+                "harness": "engine",
+            })
+            .to_string();
+            let registered = handle_request_with_body(
+                "POST",
+                "/api/v1/sessions/external",
+                temp.path(),
+                None,
+                Some(&registration),
+            )?;
+            assert_eq!(
+                registered.status, 201,
+                "registration failed for {session_id:?}: {}",
+                registered.body
+            );
+
+            let mut packet = handoff_packet();
+            packet["meta"]["sessionId"] = Value::String(session_id.to_owned());
+            let offered = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/handoffs"),
+                temp.path(),
+                None,
+                Some(&packet.to_string()),
+            )?;
+            assert_eq!(
+                offered.status, 201,
+                "handoff creation failed for {session_id:?}: {}",
+                offered.body
+            );
+            let offered: Value = serde_json::from_str(&offered.body)?;
+            let handoff_id = offered["handoff"]["id"].as_str().unwrap();
+            let generation = offered["handoff"]["generation"].as_i64().unwrap();
+            let claim = json!({
+                "expectedGeneration": generation,
+                "claimant": format!("device:{index}"),
+                "idempotencyKey": format!("claim:{index}"),
+                "destinationWorkspace": workspace,
+            });
+            let claimed = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/handoffs/{handoff_id}/claim"),
+                temp.path(),
+                None,
+                Some(&claim.to_string()),
+            )?;
+            assert_eq!(
+                claimed.status, 200,
+                "handoff claim failed for {session_id:?}: {}",
+                claimed.body
+            );
+            let acknowledged = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/handoffs/{handoff_id}/ack"),
+                temp.path(),
+                None,
+                Some(&json!({ "claimant": format!("device:{index}") }).to_string()),
+            )?;
+            assert_eq!(
+                acknowledged.status, 200,
+                "handoff acknowledgement failed for {session_id:?}: {}",
+                acknowledged.body
+            );
+            let continued = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/handoffs/{handoff_id}/continuations"),
+                temp.path(),
+                None,
+                Some(&json!({ "destination": format!("device:{index}") }).to_string()),
+            )?;
+            assert_eq!(
+                continued.status, 201,
+                "handoff continuation failed for {session_id:?}: {}",
+                continued.body
+            );
+            let continued: Value = serde_json::from_str(&continued.body)?;
+            assert_eq!(continued["provenance"]["sourceSessionId"], session_id);
+
+            let event_id = format!("event-nested-route-{index}");
+            let artifact_id = format!("artifact-{index}%2Fraw");
+            let kind = "input";
+            let plaintext = json!({ "secret": format!("nested-route-{index}") }).to_string();
+            let encrypted = SensitiveArtifactStore::load(temp.path())?.encrypt(
+                session_id,
+                &event_id,
+                kind,
+                plaintext.as_bytes(),
+            )?;
+            let conn = store::open_store(&store_path(temp.path()))?;
+            store::insert_event(
+                &conn,
+                &store::EventRecord {
+                    seq: 0,
+                    id: event_id.clone(),
+                    session_id: session_id.to_owned(),
+                    kind: kind.to_owned(),
+                    payload_json: r#"{"secret":"[REDACTED]"}"#.to_owned(),
+                    created_at: "2026-08-16T00:00:00Z".to_owned(),
+                },
+            )?;
+            store::insert_sensitive_artifact(
+                &conn,
+                &store::SensitiveArtifactRecord {
+                    id: artifact_id.clone(),
+                    session_id: session_id.to_owned(),
+                    event_id,
+                    kind: kind.to_owned(),
+                    nonce: encrypted.nonce,
+                    ciphertext: encrypted.ciphertext,
+                    created_at: "2026-08-16T00:00:00Z".to_owned(),
+                    expires_at: "9999-01-01T00:00:00Z".to_owned(),
+                },
+            )?;
+            drop(conn);
+            let artifact = handle_request(
+                "GET",
+                &format!("/api/v1/sessions/{session_id}/artifacts/{artifact_id}?raw=1"),
+                temp.path(),
+                None,
+            )?;
+            assert_eq!(
+                artifact.status, 200,
+                "artifact access failed for {session_id:?}: {}",
+                artifact.body
+            );
+            let artifact: Value = serde_json::from_str(&artifact.body)?;
+            assert_eq!(artifact["sessionId"], session_id);
+            assert_eq!(artifact["artifactId"], artifact_id);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn percent_sequences_in_nested_session_routes_remain_literal_v1_bytes() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        let raw_session_ids = ["engine%", "engine%2", "engine%GG", "%FF"];
+
+        for session_id in raw_session_ids {
+            let routes = [
+                (
+                    format!("/api/v1/sessions/{session_id}/handoffs/handoff%252Fid/claim"),
+                    json!({
+                        "expectedGeneration": 1,
+                        "claimant": "device:test",
+                        "idempotencyKey": "claim:test",
+                        "destinationWorkspace": {
+                            "repositoryId": null,
+                            "commit": null,
+                            "branch": null,
+                            "dirty": false,
+                            "touchedFiles": [],
+                            "portable": false,
+                        },
+                    })
+                    .to_string(),
+                ),
+                (
+                    format!("/api/v1/sessions/{session_id}/handoffs/handoff%252Fid/ack"),
+                    json!({ "claimant": "device:test" }).to_string(),
+                ),
+                (
+                    format!("/api/v1/sessions/{session_id}/handoffs/handoff%252Fid/continuations"),
+                    json!({ "destination": "device:test" }).to_string(),
+                ),
+            ];
+            for (route, body) in routes {
+                let response =
+                    handle_request_with_body("POST", &route, temp.path(), None, Some(&body))?;
+                assert_eq!(
+                    response.status, 404,
+                    "literal v1 handoff route changed meaning for {session_id:?}: {route}: {}",
+                    response.body
+                );
+                let body: Value = serde_json::from_str(&response.body)?;
+                assert_eq!(body["error"]["code"], "handoff_not_found");
+            }
+
+            let artifact = handle_request(
+                "GET",
+                &format!("/api/v1/sessions/{session_id}/artifacts/artifact%252Fid?raw=1"),
+                temp.path(),
+                None,
+            )?;
+            assert_eq!(
+                artifact.status, 403,
+                "literal v1 artifact route changed meaning for {session_id:?}: {}",
+                artifact.body
+            );
+            let body: Value = serde_json::from_str(&artifact.body)?;
+            assert_eq!(body["error"]["code"], "raw_artifacts_disabled");
+        }
+        Ok(())
+    }
+
+    #[test]
     fn handoff_claim_fails_closed_when_transcript_or_workspace_diverges() -> anyhow::Result<()> {
         let (temp, workspace) = portable_handoff_fixture()?;
         let offered = handle_request_with_body(
@@ -16147,6 +16762,304 @@ mod tests {
     }
 
     #[test]
+    fn events_response_trims_a_page_before_the_transport_body_cap() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        let data = "x".repeat(crate::daemon::MAX_SOCKET_BODY_BYTES / 2 + 32 * 1024);
+        for index in 1..=2 {
+            store::insert_event(
+                &conn,
+                &store::EventRecord {
+                    seq: 0,
+                    id: format!("large-event-{index}"),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json: json!({ "data": data.clone() }).to_string(),
+                    created_at: "2026-05-19T00:00:00Z".to_string(),
+                },
+            )?;
+        }
+        drop(conn);
+
+        let first = handle_request(
+            "GET",
+            "/events?sessionId=session-1&limit=2",
+            temp_dir.path(),
+            None,
+        )?;
+
+        assert_eq!(first.status, 200);
+        assert!(first.body.len() < crate::daemon::MAX_SOCKET_BODY_BYTES);
+        let first: EventsResponse = serde_json::from_str(&first.body)?;
+        assert_eq!(first.events.len(), 1);
+        assert!(first.has_more);
+        let cursor = first.next_cursor.expect("trimmed page cursor").after_seq;
+
+        let second = handle_request(
+            "GET",
+            &format!("/events?sessionId=session-1&limit=2&afterSeq={cursor}"),
+            temp_dir.path(),
+            None,
+        )?;
+        assert_eq!(second.status, 200);
+        assert!(second.body.len() < crate::daemon::MAX_SOCKET_BODY_BYTES);
+        let second: EventsResponse = serde_json::from_str(&second.body)?;
+        assert_eq!(second.events.len(), 1);
+        assert!(!second.has_more);
+        Ok(())
+    }
+
+    #[test]
+    fn individually_oversized_event_returns_a_small_explicit_error() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        store::insert_event(
+            &conn,
+            &store::EventRecord {
+                seq: 0,
+                id: "oversized-event".to_string(),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: json!({
+                    "data": "x".repeat(crate::daemon::MAX_SOCKET_BODY_BYTES)
+                })
+                .to_string(),
+                created_at: "2026-05-19T00:00:00Z".to_string(),
+            },
+        )?;
+        drop(conn);
+
+        let response = handle_request(
+            "GET",
+            "/events?sessionId=session-1&limit=1",
+            temp_dir.path(),
+            None,
+        )?;
+
+        assert_eq!(response.status, 413);
+        assert!(response.body.len() < crate::daemon::MAX_SOCKET_BODY_BYTES);
+        let body: Value = serde_json::from_str(&response.body)?;
+        assert_eq!(body["error"]["code"], "event_response_too_large");
+        Ok(())
+    }
+
+    #[test]
+    fn oversized_corrupt_db_event_is_rejected_before_payload_materialization() -> anyhow::Result<()>
+    {
+        assert!(
+            rusqlite::version_number() >= 3_043_000,
+            "the bundled SQLite must provide metadata-only octet_length()"
+        );
+        let scratch_root = std::env::current_dir()?.join("target");
+        std::fs::create_dir_all(&scratch_root)?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix("oversized-event-regression-")
+            .tempdir_in(scratch_root)?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let path = store_path(temp_dir.path());
+        let conn = store::open_initialized_store(&path)?;
+        store::insert_event(
+            &conn,
+            &store::EventRecord {
+                seq: 0,
+                id: "before".to_owned(),
+                session_id: "session-1".to_owned(),
+                kind: "output".to_owned(),
+                payload_json: r#"{"data":"before"}"#.to_owned(),
+                created_at: "2026-05-19T00:00:00Z".to_owned(),
+            },
+        )?;
+        conn.execute(
+            "INSERT INTO events(
+                 id, session_id, kind, payload_json, created_at, redaction_status
+             ) VALUES(
+                 'oversized-corrupt', 'session-1', 'output',
+                 CAST(zeroblob(?1) AS TEXT), '2026-05-19T00:00:01Z', 'redacted'
+             )",
+            [i64::try_from(MAX_EVENT_CANDIDATE_BYTES + 1)?],
+        )?;
+        store::insert_event(
+            &conn,
+            &store::EventRecord {
+                seq: 0,
+                id: "after".to_owned(),
+                session_id: "session-1".to_owned(),
+                kind: "output".to_owned(),
+                payload_json: r#"{"data":"after"}"#.to_owned(),
+                created_at: "2026-05-19T00:00:02Z".to_owned(),
+            },
+        )?;
+        let before_seq =
+            conn.query_row("SELECT rowid FROM events WHERE id = 'before'", [], |row| {
+                row.get::<_, i64>(0)
+            })?;
+        let oversized_seq = conn.query_row(
+            "SELECT rowid FROM events WHERE id = 'oversized-corrupt'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let after_seq =
+            conn.query_row("SELECT rowid FROM events WHERE id = 'after'", [], |row| {
+                row.get::<_, i64>(0)
+            })?;
+        drop(conn);
+
+        let conn = store::open_initialized_store(&path)?;
+        // Keep SQLite from returning the corrupt payload. Metadata-only length
+        // inspection remains legal, while any attempt to materialize it fails
+        // with SQLITE_TOOBIG.
+        // SAFETY: `conn` owns a live SQLite connection for the duration of the
+        // call, and sqlite3_limit does not retain the handle.
+        let previous_limit = unsafe {
+            rusqlite::ffi::sqlite3_limit(
+                conn.handle(),
+                rusqlite::ffi::SQLITE_LIMIT_LENGTH,
+                1024 * 1024,
+            )
+        };
+        assert!(previous_limit > 1024 * 1024);
+
+        let candidates = store::list_event_candidates(&conn, "session-1", None, 3)?;
+        assert_eq!(
+            candidates
+                .candidates
+                .iter()
+                .map(|candidate| candidate.seq)
+                .collect::<Vec<_>>(),
+            [before_seq, oversized_seq, after_seq]
+        );
+        assert!(
+            candidates.candidates[1].allocation_bytes > MAX_EVENT_CANDIDATE_BYTES,
+            "the corrupt row must be rejected from byte-length metadata"
+        );
+
+        let loaded = std::cell::RefCell::new(Vec::new());
+        let (first, first_stats) = bounded_events_response_from_source(
+            3,
+            None,
+            |after, limit| store::list_event_candidates(&conn, "session-1", after, limit),
+            |seq| {
+                loaded.borrow_mut().push(seq);
+                store::get_event_by_seq(&conn, "session-1", seq)
+            },
+        )?;
+        assert_eq!(first.status, 200);
+        let first: EventsResponse = serde_json::from_str(&first.body)?;
+        assert_eq!(
+            first
+                .events
+                .iter()
+                .map(|event| event.id.as_str())
+                .collect::<Vec<_>>(),
+            ["before"]
+        );
+        assert_eq!(
+            first
+                .next_cursor
+                .expect("cursor before oversized row")
+                .after_seq,
+            before_seq
+        );
+        assert!(first.has_more);
+        assert_eq!(first_stats.events_loaded, 1);
+        assert_eq!(*loaded.borrow(), [before_seq]);
+
+        let (second, second_stats) = bounded_events_response_from_source(
+            3,
+            Some(before_seq),
+            |after, limit| store::list_event_candidates(&conn, "session-1", after, limit),
+            |seq| {
+                loaded.borrow_mut().push(seq);
+                store::get_event_by_seq(&conn, "session-1", seq)
+            },
+        )?;
+        assert_eq!(second.status, 413);
+        let second: Value = serde_json::from_str(&second.body)?;
+        assert_eq!(second["error"]["code"], "event_response_too_large");
+        assert_eq!(second["error"]["details"]["eventId"], "oversized-corrupt");
+        assert_eq!(second["error"]["details"]["seq"], oversized_seq);
+        assert_eq!(second_stats.events_loaded, 0);
+        assert_eq!(
+            *loaded.borrow(),
+            [before_seq],
+            "listing must not ask SQLite to retrieve the oversized payload"
+        );
+        assert!(
+            store::get_event_by_seq(&conn, "session-1", oversized_seq).is_err(),
+            "the low SQLite length limit proves the corrupt payload cannot be materialized"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn events_response_does_not_materialize_a_thousand_large_candidates() -> anyhow::Result<()> {
+        use std::cell::Cell;
+
+        const TOTAL_EVENTS: i64 = 1_000;
+        const LARGE_EVENT_BYTES: usize = 2_200_000;
+        let candidate_queries = Cell::new(0_usize);
+        let loaded_events = Cell::new(0_usize);
+
+        let (response, stats) = bounded_events_response_from_source(
+            TOTAL_EVENTS as usize,
+            None,
+            |after_seq, limit| {
+                candidate_queries.set(candidate_queries.get() + 1);
+                let first = after_seq.unwrap_or(0) + 1;
+                let candidates = (first..=TOTAL_EVENTS)
+                    .take(limit)
+                    .map(|seq| store::EventCandidate {
+                        seq,
+                        event_id: Some(format!("large-event-{seq}")),
+                        allocation_bytes: LARGE_EVENT_BYTES,
+                        encoded_lower_bound_bytes: Some(LARGE_EVENT_BYTES),
+                    })
+                    .collect();
+                Ok(store::EventCandidatePage { candidates })
+            },
+            |seq| {
+                loaded_events.set(loaded_events.get() + 1);
+                let mut payload_json = String::with_capacity(LARGE_EVENT_BYTES);
+                payload_json.push_str(r#"{"data":""#);
+                payload_json.extend(std::iter::repeat_n(
+                    'x',
+                    LARGE_EVENT_BYTES - r#"{"data":""#.len() - 2,
+                ));
+                payload_json.push_str(r#""}"#);
+                Ok(Some(store::EventRecord {
+                    seq,
+                    id: format!("large-event-{seq}"),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json,
+                    created_at: "2026-05-19T00:00:00Z".to_string(),
+                }))
+            },
+        )?;
+
+        assert_eq!(response.status, 200);
+        assert!(response.body.len() < coven_client::MAX_RESPONSE_BODY_BYTES);
+        let body: EventsResponse = serde_json::from_str(&response.body)?;
+        assert_eq!(body.events.len(), 1);
+        assert!(body.has_more);
+        assert_eq!(body.next_cursor.expect("bounded cursor").after_seq, 1);
+        assert_eq!(candidate_queries.get(), 1);
+        assert_eq!(stats.candidate_batches, 1);
+        assert_eq!(stats.peak_candidate_batch, EVENT_CANDIDATE_BATCH_LIMIT);
+        assert_eq!(stats.candidates_examined, 2);
+        assert_eq!(stats.events_loaded, 1);
+        assert_eq!(loaded_events.get(), 1);
+        assert!(
+            stats.events_loaded < TOTAL_EVENTS as usize,
+            "large candidates must be rejected by metadata before aggregate allocation"
+        );
+        assert!(stats.peak_loaded_event_bytes <= MAX_EVENT_CANDIDATE_BYTES);
+        Ok(())
+    }
+
+    #[test]
     fn events_endpoint_supports_after_seq_cursor() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         insert_test_session(temp_dir.path(), "session-1")?;
@@ -16202,6 +17115,74 @@ mod tests {
         assert_eq!(limited.status, 200);
         assert_eq!(body["events"].as_array().unwrap().len(), 2);
         assert_eq!(body["hasMore"], true);
+        Ok(())
+    }
+
+    #[test]
+    fn events_endpoint_preserves_cursor_order_across_candidate_batches() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        insert_test_session(temp_dir.path(), "session-1")?;
+        let conn = store::open_store(&store_path(temp_dir.path()))?;
+        for index in 1..=40 {
+            store::insert_event(
+                &conn,
+                &store::EventRecord {
+                    seq: 0,
+                    id: format!("event-{index}"),
+                    session_id: "session-1".to_string(),
+                    kind: "output".to_string(),
+                    payload_json: json!({ "data": index }).to_string(),
+                    created_at: "2026-05-19T00:00:00Z".to_string(),
+                },
+            )?;
+        }
+        drop(conn);
+
+        let first = handle_request(
+            "GET",
+            "/events?sessionId=session-1&limit=30",
+            temp_dir.path(),
+            None,
+        )?;
+        let first: EventsResponse = serde_json::from_str(&first.body)?;
+        assert_eq!(first.events.len(), 30);
+        assert!(first.has_more);
+        assert!(first
+            .events
+            .windows(2)
+            .all(|pair| pair[0].seq < pair[1].seq));
+        let cursor = first.next_cursor.expect("first page cursor").after_seq;
+
+        let second = handle_request(
+            "GET",
+            &format!("/events?sessionId=session-1&limit=30&afterSeq={cursor}"),
+            temp_dir.path(),
+            None,
+        )?;
+        let second: EventsResponse = serde_json::from_str(&second.body)?;
+        assert_eq!(second.events.len(), 10);
+        assert!(!second.has_more);
+        assert!(second
+            .events
+            .windows(2)
+            .all(|pair| pair[0].seq < pair[1].seq));
+        assert!(second
+            .events
+            .first()
+            .is_some_and(|event| event.seq > cursor));
+
+        let ids = first
+            .events
+            .into_iter()
+            .chain(second.events)
+            .map(|event| event.id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids,
+            (1..=40)
+                .map(|index| format!("event-{index}"))
+                .collect::<Vec<_>>()
+        );
         Ok(())
     }
 
@@ -21127,6 +22108,114 @@ tier = 0
             "idempotent re-register should return 200"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn v1_session_routes_keep_raw_remainders_and_percent_bytes_distinct() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        for session_id in ["engine/42", "engine%2F42"] {
+            let registration = json!({
+                "id": session_id,
+                "projectRoot": temp.path().to_string_lossy(),
+                "harness": "engine",
+            })
+            .to_string();
+            let registered = handle_request_with_body(
+                "POST",
+                "/api/v1/sessions/external",
+                temp.path(),
+                None,
+                Some(&registration),
+            )?;
+            assert_eq!(registered.status, 201, "register {session_id:?}");
+
+            let detail = handle_request(
+                "GET",
+                &format!("/api/v1/sessions/{session_id}"),
+                temp.path(),
+                None,
+            )?;
+            assert_eq!(detail.status, 200, "detail {session_id:?}: {}", detail.body);
+            let detail: serde_json::Value = serde_json::from_str(&detail.body)?;
+            assert_eq!(detail["id"], session_id);
+
+            let input = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/input"),
+                temp.path(),
+                None,
+                Some(r#"{"data":"hello"}"#),
+            )?;
+            assert_eq!(input.status, 202, "input {session_id:?}: {}", input.body);
+
+            let nested_events = handle_request(
+                "GET",
+                &format!("/api/v1/sessions/{session_id}/events"),
+                temp.path(),
+                None,
+            )?;
+            assert_eq!(
+                nested_events.status, 200,
+                "nested events {session_id:?}: {}",
+                nested_events.body
+            );
+
+            let events = handle_request(
+                "GET",
+                &format!("/api/v1/events?sessionId={session_id}"),
+                temp.path(),
+                None,
+            )?;
+            assert_eq!(events.status, 200, "events {session_id:?}: {}", events.body);
+
+            let kill = handle_request(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/kill"),
+                temp.path(),
+                None,
+            )?;
+            assert_eq!(kill.status, 422, "kill {session_id:?}: {}", kill.body);
+
+            let completed = handle_request_with_body(
+                "POST",
+                &format!("/api/v1/sessions/{session_id}/complete"),
+                temp.path(),
+                None,
+                Some(r#"{"exitCode":0}"#),
+            )?;
+            assert_eq!(
+                completed.status, 200,
+                "complete {session_id:?}: {}",
+                completed.body
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn external_session_registration_rejects_empty_ids() -> anyhow::Result<()> {
+        let temp = tempfile::tempdir()?;
+        for session_id in ["", " \t "] {
+            let registration = json!({
+                "id": session_id,
+                "projectRoot": temp.path().to_string_lossy(),
+                "harness": "engine",
+            })
+            .to_string();
+
+            let response = handle_request_with_body(
+                "POST",
+                "/api/v1/sessions/external",
+                temp.path(),
+                None,
+                Some(&registration),
+            )?;
+            assert_eq!(
+                response.status, 400,
+                "unsafe external session id was registered: {session_id:?}"
+            );
+        }
         Ok(())
     }
 

--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -212,13 +212,12 @@ fn append_home_surfaces(
         cwd,
     );
     #[cfg(windows)]
-    push_path(
-        surfaces,
-        "state.daemon_ipc",
-        &crate::daemon::windows_pipe_path(home),
-        source,
-        cwd,
-    );
+    match crate::daemon::windows_pipe_path(home) {
+        Ok(path) => push_path(surfaces, "state.daemon_ipc", &path, source, cwd),
+        Err(_) => {
+            push_terminal_with_source(surfaces, "state.daemon_ipc", PathStatus::Unresolved, source)
+        }
+    }
     push_path(
         surfaces,
         "state.familiar_manifest",

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -35,6 +35,97 @@ pub struct DaemonStatus {
     pub pid: u32,
     pub started_at: String,
     pub socket: String,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_windows_process_creation_time"
+    )]
+    pub(crate) process_creation_time: Option<WindowsProcessCreationTime>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct WindowsProcessCreationTime(u64);
+
+impl WindowsProcessCreationTime {
+    #[cfg(any(windows, test))]
+    fn new(value: u64) -> Result<Self> {
+        anyhow::ensure!(value != 0, "invalid Windows process creation time: zero");
+        Ok(Self(value))
+    }
+
+    #[cfg(any(windows, test))]
+    fn get(self) -> u64 {
+        self.0
+    }
+}
+
+impl Serialize for WindowsProcessCreationTime {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for WindowsProcessCreationTime {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let serialized = value.as_str().ok_or_else(|| {
+            serde::de::Error::custom(
+                "invalid Windows process creation time: expected a decimal string",
+            )
+        })?;
+        let value = serialized.parse::<u64>().map_err(|_| {
+            serde::de::Error::custom(
+                "invalid Windows process creation time: expected an unsigned 64-bit decimal string",
+            )
+        })?;
+        if value == 0 {
+            return Err(serde::de::Error::custom(
+                "invalid Windows process creation time: zero",
+            ));
+        }
+        Ok(Self(value))
+    }
+}
+
+fn deserialize_optional_windows_process_creation_time<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<WindowsProcessCreationTime>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Err(serde::de::Error::custom(
+            "invalid Windows process creation time: null",
+        ));
+    }
+    serde_json::from_value(value)
+        .map(Some)
+        .map_err(serde::de::Error::custom)
+}
+
+#[derive(Debug)]
+struct DaemonStatusParseError {
+    source: serde_json::Error,
+    process_creation_time_present: bool,
+}
+
+impl std::fmt::Display for DaemonStatusParseError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "failed to parse daemon status: {}", self.source)
+    }
+}
+
+impl std::error::Error for DaemonStatusParseError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.source)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -43,11 +134,16 @@ pub enum DaemonStatusState {
     Stale(DaemonStatus),
 }
 
+#[cfg(any(windows, test))]
 #[derive(Debug, Deserialize)]
 struct DaemonHealthStatus {
     ok: bool,
     daemon: Option<DaemonStatus>,
 }
+
+#[cfg(not(windows))]
+const MAX_DAEMON_STATUS_BYTES: usize = coven_client::MAX_DAEMON_STATUS_BYTES;
+const DAEMON_LIFECYCLE_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DaemonSpawnSpec {
@@ -1332,26 +1428,35 @@ enum DaemonIpcPlatform {
     Windows,
 }
 
-fn daemon_windows_pipe_name(coven_home: &Path) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut h = std::collections::hash_map::DefaultHasher::new();
-    coven_home.to_string_lossy().hash(&mut h);
-    format!("coven-daemon-{:016x}.sock", h.finish())
+fn daemon_windows_pipe_name(coven_home: &Path) -> Result<String> {
+    #[cfg(windows)]
+    {
+        coven_client::owner_only_windows_pipe_name(coven_home).map_err(anyhow::Error::new)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = coven_home;
+        anyhow::bail!("Windows daemon pipe identity is unavailable on this platform")
+    }
 }
 
 fn daemon_startup_status_socket_for_platform(
     coven_home: &Path,
     platform: DaemonIpcPlatform,
-) -> String {
-    match platform {
+) -> Result<String> {
+    Ok(match platform {
         DaemonIpcPlatform::Unix => daemon_socket_path(coven_home)
-            .to_string_lossy()
-            .into_owned(),
-        DaemonIpcPlatform::Windows => daemon_windows_pipe_name(coven_home),
-    }
+            .to_str()
+            .context(
+                "canonical Coven daemon socket is not valid UTF-8; daemon status JSON requires \
+                 UTF-8 paths",
+            )?
+            .to_owned(),
+        DaemonIpcPlatform::Windows => daemon_windows_pipe_name(coven_home)?,
+    })
 }
 
-fn daemon_startup_status_socket(coven_home: &Path) -> String {
+fn daemon_startup_status_socket(coven_home: &Path) -> Result<String> {
     #[cfg(windows)]
     {
         daemon_startup_status_socket_for_platform(coven_home, DaemonIpcPlatform::Windows)
@@ -1411,15 +1516,244 @@ pub(crate) fn ensure_private_coven_home(coven_home: &Path) -> Result<()> {
 
 #[cfg(not(unix))]
 pub(crate) fn ensure_private_coven_home(coven_home: &Path) -> Result<()> {
+    #[cfg(windows)]
+    if let Ok(metadata) = std::fs::symlink_metadata(coven_home) {
+        if metadata.file_type().is_symlink() {
+            anyhow::bail!(
+                "refusing to use Coven home {}: path is a symlink",
+                coven_home.display()
+            );
+        }
+    }
     std::fs::create_dir_all(coven_home)
         .with_context(|| format!("failed to create Coven home {}", coven_home.display()))?;
+    #[cfg(windows)]
+    set_windows_owner_only_security(coven_home)?;
     Ok(())
 }
 
-pub fn background_server_spec(current_exe: &Path, coven_home: &Path) -> DaemonSpawnSpec {
+#[cfg(windows)]
+fn set_windows_owner_only_security(path: &Path) -> Result<()> {
+    use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
+    use windows_sys::Win32::Security::{
+        Authorization::{
+            ConvertStringSecurityDescriptorToSecurityDescriptorW, SetNamedSecurityInfoW,
+            SE_FILE_OBJECT,
+        },
+        GetSecurityDescriptorDacl, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+        PROTECTED_DACL_SECURITY_INFORMATION,
+    };
+
+    let descriptor_sddl: Vec<u16> = OsStr::new("D:P(A;;GA;;;OW)")
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let mut descriptor = ptr::null_mut();
+    if unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            descriptor_sddl.as_ptr(),
+            1,
+            &mut descriptor,
+            ptr::null_mut(),
+        ) == 0
+    } {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to build owner-only Windows security descriptor");
+    }
+    let _descriptor = WindowsLocalAllocation(descriptor);
+    let mut dacl_present = 0;
+    let mut dacl = ptr::null_mut();
+    let mut dacl_defaulted = 0;
+    if unsafe {
+        GetSecurityDescriptorDacl(
+            descriptor,
+            &mut dacl_present,
+            &mut dacl,
+            &mut dacl_defaulted,
+        ) == 0
+    } || dacl_present == 0
+        || dacl.is_null()
+    {
+        anyhow::bail!("owner-only Windows security descriptor did not contain a DACL");
+    }
+
+    let owner = current_windows_user_sid()?;
+    let path: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let status = unsafe {
+        SetNamedSecurityInfoW(
+            path.as_ptr(),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION
+                | DACL_SECURITY_INFORMATION
+                | PROTECTED_DACL_SECURITY_INFORMATION,
+            owner.as_ptr(),
+            ptr::null_mut(),
+            dacl,
+            ptr::null_mut(),
+        )
+    };
+    if status != 0 {
+        anyhow::bail!("failed to set owner-only security on Coven path: Windows error {status}");
+    }
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+struct WindowsTokenBuffer {
+    words: Vec<usize>,
+}
+
+#[cfg(any(windows, test))]
+impl WindowsTokenBuffer {
+    fn new(byte_len: usize) -> Self {
+        let word_len = byte_len.max(1).div_ceil(std::mem::size_of::<usize>());
+        Self {
+            words: vec![0; word_len],
+        }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut std::ffi::c_void {
+        self.words.as_mut_ptr().cast()
+    }
+
+    #[cfg(windows)]
+    fn as_ptr(&self) -> *const std::ffi::c_void {
+        self.words.as_ptr().cast()
+    }
+
+    fn byte_capacity(&self) -> usize {
+        self.words.len() * std::mem::size_of::<usize>()
+    }
+}
+
+#[cfg(windows)]
+const _: () = assert!(
+    std::mem::align_of::<usize>()
+        >= std::mem::align_of::<windows_sys::Win32::Security::TOKEN_USER>()
+);
+
+#[cfg(windows)]
+struct WindowsSid(WindowsTokenBuffer);
+
+#[cfg(windows)]
+impl WindowsSid {
+    fn as_ptr(&self) -> windows_sys::Win32::Security::PSID {
+        self.0.as_ptr().cast_mut()
+    }
+
+    fn to_sddl_string(&self) -> Result<String> {
+        use std::ptr;
+        use widestring::U16CStr;
+        use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+
+        let mut string_sid = ptr::null_mut();
+        if unsafe { ConvertSidToStringSidW(self.as_ptr(), &mut string_sid) } == 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to serialize current Windows user SID");
+        }
+        let _string_sid = WindowsLocalAllocation(string_sid.cast());
+        unsafe { U16CStr::from_ptr_str(string_sid) }
+            .to_string()
+            .context("current Windows user SID was not valid UTF-16")
+    }
+}
+
+#[cfg(windows)]
+fn current_windows_user_sid() -> Result<WindowsSid> {
+    use std::{mem::size_of, ptr};
+    use windows_sys::Win32::{
+        Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER},
+        Security::{
+            CopySid, GetLengthSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER,
+        },
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
+    };
+
+    let mut process_token = ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut process_token) == 0 } {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to inspect current Windows user");
+    }
+    let _token = WindowsHandle(process_token);
+    let mut bytes = 0;
+    let initial =
+        unsafe { GetTokenInformation(process_token, TokenUser, ptr::null_mut(), 0, &mut bytes) };
+    if initial != 0 || unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER || bytes == 0 {
+        anyhow::bail!("failed to size current Windows user token");
+    }
+    let mut buffer = WindowsTokenBuffer::new(bytes as usize);
+    if unsafe {
+        GetTokenInformation(
+            process_token,
+            TokenUser,
+            buffer.as_mut_ptr(),
+            bytes,
+            &mut bytes,
+        ) == 0
+    } {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to read current Windows user token");
+    }
+    if (bytes as usize) < size_of::<TOKEN_USER>() || bytes as usize > buffer.byte_capacity() {
+        anyhow::bail!("current Windows user token returned an invalid size");
+    }
+    let user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
+    if user.User.Sid.is_null() {
+        anyhow::bail!("current Windows user token had no SID");
+    }
+    let length = unsafe { GetLengthSid(user.User.Sid) } as usize;
+    if length == 0 {
+        anyhow::bail!("current Windows user token had an invalid SID");
+    }
+    let mut sid = WindowsTokenBuffer::new(length);
+    if unsafe { CopySid(length as u32, sid.as_mut_ptr(), user.User.Sid) } == 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to copy current Windows user SID");
+    }
+    Ok(WindowsSid(sid))
+}
+
+#[cfg(windows)]
+struct WindowsHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for WindowsHandle {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct WindowsLocalAllocation(*mut std::ffi::c_void);
+
+#[cfg(windows)]
+impl Drop for WindowsLocalAllocation {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0);
+        }
+    }
+}
+
+pub fn background_server_spec(
+    current_exe: &Path,
+    coven_home: &Path,
+    started_at: &str,
+) -> DaemonSpawnSpec {
     DaemonSpawnSpec {
         program: current_exe.to_path_buf(),
-        args: vec!["daemon".to_string(), "serve".to_string()],
+        args: vec![
+            "daemon".to_string(),
+            "serve".to_string(),
+            "--managed-started-at".to_string(),
+            started_at.to_owned(),
+        ],
         coven_home: coven_home.to_path_buf(),
     }
 }
@@ -1429,19 +1763,30 @@ pub fn start_background_server(
     current_exe: &Path,
     started_at: String,
 ) -> Result<DaemonStatus> {
-    let spec = background_server_spec(current_exe, coven_home);
-    ensure_private_coven_home(coven_home)?;
     prevent_background_server_stdio_handle_leaks()?;
-    let child = background_server_command(&spec)
-        .spawn()
-        .with_context(|| format!("failed to start Coven daemon {}", spec.program.display()))?;
-    let status = DaemonStatus {
-        pid: child.id(),
+    start_background_server_with_spawn(coven_home, current_exe, started_at, |spec| {
+        background_server_command(spec)
+            .spawn()
+            .map(|child| child.id())
+            .with_context(|| format!("failed to start Coven daemon {}", spec.program.display()))
+    })
+}
+
+fn start_background_server_with_spawn(
+    coven_home: &Path,
+    current_exe: &Path,
+    started_at: String,
+    spawn: impl FnOnce(&DaemonSpawnSpec) -> Result<u32>,
+) -> Result<DaemonStatus> {
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    let spec = background_server_spec(current_exe, &coven_home, &started_at);
+    let pid = spawn(&spec)?;
+    Ok(DaemonStatus {
+        pid,
         started_at,
-        socket: daemon_startup_status_socket(coven_home),
-    };
-    write_status(coven_home, &status)?;
-    Ok(status)
+        socket: daemon_startup_status_socket(&coven_home)?,
+        process_creation_time: None,
+    })
 }
 
 #[cfg(windows)]
@@ -1519,16 +1864,22 @@ pub fn ensure_background_server(
     current_exe: &Path,
     started_at: String,
 ) -> Result<DaemonStatus> {
-    let _lock = acquire_daemon_lifecycle_lock(coven_home)?;
-    let status = ensure_background_server_with_controllers(
-        coven_home,
+    let deadline = LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?;
+    deadline.remaining("resolving Coven daemon profile")?;
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    let _lock = acquire_daemon_lifecycle_lock_until(&coven_home, deadline)?;
+    let status = ensure_background_server_with_controllers_until(
+        &coven_home,
         current_exe,
         started_at,
         &SystemDaemonStopController,
         &SystemDaemonStartController,
+        deadline,
     )?;
     #[cfg(unix)]
-    cleanup_unreachable_duplicate_daemons(coven_home, status.pid);
+    run_optional_lifecycle_diagnostic(deadline, move |deadline| {
+        report_unreachable_duplicate_daemons(coven_home, status.pid, deadline);
+    });
     Ok(status)
 }
 
@@ -1537,64 +1888,72 @@ pub(crate) fn daemon_lifecycle_lock_path(coven_home: &Path) -> PathBuf {
 }
 
 #[cfg(unix)]
-fn cleanup_unreachable_duplicate_daemons(coven_home: &Path, active_pid: u32) {
-    use sysinfo::{Pid, ProcessesToUpdate, Signal, System};
+fn report_unreachable_duplicate_daemons(coven_home: PathBuf, active_pid: u32, deadline: Instant) {
+    use sysinfo::System;
 
-    let mut sys = System::new_all();
-    sys.refresh_all();
-    let candidates: Vec<(Pid, u64, Vec<std::ffi::OsString>)> = sys
-        .processes()
-        .iter()
-        .filter_map(|(pid, process)| {
-            if !process_is_unreachable_duplicate_daemon_candidate(
-                pid.as_u32(),
-                active_pid,
-                process.thread_kind(),
-                process.cmd(),
-                process.environ(),
-                coven_home,
-            ) {
-                return None;
-            }
-            Some((*pid, process.start_time(), process.cmd().to_vec()))
-        })
-        .collect();
-
-    for (pid, start_time, cmd) in candidates {
-        sys.refresh_processes(ProcessesToUpdate::Some(&[pid]), true);
-        let Some(process) = sys.process(pid) else {
-            continue;
-        };
-        if process.start_time() != start_time
-            || process.cmd() != cmd.as_slice()
-            || !process_is_unreachable_duplicate_daemon_candidate(
-                pid.as_u32(),
-                active_pid,
-                process.thread_kind(),
-                process.cmd(),
-                process.environ(),
-                coven_home,
-            )
-        {
-            continue;
+    let (finished_tx, finished_rx) = std::sync::mpsc::sync_channel(0);
+    std::thread::spawn(move || {
+        optional_diagnostic_test_delay();
+        if Instant::now() >= deadline {
+            let _ = finished_tx.send(());
+            return;
         }
-        match process.kill_with(Signal::Term) {
-            Some(true) => append_daemon_recovery_log(
-                coven_home,
-                &format!(
-                    "terminated unreachable duplicate daemon pid={} active_pid={}",
-                    pid.as_u32(),
-                    active_pid
-                ),
-            ),
-            Some(false) | None => append_daemon_recovery_log(
-                coven_home,
-                &format!(
-                    "failed to terminate unreachable duplicate daemon pid={} active_pid={}",
-                    pid.as_u32(),
-                    active_pid
-                ),
-            ),
+        let mut sys = System::new_all();
+        sys.refresh_all();
+        for (pid, process) in sys.processes() {
+            if Instant::now() >= deadline {
+                return;
+            }
+            if process_is_unreachable_duplicate_daemon_candidate(
+                pid.as_u32(),
+                active_pid,
+                process.thread_kind(),
+                process.cmd(),
+                process.environ(),
+                &coven_home,
+            ) {
+                append_daemon_recovery_log(
+                    &coven_home,
+                    &format!(
+                        "preserved unreachable duplicate daemon pid={} active_pid={}: no authenticated lifecycle connection",
+                        pid.as_u32(),
+                        active_pid
+                    ),
+                );
+            }
+        }
+        let _ = finished_tx.send(());
+    });
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if !remaining.is_zero() {
+        let _ = finished_rx.recv_timeout(remaining);
+    }
+}
+
+#[cfg(unix)]
+fn run_optional_lifecycle_diagnostic(
+    deadline: LifecycleDeadline,
+    diagnostic: impl FnOnce(Instant),
+) {
+    if deadline
+        .remaining("running optional daemon diagnostics")
+        .is_ok()
+    {
+        diagnostic(deadline.instant);
+    }
+}
+
+#[cfg(all(unix, test))]
+static OPTIONAL_DIAGNOSTIC_DELAY_MILLIS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(unix)]
+fn optional_diagnostic_test_delay() {
+    #[cfg(test)]
+    {
+        let delay = OPTIONAL_DIAGNOSTIC_DELAY_MILLIS.load(std::sync::atomic::Ordering::SeqCst);
+        if delay != 0 {
+            std::thread::sleep(Duration::from_millis(delay));
         }
     }
 }
@@ -1652,6 +2011,34 @@ fn acquire_daemon_lifecycle_lock(coven_home: &Path) -> Result<DaemonLifecycleLoc
     file.lock_exclusive()
         .with_context(|| format!("failed to lock daemon lifecycle {}", lock_path.display()))?;
     Ok(DaemonLifecycleLock { file })
+}
+
+fn acquire_daemon_lifecycle_lock_until(
+    coven_home: &Path,
+    deadline: LifecycleDeadline,
+) -> Result<DaemonLifecycleLock> {
+    ensure_private_coven_home(coven_home)?;
+    let lock_path = daemon_lifecycle_lock_path(coven_home);
+    let file = crate::state_lock::open_lock_file(&lock_path).with_context(|| {
+        format!(
+            "failed to open daemon lifecycle lock {}",
+            lock_path.display()
+        )
+    })?;
+    loop {
+        match file.try_lock_exclusive() {
+            Ok(()) => return Ok(DaemonLifecycleLock { file }),
+            Err(error) if crate::state_lock::is_lock_contended(&error) => {
+                let remaining = deadline.remaining("waiting for Coven daemon lifecycle lock")?;
+                std::thread::sleep(remaining.min(Duration::from_millis(10)));
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to lock daemon lifecycle {}", lock_path.display())
+                })
+            }
+        }
+    }
 }
 
 fn try_acquire_daemon_lifecycle_lock_in(
@@ -1716,6 +2103,11 @@ pub fn write_status(coven_home: &Path, status: &DaemonStatus) -> Result<()> {
     ensure_private_coven_home(coven_home)?;
     let json = serde_json::to_string_pretty(status).context("failed to serialize daemon status")?;
     let status_path = daemon_status_path(coven_home);
+    #[cfg(windows)]
+    {
+        return write_windows_status(&status_path, &json);
+    }
+    #[cfg(not(windows))]
     std::fs::write(&status_path, format!("{json}\n")).context("failed to write daemon status")?;
     #[cfg(unix)]
     std::fs::set_permissions(&status_path, std::fs::Permissions::from_mode(0o600)).with_context(
@@ -1729,16 +2121,161 @@ pub fn write_status(coven_home: &Path, status: &DaemonStatus) -> Result<()> {
     Ok(())
 }
 
+#[cfg(windows)]
+fn write_windows_status(status_path: &Path, json: &str) -> Result<()> {
+    use std::{ffi::OsStr, os::windows::ffi::OsStrExt};
+    use windows_sys::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let temporary_path =
+        status_path.with_file_name(format!(".daemon-status-{}.tmp", uuid::Uuid::new_v4()));
+    let write_result = (|| -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary_path)
+            .with_context(|| {
+                format!(
+                    "failed to create temporary daemon status {}",
+                    temporary_path.display()
+                )
+            })?;
+        file.write_all(format!("{json}\n").as_bytes())
+            .context("failed to write temporary daemon status")?;
+        file.sync_all()
+            .context("failed to sync temporary daemon status")?;
+        drop(file);
+        set_windows_owner_only_security(&temporary_path)?;
+
+        let temporary: Vec<u16> = OsStr::new(&temporary_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let destination: Vec<u16> = OsStr::new(status_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        if unsafe {
+            MoveFileExW(
+                temporary.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            ) == 0
+        } {
+            return Err(std::io::Error::last_os_error()).with_context(|| {
+                format!(
+                    "failed to atomically replace daemon status {}",
+                    status_path.display()
+                )
+            });
+        }
+        Ok(())
+    })();
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&temporary_path);
+    }
+    write_result
+}
+
 pub fn read_status(coven_home: &Path) -> Result<Option<DaemonStatus>> {
-    let path = daemon_status_path(coven_home);
-    if !path.exists() {
-        return Ok(None);
+    #[cfg(windows)]
+    {
+        let Some(json) = coven_client::read_windows_daemon_status_for_lifecycle(coven_home)
+            .map_err(anyhow::Error::new)?
+        else {
+            return Ok(None);
+        };
+        let status = parse_daemon_status(&json)?;
+        return Ok(Some(status));
     }
 
-    let json = std::fs::read_to_string(&path)
-        .with_context(|| format!("failed to read daemon status {}", path.display()))?;
-    let status = serde_json::from_str(&json).context("failed to parse daemon status")?;
-    Ok(Some(status))
+    #[cfg(not(windows))]
+    {
+        let path = daemon_status_path(coven_home);
+        let file = match std::fs::File::open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to open daemon status {}", path.display()))
+            }
+        };
+        let json = read_bounded_daemon_status(file).map_err(|error| {
+            anyhow::anyhow!("failed to read daemon status {}: {error:#}", path.display())
+        })?;
+        let status = parse_daemon_status(&json)?;
+        Ok(Some(status))
+    }
+}
+
+fn read_status_until(
+    coven_home: &Path,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
+    deadline.remaining("reading Coven daemon lifecycle status")?;
+    #[cfg(windows)]
+    {
+        let Some(json) = coven_client::read_windows_daemon_status_for_lifecycle_until(
+            coven_home,
+            deadline.instant,
+        )
+        .map_err(anyhow::Error::new)?
+        else {
+            return Ok(None);
+        };
+        let status = parse_daemon_status(&json)?;
+        deadline.remaining("parsing Coven daemon lifecycle status")?;
+        Ok(Some(status))
+    }
+    #[cfg(not(windows))]
+    {
+        let status = read_status(coven_home)?;
+        deadline.remaining("reading Coven daemon lifecycle status")?;
+        Ok(status)
+    }
+}
+
+fn parse_daemon_status(serialized: &str) -> Result<DaemonStatus> {
+    let process_creation_time_present = serde_json::from_str::<serde_json::Value>(serialized)
+        .ok()
+        .and_then(|value| {
+            value
+                .as_object()
+                .map(|object| object.contains_key("processCreationTime"))
+        })
+        .unwrap_or(false);
+    serde_json::from_str(serialized).map_err(|source| {
+        anyhow::Error::new(DaemonStatusParseError {
+            source,
+            process_creation_time_present,
+        })
+    })
+}
+
+pub(crate) fn read_status_synchronized(coven_home: &Path) -> Result<Option<DaemonStatus>> {
+    let _lock = acquire_daemon_lifecycle_lock(coven_home)?;
+    read_status(coven_home)
+}
+
+#[cfg(not(windows))]
+fn read_bounded_daemon_status(file: std::fs::File) -> Result<String> {
+    let size = file
+        .metadata()
+        .context("failed to inspect daemon status size")?
+        .len();
+    if size > MAX_DAEMON_STATUS_BYTES as u64 {
+        anyhow::bail!("daemon status exceeded the {MAX_DAEMON_STATUS_BYTES}-byte limit");
+    }
+    let capacity = usize::try_from(size).context("daemon status size was not representable")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.take((MAX_DAEMON_STATUS_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .context("failed to read bounded daemon status")?;
+    if bytes.len() > MAX_DAEMON_STATUS_BYTES {
+        anyhow::bail!("daemon status exceeded the {MAX_DAEMON_STATUS_BYTES}-byte limit");
+    }
+    String::from_utf8(bytes).context("daemon status was not valid UTF-8")
 }
 
 pub fn clear_status(coven_home: &Path) -> Result<bool> {
@@ -1753,8 +2290,11 @@ pub fn clear_status(coven_home: &Path) -> Result<bool> {
 }
 
 pub fn stop_background_server(coven_home: &Path) -> Result<bool> {
-    let _lock = acquire_daemon_lifecycle_lock(coven_home)?;
-    stop_background_server_with_controller(coven_home, &SystemDaemonStopController)
+    let deadline = LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?;
+    deadline.remaining("resolving Coven daemon profile")?;
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    let _lock = acquire_daemon_lifecycle_lock_until(&coven_home, deadline)?;
+    stop_background_server_with_controller_until(&coven_home, &SystemDaemonStopController, deadline)
 }
 
 pub fn restart_background_server(
@@ -1762,33 +2302,157 @@ pub fn restart_background_server(
     current_exe: &Path,
     started_at: String,
 ) -> Result<(bool, DaemonStatus)> {
-    let _lock = acquire_daemon_lifecycle_lock(coven_home)?;
+    let deadline = LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?;
+    deadline.remaining("resolving Coven daemon profile")?;
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    let _lock = acquire_daemon_lifecycle_lock_until(&coven_home, deadline)?;
+    restart_background_server_with_controllers_until(
+        &coven_home,
+        current_exe,
+        started_at,
+        &SystemDaemonStopController,
+        &SystemDaemonStartController,
+        deadline,
+    )
+}
+
+fn restart_background_server_with_controllers_until(
+    coven_home: &Path,
+    current_exe: &Path,
+    started_at: String,
+    stop_controller: &dyn DaemonStopController,
+    start_controller: &dyn DaemonStartController,
+    deadline: LifecycleDeadline,
+) -> Result<(bool, DaemonStatus)> {
+    let coven_home = canonical_lifecycle_home(coven_home)?;
     let was_running =
-        stop_background_server_with_controller(coven_home, &SystemDaemonStopController)?;
-    let status = start_background_server(coven_home, current_exe, started_at)?;
-    if !SystemDaemonStartController.wait_for_running_daemon(&status, Duration::from_secs(2)) {
+        stop_background_server_with_controller_until(&coven_home, stop_controller, deadline)?;
+    deadline.remaining("starting Coven daemon")?;
+    let launched =
+        start_controller.start_background_server(&coven_home, current_exe, started_at)?;
+    let Some(status) =
+        start_controller.wait_for_running_daemon(&coven_home, &launched, deadline)?
+    else {
         anyhow::bail!(
             "started Coven daemon pid {} but its socket did not become ready",
-            status.pid
+            launched.pid
         );
-    }
+    };
+    deadline.remaining("completing Coven daemon restart")?;
     #[cfg(unix)]
-    cleanup_unreachable_duplicate_daemons(coven_home, status.pid);
+    run_optional_lifecycle_diagnostic(deadline, move |deadline| {
+        report_unreachable_duplicate_daemons(coven_home, status.pid, deadline);
+    });
     Ok((was_running, status))
 }
 
 pub fn background_server_status(coven_home: &Path) -> Result<Option<DaemonStatusState>> {
-    background_server_status_with_controller(coven_home, &SystemDaemonStopController)
+    background_server_status_locked_with_controller(coven_home, &SystemDaemonStopController)
+}
+
+fn background_server_status_locked_with_controller(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+) -> Result<Option<DaemonStatusState>> {
+    let deadline = LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?;
+    deadline.remaining("resolving Coven daemon profile")?;
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    let _lock = acquire_daemon_lifecycle_lock_until(&coven_home, deadline)?;
+    background_server_status_with_controller_until(&coven_home, controller, deadline)
 }
 
 trait DaemonStopController {
-    fn signal_term(&self, pid: u32) -> Result<()>;
-    fn pid_is_alive(&self, pid: u32) -> bool;
-    fn wait_for_exit(&self, pid: u32, timeout: Duration) -> bool;
-    fn status_matches_running_daemon(&self, status: &DaemonStatus) -> bool;
-    fn status_from_default_socket(&self, coven_home: &Path) -> Result<Option<DaemonStatus>> {
+    fn stop_verified_daemon(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<VerifiedStopOutcome>;
+    fn recorded_process_state(&self, status: &DaemonStatus) -> Result<RecordedProcessState>;
+    fn status_matches_running_daemon(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<bool>;
+    fn authenticated_running_status(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<Option<DaemonStatus>> {
+        self.status_matches_running_daemon(coven_home, status, deadline)
+            .map(|matches| matches.then(|| status.clone()))
+    }
+    fn status_from_default_socket(
+        &self,
+        coven_home: &Path,
+        deadline: LifecycleDeadline,
+    ) -> Result<Option<DaemonStatus>> {
         let _ = coven_home;
+        let _ = deadline;
         Ok(None)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VerifiedStopOutcome {
+    Unverified,
+    Exited,
+    TimedOut,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RecordedProcessState {
+    Gone,
+    Matching,
+    #[cfg(any(windows, test))]
+    Mismatched,
+    Unverifiable,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LifecycleDeadline {
+    instant: Instant,
+}
+
+impl LifecycleDeadline {
+    fn after(timeout: Duration) -> Result<Self> {
+        let instant = Instant::now()
+            .checked_add(timeout)
+            .context("daemon lifecycle deadline overflowed")?;
+        Ok(Self { instant })
+    }
+
+    #[cfg(test)]
+    fn from_instant(instant: Instant) -> Self {
+        Self { instant }
+    }
+
+    fn remaining(self, phase: &'static str) -> Result<Duration> {
+        self.remaining_at(Instant::now(), phase)
+    }
+
+    fn remaining_at(self, now: Instant, phase: &'static str) -> Result<Duration> {
+        self.instant
+            .checked_duration_since(now)
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| anyhow::anyhow!("timed out {phase}"))
+    }
+}
+
+#[cfg(any(windows, test))]
+fn recorded_windows_process_state(
+    status: &DaemonStatus,
+    live_creation_time: Option<u64>,
+) -> RecordedProcessState {
+    let Some(live_creation_time) = live_creation_time else {
+        return RecordedProcessState::Gone;
+    };
+    match status.process_creation_time {
+        Some(recorded) if recorded.get() == live_creation_time => RecordedProcessState::Matching,
+        Some(_) => RecordedProcessState::Mismatched,
+        None => RecordedProcessState::Unverifiable,
     }
 }
 
@@ -1801,7 +2465,12 @@ trait DaemonStartController {
         current_exe: &Path,
         started_at: String,
     ) -> Result<DaemonStatus>;
-    fn wait_for_running_daemon(&self, status: &DaemonStatus, timeout: Duration) -> bool;
+    fn wait_for_running_daemon(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<Option<DaemonStatus>>;
 }
 
 struct SystemDaemonStartController;
@@ -1816,252 +2485,532 @@ impl DaemonStartController for SystemDaemonStartController {
         start_background_server(coven_home, current_exe, started_at)
     }
 
-    fn wait_for_running_daemon(&self, status: &DaemonStatus, timeout: Duration) -> bool {
+    fn wait_for_running_daemon(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<Option<DaemonStatus>> {
         #[cfg(unix)]
         {
-            let deadline = Instant::now() + timeout;
-            while Instant::now() < deadline {
-                if daemon_health_reports_pid(&status.socket, status.pid).unwrap_or(false) {
-                    return true;
-                }
-                std::thread::sleep(Duration::from_millis(50));
+            if !unix_status_matches_selected_home(coven_home, status) {
+                return Ok(None);
             }
-            daemon_health_reports_pid(&status.socket, status.pid).unwrap_or(false)
+            loop {
+                let remaining = deadline.remaining("waiting for Coven daemon startup health")?;
+                if let Some(live) = unix_authenticated_daemon_status(coven_home, status, remaining)?
+                {
+                    return Ok(Some(live));
+                }
+                let remaining = deadline.remaining("waiting for Coven daemon startup health")?;
+                std::thread::sleep(remaining.min(Duration::from_millis(50)));
+            }
         }
         #[cfg(windows)]
         {
-            let deadline = Instant::now() + timeout;
-            while Instant::now() < deadline {
-                if daemon_health_reports_pid_windows(&status.socket, status.pid).unwrap_or(false) {
-                    return true;
-                }
-                std::thread::sleep(Duration::from_millis(50));
-            }
-            daemon_health_reports_pid_windows(&status.socket, status.pid).unwrap_or(false)
+            let _ = coven_home;
+            wait_for_windows_running_daemon_with_identity_probe_until(
+                status,
+                deadline,
+                |pipe_name, deadline| {
+                    Ok(daemon_status_from_windows_pipe_until(pipe_name, deadline)?
+                        .and_then(|live| resolved_windows_daemon_status(status, &live)))
+                },
+            )
+            .map(Some)
         }
         #[cfg(not(any(unix, windows)))]
         {
+            let _ = coven_home;
             let _ = status;
-            let _ = timeout;
-            true
+            let _ = deadline;
+            Ok(Some(status.clone()))
         }
+    }
+}
+
+#[cfg(test)]
+fn wait_for_windows_running_daemon_with_probe<P>(
+    status: &DaemonStatus,
+    timeout: Duration,
+    probe: P,
+) -> Result<bool>
+where
+    P: FnMut(&str, u32, Duration) -> Result<bool>,
+{
+    let deadline = LifecycleDeadline::after(timeout)?;
+    wait_for_windows_running_daemon_with_probe_until(status, deadline, probe)
+}
+
+#[cfg(test)]
+fn wait_for_windows_running_daemon_with_probe_until<P>(
+    status: &DaemonStatus,
+    deadline: LifecycleDeadline,
+    mut probe: P,
+) -> Result<bool>
+where
+    P: FnMut(&str, u32, Duration) -> Result<bool>,
+{
+    wait_for_windows_running_daemon_with_identity_probe_until(
+        status,
+        deadline,
+        |pipe_name, deadline| {
+            probe(
+                pipe_name,
+                status.pid,
+                deadline.remaining("waiting for Coven daemon startup health")?,
+            )
+            .map(|matches| matches.then(|| status.clone()))
+        },
+    )
+    .map(|_| true)
+}
+
+#[cfg(any(windows, test))]
+fn wait_for_windows_running_daemon_with_identity_probe_until<P>(
+    status: &DaemonStatus,
+    deadline: LifecycleDeadline,
+    mut probe: P,
+) -> Result<DaemonStatus>
+where
+    P: FnMut(&str, LifecycleDeadline) -> Result<Option<DaemonStatus>>,
+{
+    loop {
+        deadline.remaining("waiting for Coven daemon startup health")?;
+        if let Some(live) = probe(&status.socket, deadline)? {
+            return Ok(live);
+        }
+        let remaining = deadline.remaining("waiting for Coven daemon startup health")?;
+        std::thread::sleep(remaining.min(Duration::from_millis(50)));
     }
 }
 
 impl DaemonStopController for SystemDaemonStopController {
-    fn signal_term(&self, pid: u32) -> Result<()> {
+    fn stop_verified_daemon(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<VerifiedStopOutcome> {
         #[cfg(unix)]
         {
-            let output = Command::new("kill")
-                .arg("-TERM")
-                .arg(pid.to_string())
-                .stdin(Stdio::null())
-                .output()
-                .with_context(|| format!("failed to signal Coven daemon pid {pid}"))?;
-            if output.status.success() {
-                Ok(())
-            } else {
-                anyhow::bail!(
-                    "failed to signal Coven daemon pid {pid}: {}",
-                    String::from_utf8_lossy(&output.stderr).trim()
+            if !unix_status_matches_selected_home(coven_home, status) {
+                return Ok(VerifiedStopOutcome::Unverified);
+            }
+            let expected = coven_client::LifecycleDaemonStatus {
+                pid: status.pid,
+                started_at: status.started_at.clone(),
+                socket: status.socket.clone(),
+            };
+            Ok(
+                match coven_client::shutdown_unix_daemon(
+                    coven_home,
+                    &expected,
+                    deadline.remaining("authenticating and stopping Coven daemon")?,
                 )
-            }
+                .map_err(anyhow::Error::new)?
+                {
+                    coven_client::UnixDaemonShutdown::Unavailable
+                    | coven_client::UnixDaemonShutdown::IdentityMismatch => {
+                        VerifiedStopOutcome::Unverified
+                    }
+                    coven_client::UnixDaemonShutdown::Exited => VerifiedStopOutcome::Exited,
+                    coven_client::UnixDaemonShutdown::TimedOut => VerifiedStopOutcome::TimedOut,
+                },
+            )
         }
         #[cfg(windows)]
         {
-            use windows_sys::Win32::{
-                Foundation::{CloseHandle, INVALID_HANDLE_VALUE},
-                System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE},
+            let _ = coven_home;
+            let Some(process) = coven_client::open_windows_daemon_process_for_stop_until(
+                &status.socket,
+                status.pid,
+                status.process_creation_time.map(|value| value.get()),
+                deadline.instant,
+            )
+            .map_err(anyhow::Error::new)?
+            else {
+                return Ok(VerifiedStopOutcome::Unverified);
             };
-            // SAFETY: Windows API calls; handle is closed immediately.
-            unsafe {
-                let handle = OpenProcess(PROCESS_TERMINATE, 0, pid);
-                if handle == INVALID_HANDLE_VALUE || handle == 0 as _ {
-                    // Process already gone — treat as success.
-                    return Ok(());
-                }
-                let rc = TerminateProcess(handle, 1);
-                CloseHandle(handle);
-                if rc == 0 {
-                    anyhow::bail!(
-                        "failed to terminate Coven daemon pid {pid}: {}",
-                        std::io::Error::last_os_error()
-                    );
-                }
-            }
-            Ok(())
+            anyhow::ensure!(
+                process.pid() == status.pid,
+                "verified Windows daemon process identity changed before termination"
+            );
+            Ok(
+                if process
+                    .terminate_and_wait_until(deadline.instant)
+                    .map_err(anyhow::Error::new)?
+                {
+                    VerifiedStopOutcome::Exited
+                } else {
+                    VerifiedStopOutcome::TimedOut
+                },
+            )
         }
         #[cfg(not(any(unix, windows)))]
         {
-            let _ = pid;
-            Ok(())
+            let _ = coven_home;
+            let _ = status;
+            let _ = deadline;
+            Ok(VerifiedStopOutcome::Unverified)
         }
     }
 
-    fn pid_is_alive(&self, pid: u32) -> bool {
+    fn recorded_process_state(&self, status: &DaemonStatus) -> Result<RecordedProcessState> {
         #[cfg(unix)]
         {
-            Command::new("kill")
-                .arg("-0")
-                .arg(pid.to_string())
-                .stdin(Stdio::null())
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .map(|status| status.success())
-                .unwrap_or(false)
+            let pid = status.pid;
+            let pid = libc::pid_t::try_from(pid).context("daemon PID is outside pid_t range")?;
+            if unsafe { libc::kill(pid, 0) } == 0 {
+                return Ok(RecordedProcessState::Matching);
+            }
+            let error = std::io::Error::last_os_error();
+            match error.raw_os_error() {
+                Some(libc::ESRCH) => Ok(RecordedProcessState::Gone),
+                // EPERM proves that the PID exists even though it cannot be
+                // inspected or signaled by this process.
+                Some(libc::EPERM) => Ok(RecordedProcessState::Unverifiable),
+                _ => Err(error).with_context(|| format!("failed to inspect daemon pid {pid}")),
+            }
         }
         #[cfg(windows)]
         {
-            use windows_sys::Win32::{
-                Foundation::{CloseHandle, INVALID_HANDLE_VALUE, STILL_ACTIVE},
-                System::Threading::{GetExitCodeProcess, OpenProcess, PROCESS_QUERY_INFORMATION},
-            };
-            // SAFETY: handle is closed immediately after query.
-            unsafe {
-                let handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
-                if handle == INVALID_HANDLE_VALUE || handle == 0 as _ {
-                    return false;
-                }
-                let mut exit_code: u32 = 0;
-                let ok = GetExitCodeProcess(handle, &mut exit_code);
-                CloseHandle(handle);
-                ok != 0 && exit_code == STILL_ACTIVE as u32
-            }
-        }
-        #[cfg(not(any(unix, windows)))]
-        {
-            let _ = pid;
-            false
-        }
-    }
-
-    fn wait_for_exit(&self, pid: u32, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
-        while Instant::now() < deadline {
-            if !self.pid_is_alive(pid) {
-                return true;
-            }
-            std::thread::sleep(Duration::from_millis(50));
-        }
-        !self.pid_is_alive(pid)
-    }
-
-    fn status_matches_running_daemon(&self, status: &DaemonStatus) -> bool {
-        #[cfg(unix)]
-        {
-            daemon_health_reports_pid(&status.socket, status.pid).unwrap_or(false)
-        }
-        #[cfg(windows)]
-        {
-            // On Windows, probe the named pipe health endpoint.
-            daemon_health_reports_pid_windows(&status.socket, status.pid).unwrap_or(false)
+            let live_creation_time = coven_client::windows_process_creation_time(status.pid)
+                .map_err(anyhow::Error::new)?;
+            Ok(recorded_windows_process_state(status, live_creation_time))
         }
         #[cfg(not(any(unix, windows)))]
         {
             let _ = status;
-            true
+            Ok(RecordedProcessState::Gone)
         }
     }
 
-    fn status_from_default_socket(&self, coven_home: &Path) -> Result<Option<DaemonStatus>> {
-        daemon_status_from_default_socket(coven_home)
+    fn status_matches_running_daemon(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<bool> {
+        #[cfg(unix)]
+        {
+            if !unix_status_matches_selected_home(coven_home, status) {
+                return Ok(false);
+            }
+            unix_daemon_health_matches_status(
+                coven_home,
+                status,
+                deadline.remaining("probing Coven daemon health")?,
+            )
+        }
+        #[cfg(windows)]
+        {
+            let _ = coven_home;
+            // On Windows, probe the named pipe health endpoint.
+            Ok(
+                daemon_status_from_windows_pipe_until(&status.socket, deadline)?
+                    .map(|live| windows_status_matches_authenticated_health(status, &live))
+                    .unwrap_or(false),
+            )
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = coven_home;
+            let _ = status;
+            let _ = deadline;
+            Ok(true)
+        }
+    }
+
+    fn status_from_default_socket(
+        &self,
+        coven_home: &Path,
+        deadline: LifecycleDeadline,
+    ) -> Result<Option<DaemonStatus>> {
+        daemon_status_from_default_socket_until(coven_home, deadline)
+    }
+
+    fn authenticated_running_status(
+        &self,
+        coven_home: &Path,
+        status: &DaemonStatus,
+        deadline: LifecycleDeadline,
+    ) -> Result<Option<DaemonStatus>> {
+        #[cfg(unix)]
+        {
+            if !unix_status_matches_selected_home(coven_home, status) {
+                return Ok(None);
+            }
+            unix_authenticated_daemon_status(
+                coven_home,
+                status,
+                deadline.remaining("probing Coven daemon health")?,
+            )
+        }
+        #[cfg(windows)]
+        {
+            let _ = coven_home;
+            Ok(
+                daemon_status_from_windows_pipe_until(&status.socket, deadline)?
+                    .and_then(|live| resolved_windows_daemon_status(status, &live)),
+            )
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = coven_home;
+            let _ = deadline;
+            Ok(Some(status.clone()))
+        }
     }
 }
 
+#[cfg(test)]
 fn stop_background_server_with_controller(
     coven_home: &Path,
     controller: &dyn DaemonStopController,
 ) -> Result<bool> {
-    let status = read_status(coven_home)?;
-    let Some(status) = status else {
+    stop_background_server_with_controller_until(
+        coven_home,
+        controller,
+        LifecycleDeadline::after(Duration::from_secs(2))?,
+    )
+}
+
+fn stop_background_server_with_controller_until(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+    deadline: LifecycleDeadline,
+) -> Result<bool> {
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    deadline.remaining("reading Coven daemon lifecycle status")?;
+    let status = status_for_stop_until(&coven_home, controller, deadline)?;
+    let Some(mut status) = status else {
         return Ok(false);
     };
 
-    if !controller.status_matches_running_daemon(&status) {
-        if controller.pid_is_alive(status.pid) {
-            anyhow::bail!(
-                "Coven daemon pid {} could not be verified through its socket; not signaling or clearing daemon status",
-                status.pid
-            );
-        }
-        clear_status_and_socket(coven_home)?;
-        return Ok(true);
-    }
+    let mut retried_recovered_status = false;
+    loop {
+        deadline.remaining("authenticating and stopping Coven daemon")?;
+        match controller
+            .stop_verified_daemon(&coven_home, &status, deadline)
+            .with_context(|| {
+                format!(
+                    "failed to stop Coven daemon pid {}; not clearing daemon status",
+                    status.pid
+                )
+            })? {
+            VerifiedStopOutcome::Unverified => {
+                deadline.remaining("checking Coven daemon process identity")?;
+                let process_state = controller.recorded_process_state(&status).with_context(|| {
+                    format!(
+                        "could not determine whether Coven daemon pid {} is alive with the recorded process identity; not signaling or clearing daemon status",
+                        status.pid
+                    )
+                })?;
+                if matches!(
+                    process_state,
+                    RecordedProcessState::Matching | RecordedProcessState::Unverifiable
+                ) {
+                    anyhow::bail!(
+                        "Coven daemon pid {} could not be verified through its socket; not signaling or clearing daemon status",
+                        status.pid
+                    );
+                }
 
-    match controller.signal_term(status.pid) {
-        Ok(()) => {
-            if !controller.wait_for_exit(status.pid, Duration::from_secs(2)) {
+                let Some(recovered) =
+                    recover_authenticated_status_for_stop(&coven_home, controller, deadline)?
+                else {
+                    break;
+                };
+                if retried_recovered_status {
+                    anyhow::bail!(
+                        "recovered Coven daemon identity changed while stopping; refusing to clear daemon status"
+                    );
+                }
+                status = recovered;
+                retried_recovered_status = true;
+            }
+            VerifiedStopOutcome::Exited => break,
+            VerifiedStopOutcome::TimedOut => {
                 anyhow::bail!(
                     "Coven daemon pid {} did not exit after SIGTERM; not clearing daemon status",
                     status.pid
                 );
             }
         }
-        Err(error) if controller.pid_is_alive(status.pid) => {
-            anyhow::bail!(
-                "failed to stop Coven daemon pid {}; not clearing daemon status: {error}",
-                status.pid
-            );
-        }
-        Err(_) => {}
     }
 
-    clear_status_and_socket(coven_home)?;
+    clear_status_and_socket_until(&coven_home, deadline)?;
     Ok(true)
 }
 
+fn status_for_stop_until(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
+    let read_result = read_status_until(coven_home, deadline);
+    resolve_status_read_for_stop(coven_home, controller, deadline, read_result)
+}
+
+fn resolve_status_read_for_stop(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+    deadline: LifecycleDeadline,
+    read_result: Result<Option<DaemonStatus>>,
+) -> Result<Option<DaemonStatus>> {
+    match read_result {
+        Ok(Some(status)) => Ok(Some(status)),
+        Ok(None) => recover_authenticated_status_for_stop(coven_home, controller, deadline),
+        Err(error) => {
+            let parse_error = is_daemon_status_parse_error(&error);
+            let preserve_if_unresolved =
+                !parse_error || daemon_status_process_creation_time_is_malformed(&error);
+            match recover_authenticated_status_for_stop(coven_home, controller, deadline)? {
+                Some(status) => Ok(Some(status)),
+                None if preserve_if_unresolved => Err(error),
+                None => {
+                    clear_status_and_socket_until(coven_home, deadline)?;
+                    Ok(None)
+                }
+            }
+        }
+    }
+}
+
+fn recover_authenticated_status_for_stop(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
+    deadline.remaining("recovering Coven daemon lifecycle status")?;
+    let Some(candidate) = controller
+        .status_from_default_socket(coven_home, deadline)
+        .context("failed to authenticate the default Coven daemon socket")?
+    else {
+        return Ok(None);
+    };
+    let Some(status) = controller.authenticated_running_status(coven_home, &candidate, deadline)?
+    else {
+        anyhow::bail!(
+            "could not authenticate the recovered Coven daemon identity; refusing to stop or start"
+        );
+    };
+    deadline.remaining("publishing recovered Coven daemon status")?;
+    write_status(coven_home, &status)?;
+    deadline.remaining("publishing recovered Coven daemon status")?;
+    Ok(Some(status))
+}
+
+#[cfg(test)]
 fn background_server_status_with_controller(
     coven_home: &Path,
     controller: &dyn DaemonStopController,
 ) -> Result<Option<DaemonStatusState>> {
-    let status = match read_status(coven_home) {
+    background_server_status_with_controller_until(
+        coven_home,
+        controller,
+        LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+    )
+}
+
+fn background_server_status_with_controller_until(
+    coven_home: &Path,
+    controller: &dyn DaemonStopController,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatusState>> {
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    deadline.remaining("reading Coven daemon lifecycle status")?;
+    let status = match read_status_until(&coven_home, deadline) {
         Ok(status) => status,
         Err(error) if is_daemon_status_parse_error(&error) => {
-            return recover_corrupt_status_for_status_command(coven_home);
+            let preserve_if_unresolved = daemon_status_process_creation_time_is_malformed(&error);
+            return recover_corrupt_status_for_status_command(
+                &coven_home,
+                controller,
+                preserve_if_unresolved.then_some(error),
+                deadline,
+            );
         }
         Err(error) => return Err(error),
     };
     let Some(status) = status else {
-        return recover_missing_status_from_default_socket(coven_home, controller);
+        return recover_missing_status_from_default_socket(&coven_home, controller, deadline);
     };
 
-    if controller.status_matches_running_daemon(&status) {
-        return Ok(Some(DaemonStatusState::Running(status)));
+    if let Some(running) =
+        controller.authenticated_running_status(&coven_home, &status, deadline)?
+    {
+        deadline.remaining("verifying Coven daemon health")?;
+        if running != status {
+            deadline.remaining("publishing resolved Coven daemon status")?;
+            write_status(&coven_home, &running)?;
+        }
+        deadline.remaining("publishing resolved Coven daemon status")?;
+        return Ok(Some(DaemonStatusState::Running(running)));
     }
 
-    if controller.pid_is_alive(status.pid) {
+    deadline.remaining("checking Coven daemon process identity")?;
+    let process_state = controller.recorded_process_state(&status).with_context(|| {
+        format!(
+            "could not determine whether Coven daemon pid {} is alive with the recorded process identity; not clearing daemon status",
+            status.pid
+        )
+    })?;
+    deadline.remaining("checking Coven daemon process identity")?;
+    if matches!(
+        process_state,
+        RecordedProcessState::Matching | RecordedProcessState::Unverifiable
+    ) {
         return Ok(Some(DaemonStatusState::Stale(status)));
     }
 
-    if let Some(recovered) = recover_missing_status_from_default_socket(coven_home, controller)? {
+    if let Some(recovered) =
+        recover_missing_status_from_default_socket(&coven_home, controller, deadline)?
+    {
         return Ok(Some(recovered));
     }
 
-    clear_status_and_socket(coven_home)?;
+    clear_status_and_socket_until(&coven_home, deadline)?;
     Ok(None)
 }
 
 fn recover_missing_status_from_default_socket(
     coven_home: &Path,
     controller: &dyn DaemonStopController,
+    deadline: LifecycleDeadline,
 ) -> Result<Option<DaemonStatusState>> {
-    let Some(status) = controller.status_from_default_socket(coven_home)? else {
+    let Some(status) = controller.status_from_default_socket(coven_home, deadline)? else {
         return Ok(None);
     };
 
-    if controller.status_matches_running_daemon(&status) {
-        write_status(coven_home, &status)?;
-        return Ok(Some(DaemonStatusState::Running(status)));
+    if let Some(running) = controller.authenticated_running_status(coven_home, &status, deadline)? {
+        deadline.remaining("verifying recovered Coven daemon health")?;
+        deadline.remaining("publishing recovered Coven daemon status")?;
+        write_status(coven_home, &running)?;
+        deadline.remaining("publishing recovered Coven daemon status")?;
+        return Ok(Some(DaemonStatusState::Running(running)));
     }
 
-    if controller.pid_is_alive(status.pid) {
+    deadline.remaining("checking recovered Coven daemon process identity")?;
+    let process_state = controller.recorded_process_state(&status).with_context(|| {
+        format!(
+            "could not determine whether recovered Coven daemon pid {} still has the recorded process identity",
+            status.pid
+        )
+    })?;
+    deadline.remaining("checking recovered Coven daemon process identity")?;
+    if matches!(
+        process_state,
+        RecordedProcessState::Matching | RecordedProcessState::Unverifiable
+    ) {
         return Ok(Some(DaemonStatusState::Stale(status)));
     }
 
     Ok(None)
 }
 
+#[cfg(test)]
 fn ensure_background_server_with_controllers(
     coven_home: &Path,
     current_exe: &Path,
@@ -2069,49 +3018,97 @@ fn ensure_background_server_with_controllers(
     status_controller: &dyn DaemonStopController,
     start_controller: &dyn DaemonStartController,
 ) -> Result<DaemonStatus> {
-    match background_server_status_with_controller(coven_home, status_controller)? {
+    ensure_background_server_with_controllers_until(
+        coven_home,
+        current_exe,
+        started_at,
+        status_controller,
+        start_controller,
+        LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+    )
+}
+
+fn ensure_background_server_with_controllers_until(
+    coven_home: &Path,
+    current_exe: &Path,
+    started_at: String,
+    status_controller: &dyn DaemonStopController,
+    start_controller: &dyn DaemonStartController,
+    deadline: LifecycleDeadline,
+) -> Result<DaemonStatus> {
+    let coven_home = canonical_lifecycle_home(coven_home)?;
+    match background_server_status_with_controller_until(&coven_home, status_controller, deadline)?
+    {
         Some(DaemonStatusState::Running(status)) => Ok(status),
         Some(DaemonStatusState::Stale(status)) => anyhow::bail!(
             "Coven daemon pid {} is recorded but unreachable; run `coven daemon restart`",
             status.pid
         ),
         None => {
-            let status =
-                start_controller.start_background_server(coven_home, current_exe, started_at)?;
-            if start_controller.wait_for_running_daemon(&status, Duration::from_secs(2)) {
-                Ok(status)
-            } else {
+            deadline.remaining("starting Coven daemon")?;
+            let launched =
+                start_controller.start_background_server(&coven_home, current_exe, started_at)?;
+            deadline.remaining("waiting for Coven daemon startup health")?;
+            let Some(status) =
+                start_controller.wait_for_running_daemon(&coven_home, &launched, deadline)?
+            else {
                 anyhow::bail!(
                     "started Coven daemon pid {} but its socket did not become ready",
-                    status.pid
+                    launched.pid
                 )
-            }
+            };
+            deadline.remaining("completing Coven daemon startup")?;
+            Ok(status)
         }
     }
 }
 
 fn is_daemon_status_parse_error(error: &anyhow::Error) -> bool {
-    error
-        .chain()
-        .any(|cause| cause.downcast_ref::<serde_json::Error>().is_some())
+    error.chain().any(|cause| {
+        cause.downcast_ref::<serde_json::Error>().is_some()
+            || cause.downcast_ref::<DaemonStatusParseError>().is_some()
+    })
+}
+
+fn daemon_status_process_creation_time_is_malformed(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<DaemonStatusParseError>()
+            .is_some_and(|error| error.process_creation_time_present)
+    })
 }
 
 fn recover_corrupt_status_for_status_command(
     coven_home: &Path,
+    controller: &dyn DaemonStopController,
+    unresolved_error: Option<anyhow::Error>,
+    deadline: LifecycleDeadline,
 ) -> Result<Option<DaemonStatusState>> {
-    match daemon_status_from_default_socket(coven_home) {
+    let recovered = match controller.status_from_default_socket(coven_home, deadline) {
         Ok(Some(status)) => {
-            write_status(coven_home, &status)?;
-            Ok(Some(DaemonStatusState::Running(status)))
+            controller.authenticated_running_status(coven_home, &status, deadline)?
         }
-        Ok(None) | Err(_) => {
-            clear_status(coven_home)?;
-            Ok(None)
-        }
+        Ok(None) | Err(_) => None,
+    };
+    if let Some(status) = recovered {
+        deadline.remaining("verifying recovered Coven daemon health")?;
+        deadline.remaining("publishing recovered Coven daemon status")?;
+        write_status(coven_home, &status)?;
+        deadline.remaining("publishing recovered Coven daemon status")?;
+        return Ok(Some(DaemonStatusState::Running(status)));
+    }
+    if let Some(error) = unresolved_error {
+        Err(error)
+    } else {
+        clear_status_and_socket_until(coven_home, deadline)?;
+        Ok(None)
     }
 }
 
 fn clear_status_and_socket(coven_home: &Path) -> Result<()> {
+    let Some(_serve_lock) = try_acquire_serve_lock(coven_home)? else {
+        return Ok(());
+    };
     clear_status(coven_home)?;
     let socket = daemon_socket_path(coven_home);
     if socket.exists() {
@@ -2121,93 +3118,187 @@ fn clear_status_and_socket(coven_home: &Path) -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+fn clear_status_and_socket_until(coven_home: &Path, deadline: LifecycleDeadline) -> Result<()> {
+    deadline.remaining("cleaning up Coven daemon lifecycle state")?;
+    clear_status_and_socket(coven_home)?;
+    deadline.remaining("cleaning up Coven daemon lifecycle state")?;
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
 fn daemon_status_from_default_socket(coven_home: &Path) -> Result<Option<DaemonStatus>> {
-    daemon_status_from_health_socket(&daemon_socket_path(coven_home).to_string_lossy())
+    daemon_status_from_default_socket_until(
+        coven_home,
+        LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+    )
+}
+
+#[cfg(unix)]
+fn daemon_status_from_default_socket_until(
+    coven_home: &Path,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
+    daemon_status_from_health_home(
+        coven_home,
+        deadline.remaining("probing default Coven daemon socket")?,
+    )
 }
 
 #[cfg(windows)]
-fn daemon_status_from_default_socket(coven_home: &Path) -> Result<Option<DaemonStatus>> {
-    daemon_status_from_windows_pipe(&daemon_windows_pipe_name(coven_home))
+fn daemon_status_from_default_socket_until(
+    coven_home: &Path,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
+    daemon_status_from_windows_pipe_until(&daemon_windows_pipe_name(coven_home)?, deadline)
 }
 
 #[cfg(not(any(unix, windows)))]
-fn daemon_status_from_default_socket(coven_home: &Path) -> Result<Option<DaemonStatus>> {
+fn daemon_status_from_default_socket_until(
+    coven_home: &Path,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
     let _ = coven_home;
+    let _ = deadline;
     Ok(None)
 }
 
-#[cfg(windows)]
-fn daemon_health_reports_pid_windows(pipe_name: &str, expected_pid: u32) -> Result<bool> {
-    Ok(daemon_status_from_windows_pipe(pipe_name)?
-        .map(|status| status.pid == expected_pid)
-        .unwrap_or(false))
+#[cfg(any(windows, test))]
+fn windows_status_matches_authenticated_health(
+    recorded: &DaemonStatus,
+    live: &DaemonStatus,
+) -> bool {
+    recorded.pid == live.pid
+        && recorded.started_at == live.started_at
+        && recorded.socket == live.socket
+        && match recorded.process_creation_time {
+            Some(recorded_creation_time) => {
+                live.process_creation_time == Some(recorded_creation_time)
+            }
+            None => true,
+        }
 }
 
-#[cfg(windows)]
-fn daemon_status_from_windows_pipe(pipe_name: &str) -> Result<Option<DaemonStatus>> {
-    use interprocess::{
-        local_socket::{prelude::*, ConnectOptions, GenericNamespaced},
-        ConnectWaitMode,
-    };
-    use std::io::Write;
+#[cfg(any(windows, test))]
+fn resolved_windows_daemon_status(
+    recorded: &DaemonStatus,
+    live: &DaemonStatus,
+) -> Option<DaemonStatus> {
+    windows_status_matches_authenticated_health(recorded, live).then(|| live.clone())
+}
 
-    let name = pipe_name
-        .to_ns_name::<GenericNamespaced>()
-        .context("failed to parse pipe name for health check")?;
-    let mut stream = match ConnectOptions::new()
-        .name(name)
-        .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(2)))
-        .connect_sync()
-    {
-        Ok(s) => s,
-        Err(_) => return Ok(None),
+#[cfg(test)]
+fn daemon_status_from_windows_probe<P>(pipe_name: &str, probe: P) -> Result<Option<DaemonStatus>>
+where
+    P: FnOnce(
+        &str,
+        Duration,
+    )
+        -> std::result::Result<Option<(u16, Vec<u8>, u32, u64)>, coven_client::ClientError>,
+{
+    daemon_status_from_windows_probe_until(
+        pipe_name,
+        LifecycleDeadline::after(Duration::from_secs(2))?,
+        probe,
+    )
+}
+
+#[cfg(any(windows, test))]
+fn daemon_status_from_windows_probe_until<P>(
+    pipe_name: &str,
+    deadline: LifecycleDeadline,
+    probe: P,
+) -> Result<Option<DaemonStatus>>
+where
+    P: FnOnce(
+        &str,
+        Duration,
+    )
+        -> std::result::Result<Option<(u16, Vec<u8>, u32, u64)>, coven_client::ClientError>,
+{
+    let timeout = deadline.remaining("probing Windows daemon health")?;
+    let Some((response_status, body, server_pid, server_creation_time)) =
+        probe(pipe_name, timeout).map_err(anyhow::Error::new)?
+    else {
+        return Ok(None);
     };
-    stream
-        .write_all(b"GET /health HTTP/1.1\r\nHost: coven\r\nContent-Length: 0\r\n\r\n")
-        .context("failed to write Windows health request")?;
-    stream
-        .flush()
-        .context("failed to flush Windows health request")?;
-    // Windows named pipes do not support read timeouts in interprocess.
-    // Supervise the blocking framed read from another thread so doctor/status
-    // still return deterministically when a daemon accepts but never replies.
-    // Reading to EOF is incorrect for HTTP and used to hang indefinitely when
-    // the daemon kept the pipe instance alive after writing its response.
-    let (_status, body) =
-        read_windows_pipe_http_response(stream, Duration::from_secs(2), MAX_SOCKET_BODY_BYTES)?;
+    anyhow::ensure!(
+        response_status == 200,
+        "Windows daemon health returned HTTP {response_status}"
+    );
     let body: DaemonHealthStatus =
         serde_json::from_slice(&body).context("failed to parse Windows health response")?;
-    if body.ok {
-        Ok(body.daemon)
-    } else {
-        Ok(None)
+    let Some(mut daemon) = body.daemon.filter(|_| body.ok) else {
+        return Ok(None);
+    };
+    anyhow::ensure!(
+        daemon.socket == pipe_name,
+        "Windows daemon health reported a pipe for a different Coven home"
+    );
+    anyhow::ensure!(
+        daemon.pid == server_pid,
+        "Windows daemon health PID did not match the authenticated pipe server"
+    );
+    match daemon.process_creation_time {
+        Some(reported) => anyhow::ensure!(
+            reported.get() == server_creation_time,
+            "Windows daemon health process creation time did not match the authenticated pipe server"
+        ),
+        None => {
+            daemon.process_creation_time =
+                Some(WindowsProcessCreationTime::new(server_creation_time)?);
+        }
     }
+    Ok(Some(daemon))
+}
+
+#[cfg(all(windows, test))]
+fn daemon_status_from_windows_pipe(pipe_name: &str) -> Result<Option<DaemonStatus>> {
+    daemon_status_from_windows_pipe_with_timeout(pipe_name, Duration::from_secs(2))
+}
+
+#[cfg(all(windows, test))]
+fn daemon_status_from_windows_pipe_with_timeout(
+    pipe_name: &str,
+    timeout: Duration,
+) -> Result<Option<DaemonStatus>> {
+    daemon_status_from_windows_probe_until(
+        pipe_name,
+        LifecycleDeadline::after(timeout)?,
+        |pipe_name, timeout| {
+            coven_client::probe_windows_daemon_health_with_identity(pipe_name, timeout).map(
+                |probe| {
+                    probe.map(|probe| {
+                        (
+                            probe.status,
+                            probe.body,
+                            probe.server_pid,
+                            probe.process_creation_time,
+                        )
+                    })
+                },
+            )
+        },
+    )
 }
 
 #[cfg(windows)]
-pub(crate) fn read_windows_pipe_http_response(
-    mut stream: interprocess::local_socket::Stream,
-    timeout: Duration,
-    max_body_bytes: usize,
-) -> Result<(u16, Vec<u8>)> {
-    let (tx, rx) = std::sync::mpsc::sync_channel(1);
-    std::thread::Builder::new()
-        .name("coven-pipe-response".into())
-        .spawn(move || {
-            let result = read_http_response_with_deadline(&mut stream, timeout, max_body_bytes);
-            let _ = tx.send(result);
-        })
-        .context("failed to spawn Windows pipe response reader")?;
-    match rx.recv_timeout(timeout) {
-        Ok(result) => result,
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            anyhow::bail!("timed out reading Coven daemon HTTP response")
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            anyhow::bail!("Coven daemon HTTP response reader stopped unexpectedly")
-        }
-    }
+fn daemon_status_from_windows_pipe_until(
+    pipe_name: &str,
+    deadline: LifecycleDeadline,
+) -> Result<Option<DaemonStatus>> {
+    daemon_status_from_windows_probe_until(pipe_name, deadline, |pipe_name, _| {
+        coven_client::probe_windows_daemon_health_with_identity_until(pipe_name, deadline.instant)
+            .map(|probe| {
+                probe.map(|probe| {
+                    (
+                        probe.status,
+                        probe.body,
+                        probe.server_pid,
+                        probe.process_creation_time,
+                    )
+                })
+            })
+    })
 }
 
 /// Read one HTTP response without relying on the peer closing the transport.
@@ -2216,7 +3307,7 @@ pub(crate) fn read_windows_pipe_http_response(
 /// response. HTTP/1.1 frames the body with Content-Length, so consume exactly
 /// that many bytes. The reader is expected to be nonblocking; WouldBlock is
 /// retried until `timeout` expires.
-#[cfg(any(windows, test))]
+#[cfg(test)]
 pub(crate) fn read_http_response_with_deadline<R: Read>(
     reader: &mut R,
     timeout: Duration,
@@ -2273,7 +3364,7 @@ pub(crate) fn read_http_response_with_deadline<R: Read>(
     }
 }
 
-#[cfg(any(windows, test))]
+#[cfg(test)]
 fn response_status(headers: &[u8]) -> Result<u16> {
     let headers =
         std::str::from_utf8(headers).context("daemon HTTP response headers were not UTF-8")?;
@@ -2286,12 +3377,12 @@ fn response_status(headers: &[u8]) -> Result<u16> {
         .context("daemon HTTP response had an invalid status")
 }
 
-#[cfg(any(windows, test))]
+#[cfg(test)]
 fn find_http_header_end(bytes: &[u8]) -> Option<usize> {
     bytes.windows(4).position(|window| window == b"\r\n\r\n")
 }
 
-#[cfg(any(windows, test))]
+#[cfg(test)]
 fn response_content_length(headers: &[u8]) -> Result<usize> {
     let headers =
         std::str::from_utf8(headers).context("daemon HTTP response headers were not UTF-8")?;
@@ -2309,65 +3400,99 @@ fn response_content_length(headers: &[u8]) -> Result<usize> {
 }
 
 #[cfg(unix)]
-fn daemon_health_reports_pid(socket: &str, expected_pid: u32) -> Result<bool> {
-    Ok(daemon_status_from_health_socket(socket)?
-        .map(|status| status.pid == expected_pid)
-        .unwrap_or(false))
+fn unix_daemon_health_matches_status(
+    coven_home: &Path,
+    expected: &DaemonStatus,
+    timeout: Duration,
+) -> Result<bool> {
+    unix_authenticated_daemon_status(coven_home, expected, timeout).map(|status| status.is_some())
 }
 
 #[cfg(unix)]
-fn daemon_status_from_health_socket(socket: &str) -> Result<Option<DaemonStatus>> {
-    let socket_path = std::path::Path::new(socket);
-    // Fail-closed: refuse to connect to a socket that is not owned by the
-    // current effective uid. A foreign-owned socket could be an attacker's
-    // listener planted at the expected path.
-    if let Ok(metadata) = std::fs::symlink_metadata(socket_path) {
-        use std::os::unix::fs::MetadataExt;
-        // SAFETY: geteuid() only reads the effective uid and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        check_owned_by_current_user(socket_path, metadata.uid(), euid)?;
-    }
-    let mut stream = match UnixStream::connect(socket) {
-        Ok(stream) => stream,
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
-            ) =>
-        {
-            return Ok(None);
-        }
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("failed to connect to Coven daemon socket {socket}"));
-        }
-    };
-    stream
-        .set_read_timeout(Some(Duration::from_secs(2)))
-        .context("failed to bound Coven health response time")?;
-    stream
-        .set_write_timeout(Some(Duration::from_secs(2)))
-        .context("failed to bound Coven health request time")?;
-    stream
-        .write_all(b"GET /health HTTP/1.1\r\nHost: coven\r\n\r\n")
-        .context("failed to write Coven health request")?;
-    stream
-        .shutdown(std::net::Shutdown::Write)
-        .context("failed to finish Coven health request")?;
-    let mut response = String::new();
-    stream
-        .read_to_string(&mut response)
-        .context("failed to read Coven health response")?;
-    let Some((_, body)) = response.split_once("\r\n\r\n") else {
+fn unix_authenticated_daemon_status(
+    coven_home: &Path,
+    expected: &DaemonStatus,
+    timeout: Duration,
+) -> Result<Option<DaemonStatus>> {
+    if !unix_status_matches_selected_home(coven_home, expected) {
         return Ok(None);
-    };
-    let body: DaemonHealthStatus =
-        serde_json::from_str(body).context("failed to parse Coven health response")?;
-    if body.ok {
-        Ok(body.daemon)
-    } else {
-        Ok(None)
     }
+    Ok(coven_client::probe_unix_daemon_health(coven_home, timeout)
+        .map_err(anyhow::Error::new)?
+        .filter(|status| status.pid == expected.pid && status.started_at == expected.started_at)
+        .map(|status| DaemonStatus {
+            pid: status.pid,
+            started_at: status.started_at,
+            socket: status.socket,
+            process_creation_time: None,
+        }))
+}
+
+#[cfg(unix)]
+fn daemon_status_from_health_home(
+    coven_home: &Path,
+    timeout: Duration,
+) -> Result<Option<DaemonStatus>> {
+    Ok(coven_client::probe_unix_daemon_health(coven_home, timeout)
+        .map_err(anyhow::Error::new)?
+        .map(|status| DaemonStatus {
+            pid: status.pid,
+            started_at: status.started_at,
+            socket: status.socket,
+            process_creation_time: None,
+        }))
+}
+
+fn canonical_lifecycle_home(coven_home: &Path) -> Result<PathBuf> {
+    #[cfg(unix)]
+    {
+        coven_client::validate_unix_daemon_path_encoding(coven_home).map_err(anyhow::Error::new)?;
+        ensure_private_coven_home(coven_home)?;
+        coven_client::canonical_unix_daemon_home(coven_home).map_err(anyhow::Error::new)
+    }
+    #[cfg(not(unix))]
+    {
+        ensure_private_coven_home(coven_home)?;
+        Ok(coven_home.to_path_buf())
+    }
+}
+
+#[cfg(unix)]
+fn unix_status_matches_selected_home(coven_home: &Path, status: &DaemonStatus) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let selected = daemon_socket_path(coven_home);
+    let recorded = Path::new(&status.socket);
+    if recorded.is_absolute() && recorded == selected {
+        return true;
+    }
+    let same_socket = |candidate: &Path| {
+        let (Ok(selected_canonical), Ok(recorded_canonical)) = (
+            std::fs::canonicalize(&selected),
+            std::fs::canonicalize(candidate),
+        ) else {
+            return false;
+        };
+        if recorded_canonical != selected_canonical {
+            return false;
+        }
+        let (Ok(selected), Ok(recorded)) = (
+            std::fs::metadata(selected_canonical),
+            std::fs::metadata(recorded_canonical),
+        ) else {
+            return false;
+        };
+        selected.dev() == recorded.dev() && selected.ino() == recorded.ino()
+    };
+    if recorded.is_absolute() {
+        return same_socket(recorded);
+    }
+    same_socket(recorded)
+        || selected
+            .parent()
+            .into_iter()
+            .flat_map(Path::ancestors)
+            .any(|base| same_socket(&base.join(recorded)))
 }
 
 // `bind_tcp_listener` plus the accepted-stream handler expose the TCP transport
@@ -2548,7 +3673,7 @@ pub fn bind_api_socket(coven_home: &Path) -> Result<UnixListener> {
             // stale socket — connection refused, or a non-ok health body — may be
             // reclaimed. See OpenCoven/coven#197 and docs/AUTH.md.
             if let Ok(Some(incumbent)) =
-                daemon_status_from_health_socket(&socket_path.to_string_lossy())
+                daemon_status_from_health_home(coven_home, Duration::from_secs(2))
             {
                 anyhow::bail!(
                     "a healthy Coven daemon (pid {}) is already serving {}; refusing to take over",
@@ -2797,8 +3922,9 @@ impl Drop for ShutdownGuard {
 
 #[cfg(unix)]
 fn daemon_status_file_pid(status_path: &Path) -> Option<u32> {
-    std::fs::read_to_string(status_path)
+    std::fs::File::open(status_path)
         .ok()
+        .and_then(|file| read_bounded_daemon_status(file).ok())
         .and_then(|json| serde_json::from_str::<DaemonStatus>(&json).ok())
         .map(|status| status.pid)
 }
@@ -2890,9 +4016,10 @@ pub(crate) fn daemon_serve_lock_path(coven_home: &Path) -> PathBuf {
 /// Acquire an exclusive, process-lifetime advisory lock so at most one `serve`
 /// process ever runs against a given Coven home.
 ///
-/// `ensure_background_server` already serializes `daemon start`/`stop` and prunes
-/// unreachable duplicates — but a `coven daemon serve` run *directly* (e.g. from
-/// a dev build) bypasses all of that. The socket-takeover guard in
+/// `ensure_background_server` already serializes `daemon start`/`stop` and reports
+/// unreachable duplicates without signaling stale PIDs — but a
+/// `coven daemon serve` run *directly* (e.g. from a dev build) bypasses all of
+/// that. The socket-takeover guard in
 /// `bind_api_socket` only refuses a *healthy* incumbent that answers `/health`;
 /// a daemon that is alive but wedged would have its socket reclaimed, leaving
 /// two processes writing one SQLite store — the loser then fails the
@@ -2935,7 +4062,7 @@ pub(crate) struct ResetDaemonGuard {
     _lifecycle: DaemonLifecycleLock,
     _serve: std::fs::File,
     #[cfg(windows)]
-    _pipe: interprocess::local_socket::Listener,
+    _pipes: Vec<interprocess::local_socket::Listener>,
 }
 
 /// Exclude daemon lifecycle changes for the duration of reset and detect a
@@ -2951,11 +4078,17 @@ pub(crate) fn try_acquire_reset_guard(
         return Ok(None);
     };
     #[cfg(unix)]
-    if unix_daemon_transport_is_occupied(coven_home)? {
-        return Ok(None);
+    {
+        // Reset must fail closed if an owner-credential probe cannot establish
+        // that the socket is unoccupied. This also preserves the historical
+        // daemon-active result for legacy listeners with weaker socket modes.
+        match unix_daemon_transport_is_occupied(coven_home) {
+            Ok(false) => {}
+            Ok(true) | Err(_) => return Ok(None),
+        }
     }
     #[cfg(windows)]
-    let Some(pipe) = try_reserve_windows_daemon_pipe(coven_home)?
+    let Some(pipes) = try_reserve_windows_daemon_pipes(coven_home)?
     else {
         return Ok(None);
     };
@@ -2963,30 +4096,25 @@ pub(crate) fn try_acquire_reset_guard(
         _lifecycle: lifecycle,
         _serve: serve,
         #[cfg(windows)]
-        _pipe: pipe,
+        _pipes: pipes,
     }))
 }
 
 #[cfg(unix)]
 fn unix_daemon_transport_is_occupied(coven_home: &Path) -> Result<bool> {
+    unix_daemon_transport_is_occupied_with_timeout(coven_home, Duration::from_secs(2))
+}
+
+#[cfg(unix)]
+fn unix_daemon_transport_is_occupied_with_timeout(
+    coven_home: &Path,
+    timeout: Duration,
+) -> Result<bool> {
     let socket_path = daemon_socket_path(coven_home);
-    if let Ok(metadata) = std::fs::symlink_metadata(&socket_path) {
-        use std::os::unix::fs::MetadataExt;
-        // SAFETY: geteuid() only reads the effective uid and cannot fail.
-        let euid = unsafe { libc::geteuid() };
-        check_owned_by_current_user(&socket_path, metadata.uid(), euid)?;
-    }
-    match UnixStream::connect(&socket_path) {
-        Ok(_) => Ok(true),
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
-            ) =>
-        {
-            Ok(false)
-        }
-        Err(error) => Err(error).with_context(|| {
+    match coven_client::probe_unix_daemon_health(coven_home, timeout) {
+        Ok(Some(_)) => Ok(true),
+        Ok(None) => Ok(false),
+        Err(error) => Err(anyhow::anyhow!("{error}")).with_context(|| {
             format!(
                 "failed to determine whether daemon socket {} is occupied",
                 socket_path.display()
@@ -2995,39 +4123,59 @@ fn unix_daemon_transport_is_occupied(coven_home: &Path) -> Result<bool> {
     }
 }
 
+#[cfg(any(windows, test))]
+fn reserve_windows_pipe_identities<N, T, F>(
+    pipe_names: &[N],
+    mut reserve: F,
+) -> Result<Option<Vec<T>>>
+where
+    N: AsRef<str>,
+    F: FnMut(&str) -> Result<Option<T>>,
+{
+    let mut reservations = Vec::with_capacity(pipe_names.len());
+    for pipe_name in pipe_names {
+        let Some(reservation) = reserve(pipe_name.as_ref())? else {
+            return Ok(None);
+        };
+        reservations.push(reservation);
+    }
+    Ok(Some(reservations))
+}
+
 #[cfg(windows)]
-fn try_reserve_windows_daemon_pipe(
+fn try_reserve_windows_daemon_pipes(
     coven_home: &Path,
-) -> Result<Option<interprocess::local_socket::Listener>> {
+) -> Result<Option<Vec<interprocess::local_socket::Listener>>> {
     use interprocess::{
         local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
         os::windows::local_socket::ListenerOptionsExt,
     };
 
-    let pipe_name = daemon_windows_pipe_name(coven_home);
-    let name = pipe_name
-        .as_str()
-        .to_ns_name::<GenericNamespaced>()
-        .context("failed to create reset pipe reservation name")?;
-    let security_descriptor = owner_only_pipe_security_descriptor()?;
-    match ListenerOptions::new()
-        .name(name)
-        .security_descriptor(security_descriptor)
-        .create_sync()
-    {
-        Ok(listener) => Ok(Some(listener)),
-        Err(error)
-            if matches!(
-                error.kind(),
-                std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied
-            ) =>
+    let pipe_names = coven_client::supported_windows_pipe_names(coven_home)
+        .context("failed to derive reset pipe reservation names")?;
+    reserve_windows_pipe_identities(&pipe_names, |pipe_name| {
+        let name = pipe_name
+            .to_ns_name::<GenericNamespaced>()
+            .context("failed to create reset pipe reservation name")?;
+        let security_descriptor = owner_only_pipe_security_descriptor()?;
+        match ListenerOptions::new()
+            .name(name)
+            .security_descriptor(security_descriptor)
+            .create_sync()
         {
-            Ok(None)
+            Ok(listener) => Ok(Some(listener)),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::AddrInUse | std::io::ErrorKind::PermissionDenied
+                ) =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error)
+                .with_context(|| format!("failed to reserve Windows daemon pipe {pipe_name}")),
         }
-        Err(error) => {
-            Err(error).with_context(|| format!("failed to reserve Windows daemon pipe {pipe_name}"))
-        }
-    }
+    })
 }
 
 pub(crate) fn acquire_serve_lock(coven_home: &Path) -> Result<std::fs::File> {
@@ -3080,6 +4228,8 @@ pub fn serve_forever(
     allowed_hosts: &[String],
 ) -> Result<()> {
     use std::sync::Arc;
+    let canonical_home = canonical_lifecycle_home(coven_home)?;
+    let coven_home = canonical_home.as_path();
     // `--allow-host` only widens the TCP guard; it is meaningless without `--tcp`.
     // Warn rather than fail so a stray flag doesn't take the daemon down.
     if !allowed_hosts.is_empty() && tcp_addr.is_none() {
@@ -3090,14 +4240,19 @@ pub fn serve_forever(
     // is the authoritative guard against two daemons writing one SQLite store —
     // catching the wedged-but-alive incumbent the socket guard can't, and the
     // direct `daemon serve` path that bypasses ensure_background_server.
-    let _serve_lock = acquire_serve_lock(coven_home)?;
+    let serve_lock = acquire_serve_lock(coven_home)?;
     initialize_daemon_store(coven_home)?;
     let status = DaemonStatus {
         pid: std::process::id(),
         started_at: started_at.clone(),
         socket: daemon_socket_path(coven_home)
-            .to_string_lossy()
-            .into_owned(),
+            .to_str()
+            .context(
+                "canonical Coven daemon socket is not valid UTF-8; daemon status JSON requires \
+                 UTF-8 paths",
+            )?
+            .to_owned(),
+        process_creation_time: None,
     };
     let socket_path = daemon_socket_path(coven_home);
     let status_path = daemon_status_path(coven_home);
@@ -3120,12 +4275,12 @@ pub fn serve_forever(
         .set_nonblocking(true)
         .context("failed to configure interruptible Unix API listener")?;
     write_status(coven_home, &status)?;
-    let _shutdown_guard = ShutdownGuard {
+    let shutdown_guard = ShutdownGuard {
         socket_path: socket_path.clone(),
         status_path: status_path.clone(),
         pid: status.pid,
     };
-    let _mobile_gateway =
+    let mobile_gateway =
         crate::mobile_memory::gateway::start_mobile_gateway_for_daemon(coven_home)?;
     append_daemon_recovery_log(
         coven_home,
@@ -3242,6 +4397,7 @@ pub fn serve_forever(
     // can't bring the daemon down or orphan the socket.
     const MAX_INFLIGHT: usize = 64;
     let inflight = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let shutdown_connections = Arc::new(Mutex::new(Vec::<UnixStream>::new()));
     use std::sync::atomic::Ordering;
     loop {
         if daemon_termination_requested() {
@@ -3270,15 +4426,17 @@ pub fn serve_forever(
 
         if inflight.load(Ordering::Relaxed) >= MAX_INFLIGHT {
             // Backpressure: at capacity, serve this one on the accept thread.
-            if let Err(error) =
-                serve_accepted_connection(stream, coven_home, conn_status, runtime.as_ref())
-            {
-                if !is_client_disconnect(&error) {
-                    eprintln!("coven daemon: unix connection error: {error:#}");
-                    append_daemon_recovery_log(
-                        coven_home,
-                        &format!("unix connection error: {error:#}"),
-                    );
+            match serve_accepted_connection(stream, coven_home, conn_status, runtime.as_ref()) {
+                Ok(Some(stream)) => retain_shutdown_connection(&shutdown_connections, stream),
+                Ok(None) => {}
+                Err(error) => {
+                    if !is_client_disconnect(&error) {
+                        eprintln!("coven daemon: unix connection error: {error:#}");
+                        append_daemon_recovery_log(
+                            coven_home,
+                            &format!("unix connection error: {error:#}"),
+                        );
+                    }
                 }
             }
             continue;
@@ -3288,21 +4446,28 @@ pub fn serve_forever(
         let conn_home = coven_home.to_path_buf();
         let conn_runtime = Arc::clone(&runtime);
         let conn_inflight = Arc::clone(&inflight);
+        let conn_shutdown_connections = Arc::clone(&shutdown_connections);
         let spawn_result = std::thread::Builder::new()
             .name("coven-unix-api".into())
             .spawn(move || {
-                if let Err(error) = serve_accepted_connection(
+                match serve_accepted_connection(
                     stream,
                     &conn_home,
                     conn_status,
                     conn_runtime.as_ref(),
                 ) {
-                    if !is_client_disconnect(&error) {
-                        eprintln!("coven daemon: unix connection error: {error:#}");
-                        append_daemon_recovery_log(
-                            &conn_home,
-                            &format!("unix connection error: {error:#}"),
-                        );
+                    Ok(Some(stream)) => {
+                        retain_shutdown_connection(&conn_shutdown_connections, stream);
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        if !is_client_disconnect(&error) {
+                            eprintln!("coven daemon: unix connection error: {error:#}");
+                            append_daemon_recovery_log(
+                                &conn_home,
+                                &format!("unix connection error: {error:#}"),
+                            );
+                        }
                     }
                 }
                 conn_inflight.fetch_sub(1, Ordering::Relaxed);
@@ -3352,9 +4517,25 @@ pub fn serve_forever(
     } else {
         Ok(())
     };
-    runtime_shutdown?;
-    tcp_shutdown?;
-    Ok(())
+    let shutdown_result = runtime_shutdown.and(tcp_shutdown);
+    drop(unix_listener);
+    drop(mobile_gateway);
+    drop(shutdown_guard);
+    drop(serve_lock);
+    match shutdown_connections.lock() {
+        Ok(mut connections) => connections.clear(),
+        Err(poisoned) => poisoned.into_inner().clear(),
+    }
+    shutdown_result
+}
+
+#[cfg(unix)]
+fn retain_shutdown_connection(connections: &Mutex<Vec<UnixStream>>, stream: UnixStream) {
+    match connections.lock() {
+        Ok(mut connections) => connections.push(stream),
+        Err(poisoned) => poisoned.into_inner().push(stream),
+    }
+    DAEMON_TERMINATION_REQUESTED.store(true, Ordering::Release);
 }
 
 #[cfg(unix)]
@@ -3378,9 +4559,27 @@ enum HostGuard<'a> {
     Loopback { allowed_hosts: &'a [String] },
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LifecycleControl {
+    Disabled,
+    OwnerLocal,
+}
+
+#[derive(Clone, Copy)]
+struct HttpStreamPolicy<'a> {
+    host_guard: HostGuard<'a>,
+    lifecycle: LifecycleControl,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HttpStreamOutcome {
+    Complete,
+    HoldForShutdown,
+}
+
 fn handle_http_stream<R, W>(
     read: R,
-    mut write: W,
+    write: W,
     coven_home: &Path,
     status: Option<DaemonStatus>,
     runtime: &dyn SessionRuntime,
@@ -3391,8 +4590,41 @@ where
     R: Read,
     W: Write,
 {
+    handle_http_stream_with_lifecycle(
+        read,
+        write,
+        coven_home,
+        status,
+        runtime,
+        max_body_bytes,
+        HttpStreamPolicy {
+            host_guard: guard,
+            lifecycle: LifecycleControl::Disabled,
+        },
+    )
+    .map(|_| ())
+}
+
+fn handle_http_stream_with_lifecycle<R, W>(
+    read: R,
+    mut write: W,
+    coven_home: &Path,
+    status: Option<DaemonStatus>,
+    runtime: &dyn SessionRuntime,
+    max_body_bytes: Option<usize>,
+    policy: HttpStreamPolicy<'_>,
+) -> Result<HttpStreamOutcome>
+where
+    R: Read,
+    W: Write,
+{
+    let HttpStreamPolicy {
+        host_guard: guard,
+        lifecycle,
+    } = policy;
     let mut reader = BufReader::new(read);
     let request_line = read_http_request_line(&mut reader)?;
+    let (method, path) = parse_request_line(&request_line)?;
     let headers = read_http_headers(&mut reader)?;
     // On the TCP transport (loopback-only), defend against browser-driven CSRF
     // and DNS-rebinding: a real CLI/proxy client never sends a cross-origin
@@ -3407,52 +4639,80 @@ where
     if let HostGuard::Loopback { allowed_hosts } = guard {
         let host = headers.host.as_deref();
         if !host_is_loopback(host) && !host_in_allowlist(host, allowed_hosts) {
-            return write_forbidden(
+            write_forbidden(
                 &mut write,
                 "Host header must be a loopback or allowed address.",
-            );
+            )?;
+            return Ok(HttpStreamOutcome::Complete);
         }
         if let Some(origin) = headers.origin.as_deref() {
             if !origin_is_loopback(origin) && !origin_in_allowlist(origin, allowed_hosts) {
-                return write_forbidden(&mut write, "Cross-origin requests are not allowed.");
+                write_forbidden(&mut write, "Cross-origin requests are not allowed.")?;
+                return Ok(HttpStreamOutcome::Complete);
             }
         }
     }
     if let Some(max) = max_body_bytes {
         if headers.content_length > max {
-            return write_payload_too_large(&mut write, max);
+            write_payload_too_large(&mut write, max)?;
+            return Ok(HttpStreamOutcome::Complete);
         }
     }
+    const MAX_LIFECYCLE_REQUEST_BODY_BYTES: usize = 16 * 1024;
+    if lifecycle == LifecycleControl::OwnerLocal
+        && method == "POST"
+        && path == "/api/v1/internal/lifecycle/shutdown"
+        && headers.content_length > MAX_LIFECYCLE_REQUEST_BODY_BYTES
+    {
+        write_payload_too_large(&mut write, MAX_LIFECYCLE_REQUEST_BODY_BYTES)?;
+        return Ok(HttpStreamOutcome::Complete);
+    }
     let body = read_http_body(&mut reader, headers.content_length)?;
-    let (method, path) = parse_request_line(&request_line)?;
+    let lifecycle_response = if lifecycle == LifecycleControl::OwnerLocal
+        && method == "POST"
+        && path == "/api/v1/internal/lifecycle/shutdown"
+    {
+        Some(lifecycle_shutdown_response(
+            status.as_ref(),
+            body.as_deref(),
+        )?)
+    } else {
+        None
+    };
     let local_control = if matches!(guard, HostGuard::Disabled) {
         crate::mobile_memory::gateway::handle_local_control(method, path, body.as_deref())
     } else {
         None
     };
-    let response = match local_control.unwrap_or_else(|| {
-        let authority = match guard {
-            HostGuard::Disabled => crate::api::RequestAuthority::OwnerLocalIpc,
-            HostGuard::Loopback { .. } => crate::api::RequestAuthority::Tcp,
-        };
-        crate::api::handle_request_with_runtime_and_authority(
-            method,
-            path,
-            coven_home,
-            status,
-            body.as_deref(),
-            runtime,
-            authority,
-        )
-    }) {
-        Ok(response) => response,
-        Err(error) => {
-            append_daemon_recovery_log(
+    let (response, hold_for_shutdown) = if let Some(response) = lifecycle_response {
+        response
+    } else {
+        let response = match local_control.unwrap_or_else(|| {
+            let authority = match guard {
+                HostGuard::Disabled => crate::api::RequestAuthority::OwnerLocalIpc,
+                HostGuard::Loopback { .. } => crate::api::RequestAuthority::Tcp,
+            };
+            crate::api::handle_request_with_runtime_and_authority(
+                method,
+                path,
                 coven_home,
-                &format!("API handler error for {method} {path}: {error:#}"),
-            );
-            return write_internal_server_error(&mut write, &format!("{error:#}"));
-        }
+                status,
+                body.as_deref(),
+                runtime,
+                authority,
+            )
+        }) {
+            Ok(response) => response,
+            Err(error) => {
+                append_daemon_recovery_log(
+                    coven_home,
+                    &format!("API handler error for {method} {path}: {error:#}"),
+                );
+                write_internal_server_error(&mut write, &format!("{error:#}"))?;
+                return Ok(HttpStreamOutcome::Complete);
+            }
+        };
+        (response, false)
     };
     let reason = http_reason_phrase(response.status);
     let http = format!(
@@ -3466,7 +4726,86 @@ where
     write
         .write_all(http.as_bytes())
         .context("failed to write API response")?;
-    Ok(())
+    if hold_for_shutdown {
+        Ok(HttpStreamOutcome::HoldForShutdown)
+    } else {
+        Ok(HttpStreamOutcome::Complete)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LifecycleShutdownRequest {
+    api_version: String,
+    daemon: DaemonStatus,
+}
+
+fn lifecycle_shutdown_response(
+    status: Option<&DaemonStatus>,
+    body: Option<&str>,
+) -> Result<(crate::api::ApiResponse, bool)> {
+    let request = match body
+        .filter(|body| !body.trim().is_empty())
+        .map(serde_json::from_str::<LifecycleShutdownRequest>)
+    {
+        Some(Ok(request)) => request,
+        Some(Err(error)) => {
+            return Ok((
+                crate::api::api_error(
+                    400,
+                    "invalid_request",
+                    &format!("invalid daemon shutdown request: {error}"),
+                    None,
+                )?,
+                false,
+            ))
+        }
+        None => {
+            return Ok((
+                crate::api::api_error(
+                    400,
+                    "invalid_request",
+                    "daemon shutdown request body is required",
+                    None,
+                )?,
+                false,
+            ))
+        }
+    };
+    let Some(status) = status else {
+        return Ok((
+            crate::api::api_error(
+                409,
+                "daemon_identity_mismatch",
+                "Daemon identity is unavailable; refusing lifecycle shutdown.",
+                None,
+            )?,
+            false,
+        ));
+    };
+    if request.api_version != crate::api::COVEN_API_NAMED_VERSION || request.daemon != *status {
+        return Ok((
+            crate::api::api_error(
+                409,
+                "daemon_identity_mismatch",
+                "Daemon identity did not match; refusing lifecycle shutdown.",
+                None,
+            )?,
+            false,
+        ));
+    }
+    Ok((
+        crate::api::json_response(
+            202,
+            &serde_json::json!({
+                "ok": true,
+                "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+                "capabilities": { "structuredErrors": true },
+                "daemon": status,
+            }),
+        )?,
+        true,
+    ))
 }
 
 fn write_internal_server_error<W: Write>(write: &mut W, message: &str) -> Result<()> {
@@ -3595,7 +4934,7 @@ pub fn serve_next_connection(
     let (stream, _) = listener
         .accept()
         .context("failed to accept API connection")?;
-    serve_accepted_connection(stream, coven_home, status, runtime)
+    serve_accepted_connection(stream, coven_home, status, runtime).map(|_| ())
 }
 
 /// Serve a single already-accepted Unix connection. Split out of
@@ -3608,7 +4947,7 @@ fn serve_accepted_connection(
     coven_home: &Path,
     status: Option<DaemonStatus>,
     runtime: &dyn SessionRuntime,
-) -> Result<()> {
+) -> Result<Option<UnixStream>> {
     stream
         .set_nonblocking(false)
         .context("failed to configure accepted Unix API connection")?;
@@ -3626,15 +4965,19 @@ fn serve_accepted_connection(
     let read = stream.try_clone().context("failed to clone Unix stream")?;
     // Apply a body cap even on local Unix sockets: a buggy or hostile local
     // process should not be able to OOM the daemon with a huge payload.
-    handle_http_stream(
+    let outcome = handle_http_stream_with_lifecycle(
         read,
-        stream,
+        &stream,
         coven_home,
         status,
         runtime,
         Some(MAX_SOCKET_BODY_BYTES),
-        HostGuard::Disabled,
-    )
+        HttpStreamPolicy {
+            host_guard: HostGuard::Disabled,
+            lifecycle: LifecycleControl::OwnerLocal,
+        },
+    )?;
+    Ok((outcome == HttpStreamOutcome::HoldForShutdown).then_some(stream))
 }
 
 fn http_reason_phrase(status: u16) -> &'static str {
@@ -3721,22 +5064,30 @@ fn parse_request_line(line: &str) -> Result<(&str, &str)> {
     Ok((method, path))
 }
 
+#[cfg(any(windows, test))]
+fn owner_only_pipe_sddl(owner_sid: &str) -> String {
+    format!("O:{owner_sid}D:(A;;GA;;;OW)")
+}
+
 #[cfg(windows)]
 fn owner_only_pipe_security_descriptor(
 ) -> Result<interprocess::os::windows::security_descriptor::SecurityDescriptor> {
     use interprocess::os::windows::security_descriptor::SecurityDescriptor;
     use widestring::U16CString;
 
-    // D:(A;;GA;;;OW) — allow Generic All for the object owner only. This is the
-    // Windows named-pipe equivalent of binding a Unix socket with mode 0600.
-    let sddl = U16CString::from_str("D:(A;;GA;;;OW)")
+    let owner = current_windows_user_sid()?;
+    let owner = owner.to_sddl_string()?;
+    // Explicitly bind the descriptor owner to TokenUser, rather than allowing
+    // Windows to derive it from a configurable TokenOwner. The DACL continues
+    // to grant Generic All solely through the OWNER RIGHTS SID.
+    let sddl = U16CString::from_str(owner_only_pipe_sddl(&owner))
         .context("failed to encode owner-only named pipe security descriptor")?;
     SecurityDescriptor::deserialize(&sddl)
         .context("failed to build owner-only named pipe security descriptor")
 }
 
 #[cfg(windows)]
-pub(crate) fn windows_pipe_name(coven_home: &Path) -> String {
+pub(crate) fn windows_pipe_name(coven_home: &Path) -> Result<String> {
     daemon_windows_pipe_name(coven_home)
 }
 
@@ -3746,8 +5097,8 @@ pub(crate) fn windows_pipe_name(coven_home: &Path) -> String {
 /// diagnostics need the concrete endpoint users can compare against a profile
 /// root without treating the IPC surface as absent.
 #[cfg(windows)]
-pub(crate) fn windows_pipe_path(coven_home: &Path) -> PathBuf {
-    PathBuf::from(r"\\.\pipe").join(daemon_windows_pipe_name(coven_home))
+pub(crate) fn windows_pipe_path(coven_home: &Path) -> Result<PathBuf> {
+    Ok(PathBuf::from(r"\\.\pipe").join(daemon_windows_pipe_name(coven_home)?))
 }
 
 /// Put the Windows daemon itself in a process-lifetime kill-on-close Job.
@@ -3870,12 +5221,18 @@ fn serve_forever_with_lifetime_job_installer(
 
     let _serve_lock = acquire_serve_lock(coven_home)?;
     install_lifetime_job()?;
+    let pipe_name = windows_pipe_name(coven_home)?;
     let status = DaemonStatus {
         pid: std::process::id(),
         started_at: started_at.clone(),
-        socket: windows_pipe_name(coven_home),
+        socket: pipe_name.clone(),
+        process_creation_time: Some(WindowsProcessCreationTime::new(
+            coven_client::windows_process_creation_time(std::process::id())
+                .map_err(anyhow::Error::new)?
+                .context("current Windows daemon process was not live during startup")?,
+        )?),
     };
-    let name = windows_pipe_name(coven_home)
+    let name = pipe_name
         .to_ns_name::<GenericNamespaced>()
         .context("failed to create named pipe name")?;
     let security_descriptor = owner_only_pipe_security_descriptor()?;
@@ -3971,6 +5328,329 @@ fn serve_forever_with_lifetime_job_installer(
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    static DAEMON_TERMINATION_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn windows_status_probe_passes_a_finite_timeout_to_the_shared_client() {
+        let observed_timeout = std::cell::Cell::new(None);
+        let status = daemon_status_from_windows_probe("coven-daemon-test.sock", |_, timeout| {
+            observed_timeout.set(Some(timeout));
+            Ok(Some((
+                200,
+                br#"{"ok":true,"daemon":{"pid":42,"startedAt":"2026-08-16T00:00:00Z","socket":"coven-daemon-test.sock"}}"#
+                    .to_vec(),
+                42,
+                134_157_822_123_456_789,
+            )))
+        })
+        .expect("parse successful shared probe response")
+        .expect("running daemon");
+
+        let observed_timeout = observed_timeout.get().expect("finite probe budget");
+        assert!(observed_timeout <= Duration::from_secs(2));
+        assert!(observed_timeout > Duration::from_secs(1));
+        assert_eq!(status.pid, 42);
+        assert_eq!(
+            status.process_creation_time.map(|value| value.get()),
+            Some(134_157_822_123_456_789)
+        );
+    }
+
+    #[test]
+    fn lifecycle_deadline_reuses_one_budget_and_reports_the_expired_phase() {
+        let start = Instant::now();
+        let deadline = LifecycleDeadline::from_instant(start + Duration::from_millis(100));
+
+        assert_eq!(
+            deadline
+                .remaining_at(start + Duration::from_millis(40), "authenticating daemon")
+                .expect("budget remains"),
+            Duration::from_millis(60)
+        );
+        let error = deadline
+            .remaining_at(
+                start + Duration::from_millis(100),
+                "cleaning up daemon status",
+            )
+            .expect_err("the original deadline is exhausted");
+        assert!(
+            error
+                .to_string()
+                .contains("timed out cleaning up daemon status"),
+            "unexpected phase error: {error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn expired_lifecycle_deadline_skips_optional_duplicate_scan_deterministically() {
+        let scanned = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let scanned_in_diagnostic = std::sync::Arc::clone(&scanned);
+        let expired = LifecycleDeadline::from_instant(Instant::now());
+
+        run_optional_lifecycle_diagnostic(expired, move |_| {
+            scanned_in_diagnostic.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        assert!(
+            !scanned.load(std::sync::atomic::Ordering::SeqCst),
+            "an optional process scan started after the lifecycle deadline"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restart_returns_within_deadline_when_optional_diagnostic_scan_is_slow() -> Result<()> {
+        struct DiagnosticDelayGuard;
+
+        impl Drop for DiagnosticDelayGuard {
+            fn drop(&mut self) {
+                OPTIONAL_DIAGNOSTIC_DELAY_MILLIS.store(0, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+
+        let _guard = DAEMON_TERMINATION_TEST_LOCK.lock().unwrap();
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "old".to_owned(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &status)?;
+        let started = std::sync::Arc::new(std::sync::Mutex::new(0));
+        OPTIONAL_DIAGNOSTIC_DELAY_MILLIS.store(500, std::sync::atomic::Ordering::SeqCst);
+        let _delay_guard = DiagnosticDelayGuard;
+        let deadline = LifecycleDeadline::after(Duration::from_millis(100))?;
+        let started_at = Instant::now();
+
+        let restarted = restart_background_server_with_controllers_until(
+            temp_dir.path(),
+            Path::new("/usr/bin/coven"),
+            "new".to_owned(),
+            &FakeStopController {
+                pid_alive: true,
+                exited_after_signal: true,
+                signal_error: None,
+                verified_daemon: true,
+                signaled: std::sync::Arc::default(),
+            },
+            &FakeStartController {
+                started,
+                running_after_start: true,
+            },
+            deadline,
+        )?;
+
+        assert!(restarted.0);
+        assert!(
+            started_at.elapsed() < Duration::from_millis(250),
+            "optional diagnostic scan delayed restart completion"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn expired_windows_health_deadline_never_runs_a_fixed_followup_probe() {
+        let invoked = std::cell::Cell::new(false);
+        let error = daemon_status_from_windows_probe_until(
+            "coven-daemon-test.sock",
+            LifecycleDeadline::from_instant(Instant::now()),
+            |_, _| {
+                invoked.set(true);
+                Ok::<_, coven_client::ClientError>(None)
+            },
+        )
+        .expect_err("an expired outer deadline must stop before probing");
+
+        assert!(!invoked.get());
+        assert!(
+            error
+                .to_string()
+                .contains("timed out probing Windows daemon health"),
+            "unexpected timeout phase: {error:#}"
+        );
+    }
+
+    #[test]
+    fn windows_start_wait_does_not_probe_again_after_its_total_budget() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(None))?;
+        let calls = std::cell::Cell::new(0);
+        let started = Instant::now();
+
+        let error = wait_for_windows_running_daemon_with_probe(
+            &status,
+            Duration::from_millis(20),
+            |_, _, _| {
+                calls.set(calls.get() + 1);
+                std::thread::sleep(Duration::from_millis(25));
+                Ok(false)
+            },
+        )
+        .expect_err("the single outer start budget must expire");
+
+        assert_eq!(calls.get(), 1, "no fixed post-deadline probe is allowed");
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "start readiness materially overshot its 20ms budget"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("timed out waiting for Coven daemon startup health"),
+            "unexpected timeout phase: {error:#}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn stop_cleanup_does_not_run_after_the_outer_lifecycle_deadline() -> Result<()> {
+        struct SlowVerifiedStop;
+        impl DaemonStopController for SlowVerifiedStop {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                std::thread::sleep(Duration::from_millis(25));
+                Ok(VerifiedStopOutcome::Exited)
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                Ok(RecordedProcessState::Gone)
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                Ok(false)
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 42,
+            started_at: "2026-08-16T00:00:00Z".to_owned(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &status)?;
+        let error = stop_background_server_with_controller_until(
+            temp_dir.path(),
+            &SlowVerifiedStop,
+            LifecycleDeadline::after(Duration::from_millis(10))?,
+        )
+        .expect_err("cleanup must not start after the original stop budget");
+
+        assert!(
+            error
+                .to_string()
+                .contains("timed out cleaning up Coven daemon lifecycle state"),
+            "unexpected timeout phase: {error:#}"
+        );
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
+    #[test]
+    fn windows_status_probe_preserves_unavailable_as_not_running() {
+        let status = daemon_status_from_windows_probe("coven-daemon-test.sock", |_, _| {
+            Ok::<_, coven_client::ClientError>(None)
+        })
+        .expect("an unavailable owner-safe connection is not an error");
+
+        assert_eq!(status, None);
+    }
+
+    #[test]
+    fn windows_status_probe_rejects_health_identity_not_bound_to_pipe_server() {
+        for (body, server_pid, server_creation_time) in [
+            (
+                br#"{"ok":true,"daemon":{"pid":41,"startedAt":"now","socket":"coven-daemon-test.sock","processCreationTime":"134157822123456789"}}"#.as_slice(),
+                42,
+                134_157_822_123_456_789,
+            ),
+            (
+                br#"{"ok":true,"daemon":{"pid":42,"startedAt":"now","socket":"other-profile.sock","processCreationTime":"134157822123456789"}}"#.as_slice(),
+                42,
+                134_157_822_123_456_789,
+            ),
+            (
+                br#"{"ok":true,"daemon":{"pid":42,"startedAt":"now","socket":"coven-daemon-test.sock","processCreationTime":"134157822123456788"}}"#.as_slice(),
+                42,
+                134_157_822_123_456_789,
+            ),
+        ] {
+            let result = daemon_status_from_windows_probe("coven-daemon-test.sock", |_, _| {
+                Ok(Some((
+                    200,
+                    body.to_vec(),
+                    server_pid,
+                    server_creation_time,
+                )))
+            });
+            assert!(result.is_err(), "accepted unbound health body");
+        }
+    }
+
+    #[test]
+    fn windows_recorded_status_matches_only_its_authenticated_process_identity() -> Result<()> {
+        let legacy = parse_daemon_status(&windows_status_fixture(None))?;
+        let recorded = parse_daemon_status(&windows_status_fixture(Some("134157822123456789")))?;
+        let matching = parse_daemon_status(&windows_status_fixture(Some("134157822123456789")))?;
+        let reused = parse_daemon_status(&windows_status_fixture(Some("134157822123456790")))?;
+
+        assert!(windows_status_matches_authenticated_health(
+            &recorded, &matching
+        ));
+        assert!(!windows_status_matches_authenticated_health(
+            &recorded, &reused
+        ));
+        assert!(
+            windows_status_matches_authenticated_health(&legacy, &matching),
+            "an authenticated health response may resolve a legacy record"
+        );
+        assert_eq!(
+            resolved_windows_daemon_status(&legacy, &matching),
+            Some(matching.clone()),
+            "secure health resolution should migrate the legacy fingerprint"
+        );
+        assert_eq!(resolved_windows_daemon_status(&recorded, &reused), None);
+        Ok(())
+    }
+
+    #[test]
+    fn windows_daemon_token_storage_is_word_aligned_and_covers_requested_bytes() {
+        for requested_bytes in [1, 3, 8, 31, 257] {
+            let mut buffer = WindowsTokenBuffer::new(requested_bytes);
+            assert_eq!(
+                buffer.as_mut_ptr() as usize % std::mem::align_of::<usize>(),
+                0
+            );
+            assert!(buffer.byte_capacity() >= requested_bytes);
+        }
+    }
+
+    #[test]
+    fn named_pipe_sddl_sets_token_user_as_owner_and_preserves_owner_only_dacl() {
+        assert_eq!(
+            owner_only_pipe_sddl("S-1-5-21-42"),
+            "O:S-1-5-21-42D:(A;;GA;;;OW)"
+        );
+    }
+
     #[test]
     fn daemon_store_initialization_prepares_request_connections() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -4010,6 +5690,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn termination_signal_requests_graceful_cleanup_instead_of_immediate_exit() {
+        let _test_lock = DAEMON_TERMINATION_TEST_LOCK
+            .lock()
+            .expect("termination test lock");
         DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
         handle_termination_signal(libc::SIGTERM);
         assert!(daemon_termination_requested());
@@ -4148,6 +5831,113 @@ mod tests {
         assert!(started.elapsed() < Duration::from_secs(1));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn owner_local_lifecycle_shutdown_requires_the_exact_serving_identity() -> Result<()> {
+        let _test_lock = DAEMON_TERMINATION_TEST_LOCK
+            .lock()
+            .expect("termination test lock");
+        let temp = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 42,
+            started_at: "2026-08-16T12:00:00Z".to_owned(),
+            socket: daemon_socket_path(temp.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        let wrong = DaemonStatus {
+            pid: 43,
+            ..status.clone()
+        };
+        let body = serde_json::json!({
+            "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+            "daemon": wrong,
+        })
+        .to_string();
+        let request = format!(
+            "POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\nHost: coven\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut input = std::io::Cursor::new(request.into_bytes());
+        let mut output = Vec::new();
+        DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
+
+        let outcome = handle_http_stream_with_lifecycle(
+            &mut input,
+            &mut output,
+            temp.path(),
+            Some(status),
+            &crate::api::NoopSessionRuntime,
+            Some(MAX_SOCKET_BODY_BYTES),
+            HttpStreamPolicy {
+                host_guard: HostGuard::Disabled,
+                lifecycle: LifecycleControl::OwnerLocal,
+            },
+        )?;
+
+        assert_eq!(outcome, HttpStreamOutcome::Complete);
+        assert!(String::from_utf8(output)?.starts_with("HTTP/1.1 409 Conflict\r\n"));
+        assert!(!daemon_termination_requested());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn owner_local_lifecycle_shutdown_holds_its_authenticated_connection() -> Result<()> {
+        let _test_lock = DAEMON_TERMINATION_TEST_LOCK
+            .lock()
+            .expect("termination test lock");
+        let temp = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 42,
+            started_at: "2026-08-16T12:00:00Z".to_owned(),
+            socket: daemon_socket_path(temp.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        let body = serde_json::json!({
+            "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+            "daemon": status,
+        })
+        .to_string();
+        let request = format!(
+            "POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\nHost: coven\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut input = std::io::Cursor::new(request.into_bytes());
+        let mut output = Vec::new();
+        DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
+
+        let outcome = handle_http_stream_with_lifecycle(
+            &mut input,
+            &mut output,
+            temp.path(),
+            Some(status),
+            &crate::api::NoopSessionRuntime,
+            Some(MAX_SOCKET_BODY_BYTES),
+            HttpStreamPolicy {
+                host_guard: HostGuard::Disabled,
+                lifecycle: LifecycleControl::OwnerLocal,
+            },
+        )?;
+
+        assert_eq!(outcome, HttpStreamOutcome::HoldForShutdown);
+        assert!(String::from_utf8(output)?.starts_with("HTTP/1.1 202 Accepted\r\n"));
+        assert!(
+            !daemon_termination_requested(),
+            "shutdown cannot begin before the authenticated connection is retained"
+        );
+        let (server, _client) = UnixStream::pair()?;
+        let retained = Mutex::new(Vec::new());
+        retain_shutdown_connection(&retained, server);
+        assert!(daemon_termination_requested());
+        assert_eq!(retained.into_inner().expect("retained lock").len(), 1);
+        DAEMON_TERMINATION_REQUESTED.store(false, Ordering::Release);
+        Ok(())
+    }
+
     #[test]
     fn serve_lock_is_exclusive_and_reusable() -> Result<()> {
         let home = tempfile::tempdir()?;
@@ -4163,6 +5953,83 @@ mod tests {
         drop(first);
         let _second =
             acquire_serve_lock(home.path()).expect("lock should be reacquirable once released");
+        Ok(())
+    }
+
+    #[test]
+    fn reset_pipe_reservation_retains_every_supported_identity_until_release() -> Result<()> {
+        struct TrackedReservation(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+        impl Drop for TrackedReservation {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let names = ["v2", "v1", "v0"];
+        let attempted = std::cell::RefCell::new(Vec::new());
+        let released = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let reservations = reserve_windows_pipe_identities(&names, |name| {
+            attempted.borrow_mut().push(name.to_owned());
+            Ok(Some(TrackedReservation(released.clone())))
+        })?
+        .expect("all identities were available");
+
+        assert_eq!(&*attempted.borrow(), &names);
+        assert_eq!(released.load(Ordering::SeqCst), 0);
+        drop(reservations);
+        assert_eq!(released.load(Ordering::SeqCst), names.len());
+        Ok(())
+    }
+
+    #[test]
+    fn reset_pipe_reservation_releases_partial_handles_on_legacy_collision() -> Result<()> {
+        struct TrackedReservation(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+        impl Drop for TrackedReservation {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let names = ["v2", "v1", "v0"];
+        let attempted = std::cell::Cell::new(0);
+        let released = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let reservations = reserve_windows_pipe_identities(&names, |_| {
+            let index = attempted.get();
+            attempted.set(index + 1);
+            if index == 1 {
+                Ok(None)
+            } else {
+                Ok(Some(TrackedReservation(released.clone())))
+            }
+        })?;
+
+        assert!(reservations.is_none());
+        assert_eq!(attempted.get(), 2);
+        assert_eq!(released.load(Ordering::SeqCst), 1);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reset_transport_probe_bounds_an_unresponsive_socket() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir()?;
+        std::fs::set_permissions(home.path(), std::fs::Permissions::from_mode(0o700))?;
+        let socket = daemon_socket_path(home.path());
+        let _listener = UnixListener::bind(&socket)?;
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
+        let started = Instant::now();
+
+        let error =
+            unix_daemon_transport_is_occupied_with_timeout(home.path(), Duration::from_millis(50))
+                .unwrap_err();
+
+        assert!(
+            format!("{error:#}").contains("timed out"),
+            "unexpected probe failure: {error:#}"
+        );
+        assert!(started.elapsed() < Duration::from_secs(1));
         Ok(())
     }
 
@@ -6725,14 +8592,18 @@ mod tests {
         let home = temp.path().to_path_buf();
 
         // Stand up an incumbent daemon: a bound socket plus a thread that answers
-        // a single /health probe, reporting a recognizable pid.
+        // a single /health probe, reporting its authenticated peer pid.
         let incumbent = bind_api_socket(&home).expect("bind incumbent");
-        let socket = daemon_socket_path(&home).to_string_lossy().into_owned();
+        let canonical_home = std::fs::canonicalize(&home).expect("canonicalize home");
+        let socket = daemon_socket_path(&canonical_home)
+            .to_string_lossy()
+            .into_owned();
         let server_home = home.clone();
         let status = DaemonStatus {
-            pid: 4242,
+            pid: std::process::id(),
             started_at: "2026-06-18T00:00:00Z".to_string(),
             socket,
+            process_creation_time: None,
         };
         let server = thread::spawn(move || {
             serve_next_connection(&incumbent, &server_home, Some(status), &NoopSessionRuntime)
@@ -6745,7 +8616,7 @@ mod tests {
         server.join().expect("incumbent server thread");
         let msg = format!("{error:#}");
         assert!(
-            msg.contains("refusing to take over") && msg.contains("4242"),
+            msg.contains("refusing to take over") && msg.contains(&std::process::id().to_string()),
             "unexpected error: {msg}"
         );
     }
@@ -6832,6 +8703,7 @@ mod tests {
                 .join("coven.sock")
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
 
         write_status(temp_dir.path(), &status)?;
@@ -6840,6 +8712,236 @@ mod tests {
         assert!(clear_status(temp_dir.path())?);
         assert_eq!(read_status(temp_dir.path())?, None);
         assert!(!clear_status(temp_dir.path())?);
+        Ok(())
+    }
+
+    fn windows_status_fixture(process_creation_time: Option<&str>) -> String {
+        let mut status = serde_json::json!({
+            "pid": 12345,
+            "startedAt": "2026-04-27T10:00:00Z",
+            "socket": "coven-daemon-v1-fixture.sock",
+        });
+        if let Some(process_creation_time) = process_creation_time {
+            status["processCreationTime"] =
+                serde_json::Value::String(process_creation_time.to_owned());
+        }
+        status.to_string()
+    }
+
+    #[test]
+    fn windows_status_creation_time_matches_the_same_live_process() -> Result<()> {
+        let creation_time = 134_157_822_123_456_789_u64;
+        let status =
+            parse_daemon_status(&windows_status_fixture(Some(&creation_time.to_string())))?;
+
+        assert_eq!(
+            recorded_windows_process_state(&status, Some(creation_time)),
+            RecordedProcessState::Matching
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn windows_status_creation_time_detects_a_reused_pid() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(Some("134157822123456789")))?;
+
+        assert_eq!(
+            recorded_windows_process_state(&status, Some(134_157_822_999_999_999)),
+            RecordedProcessState::Mismatched
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn legacy_windows_status_without_creation_time_remains_unverifiable() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(None))?;
+
+        assert_eq!(
+            recorded_windows_process_state(&status, Some(134_157_822_123_456_789)),
+            RecordedProcessState::Unverifiable
+        );
+        assert_eq!(
+            recorded_windows_process_state(&status, None),
+            RecordedProcessState::Gone
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn malformed_windows_status_creation_time_fails_closed() {
+        for malformed in [
+            serde_json::Value::Null,
+            serde_json::json!(134_157_822_123_456_789_u64),
+            serde_json::json!(""),
+            serde_json::json!("0"),
+            serde_json::json!("-1"),
+            serde_json::json!("not-a-filetime"),
+            serde_json::json!("18446744073709551616"),
+        ] {
+            let mut status: serde_json::Value =
+                serde_json::from_str(&windows_status_fixture(None)).unwrap();
+            status["processCreationTime"] = malformed.clone();
+
+            let error = parse_daemon_status(&status.to_string())
+                .expect_err("malformed process creation time must be rejected");
+            assert!(
+                error
+                    .to_string()
+                    .contains("invalid Windows process creation time"),
+                "unexpected error for {malformed}: {error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn windows_process_creation_time_serializes_without_losing_filetime_width() -> Result<()> {
+        let status = parse_daemon_status(&windows_status_fixture(Some(&u64::MAX.to_string())))?;
+
+        let serialized = serde_json::to_value(&status)?;
+        assert_eq!(
+            serialized["processCreationTime"],
+            serde_json::Value::String(u64::MAX.to_string())
+        );
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn reads_stale_windows_status_without_a_live_pipe() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: windows_pipe_name(temp_dir.path())?,
+            process_creation_time: None,
+        };
+
+        write_status(temp_dir.path(), &status)?;
+
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn stop_clears_stale_windows_status_without_a_live_pipe() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: windows_pipe_name(temp_dir.path())?,
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &status)?;
+
+        assert!(stop_background_server_with_controller(
+            temp_dir.path(),
+            &FakeStopController {
+                pid_alive: false,
+                exited_after_signal: false,
+                signal_error: Some("No such process".to_string()),
+                verified_daemon: false,
+                signaled: std::sync::Arc::default(),
+            },
+        )?);
+
+        assert_eq!(read_status(temp_dir.path())?, None);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn inherited_legacy_windows_status(
+        coven_home: &Path,
+        pid: u32,
+        socket: Option<String>,
+    ) -> Result<DaemonStatus> {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        let socket = socket.unwrap_or_else(|| {
+            let mut hasher = DefaultHasher::new();
+            coven_home.to_string_lossy().hash(&mut hasher);
+            format!("coven-daemon-{:016x}.sock", hasher.finish())
+        });
+        let status = DaemonStatus {
+            pid,
+            started_at: "2026-04-27T10:00:00Z".to_owned(),
+            socket,
+            process_creation_time: None,
+        };
+        std::fs::write(daemon_status_path(coven_home), serde_json::to_vec(&status)?)?;
+        Ok(status)
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn lifecycle_clears_inherited_legacy_status_only_after_pid_is_dead() -> Result<()> {
+        use coven_client::DaemonEndpoint;
+
+        let temp_dir = tempfile::tempdir()?;
+        let mut exited = Command::new("cmd.exe").args(["/C", "exit", "0"]).spawn()?;
+        let exited_pid = exited.id();
+        assert!(exited.wait()?.success());
+        let status = inherited_legacy_windows_status(temp_dir.path(), exited_pid, None)?;
+        assert!(
+            DaemonEndpoint::discover(temp_dir.path()).is_err(),
+            "endpoint discovery must reject an unavailable legacy pipe"
+        );
+
+        let state = background_server_status(temp_dir.path())?;
+
+        assert_eq!(state, None);
+        assert!(!daemon_status_path(temp_dir.path()).exists());
+        assert_ne!(status.socket, windows_pipe_name(temp_dir.path())?);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn lifecycle_preserves_inherited_legacy_status_while_pid_is_alive() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status = inherited_legacy_windows_status(temp_dir.path(), std::process::id(), None)?;
+
+        let state = background_server_status(temp_dir.path())?;
+        assert_eq!(state, Some(DaemonStatusState::Stale(status.clone())));
+        ensure_background_server(
+            temp_dir.path(),
+            Path::new("coven.exe"),
+            "2026-04-27T11:00:00Z".to_owned(),
+        )
+        .expect_err("start must not replace an unavailable legacy record with a live PID");
+        stop_background_server(temp_dir.path())
+            .expect_err("stop must not signal or clear an unverified live PID");
+        restart_background_server(
+            temp_dir.path(),
+            Path::new("coven.exe"),
+            "2026-04-27T11:00:00Z".to_owned(),
+        )
+        .expect_err("restart must not signal or clear an unverified live PID");
+
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn lifecycle_rejects_redirected_inherited_legacy_status_without_clearing() -> Result<()> {
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        let temp_dir = tempfile::tempdir()?;
+        let other_home = temp_dir.path().join("other-profile");
+        let mut hasher = DefaultHasher::new();
+        other_home.to_string_lossy().hash(&mut hasher);
+        let other_profile = format!("coven-daemon-{:016x}.sock", hasher.finish());
+
+        for socket in [other_profile, "other-daemon.sock".to_owned()] {
+            inherited_legacy_windows_status(temp_dir.path(), 12345, Some(socket))?;
+            let result = background_server_status(temp_dir.path());
+            assert!(result.is_err());
+            assert!(
+                daemon_status_path(temp_dir.path()).exists(),
+                "rejected status must not be cleared"
+            );
+        }
         Ok(())
     }
 
@@ -6870,6 +8972,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
 
         write_status(temp_dir.path(), &status)?;
@@ -6903,22 +9006,29 @@ mod tests {
     }
 
     #[test]
-    fn daemon_startup_status_socket_uses_unix_socket_for_unix_platform() {
+    fn daemon_startup_status_socket_uses_unix_socket_for_unix_platform() -> Result<()> {
         let home = Path::new("/tmp/coven-home");
         assert_eq!(
-            daemon_startup_status_socket_for_platform(home, DaemonIpcPlatform::Unix),
+            daemon_startup_status_socket_for_platform(home, DaemonIpcPlatform::Unix)?,
             daemon_socket_path(home).to_string_lossy()
         );
+        Ok(())
     }
 
+    #[cfg(windows)]
     #[test]
-    fn daemon_startup_status_socket_uses_named_pipe_for_windows_platform() {
-        let home = Path::new("C:/CovenTest/.coven");
-        let socket = daemon_startup_status_socket_for_platform(home, DaemonIpcPlatform::Windows);
+    fn daemon_startup_status_socket_uses_named_pipe_for_windows_platform() -> Result<()> {
+        let home = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let socket = daemon_startup_status_socket_for_platform(home, DaemonIpcPlatform::Windows)?;
 
+        assert_eq!(
+            socket,
+            coven_client::owner_only_windows_pipe_name(home).map_err(anyhow::Error::new)?
+        );
         assert!(socket.starts_with("coven-daemon-"), "socket={socket}");
         assert!(socket.ends_with(".sock"), "socket={socket}");
         assert_ne!(socket, daemon_socket_path(home).to_string_lossy());
+        Ok(())
     }
 
     #[cfg(unix)]
@@ -7011,6 +9121,30 @@ mod tests {
     }
 
     #[test]
+    fn read_status_rejects_oversized_metadata_without_parsing_or_removing_it() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let status_path = daemon_status_path(temp_dir.path());
+        std::fs::write(
+            &status_path,
+            vec![b' '; coven_client::MAX_DAEMON_STATUS_BYTES + 1],
+        )?;
+
+        let error = read_status(temp_dir.path()).expect_err("oversized daemon status must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("daemon status exceeded the 16384-byte limit"),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            status_path.exists(),
+            "an oversized status must be preserved"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn background_server_status_clears_corrupt_metadata_without_daemon() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         std::fs::create_dir_all(temp_dir.path())?;
@@ -7036,6 +9170,92 @@ mod tests {
     }
 
     #[test]
+    fn malformed_process_creation_time_is_repaired_only_from_authenticated_health() -> Result<()> {
+        struct AuthenticatedRecoveryController {
+            recovered: Option<DaemonStatus>,
+        }
+
+        impl DaemonStopController for AuthenticatedRecoveryController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                panic!("status recovery must not stop a daemon")
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                Ok(RecordedProcessState::Gone)
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                Ok(self.recovered.as_ref() == Some(status))
+            }
+
+            fn status_from_default_socket(
+                &self,
+                _coven_home: &Path,
+                _deadline: LifecycleDeadline,
+            ) -> Result<Option<DaemonStatus>> {
+                Ok(self.recovered.clone())
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let socket = daemon_socket_path(temp_dir.path())
+            .to_string_lossy()
+            .into_owned();
+        let malformed = serde_json::json!({
+            "pid": 12345,
+            "startedAt": "2026-08-16T15:30:00Z",
+            "socket": socket,
+            "processCreationTime": "not-a-filetime",
+        });
+        std::fs::write(
+            daemon_status_path(temp_dir.path()),
+            serde_json::to_vec(&malformed)?,
+        )?;
+
+        let unavailable = background_server_status_locked_with_controller(
+            temp_dir.path(),
+            &AuthenticatedRecoveryController { recovered: None },
+        );
+        assert!(
+            unavailable.is_err(),
+            "malformed identity without authenticated health must fail closed"
+        );
+        assert!(
+            daemon_status_path(temp_dir.path()).exists(),
+            "malformed identity must be preserved while it cannot be securely resolved"
+        );
+
+        let recovered = DaemonStatus {
+            pid: 54321,
+            started_at: "2026-08-16T15:31:00Z".to_owned(),
+            socket,
+            process_creation_time: Some(WindowsProcessCreationTime::new(134_157_822_123_456_789)?),
+        };
+        let state = background_server_status_locked_with_controller(
+            temp_dir.path(),
+            &AuthenticatedRecoveryController {
+                recovered: Some(recovered.clone()),
+            },
+        )?;
+        assert_eq!(state, Some(DaemonStatusState::Running(recovered.clone())));
+        assert_eq!(read_status(temp_dir.path())?, Some(recovered));
+        Ok(())
+    }
+
+    #[test]
     fn stop_background_server_keeps_status_when_existing_daemon_survives() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let status = DaemonStatus {
@@ -7044,6 +9264,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
 
@@ -7073,6 +9294,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
 
@@ -7100,6 +9322,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
         let controller = FakeStopController {
@@ -7120,6 +9343,373 @@ mod tests {
     }
 
     #[test]
+    fn stop_uses_one_verified_process_identity_for_signal_and_wait() -> Result<()> {
+        struct BoundIdentityController {
+            stop_calls: std::sync::Arc<std::sync::Mutex<usize>>,
+        }
+
+        impl DaemonStopController for BoundIdentityController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                *self.stop_calls.lock().unwrap() += 1;
+                Ok(VerifiedStopOutcome::Exited)
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                panic!("verified stop must not reopen a process by PID")
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                panic!("verified stop must bind health and process identity in one operation")
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        write_status(
+            temp_dir.path(),
+            &DaemonStatus {
+                pid: 12345,
+                started_at: "2026-04-27T10:00:00Z".to_owned(),
+                socket: daemon_socket_path(temp_dir.path())
+                    .to_string_lossy()
+                    .into_owned(),
+                process_creation_time: None,
+            },
+        )?;
+        let stop_calls = std::sync::Arc::new(std::sync::Mutex::new(0));
+
+        assert!(stop_background_server_with_controller(
+            temp_dir.path(),
+            &BoundIdentityController {
+                stop_calls: stop_calls.clone(),
+            },
+        )?);
+        assert_eq!(*stop_calls.lock().unwrap(), 1);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authenticated_relative_status_is_rewritten_to_the_canonical_socket() -> Result<()> {
+        use std::{
+            io::{Read, Write},
+            os::unix::{fs::PermissionsExt, net::UnixListener},
+            time::Instant,
+        };
+
+        fn relative_path(base: &Path, target: &Path) -> PathBuf {
+            let base = base.components().collect::<Vec<_>>();
+            let target = target.components().collect::<Vec<_>>();
+            let shared = base
+                .iter()
+                .zip(&target)
+                .take_while(|(left, right)| left == right)
+                .count();
+            let mut relative = PathBuf::new();
+            for _ in shared..base.len() {
+                relative.push("..");
+            }
+            for component in &target[shared..] {
+                relative.push(component.as_os_str());
+            }
+            relative
+        }
+
+        let current_dir = std::fs::canonicalize(std::env::current_dir()?)?;
+        let test_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root")
+            .join("c");
+        std::fs::create_dir_all(&test_root)?;
+        let temp_dir = tempfile::tempdir_in(&test_root)?;
+        let coven_home = temp_dir.path().to_path_buf();
+        ensure_private_coven_home(&coven_home)?;
+        let socket = daemon_socket_path(&coven_home);
+        let listener = UnixListener::bind(&socket)?;
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
+        let relative_socket = relative_path(&current_dir, &std::fs::canonicalize(&socket)?)
+            .to_string_lossy()
+            .into_owned();
+        let legacy_status = DaemonStatus {
+            pid: std::process::id(),
+            started_at: "2026-08-16T12:00:00Z".to_owned(),
+            socket: relative_socket,
+            process_creation_time: None,
+        };
+        write_status(&coven_home, &legacy_status)?;
+        listener.set_nonblocking(true)?;
+        let status_for_server = legacy_status.clone();
+        let server = std::thread::spawn(move || -> Result<()> {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            loop {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = String::new();
+                        stream.read_to_string(&mut request)?;
+                        assert!(request.starts_with("GET /health HTTP/1.1\r\n"));
+                        let body = serde_json::json!({
+                            "ok": true,
+                            "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+                            "covenVersion": crate::api::COVEN_VERSION,
+                            "capabilities": {
+                                "sessions": true,
+                                "events": true,
+                                "eventCursor": "sequence",
+                                "structuredErrors": true
+                            },
+                            "daemon": status_for_server,
+                        })
+                        .to_string();
+                        write!(
+                            stream,
+                            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{body}",
+                            body.len()
+                        )?;
+                        return Ok(());
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return Ok(());
+                        }
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            }
+        });
+
+        let state = background_server_status(&coven_home)?;
+        server.join().expect("relative-status server")?;
+
+        let running = match state {
+            Some(DaemonStatusState::Running(status)) => status,
+            other => anyhow::bail!("relative same-profile status was not running: {other:?}"),
+        };
+        let canonical_socket = std::fs::canonicalize(&socket)?;
+        assert_eq!(Path::new(&running.socket), canonical_socket);
+        let rewritten = read_status(&coven_home)?.expect("rewritten daemon status");
+        assert_eq!(Path::new(&rewritten.socket), canonical_socket);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn copied_profile_status_cannot_select_another_profiles_socket() -> Result<()> {
+        use std::{
+            io::{Read, Write},
+            os::unix::{fs::PermissionsExt, net::UnixListener},
+            sync::{
+                atomic::{AtomicBool, Ordering},
+                Arc,
+            },
+            time::Instant,
+        };
+
+        fn serve_shutdown(
+            listener: UnixListener,
+            status: DaemonStatus,
+            contacted: Arc<AtomicBool>,
+        ) -> std::thread::JoinHandle<Result<()>> {
+            listener
+                .set_nonblocking(true)
+                .expect("nonblocking listener");
+            std::thread::spawn(move || {
+                let deadline = Instant::now() + Duration::from_millis(500);
+                loop {
+                    match listener.accept() {
+                        Ok((mut stream, _)) => {
+                            contacted.store(true, Ordering::Release);
+                            let mut request = String::new();
+                            stream.read_to_string(&mut request)?;
+                            let body = serde_json::json!({
+                                "ok": true,
+                                "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+                                "capabilities": { "structuredErrors": true },
+                                "daemon": status,
+                            })
+                            .to_string();
+                            write!(
+                                stream,
+                                "HTTP/1.1 202 Accepted\r\nContent-Length: {}\r\n\r\n{body}",
+                                body.len()
+                            )?;
+                            return Ok(());
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            if Instant::now() >= deadline {
+                                return Ok(());
+                            }
+                            std::thread::sleep(Duration::from_millis(2));
+                        }
+                        Err(error) => return Err(error.into()),
+                    }
+                }
+            })
+        }
+
+        let root = tempfile::tempdir()?;
+        let profile_a = root.path().join("profile-a");
+        let profile_b = root.path().join("profile-b");
+        ensure_private_coven_home(&profile_a)?;
+        ensure_private_coven_home(&profile_b)?;
+        let socket_b = daemon_socket_path(&profile_b);
+        let listener_b = UnixListener::bind(&socket_b)?;
+        std::fs::set_permissions(&socket_b, std::fs::Permissions::from_mode(0o600))?;
+        let status_b = DaemonStatus {
+            pid: std::process::id(),
+            started_at: "2026-08-16T12:00:00Z".to_owned(),
+            socket: std::fs::canonicalize(&socket_b)?
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        write_status(&profile_a, &status_b)?;
+        let contacted_b = Arc::new(AtomicBool::new(false));
+        let server_b = serve_shutdown(listener_b, status_b, Arc::clone(&contacted_b));
+
+        let cross_profile = stop_background_server(&profile_a);
+        server_b.join().expect("profile B server thread")?;
+
+        assert!(
+            cross_profile.is_err(),
+            "profile A must not accept profile B's copied status"
+        );
+        assert!(
+            !contacted_b.load(Ordering::Acquire),
+            "profile A connected to profile B's daemon"
+        );
+
+        let socket_a = daemon_socket_path(&profile_a);
+        let listener_a = UnixListener::bind(&socket_a)?;
+        std::fs::set_permissions(&socket_a, std::fs::Permissions::from_mode(0o600))?;
+        let status_a = DaemonStatus {
+            pid: std::process::id(),
+            started_at: "2026-08-16T12:01:00Z".to_owned(),
+            socket: std::fs::canonicalize(&socket_a)?
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        write_status(&profile_a, &status_a)?;
+        let contacted_a = Arc::new(AtomicBool::new(false));
+        let server_a = serve_shutdown(listener_a, status_a, Arc::clone(&contacted_a));
+
+        assert!(stop_background_server(&profile_a)?);
+        server_a.join().expect("profile A server thread")?;
+        assert!(
+            contacted_a.load(Ordering::Acquire),
+            "same-profile stop did not reach its daemon"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_verified_stop_never_signals_a_substituted_numeric_pid() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir()?;
+        ensure_private_coven_home(temp_dir.path())?;
+        let mut substituted = Command::new("sleep")
+            .arg("5")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .context("spawn substituted process")?;
+        let canonical_home = std::fs::canonicalize(temp_dir.path())?;
+        let status = DaemonStatus {
+            pid: substituted.id(),
+            started_at: "2026-08-16T12:00:00Z".to_owned(),
+            socket: daemon_socket_path(&canonical_home)
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        let listener = UnixListener::bind(daemon_socket_path(temp_dir.path()))?;
+        std::fs::set_permissions(
+            daemon_socket_path(temp_dir.path()),
+            std::fs::Permissions::from_mode(0o600),
+        )?;
+        let server_status = status.clone();
+        let server = std::thread::spawn(move || -> Result<()> {
+            let (mut stream, _) = listener.accept()?;
+            let mut request = String::new();
+            stream.read_to_string(&mut request)?;
+            let (code, reason, body) =
+                if request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n") {
+                    (
+                        202,
+                        "Accepted",
+                        serde_json::json!({
+                            "ok": true,
+                            "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+                            "capabilities": { "structuredErrors": true },
+                            "daemon": server_status,
+                        })
+                        .to_string(),
+                    )
+                } else {
+                    (
+                        200,
+                        "OK",
+                        serde_json::json!({
+                            "ok": true,
+                            "apiVersion": crate::api::COVEN_API_NAMED_VERSION,
+                            "covenVersion": crate::api::COVEN_VERSION,
+                            "capabilities": { "structuredErrors": true },
+                            "daemon": server_status,
+                        })
+                        .to_string(),
+                    )
+                };
+            write!(
+                stream,
+                "HTTP/1.1 {code} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            )?;
+            Ok(())
+        });
+
+        let error = SystemDaemonStopController
+            .stop_verified_daemon(
+                &canonical_home,
+                &status,
+                LifecycleDeadline::after(Duration::from_millis(250))?,
+            )
+            .expect_err("the connected peer must not authenticate a substituted numeric PID");
+        server.join().expect("substitute server thread")?;
+        let still_running = substituted.try_wait()?.is_none();
+        if still_running {
+            substituted.kill()?;
+        }
+        let _ = substituted.wait();
+
+        assert!(
+            error.to_string().contains("connected peer pid"),
+            "unexpected identity rejection: {error:#}"
+        );
+        assert!(
+            still_running,
+            "a daemon connection closing must not authorize signaling its stale numeric PID"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn background_server_status_returns_running_for_verified_daemon() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let status = DaemonStatus {
@@ -7128,6 +9718,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
 
@@ -7155,6 +9746,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
 
@@ -7171,6 +9763,261 @@ mod tests {
 
         assert_eq!(state, Some(DaemonStatusState::Stale(status.clone())));
         assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
+    #[test]
+    fn reused_pid_fingerprint_mismatch_is_cleared_without_signaling() -> Result<()> {
+        struct ReusedPidController {
+            stop_calls: std::sync::Arc<std::sync::Mutex<usize>>,
+        }
+
+        impl DaemonStopController for ReusedPidController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                *self.stop_calls.lock().unwrap() += 1;
+                Ok(VerifiedStopOutcome::Unverified)
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                Ok(RecordedProcessState::Mismatched)
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                Ok(false)
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: std::process::id(),
+            started_at: "2026-08-16T15:30:00Z".to_owned(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: Some(WindowsProcessCreationTime::new(41)?),
+        };
+        write_status(temp_dir.path(), &status)?;
+        let stop_calls = std::sync::Arc::new(std::sync::Mutex::new(0));
+        let controller = ReusedPidController {
+            stop_calls: stop_calls.clone(),
+        };
+
+        assert_eq!(
+            background_server_status_locked_with_controller(temp_dir.path(), &controller)?,
+            None
+        );
+        assert!(
+            !daemon_status_path(temp_dir.path()).exists(),
+            "PID reuse must not leave lifecycle commands wedged on stale metadata"
+        );
+        assert_eq!(
+            *stop_calls.lock().unwrap(),
+            0,
+            "status cleanup must never signal a mismatched process identity"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn status_cleanup_cannot_delete_state_published_by_concurrent_startup() -> Result<()> {
+        struct BlockingDeadStatusController {
+            inspected: std::sync::mpsc::SyncSender<()>,
+            release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+        }
+
+        impl DaemonStopController for BlockingDeadStatusController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                panic!("status inspection must not stop a daemon")
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                Ok(RecordedProcessState::Gone)
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                self.inspected.send(()).unwrap();
+                self.release.lock().unwrap().recv().unwrap();
+                Ok(false)
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path().to_path_buf();
+        let old = DaemonStatus {
+            pid: 12345,
+            started_at: "old".to_owned(),
+            socket: daemon_socket_path(&home).to_string_lossy().into_owned(),
+            process_creation_time: None,
+        };
+        let replacement = DaemonStatus {
+            pid: 54321,
+            started_at: "new".to_owned(),
+            socket: daemon_socket_path(&home).to_string_lossy().into_owned(),
+            process_creation_time: None,
+        };
+        write_status(&home, &old)?;
+
+        let (inspected_tx, inspected_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let status_home = home.clone();
+        let status_thread = std::thread::spawn(move || {
+            background_server_status_locked_with_controller(
+                &status_home,
+                &BlockingDeadStatusController {
+                    inspected: inspected_tx,
+                    release: std::sync::Mutex::new(release_rx),
+                },
+            )
+        });
+        inspected_rx.recv_timeout(Duration::from_secs(2))?;
+
+        let (attempting_tx, attempting_rx) = std::sync::mpsc::sync_channel(0);
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::sync_channel(0);
+        let startup_home = home.clone();
+        let expected_replacement = replacement.clone();
+        let startup_thread = std::thread::spawn(move || -> Result<()> {
+            attempting_tx.send(())?;
+            let _lock = acquire_daemon_lifecycle_lock(&startup_home)?;
+            acquired_tx.send(())?;
+            write_status(&startup_home, &expected_replacement)
+        });
+        attempting_rx.recv_timeout(Duration::from_secs(2))?;
+        assert!(
+            acquired_rx
+                .recv_timeout(Duration::from_millis(250))
+                .is_err(),
+            "startup acquired daemon.lock while stale cleanup was still inspecting state"
+        );
+
+        release_tx.send(())?;
+        assert_eq!(status_thread.join().unwrap()?, None);
+        acquired_rx.recv_timeout(Duration::from_secs(2))?;
+        startup_thread.join().unwrap()?;
+
+        assert_eq!(read_status(&home)?, Some(replacement));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn status_cleanup_cannot_delete_state_from_direct_serve_startup() -> Result<()> {
+        struct BlockingDeadStatusController {
+            inspected: std::sync::mpsc::SyncSender<()>,
+            release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+        }
+
+        impl DaemonStopController for BlockingDeadStatusController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                panic!("status inspection must not stop a daemon")
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                Ok(RecordedProcessState::Gone)
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                self.inspected.send(()).unwrap();
+                self.release.lock().unwrap().recv().unwrap();
+                Ok(false)
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let home = temp_dir.path().to_path_buf();
+        let old = DaemonStatus {
+            pid: 12345,
+            started_at: "old".to_owned(),
+            socket: daemon_socket_path(&home).to_string_lossy().into_owned(),
+            process_creation_time: None,
+        };
+        let replacement = DaemonStatus {
+            pid: 54321,
+            started_at: "direct-serve".to_owned(),
+            socket: daemon_socket_path(&home).to_string_lossy().into_owned(),
+            process_creation_time: None,
+        };
+        write_status(&home, &old)?;
+
+        let (inspected_tx, inspected_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let status_home = home.clone();
+        let status_thread = std::thread::spawn(move || {
+            background_server_status_locked_with_controller(
+                &status_home,
+                &BlockingDeadStatusController {
+                    inspected: inspected_tx,
+                    release: std::sync::Mutex::new(release_rx),
+                },
+            )
+        });
+        inspected_rx.recv_timeout(Duration::from_secs(2))?;
+
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
+        let (finish_tx, finish_rx) = std::sync::mpsc::sync_channel(0);
+        let startup_home = home.clone();
+        let expected_replacement = replacement.clone();
+        let startup_thread = std::thread::spawn(move || -> Result<()> {
+            let _serve_lock = acquire_serve_lock(&startup_home)?;
+            let _listener = bind_api_socket(&startup_home)?;
+            write_status(&startup_home, &expected_replacement)?;
+            ready_tx.send(())?;
+            finish_rx.recv()?;
+            Ok(())
+        });
+        ready_rx.recv_timeout(Duration::from_secs(2))?;
+
+        release_tx.send(())?;
+        let state = status_thread.join().expect("status thread")?;
+        let status_after_cleanup = read_status(&home).ok().flatten();
+        let socket_survived = daemon_socket_path(&home).exists();
+        finish_tx.send(())?;
+        startup_thread.join().expect("startup thread")?;
+
+        assert_eq!(state, None);
+        assert_eq!(status_after_cleanup, Some(replacement));
+        assert!(
+            socket_survived,
+            "stale cleanup unlinked the direct serve process's bound socket"
+        );
         Ok(())
     }
 
@@ -7203,6 +10050,340 @@ mod tests {
         Ok(())
     }
 
+    struct RecoveringLifecycleStopController {
+        recovered: Option<DaemonStatus>,
+        authenticated: bool,
+        stopped: std::sync::Arc<std::sync::Mutex<Vec<DaemonStatus>>>,
+    }
+
+    impl DaemonStopController for RecoveringLifecycleStopController {
+        fn stop_verified_daemon(
+            &self,
+            _coven_home: &Path,
+            status: &DaemonStatus,
+            _deadline: LifecycleDeadline,
+        ) -> Result<VerifiedStopOutcome> {
+            self.stopped.lock().unwrap().push(status.clone());
+            Ok(VerifiedStopOutcome::Exited)
+        }
+
+        fn recorded_process_state(&self, _status: &DaemonStatus) -> Result<RecordedProcessState> {
+            Ok(RecordedProcessState::Gone)
+        }
+
+        fn status_matches_running_daemon(
+            &self,
+            _coven_home: &Path,
+            status: &DaemonStatus,
+            _deadline: LifecycleDeadline,
+        ) -> Result<bool> {
+            Ok(self.authenticated && self.recovered.as_ref() == Some(status))
+        }
+
+        fn status_from_default_socket(
+            &self,
+            _coven_home: &Path,
+            _deadline: LifecycleDeadline,
+        ) -> Result<Option<DaemonStatus>> {
+            Ok(self.recovered.clone())
+        }
+    }
+
+    #[test]
+    fn restart_recovers_and_stops_live_daemon_when_status_is_missing_or_corrupt() -> Result<()> {
+        for corrupt in [false, true] {
+            let temp_dir = tempfile::tempdir()?;
+            if corrupt {
+                std::fs::write(daemon_status_path(temp_dir.path()), "{not json\n")?;
+            }
+            let recovered = DaemonStatus {
+                pid: 12345,
+                started_at: "old".to_string(),
+                socket: daemon_socket_path(temp_dir.path())
+                    .to_string_lossy()
+                    .into_owned(),
+                process_creation_time: None,
+            };
+            let stopped = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let started = std::sync::Arc::new(std::sync::Mutex::new(0));
+
+            let (was_running, replacement) = restart_background_server_with_controllers_until(
+                temp_dir.path(),
+                Path::new("/usr/bin/coven"),
+                "new".to_string(),
+                &RecoveringLifecycleStopController {
+                    recovered: Some(recovered.clone()),
+                    authenticated: true,
+                    stopped: stopped.clone(),
+                },
+                &FakeStartController {
+                    started: started.clone(),
+                    running_after_start: true,
+                },
+                LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+            )?;
+
+            assert!(was_running, "recovery mode corrupt={corrupt}");
+            assert_eq!(&*stopped.lock().unwrap(), &[recovered]);
+            assert_eq!(*started.lock().unwrap(), 1);
+            assert_eq!(read_status(temp_dir.path())?, Some(replacement));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn restart_recovers_live_default_socket_after_corrupt_recorded_identity() -> Result<()> {
+        struct ReauthenticatingStopController {
+            recovered: DaemonStatus,
+            stopped: std::sync::Arc<std::sync::Mutex<Vec<DaemonStatus>>>,
+        }
+
+        impl DaemonStopController for ReauthenticatingStopController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                self.stopped.lock().unwrap().push(status.clone());
+                Ok(if status == &self.recovered {
+                    VerifiedStopOutcome::Exited
+                } else {
+                    VerifiedStopOutcome::Unverified
+                })
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                Ok(RecordedProcessState::Gone)
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                Ok(status == &self.recovered)
+            }
+
+            fn status_from_default_socket(
+                &self,
+                _coven_home: &Path,
+                _deadline: LifecycleDeadline,
+            ) -> Result<Option<DaemonStatus>> {
+                Ok(Some(self.recovered.clone()))
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let socket = daemon_socket_path(temp_dir.path())
+            .to_string_lossy()
+            .into_owned();
+        let corrupt = DaemonStatus {
+            pid: 11111,
+            started_at: "corrupt".to_string(),
+            socket: socket.clone(),
+            process_creation_time: None,
+        };
+        let recovered = DaemonStatus {
+            pid: 22222,
+            started_at: "authenticated".to_string(),
+            socket,
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &corrupt)?;
+        let stopped = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let started = std::sync::Arc::new(std::sync::Mutex::new(0));
+
+        restart_background_server_with_controllers_until(
+            temp_dir.path(),
+            Path::new("/usr/bin/coven"),
+            "new".to_string(),
+            &ReauthenticatingStopController {
+                recovered: recovered.clone(),
+                stopped: stopped.clone(),
+            },
+            &FakeStartController {
+                started: started.clone(),
+                running_after_start: true,
+            },
+            LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+        )?;
+
+        assert_eq!(&*stopped.lock().unwrap(), &[corrupt, recovered]);
+        assert_eq!(*started.lock().unwrap(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn stop_recovers_authenticated_default_after_untrusted_status_read() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let recovered = DaemonStatus {
+            pid: 22222,
+            started_at: "authenticated".to_string(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        let controller = RecoveringLifecycleStopController {
+            recovered: Some(recovered.clone()),
+            authenticated: true,
+            stopped: std::sync::Arc::default(),
+        };
+
+        let status = resolve_status_read_for_stop(
+            temp_dir.path(),
+            &controller,
+            LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+            Err(anyhow::anyhow!(
+                "daemon status contained an untrusted profile identity"
+            )),
+        )?;
+
+        assert_eq!(status, Some(recovered));
+        Ok(())
+    }
+
+    #[test]
+    fn restart_without_status_or_live_default_socket_starts_exactly_once() -> Result<()> {
+        for corrupt in [false, true] {
+            let temp_dir = tempfile::tempdir()?;
+            if corrupt {
+                std::fs::write(daemon_status_path(temp_dir.path()), "{not json\n")?;
+            }
+            let stopped = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+            let started = std::sync::Arc::new(std::sync::Mutex::new(0));
+
+            let (was_running, replacement) = restart_background_server_with_controllers_until(
+                temp_dir.path(),
+                Path::new("/usr/bin/coven"),
+                "new".to_string(),
+                &RecoveringLifecycleStopController {
+                    recovered: None,
+                    authenticated: false,
+                    stopped: stopped.clone(),
+                },
+                &FakeStartController {
+                    started: started.clone(),
+                    running_after_start: true,
+                },
+                LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+            )?;
+
+            assert!(!was_running, "no-daemon mode corrupt={corrupt}");
+            assert!(stopped.lock().unwrap().is_empty());
+            assert_eq!(*started.lock().unwrap(), 1);
+            assert_eq!(read_status(temp_dir.path())?, Some(replacement));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn restart_never_spawns_from_an_unauthenticated_default_socket_status() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let recovered = DaemonStatus {
+            pid: 12345,
+            started_at: "untrusted".to_string(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        let started = std::sync::Arc::new(std::sync::Mutex::new(0));
+
+        let error = restart_background_server_with_controllers_until(
+            temp_dir.path(),
+            Path::new("/usr/bin/coven"),
+            "new".to_string(),
+            &RecoveringLifecycleStopController {
+                recovered: Some(recovered),
+                authenticated: false,
+                stopped: std::sync::Arc::default(),
+            },
+            &FakeStartController {
+                started: started.clone(),
+                running_after_start: true,
+            },
+            LifecycleDeadline::after(DAEMON_LIFECYCLE_TIMEOUT)?,
+        )
+        .expect_err("an unauthenticated recovery candidate must fail closed");
+
+        assert!(error.to_string().contains("authenticate"));
+        assert_eq!(*started.lock().unwrap(), 0);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_background_server_passes_the_canonical_home_through_startup() -> Result<()> {
+        struct RecordingStartController {
+            homes: std::sync::Arc<std::sync::Mutex<Vec<PathBuf>>>,
+        }
+
+        impl DaemonStartController for RecordingStartController {
+            fn start_background_server(
+                &self,
+                coven_home: &Path,
+                _current_exe: &Path,
+                started_at: String,
+            ) -> Result<DaemonStatus> {
+                self.homes.lock().unwrap().push(coven_home.to_path_buf());
+                let status = DaemonStatus {
+                    pid: 54321,
+                    started_at,
+                    socket: daemon_socket_path(coven_home)
+                        .to_string_lossy()
+                        .into_owned(),
+                    process_creation_time: None,
+                };
+                write_status(coven_home, &status)?;
+                Ok(status)
+            }
+
+            fn wait_for_running_daemon(
+                &self,
+                coven_home: &Path,
+                status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<Option<DaemonStatus>> {
+                self.homes.lock().unwrap().push(coven_home.to_path_buf());
+                Ok(Some(status.clone()))
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        std::fs::create_dir(temp_dir.path().join("nested"))?;
+        let selected_home = temp_dir.path().join("nested").join("..");
+        let canonical_home = std::fs::canonicalize(temp_dir.path())?;
+        let homes = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        ensure_background_server_with_controllers(
+            &selected_home,
+            Path::new("/usr/bin/coven"),
+            "2026-04-27T10:00:00Z".to_owned(),
+            &FakeStopController {
+                pid_alive: false,
+                exited_after_signal: false,
+                signal_error: None,
+                verified_daemon: false,
+                signaled: std::sync::Arc::default(),
+            },
+            &RecordingStartController {
+                homes: homes.clone(),
+            },
+        )?;
+
+        assert_eq!(
+            *homes.lock().unwrap(),
+            vec![canonical_home.clone(), canonical_home]
+        );
+        Ok(())
+    }
+
     #[test]
     fn ensure_background_server_reuses_verified_running_daemon() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
@@ -7212,6 +10393,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &status)?;
         let started = std::sync::Arc::new(std::sync::Mutex::new(0));
@@ -7257,12 +10439,14 @@ mod tests {
         use std::thread;
 
         let temp_dir = tempfile::tempdir()?;
+        let canonical_home = std::fs::canonicalize(temp_dir.path())?;
         let status = DaemonStatus {
-            pid: 12345,
+            pid: std::process::id(),
             started_at: "2026-04-27T10:00:00Z".to_string(),
-            socket: daemon_socket_path(temp_dir.path())
+            socket: daemon_socket_path(&canonical_home)
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         let listener = bind_api_socket(temp_dir.path())?;
         let home = temp_dir.path().to_path_buf();
@@ -7313,21 +10497,24 @@ mod tests {
         use std::thread;
 
         let temp_dir = tempfile::tempdir()?;
+        let canonical_home = std::fs::canonicalize(temp_dir.path())?;
         let recovered = DaemonStatus {
-            pid: 12345,
+            pid: std::process::id(),
             started_at: "2026-04-27T10:00:00Z".to_string(),
-            socket: daemon_socket_path(temp_dir.path())
+            socket: daemon_socket_path(&canonical_home)
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         let stale = DaemonStatus {
             // Keep this within the range Linux `kill -0` treats as a plain
             // PID; u32::MAX can be interpreted as -1 by the shell utility.
             pid: 999_999,
             started_at: "2026-04-27T09:00:00Z".to_string(),
-            socket: daemon_socket_path(temp_dir.path())
+            socket: daemon_socket_path(&canonical_home)
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         write_status(temp_dir.path(), &stale)?;
         let listener = bind_api_socket(temp_dir.path())?;
@@ -7370,6 +10557,58 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn lifecycle_preserves_status_when_pid_liveness_is_ambiguous() -> Result<()> {
+        struct AmbiguousPidController;
+
+        impl DaemonStopController for AmbiguousPidController {
+            fn stop_verified_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<VerifiedStopOutcome> {
+                panic!("status inspection must not stop a daemon")
+            }
+
+            fn recorded_process_state(
+                &self,
+                _status: &DaemonStatus,
+            ) -> Result<RecordedProcessState> {
+                anyhow::bail!("process identity could not be inspected")
+            }
+
+            fn status_matches_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<bool> {
+                Ok(false)
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_owned(),
+            socket: daemon_socket_path(temp_dir.path())
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &status)?;
+
+        let error =
+            background_server_status_with_controller(temp_dir.path(), &AmbiguousPidController)
+                .expect_err("ambiguous PID liveness must fail closed");
+        assert!(error
+            .to_string()
+            .contains("could not determine whether Coven daemon pid 12345 is alive"));
+        assert_eq!(read_status(temp_dir.path())?, Some(status));
+        Ok(())
+    }
+
     struct FakeStopController {
         pid_alive: bool,
         exited_after_signal: bool,
@@ -7379,24 +10618,39 @@ mod tests {
     }
 
     impl DaemonStopController for FakeStopController {
-        fn signal_term(&self, _pid: u32) -> Result<()> {
+        fn stop_verified_daemon(
+            &self,
+            _coven_home: &Path,
+            _status: &DaemonStatus,
+            _deadline: LifecycleDeadline,
+        ) -> Result<VerifiedStopOutcome> {
+            if !self.verified_daemon {
+                return Ok(VerifiedStopOutcome::Unverified);
+            }
             *self.signaled.lock().unwrap() += 1;
             match &self.signal_error {
+                Some(_) if !self.pid_alive => Ok(VerifiedStopOutcome::Exited),
                 Some(error) => anyhow::bail!(error.clone()),
-                None => Ok(()),
+                None if self.exited_after_signal => Ok(VerifiedStopOutcome::Exited),
+                None => Ok(VerifiedStopOutcome::TimedOut),
             }
         }
 
-        fn pid_is_alive(&self, _pid: u32) -> bool {
-            self.pid_alive
+        fn recorded_process_state(&self, _status: &DaemonStatus) -> Result<RecordedProcessState> {
+            Ok(if self.pid_alive {
+                RecordedProcessState::Matching
+            } else {
+                RecordedProcessState::Gone
+            })
         }
 
-        fn wait_for_exit(&self, _pid: u32, _timeout: std::time::Duration) -> bool {
-            self.exited_after_signal
-        }
-
-        fn status_matches_running_daemon(&self, _status: &DaemonStatus) -> bool {
-            self.verified_daemon
+        fn status_matches_running_daemon(
+            &self,
+            _coven_home: &Path,
+            _status: &DaemonStatus,
+            _deadline: LifecycleDeadline,
+        ) -> Result<bool> {
+            Ok(self.verified_daemon)
         }
     }
 
@@ -7419,14 +10673,78 @@ mod tests {
                 socket: daemon_socket_path(coven_home)
                     .to_string_lossy()
                     .into_owned(),
+                process_creation_time: None,
             };
             write_status(coven_home, &status)?;
             Ok(status)
         }
 
-        fn wait_for_running_daemon(&self, _status: &DaemonStatus, _timeout: Duration) -> bool {
-            self.running_after_start
+        fn wait_for_running_daemon(
+            &self,
+            _coven_home: &Path,
+            status: &DaemonStatus,
+            _deadline: LifecycleDeadline,
+        ) -> Result<Option<DaemonStatus>> {
+            Ok(self.running_after_start.then(|| status.clone()))
         }
+    }
+
+    #[test]
+    fn managed_start_returns_the_authenticated_child_identity() -> Result<()> {
+        struct VerifiedIdentityStart {
+            health: DaemonStatus,
+        }
+
+        impl DaemonStartController for VerifiedIdentityStart {
+            fn start_background_server(
+                &self,
+                _coven_home: &Path,
+                _current_exe: &Path,
+                started_at: String,
+            ) -> Result<DaemonStatus> {
+                Ok(DaemonStatus {
+                    pid: self.health.pid,
+                    started_at,
+                    socket: self.health.socket.clone(),
+                    process_creation_time: None,
+                })
+            }
+
+            fn wait_for_running_daemon(
+                &self,
+                _coven_home: &Path,
+                _status: &DaemonStatus,
+                _deadline: LifecycleDeadline,
+            ) -> Result<Option<DaemonStatus>> {
+                Ok(Some(self.health.clone()))
+            }
+        }
+
+        let temp_dir = tempfile::tempdir()?;
+        let health = DaemonStatus {
+            pid: 54321,
+            started_at: "2026-08-16T15:30:00Z".to_owned(),
+            socket: daemon_startup_status_socket(temp_dir.path())?,
+            process_creation_time: Some(WindowsProcessCreationTime::new(134_157_822_123_456_789)?),
+        };
+        let ensured = ensure_background_server_with_controllers(
+            temp_dir.path(),
+            Path::new("/usr/local/bin/coven"),
+            health.started_at.clone(),
+            &FakeStopController {
+                pid_alive: false,
+                exited_after_signal: true,
+                signal_error: None,
+                verified_daemon: false,
+                signaled: std::sync::Arc::default(),
+            },
+            &VerifiedIdentityStart {
+                health: health.clone(),
+            },
+        )?;
+
+        assert_eq!(ensured, health);
+        Ok(())
     }
 
     #[test]
@@ -7434,11 +10752,133 @@ mod tests {
         let spec = background_server_spec(
             Path::new("/usr/local/bin/coven"),
             Path::new("/tmp/coven-home"),
+            "2026-08-16T15:30:00.000000000Z",
         );
 
         assert_eq!(spec.program, PathBuf::from("/usr/local/bin/coven"));
-        assert_eq!(spec.args, vec!["daemon".to_string(), "serve".to_string()]);
+        assert_eq!(
+            spec.args,
+            vec![
+                "daemon".to_string(),
+                "serve".to_string(),
+                "--managed-started-at".to_string(),
+                "2026-08-16T15:30:00.000000000Z".to_string(),
+            ]
+        );
         assert_eq!(spec.coven_home, PathBuf::from("/tmp/coven-home"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_launcher_rejects_non_utf8_home_before_spawn_or_artifacts() -> Result<()> {
+        use std::{cell::Cell, ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let test_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root")
+            .join("c");
+        std::fs::create_dir_all(&test_root)?;
+        let root = tempfile::tempdir_in(test_root)?;
+        let coven_home = root
+            .path()
+            .join(OsString::from_vec(b"non-utf8-\xff".to_vec()));
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            std::fs::create_dir(&coven_home)?;
+            std::fs::set_permissions(&coven_home, std::fs::Permissions::from_mode(0o700))?;
+        }
+        let spawned = Cell::new(false);
+
+        let error = start_background_server_with_spawn(
+            &coven_home,
+            Path::new("/usr/local/bin/coven"),
+            "2026-08-16T15:30:00Z".to_owned(),
+            |_| {
+                spawned.set(true);
+                Ok(4242)
+            },
+        )
+        .expect_err("non-UTF-8 lifecycle state must be rejected before child launch");
+
+        assert!(
+            !spawned.get(),
+            "the daemon child launch must not be attempted"
+        );
+        assert!(
+            error.to_string().contains("valid UTF-8"),
+            "error must explain the JSON path requirement: {error:#}"
+        );
+        assert!(!daemon_socket_path(&coven_home).exists());
+        assert!(!daemon_status_path(&coven_home).exists());
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_serve_rejects_non_utf8_home_before_lifecycle_state() -> Result<()> {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let test_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root")
+            .join("c");
+        std::fs::create_dir_all(&test_root)?;
+        let root = tempfile::tempdir_in(test_root)?;
+        let coven_home = root
+            .path()
+            .join(OsString::from_vec(b"serve-non-utf8-\xff".to_vec()));
+
+        let error = serve_forever(&coven_home, "2026-08-16T15:30:00Z".to_owned(), None, &[])
+            .expect_err("direct serve must reject non-UTF-8 lifecycle state before startup");
+
+        assert!(
+            error.to_string().contains("valid UTF-8"),
+            "error must explain the JSON path requirement: {error:#}"
+        );
+        assert!(!daemon_socket_path(&coven_home).exists());
+        assert!(!daemon_status_path(&coven_home).exists());
+        assert!(!daemon_lifecycle_lock_path(&coven_home).exists());
+        assert!(!daemon_serve_lock_path(&coven_home).exists());
+        assert!(!coven_home.join("coven.sqlite3").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn managed_launcher_never_overwrites_status_already_published_by_child() -> Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let started_at = "2026-08-16T15:30:00.000000000Z";
+        let socket = daemon_startup_status_socket(temp_dir.path())?;
+
+        let launched = start_background_server_with_spawn(
+            temp_dir.path(),
+            Path::new("/usr/local/bin/coven"),
+            started_at.to_owned(),
+            |_| {
+                std::fs::write(
+                    daemon_status_path(temp_dir.path()),
+                    serde_json::to_vec(&serde_json::json!({
+                        "pid": 4242,
+                        "startedAt": started_at,
+                        "socket": socket,
+                        "_publisher": "child",
+                    }))?,
+                )?;
+                Ok(4242)
+            },
+        )?;
+
+        assert_eq!(launched.pid, 4242);
+        assert_eq!(launched.started_at, started_at);
+        let serialized = std::fs::read_to_string(daemon_status_path(temp_dir.path()))?;
+        assert!(
+            serialized.contains(r#""_publisher":"child""#),
+            "the launcher republished daemon.json after the child: {serialized}"
+        );
+        Ok(())
     }
 
     #[cfg(windows)]
@@ -7467,6 +10907,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         let listener = bind_api_socket(temp_dir.path())?;
         let home = temp_dir.path().to_path_buf();
@@ -7729,12 +11170,14 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn serves_health_over_windows_named_pipe() -> Result<()> {
-        use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream};
-        use std::io::Write;
+        use interprocess::{
+            local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
+            os::windows::local_socket::ListenerOptionsExt,
+        };
         use std::thread;
 
         let temp_dir = tempfile::tempdir()?;
-        let pipe_name = windows_pipe_name(temp_dir.path());
+        let pipe_name = windows_pipe_name(temp_dir.path())?;
 
         let name = pipe_name
             .clone()
@@ -7742,13 +11185,19 @@ mod tests {
             .expect("pipe name");
         let listener = ListenerOptions::new()
             .name(name)
+            .security_descriptor(owner_only_pipe_security_descriptor()?)
             .create_sync()
             .expect("bind pipe");
 
+        let server_pid = std::process::id();
+        let server_creation_time = coven_client::windows_process_creation_time(server_pid)
+            .map_err(anyhow::Error::new)?
+            .context("test named-pipe server process was not live")?;
         let status = DaemonStatus {
-            pid: 12345,
+            pid: server_pid,
             started_at: "2026-04-27T10:00:00Z".to_string(),
             socket: pipe_name.clone(),
+            process_creation_time: Some(WindowsProcessCreationTime::new(server_creation_time)?),
         };
         let home = temp_dir.path().to_path_buf();
         let runtime = LiveSessionRuntime::default();
@@ -7768,36 +11217,350 @@ mod tests {
             Ok::<_, anyhow::Error>(())
         });
 
-        for _ in 0..2 {
-            let client_name = pipe_name
-                .clone()
-                .to_ns_name::<GenericNamespaced>()
-                .expect("client pipe name");
-            let mut client = Stream::connect(client_name).expect("connect");
-            client
-                .write_all(b"GET /api/v1/health HTTP/1.1\r\nHost: coven\r\n\r\n")
-                .expect("write request");
-            client.flush().expect("flush");
-            let (status_code, response) = read_windows_pipe_http_response(
-                client,
-                // Windows CI runners can take longer than one second to
-                // schedule the server thread while the Rust suite is busy.
-                Duration::from_secs(5),
-                MAX_SOCKET_BODY_BYTES,
-            )
-            .expect("read response");
-            assert_eq!(status_code, 200);
-            let response = String::from_utf8(response)?;
-            assert!(response.contains("\"apiVersion\""), "got: {response}");
-        }
+        let probed_status =
+            daemon_status_from_windows_pipe(&pipe_name)?.expect("probe running daemon status");
+        assert_eq!(probed_status.pid, server_pid);
+        assert_eq!(
+            probed_status
+                .process_creation_time
+                .map(WindowsProcessCreationTime::get),
+            Some(server_creation_time)
+        );
+
+        let (status_code, response) = coven_client::probe_windows_daemon_health(
+            &pipe_name,
+            // Windows CI runners can take longer than one second to schedule
+            // the server thread while the Rust suite is busy.
+            Duration::from_secs(5),
+        )
+        .map_err(anyhow::Error::new)?
+        .expect("connect to owner-safe daemon pipe");
+        assert_eq!(status_code, 200);
+        let response = String::from_utf8(response)?;
+        assert!(response.contains("\"apiVersion\""), "got: {response}");
+        let response: serde_json::Value = serde_json::from_str(&response)?;
+        assert_eq!(response["daemon"]["pid"], server_pid);
+        assert_eq!(
+            response["daemon"]["processCreationTime"],
+            server_creation_time.to_string()
+        );
         server.join().expect("server thread")?;
         Ok(())
     }
 
     #[cfg(windows)]
     #[test]
-    fn owner_only_pipe_security_descriptor_parses_sddl() -> Result<()> {
-        owner_only_pipe_security_descriptor()?;
+    fn shared_windows_probe_deadline_bounds_a_busy_pipe() -> Result<()> {
+        use interprocess::{
+            local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream},
+            os::windows::local_socket::ListenerOptionsExt,
+        };
+
+        let temp_dir = tempfile::tempdir()?;
+        let pipe_name = windows_pipe_name(temp_dir.path())?;
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .security_descriptor(owner_only_pipe_security_descriptor()?)
+            .create_sync()
+            .expect("bind pipe");
+        let client_name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("client pipe name");
+        let _busy_client = Stream::connect(client_name).expect("occupy pipe instance");
+
+        let started = Instant::now();
+        let _ = coven_client::probe_windows_daemon_health(&pipe_name, Duration::from_millis(50));
+
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "a busy named pipe must not invoke an infinite WaitNamedPipeW"
+        );
+        drop(listener);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_discovery_retries_a_busy_pipe_until_an_owner_only_instance_is_available(
+    ) -> Result<()> {
+        use coven_client::DaemonEndpoint;
+        use interprocess::{
+            local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream},
+            os::windows::local_socket::ListenerOptionsExt,
+            TryClone,
+        };
+        use std::sync::mpsc;
+
+        let temp_dir = tempfile::tempdir()?;
+        let pipe_name = windows_pipe_name(temp_dir.path())?;
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("busy pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .security_descriptor(owner_only_pipe_security_descriptor()?)
+            .create_sync()
+            .expect("bind busy pipe");
+        let client_name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("busy client pipe name");
+        let busy_client = Stream::connect(client_name).expect("occupy pipe instance");
+        let descriptor = owner_only_pipe_security_descriptor()?;
+        let replacement_name = pipe_name
+            .to_ns_name::<GenericNamespaced>()
+            .expect("replacement pipe name");
+        let (replacement_ready_tx, replacement_ready_rx) = mpsc::sync_channel(0);
+        let (release_tx, release_rx) = mpsc::sync_channel(0);
+        let replacement = std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            drop(busy_client);
+            drop(listener);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let replacement = loop {
+                match ListenerOptions::new()
+                    .name(replacement_name.clone())
+                    .security_descriptor(
+                        descriptor
+                            .try_clone()
+                            .expect("clone owner-only pipe descriptor"),
+                    )
+                    .create_sync()
+                {
+                    Ok(listener) => break listener,
+                    Err(error) if Instant::now() < deadline => {
+                        let _ = error;
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("replace released busy pipe: {error}"),
+                }
+            };
+            replacement_ready_tx
+                .send(())
+                .expect("report replacement pipe");
+            release_rx.recv().expect("release replacement pipe");
+            drop(replacement);
+        });
+
+        let started = Instant::now();
+        let endpoint = DaemonEndpoint::discover(temp_dir.path()).map_err(anyhow::Error::new);
+        let discovery_elapsed = started.elapsed();
+        replacement_ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("replacement pipe became available");
+        let owner_local = endpoint
+            .as_ref()
+            .is_ok_and(|endpoint| endpoint.is_owner_local());
+        release_tx.send(()).expect("release replacement listener");
+        replacement.join().expect("replacement pipe thread");
+        let _endpoint = endpoint?;
+        assert!(owner_local);
+        assert!(
+            discovery_elapsed >= Duration::from_millis(25),
+            "discovery did not exercise the busy-instance retry"
+        );
+        assert!(discovery_elapsed < Duration::from_secs(2));
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_discovery_fails_a_persistently_busy_pipe_within_its_budget() -> Result<()> {
+        use coven_client::DaemonEndpoint;
+        use interprocess::{
+            local_socket::{prelude::*, GenericNamespaced, ListenerOptions, Stream},
+            os::windows::local_socket::ListenerOptionsExt,
+        };
+
+        let temp_dir = tempfile::tempdir()?;
+        let pipe_name = windows_pipe_name(temp_dir.path())?;
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("busy pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .security_descriptor(owner_only_pipe_security_descriptor()?)
+            .create_sync()
+            .expect("bind busy pipe");
+        let client_name = pipe_name
+            .to_ns_name::<GenericNamespaced>()
+            .expect("busy client pipe name");
+        let busy_client = Stream::connect(client_name).expect("occupy pipe instance");
+
+        let started = Instant::now();
+        let result = DaemonEndpoint::discover(temp_dir.path());
+
+        assert!(result.is_err(), "persistently busy pipe was discovered");
+        assert!(
+            started.elapsed() >= Duration::from_millis(250),
+            "busy discovery failed fast instead of sharing its retry deadline"
+        );
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "busy discovery exceeded its two-second budget"
+        );
+        drop(busy_client);
+        drop(listener);
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn owner_only_pipe_security_descriptor_has_explicit_token_user_owner() -> Result<()> {
+        use interprocess::os::windows::security_descriptor::AsSecurityDescriptorExt;
+        use windows_sys::Win32::Security::EqualSid;
+
+        let descriptor = owner_only_pipe_security_descriptor()?;
+        let (owner, defaulted) = descriptor.owner()?;
+        let current_user = current_windows_user_sid()?;
+
+        assert!(!owner.is_null());
+        assert!(!defaulted);
+        assert_ne!(
+            unsafe { EqualSid(owner.cast_mut(), current_user.as_ptr()) },
+            0
+        );
+        assert!(descriptor.dacl()?.is_some());
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn client_accepts_object_manager_mapped_owner_only_pipe_and_status_acls() -> Result<()> {
+        use coven_client::DaemonEndpoint;
+        use interprocess::{
+            local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
+            os::windows::local_socket::ListenerOptionsExt,
+        };
+
+        let temp_dir = tempfile::tempdir()?;
+        ensure_private_coven_home(temp_dir.path())?;
+        let pipe_name = windows_pipe_name(temp_dir.path())?;
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("daemon pipe name");
+        let _listener = ListenerOptions::new()
+            .name(name)
+            .security_descriptor(owner_only_pipe_security_descriptor()?)
+            .create_sync()
+            .expect("bind owner-only pipe");
+        let status = DaemonStatus {
+            pid: std::process::id(),
+            started_at: "2026-08-16T12:00:00Z".to_owned(),
+            socket: pipe_name,
+            process_creation_time: None,
+        };
+        write_status(temp_dir.path(), &status)?;
+
+        let serialized = coven_client::read_windows_daemon_status_for_lifecycle(temp_dir.path())
+            .map_err(anyhow::Error::new)?
+            .context("read hardened status")?;
+        assert_eq!(parse_daemon_status(&serialized)?, status);
+        DaemonEndpoint::discover(temp_dir.path()).map_err(anyhow::Error::new)?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn discovers_same_profile_legacy_pipe_from_an_inherited_acl_status_file() -> Result<()> {
+        use coven_client::{DaemonClient, DaemonEndpoint};
+        use interprocess::{
+            local_socket::{prelude::*, GenericNamespaced, ListenerOptions},
+            os::windows::local_socket::ListenerOptionsExt,
+        };
+        use std::{
+            hash::{DefaultHasher, Hash, Hasher},
+            thread,
+        };
+
+        let temp_dir = tempfile::tempdir()?;
+        let mut hasher = DefaultHasher::new();
+        temp_dir.path().to_string_lossy().hash(&mut hasher);
+        let pipe_name = format!("coven-daemon-{:016x}.sock", hasher.finish());
+        let name = pipe_name
+            .clone()
+            .to_ns_name::<GenericNamespaced>()
+            .expect("legacy pipe name");
+        let listener = ListenerOptions::new()
+            .name(name)
+            .security_descriptor(owner_only_pipe_security_descriptor()?)
+            .create_sync()
+            .expect("bind protected legacy pipe");
+        let status = DaemonStatus {
+            pid: 12345,
+            started_at: "2026-04-27T10:00:00Z".to_string(),
+            socket: pipe_name,
+            process_creation_time: None,
+        };
+        std::fs::write(
+            daemon_status_path(temp_dir.path()),
+            serde_json::to_vec(&status)?,
+        )?;
+
+        let home = temp_dir.path().to_path_buf();
+        let server_status = status.clone();
+        let server = thread::spawn(move || {
+            for _ in 0..2 {
+                let conn = listener.incoming().next().expect("accept").expect("stream");
+                handle_http_stream(
+                    &conn,
+                    &conn,
+                    &home,
+                    Some(server_status.clone()),
+                    &LiveSessionRuntime::default(),
+                    None,
+                    HostGuard::Disabled,
+                )?;
+            }
+            Ok::<_, anyhow::Error>(())
+        });
+
+        let endpoint = DaemonEndpoint::discover(temp_dir.path()).map_err(anyhow::Error::new)?;
+        let health = DaemonClient::new(endpoint)
+            .health()
+            .map_err(anyhow::Error::new)?;
+        assert_eq!(health.api_version, "coven.daemon.v1");
+        server.join().expect("server thread")?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn inherited_acl_status_rejects_cross_profile_and_arbitrary_pipe_redirection() -> Result<()> {
+        use coven_client::DaemonEndpoint;
+        use std::hash::{DefaultHasher, Hash, Hasher};
+
+        let temp_dir = tempfile::tempdir()?;
+        let other_home = temp_dir.path().join("other-profile");
+        let mut hasher = DefaultHasher::new();
+        other_home.to_string_lossy().hash(&mut hasher);
+        let other_profile_pipe = format!("coven-daemon-{:016x}.sock", hasher.finish());
+
+        for redirected in [other_profile_pipe.as_str(), "other-daemon.sock"] {
+            let status = DaemonStatus {
+                pid: 12345,
+                started_at: "2026-04-27T10:00:00Z".to_string(),
+                socket: redirected.to_owned(),
+                process_creation_time: None,
+            };
+            std::fs::write(
+                daemon_status_path(temp_dir.path()),
+                serde_json::to_vec(&status)?,
+            )?;
+
+            assert!(
+                DaemonEndpoint::discover(temp_dir.path()).is_err(),
+                "inherited status redirected discovery to {redirected}"
+            );
+        }
         Ok(())
     }
 
@@ -7814,6 +11577,7 @@ mod tests {
                 pid: 42,
                 started_at: "2026-06-14T00:00:00Z".to_string(),
                 socket: socket_path.to_string_lossy().into_owned(),
+                process_creation_time: None,
             })?,
         )?;
         assert!(socket_path.exists());
@@ -7865,6 +11629,7 @@ mod tests {
                 pid: 100,
                 started_at: "2026-06-14T00:01:00Z".to_string(),
                 socket: socket_path.to_string_lossy().into_owned(),
+                process_creation_time: None,
             })?,
         )?;
 
@@ -8148,6 +11913,7 @@ mod tests {
             socket: daemon_socket_path(temp_dir.path())
                 .to_string_lossy()
                 .into_owned(),
+            process_creation_time: None,
         };
         let stop = Arc::new(AtomicBool::new(false));
         let stop_thread = Arc::clone(&stop);

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -876,6 +876,8 @@ enum DaemonCommand {
     Stop,
     #[command(hide = true)]
     Serve {
+        #[arg(long, hide = true)]
+        managed_started_at: Option<String>,
         #[arg(
             long,
             value_name = "ADDR",
@@ -3635,17 +3637,23 @@ fn run_daemon_command(command: DaemonCommand) -> Result<()> {
                 println!("Coven daemon: was not running");
             }
         }
-        DaemonCommand::Serve { tcp, allow_host } => {
+        DaemonCommand::Serve {
+            managed_started_at,
+            tcp,
+            allow_host,
+        } => {
+            let started_at = managed_started_at.unwrap_or_else(current_timestamp);
             #[cfg(unix)]
             {
-                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref(), &allow_host)?;
+                daemon::serve_forever(&home, started_at, tcp.as_deref(), &allow_host)?;
             }
             #[cfg(windows)]
             {
-                daemon::serve_forever(&home, current_timestamp(), tcp.as_deref(), &allow_host)?;
+                daemon::serve_forever(&home, started_at, tcp.as_deref(), &allow_host)?;
             }
             #[cfg(not(any(unix, windows)))]
             {
+                let _ = started_at;
                 let _ = tcp;
                 let _ = allow_host;
                 anyhow::bail!(
@@ -7243,6 +7251,7 @@ mod tests {
             pid: 4242,
             started_at: "2026-01-01T00:00:00Z".to_string(),
             socket: "/tmp/coven.sock".to_string(),
+            process_creation_time: None,
         }
     }
 
@@ -7731,6 +7740,7 @@ mod tests {
             pid: 42,
             started_at: "2026-01-01T00:00:00Z".to_string(),
             socket: socket.clone(),
+            process_creation_time: None,
         }));
 
         let redactor = DoctorJsonPathRedactor::new(&report);
@@ -7764,6 +7774,7 @@ mod tests {
                 pid: 42,
                 started_at: "2026-01-01T00:00:00Z".to_string(),
                 socket: "/tmp/coven-home/coven.sock".to_string(),
+                process_creation_time: None,
             })),
             repos: vec![],
             harnesses: vec![make_harness_with_hint("codex", true, "npm i -g codex")],
@@ -7791,6 +7802,7 @@ mod tests {
             pid: 42,
             started_at: "2026-01-01T00:00:00Z".to_string(),
             socket: "/tmp/coven-home/coven.sock".to_string(),
+            process_creation_time: None,
         }));
 
         let mut bad_repo = make_doctor_report();

--- a/crates/coven-cli/src/state_lock.rs
+++ b/crates/coven-cli/src/state_lock.rs
@@ -80,10 +80,24 @@ pub(crate) fn open_lock_file_in(
     let mut options = cap_std::fs::OpenOptions::new();
     options.create(true).truncate(false).read(true).write(true);
     options.follow(FollowSymlinks::No);
-    let file = dir
-        .open_with(name, &options)
-        .with_context(|| format!("failed to open state lock {}", display_path.display()))?
-        .into_std();
+    let name = name.as_ref();
+    let mut attempts = 0;
+    let file = loop {
+        match dir.open_with(name, &options) {
+            Ok(file) => break file.into_std(),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound && attempts < 2 => {
+                // The no-follow create path can transiently lose a race with
+                // another process creating this same lock entry.
+                attempts += 1;
+                std::thread::yield_now();
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to open state lock {}", display_path.display())
+                })
+            }
+        }
+    };
     validate_lock_file(&file, display_path)?;
     #[cfg(unix)]
     {

--- a/crates/coven-cli/src/store.rs
+++ b/crates/coven-cli/src/store.rs
@@ -433,6 +433,19 @@ pub struct EventsQueryOptions {
     pub limit: Option<i64>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EventCandidate {
+    pub(crate) seq: i64,
+    pub(crate) event_id: Option<String>,
+    pub(crate) allocation_bytes: usize,
+    pub(crate) encoded_lower_bound_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct EventCandidatePage {
+    pub(crate) candidates: Vec<EventCandidate>,
+}
+
 fn load_ward_audit_schema_state(conn: &Connection) -> Result<String> {
     use coven_threads_core::WARD_AUDIT_SCHEMA_STATE_SQL;
 
@@ -4410,27 +4423,160 @@ pub fn event_kind_exists(conn: &Connection, session_id: &str, kind: &str) -> Res
     Ok(exists)
 }
 
+pub(crate) fn resolve_event_after_rowid(
+    conn: &Connection,
+    session_id: &str,
+    opts: &EventsQueryOptions,
+) -> Result<Option<i64>> {
+    if let Some(seq) = opts.after_seq {
+        return Ok(Some(seq));
+    }
+    let Some(event_id) = opts.after_event_id.as_ref() else {
+        return Ok(None);
+    };
+    conn.query_row(
+        "SELECT rowid FROM events WHERE id = ?1 AND session_id = ?2 LIMIT 1",
+        params![event_id, session_id],
+        |row| row.get::<_, i64>(0),
+    )
+    .optional()
+    .context("failed to resolve event cursor by event id")
+}
+
+pub(crate) fn list_event_candidates(
+    conn: &Connection,
+    session_id: &str,
+    after_rowid: Option<i64>,
+    limit: usize,
+) -> Result<EventCandidatePage> {
+    const ERROR_EVENT_ID_MAX_BYTES: i64 = 512;
+
+    if limit == 0 {
+        return Ok(EventCandidatePage {
+            candidates: Vec::new(),
+        });
+    }
+    let limit = i64::try_from(limit).context("event candidate limit exceeded SQLite range")?;
+    let (sql, params): (&str, Vec<rusqlite::types::Value>) = if let Some(after_rowid) = after_rowid
+    {
+        (
+            "SELECT
+                rowid,
+                CASE WHEN octet_length(id) <= ?3 THEN id ELSE NULL END,
+                octet_length(id),
+                octet_length(session_id),
+                octet_length(kind),
+                octet_length(payload_json),
+                octet_length(created_at),
+                redaction_status = 'legacy'
+             FROM events
+             WHERE session_id = ?1 AND rowid > ?2
+             ORDER BY rowid ASC
+             LIMIT ?4",
+            vec![
+                session_id.to_owned().into(),
+                after_rowid.into(),
+                ERROR_EVENT_ID_MAX_BYTES.into(),
+                limit.into(),
+            ],
+        )
+    } else {
+        (
+            "SELECT
+                rowid,
+                CASE WHEN octet_length(id) <= ?2 THEN id ELSE NULL END,
+                octet_length(id),
+                octet_length(session_id),
+                octet_length(kind),
+                octet_length(payload_json),
+                octet_length(created_at),
+                redaction_status = 'legacy'
+             FROM events
+             WHERE session_id = ?1
+             ORDER BY rowid ASC
+             LIMIT ?3",
+            vec![
+                session_id.to_owned().into(),
+                ERROR_EVENT_ID_MAX_BYTES.into(),
+                limit.into(),
+            ],
+        )
+    };
+    let mut statement = conn
+        .prepare(sql)
+        .context("failed to prepare bounded event candidate query")?;
+    let mut rows = statement
+        .query(rusqlite::params_from_iter(params))
+        .context("failed to query bounded event candidates")?;
+    let mut candidates = Vec::with_capacity(usize::try_from(limit).unwrap_or_default());
+    while let Some(row) = rows
+        .next()
+        .context("failed to read bounded event candidate")?
+    {
+        let mut allocation_bytes = 0_usize;
+        for column in 2..=6 {
+            let field_bytes: i64 = row
+                .get(column)
+                .context("event candidate contained an invalid field length")?;
+            let field_bytes = usize::try_from(field_bytes)
+                .context("event candidate contained a negative or oversized field length")?;
+            allocation_bytes = allocation_bytes
+                .checked_add(field_bytes)
+                .context("event candidate allocation size overflowed")?;
+        }
+        let is_legacy_redaction: bool = row
+            .get(7)
+            .context("event candidate contained an invalid redaction status")?;
+        candidates.push(EventCandidate {
+            seq: row.get(0).context("event candidate had no sequence")?,
+            event_id: row
+                .get(1)
+                .context("event candidate had an invalid bounded id")?,
+            allocation_bytes,
+            encoded_lower_bound_bytes: (!is_legacy_redaction).then_some(allocation_bytes),
+        });
+    }
+    Ok(EventCandidatePage { candidates })
+}
+
+pub(crate) fn get_event_by_seq(
+    conn: &Connection,
+    session_id: &str,
+    seq: i64,
+) -> Result<Option<EventRecord>> {
+    conn.query_row(
+        "SELECT rowid AS seq, id, session_id, kind, payload_json, created_at, redaction_status
+         FROM events
+         WHERE session_id = ?1 AND rowid = ?2",
+        params![session_id, seq],
+        event_record_from_row,
+    )
+    .optional()
+    .context("failed to load bounded event candidate")
+}
+
+fn event_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<EventRecord> {
+    let mut record = EventRecord {
+        seq: row.get(0)?,
+        id: row.get(1)?,
+        session_id: row.get(2)?,
+        kind: row.get(3)?,
+        payload_json: row.get(4)?,
+        created_at: row.get(5)?,
+    };
+    let redaction_status: String = row.get(6)?;
+    if redaction_status == "legacy" {
+        record.payload_json = privacy::redact_payload_json(&record.payload_json);
+    }
+    Ok(record)
+}
+
 pub fn list_events_with_options(
     conn: &Connection,
     session_id: &str,
     opts: &EventsQueryOptions,
 ) -> Result<Vec<EventRecord>> {
-    use rusqlite::OptionalExtension;
-
-    // Resolve the cursor to a rowid lower bound.
-    let after_rowid: Option<i64> = if let Some(seq) = opts.after_seq {
-        Some(seq)
-    } else if let Some(ref event_id) = opts.after_event_id {
-        conn.query_row(
-            "SELECT rowid FROM events WHERE id = ?1 AND session_id = ?2 LIMIT 1",
-            params![event_id, session_id],
-            |row| row.get::<_, i64>(0),
-        )
-        .optional()
-        .context("failed to resolve event cursor by event id")?
-    } else {
-        None
-    };
+    let after_rowid = resolve_event_after_rowid(conn, session_id, opts)?;
 
     // The query is built dynamically based on which optional parameters are
     // present.  All user-provided values are bound via parameterized placeholders
@@ -4453,34 +4599,18 @@ pub fn list_events_with_options(
         .prepare(&sql)
         .context("failed to prepare event list query")?;
 
-    let map_row = |row: &rusqlite::Row<'_>| {
-        let mut record = EventRecord {
-            seq: row.get(0)?,
-            id: row.get(1)?,
-            session_id: row.get(2)?,
-            kind: row.get(3)?,
-            payload_json: row.get(4)?,
-            created_at: row.get(5)?,
-        };
-        let redaction_status: String = row.get(6)?;
-        if redaction_status == "legacy" {
-            record.payload_json = privacy::redact_payload_json(&record.payload_json);
-        }
-        Ok(record)
-    };
-
     let events = match (after_rowid, opts.limit) {
         (Some(after), Some(limit)) => statement
-            .query_map(params![session_id, after, limit], map_row)
+            .query_map(params![session_id, after, limit], event_record_from_row)
             .context("failed to query events")?,
         (Some(after), None) => statement
-            .query_map(params![session_id, after], map_row)
+            .query_map(params![session_id, after], event_record_from_row)
             .context("failed to query events")?,
         (None, Some(limit)) => statement
-            .query_map(params![session_id, limit], map_row)
+            .query_map(params![session_id, limit], event_record_from_row)
             .context("failed to query events")?,
         (None, None) => statement
-            .query_map(params![session_id], map_row)
+            .query_map(params![session_id], event_record_from_row)
             .context("failed to query events")?,
     }
     .collect::<std::result::Result<Vec<_>, _>>()

--- a/crates/coven-cli/src/tui/cast/attach.rs
+++ b/crates/coven-cli/src/tui/cast/attach.rs
@@ -68,11 +68,29 @@ pub(crate) struct CastQuestAttachInfo {
 /// quest title and progress so they can re-run `/quest <goal>` if they
 /// want to continue. Full state rebuild (replay handoffs, render the next
 /// card) is deferred to a later phase.
+#[cfg(test)]
 pub(crate) fn find_cast_quest_info(events: &[store::EventRecord]) -> Option<CastQuestAttachInfo> {
     let started = events
         .iter()
         .rev()
         .find(|event| event.kind == CAST_QUEST_STARTED_KIND)?;
+    Some(decode_quest_info(
+        started,
+        events
+            .iter()
+            .filter(|event| event.kind == CAST_QUEST_PHASE_COMPLETED_KIND)
+            .count(),
+        events
+            .iter()
+            .any(|event| event.kind == CAST_QUEST_COMPLETED_KIND),
+    ))
+}
+
+fn decode_quest_info(
+    started: &store::EventRecord,
+    completed_phases: usize,
+    is_complete: bool,
+) -> CastQuestAttachInfo {
     let payload = serde_json::from_str::<Value>(&started.payload_json).unwrap_or(Value::Null);
     let title = payload
         .get("title")
@@ -90,21 +108,14 @@ pub(crate) fn find_cast_quest_info(events: &[store::EventRecord]) -> Option<Cast
         .get("phases")
         .and_then(Value::as_array)
         .map(|arr| arr.len());
-    let completed_phases = events
-        .iter()
-        .filter(|event| event.kind == CAST_QUEST_PHASE_COMPLETED_KIND)
-        .count();
-    let is_complete = events
-        .iter()
-        .any(|event| event.kind == CAST_QUEST_COMPLETED_KIND);
-    Some(CastQuestAttachInfo {
+    CastQuestAttachInfo {
         title,
         goal,
         harness,
         total_phases,
         completed_phases,
         is_complete,
-    })
+    }
 }
 
 /// Replayed quest state plus the anchor session id we attached to. The
@@ -118,6 +129,75 @@ pub(crate) struct ReconstructedQuest {
     pub(crate) anchor_session_id: String,
 }
 
+#[derive(Default)]
+pub(crate) struct CastAttachReplayState {
+    summary: Option<CastAttachSummary>,
+    quest_info: Option<CastQuestAttachInfo>,
+    reconstructed_quest: Option<ReconstructedQuest>,
+    completed_phases: usize,
+    quest_is_complete: bool,
+    saw_reconstruction_start: bool,
+}
+
+impl CastAttachReplayState {
+    pub(crate) fn observe(&mut self, event: &store::EventRecord) {
+        match event.kind.as_str() {
+            CAST_SUMMARY_KIND => {
+                self.summary = Some(decode_summary(event));
+            }
+            CAST_QUEST_STARTED_KIND => {
+                self.quest_info = Some(decode_quest_info(
+                    event,
+                    self.completed_phases,
+                    self.quest_is_complete,
+                ));
+                if !self.saw_reconstruction_start {
+                    self.saw_reconstruction_start = true;
+                    self.reconstructed_quest = reconstruct_quest_start(event);
+                }
+            }
+            CAST_QUEST_PHASE_COMPLETED_KIND => {
+                self.completed_phases = self.completed_phases.saturating_add(1);
+                if let Some(info) = self.quest_info.as_mut() {
+                    info.completed_phases = self.completed_phases;
+                }
+                if let Some(quest) = self.reconstructed_quest.as_mut() {
+                    apply_quest_event(quest, event);
+                }
+            }
+            CAST_QUEST_COMPLETED_KIND => {
+                self.quest_is_complete = true;
+                if let Some(info) = self.quest_info.as_mut() {
+                    info.is_complete = true;
+                }
+                if let Some(quest) = self.reconstructed_quest.as_mut() {
+                    apply_quest_event(quest, event);
+                }
+            }
+            CAST_QUEST_PHASE_STARTED_KIND
+            | CAST_QUEST_PHASE_EDITED_KIND
+            | CAST_QUEST_PHASE_SKIPPED_KIND => {
+                if let Some(quest) = self.reconstructed_quest.as_mut() {
+                    apply_quest_event(quest, event);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn summary(&self) -> Option<&CastAttachSummary> {
+        self.summary.as_ref()
+    }
+
+    pub(crate) fn quest_info(&self) -> Option<&CastQuestAttachInfo> {
+        self.quest_info.as_ref()
+    }
+
+    pub(crate) fn take_reconstructed_quest(&mut self) -> Option<ReconstructedQuest> {
+        self.reconstructed_quest.take()
+    }
+}
+
 /// Replay `cast.quest.*` events from an anchor session to rebuild a
 /// `Quest` in the state it was in when the user last interacted with it.
 ///
@@ -125,11 +205,17 @@ pub(crate) struct ReconstructedQuest {
 /// payload (the session is not a quest anchor). The reconstructor is
 /// best-effort: malformed event payloads and out-of-range indices are
 /// skipped silently so a corrupt event log never blocks the resume path.
+#[cfg(test)]
 pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<ReconstructedQuest> {
-    let started = events
-        .iter()
-        .find(|event| event.kind == CAST_QUEST_STARTED_KIND)?;
-    let payload = serde_json::from_str::<Value>(&started.payload_json).ok()?;
+    let mut replay = CastAttachReplayState::default();
+    for event in events {
+        replay.observe(event);
+    }
+    replay.take_reconstructed_quest()
+}
+
+fn reconstruct_quest_start(event: &store::EventRecord) -> Option<ReconstructedQuest> {
+    let payload = serde_json::from_str::<Value>(&event.payload_json).ok()?;
     let goal = payload.get("goal").and_then(Value::as_str)?.to_string();
     let default_harness = payload
         .get("harness")
@@ -149,91 +235,80 @@ pub(crate) fn reconstruct_quest(events: &[store::EventRecord]) -> Option<Reconst
             }
         }
     }
-    let mut is_complete = false;
-
-    for event in events {
-        match event.kind.as_str() {
-            kind if kind == CAST_QUEST_PHASE_STARTED_KIND => {
-                // Phase 10 defensive: if Cast crashed between dispatch and
-                // advance, the anchor will hold a `phase_started` event
-                // without a matching `phase_completed`. Mark the phase
-                // Running so resume can show "this phase was already
-                // started". When a `phase_completed` later in the log
-                // exists, `advance` below overwrites the status to
-                // Complete and the Running mark becomes invisible.
-                let payload =
-                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
-                let idx = payload.get("index").and_then(Value::as_u64);
-                let session_id = payload
-                    .get("session_id")
-                    .and_then(Value::as_str)
-                    .unwrap_or("")
-                    .to_string();
-                if let Some(idx) = idx {
-                    let _ = mark_phase_running(&mut quest, idx as usize, session_id);
-                }
-            }
-            kind if kind == CAST_QUEST_PHASE_EDITED_KIND => {
-                let payload =
-                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
-                let idx = payload.get("index").and_then(Value::as_u64);
-                let sub_prompt = payload.get("sub_prompt").and_then(Value::as_str);
-                if let (Some(idx), Some(text)) = (idx, sub_prompt) {
-                    let _ = set_phase_sub_prompt(&mut quest, idx as usize, text.to_string());
-                }
-            }
-            kind if kind == CAST_QUEST_PHASE_COMPLETED_KIND => {
-                let Ok(payload) = serde_json::from_str::<Value>(&event.payload_json) else {
-                    continue;
-                };
-                let Some(idx) = payload
-                    .get("index")
-                    .and_then(Value::as_u64)
-                    .map(|v| v as usize)
-                else {
-                    continue;
-                };
-                if quest.current_index() != Some(idx) {
-                    continue;
-                }
-                let summary = QuestPhaseSummary {
-                    session_id: payload
-                        .get("session_id")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned),
-                    exit_status: payload
-                        .get("exit_status")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned),
-                    exit_code: payload
-                        .get("exit_code")
-                        .and_then(Value::as_i64)
-                        .map(|v| v as i32),
-                    carried_context: Vec::new(),
-                };
-                advance(&mut quest, summary);
-            }
-            kind if kind == CAST_QUEST_PHASE_SKIPPED_KIND => {
-                let payload =
-                    serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
-                let idx = payload.get("index").and_then(Value::as_u64);
-                let reason = payload.get("reason").and_then(Value::as_str);
-                if let (Some(idx), Some(reason)) = (idx, reason) {
-                    let _ = skip_phase(&mut quest, idx as usize, reason.to_string());
-                }
-            }
-            kind if kind == CAST_QUEST_COMPLETED_KIND => {
-                is_complete = true;
-            }
-            _ => {}
-        }
-    }
-
     Some(ReconstructedQuest {
         quest,
-        is_complete,
-        anchor_session_id: started.session_id.clone(),
+        is_complete: false,
+        anchor_session_id: event.session_id.clone(),
     })
+}
+
+fn apply_quest_event(reconstructed: &mut ReconstructedQuest, event: &store::EventRecord) {
+    let quest = &mut reconstructed.quest;
+    match event.kind.as_str() {
+        kind if kind == CAST_QUEST_PHASE_STARTED_KIND => {
+            let payload = serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+            let idx = payload.get("index").and_then(Value::as_u64);
+            let session_id = payload
+                .get("session_id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if let Some(idx) = idx {
+                let _ = mark_phase_running(quest, idx as usize, session_id);
+            }
+        }
+        kind if kind == CAST_QUEST_PHASE_EDITED_KIND => {
+            let payload = serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+            let idx = payload.get("index").and_then(Value::as_u64);
+            let sub_prompt = payload.get("sub_prompt").and_then(Value::as_str);
+            if let (Some(idx), Some(text)) = (idx, sub_prompt) {
+                let _ = set_phase_sub_prompt(quest, idx as usize, text.to_string());
+            }
+        }
+        kind if kind == CAST_QUEST_PHASE_COMPLETED_KIND => {
+            let Ok(payload) = serde_json::from_str::<Value>(&event.payload_json) else {
+                return;
+            };
+            let Some(idx) = payload
+                .get("index")
+                .and_then(Value::as_u64)
+                .map(|v| v as usize)
+            else {
+                return;
+            };
+            if quest.current_index() != Some(idx) {
+                return;
+            }
+            let summary = QuestPhaseSummary {
+                session_id: payload
+                    .get("session_id")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                exit_status: payload
+                    .get("exit_status")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+                exit_code: payload
+                    .get("exit_code")
+                    .and_then(Value::as_i64)
+                    .map(|v| v as i32),
+                carried_context: Vec::new(),
+            };
+            advance(quest, summary);
+        }
+        kind if kind == CAST_QUEST_PHASE_SKIPPED_KIND => {
+            let payload = serde_json::from_str::<Value>(&event.payload_json).unwrap_or(Value::Null);
+            let idx = payload.get("index").and_then(Value::as_u64);
+            let reason = payload.get("reason").and_then(Value::as_str);
+            if let (Some(idx), Some(reason)) = (idx, reason) {
+                let _ = skip_phase(quest, idx as usize, reason.to_string());
+            }
+        }
+        kind if kind == CAST_QUEST_COMPLETED_KIND => {
+            reconstructed.is_complete = true;
+        }
+        _ => {}
+    }
 }
 
 /// One-line note for the attach outcome card describing the quest this

--- a/crates/coven-cli/src/tui/cast/follow.rs
+++ b/crates/coven-cli/src/tui/cast/follow.rs
@@ -14,7 +14,9 @@ use anyhow::Result;
 use serde_json::Value;
 
 use crate::store;
-use crate::tui::chat::client::{ChatClient, ChatEventQuery};
+use crate::tui::chat::client::{
+    validated_event_page_cursor, ChatClient, ChatEventQuery, EVENT_PAGES_PER_POLL, EVENT_PAGE_LIMIT,
+};
 
 /// A monotonic cursor over a session's event stream. The cursor only ever
 /// advances forward; passing the cursor back to the daemon as `afterSeq`
@@ -109,14 +111,14 @@ pub(crate) fn decode_event(record: &store::EventRecord) -> CastFollowEvent {
     }
 }
 
-/// Decoded follower batch returned by a single poll. Carries the cursor
-/// the caller should use for the next request (or save in case it
-/// reconnects after a crash).
+/// Decoded follower batch returned by a bounded poll burst. Carries the cursor
+/// for the next request and reports whether continuation work remains.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct CastFollowBatch {
     pub(crate) events: Vec<CastFollowEvent>,
     pub(crate) cursor: CastFollowCursor,
     pub(crate) exit: Option<CastSessionExit>,
+    pub(crate) continuation_pending: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -158,6 +160,7 @@ pub(crate) fn follow_until_exit(
     pacer: &mut dyn FollowerPacer,
 ) -> Result<CastSessionExit> {
     let mut cursor = CastFollowCursor::new();
+    let mut pending_exit = None;
     loop {
         let batch = poll_once(client, session_id, cursor)?;
         cursor = batch.cursor;
@@ -171,7 +174,12 @@ pub(crate) fn follow_until_exit(
             }
         }
         if let Some(exit) = batch.exit {
-            return Ok(exit);
+            pending_exit = Some(exit);
+        }
+        if !batch.continuation_pending {
+            if let Some(exit) = pending_exit.take() {
+                return Ok(exit);
+            }
         }
         pacer.between_polls()?;
     }
@@ -180,38 +188,49 @@ pub(crate) fn follow_until_exit(
 /// Poll the daemon once for events past `cursor`, decode them, and return
 /// a typed batch. The returned cursor reflects the maximum seq seen — pass
 /// it back on the next call to avoid re-fetching events. If an `exit`
-/// event lands in this batch, `batch.exit` is populated; the caller should
-/// stop polling.
+/// event lands in this batch, `batch.exit` is populated. A continuation may
+/// still need another bounded poll before the caller returns that exit.
 pub(crate) fn poll_once(
     client: &mut dyn ChatClient,
     session_id: &str,
     cursor: CastFollowCursor,
 ) -> Result<CastFollowBatch> {
-    let records = client.list_events(ChatEventQuery {
-        session_id,
-        after_seq: cursor.after_seq(),
-        limit: None,
-    })?;
-
     let mut new_cursor = cursor;
-    let mut events = Vec::with_capacity(records.len());
+    let mut events = Vec::new();
     let mut exit = None;
-    for record in records {
-        new_cursor.advance(record.seq);
-        let decoded = decode_event(&record);
-        if let CastFollowEvent::Exit { status, exit_code } = &decoded {
-            exit = Some(CastSessionExit {
-                status: status.clone(),
-                exit_code: *exit_code,
-            });
+    let mut pages = 0;
+    let continuation_pending = loop {
+        let requested_after_seq = new_cursor.after_seq();
+        let page = client.list_event_page(ChatEventQuery {
+            session_id,
+            after_seq: requested_after_seq,
+            limit: Some(EVENT_PAGE_LIMIT),
+        })?;
+        validated_event_page_cursor(requested_after_seq, &page)?;
+        let has_more = page.has_more;
+        pages += 1;
+
+        for record in page.events {
+            new_cursor.advance(record.seq);
+            let decoded = decode_event(&record);
+            if let CastFollowEvent::Exit { status, exit_code } = &decoded {
+                exit = Some(CastSessionExit {
+                    status: status.clone(),
+                    exit_code: *exit_code,
+                });
+            }
+            events.push(decoded);
         }
-        events.push(decoded);
-    }
+        if !has_more || pages >= EVENT_PAGES_PER_POLL {
+            break has_more;
+        }
+    };
 
     Ok(CastFollowBatch {
         events,
         cursor: new_cursor,
         exit,
+        continuation_pending,
     })
 }
 
@@ -232,6 +251,7 @@ mod tests {
     struct StubClient {
         batches: RefCell<Vec<Vec<store::EventRecord>>>,
         queries: RefCell<Vec<(Option<i64>, String)>>,
+        limits: RefCell<Vec<Option<i64>>>,
     }
 
     impl StubClient {
@@ -239,6 +259,7 @@ mod tests {
             Self {
                 batches: RefCell::new(batches),
                 queries: RefCell::new(Vec::new()),
+                limits: RefCell::new(Vec::new()),
             }
         }
     }
@@ -267,6 +288,7 @@ mod tests {
             self.queries
                 .borrow_mut()
                 .push((query.after_seq, query.session_id.to_string()));
+            self.limits.borrow_mut().push(query.limit);
             let mut batches = self.batches.borrow_mut();
             if batches.is_empty() {
                 Ok(vec![])
@@ -293,6 +315,73 @@ mod tests {
 
         fn sacrifice_session(&mut self, _session_id: &str) -> Result<()> {
             unimplemented!("not exercised in follower tests")
+        }
+    }
+
+    struct GeneratedReplayClient {
+        final_seq: i64,
+        queries: RefCell<Vec<Option<i64>>>,
+    }
+
+    impl GeneratedReplayClient {
+        fn new(final_seq: i64) -> Self {
+            Self {
+                final_seq,
+                queries: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl ChatClient for GeneratedReplayClient {
+        fn daemon_status(&mut self) -> Result<ChatDaemonStatus> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn launch_session(&mut self, _request: LaunchRequest) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn get_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {
+            self.queries.borrow_mut().push(query.after_seq);
+            let first = query.after_seq.unwrap_or(0) + 1;
+            if first > self.final_seq {
+                return Ok(Vec::new());
+            }
+            let limit = query.limit.unwrap_or(EVENT_PAGE_LIMIT).max(1);
+            let last = self
+                .final_seq
+                .min(first.saturating_add(limit).saturating_sub(1));
+            Ok((first..=last)
+                .map(|seq| output_event(seq, &format!("{seq}\n")))
+                .collect())
+        }
+
+        fn send_input(&mut self, _session_id: &str, _data: &str) -> Result<()> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn kill_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn archive_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn summon_session(&mut self, _session_id: &str) -> Result<store::SessionRecord> {
+            unimplemented!("not exercised in generated replay tests")
+        }
+
+        fn sacrifice_session(&mut self, _session_id: &str) -> Result<()> {
+            unimplemented!("not exercised in generated replay tests")
         }
     }
 
@@ -566,6 +655,166 @@ mod tests {
             Some(2),
             "the second poll must request events after seq 2 to avoid replaying a/b"
         );
+    }
+
+    #[test]
+    fn follow_until_exit_drains_more_than_one_bounded_event_page_without_gaps() {
+        let first_page = (1..=512)
+            .map(|seq| output_event(seq, &format!("{seq}\n")))
+            .collect();
+        let second_page = vec![
+            output_event(513, "513\n"),
+            exit_event(514, "completed", Some(0)),
+        ];
+        let mut client = StubClient::new(vec![first_page, second_page]);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 1 };
+
+        let exit = follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer).unwrap();
+
+        assert_eq!(exit.exit_code, Some(0));
+        assert_eq!(observer.output.len(), 513);
+        assert_eq!(observer.output.first().map(String::as_str), Some("1\n"));
+        assert_eq!(observer.output.last().map(String::as_str), Some("513\n"));
+        assert_eq!(
+            &*client.queries.borrow(),
+            &[
+                (None, "session-1".to_string()),
+                (Some(512), "session-1".to_string()),
+            ]
+        );
+        assert!(client
+            .limits
+            .borrow()
+            .iter()
+            .all(|limit| *limit == Some(crate::tui::chat::client::EVENT_PAGE_LIMIT)));
+        assert_eq!(
+            pacer.remaining, 1,
+            "continuation pages must drain immediately without an idle sleep"
+        );
+    }
+
+    #[test]
+    fn completed_replay_streams_many_pages_with_one_page_of_peak_buffering() {
+        const FULL_PAGES: i64 = 24;
+        let final_seq = FULL_PAGES * 512 + 1;
+        let mut client = GeneratedReplayClient::new(final_seq);
+        let mut expected_seq = 1;
+
+        let stats =
+            crate::tui::chat::client::consume_event_pages(&mut client, "session-1", |events| {
+                for event in events {
+                    assert_eq!(event.seq, expected_seq);
+                    expected_seq += 1;
+                }
+                Ok(crate::tui::chat::client::EventPageControl::Continue)
+            })
+            .unwrap();
+
+        assert!(stats.completed);
+        assert_eq!(stats.pages, FULL_PAGES as usize + 1);
+        assert_eq!(stats.events, final_seq as usize);
+        assert_eq!(stats.peak_buffered_events, 512);
+        assert!(
+            stats.events > stats.peak_buffered_events * 20,
+            "the stream must not retain an aggregate transcript allocation"
+        );
+        assert_eq!(expected_seq, final_seq + 1);
+        assert_eq!(client.queries.borrow().len(), stats.pages);
+        for (index, query) in client.queries.borrow().iter().enumerate() {
+            let expected_cursor = (index != 0).then_some(index as i64 * 512);
+            assert_eq!(*query, expected_cursor);
+        }
+    }
+
+    #[test]
+    fn completed_replay_page_consumer_can_cancel_without_fetching_another_page() {
+        let first_page = (1..=512).map(|seq| output_event(seq, "chunk\n")).collect();
+        let second_page = vec![output_event(513, "must not be fetched\n")];
+        let mut client = StubClient::new(vec![first_page, second_page]);
+
+        let stats = crate::tui::chat::client::consume_event_pages(&mut client, "session-1", |_| {
+            Ok(crate::tui::chat::client::EventPageControl::Cancel)
+        })
+        .unwrap();
+
+        assert!(!stats.completed);
+        assert_eq!(stats.pages, 1);
+        assert_eq!(stats.events, 512);
+        assert_eq!(client.queries.borrow().len(), 1);
+    }
+
+    #[test]
+    fn exit_on_a_full_page_still_drains_the_remaining_cursor_page() {
+        let mut first_page = (1..=511)
+            .map(|seq| output_event(seq, &format!("{seq}\n")))
+            .collect::<Vec<_>>();
+        first_page.push(exit_event(512, "completed", Some(0)));
+        let post_exit = store::EventRecord {
+            seq: 513,
+            id: "event-513".to_string(),
+            session_id: "session-1".to_string(),
+            kind: "cast.summary".to_string(),
+            payload_json: "{}".to_string(),
+            created_at: "2026-05-19T00:00:00Z".to_string(),
+        };
+        let mut client = StubClient::new(vec![first_page, vec![post_exit]]);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 1 };
+
+        let exit = follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer).unwrap();
+
+        assert_eq!(exit.status, "completed");
+        assert_eq!(observer.others, vec!["cast.summary"]);
+        assert_eq!(client.queries.borrow().len(), 2);
+        assert_eq!(client.queries.borrow()[1].0, Some(512));
+    }
+
+    #[test]
+    fn follower_returns_to_its_pacer_after_bounded_continuation_work() {
+        let pages = (0..9)
+            .map(|page| {
+                let first = page * 512 + 1;
+                (first..first + 512)
+                    .map(|seq| output_event(seq, "chunk\n"))
+                    .collect()
+            })
+            .collect();
+        let mut client = StubClient::new(pages);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 0 };
+
+        let error = follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer)
+            .expect_err("pacer cancellation must be observed between bounded page bursts");
+
+        assert!(error.to_string().contains("idled too many times"));
+        assert_eq!(client.queries.borrow().len(), 8);
+        assert_eq!(observer.output.len(), 8 * 512);
+    }
+
+    #[test]
+    fn exit_does_not_bypass_bounded_continuation_cancellation() {
+        let pages = (0..9)
+            .map(|page| {
+                let first = page * 512 + 1;
+                let mut events = (first..first + 512)
+                    .map(|seq| output_event(seq, "chunk\n"))
+                    .collect::<Vec<_>>();
+                if page == 0 {
+                    events[0] = exit_event(first, "completed", Some(0));
+                }
+                events
+            })
+            .collect();
+        let mut client = StubClient::new(pages);
+        let mut observer = RecordingObserver::default();
+        let mut pacer = CountingPacer { remaining: 0 };
+
+        let error = follow_until_exit(&mut client, "session-1", &mut observer, &mut pacer)
+            .expect_err("post-exit continuation must retain cancellation opportunities");
+
+        assert!(error.to_string().contains("idled too many times"));
+        assert_eq!(client.queries.borrow().len(), 8);
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/cast/mod.rs
+++ b/crates/coven-cli/src/tui/cast/mod.rs
@@ -25,8 +25,8 @@ use anyhow::Result;
 use crate::harness;
 
 pub(crate) use attach::{
-    find_cast_quest_info, find_cast_summary, format_quest_attach_note, format_summary_note,
-    reconstruct_quest, ReconstructedQuest,
+    find_cast_summary, format_quest_attach_note, format_summary_note, CastAttachReplayState,
+    ReconstructedQuest,
 };
 pub(crate) use follow::{follow_until_exit, CastSessionExit, FollowerObserver, FollowerPacer};
 pub(crate) use gate::{evaluate_gate, GateOutcome, SACRIFICE_CONFIRM_WORD};

--- a/crates/coven-cli/src/tui/chat/app.rs
+++ b/crates/coven-cli/src/tui/chat/app.rs
@@ -18,7 +18,8 @@ use crate::{
 };
 
 use super::client::{
-    ChatClient, ChatDaemonStatus, ChatEventQuery, DaemonChatClient, LaunchRequest,
+    validated_event_page_cursor, ChatClient, ChatDaemonStatus, ChatEventQuery, DaemonChatClient,
+    LaunchRequest, EVENT_PAGES_PER_POLL, EVENT_PAGE_LIMIT,
 };
 use super::persistence;
 use super::render::collapse_session_overlay_indices;
@@ -1798,33 +1799,46 @@ impl App {
         if self.event_poll_paused_for_api_mismatch {
             return false;
         }
-        match self.client.list_events(ChatEventQuery {
-            session_id: &session_id,
-            after_seq: self.last_event_seq,
-            limit: Some(200),
-        }) {
-            Ok(events) => {
-                self.reset_event_poll_failures();
-                let mut changed = false;
-                for event in events {
-                    // If `push_event_message` swapped the active session
-                    // mid-batch (e.g. stale-id recovery auto-relaunched
-                    // into a new session and reset `last_event_seq` to
-                    // None), stop processing this batch. Continuing
-                    // would advance `last_event_seq` to one of the OLD
-                    // session's seqs, causing the next poll for the NEW
-                    // session to query with a cursor that filters out
-                    // the new session's own events.
-                    if self.active_session_id.as_deref() != Some(session_id.as_str()) {
-                        break;
-                    }
-                    self.last_event_seq = Some(event.seq);
-                    self.push_event_message(&event);
-                    changed = true;
-                }
-                changed
+        let mut changed = false;
+        let mut pages = 0;
+        loop {
+            let requested_after_seq = self.last_event_seq;
+            let page = match self.client.list_event_page(ChatEventQuery {
+                session_id: &session_id,
+                after_seq: requested_after_seq,
+                limit: Some(EVENT_PAGE_LIMIT),
+            }) {
+                Ok(page) => page,
+                Err(error) => return self.record_event_poll_failure(error) || changed,
+            };
+            if let Err(error) = validated_event_page_cursor(requested_after_seq, &page) {
+                return self.record_event_poll_failure(error) || changed;
             }
-            Err(error) => self.record_event_poll_failure(error),
+            self.reset_event_poll_failures();
+            let has_more = page.has_more;
+            pages += 1;
+            for event in page.events {
+                // If `push_event_message` swapped the active session
+                // mid-batch (e.g. stale-id recovery auto-relaunched
+                // into a new session and reset `last_event_seq` to
+                // None), stop processing this batch. Continuing
+                // would advance `last_event_seq` to one of the OLD
+                // session's seqs, causing the next poll for the NEW
+                // session to query with a cursor that filters out
+                // the new session's own events.
+                if self.active_session_id.as_deref() != Some(session_id.as_str()) {
+                    return changed;
+                }
+                self.last_event_seq = Some(event.seq);
+                self.push_event_message(&event);
+                changed = true;
+            }
+            if self.active_session_id.as_deref() != Some(session_id.as_str())
+                || !has_more
+                || pages >= EVENT_PAGES_PER_POLL
+            {
+                return changed;
+            }
         }
     }
 
@@ -3490,6 +3504,7 @@ mod tests {
         launched: Rc<RefCell<Vec<LaunchRequest>>>,
         sessions: Rc<RefCell<Vec<SessionRecord>>>,
         events: Rc<RefCell<Vec<EventRecord>>>,
+        event_limits: Rc<RefCell<Vec<Option<i64>>>>,
         daemon_status: Rc<RefCell<ChatDaemonStatus>>,
         event_error: Rc<RefCell<Option<String>>>,
         launch_error: Rc<RefCell<Option<String>>>,
@@ -3542,15 +3557,21 @@ mod tests {
                 query.session_id,
                 query.after_seq.unwrap_or(0)
             ));
+            self.event_limits.borrow_mut().push(query.limit);
             if let Some(error) = self.event_error.borrow().clone() {
                 return Err(anyhow::anyhow!(error));
             }
+            let limit = query
+                .limit
+                .and_then(|limit| usize::try_from(limit).ok())
+                .unwrap_or(usize::MAX);
             Ok(self
                 .events
                 .borrow()
                 .iter()
                 .filter(|event| event.session_id == query.session_id)
                 .filter(|event| query.after_seq.map(|seq| event.seq > seq).unwrap_or(true))
+                .take(limit)
                 .cloned()
                 .collect())
         }
@@ -6581,6 +6602,48 @@ mod tests {
         assert_eq!(
             app.last_event_seq, None,
             "active-session swap during a batch must stop the loop from advancing the cursor past the swap"
+        );
+    }
+
+    #[test]
+    fn poll_session_events_drains_more_than_513_events_in_bounded_pages() {
+        let client = RecordingChatClient::default();
+        let (mut app, mirror) = app_with_client(client);
+        app.active_session_id = Some("session-1".to_string());
+        mirror
+            .events
+            .borrow_mut()
+            .extend((1..=514).map(|seq| EventRecord {
+                seq,
+                id: format!("event-{seq}"),
+                session_id: "session-1".to_string(),
+                kind: "output".to_string(),
+                payload_json: serde_json::json!({ "data": format!("{seq}\n") }).to_string(),
+                created_at: "2026-05-19T00:00:00Z".to_string(),
+            }));
+
+        assert!(app.poll_session_events());
+
+        assert_eq!(app.last_event_seq, Some(514));
+        assert_eq!(
+            mirror
+                .calls
+                .borrow()
+                .iter()
+                .filter(|call| call.starts_with("events:session-1:"))
+                .cloned()
+                .collect::<Vec<_>>(),
+            vec![
+                "events:session-1:0".to_string(),
+                "events:session-1:512".to_string(),
+            ]
+        );
+        assert_eq!(
+            &*mirror.event_limits.borrow(),
+            &[
+                Some(crate::tui::chat::client::EVENT_PAGE_LIMIT),
+                Some(crate::tui::chat::client::EVENT_PAGE_LIMIT),
+            ]
         );
     }
 

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -5,21 +5,18 @@
 //! ritual verbs use the shared store path/timestamp helpers because they are
 //! ledger-only mutations.
 
-#[cfg(unix)]
-use std::io::Read;
-#[cfg(any(unix, windows))]
-use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-#[cfg(any(unix, windows))]
-use anyhow::anyhow;
 use anyhow::{Context, Result};
-use serde::Deserialize;
 use serde_json::{json, Value};
 use uuid::Uuid;
 
+use coven_client::{
+    ClientError, DaemonClient, DaemonEndpoint, ReadEndpoint, WriteEndpoint, PROTOCOL_VERSION,
+};
+
 use crate::{
-    api::{EventsResponse, HealthResponse, SessionPageResponse, COVEN_API_NAMED_VERSION},
+    api::{EventsResponse, SessionPageResponse},
     current_timestamp, daemon, harness, store, STORE_FILE_NAME,
 };
 
@@ -98,12 +95,33 @@ pub(crate) struct ChatEventQuery<'a> {
     pub(crate) limit: Option<i64>,
 }
 
+pub(crate) const EVENT_PAGE_LIMIT: i64 = 512;
+pub(crate) const EVENT_PAGES_PER_POLL: usize = 8;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ChatEventPage {
+    pub(crate) events: Vec<store::EventRecord>,
+    pub(crate) next_after_seq: Option<i64>,
+    pub(crate) has_more: bool,
+}
+
 pub(crate) trait ChatClient {
     fn daemon_status(&mut self) -> Result<ChatDaemonStatus>;
     fn launch_session(&mut self, request: LaunchRequest) -> Result<store::SessionRecord>;
     fn get_session(&mut self, session_id: &str) -> Result<store::SessionRecord>;
     fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>>;
     fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>>;
+    fn list_event_page(&mut self, query: ChatEventQuery<'_>) -> Result<ChatEventPage> {
+        let requested_limit = query.limit;
+        let events = self.list_events(query)?;
+        let next_after_seq = events.last().map(|event| event.seq);
+        let has_more = requested_limit.is_some_and(|limit| events.len() as i64 >= limit);
+        Ok(ChatEventPage {
+            events,
+            next_after_seq,
+            has_more,
+        })
+    }
     fn send_input(&mut self, session_id: &str, data: &str) -> Result<()>;
     fn kill_session(&mut self, session_id: &str) -> Result<()>;
     fn archive_session(&mut self, session_id: &str) -> Result<()>;
@@ -111,9 +129,82 @@ pub(crate) trait ChatClient {
     fn sacrifice_session(&mut self, session_id: &str) -> Result<()>;
 }
 
+pub(crate) fn validated_event_page_cursor(
+    requested_after_seq: Option<i64>,
+    page: &ChatEventPage,
+) -> Result<Option<i64>> {
+    let mut cursor = requested_after_seq;
+    for event in &page.events {
+        if cursor.is_some_and(|previous| event.seq <= previous) {
+            anyhow::bail!(
+                "daemon event page was not strictly ordered after sequence {}",
+                cursor.expect("checked cursor")
+            );
+        }
+        cursor = Some(event.seq);
+    }
+
+    let expected_cursor = page.events.last().map(|event| event.seq);
+    if page.next_after_seq != expected_cursor {
+        anyhow::bail!("daemon event page returned an inconsistent continuation cursor");
+    }
+    if page.has_more && page.events.is_empty() {
+        anyhow::bail!("daemon event page claimed a continuation without advancing its cursor");
+    }
+    Ok(cursor)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EventPageControl {
+    Continue,
+    Cancel,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct EventPageStreamStats {
+    pub(crate) completed: bool,
+    pub(crate) pages: usize,
+    pub(crate) events: usize,
+    pub(crate) peak_buffered_events: usize,
+}
+
+pub(crate) fn consume_event_pages<F>(
+    client: &mut dyn ChatClient,
+    session_id: &str,
+    mut consume: F,
+) -> Result<EventPageStreamStats>
+where
+    F: FnMut(&[store::EventRecord]) -> Result<EventPageControl>,
+{
+    let mut after_seq = None;
+    let mut stats = EventPageStreamStats::default();
+    loop {
+        let page = client.list_event_page(ChatEventQuery {
+            session_id,
+            after_seq,
+            limit: Some(EVENT_PAGE_LIMIT),
+        })?;
+        let next_after_seq = validated_event_page_cursor(after_seq, &page)?;
+        let has_more = page.has_more;
+        stats.pages += 1;
+        stats.events = stats.events.saturating_add(page.events.len());
+        stats.peak_buffered_events = stats.peak_buffered_events.max(page.events.len());
+        if consume(&page.events)? == EventPageControl::Cancel {
+            return Ok(stats);
+        }
+        if !has_more {
+            stats.completed = true;
+            return Ok(stats);
+        }
+        after_seq = next_after_seq;
+    }
+}
+
 pub(crate) struct DaemonChatClient {
     coven_home: PathBuf,
     api_checked: bool,
+    daemon_client: Option<DaemonClient>,
+    daemon_identity: Option<daemon::DaemonStatus>,
 }
 
 impl DaemonChatClient {
@@ -123,6 +214,8 @@ impl DaemonChatClient {
         Ok(Self {
             coven_home: crate::paths::coven_home_dir()?,
             api_checked: false,
+            daemon_client: None,
+            daemon_identity: None,
         })
     }
 
@@ -133,6 +226,8 @@ impl DaemonChatClient {
         Self {
             coven_home,
             api_checked: false,
+            daemon_client: None,
+            daemon_identity: None,
         }
     }
 }
@@ -146,87 +241,215 @@ impl DaemonChatClient {
         store::open_store(&self.store_path())
     }
 
-    fn request_json<T: for<'de> Deserialize<'de>>(
-        &mut self,
-        method: &str,
-        path: &str,
-        body: Option<Value>,
-    ) -> Result<T> {
-        let response = self.request(method, path, body)?;
-        serde_json::from_str(&response.body).with_context(|| {
-            format!(
-                "failed to parse Coven daemon response for {method} {path}: {}",
-                response.body
-            )
-        })
-    }
-
-    fn request_empty(&mut self, method: &str, path: &str, body: Option<Value>) -> Result<()> {
-        self.request(method, path, body).map(|_| ())
-    }
-
-    fn request(&mut self, method: &str, path: &str, body: Option<Value>) -> Result<HttpResponse> {
-        if path != "/api/v1/health" {
-            self.ensure_api_contract()?;
+    fn daemon_client(&mut self) -> Result<&mut DaemonClient> {
+        if self.daemon_client.is_none() {
+            let endpoint = DaemonEndpoint::discover(&self.coven_home)
+                .map_err(|error| cli_error(error, &self.coven_home))?;
+            self.daemon_client = Some(DaemonClient::new(endpoint));
         }
-        self.raw_request(method, path, body)
+        Ok(self
+            .daemon_client
+            .as_mut()
+            .expect("daemon client initialized"))
     }
 
-    fn raw_request(&self, method: &str, path: &str, body: Option<Value>) -> Result<HttpResponse> {
-        request_daemon(&self.coven_home, method, path, body)
+    fn get_json<T: serde::de::DeserializeOwned>(&mut self, endpoint: ReadEndpoint) -> Result<T> {
+        self.ensure_api_contract()?;
+        match self.daemon_client()?.get_json(endpoint.clone()) {
+            Ok(value) => Ok(value),
+            Err(error) if safe_request_may_retry(&error) => {
+                self.invalidate_daemon_cache();
+                self.ensure_api_contract()?;
+                let result = self.daemon_client()?.get_json(endpoint);
+                match result {
+                    Ok(value) => Ok(value),
+                    Err(error) => Err(self.read_error(error)),
+                }
+            }
+            Err(error) => Err(self.read_error(error)),
+        }
+    }
+
+    fn post_json<T: serde::de::DeserializeOwned>(
+        &mut self,
+        endpoint: WriteEndpoint,
+        body: &Value,
+    ) -> Result<T> {
+        self.ensure_api_contract()?;
+        match self.daemon_client()?.post_json(endpoint.clone(), body) {
+            Ok(value) => Ok(value),
+            Err(error) if mutation_was_definitely_not_sent(&error) => {
+                self.invalidate_daemon_cache();
+                self.ensure_api_contract()?;
+                match self.daemon_client()?.post_json(endpoint, body) {
+                    Ok(value) => Ok(value),
+                    Err(error) => Err(self.mutation_error(error)),
+                }
+            }
+            Err(error) => Err(self.mutation_error(error)),
+        }
+    }
+
+    fn post_empty(&mut self, endpoint: WriteEndpoint, body: &Value) -> Result<()> {
+        self.ensure_api_contract()?;
+        match self.daemon_client()?.post_empty(endpoint.clone(), body) {
+            Ok(()) => Ok(()),
+            Err(error) if mutation_was_definitely_not_sent(&error) => {
+                self.invalidate_daemon_cache();
+                self.ensure_api_contract()?;
+                match self.daemon_client()?.post_empty(endpoint, body) {
+                    Ok(()) => Ok(()),
+                    Err(error) => Err(self.mutation_error(error)),
+                }
+            }
+            Err(error) => Err(self.mutation_error(error)),
+        }
     }
 
     fn ensure_api_contract(&mut self) -> Result<()> {
+        self.invalidate_if_daemon_identity_changed()?;
         if self.api_checked {
             return Ok(());
         }
 
-        let current_exe =
-            std::env::current_exe().context("failed to resolve current executable")?;
-        daemon::ensure_background_server(&self.coven_home, &current_exe, current_timestamp())
-            .context("failed to start Coven daemon")?;
-        let response = self.raw_request("GET", "/api/v1/health", None)?;
-        let health: HealthResponse = serde_json::from_str(&response.body).with_context(|| {
-            format!(
-                "failed to parse Coven daemon response for GET /api/v1/health: {}",
-                response.body
+        let mut retried_health = false;
+        loop {
+            let current_exe =
+                std::env::current_exe().context("failed to resolve current executable")?;
+            let status = daemon::ensure_background_server(
+                &self.coven_home,
+                &current_exe,
+                current_timestamp(),
             )
-        })?;
-        if health.api_version != COVEN_API_NAMED_VERSION {
-            anyhow::bail!(
-                "Coven daemon API mismatch: expected {COVEN_API_NAMED_VERSION}, got {}",
-                health.api_version
-            );
+            .context("failed to start Coven daemon")?;
+            let endpoint = DaemonEndpoint::discover(&self.coven_home)
+                .map_err(|error| cli_error(error, &self.coven_home))?;
+            let mut client = DaemonClient::new(endpoint);
+            match client.health() {
+                Ok(_) => {
+                    self.daemon_client = Some(client);
+                    self.daemon_identity = Some(status);
+                    self.api_checked = true;
+                    return Ok(());
+                }
+                Err(error) if !retried_health && safe_request_may_retry(&error) => {
+                    retried_health = true;
+                    self.invalidate_daemon_cache();
+                }
+                Err(error) => {
+                    self.invalidate_daemon_cache();
+                    return Err(cli_error(error, &self.coven_home));
+                }
+            }
         }
-        self.api_checked = true;
+    }
+
+    fn invalidate_if_daemon_identity_changed(&mut self) -> Result<()> {
+        if !self.api_checked {
+            return Ok(());
+        }
+        let current = daemon::read_status_synchronized(&self.coven_home)?;
+        if current.as_ref() != self.daemon_identity.as_ref() {
+            self.invalidate_daemon_cache();
+        }
         Ok(())
     }
+
+    fn invalidate_daemon_cache(&mut self) {
+        self.api_checked = false;
+        self.daemon_client = None;
+        self.daemon_identity = None;
+    }
+
+    fn read_error(&mut self, error: ClientError) -> anyhow::Error {
+        if safe_request_may_retry(&error) {
+            self.invalidate_daemon_cache();
+        }
+        cli_error(error, &self.coven_home)
+    }
+
+    fn mutation_error(&mut self, error: ClientError) -> anyhow::Error {
+        if mutation_outcome_is_ambiguous(&error) {
+            self.invalidate_daemon_cache();
+            anyhow::Error::new(error).context(
+                "Coven daemon mutation outcome is unknown; reconcile daemon session state before retrying",
+            )
+        } else {
+            if mutation_was_definitely_not_sent(&error) {
+                self.invalidate_daemon_cache();
+            }
+            cli_error(error, &self.coven_home)
+        }
+    }
+}
+
+fn safe_request_may_retry(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Io { .. }
+            | ClientError::InvalidHttpResponse(_)
+            // Unix/Windows transports only raise `DaemonInstanceChanged` while
+            // confirming peer identity during connect, strictly before any
+            // request bytes are written, so it is always safe to rediscover
+            // and retry once.
+            | ClientError::DaemonInstanceChanged
+    )
+}
+
+fn mutation_was_definitely_not_sent(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Io {
+            operation: "failed to connect to Coven daemon socket"
+                | "failed to connect to Coven daemon pipe"
+                | "failed to configure nonblocking Coven daemon socket writes"
+                | "failed to configure nonblocking Coven daemon pipe writes",
+            ..
+        }
+            // Same connect-time-only guarantee as above: no mutation bytes
+            // can have reached the daemon yet, so a single retry against the
+            // rediscovered/renegotiated endpoint cannot duplicate the send.
+            | ClientError::DaemonInstanceChanged
+    )
+}
+
+fn mutation_outcome_is_ambiguous(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Io { .. }
+            | ClientError::InvalidHttpResponse(_)
+            | ClientError::ResponseTooLarge { .. }
+            | ClientError::InvalidUtf8(_)
+            | ClientError::InvalidJson(_)
+    ) && !mutation_was_definitely_not_sent(error)
 }
 
 impl ChatClient for DaemonChatClient {
     fn daemon_status(&mut self) -> Result<ChatDaemonStatus> {
         match daemon::background_server_status(&self.coven_home)? {
             Some(daemon::DaemonStatusState::Running(status)) => {
-                let response = match self.raw_request("GET", "/api/v1/health", None) {
-                    Ok(response) => response,
+                let endpoint = match DaemonEndpoint::discover(&self.coven_home) {
+                    Ok(endpoint) => endpoint,
                     Err(error) => {
                         return Ok(ChatDaemonStatus::Unavailable {
-                            message: error.to_string(),
+                            message: cli_error(error, &self.coven_home).to_string(),
                         })
                     }
                 };
-                let health: HealthResponse =
-                    serde_json::from_str(&response.body).with_context(|| {
-                        format!(
-                            "failed to parse Coven daemon response for GET /api/v1/health: {}",
-                            response.body
-                        )
-                    })?;
-                if health.api_version != COVEN_API_NAMED_VERSION {
-                    return Ok(ChatDaemonStatus::ApiMismatch {
-                        expected: COVEN_API_NAMED_VERSION.to_string(),
-                        actual: health.api_version,
-                    });
+                let mut client = DaemonClient::new(endpoint);
+                match client.health() {
+                    Ok(_) => {}
+                    Err(ClientError::ProtocolVersion { actual, .. }) => {
+                        return Ok(ChatDaemonStatus::ApiMismatch {
+                            expected: PROTOCOL_VERSION.to_string(),
+                            actual,
+                        });
+                    }
+                    Err(error) => {
+                        return Ok(ChatDaemonStatus::Unavailable {
+                            message: cli_error(error, &self.coven_home).to_string(),
+                        })
+                    }
                 }
                 Ok(ChatDaemonStatus::Running { pid: status.pid })
             }
@@ -264,44 +487,53 @@ impl ChatClient for DaemonChatClient {
                 .expect("json! literal is an object")
                 .insert("conversationId".to_string(), json!(conversation_id));
         }
-        self.request_json("POST", "/api/v1/sessions", Some(body))
+        self.post_json(WriteEndpoint::Sessions, &body)
     }
 
     fn get_session(&mut self, session_id: &str) -> Result<store::SessionRecord> {
-        self.request_json("GET", &format!("/api/v1/sessions/{session_id}"), None)
+        self.get_json(ReadEndpoint::Session {
+            session_id: session_id.to_string(),
+        })
     }
 
     fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
         let page: SessionPageResponse =
-            self.request_json("GET", "/api/v1/sessions?limit=100", None)?;
+            self.get_json(ReadEndpoint::Sessions { limit: Some(100) })?;
         Ok(page.sessions)
     }
 
     fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {
-        let mut path = format!("/api/v1/events?sessionId={}", query.session_id);
-        if let Some(after_seq) = query.after_seq {
-            path.push_str(&format!("&afterSeq={after_seq}"));
-        }
-        if let Some(limit) = query.limit {
-            path.push_str(&format!("&limit={limit}"));
-        }
-        let response: EventsResponse = self.request_json("GET", &path, None)?;
-        Ok(response.events)
+        Ok(self.list_event_page(query)?.events)
+    }
+
+    fn list_event_page(&mut self, query: ChatEventQuery<'_>) -> Result<ChatEventPage> {
+        let response: EventsResponse = self.get_json(ReadEndpoint::Events {
+            session_id: query.session_id.to_string(),
+            after_seq: query.after_seq,
+            limit: query.limit,
+        })?;
+        Ok(ChatEventPage {
+            events: response.events,
+            next_after_seq: response.next_cursor.map(|cursor| cursor.after_seq),
+            has_more: response.has_more,
+        })
     }
 
     fn send_input(&mut self, session_id: &str, data: &str) -> Result<()> {
-        self.request_empty(
-            "POST",
-            &format!("/api/v1/sessions/{session_id}/input"),
-            Some(json!({ "data": data })),
+        self.post_empty(
+            WriteEndpoint::SessionInput {
+                session_id: session_id.to_string(),
+            },
+            &json!({ "data": data }),
         )
     }
 
     fn kill_session(&mut self, session_id: &str) -> Result<()> {
-        self.request_empty(
-            "POST",
-            &format!("/api/v1/sessions/{session_id}/kill"),
-            Some(json!({})),
+        self.post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: session_id.to_string(),
+            },
+            &json!({}),
         )
     }
 
@@ -337,141 +569,56 @@ impl ChatClient for DaemonChatClient {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-struct HttpResponse {
-    status: u16,
-    body: String,
-}
-
-#[cfg(unix)]
-fn request_daemon(
-    coven_home: &Path,
-    method: &str,
-    path: &str,
-    body: Option<Value>,
-) -> Result<HttpResponse> {
-    use std::os::unix::net::UnixStream;
-
-    let socket = daemon::daemon_socket_path(coven_home);
-    let body = body.map(|value| value.to_string()).unwrap_or_default();
-    let request = format!(
-        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    let mut stream = UnixStream::connect(&socket).with_context(|| {
-        format!(
-            "failed to connect to Coven daemon socket {}; run `coven daemon start` and retry",
-            socket.display()
-        )
-    })?;
-    stream
-        .write_all(request.as_bytes())
-        .context("failed to write Coven daemon request")?;
-    stream
-        .shutdown(std::net::Shutdown::Write)
-        .context("failed to finish Coven daemon request")?;
-    let mut response = String::new();
-    stream
-        .read_to_string(&mut response)
-        .context("failed to read Coven daemon response")?;
-    parse_http_response(&response)
-}
-
-#[cfg(windows)]
-fn request_daemon(
-    coven_home: &Path,
-    method: &str,
-    path: &str,
-    body: Option<Value>,
-) -> Result<HttpResponse> {
-    use interprocess::{
-        local_socket::{prelude::*, ConnectOptions, GenericNamespaced},
-        ConnectWaitMode,
-    };
-    use std::time::Duration;
-
-    let body = body.map(|value| value.to_string()).unwrap_or_default();
-    let request = format!(
-        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    let pipe_name = daemon::windows_pipe_name(coven_home);
-    let name = pipe_name
-        .clone()
-        .to_ns_name::<GenericNamespaced>()
-        .context("failed to parse Coven daemon pipe name")?;
-    let mut stream = ConnectOptions::new()
-        .name(name)
-        .wait_mode(ConnectWaitMode::Timeout(Duration::from_secs(5)))
-        .connect_sync()
-        .with_context(|| {
-            format!(
-                "failed to connect to Coven daemon pipe {pipe_name}; run `coven daemon start` and retry"
+fn cli_error(error: ClientError, coven_home: &std::path::Path) -> anyhow::Error {
+    match error {
+        ClientError::Daemon { status, error } => {
+            anyhow::anyhow!(
+                "Coven daemon rejected request with HTTP {status}: {}",
+                error.message
             )
-        })?;
-    stream
-        .write_all(request.as_bytes())
-        .context("failed to write Coven daemon request")?;
-    stream
-        .flush()
-        .context("failed to flush Coven daemon request")?;
-    let (status, body) = daemon::read_windows_pipe_http_response(
-        stream,
-        Duration::from_secs(5),
-        daemon::MAX_SOCKET_BODY_BYTES,
-    )?;
-    let body = String::from_utf8(body).context("Coven daemon response body was not UTF-8")?;
-    if !(200..300).contains(&status) {
-        return Err(daemon_error(status, &body));
-    }
-    Ok(HttpResponse { status, body })
-}
-
-#[cfg(not(any(unix, windows)))]
-fn request_daemon(
-    _coven_home: &Path,
-    _method: &str,
-    _path: &str,
-    _body: Option<Value>,
-) -> Result<HttpResponse> {
-    anyhow::bail!("Coven daemon chat is not implemented on this platform")
-}
-
-#[cfg(unix)]
-fn parse_http_response(response: &str) -> Result<HttpResponse> {
-    let (head, body) = response
-        .split_once("\r\n\r\n")
-        .or_else(|| response.split_once("\n\n"))
-        .context("invalid Coven daemon HTTP response")?;
-    let status = head
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .and_then(|status| status.parse::<u16>().ok())
-        .context("invalid Coven daemon HTTP status")?;
-    if !(200..300).contains(&status) {
-        return Err(daemon_error(status, body));
-    }
-    Ok(HttpResponse {
-        status,
-        body: body.to_string(),
-    })
-}
-
-#[cfg(any(unix, windows))]
-fn daemon_error(status: u16, body: &str) -> anyhow::Error {
-    if let Ok(value) = serde_json::from_str::<Value>(body) {
-        if let Some(message) = value
-            .get("error")
-            .and_then(|error| error.get("message"))
-            .and_then(Value::as_str)
-        {
-            return anyhow!("Coven daemon rejected request with HTTP {status}: {message}");
         }
+        ClientError::Io {
+            operation: "failed to connect to Coven daemon socket",
+            source,
+        } => {
+            #[cfg(unix)]
+            {
+                let _ = source;
+                anyhow::anyhow!(
+                    "failed to connect to Coven daemon socket {}; run `coven daemon start` and retry",
+                    daemon::daemon_socket_path(coven_home).display()
+                )
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = coven_home;
+                anyhow::anyhow!("failed to connect to Coven daemon: {source}")
+            }
+        }
+        ClientError::Io {
+            operation: "failed to connect to Coven daemon pipe",
+            source,
+        } => {
+            #[cfg(windows)]
+            {
+                let _ = source;
+                match daemon::windows_pipe_name(coven_home) {
+                    Ok(pipe_name) => anyhow::anyhow!(
+                        "failed to connect to Coven daemon pipe {pipe_name}; run `coven daemon start` and retry"
+                    ),
+                    Err(error) => error.context(
+                        "failed to derive the selected Coven profile's daemon pipe identity",
+                    ),
+                }
+            }
+            #[cfg(not(windows))]
+            {
+                let _ = coven_home;
+                anyhow::anyhow!("failed to connect to Coven daemon pipe: {source}")
+            }
+        }
+        error => anyhow::Error::new(error),
     }
-    anyhow!("Coven daemon rejected request with HTTP {status}")
 }
 
 fn session_title(prompt: &str) -> String {
@@ -491,64 +638,741 @@ fn session_title(prompt: &str) -> String {
 mod tests {
     use super::*;
 
-    #[cfg(windows)]
     #[test]
-    fn windows_daemon_client_reads_framed_response_without_waiting_for_pipe_close() -> Result<()> {
-        use interprocess::local_socket::{prelude::*, GenericNamespaced, ListenerOptions};
-        use std::io::{Read, Write};
-        use std::thread;
+    fn event_page_continuation_must_advance_before_another_request() {
+        let page = ChatEventPage {
+            events: Vec::new(),
+            next_after_seq: None,
+            has_more: true,
+        };
+
+        let error = validated_event_page_cursor(Some(513), &page).unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("claimed a continuation without advancing"));
+    }
+
+    #[cfg(unix)]
+    fn test_health(status: &daemon::DaemonStatus) -> String {
+        serde_json::json!({
+            "ok": true,
+            "apiVersion": PROTOCOL_VERSION,
+            "covenVersion": "test",
+            "capabilities": {
+                "sessions": true,
+                "events": true,
+                "eventCursor": "sequence",
+                "structuredErrors": true
+            },
+            "daemon": status
+        })
+        .to_string()
+    }
+
+    #[cfg(unix)]
+    fn read_request_path(stream: &mut std::os::unix::net::UnixStream) -> String {
+        use std::io::Read;
+
+        let mut request = String::new();
+        stream
+            .read_to_string(&mut request)
+            .expect("read test daemon request");
+        request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .expect("request path")
+            .to_owned()
+    }
+
+    #[cfg(unix)]
+    fn write_response(stream: &mut std::os::unix::net::UnixStream, status: u16, body: &str) {
+        use std::io::Write;
+
+        write!(
+            stream,
+            "HTTP/1.1 {status} Test\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        )
+        .expect("write test daemon response");
+    }
+
+    #[cfg(unix)]
+    fn bind_test_daemon(home: &std::path::Path) -> std::os::unix::net::UnixListener {
+        use std::os::unix::fs::PermissionsExt;
+
+        std::fs::set_permissions(home, std::fs::Permissions::from_mode(0o700))
+            .expect("make test Coven home private");
+        let socket = daemon::daemon_socket_path(home);
+        let listener =
+            std::os::unix::net::UnixListener::bind(&socket).expect("bind test daemon socket");
+        std::fs::set_permissions(socket, std::fs::Permissions::from_mode(0o600))
+            .expect("make test daemon socket private");
+        listener
+    }
+
+    /// Reads a request from a connection that may be a pre-write
+    /// `DaemonInstanceChanged` probe: the transport connects, confirms the
+    /// peer/socket identity no longer matches what was negotiated, and
+    /// closes without ever writing request bytes. Such a connection reads as
+    /// empty; a real request always carries a request line.
+    #[cfg(unix)]
+    fn read_request_path_if_present(stream: &mut std::os::unix::net::UnixStream) -> Option<String> {
+        use std::io::Read;
+
+        let mut request = String::new();
+        stream
+            .read_to_string(&mut request)
+            .expect("read test daemon connection");
+        if request.is_empty() {
+            return None;
+        }
+        Some(
+            request
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .expect("request path")
+                .to_owned(),
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cached_legacy_endpoint_is_rediscovered_and_renegotiated_after_stable_restart() -> Result<()>
+    {
         use std::time::{Duration, Instant};
 
-        let home = tempfile::tempdir()?;
-        let name = daemon::windows_pipe_name(home.path())
-            .to_ns_name::<GenericNamespaced>()
-            .context("pipe name")?;
-        let listener = ListenerOptions::new().name(name).create_sync()?;
-        let server = thread::spawn(move || -> Result<()> {
-            let mut stream = listener.incoming().next().context("accept ended")??;
-            let mut request = Vec::new();
-            let mut byte = [0_u8; 1];
-            while !request.ends_with(b"\r\n\r\n") {
-                stream.read_exact(&mut byte)?;
-                request.push(byte[0]);
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let old_listener = bind_test_daemon(&home);
+        let old_status = daemon::DaemonStatus {
+            pid: 41,
+            started_at: "legacy".to_owned(),
+            socket: "coven-daemon-0123456789abcdef.sock".to_owned(),
+            process_creation_time: None,
+        };
+        let old_health = test_health(&old_status);
+        let old_server = std::thread::spawn(move || {
+            let (mut stream, _) = old_listener.accept().expect("accept old health");
+            assert_eq!(read_request_path(&mut stream), "/api/v1/health");
+            write_response(&mut stream, 200, &old_health);
+        });
+        let endpoint = DaemonEndpoint::discover(&home)?;
+        let mut cached = DaemonClient::new(endpoint);
+        cached.health()?;
+        old_server.join().unwrap();
+        std::fs::remove_file(daemon::daemon_socket_path(&home))?;
+
+        let listener = bind_test_daemon(&home);
+        listener.set_nonblocking(true)?;
+        let stable_status = daemon::DaemonStatus {
+            pid: std::process::id(),
+            started_at: "stable".to_owned(),
+            socket: daemon::daemon_socket_path(&std::fs::canonicalize(&home)?)
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        daemon::write_status(&home, &stable_status)?;
+        let health = test_health(&stable_status);
+        let server = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(3);
+            let mut paths = Vec::new();
+            while paths.len() < 3 && Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let path = read_request_path(&mut stream);
+                        let body = if path == "/api/v1/sessions" {
+                            r#"{"source":"stable"}"#
+                        } else {
+                            &health
+                        };
+                        write_response(&mut stream, 200, body);
+                        paths.push(path);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept stable daemon request: {error}"),
+                }
             }
-            stream.write_all(
-                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\nConnection: keep-alive\r\n\r\n{\"ok\":true}",
-            )?;
-            stream.flush()?;
-            thread::sleep(Duration::from_secs(2));
-            Ok(())
+            paths
         });
 
-        let started = Instant::now();
-        let response = request_daemon(home.path(), "GET", "/api/v1/health", None)?;
-        assert_eq!(response.status, 200);
-        assert_eq!(response.body, r#"{"ok":true}"#);
-        assert!(started.elapsed() < Duration::from_millis(1500));
-        server.join().expect("server thread")?;
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(old_status),
+        };
+        let response: Value = client.get_json(ReadEndpoint::Sessions { limit: None })?;
+
+        assert_eq!(response["source"], "stable");
+        assert_eq!(
+            server.join().unwrap(),
+            vec!["/health", "/api/v1/health", "/api/v1/sessions"]
+        );
         Ok(())
     }
 
     #[cfg(unix)]
     #[test]
-    fn parses_successful_http_response_body() -> Result<()> {
-        let response =
-            parse_http_response("HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n{\"ok\":true}")?;
+    fn ambiguous_mutation_failure_is_not_replayed() -> Result<()> {
+        use std::time::{Duration, Instant};
 
-        assert_eq!(response.status, 200);
-        assert_eq!(response.body, r#"{"ok":true}"#);
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let listener = bind_test_daemon(&home);
+        let status = daemon::DaemonStatus {
+            pid: std::process::id(),
+            started_at: "stable".to_owned(),
+            socket: daemon::daemon_socket_path(&home)
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        daemon::write_status(&home, &status)?;
+        let health = test_health(&status);
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept initial health");
+            assert_eq!(read_request_path(&mut stream), "/api/v1/health");
+            write_response(&mut stream, 200, &health);
+
+            let (mut stream, _) = listener.accept().expect("accept mutation");
+            assert!(read_request_path(&mut stream).ends_with("/kill"));
+            drop(stream);
+
+            listener
+                .set_nonblocking(true)
+                .expect("make listener nonblocking");
+            let deadline = Instant::now() + Duration::from_millis(400);
+            let mut duplicate = false;
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((_stream, _)) => {
+                        duplicate = true;
+                        break;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("check duplicate mutation: {error}"),
+                }
+            }
+            duplicate
+        });
+
+        let endpoint = DaemonEndpoint::discover(&home)?;
+        let mut cached = DaemonClient::new(endpoint);
+        cached.health()?;
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(status),
+        };
+
+        let error = client
+            .post_empty(
+                WriteEndpoint::SessionKill {
+                    session_id: "session-1".to_owned(),
+                },
+                &json!({}),
+            )
+            .expect_err("closed response leaves mutation outcome ambiguous");
+
+        assert!(
+            error.to_string().contains("reconcile"),
+            "mutation error must require reconciliation: {error:#}"
+        );
+        assert!(!server.join().unwrap(), "mutation was replayed");
+        Ok(())
+    }
+
+    #[test]
+    fn mutations_retry_only_when_transport_proves_no_request_bytes_were_sent() {
+        let io_error = |operation| ClientError::Io {
+            operation,
+            source: std::io::Error::from(std::io::ErrorKind::ConnectionReset),
+        };
+
+        assert!(mutation_was_definitely_not_sent(&io_error(
+            "failed to connect to Coven daemon socket"
+        )));
+        assert!(!mutation_was_definitely_not_sent(&io_error(
+            "failed to write Coven daemon request"
+        )));
+        assert!(mutation_outcome_is_ambiguous(&io_error(
+            "failed to read Coven daemon response"
+        )));
+    }
+
+    #[test]
+    fn daemon_instance_changed_is_safe_to_retry_and_never_ambiguous() {
+        // Both Unix and Windows transports only ever raise this error while
+        // confirming peer identity during connect, strictly before any
+        // request bytes are written.
+        assert!(safe_request_may_retry(&ClientError::DaemonInstanceChanged));
+        assert!(mutation_was_definitely_not_sent(
+            &ClientError::DaemonInstanceChanged
+        ));
+        assert!(!mutation_outcome_is_ambiguous(
+            &ClientError::DaemonInstanceChanged
+        ));
+    }
+
+    /// Sets up an original daemon health negotiation, then swaps the socket
+    /// for a fresh listener bound at the same path without touching the
+    /// on-disk `DaemonStatus` file. This mirrors the narrow window in which
+    /// a real daemon replacement outruns the identity file: the cached
+    /// client's negotiated peer identity (socket device/inode) no longer
+    /// matches what a live connect confirms, so the transport raises
+    /// `DaemonInstanceChanged` before writing any request bytes.
+    #[cfg(unix)]
+    fn setup_swapped_daemon_instance(
+        home: &std::path::Path,
+    ) -> Result<(DaemonClient, daemon::DaemonStatus, String)> {
+        let original_listener = bind_test_daemon(home);
+        let status = daemon::DaemonStatus {
+            pid: std::process::id(),
+            started_at: "stable".to_owned(),
+            socket: daemon::daemon_socket_path(&std::fs::canonicalize(home)?)
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        daemon::write_status(home, &status)?;
+        let health = test_health(&status);
+        let original_health = health.clone();
+        let original_server = std::thread::spawn(move || {
+            let (mut stream, _) = original_listener.accept().expect("accept original health");
+            assert_eq!(read_request_path(&mut stream), "/api/v1/health");
+            write_response(&mut stream, 200, &original_health);
+        });
+
+        let endpoint = DaemonEndpoint::discover(home)?;
+        let mut cached = DaemonClient::new(endpoint);
+        cached.health()?;
+        original_server.join().unwrap();
+
+        std::fs::remove_file(daemon::daemon_socket_path(home))?;
+        Ok((cached, status, health))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_instance_change_retries_once_for_reads() -> Result<()> {
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let (cached, status, health) = setup_swapped_daemon_instance(&home)?;
+
+        let replacement_listener = bind_test_daemon(&home);
+        let sessions_body = r#"{"source":"replacement"}"#;
+        let replacement_server = std::thread::spawn(move || {
+            let mut real_paths = Vec::new();
+            while real_paths.len() < 3 {
+                let (mut stream, _) = replacement_listener
+                    .accept()
+                    .expect("accept replacement connection");
+                match read_request_path_if_present(&mut stream) {
+                    None => continue, // pre-write DaemonInstanceChanged probe
+                    Some(path) => {
+                        let body = if path == "/health" || path == "/api/v1/health" {
+                            &health
+                        } else {
+                            sessions_body
+                        };
+                        write_response(&mut stream, 200, body);
+                        real_paths.push(path);
+                    }
+                }
+            }
+            real_paths
+        });
+
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(status),
+        };
+        let response: Value = client.get_json(ReadEndpoint::Sessions { limit: None })?;
+
+        assert_eq!(response["source"], "replacement");
+        assert_eq!(
+            replacement_server.join().unwrap(),
+            vec!["/health", "/api/v1/health", "/api/v1/sessions"]
+        );
         Ok(())
     }
 
     #[cfg(unix)]
     #[test]
-    fn turns_structured_daemon_errors_into_readable_errors() {
-        let error = parse_http_response(
-            "HTTP/1.1 409 Conflict\r\n\r\n{\"error\":{\"message\":\"Session is not live.\"}}",
-        )
-        .unwrap_err();
+    fn cached_negative_capability_renegotiates_once_after_daemon_replacement() -> Result<()> {
+        use std::time::{Duration, Instant};
 
-        assert!(error.to_string().contains("Session is not live."));
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let original_listener = bind_test_daemon(&home);
+        let status = daemon::DaemonStatus {
+            pid: std::process::id(),
+            started_at: "stable".to_owned(),
+            socket: daemon::daemon_socket_path(&std::fs::canonicalize(&home)?)
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        daemon::write_status(&home, &status)?;
+        let mut incapable_health: Value = serde_json::from_str(&test_health(&status))?;
+        incapable_health["capabilities"]["sessions"] = Value::Bool(false);
+        let incapable_health = incapable_health.to_string();
+        let original_server = std::thread::spawn(move || {
+            let (mut stream, _) = original_listener.accept().expect("accept original health");
+            assert_eq!(read_request_path(&mut stream), "/api/v1/health");
+            write_response(&mut stream, 200, &incapable_health);
+        });
+        let endpoint = DaemonEndpoint::discover(&home)?;
+        let mut cached = DaemonClient::new(endpoint);
+        cached.health()?;
+        original_server.join().unwrap();
+        std::fs::remove_file(daemon::daemon_socket_path(&home))?;
+
+        let replacement = bind_test_daemon(&home);
+        replacement.set_nonblocking(true)?;
+        let replacement_health = test_health(&status);
+        let replacement_server = std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut empty_checks = 0;
+            let mut paths = Vec::new();
+            while Instant::now() < deadline && paths.len() < 3 {
+                match replacement.accept() {
+                    Ok((mut stream, _)) => match read_request_path_if_present(&mut stream) {
+                        None => empty_checks += 1,
+                        Some(path) => {
+                            let body = if path == "/api/v1/sessions" {
+                                r#"{"source":"replacement"}"#
+                            } else {
+                                &replacement_health
+                            };
+                            write_response(&mut stream, 200, body);
+                            paths.push(path);
+                        }
+                    },
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("accept replacement connection: {error}"),
+                }
+            }
+            (empty_checks, paths)
+        });
+
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(status),
+        };
+        let response = client.get_json::<Value>(ReadEndpoint::Sessions { limit: None });
+        let (empty_checks, paths) = replacement_server.join().unwrap();
+
+        assert_eq!(response?["source"], "replacement");
+        assert_eq!(empty_checks, 1);
+        assert_eq!(paths, vec!["/health", "/api/v1/health", "/api/v1/sessions"]);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn cached_negative_capability_on_unchanged_daemon_does_not_retry_or_send_request() -> Result<()>
+    {
+        use std::time::{Duration, Instant};
+
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let listener = bind_test_daemon(&home);
+        let status = daemon::DaemonStatus {
+            pid: std::process::id(),
+            started_at: "stable".to_owned(),
+            socket: daemon::daemon_socket_path(&std::fs::canonicalize(&home)?)
+                .to_string_lossy()
+                .into_owned(),
+            process_creation_time: None,
+        };
+        daemon::write_status(&home, &status)?;
+        let mut incapable_health: Value = serde_json::from_str(&test_health(&status))?;
+        incapable_health["capabilities"]["sessions"] = Value::Bool(false);
+        let incapable_health = incapable_health.to_string();
+        let server = std::thread::spawn(move || {
+            let (mut health, _) = listener.accept().expect("accept original health");
+            assert_eq!(read_request_path(&mut health), "/api/v1/health");
+            write_response(&mut health, 200, &incapable_health);
+
+            listener
+                .set_nonblocking(true)
+                .expect("make test listener nonblocking");
+            let deadline = Instant::now() + Duration::from_millis(500);
+            let mut requests = Vec::new();
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        requests.push(read_request_path_if_present(&mut stream));
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("check unchanged daemon requests: {error}"),
+                }
+            }
+            requests
+        });
+        let endpoint = DaemonEndpoint::discover(&home)?;
+        let mut cached = DaemonClient::new(endpoint);
+        cached.health()?;
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(status),
+        };
+
+        let error = client
+            .get_json::<Value>(ReadEndpoint::Sessions { limit: None })
+            .expect_err("unchanged incapable daemon must remain unavailable");
+        let requests = server.join().unwrap();
+
+        assert!(error.to_string().contains("capabilities.sessions"));
+        assert_eq!(requests, vec![None]);
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_instance_change_retries_once_for_mutations_without_duplicate_send() -> Result<()> {
+        use std::time::{Duration, Instant};
+
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let (cached, status, health) = setup_swapped_daemon_instance(&home)?;
+
+        let replacement_listener = bind_test_daemon(&home);
+        let replacement_server = std::thread::spawn(move || {
+            let mut real_paths = Vec::new();
+            while real_paths.len() < 3 {
+                let (mut stream, _) = replacement_listener
+                    .accept()
+                    .expect("accept replacement connection");
+                match read_request_path_if_present(&mut stream) {
+                    None => continue, // pre-write DaemonInstanceChanged probe
+                    Some(path) => {
+                        let body = if path == "/health" || path == "/api/v1/health" {
+                            &health
+                        } else {
+                            "{}"
+                        };
+                        write_response(&mut stream, 200, body);
+                        real_paths.push(path);
+                    }
+                }
+            }
+
+            // Prove there is no duplicate send: no further connection
+            // (i.e. a second kill request) ever arrives after the retry.
+            replacement_listener
+                .set_nonblocking(true)
+                .expect("make listener nonblocking");
+            let deadline = Instant::now() + Duration::from_millis(300);
+            let mut duplicate = false;
+            while Instant::now() < deadline {
+                match replacement_listener.accept() {
+                    Ok((_stream, _)) => {
+                        duplicate = true;
+                        break;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("check duplicate mutation: {error}"),
+                }
+            }
+            (real_paths, duplicate)
+        });
+
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(status),
+        };
+        client.post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "session-1".to_owned(),
+            },
+            &json!({}),
+        )?;
+
+        let (real_paths, duplicate) = replacement_server.join().unwrap();
+        assert_eq!(
+            real_paths,
+            vec![
+                "/health",
+                "/api/v1/health",
+                "/api/v1/sessions/session-1/kill"
+            ]
+        );
+        assert!(!duplicate, "mutation was sent more than once");
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn daemon_instance_change_retry_is_bounded_when_replacement_changes_again() -> Result<()> {
+        use std::time::{Duration, Instant};
+
+        let temp = tempfile::tempdir()?;
+        let home = temp.path().to_path_buf();
+        let (cached, status, health) = setup_swapped_daemon_instance(&home)?;
+
+        let home_for_thread = home.clone();
+        let first_replacement = bind_test_daemon(&home);
+        let replacement_server = std::thread::spawn(move || {
+            // First connection against the first replacement: a pre-write
+            // probe against the still-cached (original) identity.
+            let (mut probe, _) = first_replacement
+                .accept()
+                .expect("accept first replacement probe");
+            assert!(
+                read_request_path_if_present(&mut probe).is_none(),
+                "expected a pre-write DaemonInstanceChanged probe with no request bytes"
+            );
+
+            // Second connection: the legacy liveness probe `ensure_background_server`
+            // issues while confirming the recorded daemon is still alive before
+            // renegotiating.
+            let (mut legacy_health, _) = first_replacement
+                .accept()
+                .expect("accept legacy health probe");
+            assert_eq!(read_request_path(&mut legacy_health), "/health");
+            write_response(&mut legacy_health, 200, &health);
+
+            // Third connection: the real health renegotiation against the
+            // first replacement. The response is deferred until after the
+            // daemon is swapped again below, guaranteeing (by program
+            // order, not timing) that the retried mutation attempt below
+            // observes the *second* replacement rather than racing it.
+            let (mut health_stream, _) = first_replacement
+                .accept()
+                .expect("accept replacement health");
+            assert_eq!(read_request_path(&mut health_stream), "/api/v1/health");
+
+            drop(first_replacement);
+            std::fs::remove_file(daemon::daemon_socket_path(&home_for_thread))
+                .expect("remove first replacement socket");
+            let second_replacement = bind_test_daemon(&home_for_thread);
+
+            write_response(&mut health_stream, 200, &health);
+            drop(health_stream);
+
+            // Fourth connection, against the second replacement: another
+            // pre-write probe, since the identity just negotiated against
+            // the first replacement no longer matches.
+            let (mut probe, _) = second_replacement
+                .accept()
+                .expect("accept second replacement probe");
+            assert!(
+                read_request_path_if_present(&mut probe).is_none(),
+                "expected a second pre-write DaemonInstanceChanged probe with no request bytes"
+            );
+
+            // The retry is bounded to one attempt: no fifth connection
+            // (i.e. another retry) should ever arrive.
+            second_replacement
+                .set_nonblocking(true)
+                .expect("make listener nonblocking");
+            let deadline = Instant::now() + Duration::from_millis(300);
+            let mut unbounded_retry = false;
+            while Instant::now() < deadline {
+                match second_replacement.accept() {
+                    Ok((_stream, _)) => {
+                        unbounded_retry = true;
+                        break;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    Err(error) => panic!("check bounded retry: {error}"),
+                }
+            }
+            unbounded_retry
+        });
+
+        let mut client = DaemonChatClient {
+            coven_home: home,
+            api_checked: true,
+            daemon_client: Some(cached),
+            daemon_identity: Some(status),
+        };
+        let error = client
+            .post_empty(
+                WriteEndpoint::SessionKill {
+                    session_id: "session-1".to_owned(),
+                },
+                &json!({}),
+            )
+            .expect_err("a second instance change must fail rather than retry again");
+
+        assert!(
+            !error.to_string().contains("reconcile"),
+            "a pre-write instance change must not be treated as an ambiguous mutation outcome: {error:#}"
+        );
+        assert!(
+            !replacement_server.join().unwrap(),
+            "retry must be bounded to a single attempt"
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_connect_error_keeps_the_pre_extraction_output() {
+        let home = PathBuf::from("/private/coven-test");
+        let error = cli_error(
+            ClientError::Io {
+                operation: "failed to connect to Coven daemon socket",
+                source: std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "ignored"),
+            },
+            &home,
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "failed to connect to Coven daemon socket /private/coven-test/coven.sock; run `coven daemon start` and retry"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_connect_error_keeps_the_pre_extraction_output() -> Result<()> {
+        let home = tempfile::tempdir()?;
+        let error = cli_error(
+            ClientError::Io {
+                operation: "failed to connect to Coven daemon pipe",
+                source: std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "ignored"),
+            },
+            home.path(),
+        );
+        let pipe_name = daemon::windows_pipe_name(home.path())?;
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "failed to connect to Coven daemon pipe {}; run `coven daemon start` and retry",
+                pipe_name
+            )
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/coven-cli/src/tui/shell.rs
+++ b/crates/coven-cli/src/tui/shell.rs
@@ -23,7 +23,9 @@ use super::cast::{
     CAST_QUEST_PHASE_SKIPPED_KIND, CAST_QUEST_PHASE_STARTED_KIND, CAST_QUEST_STARTED_KIND,
     PHASE_PROMPT_HINT,
 };
-use super::chat::client::{ChatClient, ChatEventQuery, DaemonChatClient, LaunchRequest};
+use super::chat::client::{
+    consume_event_pages, ChatClient, DaemonChatClient, EventPageControl, LaunchRequest,
+};
 use super::{is_key_press, sessions};
 use crate::{
     archive_session_command, attach_session, coven_home_dir, coven_store_path, current_timestamp,
@@ -1450,16 +1452,7 @@ fn attach_via_daemon(
         maybe_spawn_cast_input_forwarder(coven_home_dir()?, session.id.clone());
     }
 
-    let replay_history = if is_live {
-        Vec::new()
-    } else {
-        client.list_events(ChatEventQuery {
-            session_id: &session.id,
-            after_seq: None,
-            limit: None,
-        })?
-    };
-
+    let mut replay_state = cast::CastAttachReplayState::default();
     let mut observer = TranscriptObserver::new(io::stdout());
     let exit = if is_live {
         let mut pacer = SleepPacer::new(Duration::from_millis(250));
@@ -1473,7 +1466,17 @@ fn attach_via_daemon(
         // For completed sessions, drain the historical event log once. The
         // follower observer renders the transcript exactly as it did on the
         // original run and reports the exit when it lands in the replay.
-        replay_completed_session(&replay_history, &mut observer)
+        let mut exit = None;
+        let stream = consume_event_pages(&mut client, &session.id, |records| {
+            if let Some(page_exit) =
+                replay_completed_session(records, &mut observer, &mut replay_state)
+            {
+                exit = Some(page_exit);
+            }
+            Ok(EventPageControl::Continue)
+        })?;
+        debug_assert!(stream.completed);
+        exit
     };
 
     if is_live {
@@ -1499,7 +1502,7 @@ fn attach_via_daemon(
         // standard attach outcome — the quest is the user's foreground
         // activity now. Completed quests fall through to the
         // detect-and-inform note that Phase 7 introduced.
-        if let Some(reconstructed) = cast::reconstruct_quest(&replay_history) {
+        if let Some(reconstructed) = replay_state.take_reconstructed_quest() {
             if !reconstructed.is_complete && reconstructed.quest.current_index().is_some() {
                 println!();
                 println!(
@@ -1516,13 +1519,12 @@ fn attach_via_daemon(
             }
         }
 
-        if let Some(note) =
-            cast::find_cast_summary(&replay_history).and_then(|s| format_summary_note(&s))
-        {
+        if let Some(note) = replay_state.summary().and_then(format_summary_note) {
             notes.push(note);
         }
-        if let Some(note) = cast::find_cast_quest_info(&replay_history)
-            .and_then(|info| cast::format_quest_attach_note(&info))
+        if let Some(note) = replay_state
+            .quest_info()
+            .and_then(cast::format_quest_attach_note)
         {
             notes.push(note);
         }
@@ -1569,9 +1571,11 @@ fn attach_via_daemon(
 fn replay_completed_session(
     records: &[store::EventRecord],
     observer: &mut dyn FollowerObserver,
+    replay_state: &mut cast::CastAttachReplayState,
 ) -> Option<CastSessionExit> {
     let mut exit = None;
     for record in records {
+        replay_state.observe(record);
         let decoded = cast::follow::decode_event(record);
         match &decoded {
             cast::follow::CastFollowEvent::Output(chunk) => observer.on_output(chunk),
@@ -2373,8 +2377,9 @@ mod attach_tests {
         ];
         let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut observer = TranscriptObserver::new(&mut buffer);
+        let mut replay_state = cast::CastAttachReplayState::default();
 
-        let exit = replay_completed_session(&records, &mut observer);
+        let exit = replay_completed_session(&records, &mut observer, &mut replay_state);
 
         let rendered = String::from_utf8(buffer.into_inner()).unwrap();
         assert!(
@@ -2403,8 +2408,9 @@ mod attach_tests {
         ];
         let mut buffer: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut observer = TranscriptObserver::new(&mut buffer);
+        let mut replay_state = cast::CastAttachReplayState::default();
 
-        let exit = replay_completed_session(&records, &mut observer);
+        let exit = replay_completed_session(&records, &mut observer, &mut replay_state);
 
         assert!(
             exit.is_none(),

--- a/crates/coven-cli/tests/fixtures/unix_base_daemon.rs
+++ b/crates/coven-cli/tests/fixtures/unix_base_daemon.rs
@@ -1,0 +1,141 @@
+#![cfg(unix)]
+
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::os::unix::net::UnixListener;
+use std::path::Path;
+
+fn json_string(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            character if character.is_control() => {
+                use std::fmt::Write as _;
+                write!(escaped, "\\u{:04x}", character as u32).expect("write JSON escape");
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+fn relative_path(base: &Path, target: &Path) -> std::path::PathBuf {
+    let base = base.components().collect::<Vec<_>>();
+    let target = target.components().collect::<Vec<_>>();
+    let shared = base
+        .iter()
+        .zip(&target)
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = std::path::PathBuf::new();
+    for _ in shared..base.len() {
+        relative.push("..");
+    }
+    for component in &target[shared..] {
+        relative.push(component.as_os_str());
+    }
+    relative
+}
+
+fn write_response(stream: &mut std::os::unix::net::UnixStream, status: u16, body: &str) {
+    let reason = if status == 200 { "OK" } else { "Not Found" };
+    write!(
+        stream,
+        "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+    .expect("write BASE fixture response");
+}
+
+fn main() {
+    let mut arguments = std::env::args_os().skip(1);
+    let coven_home = arguments.next().expect("missing Coven home");
+    let started_at = arguments
+        .next()
+        .expect("missing started-at identity")
+        .into_string()
+        .expect("started-at identity was not UTF-8");
+    let reported_pid = match arguments
+        .next()
+        .expect("missing reported PID")
+        .to_str()
+        .expect("reported PID was not UTF-8")
+    {
+        "self" => std::process::id(),
+        pid => pid.parse().expect("reported PID was invalid"),
+    };
+    let health_style = arguments
+        .next()
+        .expect("missing health style")
+        .into_string()
+        .expect("health style was not UTF-8");
+    let coven_home = Path::new(&coven_home);
+    fs::create_dir_all(coven_home).expect("create Coven home");
+    fs::set_permissions(coven_home, fs::Permissions::from_mode(0o700))
+        .expect("protect Coven home");
+    let socket = coven_home.join("coven.sock");
+    let status = coven_home.join("daemon.json");
+    let requests = coven_home.join("base-requests.log");
+    let _ = fs::remove_file(&socket);
+    let listener = UnixListener::bind(&socket).expect("bind BASE daemon socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("protect BASE daemon socket");
+    let recorded_socket = match std::env::var("COVEN_TEST_BASE_RECORDED_SOCKET").as_deref() {
+        Ok("relative") => relative_path(
+            &std::env::current_dir().expect("read BASE fixture current directory"),
+            &socket,
+        ),
+        Ok(other) => panic!("unknown recorded socket style {other}"),
+        Err(std::env::VarError::NotPresent) => socket.clone(),
+        Err(error) => panic!("invalid recorded socket style: {error}"),
+    };
+    let socket_json = json_string(recorded_socket.to_string_lossy().as_ref());
+    let started_at_json = json_string(&started_at);
+    let daemon = format!(
+        r#"{{"pid":{reported_pid},"startedAt":{started_at_json},"socket":{socket_json}}}"#
+    );
+    let capabilities = match health_style.as_str() {
+        "base" => r#"{"sessions":true,"events":true,"travel":true,"scheduler":true,"hub":true,"executorDispatch":true,"eventCursor":"sequence","structuredErrors":true,"sessionHandoff":true,"sessionLaunchPolicy":false,"afs":true,"afsMount":false,"afsCommit":true,"afsCommitDryRun":true,"executionBindingContracts":["psyche.execution_binding.v1"]}"#,
+        "incompatible" => r#"{"structuredErrors":true}"#,
+        other => panic!("unknown health style {other}"),
+    };
+    let health = format!(
+        r#"{{"ok":true,"apiVersion":"coven.daemon.v1","covenVersion":"0.1.0","capabilities":{capabilities},"daemon":{daemon}}}"#
+    );
+    fs::write(&status, &daemon).expect("publish BASE daemon status");
+    fs::set_permissions(&status, fs::Permissions::from_mode(0o600))
+        .expect("protect BASE daemon status");
+
+    for incoming in listener.incoming() {
+        let mut stream = incoming.expect("accept BASE daemon connection");
+        let mut request = String::new();
+        stream
+            .read_to_string(&mut request)
+            .expect("read BASE daemon request");
+        let request_line = request.lines().next().unwrap_or_default();
+        let mut log = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .mode(0o600)
+            .open(&requests)
+            .expect("open BASE request log");
+        writeln!(log, "{request_line}").expect("record BASE request");
+        if request_line == "GET /health HTTP/1.1" {
+            write_response(&mut stream, 200, &health);
+        } else {
+            write_response(
+                &mut stream,
+                404,
+                r#"{"error":{"code":"not_found","message":"route not found"}}"#,
+            );
+        }
+    }
+}

--- a/crates/coven-cli/tests/smoke.rs
+++ b/crates/coven-cli/tests/smoke.rs
@@ -147,6 +147,189 @@ fn daemon_start_is_idempotent_when_daemon_is_already_running() -> anyhow::Result
 }
 
 #[test]
+fn managed_daemon_identity_matches_health_across_restart_and_stop() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let coven_home = temp_dir.path().join("coven-home");
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+    let _daemon_guard = DaemonGuard {
+        coven: coven.clone(),
+        coven_home: coven_home.clone(),
+        path: path.clone(),
+    };
+
+    let start = run_coven(&coven, &coven_home, &path, &["daemon", "start"])?;
+    assert_success("managed daemon start", &start);
+    let first = wait_for_daemon_identity(&coven_home)?;
+
+    let restart = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
+    assert_success("managed daemon restart", &restart);
+    let restarted = wait_for_daemon_identity(&coven_home)?;
+    assert_ne!(
+        first.get("pid"),
+        restarted.get("pid"),
+        "restart must replace the launched daemon process"
+    );
+    assert_ne!(
+        first.get("startedAt"),
+        restarted.get("startedAt"),
+        "restart must publish a new canonical daemon identity"
+    );
+
+    let stop = run_coven(&coven, &coven_home, &path, &["daemon", "stop"])?;
+    assert_success("managed daemon stop", &stop);
+    assert!(
+        !coven_home.join("daemon.json").exists(),
+        "stop must remove the launched daemon's status"
+    );
+    assert!(
+        !coven_home.join("coven.sock").exists(),
+        "stop must remove the launched daemon's socket"
+    );
+    Ok(())
+}
+
+#[test]
+fn daemon_restart_uses_only_platform_safe_base_fallback() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let selected_home = temp_dir.path().join("coven-home");
+    fs::create_dir(&selected_home)?;
+    let coven_home = fs::canonicalize(selected_home)?;
+    let fixture = temp_dir.path().join("base-daemon");
+    compile_unix_base_daemon_fixture(&fixture)?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let coven = coven_bin();
+    let _daemon_guard = DaemonGuard {
+        coven: coven.clone(),
+        coven_home: coven_home.clone(),
+        path: path.clone(),
+    };
+    let mut unrelated = ChildGuard::spawn(
+        Command::new("sleep")
+            .arg("30")
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null()),
+    )?;
+
+    let mut spoofed = spawn_base_daemon(
+        &fixture,
+        &coven_home,
+        &unrelated.id().to_string(),
+        "base",
+        false,
+    )?;
+    wait_for_base_daemon_status(&coven_home, unrelated.id())?;
+    let rejected = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
+    assert_failure(
+        "restart with BASE health claiming an unrelated PID",
+        &rejected,
+    );
+    assert!(
+        spoofed.is_running()?,
+        "identity rejection signaled the connected BASE fixture"
+    );
+    assert!(
+        unrelated.is_running()?,
+        "identity rejection signaled an unrelated process"
+    );
+    spoofed.terminate()?;
+    fs::remove_file(coven_home.join("daemon.json"))?;
+    fs::remove_file(coven_home.join("coven.sock"))?;
+    let _ = fs::remove_file(coven_home.join("base-requests.log"));
+
+    let mut incompatible = spawn_base_daemon(&fixture, &coven_home, "self", "incompatible", false)?;
+    let incompatible_pid = incompatible.id();
+    wait_for_base_daemon_status(&coven_home, incompatible_pid)?;
+    let rejected = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
+    assert_failure("restart with non-BASE health capabilities", &rejected);
+    assert!(
+        incompatible.is_running()?,
+        "fallback signaled a daemon without BASE health capabilities"
+    );
+    incompatible.terminate()?;
+    fs::remove_file(coven_home.join("daemon.json"))?;
+    fs::remove_file(coven_home.join("coven.sock"))?;
+    let _ = fs::remove_file(coven_home.join("base-requests.log"));
+
+    let mut base = spawn_base_daemon(&fixture, &coven_home, "self", "base", true)?;
+    let base_pid = base.id();
+    wait_for_base_daemon_status(&coven_home, base_pid)?;
+    let restart = run_coven(&coven, &coven_home, &path, &["daemon", "restart"])?;
+
+    #[cfg(target_os = "linux")]
+    {
+        if !restart.status.success() {
+            eprintln!(
+                "BASE requests before restart failure:\n{}",
+                fs::read_to_string(coven_home.join("base-requests.log")).unwrap_or_default()
+            );
+        }
+        assert_success("restart from BASE daemon", &restart);
+        wait_for_child_exit(&mut base, "BASE daemon")?;
+        let replacement = wait_for_daemon_identity(&coven_home)?;
+        assert_ne!(replacement["pid"].as_u64(), Some(u64::from(base_pid)));
+        assert!(
+            unrelated.is_running()?,
+            "BASE fallback signaled an unrelated process"
+        );
+        let requests = fs::read_to_string(coven_home.join("base-requests.log"))?;
+        assert_eq!(
+            requests.lines().collect::<Vec<_>>(),
+            vec![
+                "POST /api/v1/internal/lifecycle/shutdown HTTP/1.1",
+                "GET /health HTTP/1.1",
+            ],
+            "restart must prefer the authenticated shutdown route before BASE fallback"
+        );
+
+        let stop = run_coven(&coven, &coven_home, &path, &["daemon", "stop"])?;
+        assert_success("stop replacement daemon", &stop);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        assert_failure(
+            "restart from a BASE daemon without identity-bound signaling",
+            &restart,
+        );
+        assert_stderr_contains(
+            "legacy BASE restart upgrade guidance",
+            &restart,
+            "upgrade Coven",
+        );
+        assert_stderr_contains(
+            "legacy BASE restart manual recovery guidance",
+            &restart,
+            "restart the daemon manually",
+        );
+        assert!(
+            base.is_running()?,
+            "fail-closed legacy fallback signaled the BASE daemon"
+        );
+        assert!(
+            unrelated.is_running()?,
+            "fail-closed legacy fallback signaled an unrelated process"
+        );
+        let requests = fs::read_to_string(coven_home.join("base-requests.log"))?;
+        assert_eq!(
+            requests.lines().collect::<Vec<_>>(),
+            vec![
+                "POST /api/v1/internal/lifecycle/shutdown HTTP/1.1",
+                "GET /health HTTP/1.1",
+            ],
+            "upgrade refusal must still authenticate BASE health after an exact 404"
+        );
+        base.terminate()?;
+        fs::remove_file(coven_home.join("daemon.json"))?;
+        fs::remove_file(coven_home.join("coven.sock"))?;
+    }
+
+    unrelated.terminate()?;
+    Ok(())
+}
+
+#[test]
 fn daemon_stop_terminates_live_piped_session_descendants() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir()?;
     let coven_home = temp_dir.path().join("coven-home");
@@ -1595,6 +1778,43 @@ struct DaemonStatusRestoreGuard {
     contents: String,
 }
 
+struct ChildGuard {
+    child: std::process::Child,
+}
+
+impl ChildGuard {
+    fn spawn(command: &mut Command) -> anyhow::Result<Self> {
+        Ok(Self {
+            child: command.spawn()?,
+        })
+    }
+
+    fn id(&self) -> u32 {
+        self.child.id()
+    }
+
+    fn is_running(&mut self) -> anyhow::Result<bool> {
+        Ok(self.child.try_wait()?.is_none())
+    }
+
+    fn terminate(&mut self) -> anyhow::Result<()> {
+        if self.child.try_wait()?.is_none() {
+            self.child.kill()?;
+        }
+        let _ = self.child.wait()?;
+        Ok(())
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
 impl Drop for DaemonStatusRestoreGuard {
     fn drop(&mut self) {
         let _ = fs::write(&self.path, &self.contents);
@@ -1770,6 +1990,56 @@ printf 'fake codex complete: %s\n' "$*"
     Ok(())
 }
 
+fn compile_unix_base_daemon_fixture(output: &Path) -> anyhow::Result<()> {
+    let source =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/unix_base_daemon.rs");
+    let compile = Command::new("rustc")
+        .args(["--edition=2021", "-o"])
+        .arg(output)
+        .arg(source)
+        .output()?;
+    assert_success("compile BASE daemon fixture", &compile);
+    Ok(())
+}
+
+fn spawn_base_daemon(
+    fixture: &Path,
+    coven_home: &Path,
+    reported_pid: &str,
+    health_style: &str,
+    relative_socket: bool,
+) -> anyhow::Result<ChildGuard> {
+    let mut command = Command::new(fixture);
+    command
+        .arg(coven_home)
+        .arg("2026-08-16T12:00:00Z")
+        .arg(reported_pid)
+        .arg(health_style)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    if relative_socket {
+        command.env("COVEN_TEST_BASE_RECORDED_SOCKET", "relative");
+    }
+    ChildGuard::spawn(&mut command)
+}
+
+fn wait_for_base_daemon_status(coven_home: &Path, expected_pid: u32) -> anyhow::Result<()> {
+    wait_until("BASE daemon status", || {
+        let status_path = coven_home.join("daemon.json");
+        if !status_path.exists() || !coven_home.join("coven.sock").exists() {
+            return Ok(false);
+        }
+        let status: Value = serde_json::from_str(&fs::read_to_string(status_path)?)?;
+        Ok(status["pid"].as_u64() == Some(u64::from(expected_pid)))
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_child_exit(child: &mut ChildGuard, label: &str) -> anyhow::Result<()> {
+    wait_until(&format!("{label} exit"), || Ok(!child.is_running()?))
+}
+
 fn write_fake_copilot(fake_bin: &Path) -> anyhow::Result<()> {
     let copilot = fake_bin.join("copilot");
     fs::write(
@@ -1848,6 +2118,31 @@ fn wait_for_daemon_health(coven_home: &Path) -> anyhow::Result<()> {
         let (status, body) = unix_http_request(coven_home, "GET", "/health", None)?;
         Ok(status == 200 && body.contains(r#""ok":true"#))
     })
+}
+
+fn wait_for_daemon_identity(coven_home: &Path) -> anyhow::Result<Value> {
+    let mut identity = None;
+    wait_until("daemon status and health identity agreement", || {
+        let status_path = coven_home.join("daemon.json");
+        if !status_path.exists() || !coven_home.join("coven.sock").exists() {
+            return Ok(false);
+        }
+        let status: Value = serde_json::from_str(&fs::read_to_string(status_path)?)?;
+        let (http_status, body) = unix_http_request(coven_home, "GET", "/health", None)?;
+        if http_status != 200 {
+            return Ok(false);
+        }
+        let health: Value = serde_json::from_str(&body)?;
+        let Some(daemon) = health.get("daemon") else {
+            return Ok(false);
+        };
+        if daemon != &status {
+            return Ok(false);
+        }
+        identity = Some(status);
+        Ok(true)
+    })?;
+    identity.ok_or_else(|| anyhow::anyhow!("daemon identity was not captured"))
 }
 
 fn daemon_status_pid(coven_home: &Path) -> anyhow::Result<u64> {

--- a/crates/coven-cli/tests/windows_daemon_lifecycle.rs
+++ b/crates/coven-cli/tests/windows_daemon_lifecycle.rs
@@ -221,6 +221,71 @@ fn process_is_alive(pid: u32) -> bool {
     result == WAIT_TIMEOUT
 }
 
+fn legacy_pipe_name(coven_home: &Path) -> String {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    coven_home.to_string_lossy().hash(&mut hasher);
+    format!("coven-daemon-{:016x}.sock", hasher.finish())
+}
+
+fn lowercase_hash_pipe_name(coven_home: &Path) -> String {
+    use sha2::{Digest, Sha256};
+
+    let canonical = std::fs::canonicalize(coven_home).unwrap_or_else(|_| coven_home.to_path_buf());
+    let mut path = canonical.to_string_lossy().replace('/', "\\");
+    let mut is_unc = path.starts_with(r"\\");
+    if let Some(unc_path) = path.strip_prefix(r"\\?\UNC\") {
+        path = format!(r"\\{unc_path}");
+        is_unc = true;
+    } else if let Some(path_without_prefix) = path.strip_prefix(r"\\?\") {
+        path = path_without_prefix.to_owned();
+    }
+    let mut components = Vec::new();
+    if is_unc {
+        components.push("unc".to_owned());
+    }
+    for component in path.split('\\') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            component => components.push(component.to_ascii_lowercase()),
+        }
+    }
+    let mut digest = Sha256::new();
+    digest.update(b"coven.daemon.pipe.v1\0");
+    digest.update(components.join("\\").as_bytes());
+    let digest = digest.finalize();
+    let suffix = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("coven-daemon-v1-{suffix}.sock")
+}
+
+fn write_inherited_legacy_status(coven_home: &Path, pid: u32, socket: &str) -> Result<()> {
+    std::fs::create_dir_all(coven_home)?;
+    std::fs::write(
+        coven_home.join("daemon.json"),
+        serde_json::to_vec(&serde_json::json!({
+            "pid": pid,
+            "startedAt": "2026-04-27T10:00:00Z",
+            "socket": socket,
+        }))?,
+    )?;
+    Ok(())
+}
+
+fn run_daemon_command(coven_home: &Path, args: &[&str]) -> Result<Output> {
+    Ok(Command::new(env!("CARGO_BIN_EXE_coven"))
+        .arg("daemon")
+        .args(args)
+        .env("COVEN_HOME", coven_home)
+        .output()?)
+}
+
 fn prepend_path(dir: &Path) -> OsString {
     let mut paths = vec![dir.to_path_buf()];
     if let Some(existing) = std::env::var_os("PATH") {
@@ -286,7 +351,17 @@ fn wait_for_daemon_status(coven_home: &Path, path: &OsString) -> Result<serde_js
             .output()?;
         Ok(status.status.success())
     })?;
-    Ok(serde_json::from_slice(&std::fs::read(status_path)?)?)
+    let status: serde_json::Value = serde_json::from_slice(&std::fs::read(status_path)?)?;
+    let creation_time = status["processCreationTime"]
+        .as_str()
+        .context("managed Windows daemon status omitted its process creation time")?
+        .parse::<u64>()
+        .context("managed Windows daemon status had an invalid process creation time")?;
+    anyhow::ensure!(
+        creation_time != 0,
+        "managed Windows daemon status had a zero process creation time"
+    );
+    Ok(status)
 }
 
 fn send_launch_request(
@@ -319,6 +394,130 @@ fn send_launch_request(
     )?;
     stream.flush()?;
     Ok(stream)
+}
+
+#[test]
+fn inherited_legacy_status_with_dead_pid_does_not_wedge_lifecycle_commands() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let coven_home = temp.path().join("coven-home");
+    std::fs::create_dir_all(&coven_home)?;
+    let pipe_name = lowercase_hash_pipe_name(&coven_home);
+    let mut exited = Command::new("cmd.exe")
+        .args(["/C", "exit", "/B", "0"])
+        .spawn()?;
+    let exited_pid = exited.id();
+    assert!(exited.wait()?.success());
+    let _guard = DaemonGuard {
+        coven_home: coven_home.clone(),
+    };
+
+    write_inherited_legacy_status(&coven_home, exited_pid, &pipe_name)?;
+    let status = run_daemon_command(&coven_home, &["status", "--json"])?;
+    assert_success("status with dead inherited legacy record", &status);
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout)?;
+    assert_eq!(status["status"], "stopped");
+    assert!(!coven_home.join("daemon.json").exists());
+
+    write_inherited_legacy_status(&coven_home, exited_pid, &pipe_name)?;
+    let stop = run_daemon_command(&coven_home, &["stop"])?;
+    assert_success("stop with dead inherited legacy record", &stop);
+    assert!(!coven_home.join("daemon.json").exists());
+
+    write_inherited_legacy_status(&coven_home, exited_pid, &pipe_name)?;
+    let mut start = Command::new(env!("CARGO_BIN_EXE_coven"));
+    start
+        .args(["daemon", "start"])
+        .env("COVEN_HOME", &coven_home);
+    let start = captured_output_with_timeout(
+        "start after dead inherited legacy record",
+        &mut start,
+        &coven_home,
+    )?;
+    assert_success("start after dead inherited legacy record", &start);
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    let migrated = wait_for_daemon_status(&coven_home, &path)?;
+    assert_ne!(migrated["socket"], pipe_name);
+    assert!(
+        migrated["socket"]
+            .as_str()
+            .is_some_and(|socket| socket.starts_with("coven-daemon-v2-")),
+        "new daemon did not migrate to its filesystem-identity pipe: {migrated}"
+    );
+    let stop = run_daemon_command(&coven_home, &["stop"])?;
+    assert_success("stop daemon after stale start recovery", &stop);
+
+    write_inherited_legacy_status(&coven_home, exited_pid, &pipe_name)?;
+    let mut restart = Command::new(env!("CARGO_BIN_EXE_coven"));
+    restart
+        .args(["daemon", "restart"])
+        .env("COVEN_HOME", &coven_home);
+    let restart = captured_output_with_timeout(
+        "restart after dead inherited legacy record",
+        &mut restart,
+        &coven_home,
+    )?;
+    assert_success("restart after dead inherited legacy record", &restart);
+    wait_for_daemon_status(&coven_home, &path)?;
+    let stop = run_daemon_command(&coven_home, &["stop"])?;
+    assert_success("stop daemon after stale restart recovery", &stop);
+    Ok(())
+}
+
+#[test]
+fn inherited_legacy_status_with_live_pid_is_preserved_by_lifecycle_commands() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let coven_home = temp.path().join("coven-home");
+    let pipe_name = legacy_pipe_name(&coven_home);
+    write_inherited_legacy_status(&coven_home, std::process::id(), &pipe_name)?;
+
+    let status = run_daemon_command(&coven_home, &["status", "--json"])?;
+    assert_success("status with live inherited legacy PID", &status);
+    let status: serde_json::Value = serde_json::from_slice(&status.stdout)?;
+    assert_eq!(status["status"], "stale");
+
+    for command in [&["start"][..], &["stop"][..], &["restart"][..]] {
+        let output = run_daemon_command(&coven_home, command)?;
+        assert!(
+            !output.status.success(),
+            "daemon {} unexpectedly replaced a live inherited legacy PID",
+            command[0]
+        );
+        assert!(coven_home.join("daemon.json").exists());
+    }
+    Ok(())
+}
+
+#[test]
+fn inherited_legacy_status_rejects_cross_profile_and_arbitrary_records() -> Result<()> {
+    let temp = tempfile::tempdir()?;
+    let coven_home = temp.path().join("coven-home");
+    let other_home = temp.path().join("other-profile");
+    let redirected = [
+        legacy_pipe_name(&other_home),
+        "other-daemon.sock".to_owned(),
+    ];
+
+    for pipe_name in redirected {
+        write_inherited_legacy_status(&coven_home, u32::MAX, &pipe_name)?;
+        let status = run_daemon_command(&coven_home, &["status", "--json"])?;
+        assert!(
+            !status.status.success(),
+            "status accepted redirected inherited record {pipe_name}"
+        );
+        assert!(coven_home.join("daemon.json").exists());
+    }
+
+    let same_profile = legacy_pipe_name(&coven_home);
+    std::fs::write(
+        coven_home.join("daemon.json"),
+        format!(
+            r#"{{"pid":"ambiguous","startedAt":"2026-04-27T10:00:00Z","socket":"{same_profile}"}}"#
+        ),
+    )?;
+    let status = run_daemon_command(&coven_home, &["status", "--json"])?;
+    assert!(!status.status.success());
+    assert!(coven_home.join("daemon.json").exists());
+    Ok(())
 }
 
 #[test]

--- a/crates/coven-client/Cargo.toml
+++ b/crates/coven-client/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "coven-client"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.11"
+thiserror = "2"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+socket2 = "0.6"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading"] }

--- a/crates/coven-client/fixtures/error.json
+++ b/crates/coven-client/fixtures/error.json
@@ -1,0 +1,9 @@
+{
+  "error": {
+    "code": "session_not_live",
+    "message": "Session is not live.",
+    "details": {
+      "sessionId": "session-1"
+    }
+  }
+}

--- a/crates/coven-client/fixtures/health.json
+++ b/crates/coven-client/fixtures/health.json
@@ -1,0 +1,11 @@
+{
+  "ok": true,
+  "apiVersion": "coven.daemon.v1",
+  "covenVersion": "0.1.0",
+  "capabilities": {
+    "sessions": true,
+    "events": true,
+    "eventCursor": "sequence",
+    "structuredErrors": true
+  }
+}

--- a/crates/coven-client/src/discovery.rs
+++ b/crates/coven-client/src/discovery.rs
@@ -1,0 +1,2691 @@
+use std::path::Path;
+
+#[cfg(any(windows, test))]
+use sha2::{Digest, Sha256};
+
+use crate::ClientError;
+
+pub(crate) const MAX_DAEMON_STATUS_BYTES: usize = 16 * 1024;
+#[cfg(unix)]
+pub(crate) const UNIX_SOCKET_DISAPPEARED_OPERATION: &str =
+    "selected Coven daemon socket disappeared during discovery";
+#[cfg(windows)]
+const WINDOWS_DISCOVERY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[cfg(any(windows, test))]
+fn windows_status_remaining_at(
+    deadline: std::time::Instant,
+    now: std::time::Instant,
+    operation: &'static str,
+) -> Result<std::time::Duration, ClientError> {
+    deadline
+        .checked_duration_since(now)
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| ClientError::Io {
+            operation,
+            source: std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("timed out {operation}"),
+            ),
+        })
+}
+
+pub struct DaemonEndpoint {
+    owner_local: bool,
+    #[cfg(unix)]
+    socket: std::path::PathBuf,
+    #[cfg(unix)]
+    owner_uid: u32,
+    #[cfg(windows)]
+    pipe_name: String,
+}
+
+impl std::fmt::Debug for DaemonEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DaemonEndpoint::OwnerLocal")
+    }
+}
+
+impl DaemonEndpoint {
+    pub fn discover(coven_home: impl AsRef<Path>) -> Result<Self, ClientError> {
+        let coven_home = coven_home.as_ref();
+        #[cfg(unix)]
+        validate_unix_daemon_path_encoding(coven_home)?;
+        ensure_private_home(coven_home)?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+            let coven_home = canonical_unix_daemon_home(coven_home)?;
+            let socket_candidate = coven_home.join("coven.sock");
+            let candidate_metadata =
+                std::fs::symlink_metadata(&socket_candidate).map_err(|source| {
+                    selected_unix_socket_discovery_error(&socket_candidate, source, "inspect")
+                })?;
+            if candidate_metadata.file_type().is_symlink() {
+                return Err(ClientError::Discovery(format!(
+                    "{} is not an owner-local Unix socket",
+                    socket_candidate.display()
+                )));
+            }
+            // Resolve symlinked ancestors and `..` before the definitive
+            // metadata checks, then retain this exact validated path.
+            let socket = std::fs::canonicalize(&socket_candidate).map_err(|source| {
+                selected_unix_socket_discovery_error(&socket_candidate, source, "resolve")
+            })?;
+            let metadata = std::fs::symlink_metadata(&socket).map_err(|source| {
+                selected_unix_socket_discovery_error(&socket_candidate, source, "inspect")
+            })?;
+            if metadata.file_type().is_symlink() || !metadata.file_type().is_socket() {
+                return Err(ClientError::Discovery(format!(
+                    "{} is not an owner-local Unix socket",
+                    socket.display()
+                )));
+            }
+            // SAFETY: geteuid reads process state and cannot fail.
+            if metadata.uid() != unsafe { libc::geteuid() } {
+                return Err(ClientError::Discovery(format!(
+                    "{} is not owned by the current user",
+                    socket.display()
+                )));
+            }
+            if metadata.mode() & 0o077 != 0 {
+                return Err(ClientError::Discovery(format!(
+                    "{} is accessible by users other than its owner",
+                    socket.display()
+                )));
+            }
+            Ok(Self {
+                owner_local: true,
+                socket,
+                owner_uid: metadata.uid(),
+            })
+        }
+
+        #[cfg(windows)]
+        {
+            let deadline = std::time::Instant::now()
+                .checked_add(WINDOWS_DISCOVERY_TIMEOUT)
+                .ok_or_else(|| {
+                    ClientError::Discovery("daemon discovery deadline overflowed".to_owned())
+                })?;
+            let stable_pipe_name = owner_only_windows_pipe_name(coven_home)?;
+            let pipe_name =
+                match validate_windows_daemon_pipe_name_until(&stable_pipe_name, deadline) {
+                    Ok(()) => stable_pipe_name,
+                    Err(stable_error) => {
+                        match recorded_windows_pipe_candidate_until(coven_home, deadline)? {
+                            Some(recorded_pipe_name) if recorded_pipe_name != stable_pipe_name => {
+                                validate_windows_daemon_pipe_name_until(
+                                    &recorded_pipe_name,
+                                    deadline,
+                                )?;
+                                recorded_pipe_name
+                            }
+                            _ => return Err(stable_error),
+                        }
+                    }
+                };
+            Ok(Self {
+                owner_local: true,
+                pipe_name,
+            })
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = coven_home;
+            Err(ClientError::UnsupportedPlatform)
+        }
+    }
+
+    pub fn is_owner_local(&self) -> bool {
+        self.owner_local
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn socket(&self) -> &Path {
+        &self.socket
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn owner_uid(&self) -> u32 {
+        self.owner_uid
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn pipe_name(&self) -> &str {
+        &self.pipe_name
+    }
+}
+
+#[cfg(unix)]
+fn selected_unix_socket_discovery_error(
+    socket: &Path,
+    source: std::io::Error,
+    action: &str,
+) -> ClientError {
+    if source.kind() == std::io::ErrorKind::NotFound {
+        ClientError::Io {
+            operation: UNIX_SOCKET_DISAPPEARED_OPERATION,
+            source,
+        }
+    } else {
+        ClientError::Discovery(format!(
+            "cannot {action} selected Coven daemon socket {}: {source}",
+            socket.display()
+        ))
+    }
+}
+
+#[cfg(unix)]
+#[doc(hidden)]
+pub fn validate_unix_daemon_path_encoding(coven_home: &Path) -> Result<(), ClientError> {
+    let (home, label) = match std::fs::canonicalize(coven_home) {
+        Ok(canonical) => (canonical, "canonical COVEN_HOME"),
+        Err(source)
+            if matches!(
+                source.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::InvalidInput
+            ) =>
+        {
+            (coven_home.to_path_buf(), "COVEN_HOME")
+        }
+        Err(source) => {
+            return Err(ClientError::Io {
+                operation: "failed to resolve COVEN_HOME before daemon lifecycle validation",
+                source,
+            })
+        }
+    };
+    validate_utf8_daemon_path(&home, label)?;
+    validate_utf8_daemon_path(&home.join("coven.sock"), "Coven daemon socket")
+}
+
+#[cfg(unix)]
+#[doc(hidden)]
+pub fn canonical_unix_daemon_home(coven_home: &Path) -> Result<std::path::PathBuf, ClientError> {
+    validate_unix_daemon_path_encoding(coven_home)?;
+    let canonical_home = std::fs::canonicalize(coven_home).map_err(|source| ClientError::Io {
+        operation: "failed to resolve canonical COVEN_HOME",
+        source,
+    })?;
+    validate_utf8_daemon_path(&canonical_home, "canonical COVEN_HOME")?;
+    validate_utf8_daemon_path(
+        &canonical_home.join("coven.sock"),
+        "canonical Coven daemon socket",
+    )?;
+    Ok(canonical_home)
+}
+
+#[cfg(unix)]
+fn validate_utf8_daemon_path(path: &Path, label: &str) -> Result<(), ClientError> {
+    if path.to_str().is_none() {
+        return Err(ClientError::Discovery(format!(
+            "{label} {:?} is not valid UTF-8; Coven daemon status JSON requires UTF-8 home and \
+             socket paths",
+            path.as_os_str()
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_private_home(coven_home: &Path) -> Result<(), ClientError> {
+    let metadata = std::fs::symlink_metadata(coven_home).map_err(|error| {
+        ClientError::Discovery(format!("cannot inspect {}: {error}", coven_home.display()))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(ClientError::Discovery(format!(
+            "{} is not a Coven home directory",
+            coven_home.display()
+        )));
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        // SAFETY: geteuid reads process state and cannot fail.
+        if metadata.uid() != unsafe { libc::geteuid() } {
+            return Err(ClientError::Discovery(format!(
+                "{} is not owned by the current user",
+                coven_home.display()
+            )));
+        }
+        if metadata.mode() & 0o077 != 0 {
+            return Err(ClientError::Discovery(format!(
+                "{} is accessible by users other than its owner",
+                coven_home.display()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Shared daemon/client naming for the owner-only Windows pipe.
+///
+/// The v2 identity comes from the canonical directory's volume serial and file
+/// ID, so aliases converge without folding case-sensitive path components.
+/// This returns the daemon's reserved name, not a user-supplied endpoint.
+#[doc(hidden)]
+#[cfg(any(windows, test))]
+pub fn owner_only_windows_pipe_name(coven_home: &Path) -> Result<String, ClientError> {
+    Ok(owner_only_windows_pipe_name_from_identity(
+        windows_directory_identity(coven_home)?,
+    ))
+}
+
+#[doc(hidden)]
+#[cfg(any(windows, test))]
+pub fn supported_windows_pipe_names(coven_home: &Path) -> Result<[String; 3], ClientError> {
+    Ok([
+        owner_only_windows_pipe_name(coven_home)?,
+        lowercase_path_windows_pipe_name(coven_home),
+        legacy_windows_pipe_name(coven_home),
+    ])
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct WindowsDirectoryIdentity {
+    volume_serial_number: u64,
+    file_id: [u8; 16],
+}
+
+#[cfg(any(windows, test))]
+fn owner_only_windows_pipe_name_from_identity(identity: WindowsDirectoryIdentity) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"coven.daemon.pipe.v2\0");
+    digest.update(identity.volume_serial_number.to_le_bytes());
+    digest.update(identity.file_id);
+    let digest = digest.finalize();
+    let suffix = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("coven-daemon-v2-{suffix}.sock")
+}
+
+#[cfg(windows)]
+fn windows_directory_identity(coven_home: &Path) -> Result<WindowsDirectoryIdentity, ClientError> {
+    let canonical_home = std::fs::canonicalize(coven_home).map_err(|source| ClientError::Io {
+        operation: "failed to resolve Coven home for Windows daemon pipe identity",
+        source,
+    })?;
+    windows_directory_identity_from_resolved_path(&canonical_home)
+}
+
+#[cfg(windows)]
+fn windows_directory_identity_from_resolved_path(
+    resolved_home: &Path,
+) -> Result<WindowsDirectoryIdentity, ClientError> {
+    use std::{
+        mem::{size_of, MaybeUninit},
+        os::windows::{ffi::OsStrExt, io::FromRawHandle},
+        ptr,
+    };
+    use windows_sys::Win32::{
+        Foundation::INVALID_HANDLE_VALUE,
+        Storage::FileSystem::{
+            CreateFileW, FileIdInfo, GetFileInformationByHandleEx, FILE_FLAG_BACKUP_SEMANTICS,
+            FILE_ID_INFO, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        },
+    };
+
+    let resolved_home: Vec<u16> = resolved_home
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let handle = unsafe {
+        CreateFileW(
+            resolved_home.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(ClientError::Io {
+            operation: "failed to open canonical Coven home for Windows daemon pipe identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    let _directory = unsafe { std::fs::File::from_raw_handle(handle) };
+    let mut information = MaybeUninit::<FILE_ID_INFO>::uninit();
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileIdInfo,
+            information.as_mut_ptr().cast(),
+            size_of::<FILE_ID_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to inspect canonical Coven home for Windows daemon pipe identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    // SAFETY: the successful FileIdInfo query initialized the full structure.
+    let information = unsafe { information.assume_init() };
+    Ok(WindowsDirectoryIdentity {
+        volume_serial_number: information.VolumeSerialNumber,
+        file_id: information.FileId.Identifier,
+    })
+}
+
+#[cfg(all(test, not(windows)))]
+fn windows_directory_identity(coven_home: &Path) -> Result<WindowsDirectoryIdentity, ClientError> {
+    let canonical_home = std::fs::canonicalize(coven_home).map_err(|source| ClientError::Io {
+        operation: "failed to resolve test Coven home filesystem identity",
+        source,
+    })?;
+    windows_directory_identity_from_resolved_path(&canonical_home)
+}
+
+#[cfg(all(test, not(windows)))]
+fn windows_directory_identity_from_resolved_path(
+    resolved_home: &Path,
+) -> Result<WindowsDirectoryIdentity, ClientError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(resolved_home).map_err(|source| ClientError::Io {
+        operation: "failed to inspect test Coven home filesystem identity",
+        source,
+    })?;
+    Ok(WindowsDirectoryIdentity {
+        volume_serial_number: metadata.dev(),
+        file_id: u128::from(metadata.ino()).to_le_bytes(),
+    })
+}
+
+#[cfg(any(windows, test))]
+pub(crate) fn is_coven_daemon_pipe_name(pipe_name: &str) -> bool {
+    is_stable_coven_daemon_pipe_name(pipe_name)
+        || is_lowercase_path_coven_daemon_pipe_name(pipe_name)
+        || is_legacy_coven_daemon_pipe_name(pipe_name)
+}
+
+#[cfg(any(windows, test))]
+fn is_stable_coven_daemon_pipe_name(pipe_name: &str) -> bool {
+    let Some(name) = pipe_name.strip_suffix(".sock") else {
+        return false;
+    };
+    let Some(hex) = name.strip_prefix("coven-daemon-v2-") else {
+        return false;
+    };
+    is_lowercase_hex_suffix(hex, 32)
+}
+
+#[cfg(any(windows, test))]
+fn is_lowercase_path_coven_daemon_pipe_name(pipe_name: &str) -> bool {
+    let Some(name) = pipe_name.strip_suffix(".sock") else {
+        return false;
+    };
+    let Some(hex) = name.strip_prefix("coven-daemon-v1-") else {
+        return false;
+    };
+    is_lowercase_hex_suffix(hex, 32)
+}
+
+#[cfg(any(windows, test))]
+fn is_legacy_coven_daemon_pipe_name(pipe_name: &str) -> bool {
+    let Some(name) = pipe_name.strip_suffix(".sock") else {
+        return false;
+    };
+    let Some(hex) = name.strip_prefix("coven-daemon-") else {
+        return false;
+    };
+    is_lowercase_hex_suffix(hex, 16)
+}
+
+#[cfg(any(windows, test))]
+fn legacy_windows_pipe_name(coven_home: &Path) -> String {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    coven_home.to_string_lossy().hash(&mut hasher);
+    format!("coven-daemon-{:016x}.sock", hasher.finish())
+}
+
+#[cfg(any(windows, test))]
+fn lowercase_path_windows_pipe_name(coven_home: &Path) -> String {
+    // Preserve the exact v1 lossy/lowercased derivation solely for upgrades.
+    let normalized = canonical_windows_home_key(coven_home);
+    let mut digest = Sha256::new();
+    digest.update(b"coven.daemon.pipe.v1\0");
+    digest.update(normalized.as_bytes());
+    let digest = digest.finalize();
+    let suffix = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    format!("coven-daemon-v1-{suffix}.sock")
+}
+
+#[cfg(any(windows, test))]
+fn is_lowercase_hex_suffix(value: &str, expected_len: usize) -> bool {
+    value.len() == expected_len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+}
+
+#[cfg(any(windows, test))]
+fn recorded_pipe_name_from_status(serialized: &str) -> Result<String, ClientError> {
+    #[derive(serde::Deserialize)]
+    struct RecordedDaemonStatus {
+        socket: String,
+    }
+
+    let status: RecordedDaemonStatus =
+        serde_json::from_str(serialized).map_err(ClientError::InvalidJson)?;
+    if !is_coven_daemon_pipe_name(&status.socket) {
+        return Err(ClientError::Discovery(
+            "daemon status reported an unsupported daemon pipe name".to_owned(),
+        ));
+    }
+    Ok(status.socket)
+}
+
+#[cfg(any(windows, test))]
+fn recorded_pipe_name_from_status_for_home(
+    coven_home: &Path,
+    serialized: &str,
+) -> Result<String, ClientError> {
+    let pipe_name = recorded_pipe_name_from_status(serialized)?;
+    let matches_profile = if is_stable_coven_daemon_pipe_name(&pipe_name) {
+        pipe_name == owner_only_windows_pipe_name(coven_home)?
+    } else {
+        legacy_windows_pipe_is_safe_for_home(coven_home, &pipe_name)?
+    };
+    if matches_profile {
+        return Ok(pipe_name);
+    }
+    Err(ClientError::Discovery(
+        "daemon status reported a pipe for a different Coven home".to_owned(),
+    ))
+}
+
+#[cfg(any(windows, test))]
+fn legacy_windows_pipe_is_safe_for_home(
+    coven_home: &Path,
+    pipe_name: &str,
+) -> Result<bool, ClientError> {
+    if pipe_name == legacy_windows_pipe_name(coven_home) {
+        return Ok(true);
+    }
+    if pipe_name != lowercase_path_windows_pipe_name(coven_home) {
+        return Ok(false);
+    }
+    legacy_windows_v1_home_is_safe(coven_home)
+}
+
+#[cfg(any(windows, test))]
+fn legacy_windows_v1_home_is_safe(coven_home: &Path) -> Result<bool, ClientError> {
+    let canonical_home = std::fs::canonicalize(coven_home).map_err(|source| ClientError::Io {
+        operation: "failed to resolve selected Coven home for legacy Windows migration",
+        source,
+    })?;
+    let selected_identity = windows_directory_identity_from_resolved_path(&canonical_home)?;
+    verify_legacy_windows_v1_home(
+        &canonical_home,
+        selected_identity,
+        windows_directory_is_case_sensitive,
+        |case_folded_home| {
+            let resolved_case_folded_home =
+                std::fs::canonicalize(case_folded_home).map_err(|source| ClientError::Io {
+                    operation:
+                        "failed to resolve case-folded Coven home for legacy Windows migration",
+                    source,
+                })?;
+            windows_directory_identity_from_resolved_path(&resolved_case_folded_home)
+        },
+    )
+}
+
+#[cfg(any(windows, test))]
+fn verify_legacy_windows_home_ancestors_are_case_insensitive<F>(
+    canonical_home: &Path,
+    mut directory_is_case_sensitive: F,
+) -> Result<bool, ClientError>
+where
+    F: FnMut(&Path) -> Result<bool, ClientError>,
+{
+    if !canonical_home.is_absolute() {
+        return Err(ClientError::Discovery(
+            "canonical Coven home for legacy Windows migration was not absolute".to_owned(),
+        ));
+    }
+
+    let mut ancestors = canonical_home
+        .ancestors()
+        .filter(|ancestor| !ancestor.as_os_str().is_empty())
+        .collect::<Vec<_>>();
+    ancestors.reverse();
+    for ancestor in ancestors {
+        if directory_is_case_sensitive(ancestor)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+#[cfg(any(windows, test))]
+fn verify_legacy_windows_v1_home<FCaseSensitivity, FResolveFolded>(
+    canonical_home: &Path,
+    selected_identity: WindowsDirectoryIdentity,
+    inspect_case_sensitivity: FCaseSensitivity,
+    resolve_case_folded_identity: FResolveFolded,
+) -> Result<bool, ClientError>
+where
+    FCaseSensitivity: FnMut(&Path) -> Result<bool, ClientError>,
+    FResolveFolded: FnOnce(&Path) -> Result<WindowsDirectoryIdentity, ClientError>,
+{
+    if !verify_legacy_windows_home_ancestors_are_case_insensitive(
+        canonical_home,
+        inspect_case_sensitivity,
+    )? {
+        return Ok(false);
+    }
+    verify_legacy_case_folded_windows_home_identity(
+        canonical_home,
+        selected_identity,
+        resolve_case_folded_identity,
+    )
+}
+
+#[cfg(any(windows, test))]
+fn verify_legacy_case_folded_windows_home_identity<F>(
+    canonical_home: &Path,
+    selected_identity: WindowsDirectoryIdentity,
+    resolve_case_folded_identity: F,
+) -> Result<bool, ClientError>
+where
+    F: FnOnce(&Path) -> Result<WindowsDirectoryIdentity, ClientError>,
+{
+    let canonical_home = canonical_home.to_str().ok_or_else(|| {
+        ClientError::Discovery(
+            "canonical Coven home cannot be represented by the legacy Windows path identity"
+                .to_owned(),
+        )
+    })?;
+    let case_folded_home = std::path::PathBuf::from(canonical_home.to_ascii_lowercase());
+    Ok(resolve_case_folded_identity(&case_folded_home)? == selected_identity)
+}
+
+#[cfg(windows)]
+fn windows_directory_is_case_sensitive(directory: &Path) -> Result<bool, ClientError> {
+    use std::{
+        mem::{size_of, MaybeUninit},
+        os::windows::{ffi::OsStrExt, io::FromRawHandle},
+        ptr,
+    };
+    use windows_sys::Win32::{
+        Foundation::INVALID_HANDLE_VALUE,
+        Storage::FileSystem::{
+            CreateFileW, FileCaseSensitiveInfo, GetFileInformationByHandle,
+            GetFileInformationByHandleEx, BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_REPARSE_POINT,
+            FILE_CASE_SENSITIVE_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        },
+    };
+    const FILE_CS_FLAG_CASE_SENSITIVE_DIR: u32 = 0x0000_0001;
+
+    let directory: Vec<u16> = directory
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    // SAFETY: `directory` is NUL-terminated and all pointer arguments remain
+    // valid for the duration of the call.
+    let handle = unsafe {
+        CreateFileW(
+            directory.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(ClientError::Io {
+            operation:
+                "failed to open canonical Coven home ancestor for case-sensitivity validation",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    // SAFETY: ownership of the checked handle transfers exactly once.
+    let _directory = unsafe { std::fs::File::from_raw_handle(handle) };
+
+    let mut attributes = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::uninit();
+    // SAFETY: the handle is live and `attributes` is the exact writable output
+    // structure required by GetFileInformationByHandle.
+    if unsafe { GetFileInformationByHandle(handle, attributes.as_mut_ptr()) } == 0 {
+        return Err(ClientError::Io {
+            operation:
+                "failed to inspect canonical Coven home ancestor for case-sensitivity validation",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    // SAFETY: the successful query initialized the full structure.
+    let attributes = unsafe { attributes.assume_init() };
+    if attributes.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(ClientError::Discovery(
+            "canonical Coven home ancestor was an unverifiable reparse point".to_owned(),
+        ));
+    }
+
+    let mut information = MaybeUninit::<FILE_CASE_SENSITIVE_INFO>::uninit();
+    // SAFETY: the live directory handle and output buffer match
+    // FileCaseSensitiveInfo for the duration of the call.
+    if unsafe {
+        GetFileInformationByHandleEx(
+            handle,
+            FileCaseSensitiveInfo,
+            information.as_mut_ptr().cast(),
+            size_of::<FILE_CASE_SENSITIVE_INFO>() as u32,
+        )
+    } == 0
+    {
+        return Err(ClientError::Io {
+            operation:
+                "failed to inspect canonical Coven home ancestor case-sensitivity information",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    // SAFETY: the successful query initialized the full structure.
+    let information = unsafe { information.assume_init() };
+    Ok(information.Flags & FILE_CS_FLAG_CASE_SENSITIVE_DIR != 0)
+}
+
+#[cfg(all(test, not(windows)))]
+fn windows_directory_is_case_sensitive(_directory: &Path) -> Result<bool, ClientError> {
+    Ok(false)
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WindowsStatusFileSecurity {
+    Hardened,
+    LegacyCurrentOwner,
+}
+
+#[cfg(any(windows, test))]
+const fn windows_status_validation_phase(security: WindowsStatusFileSecurity) -> &'static str {
+    match security {
+        WindowsStatusFileSecurity::Hardened => "validating Coven daemon status",
+        WindowsStatusFileSecurity::LegacyCurrentOwner => {
+            "authenticating legacy Coven daemon status"
+        }
+    }
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UnavailableLegacyPipePolicy {
+    Reject,
+    ReturnRecordedStatus,
+}
+
+#[cfg(test)]
+fn trusted_windows_status<P>(
+    coven_home: &Path,
+    serialized: String,
+    security: WindowsStatusFileSecurity,
+    probe: P,
+) -> Result<String, ClientError>
+where
+    P: FnOnce(&str, std::time::Duration) -> Result<Option<(u16, Vec<u8>)>, ClientError>,
+{
+    trusted_windows_status_with_policy(
+        coven_home,
+        serialized,
+        security,
+        UnavailableLegacyPipePolicy::Reject,
+        probe,
+    )
+}
+
+#[cfg(test)]
+fn trusted_windows_status_for_lifecycle<P>(
+    coven_home: &Path,
+    serialized: String,
+    security: WindowsStatusFileSecurity,
+    probe: P,
+) -> Result<String, ClientError>
+where
+    P: FnOnce(&str, std::time::Duration) -> Result<Option<(u16, Vec<u8>)>, ClientError>,
+{
+    trusted_windows_status_with_policy(
+        coven_home,
+        serialized,
+        security,
+        UnavailableLegacyPipePolicy::ReturnRecordedStatus,
+        probe,
+    )
+}
+
+#[cfg(test)]
+fn trusted_windows_status_with_policy<P>(
+    coven_home: &Path,
+    serialized: String,
+    security: WindowsStatusFileSecurity,
+    unavailable_legacy_pipe: UnavailableLegacyPipePolicy,
+    probe: P,
+) -> Result<String, ClientError>
+where
+    P: FnOnce(&str, std::time::Duration) -> Result<Option<(u16, Vec<u8>)>, ClientError>,
+{
+    trusted_windows_status_with_policy_and_timeout(
+        coven_home,
+        serialized,
+        security,
+        unavailable_legacy_pipe,
+        std::time::Duration::from_secs(2),
+        probe,
+    )
+}
+
+#[cfg(any(windows, test))]
+fn trusted_windows_status_with_policy_and_timeout<P>(
+    coven_home: &Path,
+    serialized: String,
+    security: WindowsStatusFileSecurity,
+    unavailable_legacy_pipe: UnavailableLegacyPipePolicy,
+    probe_timeout: std::time::Duration,
+    probe: P,
+) -> Result<String, ClientError>
+where
+    P: FnOnce(&str, std::time::Duration) -> Result<Option<(u16, Vec<u8>)>, ClientError>,
+{
+    match security {
+        WindowsStatusFileSecurity::Hardened => {
+            recorded_pipe_name_from_status_for_home(coven_home, &serialized)?;
+            Ok(serialized)
+        }
+        WindowsStatusFileSecurity::LegacyCurrentOwner => legacy_status_from_probe_with_policy(
+            coven_home,
+            &serialized,
+            unavailable_legacy_pipe,
+            probe_timeout,
+            probe,
+        ),
+    }
+}
+
+#[cfg(test)]
+fn legacy_status_from_probe<P>(
+    coven_home: &Path,
+    serialized: &str,
+    probe: P,
+) -> Result<String, ClientError>
+where
+    P: FnOnce(&str, std::time::Duration) -> Result<Option<(u16, Vec<u8>)>, ClientError>,
+{
+    legacy_status_from_probe_with_policy(
+        coven_home,
+        serialized,
+        UnavailableLegacyPipePolicy::Reject,
+        std::time::Duration::from_secs(2),
+        probe,
+    )
+}
+
+#[cfg(any(windows, test))]
+fn legacy_status_from_probe_with_policy<P>(
+    coven_home: &Path,
+    serialized: &str,
+    unavailable_pipe: UnavailableLegacyPipePolicy,
+    probe_timeout: std::time::Duration,
+    probe: P,
+) -> Result<String, ClientError>
+where
+    P: FnOnce(&str, std::time::Duration) -> Result<Option<(u16, Vec<u8>)>, ClientError>,
+{
+    #[derive(serde::Deserialize)]
+    struct LegacyHealth {
+        ok: bool,
+        daemon: Option<serde_json::Value>,
+    }
+
+    let recorded_pipe = match recorded_pipe_name_from_status(serialized) {
+        Ok(recorded_pipe) => recorded_pipe,
+        Err(_) if unavailable_pipe == UnavailableLegacyPipePolicy::ReturnRecordedStatus => {
+            return Err(ClientError::Discovery(
+                "inherited daemon status identity could not be validated".to_owned(),
+            ));
+        }
+        Err(error) => return Err(error),
+    };
+    if !legacy_windows_pipe_is_safe_for_home(coven_home, &recorded_pipe)? {
+        return Err(ClientError::Discovery(
+            "inherited daemon status did not name a legacy pipe for this Coven home".to_owned(),
+        ));
+    }
+    let Some((status, body)) = probe(&recorded_pipe, probe_timeout)? else {
+        return match unavailable_pipe {
+            UnavailableLegacyPipePolicy::Reject => Err(ClientError::Discovery(
+                "legacy daemon pipe was not available through an owner-validated connection"
+                    .to_owned(),
+            )),
+            UnavailableLegacyPipePolicy::ReturnRecordedStatus => {
+                validate_legacy_lifecycle_identity(serialized)?;
+                Ok(serialized.to_owned())
+            }
+        };
+    };
+    if status != 200 {
+        return Err(ClientError::Discovery(format!(
+            "legacy daemon health returned HTTP {status}"
+        )));
+    }
+    let health: LegacyHealth = serde_json::from_slice(&body).map_err(|_| {
+        ClientError::Discovery("legacy daemon health response was invalid".to_owned())
+    })?;
+    if !health.ok {
+        return Err(ClientError::Discovery(
+            "legacy daemon health did not report ready".to_owned(),
+        ));
+    }
+    let daemon = health.daemon.ok_or_else(|| {
+        ClientError::Discovery("legacy daemon health did not include daemon status".to_owned())
+    })?;
+    if daemon.get("socket").and_then(serde_json::Value::as_str) != Some(recorded_pipe.as_str()) {
+        return Err(ClientError::Discovery(
+            "legacy daemon health reported a pipe for a different Coven home".to_owned(),
+        ));
+    }
+    serde_json::to_string(&daemon)
+        .map_err(|_| ClientError::Discovery("legacy daemon health status was invalid".to_owned()))
+}
+
+#[cfg(any(windows, test))]
+fn validate_legacy_lifecycle_identity(serialized: &str) -> Result<(), ClientError> {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LegacyLifecycleIdentity {
+        pid: u32,
+        started_at: String,
+    }
+
+    let identity: LegacyLifecycleIdentity = serde_json::from_str(serialized).map_err(|_| {
+        ClientError::Discovery("inherited daemon status identity could not be validated".to_owned())
+    })?;
+    if identity.pid == 0 {
+        return Err(ClientError::Discovery(
+            "inherited daemon status PID was not a process identity".to_owned(),
+        ));
+    }
+    let _ = identity.started_at;
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+fn canonical_windows_home_key(coven_home: &Path) -> String {
+    #[cfg(windows)]
+    let coven_home = std::fs::canonicalize(coven_home).unwrap_or_else(|_| coven_home.to_path_buf());
+
+    #[cfg(not(windows))]
+    let coven_home = coven_home.to_path_buf();
+
+    let mut path = coven_home.to_string_lossy().replace('/', "\\");
+    let mut is_unc = path.starts_with(r"\\");
+    if let Some(unc_path) = path.strip_prefix(r"\\?\UNC\") {
+        path = format!(r"\\{unc_path}");
+        is_unc = true;
+    } else if let Some(path_without_prefix) = path.strip_prefix(r"\\?\") {
+        path = path_without_prefix.to_owned();
+    }
+    let mut components = Vec::new();
+    if is_unc {
+        components.push("unc".to_owned());
+    }
+    for component in path.split('\\') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            component => components.push(component.to_ascii_lowercase()),
+        }
+    }
+    components.join("\\")
+}
+
+#[cfg(test)]
+const OWNER_ONLY_PIPE_ACCESS_MASK: u32 = 0x1000_0000;
+#[cfg(any(windows, test))]
+const WINDOWS_FILE_ALL_ACCESS_MASK: u32 = 0x001f_01ff;
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy)]
+struct PipeAccessRule {
+    is_allow: bool,
+    access_mask: u32,
+    applies_to_owner_rights: bool,
+}
+
+#[cfg(any(windows, test))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WindowsAceParseError {
+    Unsupported,
+    Malformed,
+}
+
+#[cfg(any(windows, test))]
+fn parse_windows_access_allowed_ace(bytes: &[u8]) -> Result<PipeAccessRule, WindowsAceParseError> {
+    const ACCESS_ALLOWED_ACE_TYPE: u8 = 0;
+    const SID_REVISION: u8 = 1;
+    const SID_MAX_SUB_AUTHORITIES: usize = 15;
+    const ACE_PREFIX_BYTES: usize = 8;
+    const SID_PREFIX_BYTES: usize = 8;
+    const OWNER_RIGHTS_SID: [u8; 12] = [1, 1, 0, 0, 0, 0, 0, 3, 4, 0, 0, 0];
+
+    if bytes.len() < ACE_PREFIX_BYTES {
+        return Err(WindowsAceParseError::Malformed);
+    }
+    if bytes[0] != ACCESS_ALLOWED_ACE_TYPE || bytes[1] != 0 {
+        return Err(WindowsAceParseError::Unsupported);
+    }
+    let ace_size = usize::from(u16::from_le_bytes([bytes[2], bytes[3]]));
+    if ace_size != bytes.len() || ace_size % 4 != 0 {
+        return Err(WindowsAceParseError::Malformed);
+    }
+
+    let sid = bytes
+        .get(ACE_PREFIX_BYTES..ace_size)
+        .ok_or(WindowsAceParseError::Malformed)?;
+    if sid.len() < SID_PREFIX_BYTES || sid[0] != SID_REVISION {
+        return Err(WindowsAceParseError::Malformed);
+    }
+    let sub_authorities = usize::from(sid[1]);
+    if sub_authorities > SID_MAX_SUB_AUTHORITIES {
+        return Err(WindowsAceParseError::Malformed);
+    }
+    let sid_size = SID_PREFIX_BYTES
+        .checked_add(
+            sub_authorities
+                .checked_mul(std::mem::size_of::<u32>())
+                .ok_or(WindowsAceParseError::Malformed)?,
+        )
+        .ok_or(WindowsAceParseError::Malformed)?;
+    if sid.len() != sid_size {
+        return Err(WindowsAceParseError::Malformed);
+    }
+
+    Ok(PipeAccessRule {
+        is_allow: true,
+        access_mask: u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+        applies_to_owner_rights: sid == OWNER_RIGHTS_SID,
+    })
+}
+
+#[cfg(any(windows, test))]
+fn owner_only_pipe_security_is_valid(
+    owner_is_current_user: bool,
+    access_rules: &[PipeAccessRule],
+) -> bool {
+    let [rule] = access_rules else {
+        return false;
+    };
+    owner_is_current_user
+        && rule.is_allow
+        && rule.applies_to_owner_rights
+        && canonical_windows_file_access_mask(rule.access_mask) == WINDOWS_FILE_ALL_ACCESS_MASK
+}
+
+#[cfg(windows)]
+fn canonical_windows_file_access_mask(mut access_mask: u32) -> u32 {
+    use windows_sys::Win32::{
+        Security::{MapGenericMask, GENERIC_MAPPING},
+        Storage::FileSystem::{
+            FILE_ALL_ACCESS, FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE,
+        },
+    };
+
+    let mapping = GENERIC_MAPPING {
+        GenericRead: FILE_GENERIC_READ,
+        GenericWrite: FILE_GENERIC_WRITE,
+        GenericExecute: FILE_GENERIC_EXECUTE,
+        GenericAll: FILE_ALL_ACCESS,
+    };
+    unsafe {
+        MapGenericMask(&mut access_mask, &mapping);
+    }
+    access_mask
+}
+
+#[cfg(all(test, not(windows)))]
+fn canonical_windows_file_access_mask(mut access_mask: u32) -> u32 {
+    const GENERIC_READ: u32 = 0x8000_0000;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const GENERIC_EXECUTE: u32 = 0x2000_0000;
+    const GENERIC_ALL: u32 = 0x1000_0000;
+    const FILE_GENERIC_READ: u32 = 0x0012_0089;
+    const FILE_GENERIC_WRITE: u32 = 0x0012_0116;
+    const FILE_GENERIC_EXECUTE: u32 = 0x0012_00a0;
+
+    for (generic, mapped) in [
+        (GENERIC_READ, FILE_GENERIC_READ),
+        (GENERIC_WRITE, FILE_GENERIC_WRITE),
+        (GENERIC_EXECUTE, FILE_GENERIC_EXECUTE),
+        (GENERIC_ALL, WINDOWS_FILE_ALL_ACCESS_MASK),
+    ] {
+        if access_mask & generic != 0 {
+            access_mask = (access_mask & !generic) | mapped;
+        }
+    }
+    access_mask
+}
+
+#[cfg(any(windows, test))]
+struct WindowsTokenBuffer {
+    words: Vec<usize>,
+}
+
+#[cfg(any(windows, test))]
+impl WindowsTokenBuffer {
+    fn new(byte_len: usize) -> Self {
+        let word_len = byte_len.max(1).div_ceil(std::mem::size_of::<usize>());
+        Self {
+            words: vec![0; word_len],
+        }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut std::ffi::c_void {
+        self.words.as_mut_ptr().cast()
+    }
+
+    #[cfg(windows)]
+    fn as_ptr(&self) -> *const std::ffi::c_void {
+        self.words.as_ptr().cast()
+    }
+
+    fn byte_capacity(&self) -> usize {
+        self.words.len() * std::mem::size_of::<usize>()
+    }
+}
+
+#[cfg(windows)]
+const _: () = assert!(
+    std::mem::align_of::<usize>()
+        >= std::mem::align_of::<windows_sys::Win32::Security::TOKEN_USER>()
+);
+
+#[cfg(any(windows, test))]
+fn read_bounded_windows_status<R: std::io::Read>(
+    reader: R,
+    known_size: u64,
+) -> Result<String, ClientError> {
+    use std::io::Read as _;
+
+    if known_size > MAX_DAEMON_STATUS_BYTES as u64 {
+        return Err(ClientError::Discovery(format!(
+            "daemon status exceeded the {MAX_DAEMON_STATUS_BYTES}-byte limit"
+        )));
+    }
+    let capacity = usize::try_from(known_size).map_err(|_| {
+        ClientError::Discovery("daemon status size was not representable".to_owned())
+    })?;
+    let mut bytes = Vec::with_capacity(capacity);
+    reader
+        .take((MAX_DAEMON_STATUS_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            ClientError::Discovery(format!("cannot read owner-only daemon status: {error}"))
+        })?;
+    if bytes.len() > MAX_DAEMON_STATUS_BYTES {
+        return Err(ClientError::Discovery(format!(
+            "daemon status exceeded the {MAX_DAEMON_STATUS_BYTES}-byte limit"
+        )));
+    }
+    String::from_utf8(bytes)
+        .map_err(|_| ClientError::Discovery("daemon status was not valid UTF-8".to_owned()))
+}
+
+#[cfg(any(windows, test))]
+fn finite_windows_security_wait_millis(remaining: std::time::Duration) -> Option<u32> {
+    (!remaining.is_zero()).then(|| remaining.as_millis().max(1).min((u32::MAX - 1) as u128) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        finite_windows_security_wait_millis, is_coven_daemon_pipe_name, legacy_status_from_probe,
+        legacy_windows_pipe_name, lowercase_path_windows_pipe_name,
+        owner_only_pipe_security_is_valid, owner_only_windows_pipe_name,
+        owner_only_windows_pipe_name_from_identity, parse_windows_access_allowed_ace,
+        read_bounded_windows_status, recorded_pipe_name_from_status,
+        recorded_pipe_name_from_status_for_home, verify_legacy_case_folded_windows_home_identity,
+        verify_legacy_windows_home_ancestors_are_case_insensitive, verify_legacy_windows_v1_home,
+        windows_status_validation_phase, PipeAccessRule, WindowsDirectoryIdentity,
+        WindowsStatusFileSecurity, WindowsTokenBuffer, MAX_DAEMON_STATUS_BYTES,
+        OWNER_ONLY_PIPE_ACCESS_MASK,
+    };
+    #[cfg(windows)]
+    use super::{
+        legacy_windows_v1_home_is_safe, windows_directory_is_case_sensitive,
+        windows_status_file_share_mode,
+    };
+    use crate::ClientError;
+    use std::{
+        hash::{DefaultHasher, Hash, Hasher},
+        path::{Path, PathBuf},
+    };
+
+    fn historical_legacy_windows_pipe_name(coven_home: &Path) -> String {
+        let mut hasher = DefaultHasher::new();
+        coven_home.to_string_lossy().hash(&mut hasher);
+        format!("coven-daemon-{:016x}.sock", hasher.finish())
+    }
+
+    #[cfg(windows)]
+    fn enable_windows_directory_case_sensitivity(directory: &Path) -> std::io::Result<()> {
+        use std::{
+            mem::size_of,
+            os::windows::{ffi::OsStrExt, io::FromRawHandle},
+            ptr,
+        };
+        use windows_sys::Win32::{
+            Foundation::INVALID_HANDLE_VALUE,
+            Storage::FileSystem::{
+                CreateFileW, FileCaseSensitiveInfo, SetFileInformationByHandle,
+                FILE_CASE_SENSITIVE_INFO, FILE_FLAG_BACKUP_SEMANTICS, FILE_SHARE_DELETE,
+                FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_WRITE_ATTRIBUTES, OPEN_EXISTING,
+            },
+        };
+
+        let directory: Vec<u16> = directory
+            .as_os_str()
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        // SAFETY: `directory` is NUL-terminated and the pointers remain valid
+        // for the duration of the call.
+        let handle = unsafe {
+            CreateFileW(
+                directory.as_ptr(),
+                FILE_WRITE_ATTRIBUTES,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                ptr::null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                ptr::null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: ownership of the checked handle transfers exactly once.
+        let _directory = unsafe { std::fs::File::from_raw_handle(handle) };
+        let information = FILE_CASE_SENSITIVE_INFO { Flags: 1 };
+        // SAFETY: the handle is live and the immutable information buffer has
+        // the exact type and size required by FileCaseSensitiveInfo.
+        if unsafe {
+            SetFileInformationByHandle(
+                handle,
+                FileCaseSensitiveInfo,
+                std::ptr::addr_of!(information).cast(),
+                size_of::<FILE_CASE_SENSITIVE_INFO>() as u32,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    fn windows_case_sensitivity_is_unavailable(error: &std::io::Error) -> bool {
+        matches!(error.raw_os_error(), Some(1 | 5 | 50 | 87 | 1314))
+    }
+
+    #[test]
+    fn windows_pipe_names_do_not_alias_distinct_case_sensitive_directories() {
+        let upper = WindowsDirectoryIdentity {
+            volume_serial_number: 7,
+            file_id: 100_u128.to_le_bytes(),
+        };
+        let lower = WindowsDirectoryIdentity {
+            volume_serial_number: 7,
+            file_id: 101_u128.to_le_bytes(),
+        };
+
+        assert_ne!(
+            owner_only_windows_pipe_name_from_identity(upper),
+            owner_only_windows_pipe_name_from_identity(lower),
+            "distinct filesystem identities must never share a daemon pipe"
+        );
+    }
+
+    #[test]
+    fn windows_pipe_identity_hashes_every_file_id_byte_without_truncation() {
+        let lower_half = WindowsDirectoryIdentity {
+            volume_serial_number: 0x8877_6655_4433_2211,
+            file_id: [
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff,
+            ],
+        };
+        let mut upper_half = lower_half;
+        upper_half.file_id[15] ^= 0x80;
+
+        assert_eq!(
+            owner_only_windows_pipe_name_from_identity(lower_half),
+            "coven-daemon-v2-0ac550f4d9218a34aea335e8edd4d6f2.sock"
+        );
+        assert_ne!(
+            owner_only_windows_pipe_name_from_identity(lower_half),
+            owner_only_windows_pipe_name_from_identity(upper_half),
+            "changing only the high 64 bits of FILE_ID_128 must change the pipe identity"
+        );
+    }
+
+    #[test]
+    fn windows_pipe_name_is_stable_for_equivalent_coven_home_spellings() {
+        let home = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let expected = owner_only_windows_pipe_name(home).expect("derive canonical home pipe");
+
+        assert_eq!(
+            owner_only_windows_pipe_name(&home.join(".")).expect("derive dot-alias pipe"),
+            expected
+        );
+        assert_eq!(
+            owner_only_windows_pipe_name(
+                &std::fs::canonicalize(home).expect("canonical home spelling")
+            )
+            .expect("derive canonical-spelling pipe"),
+            expected
+        );
+    }
+
+    #[test]
+    fn supported_windows_pipe_names_cover_v2_v1_and_v0_identities() {
+        let home = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let names = super::supported_windows_pipe_names(home).expect("supported Windows names");
+
+        assert_eq!(names.len(), 3);
+        assert!(super::is_stable_coven_daemon_pipe_name(&names[0]));
+        assert!(super::is_lowercase_path_coven_daemon_pipe_name(&names[1]));
+        assert!(super::is_legacy_coven_daemon_pipe_name(&names[2]));
+        assert_ne!(names[0], names[1]);
+        assert_ne!(names[1], names[2]);
+    }
+
+    #[test]
+    fn status_deadline_phase_names_only_legacy_authentication_as_legacy() {
+        assert_eq!(
+            windows_status_validation_phase(WindowsStatusFileSecurity::Hardened),
+            "validating Coven daemon status"
+        );
+        assert_eq!(
+            windows_status_validation_phase(WindowsStatusFileSecurity::LegacyCurrentOwner),
+            "authenticating legacy Coven daemon status"
+        );
+    }
+
+    #[test]
+    fn windows_security_inspection_waits_are_finite_and_preserve_submillisecond_budget() {
+        assert_eq!(
+            finite_windows_security_wait_millis(std::time::Duration::ZERO),
+            None
+        );
+        assert_eq!(
+            finite_windows_security_wait_millis(std::time::Duration::from_nanos(1)),
+            Some(1)
+        );
+        assert_eq!(
+            finite_windows_security_wait_millis(std::time::Duration::from_millis(
+                u64::from(u32::MAX) + 1
+            )),
+            Some(u32::MAX - 1)
+        );
+    }
+
+    #[test]
+    fn recorded_windows_pipe_candidates_accept_only_coven_stable_or_legacy_shapes() {
+        assert!(is_coven_daemon_pipe_name(
+            "coven-daemon-v2-ea05fac3452199fa7c8e19af2cc07659.sock"
+        ));
+        assert!(is_coven_daemon_pipe_name(
+            "coven-daemon-v1-ea05fac3452199fa7c8e19af2cc07659.sock"
+        ));
+        assert!(is_coven_daemon_pipe_name(
+            "coven-daemon-0123456789abcdef.sock"
+        ));
+        assert!(!is_coven_daemon_pipe_name(r"\\.\pipe\other-daemon.sock"));
+        assert!(!is_coven_daemon_pipe_name("coven-daemon-not-hex.sock"));
+        assert!(!is_coven_daemon_pipe_name("coven-daemon-v1-0123.sock"));
+    }
+
+    #[test]
+    fn recorded_daemon_status_accepts_only_allowlisted_pipe_names() {
+        assert_eq!(
+            recorded_pipe_name_from_status(r#"{"socket":"coven-daemon-0123456789abcdef.sock"}"#)
+                .expect("allow legacy pipe"),
+            "coven-daemon-0123456789abcdef.sock"
+        );
+        assert!(recorded_pipe_name_from_status(r#"{"socket":"other-daemon.sock"}"#).is_err());
+        assert!(recorded_pipe_name_from_status(r#"{"socket":42}"#).is_err());
+    }
+
+    #[test]
+    fn recorded_daemon_status_rejects_a_stable_pipe_for_another_profile() {
+        let coven_home = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let other_home = coven_home.parent().expect("workspace crates directory");
+        let other_profile_pipe =
+            owner_only_windows_pipe_name(other_home).expect("derive other profile pipe");
+        let serialized = format!(r#"{{"socket":"{other_profile_pipe}"}}"#);
+
+        assert!(recorded_pipe_name_from_status_for_home(coven_home, &serialized).is_err());
+    }
+
+    #[test]
+    fn lowercase_hash_status_is_a_profile_bound_migration_candidate() {
+        let coven_home = Path::new(std::path::MAIN_SEPARATOR_STR);
+        let lowercase_pipe = lowercase_path_windows_pipe_name(coven_home);
+        let serialized = format!(r#"{{"socket":"{lowercase_pipe}"}}"#);
+
+        assert_eq!(
+            recorded_pipe_name_from_status_for_home(coven_home, &serialized)
+                .expect("same-profile lowercase-hash status remains migratable"),
+            lowercase_pipe
+        );
+        let other_home = Path::new(r"C:\CovenTest\Other");
+        assert!(
+            recorded_pipe_name_from_status_for_home(other_home, &serialized).is_err(),
+            "a lowercase-hash migration record must remain bound to its selected profile"
+        );
+    }
+
+    #[test]
+    fn lowercase_hash_migration_requires_the_case_folded_alias_to_have_the_same_full_identity() {
+        let canonical_home = Path::new(r"\\?\C:\Profiles\Foo\Coven");
+        let selected = WindowsDirectoryIdentity {
+            volume_serial_number: 0x8877_6655_4433_2211,
+            file_id: [
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff,
+            ],
+        };
+
+        let same_alias = verify_legacy_case_folded_windows_home_identity(
+            canonical_home,
+            selected,
+            |case_folded_home| {
+                assert_eq!(
+                    case_folded_home,
+                    Path::new(r"\\?\c:\profiles\foo\coven"),
+                    "the exact v1 ASCII-case-folded spelling must be resolved"
+                );
+                Ok(selected)
+            },
+        )
+        .expect("same-identity alias can be verified");
+        assert!(same_alias);
+
+        let mut distinct_foo = selected;
+        distinct_foo.file_id[15] ^= 0x80;
+        assert!(
+            !verify_legacy_case_folded_windows_home_identity(canonical_home, selected, |_| Ok(
+                distinct_foo
+            ),)
+            .expect("distinct Foo/foo identities can be compared"),
+            "all 128 file-ID bits and the volume must match"
+        );
+
+        let mut distinct_volume = selected;
+        distinct_volume.volume_serial_number ^= 1;
+        assert!(
+            !verify_legacy_case_folded_windows_home_identity(canonical_home, selected, |_| Ok(
+                distinct_volume
+            ),)
+            .expect("distinct volumes can be compared"),
+            "a matching file ID on another volume is not the selected profile"
+        );
+
+        assert!(
+            verify_legacy_case_folded_windows_home_identity(canonical_home, selected, |_| {
+                Err(ClientError::Discovery(
+                    "case-folded spelling did not resolve".to_owned(),
+                ))
+            })
+            .is_err(),
+            "an unresolvable or unverifiable folded spelling must fail closed"
+        );
+    }
+
+    #[test]
+    fn legacy_v1_case_check_walks_every_component_from_root_to_coven_home() {
+        #[cfg(windows)]
+        let canonical_home = Path::new(r"C:\Profiles\foo\Coven");
+        #[cfg(not(windows))]
+        let canonical_home = Path::new("/Profiles/foo/Coven");
+
+        let mut inspected = Vec::new();
+        assert!(verify_legacy_windows_home_ancestors_are_case_insensitive(
+            canonical_home,
+            |directory| {
+                inspected.push(directory.to_path_buf());
+                Ok(false)
+            },
+        )
+        .expect("all path components can be verified"));
+
+        #[cfg(windows)]
+        let expected = [
+            PathBuf::from(r"C:\"),
+            PathBuf::from(r"C:\Profiles"),
+            PathBuf::from(r"C:\Profiles\foo"),
+            PathBuf::from(r"C:\Profiles\foo\Coven"),
+        ];
+        #[cfg(not(windows))]
+        let expected = [
+            PathBuf::from("/"),
+            PathBuf::from("/Profiles"),
+            PathBuf::from("/Profiles/foo"),
+            PathBuf::from("/Profiles/foo/Coven"),
+        ];
+        assert_eq!(inspected, expected);
+    }
+
+    #[test]
+    fn legacy_v1_case_check_rejects_sensitive_or_unverifiable_ancestors() {
+        let canonical_home = std::env::current_dir()
+            .expect("current directory")
+            .join("Profiles")
+            .join("foo")
+            .join("Coven");
+        let mut after_sensitive_ancestor_was_inspected = false;
+        let safe = verify_legacy_windows_home_ancestors_are_case_insensitive(
+            &canonical_home,
+            |directory| {
+                if after_sensitive_ancestor_was_inspected {
+                    panic!("case-sensitive ancestors must reject before inspecting descendants");
+                }
+                let sensitive = directory.file_name().is_some_and(|name| name == "Profiles");
+                after_sensitive_ancestor_was_inspected = sensitive;
+                Ok(sensitive)
+            },
+        )
+        .expect("case-sensitive status was verified");
+        assert!(!safe);
+
+        let error = verify_legacy_windows_home_ancestors_are_case_insensitive(
+            &canonical_home,
+            |directory| {
+                if directory.file_name().is_some_and(|name| name == "foo") {
+                    return Err(ClientError::Discovery(
+                        "case-sensitivity query unavailable".to_owned(),
+                    ));
+                }
+                Ok(false)
+            },
+        )
+        .expect_err("an unverifiable ancestor must fail closed");
+        assert!(error.to_string().contains("query unavailable"));
+    }
+
+    #[test]
+    fn legacy_v1_rejects_lowercase_selected_home_under_case_sensitive_parent() {
+        let canonical_home = std::env::current_dir()
+            .expect("current directory")
+            .join("Profiles")
+            .join("foo")
+            .join("Coven");
+        let selected = WindowsDirectoryIdentity {
+            volume_serial_number: 7,
+            file_id: 101_u128.to_le_bytes(),
+        };
+        let sibling = WindowsDirectoryIdentity {
+            volume_serial_number: 7,
+            file_id: 102_u128.to_le_bytes(),
+        };
+        assert_ne!(selected, sibling, "foo and Foo are distinct directories");
+
+        let accepted = verify_legacy_windows_v1_home(
+            &canonical_home,
+            selected,
+            |directory| Ok(directory.file_name().is_some_and(|name| name == "Profiles")),
+            |case_folded_home| {
+                assert_eq!(
+                    case_folded_home,
+                    PathBuf::from(canonical_home.to_string_lossy().to_ascii_lowercase())
+                );
+                Ok(selected)
+            },
+        )
+        .expect("case sensitivity was verified");
+        assert!(
+            !accepted,
+            "the lowercase foo identity matching itself cannot make v1 safe when Foo collides"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_case_sensitive_ancestor_blocks_lowercase_v1_sibling_collision() {
+        struct Cleanup(PathBuf);
+
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                let _ = std::fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let root = std::env::current_dir()
+            .expect("current directory")
+            .join("target")
+            .join(format!(
+                "coven-client-case-sensitive-{}",
+                std::process::id()
+            ));
+        let cleanup = Cleanup(root.clone());
+        let profiles = root.join("profiles");
+        std::fs::create_dir_all(&profiles).expect("create case-sensitivity test parent");
+        if let Err(error) = enable_windows_directory_case_sensitivity(&profiles) {
+            if windows_case_sensitivity_is_unavailable(&error) {
+                eprintln!(
+                    "skipping case-sensitive-directory runtime test: Windows denied support ({error})"
+                );
+                return;
+            }
+            panic!("enable case-sensitive-directory test fixture: {error}");
+        }
+        assert!(windows_directory_is_case_sensitive(&profiles)
+            .expect("query enabled directory case sensitivity"));
+
+        let lower_home = profiles.join("foo").join("coven");
+        let upper_home = profiles.join("Foo").join("coven");
+        std::fs::create_dir_all(&lower_home).expect("create lowercase profile");
+        std::fs::create_dir_all(&upper_home).expect("create uppercase sibling profile");
+        assert_ne!(
+            super::windows_directory_identity(&lower_home).expect("lowercase profile identity"),
+            super::windows_directory_identity(&upper_home).expect("uppercase profile identity")
+        );
+        assert_eq!(
+            lowercase_path_windows_pipe_name(&lower_home),
+            lowercase_path_windows_pipe_name(&upper_home),
+            "the v1 lowercase hash aliases foo and Foo"
+        );
+
+        let canonical_lower = std::fs::canonicalize(&lower_home).expect("canonical lowercase home");
+        let selected = super::windows_directory_identity_from_resolved_path(&canonical_lower)
+            .expect("selected profile identity");
+        let folded_identity_still_matches =
+            verify_legacy_case_folded_windows_home_identity(&canonical_lower, selected, |folded| {
+                let folded = std::fs::canonicalize(folded).map_err(|source| ClientError::Io {
+                    operation: "failed to resolve folded Windows test profile",
+                    source,
+                })?;
+                super::windows_directory_identity_from_resolved_path(&folded)
+            })
+            .expect("resolve lowercase selected profile");
+        if !folded_identity_still_matches {
+            eprintln!(
+                "skipping sibling-collision assertion: an outer test ancestor is case-sensitive"
+            );
+            return;
+        }
+        assert!(
+            !legacy_windows_v1_home_is_safe(&lower_home)
+                .expect("verify every selected profile ancestor"),
+            "a matching folded identity cannot make the colliding v1 pipe safe"
+        );
+        let serialized = format!(
+            r#"{{"socket":"{}"}}"#,
+            lowercase_path_windows_pipe_name(&lower_home)
+        );
+        assert!(
+            recorded_pipe_name_from_status_for_home(&lower_home, &serialized).is_err(),
+            "discovery must reject the ambiguous inherited v1 status"
+        );
+        drop(cleanup);
+    }
+
+    #[test]
+    fn recorded_daemon_status_accepts_a_strict_legacy_pipe_for_its_profile() {
+        let coven_home = Path::new(r"C:\CovenTest\Profile");
+        let legacy_pipe = historical_legacy_windows_pipe_name(coven_home);
+        assert_eq!(
+            legacy_pipe, "coven-daemon-fa932683394959d8.sock",
+            "the historical DefaultHasher profile identity must remain compatible"
+        );
+        let serialized = format!(r#"{{"socket":"{legacy_pipe}"}}"#);
+
+        assert_eq!(
+            recorded_pipe_name_from_status_for_home(coven_home, &serialized)
+                .expect("legacy pipe is a supported upgrade record"),
+            legacy_pipe
+        );
+    }
+
+    #[test]
+    fn recorded_daemon_status_rejects_a_legacy_pipe_for_another_profile() {
+        let coven_home = Path::new(r"C:\CovenTest\Profile");
+        let other_profile_pipe =
+            historical_legacy_windows_pipe_name(Path::new(r"C:\CovenTest\Other"));
+        let serialized = format!(r#"{{"socket":"{other_profile_pipe}"}}"#);
+
+        assert!(recorded_pipe_name_from_status_for_home(coven_home, &serialized).is_err());
+    }
+
+    #[test]
+    fn inherited_lowercase_hash_status_uses_owner_validated_profile_pipe_health() {
+        let coven_home = Path::new(std::path::MAIN_SEPARATOR_STR);
+        let expected_pipe = lowercase_path_windows_pipe_name(coven_home);
+        let serialized =
+            format!(r#"{{"pid":999,"startedAt":"untrusted","socket":"{expected_pipe}"}}"#);
+        let observed = std::cell::RefCell::new(None);
+
+        let trusted = super::trusted_windows_status(
+            coven_home,
+            serialized,
+            WindowsStatusFileSecurity::LegacyCurrentOwner,
+            |pipe_name, timeout| {
+                observed.replace(Some((pipe_name.to_owned(), timeout)));
+                Ok(Some((
+                    200,
+                    format!(
+                        r#"{{"ok":true,"daemon":{{"pid":42,"startedAt":"trusted","socket":"{expected_pipe}"}}}}"#
+                    )
+                    .into_bytes(),
+                )))
+            },
+        )
+        .expect("same-profile inherited legacy status should use the validated health response");
+
+        assert_eq!(
+            observed.into_inner(),
+            Some((expected_pipe.clone(), std::time::Duration::from_secs(2)))
+        );
+        let trusted: serde_json::Value =
+            serde_json::from_str(&trusted).expect("trusted daemon status JSON");
+        assert_eq!(trusted["pid"], 42);
+        assert_eq!(trusted["startedAt"], "trusted");
+        assert_eq!(trusted["socket"], expected_pipe);
+    }
+
+    #[test]
+    fn legacy_status_probe_uses_only_the_remaining_outer_deadline() {
+        let start = std::time::Instant::now();
+        let deadline = start + std::time::Duration::from_millis(100);
+        assert_eq!(
+            super::windows_status_remaining_at(
+                deadline,
+                start + std::time::Duration::from_millis(65),
+                "authenticating legacy Coven daemon status",
+            )
+            .expect("budget remains"),
+            std::time::Duration::from_millis(35)
+        );
+        let error = super::windows_status_remaining_at(
+            deadline,
+            deadline,
+            "authenticating legacy Coven daemon status",
+        )
+        .expect_err("expired deadline");
+        assert!(matches!(
+            error,
+            ClientError::Io {
+                operation: "authenticating legacy Coven daemon status",
+                source,
+            } if source.kind() == std::io::ErrorKind::TimedOut
+        ));
+    }
+
+    #[test]
+    fn inherited_legacy_status_rejects_cross_profile_and_arbitrary_redirection_before_connecting() {
+        let coven_home = Path::new(r"C:\CovenTest\Profile");
+        let other_pipe = legacy_windows_pipe_name(Path::new(r"C:\CovenTest\Other"));
+
+        for redirected in [other_pipe.as_str(), "other-daemon.sock"] {
+            let serialized = format!(r#"{{"socket":"{redirected}"}}"#);
+            let result = legacy_status_from_probe(coven_home, &serialized, |_, _| {
+                panic!("a redirected inherited status file must not select a pipe")
+            });
+            assert!(
+                result.is_err(),
+                "redirected status was accepted: {serialized}"
+            );
+        }
+    }
+
+    #[test]
+    fn inherited_legacy_status_rejects_a_health_response_for_another_pipe() {
+        let coven_home = Path::new(r"C:\CovenTest\Profile");
+        let expected_pipe = legacy_windows_pipe_name(coven_home);
+        let serialized = format!(r#"{{"socket":"{expected_pipe}"}}"#);
+
+        let result = legacy_status_from_probe(coven_home, &serialized, |_, _| {
+            Ok(Some((
+                200,
+                br#"{"ok":true,"daemon":{"pid":42,"startedAt":"trusted","socket":"coven-daemon-0000000000000000.sock"}}"#
+                    .to_vec(),
+            )))
+        });
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn lifecycle_legacy_status_allows_only_an_unavailable_same_profile_pipe() {
+        let coven_home = Path::new(r"C:\CovenTest\Profile");
+        let expected_pipe = legacy_windows_pipe_name(coven_home);
+        let serialized = format!(r#"{{"pid":42,"startedAt":"legacy","socket":"{expected_pipe}"}}"#);
+
+        let accepted = super::trusted_windows_status_for_lifecycle(
+            coven_home,
+            serialized.clone(),
+            WindowsStatusFileSecurity::LegacyCurrentOwner,
+            |pipe_name, _| {
+                assert_eq!(pipe_name, expected_pipe);
+                Ok(None)
+            },
+        )
+        .expect("CLI lifecycle may inspect a same-profile unavailable legacy record");
+        assert_eq!(accepted, serialized);
+
+        assert!(
+            super::trusted_windows_status(
+                coven_home,
+                serialized,
+                WindowsStatusFileSecurity::LegacyCurrentOwner,
+                |_, _| Ok(None),
+            )
+            .is_err(),
+            "endpoint discovery must continue to reject an unavailable legacy pipe"
+        );
+    }
+
+    #[test]
+    fn lifecycle_legacy_status_rejects_redirects_and_pipe_validation_errors() {
+        let coven_home = Path::new(r"C:\CovenTest\Profile");
+        let other_pipe = legacy_windows_pipe_name(Path::new(r"C:\CovenTest\Other"));
+        for redirected in [other_pipe.as_str(), "other-daemon.sock"] {
+            let serialized =
+                format!(r#"{{"pid":42,"startedAt":"legacy","socket":"{redirected}"}}"#);
+            let result = super::trusted_windows_status_for_lifecycle(
+                coven_home,
+                serialized,
+                WindowsStatusFileSecurity::LegacyCurrentOwner,
+                |_, _| panic!("redirected status must be rejected before probing"),
+            );
+            assert!(result.is_err(), "accepted redirected status {redirected}");
+        }
+
+        let expected_pipe = legacy_windows_pipe_name(coven_home);
+        let serialized = format!(r#"{{"pid":42,"startedAt":"legacy","socket":"{expected_pipe}"}}"#);
+        let result = super::trusted_windows_status_for_lifecycle(
+            coven_home,
+            serialized,
+            WindowsStatusFileSecurity::LegacyCurrentOwner,
+            |_, _| {
+                Err(ClientError::Discovery(
+                    "connected legacy pipe failed owner-handle validation".to_owned(),
+                ))
+            },
+        );
+        let error = result.expect_err("available but untrusted pipe must fail closed");
+        assert!(error.to_string().contains("owner-handle validation"));
+
+        let invalid_health = super::trusted_windows_status_for_lifecycle(
+            coven_home,
+            format!(r#"{{"pid":42,"startedAt":"legacy","socket":"{expected_pipe}"}}"#),
+            WindowsStatusFileSecurity::LegacyCurrentOwner,
+            |_, _| Ok(Some((200, b"{invalid health".to_vec()))),
+        );
+        assert!(
+            matches!(invalid_health, Err(ClientError::Discovery(_))),
+            "invalid legacy health identity did not fail closed: {invalid_health:?}"
+        );
+
+        for ambiguous in [
+            format!(r#"{{"startedAt":"legacy","socket":"{expected_pipe}"}}"#),
+            format!(r#"{{"pid":"42","startedAt":"legacy","socket":"{expected_pipe}"}}"#),
+            format!(r#"{{"pid":0,"startedAt":"legacy","socket":"{expected_pipe}"}}"#),
+        ] {
+            let result = super::trusted_windows_status_for_lifecycle(
+                coven_home,
+                ambiguous,
+                WindowsStatusFileSecurity::LegacyCurrentOwner,
+                |_, _| Ok(None),
+            );
+            assert!(
+                matches!(result, Err(ClientError::Discovery(_))),
+                "ambiguous legacy lifecycle identity did not fail closed: {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hardened_status_content_never_uses_the_legacy_probe_path() {
+        let coven_home = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let stable_pipe =
+            owner_only_windows_pipe_name(coven_home).expect("derive stable profile pipe");
+        let serialized = format!(r#"{{"socket":"{stable_pipe}"}}"#);
+
+        let trusted = super::trusted_windows_status(
+            coven_home,
+            serialized.clone(),
+            WindowsStatusFileSecurity::Hardened,
+            |_, _| panic!("a hardened status file must not use legacy downgrade probing"),
+        )
+        .expect("hardened same-profile status");
+
+        assert_eq!(trusted, serialized);
+    }
+
+    #[test]
+    fn owner_only_pipe_validation_accepts_generic_and_mapped_file_all_access() {
+        let owner_rights_allow = PipeAccessRule {
+            is_allow: true,
+            access_mask: OWNER_ONLY_PIPE_ACCESS_MASK,
+            applies_to_owner_rights: true,
+        };
+        let mapped_file_all_access = PipeAccessRule {
+            access_mask: 0x001f_01ff,
+            ..owner_rights_allow
+        };
+
+        assert!(owner_only_pipe_security_is_valid(
+            true,
+            &[owner_rights_allow]
+        ));
+        assert!(owner_only_pipe_security_is_valid(
+            true,
+            &[mapped_file_all_access]
+        ));
+        assert!(!owner_only_pipe_security_is_valid(
+            false,
+            &[owner_rights_allow]
+        ));
+        assert!(!owner_only_pipe_security_is_valid(
+            true,
+            &[PipeAccessRule {
+                access_mask: OWNER_ONLY_PIPE_ACCESS_MASK,
+                applies_to_owner_rights: false,
+                ..owner_rights_allow
+            }]
+        ));
+        assert!(!owner_only_pipe_security_is_valid(
+            true,
+            &[
+                owner_rights_allow,
+                PipeAccessRule {
+                    is_allow: true,
+                    access_mask: OWNER_ONLY_PIPE_ACCESS_MASK,
+                    applies_to_owner_rights: true,
+                },
+            ]
+        ));
+        assert!(!owner_only_pipe_security_is_valid(
+            true,
+            &[PipeAccessRule {
+                access_mask: 0x011f_01ff,
+                ..owner_rights_allow
+            }]
+        ));
+    }
+
+    fn owner_rights_allow_ace() -> Vec<u8> {
+        let mut ace = vec![0, 0];
+        ace.extend_from_slice(&20_u16.to_le_bytes());
+        ace.extend_from_slice(&OWNER_ONLY_PIPE_ACCESS_MASK.to_le_bytes());
+        ace.extend_from_slice(&[1, 1, 0, 0, 0, 0, 0, 3, 4, 0, 0, 0]);
+        ace
+    }
+
+    #[test]
+    fn windows_ace_parser_accepts_only_a_bounded_plain_owner_rights_allow_ace() {
+        let valid = owner_rights_allow_ace();
+        let rule =
+            parse_windows_access_allowed_ace(&valid).expect("parse plain owner-rights allow ACE");
+        assert!(rule.is_allow);
+        assert_eq!(rule.access_mask, OWNER_ONLY_PIPE_ACCESS_MASK);
+        assert!(rule.applies_to_owner_rights);
+
+        let mut unaligned = vec![0xff];
+        unaligned.extend_from_slice(&valid);
+        assert!(
+            parse_windows_access_allowed_ace(&unaligned[1..]).is_ok(),
+            "byte parser must not require aligned ACE storage"
+        );
+
+        for prefix_len in 0..valid.len() {
+            assert!(
+                parse_windows_access_allowed_ace(&valid[..prefix_len]).is_err(),
+                "accepted truncated ACE prefix of {prefix_len} bytes"
+            );
+        }
+
+        for unsupported_type in [1_u8, 5, 6, 9, 10, 11, 12, 13, 15] {
+            let mut hostile = valid.clone();
+            hostile[0] = unsupported_type;
+            assert!(
+                parse_windows_access_allowed_ace(&hostile).is_err(),
+                "accepted unsupported ACE type {unsupported_type}"
+            );
+        }
+
+        for claimed_size in [0_u16, 4, 8, 16, u16::MAX] {
+            let mut hostile = valid.clone();
+            hostile[2..4].copy_from_slice(&claimed_size.to_le_bytes());
+            assert!(
+                parse_windows_access_allowed_ace(&hostile).is_err(),
+                "accepted hostile ACE size {claimed_size}"
+            );
+        }
+
+        let mut bad_sid_revision = valid.clone();
+        bad_sid_revision[8] = 0;
+        assert!(parse_windows_access_allowed_ace(&bad_sid_revision).is_err());
+
+        let mut oversized_sid = valid.clone();
+        oversized_sid[9] = 16;
+        assert!(parse_windows_access_allowed_ace(&oversized_sid).is_err());
+
+        let mut flagged = valid.clone();
+        flagged[1] = 1;
+        assert!(parse_windows_access_allowed_ace(&flagged).is_err());
+
+        let mut trailing = valid;
+        trailing.push(0);
+        assert!(parse_windows_access_allowed_ace(&trailing).is_err());
+    }
+
+    #[test]
+    fn windows_token_storage_is_word_aligned_and_covers_requested_bytes() {
+        for requested_bytes in [1, 3, 8, 31, 257] {
+            let mut buffer = WindowsTokenBuffer::new(requested_bytes);
+            assert_eq!(
+                buffer.as_mut_ptr() as usize % std::mem::align_of::<usize>(),
+                0
+            );
+            assert!(buffer.byte_capacity() >= requested_bytes);
+        }
+    }
+
+    #[test]
+    fn windows_status_limit_is_checked_before_read_and_rechecked_for_growth() {
+        struct MustNotRead;
+
+        impl std::io::Read for MustNotRead {
+            fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+                panic!("an oversized status must be rejected before any read or allocation")
+            }
+        }
+
+        let error = read_bounded_windows_status(MustNotRead, (MAX_DAEMON_STATUS_BYTES + 1) as u64)
+            .expect_err("known oversized status");
+        assert!(error.to_string().contains("16384-byte limit"));
+
+        let growing = std::io::Cursor::new(vec![b'x'; MAX_DAEMON_STATUS_BYTES + 1]);
+        let error = read_bounded_windows_status(growing, 0)
+            .expect_err("status growth after metadata inspection must remain bounded");
+        assert!(error.to_string().contains("16384-byte limit"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn status_file_reader_allows_an_atomic_status_replacement() {
+        use std::{ffi::OsStr, os::windows::ffi::OsStrExt, ptr};
+        use windows_sys::Win32::{
+            Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE},
+            Storage::FileSystem::{
+                CreateFileW, MoveFileExW, FILE_ATTRIBUTE_NORMAL, MOVEFILE_REPLACE_EXISTING,
+                MOVEFILE_WRITE_THROUGH, OPEN_EXISTING,
+            },
+        };
+
+        let test_prefix = format!(".coven-client-status-share-{}", std::process::id());
+        let status_path = std::env::current_dir()
+            .expect("test working directory")
+            .join(format!("{test_prefix}.json"));
+        let replacement_path = status_path.with_file_name(format!("{test_prefix}-next.json"));
+        let _ = std::fs::remove_file(&status_path);
+        let _ = std::fs::remove_file(&replacement_path);
+        std::fs::write(&status_path, b"{\"pid\":1}").expect("write current status");
+        std::fs::write(&replacement_path, b"{\"pid\":2}").expect("write replacement status");
+        let status_path_wide: Vec<u16> = OsStr::new(&status_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        let replacement_path_wide: Vec<u16> = OsStr::new(&replacement_path)
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+
+        let reader = unsafe {
+            CreateFileW(
+                status_path_wide.as_ptr(),
+                GENERIC_READ,
+                windows_status_file_share_mode(),
+                ptr::null(),
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                ptr::null_mut(),
+            )
+        };
+        assert_ne!(reader, INVALID_HANDLE_VALUE, "open status reader");
+        let replaced = unsafe {
+            MoveFileExW(
+                replacement_path_wide.as_ptr(),
+                status_path_wide.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        let replacement_error = std::io::Error::last_os_error();
+        unsafe {
+            CloseHandle(reader);
+        }
+        let _ = std::fs::remove_file(&replacement_path);
+        let _ = std::fs::remove_file(&status_path);
+        assert_ne!(
+            replaced, 0,
+            "atomic status replacement must not be blocked by a reader: {replacement_error}"
+        );
+    }
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn validate_windows_daemon_pipe_name(pipe_name: &str) -> Result<(), ClientError> {
+    let deadline = std::time::Instant::now()
+        .checked_add(WINDOWS_DISCOVERY_TIMEOUT)
+        .ok_or_else(|| ClientError::Discovery("daemon discovery deadline overflowed".to_owned()))?;
+    validate_windows_daemon_pipe_name_until(pipe_name, deadline)
+}
+
+#[cfg(windows)]
+fn validate_windows_daemon_pipe_name_until(
+    pipe_name: &str,
+    deadline: std::time::Instant,
+) -> Result<(), ClientError> {
+    if !is_coven_daemon_pipe_name(pipe_name) {
+        return Err(ClientError::Discovery(
+            "unsupported Coven daemon pipe name".to_owned(),
+        ));
+    }
+    validate_owner_only_windows_pipe_until(pipe_name, deadline)
+}
+
+#[cfg(windows)]
+fn validate_owner_only_windows_pipe_until(
+    pipe_name: &str,
+    deadline: std::time::Instant,
+) -> Result<(), ClientError> {
+    use std::ffi::OsStr;
+
+    let pipe_path = format!(r"\\.\pipe\{pipe_name}");
+    validate_owner_only_windows_named_pipe_until(
+        OsStr::new(&pipe_path),
+        "Coven daemon pipe",
+        deadline,
+    )
+}
+
+#[cfg(windows)]
+fn validate_owner_only_windows_named_pipe_until(
+    object_path: &std::ffi::OsStr,
+    object_label: &str,
+    deadline: std::time::Instant,
+) -> Result<(), ClientError> {
+    use std::{os::windows::ffi::OsStrExt, ptr};
+    use windows_sys::Win32::{
+        Foundation::{ERROR_PIPE_BUSY, ERROR_SEM_TIMEOUT},
+        Security::{
+            Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT},
+            DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+        },
+        System::Pipes::WaitNamedPipeW,
+    };
+
+    let mut object_path: Vec<u16> = object_path
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    loop {
+        deadline
+            .checked_duration_since(std::time::Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| windows_pipe_security_timeout(object_label))?;
+        let mut owner = ptr::null_mut();
+        let mut dacl = ptr::null_mut();
+        let mut descriptor = ptr::null_mut();
+        // `\\.\pipe` is queried by name as a file object; status files instead
+        // use GetSecurityInfo on their already-open file handle below.
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                object_path.as_mut_ptr(),
+                SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                &mut owner,
+                ptr::null_mut(),
+                &mut dacl,
+                ptr::null_mut(),
+                &mut descriptor,
+            )
+        };
+        let descriptor = LocalAllocation(descriptor);
+        if status == 0 {
+            return validate_owner_only_windows_owner_and_dacl(owner, dacl, object_label);
+        }
+        drop(descriptor);
+        if status != ERROR_PIPE_BUSY {
+            return Err(ClientError::Discovery(format!(
+                "cannot inspect owner-only {object_label}: Windows error {status}"
+            )));
+        }
+
+        let remaining = deadline
+            .checked_duration_since(std::time::Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| windows_pipe_security_timeout(object_label))?;
+        let wait_millis = finite_windows_security_wait_millis(remaining)
+            .ok_or_else(|| windows_pipe_security_timeout(object_label))?;
+        if unsafe { WaitNamedPipeW(object_path.as_ptr(), wait_millis) } == 0 {
+            let source = std::io::Error::last_os_error();
+            if source.raw_os_error() == Some(ERROR_SEM_TIMEOUT as i32)
+                || std::time::Instant::now() >= deadline
+            {
+                return Err(windows_pipe_security_timeout(object_label));
+            }
+            let code = source.raw_os_error();
+            if code != Some(ERROR_PIPE_BUSY as i32)
+                && code != Some(windows_sys::Win32::Foundation::ERROR_FILE_NOT_FOUND as i32)
+                && code != Some(windows_sys::Win32::Foundation::ERROR_PATH_NOT_FOUND as i32)
+            {
+                return Err(ClientError::Discovery(format!(
+                    "cannot inspect owner-only {object_label}: {source}"
+                )));
+            }
+            std::thread::sleep(
+                deadline
+                    .saturating_duration_since(std::time::Instant::now())
+                    .min(std::time::Duration::from_millis(1)),
+            );
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_pipe_security_timeout(object_label: &str) -> ClientError {
+    ClientError::Discovery(format!("timed out inspecting owner-only {object_label}"))
+}
+
+#[cfg(windows)]
+fn validate_owner_only_windows_owner_and_dacl(
+    owner: windows_sys::Win32::Security::PSID,
+    dacl: *mut windows_sys::Win32::Security::ACL,
+    object_label: &str,
+) -> Result<(), ClientError> {
+    use windows_sys::Win32::Security::EqualSid;
+
+    if owner.is_null() || dacl.is_null() {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} does not expose an owner-only security descriptor"
+        )));
+    }
+
+    let current_user = current_process_user_sid()?;
+    let owner_is_current_user = unsafe { EqualSid(owner, current_user.as_ptr()) != 0 };
+    let dacl_is_owner_only = exact_owner_only_windows_dacl(dacl, object_label)?;
+    if !owner_is_current_user || !dacl_is_owner_only {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} is not owned by the current user with an owner-only DACL"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn exact_owner_only_windows_dacl(
+    dacl: *mut windows_sys::Win32::Security::ACL,
+    object_label: &str,
+) -> Result<bool, ClientError> {
+    use std::{mem::size_of, ptr};
+    use windows_sys::Win32::Security::{
+        AclSizeInformation, GetAce, GetAclInformation, ACL, ACL_SIZE_INFORMATION,
+    };
+
+    let mut acl_size = ACL_SIZE_INFORMATION::default();
+    if unsafe {
+        GetAclInformation(
+            dacl,
+            (&mut acl_size as *mut ACL_SIZE_INFORMATION).cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        ) == 0
+    } {
+        return Err(ClientError::Discovery(format!(
+            "cannot inspect {object_label} access rules"
+        )));
+    }
+    if acl_size.AceCount != 1 {
+        return Ok(false);
+    }
+
+    let mut ace = ptr::null_mut();
+    if unsafe { GetAce(dacl, 0, &mut ace) == 0 } || ace.is_null() {
+        return Err(ClientError::Discovery(format!(
+            "cannot read {object_label} access rule"
+        )));
+    }
+    let acl_bytes = usize::try_from(acl_size.AclBytesInUse).map_err(|_| {
+        ClientError::Discovery(format!("{object_label} ACL size was not representable"))
+    })?;
+    if acl_bytes < size_of::<ACL>() {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} ACL was smaller than its header"
+        )));
+    }
+    let acl_start = dacl.cast::<u8>() as usize;
+    let acl_end = acl_start
+        .checked_add(acl_bytes)
+        .ok_or_else(|| ClientError::Discovery(format!("{object_label} ACL bounds overflowed")))?;
+    let acl_header_end = acl_start.checked_add(size_of::<ACL>()).ok_or_else(|| {
+        ClientError::Discovery(format!("{object_label} ACL header bounds overflowed"))
+    })?;
+    let ace_start = ace.cast::<u8>() as usize;
+    let ace_header_end = ace_start.checked_add(4).ok_or_else(|| {
+        ClientError::Discovery(format!("{object_label} ACE header bounds overflowed"))
+    })?;
+    if ace_start < acl_header_end || ace_header_end > acl_end {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} ACE header was outside its ACL"
+        )));
+    }
+    let header = unsafe { std::slice::from_raw_parts(ace.cast::<u8>(), 4) };
+    let ace_size = usize::from(u16::from_le_bytes([header[2], header[3]]));
+    let ace_end = ace_start
+        .checked_add(ace_size)
+        .ok_or_else(|| ClientError::Discovery(format!("{object_label} ACE bounds overflowed")))?;
+    if ace_size < 4 || ace_end > acl_end {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} ACE size exceeded its ACL"
+        )));
+    }
+    let ace_bytes = unsafe { std::slice::from_raw_parts(ace.cast::<u8>(), ace_size) };
+    let rule = match parse_windows_access_allowed_ace(ace_bytes) {
+        Ok(rule) => rule,
+        Err(WindowsAceParseError::Unsupported) => return Ok(false),
+        Err(WindowsAceParseError::Malformed) => {
+            return Err(ClientError::Discovery(format!(
+                "{object_label} access rule was malformed"
+            )))
+        }
+    };
+    Ok(owner_only_pipe_security_is_valid(true, &[rule]))
+}
+
+#[cfg(windows)]
+fn classify_windows_status_file_handle(
+    file: &std::fs::File,
+    object_label: &str,
+) -> Result<WindowsStatusFileSecurity, ClientError> {
+    use std::os::windows::io::AsRawHandle;
+    use std::ptr;
+    use windows_sys::Win32::Security::{
+        Authorization::{GetSecurityInfo, SE_FILE_OBJECT},
+        EqualSid, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+    };
+
+    let mut owner = ptr::null_mut();
+    let mut dacl = ptr::null_mut();
+    let mut descriptor = ptr::null_mut();
+    let status = unsafe {
+        GetSecurityInfo(
+            file.as_raw_handle(),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            &mut owner,
+            ptr::null_mut(),
+            &mut dacl,
+            ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(ClientError::Discovery(format!(
+            "cannot inspect {object_label}: Windows error {status}"
+        )));
+    }
+    let _descriptor = LocalAllocation(descriptor);
+    if owner.is_null() || dacl.is_null() {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} did not expose an owner and DACL"
+        )));
+    }
+    let current_user = current_process_user_sid()?;
+    if unsafe { EqualSid(owner, current_user.as_ptr()) } == 0 {
+        return Err(ClientError::Discovery(format!(
+            "{object_label} is not owned by the current user"
+        )));
+    }
+    if exact_owner_only_windows_dacl(dacl, object_label)? {
+        Ok(WindowsStatusFileSecurity::Hardened)
+    } else {
+        Ok(WindowsStatusFileSecurity::LegacyCurrentOwner)
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn validate_owner_only_windows_pipe_handle(
+    handle: std::os::windows::io::RawHandle,
+) -> Result<(), ClientError> {
+    use windows_sys::Win32::Security::Authorization::SE_FILE_OBJECT;
+
+    validate_owner_only_windows_handle(handle, SE_FILE_OBJECT, "connected Coven daemon pipe")
+}
+
+#[cfg(windows)]
+fn validate_owner_only_windows_handle(
+    handle: std::os::windows::io::RawHandle,
+    object_type: windows_sys::Win32::Security::Authorization::SE_OBJECT_TYPE,
+    object_label: &str,
+) -> Result<(), ClientError> {
+    use std::ptr;
+    use windows_sys::Win32::Security::{
+        Authorization::GetSecurityInfo, DACL_SECURITY_INFORMATION, OWNER_SECURITY_INFORMATION,
+    };
+
+    let mut owner = ptr::null_mut();
+    let mut dacl = ptr::null_mut();
+    let mut descriptor = ptr::null_mut();
+    let status = unsafe {
+        GetSecurityInfo(
+            handle,
+            object_type,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            &mut owner,
+            ptr::null_mut(),
+            &mut dacl,
+            ptr::null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(ClientError::Discovery(format!(
+            "cannot inspect owner-only {object_label}: Windows error {status}"
+        )));
+    }
+    let _descriptor = LocalAllocation(descriptor);
+    validate_owner_only_windows_owner_and_dacl(owner, dacl, object_label)
+}
+
+#[cfg(windows)]
+fn recorded_windows_pipe_candidate_until(
+    coven_home: &Path,
+    deadline: std::time::Instant,
+) -> Result<Option<String>, ClientError> {
+    read_windows_daemon_status(coven_home, UnavailableLegacyPipePolicy::Reject, deadline)?
+        .map(|serialized| recorded_pipe_name_from_status_for_home(coven_home, &serialized))
+        .transpose()
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn read_validated_windows_daemon_status(
+    coven_home: &Path,
+) -> Result<Option<String>, ClientError> {
+    let deadline = std::time::Instant::now()
+        .checked_add(std::time::Duration::from_secs(2))
+        .ok_or_else(|| ClientError::Discovery("daemon status deadline overflowed".to_owned()))?;
+    read_windows_daemon_status(coven_home, UnavailableLegacyPipePolicy::Reject, deadline)
+}
+
+/// Read daemon status for CLI lifecycle recovery.
+///
+/// Unlike endpoint discovery, this permits an inherited-ACL legacy record only
+/// when it names this profile's derived legacy pipe and that pipe is absent.
+/// The lifecycle caller must still prove the recorded PID dead before clearing
+/// the record. Available pipes remain subject to owner-handle validation.
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn read_windows_daemon_status_for_lifecycle(
+    coven_home: &Path,
+) -> Result<Option<String>, ClientError> {
+    let deadline = std::time::Instant::now()
+        .checked_add(std::time::Duration::from_secs(2))
+        .ok_or_else(|| ClientError::Discovery("daemon status deadline overflowed".to_owned()))?;
+    read_windows_daemon_status_for_lifecycle_until(coven_home, deadline)
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn read_windows_daemon_status_for_lifecycle_until(
+    coven_home: &Path,
+    deadline: std::time::Instant,
+) -> Result<Option<String>, ClientError> {
+    read_windows_daemon_status(
+        coven_home,
+        UnavailableLegacyPipePolicy::ReturnRecordedStatus,
+        deadline,
+    )
+}
+
+#[cfg(windows)]
+fn read_windows_daemon_status(
+    coven_home: &Path,
+    unavailable_legacy_pipe: UnavailableLegacyPipePolicy,
+    deadline: std::time::Instant,
+) -> Result<Option<String>, ClientError> {
+    windows_status_remaining_at(
+        deadline,
+        std::time::Instant::now(),
+        "opening Coven daemon status",
+    )?;
+    let Some((status_file, security, size)) = open_validated_windows_status_file(coven_home)?
+    else {
+        return Ok(None);
+    };
+    windows_status_remaining_at(
+        deadline,
+        std::time::Instant::now(),
+        "reading Coven daemon status",
+    )?;
+    let serialized = read_bounded_windows_status(status_file, size)?;
+    let probe_timeout = windows_status_remaining_at(
+        deadline,
+        std::time::Instant::now(),
+        windows_status_validation_phase(security),
+    )?;
+    let status = trusted_windows_status_with_policy_and_timeout(
+        coven_home,
+        serialized,
+        security,
+        unavailable_legacy_pipe,
+        probe_timeout,
+        |pipe_name, _| {
+            crate::transport::probe_windows_daemon_health_with_identity_until(pipe_name, deadline)
+                .map(|probe| probe.map(|probe| (probe.status, probe.body)))
+        },
+    )?;
+    windows_status_remaining_at(
+        deadline,
+        std::time::Instant::now(),
+        "validating Coven daemon status",
+    )?;
+    Ok(Some(status))
+}
+
+#[cfg(windows)]
+fn open_validated_windows_status_file(
+    coven_home: &Path,
+) -> Result<Option<(std::fs::File, WindowsStatusFileSecurity, u64)>, ClientError> {
+    use std::{
+        os::windows::{ffi::OsStrExt, io::FromRawHandle},
+        ptr,
+    };
+    use windows_sys::Win32::{
+        Foundation::{ERROR_FILE_NOT_FOUND, GENERIC_READ, INVALID_HANDLE_VALUE},
+        Storage::FileSystem::{
+            CreateFileW, GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION,
+            FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_REPARSE_POINT, FILE_FLAG_OPEN_REPARSE_POINT,
+            OPEN_EXISTING, READ_CONTROL,
+        },
+    };
+
+    let status_path = coven_home.join("daemon.json");
+    let status_path: Vec<u16> = status_path
+        .as_os_str()
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+    let handle = unsafe {
+        CreateFileW(
+            status_path.as_ptr(),
+            GENERIC_READ | READ_CONTROL,
+            windows_status_file_share_mode(),
+            ptr::null(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() == Some(ERROR_FILE_NOT_FOUND as i32) {
+            return Ok(None);
+        }
+        return Err(ClientError::Discovery(format!(
+            "cannot open owner-only daemon status: {error}"
+        )));
+    }
+    let file = unsafe { std::fs::File::from_raw_handle(handle) };
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    if unsafe { GetFileInformationByHandle(handle, &mut information) == 0 } {
+        return Err(ClientError::Discovery(format!(
+            "cannot inspect owner-only daemon status: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    if information.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(ClientError::Discovery(
+            "daemon status must not be a reparse point".to_owned(),
+        ));
+    }
+    let size = (u64::from(information.nFileSizeHigh) << 32) | u64::from(information.nFileSizeLow);
+    let security = classify_windows_status_file_handle(&file, "Coven daemon status file")?;
+    Ok(Some((file, security, size)))
+}
+
+#[cfg(windows)]
+fn windows_status_file_share_mode() -> u32 {
+    use windows_sys::Win32::Storage::FileSystem::{FILE_SHARE_DELETE, FILE_SHARE_READ};
+
+    FILE_SHARE_READ | FILE_SHARE_DELETE
+}
+
+#[cfg(windows)]
+struct WindowsSid(WindowsTokenBuffer);
+
+#[cfg(windows)]
+impl WindowsSid {
+    fn as_ptr(&self) -> windows_sys::Win32::Security::PSID {
+        self.0.as_ptr().cast_mut()
+    }
+}
+
+#[cfg(windows)]
+fn current_process_user_sid() -> Result<WindowsSid, ClientError> {
+    use std::{mem::size_of, ptr};
+    use windows_sys::Win32::{
+        Foundation::{GetLastError, ERROR_INSUFFICIENT_BUFFER},
+        Security::{
+            CopySid, GetLengthSid, GetTokenInformation, TokenUser, TOKEN_QUERY, TOKEN_USER,
+        },
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
+    };
+
+    let mut process_token = ptr::null_mut();
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut process_token) == 0 } {
+        return Err(ClientError::Discovery(format!(
+            "cannot inspect current Windows user: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    let _token = WindowsHandle(process_token);
+    let mut bytes = 0;
+    let initial =
+        unsafe { GetTokenInformation(process_token, TokenUser, ptr::null_mut(), 0, &mut bytes) };
+    if initial != 0 || unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER || bytes == 0 {
+        return Err(ClientError::Discovery(
+            "cannot size current Windows user token".to_owned(),
+        ));
+    }
+    let mut buffer = WindowsTokenBuffer::new(bytes as usize);
+    if unsafe {
+        GetTokenInformation(
+            process_token,
+            TokenUser,
+            buffer.as_mut_ptr(),
+            bytes,
+            &mut bytes,
+        ) == 0
+    } {
+        return Err(ClientError::Discovery(format!(
+            "cannot read current Windows user token: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    if (bytes as usize) < size_of::<TOKEN_USER>() || bytes as usize > buffer.byte_capacity() {
+        return Err(ClientError::Discovery(
+            "current Windows user token returned an invalid size".to_owned(),
+        ));
+    }
+    let user = unsafe { &*buffer.as_ptr().cast::<TOKEN_USER>() };
+    if user.User.Sid.is_null() {
+        return Err(ClientError::Discovery(
+            "current Windows user token had no SID".to_owned(),
+        ));
+    }
+    let length = unsafe { GetLengthSid(user.User.Sid) } as usize;
+    if length == 0 {
+        return Err(ClientError::Discovery(
+            "current Windows user token had an invalid SID".to_owned(),
+        ));
+    }
+    let mut sid = WindowsTokenBuffer::new(length);
+    if unsafe { CopySid(length as u32, sid.as_mut_ptr(), user.User.Sid) } == 0 {
+        return Err(ClientError::Discovery(format!(
+            "cannot copy current Windows user SID: {}",
+            std::io::Error::last_os_error()
+        )));
+    }
+    Ok(WindowsSid(sid))
+}
+
+#[cfg(windows)]
+struct WindowsHandle(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for WindowsHandle {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct LocalAllocation(*mut std::ffi::c_void);
+
+#[cfg(windows)]
+impl Drop for LocalAllocation {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::LocalFree(self.0);
+        }
+    }
+}

--- a/crates/coven-client/src/error.rs
+++ b/crates/coven-client/src/error.rs
@@ -1,0 +1,70 @@
+use std::io;
+
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DaemonError {
+    pub code: String,
+    pub message: String,
+    pub details: Value,
+}
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("failed to discover owner-local Coven endpoint: {0}")]
+    Discovery(String),
+    #[error("{operation}: {source}")]
+    Io {
+        operation: &'static str,
+        #[source]
+        source: io::Error,
+    },
+    #[error("Coven daemon response exceeded the {max_bytes}-byte body limit")]
+    ResponseTooLarge { max_bytes: usize },
+    #[error(
+        "Coven daemon request body of {actual_bytes} bytes exceeded the {max_bytes}-byte limit"
+    )]
+    RequestTooLarge {
+        max_bytes: usize,
+        actual_bytes: usize,
+    },
+    #[error("invalid Coven daemon HTTP response: {0}")]
+    InvalidHttpResponse(String),
+    #[error("Coven daemon response was not valid UTF-8")]
+    InvalidUtf8(#[source] std::string::FromUtf8Error),
+    #[error("failed to parse Coven daemon response: {0}")]
+    InvalidJson(#[source] serde_json::Error),
+    #[error("Coven daemon API mismatch: expected {expected}, got {actual}")]
+    ProtocolVersion {
+        expected: &'static str,
+        actual: String,
+    },
+    #[error("Coven daemon does not advertise capabilities.structuredErrors")]
+    StructuredErrorsUnavailable,
+    #[error("Coven daemon does not advertise required capabilities.{capability}")]
+    CapabilityUnavailable { capability: &'static str },
+    #[error("Coven daemon health reported not ready")]
+    HealthNotReady,
+    #[error("Coven daemon instance changed; health negotiation is required")]
+    DaemonInstanceChanged,
+    #[error("Coven daemon rejected request with HTTP {status}: {error}")]
+    Daemon { status: u16, error: DaemonError },
+    #[error("Coven daemon rejected request with HTTP {0}")]
+    HttpStatus(u16),
+    #[error("invalid Coven API route parameter: {0}")]
+    InvalidRouteParameter(&'static str),
+    #[error(
+        "cannot safely stop a legacy BASE Coven daemon on {platform}: identity-bound process \
+         signaling is unavailable; upgrade Coven and retry, or restart the daemon manually"
+    )]
+    LegacyShutdownUpgradeRequired { platform: &'static str },
+    #[error("Coven daemon client is not implemented on this platform")]
+    UnsupportedPlatform,
+}
+
+impl std::fmt::Display for DaemonError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.message, self.code)
+    }
+}

--- a/crates/coven-client/src/http.rs
+++ b/crates/coven-client/src/http.rs
@@ -1,0 +1,457 @@
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+
+use crate::{
+    error::DaemonError,
+    models::{Health, HealthCapabilities, ReadEndpoint, WriteEndpoint, PROTOCOL_VERSION},
+    transport::{self, HttpResponse, PeerIdentity},
+    ClientError, DaemonEndpoint,
+};
+
+const HEALTH_PATH: &str = "/api/v1/health";
+const RESERVED_SESSION_DETAIL_ROUTE_ERROR: &str =
+    "ReadEndpoint::Session id collides with a reserved BASE v1 nested route";
+
+pub struct DaemonClient {
+    endpoint: DaemonEndpoint,
+    negotiated: Option<NegotiatedDaemon>,
+}
+
+struct NegotiatedDaemon {
+    capabilities: HealthCapabilities,
+    peer_identity: PeerIdentity,
+}
+
+impl DaemonClient {
+    pub fn new(endpoint: DaemonEndpoint) -> Self {
+        Self {
+            endpoint,
+            negotiated: None,
+        }
+    }
+
+    pub fn health(&mut self) -> Result<Health, ClientError> {
+        // Clear any prior negotiation before every attempt: a failure below
+        // must never leave `ensure_health` trusting a stale success from an
+        // earlier call, which would let dependent requests bypass
+        // revalidation against a now-incompatible daemon.
+        self.negotiated = None;
+        let transport = transport::request(&self.endpoint, "GET", HEALTH_PATH, None)?;
+        let health: Health = self.decode(transport.response)?;
+        if health.api_version != PROTOCOL_VERSION {
+            return Err(ClientError::ProtocolVersion {
+                expected: PROTOCOL_VERSION,
+                actual: health.api_version,
+            });
+        }
+        if !health.capabilities.structured_errors {
+            return Err(ClientError::StructuredErrorsUnavailable);
+        }
+        if !health.ok {
+            return Err(ClientError::HealthNotReady);
+        }
+        self.negotiated = Some(NegotiatedDaemon {
+            capabilities: health.capabilities.clone(),
+            peer_identity: transport.peer_identity,
+        });
+        Ok(health)
+    }
+
+    pub fn get_json<T: DeserializeOwned>(
+        &mut self,
+        endpoint: ReadEndpoint,
+    ) -> Result<T, ClientError> {
+        let path = read_path(&endpoint)?;
+        self.ensure_health()?;
+        self.require_read_capabilities(&endpoint)?;
+        let response = self.send_bound("GET", &path, None)?;
+        self.decode(response)
+    }
+
+    pub fn post_json<T: DeserializeOwned, B: Serialize>(
+        &mut self,
+        endpoint: WriteEndpoint,
+        body: &B,
+    ) -> Result<T, ClientError> {
+        self.ensure_health()?;
+        self.require_write_capabilities(&endpoint)?;
+        let path = write_path(endpoint)?;
+        let body = serde_json::to_vec(body).map_err(ClientError::InvalidJson)?;
+        let response = self.send_bound("POST", &path, Some(&body))?;
+        self.decode(response)
+    }
+
+    pub fn post_empty<B: Serialize>(
+        &mut self,
+        endpoint: WriteEndpoint,
+        body: &B,
+    ) -> Result<(), ClientError> {
+        self.ensure_health()?;
+        self.require_write_capabilities(&endpoint)?;
+        let path = write_path(endpoint)?;
+        let body = serde_json::to_vec(body).map_err(ClientError::InvalidJson)?;
+        let response = self.send_bound("POST", &path, Some(&body))?;
+        if !(200..300).contains(&response.status) {
+            return Err(daemon_error(response.status, response.body)?);
+        }
+        Ok(())
+    }
+
+    fn ensure_health(&mut self) -> Result<(), ClientError> {
+        if self.negotiated.is_some() {
+            Ok(())
+        } else {
+            self.health().map(|_| ())
+        }
+    }
+
+    fn require_read_capabilities(&mut self, endpoint: &ReadEndpoint) -> Result<(), ClientError> {
+        let missing = {
+            let capabilities = self.capabilities()?;
+            match endpoint {
+                ReadEndpoint::Session { .. } | ReadEndpoint::Sessions { .. } => {
+                    (!capabilities.sessions).then_some("sessions")
+                }
+                ReadEndpoint::Events { after_seq, .. } => {
+                    if !capabilities.events {
+                        Some("events")
+                    } else if after_seq.is_some()
+                        && capabilities.event_cursor.as_deref() != Some("sequence")
+                    {
+                        Some("eventCursor")
+                    } else {
+                        None
+                    }
+                }
+            }
+        };
+        self.reject_missing_capability(missing)
+    }
+
+    fn require_write_capabilities(&mut self, _endpoint: &WriteEndpoint) -> Result<(), ClientError> {
+        let missing = (!self.capabilities()?.sessions).then_some("sessions");
+        self.reject_missing_capability(missing)
+    }
+
+    fn reject_missing_capability(
+        &mut self,
+        missing: Option<&'static str>,
+    ) -> Result<(), ClientError> {
+        let Some(capability) = missing else {
+            return Ok(());
+        };
+        let expected_peer = self
+            .negotiated
+            .as_ref()
+            .ok_or(ClientError::HealthNotReady)?
+            .peer_identity
+            .clone();
+        match transport::verify_peer(&self.endpoint, &expected_peer) {
+            Ok(()) => Err(ClientError::CapabilityUnavailable { capability }),
+            Err(error) => {
+                if matches!(error, ClientError::DaemonInstanceChanged) {
+                    self.negotiated = None;
+                }
+                Err(error)
+            }
+        }
+    }
+
+    fn capabilities(&self) -> Result<&HealthCapabilities, ClientError> {
+        self.negotiated
+            .as_ref()
+            .map(|negotiated| &negotiated.capabilities)
+            .ok_or(ClientError::HealthNotReady)
+    }
+
+    fn send_bound(
+        &mut self,
+        method: &'static str,
+        path: &str,
+        body: Option<&[u8]>,
+    ) -> Result<HttpResponse, ClientError> {
+        let expected_peer = self
+            .negotiated
+            .as_ref()
+            .ok_or(ClientError::HealthNotReady)?
+            .peer_identity
+            .clone();
+        match transport::request_bound(&self.endpoint, method, path, body, &expected_peer) {
+            Ok(response) => Ok(response.response),
+            Err(error) => {
+                if matches!(error, ClientError::DaemonInstanceChanged) {
+                    self.negotiated = None;
+                }
+                Err(error)
+            }
+        }
+    }
+
+    fn decode<T: DeserializeOwned>(&self, response: HttpResponse) -> Result<T, ClientError> {
+        if !(200..300).contains(&response.status) {
+            return Err(daemon_error(response.status, response.body)?);
+        }
+        serde_json::from_slice(&response.body).map_err(ClientError::InvalidJson)
+    }
+}
+
+fn daemon_error(status: u16, body: Vec<u8>) -> Result<ClientError, ClientError> {
+    let body = String::from_utf8(body).map_err(ClientError::InvalidUtf8)?;
+    let value: Value = serde_json::from_str(&body).map_err(ClientError::InvalidJson)?;
+    let Some(error) = value.get("error") else {
+        return Ok(ClientError::HttpStatus(status));
+    };
+    let Some(code) = error.get("code").and_then(Value::as_str) else {
+        return Ok(ClientError::HttpStatus(status));
+    };
+    let Some(message) = error.get("message").and_then(Value::as_str) else {
+        return Ok(ClientError::HttpStatus(status));
+    };
+    Ok(ClientError::Daemon {
+        status,
+        error: DaemonError {
+            code: code.to_owned(),
+            message: message.to_owned(),
+            details: error.get("details").cloned().unwrap_or(Value::Null),
+        },
+    })
+}
+
+fn read_path(endpoint: &ReadEndpoint) -> Result<String, ClientError> {
+    match endpoint {
+        ReadEndpoint::Session { session_id } => {
+            validate_session_path_remainder(session_id)?;
+            if session_id_collides_with_reserved_detail_route(session_id) {
+                return Err(ClientError::InvalidRouteParameter(
+                    RESERVED_SESSION_DETAIL_ROUTE_ERROR,
+                ));
+            }
+            Ok(format!("/api/v1/sessions/{session_id}"))
+        }
+        ReadEndpoint::Sessions { limit } => Ok(limit.map_or_else(
+            || "/api/v1/sessions".to_owned(),
+            |limit| format!("/api/v1/sessions?limit={limit}"),
+        )),
+        ReadEndpoint::Events {
+            session_id,
+            after_seq,
+            limit,
+        } => {
+            validate_session_query_value(session_id)?;
+            let mut path = format!("/api/v1/events?sessionId={session_id}");
+            if let Some(after_seq) = after_seq {
+                path.push_str(&format!("&afterSeq={after_seq}"));
+            }
+            if let Some(limit) = limit {
+                path.push_str(&format!("&limit={limit}"));
+            }
+            Ok(path)
+        }
+    }
+}
+
+fn session_id_collides_with_reserved_detail_route(session_id: &str) -> bool {
+    const RESERVED_SUFFIXES: [&str; 3] = ["events", "log", "handoffs"];
+
+    RESERVED_SUFFIXES.contains(&session_id.rsplit('/').next().unwrap_or_default())
+        || session_id.starts_with("artifacts/")
+        || session_id.contains("/artifacts/")
+}
+
+fn write_path(endpoint: WriteEndpoint) -> Result<String, ClientError> {
+    match endpoint {
+        WriteEndpoint::Sessions => Ok("/api/v1/sessions".to_owned()),
+        WriteEndpoint::SessionInput { session_id } => {
+            validate_session_path_remainder(&session_id)?;
+            Ok(format!("/api/v1/sessions/{session_id}/input"))
+        }
+        WriteEndpoint::SessionKill { session_id } => {
+            validate_session_path_remainder(&session_id)?;
+            Ok(format!("/api/v1/sessions/{session_id}/kill"))
+        }
+    }
+}
+
+fn validate_session_path_remainder(value: &str) -> Result<(), ClientError> {
+    validate_session_request_target_data(value)?;
+    if value.contains('?') {
+        return Err(ClientError::InvalidRouteParameter("session id"));
+    }
+    Ok(())
+}
+
+fn validate_session_query_value(value: &str) -> Result<(), ClientError> {
+    validate_session_request_target_data(value)?;
+    if value.contains('&') {
+        return Err(ClientError::InvalidRouteParameter(
+            "session id is ambiguous in the inherited v1 events query",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_session_request_target_data(value: &str) -> Result<(), ClientError> {
+    if value.is_empty()
+        || value
+            .chars()
+            .any(|character| character.is_whitespace() || character.is_control())
+    {
+        return Err(ClientError::InvalidRouteParameter("session id"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{read_path, write_path, RESERVED_SESSION_DETAIL_ROUTE_ERROR};
+    use crate::models::{ReadEndpoint, WriteEndpoint};
+    use crate::ClientError;
+
+    #[test]
+    fn session_routes_preserve_the_v1_raw_remainder() {
+        let cases = [
+            ("engine/42", "engine/42"),
+            ("engine:42", "engine:42"),
+            (r"engine\42", r"engine\42"),
+            ("engine%3A42", "engine%3A42"),
+            ("engine%2F42", "engine%2F42"),
+            (".", "."),
+            ("..", ".."),
+        ];
+
+        for (session_id, raw) in cases {
+            assert_eq!(
+                read_path(&ReadEndpoint::Session {
+                    session_id: session_id.to_owned(),
+                })
+                .expect("contract-valid external session id"),
+                format!("/api/v1/sessions/{raw}")
+            );
+            assert_eq!(
+                write_path(WriteEndpoint::SessionInput {
+                    session_id: session_id.to_owned(),
+                })
+                .expect("contract-valid external session id"),
+                format!("/api/v1/sessions/{raw}/input")
+            );
+        }
+    }
+
+    #[test]
+    fn events_query_preserves_representable_v1_bytes() {
+        assert_eq!(
+            read_path(&ReadEndpoint::Events {
+                session_id: "engine/42%2Fraw+value?literal".to_owned(),
+                after_seq: Some(7),
+                limit: Some(10),
+            })
+            .expect("representable raw v1 query value"),
+            "/api/v1/events?sessionId=engine/42%2Fraw+value?literal&afterSeq=7&limit=10"
+        );
+    }
+
+    #[test]
+    fn session_routes_reject_only_bytes_the_inherited_wire_cannot_represent() {
+        for session_id in ["", "engine 42", "engine\n42", "engine?other=route"] {
+            assert!(
+                read_path(&ReadEndpoint::Session {
+                    session_id: session_id.to_owned(),
+                })
+                .is_err(),
+                "unsafe session id was accepted: {session_id:?}"
+            );
+            assert!(
+                write_path(WriteEndpoint::SessionKill {
+                    session_id: session_id.to_owned(),
+                })
+                .is_err(),
+                "unsafe session id was accepted: {session_id:?}"
+            );
+        }
+
+        assert!(
+            read_path(&ReadEndpoint::Events {
+                session_id: "engine&limit=999".to_owned(),
+                after_seq: None,
+                limit: None,
+            })
+            .is_err(),
+            "the raw v1 query grammar cannot represent ampersands in sessionId"
+        );
+    }
+
+    #[test]
+    fn session_detail_rejects_every_reserved_root_and_nested_collision() {
+        for session_id in [
+            "events",
+            "engine/events",
+            "/events",
+            "log",
+            "engine/log",
+            "/log",
+            "handoffs",
+            "engine/handoffs",
+            "/handoffs",
+            "artifacts/item",
+            "artifacts/",
+            "engine/artifacts/item",
+            "engine/artifacts/",
+            "/artifacts/item",
+        ] {
+            let error = read_path(&ReadEndpoint::Session {
+                session_id: session_id.to_owned(),
+            })
+            .expect_err("reserved BASE nested route must not become a detail endpoint");
+
+            assert!(
+                matches!(
+                    error,
+                    ClientError::InvalidRouteParameter(message)
+                        if message == RESERVED_SESSION_DETAIL_ROUTE_ERROR
+                ),
+                "unexpected error for {session_id:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn session_detail_accepts_reserved_route_near_misses_and_method_only_actions() {
+        for session_id in [
+            "event",
+            "events/item",
+            "engine/events/item",
+            "logs",
+            "log/item",
+            "engine/log/item",
+            "handoff",
+            "handoffs/item",
+            "engine/handoffs/item",
+            "artifacts",
+            "engine/artifacts",
+            "artifact/item",
+            "artifacts-item/child",
+            "input",
+            "engine/input",
+            "kill",
+            "engine/kill",
+            "complete",
+            "engine/complete",
+            "claim",
+            "engine/claim",
+            "ack",
+            "engine/ack",
+            "continuations",
+            "engine/continuations",
+            "external",
+        ] {
+            assert_eq!(
+                read_path(&ReadEndpoint::Session {
+                    session_id: session_id.to_owned(),
+                })
+                .expect("near-miss remains a reachable BASE detail route"),
+                format!("/api/v1/sessions/{session_id}"),
+                "unexpected path for {session_id:?}"
+            );
+        }
+    }
+}

--- a/crates/coven-client/src/lib.rs
+++ b/crates/coven-client/src/lib.rs
@@ -1,0 +1,38 @@
+mod discovery;
+mod error;
+mod http;
+#[cfg(unix)]
+mod lifecycle;
+mod models;
+mod transport;
+
+pub use discovery::DaemonEndpoint;
+#[cfg(unix)]
+#[doc(hidden)]
+pub use discovery::{canonical_unix_daemon_home, validate_unix_daemon_path_encoding};
+#[cfg(windows)]
+pub use discovery::{
+    owner_only_windows_pipe_name, read_validated_windows_daemon_status,
+    read_windows_daemon_status_for_lifecycle, read_windows_daemon_status_for_lifecycle_until,
+    supported_windows_pipe_names, validate_windows_daemon_pipe_name,
+};
+pub use error::{ClientError, DaemonError};
+pub use http::DaemonClient;
+#[cfg(unix)]
+#[doc(hidden)]
+pub use lifecycle::{probe_unix_daemon_health, shutdown_unix_daemon};
+pub use models::{Health, HealthCapabilities, ReadEndpoint, WriteEndpoint, PROTOCOL_VERSION};
+#[cfg(unix)]
+#[doc(hidden)]
+pub use models::{LifecycleDaemonStatus, UnixDaemonShutdown};
+#[doc(hidden)]
+pub const MAX_DAEMON_STATUS_BYTES: usize = discovery::MAX_DAEMON_STATUS_BYTES;
+#[doc(hidden)]
+pub const MAX_RESPONSE_BODY_BYTES: usize = transport::MAX_RESPONSE_BODY_BYTES;
+#[cfg(windows)]
+pub use transport::{
+    open_windows_daemon_process_for_stop, open_windows_daemon_process_for_stop_until,
+    open_windows_daemon_process_for_stop_with_creation_time, probe_windows_daemon_health,
+    probe_windows_daemon_health_with_identity, probe_windows_daemon_health_with_identity_until,
+    windows_process_creation_time, WindowsDaemonHealthProbe, WindowsDaemonProcess,
+};

--- a/crates/coven-client/src/lifecycle.rs
+++ b/crates/coven-client/src/lifecycle.rs
@@ -1,0 +1,765 @@
+use std::{
+    path::Path,
+    time::{Duration, Instant},
+};
+
+use serde::Deserialize;
+
+#[cfg(target_os = "linux")]
+use crate::transport::unix_process_identity;
+use crate::{
+    transport::{
+        request_retaining_connection, request_with_timeout, request_with_timeout_bound,
+        AuthenticatedUnixResponse, PeerIdentity,
+    },
+    ClientError, DaemonEndpoint, HealthCapabilities, LifecycleDaemonStatus, UnixDaemonShutdown,
+    PROTOCOL_VERSION,
+};
+
+const HEALTH_PATH: &str = "/health";
+const SHUTDOWN_PATH: &str = "/api/v1/internal/lifecycle/shutdown";
+const MAX_LIFECYCLE_BODY_BYTES: usize = 64 * 1024;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LifecycleHealth {
+    ok: bool,
+    api_version: String,
+    coven_version: String,
+    capabilities: HealthCapabilities,
+    daemon: Option<LifecycleDaemonStatus>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ShutdownAcknowledgement {
+    ok: bool,
+    api_version: String,
+    capabilities: HealthCapabilities,
+    daemon: LifecycleDaemonStatus,
+}
+
+pub fn probe_unix_daemon_health(
+    coven_home: &Path,
+    timeout: Duration,
+) -> Result<Option<LifecycleDaemonStatus>, ClientError> {
+    let Some(endpoint) = lifecycle_endpoint(coven_home)? else {
+        return Ok(None);
+    };
+    let (response, peer) = match request_with_timeout(
+        &endpoint,
+        "GET",
+        HEALTH_PATH,
+        None,
+        timeout,
+        MAX_LIFECYCLE_BODY_BYTES,
+    ) {
+        Ok(response) => response,
+        Err(error) if endpoint_unavailable(&error) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if response.status != 200 {
+        return Err(ClientError::HttpStatus(response.status));
+    }
+    let health: LifecycleHealth =
+        serde_json::from_slice(&response.body).map_err(ClientError::InvalidJson)?;
+    validate_lifecycle_contract(health.ok, &health.api_version, &health.capabilities)?;
+    match health.daemon {
+        Some(mut status) => {
+            canonicalize_profile_binding(&endpoint, &mut status, Some(&peer))?;
+            Ok(Some(status))
+        }
+        None => Ok(None),
+    }
+}
+
+pub fn shutdown_unix_daemon(
+    coven_home: &Path,
+    expected: &LifecycleDaemonStatus,
+    timeout: Duration,
+) -> Result<UnixDaemonShutdown, ClientError> {
+    let deadline = Instant::now().checked_add(timeout).ok_or_else(|| {
+        ClientError::InvalidHttpResponse("lifecycle shutdown deadline overflowed".to_owned())
+    })?;
+    let Some(endpoint) = lifecycle_endpoint(coven_home)? else {
+        return Ok(UnixDaemonShutdown::Unavailable);
+    };
+    // Snapshot the canonical selected/recorded socket binding before any
+    // request bytes go out: this is the only point at which `expected`'s
+    // reported socket pathname is resolved against the filesystem. Once the
+    // request below is written, the daemon may legitimately unlink that same
+    // pathname while it finishes handling this very shutdown, so nothing
+    // past this point may repeat that resolution.
+    let mut canonical_expected = expected.clone();
+    if canonicalize_profile_binding(&endpoint, &mut canonical_expected, None).is_err() {
+        return Ok(UnixDaemonShutdown::IdentityMismatch);
+    }
+    let body = serde_json::to_vec(&serde_json::json!({
+        "apiVersion": PROTOCOL_VERSION,
+        "daemon": expected,
+    }))
+    .map_err(ClientError::InvalidJson)?;
+    let pending = match request_retaining_connection(
+        &endpoint,
+        "POST",
+        SHUTDOWN_PATH,
+        Some(&body),
+        remaining(
+            deadline,
+            "failed to stop Coven daemon before the lifecycle deadline",
+        )?,
+        MAX_LIFECYCLE_BODY_BYTES,
+    ) {
+        Ok(response) => response,
+        Err(error) if endpoint_unavailable(&error) => return Ok(UnixDaemonShutdown::Unavailable),
+        Err(error) => return Err(error),
+    };
+    // `request_retaining_connection` already captured the connected peer
+    // identity (pid plus the selected socket's device/inode, re-confirmed
+    // immediately after connect) before writing the request bytes above, and
+    // rejected the connection outright if the binding changed underneath it
+    // in that window. Comparing the peer pid here validates the response
+    // against that pre-send snapshot with a plain integer comparison instead
+    // of re-canonicalizing a socket pathname the daemon may have already
+    // unlinked while completing shutdown. A kernel-authenticated pid that
+    // does not match `expected` is treated as a hard failure rather than a
+    // soft identity mismatch, regardless of the response that follows: it
+    // means the numeric pid we hold has already been substituted, which must
+    // never be papered over as "the daemon changed" and quietly waved through.
+    if pending.peer_identity().peer_pid != canonical_expected.pid {
+        return Err(ClientError::Discovery(format!(
+            "expected Coven daemon pid {} but the connected peer pid was {}",
+            canonical_expected.pid,
+            pending.peer_identity().peer_pid
+        )));
+    }
+    let response_status = pending.response()?.status;
+    if response_status == 409 {
+        return Ok(UnixDaemonShutdown::IdentityMismatch);
+    }
+    if response_status == 404 {
+        return shutdown_base_unix_daemon(&endpoint, &canonical_expected, pending, deadline);
+    }
+    if response_status != 202 {
+        return Err(ClientError::HttpStatus(response_status));
+    }
+    let acknowledgement: ShutdownAcknowledgement =
+        serde_json::from_slice(&pending.response()?.body).map_err(ClientError::InvalidJson)?;
+    validate_lifecycle_contract(
+        acknowledgement.ok,
+        &acknowledgement.api_version,
+        &acknowledgement.capabilities,
+    )?;
+    // The daemon only returns 202 when the request body's `daemon` (an exact
+    // copy of `expected`) matched its own recorded identity, and it echoes
+    // that same value back verbatim on success. Comparing the acknowledged
+    // identity directly against `expected` therefore validates the response
+    // body against the pre-send snapshot without touching the filesystem.
+    if acknowledgement.daemon != *expected {
+        return Ok(UnixDaemonShutdown::IdentityMismatch);
+    }
+    if pending.wait_for_close()? {
+        Ok(UnixDaemonShutdown::Exited)
+    } else {
+        Ok(UnixDaemonShutdown::TimedOut)
+    }
+}
+
+fn shutdown_base_unix_daemon(
+    endpoint: &DaemonEndpoint,
+    expected: &LifecycleDaemonStatus,
+    missing_route: AuthenticatedUnixResponse,
+    deadline: Instant,
+) -> Result<UnixDaemonShutdown, ClientError> {
+    let peer = missing_route.peer_identity().clone();
+    if peer.peer_pid != expected.pid {
+        return Ok(UnixDaemonShutdown::IdentityMismatch);
+    }
+    drop(missing_route);
+
+    let response = match request_with_timeout_bound(
+        endpoint,
+        "GET",
+        HEALTH_PATH,
+        None,
+        &peer,
+        remaining(
+            deadline,
+            "failed to authenticate BASE Coven daemon health before the lifecycle deadline",
+        )?,
+        MAX_LIFECYCLE_BODY_BYTES,
+    ) {
+        Ok(response) => response,
+        Err(error) if endpoint_unavailable(&error) => return Ok(UnixDaemonShutdown::Unavailable),
+        Err(error) => return Err(error),
+    };
+    if response.status != 200 {
+        return Err(ClientError::HttpStatus(response.status));
+    }
+    let health: LifecycleHealth =
+        serde_json::from_slice(&response.body).map_err(ClientError::InvalidJson)?;
+    validate_lifecycle_contract(health.ok, &health.api_version, &health.capabilities)?;
+    validate_base_capabilities(&health.capabilities)?;
+    if health.coven_version.is_empty() {
+        return Err(ClientError::InvalidHttpResponse(
+            "BASE Coven daemon health omitted covenVersion".to_owned(),
+        ));
+    }
+    let Some(mut status) = health.daemon else {
+        return Ok(UnixDaemonShutdown::IdentityMismatch);
+    };
+    canonicalize_profile_binding(endpoint, &mut status, Some(&peer))?;
+    if status != *expected {
+        return Ok(UnixDaemonShutdown::IdentityMismatch);
+    }
+
+    finish_legacy_shutdown(&peer, deadline)
+}
+
+#[cfg(target_os = "linux")]
+fn finish_legacy_shutdown(
+    peer: &PeerIdentity,
+    deadline: Instant,
+) -> Result<UnixDaemonShutdown, ClientError> {
+    match signal_legacy_peer(peer, deadline)? {
+        LegacySignal::Exited => Ok(UnixDaemonShutdown::Exited),
+        LegacySignal::IdentityMismatch => Ok(UnixDaemonShutdown::IdentityMismatch),
+        LegacySignal::TimedOut => Ok(UnixDaemonShutdown::TimedOut),
+        LegacySignal::Signaled => {
+            if wait_for_legacy_peer_exit(peer, deadline)? {
+                Ok(UnixDaemonShutdown::Exited)
+            } else {
+                Ok(UnixDaemonShutdown::TimedOut)
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn finish_legacy_shutdown(
+    _peer: &PeerIdentity,
+    deadline: Instant,
+) -> Result<UnixDaemonShutdown, ClientError> {
+    remaining(
+        deadline,
+        "failed to stop BASE Coven daemon before the lifecycle deadline",
+    )?;
+    Err(legacy_shutdown_upgrade_required("macOS"))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn finish_legacy_shutdown(
+    _peer: &PeerIdentity,
+    deadline: Instant,
+) -> Result<UnixDaemonShutdown, ClientError> {
+    remaining(
+        deadline,
+        "failed to stop BASE Coven daemon before the lifecycle deadline",
+    )?;
+    Err(legacy_shutdown_upgrade_required(std::env::consts::OS))
+}
+
+fn validate_base_capabilities(capabilities: &HealthCapabilities) -> Result<(), ClientError> {
+    if !capabilities.sessions {
+        return Err(ClientError::CapabilityUnavailable {
+            capability: "sessions",
+        });
+    }
+    if !capabilities.events {
+        return Err(ClientError::CapabilityUnavailable {
+            capability: "events",
+        });
+    }
+    if capabilities.event_cursor.as_deref() != Some("sequence") {
+        return Err(ClientError::CapabilityUnavailable {
+            capability: "eventCursor",
+        });
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Debug, PartialEq, Eq)]
+enum LegacySignal {
+    Exited,
+    IdentityMismatch,
+    TimedOut,
+    Signaled,
+}
+
+#[cfg(target_os = "linux")]
+fn signal_legacy_peer(peer: &PeerIdentity, deadline: Instant) -> Result<LegacySignal, ClientError> {
+    remaining(
+        deadline,
+        "failed to revalidate BASE Coven daemon before the lifecycle deadline",
+    )?;
+    let Some(expected_identity) = peer.process_identity else {
+        return Err(ClientError::Discovery(
+            "authenticated BASE Coven daemon process identity was not retained".to_owned(),
+        ));
+    };
+    let Some(process) = peer.process_handle() else {
+        return Err(legacy_shutdown_upgrade_required("Linux"));
+    };
+    let current_identity = unix_process_identity(peer.peer_pid)?;
+    signal_if_identity_still_matches(expected_identity, current_identity, deadline, || {
+        if process.send_sigterm()? {
+            Ok(LegacySignal::Signaled)
+        } else {
+            Ok(LegacySignal::Exited)
+        }
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn signal_if_identity_still_matches<T: PartialEq>(
+    expected_identity: T,
+    current_identity: Option<T>,
+    deadline: Instant,
+    signal: impl FnOnce() -> Result<LegacySignal, ClientError>,
+) -> Result<LegacySignal, ClientError> {
+    let Some(current_identity) = current_identity else {
+        return Ok(LegacySignal::Exited);
+    };
+    if current_identity != expected_identity {
+        return Ok(LegacySignal::IdentityMismatch);
+    }
+    if Instant::now() >= deadline {
+        return Ok(LegacySignal::TimedOut);
+    }
+    signal()
+}
+
+fn legacy_shutdown_upgrade_required(platform: &'static str) -> ClientError {
+    ClientError::LegacyShutdownUpgradeRequired { platform }
+}
+
+#[cfg(target_os = "linux")]
+fn wait_for_legacy_peer_exit(peer: &PeerIdentity, deadline: Instant) -> Result<bool, ClientError> {
+    let Some(expected_identity) = peer.process_identity else {
+        return Err(ClientError::Discovery(
+            "authenticated BASE Coven daemon process identity was not retained".to_owned(),
+        ));
+    };
+    loop {
+        match unix_process_identity(peer.peer_pid)? {
+            None => return Ok(true),
+            Some(identity) if identity != expected_identity => return Ok(true),
+            Some(_) => {}
+        }
+        let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+            return Ok(false);
+        };
+        if remaining.is_zero() {
+            return Ok(false);
+        }
+        std::thread::sleep(remaining.min(Duration::from_millis(10)));
+    }
+}
+
+fn remaining(deadline: Instant, message: &'static str) -> Result<Duration, ClientError> {
+    deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| ClientError::Io {
+            operation: message,
+            source: std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Coven daemon lifecycle deadline expired",
+            ),
+        })
+}
+
+fn lifecycle_endpoint(coven_home: &Path) -> Result<Option<DaemonEndpoint>, ClientError> {
+    lifecycle_endpoint_with_discovery(coven_home, |home| DaemonEndpoint::discover(home))
+}
+
+fn lifecycle_endpoint_with_discovery(
+    coven_home: &Path,
+    discover: impl FnOnce(&Path) -> Result<DaemonEndpoint, ClientError>,
+) -> Result<Option<DaemonEndpoint>, ClientError> {
+    crate::validate_unix_daemon_path_encoding(coven_home)?;
+    match std::fs::symlink_metadata(coven_home) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(ClientError::Discovery(format!(
+                "cannot inspect COVEN_HOME {:?}: {error}",
+                coven_home.as_os_str()
+            )))
+        }
+    }
+    let coven_home = crate::canonical_unix_daemon_home(coven_home)?;
+    let home_identity = lifecycle_home_snapshot(&coven_home)?;
+    let selected_socket = coven_home.join("coven.sock");
+    match std::fs::symlink_metadata(&selected_socket) {
+        Ok(_) => match discover(&coven_home) {
+            Ok(endpoint) => Ok(Some(endpoint)),
+            Err(ClientError::Io { operation, source })
+                if operation == crate::discovery::UNIX_SOCKET_DISAPPEARED_OPERATION
+                    && source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                ensure_lifecycle_home_identity(&coven_home, home_identity)?;
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(ClientError::Discovery(format!(
+            "cannot inspect {}: {error}",
+            selected_socket.display()
+        ))),
+    }
+}
+
+fn lifecycle_home_snapshot(coven_home: &Path) -> Result<(u64, u64, u32, u32), ClientError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::symlink_metadata(coven_home).map_err(|error| {
+        ClientError::Discovery(format!(
+            "cannot inspect COVEN_HOME {} before lifecycle discovery: {error}",
+            coven_home.display()
+        ))
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(ClientError::Discovery(format!(
+            "COVEN_HOME {} is not a stable lifecycle directory",
+            coven_home.display()
+        )));
+    }
+    Ok((
+        metadata.dev(),
+        metadata.ino(),
+        metadata.uid(),
+        metadata.mode(),
+    ))
+}
+
+fn ensure_lifecycle_home_identity(
+    coven_home: &Path,
+    expected: (u64, u64, u32, u32),
+) -> Result<(), ClientError> {
+    let actual = lifecycle_home_snapshot(coven_home).map_err(|error| {
+        ClientError::Discovery(format!(
+            "cannot confirm the selected COVEN_HOME while classifying a missing daemon socket: \
+             {error}"
+        ))
+    })?;
+    if actual.0 != expected.0 || actual.1 != expected.1 {
+        return Err(ClientError::Discovery(format!(
+            "COVEN_HOME {} changed while classifying a missing daemon socket",
+            coven_home.display()
+        )));
+    }
+    // SAFETY: geteuid reads process state and cannot fail.
+    if actual.2 != unsafe { libc::geteuid() } {
+        return Err(ClientError::Discovery(format!(
+            "COVEN_HOME {} is not owned by the current user",
+            coven_home.display()
+        )));
+    }
+    if actual.3 & 0o077 != 0 {
+        return Err(ClientError::Discovery(format!(
+            "COVEN_HOME {} is accessible by users other than its owner",
+            coven_home.display()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_lifecycle_contract(
+    ok: bool,
+    api_version: &str,
+    capabilities: &HealthCapabilities,
+) -> Result<(), ClientError> {
+    if api_version != PROTOCOL_VERSION {
+        return Err(ClientError::ProtocolVersion {
+            expected: PROTOCOL_VERSION,
+            actual: api_version.to_owned(),
+        });
+    }
+    if !capabilities.structured_errors {
+        return Err(ClientError::StructuredErrorsUnavailable);
+    }
+    if !ok {
+        return Err(ClientError::HealthNotReady);
+    }
+    Ok(())
+}
+
+fn canonicalize_profile_binding(
+    endpoint: &DaemonEndpoint,
+    status: &mut LifecycleDaemonStatus,
+    peer: Option<&PeerIdentity>,
+) -> Result<(), ClientError> {
+    if let Some(peer) = peer {
+        if status.pid != peer.peer_pid {
+            return Err(ClientError::Discovery(format!(
+                "daemon health reported pid {} but the connected peer pid was {}",
+                status.pid, peer.peer_pid
+            )));
+        }
+    }
+    let reported = Path::new(&status.socket);
+    let socket_identity = peer.map(|peer| (peer.socket_device, peer.socket_inode));
+    let matches_selected = if reported.is_absolute() {
+        same_filesystem_object(endpoint.socket(), reported, socket_identity)
+    } else {
+        same_filesystem_object(endpoint.socket(), reported, socket_identity)
+            || endpoint
+                .socket()
+                .parent()
+                .into_iter()
+                .flat_map(Path::ancestors)
+                .any(|base| {
+                    same_filesystem_object(endpoint.socket(), &base.join(reported), socket_identity)
+                })
+    };
+    if !matches_selected {
+        return Err(ClientError::Discovery(
+            "daemon health reported a socket for a different Coven home".to_owned(),
+        ));
+    }
+    status.socket = endpoint
+        .socket()
+        .to_str()
+        .ok_or_else(|| {
+            ClientError::Discovery(
+                "canonical Coven daemon socket is not valid UTF-8; daemon status JSON requires \
+                 UTF-8 paths"
+                    .to_owned(),
+            )
+        })?
+        .to_owned();
+    Ok(())
+}
+
+fn same_filesystem_object(
+    selected: &Path,
+    candidate: &Path,
+    expected_identity: Option<(u64, u64)>,
+) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    let (Ok(selected_path), Ok(candidate_path)) = (
+        std::fs::canonicalize(selected),
+        std::fs::canonicalize(candidate),
+    ) else {
+        return false;
+    };
+    if selected_path != candidate_path {
+        return false;
+    }
+    let (Ok(selected), Ok(candidate)) = (
+        std::fs::metadata(selected_path),
+        std::fs::metadata(candidate_path),
+    ) else {
+        return false;
+    };
+    selected.dev() == candidate.dev()
+        && selected.ino() == candidate.ino()
+        && expected_identity
+            .is_none_or(|(device, inode)| selected.dev() == device && selected.ino() == inode)
+}
+
+fn endpoint_unavailable(error: &ClientError) -> bool {
+    matches!(
+        error,
+        ClientError::Io { source, .. }
+            if matches!(
+                source.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::ConnectionRefused
+            )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(unix)]
+    struct LifecycleTestHome(std::path::PathBuf);
+
+    #[cfg(unix)]
+    impl LifecycleTestHome {
+        fn new() -> Self {
+            use std::os::unix::fs::PermissionsExt;
+
+            static NEXT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+            let workspace = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .expect("workspace root");
+            let path = workspace.join("c").join(format!(
+                "r{:x}{:x}",
+                std::process::id(),
+                NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(&path).expect("create lifecycle test home");
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o700))
+                .expect("make lifecycle test home private");
+            Self(path)
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for LifecycleTestHome {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rediscovery_classifies_an_exact_selected_socket_unlink_as_unavailable() {
+        use std::os::unix::{fs::PermissionsExt, net::UnixListener};
+
+        let home = LifecycleTestHome::new();
+        let socket = home.0.join("coven.sock");
+        let listener = UnixListener::bind(&socket).expect("bind selected lifecycle socket");
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))
+            .expect("make selected socket private");
+        std::fs::symlink_metadata(&socket).expect("lifecycle pre-check sees selected socket");
+        std::fs::remove_file(&socket).expect("unlink selected socket before rediscovery");
+
+        let error = crate::DaemonEndpoint::discover(&home.0)
+            .expect_err("rediscovery must preserve the selected socket disappearance");
+
+        assert!(matches!(
+            error,
+            crate::ClientError::Io {
+                operation: "selected Coven daemon socket disappeared during discovery",
+                source,
+            } if source.kind() == std::io::ErrorKind::NotFound
+        ));
+        drop(listener);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_discovery_returns_none_when_the_prechecked_socket_is_unlinked() {
+        use std::os::unix::{fs::PermissionsExt, net::UnixListener};
+
+        let home = LifecycleTestHome::new();
+        let socket = home.0.join("coven.sock");
+        let listener = UnixListener::bind(&socket).expect("bind selected lifecycle socket");
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))
+            .expect("make selected socket private");
+
+        let endpoint = super::lifecycle_endpoint_with_discovery(&home.0, |canonical_home| {
+            let selected = canonical_home.join("coven.sock");
+            std::fs::remove_file(&selected)
+                .expect("unlink selected socket after lifecycle pre-check");
+            crate::DaemonEndpoint::discover(canonical_home)
+        })
+        .expect("an exact selected-socket unlink is lifecycle unavailability");
+
+        assert!(endpoint.is_none());
+        drop(listener);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_discovery_preserves_socket_permission_errors() {
+        use std::os::unix::{fs::PermissionsExt, net::UnixListener};
+
+        let home = LifecycleTestHome::new();
+        let socket = home.0.join("coven.sock");
+        let listener = UnixListener::bind(&socket).expect("bind selected lifecycle socket");
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o666))
+            .expect("make selected socket intentionally non-private");
+
+        let error = super::lifecycle_endpoint(&home.0)
+            .expect_err("a non-owner-only selected socket must fail closed");
+        assert!(matches!(error, crate::ClientError::Discovery(_)));
+        drop(listener);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn lifecycle_discovery_does_not_hide_a_replaced_profile_home() {
+        use std::os::unix::{fs::PermissionsExt, net::UnixListener};
+
+        let home = LifecycleTestHome::new();
+        let socket = home.0.join("coven.sock");
+        let moved_home = home.0.with_extension("selected");
+        let listener = UnixListener::bind(&socket).expect("bind selected lifecycle socket");
+        std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))
+            .expect("make selected socket private");
+
+        let error = super::lifecycle_endpoint_with_discovery(&home.0, |canonical_home| {
+            std::fs::remove_file(canonical_home.join("coven.sock"))
+                .expect("unlink selected socket after lifecycle pre-check");
+            std::fs::rename(canonical_home, &moved_home)
+                .expect("move selected profile out of the way");
+            std::fs::create_dir(canonical_home).expect("create substituted profile home");
+            std::fs::set_permissions(canonical_home, std::fs::Permissions::from_mode(0o700))
+                .expect("make substituted profile private");
+            crate::DaemonEndpoint::discover(canonical_home)
+        })
+        .expect_err("profile replacement must not be classified as a stopped daemon");
+
+        assert!(matches!(error, crate::ClientError::Discovery(_)));
+        drop(listener);
+        std::fs::remove_dir_all(moved_home).expect("clean moved lifecycle test home");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_identity_substitution_never_reaches_the_bound_signal() {
+        let signal_called = std::cell::Cell::new(false);
+
+        let result = super::signal_if_identity_still_matches(
+            11_u64,
+            Some(12_u64),
+            std::time::Instant::now() + std::time::Duration::from_secs(1),
+            || {
+                signal_called.set(true);
+                Ok(super::LegacySignal::Signaled)
+            },
+        )
+        .expect("identity substitution is a non-error mismatch");
+
+        assert_eq!(result, super::LegacySignal::IdentityMismatch);
+        assert!(
+            !signal_called.get(),
+            "identity substitution reached a signaling operation"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_legacy_shutdown_fails_closed_with_upgrade_guidance() {
+        let peer = crate::transport::PeerIdentity {
+            socket_device: 0,
+            socket_inode: 0,
+            peer_pid: u32::MAX,
+            peer_uid: 0,
+            peer_gid: 0,
+            process_identity: None,
+        };
+
+        let error = super::finish_legacy_shutdown(
+            &peer,
+            std::time::Instant::now() + std::time::Duration::from_secs(1),
+        )
+        .expect_err("macOS must not fall back to signaling a numeric PID");
+
+        assert!(matches!(
+            &error,
+            crate::ClientError::LegacyShutdownUpgradeRequired { platform }
+                if *platform == "macOS"
+        ));
+        let message = error.to_string();
+        assert!(message.contains("upgrade Coven"));
+        assert!(message.contains("restart the daemon manually"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_tmp_spellings_have_the_same_canonical_filesystem_identity() {
+        assert!(super::same_filesystem_object(
+            std::path::Path::new("/private/tmp"),
+            std::path::Path::new("/tmp"),
+            None,
+        ));
+    }
+}

--- a/crates/coven-client/src/models.rs
+++ b/crates/coven-client/src/models.rs
@@ -1,0 +1,69 @@
+use serde::Deserialize;
+#[cfg(unix)]
+use serde::Serialize;
+
+pub const PROTOCOL_VERSION: &str = "coven.daemon.v1";
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Health {
+    pub ok: bool,
+    pub api_version: String,
+    pub coven_version: String,
+    pub capabilities: HealthCapabilities,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthCapabilities {
+    #[serde(default)]
+    pub sessions: bool,
+    #[serde(default)]
+    pub events: bool,
+    #[serde(default)]
+    pub event_cursor: Option<String>,
+    #[serde(default)]
+    pub structured_errors: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum ReadEndpoint {
+    Session {
+        session_id: String,
+    },
+    Sessions {
+        limit: Option<u16>,
+    },
+    Events {
+        session_id: String,
+        after_seq: Option<i64>,
+        limit: Option<i64>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub enum WriteEndpoint {
+    Sessions,
+    SessionInput { session_id: String },
+    SessionKill { session_id: String },
+}
+
+#[doc(hidden)]
+#[cfg(unix)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleDaemonStatus {
+    pub pid: u32,
+    pub started_at: String,
+    pub socket: String,
+}
+
+#[doc(hidden)]
+#[cfg(unix)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnixDaemonShutdown {
+    Unavailable,
+    IdentityMismatch,
+    Exited,
+    TimedOut,
+}

--- a/crates/coven-client/src/transport/mod.rs
+++ b/crates/coven-client/src/transport/mod.rs
@@ -1,0 +1,314 @@
+#[cfg(any(unix, test))]
+use std::time::{Duration, Instant};
+
+use crate::{ClientError, DaemonEndpoint};
+
+pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 4 * 1024 * 1024;
+/// Matches the Coven daemon's own Unix-socket/named-pipe request body cap
+/// (`MAX_SOCKET_BODY_BYTES` in `coven-cli`). Rejecting oversized bodies here,
+/// before any I/O, avoids ever sending a request the daemon is guaranteed to
+/// answer with a structured 413 -- or, worse, reset the connection on before
+/// that 413 can be read back, turning a structured error into a bare I/O
+/// error.
+pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 4 * 1024 * 1024;
+
+#[cfg(any(unix, test))]
+const MIN_WRITE_RETRY_DELAY: Duration = Duration::from_millis(1);
+
+pub(crate) struct HttpResponse {
+    pub(crate) status: u16,
+    pub(crate) body: Vec<u8>,
+}
+
+#[cfg(unix)]
+#[derive(Clone, Debug)]
+pub(crate) struct PeerIdentity {
+    pub(crate) socket_device: u64,
+    pub(crate) socket_inode: u64,
+    pub(crate) peer_pid: u32,
+    pub(crate) peer_uid: u32,
+    pub(crate) peer_gid: u32,
+    pub(crate) process_identity: Option<unix::UnixProcessIdentity>,
+    #[cfg(target_os = "linux")]
+    process_handle: Option<std::sync::Arc<unix::LinuxProcessHandle>>,
+}
+
+#[cfg(unix)]
+impl PartialEq for PeerIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        // Separate pidfds for the same process have different descriptor
+        // numbers. The PID and birth marker establish equality; the original
+        // handle is retained only to make a later legacy signal identity-bound.
+        self.socket_device == other.socket_device
+            && self.socket_inode == other.socket_inode
+            && self.peer_pid == other.peer_pid
+            && self.peer_uid == other.peer_uid
+            && self.peer_gid == other.peer_gid
+            && self.process_identity == other.process_identity
+    }
+}
+
+#[cfg(unix)]
+impl Eq for PeerIdentity {}
+
+#[cfg(target_os = "linux")]
+impl PeerIdentity {
+    pub(crate) fn process_handle(&self) -> Option<&unix::LinuxProcessHandle> {
+        self.process_handle.as_deref()
+    }
+}
+
+#[cfg(windows)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PeerIdentity {
+    pub(crate) server_pid: u32,
+    pub(crate) process_creation_time: u64,
+}
+
+#[cfg(not(any(unix, windows)))]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PeerIdentity;
+
+pub(crate) struct TransportResponse {
+    pub(crate) response: HttpResponse,
+    pub(crate) peer_identity: PeerIdentity,
+}
+
+/// Writes `buf` to a stream already in nonblocking mode, bounded by
+/// `deadline`. `WouldBlock`/`TimedOut` are treated as "try again" rather than
+/// an error, and interrupted calls are resumed, so a peer that never drains
+/// its receive buffer cannot block the caller past `deadline`.
+#[cfg(any(unix, test))]
+pub(crate) fn write_with_deadline<S: std::io::Write>(
+    stream: &mut S,
+    mut buf: &[u8],
+    deadline: Instant,
+    operation: &'static str,
+) -> Result<(), ClientError> {
+    while !buf.is_empty() {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero());
+        let Some(remaining) = remaining else {
+            return Err(ClientError::Io {
+                operation,
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out writing Coven daemon request",
+                ),
+            });
+        };
+        match stream.write(buf) {
+            Ok(0) => {
+                return Err(ClientError::Io {
+                    operation,
+                    source: std::io::Error::new(
+                        std::io::ErrorKind::WriteZero,
+                        "failed to write whole buffer",
+                    ),
+                })
+            }
+            Ok(written) => buf = &buf[written..],
+            Err(source)
+                if matches!(
+                    source.kind(),
+                    std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                        | std::io::ErrorKind::Interrupted
+                ) =>
+            {
+                if source.kind() != std::io::ErrorKind::Interrupted {
+                    std::thread::sleep(remaining.min(MIN_WRITE_RETRY_DELAY));
+                }
+            }
+            Err(source) => return Err(ClientError::Io { operation, source }),
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn request(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+) -> Result<TransportResponse, ClientError> {
+    request_with_peer(endpoint, method, path, body, None)
+}
+
+pub(crate) fn request_bound(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: &PeerIdentity,
+) -> Result<TransportResponse, ClientError> {
+    request_with_peer(endpoint, method, path, body, Some(expected_peer))
+}
+
+pub(crate) fn verify_peer(
+    endpoint: &DaemonEndpoint,
+    expected_peer: &PeerIdentity,
+) -> Result<(), ClientError> {
+    #[cfg(unix)]
+    {
+        unix::verify_peer(endpoint, expected_peer)
+    }
+
+    #[cfg(windows)]
+    {
+        windows::verify_peer(endpoint, expected_peer)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (endpoint, expected_peer);
+        Err(ClientError::UnsupportedPlatform)
+    }
+}
+
+fn request_with_peer(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: Option<&PeerIdentity>,
+) -> Result<TransportResponse, ClientError> {
+    if !path.starts_with("/api/v1/") {
+        return Err(ClientError::InvalidHttpResponse(
+            "attempted request outside /api/v1".to_owned(),
+        ));
+    }
+    if let Some(body) = body {
+        if body.len() > MAX_REQUEST_BODY_BYTES {
+            return Err(ClientError::RequestTooLarge {
+                max_bytes: MAX_REQUEST_BODY_BYTES,
+                actual_bytes: body.len(),
+            });
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        unix::request(endpoint, method, path, body, expected_peer)
+    }
+
+    #[cfg(windows)]
+    {
+        windows::request(endpoint, method, path, body, expected_peer)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (endpoint, method, path, body, expected_peer);
+        Err(ClientError::UnsupportedPlatform)
+    }
+}
+
+#[cfg(unix)]
+mod unix;
+#[cfg(target_os = "linux")]
+pub(crate) use unix::unix_process_identity;
+#[cfg(unix)]
+pub(crate) use unix::{
+    request_retaining_connection, request_with_timeout, request_with_timeout_bound,
+    AuthenticatedUnixResponse,
+};
+#[cfg(any(windows, test))]
+mod windows;
+#[cfg(windows)]
+pub use windows::{
+    open_windows_daemon_process_for_stop, open_windows_daemon_process_for_stop_until,
+    open_windows_daemon_process_for_stop_with_creation_time, probe_windows_daemon_health,
+    probe_windows_daemon_health_with_identity, probe_windows_daemon_health_with_identity_until,
+    windows_process_creation_time, WindowsDaemonHealthProbe, WindowsDaemonProcess,
+};
+
+#[cfg(test)]
+mod tests {
+    use crate::ClientError;
+    use std::{io::Write, time::Instant};
+
+    #[derive(Default)]
+    struct WriteRecorder(Vec<u8>);
+
+    impl Write for WriteRecorder {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_with_deadline_rejects_an_already_expired_deadline_without_writing() {
+        let mut stream = WriteRecorder::default();
+        let expired = Instant::now() - std::time::Duration::from_millis(1);
+
+        let error = super::write_with_deadline(&mut stream, b"payload", expired, "write")
+            .expect_err("an expired deadline must not attempt a write");
+
+        assert!(matches!(error, ClientError::Io { .. }));
+        assert!(stream.0.is_empty());
+    }
+
+    struct AlwaysWouldBlock;
+
+    impl Write for AlwaysWouldBlock {
+        fn write(&mut self, _bytes: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::from(std::io::ErrorKind::WouldBlock))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_with_deadline_times_out_a_stalled_nonblocking_writer() {
+        let mut stream = AlwaysWouldBlock;
+        let deadline = Instant::now() + std::time::Duration::from_millis(20);
+        let started = Instant::now();
+
+        let error = super::write_with_deadline(&mut stream, b"payload", deadline, "write")
+            .expect_err("a permanently blocked write must be bounded by the deadline");
+
+        assert!(matches!(error, ClientError::Io { .. }));
+        assert!(started.elapsed() < std::time::Duration::from_secs(2));
+    }
+
+    #[derive(Default)]
+    struct InterruptedOnceWriter {
+        interrupted: bool,
+        bytes: Vec<u8>,
+    }
+
+    impl Write for InterruptedOnceWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            if !self.interrupted {
+                self.interrupted = true;
+                return Err(std::io::Error::from(std::io::ErrorKind::Interrupted));
+            }
+            self.bytes.extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn write_with_deadline_retries_interrupted_writes() {
+        let mut stream = InterruptedOnceWriter::default();
+        let deadline = Instant::now() + std::time::Duration::from_secs(1);
+
+        super::write_with_deadline(&mut stream, b"payload", deadline, "write")
+            .expect("an interrupted write must be retried under the same deadline");
+
+        assert_eq!(stream.bytes, b"payload");
+    }
+}

--- a/crates/coven-client/src/transport/unix.rs
+++ b/crates/coven-client/src/transport/unix.rs
@@ -1,0 +1,1184 @@
+use std::{
+    io::Read,
+    os::unix::net::UnixStream,
+    time::{Duration, Instant},
+};
+
+use socket2::{Domain, SockAddr, Socket, Type};
+
+use crate::{
+    transport::{
+        write_with_deadline, HttpResponse, PeerIdentity, TransportResponse, MAX_RESPONSE_BODY_BYTES,
+    },
+    ClientError, DaemonEndpoint,
+};
+
+const MAX_RESPONSE_HEADERS_BYTES: usize = 64 * 1024;
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+const MIN_READ_TIMEOUT: Duration = Duration::from_millis(1);
+
+struct RetainedRequestOptions {
+    timeout: Duration,
+    max_response_body_bytes: usize,
+    bind_process_identity: bool,
+}
+
+struct FramedResponse {
+    response: HttpResponse,
+    buffered_remainder: Vec<u8>,
+}
+
+pub(crate) fn request(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: Option<&PeerIdentity>,
+) -> Result<TransportResponse, ClientError> {
+    request_bound(
+        endpoint,
+        method,
+        path,
+        body,
+        expected_peer,
+        RESPONSE_TIMEOUT,
+        MAX_RESPONSE_BODY_BYTES,
+    )
+}
+
+pub(crate) fn verify_peer(
+    endpoint: &DaemonEndpoint,
+    expected_peer: &PeerIdentity,
+) -> Result<(), ClientError> {
+    let deadline = Instant::now()
+        .checked_add(RESPONSE_TIMEOUT)
+        .ok_or_else(|| {
+            ClientError::InvalidHttpResponse("peer verification deadline overflowed".to_owned())
+        })?;
+    let (_stream, peer_identity) = connect_with_deadline(endpoint, deadline, false)?;
+    if &peer_identity != expected_peer {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    Ok(())
+}
+
+fn request_bound(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: Option<&PeerIdentity>,
+    timeout: Duration,
+    max_response_body_bytes: usize,
+) -> Result<TransportResponse, ClientError> {
+    let pending = request_retaining_connection_bound(
+        endpoint,
+        method,
+        path,
+        body,
+        expected_peer,
+        RetainedRequestOptions {
+            timeout,
+            max_response_body_bytes,
+            bind_process_identity: false,
+        },
+    )?;
+    let (response, peer_identity) = pending.into_response_and_peer()?;
+    Ok(TransportResponse {
+        response,
+        peer_identity,
+    })
+}
+
+pub(crate) fn request_with_timeout(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    timeout: Duration,
+    max_response_body_bytes: usize,
+) -> Result<(HttpResponse, PeerIdentity), ClientError> {
+    let pending = request_retaining_connection_bound(
+        endpoint,
+        method,
+        path,
+        body,
+        None,
+        RetainedRequestOptions {
+            timeout,
+            max_response_body_bytes,
+            bind_process_identity: false,
+        },
+    )?;
+    pending.into_response_and_peer()
+}
+
+pub(crate) fn request_with_timeout_bound(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: &PeerIdentity,
+    timeout: Duration,
+    max_response_body_bytes: usize,
+) -> Result<HttpResponse, ClientError> {
+    let pending = request_retaining_connection_bound(
+        endpoint,
+        method,
+        path,
+        body,
+        Some(expected_peer),
+        RetainedRequestOptions {
+            timeout,
+            max_response_body_bytes,
+            bind_process_identity: true,
+        },
+    )?;
+    Ok(pending.into_response_and_peer()?.0)
+}
+
+pub(crate) struct AuthenticatedUnixResponse {
+    response: HttpResponse,
+    peer_identity: PeerIdentity,
+    stream: UnixStream,
+    deadline: Instant,
+    buffered_remainder: Vec<u8>,
+}
+
+impl AuthenticatedUnixResponse {
+    pub(crate) fn peer_identity(&self) -> &PeerIdentity {
+        &self.peer_identity
+    }
+
+    pub(crate) fn response(&self) -> Result<&HttpResponse, ClientError> {
+        self.ensure_framing_valid("daemon sent bytes after its lifecycle response completed")?;
+        Ok(&self.response)
+    }
+
+    fn into_response_and_peer(self) -> Result<(HttpResponse, PeerIdentity), ClientError> {
+        self.ensure_framing_valid("daemon sent bytes after its response completed")?;
+        Ok((self.response, self.peer_identity))
+    }
+
+    pub(crate) fn wait_for_close(mut self) -> Result<bool, ClientError> {
+        self.ensure_framing_valid("daemon sent bytes after its lifecycle response completed")?;
+        let mut byte = [0_u8; 1];
+        loop {
+            if Instant::now() >= self.deadline {
+                return Ok(false);
+            }
+            match self.stream.read(&mut byte) {
+                Ok(0) => return Ok(true),
+                Ok(_) => {
+                    return Err(ClientError::InvalidHttpResponse(
+                        "daemon sent bytes after its lifecycle response completed".to_owned(),
+                    ))
+                }
+                Err(source)
+                    if matches!(
+                        source.kind(),
+                        std::io::ErrorKind::TimedOut
+                            | std::io::ErrorKind::WouldBlock
+                            | std::io::ErrorKind::Interrupted
+                    ) =>
+                {
+                    if source.kind() != std::io::ErrorKind::Interrupted {
+                        let remaining = self
+                            .deadline
+                            .saturating_duration_since(Instant::now())
+                            .min(MIN_READ_TIMEOUT);
+                        if !remaining.is_zero() {
+                            std::thread::sleep(remaining);
+                        }
+                    }
+                }
+                Err(source) => {
+                    return Err(ClientError::Io {
+                        operation: "failed to wait for Coven daemon shutdown",
+                        source,
+                    })
+                }
+            }
+        }
+    }
+
+    fn ensure_framing_valid(&self, message: &'static str) -> Result<(), ClientError> {
+        if self.buffered_remainder.is_empty() {
+            Ok(())
+        } else {
+            Err(ClientError::InvalidHttpResponse(message.to_owned()))
+        }
+    }
+}
+
+pub(crate) fn request_retaining_connection(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    timeout: Duration,
+    max_response_body_bytes: usize,
+) -> Result<AuthenticatedUnixResponse, ClientError> {
+    request_retaining_connection_bound(
+        endpoint,
+        method,
+        path,
+        body,
+        None,
+        RetainedRequestOptions {
+            timeout,
+            max_response_body_bytes,
+            bind_process_identity: true,
+        },
+    )
+}
+
+fn request_retaining_connection_bound(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: Option<&PeerIdentity>,
+    options: RetainedRequestOptions,
+) -> Result<AuthenticatedUnixResponse, ClientError> {
+    // A single deadline covers connect, write, and read: previously only the
+    // read phase was bounded, so a daemon that accepted a connection but
+    // never read from it (or a socket whose listen backlog was full) could
+    // block the caller indefinitely.
+    let deadline = Instant::now().checked_add(options.timeout).ok_or_else(|| {
+        ClientError::InvalidHttpResponse("request deadline overflowed".to_owned())
+    })?;
+    let body = body.unwrap_or_default();
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    );
+    let (mut stream, peer_identity) =
+        connect_with_deadline(endpoint, deadline, options.bind_process_identity)?;
+    if expected_peer.is_some_and(|expected| expected != &peer_identity) {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    stream
+        .set_nonblocking(true)
+        .map_err(|source| ClientError::Io {
+            operation: "failed to configure nonblocking Coven daemon socket writes",
+            source,
+        })?;
+    const WRITE_OPERATION: &str = "failed to write Coven daemon request";
+    write_with_deadline(&mut stream, request.as_bytes(), deadline, WRITE_OPERATION)?;
+    write_with_deadline(&mut stream, body, deadline, WRITE_OPERATION)?;
+    stream
+        .shutdown(std::net::Shutdown::Write)
+        .map_err(|source| ClientError::Io {
+            operation: "failed to finish Coven daemon request",
+            source,
+        })?;
+
+    let framed = read_framed_response(&mut stream, deadline, options.max_response_body_bytes)?;
+    Ok(AuthenticatedUnixResponse {
+        response: framed.response,
+        peer_identity,
+        stream,
+        deadline,
+        buffered_remainder: framed.buffered_remainder,
+    })
+}
+
+/// Connects to the daemon's Unix socket bounded by `deadline`.
+///
+/// `UnixStream::connect` has no built-in timeout and, for a listener whose
+/// accept backlog is full, can block for an unbounded time. `socket2` performs
+/// a nonblocking connect and polls for completion without leaving a worker
+/// thread behind after a timeout.
+fn connect_with_deadline(
+    endpoint: &DaemonEndpoint,
+    deadline: Instant,
+    bind_process_identity: bool,
+) -> Result<(UnixStream, PeerIdentity), ClientError> {
+    const OPERATION: &str = "failed to connect to Coven daemon socket";
+    let socket_identity = validated_socket_identity(endpoint)?;
+    let socket =
+        Socket::new(Domain::UNIX, Type::STREAM, None).map_err(|source| ClientError::Io {
+            operation: OPERATION,
+            source,
+        })?;
+    let address = SockAddr::unix(endpoint.socket()).map_err(|source| ClientError::Io {
+        operation: OPERATION,
+        source,
+    })?;
+    connect_operation_with_deadline(deadline, |remaining| {
+        socket.connect_timeout(&address, remaining)
+    })?;
+    let socket: std::os::fd::OwnedFd = socket.into();
+    let stream: UnixStream = socket.into();
+    let peer = validate_connected_peer(&stream, endpoint.owner_uid())?;
+    let bound_process = bind_process_identity
+        .then(|| bind_connected_process_identity(&stream, endpoint.owner_uid(), peer))
+        .transpose()?;
+    let process_identity = bound_process.as_ref().map(|bound| bound.identity);
+    #[cfg(target_os = "linux")]
+    let process_handle = bound_process.and_then(|bound| bound.handle);
+    let confirmed_socket_identity =
+        validated_socket_identity(endpoint).map_err(|_| ClientError::DaemonInstanceChanged)?;
+    if confirmed_socket_identity != socket_identity {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    Ok((
+        stream,
+        PeerIdentity {
+            socket_device: socket_identity.device,
+            socket_inode: socket_identity.inode,
+            peer_pid: peer.pid,
+            peer_uid: peer.uid,
+            peer_gid: peer.gid,
+            process_identity,
+            #[cfg(target_os = "linux")]
+            process_handle,
+        },
+    ))
+}
+
+struct BoundUnixProcessIdentity {
+    identity: UnixProcessIdentity,
+    #[cfg(target_os = "linux")]
+    handle: Option<std::sync::Arc<LinuxProcessHandle>>,
+}
+
+fn bind_connected_process_identity(
+    stream: &UnixStream,
+    expected_uid: u32,
+    peer: UnixPeerCredentials,
+) -> Result<BoundUnixProcessIdentity, ClientError> {
+    let identity = unix_process_identity(peer.pid)?.ok_or_else(|| {
+        ClientError::Discovery(
+            "connected Coven daemon peer exited before its process identity was bound".to_owned(),
+        )
+    })?;
+    #[cfg(target_os = "linux")]
+    let handle = LinuxProcessHandle::open(peer.pid)?.map(std::sync::Arc::new);
+    let confirmed_peer = validate_connected_peer(stream, expected_uid)
+        .map_err(|_| ClientError::DaemonInstanceChanged)?;
+    if confirmed_peer != peer || unix_process_identity(peer.pid)? != Some(identity) {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    Ok(BoundUnixProcessIdentity {
+        identity,
+        #[cfg(target_os = "linux")]
+        handle,
+    })
+}
+
+fn connect_operation_with_deadline(
+    deadline: Instant,
+    connect: impl FnOnce(Duration) -> std::io::Result<()>,
+) -> Result<(), ClientError> {
+    const OPERATION: &str = "failed to connect to Coven daemon socket";
+    let remaining = deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| ClientError::Io {
+            operation: OPERATION,
+            source: std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "timed out connecting to Coven daemon socket",
+            ),
+        })?;
+    connect(remaining).map_err(|source| ClientError::Io {
+        operation: OPERATION,
+        source,
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct UnixSocketIdentity {
+    device: u64,
+    inode: u64,
+}
+
+fn validated_socket_identity(endpoint: &DaemonEndpoint) -> Result<UnixSocketIdentity, ClientError> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+    let metadata =
+        std::fs::symlink_metadata(endpoint.socket()).map_err(|source| ClientError::Io {
+            operation: "failed to connect to Coven daemon socket",
+            source,
+        })?;
+    let current_uid = unsafe { libc::geteuid() };
+    if metadata.file_type().is_symlink()
+        || !metadata.file_type().is_socket()
+        || metadata.uid() != endpoint.owner_uid()
+        || metadata.uid() != current_uid
+        || metadata.mode() & 0o077 != 0
+    {
+        return Err(ClientError::Discovery(format!(
+            "{} is no longer an owner-local Unix socket",
+            endpoint.socket().display()
+        )));
+    }
+    Ok(UnixSocketIdentity {
+        device: metadata.dev(),
+        inode: metadata.ino(),
+    })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct UnixPeerCredentials {
+    pid: u32,
+    uid: u32,
+    gid: u32,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct UnixProcessIdentity {
+    start_ticks: u64,
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct UnixProcessIdentity {
+    start_seconds: u64,
+    start_microseconds: u64,
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct UnixProcessIdentity;
+
+#[cfg(target_os = "linux")]
+#[derive(Debug)]
+pub(crate) struct LinuxProcessHandle(std::os::fd::OwnedFd);
+
+#[cfg(target_os = "linux")]
+impl LinuxProcessHandle {
+    fn open(pid: u32) -> Result<Option<Self>, ClientError> {
+        use std::os::fd::FromRawFd;
+
+        let pid = libc::pid_t::try_from(pid).map_err(|_| {
+            ClientError::Discovery("connected Coven daemon peer PID exceeded pid_t".to_owned())
+        })?;
+        // SAFETY: pidfd_open takes a numeric PID and zero flags, returns a new
+        // descriptor on success, and does not dereference userspace pointers.
+        let descriptor = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0_u32) };
+        if descriptor >= 0 {
+            let descriptor = libc::c_int::try_from(descriptor).map_err(|_| {
+                ClientError::Discovery("Linux pidfd exceeded the file-descriptor range".to_owned())
+            })?;
+            // SAFETY: a successful pidfd_open returned this fresh descriptor,
+            // whose ownership transfers exactly once to OwnedFd.
+            return Ok(Some(Self(unsafe {
+                std::os::fd::OwnedFd::from_raw_fd(descriptor)
+            })));
+        }
+
+        let source = std::io::Error::last_os_error();
+        match source.raw_os_error() {
+            Some(libc::ESRCH) => Err(ClientError::Discovery(
+                "connected Coven daemon peer exited before its process handle was retained"
+                    .to_owned(),
+            )),
+            // Do not block the authenticated shutdown route merely because
+            // this kernel or app policy lacks pidfds. Exact-404 legacy fallback
+            // checks the missing handle and fails closed with upgrade guidance.
+            Some(libc::ENOSYS | libc::EPERM | libc::EACCES) => Ok(None),
+            _ => Err(ClientError::Io {
+                operation: "failed to retain connected Coven daemon process handle",
+                source,
+            }),
+        }
+    }
+
+    pub(crate) fn send_sigterm(&self) -> Result<bool, ClientError> {
+        use std::os::fd::AsRawFd;
+
+        // SAFETY: the owned pidfd remains live for this call, SIGTERM is a
+        // valid signal, siginfo is intentionally null, and flags must be zero.
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.0.as_raw_fd(),
+                libc::SIGTERM,
+                std::ptr::null::<libc::siginfo_t>(),
+                0_u32,
+            )
+        };
+        if result == 0 {
+            return Ok(true);
+        }
+
+        let source = std::io::Error::last_os_error();
+        match source.raw_os_error() {
+            Some(libc::ESRCH) => Ok(false),
+            Some(libc::ENOSYS) => {
+                Err(ClientError::LegacyShutdownUpgradeRequired { platform: "Linux" })
+            }
+            _ => Err(ClientError::Io {
+                operation: "failed to signal authenticated BASE Coven daemon through pidfd",
+                source,
+            }),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn unix_process_identity(pid: u32) -> Result<Option<UnixProcessIdentity>, ClientError> {
+    let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+        Ok(stat) => stat,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(ClientError::Io {
+                operation: "failed to inspect Coven daemon process identity",
+                source,
+            })
+        }
+    };
+    let Some(command_end) = stat.rfind(')') else {
+        return Err(ClientError::Discovery(
+            "Coven daemon process status omitted its command boundary".to_owned(),
+        ));
+    };
+    let fields = stat[command_end + 1..]
+        .split_whitespace()
+        .collect::<Vec<_>>();
+    if fields.len() <= 19 {
+        return Err(ClientError::Discovery(
+            "Coven daemon process status omitted its start identity".to_owned(),
+        ));
+    }
+    if matches!(fields[0], "Z" | "X") {
+        return Ok(None);
+    }
+    let start_ticks = fields[19].parse::<u64>().map_err(|_| {
+        ClientError::Discovery("Coven daemon process start identity was invalid".to_owned())
+    })?;
+    if start_ticks == 0 {
+        return Err(ClientError::Discovery(
+            "Coven daemon process start identity was zero".to_owned(),
+        ));
+    }
+    Ok(Some(UnixProcessIdentity { start_ticks }))
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn unix_process_identity(pid: u32) -> Result<Option<UnixProcessIdentity>, ClientError> {
+    use std::mem::MaybeUninit;
+
+    const PROC_PIDTBSDINFO: libc::c_int = 3;
+    const SZOMB: u32 = 5;
+
+    #[repr(C)]
+    struct ProcBsdInfo {
+        pbi_flags: u32,
+        pbi_status: u32,
+        pbi_xstatus: u32,
+        pbi_pid: u32,
+        pbi_ppid: u32,
+        pbi_uid: u32,
+        pbi_gid: u32,
+        pbi_ruid: u32,
+        pbi_rgid: u32,
+        pbi_svuid: u32,
+        pbi_svgid: u32,
+        rfu_1: u32,
+        pbi_comm: [libc::c_char; 16],
+        pbi_name: [libc::c_char; 32],
+        pbi_nfiles: u32,
+        pbi_pgid: u32,
+        pbi_pjobc: u32,
+        e_tdev: u32,
+        e_tpgid: u32,
+        pbi_nice: i32,
+        pbi_start_tvsec: u64,
+        pbi_start_tvusec: u64,
+    }
+
+    #[link(name = "proc")]
+    unsafe extern "C" {
+        fn proc_pidinfo(
+            pid: libc::c_int,
+            flavor: libc::c_int,
+            argument: u64,
+            buffer: *mut libc::c_void,
+            buffer_size: libc::c_int,
+        ) -> libc::c_int;
+    }
+
+    let pid_as_int = libc::c_int::try_from(pid).map_err(|_| {
+        ClientError::Discovery("connected Coven daemon peer PID exceeded pid_t".to_owned())
+    })?;
+    let expected_size = std::mem::size_of::<ProcBsdInfo>();
+    let buffer_size = libc::c_int::try_from(expected_size).map_err(|_| {
+        ClientError::Discovery("macOS process identity buffer size overflowed".to_owned())
+    })?;
+    let mut info = MaybeUninit::<ProcBsdInfo>::uninit();
+    let result = unsafe {
+        proc_pidinfo(
+            pid_as_int,
+            PROC_PIDTBSDINFO,
+            0,
+            info.as_mut_ptr().cast(),
+            buffer_size,
+        )
+    };
+    if result == 0 {
+        let source = std::io::Error::last_os_error();
+        return if source.raw_os_error() == Some(libc::ESRCH) {
+            Ok(None)
+        } else {
+            Err(ClientError::Io {
+                operation: "failed to inspect Coven daemon process identity",
+                source,
+            })
+        };
+    }
+    if usize::try_from(result).ok() != Some(expected_size) {
+        return Err(ClientError::Discovery(
+            "macOS returned a truncated Coven daemon process identity".to_owned(),
+        ));
+    }
+    let info = unsafe { info.assume_init() };
+    if info.pbi_pid != pid {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    if info.pbi_status == SZOMB {
+        return Ok(None);
+    }
+    if info.pbi_start_tvsec == 0 && info.pbi_start_tvusec == 0 {
+        return Err(ClientError::Discovery(
+            "Coven daemon process start identity was zero".to_owned(),
+        ));
+    }
+    Ok(Some(UnixProcessIdentity {
+        start_seconds: info.pbi_start_tvsec,
+        start_microseconds: info.pbi_start_tvusec,
+    }))
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub(crate) fn unix_process_identity(_pid: u32) -> Result<Option<UnixProcessIdentity>, ClientError> {
+    Err(ClientError::UnsupportedPlatform)
+}
+
+fn peer_uid_matches(expected_uid: u32, current_uid: u32, peer_uid: u32) -> bool {
+    peer_uid == expected_uid && peer_uid == current_uid
+}
+
+fn validate_connected_peer(
+    stream: &UnixStream,
+    expected_uid: u32,
+) -> Result<UnixPeerCredentials, ClientError> {
+    let peer = connected_peer_credentials(stream).map_err(|source| ClientError::Io {
+        operation: "failed to inspect connected Coven daemon peer credentials",
+        source,
+    })?;
+    // SAFETY: geteuid only reads process credentials and cannot fail.
+    let current_uid = unsafe { libc::geteuid() };
+    if !peer_uid_matches(expected_uid, current_uid, peer.uid) {
+        return Err(ClientError::Discovery(format!(
+            "connected Coven daemon peer uid {} did not match expected current owner uid {expected_uid}",
+            peer.uid
+        )));
+    }
+    Ok(peer)
+}
+
+#[cfg(target_os = "linux")]
+fn connected_peer_credentials(stream: &UnixStream) -> std::io::Result<UnixPeerCredentials> {
+    use std::{mem::MaybeUninit, os::fd::AsRawFd};
+
+    let mut credentials = MaybeUninit::<libc::ucred>::uninit();
+    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::ucred>())
+        .map_err(|_| std::io::Error::other("Linux peer credential size overflow"))?;
+    let result = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            credentials.as_mut_ptr().cast(),
+            &mut length,
+        )
+    };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::ucred>()) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Linux peer credential response had an unexpected size",
+        ));
+    }
+    let credentials = unsafe { credentials.assume_init() };
+    let pid = u32::try_from(credentials.pid)
+        .map_err(|_| std::io::Error::other("Linux peer PID was not positive"))?;
+    if pid == 0 {
+        return Err(std::io::Error::other("Linux peer PID was zero"));
+    }
+    Ok(UnixPeerCredentials {
+        pid,
+        uid: credentials.uid,
+        gid: credentials.gid,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn connected_peer_credentials(stream: &UnixStream) -> std::io::Result<UnixPeerCredentials> {
+    use std::{mem::MaybeUninit, os::fd::AsRawFd};
+
+    let mut uid = 0;
+    let mut gid = 0;
+    if unsafe { libc::getpeereid(stream.as_raw_fd(), &mut uid, &mut gid) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let mut pid = MaybeUninit::<libc::pid_t>::uninit();
+    let mut length = libc::socklen_t::try_from(std::mem::size_of::<libc::pid_t>())
+        .map_err(|_| std::io::Error::other("macOS peer PID size overflow"))?;
+    if unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERPID,
+            pid.as_mut_ptr().cast(),
+            &mut length,
+        )
+    } != 0
+    {
+        return Err(std::io::Error::last_os_error());
+    }
+    if usize::try_from(length).ok() != Some(std::mem::size_of::<libc::pid_t>()) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "macOS peer PID response had an unexpected size",
+        ));
+    }
+    let pid = u32::try_from(unsafe { pid.assume_init() })
+        .map_err(|_| std::io::Error::other("macOS peer PID was not positive"))?;
+    if pid == 0 {
+        return Err(std::io::Error::other("macOS peer PID was zero"));
+    }
+    Ok(UnixPeerCredentials { pid, uid, gid })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn connected_peer_credentials(_stream: &UnixStream) -> std::io::Result<UnixPeerCredentials> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Unix peer credential validation is unavailable on this platform",
+    ))
+}
+
+fn read_framed_response<R: Read>(
+    stream: &mut R,
+    deadline: Instant,
+    max_response_body_bytes: usize,
+) -> Result<FramedResponse, ClientError> {
+    let mut received = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 4096];
+    let (status, body_start, content_length) = loop {
+        if let Some((header_end, body_start)) = find_header_end(&received) {
+            if header_end > MAX_RESPONSE_HEADERS_BYTES {
+                return Err(ClientError::InvalidHttpResponse(format!(
+                    "response headers exceeded {MAX_RESPONSE_HEADERS_BYTES} bytes"
+                )));
+            }
+            let (status, content_length) = parse_headers(&received[..header_end])?;
+            if content_length > max_response_body_bytes {
+                return Err(ClientError::ResponseTooLarge {
+                    max_bytes: max_response_body_bytes,
+                });
+            }
+            break (status, body_start, content_length);
+        }
+        if received.len() > MAX_RESPONSE_HEADERS_BYTES {
+            return Err(ClientError::InvalidHttpResponse(format!(
+                "response headers exceeded {MAX_RESPONSE_HEADERS_BYTES} bytes"
+            )));
+        }
+        read_with_deadline(stream, &mut chunk, deadline, &mut received)?;
+    };
+
+    while received.len().saturating_sub(body_start) < content_length {
+        let remaining = content_length - (received.len() - body_start);
+        let read_len = remaining.saturating_add(1).min(chunk.len());
+        read_with_deadline(stream, &mut chunk[..read_len], deadline, &mut received)?;
+    }
+
+    let mut body_and_remainder = received.split_off(body_start);
+    let mut buffered_remainder = body_and_remainder.split_off(content_length);
+    if buffered_remainder.is_empty() {
+        if let Some(byte) = nonblocking_boundary_probe(stream, deadline)? {
+            buffered_remainder.push(byte);
+        }
+    }
+    Ok(FramedResponse {
+        response: HttpResponse {
+            status,
+            body: body_and_remainder,
+        },
+        buffered_remainder,
+    })
+}
+
+fn nonblocking_boundary_probe<R: Read>(
+    stream: &mut R,
+    deadline: Instant,
+) -> Result<Option<u8>, ClientError> {
+    let mut byte = [0_u8; 1];
+    loop {
+        match stream.read(&mut byte) {
+            Ok(0) => return Ok(None),
+            Ok(_) => return Ok(Some(byte[0])),
+            Err(source)
+                if matches!(
+                    source.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) =>
+            {
+                return Ok(None);
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::Interrupted => {
+                read_timeout_until(deadline, Instant::now())?;
+            }
+            Err(source) => {
+                return Err(ClientError::Io {
+                    operation: "failed to validate Coven daemon response framing",
+                    source,
+                })
+            }
+        }
+    }
+}
+
+fn read_with_deadline<R: Read>(
+    stream: &mut R,
+    chunk: &mut [u8],
+    deadline: Instant,
+    received: &mut Vec<u8>,
+) -> Result<(), ClientError> {
+    let timeout = read_timeout_until(deadline, Instant::now())?;
+    match stream.read(chunk) {
+        Ok(0) => Err(ClientError::InvalidHttpResponse(
+            "connection closed before response completed".to_owned(),
+        )),
+        Ok(read) => {
+            received.extend_from_slice(&chunk[..read]);
+            Ok(())
+        }
+        Err(source)
+            if matches!(
+                source.kind(),
+                std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::WouldBlock
+                    | std::io::ErrorKind::Interrupted
+            ) =>
+        {
+            if source.kind() != std::io::ErrorKind::Interrupted {
+                std::thread::sleep(timeout.min(MIN_READ_TIMEOUT));
+            }
+            Ok(())
+        }
+        Err(source) => Err(ClientError::Io {
+            operation: "failed to read Coven daemon response",
+            source,
+        }),
+    }
+}
+
+fn read_timeout_until(deadline: Instant, now: Instant) -> Result<Duration, ClientError> {
+    let remaining = deadline
+        .checked_duration_since(now)
+        .filter(|duration| !duration.is_zero());
+    remaining.map_or_else(
+        || {
+            Err(ClientError::InvalidHttpResponse(
+                "timed out reading Coven daemon response".to_owned(),
+            ))
+        },
+        Ok,
+    )
+}
+
+fn parse_headers(headers: &[u8]) -> Result<(u16, usize), ClientError> {
+    let headers = std::str::from_utf8(headers)
+        .map_err(|_| ClientError::InvalidHttpResponse("headers were not UTF-8".to_owned()))?;
+    let status = headers
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|status| status.parse().ok())
+        .ok_or_else(|| ClientError::InvalidHttpResponse("missing HTTP status".to_owned()))?;
+    let mut content_length = None;
+    for line in headers.lines().skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(ClientError::InvalidHttpResponse(
+                "malformed HTTP response header".to_owned(),
+            ));
+        };
+        if name.eq_ignore_ascii_case("transfer-encoding") {
+            return Err(ClientError::InvalidHttpResponse(format!(
+                "unsupported Transfer-Encoding: {}",
+                value.trim()
+            )));
+        }
+        if name.eq_ignore_ascii_case("content-length") {
+            if content_length.is_some() {
+                return Err(ClientError::InvalidHttpResponse(
+                    "duplicate Content-Length header".to_owned(),
+                ));
+            }
+            content_length = Some(value.trim().parse().map_err(|_| {
+                ClientError::InvalidHttpResponse("invalid Content-Length header".to_owned())
+            })?);
+        }
+    }
+    let content_length = content_length.ok_or_else(|| {
+        ClientError::InvalidHttpResponse("missing Content-Length header".to_owned())
+    })?;
+    Ok((status, content_length))
+}
+
+fn find_header_end(response: &[u8]) -> Option<(usize, usize)> {
+    response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|position| (position, position + 4))
+        .or_else(|| {
+            response
+                .windows(2)
+                .position(|window| window == b"\n\n")
+                .map(|position| (position, position + 2))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        connect_operation_with_deadline, connected_peer_credentials, peer_uid_matches,
+        read_framed_response, read_timeout_until,
+    };
+    use std::{
+        io::{Cursor, Read},
+        time::{Duration, Instant},
+    };
+
+    #[test]
+    fn deadline_timeout_preserves_sub_resolution_durations_and_rejects_expiry() {
+        let now = Instant::now();
+
+        assert_eq!(
+            read_timeout_until(now + Duration::from_nanos(1), now).expect("future deadline"),
+            Duration::from_nanos(1)
+        );
+        assert!(read_timeout_until(now, now).is_err());
+    }
+
+    #[test]
+    fn stalled_connect_receives_only_the_absolute_deadline_budget() {
+        let observed = std::cell::Cell::new(None);
+        let deadline = Instant::now() + Duration::from_millis(25);
+
+        let error = connect_operation_with_deadline(deadline, |remaining| {
+            observed.set(Some(remaining));
+            Err(std::io::Error::from(std::io::ErrorKind::TimedOut))
+        })
+        .expect_err("simulated stalled connect must time out");
+
+        assert!(matches!(error, crate::ClientError::Io { .. }));
+        let remaining = observed.get().expect("connect timeout was supplied");
+        assert!(!remaining.is_zero());
+        assert!(remaining <= Duration::from_millis(25));
+
+        let invoked = std::cell::Cell::new(false);
+        connect_operation_with_deadline(Instant::now(), |_| {
+            invoked.set(true);
+            Ok(())
+        })
+        .expect_err("expired connect deadline must fail before connect");
+        assert!(!invoked.get());
+    }
+
+    #[test]
+    fn connected_peer_uid_must_match_discovered_and_current_owner() {
+        assert!(peer_uid_matches(501, 501, 501));
+        assert!(!peer_uid_matches(501, 501, 502));
+        assert!(!peer_uid_matches(501, 502, 501));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn platform_peer_credentials_report_the_connected_process_uid() {
+        let (client, _server) =
+            std::os::unix::net::UnixStream::pair().expect("create connected Unix stream pair");
+
+        let peer = connected_peer_credentials(&client).expect("inspect connected peer credentials");
+
+        assert_eq!(peer.uid, unsafe { libc::geteuid() });
+        assert_eq!(peer.pid, std::process::id());
+    }
+
+    struct InterruptedOnceReader {
+        interrupted: bool,
+        response: Cursor<&'static [u8]>,
+    }
+
+    impl Read for InterruptedOnceReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            if !self.interrupted {
+                self.interrupted = true;
+                return Err(std::io::Error::from(std::io::ErrorKind::Interrupted));
+            }
+            self.response.read(buffer)
+        }
+    }
+
+    struct ChunkedReader {
+        chunks: std::collections::VecDeque<&'static [u8]>,
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let Some(chunk) = self.chunks.pop_front() else {
+                return Ok(0);
+            };
+            assert!(chunk.len() <= buffer.len());
+            buffer[..chunk.len()].copy_from_slice(chunk);
+            Ok(chunk.len())
+        }
+    }
+
+    struct FirstReadBoundedSocket {
+        stream: std::os::unix::net::UnixStream,
+        first_read_limit: Option<usize>,
+    }
+
+    impl Read for FirstReadBoundedSocket {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let limit = self
+                .first_read_limit
+                .take()
+                .unwrap_or(buffer.len())
+                .min(buffer.len());
+            self.stream.read(&mut buffer[..limit])
+        }
+    }
+
+    #[test]
+    fn response_reader_retries_interrupted_reads() {
+        let mut reader = InterruptedOnceReader {
+            interrupted: false,
+            response: Cursor::new(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}"),
+        };
+
+        let framed = read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_secs(1),
+            super::MAX_RESPONSE_BODY_BYTES,
+        )
+        .expect("an interrupted read must be retried under the same deadline");
+
+        assert_eq!(framed.response.status, 200);
+        assert_eq!(framed.response.body, b"{}");
+        assert!(framed.buffered_remainder.is_empty());
+    }
+
+    #[test]
+    fn response_reader_accepts_a_header_coalesced_with_a_partial_body() {
+        let mut reader = ChunkedReader {
+            chunks: std::collections::VecDeque::from([
+                &b"HTTP/1.1 200 OK\r\nContent-Length: 7\r\n\r\npar"[..],
+                &b"tial"[..],
+            ]),
+        };
+
+        let framed = read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_secs(1),
+            super::MAX_RESPONSE_BODY_BYTES,
+        )
+        .expect("read a body split across the header read and a later read");
+
+        assert_eq!(framed.response.status, 200);
+        assert_eq!(framed.response.body, b"partial");
+        assert!(framed.buffered_remainder.is_empty());
+    }
+
+    #[test]
+    fn response_reader_preserves_all_bytes_after_a_zero_length_body() {
+        let mut reader =
+            Cursor::new(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\nXYZ".as_slice());
+
+        let framed = read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_secs(1),
+            super::MAX_RESPONSE_BODY_BYTES,
+        )
+        .expect("read the complete frame and buffered remainder");
+
+        assert_eq!(framed.response.status, 204);
+        assert!(framed.response.body.is_empty());
+        assert_eq!(framed.buffered_remainder, b"XYZ");
+    }
+
+    #[test]
+    fn real_socket_reader_preserves_trailing_bytes_queued_with_a_later_body_read() {
+        use std::io::Write;
+
+        let (reader, mut writer) =
+            std::os::unix::net::UnixStream::pair().expect("create response socket pair");
+        reader
+            .set_nonblocking(true)
+            .expect("make response reader nonblocking");
+        let server = std::thread::spawn(move || {
+            writer
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n")
+                .expect("write response headers");
+            std::thread::sleep(Duration::from_millis(20));
+            writer
+                .write_all(b"bodyX")
+                .expect("write body and trailing byte together");
+        });
+        let mut reader = FirstReadBoundedSocket {
+            stream: reader,
+            first_read_limit: None,
+        };
+
+        let framed = read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_secs(1),
+            super::MAX_RESPONSE_BODY_BYTES,
+        )
+        .expect("read framed socket response");
+
+        assert_eq!(framed.response.body, b"body");
+        assert_eq!(framed.buffered_remainder, b"X");
+        server.join().expect("response server");
+    }
+
+    #[test]
+    fn real_socket_reader_probes_after_a_header_only_zero_length_frame() {
+        use std::io::Write;
+
+        let header = b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
+        let (reader, mut writer) =
+            std::os::unix::net::UnixStream::pair().expect("create response socket pair");
+        reader
+            .set_nonblocking(true)
+            .expect("make response reader nonblocking");
+        writer
+            .write_all(&[header.as_slice(), b"X"].concat())
+            .expect("queue header and trailing byte");
+        let mut reader = FirstReadBoundedSocket {
+            stream: reader,
+            first_read_limit: Some(header.len()),
+        };
+
+        let framed = read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_secs(1),
+            super::MAX_RESPONSE_BODY_BYTES,
+        )
+        .expect("read zero-length socket response");
+
+        assert!(framed.response.body.is_empty());
+        assert_eq!(framed.buffered_remainder, b"X");
+    }
+}

--- a/crates/coven-client/src/transport/windows.rs
+++ b/crates/coven-client/src/transport/windows.rs
@@ -1,0 +1,1751 @@
+use std::{
+    io::{Read, Write},
+    time::{Duration, Instant},
+};
+
+#[cfg(windows)]
+use crate::{
+    discovery::{is_coven_daemon_pipe_name, validate_owner_only_windows_pipe_handle},
+    transport::{PeerIdentity, TransportResponse, MAX_RESPONSE_BODY_BYTES},
+    DaemonEndpoint,
+};
+use crate::{transport::HttpResponse, ClientError};
+
+const MAX_RESPONSE_HEADERS_BYTES: usize = 64 * 1024;
+const ERROR_BROKEN_PIPE_CODE: i32 = 109;
+const ERROR_NO_DATA_CODE: i32 = 232;
+const TRAILING_RESPONSE_BYTES: &str =
+    "daemon sent bytes beyond its declared response Content-Length";
+#[cfg(windows)]
+const RESPONSE_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(any(windows, test))]
+const fn windows_pipe_client_flags() -> u32 {
+    // SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION. Passing zero asks
+    // CreateFileW for SecurityImpersonation, which lets a pipe server
+    // impersonate an elevated client.
+    0x0010_0000 | 0x0001_0000
+}
+
+const fn filetime_parts_to_u64(low: u32, high: u32) -> u64 {
+    (high as u64) << 32 | low as u64
+}
+
+fn remaining_for_phase(
+    deadline: Instant,
+    now: Instant,
+    operation: &'static str,
+) -> Result<Duration, ClientError> {
+    deadline
+        .checked_duration_since(now)
+        .filter(|remaining| !remaining.is_zero())
+        .ok_or_else(|| ClientError::Io {
+            operation,
+            source: std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                format!("timed out {operation}"),
+            ),
+        })
+}
+
+#[cfg(windows)]
+pub(crate) fn request(
+    endpoint: &DaemonEndpoint,
+    method: &'static str,
+    path: &str,
+    body: Option<&[u8]>,
+    expected_peer: Option<&PeerIdentity>,
+) -> Result<TransportResponse, ClientError> {
+    // One deadline covers the finite WaitNamedPipe/CreateFile loop and all
+    // subsequent nonblocking I/O.
+    let deadline = Instant::now() + RESPONSE_TIMEOUT;
+    let body = body.unwrap_or_default();
+    let request = format!(
+        "{method} {path} HTTP/1.1\r\nHost: coven\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    );
+    let mut stream = connect_validated_with_deadline(endpoint.pipe_name(), deadline)?;
+    let peer_identity = connected_windows_peer_identity(&stream)?;
+    if expected_peer.is_some_and(|expected| expected != &peer_identity) {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    const OPERATION: &str = "failed to write Coven daemon request";
+    write_windows_pipe_with_deadline(&mut stream, request.as_bytes(), deadline, OPERATION)?;
+    write_windows_pipe_with_deadline(&mut stream, body, deadline, OPERATION)?;
+    Ok(TransportResponse {
+        response: read_response(&mut stream, deadline)?,
+        peer_identity,
+    })
+}
+
+#[cfg(windows)]
+pub(crate) fn verify_peer(
+    endpoint: &DaemonEndpoint,
+    expected_peer: &PeerIdentity,
+) -> Result<(), ClientError> {
+    let deadline = Instant::now() + RESPONSE_TIMEOUT;
+    let stream = connect_validated_with_deadline(endpoint.pipe_name(), deadline)?;
+    if &connected_windows_peer_identity(&stream)? != expected_peer {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn connect_validated_with_deadline(
+    pipe_name: &str,
+    deadline: Instant,
+) -> Result<std::fs::File, ClientError> {
+    let stream = connect_with_deadline(pipe_name, deadline)?;
+    validate_connected_windows_pipe_file(&stream)?;
+    set_windows_pipe_nonblocking(&stream)?;
+    Ok(stream)
+}
+
+#[cfg(windows)]
+fn connect_with_deadline(pipe_name: &str, deadline: Instant) -> Result<std::fs::File, ClientError> {
+    use std::{
+        ffi::OsStr,
+        os::windows::{ffi::OsStrExt, io::FromRawHandle},
+        ptr,
+    };
+    use windows_sys::Win32::{
+        Foundation::{
+            ERROR_PIPE_BUSY, ERROR_SEM_TIMEOUT, GENERIC_READ, GENERIC_WRITE, INVALID_HANDLE_VALUE,
+        },
+        Storage::FileSystem::{CreateFileW, OPEN_EXISTING, READ_CONTROL},
+        System::Pipes::WaitNamedPipeW,
+    };
+
+    const OPERATION: &str = "failed to connect to Coven daemon pipe";
+    let pipe_path = format!(r"\\.\pipe\{pipe_name}");
+    let pipe_path: Vec<u16> = OsStr::new(&pipe_path)
+        .encode_wide()
+        .chain(std::iter::once(0))
+        .collect();
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err(connect_timeout_error());
+        }
+        // SAFETY: `pipe_path` is NUL-terminated and all optional pointers are
+        // null; a successful call returns a fresh owned handle.
+        let handle = unsafe {
+            CreateFileW(
+                pipe_path.as_ptr(),
+                GENERIC_READ | GENERIC_WRITE | READ_CONTROL,
+                0,
+                ptr::null(),
+                OPEN_EXISTING,
+                windows_pipe_client_flags(),
+                ptr::null_mut(),
+            )
+        };
+        if handle != INVALID_HANDLE_VALUE {
+            // SAFETY: ownership of the fresh handle transfers to `File`
+            // exactly once.
+            return Ok(unsafe { std::fs::File::from_raw_handle(handle) });
+        }
+
+        let error = std::io::Error::last_os_error();
+        if error.raw_os_error() != Some(ERROR_PIPE_BUSY as i32) {
+            return Err(ClientError::Io {
+                operation: OPERATION,
+                source: error,
+            });
+        }
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .and_then(finite_windows_wait_millis)
+            .ok_or_else(connect_timeout_error)?;
+        // SAFETY: `pipe_path` remains a valid NUL-terminated buffer and the
+        // timeout is finite.
+        if unsafe { WaitNamedPipeW(pipe_path.as_ptr(), remaining) } == 0 {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(ERROR_SEM_TIMEOUT as i32) || Instant::now() >= deadline
+            {
+                return Err(connect_timeout_error());
+            }
+            return Err(ClientError::Io {
+                operation: OPERATION,
+                source: error,
+            });
+        }
+    }
+}
+
+fn finite_windows_wait_millis(remaining: Duration) -> Option<u32> {
+    let millis = remaining.as_millis();
+    (millis > 0).then(|| millis.min((u32::MAX - 1) as u128) as u32)
+}
+
+#[cfg(windows)]
+fn connect_timeout_error() -> ClientError {
+    ClientError::Io {
+        operation: "failed to connect to Coven daemon pipe",
+        source: std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "timed out connecting to Coven daemon pipe",
+        ),
+    }
+}
+
+#[cfg(windows)]
+fn validate_connected_windows_pipe_file(stream: &std::fs::File) -> Result<(), ClientError> {
+    use std::os::windows::io::AsRawHandle;
+
+    validate_owner_only_windows_pipe_handle(stream.as_raw_handle())
+}
+
+#[cfg(windows)]
+fn connected_windows_peer_identity(stream: &std::fs::File) -> Result<PeerIdentity, ClientError> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use windows_sys::Win32::{
+        Foundation::{FILETIME, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        System::{
+            Pipes::GetNamedPipeServerProcessId,
+            Threading::{
+                GetProcessTimes, OpenProcess, WaitForSingleObject,
+                PROCESS_QUERY_LIMITED_INFORMATION,
+            },
+        },
+    };
+
+    let mut server_pid = 0;
+    if unsafe { GetNamedPipeServerProcessId(stream.as_raw_handle(), &mut server_pid) } == 0
+        || server_pid == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to identify connected Coven daemon pipe server",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+
+    const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE_ACCESS,
+            0,
+            server_pid,
+        )
+    };
+    if process.is_null() {
+        return Err(ClientError::Io {
+            operation: "failed to retain connected Coven daemon process identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    let process = unsafe { std::os::windows::io::OwnedHandle::from_raw_handle(process) };
+    let mut creation = FILETIME::default();
+    let mut exit = FILETIME::default();
+    let mut kernel = FILETIME::default();
+    let mut user = FILETIME::default();
+    if unsafe {
+        GetProcessTimes(
+            process.as_raw_handle(),
+            &mut creation,
+            &mut exit,
+            &mut kernel,
+            &mut user,
+        )
+    } == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to inspect connected Coven daemon process identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    match unsafe { WaitForSingleObject(process.as_raw_handle(), 0) } {
+        WAIT_TIMEOUT => {}
+        WAIT_OBJECT_0 => {
+            return Err(ClientError::Discovery(
+                "connected Coven daemon process exited during identity validation".to_owned(),
+            ))
+        }
+        WAIT_FAILED => {
+            return Err(ClientError::Io {
+                operation: "failed to retain connected Coven daemon process identity",
+                source: std::io::Error::last_os_error(),
+            })
+        }
+        result => {
+            return Err(ClientError::Io {
+                operation: "failed to retain connected Coven daemon process identity",
+                source: std::io::Error::other(format!("unexpected Windows wait result {result}")),
+            })
+        }
+    }
+    let mut confirmed_pid = 0;
+    if unsafe { GetNamedPipeServerProcessId(stream.as_raw_handle(), &mut confirmed_pid) } == 0
+        || confirmed_pid != server_pid
+    {
+        return Err(ClientError::Discovery(
+            "connected Coven daemon pipe server identity changed during validation".to_owned(),
+        ));
+    }
+
+    Ok(PeerIdentity {
+        server_pid,
+        process_creation_time: filetime_parts_to_u64(
+            creation.dwLowDateTime,
+            creation.dwHighDateTime,
+        ),
+    })
+}
+
+#[cfg(windows)]
+fn set_windows_pipe_nonblocking(stream: &std::fs::File) -> Result<(), ClientError> {
+    use std::{os::windows::io::AsRawHandle, ptr};
+    use windows_sys::Win32::System::Pipes::{
+        SetNamedPipeHandleState, PIPE_NOWAIT, PIPE_READMODE_BYTE,
+    };
+
+    let mode = PIPE_READMODE_BYTE | PIPE_NOWAIT;
+    // SAFETY: the borrowed file owns a connected pipe handle and the mode
+    // pointer remains valid for the call.
+    if unsafe { SetNamedPipeHandleState(stream.as_raw_handle(), &mode, ptr::null(), ptr::null()) }
+        == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to configure nonblocking Coven daemon pipe writes",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    Ok(())
+}
+
+fn write_windows_pipe_with_deadline<W: Write>(
+    writer: &mut W,
+    mut buffer: &[u8],
+    deadline: Instant,
+    operation: &'static str,
+) -> Result<(), ClientError> {
+    while !buffer.is_empty() {
+        let remaining = deadline
+            .checked_duration_since(Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| ClientError::Io {
+                operation,
+                source: std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out writing Coven daemon request",
+                ),
+            })?;
+        match writer.write(buffer) {
+            Ok(0) => std::thread::sleep(remaining.min(Duration::from_millis(1))),
+            Ok(written) => buffer = &buffer[written..],
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock
+                        | std::io::ErrorKind::TimedOut
+                        | std::io::ErrorKind::Interrupted
+                ) =>
+            {
+                if error.kind() != std::io::ErrorKind::Interrupted {
+                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
+                }
+            }
+            Err(source) => return Err(ClientError::Io { operation, source }),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(any(windows, test))]
+#[derive(Debug, PartialEq, Eq)]
+struct WindowsStopIdentity {
+    pid: u32,
+    creation_time: u64,
+}
+
+#[cfg(any(windows, test))]
+fn recorded_windows_process_matches_pipe_server(
+    expected_creation_time: Option<u64>,
+    server_creation_time: u64,
+) -> bool {
+    expected_creation_time.is_none_or(|expected| expected == server_creation_time)
+}
+
+#[cfg(any(windows, test))]
+fn windows_stop_identity_from_health(
+    pipe_name: &str,
+    expected_pid: u32,
+    expected_creation_time: Option<u64>,
+    server_pid: u32,
+    server_creation_time: u64,
+    body: &[u8],
+) -> Result<WindowsStopIdentity, ClientError> {
+    #[derive(serde::Deserialize)]
+    struct StopHealth {
+        ok: bool,
+        daemon: Option<StopDaemonIdentity>,
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct StopDaemonIdentity {
+        pid: u32,
+        socket: String,
+        #[serde(default)]
+        process_creation_time: Option<String>,
+    }
+
+    if !crate::discovery::is_coven_daemon_pipe_name(pipe_name) {
+        return Err(ClientError::Discovery(
+            "unsupported Coven daemon pipe name".to_owned(),
+        ));
+    }
+    let health: StopHealth = serde_json::from_slice(body).map_err(|_| {
+        ClientError::Discovery("Windows daemon health identity was invalid".to_owned())
+    })?;
+    let daemon = health.daemon.filter(|_| health.ok).ok_or_else(|| {
+        ClientError::Discovery("Windows daemon health did not report a ready identity".to_owned())
+    })?;
+    if daemon.socket != pipe_name {
+        return Err(ClientError::Discovery(
+            "Windows daemon health reported a pipe for a different Coven home".to_owned(),
+        ));
+    }
+    if expected_pid == 0 || daemon.pid != expected_pid || server_pid != expected_pid {
+        return Err(ClientError::Discovery(
+            "Windows daemon health PID did not match the connected pipe server".to_owned(),
+        ));
+    }
+    if expected_creation_time.is_some_and(|expected| expected != server_creation_time) {
+        return Err(ClientError::Discovery(
+            "recorded Windows daemon process creation time did not match the connected pipe server"
+                .to_owned(),
+        ));
+    }
+    if let Some(reported) = daemon.process_creation_time {
+        let reported = reported.parse::<u64>().map_err(|_| {
+            ClientError::Discovery(
+                "Windows daemon health process creation time was invalid".to_owned(),
+            )
+        })?;
+        if reported == 0 || reported != server_creation_time {
+            return Err(ClientError::Discovery(
+                "Windows daemon health process creation time did not match the connected pipe server"
+                    .to_owned(),
+            ));
+        }
+    }
+    Ok(WindowsStopIdentity {
+        pid: expected_pid,
+        creation_time: server_creation_time,
+    })
+}
+
+#[cfg(any(windows, test))]
+fn windows_stop_pipe_preflight(bytes_available: u32) -> Result<(), ClientError> {
+    if bytes_available == 0 {
+        Ok(())
+    } else {
+        Err(ClientError::Discovery(
+            "connected Coven daemon pipe sent data before its health identity request".to_owned(),
+        ))
+    }
+}
+
+#[cfg(windows)]
+pub struct WindowsDaemonProcess {
+    process: std::os::windows::io::OwnedHandle,
+    pid: u32,
+    creation_time: u64,
+}
+
+#[cfg(windows)]
+impl WindowsDaemonProcess {
+    pub fn pid(&self) -> u32 {
+        self.pid
+    }
+
+    #[doc(hidden)]
+    pub fn creation_time(&self) -> u64 {
+        self.creation_time
+    }
+
+    pub fn terminate_and_wait(self, timeout: Duration) -> Result<bool, ClientError> {
+        let deadline = Instant::now()
+            .checked_add(timeout)
+            .ok_or_else(connect_timeout_error)?;
+        self.terminate_and_wait_until(deadline)
+    }
+
+    #[doc(hidden)]
+    pub fn terminate_and_wait_until(self, deadline: Instant) -> Result<bool, ClientError> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::{
+            Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+            System::Threading::{TerminateProcess, WaitForSingleObject},
+        };
+
+        let handle = self.process.as_raw_handle();
+        remaining_for_phase(
+            deadline,
+            Instant::now(),
+            "terminating verified Coven daemon process",
+        )?;
+        if unsafe { TerminateProcess(handle, 1) } == 0 {
+            let source = std::io::Error::last_os_error();
+            if unsafe { WaitForSingleObject(handle, 0) } == WAIT_OBJECT_0 {
+                return Ok(true);
+            }
+            return Err(ClientError::Io {
+                operation: "failed to terminate verified Coven daemon process",
+                source,
+            });
+        }
+
+        let remaining = remaining_for_phase(
+            deadline,
+            Instant::now(),
+            "waiting for verified Coven daemon process to exit",
+        )?;
+        let milliseconds = remaining.as_millis().min((u32::MAX - 1) as u128) as u32;
+        match unsafe { WaitForSingleObject(handle, milliseconds) } {
+            WAIT_OBJECT_0 => Ok(true),
+            WAIT_TIMEOUT => Ok(false),
+            WAIT_FAILED => Err(ClientError::Io {
+                operation: "failed to wait for verified Coven daemon process",
+                source: std::io::Error::last_os_error(),
+            }),
+            result => Err(ClientError::Io {
+                operation: "failed to wait for verified Coven daemon process",
+                source: std::io::Error::other(format!("unexpected Windows wait result {result}")),
+            }),
+        }
+    }
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn windows_process_creation_time(pid: u32) -> Result<Option<u64>, ClientError> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use windows_sys::Win32::{
+        Foundation::{ERROR_INVALID_PARAMETER, FILETIME, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        System::Threading::{
+            GetProcessTimes, OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
+        },
+    };
+
+    const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE_ACCESS,
+            0,
+            pid,
+        )
+    };
+    if process.is_null() {
+        let source = std::io::Error::last_os_error();
+        return if source.raw_os_error() == Some(ERROR_INVALID_PARAMETER as i32) {
+            Ok(None)
+        } else {
+            Err(ClientError::Io {
+                operation: "failed to inspect recorded Coven daemon process identity",
+                source,
+            })
+        };
+    }
+    let process = unsafe { std::os::windows::io::OwnedHandle::from_raw_handle(process) };
+    let mut creation = FILETIME::default();
+    let mut exit = FILETIME::default();
+    let mut kernel = FILETIME::default();
+    let mut user = FILETIME::default();
+    if unsafe {
+        GetProcessTimes(
+            process.as_raw_handle(),
+            &mut creation,
+            &mut exit,
+            &mut kernel,
+            &mut user,
+        )
+    } == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to inspect recorded Coven daemon process identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    match unsafe { WaitForSingleObject(process.as_raw_handle(), 0) } {
+        WAIT_TIMEOUT => Ok(Some(filetime_parts_to_u64(
+            creation.dwLowDateTime,
+            creation.dwHighDateTime,
+        ))),
+        WAIT_OBJECT_0 => Ok(None),
+        WAIT_FAILED => Err(ClientError::Io {
+            operation: "failed to inspect recorded Coven daemon process identity",
+            source: std::io::Error::last_os_error(),
+        }),
+        result => Err(ClientError::Io {
+            operation: "failed to inspect recorded Coven daemon process identity",
+            source: std::io::Error::other(format!("unexpected Windows wait result {result}")),
+        }),
+    }
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn open_windows_daemon_process_for_stop(
+    pipe_name: &str,
+    expected_pid: u32,
+    timeout: Duration,
+) -> Result<Option<WindowsDaemonProcess>, ClientError> {
+    open_windows_daemon_process_for_stop_with_creation_time(pipe_name, expected_pid, None, timeout)
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn open_windows_daemon_process_for_stop_with_creation_time(
+    pipe_name: &str,
+    expected_pid: u32,
+    expected_creation_time: Option<u64>,
+    timeout: Duration,
+) -> Result<Option<WindowsDaemonProcess>, ClientError> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(connect_timeout_error)?;
+    open_windows_daemon_process_for_stop_until(
+        pipe_name,
+        expected_pid,
+        expected_creation_time,
+        deadline,
+    )
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn open_windows_daemon_process_for_stop_until(
+    pipe_name: &str,
+    expected_pid: u32,
+    expected_creation_time: Option<u64>,
+    deadline: Instant,
+) -> Result<Option<WindowsDaemonProcess>, ClientError> {
+    use std::os::windows::io::{AsRawHandle, FromRawHandle};
+    use windows_sys::Win32::{
+        Foundation::{FILETIME, WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        System::{
+            Pipes::{GetNamedPipeServerProcessId, PeekNamedPipe},
+            Threading::{
+                GetProcessTimes, OpenProcess, WaitForSingleObject,
+                PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_TERMINATE,
+            },
+        },
+    };
+
+    if !is_coven_daemon_pipe_name(pipe_name) {
+        return Err(ClientError::Discovery(
+            "unsupported Coven daemon pipe name".to_owned(),
+        ));
+    }
+    let mut stream = match connect_validated_with_deadline(pipe_name, deadline) {
+        Ok(stream) => stream,
+        Err(error) if windows_pipe_connection_is_unavailable(&error) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "authenticating connected Coven daemon process",
+    )?;
+
+    let mut server_pid = 0;
+    if unsafe { GetNamedPipeServerProcessId(stream.as_raw_handle(), &mut server_pid) } == 0 {
+        return Err(ClientError::Io {
+            operation: "failed to identify connected Coven daemon pipe server",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    const SYNCHRONIZE_ACCESS: u32 = 0x0010_0000;
+    let process = unsafe {
+        OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | SYNCHRONIZE_ACCESS,
+            0,
+            server_pid,
+        )
+    };
+    if process.is_null() {
+        return Err(ClientError::Io {
+            operation: "failed to retain connected Coven daemon process identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    let process = unsafe { std::os::windows::io::OwnedHandle::from_raw_handle(process) };
+
+    let mut creation = FILETIME::default();
+    let mut exit = FILETIME::default();
+    let mut kernel = FILETIME::default();
+    let mut user = FILETIME::default();
+    if unsafe {
+        GetProcessTimes(
+            process.as_raw_handle(),
+            &mut creation,
+            &mut exit,
+            &mut kernel,
+            &mut user,
+        )
+    } == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to inspect connected Coven daemon process identity",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    let creation_time = filetime_parts_to_u64(creation.dwLowDateTime, creation.dwHighDateTime);
+    if !recorded_windows_process_matches_pipe_server(expected_creation_time, creation_time) {
+        return Ok(None);
+    }
+
+    // A dead server could otherwise leave a health-shaped response buffered,
+    // then have its PID reused before OpenProcess. Requiring an empty pipe
+    // before our request makes the response below prove that the process
+    // retained above was still the connected server after its handle opened.
+    let mut bytes_available = 0;
+    if unsafe {
+        PeekNamedPipe(
+            stream.as_raw_handle(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            &mut bytes_available,
+            std::ptr::null_mut(),
+        )
+    } == 0
+    {
+        return Err(ClientError::Io {
+            operation: "failed to inspect connected Coven daemon pipe state",
+            source: std::io::Error::last_os_error(),
+        });
+    }
+    windows_stop_pipe_preflight(bytes_available)?;
+
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "requesting authenticated Coven daemon health identity",
+    )?;
+    const OPERATION: &str = "failed to write Coven daemon stop identity request";
+    write_windows_pipe_with_deadline(
+        &mut stream,
+        b"GET /health HTTP/1.1\r\nHost: coven\r\nContent-Length: 0\r\n\r\n",
+        deadline,
+        OPERATION,
+    )?;
+    let response = read_windows_framed_response(&stream, deadline, MAX_RESPONSE_BODY_BYTES)?;
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "authenticating Coven daemon health identity",
+    )?;
+    if response.status != 200 {
+        return Err(ClientError::HttpStatus(response.status));
+    }
+    let identity = windows_stop_identity_from_health(
+        pipe_name,
+        expected_pid,
+        expected_creation_time,
+        server_pid,
+        creation_time,
+        &response.body,
+    )?;
+    let mut confirmed_server_pid = 0;
+    if unsafe { GetNamedPipeServerProcessId(stream.as_raw_handle(), &mut confirmed_server_pid) }
+        == 0
+        || confirmed_server_pid != identity.pid
+    {
+        return Err(ClientError::Discovery(
+            "connected Coven daemon pipe server identity changed during validation".to_owned(),
+        ));
+    }
+    match unsafe { WaitForSingleObject(process.as_raw_handle(), 0) } {
+        WAIT_TIMEOUT => {}
+        WAIT_OBJECT_0 => {
+            return Err(ClientError::Discovery(
+                "connected Coven daemon process exited during identity validation".to_owned(),
+            ))
+        }
+        WAIT_FAILED => {
+            return Err(ClientError::Io {
+                operation: "failed to retain connected Coven daemon process identity",
+                source: std::io::Error::last_os_error(),
+            })
+        }
+        result => {
+            return Err(ClientError::Io {
+                operation: "failed to retain connected Coven daemon process identity",
+                source: std::io::Error::other(format!("unexpected Windows wait result {result}")),
+            })
+        }
+    }
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "retaining verified Coven daemon process identity",
+    )?;
+
+    Ok(Some(WindowsDaemonProcess {
+        process,
+        pid: identity.pid,
+        creation_time: identity.creation_time,
+    }))
+}
+
+#[cfg(windows)]
+/// Internal compatibility probe for `coven-cli` daemon lifecycle commands.
+///
+/// This accepts only Coven-shaped, owner-only pipe names and applies one
+/// deadline to the validated connection, request write, and framed response.
+/// It is intentionally not a general-purpose transport entry point.
+#[doc(hidden)]
+pub fn probe_windows_daemon_health(
+    pipe_name: &str,
+    timeout: Duration,
+) -> Result<Option<(u16, Vec<u8>)>, ClientError> {
+    Ok(
+        probe_windows_daemon_health_with_identity(pipe_name, timeout)?
+            .map(|probe| (probe.status, probe.body)),
+    )
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub struct WindowsDaemonHealthProbe {
+    pub status: u16,
+    pub body: Vec<u8>,
+    pub server_pid: u32,
+    pub process_creation_time: u64,
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn probe_windows_daemon_health_with_identity(
+    pipe_name: &str,
+    timeout: Duration,
+) -> Result<Option<WindowsDaemonHealthProbe>, ClientError> {
+    let deadline = Instant::now()
+        .checked_add(timeout)
+        .ok_or_else(connect_timeout_error)?;
+    probe_windows_daemon_health_with_identity_until(pipe_name, deadline)
+}
+
+#[cfg(windows)]
+#[doc(hidden)]
+pub fn probe_windows_daemon_health_with_identity_until(
+    pipe_name: &str,
+    deadline: Instant,
+) -> Result<Option<WindowsDaemonHealthProbe>, ClientError> {
+    if !is_coven_daemon_pipe_name(pipe_name) {
+        return Err(ClientError::Discovery(
+            "unsupported Coven daemon pipe name".to_owned(),
+        ));
+    }
+    let mut stream = match connect_validated_with_deadline(pipe_name, deadline) {
+        Ok(stream) => stream,
+        Err(error) if windows_pipe_connection_is_unavailable(&error) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "authenticating connected Coven daemon pipe",
+    )?;
+    let peer_identity = connected_windows_peer_identity(&stream)?;
+    remaining_for_phase(deadline, Instant::now(), "requesting Coven daemon health")?;
+    const OPERATION: &str = "failed to write Coven daemon health request";
+    write_windows_pipe_with_deadline(
+        &mut stream,
+        b"GET /health HTTP/1.1\r\nHost: coven\r\nContent-Length: 0\r\n\r\n",
+        deadline,
+        OPERATION,
+    )?;
+    let response = read_windows_framed_response(&stream, deadline, MAX_RESPONSE_BODY_BYTES)?;
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "authenticating Coven daemon health response",
+    )?;
+    let confirmed_peer = connected_windows_peer_identity(&stream)?;
+    remaining_for_phase(
+        deadline,
+        Instant::now(),
+        "authenticating Coven daemon health response",
+    )?;
+    if confirmed_peer != peer_identity {
+        return Err(ClientError::DaemonInstanceChanged);
+    }
+    Ok(Some(WindowsDaemonHealthProbe {
+        status: response.status,
+        body: response.body,
+        server_pid: peer_identity.server_pid,
+        process_creation_time: peer_identity.process_creation_time,
+    }))
+}
+
+#[cfg(any(windows, test))]
+fn windows_pipe_connection_is_unavailable(error: &ClientError) -> bool {
+    const ERROR_FILE_NOT_FOUND_CODE: i32 = 2;
+    const ERROR_PATH_NOT_FOUND_CODE: i32 = 3;
+
+    matches!(
+        error,
+        ClientError::Io { source, .. }
+            if matches!(
+                source.raw_os_error(),
+                Some(ERROR_FILE_NOT_FOUND_CODE | ERROR_PATH_NOT_FOUND_CODE)
+            )
+    )
+}
+
+#[cfg(windows)]
+fn read_response(
+    stream: &mut std::fs::File,
+    deadline: Instant,
+) -> Result<HttpResponse, ClientError> {
+    read_windows_framed_response(stream, deadline, MAX_RESPONSE_BODY_BYTES)
+}
+
+#[cfg(windows)]
+struct WindowsPipeReader<'a>(&'a std::fs::File);
+
+#[cfg(windows)]
+impl Read for WindowsPipeReader<'_> {
+    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, std::io::Error> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Storage::FileSystem::ReadFile;
+
+        let mut bytes_read = 0;
+        let buffer_len = u32::try_from(buffer.len()).unwrap_or(u32::MAX);
+        // SAFETY: the borrowed file owns a synchronous connected pipe handle,
+        // `buffer` is writable for `buffer_len` bytes, and both out-pointers
+        // remain valid for this nonblocking call.
+        if unsafe {
+            ReadFile(
+                self.0.as_raw_handle(),
+                buffer.as_mut_ptr(),
+                buffer_len,
+                &mut bytes_read,
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            // File::read turns ERROR_NO_DATA into Ok(0) because Windows maps it
+            // to BrokenPipe. Preserve the raw status so the parser can tell a
+            // live empty pipe from EOF and an actual disconnect.
+            Err(std::io::Error::last_os_error())
+        } else {
+            Ok(bytes_read as usize)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn read_windows_framed_response(
+    stream: &std::fs::File,
+    deadline: Instant,
+    max_body_bytes: usize,
+) -> Result<HttpResponse, ClientError> {
+    read_framed_response(&mut WindowsPipeReader(stream), deadline, max_body_bytes)
+}
+
+fn read_framed_response<R: Read>(
+    reader: &mut R,
+    deadline: Instant,
+    max_body_bytes: usize,
+) -> Result<HttpResponse, ClientError> {
+    let mut response = Vec::with_capacity(1024);
+    let mut chunk = [0_u8; 4096];
+
+    loop {
+        if let Some((head, body)) = split_response(&response) {
+            if head.len() > MAX_RESPONSE_HEADERS_BYTES {
+                return Err(ClientError::InvalidHttpResponse(format!(
+                    "response headers exceeded {MAX_RESPONSE_HEADERS_BYTES} bytes"
+                )));
+            }
+            let header = std::str::from_utf8(head).map_err(|_| {
+                ClientError::InvalidHttpResponse("headers were not UTF-8".to_owned())
+            })?;
+            let status = header
+                .lines()
+                .next()
+                .and_then(|line| line.split_whitespace().nth(1))
+                .and_then(|status| status.parse().ok())
+                .ok_or_else(|| {
+                    ClientError::InvalidHttpResponse("missing HTTP status".to_owned())
+                })?;
+            let content_length = content_length(header)?;
+            if content_length > max_body_bytes {
+                return Err(ClientError::ResponseTooLarge {
+                    max_bytes: max_body_bytes,
+                });
+            }
+            match body.len().cmp(&content_length) {
+                std::cmp::Ordering::Greater => {
+                    return Err(ClientError::InvalidHttpResponse(
+                        TRAILING_RESPONSE_BYTES.to_owned(),
+                    ));
+                }
+                std::cmp::Ordering::Equal => {
+                    ensure_no_immediately_available_response_bytes(reader, deadline)?;
+                    return Ok(HttpResponse {
+                        status,
+                        body: body.to_vec(),
+                    });
+                }
+                std::cmp::Ordering::Less => {}
+            }
+        } else if response.len() > MAX_RESPONSE_HEADERS_BYTES {
+            return Err(ClientError::InvalidHttpResponse(format!(
+                "response headers exceeded {MAX_RESPONSE_HEADERS_BYTES} bytes"
+            )));
+        }
+        if Instant::now() >= deadline {
+            return Err(ClientError::InvalidHttpResponse(
+                "timed out reading Coven daemon response".to_owned(),
+            ));
+        }
+        match reader.read(&mut chunk) {
+            Ok(0) => {
+                return Err(ClientError::InvalidHttpResponse(
+                    "connection closed before response completed".to_owned(),
+                ))
+            }
+            Ok(read) => response.extend_from_slice(&chunk[..read]),
+            Err(error)
+                if error.raw_os_error() == Some(ERROR_NO_DATA_CODE)
+                    || matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock
+                            | std::io::ErrorKind::TimedOut
+                            | std::io::ErrorKind::Interrupted
+                    ) =>
+            {
+                if error.kind() != std::io::ErrorKind::Interrupted {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return Err(ClientError::InvalidHttpResponse(
+                            "timed out reading Coven daemon response".to_owned(),
+                        ));
+                    }
+                    std::thread::sleep(remaining.min(Duration::from_millis(10)));
+                }
+            }
+            Err(source) => {
+                return Err(ClientError::Io {
+                    operation: "failed to read Coven daemon response",
+                    source,
+                })
+            }
+        }
+    }
+}
+
+fn ensure_no_immediately_available_response_bytes<R: Read>(
+    reader: &mut R,
+    deadline: Instant,
+) -> Result<(), ClientError> {
+    let mut byte = [0_u8; 1];
+    loop {
+        match reader.read(&mut byte) {
+            Ok(0) => return Ok(()),
+            Ok(_) => {
+                return Err(ClientError::InvalidHttpResponse(
+                    TRAILING_RESPONSE_BYTES.to_owned(),
+                ));
+            }
+            Err(source)
+                if source.raw_os_error() == Some(ERROR_NO_DATA_CODE)
+                    || source.raw_os_error() == Some(ERROR_BROKEN_PIPE_CODE)
+                    || matches!(
+                        source.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) =>
+            {
+                return Ok(());
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::Interrupted => {
+                if Instant::now() >= deadline {
+                    return Err(ClientError::InvalidHttpResponse(
+                        "timed out validating Coven daemon response framing".to_owned(),
+                    ));
+                }
+            }
+            Err(source) => {
+                return Err(ClientError::Io {
+                    operation: "failed to validate Coven daemon response framing",
+                    source,
+                });
+            }
+        }
+    }
+}
+
+fn content_length(headers: &str) -> Result<usize, ClientError> {
+    let mut content_length = None;
+    for line in headers.lines().skip(1) {
+        let Some((name, value)) = line.split_once(':') else {
+            return Err(ClientError::InvalidHttpResponse(
+                "malformed HTTP response header".to_owned(),
+            ));
+        };
+        if name.eq_ignore_ascii_case("transfer-encoding") {
+            return Err(ClientError::InvalidHttpResponse(format!(
+                "unsupported Transfer-Encoding: {}",
+                value.trim()
+            )));
+        }
+        if name.eq_ignore_ascii_case("content-length") {
+            if content_length.is_some() {
+                return Err(ClientError::InvalidHttpResponse(
+                    "duplicate Content-Length header".to_owned(),
+                ));
+            }
+            content_length = Some(value.trim().parse().map_err(|_| {
+                ClientError::InvalidHttpResponse("invalid Content-Length header".to_owned())
+            })?);
+        }
+    }
+    content_length
+        .ok_or_else(|| ClientError::InvalidHttpResponse("missing Content-Length header".to_owned()))
+}
+
+fn split_response(response: &[u8]) -> Option<(&[u8], &[u8])> {
+    response
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|position| (&response[..position], &response[position + 4..]))
+        .or_else(|| {
+            response
+                .windows(2)
+                .position(|window| window == b"\n\n")
+                .map(|position| (&response[..position], &response[position + 2..]))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        filetime_parts_to_u64, finite_windows_wait_millis, read_framed_response,
+        windows_pipe_client_flags, windows_pipe_connection_is_unavailable,
+        windows_stop_identity_from_health, windows_stop_pipe_preflight,
+        write_windows_pipe_with_deadline, MAX_RESPONSE_HEADERS_BYTES,
+    };
+    use crate::{discovery::supported_windows_pipe_names, ClientError};
+    use std::{
+        collections::VecDeque,
+        io::{Cursor, Read, Write},
+        path::Path,
+        time::{Duration, Instant},
+    };
+
+    // Regression test for a Windows-side gap: once the header terminator is
+    // found, an over-sized header block must be rejected immediately rather
+    // than falling through to header parsing (or the much looser
+    // `MAX_RESPONSE_HEADERS_BYTES + max_body_bytes` catch-all that only
+    // guards against a terminator never arriving).
+    #[test]
+    fn oversized_headers_are_rejected_once_the_terminator_is_found() {
+        let mut oversized = vec![b'x'; MAX_RESPONSE_HEADERS_BYTES + 1];
+        oversized.extend_from_slice(b"\r\n\r\n");
+        let mut reader = Cursor::new(oversized);
+
+        match read_framed_response(&mut reader, Instant::now() + Duration::from_secs(1), 1024) {
+            Ok(_) => panic!("oversized headers must be rejected"),
+            Err(error) => assert!(
+                error.to_string().contains("response headers exceeded"),
+                "unexpected error: {error}"
+            ),
+        }
+    }
+
+    #[test]
+    fn unterminated_oversized_headers_are_rejected_at_the_header_limit() {
+        let mut reader = Cursor::new(vec![b'x'; MAX_RESPONSE_HEADERS_BYTES + 1]);
+
+        match read_framed_response(
+            &mut reader,
+            Instant::now() + Duration::from_secs(1),
+            4 * 1024 * 1024,
+        ) {
+            Ok(_) => panic!("unterminated oversized headers must be rejected"),
+            Err(error) => assert!(
+                error.to_string().contains("response headers exceeded"),
+                "unexpected error: {error}"
+            ),
+        }
+    }
+
+    struct NoDataOnceReader {
+        returned_no_data: bool,
+        response: Cursor<&'static [u8]>,
+    }
+
+    impl Read for NoDataOnceReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            if !self.returned_no_data {
+                self.returned_no_data = true;
+                return Err(std::io::Error::from_raw_os_error(232));
+            }
+            self.response.read(buffer)
+        }
+    }
+
+    #[test]
+    fn empty_nonblocking_pipe_reads_are_retried() {
+        let mut reader = NoDataOnceReader {
+            returned_no_data: false,
+            response: Cursor::new(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}"),
+        };
+
+        let response =
+            read_framed_response(&mut reader, Instant::now() + Duration::from_secs(1), 1024)
+                .expect("ERROR_NO_DATA from an empty PIPE_NOWAIT pipe must be retried");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"{}");
+    }
+
+    struct ChunkedReader {
+        chunks: VecDeque<&'static [u8]>,
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buffer: &mut [u8]) -> std::io::Result<usize> {
+            let Some(chunk) = self.chunks.pop_front() else {
+                return Ok(0);
+            };
+            assert!(chunk.len() <= buffer.len());
+            buffer[..chunk.len()].copy_from_slice(chunk);
+            Ok(chunk.len())
+        }
+    }
+
+    fn assert_trailing_response_rejected(reader: &mut impl Read) {
+        let error =
+            match read_framed_response(reader, Instant::now() + Duration::from_secs(1), 1024) {
+                Ok(_) => panic!("bytes beyond Content-Length must be rejected"),
+                Err(error) => error,
+            };
+
+        assert!(matches!(
+            error,
+            ClientError::InvalidHttpResponse(message)
+                if message == super::TRAILING_RESPONSE_BYTES
+        ));
+    }
+
+    #[test]
+    fn response_reader_rejects_coalesced_bytes_beyond_content_length() {
+        let mut reader = Cursor::new(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}X".as_slice());
+
+        assert_trailing_response_rejected(&mut reader);
+    }
+
+    #[test]
+    fn response_reader_rejects_a_delayed_body_coalesced_with_trailing_bytes() {
+        let mut reader = ChunkedReader {
+            chunks: VecDeque::from([
+                &b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\n"[..],
+                &b"bodyX"[..],
+            ]),
+        };
+
+        assert_trailing_response_rejected(&mut reader);
+    }
+
+    #[test]
+    fn response_reader_rejects_an_immediately_available_byte_after_an_exact_body() {
+        let mut reader = ChunkedReader {
+            chunks: VecDeque::from([
+                &b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\nbody"[..],
+                &b"X"[..],
+            ]),
+        };
+
+        assert_trailing_response_rejected(&mut reader);
+    }
+
+    #[test]
+    fn response_reader_probes_beyond_a_zero_length_frame() {
+        let mut reader = ChunkedReader {
+            chunks: VecDeque::from([
+                &b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n"[..],
+                &b"X"[..],
+            ]),
+        };
+
+        assert_trailing_response_rejected(&mut reader);
+    }
+
+    #[test]
+    fn zero_byte_read_is_eof_not_live_pipe_backpressure() {
+        let started = Instant::now();
+        let error = match read_framed_response(
+            &mut Cursor::new(Vec::<u8>::new()),
+            Instant::now() + Duration::from_secs(1),
+            1024,
+        ) {
+            Ok(_) => panic!("EOF before a response must fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("connection closed before response completed"),
+            "unexpected error: {error}"
+        );
+        assert!(started.elapsed() < Duration::from_millis(100));
+    }
+
+    struct AlwaysNoDataReader {
+        reads: usize,
+    }
+
+    impl Read for AlwaysNoDataReader {
+        fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+            self.reads += 1;
+            Err(std::io::Error::from_raw_os_error(232))
+        }
+    }
+
+    #[test]
+    fn live_empty_pipe_polling_sleeps_and_obeys_the_absolute_deadline() {
+        let mut reader = AlwaysNoDataReader { reads: 0 };
+        let started = Instant::now();
+        let error =
+            match read_framed_response(&mut reader, started + Duration::from_millis(25), 1024) {
+                Ok(_) => panic!("a permanently empty live pipe must time out"),
+                Err(error) => error,
+            };
+
+        assert!(
+            error
+                .to_string()
+                .contains("timed out reading Coven daemon response"),
+            "unexpected error: {error}"
+        );
+        assert!(started.elapsed() < Duration::from_secs(1));
+        assert!(
+            reader.reads <= 5,
+            "empty pipe polling spun {} times",
+            reader.reads
+        );
+    }
+
+    #[derive(Default)]
+    struct ZeroOnceWriter {
+        returned_zero: bool,
+        bytes: Vec<u8>,
+    }
+
+    impl Write for ZeroOnceWriter {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            if !self.returned_zero {
+                self.returned_zero = true;
+                return Ok(0);
+            }
+            self.bytes.extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn zero_byte_nonblocking_pipe_writes_are_retried() {
+        let mut writer = ZeroOnceWriter::default();
+
+        write_windows_pipe_with_deadline(
+            &mut writer,
+            b"payload",
+            Instant::now() + Duration::from_secs(1),
+            "write",
+        )
+        .expect("a zero-byte PIPE_NOWAIT write must be retried as backpressure");
+
+        assert_eq!(writer.bytes, b"payload");
+    }
+
+    #[test]
+    fn named_pipe_waits_are_finite_and_never_use_the_infinite_sentinel() {
+        assert_eq!(finite_windows_wait_millis(Duration::from_micros(999)), None);
+        assert_eq!(
+            finite_windows_wait_millis(Duration::from_millis(1)),
+            Some(1)
+        );
+        assert_eq!(
+            finite_windows_wait_millis(Duration::from_millis(u64::from(u32::MAX) + 1)),
+            Some(u32::MAX - 1)
+        );
+    }
+
+    #[test]
+    fn named_pipe_clients_request_identification_only_sqos() {
+        assert_eq!(windows_pipe_client_flags(), 0x0011_0000);
+    }
+
+    #[test]
+    fn one_absolute_deadline_threads_only_remaining_budget_to_each_phase() {
+        let start = Instant::now();
+        let deadline = start + Duration::from_millis(100);
+
+        assert_eq!(
+            super::remaining_for_phase(
+                deadline,
+                start + Duration::from_millis(70),
+                "authenticating Coven daemon",
+            )
+            .expect("budget remains"),
+            Duration::from_millis(30)
+        );
+        let error = super::remaining_for_phase(
+            deadline,
+            start + Duration::from_millis(100),
+            "waiting for Coven daemon exit",
+        )
+        .expect_err("expired absolute deadline");
+        assert!(matches!(
+            error,
+            ClientError::Io {
+                operation: "waiting for Coven daemon exit",
+                source,
+            } if source.kind() == std::io::ErrorKind::TimedOut
+        ));
+    }
+
+    #[test]
+    fn only_missing_named_pipe_errors_are_classified_as_unavailable() {
+        let io_error = |code| ClientError::Io {
+            operation: "connect fixture",
+            source: std::io::Error::from_raw_os_error(code),
+        };
+
+        assert!(windows_pipe_connection_is_unavailable(&io_error(2)));
+        assert!(windows_pipe_connection_is_unavailable(&io_error(3)));
+        assert!(!windows_pipe_connection_is_unavailable(&io_error(5)));
+        assert!(!windows_pipe_connection_is_unavailable(
+            &ClientError::Discovery("connected pipe handle was not owner-only".to_owned())
+        ));
+    }
+
+    #[test]
+    fn windows_stop_identity_binds_health_pid_and_socket_to_pipe_server() {
+        let supported_pipes = supported_windows_pipe_names(Path::new(env!("CARGO_MANIFEST_DIR")))
+            .expect("supported Windows pipe names");
+        let pipe = supported_pipes[0].as_str();
+        let creation_time = 134_157_822_123_456_789_u64;
+        let health = |pid: u32, socket: &str, fingerprint: Option<&str>| {
+            let fingerprint = fingerprint
+                .map(|value| format!(r#","processCreationTime":"{value}""#))
+                .unwrap_or_default();
+            format!(
+                r#"{{"ok":true,"daemon":{{"pid":{pid},"startedAt":"now","socket":"{socket}"{fingerprint}}}}}"#
+            )
+        };
+
+        let identity = windows_stop_identity_from_health(
+            pipe,
+            41,
+            Some(creation_time),
+            41,
+            creation_time,
+            health(41, pipe, Some(&creation_time.to_string())).as_bytes(),
+        )
+        .expect("matching pipe server, status fingerprint, and health identity");
+        assert_eq!(identity.pid, 41);
+        assert_eq!(identity.creation_time, creation_time);
+
+        windows_stop_identity_from_health(
+            pipe,
+            41,
+            None,
+            41,
+            creation_time,
+            health(41, pipe, None).as_bytes(),
+        )
+        .expect("authenticated legacy health may acquire the live process fingerprint");
+
+        for (expected_pid, expected_creation, server_pid, server_creation, body) in [
+            (
+                40,
+                Some(creation_time),
+                41,
+                creation_time,
+                health(41, pipe, Some(&creation_time.to_string())),
+            ),
+            (
+                41,
+                Some(creation_time),
+                42,
+                creation_time,
+                health(41, pipe, Some(&creation_time.to_string())),
+            ),
+            (
+                41,
+                Some(creation_time),
+                41,
+                creation_time,
+                health(42, pipe, Some(&creation_time.to_string())),
+            ),
+            (
+                41,
+                Some(creation_time - 1),
+                41,
+                creation_time,
+                health(41, pipe, Some(&creation_time.to_string())),
+            ),
+            (
+                41,
+                Some(creation_time),
+                41,
+                creation_time,
+                health(41, pipe, Some(&(creation_time - 1).to_string())),
+            ),
+            (
+                41,
+                Some(creation_time),
+                41,
+                creation_time,
+                health(
+                    41,
+                    "coven-daemon-v1-ffffffffffffffffffffffffffffffff.sock",
+                    Some(&creation_time.to_string()),
+                ),
+            ),
+        ] {
+            assert!(
+                windows_stop_identity_from_health(
+                    pipe,
+                    expected_pid,
+                    expected_creation,
+                    server_pid,
+                    server_creation,
+                    body.as_bytes(),
+                )
+                .is_err(),
+                "accepted expected_pid={expected_pid}, expected_creation={expected_creation:?}, server_pid={server_pid}, server_creation={server_creation}, body={body}"
+            );
+        }
+    }
+
+    #[test]
+    fn reused_pid_creation_mismatch_is_unverified_before_any_stop_request() {
+        assert!(super::recorded_windows_process_matches_pipe_server(
+            None, 200
+        ));
+        assert!(super::recorded_windows_process_matches_pipe_server(
+            Some(200),
+            200
+        ));
+        assert!(!super::recorded_windows_process_matches_pipe_server(
+            Some(100),
+            200
+        ));
+    }
+
+    #[test]
+    fn filetime_conversion_preserves_both_32_bit_halves() {
+        assert_eq!(
+            filetime_parts_to_u64(0x89ab_cdef, 0x0123_4567),
+            0x0123_4567_89ab_cdef
+        );
+        assert_eq!(filetime_parts_to_u64(u32::MAX, u32::MAX), u64::MAX);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn live_process_creation_time_queries_the_exact_running_process() {
+        let creation_time = super::windows_process_creation_time(std::process::id())
+            .expect("query current process")
+            .expect("current process must be live");
+        assert_ne!(creation_time, 0);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn live_empty_named_pipe_waits_for_a_delayed_response() {
+        use std::{
+            ffi::OsStr,
+            os::windows::{
+                ffi::OsStrExt,
+                io::{AsRawHandle, FromRawHandle},
+            },
+            ptr,
+            sync::{
+                atomic::{AtomicU64, Ordering},
+                mpsc,
+            },
+            thread,
+        };
+        use windows_sys::Win32::{
+            Foundation::{ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE},
+            Storage::FileSystem::{ReadFile, PIPE_ACCESS_DUPLEX},
+            System::Pipes::{
+                ConnectNamedPipe, CreateNamedPipeW, PIPE_READMODE_BYTE, PIPE_TYPE_BYTE, PIPE_WAIT,
+            },
+        };
+
+        static NEXT_PIPE_ID: AtomicU64 = AtomicU64::new(0);
+        let pipe_name = format!(
+            "coven-client-read-regression-{}-{}",
+            std::process::id(),
+            NEXT_PIPE_ID.fetch_add(1, Ordering::Relaxed)
+        );
+        let pipe_path: Vec<u16> = OsStr::new(&format!(r"\\.\pipe\{pipe_name}"))
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect();
+        // SAFETY: `pipe_path` is NUL-terminated and the optional security
+        // attributes pointer is null.
+        let server_handle = unsafe {
+            CreateNamedPipeW(
+                pipe_path.as_ptr(),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                1,
+                4096,
+                4096,
+                0,
+                ptr::null(),
+            )
+        };
+        assert_ne!(
+            server_handle,
+            INVALID_HANDLE_VALUE,
+            "create test named pipe: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: ownership of the fresh valid handle transfers exactly once.
+        let mut server_pipe = unsafe { std::fs::File::from_raw_handle(server_handle) };
+        let (connected_tx, connected_rx) = mpsc::channel();
+        let (respond_tx, respond_rx) = mpsc::channel();
+        let (read_done_tx, read_done_rx) = mpsc::channel();
+        let server = thread::spawn(move || {
+            // SAFETY: `server_pipe` owns a synchronous server pipe handle; a
+            // null OVERLAPPED pointer selects synchronous connection setup.
+            if unsafe { ConnectNamedPipe(server_pipe.as_raw_handle(), ptr::null_mut()) } == 0 {
+                let error = std::io::Error::last_os_error();
+                assert_eq!(
+                    error.raw_os_error(),
+                    Some(ERROR_PIPE_CONNECTED as i32),
+                    "connect test named pipe: {error}"
+                );
+            }
+            connected_tx.send(()).expect("signal connected test pipe");
+            respond_rx.recv().expect("wait for client read");
+            thread::sleep(Duration::from_millis(50));
+            server_pipe
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+                .expect("write delayed response");
+            read_done_rx.recv().expect("wait for response read");
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let client =
+            super::connect_with_deadline(&pipe_name, deadline).expect("connect test client");
+        super::set_windows_pipe_nonblocking(&client).expect("configure test client");
+        connected_rx.recv().expect("wait for connected test pipe");
+
+        let mut probe = [0_u8; 1];
+        let mut bytes_read = 0;
+        // SAFETY: `client` owns a connected synchronous pipe handle, and both
+        // output buffers remain valid for this nonblocking call.
+        let read_result = unsafe {
+            ReadFile(
+                client.as_raw_handle(),
+                probe.as_mut_ptr(),
+                probe.len() as u32,
+                &mut bytes_read,
+                ptr::null_mut(),
+            )
+        };
+        let read_error = std::io::Error::last_os_error();
+        assert_eq!(
+            read_result, 0,
+            "a live empty PIPE_NOWAIT read unexpectedly succeeded with {bytes_read} bytes"
+        );
+        assert_eq!(
+            read_error.raw_os_error(),
+            Some(super::ERROR_NO_DATA_CODE),
+            "an empty connected pipe must report ERROR_NO_DATA"
+        );
+        respond_tx.send(()).expect("request delayed response");
+        let response = super::read_windows_framed_response(&client, deadline, 1024);
+        read_done_tx
+            .send(())
+            .expect("signal completed response read");
+        server.join().expect("join test named-pipe server");
+        let response = response.expect("wait for a delayed response from a live pipe");
+
+        assert_eq!(response.status, 200);
+        assert_eq!(response.body, b"{}");
+    }
+
+    #[test]
+    fn windows_stop_rejects_a_response_buffered_before_its_health_request() {
+        windows_stop_pipe_preflight(0).expect("empty connected pipe");
+        assert!(windows_stop_pipe_preflight(1).is_err());
+        assert!(windows_stop_pipe_preflight(u32::MAX).is_err());
+    }
+
+    struct DisconnectedReader;
+
+    impl Read for DisconnectedReader {
+        fn read(&mut self, _buffer: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::from_raw_os_error(109))
+        }
+    }
+
+    #[test]
+    fn a_disconnected_pipe_read_fails_without_waiting_for_the_deadline() {
+        let started = Instant::now();
+        let error = match read_framed_response(
+            &mut DisconnectedReader,
+            Instant::now() + Duration::from_secs(1),
+            1024,
+        ) {
+            Ok(_) => panic!("ERROR_BROKEN_PIPE is a disconnect, not backpressure"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            crate::ClientError::Io { source, .. } if source.raw_os_error() == Some(109)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(100));
+    }
+
+    struct DisconnectedWriter;
+
+    impl Write for DisconnectedWriter {
+        fn write(&mut self, _buffer: &[u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::from_raw_os_error(232))
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn a_disconnected_pipe_write_fails_without_waiting_for_the_deadline() {
+        let started = Instant::now();
+        let error = write_windows_pipe_with_deadline(
+            &mut DisconnectedWriter,
+            b"payload",
+            Instant::now() + Duration::from_secs(1),
+            "write",
+        )
+        .expect_err("ERROR_NO_DATA while writing is a disconnect, not backpressure");
+
+        assert!(matches!(
+            error,
+            crate::ClientError::Io { source, .. } if source.raw_os_error() == Some(232)
+        ));
+        assert!(started.elapsed() < Duration::from_millis(100));
+    }
+}

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -1,0 +1,1731 @@
+#![cfg(unix)]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use coven_client::{
+    probe_unix_daemon_health, shutdown_unix_daemon, ClientError, DaemonClient, DaemonEndpoint,
+    LifecycleDaemonStatus, ReadEndpoint, UnixDaemonShutdown, WriteEndpoint, PROTOCOL_VERSION,
+};
+
+const HEALTH: &str = include_str!("../fixtures/health.json");
+const ERROR: &str = include_str!("../fixtures/error.json");
+
+struct TestHome {
+    path: PathBuf,
+}
+
+impl TestHome {
+    fn new() -> Self {
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root");
+        let path = workspace.join("c").join(format!(
+            "{:x}{:x}",
+            std::process::id(),
+            NEXT.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&path).expect("create test Coven home");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o700))
+                .expect("make test Coven home private");
+        }
+        Self { path }
+    }
+}
+
+impl Drop for TestHome {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+        let _ = fs::remove_dir(self.path.parent().expect("test root"));
+    }
+}
+
+#[cfg(unix)]
+fn serve_once(home: &Path, status: u16, body: String) -> std::thread::JoinHandle<()> {
+    serve_responses(home, vec![("/api/v1/health".to_owned(), status, body)])
+}
+
+#[cfg(unix)]
+fn serve_responses(
+    home: &Path,
+    responses: Vec<(String, u16, String)>,
+) -> std::thread::JoinHandle<()> {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let socket = home.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind test daemon socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make test daemon socket owner-only");
+    std::thread::spawn(move || {
+        for (expected_path, status, body) in responses {
+            let (mut stream, _) = listener.accept().expect("accept client request");
+            let mut request = String::new();
+            stream
+                .read_to_string(&mut request)
+                .expect("read client request");
+            if expected_path == "<peer-check>" {
+                assert!(
+                    request.is_empty(),
+                    "capability peer check must not send request bytes"
+                );
+                continue;
+            }
+            assert!(
+                request.starts_with(&format!("GET {expected_path} HTTP/1.1\r\n"))
+                    || request.starts_with(&format!("POST {expected_path} HTTP/1.1\r\n"))
+            );
+            let response = format!(
+                "HTTP/1.1 {status} test\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write daemon response");
+        }
+    })
+}
+
+#[cfg(unix)]
+fn serve_raw_response_then_hold(
+    home: &Path,
+    response: String,
+    hold_open: std::time::Duration,
+) -> std::thread::JoinHandle<()> {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let socket = home.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind test daemon socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make test daemon socket owner-only");
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept client request");
+        let mut request = String::new();
+        stream
+            .read_to_string(&mut request)
+            .expect("read client request");
+        stream
+            .write_all(response.as_bytes())
+            .expect("write daemon response");
+        stream.flush().expect("flush daemon response");
+        std::thread::sleep(hold_open);
+    })
+}
+
+fn health_with_capabilities(capabilities: serde_json::Value) -> String {
+    let mut health: serde_json::Value = serde_json::from_str(HEALTH).expect("parse health fixture");
+    health["capabilities"] = capabilities;
+    health.to_string()
+}
+
+#[test]
+fn lifecycle_client_rejects_non_utf8_home_before_creating_daemon_artifacts() {
+    use std::{ffi::OsString, os::unix::ffi::OsStringExt, time::Duration};
+
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root");
+    let mut home_name = format!("client-{}-", std::process::id()).into_bytes();
+    home_name.push(0xff);
+    let home = workspace.join("c").join(OsString::from_vec(home_name));
+
+    let probe_error = probe_unix_daemon_health(&home, Duration::from_millis(10))
+        .expect_err("lifecycle discovery must reject a non-UTF-8 profile");
+    assert!(
+        probe_error.to_string().contains("valid UTF-8"),
+        "probe error must explain the JSON path requirement: {probe_error}"
+    );
+
+    let expected = LifecycleDaemonStatus {
+        pid: std::process::id(),
+        started_at: "2026-08-16T18:29:29Z".to_owned(),
+        socket: "unpublished".to_owned(),
+    };
+    let shutdown_error = shutdown_unix_daemon(&home, &expected, Duration::from_millis(10))
+        .expect_err("shutdown discovery must reject a non-UTF-8 profile");
+    assert!(
+        shutdown_error.to_string().contains("valid UTF-8"),
+        "shutdown error must explain the JSON path requirement: {shutdown_error}"
+    );
+    assert!(!home.join("coven.sock").exists());
+    assert!(!home.join("daemon.json").exists());
+}
+
+#[cfg(unix)]
+fn serve_health_then_stall_write(home: &Path) -> std::thread::JoinHandle<()> {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let socket = home.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind test daemon socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make test daemon socket owner-only");
+    std::thread::spawn(move || {
+        // First connection: negotiate health normally, over its own socket
+        // connection (the client never reuses connections).
+        let (mut stream, _) = listener.accept().expect("accept health request");
+        let mut request = String::new();
+        stream
+            .read_to_string(&mut request)
+            .expect("read health request");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            HEALTH.len(),
+            HEALTH
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write health response");
+        drop(stream);
+
+        // Second connection: accept but deliberately never read from it, so
+        // a large dependent request's write fills the kernel socket buffer
+        // (8KB by default on macOS/Linux) and cannot complete without the
+        // client-side write deadline.
+        let (stream, _) = listener.accept().expect("accept stalled request");
+        std::thread::sleep(std::time::Duration::from_secs(10));
+        drop(stream);
+    })
+}
+
+#[cfg(unix)]
+#[test]
+fn oversized_request_bodies_are_rejected_before_any_connection_attempt() {
+    let home = TestHome::new();
+    let server = serve_once(&home.path, 200, HEALTH.to_string());
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client.health().expect("negotiate health");
+
+    let oversized_body = serde_json::json!({ "padding": "a".repeat(5 * 1024 * 1024) });
+    let error = client
+        .post_empty(
+            WriteEndpoint::SessionInput {
+                session_id: "session-1".to_owned(),
+            },
+            &oversized_body,
+        )
+        .expect_err(
+            "an oversized body must be rejected before any I/O, since the daemon would \
+             otherwise reset the connection instead of returning a structured 413",
+        );
+
+    assert!(matches!(
+        error,
+        ClientError::RequestTooLarge { max_bytes, .. } if max_bytes == 4 * 1024 * 1024
+    ));
+
+    // Only the health request above should have reached the daemon: the
+    // oversized POST must never open a second connection, so the server
+    // thread (which only expects a single accept()) joins cleanly instead
+    // of hanging on a second `accept()` that never arrives.
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn a_stalled_daemon_connection_bounds_the_write_phase_of_a_dependent_request() {
+    let home = TestHome::new();
+    let server = serve_health_then_stall_write(&home.path);
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client
+        .health()
+        .expect("negotiate health over the first connection");
+
+    // Larger than the platform's default AF_UNIX socket buffer (8KB on
+    // macOS/Linux, and comfortably under the 4MiB request-body cap), so the
+    // write cannot complete without the peer ever reading it.
+    let body = serde_json::json!({ "padding": "a".repeat(256 * 1024) });
+    let started = std::time::Instant::now();
+
+    let error = client
+        .post_empty(
+            WriteEndpoint::SessionInput {
+                session_id: "session-1".to_owned(),
+            },
+            &body,
+        )
+        .expect_err(
+            "a daemon that accepts a connection but never reads from it must not block \
+             the caller's write forever",
+        );
+
+    assert!(matches!(error, ClientError::Io { .. }));
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(8),
+        "the write phase must be bounded by the request deadline, not the server's 10s stall"
+    );
+
+    // The server thread's second `accept()` only unblocks once the client
+    // above drops its connection (after timing out) or the process exits;
+    // deliberately do not join it here to avoid re-waiting out its sleep.
+    drop(server);
+}
+
+#[cfg(unix)]
+#[test]
+fn negotiates_the_v1_health_contract_and_structured_errors() {
+    let home = TestHome::new();
+    let server = serve_once(&home.path, 200, HEALTH.to_string());
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    let health = client.health().expect("negotiate health");
+
+    assert_eq!(health.api_version, PROTOCOL_VERSION);
+    assert!(health.capabilities.structured_errors);
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn missing_sessions_capability_blocks_sessions_but_not_events() {
+    let home = TestHome::new();
+    let health = health_with_capabilities(serde_json::json!({
+        "events": true,
+        "eventCursor": "sequence",
+        "structuredErrors": true
+    }));
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, health),
+            ("<peer-check>".to_owned(), 0, String::new()),
+            (
+                "/api/v1/events?sessionId=session-1".to_owned(),
+                200,
+                r#"{"events":[]}"#.to_owned(),
+            ),
+        ],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client.health().expect("health remains a valid v1 response");
+    let error = client
+        .get_json::<serde_json::Value>(coven_client::ReadEndpoint::Sessions { limit: None })
+        .expect_err("sessions must be blocked before request transmission");
+    assert!(
+        error.to_string().contains("capabilities.sessions"),
+        "unexpected error: {error}"
+    );
+
+    let events: serde_json::Value = client
+        .get_json(coven_client::ReadEndpoint::Events {
+            session_id: "session-1".to_owned(),
+            after_seq: None,
+            limit: None,
+        })
+        .expect("unrelated supported events remain usable");
+    assert_eq!(events["events"], serde_json::json!([]));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn missing_events_capability_blocks_events_but_not_sessions() {
+    let home = TestHome::new();
+    let health = health_with_capabilities(serde_json::json!({
+        "sessions": true,
+        "eventCursor": "sequence",
+        "structuredErrors": true
+    }));
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, health),
+            ("<peer-check>".to_owned(), 0, String::new()),
+            (
+                "/api/v1/sessions".to_owned(),
+                200,
+                r#"{"sessions":[]}"#.to_owned(),
+            ),
+        ],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client.health().expect("health remains a valid v1 response");
+    let error = client
+        .get_json::<serde_json::Value>(coven_client::ReadEndpoint::Events {
+            session_id: "session-1".to_owned(),
+            after_seq: None,
+            limit: None,
+        })
+        .expect_err("events must be blocked before request transmission");
+    assert!(
+        error.to_string().contains("capabilities.events"),
+        "unexpected error: {error}"
+    );
+
+    let sessions: serde_json::Value = client
+        .get_json(coven_client::ReadEndpoint::Sessions { limit: None })
+        .expect("unrelated supported sessions remain usable");
+    assert_eq!(sessions["sessions"], serde_json::json!([]));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn missing_event_cursor_blocks_cursor_reads_but_not_plain_event_reads() {
+    let home = TestHome::new();
+    let health = health_with_capabilities(serde_json::json!({
+        "sessions": true,
+        "events": true,
+        "structuredErrors": true
+    }));
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, health),
+            ("<peer-check>".to_owned(), 0, String::new()),
+            (
+                "/api/v1/events?sessionId=session-1".to_owned(),
+                200,
+                r#"{"events":[]}"#.to_owned(),
+            ),
+        ],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client.health().expect("health remains a valid v1 response");
+    let error = client
+        .get_json::<serde_json::Value>(coven_client::ReadEndpoint::Events {
+            session_id: "session-1".to_owned(),
+            after_seq: Some(7),
+            limit: None,
+        })
+        .expect_err("cursor reads must be blocked before request transmission");
+    assert!(
+        error.to_string().contains("capabilities.eventCursor"),
+        "unexpected error: {error}"
+    );
+
+    let events: serde_json::Value = client
+        .get_json(coven_client::ReadEndpoint::Events {
+            session_id: "session-1".to_owned(),
+            after_seq: None,
+            limit: None,
+        })
+        .expect("plain reads do not require the cursor capability");
+    assert_eq!(events["events"], serde_json::json!([]));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_an_incompatible_health_version() {
+    let home = TestHome::new();
+    let server = serve_once(
+        &home.path,
+        200,
+        HEALTH.replace(PROTOCOL_VERSION, "coven.daemon.v2"),
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    let error = client.health().expect_err("reject incompatible protocol");
+
+    assert!(matches!(
+        error,
+        ClientError::ProtocolVersion {
+            expected,
+            actual
+        } if expected == PROTOCOL_VERSION && actual == "coven.daemon.v2"
+    ));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn preserves_structured_daemon_error_fields() {
+    let home = TestHome::new();
+    let server = serve_once(&home.path, 409, ERROR.to_string());
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    let error = client.health().expect_err("preserve daemon error");
+
+    assert!(matches!(
+        error,
+        ClientError::Daemon {
+            status: 409,
+            error
+        } if error.code == "session_not_live"
+            && error.message == "Session is not live."
+            && error.details == serde_json::json!({ "sessionId": "session-1" })
+    ));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn discovers_only_an_owner_local_unix_socket() {
+    use std::os::unix::{fs::PermissionsExt, net::UnixListener};
+
+    let home = TestHome::new();
+    let socket = home.path.join("coven.sock");
+    let _listener = UnixListener::bind(&socket).expect("bind test daemon socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make test daemon socket owner-only");
+
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+
+    assert!(endpoint.is_owner_local());
+}
+
+#[cfg(unix)]
+#[test]
+fn reads_a_framed_health_fixture_without_waiting_for_socket_close() {
+    let home = TestHome::new();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        HEALTH.len(),
+        HEALTH
+    );
+    let server =
+        serve_raw_response_then_hold(&home.path, response, std::time::Duration::from_secs(1));
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+    let started = std::time::Instant::now();
+
+    let health = client.health().expect("read complete framed response");
+
+    assert_eq!(health.api_version, PROTOCOL_VERSION);
+    assert!(started.elapsed() < std::time::Duration::from_millis(500));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_bytes_buffered_after_an_ordinary_framed_response() {
+    let home = TestHome::new();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}X",
+        HEALTH.len(),
+        HEALTH
+    );
+    let server =
+        serve_raw_response_then_hold(&home.path, response, std::time::Duration::from_millis(0));
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    let error = client
+        .health()
+        .expect_err("reject a byte after the complete response frame");
+
+    assert!(matches!(
+        error,
+        ClientError::InvalidHttpResponse(message)
+            if message.contains("bytes after") && message.contains("response completed")
+    ));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_a_trailing_byte_queued_with_the_body_after_a_header_only_read() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind test daemon socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make test daemon socket owner-only");
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept client request");
+        let mut request = String::new();
+        stream
+            .read_to_string(&mut request)
+            .expect("read client request");
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+            HEALTH.len()
+        )
+        .expect("write response headers");
+        stream.flush().expect("flush response headers");
+        std::thread::sleep(Duration::from_millis(20));
+        write!(stream, "{HEALTH}X").expect("write body and trailing byte");
+    });
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    let error = client
+        .health()
+        .expect_err("reject a trailing byte queued with a later body read");
+
+    assert!(matches!(
+        error,
+        ClientError::InvalidHttpResponse(message)
+            if message.contains("bytes after") && message.contains("response completed")
+    ));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_chunked_health_responses_when_chunked_framing_is_unsupported() {
+    let home = TestHome::new();
+    let response =
+        "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n1\r\n{\r\n0\r\n\r\n".to_owned();
+    let server =
+        serve_raw_response_then_hold(&home.path, response, std::time::Duration::from_millis(0));
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    let error = client.health().expect_err("reject chunked framing");
+
+    assert!(matches!(
+        error,
+        ClientError::InvalidHttpResponse(message) if message.contains("Transfer-Encoding")
+    ));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn health_framing_stays_stable_under_parallel_requests() {
+    let clients = (0..16)
+        .map(|_| {
+            std::thread::spawn(|| {
+                let home = TestHome::new();
+                let server = serve_once(&home.path, 200, HEALTH.to_owned());
+                let endpoint =
+                    DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+                let mut client = DaemonClient::new(endpoint);
+
+                assert_eq!(
+                    client.health().expect("negotiate health").api_version,
+                    PROTOCOL_VERSION
+                );
+                server.join().expect("server thread");
+            })
+        })
+        .collect::<Vec<_>>();
+
+    for client in clients {
+        client.join().expect("parallel client");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn a_failed_renegotiation_blocks_dependent_requests_until_health_succeeds_again() {
+    let health_ok = HEALTH.to_owned();
+    let mut not_ready: serde_json::Value = serde_json::from_str(HEALTH).expect("parse fixture");
+    not_ready["ok"] = serde_json::json!(false);
+    let health_not_ready = not_ready.to_string();
+
+    let home = TestHome::new();
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, health_ok),
+            ("/api/v1/health".to_owned(), 200, health_not_ready.clone()),
+            // A dependent request must trigger its own revalidation instead
+            // of trusting the stale success from the first call; if it does,
+            // this third accept() observes another /api/v1/health hit (which
+            // also reports not-ready) rather than the kill request below.
+            ("/api/v1/health".to_owned(), 200, health_not_ready),
+        ],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client
+        .health()
+        .expect("first health negotiates successfully");
+    let renegotiation_error = client
+        .health()
+        .expect_err("second health call reports the daemon is not ready");
+    assert!(matches!(renegotiation_error, ClientError::HealthNotReady));
+
+    let dependent_error = client
+        .post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "session-1".to_owned(),
+            },
+            &serde_json::json!({}),
+        )
+        .expect_err("a dependent request must not proceed on stale negotiated state");
+    assert!(matches!(dependent_error, ClientError::HealthNotReady));
+
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn a_disappeared_cached_socket_preserves_the_connect_error_contract() {
+    let home = TestHome::new();
+    let original = serve_once(&home.path, 200, HEALTH.to_owned());
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover original daemon");
+    let mut client = DaemonClient::new(endpoint);
+    client.health().expect("negotiate original daemon");
+    original.join().expect("original daemon thread");
+    fs::remove_file(home.path.join("coven.sock")).expect("remove original daemon endpoint");
+
+    let error = client
+        .get_json::<serde_json::Value>(ReadEndpoint::Sessions { limit: None })
+        .expect_err("a disappeared endpoint must fail before request bytes");
+
+    assert!(matches!(
+        error,
+        ClientError::Io {
+            operation: "failed to connect to Coven daemon socket",
+            ..
+        }
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn a_mutation_is_not_sent_to_a_replacement_before_that_peer_is_negotiated() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let home = TestHome::new();
+    let original = serve_once(&home.path, 200, HEALTH.to_owned());
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover original daemon");
+    let mut client = DaemonClient::new(endpoint);
+    client.health().expect("negotiate original daemon");
+    original.join().expect("original daemon thread");
+
+    let socket = home.path.join("coven.sock");
+    fs::remove_file(&socket).expect("remove original daemon endpoint");
+    let replacement = UnixListener::bind(&socket).expect("bind replacement daemon");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make replacement endpoint owner-only");
+    let server = std::thread::spawn(move || {
+        let (mut first, _) = replacement.accept().expect("accept peer check");
+        let mut first_request = String::new();
+        first
+            .read_to_string(&mut first_request)
+            .expect("read peer-check connection");
+        if !first_request.is_empty() {
+            first
+                .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                .expect("finish incorrectly transmitted mutation");
+            return vec![first_request];
+        }
+
+        let (mut health, _) = replacement.accept().expect("accept replacement health");
+        let mut health_request = String::new();
+        health
+            .read_to_string(&mut health_request)
+            .expect("read replacement health");
+        let health_response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            HEALTH.len(),
+            HEALTH
+        );
+        health
+            .write_all(health_response.as_bytes())
+            .expect("write replacement health");
+
+        let (mut mutation, _) = replacement
+            .accept()
+            .expect("accept mutation after replacement health");
+        let mut mutation_request = String::new();
+        mutation
+            .read_to_string(&mut mutation_request)
+            .expect("read negotiated mutation");
+        mutation
+            .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+            .expect("acknowledge negotiated mutation");
+        vec![first_request, health_request, mutation_request]
+    });
+
+    let error = client
+        .post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "engine/42".to_owned(),
+            },
+            &serde_json::json!({}),
+        )
+        .expect_err("cached health must not authorize bytes to a replacement daemon");
+    assert!(
+        error.to_string().contains("daemon instance changed"),
+        "unexpected replacement error: {error}"
+    );
+
+    client.health().expect("negotiate replacement daemon");
+    client
+        .post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "engine/42".to_owned(),
+            },
+            &serde_json::json!({}),
+        )
+        .expect("send only after negotiating the replacement");
+
+    let requests = server.join().expect("replacement daemon thread");
+    assert!(requests[0].is_empty(), "mutation leaked before negotiation");
+    assert!(requests[1].starts_with("GET /api/v1/health HTTP/1.1\r\n"));
+    assert!(requests[2].starts_with("POST /api/v1/sessions/engine/42/kill HTTP/1.1\r\n"));
+}
+
+#[cfg(unix)]
+#[test]
+fn replacement_capabilities_are_enforced_before_mutation_bytes() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+    };
+
+    let home = TestHome::new();
+    let original = serve_once(&home.path, 200, HEALTH.to_owned());
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover original daemon");
+    let mut client = DaemonClient::new(endpoint);
+    client.health().expect("negotiate original daemon");
+    original.join().expect("original daemon thread");
+
+    let socket = home.path.join("coven.sock");
+    fs::remove_file(&socket).expect("remove original daemon endpoint");
+    let replacement = UnixListener::bind(&socket).expect("bind replacement daemon");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make replacement endpoint owner-only");
+    let replacement_health = health_with_capabilities(serde_json::json!({
+        "events": true,
+        "eventCursor": "sequence",
+        "structuredErrors": true
+    }));
+    let server = std::thread::spawn(move || {
+        let (mut first, _) = replacement.accept().expect("accept peer check");
+        let mut first_request = String::new();
+        first
+            .read_to_string(&mut first_request)
+            .expect("read peer-check connection");
+        if !first_request.is_empty() {
+            first
+                .write_all(b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n")
+                .expect("finish incorrectly transmitted mutation");
+            return first_request;
+        }
+
+        let (mut health, _) = replacement.accept().expect("accept replacement health");
+        let mut health_request = String::new();
+        health
+            .read_to_string(&mut health_request)
+            .expect("read replacement health");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+            replacement_health.len(),
+            replacement_health
+        );
+        health
+            .write_all(response.as_bytes())
+            .expect("write replacement health");
+        let (mut capability_check, _) = replacement
+            .accept()
+            .expect("accept replacement capability peer check");
+        let mut capability_request = String::new();
+        capability_check
+            .read_to_string(&mut capability_request)
+            .expect("read replacement capability peer check");
+        if capability_request.is_empty() {
+            first_request
+        } else {
+            capability_request
+        }
+    });
+
+    client
+        .post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "session-1".to_owned(),
+            },
+            &serde_json::json!({}),
+        )
+        .expect_err("replacement must first invalidate cached negotiation");
+    client.health().expect("negotiate replacement capabilities");
+    let error = client
+        .post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "session-1".to_owned(),
+            },
+            &serde_json::json!({}),
+        )
+        .expect_err("missing replacement capability must block mutation");
+    assert!(matches!(
+        error,
+        ClientError::CapabilityUnavailable {
+            capability: "sessions"
+        }
+    ));
+    assert!(
+        server.join().expect("replacement daemon thread").is_empty(),
+        "mutation leaked to replacement before capability enforcement"
+    );
+}
+
+#[cfg(unix)]
+static PROCESS_CWD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Computes `target` relative to `base` by walking up past the shared
+/// prefix, without touching the filesystem.
+#[cfg(unix)]
+fn relative_path(base: &Path, target: &Path) -> PathBuf {
+    let base_components: Vec<_> = base.components().collect();
+    let target_components: Vec<_> = target.components().collect();
+    let shared = base_components
+        .iter()
+        .zip(target_components.iter())
+        .take_while(|(left, right)| left == right)
+        .count();
+    let mut relative = PathBuf::new();
+    for _ in shared..base_components.len() {
+        relative.push("..");
+    }
+    for component in &target_components[shared..] {
+        relative.push(component.as_os_str());
+    }
+    relative
+}
+
+/// Restores the process's working directory on drop, even if the guarded
+/// test body panics, so a single failure cannot leave later tests running
+/// against the wrong cwd.
+#[cfg(unix)]
+struct RestoreCwd {
+    original: PathBuf,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(unix)]
+impl Drop for RestoreCwd {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn discovered_endpoint_is_stable_after_the_process_changes_directory() {
+    // Discovery must not store a socket path that is only valid relative to
+    // the cwd at discovery time. If it did, a caller changing directories
+    // afterwards (e.g. a long-lived CLI process switching working trees)
+    // would silently redirect requests to whatever now resolves at that
+    // relative path -- potentially a different, unvalidated socket -- rather
+    // than the owner-local socket that was actually checked above.
+    //
+    // This test mutates the process-wide cwd, which is unsafe to do
+    // concurrently with other cwd-sensitive tests. Serialize via a
+    // process-wide lock and always restore the original cwd through a
+    // panic-safe guard; no other test in this binary depends on the cwd, so
+    // this cannot make unrelated parallel tests flaky.
+    let guard = PROCESS_CWD_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let original_cwd = std::env::current_dir().expect("read current directory");
+    let _restore = RestoreCwd {
+        original: original_cwd.clone(),
+        _guard: guard,
+    };
+
+    // Reuse `TestHome`'s collision-safe unique directory allocation (its own
+    // pid + atomic counter) instead of inventing a second counter here,
+    // which previously raced with concurrently running tests for the same
+    // path.
+    let home = TestHome::new();
+    let relative_home = relative_path(&original_cwd, &home.path);
+
+    let server = serve_once(&home.path, 200, HEALTH.to_string());
+    // Discover with a *relative* coven_home: the resulting endpoint must
+    // resolve to an absolute socket path immediately rather than one that
+    // stays relative to the cwd at this moment.
+    let endpoint =
+        DaemonEndpoint::discover(&relative_home).expect("discover with a relative coven_home");
+
+    // Move away from the coven_home's parent directory before issuing any
+    // request. If the endpoint still held a relative path, this request
+    // would resolve through the *new* cwd instead of the socket that was
+    // actually validated by `discover`.
+    std::env::set_current_dir("/").expect("change the process working directory");
+
+    let mut client = DaemonClient::new(endpoint);
+    let health = client
+        .health()
+        .expect("connect through the pre-resolved absolute socket path after a cwd change");
+    assert_eq!(health.api_version, PROTOCOL_VERSION);
+
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_ancestor_parent_components_connect_to_the_validated_socket() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{
+            fs::{symlink, PermissionsExt},
+            net::UnixListener,
+        },
+        sync::{atomic::AtomicBool, Arc},
+        time::{Duration, Instant},
+    };
+
+    fn serve_until(
+        listener: UnixListener,
+        body: String,
+        stop: Arc<AtomicBool>,
+    ) -> std::thread::JoinHandle<bool> {
+        listener
+            .set_nonblocking(true)
+            .expect("configure nonblocking test listener");
+        std::thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            loop {
+                if stop.load(Ordering::Acquire) {
+                    return false;
+                }
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = String::new();
+                        stream
+                            .read_to_string(&mut request)
+                            .expect("read client request");
+                        let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                        stream
+                            .write_all(response.as_bytes())
+                            .expect("write daemon response");
+                        return true;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        if Instant::now() >= deadline {
+                            return false;
+                        }
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => panic!("accept client request: {error}"),
+                }
+            }
+        })
+    }
+
+    let sandbox = TestHome::new();
+    let target_parent = sandbox.path.join("target");
+    let symlink_target = target_parent.join("pivot");
+    let validated_home = target_parent.join("home");
+    let lexically_retargeted_home = sandbox.path.join("home");
+    fs::create_dir_all(&symlink_target).expect("create symlink target");
+    fs::create_dir_all(&validated_home).expect("create validated Coven home");
+    fs::create_dir_all(&lexically_retargeted_home).expect("create retargeted Coven home");
+    fs::set_permissions(&validated_home, fs::Permissions::from_mode(0o700))
+        .expect("make validated Coven home private");
+    fs::set_permissions(
+        &lexically_retargeted_home,
+        fs::Permissions::from_mode(0o700),
+    )
+    .expect("make retargeted Coven home private");
+    let linked_ancestor = sandbox.path.join("linked-ancestor");
+    symlink(&symlink_target, &linked_ancestor).expect("create symlinked ancestor");
+
+    let validated_socket = validated_home.join("coven.sock");
+    let validated_listener =
+        UnixListener::bind(&validated_socket).expect("bind validated daemon socket");
+    fs::set_permissions(&validated_socket, fs::Permissions::from_mode(0o600))
+        .expect("make validated daemon socket owner-only");
+
+    let retargeted_socket = lexically_retargeted_home.join("coven.sock");
+    let retargeted_listener =
+        UnixListener::bind(&retargeted_socket).expect("bind retargeted daemon socket");
+    fs::set_permissions(&retargeted_socket, fs::Permissions::from_mode(0o600))
+        .expect("make retargeted daemon socket owner-only");
+
+    let stop_servers = Arc::new(AtomicBool::new(false));
+    let validated_server = serve_until(
+        validated_listener,
+        HEALTH.to_owned(),
+        Arc::clone(&stop_servers),
+    );
+    let retargeted_server = serve_until(
+        retargeted_listener,
+        HEALTH.replace(PROTOCOL_VERSION, "coven.daemon.v2"),
+        Arc::clone(&stop_servers),
+    );
+
+    let discovered_home = linked_ancestor.join("..").join("home");
+    let endpoint = DaemonEndpoint::discover(&discovered_home)
+        .expect("discover through a symlinked ancestor followed by parent traversal");
+    let mut client = DaemonClient::new(endpoint);
+    let health = client.health();
+    stop_servers.store(true, Ordering::Release);
+
+    let validated_was_connected = validated_server.join().expect("validated server thread");
+    let retargeted_was_connected = retargeted_server.join().expect("retargeted server thread");
+    let health = health.expect("connect to the socket whose target was validated");
+    assert_eq!(health.api_version, PROTOCOL_VERSION);
+    assert!(validated_was_connected);
+    assert!(!retargeted_was_connected);
+}
+
+#[cfg(unix)]
+#[test]
+fn negotiates_before_an_empty_dependent_response() {
+    let home = TestHome::new();
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, HEALTH.to_string()),
+            (
+                "/api/v1/sessions/session-1/kill".to_owned(),
+                204,
+                String::new(),
+            ),
+        ],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client
+        .post_empty(
+            WriteEndpoint::SessionKill {
+                session_id: "session-1".to_owned(),
+            },
+            &serde_json::json!({}),
+        )
+        .expect("accept empty success response");
+
+    server.join().expect("server thread");
+}
+
+fn lifecycle_status(home: &Path) -> LifecycleDaemonStatus {
+    LifecycleDaemonStatus {
+        pid: std::process::id(),
+        started_at: "2026-08-16T12:00:00Z".to_owned(),
+        socket: home.join("coven.sock").to_string_lossy().into_owned(),
+    }
+}
+
+fn lifecycle_health(status: &LifecycleDaemonStatus) -> String {
+    serde_json::json!({
+        "ok": true,
+        "apiVersion": PROTOCOL_VERSION,
+        "covenVersion": "0.1.0",
+        "capabilities": {
+            "sessions": true,
+            "events": true,
+            "eventCursor": "sequence",
+            "structuredErrors": true
+        },
+        "daemon": status,
+    })
+    .to_string()
+}
+
+#[test]
+fn lifecycle_probe_returns_the_profile_bound_daemon_identity() {
+    use std::time::Duration;
+
+    let home = TestHome::new();
+    let expected = lifecycle_status(&home.path);
+    let server = serve_responses(
+        &home.path,
+        vec![("/health".to_owned(), 200, lifecycle_health(&expected))],
+    );
+
+    let actual = probe_unix_daemon_health(&home.path, Duration::from_secs(1))
+        .expect("probe owner-local daemon")
+        .expect("health included daemon identity");
+
+    assert_eq!(actual, expected);
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_probe_rejects_a_forged_pid_from_the_connected_peer() {
+    use std::time::Duration;
+
+    let home = TestHome::new();
+    let mut forged = lifecycle_status(&home.path);
+    forged.pid = if std::process::id() == u32::MAX {
+        u32::MAX - 1
+    } else {
+        std::process::id() + 1
+    };
+    let server = serve_responses(
+        &home.path,
+        vec![("/health".to_owned(), 200, lifecycle_health(&forged))],
+    );
+
+    let error = probe_unix_daemon_health(&home.path, Duration::from_secs(1))
+        .expect_err("health cannot claim a PID other than its connected Unix peer");
+
+    assert!(matches!(
+        error,
+        ClientError::Discovery(message)
+            if message
+                == format!(
+                    "daemon health reported pid {} but the connected peer pid was {}",
+                    forged.pid,
+                    std::process::id()
+                )
+    ));
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_probe_accepts_and_canonicalizes_a_relative_same_profile_socket() {
+    use std::time::Duration;
+
+    let home = TestHome::new();
+    let canonical_socket = fs::canonicalize(home.path.join("coven.sock"))
+        .unwrap_or_else(|_| home.path.join("coven.sock"));
+    let current_dir = std::env::current_dir().expect("current directory");
+    let relative_socket = relative_path(&current_dir, &home.path.join("coven.sock"));
+    let mut reported = lifecycle_status(&home.path);
+    reported.socket = relative_socket.to_string_lossy().into_owned();
+    let server = serve_responses(
+        &home.path,
+        vec![("/health".to_owned(), 200, lifecycle_health(&reported))],
+    );
+
+    let actual = probe_unix_daemon_health(&home.path, Duration::from_secs(1))
+        .expect("probe same-profile relative socket")
+        .expect("health included daemon identity");
+
+    assert_eq!(Path::new(&actual.socket), canonical_socket);
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_probe_rejects_an_existing_cross_profile_socket() {
+    use std::{
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let profile_a = TestHome::new();
+    let profile_b = TestHome::new();
+    let socket_b = profile_b.path.join("coven.sock");
+    let _listener_b = UnixListener::bind(&socket_b).expect("bind other-profile socket");
+    fs::set_permissions(&socket_b, fs::Permissions::from_mode(0o600))
+        .expect("protect other-profile socket");
+    let mut redirected = lifecycle_status(&profile_a.path);
+    redirected.socket = socket_b.to_string_lossy().into_owned();
+    let server = serve_responses(
+        &profile_a.path,
+        vec![("/health".to_owned(), 200, lifecycle_health(&redirected))],
+    );
+
+    let error = probe_unix_daemon_health(&profile_a.path, Duration::from_secs(1))
+        .expect_err("reject a health identity for another profile");
+
+    assert!(matches!(error, ClientError::Discovery(_)));
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_probe_uses_one_absolute_deadline_for_a_stalled_response() {
+    use std::{
+        io::Read,
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        sync::mpsc,
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make lifecycle socket private");
+    let (accepted_tx, accepted_rx) = mpsc::sync_channel(0);
+    let (release_tx, release_rx) = mpsc::sync_channel(0);
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept lifecycle probe");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read probe");
+        accepted_tx.send(()).expect("report accepted probe");
+        release_rx.recv().expect("release stalled probe");
+    });
+    let home_path = home.path.clone();
+    let (result_tx, result_rx) = mpsc::sync_channel(0);
+    let client = std::thread::spawn(move || {
+        result_tx
+            .send(probe_unix_daemon_health(
+                &home_path,
+                Duration::from_millis(30),
+            ))
+            .expect("return probe result");
+    });
+
+    accepted_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("probe connected");
+    let result = result_rx
+        .recv_timeout(Duration::from_millis(250))
+        .expect("stalled probe respected its deadline");
+    assert!(result.is_err(), "stalled probe unexpectedly succeeded");
+    release_tx.send(()).expect("release server");
+    client.join().expect("client thread");
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_probe_rejects_trickling_and_unbounded_responses_quickly() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let status = LifecycleDaemonStatus {
+        pid: 42,
+        started_at: "2026-08-16T12:00:00Z".to_owned(),
+        socket: String::new(),
+    };
+    let health = lifecycle_health(&status);
+    let valid = format!(
+        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{health}",
+        health.len()
+    )
+    .into_bytes();
+    let oversized_body = b"HTTP/1.1 200 OK\r\nContent-Length: 999999999\r\n\r\n".to_vec();
+    let oversized_headers =
+        format!("HTTP/1.1 200 OK\r\nX-Fill: {}\r\n", "x".repeat(70 * 1024)).into_bytes();
+
+    for (response, trickle) in [
+        (valid, true),
+        (oversized_body, false),
+        (oversized_headers, false),
+    ] {
+        let home = TestHome::new();
+        let socket = home.path.join("coven.sock");
+        let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+        fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+            .expect("make lifecycle socket private");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept lifecycle probe");
+            let mut request = String::new();
+            stream.read_to_string(&mut request).expect("read probe");
+            if trickle {
+                for byte in response {
+                    if stream.write_all(&[byte]).is_err() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+            } else {
+                let _ = stream.write_all(&response);
+            }
+        });
+
+        let started = std::time::Instant::now();
+        let result = probe_unix_daemon_health(&home.path, Duration::from_millis(30));
+        assert!(result.is_err(), "malformed unbounded response was accepted");
+        assert!(
+            started.elapsed() < Duration::from_millis(250),
+            "response deadline was reset by trickling bytes"
+        );
+        server.join().expect("server thread");
+    }
+}
+
+#[test]
+fn lifecycle_shutdown_waits_for_eof_on_the_authenticated_connection() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        sync::mpsc,
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let expected = lifecycle_status(&home.path);
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make lifecycle socket private");
+    let acknowledged = serde_json::json!({
+        "ok": true,
+        "apiVersion": PROTOCOL_VERSION,
+        "capabilities": { "structuredErrors": true },
+        "daemon": expected,
+    })
+    .to_string();
+    let (ack_tx, ack_rx) = mpsc::sync_channel(0);
+    let (release_tx, release_rx) = mpsc::sync_channel(0);
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept shutdown");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read shutdown");
+        assert!(request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n"));
+        let response = format!(
+            "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            acknowledged.len(),
+            acknowledged
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("acknowledge shutdown");
+        ack_tx.send(()).expect("report acknowledgement");
+        release_rx.recv().expect("release shutdown connection");
+    });
+    let expected_for_client = lifecycle_status(&home.path);
+    let home_path = home.path.clone();
+    let (result_tx, result_rx) = mpsc::sync_channel(0);
+    let client = std::thread::spawn(move || {
+        result_tx
+            .send(shutdown_unix_daemon(
+                &home_path,
+                &expected_for_client,
+                Duration::from_secs(1),
+            ))
+            .expect("return shutdown result");
+    });
+
+    ack_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("shutdown was acknowledged");
+    assert!(
+        result_rx.recv_timeout(Duration::from_millis(30)).is_err(),
+        "client returned before its authenticated connection closed"
+    );
+    release_tx.send(()).expect("close authenticated connection");
+    assert_eq!(
+        result_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("shutdown result")
+            .expect("valid shutdown response"),
+        UnixDaemonShutdown::Exited
+    );
+    client.join().expect("client thread");
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_shutdown_rejects_a_buffered_post_response_byte() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let expected = lifecycle_status(&home.path);
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make lifecycle socket private");
+    let acknowledged = serde_json::json!({
+        "ok": true,
+        "apiVersion": PROTOCOL_VERSION,
+        "capabilities": { "structuredErrors": true },
+        "daemon": expected,
+    })
+    .to_string();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept shutdown");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read shutdown");
+        assert!(request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n"));
+        let response = format!(
+            "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}X",
+            acknowledged.len(),
+            acknowledged
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write response and trailing byte together");
+    });
+
+    let error = shutdown_unix_daemon(
+        &home.path,
+        &lifecycle_status(&home.path),
+        Duration::from_secs(1),
+    )
+    .expect_err("reject a byte after the retained lifecycle response");
+
+    assert!(matches!(
+        error,
+        ClientError::InvalidHttpResponse(message)
+            if message == "daemon sent bytes after its lifecycle response completed"
+    ));
+    server.join().expect("server thread");
+}
+
+#[test]
+fn lifecycle_shutdown_validates_a_malformed_404_before_base_fallback() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        time::{Duration, Instant},
+    };
+
+    let home = TestHome::new();
+    let mut expected = lifecycle_status(&home.path);
+    expected.pid = std::process::id();
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make lifecycle socket private");
+    let fallback_observed = Arc::new(AtomicBool::new(false));
+    let fallback_for_server = Arc::clone(&fallback_observed);
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept shutdown");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read shutdown");
+        assert!(request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n"));
+        stream
+            .write_all(b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\nX")
+            .expect("write malformed missing-route response");
+        drop(stream);
+
+        listener
+            .set_nonblocking(true)
+            .expect("make fallback detection nonblocking");
+        let deadline = Instant::now() + Duration::from_millis(100);
+        while Instant::now() < deadline {
+            match listener.accept() {
+                Ok((mut fallback, _)) => {
+                    fallback_for_server.store(true, Ordering::Release);
+                    let mut request = String::new();
+                    fallback
+                        .read_to_string(&mut request)
+                        .expect("read fallback request");
+                    fallback
+                        .write_all(b"HTTP/1.1 500 Error\r\nContent-Length: 0\r\n\r\n")
+                        .expect("reject unexpected fallback");
+                    return;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+                Err(error) => panic!("failed checking for fallback request: {error}"),
+            }
+        }
+    });
+
+    let error = shutdown_unix_daemon(&home.path, &expected, Duration::from_secs(1))
+        .expect_err("reject malformed 404 framing before fallback");
+
+    assert!(matches!(
+        error,
+        ClientError::InvalidHttpResponse(message) if message.contains("bytes after")
+    ));
+    server.join().expect("server thread");
+    assert!(
+        !fallback_observed.load(Ordering::Acquire),
+        "malformed 404 triggered BASE fallback"
+    );
+}
+
+#[test]
+fn lifecycle_shutdown_never_uses_legacy_fallback_for_non_404_errors() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::{Duration, Instant},
+    };
+
+    for status in [400, 401, 403, 405, 429, 500, 503] {
+        let home = TestHome::new();
+        let expected = lifecycle_status(&home.path);
+        let socket = home.path.join("coven.sock");
+        let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+        fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+            .expect("make lifecycle socket private");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept shutdown");
+            let mut request = String::new();
+            stream.read_to_string(&mut request).expect("read shutdown");
+            assert!(request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n"));
+            write!(
+                stream,
+                "HTTP/1.1 {status} Error\r\nContent-Length: 0\r\n\r\n"
+            )
+            .expect("write rejected shutdown");
+            drop(stream);
+
+            listener
+                .set_nonblocking(true)
+                .expect("make fallback detection nonblocking");
+            let deadline = Instant::now() + Duration::from_millis(100);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok(_) => panic!("HTTP {status} incorrectly triggered a legacy health request"),
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => panic!("failed checking for a fallback request: {error}"),
+                }
+            }
+        });
+
+        let error = shutdown_unix_daemon(&home.path, &expected, Duration::from_secs(1))
+            .expect_err("non-404 shutdown error must be returned");
+        assert!(
+            matches!(error, ClientError::HttpStatus(actual) if actual == status),
+            "unexpected shutdown result for HTTP {status}: {error}"
+        );
+        server.join().expect("server thread");
+    }
+}
+
+/// A daemon that accepts a shutdown request, writes its 202 acknowledgement,
+/// and then unlinks its own socket path before closing the authenticated
+/// connection is exercising a legitimate shutdown sequence: nothing after
+/// the pre-send snapshot may re-resolve that pathname against the
+/// filesystem, since it may no longer exist by the time validation runs.
+/// The stop must still resolve to `Exited`, and the now-unlinked path must
+/// be immediately reusable by a freshly started daemon.
+#[test]
+fn lifecycle_shutdown_succeeds_when_the_daemon_unlinks_its_socket_before_closing() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let expected = lifecycle_status(&home.path);
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make lifecycle socket private");
+    let acknowledged = serde_json::json!({
+        "ok": true,
+        "apiVersion": PROTOCOL_VERSION,
+        "capabilities": { "structuredErrors": true },
+        "daemon": expected,
+    })
+    .to_string();
+    let socket_for_server = socket.clone();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept shutdown");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read shutdown");
+        assert!(request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n"));
+        let response = format!(
+            "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            acknowledged.len(),
+            acknowledged
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("acknowledge shutdown");
+        // Legitimate daemon shutdown: unlink the socket path before the
+        // authenticated connection is closed, exactly as a real daemon does
+        // when it releases its listener ahead of process exit.
+        fs::remove_file(&socket_for_server).expect("unlink daemon socket during shutdown");
+        drop(stream);
+    });
+
+    let result = shutdown_unix_daemon(&home.path, &expected, Duration::from_secs(1))
+        .expect("an unlinked-before-close shutdown must not be treated as an error");
+    server.join().expect("server thread");
+
+    assert_eq!(result, UnixDaemonShutdown::Exited);
+    assert!(
+        !socket.exists(),
+        "the daemon's unlink of its own socket must not be undone by validation"
+    );
+
+    // Stop/restart succeeds: nothing left over from validating the shutdown
+    // may block a freshly started daemon from binding the same path.
+    let restarted = UnixListener::bind(&socket).expect("restart must reuse the unlinked path");
+    drop(restarted);
+}
+
+/// If the socket path is rebound to a different daemon before the shutdown
+/// request is authenticated, the connected peer's real (kernel-authenticated)
+/// identity must still be checked against the caller's expectation, even if
+/// a response body claims otherwise. The daemon-echoed acknowledgement body
+/// alone is not sufficient: a numeric pid substitution is a hard failure,
+/// not a soft identity mismatch, so it must fail closed rather than report a
+/// successful stop or silently defer to a fallback path for a peer it never
+/// actually expected to reach.
+#[test]
+fn lifecycle_shutdown_rejects_a_binding_replaced_before_the_request() {
+    use std::{
+        io::{Read, Write},
+        os::unix::{fs::PermissionsExt, net::UnixListener},
+        time::Duration,
+    };
+
+    let home = TestHome::new();
+    let mut expected = lifecycle_status(&home.path);
+    // The recorded identity no longer matches the real, kernel-authenticated
+    // peer this connection will reach (which, over a Unix socket, is always
+    // this test process' own pid): this models the path having been rebound
+    // to a different daemon since `expected` was last recorded.
+    expected.pid = if std::process::id() == u32::MAX {
+        u32::MAX - 1
+    } else {
+        std::process::id() + 1
+    };
+    let socket = home.path.join("coven.sock");
+    let listener = UnixListener::bind(&socket).expect("bind lifecycle socket");
+    fs::set_permissions(&socket, fs::Permissions::from_mode(0o600))
+        .expect("make lifecycle socket private");
+    let acknowledged = serde_json::json!({
+        "ok": true,
+        "apiVersion": PROTOCOL_VERSION,
+        "capabilities": { "structuredErrors": true },
+        "daemon": expected,
+    })
+    .to_string();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept shutdown");
+        let mut request = String::new();
+        stream.read_to_string(&mut request).expect("read shutdown");
+        assert!(request.starts_with("POST /api/v1/internal/lifecycle/shutdown HTTP/1.1\r\n"));
+        // Even a (misbehaving or confused) peer that echoes back an
+        // acknowledgement matching the client's claimed identity must not be
+        // trusted over the authenticated connection's real peer identity.
+        let response = format!(
+            "HTTP/1.1 202 Accepted\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            acknowledged.len(),
+            acknowledged
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("acknowledge mismatched shutdown");
+    });
+
+    let error = shutdown_unix_daemon(&home.path, &expected, Duration::from_secs(1)).expect_err(
+        "a substituted pid must not be authenticated as the expected daemon, even when the \
+         response body claims otherwise",
+    );
+
+    assert!(
+        matches!(&error, ClientError::Discovery(message) if message.contains("connected peer pid")),
+        "unexpected rejection for a replaced binding: {error}"
+    );
+    server.join().expect("server thread");
+}

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -39,6 +39,47 @@ proof of `coven.daemon.v1` support.
 - Events include a monotonic `seq` cursor for incremental reads.
 - Event payloads are redacted by default before API display.
 
+### Reusable Rust client
+
+Rust integrations should use `coven-client` rather than compose HTTP over the
+daemon transport themselves. Construct a `DaemonEndpoint` only through
+`DaemonEndpoint::discover(coven_home)`, then pass it to `DaemonClient::new`.
+The public client accepts no URLs or arbitrary socket/pipe paths, exposes only
+known `/api/v1/*` operations, caps response bodies at 4 MiB, and negotiates
+health before dependent operations. Negotiation is bound to a transport peer
+fingerprint. If the daemon endpoint is replaced, the next dependent operation
+fails before sending request bytes and clears the cached negotiation. Call
+`health` again, re-check capabilities, and then decide whether to retry; the
+client never replays a mutation automatically.
+
+On Unix, discovery accepts only the current user's private
+`<COVEN_HOME>/coven.sock`. On Windows, it derives only Coven's owner-only pipe
+for the supplied private Coven home, then verifies that the pipe owner is the
+current user and that its DACL is exactly Coven's owner-rights `GENERIC_ALL`
+rule. During an upgrade, it may use a legacy pipe recorded in the private
+`daemon.json` only when the file and recorded pipe pass the same owner-only
+validation and the name matches Coven's fixed pipe-name shape. The daemon
+status must also match the historical deterministic pipe name for the selected
+`COVEN_HOME`; copying a protected status file between profiles is rejected.
+The daemon remains responsible for creating that descriptor.
+`ClientError::Daemon` preserves the HTTP status and `error.code`,
+`error.message`, and `error.details` from a structured daemon failure.
+
+`coven.daemon.v1` session routing predates URL-component semantics. The daemon
+does not percent-decode session ids: path routes consume the raw remainder
+between `/sessions/` and an action suffix, and `GET /events` reads the raw
+`sessionId` query value up to the next `&`. A literal `%2F` therefore names
+`%2F`, while `engine/42` remains a reachable id. Changing those bytes under the
+same named contract would retarget mixed-version mutations.
+
+The typed client emits representable ids verbatim. It rejects empty ids,
+whitespace, control characters, and `?` in path-routed ids because the
+inherited HTTP request line cannot preserve them; the events query rejects
+empty ids, whitespace, control characters, and `&`. Session detail ids that
+collide with inherited nested route suffixes (`/handoffs`, `/log`, `/events`,
+or `/artifacts/`) are not exposed by that typed operation. These are inherited
+`v1` routing limitations, not a new id grammar.
+
 ## `GET /api/v1/health`
 
 `GET /api/v1/health` returns daemon reachability, the named contract version, coven version, and machine-readable capabilities:
@@ -69,7 +110,8 @@ proof of `coven.daemon.v1` support.
   "daemon": {
     "pid": 12345,
     "startedAt": "2026-05-09T06:43:00Z",
-    "socket": "<local IPC endpoint>"
+    "socket": "<local IPC endpoint>",
+    "processCreationTime": "134157822123456789"
   },
   "eventWriter": {
     "state": "healthy",
@@ -89,6 +131,10 @@ proof of `coven.daemon.v1` support.
   }
 }
 ```
+
+`processCreationTime` is an optional Windows-only process fingerprint. It is a
+decimal string so the full 64-bit FILETIME survives JSON consumers; clients
+must continue to accept records and health responses that omit it.
 
 If the daemon metadata is unavailable, `daemon` may be `null`. When present,
 `daemon.socket` reports the active local IPC endpoint. The `hub` block reports
@@ -597,6 +643,11 @@ Registers a session that is already running outside the daemon (for example, the
 | `harness`        | string | Yes      | Harness identifier (e.g. `"coven-code"`). Must be non-empty after trimming.|
 | `title`          | string | No       | Display title. Defaults to `"External session"` when absent or empty.      |
 | `transcriptPath` | string | No       | Absolute path to the external session's transcript file. Stored as-is; the daemon does not read or validate the path. |
+
+Session ids use the inherited raw `v1` routing described under
+[Reusable Rust client](#reusable-rust-client). Do not percent-encode them while
+claiming `coven.daemon.v1`; doing so changes the id selected by an existing
+daemon.
 
 ### Responses
 

--- a/docs/CLIENT-INTEGRATION.md
+++ b/docs/CLIENT-INTEGRATION.md
@@ -24,6 +24,29 @@ Recommended handshake:
 3. Call `GET /api/v1/capabilities` if using control-plane actions.
 4. Use versioned `/api/v1/...` routes only.
 
+Rust integrations should use the owner-adjacent `coven-client` crate for this
+handshake and daemon framing. Discover `DaemonEndpoint` from the chosen Coven
+home, pass it to `DaemonClient::new`, and use its typed `/api/v1` operations.
+It does not accept URLs, arbitrary socket paths, or arbitrary request paths:
+Unix discovery requires the current user's private `coven.sock`, and Windows
+discovery derives and validates only the daemon's owner-only named pipe. The
+client accepts a recorded legacy Windows pipe only from a validated private
+`daemon.json`, allowing an upgrade to reconnect without accepting arbitrary
+pipe names. It performs health negotiation before dependent calls and returns
+structured daemon errors with their code, message, and details intact.
+The negotiated capabilities are tied to the connected daemon's peer
+fingerprint. Endpoint replacement invalidates the cache before request bytes
+are sent; callers must negotiate again, and mutations are never replayed
+automatically.
+
+The `coven.daemon.v1` session routes use their historical raw-byte behavior,
+not URL-component decoding. `engine/42` is a valid raw path remainder and a
+literal `%2F` remains literal. The typed client sends representable ids
+verbatim. Path targets reject empty ids, whitespace, control characters, and
+`?`; the events query rejects empty ids, whitespace, control characters, and
+`&`; detail ids that collide with a nested session route are also unavailable.
+Do not add percent-encoding without a future named protocol version.
+
 ```mermaid
 sequenceDiagram
   participant Client

--- a/docs/daemon/capabilities-handshake.md
+++ b/docs/daemon/capabilities-handshake.md
@@ -15,6 +15,14 @@ Treat a missing, false, or malformed required capability as unsupported and
 fail before sending the dependent request. Clients should ignore unknown
 additive capabilities.
 
+Cache negotiation only while it remains bound to the same daemon instance.
+Local clients should fingerprint the connected Unix peer and socket identity,
+or the Windows named-pipe server process and creation identity, during health.
+Before sending any dependent request, verify the new connection has the same
+fingerprint. If the endpoint was replaced, send no dependent bytes, discard
+the cache, and negotiate again. Never automatically replay a mutation; a read
+retry, if offered, must be explicit and bounded.
+
 For example, a client must require `capabilities.sessionLaunchPolicy === true`
 before adding `launchPolicy` to `POST /api/v1/sessions`. The capability says
 the daemon understands that request shape; it does not grant filesystem

--- a/docs/daemon/lifecycle.md
+++ b/docs/daemon/lifecycle.md
@@ -26,6 +26,9 @@ coven daemon start
 ```
 
 Start creates `COVEN_HOME` when needed, binds the local daemon transport, records daemon metadata, and returns after the daemon is reachable.
+The launched daemon is the sole publisher of `daemon.json`; the launcher passes
+one canonical start timestamp and verifies that same identity through health
+before reporting success.
 
 Run this after install:
 
@@ -77,6 +80,19 @@ coven daemon stop
 ```
 
 Stop the daemon before uninstalling Coven, moving `COVEN_HOME`, changing service-manager configuration, or replacing a source-built binary.
+
+On Unix, status, stop, and restart are bound to the selected profile. The
+recorded `daemon.json` socket must exactly equal the canonical
+`<COVEN_HOME>/coven.sock`; Coven never derives the selected home from the
+recorded socket. Copying daemon status between profiles therefore cannot make
+one profile connect to or shut down another.
+
+On Windows, new status records also contain `processCreationTime`, a decimal
+64-bit FILETIME string. Lifecycle commands compare it with the connected or
+live process so a reused PID is never treated as the recorded daemon. Legacy
+records without this field remain supported when owner-validated,
+profile-bound pipe health authenticates the daemon; otherwise cleanup fails
+closed.
 
 ## First session after daemon start
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -49,9 +49,10 @@ The health `capabilities` object currently contains all 16 fields:
 `sessionLaunchPolicy` field is `true` only over owner-gated local IPC and is
 always `false` over TCP; Host and Origin allowlists do not elevate TCP
 authority. `daemon` is either `null` or
-`{ pid, startedAt, socket }`, where the socket is under
+`{ pid, startedAt, socket, processCreationTime? }`, where the socket is under
 the active local IPC endpoint; the optional `hub` field is a control-plane
-summary.
+summary. `processCreationTime` is a Windows-only decimal string containing the
+full 64-bit process FILETIME fingerprint.
 The optional `eventWriter` field reports the daemon-owned persistence queue,
 including its state, exact queued events/bytes, capacity, dropped output,
 connection, transaction, commit, and last-error counters.


### PR DESCRIPTION
## Context

- Summary: Extracts a typed `coven-client` Rust crate and migrates CLI/TUI daemon callers onto validated local IPC.
- Files changed: 37 files across the new client crate, daemon/CLI/TUI adoption, tests, and API/integration docs.
- Closes #756

## Implementation

- Approach: Owner-validated Unix/Windows discovery and transport, mandatory `coven.daemon.v1` negotiation, bounded framing/deadlines, lifecycle helpers, typed session APIs, and daemon smoke coverage.
- User-visible behavior: CLI/TUI integrations use the same typed client contract for daemon health, lifecycle, and session operations.
- Compatibility notes: Preserves v1 raw session-id route semantics and legacy Windows status compatibility while rejecting untrusted local IPC endpoints.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked -- --test-threads=1` (serial: 2,262 primary binary tests plus workspace integration/doc tests)
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Commit hook gitleaks scan

## Risk and Rollback

- Risk level: medium; this redirects local daemon callers through a shared client boundary.
- Rollback plan: revert this commit; no persisted schema migration is introduced.

## Agent Handoff

- Current state: ready for review; branch is clean and pushed.
- Follow-ups: hosted CI should exercise Windows-specific transport paths.
- Known gaps: none reported.