### PR TITLE
fix(config): preserve Windows engine provenance

### DIFF
--- a/crates/coven-cli/src/config_paths.rs
+++ b/crates/coven-cli/src/config_paths.rs
@@ -593,15 +593,11 @@ fn settings_source() -> PathSource {
 }
 
 fn user_home_source(home: Option<&Path>) -> PathSource {
-    let Some(home) = home else {
-        return PathSource::Default;
-    };
-    let matches_home = ["HOME", "USERPROFILE"]
+    let environment_homes = ["HOME", "USERPROFILE"]
         .into_iter()
         .filter_map(std::env::var_os)
         .filter(|value| !value.is_empty())
-        .map(PathBuf::from)
-        .any(|candidate| candidate == home);
+        .map(PathBuf::from);
     let drive_and_path = std::env::var_os("HOMEDRIVE")
         .filter(|value| !value.is_empty())
         .zip(std::env::var_os("HOMEPATH").filter(|value| !value.is_empty()))
@@ -609,7 +605,22 @@ fn user_home_source(home: Option<&Path>) -> PathSource {
             drive.push(path);
             PathBuf::from(drive)
         });
-    if matches_home || drive_and_path.is_some_and(|candidate| candidate == home) {
+    user_home_source_from_candidates(
+        home,
+        !cfg!(windows),
+        environment_homes.chain(drive_and_path),
+    )
+}
+
+fn user_home_source_from_candidates(
+    home: Option<&Path>,
+    resolver_uses_environment: bool,
+    candidates: impl IntoIterator<Item = PathBuf>,
+) -> PathSource {
+    let Some(home) = home.filter(|_| resolver_uses_environment) else {
+        return PathSource::Default;
+    };
+    if candidates.into_iter().any(|candidate| candidate == home) {
         PathSource::Environment
     } else {
         PathSource::Default
@@ -674,6 +685,16 @@ mod tests {
         assert_eq!(surfaces.len(), 1);
         assert!(matches!(surfaces[0].status, PathStatus::Unresolved));
         assert!(matches!(surfaces[0].source, PathSource::Environment));
+    }
+
+    #[test]
+    fn native_profile_home_is_default_even_when_environment_matches() {
+        let home = Path::new("/native-profile");
+
+        assert_eq!(
+            user_home_source_from_candidates(Some(home), false, [home.to_path_buf()].into_iter()),
+            PathSource::Default
+        );
     }
 
     #[cfg(unix)]

--- a/docs/superpowers/plans/2026-08-17-windows-engine-provenance.md
+++ b/docs/superpowers/plans/2026-08-17-windows-engine-provenance.md
@@ -1,0 +1,115 @@
+# Windows Engine Provenance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Report Windows managed and legacy engine paths as default-derived when `dirs_next` resolves the native profile directory, even if environment variables contain the same path.
+
+**Architecture:** Keep engine-source classification at the existing `user_home_source` boundary. Pass the platform resolver's environment dependency into a small candidate classifier so Windows always returns `PathSource::Default`, while non-Windows platforms retain environment comparison.
+
+**Tech Stack:** Rust, Cargo, `dirs-next`, existing `coven-cli` unit and integration tests
+
+---
+
+### Task 1: Correct native Windows profile provenance
+
+**Files:**
+- Modify: `crates/coven-cli/src/config_paths.rs:595-617`
+- Test: `crates/coven-cli/src/config_paths.rs:679-701`
+- Test: `crates/coven-cli/tests/config_paths.rs:55-189`
+
+- [x] **Step 1: Confirm the failing provenance contract**
+
+Add a platform-neutral unit assertion around the resolver contract:
+
+```rust
+#[test]
+fn native_profile_home_is_default_even_when_environment_matches() {
+    let home = Path::new("/native-profile");
+
+    assert_eq!(
+        user_home_source_from_candidates(
+            Some(home),
+            false,
+            [home.to_path_buf()].into_iter()
+        ),
+        PathSource::Default
+    );
+}
+```
+
+Run:
+
+```bash
+cargo test -p coven-cli native_profile_home_is_default_even_when_environment_matches
+```
+
+Expected before the fix: FAIL because `user_home_source_from_candidates` does not exist. The existing Windows integration assertion independently verifies the full report emits `"default"`.
+
+- [x] **Step 2: Make provenance follow the platform resolver**
+
+Separate environment candidate collection from provenance classification:
+
+```rust
+fn user_home_source(home: Option<&Path>) -> PathSource {
+    let environment_homes = ["HOME", "USERPROFILE"]
+        .into_iter()
+        .filter_map(std::env::var_os)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from);
+    let drive_and_path = std::env::var_os("HOMEDRIVE")
+        .filter(|value| !value.is_empty())
+        .zip(std::env::var_os("HOMEPATH").filter(|value| !value.is_empty()))
+        .map(|(mut drive, path)| {
+            drive.push(path);
+            PathBuf::from(drive)
+        });
+    user_home_source_from_candidates(
+        home,
+        !cfg!(windows),
+        environment_homes.chain(drive_and_path),
+    )
+}
+
+fn user_home_source_from_candidates(
+    home: Option<&Path>,
+    resolver_uses_environment: bool,
+    candidates: impl IntoIterator<Item = PathBuf>,
+) -> PathSource {
+    let Some(home) = home.filter(|_| resolver_uses_environment) else {
+        return PathSource::Default;
+    };
+    if candidates.into_iter().any(|candidate| candidate == home) {
+        PathSource::Environment
+    } else {
+        PathSource::Default
+    }
+}
+```
+
+- [x] **Step 3: Run focused tests**
+
+```bash
+cargo test -p coven-cli config_paths
+cargo test -p coven-cli --test config_paths
+```
+
+Expected: all selected tests pass; Windows runs specifically exercise the default-provenance assertion.
+
+- [x] **Step 4: Run formatting and lint checks**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -p coven-cli --all-targets -- -D warnings
+```
+
+Expected: both commands exit successfully with no diagnostics.
+
+- [x] **Step 5: Commit the fix**
+
+```bash
+git add crates/coven-cli/src/config_paths.rs \
+  docs/superpowers/plans/2026-08-17-windows-engine-provenance.md
+git commit -m "fix(config): preserve Windows engine provenance"
+```
+
+Expected: a commit containing only the provenance correction and its implementation plan.


### PR DESCRIPTION
## Summary
- Classify native Windows profile paths as default-derived instead of environment-derived.
- Preserve environment provenance for explicit engine overrides, PATH lookup, and non-Windows environment-backed home resolution.
- Add a platform-neutral classifier regression test alongside the existing Windows report assertion.

## Test plan
- cargo test -p coven-cli native_profile_home_is_default_even_when_environment_matches
- cargo test -p coven-cli --test config_paths
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- python scripts/check-secrets.py
- python3 scripts/check-coven-privacy.py --staged

## Full-suite note
cargo test --workspace --locked reached 2,197 passing tests but exposed unrelated timing and state failures in existing PTY and claim-lock tests. The branch changes only config-path provenance and its plan; clean Ubuntu and Windows CI are the authoritative full-suite gates.