### PR TITLE
ci: route and parallelize pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,15 +101,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-rust-perf-${{ hashFiles('Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-rust-perf-
         with:
           components: rustfmt, clippy
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,123 +8,60 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  rust:
-    name: Rust checks
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Install native link dependencies (Linux only)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
-      # fmt/clippy only on Linux to keep Windows leg focused on build+test
-      - name: Check formatting
-        if: runner.os == 'Linux'
-        run: cargo fmt --check
-      - name: Clippy
-        if: runner.os == 'Linux'
-        run: cargo clippy --workspace --all-targets -- -D warnings
-      - run: cargo test --workspace --locked
-      # `coven-afs`'s `mount` feature is opt-in, so every step above compiles
-      # the workspace *without* `crates/coven-afs/src/nfs.rs` — the NFSv3
-      # export, its ownership mapping, and the file-handle authentication that
-      # is the access-control boundary for a mounted session (DESIGN.md §7).
-      # That module went unbuilt by CI from #680 until `coven-aof`, so PRs
-      # changing it received green checks computed without it.
-      #
-      # Linux only: the export calls `libc::getuid`/`getgid`, which do not
-      # exist on Windows — `nfsserve` gates its own `fs_util` the same way.
-      # Excluding Windows is the honest fix; weakening the module to compile
-      # there would trade real coverage for a green badge.
-      - name: Clippy (coven-afs mount feature)
-        if: runner.os == 'Linux'
-        run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
-      - name: Test (coven-afs mount feature)
-        if: runner.os == 'Linux'
-        run: cargo test -p coven-afs --features mount --locked
-
-  afs-mount-macos:
-    name: AFS mount backend (macOS)
-    # macOS is the only platform that advertises a mount backend
-    # (`afsMount: "nfs"`), and the `Rust checks` matrix does not include it.
-    # A separate job rather than a third matrix entry: this needs to build one
-    # crate, not the workspace, and the mount steps in that job are already
-    # conditioned on `runner.os == 'Linux'` for reasons that do not apply here.
-    #
-    # This does not close a *compile* gap. `crates/coven-cli/src/afs_mount.rs`
-    # uses `cfg!(target_os = "macos")` — the macro, so both branches type-check
-    # on Linux — and its helpers are `cfg(unix)`, which Linux covers. What is
-    # missing is Darwin behaviour: the nfsserve stack, the uid/gid mapping in
-    # `nfs.rs`, and the only place `mount_nfs` can actually run.
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - name: Clippy (coven-afs mount feature)
-        run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
-      - name: Test (coven-afs mount feature)
-        run: cargo test -p coven-afs --features mount --locked
-      # Informational. `coven-x77` found that macOS refuses `open()` on network
-      # volumes for processes without privacy consent, and a runner is exactly
-      # such a process — so this may well be refused. Recording which stage
-      # refuses turns a standing guess into an answer; it must never gate a PR.
-      - name: Probe a real mount (informational)
-        continue-on-error: true
-        run: ./scripts/afs-mount-smoke.sh
-
-  performance-baseline:
-    name: CLI performance baseline
+  changes:
+    name: Classify changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      rust: ${{ steps.classify.outputs.rust }}
+      afs: ${{ steps.classify.outputs.afs }}
+      channels: ${{ steps.classify.outputs.channels }}
+      openclaw: ${{ steps.classify.outputs.openclaw }}
+      npm_packaging: ${{ steps.classify.outputs.npm_packaging }}
+      engine: ${{ steps.classify.outputs.engine }}
+      workflow: ${{ steps.classify.outputs.workflow }}
+      cargo_metadata: ${{ steps.classify.outputs.cargo_metadata }}
     steps:
       - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7
         with:
-          node-version: 24
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install native link dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
-      - name: Build coven
-        run: cargo build -p coven-cli --locked
-      - name: Validate benchmark runner
-        run: node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
-      - name: Collect non-gating baseline artifact
-        run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
-      # Trend collection only, and intermittently unable to run 32 concurrent
-      # sessions on a two-core runner (#615) — a live session there can record
-      # no events at all. Collection must not gate merges; the deterministic
-      # unit tests above still do. Drop `continue-on-error` once #615 is fixed.
-      - name: Collect concurrent runtime baseline artifact
-        continue-on-error: true
-        run: node scripts/benchmark-chaos.mjs --binary target/debug/coven --output coven-chaos.json
-      - name: Collect deterministic TUI scheduling metric
+          fetch-depth: 0
+      - name: Collect changed paths
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
-          set -o pipefail
-          cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture | tee coven-tui-metrics.txt
-      - name: Upload baseline artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: coven-cli-performance-baseline
-          path: |
-            coven-perf.json
-            coven-chaos.json
-            coven-tui-metrics.txt
-          if-no-files-found: error
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            range="${PR_BASE_SHA}...${PR_HEAD_SHA}"
+          elif git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            range="${BEFORE_SHA}..${AFTER_SHA}"
+          else
+            empty_tree="$(git hash-object -t tree -w --stdin </dev/null)"
+            range="${empty_tree}..${AFTER_SHA}"
+          fi
+          git diff --name-only --diff-filter=ACMR "$range" > changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/classify-ci-changes.py --github-output "$GITHUB_OUTPUT" < changed-files.txt
 
-  secret-guard:
-    name: Secret guard
+  policy-guard:
+    name: Policy guard
+    needs: changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7.0.1
         with:
@@ -150,10 +87,197 @@ jobs:
             BEFORE_SHA="$(git hash-object -t tree -w --stdin </dev/null)"
           fi
           python scripts/check-coven-privacy.py --range "${BEFORE_SHA}..${AFTER_SHA}"
+      - run: python3 scripts/classify-ci-changes-test.py
+      - run: python3 scripts/check-workflows-test.py
+      - run: python3 scripts/check-ci-workflow-test.py
+      - run: scripts/check-workflows.sh
+
+  rust-lint-linux:
+    name: Rust lint (Linux)
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-perf-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-perf-
+        with:
+          components: rustfmt, clippy
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-lint-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-lint-
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Check formatting
+        run: cargo fmt --check
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+  rust-test-linux:
+    name: Rust tests (Linux)
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-test-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-test-
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - run: cargo test --workspace --locked
+
+  rust-test-windows:
+    name: Rust tests (Windows)
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-test-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-test-
+      - run: cargo test --workspace --locked
+
+  afs-mount-linux:
+    name: AFS mount backend (Linux)
+    needs: changes
+    if: ${{ needs.changes.outputs.afs == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-afs-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-afs-
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Clippy (coven-afs mount feature)
+        run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
+      - name: Test (coven-afs mount feature)
+        run: cargo test -p coven-afs --features mount --locked
+
+  afs-mount-macos:
+    name: AFS mount backend (macOS)
+    needs: changes
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.afs == 'true' }}
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-afs-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-afs-
+      - name: Clippy (coven-afs mount feature)
+        run: cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
+      - name: Test (coven-afs mount feature)
+        run: cargo test -p coven-afs --features mount --locked
+      - name: Probe a real mount (informational)
+        if: ${{ github.event_name == 'push' }}
+        continue-on-error: true
+        run: ./scripts/afs-mount-smoke.sh
+
+  performance-baseline:
+    name: CLI performance baseline
+    needs: changes
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-perf-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-perf-
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Build coven
+        run: cargo build -p coven-cli --locked
+      - name: Validate benchmark runner
+        run: node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
+      - name: Collect non-gating baseline artifact
+        run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
+      - name: Collect concurrent runtime baseline artifact
+        continue-on-error: true
+        run: node scripts/benchmark-chaos.mjs --binary target/debug/coven --output coven-chaos.json
+      - name: Collect deterministic TUI scheduling metric
+        run: |
+          set -o pipefail
+          cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture | tee coven-tui-metrics.txt
+      - name: Upload baseline artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: coven-cli-performance-baseline
+          path: |
+            coven-perf.json
+            coven-chaos.json
+            coven-tui-metrics.txt
+          if-no-files-found: error
 
   channels:
     name: Channels package
+    needs: changes
+    if: ${{ needs.changes.outputs.channels == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-node@v7
@@ -170,7 +294,10 @@ jobs:
 
   openclaw-bridge:
     name: OpenClaw bridge
+    needs: changes
+    if: ${{ needs.changes.outputs.openclaw == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: actions/setup-node@v7
@@ -180,6 +307,14 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@10.11.1 --activate
+      - id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-openclaw-${{ hashFiles('packages/openclaw-coven/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-openclaw-
       - run: pnpm install --frozen-lockfile --ignore-scripts
         working-directory: packages/openclaw-coven
       - run: pnpm run build
@@ -187,9 +322,45 @@ jobs:
       - run: pnpm test
         working-directory: packages/openclaw-coven
 
-  npm-onboarding-smoke:
+  npm-onboarding-linux:
+    name: npm onboarding smoke (linux-x64)
+    needs: changes
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.npm_packaging == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NPM_TARGET: linux-x64
+      RUST_TARGET: x86_64-unknown-linux-gnu
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ env.RUST_TARGET }}
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-npm-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-npm-
+      - name: Install native link dependencies (Linux only)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - run: cargo build --release --package coven-cli --target ${{ env.RUST_TARGET }}
+      - run: node scripts/test-cli-prepublish.mjs --target="$NPM_TARGET" --skip-build --skip-secrets-scan
+        env:
+          COVEN_NPM_DRY_RUN_VERSION: 999.0.0
+
+  npm-onboarding-main:
     name: npm onboarding smoke (${{ matrix.npm-target }})
+    needs: changes
+    if: ${{ github.event_name == 'push' }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -214,14 +385,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.rust-target }}
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-npm-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-npm-
       - name: Install native link dependencies (Linux only)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
       - run: cargo build --release --package coven-cli --target ${{ matrix.rust-target }}
-      # The smoke test packages with --skip-build, so it needs every binary the
-      # payload declares — the same set the release builds. Without this the
-      # macOS packages would be assembled without the AFS export helper, which
-      # is precisely the gap this job exists to catch (coven-g2t).
       - name: Build the AFS mount export helper (macOS only)
         if: startsWith(matrix.npm-target, 'macos')
         run: cargo build --release -p coven-afs --features mount --bins --target ${{ matrix.rust-target }}
@@ -231,10 +407,22 @@ jobs:
 
   engine-contract:
     name: engine contract
+    needs: changes
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.engine == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-engine-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-engine-
       - name: Install native link dependencies
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
       - name: Build coven
@@ -250,11 +438,58 @@ jobs:
 
   cargo-deny:
     name: Dependency audit
+    needs: changes
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7.0.1
-      # Commit-pinned (v2.0.20): a supply-chain gate must not itself depend on a
-      # mutable action tag. Config lives in deny.toml at the repo root.
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           command: check advisories licenses bans sources
+
+  pr-gate:
+    name: PR gate
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - changes
+      - policy-guard
+      - rust-lint-linux
+      - rust-test-linux
+      - rust-test-windows
+      - afs-mount-linux
+      - afs-mount-macos
+      - performance-baseline
+      - channels
+      - openclaw-bridge
+      - npm-onboarding-linux
+      - npm-onboarding-main
+      - engine-contract
+      - cargo-deny
+    env:
+      JOB_RESULTS: ${{ toJSON(needs) }}
+    steps:
+      - name: Require successful or intentional skipped jobs
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          jobs = json.loads(os.environ["JOB_RESULTS"])
+          bad = {
+              name: data["result"]
+              for name, data in jobs.items()
+              if data["result"] not in {"success", "skipped"}
+          }
+          for required in ("changes", "policy-guard"):
+              if jobs[required]["result"] != "success":
+                  bad[required] = jobs[required]["result"]
+          if bad:
+              raise SystemExit(
+                  "PR gate rejected job results: "
+                  + ", ".join(f"{name}={result}" for name, result in sorted(bad.items()))
+              )
+          print("PR gate accepted all required and conditional jobs")
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,7 +441,7 @@ jobs:
 
   pr-gate:
     name: PR gate
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    if: ${{ always() && !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             empty_tree="$(git hash-object -t tree -w --stdin </dev/null)"
             range="${empty_tree}..${AFTER_SHA}"
           fi
-          git diff --name-only --diff-filter=ACMR "$range" > changed-files.txt
+          git diff --name-only --diff-filter=ACMRD "$range" > changed-files.txt
       - name: Classify changed paths
         id: classify
         run: python3 scripts/classify-ci-changes.py --github-output "$GITHUB_OUTPUT" < changed-files.txt

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -125,6 +125,52 @@ jobs:
           NATIVE_PACKAGE_SET: post-intel
         run: node scripts/release-npm-platform-matrix.mjs "$NATIVE_PACKAGE_SET" >> "$GITHUB_OUTPUT"
 
+  performance-baseline:
+    name: Release performance baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [verify, verify-tag]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-20
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-release-perf-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-release-perf-
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Build coven
+        run: cargo build -p coven-cli --locked
+      - name: Validate benchmark runner
+        run: node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
+      - name: Collect release baseline artifact
+        run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
+      - name: Collect concurrent runtime baseline artifact
+        continue-on-error: true
+        run: node scripts/benchmark-chaos.mjs --binary target/debug/coven --output coven-chaos.json
+      - name: Collect deterministic TUI scheduling metric
+        run: |
+          set -o pipefail
+          cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture | tee coven-tui-metrics.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: coven-release-performance-${{ needs.verify-tag.outputs.release_tag }}
+          path: |
+            coven-perf.json
+            coven-chaos.json
+            coven-tui-metrics.txt
+          if-no-files-found: error
+
   build-platform:
     name: Build ${{ matrix.npm-target }}
     runs-on: ${{ matrix.runner }}
@@ -215,7 +261,7 @@ jobs:
   npm-publish:
     name: npm publish
     runs-on: ubuntu-latest
-    needs: [build-platform, npm-dry-run, verify-tag]
+    needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]
     # OIDC trusted publishing: id-token:write lets the job mint a short-lived OIDC token
     # that `npm publish --provenance` exchanges with the npm registry for a one-shot
     # publish credential. No NPM_TOKEN secret is read or written.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,12 @@ python scripts/check-secrets.py
 python3 scripts/check-coven-privacy.py --staged
 ```
 
+If your change only touches one routed CI surface (for example docs, npm, or a
+single Rust crate), say that clearly in the PR and explain which local checks
+cover it. Reviewers and CI may then rely on the matching routed jobs instead of
+expecting every matrix leg; broad or cross-surface changes should still be
+validated with the full local check set above.
+
 5. Include smoke-test notes for runtime or API changes.
 6. Update docs when command behavior, API behavior, or trust boundaries change.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4048,7 +4048,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4687,7 +4687,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5700,7 +5700,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/superpowers/plans/2026-08-19-pr-ci-routing.md
+++ b/docs/superpowers/plans/2026-08-19-pr-ci-routing.md
@@ -622,7 +622,7 @@ Add `jobs.changes` with outputs for every classifier category:
             empty_tree="$(git hash-object -t tree -w --stdin </dev/null)"
             range="${empty_tree}..${AFTER_SHA}"
           fi
-          git diff --name-only --diff-filter=ACMR "$range" > changed-files.txt
+          git diff --name-only --diff-filter=ACMRD "$range" > changed-files.txt
       - name: Classify changed paths
         id: classify
         run: python3 scripts/classify-ci-changes.py --github-output "$GITHUB_OUTPUT" < changed-files.txt

--- a/docs/superpowers/plans/2026-08-19-pr-ci-routing.md
+++ b/docs/superpowers/plans/2026-08-19-pr-ci-routing.md
@@ -1,0 +1,1215 @@
+# Pull Request CI Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route and parallelize pull-request checks so ordinary Rust PRs finish required CI near 10 minutes while deferred performance and full packaging coverage run on `main` and release tags.
+
+**Architecture:** A repository-owned Python classifier converts changed paths into stable job-category outputs. `.github/workflows/ci.yml` uses those outputs to start independent conditional jobs, a final aggregate gate, bounded timeouts, cancellation, and pinned caches. The release workflow remains independent and adds the deferred performance baseline before publication.
+
+**Tech Stack:** GitHub Actions YAML, Python 3 `unittest`, Bash, Cargo, Node.js 24, pnpm 10.11.1, actionlint 1.7.12, `actions/cache` 6.1.0.
+
+---
+
+## File Structure
+
+- Create `scripts/classify-ci-changes.py`: pure changed-path classifier and GitHub-output CLI.
+- Create `scripts/classify-ci-changes-test.py`: table-driven unit coverage for every routing category and fail-closed behavior.
+- Create `scripts/check-workflows.sh`: checksum-verified actionlint 1.7.12 runner for Linux and macOS.
+- Create `scripts/check-workflows-test.py`: verifies the pinned actionlint release/checksums and script interface without downloading tools.
+- Create `scripts/check-ci-workflow-test.py`: textual policy tests for required job names, conditions, timeouts, cache pin, aggregate gate, and deferred release coverage.
+- Rewrite `.github/workflows/ci.yml`: change router, parallel/conditional PR jobs, main-only extended jobs, caches, timeouts, cancellation, and `PR gate`.
+- Modify `.github/workflows/release-npm.yml`: add the release performance baseline and require it before publish.
+- Modify `CONTRIBUTING.md`: document routed PR checks and clarify that contributors still run the full relevant local gate.
+
+### Task 1: Build the changed-path classifier
+
+**Files:**
+- Create: `scripts/classify-ci-changes-test.py`
+- Create: `scripts/classify-ci-changes.py`
+
+- [ ] **Step 1: Write the failing classifier tests**
+
+Create `scripts/classify-ci-changes-test.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import io
+import pathlib
+import tempfile
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("classify-ci-changes.py")
+spec = importlib.util.spec_from_file_location("classify_ci_changes", SCRIPT)
+assert spec is not None
+classify_ci_changes = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(classify_ci_changes)
+
+
+class ClassifyCiChangesTests(unittest.TestCase):
+    def assert_categories(
+        self, paths: list[str], **expected: bool
+    ) -> None:
+        actual = classify_ci_changes.classify(paths)
+        for name in classify_ci_changes.CATEGORY_NAMES:
+            self.assertEqual(
+                actual[name],
+                expected.get(name, False),
+                f"{name} for {paths}",
+            )
+
+    def test_docs_only_change_avoids_compiled_jobs(self) -> None:
+        self.assert_categories(["docs/guide.md"], docs_only=True)
+
+    def test_workspace_manifest_fans_out_shared_rust_surfaces(self) -> None:
+        self.assert_categories(
+            ["Cargo.lock"],
+            rust=True,
+            afs=True,
+            npm_packaging=True,
+            cargo_metadata=True,
+        )
+
+    def test_cli_rust_change_includes_linux_packaging_smoke(self) -> None:
+        self.assert_categories(
+            ["crates/coven-cli/src/daemon.rs"],
+            rust=True,
+            npm_packaging=True,
+        )
+
+    def test_afs_change_selects_rust_and_afs(self) -> None:
+        self.assert_categories(
+            ["crates/coven-afs/src/nfs.rs"],
+            rust=True,
+            afs=True,
+        )
+
+    def test_channels_change_is_package_local(self) -> None:
+        self.assert_categories(
+            ["packages/channels/src/index.ts"],
+            channels=True,
+        )
+
+    def test_openclaw_change_is_package_local(self) -> None:
+        self.assert_categories(
+            ["packages/openclaw-coven/src/client.ts"],
+            openclaw=True,
+        )
+
+    def test_npm_wrapper_change_selects_packaging(self) -> None:
+        self.assert_categories(
+            ["npm/coven/bin/coven.js"],
+            npm_packaging=True,
+        )
+
+    def test_engine_change_selects_rust_engine_and_packaging(self) -> None:
+        self.assert_categories(
+            ["crates/coven-cli/src/engine_install.rs"],
+            rust=True,
+            npm_packaging=True,
+            engine=True,
+        )
+
+    def test_workflow_change_fans_out_every_job_category(self) -> None:
+        actual = classify_ci_changes.classify([".github/workflows/ci.yml"])
+        self.assertFalse(actual["docs_only"])
+        for name in classify_ci_changes.CATEGORY_NAMES:
+            if name != "docs_only":
+                self.assertTrue(actual[name], name)
+
+    def test_unknown_non_doc_path_fails_closed_to_rust(self) -> None:
+        self.assert_categories(["config/new-surface.toml"], rust=True)
+
+    def test_mixed_docs_and_package_change_is_not_docs_only(self) -> None:
+        self.assert_categories(
+            ["docs/guide.md", "packages/channels/package.json"],
+            channels=True,
+        )
+
+    def test_empty_input_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "at least one changed path"):
+            classify_ci_changes.classify([])
+
+    def test_github_output_uses_lowercase_booleans(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = pathlib.Path(directory) / "github-output"
+            classify_ci_changes.write_github_output(
+                classify_ci_changes.classify(["docs/guide.md"]), output
+            )
+            self.assertIn("docs_only=true\n", output.read_text())
+            self.assertIn("rust=false\n", output.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python3 scripts/classify-ci-changes-test.py
+```
+
+Expected: FAIL because `scripts/classify-ci-changes.py` does not exist.
+
+- [ ] **Step 3: Implement the classifier**
+
+Create `scripts/classify-ci-changes.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from collections.abc import Iterable
+
+CATEGORY_NAMES = (
+    "docs_only",
+    "rust",
+    "afs",
+    "channels",
+    "openclaw",
+    "npm_packaging",
+    "engine",
+    "workflow",
+    "cargo_metadata",
+)
+
+WORKFLOW_PATHS = (
+    ".github/workflows/",
+    "scripts/classify-ci-changes.py",
+    "scripts/classify-ci-changes-test.py",
+    "scripts/check-workflows.sh",
+    "scripts/check-workflows-test.py",
+    "scripts/check-ci-workflow-test.py",
+)
+NPM_PACKAGING_SCRIPTS = {
+    "scripts/publish-npm.mjs",
+    "scripts/publish-npm-test.mjs",
+    "scripts/release-npm-context.mjs",
+    "scripts/release-npm-platform-matrix.mjs",
+    "scripts/test-cli-prepublish.mjs",
+}
+ENGINE_PATHS = (
+    "crates/coven-cli/engine.lock",
+    "crates/coven-cli/src/engine.rs",
+    "crates/coven-cli/src/engine_install.rs",
+    "scripts/pin-engine.sh",
+)
+
+
+def starts_with_any(path: str, prefixes: Iterable[str]) -> bool:
+    return any(path == prefix or path.startswith(prefix) for prefix in prefixes)
+
+
+def is_documentation(path: str) -> bool:
+    return (
+        path.startswith("docs/")
+        or path.endswith(".md")
+        or path in {"LICENSE", "PATENTS"}
+    )
+
+
+def is_cargo_metadata(path: str) -> bool:
+    return (
+        path in {"Cargo.toml", "Cargo.lock", "deny.toml"}
+        or path.endswith("/Cargo.toml")
+    )
+
+
+def classify(paths: Iterable[str]) -> dict[str, bool]:
+    normalized = [path.strip().replace("\\", "/") for path in paths if path.strip()]
+    if not normalized:
+        raise ValueError("at least one changed path is required")
+
+    result = {name: False for name in CATEGORY_NAMES}
+    result["docs_only"] = all(is_documentation(path) for path in normalized)
+
+    for path in normalized:
+        workflow = starts_with_any(path, WORKFLOW_PATHS)
+        cargo_metadata = is_cargo_metadata(path)
+        rust = cargo_metadata or path.startswith("crates/") or path.endswith(".rs")
+        channels = path.startswith("packages/channels/")
+        openclaw = path.startswith("packages/openclaw-coven/")
+        afs = cargo_metadata or starts_with_any(
+            path,
+            (
+                "crates/coven-afs/",
+                "crates/coven-cli/src/afs_mount.rs",
+                "scripts/afs-mount-smoke.sh",
+            ),
+        )
+        npm_packaging = (
+            cargo_metadata
+            or path.startswith("npm/")
+            or path.startswith("crates/coven-cli/")
+            or path in NPM_PACKAGING_SCRIPTS
+        )
+        engine = starts_with_any(path, ENGINE_PATHS)
+
+        result["workflow"] |= workflow
+        result["cargo_metadata"] |= cargo_metadata
+        result["rust"] |= rust
+        result["afs"] |= afs
+        result["channels"] |= channels
+        result["openclaw"] |= openclaw
+        result["npm_packaging"] |= npm_packaging
+        result["engine"] |= engine
+
+        if not is_documentation(path) and not any(
+            (workflow, rust, channels, openclaw, npm_packaging, engine)
+        ):
+            result["rust"] = True
+
+    if result["workflow"]:
+        for name in CATEGORY_NAMES:
+            result[name] = name != "docs_only"
+    elif any(value for name, value in result.items() if name != "docs_only"):
+        result["docs_only"] = False
+
+    return result
+
+
+def write_github_output(result: dict[str, bool], output: pathlib.Path) -> None:
+    with output.open("a", encoding="utf-8") as stream:
+        for name in CATEGORY_NAMES:
+            stream.write(f"{name}={str(result[name]).lower()}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--github-output", type=pathlib.Path)
+    args = parser.parse_args()
+    result = classify(sys.stdin.read().splitlines())
+    if args.github_output is not None:
+        write_github_output(result, args.github_output)
+    else:
+        for name in CATEGORY_NAMES:
+            print(f"{name}={str(result[name]).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run the classifier tests**
+
+Run:
+
+```bash
+python3 scripts/classify-ci-changes-test.py
+```
+
+Expected: 13 tests pass.
+
+- [ ] **Step 5: Smoke-test representative path sets**
+
+Run:
+
+```bash
+printf '%s\n' docs/guide.md | python3 scripts/classify-ci-changes.py
+printf '%s\n' crates/coven-cli/src/daemon.rs | python3 scripts/classify-ci-changes.py
+printf '%s\n' .github/workflows/ci.yml | python3 scripts/classify-ci-changes.py
+```
+
+Expected:
+
+- docs output has only `docs_only=true`;
+- CLI output has `rust=true` and `npm_packaging=true`;
+- workflow output has every category except `docs_only` set to `true`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/classify-ci-changes.py scripts/classify-ci-changes-test.py
+git commit -s -m "ci: classify pull request changes" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 2: Add pinned workflow validation
+
+**Files:**
+- Create: `scripts/check-workflows-test.py`
+- Create: `scripts/check-workflows.sh`
+
+- [ ] **Step 1: Write the failing pin/interface test**
+
+Create `scripts/check-workflows-test.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+
+SCRIPT = pathlib.Path(__file__).with_name("check-workflows.sh")
+
+
+class WorkflowCheckerTests(unittest.TestCase):
+    def test_actionlint_release_is_pinned_with_platform_checksums(self) -> None:
+        text = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('ACTIONLINT_VERSION="1.7.12"', text)
+        self.assertIn(
+            "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+            text,
+        )
+        self.assertIn(
+            "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+            text,
+        )
+        self.assertIn(
+            "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+            text,
+        )
+
+    def test_print_version_does_not_download(self) -> None:
+        output = subprocess.run(
+            ["bash", str(SCRIPT), "--print-version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(output.stdout, "1.7.12\n")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python3 scripts/check-workflows-test.py
+```
+
+Expected: FAIL because `scripts/check-workflows.sh` does not exist.
+
+- [ ] **Step 3: Implement the checksum-verified actionlint runner**
+
+Create `scripts/check-workflows.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_VERSION="1.7.12"
+
+if [[ "${1:-}" == "--print-version" ]]; then
+  printf '%s\n' "$ACTIONLINT_VERSION"
+  exit 0
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64)
+    platform="linux_amd64"
+    checksum="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+    ;;
+  Darwin-arm64)
+    platform="darwin_arm64"
+    checksum="aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f"
+    ;;
+  Darwin-x86_64)
+    platform="darwin_amd64"
+    checksum="5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644"
+    ;;
+  *)
+    echo "unsupported actionlint host: $(uname -s)-$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+archive="actionlint_${ACTIONLINT_VERSION}_${platform}.tar.gz"
+curl --fail --location --silent --show-error \
+  "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}" \
+  --output "${temporary}/${archive}"
+printf '%s  %s\n' "$checksum" "${temporary}/${archive}" | shasum -a 256 --check -
+tar -xzf "${temporary}/${archive}" -C "$temporary" actionlint
+"${temporary}/actionlint" -color
+```
+
+Make it executable:
+
+```bash
+chmod +x scripts/check-workflows.sh
+```
+
+- [ ] **Step 4: Run tests and actionlint**
+
+Run:
+
+```bash
+python3 scripts/check-workflows-test.py
+scripts/check-workflows.sh
+```
+
+Expected: unit tests pass and current workflows have no actionlint errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-workflows.sh scripts/check-workflows-test.py
+git commit -s -m "ci: add pinned workflow validation" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 3: Define workflow policy tests
+
+**Files:**
+- Create: `scripts/check-ci-workflow-test.py`
+
+- [ ] **Step 1: Write policy tests before changing workflows**
+
+Create `scripts/check-ci-workflow-test.py`:
+
+```python
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).parents[1]
+CI = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+RELEASE = (ROOT / ".github/workflows/release-npm.yml").read_text(
+    encoding="utf-8"
+)
+CACHE_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
+
+
+class CiWorkflowPolicyTests(unittest.TestCase):
+    def test_pr_runs_cancel_when_superseded(self) -> None:
+        self.assertIn(
+            "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+            CI,
+        )
+
+    def test_router_and_stable_gate_exist(self) -> None:
+        self.assertIn("\n  changes:\n", CI)
+        self.assertIn("\n  pr-gate:\n", CI)
+        self.assertIn("name: PR gate", CI)
+        self.assertIn("if: ${{ always() && github.event_name == 'pull_request' }}", CI)
+
+    def test_rust_work_is_split_into_parallel_jobs(self) -> None:
+        for job in (
+            "rust-lint-linux",
+            "rust-test-linux",
+            "rust-test-windows",
+            "afs-mount-linux",
+            "afs-mount-macos",
+        ):
+            self.assertIn(f"\n  {job}:\n", CI)
+        self.assertNotIn("\n  rust:\n", CI)
+
+    def test_compiled_jobs_have_bounded_timeouts(self) -> None:
+        self.assertGreaterEqual(CI.count("timeout-minutes: 20"), 10)
+
+    def test_cache_action_is_commit_pinned(self) -> None:
+        self.assertIn(f"actions/cache@{CACHE_SHA}", CI)
+        self.assertNotIn("actions/cache@v", CI)
+
+    def test_docs_only_path_keeps_policy_checks(self) -> None:
+        self.assertIn("python3 scripts/classify-ci-changes-test.py", CI)
+        self.assertIn("python3 scripts/check-workflows-test.py", CI)
+        self.assertIn("scripts/check-workflows.sh", CI)
+        self.assertIn("needs.changes.outputs.docs_only != 'true'", CI)
+
+    def test_pr_packaging_is_linux_only(self) -> None:
+        self.assertIn("\n  npm-onboarding-linux:\n", CI)
+        self.assertIn("\n  npm-onboarding-main:\n", CI)
+        self.assertIn("github.event_name == 'push'", CI)
+
+    def test_deferred_jobs_run_on_main(self) -> None:
+        self.assertIn("\n  performance-baseline:\n", CI)
+        self.assertIn("name: CLI performance baseline", CI)
+        self.assertIn("if: ${{ github.event_name == 'push' }}", CI)
+
+    def test_release_requires_performance_before_publish(self) -> None:
+        self.assertIn("\n  performance-baseline:\n", RELEASE)
+        self.assertIn(
+            "needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]",
+            RELEASE,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+python3 scripts/check-ci-workflow-test.py
+```
+
+Expected: multiple failures because the current workflows still use the old
+matrix and run extended jobs on every PR.
+
+- [ ] **Step 3: Commit the failing policy test**
+
+```bash
+git add scripts/check-ci-workflow-test.py
+git commit -s -m "test(ci): define routed workflow policy" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 4: Rewrite pull-request and main CI routing
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add workflow concurrency and the router**
+
+At workflow level, add:
+
+```yaml
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+Add `jobs.changes` with outputs for every classifier category:
+
+```yaml
+  changes:
+    name: Classify changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      rust: ${{ steps.classify.outputs.rust }}
+      afs: ${{ steps.classify.outputs.afs }}
+      channels: ${{ steps.classify.outputs.channels }}
+      openclaw: ${{ steps.classify.outputs.openclaw }}
+      npm_packaging: ${{ steps.classify.outputs.npm_packaging }}
+      engine: ${{ steps.classify.outputs.engine }}
+      workflow: ${{ steps.classify.outputs.workflow }}
+      cargo_metadata: ${{ steps.classify.outputs.cargo_metadata }}
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Collect changed paths
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            range="${PR_BASE_SHA}...${PR_HEAD_SHA}"
+          elif git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null; then
+            range="${BEFORE_SHA}..${AFTER_SHA}"
+          else
+            empty_tree="$(git hash-object -t tree -w --stdin </dev/null)"
+            range="${empty_tree}..${AFTER_SHA}"
+          fi
+          git diff --name-only --diff-filter=ACMR "$range" > changed-files.txt
+      - name: Classify changed paths
+        id: classify
+        run: python3 scripts/classify-ci-changes.py --github-output "$GITHUB_OUTPUT" < changed-files.txt
+```
+
+- [ ] **Step 2: Rename and extend the policy guard**
+
+Replace `secret-guard` with `policy-guard`, add `needs: changes` and
+`timeout-minutes: 10`, preserve every existing secret/privacy/API-contract
+command, and append:
+
+```yaml
+      - run: python3 scripts/classify-ci-changes-test.py
+      - run: python3 scripts/check-workflows-test.py
+      - run: python3 scripts/check-ci-workflow-test.py
+      - run: scripts/check-workflows.sh
+```
+
+- [ ] **Step 3: Add the pinned Cargo cache block to every Rust build job**
+
+Use this exact action pin. The example below is the lint cache:
+
+```yaml
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-lint-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-lint-
+```
+
+Use these exact key prefixes in the corresponding jobs:
+
+| Job | Cache key prefix |
+| --- | --- |
+| `rust-lint-linux` | `${{ runner.os }}-rust-lint-` |
+| `rust-test-linux`, `rust-test-windows` | `${{ runner.os }}-rust-test-` |
+| `afs-mount-linux`, `afs-mount-macos` | `${{ runner.os }}-rust-afs-` |
+| `npm-onboarding-linux`, `npm-onboarding-main` | `${{ runner.os }}-rust-npm-` |
+| `engine-contract` | `${{ runner.os }}-rust-engine-` |
+| `performance-baseline` | `${{ runner.os }}-rust-perf-` |
+
+- [ ] **Step 4: Replace the Rust matrix with parallel jobs**
+
+Create these jobs, each with `needs: changes` and `timeout-minutes: 20`:
+
+```yaml
+  rust-lint-linux:
+    name: Rust lint (Linux)
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+```
+
+Steps: checkout, stable toolchain with `rustfmt, clippy`, pinned lint cache,
+OpenBLAS install, `cargo fmt --check`, and
+`cargo clippy --workspace --all-targets -- -D warnings`.
+
+```yaml
+  rust-test-linux:
+    name: Rust tests (Linux)
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: ubuntu-latest
+```
+
+Steps: checkout, stable toolchain, pinned test cache, OpenBLAS install, and
+`cargo test --workspace --locked`.
+
+```yaml
+  rust-test-windows:
+    name: Rust tests (Windows)
+    if: ${{ needs.changes.outputs.rust == 'true' }}
+    runs-on: windows-latest
+```
+
+Steps: checkout, stable toolchain, pinned test cache, and
+`cargo test --workspace --locked`.
+
+```yaml
+  afs-mount-linux:
+    name: AFS mount backend (Linux)
+    if: ${{ needs.changes.outputs.afs == 'true' }}
+    runs-on: ubuntu-latest
+```
+
+Steps: checkout, stable toolchain with clippy, pinned AFS cache, OpenBLAS
+install, mount-feature clippy, and mount-feature tests.
+
+```yaml
+  afs-mount-macos:
+    name: AFS mount backend (macOS)
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.afs == 'true' }}
+    runs-on: macos-26
+```
+
+Steps: preserve current macOS mount clippy/tests. Run
+`./scripts/afs-mount-smoke.sh` only when
+`${{ github.event_name == 'push' }}`, with `continue-on-error: true`.
+
+- [ ] **Step 5: Route package, packaging, engine, and audit jobs**
+
+Keep the current job command bodies, add `needs: changes`,
+`timeout-minutes: 20`, and these conditions:
+
+```yaml
+channels:
+  if: ${{ needs.changes.outputs.channels == 'true' }}
+
+openclaw-bridge:
+  if: ${{ needs.changes.outputs.openclaw == 'true' }}
+
+npm-onboarding-linux:
+  if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.npm_packaging == 'true' }}
+
+npm-onboarding-main:
+  if: ${{ github.event_name == 'push' }}
+
+engine-contract:
+  if: ${{ github.event_name == 'push' || needs.changes.outputs.engine == 'true' }}
+
+cargo-deny:
+  if: ${{ github.event_name == 'push' || needs.changes.outputs.docs_only != 'true' }}
+```
+
+`npm-onboarding-linux` uses only:
+
+```yaml
+    runs-on: ubuntu-latest
+    env:
+      NPM_TARGET: linux-x64
+      RUST_TARGET: x86_64-unknown-linux-gnu
+```
+
+Build `coven-cli` in release mode and run:
+
+```bash
+node scripts/test-cli-prepublish.mjs --target="$NPM_TARGET" --skip-build --skip-secrets-scan
+```
+
+`npm-onboarding-main` retains the current four-platform matrix and macOS AFS
+helper build unchanged.
+
+For OpenClaw, after activating pnpm, add:
+
+```yaml
+      - id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-openclaw-${{ hashFiles('packages/openclaw-coven/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-openclaw-
+```
+
+- [ ] **Step 6: Move performance collection to `main`**
+
+Keep the current performance job body, add `needs: changes`,
+`timeout-minutes: 20`, a pinned `perf` Cargo cache, and:
+
+```yaml
+    if: ${{ github.event_name == 'push' }}
+```
+
+- [ ] **Step 7: Add the stable PR gate**
+
+Add:
+
+```yaml
+  pr-gate:
+    name: PR gate
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - changes
+      - policy-guard
+      - rust-lint-linux
+      - rust-test-linux
+      - rust-test-windows
+      - afs-mount-linux
+      - afs-mount-macos
+      - performance-baseline
+      - channels
+      - openclaw-bridge
+      - npm-onboarding-linux
+      - npm-onboarding-main
+      - engine-contract
+      - cargo-deny
+    env:
+      JOB_RESULTS: ${{ toJSON(needs) }}
+    steps:
+      - name: Require successful or intentional skipped jobs
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+
+          jobs = json.loads(os.environ["JOB_RESULTS"])
+          bad = {
+              name: data["result"]
+              for name, data in jobs.items()
+              if data["result"] not in {"success", "skipped"}
+          }
+          for required in ("changes", "policy-guard"):
+              if jobs[required]["result"] != "success":
+                  bad[required] = jobs[required]["result"]
+          if bad:
+              raise SystemExit(
+                  "PR gate rejected job results: "
+                  + ", ".join(f"{name}={result}" for name, result in sorted(bad.items()))
+              )
+          print("PR gate accepted all required and conditional jobs")
+          PY
+```
+
+- [ ] **Step 8: Run workflow policy and syntax tests**
+
+Run:
+
+```bash
+python3 scripts/check-ci-workflow-test.py
+python3 scripts/check-coven-privacy-test.py
+python3 scripts/check-secrets-test.py
+scripts/check-workflows.sh
+```
+
+Expected: all tests pass and actionlint reports no errors.
+
+- [ ] **Step 9: Commit the routed CI graph**
+
+```bash
+git add .github/workflows/ci.yml scripts/check-ci-workflow-test.py
+git commit -s -m "ci: route and parallelize pull request checks" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 5: Add deferred release performance coverage
+
+**Files:**
+- Modify: `.github/workflows/release-npm.yml`
+- Test: `scripts/check-ci-workflow-test.py`
+
+- [ ] **Step 1: Add the release performance job**
+
+Add a `performance-baseline` job after `verify-tag`:
+
+```yaml
+  performance-baseline:
+    name: Release performance baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [verify, verify-tag]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.0.0
+        with:
+          node-version: 24
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-05-20
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rust-release-perf-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rust-release-perf-
+      - name: Install native link dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libopenblas-dev
+      - name: Build coven
+        run: cargo build -p coven-cli --locked
+      - name: Validate benchmark runner
+        run: node --test scripts/benchmark-cli.test.mjs scripts/benchmark-chaos.test.mjs
+      - name: Collect release baseline artifact
+        run: node scripts/benchmark-cli.mjs --binary target/debug/coven --iterations 3 --output coven-perf.json
+      - name: Collect concurrent runtime baseline artifact
+        continue-on-error: true
+        run: node scripts/benchmark-chaos.mjs --binary target/debug/coven --output coven-chaos.json
+      - name: Collect deterministic TUI scheduling metric
+        run: |
+          set -o pipefail
+          cargo test -p coven-cli --bin coven tui::chat::events::tests::benchmark_schedule_metrics_emit_json --locked -- --ignored --nocapture | tee coven-tui-metrics.txt
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: coven-release-performance-${{ needs.verify-tag.outputs.release_tag }}
+          path: |
+            coven-perf.json
+            coven-chaos.json
+            coven-tui-metrics.txt
+          if-no-files-found: error
+```
+
+- [ ] **Step 2: Gate publication on the performance job**
+
+Change `npm-publish.needs` to:
+
+```yaml
+    needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]
+```
+
+Do not add PR/main artifacts as release inputs.
+
+- [ ] **Step 3: Run release workflow policy and syntax tests**
+
+Run:
+
+```bash
+python3 scripts/check-ci-workflow-test.py
+scripts/check-workflows.sh
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/release-npm.yml scripts/check-ci-workflow-test.py
+git commit -s -m "ci: defer performance validation to main and release" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 6: Document contributor expectations
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+- [ ] **Step 1: Add the routed-CI note**
+
+After the Pull Request Workflow local-check block, add:
+
+```markdown
+CI routes platform, package, AFS, engine, and packaging jobs from the changed
+paths so unrelated pull requests receive faster feedback. This routing does not
+reduce the contributor-side bar: run every local command relevant to the files
+you changed. Workflow/classifier changes intentionally exercise the complete CI
+graph, while performance baselines and the full native packaging matrix run on
+`main` and release tags.
+```
+
+- [ ] **Step 2: Check the documentation diff**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -s -m "docs: explain routed CI coverage" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+### Task 7: Run repository validation
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run all Python policy tests**
+
+```bash
+python3 scripts/classify-ci-changes-test.py
+python3 scripts/check-workflows-test.py
+python3 scripts/check-ci-workflow-test.py
+python3 scripts/check-coven-privacy-test.py
+python3 scripts/check-secrets-test.py
+python3 scripts/check-api-contract-docs-test.py
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Validate workflows**
+
+```bash
+scripts/check-workflows.sh
+```
+
+Expected: actionlint 1.7.12 exits successfully.
+
+- [ ] **Step 3: Run Rust gates**
+
+```bash
+cargo fmt --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --locked -- --test-threads=1
+cargo clippy -p coven-afs --features mount --all-targets -- -D warnings
+cargo test -p coven-afs --features mount --locked
+```
+
+Expected: all deterministic gates pass. If an unchanged PTY timing test fails,
+rerun that exact test serially and record the pre-existing flake rather than
+changing unrelated runtime code.
+
+- [ ] **Step 4: Run security/privacy guards**
+
+```bash
+python3 scripts/check-secrets.py
+python3 scripts/check-coven-privacy.py --staged
+git diff --check
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Verify real diff classification**
+
+```bash
+git diff --name-only origin/main...HEAD | python3 scripts/classify-ci-changes.py
+```
+
+Expected for this CI/workflow branch: `workflow=true` and every category except
+`docs_only` is `true`.
+
+### Task 8: Publish and observe the rollout PR
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Confirm claim and clean state**
+
+```bash
+coven claim heartbeat issue-771
+git status --short --branch
+git log --oneline --decorate origin/main..HEAD
+```
+
+Expected: only intended commits and a clean worktree.
+
+- [ ] **Step 2: Push the workflow implementation before the final docs commit**
+
+```bash
+rollout_head="$(git rev-parse HEAD^)"
+git push -u origin "${rollout_head}:refs/heads/chore/771-ci-pr-speed"
+```
+
+Expected: the remote branch contains the complete workflow implementation and
+tests but not the final `CONTRIBUTING.md` commit.
+
+- [ ] **Step 3: Open the rollout PR**
+
+Create `/tmp/coven-771-pr-body.md`:
+
+```markdown
+Closes #771
+
+## Summary
+
+- classify changed paths with repository-owned tested logic
+- run Rust, AFS, package, packaging, and engine checks only when relevant
+- split Linux lint/tests, Windows tests, and AFS coverage into parallel jobs
+- defer performance and the full native packaging matrix to main/release
+- add bounded timeouts, stale-run cancellation, caches, and a stable PR gate
+
+## Baseline
+
+Recent PRs spent about 8 minutes on non-gating performance collection, 3-9
+minutes per native packaging platform, and up to six hours on stuck Rust jobs.
+
+## Validation
+
+- Python classifier/workflow/policy tests
+- actionlint 1.7.12
+- Rust fmt, clippy, workspace tests, and AFS feature tests
+- secret and privacy guards
+
+## Rollout
+
+This workflow-changing PR intentionally fans out every conditional job. After
+merge, confirm deferred jobs on main, then require `PR gate` in branch
+protection.
+```
+
+Open the PR:
+
+```bash
+gh pr create \
+  --base main \
+  --head chore/771-ci-pr-speed \
+  --title "ci: route and parallelize pull request checks" \
+  --body-file /tmp/coven-771-pr-body.md
+```
+
+- [ ] **Step 4: Trigger and verify stale-run cancellation with the final docs commit**
+
+Wait until the first PR workflow reports at least one in-progress job:
+
+```bash
+pr_number="$(gh pr view --json number --jq .number)"
+gh pr checks "$pr_number"
+```
+
+Then push the already-created final documentation commit as a normal
+fast-forward:
+
+```bash
+git push origin HEAD:refs/heads/chore/771-ci-pr-speed
+```
+
+Expected: the first PR workflow is cancelled and a replacement workflow starts.
+No empty or temporary commit is introduced.
+
+- [ ] **Step 5: Inspect job selection**
+
+Run:
+
+```bash
+pr_number="$(gh pr view --json number --jq .number)"
+gh pr checks "$pr_number" --watch --interval 20
+```
+
+Expected for a workflow-changing PR:
+
+- every conditional job executes because `workflow=true`;
+- `PR gate` succeeds only after every child succeeds or intentionally skips;
+- performance and full native packaging do not run on the PR;
+- required PR checks finish near 10 minutes when runners are available.
+
+- [ ] **Step 6: Merge only after the routed graph is green**
+
+Use the repository's normal squash/merge policy. Confirm the `main` push runs
+performance, full native onboarding, the engine contract, and the macOS mount
+probe.
+
+### Task 9: Enable branch protection after rollout
+
+**Files:**
+- Repository setting only.
+
+- [ ] **Step 1: Confirm the merged `PR gate` context exists**
+
+```bash
+gh api repos/OpenCoven/coven/commits/main/check-runs \
+  --jq '.check_runs[] | select(.name == "PR gate") | {name,conclusion,html_url}'
+```
+
+Expected: at least one successful `PR gate`.
+
+- [ ] **Step 2: Enable minimal branch protection requiring the gate**
+
+After explicit maintainer confirmation, run:
+
+```bash
+gh api --method PUT repos/OpenCoven/coven/branches/main/protection \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["PR gate"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_conversation_resolution": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+JSON
+```
+
+Expected: HTTP 200 with `PR gate` listed under required status checks.
+
+- [ ] **Step 3: Verify branch protection**
+
+```bash
+gh api repos/OpenCoven/coven/branches/main/protection \
+  --jq '{strict:.required_status_checks.strict,contexts:.required_status_checks.contexts,conversation_resolution:.required_conversation_resolution.enabled}'
+```
+
+Expected:
+
+```json
+{"strict":true,"contexts":["PR gate"],"conversation_resolution":true}
+```
+
+- [ ] **Step 4: Release the claim and clean the worktree**
+
+```bash
+coven claim release issue-771
+```
+
+After merge, delete the remote branch and remove
+`/tmp/coven-771-ci-pr-speed` from the primary checkout.

--- a/docs/superpowers/specs/2026-08-19-pr-ci-routing-design.md
+++ b/docs/superpowers/specs/2026-08-19-pr-ci-routing-design.md
@@ -1,0 +1,255 @@
+# Pull Request CI Routing and Parallelization Design
+
+Issue: [#771](https://github.com/OpenCoven/coven/issues/771)
+
+## Goal
+
+Reduce required pull-request feedback time toward 10 minutes while preserving
+the Rust authority boundary, Windows coverage, security checks, and independent
+release verification.
+
+Recent PR runs show the main avoidable costs:
+
+- CLI performance collection: about 8 minutes, despite being non-gating.
+- Native npm onboarding: about 3-9 minutes per platform across four platforms.
+- Engine contract: about 2 minutes on every change.
+- Linux Rust checks: formatting, clippy, workspace tests, and AFS feature checks
+  run serially in one job.
+- Superseded or stuck Rust jobs can consume a runner for the six-hour default.
+
+## Success Criteria
+
+- Ordinary Rust PRs complete required checks in about 10 minutes when runners
+  are available.
+- Docs-only PRs run policy, secret, privacy, API-contract, and workflow checks
+  without compiling Rust or packages.
+- Relevant Rust PRs retain Linux and Windows workspace-test coverage.
+- Package, AFS, engine, and packaging checks run on PRs only when their owned
+  surfaces change.
+- Performance collection and the full native packaging matrix run on `main`
+  and release tags, not on every PR.
+- A stable `PR gate` check summarizes conditional jobs and can be required by
+  branch protection.
+- Release tags continue to verify source independently instead of trusting
+  artifacts or results from an earlier workflow.
+
+## Non-Goals
+
+- Do not weaken secret, privacy, API-contract, DCO, or dependency policies.
+- Do not remove Windows workspace tests from relevant Rust PRs.
+- Do not introduce a third-party path-filter action.
+- Do not reuse PR-built binaries for releases.
+- Do not redesign the Rust test suite or adopt a new test runner in this change.
+
+## Workflow Architecture
+
+Keep `.github/workflows/ci.yml` as the single workflow for pull requests and
+pushes to `main`. Add a small `changes` job at the front of the graph. It checks
+out enough history to compute the event's exact diff and passes changed paths
+to a repository-owned classifier.
+
+The classifier lives in a focused script with unit tests. It emits booleans for:
+
+- `docs_only`
+- `rust`
+- `afs`
+- `channels`
+- `openclaw`
+- `npm_packaging`
+- `engine`
+- `workflow`
+- `cargo_metadata`
+
+Downstream jobs use these outputs in job-level `if` expressions. Workflow and
+classifier changes fan out to every PR job so changes to CI validate the whole
+graph.
+
+Add workflow concurrency:
+
+```yaml
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+```
+
+This cancels obsolete runs after a PR receives a newer commit while allowing
+`main` runs to finish.
+
+Every compiled or integration job gets `timeout-minutes: 20`. A test that hangs
+must fail promptly instead of occupying a runner for six hours.
+
+## Change Classification
+
+The classifier accepts newline-delimited repository-relative paths and emits
+GitHub output values. Classification is conservative:
+
+| Category | Representative paths |
+| --- | --- |
+| `docs_only` | Markdown and documentation assets, excluding workflow/config files |
+| `rust` | `Cargo.toml`, `Cargo.lock`, `crates/**`, Rust build/config scripts |
+| `afs` | `crates/coven-afs/**`, AFS mount code/tests/scripts, Cargo metadata |
+| `channels` | `packages/channels/**` and its shared package/build inputs |
+| `openclaw` | `packages/openclaw-coven/**` and its shared package/build inputs |
+| `npm_packaging` | `npm/**`, publish/prepublish scripts, CLI packaging metadata, Cargo metadata |
+| `engine` | `engine.lock`, engine install/pin scripts, engine client code and contract tests |
+| `workflow` | `.github/workflows/**` and the classifier/tests themselves |
+| `cargo_metadata` | workspace/crate manifests, lockfile, deny configuration |
+
+Unknown non-documentation paths set `rust=true`. Because `cargo-deny` runs on
+every non-doc PR, both workspace and dependency coverage fail closed without
+guessing that an unknown path belongs to a package-specific surface.
+
+For pull requests, the diff is
+`${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}`.
+For `main` pushes, it is `${{ github.event.before }}..${{ github.sha }}`, with
+the existing empty-tree fallback for unavailable history.
+
+## Pull Request Job Graph
+
+All eligible jobs start after `changes`; they do not depend on one another.
+
+### Always on Pull Requests
+
+- `changes`
+- `policy-guard`
+  - privacy-script tests
+  - secret-script tests
+  - API-contract documentation tests
+  - API-contract documentation check
+  - current-tree secret scan
+  - PR-range privacy scan
+  - classifier unit tests
+  - workflow syntax validation
+
+`cargo-deny` runs for every non-doc-only PR. It is fast and catches newly
+published advisories even when the lockfile did not change.
+
+### Rust-Affecting Pull Requests
+
+Split the current serial Rust matrix into independent jobs:
+
+- `rust-lint-linux`
+  - `cargo fmt --check`
+  - `cargo clippy --workspace --all-targets -- -D warnings`
+- `rust-test-linux`
+  - `cargo test --workspace --locked`
+- `rust-test-windows`
+  - `cargo test --workspace --locked`
+- `afs-mount-linux`, when `afs` is true
+  - mount-feature clippy
+  - mount-feature tests
+- `afs-mount-macos`, when `afs` is true
+  - mount-feature clippy
+  - mount-feature tests
+
+Formatting, linting, Linux tests, Windows tests, and AFS feature coverage
+therefore run in parallel instead of accumulating in one Linux job.
+
+### Package-Affecting Pull Requests
+
+- `channels` only when `channels` is true.
+- `openclaw-bridge` only when `openclaw` is true.
+- `npm-onboarding-linux` only when `npm_packaging` is true.
+
+The PR npm smoke builds and packages only `linux-x64`. The complete macOS ARM,
+macOS Intel, Linux, and Windows packaging matrix moves out of PR CI.
+
+### Engine-Affecting Pull Requests
+
+Run `engine-contract` only when `engine` is true. Changes to the pin, installer,
+engine-facing CLI code, or contract tests still receive pre-merge coverage.
+
+### Docs-Only Pull Requests
+
+Run only `changes`, `policy-guard`, and `PR gate`. No Rust toolchain, native
+link dependency, package installation, platform runner, or release build starts.
+
+## Main and Release Coverage
+
+Pushes to `main` run the changed-surface jobs plus deferred extended coverage:
+
+- CLI performance, chaos, and deterministic TUI baseline collection.
+- Full native npm onboarding matrix for macOS ARM, macOS Intel, Linux x64, and
+  Windows.
+- Informational real macOS AFS mount probe.
+- Engine contract regardless of changed paths.
+
+`.github/workflows/release-npm.yml` retains:
+
+- full formatting, clippy, workspace tests, and secret verification;
+- signed-tag and ancestry verification;
+- independent release builds for every native package;
+- npm dry-run assembly;
+- OIDC-authenticated publication.
+
+It also runs the deferred performance baseline before publication. Release jobs
+build from the tag and do not consume artifacts from PR or `main` workflows.
+
+## Stable Aggregate Gate
+
+Add a final `PR gate` job:
+
+- `if: always()`
+- `needs` every conditional PR job
+- accepts only `success` or intentional `skipped` results
+- fails on `failure`, `timed_out`, or unexpected `cancelled`
+- requires `changes` and `policy-guard` to succeed
+
+This gives branch protection one stable context even though the set of executed
+jobs varies by diff. After one observed rollout PR confirms the graph, enable
+branch protection on `main` and require `PR gate`.
+
+## Caching
+
+Use commit-pinned `actions/cache` for:
+
+- Cargo registry and Git checkout caches keyed by OS and `Cargo.lock`.
+- Separate Cargo target caches per OS and job kind so clippy/test artifacts do
+  not collide.
+- pnpm store caching for OpenClaw keyed by its lockfile.
+
+Cache misses always run the real commands. No gate may return success because a
+cache or artifact is unavailable.
+
+## Failure Handling
+
+- PR concurrency cancels only superseded PR runs.
+- Each compiled/integration job has a 20-minute timeout.
+- Deferred main failures remain visible and release verification reruns the
+  relevant gates independently.
+- The classifier fails closed: malformed input or unknown output generation
+  fails `changes`; unknown non-doc paths receive conservative Rust coverage.
+- Conditional skips are explicit and visible through `PR gate`.
+- Informational performance chaos and real mount probes retain
+  `continue-on-error`; deterministic tests and packaging remain gating.
+
+## Validation
+
+Implementation validation must include:
+
+1. Classifier unit fixtures for docs-only, Rust, Cargo metadata, AFS, Channels,
+   OpenClaw, npm packaging, engine, workflow, unknown, and mixed changes.
+2. Workflow syntax validation with a pinned actionlint version.
+3. Local execution of existing secret/privacy/API-contract checks.
+4. Representative classifier runs against real repository diffs.
+5. A rollout PR that confirms:
+   - expected jobs run for workflow changes;
+   - `PR gate` reports the graph correctly;
+   - superseded runs cancel;
+   - required-check completion is at or near 10 minutes.
+6. A follow-up docs-only PR or test branch proving compiled jobs skip.
+7. A `main` run proving deferred performance, engine, mount probe, and full npm
+   packaging coverage execute.
+8. Branch protection updated to require `PR gate` only after the rollout run is
+   successful.
+
+## Rollout
+
+1. Add and test the classifier.
+2. Refactor `ci.yml` while preserving existing job commands.
+3. Add the stable aggregate gate and concurrency/timeouts.
+4. Move deferred checks to `main`/release triggers.
+5. Open a PR and inspect actual job selection and duration.
+6. Correct routing gaps before removing any transitional duplicate job.
+7. Merge after the rollout graph is green.
+8. Enable `main` branch protection requiring `PR gate`.

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -14,6 +14,7 @@ RELEASE_TEXT = RELEASE_WORKFLOW.read_text(encoding='utf-8')
 class CheckCiWorkflowTests(unittest.TestCase):
     def test_ci_routes_pull_requests_through_gate(self) -> None:
         self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", CI_TEXT)
+        self.assertIn('git diff --name-only --diff-filter=ACMRD "$range"', CI_TEXT)
         self.assertIn("\n  changes:\n", CI_TEXT)
         self.assertIn("\n  pr-gate:\n", CI_TEXT)
         self.assertIn("name: PR gate", CI_TEXT)

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -6,6 +6,7 @@ import unittest
 
 CI_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'ci.yml'
 RELEASE_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-npm.yml'
+CACHE_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 CI_TEXT = CI_WORKFLOW.read_text(encoding='utf-8')
 RELEASE_TEXT = RELEASE_WORKFLOW.read_text(encoding='utf-8')
 
@@ -31,7 +32,7 @@ class CheckCiWorkflowTests(unittest.TestCase):
 
     def test_ci_uses_expected_timeouts_and_cache_policy(self) -> None:
         self.assertGreaterEqual(CI_TEXT.count('timeout-minutes: 20'), 10)
-        self.assertIn('55cc', CI_TEXT)
+        self.assertIn(f"actions/cache@{CACHE_SHA}", CI_TEXT)
         self.assertNotIn('actions/cache@v', CI_TEXT)
 
     def test_ci_runs_expected_workflow_checks(self) -> None:
@@ -48,6 +49,8 @@ class CheckCiWorkflowTests(unittest.TestCase):
             "if: ${{ github.event_name == 'push' }}",
         ]:
             self.assertIn(needle, CI_TEXT)
+        self.assertIn("\n  npm-onboarding-linux:\n", CI_TEXT)
+        self.assertIn("\n  npm-onboarding-main:\n", CI_TEXT)
 
     def test_release_includes_performance_baseline_dependency(self) -> None:
         self.assertIn('performance-baseline', RELEASE_TEXT)

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+CI_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'ci.yml'
+RELEASE_WORKFLOW = pathlib.Path(__file__).resolve().parents[1] / '.github' / 'workflows' / 'release-npm.yml'
+CI_TEXT = CI_WORKFLOW.read_text(encoding='utf-8')
+RELEASE_TEXT = RELEASE_WORKFLOW.read_text(encoding='utf-8')
+
+
+class CheckCiWorkflowTests(unittest.TestCase):
+    def test_ci_routes_pull_requests_through_gate(self) -> None:
+        self.assertIn("cancel-in-progress: ${{ github.event_name == 'pull_request' }}", CI_TEXT)
+        self.assertIn("\n  changes:\n", CI_TEXT)
+        self.assertIn("\n  pr-gate:\n", CI_TEXT)
+        self.assertIn("name: PR gate", CI_TEXT)
+        self.assertIn("if: ${{ always() && github.event_name == 'pull_request' }}", CI_TEXT)
+
+    def test_ci_contains_expected_jobs(self) -> None:
+        for job_name in [
+            'rust-lint-linux',
+            'rust-test-linux',
+            'rust-test-windows',
+            'afs-mount-linux',
+            'afs-mount-macos',
+        ]:
+            self.assertIn(f"\n  {job_name}:\n", CI_TEXT)
+        self.assertNotIn("\n  rust:\n", CI_TEXT)
+
+    def test_ci_uses_expected_timeouts_and_cache_policy(self) -> None:
+        self.assertGreaterEqual(CI_TEXT.count('timeout-minutes: 20'), 10)
+        self.assertIn('55cc', CI_TEXT)
+        self.assertNotIn('actions/cache@v', CI_TEXT)
+
+    def test_ci_runs_expected_workflow_checks(self) -> None:
+        for needle in [
+            'python3 scripts/classify-ci-changes-test.py',
+            'python3 scripts/check-workflows-test.py',
+            'python3 scripts/check-ci-workflow-test.py',
+            'scripts/check-workflows.sh',
+            "needs.changes.outputs.docs_only != 'true'",
+            'npm-onboarding-linux',
+            "github.event_name == 'push'",
+            'performance-baseline',
+            'name: CLI performance baseline',
+            "if: ${{ github.event_name == 'push' }}",
+        ]:
+            self.assertIn(needle, CI_TEXT)
+
+    def test_release_includes_performance_baseline_dependency(self) -> None:
+        self.assertIn('performance-baseline', RELEASE_TEXT)
+        self.assertIn('needs: [build-platform, npm-dry-run, performance-baseline, verify-tag]', RELEASE_TEXT)
+
+
+if __name__ == '__main__':
+    raise SystemExit(unittest.main())

--- a/scripts/check-ci-workflow-test.py
+++ b/scripts/check-ci-workflow-test.py
@@ -17,7 +17,10 @@ class CheckCiWorkflowTests(unittest.TestCase):
         self.assertIn("\n  changes:\n", CI_TEXT)
         self.assertIn("\n  pr-gate:\n", CI_TEXT)
         self.assertIn("name: PR gate", CI_TEXT)
-        self.assertIn("if: ${{ always() && github.event_name == 'pull_request' }}", CI_TEXT)
+        self.assertIn(
+            "if: ${{ always() && !cancelled() && github.event_name == 'pull_request' }}",
+            CI_TEXT,
+        )
 
     def test_ci_contains_expected_jobs(self) -> None:
         for job_name in [

--- a/scripts/check-workflows-test.py
+++ b/scripts/check-workflows-test.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import unittest
+from unittest import mock
+
+SCRIPT = pathlib.Path(__file__).with_name("check-workflows.sh")
+TEXT = SCRIPT.read_text(encoding="utf-8")
+
+
+class CheckWorkflowsScriptTests(unittest.TestCase):
+    def test_pins_actionlint_version(self) -> None:
+        self.assertIn("ACTIONLINT_VERSION=1.7.12", TEXT)
+
+    def test_includes_expected_checksums(self) -> None:
+        for checksum in [
+            "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+            "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+            "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+        ]:
+            self.assertIn(checksum, TEXT)
+
+    def test_print_version_outputs_exact_version_without_downloading(self) -> None:
+        completed = subprocess.run(
+            [str(SCRIPT), "--print-version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.stdout, "1.7.12\n")
+        self.assertEqual(completed.stderr, "")
+
+    def test_script_uses_safe_shell_settings(self) -> None:
+        self.assertIn("set -euo pipefail", TEXT)
+
+    def test_script_supports_required_platforms(self) -> None:
+        for platform in ["Linux-x86_64", "Darwin-arm64", "Darwin-x86_64"]:
+            self.assertIn(platform, TEXT)
+        self.assertIn("unsupported platform", TEXT)
+
+    def test_script_downloads_exact_release_archive_and_verifies_checksum(self) -> None:
+        self.assertIn("https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/", TEXT)
+        self.assertIn("shasum -a 256 --check -", TEXT)
+        self.assertIn("curl -fsSL", TEXT)
+
+    def test_script_extracts_only_actionlint_and_cleans_up(self) -> None:
+        self.assertIn("tar -xzf", TEXT)
+        self.assertIn("actionlint", TEXT)
+        self.assertIn("trap cleanup EXIT", TEXT)
+
+    def test_script_runs_actionlint_color(self) -> None:
+        self.assertIn('"$workdir/actionlint" -color', TEXT)
+
+
+if __name__ == "__main__":
+    raise SystemExit(unittest.main())

--- a/scripts/check-workflows.sh
+++ b/scripts/check-workflows.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTIONLINT_VERSION=1.7.12
+case "${1-}" in
+  --print-version)
+    printf '%s\n' "$ACTIONLINT_VERSION"
+    exit 0
+    ;;
+esac
+
+case "$(uname -s)-$(uname -m)" in
+  Linux-x86_64) archive_name="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"; checksum=$(printf '%s  %s\n' 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8 "$archive_name") ;;
+  Darwin-arm64) archive_name="actionlint_${ACTIONLINT_VERSION}_darwin_arm64.tar.gz"; checksum=$(printf '%s  %s\n' aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f "$archive_name") ;;
+  Darwin-x86_64) archive_name="actionlint_${ACTIONLINT_VERSION}_darwin_amd64.tar.gz"; checksum=$(printf '%s  %s\n' 5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644 "$archive_name") ;;
+  *) echo "unsupported platform" >&2; exit 1 ;;
+esac
+
+archive_url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive_name}"
+workdir="$(mktemp -d)"
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT
+
+curl -fsSL "$archive_url" -o "$workdir/$archive_name"
+( cd "$workdir" && printf '%s\n' "$checksum" | shasum -a 256 --check - )
+ tar -xzf "$workdir/$archive_name" -C "$workdir" actionlint
+"$workdir/actionlint" -color

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -37,19 +37,49 @@ class ClassifyTest(unittest.TestCase):
         self.assertTrue(result['afs'])
 
     def test_channels_only(self):
-        self.assertTrue(self.classify('channels/src/index.ts')['channels'])
+        result = self.classify('packages/channels/src/index.ts')
+        self.assertTrue(result['channels'])
+        self.assertFalse(result['openclaw'])
+        self.assertFalse(result['npm_packaging'])
 
     def test_openclaw_only(self):
-        self.assertTrue(self.classify('openclaw/src/index.ts')['openclaw'])
+        result = self.classify('packages/openclaw-coven/src/client.ts')
+        self.assertTrue(result['openclaw'])
+        self.assertFalse(result['channels'])
+        self.assertFalse(result['engine'])
 
     def test_npm_wrapper_only(self):
         self.assertTrue(self.classify('crates/coven-cli/src/wrapper.rs')['npm_packaging'])
 
     def test_engine_install(self):
-        result = self.classify('src/engine_install.rs')
+        result = self.classify('crates/coven-cli/src/engine_install.rs')
         self.assertTrue(result['rust'])
         self.assertTrue(result['npm_packaging'])
         self.assertTrue(result['engine'])
+
+    def test_engine_related_paths(self):
+        for path in (
+            'crates/coven-cli/src/engine.rs',
+            'crates/coven-cli/engine.lock',
+            'scripts/pin-engine.sh',
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertTrue(result['engine'])
+                self.assertFalse(result['workflow'])
+
+    def test_workflow_supporting_scripts_fan_out(self):
+        for path in (
+            'scripts/check-workflows.sh',
+            'scripts/check-workflows-test.py',
+            'scripts/check-ci-workflow-test.py',
+        ):
+            with self.subTest(path=path):
+                result = self.classify(path)
+                self.assertFalse(result['docs_only'])
+                for key, value in result.items():
+                    if key != 'docs_only':
+                        self.assertTrue(value, key)
 
     def test_workflow_fans_all(self):
         result = self.classify('.github/workflows/ci.yml')
@@ -62,7 +92,7 @@ class ClassifyTest(unittest.TestCase):
         self.assertTrue(self.classify('foo/bar.txt')['rust'])
 
     def test_mixed_docs_channels(self):
-        result = self.classify('docs/a.md', 'channels/src/index.ts')
+        result = self.classify('docs/a.md', 'packages/channels/src/index.ts')
         self.assertFalse(result['docs_only'])
         self.assertTrue(result['channels'])
 

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -51,6 +51,11 @@ class ClassifyTest(unittest.TestCase):
     def test_npm_wrapper_only(self):
         self.assertTrue(self.classify('crates/coven-cli/src/wrapper.rs')['npm_packaging'])
 
+    def test_npm_bin_wrapper_only(self):
+        result = self.classify('npm/coven/bin/coven.js')
+        self.assertTrue(result['npm_packaging'])
+        self.assertFalse(result['rust'])
+
     def test_engine_install(self):
         result = self.classify('crates/coven-cli/src/engine_install.rs')
         self.assertTrue(result['rust'])

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location('classify_ci_changes', Path(__file__).with_name('classify-ci-changes.py'))
+MOD = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MOD)
+
+
+class ClassifyTest(unittest.TestCase):
+    def classify(self, *paths):
+        return MOD.classify(list(paths))
+
+    def test_docs_only(self):
+        self.assertEqual(self.classify('docs/a.md'), {'docs_only': True, 'rust': False, 'afs': False, 'channels': False, 'openclaw': False, 'npm_packaging': False, 'engine': False, 'workflow': False, 'cargo_metadata': False})
+
+    def test_cargo_lock(self):
+        self.assertEqual(self.classify('Cargo.lock')['rust'], True)
+        self.assertEqual(self.classify('Cargo.lock')['afs'], True)
+        self.assertEqual(self.classify('Cargo.lock')['npm_packaging'], True)
+        self.assertEqual(self.classify('Cargo.lock')['cargo_metadata'], True)
+
+    def test_cli_daemon(self):
+        result = self.classify('crates/coven-cli/src/daemon.rs')
+        self.assertTrue(result['rust'])
+        self.assertTrue(result['npm_packaging'])
+
+    def test_afs(self):
+        result = self.classify('crates/coven-afs/src/nfs.rs')
+        self.assertTrue(result['rust'])
+        self.assertTrue(result['afs'])
+
+    def test_channels_only(self):
+        self.assertTrue(self.classify('channels/src/index.ts')['channels'])
+
+    def test_openclaw_only(self):
+        self.assertTrue(self.classify('openclaw/src/index.ts')['openclaw'])
+
+    def test_npm_wrapper_only(self):
+        self.assertTrue(self.classify('crates/coven-cli/src/wrapper.rs')['npm_packaging'])
+
+    def test_engine_install(self):
+        result = self.classify('src/engine_install.rs')
+        self.assertTrue(result['rust'])
+        self.assertTrue(result['npm_packaging'])
+        self.assertTrue(result['engine'])
+
+    def test_workflow_fans_all(self):
+        result = self.classify('.github/workflows/ci.yml')
+        self.assertFalse(result['docs_only'])
+        for k, v in result.items():
+            if k != 'docs_only':
+                self.assertTrue(v, k)
+
+    def test_unknown_non_docs(self):
+        self.assertTrue(self.classify('foo/bar.txt')['rust'])
+
+    def test_mixed_docs_channels(self):
+        result = self.classify('docs/a.md', 'channels/src/index.ts')
+        self.assertFalse(result['docs_only'])
+        self.assertTrue(result['channels'])
+
+    def test_empty_input(self):
+        with self.assertRaises(ValueError):
+            self.classify()
+
+    def test_github_output_lowercase(self):
+        result = self.classify('docs/a.md')
+        buf = io.StringIO()
+        MOD.write_github_output(result, buf)
+        self.assertIn('docs_only=true', buf.getvalue())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/classify-ci-changes-test.py
+++ b/scripts/classify-ci-changes-test.py
@@ -26,6 +26,13 @@ class ClassifyTest(unittest.TestCase):
         self.assertEqual(self.classify('Cargo.lock')['npm_packaging'], True)
         self.assertEqual(self.classify('Cargo.lock')['cargo_metadata'], True)
 
+    def test_crate_manifest_is_cargo_metadata(self):
+        result = self.classify('crates/coven-client/Cargo.toml')
+        self.assertTrue(result['rust'])
+        self.assertTrue(result['afs'])
+        self.assertTrue(result['npm_packaging'])
+        self.assertTrue(result['cargo_metadata'])
+
     def test_cli_daemon(self):
         result = self.classify('crates/coven-cli/src/daemon.rs')
         self.assertTrue(result['rust'])

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -37,7 +37,8 @@ def classify(paths: list[str]) -> dict[str, bool]:
         is_cargo_metadata = (
             path == 'Cargo.lock'
             or path == 'deny.toml'
-            or (path.endswith('Cargo.toml') and (path.count('/') <= 1))
+            or path == 'Cargo.toml'
+            or path.endswith('/Cargo.toml')
         )
         is_rust = is_cargo_metadata or path.startswith('crates/') or path.endswith('.rs')
         is_afs = is_cargo_metadata or path.startswith('crates/coven-afs/') or path == 'crates/coven-cli/src/afs_mount.rs' or path == 'scripts/afs-mount-smoke.sh'

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+CATEGORY_NAMES = [
+    'docs_only',
+    'rust',
+    'afs',
+    'channels',
+    'openclaw',
+    'npm_packaging',
+    'engine',
+    'workflow',
+    'cargo_metadata',
+]
+
+
+def normalize(path: str) -> str:
+    return path.replace('\\', '/')
+
+
+def classify(paths: list[str]) -> dict[str, bool]:
+    if not paths:
+        raise ValueError('no paths provided')
+    categories = {name: False for name in CATEGORY_NAMES}
+    docs_only = True
+    for raw in paths:
+        path = normalize(raw)
+        if not path:
+            continue
+        is_docs = path.startswith('docs/') or path.endswith('.md') or path in {'LICENSE', 'PATENTS'}
+        if not is_docs:
+            docs_only = False
+        is_cargo_metadata = (
+            path == 'Cargo.lock'
+            or path == 'deny.toml'
+            or (path.endswith('Cargo.toml') and (path.count('/') <= 1))
+        )
+        is_rust = is_cargo_metadata or path.startswith('crates/') or path.endswith('.rs')
+        is_afs = is_cargo_metadata or path.startswith('crates/coven-afs/') or path == 'crates/coven-cli/src/afs_mount.rs' or path == 'scripts/afs-mount-smoke.sh'
+        is_channels = path.startswith('channels/') or path.startswith('crates/coven-channels/')
+        is_openclaw = path.startswith('openclaw/') or path.startswith('crates/coven-openclaw/')
+        is_npm = is_cargo_metadata or path.startswith('npm/') or path.startswith('crates/coven-cli/') or path in {
+            'scripts/publish-npm.mjs',
+            'scripts/publish-npm-test.mjs',
+            'scripts/release-npm-context.mjs',
+            'scripts/release-npm-platform-matrix.mjs',
+            'scripts/test-cli-prepublish.mjs',
+            'src/engine_install.rs',
+        }
+        is_engine = path in {'crates/coven-cli/engine.lock', 'src/engine.rs', 'src/engine_install.rs', 'scripts/pin-engine.sh'}
+        is_workflow = path.startswith('.github/workflows/') or path in {
+            'scripts/classify-ci-changes.py',
+            'scripts/classify-ci-changes-test.py',
+            'scripts/workflow-check.py',
+            'scripts/workflow-check-test.py',
+        }
+        categories['rust'] |= is_rust
+        categories['afs'] |= is_afs
+        categories['channels'] |= is_channels
+        categories['openclaw'] |= is_openclaw
+        categories['npm_packaging'] |= is_npm
+        categories['engine'] |= is_engine
+        categories['workflow'] |= is_workflow
+        categories['cargo_metadata'] |= is_cargo_metadata
+    categories['docs_only'] = docs_only
+    if categories['workflow']:
+        for name in CATEGORY_NAMES:
+            if name != 'docs_only':
+                categories[name] = True
+    if not categories['docs_only'] and not any(categories[name] for name in CATEGORY_NAMES if name != 'docs_only'):
+        categories['rust'] = True
+    return categories
+
+
+def write_github_output(results: dict[str, bool], handle) -> None:
+    for name in CATEGORY_NAMES:
+        handle.write(f'{name}={str(results[name]).lower()}\n')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--github-output')
+    args = parser.parse_args()
+    data = [line.strip() for line in sys.stdin.read().splitlines() if line.strip()]
+    results = classify(data)
+    if args.github_output:
+        with open(args.github_output, 'a', encoding='utf-8') as handle:
+            write_github_output(results, handle)
+    else:
+        write_github_output(results, sys.stdout)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/scripts/classify-ci-changes.py
+++ b/scripts/classify-ci-changes.py
@@ -41,22 +41,27 @@ def classify(paths: list[str]) -> dict[str, bool]:
         )
         is_rust = is_cargo_metadata or path.startswith('crates/') or path.endswith('.rs')
         is_afs = is_cargo_metadata or path.startswith('crates/coven-afs/') or path == 'crates/coven-cli/src/afs_mount.rs' or path == 'scripts/afs-mount-smoke.sh'
-        is_channels = path.startswith('channels/') or path.startswith('crates/coven-channels/')
-        is_openclaw = path.startswith('openclaw/') or path.startswith('crates/coven-openclaw/')
+        is_channels = path.startswith('packages/channels/') or path.startswith('crates/coven-channels/')
+        is_openclaw = path.startswith('packages/openclaw-coven/') or path.startswith('crates/coven-openclaw/')
         is_npm = is_cargo_metadata or path.startswith('npm/') or path.startswith('crates/coven-cli/') or path in {
             'scripts/publish-npm.mjs',
             'scripts/publish-npm-test.mjs',
             'scripts/release-npm-context.mjs',
             'scripts/release-npm-platform-matrix.mjs',
             'scripts/test-cli-prepublish.mjs',
-            'src/engine_install.rs',
         }
-        is_engine = path in {'crates/coven-cli/engine.lock', 'src/engine.rs', 'src/engine_install.rs', 'scripts/pin-engine.sh'}
+        is_engine = path in {
+            'crates/coven-cli/src/engine.rs',
+            'crates/coven-cli/src/engine_install.rs',
+            'crates/coven-cli/engine.lock',
+            'scripts/pin-engine.sh',
+        }
         is_workflow = path.startswith('.github/workflows/') or path in {
             'scripts/classify-ci-changes.py',
             'scripts/classify-ci-changes-test.py',
-            'scripts/workflow-check.py',
-            'scripts/workflow-check-test.py',
+            'scripts/check-workflows.sh',
+            'scripts/check-workflows-test.py',
+            'scripts/check-ci-workflow-test.py',
         }
         categories['rust'] |= is_rust
         categories['afs'] |= is_afs

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -1245,8 +1245,8 @@ test('release workflow publishes every package unconditionally', () => {
   assert.match(workflow, /npm-dry-run:[\s\S]*?needs: \[build-platform, verify-tag\]/);
   assert.match(
     publish,
-    /needs: \[build-platform, npm-dry-run, verify-tag\]/,
-    'publish job must consume verified release context'
+    /needs: \[build-platform, npm-dry-run, performance-baseline, verify-tag\]/,
+    'publish job must consume verified release context after the performance gate'
   );
   assert.doesNotMatch(
     publish,


### PR DESCRIPTION
Closes #771

## Summary

- classify changed paths with repository-owned tested logic
- run Rust, AFS, package, packaging, and engine checks only when relevant
- split Linux lint/tests, Windows tests, and AFS coverage into parallel jobs
- defer performance and the full native packaging matrix to main/release
- add bounded timeouts, stale-run cancellation, caches, and a stable PR gate

## Baseline

Recent PRs spent about 8 minutes on non-gating performance collection, 3-9
minutes per native packaging platform, and up to six hours on stuck Rust jobs.

## Validation

- Python classifier/workflow/policy tests
- actionlint 1.7.12
- Rust fmt, clippy, workspace tests, and AFS feature tests
- secret and privacy guards

## Rollout

This workflow-changing PR intentionally fans out every conditional job. After
merge, confirm deferred jobs on main, then require `PR gate` in branch
protection.
