### PR TITLE
fix(agents): reject reused tool call ids

### DIFF
--- a/crates/coven-agents/README.md
+++ b/crates/coven-agents/README.md
@@ -19,6 +19,11 @@ the failure alongside the error, so a failing tool never costs the caller the
 items the run already produced. The runner does not append a failed run's items
 to the session; persisting them is the caller's decision.
 
+Tool call ids must be unique across a run, including ids loaded from session
+history. Results correlate to calls by id, so the runner rejects a response that
+reuses one — before running any tool in that response — with
+`RunError::DuplicateToolCallId`.
+
 The crate deliberately does not include an OpenAI client, a daemon command,
 MCP, sandbox execution, voice, or realtime transport. Those are adapters and
 application concerns. Keeping this crate as a workspace leaf also allows it to

--- a/crates/coven-agents/src/error.rs
+++ b/crates/coven-agents/src/error.rs
@@ -74,6 +74,8 @@ pub enum RunError {
     },
     #[error("agent `{agent}` requested unknown tool `{tool}`")]
     UnknownTool { agent: AgentId, tool: String },
+    #[error("agent `{agent}` reused tool call id `{call_id}`")]
+    DuplicateToolCallId { agent: AgentId, call_id: String },
     #[error("tool `{tool}` for agent `{agent}` failed")]
     ToolFailed {
         agent: AgentId,

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -246,6 +246,13 @@ where
             }
             (None, _) => progress.items.clone(),
         };
+        let mut seen_call_ids: BTreeSet<String> = model_items
+            .iter()
+            .filter_map(|item| match item {
+                RunItem::ToolCall { call, .. } => Some(call.id.clone()),
+                _ => None,
+            })
+            .collect();
 
         for turn in 1..=options.max_turns {
             progress.turns = turn;
@@ -453,6 +460,26 @@ where
                 });
                 current = target;
                 continue;
+            }
+
+            // A tool result correlates to its call by id, so a reused id makes
+            // the transcript ambiguous. The whole response is screened before
+            // any tool runs: rejecting mid-batch would leave the side effects
+            // of the earlier calls behind with no way to correlate them.
+            for action in &response.actions {
+                let ModelAction::ToolCall(call) = action else {
+                    continue;
+                };
+                if !seen_call_ids.insert(call.id.clone()) {
+                    return Err(self.fail(
+                        &current.id,
+                        RunFailureKind::InvalidResponse,
+                        RunError::DuplicateToolCallId {
+                            agent: current.id.clone(),
+                            call_id: call.id.clone(),
+                        },
+                    ));
+                }
             }
 
             for action in response.actions {

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -110,6 +110,32 @@ impl Tool<()> for CountingDefinitionTool {
     }
 }
 
+/// Records how many times the runner actually executed a tool, so tests can
+/// prove a rejected response ran nothing.
+struct CountingCallTool {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool<()> for CountingCallTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "add",
+            "Counts executions",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            }),
+        )
+    }
+
+    async fn execute(&self, _arguments: Value, _context: &()) -> Result<Value, BoxError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({ "ok": true }))
+    }
+}
+
 struct RejectInput;
 
 #[async_trait]
@@ -417,14 +443,17 @@ async fn rejected_output_is_not_appended_to_the_session() {
 
 #[tokio::test]
 async fn bounded_runner_stops_repeated_tool_turns() {
-    let repeated_call = || {
+    let repeated_call = |id: &str| {
         ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
-            "call",
+            id,
             "add",
             json!({ "left": 1, "right": 1 }),
         ))])
     };
-    let model = Arc::new(QueueModel::new([repeated_call(), repeated_call()]));
+    let model = Arc::new(QueueModel::new([
+        repeated_call("call-1"),
+        repeated_call("call-2"),
+    ]));
     let agent = Agent::new("loop", "Loop", "Keep calling.", model).with_tool(Arc::new(AddTool));
     let runner = Runner::new([agent]).unwrap();
     let options = RunOptions {
@@ -725,4 +754,138 @@ async fn tool_failure_after_a_handoff_returns_the_whole_run_transcript() {
         &items[2],
         RunItem::ToolCall { agent, call } if agent.as_str() == "worker" && call.name == "explode"
     ));
+}
+
+#[tokio::test]
+async fn rejects_duplicate_tool_call_ids_within_one_response() {
+    let model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "add",
+            json!({ "left": 1, "right": 2 }),
+        )),
+        ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "add",
+            json!({ "left": 3, "right": 4 }),
+        )),
+    ])]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(CountingCallTool {
+            calls: calls.clone(),
+        }));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let failure = runner
+        .run("worker", "Add twice.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(
+        failure.error.to_string(),
+        "agent `worker` reused tool call id `call-1`"
+    );
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        0,
+        "the whole response is screened before any tool runs"
+    );
+    assert!(
+        !failure
+            .new_items
+            .iter()
+            .any(|item| matches!(item, RunItem::ToolCall { .. })),
+        "an ambiguous call never enters the transcript, got {:?}",
+        failure.new_items
+    );
+    assert_paired_lifecycle(&observer.events());
+    assert!(observer.events().iter().any(|event| matches!(
+        event,
+        RunEvent::RunFailed {
+            kind: RunFailureKind::InvalidResponse,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn rejects_tool_call_ids_reused_across_turns() {
+    let repeated = || {
+        ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "add",
+            json!({ "left": 1, "right": 1 }),
+        ))])
+    };
+    let model = Arc::new(QueueModel::new([repeated(), repeated()]));
+    let agent = Agent::new("loop", "Loop", "Keep calling.", model).with_tool(Arc::new(AddTool));
+    let runner = Runner::new([agent]).unwrap();
+
+    let failure = runner
+        .run("loop", "Loop.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(failure.turns, 2);
+    assert_eq!(
+        failure.new_items.len(),
+        3,
+        "the first turn's call and result are kept, got {:?}",
+        failure.new_items
+    );
+}
+
+#[tokio::test]
+async fn rejects_tool_call_ids_already_present_in_session_history() {
+    let session = Arc::new(InMemorySession::default());
+    session
+        .append(
+            "conversation-1",
+            &[RunItem::ToolCall {
+                agent: "worker".into(),
+                call: ToolCall::new("call-1", "add", json!({ "left": 1, "right": 1 })),
+            }],
+        )
+        .await
+        .unwrap();
+    let model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "add",
+            json!({ "left": 2, "right": 2 }),
+        )),
+    ])]));
+    let agent = Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(AddTool));
+    let runner = Runner::new([agent]).unwrap().with_session(session.clone());
+    let options = RunOptions {
+        session_id: Some("conversation-1".to_owned()),
+        ..RunOptions::default()
+    };
+
+    let failure = runner
+        .run("worker", "Add again.", &(), options)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(
+        session.items("conversation-1").await.unwrap().len(),
+        1,
+        "the rejected run adds nothing to durable history"
+    );
 }

--- a/docs/superpowers/plans/2026-08-20-bound-spend-authority.md
+++ b/docs/superpowers/plans/2026-08-20-bound-spend-authority.md
@@ -1,0 +1,136 @@
+# Bound Spend Authority Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a runnable v1 of Bound — a signed, agent-unforgeable USD 25.00/month spend ceiling for OpenCoven familiars — that Val can start in dev mode on this machine and demo end to end, including live bypass attempts that all deny.
+
+**Architecture:** Three loopback HTTP services plus a signed policy file. The **authority** owns the ledger and mints short-lived ed25519-signed grants; the **gateway** is the only holder of provider credentials and refuses any request without a valid grant; a **provider stub** stands in for a metered vendor so the demo costs no real money. Policy lives in `BOUNDS.md` / `BOUND.md` and is authoritative only when a detached Val signature verifies. Design source: `docs/superpowers/specs/2026-08-20-bound-spend-authority-design.md`.
+
+**Tech Stack:** Node 24 with native TypeScript type stripping, zero runtime dependencies, `node:crypto` ed25519, `node:http`, `node:test`. No install step, so `node packages/bound/bin/bound.ts dev` works immediately.
+
+---
+
+## File Structure
+
+```
+packages/bound/
+  package.json              # scripts only: dev, demo, test, keygen, sign
+  README.md                 # what Bound is, how to run the demo
+  BOUNDS.md                 # signed coven policy (ceiling 25.00)
+  familiars/cody/BOUND.md   # signed per-familiar override
+  bin/bound.ts              # CLI: keygen | sign | verify | serve | dev | demo | status
+  src/
+    canonical.ts            # bound block subset parser + canonical bytes for signing
+    policy.ts               # document parse, signature verify, effective policy merge
+    keystore.ts             # key material outside the repo; load/generate/list
+    pricing.ts              # metered action classes and bounded cost estimation
+    ledger.ts               # SpendLedger: reserve, settle, expire, receipts, persistence
+    grant.ts                # grant mint + verify, nonce replay guard
+    authority.ts            # HTTP: /v1/grant /v1/settle /v1/policy /v1/ledger /v1/receipts
+    gateway.ts              # HTTP: /v1/proxy — credential holder, clamp, meter, settle
+    provider-stub.ts        # HTTP: fake metered vendor, returns usage
+    dashboard.ts            # HTML + /v1/state feed for the live demo surface
+    client.ts               # BoundClient an agent uses: grant -> gateway -> BoundDenied
+    http.ts                 # tiny shared route/json helpers
+  demo/
+    agent.ts                # honest familiar burning budget until the cap denies
+    attacks.ts              # the 10 adversarial bypass attempts from the spec
+  test/
+    canonical.test.ts
+    policy.test.ts
+    ledger.test.ts
+    grant.test.ts
+    adversarial.test.ts
+```
+
+Boundaries: `policy.ts` does no I/O, `ledger.ts` knows nothing about HTTP, `gateway.ts` is the only module that reads a provider credential, and `client.ts` is the only module an agent links against.
+
+---
+
+## Task 1 — Canonical form and policy parsing
+
+- [ ] Write `test/canonical.test.ts`: a `bound` block parses to the expected object; key order changes produce identical canonical bytes; prose outside the block does not change canonical bytes; a second `bound` block is an error; unknown version is an error.
+- [ ] Run it, confirm it fails.
+- [ ] Implement `src/canonical.ts`: extract the single fenced `bound` block, parse the restricted `key: value` / `- item` subset, reject duplicates and tabs, emit canonical bytes as `bound:v1\n<role>\n<issued_at>\n<sorted-json>`.
+- [ ] Run the tests, confirm they pass.
+- [ ] Commit.
+
+## Task 2 — Signature verification and effective policy
+
+- [ ] Write `test/policy.test.ts`: valid signature verifies; tampered block, tampered role, tampered `issued_at`, wrong key id, unknown key, and expired `not_after` all fail with distinct reason codes; merge inherits, honours explicit `0`, clamps an override above the ceiling, and gives an unsigned override zero budget.
+- [ ] Run it, confirm it fails.
+- [ ] Implement `src/policy.ts` — `parseDocument`, `verifyDocument`, `computeEffectivePolicy(global, overrides)` — returning `{ ok, reason }` results and never throwing on bad input.
+- [ ] Add the fast-check style property assertion: for arbitrary overrides, `effective.ceilingUsd <= global.ceilingUsd`.
+- [ ] Run the tests, confirm they pass.
+- [ ] Commit.
+
+## Task 3 — Keystore and signing CLI
+
+- [ ] Implement `src/keystore.ts`: keys live under `BOUND_KEYSTORE` (default `<familiar-workspace>/.bound/keys`, deliberately outside the repo), `0600` files, `val-hw-*` signing key plus an authority key.
+- [ ] Implement `bin/bound.ts keygen` and `bound sign <file> --role <role>` writing the `<!-- bound:sig ... -->` trailer, and `bound verify <file>`.
+- [ ] Generate the demo keys, write and sign `BOUNDS.md` (ceiling 25.00) and `familiars/cody/BOUND.md`.
+- [ ] Run `bound verify` on both; confirm that hand-editing a ceiling makes verify fail.
+- [ ] Commit (policy files yes, key material never).
+
+## Task 4 — SpendLedger
+
+- [ ] Write `test/ledger.test.ts`: reserve then settle reduces remaining by the actual amount; N parallel reserves never exceed the ceiling; settle is idempotent per `grantId`; expired reservations release exactly once; a familiar sub-budget denies before the global ceiling; period rollover starts clean.
+- [ ] Run it, confirm it fails.
+- [ ] Implement `src/ledger.ts` with a serialized async queue per `(coven, period)`, atomic JSON persistence, and append-only receipts.
+- [ ] Run the tests, confirm they pass.
+- [ ] Commit.
+
+## Task 5 — Grants
+
+- [ ] Write `test/grant.test.ts`: a minted grant verifies; tampered field, expired `exp`, skew beyond tolerance, replayed nonce, and out-of-scope provider/model/limits all reject with reason codes.
+- [ ] Run it, confirm it fails.
+- [ ] Implement `src/grant.ts` (`mintGrant`, `verifyGrant`, `NonceGuard`) and `src/pricing.ts` bounded estimation per action class.
+- [ ] Run the tests, confirm they pass.
+- [ ] Commit.
+
+## Task 6 — Authority, gateway, provider stub
+
+- [ ] Implement `src/http.ts`, then `src/authority.ts` (`/v1/grant`, `/v1/settle`, `/v1/policy`, `/v1/ledger`, `/v1/receipts`, `/v1/denials`), loading and verifying policy on every grant and failing closed on any verification, digest, or ledger error.
+- [ ] Implement `src/provider-stub.ts` returning usage for a fake model, rejecting a missing or wrong credential.
+- [ ] Implement `src/gateway.ts`: verify grant, clamp requested limits down to the grant, inject the credential, meter actual usage, settle, and return a receipt. Deny when the authority is unreachable.
+- [ ] Implement `src/client.ts` exposing `spend()` that returns either a result or a structured `BoundDenied` with a reason code, and never retries a denial.
+- [ ] Add `bin/bound.ts dev` to start all three on loopback and print the dashboard URL.
+- [ ] Smoke test by hand with curl: one successful paid call end to end.
+- [ ] Commit.
+
+## Task 7 — Dashboard
+
+- [ ] Implement `src/dashboard.ts`: server-rendered HTML at `/` plus a `/v1/state` JSON poll showing period, ceiling, settled, reserved, remaining, per-familiar sub-budgets, recent receipts, and recent denials with reason codes.
+- [ ] Verify with curl that `/` returns 200 and `/v1/state` reflects a real settled charge.
+- [ ] Commit.
+
+## Task 8 — Demo and adversarial suite
+
+- [ ] Implement `demo/agent.ts`: an honest familiar that spends repeatedly until it is denied at the cap, then proves a free local action still succeeds.
+- [ ] Implement `demo/attacks.ts` and `test/adversarial.test.ts` covering all ten spec scenarios: self-edited `BOUND.md`, unsigned new override, spoofed authority/gateway env vars, direct provider call, forged grant, replayed grant, oversized `max_tokens`, ten subagents splitting spend, authority offline, ledger write attempt. Each must assert a denial with a specific reason code.
+- [ ] Run the whole suite, confirm green.
+- [ ] Commit.
+
+## Task 9 — Wire-up, docs, verification
+
+- [ ] Write `packages/bound/README.md`: what Bound is, the trust model, `node bin/bound.ts dev`, `demo`, `test`, and the production differences (Secure Enclave signing, Workers deployment, real provider keys).
+- [ ] Add `packages/bound/package.json` scripts `dev`, `demo`, `attacks`, `test`.
+- [ ] Run the full suite plus a live dev-mode run; capture the denial at the cap.
+- [ ] Commit.
+
+---
+
+## Verification gates
+
+```
+node --test packages/bound/test          # all suites, adversarial included
+node packages/bound/bin/bound.ts dev     # loopback services + dashboard
+node packages/bound/demo/agent.ts        # honest spend to the cap
+node packages/bound/demo/attacks.ts      # 10 bypass attempts, all denied
+```
+
+Enforcement is not considered working until every adversarial case denies **and** a free action immediately afterwards still succeeds.
+
+## Out of scope for this plan
+
+Cloudflare deployment, Durable Object ledger, Secure Enclave signing, the public `bound.md` / `bounds.md` sites, the Cave panel, and real provider credentials. Those follow once the local product is proven.

--- a/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
+++ b/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
@@ -87,6 +87,14 @@ Configuration errors are detected before a run. Runtime errors preserve the
 agent, tool, guardrail stage, operation, and source error where applicable.
 Unknown model-requested tools or handoffs fail closed.
 
+Tool call ids must be unique across a run, including ids already present in
+loaded session history. A `ToolResult` correlates to its call by id, so a reused
+id makes the transcript ambiguous and no consumer can pair a result with the
+call that produced it. The runner screens an entire response for duplicates
+before executing any of its tools, so a duplicate late in a batch cannot leave
+the side effects of earlier calls behind. Violations fail closed with
+`RunError::DuplicateToolCallId`.
+
 Input guardrails are blocking by default. This is safer for a local tool runtime
 because rejected input cannot race with model calls or tool side effects.
 

--- a/docs/superpowers/specs/2026-08-20-bound-spend-authority-design.md
+++ b/docs/superpowers/specs/2026-08-20-bound-spend-authority-design.md
@@ -1,0 +1,323 @@
+# Bound: Signed Spend Authority for Coven Agents
+
+## Decision
+
+Introduce **Bound**, a signed spend-authority system that enforces a hard
+billing cap no familiar, agent, subagent, or automation can raise, disable, or
+route around.
+
+Bound has two faces:
+
+- an **agent file convention** — `BOUNDS.md` (coven-wide) and `BOUND.md`
+  (per-familiar override), living beside `SOUL.md` and `IDENTITY.md`;
+- a **protocol and enforcement path** — a remote, Val-signed authority that
+  issues short-lived spend grants, and a credential-holding gateway that is the
+  only route to metered providers.
+
+The two domains we own carry the two faces:
+
+| Domain | Role |
+| --- | --- |
+| `bounds.md` | Human documentation: the format, examples, rationale, versioning. |
+| `bound.md` | Machine surface: `/v1/schema.json`, `/.well-known/bound-keys.json`, format canonicalization rules. |
+
+The authority and gateway for our own coven run on private OpenCoven endpoints.
+`bound.md` and `bounds.md` publish the open format and our public verification
+keys; they never hold budget state and are never in the enforcement path.
+
+First rollout target: **OpenCoven agents** (`crates/coven-agents`).
+
+## Why the file alone is not the control
+
+A markdown file inside an agent's own workspace is advisory. An agent that can
+write files can rewrite its own limit; an agent that holds a provider API key
+can spend without asking anyone. So the file is the *statement of policy*, and
+two mechanisms make it *authority*:
+
+1. **Val-only hardware signing.** `BOUNDS.md` and `BOUND.md` are meaningless
+   unless accompanied by a valid detached signature from a hardware-backed key
+   that only Val holds (Secure Enclave or hardware token). No familiar, harness,
+   CI job, or service holds the private key. An agent editing the file
+   invalidates the signature, and an invalid file grants nothing.
+2. **Signed remote authority with credential separation.** The ledger runs
+   off-host. Agents never hold provider credentials; they hold short-lived,
+   scoped, signed grants. The gateway holds the real keys and refuses any
+   request without a valid grant.
+
+An agent cannot exceed the cap because it never possesses the thing that spends
+money.
+
+## Approved parameters
+
+| Parameter | Value |
+| --- | --- |
+| Cap | **USD 25.00** per UTC calendar month, coven-wide |
+| Scope | **All metered costs** — model tokens, hosted tools, image/audio/video generation, TTS/STT, search APIs, render and compute minutes, paid storage/egress, paid infrastructure and domain actions |
+| Enforcement mode | **Deny paid actions only** — free and local work continues |
+| Policy layering | **Global plus overrides** — `BOUNDS.md` sets the ceiling; per-familiar `BOUND.md` sets sub-budgets |
+| Trust root | **Val-only hardware signing** |
+| Authority | **Signed remote authority**, not a local check |
+| Failure posture | **Fail closed immediately** — no grace period, no cached allow, no fail-open |
+
+### Global plus overrides
+
+Effective policy for a familiar is computed as:
+
+```
+effective = merge(BOUNDS.md, BOUND.md[familiar])
+```
+
+Rules:
+
+- Both files must carry a valid Val signature. An unsigned or stale-signed
+  override is not "ignored in favour of the global" — it makes the familiar's
+  effective policy **zero paid budget** until repaired.
+- An override may set any sub-budget less than or equal to the global ceiling.
+  A signed override *may* raise a familiar above another familiar's share, but
+  never above the global `ceiling_usd`; the global ceiling is a hard clamp
+  applied after merge.
+- Absent override key means "inherit"; explicit `0` means "no paid actions".
+- Sub-budgets do not need to sum to the ceiling. The ceiling is enforced
+  independently, so one familiar cannot consume another's headroom past the
+  global remaining balance.
+
+### File format (`bound:v1`)
+
+`BOUND.md` and `BOUNDS.md` are readable markdown with one fenced `bound` block
+and one detached signature comment.
+
+````markdown
+# BOUNDS.md
+
+Coven-wide spend authority. Edited and signed by Val only.
+
+```bound
+version: 1
+scope: coven
+issued_at: 2026-08-20T00:00:00Z
+not_after: 2027-08-20T00:00:00Z
+period: monthly-utc
+ceiling_usd: 25.00
+mode: deny-paid   # deny-paid | shadow — only Val's signature can change this
+metered:
+  - model.tokens
+  - model.images
+  - model.audio
+  - tools.hosted
+  - search.api
+  - compute.render
+  - storage.egress
+  - infra.paid
+authority: https://authority.opencoven.ai
+authority_key: ed25519:BASE64URL
+gateway: https://gateway.opencoven.ai
+grant_ttl_seconds: 120
+clock_skew_seconds: 60
+```
+
+<!-- bound:sig v=1 alg=ed25519 key=val-hw-2026-08 sig=BASE64URL -->
+````
+
+The signature covers the canonical serialization of the `bound` block bytes,
+the document role (`coven` or `familiar:<id>`), and `issued_at`. Canonical
+serialization rules are published at `https://bound.md/v1/canonical`. Anything
+outside the fenced block is prose and is not signed, so editing the surrounding
+documentation never invalidates authority — and never grants any.
+
+## Architecture
+
+Four layers, each with a single job:
+
+1. **Policy layer** — signed `BOUNDS.md` / `BOUND.md` in git. Declarative,
+   reviewable, diffable. Holds no state.
+2. **Authority layer** — the Bound Authority service. Holds the ledger, verifies
+   policy signatures, issues signed grants. Off-host, not writable by agents.
+3. **Enforcement layer** — the Bound Gateway. The only process holding provider
+   credentials. Accepts a request only with a valid, unexpired, in-scope,
+   unreplayed grant.
+4. **Audit layer** — append-only receipts and an operator surface in Cave.
+
+The critical invariant: **the enforcement layer and the credential store are the
+same process, and neither is reachable by agent-authored configuration.** The
+authority URL, authority public key, and gateway URL are read from the *signed*
+policy, not from environment variables an agent can set.
+
+## Components
+
+| Component | Home | Responsibility |
+| --- | --- | --- |
+| `bound-policy` | `crates/bound-policy` (Rust) | Parse `bound:v1`, verify signatures, compute effective policy, expose a digest. No I/O beyond reading given bytes. |
+| `bound-authority` | Cloudflare Worker | `POST /v1/grant`, `POST /v1/settle`, `GET /v1/policy`, `GET /v1/ledger`. Verifies caller identity and policy digest before any grant. |
+| `SpendLedger` | Durable Object, one per `(coven, period)` | Strongly consistent reserve/settle accounting. Single-threaded per period, so concurrent reserves cannot race past the cap. |
+| `bound-gateway` | Cloudflare Worker + Secrets Store | Holds provider keys. Verifies grant signature, TTL, nonce, scope, and provider-side limits. Forwards, meters actual cost, calls `settle`. |
+| `BoundGuardrail` | `crates/coven-agents` | Implements the existing `InputGuardrail`/tool-gate traits. Requests grants, converts denials into a structured `BoundDenied` outcome rather than a panic or retry loop. |
+| Bound panel | Coven Cave | Shows period spend, remaining, per-familiar sub-budgets, recent denials, incidents. Read-only. |
+| `bound.md` / `bounds.md` | Cloudflare Pages | Public spec, JSON schema, published verification keys. Static. |
+
+## Data flow
+
+Happy path for one paid action:
+
+1. An agent reaches a metered action. `BoundGuardrail` estimates a bounded
+   maximum cost (model price × `max_tokens`, or the published unit price).
+2. The agent calls `POST /v1/grant` with its identity, the action class, the
+   estimate, and the policy digest it believes is current.
+3. The authority verifies the caller identity, verifies the Val signature over
+   the stored policy, compares digests, and asks the `SpendLedger` DO to
+   **reserve** the estimate against the remaining balance.
+4. On success the authority returns a signed grant:
+   `{grant_id, familiar, action_class, provider, model, max_usd, max_units,
+   nonce, exp}` — TTL ≤ 120 s.
+5. The agent calls the gateway with the grant. The gateway verifies signature,
+   `exp`, clock skew, nonce freshness, and that the requested provider/model/
+   limits are inside the grant. It clamps provider-side limits (for example
+   `max_tokens`) to the grant so actual cost cannot exceed the reservation.
+6. The gateway injects the real provider credential, forwards the call, and
+   meters actual usage.
+7. The gateway calls `POST /v1/settle` with `{grant_id, actual_usd, units}`.
+   The ledger converts the reservation into a settled charge and appends a
+   receipt. Settle is idempotent on `grant_id`.
+8. Unsettled reservations expire at `exp` and release their hold, so a crashed
+   agent cannot permanently consume budget.
+
+An agent never sees a provider key, never talks to a provider directly, and
+cannot mint a grant, because grant signing happens only inside the authority.
+
+## Failure handling
+
+Every failure resolves to **deny the paid action, immediately, with a reason**.
+There is no fail-open branch anywhere in the design, and no code path that
+treats "authority unavailable" as "assume allowed".
+
+| Failure | Behaviour |
+| --- | --- |
+| Missing, malformed, or invalid policy signature | Authority refuses to issue any grant for that scope. All paid actions denied. |
+| Policy `not_after` passed | Same as invalid signature. Policy must be re-signed. |
+| Digest mismatch between the repo copy and the authority copy | Deny, and raise an integrity incident. Never auto-reconcile toward the more permissive copy. |
+| Authority unreachable, timeout, or 5xx | Gateway denies. No cached grant, no offline allowance, no retry-until-allowed. |
+| Ledger write failure | Reserve fails, therefore no grant, therefore deny. Accounting is the gate, not a side effect. |
+| Clock skew beyond `clock_skew_seconds` | Grant rejected at the gateway. |
+| Replayed nonce or reused `grant_id` | Rejected and recorded as an abuse incident. |
+| Grant scope mismatch (different provider, model, or larger limits) | Rejected. |
+| Cap reached | Paid actions denied; free and local actions continue; one notification to Val per period, not per attempt. |
+| Actual cost exceeds reservation | Bounded by gateway-clamped provider limits. Any residual overage settles, marks an over-reservation incident, and tightens the estimator multiplier for that action class. |
+| Malformed markdown in a policy file | Parse failure is a denial, never a fallback to defaults. |
+
+Additional guarantees:
+
+- **No cheaper-path escape.** Every metered provider is behind the same
+  gateway, so "try a cheaper model instead" still requires a grant.
+- **No sharding escape.** Subagents and spawned sessions get their own
+  identities but share one `SpendLedger` per period. Splitting work across
+  agents does not multiply the budget.
+- **No retry storms.** `BoundDenied` is terminal for that action. The agent
+  records a blocked status and continues free work or stops; it does not loop.
+- **Kill switch.** Val can publish a signed policy with `ceiling_usd: 0.00`, or
+  a signed revocation for a key id. Because grant TTL is ≤ 120 s, the maximum
+  exposure window after revocation is one TTL.
+- **Denials are visible.** Every denial carries a machine-readable reason code
+  and surfaces in the Cave Bound panel, so a silent stall is never mistaken for
+  a working system.
+- **Shadow mode is not a failure mode.** `mode: shadow` (see Rollout) suppresses
+  blocking only while the policy verifies. Every row of the table above still
+  denies in shadow mode, because an unverifiable policy has no mode at all.
+
+## Testing
+
+Bound is a security control, so the test suite is written adversarially: the
+default assumption is that an agent will try to get around it.
+
+### Unit
+
+- `bound-policy` parser: valid documents, missing block, two blocks, unknown
+  keys, wrong version, non-UTF-8, truncated signature comment.
+- Signature verification vectors: valid, tampered block, tampered role,
+  tampered `issued_at`, wrong key id, revoked key, expired `not_after`.
+- Effective-policy merge: inherit, explicit zero, sub-budget below ceiling,
+  sub-budget above ceiling (clamped), unsigned override (zero budget).
+- Cost estimator: per-provider unit pricing, bounded maximum derivation.
+
+### Property and fuzz
+
+- For arbitrary override inputs, `effective.ceiling_usd <= global.ceiling_usd`
+  always holds.
+- For arbitrary byte inputs, the parser either fails or yields a policy no more
+  permissive than the signed source. No input produces a permissive default.
+
+### Ledger concurrency
+
+- N concurrent reserves against a remaining balance never exceed the cap.
+- Settle is idempotent under duplicate delivery.
+- Expired reservations release exactly once.
+- Period rollover opens a fresh ledger without carrying reservations forward.
+
+### Integration
+
+Run against `wrangler dev` / Miniflare with the Worker test harness:
+
+- Happy path: grant → gateway → provider stub → settle → receipt.
+- One case per row of the failure table above, asserting denial *and* asserting
+  that a free action issued immediately afterwards still succeeds.
+
+### Adversarial suite
+
+Each of these must produce a denial, and each is a permanent regression test:
+
+1. Agent edits its own `BOUND.md` to raise the cap → signature invalid → denied.
+2. Agent writes a brand-new `BOUND.md` for an unknown familiar → unsigned →
+   zero budget.
+3. Agent sets `BOUND_AUTHORITY` / `BOUND_GATEWAY` environment variables to a
+   fake endpoint → endpoints come from signed policy, gateway holds the keys →
+   denied.
+4. Agent calls the provider API directly → holds no credential → denied.
+5. Agent forges a grant → signature check fails → denied.
+6. Agent replays a settled grant → nonce rejected → denied.
+7. Agent requests a larger `max_tokens` than the grant allows → clamped at the
+   gateway → cost cannot exceed reservation.
+8. Agent spawns ten subagents to split the spend → shared ledger → denied at
+   cap.
+9. Agent takes the authority offline (simulated) and retries → denied, not
+   allowed.
+10. Agent attempts to edit the ledger or receipts → no write path exists.
+
+### Chaos
+
+Authority down, DO storage error, network partition, ±10 minute clock skew.
+Assert deny-closed in all cases and assert free work is unaffected.
+
+### Verification gates
+
+```
+cargo test -p bound-policy
+cargo test -p coven-agents bound_guardrail
+pnpm --filter bound-authority test
+pnpm --filter bound-gateway test
+```
+
+The adversarial suite must be green before enforcement is enabled for any
+familiar.
+
+## Rollout
+
+1. **Ship the format.** Publish `bound:v1` schema, canonicalization rules, and
+   public keys on `bound.md`; publish documentation on `bounds.md`.
+2. **Sign the first policy.** Val signs `BOUNDS.md` with `ceiling_usd: 25.00`.
+3. **Shadow phase, scoped to `coven-agents` only.** The guardrail requests
+   grants and records outcomes but does not block, for a fixed, explicitly
+   ended window. Shadow is a rollout stage owned by Val, expressed in the signed
+   policy as `mode: shadow`; an agent cannot re-enter it, because changing the
+   mode requires Val's hardware key.
+4. **Enforce for OpenCoven agents.** Flip the signed policy to
+   `mode: deny-paid`. Verify a real denial at the cap and verify free work
+   continues.
+5. **Extend outward** to Cave-initiated work, research missions, and media
+   generation once the adversarial suite covers each new metered class.
+
+## Out of scope for v1
+
+- Multi-tenant hosting of Bound for other people's covens.
+- Per-action human approval prompts (Bound is a ceiling, not an approval queue).
+- Cost forecasting or optimization.
+- Non-USD currencies and non-monthly periods.
+- Trusting any provider's own budget dashboard as an enforcement mechanism;
+  provider caps are a backstop, not the control.

--- a/packages/bound/.gitignore
+++ b/packages/bound/.gitignore
@@ -1,0 +1,3 @@
+.bound-state/
+.bound-tmp/
+*.bak

--- a/packages/bound/BOUNDS.md
+++ b/packages/bound/BOUNDS.md
@@ -1,0 +1,55 @@
+# BOUNDS.md
+
+Coven-wide spend authority for OpenCoven.
+
+This file is **readable by every familiar and writable by none**. It is only
+authoritative while the signature below verifies against Val's key. A familiar
+that edits the block invalidates the signature, and an unverified policy grants
+nothing — it denies every paid action.
+
+```bound
+version: 1
+scope: coven
+issued_at: 2026-08-20T00:00:00Z
+not_after: 2027-08-20T00:00:00Z
+period: monthly-utc
+ceiling_usd: 25.00
+mode: deny-paid
+metered:
+  - model.tokens
+  - model.images
+  - model.audio
+  - tools.hosted
+  - search.api
+  - compute.render
+  - storage.egress
+  - infra.paid
+authority: http://127.0.0.1:8787
+authority_key: ed25519:qKnyQMcdaW96J2WGc43uJp2RRTOOg7FrO97E4rXhc0A
+gateway: http://127.0.0.1:8788
+grant_ttl_seconds: 120
+clock_skew_seconds: 60
+```
+
+## What this means in practice
+
+- Paid work stops at USD 25.00 per UTC calendar month across the whole coven.
+- Free and local work — reading files, editing code, running tests — is never
+  gated by Bound and continues after the cap is reached.
+- Every paid action must first obtain a short-lived signed grant. The gateway
+  holds the provider credentials; familiars hold none.
+- Splitting work across subagents does not multiply the budget. One ledger
+  serves the whole period.
+
+## Changing this file
+
+Only Val can change it, and only by re-signing:
+
+```
+node bin/bound.ts sign BOUNDS.md coven
+```
+
+The signing key lives outside this repository. There is no path by which a
+familiar can produce a valid signature.
+
+<!-- bound:sig v=1 alg=ed25519 key=val-hw-2026-08 sig=pG5Kb3Ug_pXCxRsE6JA20gTJ5uF8DsEUkFOGUFarVFRMEus8JVINGA9R-ESAldelDvYhX1x8U_oIJwyPrB80AA -->

--- a/packages/bound/README.md
+++ b/packages/bound/README.md
@@ -1,0 +1,130 @@
+# Bound
+
+**A spend cap no agent can raise.**
+
+Bound is a signed spend-authority system for Coven familiars. It answers one
+question: how do you set a billing cap that the agents subject to it cannot
+edit, disable, argue with, or route around?
+
+The design lives in
+[`docs/superpowers/specs/2026-08-20-bound-spend-authority-design.md`](../../docs/superpowers/specs/2026-08-20-bound-spend-authority-design.md).
+
+## Run it
+
+No install step. Node 24 runs the TypeScript directly.
+
+```bash
+cd packages/bound
+node bin/bound.ts dev
+```
+
+Then open the dashboard URL it prints (default <http://127.0.0.1:8787>). Dev
+mode also binds the gateway on `:8788` and the demo provider stub on `:8789`,
+so the gateway URL a familiar reads out of the signed `BOUNDS.md` is the URL
+that actually enforces.
+
+In a second terminal:
+
+```bash
+node demo/agent.ts      # honest familiars spending until the ceiling stops them
+node demo/attacks.ts    # eleven bypass attempts, every one denied
+node --test "test/*.test.ts"
+```
+
+`npm run typecheck` runs strict `tsc` over the package if you have TypeScript
+available; it is a check only, never a build step — nothing here is compiled.
+
+## Why a markdown file is not the control
+
+`BOUNDS.md` and `familiars/<id>/BOUND.md` are ordinary agent files, peers to
+`SOUL.md` and `IDENTITY.md`. A familiar can read them. A familiar can even
+write to them — and gain nothing, because two mechanisms carry the authority:
+
+1. **Val-only signing.** The fenced ` ```bound ` block is covered by a detached
+   ed25519 signature from a key held outside this repository. Editing the block
+   invalidates the signature, and an unverified policy grants nothing. Try it:
+
+   ```bash
+   node bin/bound.ts status                       # policy verified
+   sed -i '' 's/ceiling_usd: 25.00/ceiling_usd: 9999.00/' BOUNDS.md
+   node bin/bound.ts status                       # policy NOT verified — all paid actions denied
+   git checkout BOUNDS.md
+   ```
+
+2. **Credential separation.** Familiars hold no provider credentials. The
+   gateway holds them, and refuses to use them without a short-lived signed
+   grant that only the authority can mint. An agent cannot exceed a budget it
+   has no way to spend against.
+
+## Shape
+
+```
+BOUNDS.md                 signed coven policy — $25.00 / UTC month
+familiars/cody/BOUND.md   signed override — $10.00 sub-budget
+bin/bound.ts              keygen · sign · verify · status · dev
+src/canonical.ts          bound:v1 block parsing and canonical signing bytes
+src/policy.ts             signature verification, global-plus-overrides merge
+src/keystore.ts           key material, kept outside the repository
+src/ledger.ts             reserve / settle accounting, one ledger per period
+src/grant.ts              short-lived signed grants, nonce replay guard
+src/authority.ts          the only minter of grants; owns the ledger
+src/gateway.ts            the only holder of provider credentials
+src/provider-stub.ts      fake metered vendor, so the demo costs nothing
+src/client.ts             the surface an agent links against
+src/dashboard.ts          live read-only view
+demo/                     honest agent + adversarial suite
+```
+
+## Policy semantics
+
+| Rule | Behaviour |
+| --- | --- |
+| Ceiling | USD 25.00 per UTC calendar month, coven-wide |
+| Overrides | `BOUND.md` may only narrow; the coven ceiling is a hard clamp |
+| Unsigned override | Zero paid budget — never silent inheritance |
+| Breach | Paid actions denied; free and local work continues |
+| Any failure | Deny immediately. No cache, no grace period, no fail-open |
+| Subagents | One ledger per period, so sharding does not multiply budget |
+| Denials | Terminal. No retry, no cheaper-model fallback |
+
+## What the adversarial suite proves
+
+`node demo/attacks.ts` runs each of these against a live stack:
+
+| # | Attempt | Denied by |
+| --- | --- | --- |
+| 1 | Familiar raises its own cap in `BOUND.md` | signature no longer verifies |
+| 2 | Familiar invents an unsigned override | unsigned override means zero |
+| 3 | Familiar runs its own authority and self-issues grants | gateway pins the key from signed policy |
+| 4 | Familiar calls the provider directly | it holds no credential |
+| 5 | Hand-forged grant | grant signature check |
+| 6 | Replaying a spent grant | nonce guard |
+| 7 | Requesting more output than granted | gateway clamps to the grant |
+| 8 | Ten subagents splitting the spend | one shared ledger |
+| 9 | Spending while the authority is offline | fail closed |
+| 10 | Editing the ledger or policy over HTTP | no write route exists |
+| 11 | Reading the provider credential | it never crosses the wire |
+
+## Local demo vs production
+
+| | Local demo | Production |
+| --- | --- | --- |
+| Signing key | 0600 file outside the repo | Secure Enclave / hardware token |
+| Authority | loopback Node process | Cloudflare Worker |
+| Ledger | serialized in-process queue + JSON | Durable Object, one per period |
+| Gateway credential | demo string | Workers Secrets Store |
+| Provider | local stub, zero real cost | real metered vendors |
+
+The trust model is identical in both. Only the hosting changes.
+
+## Keys
+
+```bash
+node bin/bound.ts keygen                          # Val signing key
+node bin/bound.ts keys                            # list trusted key ids
+node bin/bound.ts sign BOUNDS.md coven            # re-sign after an authorized edit
+node bin/bound.ts verify BOUNDS.md coven
+```
+
+Keys live in `$BOUND_KEYSTORE` (default: the familiar workspace's `.bound/keys`,
+deliberately outside this repository). Private key material is never committed.

--- a/packages/bound/bin/bound.ts
+++ b/packages/bound/bin/bound.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * bound — CLI for the Bound spend authority.
+ *
+ *   bound keygen [keyId]        generate a signing key in the out-of-repo keystore
+ *   bound keys                  list trusted key ids
+ *   bound sign <file> <role>    sign a policy document (role: coven | familiar:<id>)
+ *   bound verify <file> <role>  verify a policy document
+ *   bound status                print the verified effective policy
+ *   bound dev [--port N]        run the full local stack and dashboard
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { extractBlock, canonicalBytes } from '../src/canonical.ts';
+import { verifyDocument, computeEffectivePolicy } from '../src/policy.ts';
+import { ensureKey, listKeys, signBytes, trustedKeys, keystoreDir, loadKey } from '../src/keystore.ts';
+import { loadPolicy, discoverFamiliars } from '../src/authority.ts';
+import { startStack, PACKAGE_ROOT } from '../src/stack.ts';
+
+export const VAL_KEY_ID = 'val-hw-2026-08';
+
+const SIG_LINE = /^<!--\s*bound:sig[\s\S]*?-->\s*$/m;
+
+function die(message: string): never {
+  console.error(`bound: ${message}`);
+  process.exit(1);
+}
+
+function cmdKeygen(keyId: string): void {
+  const record = ensureKey(keyId);
+  console.log(`key ${record.keyId}`);
+  console.log(`  public   ${record.publicKey}`);
+  console.log(`  keystore ${keystoreDir()}`);
+}
+
+function cmdKeys(): void {
+  const keys = listKeys();
+  if (keys.length === 0) return console.log('no keys; run `bound keygen`');
+  for (const key of keys) console.log(`${key.keyId}\t${key.publicKey}\t${key.createdAt}`);
+}
+
+function cmdSign(file: string, role: string, keyId: string): void {
+  const path = resolve(file);
+  const original = readFileSync(path, 'utf8');
+  const parsed = extractBlock(original);
+  if (!parsed.ok) die(`cannot sign: ${parsed.reason} — ${parsed.detail}`);
+
+  const declared = String(parsed.block.scope);
+  if (declared !== role) die(`document declares scope "${declared}" but role "${role}" was given`);
+
+  const key = loadKey(keyId);
+  if (!key) die(`no key ${keyId} in ${keystoreDir()} — run \`bound keygen ${keyId}\``);
+
+  const sig = signBytes(key, canonicalBytes(parsed.block, role));
+  const trailer = `<!-- bound:sig v=1 alg=ed25519 key=${keyId} sig=${sig} -->`;
+  const body = original.replace(SIG_LINE, '').trimEnd();
+  writeFileSync(path, `${body}\n\n${trailer}\n`);
+  console.log(`signed ${path} as role ${role} with ${keyId}`);
+}
+
+function cmdVerify(file: string, role: string): void {
+  const path = resolve(file);
+  const result = verifyDocument(readFileSync(path, 'utf8'), role, trustedKeys());
+  if (!result.ok) {
+    console.error(`INVALID  ${path}\n  ${result.reason}: ${result.detail}`);
+    process.exit(2);
+  }
+  console.log(`VALID    ${path}\n  role ${role}  digest ${result.digest}`);
+}
+
+function cmdStatus(policyDir: string): void {
+  const familiars = discoverFamiliars(policyDir);
+  const load = loadPolicy(policyDir, familiars);
+  if (!load.ok) {
+    console.error(`policy NOT verified: ${load.reason} — ${load.detail}`);
+    console.error('all paid actions would be denied.');
+    process.exit(2);
+  }
+  const p = load.policy!;
+  console.log(`policy verified`);
+  console.log(`  ceiling      $${p.ceilingUsd.toFixed(2)} (${p.period})`);
+  console.log(`  mode         ${p.mode}`);
+  console.log(`  grant TTL    ${p.grantTtlSeconds}s   skew ${p.clockSkewSeconds}s`);
+  console.log(`  metered      ${p.metered.join(', ')}`);
+  console.log(`  digest       ${p.digest}`);
+  for (const [familiar, cap] of Object.entries(p.subBudgets)) {
+    const bad = load.rejected[familiar];
+    console.log(`  ${familiar.padEnd(12)} $${cap.toFixed(2)}${bad ? `  REJECTED: ${bad.detail}` : ''}`);
+  }
+}
+
+async function cmdDev(port: number): Promise<void> {
+  // Bind the gateway to the port the signed policy advertises, so the URL a
+  // familiar reads in BOUNDS.md is the URL that actually enforces.
+  const stack = await startStack({
+    authorityPort: port,
+    gatewayPort: Number(process.env.BOUND_GATEWAY_PORT ?? 8788),
+    providerPort: Number(process.env.BOUND_PROVIDER_PORT ?? 8789),
+  });
+  const load = loadPolicy(PACKAGE_ROOT, discoverFamiliars(PACKAGE_ROOT));
+  console.log('');
+  console.log('  Bound is running.');
+  console.log('');
+  console.log(`  dashboard   ${stack.dashboardUrl}`);
+  console.log(`  authority   ${stack.authority.origin}`);
+  console.log(`  gateway     ${stack.gateway.origin}   (holds the provider credential)`);
+  console.log(`  provider    ${stack.provider.origin}   (demo stub, spends no real money)`);
+  console.log('');
+  console.log(`  ceiling     $${load.policy!.ceilingUsd.toFixed(2)} / ${load.policy!.period}`);
+  console.log(`  mode        ${load.policy!.mode}`);
+  console.log('');
+  console.log('  try:  node demo/agent.ts     honest familiars spending to the cap');
+  console.log('        node demo/attacks.ts   eleven bypass attempts, all denied');
+  console.log('');
+  console.log('  tamper test:');
+  console.log("        sed -i '' 's/ceiling_usd: 25.00/ceiling_usd: 9999.00/' BOUNDS.md");
+  console.log('        node bin/bound.ts status     # policy NOT verified, everything denies');
+  console.log('        git checkout BOUNDS.md');
+  console.log('');
+  console.log('  Ctrl-C to stop.');
+
+  const shutdown = async () => {
+    await stack.close();
+    process.exit(0);
+  };
+  process.on('SIGINT', shutdown);
+  process.on('SIGTERM', shutdown);
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+  switch (command) {
+    case 'keygen':
+      return cmdKeygen(args[0] ?? VAL_KEY_ID);
+    case 'keys':
+      return cmdKeys();
+    case 'sign': {
+      const file = args[0] ?? die('usage: bound sign <file> <role> [keyId]');
+      const role = args[1] ?? die('usage: bound sign <file> <role> [keyId]');
+      return cmdSign(file, role, args[2] ?? VAL_KEY_ID);
+    }
+    case 'verify': {
+      const file = args[0] ?? die('usage: bound verify <file> <role>');
+      const role = args[1] ?? die('usage: bound verify <file> <role>');
+      return cmdVerify(file, role);
+    }
+    case 'status':
+      return cmdStatus(args[0] ? resolve(args[0]) : PACKAGE_ROOT);
+    case 'dev':
+      return cmdDev(Number(process.env.BOUND_PORT ?? args[0] ?? 8787));
+    default:
+      console.log(readFileSync(new URL(import.meta.url), 'utf8').split('\n').slice(2, 12).join('\n'));
+      process.exit(command ? 1 : 0);
+  }
+}
+
+await main();
+
+export { computeEffectivePolicy };

--- a/packages/bound/demo/agent.ts
+++ b/packages/bound/demo/agent.ts
@@ -1,0 +1,89 @@
+/**
+ * Honest familiar demo.
+ *
+ * Spends real (metered, fake-money) budget until Bound denies it, then proves
+ * two things that matter: the denial is terminal, and free local work keeps
+ * working afterwards. Run `node bin/bound.ts dev` first, or run this alone and
+ * it will start its own stack.
+ */
+
+import { readdirSync } from 'node:fs';
+import { BoundClient } from '../src/client.ts';
+import { startStack, PACKAGE_ROOT } from '../src/stack.ts';
+
+const money = (n: number) => `$${n.toFixed(4)}`;
+
+function bar(used: number, ceiling: number): string {
+  const width = 28;
+  const filled = Math.min(width, Math.round((used / ceiling) * width));
+  return `[${'#'.repeat(filled)}${'.'.repeat(width - filled)}]`;
+}
+
+async function runFamiliar(
+  client: BoundClient,
+  familiar: string,
+  ceiling: number,
+  maxOutputTokens: number,
+): Promise<void> {
+  console.log(`\n── ${familiar} ${'─'.repeat(Math.max(0, 46 - familiar.length))}`);
+  let spent = 0;
+  for (let attempt = 1; attempt <= 200; attempt += 1) {
+    const outcome = await client.spend<{ output: string }>({
+      familiar,
+      provider: 'demo-provider',
+      model: 'demo-large',
+      prompt: `analysis request ${attempt} from ${familiar}`,
+      maxOutputTokens,
+    });
+
+    if (!outcome.ok) {
+      console.log(`  ${String(attempt).padStart(3)}  DENIED  ${outcome.reason}`);
+      console.log(`       ${outcome.detail}`);
+      console.log(`\n  Bound stopped ${familiar} after ${money(spent)}. No retry, no cheaper model.`);
+      return;
+    }
+
+    spent += outcome.actualUsd;
+    console.log(
+      `  ${String(attempt).padStart(3)}  paid ${money(outcome.actualUsd)}  ${bar(spent, ceiling)}  total ${money(spent)}`,
+    );
+  }
+  console.log('  loop limit reached before the cap — check the pricing table');
+}
+
+async function main(): Promise<void> {
+  const external = process.env.BOUND_AUTHORITY_ORIGIN && process.env.BOUND_GATEWAY_ORIGIN;
+  const stack = external ? null : await startStack({ statePath: null });
+
+  const authorityOrigin = process.env.BOUND_AUTHORITY_ORIGIN ?? stack!.authority.origin;
+  const gatewayOrigin = process.env.BOUND_GATEWAY_ORIGIN ?? stack!.gateway.origin;
+  const client = new BoundClient({ authorityOrigin, gatewayOrigin });
+
+  console.log('Bound demo — honest familiars spending until the signed ceiling stops them.');
+  console.log(`  authority ${authorityOrigin}`);
+  console.log(`  gateway   ${gatewayOrigin}   (sole holder of the provider credential)`);
+  console.log(`  dashboard ${authorityOrigin}`);
+
+  // cody carries a signed $10 sub-budget; nova has no override and so is
+  // limited only by the $25 coven ceiling.
+  await runFamiliar(client, 'cody', 10, 60_000);
+  await runFamiliar(client, 'nova', 25, 60_000);
+
+  console.log('\n── free work after the cap ' + '─'.repeat(23));
+  const files = readdirSync(PACKAGE_ROOT).length;
+  console.log(`  read ${files} entries from the package root — no grant needed, not denied.`);
+  console.log('  Bound denies paid actions only. Local and free work is untouched.\n');
+
+  const state = (await fetch(`${authorityOrigin}/v1/state`).then((r) => r.json())) as {
+    ledger: { settledUsd: number; ceilingUsd: number; receipts: unknown[]; denials: unknown[] };
+  };
+  console.log(
+    `  ledger: settled ${money(state.ledger.settledUsd)} of ${money(
+      state.ledger.ceilingUsd,
+    )}  ·  receipts ${state.ledger.receipts.length}  ·  denials ${state.ledger.denials.length}`,
+  );
+
+  if (stack) await stack.close();
+}
+
+await main();

--- a/packages/bound/demo/attacks.ts
+++ b/packages/bound/demo/attacks.ts
@@ -1,0 +1,391 @@
+/**
+ * Adversarial suite — every documented way an agent might try to get around
+ * Bound, run for real against a live stack.
+ *
+ * Each scenario must end in a denial. This file is both the demo Val runs and
+ * the source of truth for `test/adversarial.test.ts`, so the demo can never
+ * drift from what is actually asserted.
+ */
+
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { startStack, PACKAGE_ROOT, type Stack } from '../src/stack.ts';
+import { BoundClient } from '../src/client.ts';
+import { postJson } from '../src/http.ts';
+import { mintGrant, type SignedGrant } from '../src/grant.ts';
+import { generateKeyPairSync } from 'node:crypto';
+import { DEMO_CREDENTIAL } from '../src/provider-stub.ts';
+
+export interface AttackResult {
+  id: number;
+  name: string;
+  denied: boolean;
+  reason: string;
+  detail: string;
+}
+
+const SCRATCH = join(PACKAGE_ROOT, '.bound-tmp');
+
+function scratchPolicy(name: string, mutate: (dir: string) => void): string {
+  const dir = join(SCRATCH, name);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+  cpSync(join(PACKAGE_ROOT, 'BOUNDS.md'), join(dir, 'BOUNDS.md'));
+  cpSync(join(PACKAGE_ROOT, 'familiars'), join(dir, 'familiars'), { recursive: true });
+  mutate(dir);
+  return dir;
+}
+
+async function withStack<T>(
+  options: Parameters<typeof startStack>[0],
+  fn: (stack: Stack) => Promise<T>,
+): Promise<T> {
+  const stack = await startStack({ ...options, statePath: null });
+  try {
+    return await fn(stack);
+  } finally {
+    await stack.close();
+  }
+}
+
+function client(stack: Stack): BoundClient {
+  return new BoundClient({
+    authorityOrigin: stack.authority.origin,
+    gatewayOrigin: stack.gateway.origin,
+  });
+}
+
+const SPEND = {
+  provider: 'demo-provider',
+  model: 'demo-large',
+  prompt: 'attack probe',
+  maxOutputTokens: 1000,
+};
+
+/** 1. The familiar rewrites its own BOUND.md to give itself a bigger budget. */
+async function attackSelfEdit(): Promise<AttackResult> {
+  const dir = scratchPolicy('self-edit', (d) => {
+    const path = join(d, 'familiars', 'cody', 'BOUND.md');
+    writeFileSync(
+      path,
+      readFileSync(path, 'utf8').replace('ceiling_usd: 10.00', 'ceiling_usd: 100000.00'),
+    );
+  });
+
+  return withStack({ policyDir: dir }, async (stack) => {
+    const outcome = await client(stack).spend({ familiar: 'cody', ...SPEND });
+    return {
+      id: 1,
+      name: 'familiar raises its own cap in BOUND.md',
+      denied: !outcome.ok,
+      reason: outcome.ok ? 'ALLOWED' : outcome.reason,
+      detail: outcome.ok ? 'budget was raised' : outcome.detail,
+    };
+  });
+}
+
+/** 2. The familiar invents an unsigned override for a new identity. */
+async function attackUnsignedOverride(): Promise<AttackResult> {
+  const dir = scratchPolicy('unsigned-override', (d) => {
+    const path = join(d, 'familiars', 'ghost');
+    mkdirSync(path, { recursive: true });
+    writeFileSync(
+      join(path, 'BOUND.md'),
+      '# BOUND.md\n\n```bound\nversion: 1\nscope: familiar:ghost\nissued_at: 2026-08-20T00:00:00Z\nceiling_usd: 25.00\n```\n',
+    );
+  });
+
+  return withStack({ policyDir: dir }, async (stack) => {
+    const outcome = await client(stack).spend({ familiar: 'ghost', ...SPEND });
+    return {
+      id: 2,
+      name: 'unsigned override for a new familiar',
+      denied: !outcome.ok,
+      reason: outcome.ok ? 'ALLOWED' : outcome.reason,
+      detail: outcome.ok ? 'unsigned override granted budget' : outcome.detail,
+    };
+  });
+}
+
+/** 3. The familiar repoints the authority and gateway at endpoints it controls. */
+async function attackSpoofedEndpoints(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    // The agent stands up its own "authority" that says yes to everything, and
+    // points a client at it. It gets a grant — and it is worth nothing, because
+    // the real gateway verifies against the key pinned in the signed policy.
+    const rogue = generateKeyPairSync('ed25519');
+    const rogueGrant = mintGrant(
+      Buffer.from(rogue.privateKey.export({ type: 'pkcs8', format: 'der' })).toString('base64url'),
+      {
+        familiar: 'cody',
+        actionClass: 'model.tokens',
+        provider: SPEND.provider,
+        model: SPEND.model,
+        maxUsd: 9999,
+        maxOutputUnits: 1_000_000,
+        ttlSeconds: 300,
+      },
+    );
+
+    const response = await postJson<{ ok: boolean; reason?: string; detail?: string }>(
+      `${stack.gateway.origin}/v1/proxy`,
+      { grant: rogueGrant, ...SPEND },
+    );
+    return {
+      id: 3,
+      name: 'agent-run authority issuing its own grants',
+      denied: response.body?.ok !== true,
+      reason: response.body?.reason ?? 'ALLOWED',
+      detail: response.body?.detail ?? 'rogue authority was trusted',
+    };
+  });
+}
+
+/** 4. The familiar skips Bound entirely and calls the provider itself. */
+async function attackDirectProvider(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const response = await fetch(`${stack.provider.origin}/v1/complete`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ model: 'demo-large', prompt: 'direct', maxOutputTokens: 1000 }),
+    });
+    const body = (await response.json()) as { error?: string };
+    return {
+      id: 4,
+      name: 'direct provider call, bypassing the gateway',
+      denied: response.status === 401,
+      reason: body.error ?? `status_${response.status}`,
+      detail:
+        response.status === 401
+          ? 'the agent holds no provider credential; only the gateway does'
+          : 'provider served an uncredentialed request',
+    };
+  });
+}
+
+/** 5. The familiar forges a grant with a key it generated itself. */
+async function attackForgedGrant(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const forged: SignedGrant = {
+      claims: {
+        grantId: 'forged-0001',
+        familiar: 'cody',
+        actionClass: 'model.tokens',
+        provider: SPEND.provider,
+        model: SPEND.model,
+        maxUsd: 9999,
+        maxOutputUnits: 1_000_000,
+        nonce: 'forged-nonce',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+      sig: Buffer.alloc(64).toString('base64url'),
+    };
+    const response = await postJson<{ ok: boolean; reason?: string; detail?: string }>(
+      `${stack.gateway.origin}/v1/proxy`,
+      { grant: forged, ...SPEND },
+    );
+    return {
+      id: 5,
+      name: 'hand-forged grant',
+      denied: response.body?.ok !== true,
+      reason: response.body?.reason ?? 'ALLOWED',
+      detail: response.body?.detail ?? 'forged grant accepted',
+    };
+  });
+}
+
+/** 6. The familiar reuses a grant it already spent. */
+async function attackReplay(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const granted = await client(stack).requestGrant({ familiar: 'cody', ...SPEND });
+    if (!granted.ok) {
+      return { id: 6, name: 'grant replay', denied: true, reason: granted.reason, detail: granted.detail };
+    }
+    await postJson(`${stack.gateway.origin}/v1/proxy`, { grant: granted.grant, ...SPEND });
+    const second = await postJson<{ ok: boolean; reason?: string; detail?: string }>(
+      `${stack.gateway.origin}/v1/proxy`,
+      { grant: granted.grant, ...SPEND },
+    );
+    return {
+      id: 6,
+      name: 'grant replay',
+      denied: second.body?.ok !== true,
+      reason: second.body?.reason ?? 'ALLOWED',
+      detail: second.body?.detail ?? 'replayed grant was honoured',
+    };
+  });
+}
+
+/** 7. The familiar asks the provider for far more output than the grant covers. */
+async function attackOversizedRequest(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const granted = await client(stack).requestGrant({
+      familiar: 'cody',
+      ...SPEND,
+      maxOutputTokens: 100,
+    });
+    if (!granted.ok) {
+      return { id: 7, name: 'oversized request', denied: true, reason: granted.reason, detail: granted.detail };
+    }
+    const response = await postJson<{ ok: boolean; reason?: string; detail?: string }>(
+      `${stack.gateway.origin}/v1/proxy`,
+      { grant: granted.grant, ...SPEND, maxOutputTokens: 1_000_000 },
+    );
+    return {
+      id: 7,
+      name: 'request exceeds the granted output limit',
+      denied: response.body?.ok !== true,
+      reason: response.body?.reason ?? 'ALLOWED',
+      detail: response.body?.detail ?? 'oversized request was served',
+    };
+  });
+}
+
+/** 8. The familiar spawns ten identities to multiply the budget. */
+async function attackSubagentSharding(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const c = client(stack);
+    let allowed = 0;
+    let lastReason = 'none';
+    let lastDetail = '';
+
+    // Ten "subagents", each with its own identity, hammering in parallel.
+    for (let round = 0; round < 6; round += 1) {
+      const outcomes = await Promise.all(
+        Array.from({ length: 10 }, (_, i) =>
+          c.spend({
+            familiar: `subagent-${i}`,
+            provider: 'demo-provider',
+            model: 'demo-large',
+            prompt: 'shard',
+            maxOutputTokens: 60_000,
+          }),
+        ),
+      );
+      for (const outcome of outcomes) {
+        if (outcome.ok) allowed += 1;
+        else {
+          lastReason = outcome.reason;
+          lastDetail = outcome.detail;
+        }
+      }
+    }
+
+    const snapshot = stack.authority.ledger.snapshot();
+    const withinCap = snapshot.settledUsd <= snapshot.ceilingUsd;
+    return {
+      id: 8,
+      name: 'ten subagents splitting the spend',
+      denied: lastReason !== 'none' && withinCap,
+      reason: lastReason,
+      detail: `${allowed} calls allowed, settled $${snapshot.settledUsd.toFixed(4)} of $${snapshot.ceilingUsd.toFixed(2)} — one ledger, not ten. ${lastDetail}`,
+    };
+  });
+}
+
+/** 9. The familiar waits for the authority to be unavailable. */
+async function attackAuthorityOffline(): Promise<AttackResult> {
+  const stack = await startStack({ statePath: null });
+  const gatewayOrigin = stack.gateway.origin;
+  const granted = await client(stack).requestGrant({ familiar: 'cody', ...SPEND });
+  await stack.authority.close(); // authority goes dark, gateway still up
+
+  try {
+    if (!granted.ok) {
+      return { id: 9, name: 'authority offline', denied: true, reason: granted.reason, detail: granted.detail };
+    }
+    const response = await postJson<{ ok: boolean; reason?: string; detail?: string }>(
+      `${gatewayOrigin}/v1/proxy`,
+      { grant: granted.grant, ...SPEND },
+    );
+    return {
+      id: 9,
+      name: 'authority offline with a valid grant in hand',
+      denied: response.body?.ok !== true,
+      reason: response.body?.reason ?? 'ALLOWED',
+      detail: response.body?.detail ?? 'spend proceeded with no way to record it',
+    };
+  } finally {
+    await stack.gateway.close();
+    await stack.provider.close();
+  }
+}
+
+/** 10. The familiar tries to edit the ledger directly. */
+async function attackLedgerWrite(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const attempts = await Promise.all([
+      postJson<{ ok: boolean }>(`${stack.authority.origin}/v1/ledger`, { settledUsd: 0 }),
+      postJson<{ ok: boolean }>(`${stack.authority.origin}/v1/receipts`, { receipts: [] }),
+      postJson<{ ok: boolean }>(`${stack.authority.origin}/v1/policy`, { ceilingUsd: 9999 }),
+    ]);
+    const anyAccepted = attempts.some((a) => a.status === 200);
+    return {
+      id: 10,
+      name: 'direct ledger and policy mutation',
+      denied: !anyAccepted,
+      reason: anyAccepted ? 'ALLOWED' : 'not_found',
+      detail: anyAccepted
+        ? 'a mutation endpoint exists'
+        : 'the ledger and policy expose no write route at all',
+    };
+  });
+}
+
+/** 11. Provider credential is never visible to the agent's side of the wire. */
+async function attackCredentialLeak(): Promise<AttackResult> {
+  return withStack({}, async (stack) => {
+    const granted = await client(stack).requestGrant({ familiar: 'cody', ...SPEND });
+    const grantBlob = JSON.stringify(granted);
+    const response = await postJson<unknown>(`${stack.gateway.origin}/v1/proxy`, {
+      grant: granted.ok ? granted.grant : null,
+      ...SPEND,
+    });
+    const responseBlob = JSON.stringify(response.body);
+    const leaked =
+      grantBlob.includes(DEMO_CREDENTIAL) || responseBlob.includes(DEMO_CREDENTIAL);
+    return {
+      id: 11,
+      name: 'provider credential leaking to the agent',
+      denied: !leaked,
+      reason: leaked ? 'LEAKED' : 'no_credential',
+      detail: leaked
+        ? 'the credential appeared in agent-visible data'
+        : 'no grant or gateway response carries the provider credential',
+    };
+  });
+}
+
+export async function runAttacks(): Promise<AttackResult[]> {
+  const results: AttackResult[] = [];
+  // Sequential on purpose: each scenario owns its own stack and ports.
+  results.push(await attackSelfEdit());
+  results.push(await attackUnsignedOverride());
+  results.push(await attackSpoofedEndpoints());
+  results.push(await attackDirectProvider());
+  results.push(await attackForgedGrant());
+  results.push(await attackReplay());
+  results.push(await attackOversizedRequest());
+  results.push(await attackSubagentSharding());
+  results.push(await attackAuthorityOffline());
+  results.push(await attackLedgerWrite());
+  results.push(await attackCredentialLeak());
+  rmSync(SCRATCH, { recursive: true, force: true });
+  return results;
+}
+
+if (import.meta.filename === process.argv[1]) {
+  const results = await runAttacks();
+  console.log('\nBound adversarial suite — every one of these must be denied.\n');
+  for (const r of results) {
+    const mark = r.denied ? 'DENIED ' : 'ALLOWED';
+    console.log(`  ${String(r.id).padStart(2)}  ${mark}  ${r.name}`);
+    console.log(`      ${r.reason}: ${r.detail}`);
+  }
+  const failures = results.filter((r) => !r.denied);
+  console.log(
+    `\n  ${results.length - failures.length}/${results.length} bypass attempts denied.\n`,
+  );
+  process.exit(failures.length === 0 ? 0 : 1);
+}

--- a/packages/bound/familiars/cody/BOUND.md
+++ b/packages/bound/familiars/cody/BOUND.md
@@ -1,0 +1,21 @@
+# BOUND.md — cody
+
+Per-familiar spend override for the coding familiar.
+
+An override may only narrow. The coven ceiling in `BOUNDS.md` is applied as a
+hard clamp after this file is merged, so no signed override can raise a
+familiar above the coven ceiling.
+
+```bound
+version: 1
+scope: familiar:cody
+issued_at: 2026-08-20T00:00:00Z
+not_after: 2027-08-20T00:00:00Z
+ceiling_usd: 10.00
+```
+
+Absent this file, cody would inherit the full coven ceiling. Present but
+unsigned, cody would get **zero** paid budget — an unverifiable override is
+never quietly ignored.
+
+<!-- bound:sig v=1 alg=ed25519 key=val-hw-2026-08 sig=Lr1QKDVtwcrTcEoHmVVKrVHyjqJDvPv1O_WNWu7jvir-uGXsNHu6RNMaHjdAQfjJfzpSp9Vs46y_058U1aeUCg -->

--- a/packages/bound/package.json
+++ b/packages/bound/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@opencoven/bound",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Bound — signed spend authority for Coven familiars. A cap no agent can raise.",
+  "license": "MIT",
+  "engines": { "node": ">=22.18.0" },
+  "scripts": {
+    "dev": "node bin/bound.ts dev",
+    "status": "node bin/bound.ts status",
+    "demo": "node demo/agent.ts",
+    "attacks": "node demo/attacks.ts",
+    "test": "node --test \"test/*.test.ts\"",
+    "typecheck": "tsc -p tsconfig.json"
+  }
+}

--- a/packages/bound/src/authority.ts
+++ b/packages/bound/src/authority.ts
@@ -1,0 +1,316 @@
+/**
+ * The Bound Authority.
+ *
+ * Owns the ledger and is the only minter of grants. Every grant request
+ * re-verifies the Val signature over the policy documents on disk, so
+ * tampering with a policy file takes effect immediately — as a denial.
+ *
+ * There is no branch in this file that returns an enforceable grant when
+ * verification, digest comparison, or ledger accounting fails.
+ */
+
+import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { json, listen, readJson, type RunningService } from './http.ts';
+import {
+  computeEffectivePolicy,
+  verifyDocument,
+  type EffectivePolicy,
+  type DenyReason,
+} from './policy.ts';
+import { trustedKeys, ensureKey } from './keystore.ts';
+import { SpendLedger, currentPeriod, defaultLedgerPath } from './ledger.ts';
+import { estimate } from './pricing.ts';
+import { mintGrant } from './grant.ts';
+import { renderDashboard } from './dashboard.ts';
+
+export const COVEN_ID = 'opencoven';
+export const AUTHORITY_KEY_ID = 'bound-authority-2026-08';
+
+export interface AuthorityOptions {
+  policyDir: string;
+  port?: number;
+  statePath?: string | null;
+  familiars?: string[];
+}
+
+export interface PolicyLoad {
+  ok: boolean;
+  policy?: EffectivePolicy;
+  rejected: Record<string, { reason: DenyReason; detail: string }>;
+  reason?: DenyReason;
+  detail?: string;
+}
+
+function readIfPresent(path: string): string | null {
+  return existsSync(path) ? readFileSync(path, 'utf8') : null;
+}
+
+export function discoverFamiliars(policyDir: string): string[] {
+  const dir = join(policyDir, 'familiars');
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((name) => statSync(join(dir, name)).isDirectory());
+}
+
+/** Load and verify policy from disk on every call. Never cached, never trusted stale. */
+export function loadPolicy(policyDir: string, familiars: string[], now = new Date()): PolicyLoad {
+  const trusted = trustedKeys();
+  const globalMarkdown = readIfPresent(join(policyDir, 'BOUNDS.md'));
+  const verified = verifyDocument(globalMarkdown, 'coven', trusted, now);
+  if (!verified.ok) {
+    return { ok: false, rejected: {}, reason: verified.reason, detail: verified.detail };
+  }
+
+  const overrides = familiars.map((familiar) => ({
+    familiar,
+    markdown: readIfPresent(join(policyDir, 'familiars', familiar, 'BOUND.md')),
+  }));
+
+  const { policy, rejected } = computeEffectivePolicy(verified.policy, overrides, trusted, now);
+  return { ok: true, policy, rejected };
+}
+
+export interface AuthorityHandle extends RunningService {
+  ledger: SpendLedger;
+  publicKey: string;
+  reload: () => PolicyLoad;
+}
+
+interface GrantContext {
+  policyDir: string;
+  familiars: string[];
+  ledger: SpendLedger;
+  authorityKeyB64u: string;
+}
+
+export async function startAuthority(options: AuthorityOptions): Promise<AuthorityHandle> {
+  const familiars = options.familiars ?? discoverFamiliars(options.policyDir);
+  const initial = loadPolicy(options.policyDir, familiars);
+  if (!initial.ok) {
+    throw new Error(
+      `refusing to start without verified policy: ${initial.reason} — ${initial.detail}`,
+    );
+  }
+
+  const authorityKey = ensureKey(AUTHORITY_KEY_ID);
+  const period = currentPeriod();
+  const ledger = new SpendLedger({
+    coven: COVEN_ID,
+    ceilingUsd: initial.policy!.ceilingUsd,
+    period,
+    path:
+      options.statePath === null
+        ? null
+        : (options.statePath ?? defaultLedgerPath(COVEN_ID, period)),
+  });
+
+  const ctx: GrantContext = {
+    policyDir: options.policyDir,
+    familiars,
+    ledger,
+    authorityKeyB64u: authorityKey.privateKey!,
+  };
+
+  const service = await listen(
+    async (req, res, url) => {
+      const path = url.pathname;
+
+      if (req.method === 'GET' && (path === '/' || path === '/index.html')) {
+        return renderDashboard(res, ledger.snapshot(), loadPolicy(ctx.policyDir, familiars));
+      }
+
+      if (req.method === 'GET' && path === '/v1/state') {
+        const load = loadPolicy(ctx.policyDir, familiars);
+        return json(res, 200, {
+          ok: load.ok,
+          policy: load.policy ?? null,
+          policyError: load.ok ? null : { reason: load.reason, detail: load.detail },
+          rejected: load.rejected,
+          ledger: ledger.snapshot(),
+        });
+      }
+
+      if (req.method === 'GET' && path === '/v1/policy') {
+        const load = loadPolicy(ctx.policyDir, familiars);
+        if (!load.ok) return json(res, 409, { ok: false, reason: load.reason, detail: load.detail });
+        return json(res, 200, { ok: true, policy: load.policy, rejected: load.rejected });
+      }
+
+      if (req.method === 'GET' && path === '/v1/ledger') {
+        return json(res, 200, { ok: true, ledger: ledger.snapshot() });
+      }
+
+      if (req.method === 'GET' && path === '/v1/receipts') {
+        return json(res, 200, { ok: true, receipts: ledger.snapshot().receipts });
+      }
+
+      if (req.method === 'GET' && path === '/v1/denials') {
+        return json(res, 200, { ok: true, denials: ledger.snapshot().denials });
+      }
+
+      if (req.method === 'POST' && path === '/v1/grant') return handleGrant(req, res, ctx);
+      if (req.method === 'POST' && path === '/v1/settle') return handleSettle(req, res, ledger);
+
+      return json(res, 404, { ok: false, reason: 'not_found', detail: path });
+    },
+    options.port ?? 8787,
+    'authority',
+  );
+
+  return {
+    ...service,
+    ledger,
+    publicKey: authorityKey.publicKey,
+    reload: () => loadPolicy(ctx.policyDir, familiars),
+  };
+}
+
+interface GrantRequestBody {
+  familiar?: string;
+  provider?: string;
+  model?: string;
+  inputUnits?: number;
+  maxOutputUnits?: number;
+  policyDigest?: string;
+}
+
+async function handleGrant(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: GrantContext,
+): Promise<void> {
+  const body = await readJson<GrantRequestBody>(req);
+  if (!body || !body.familiar || !body.provider || !body.model) {
+    return json(res, 400, {
+      ok: false,
+      reason: 'grant_invalid',
+      detail: 'familiar, provider and model are required',
+    });
+  }
+  const familiar = body.familiar;
+
+  // Re-verify signed policy on every grant. A tampered file denies at once.
+  const load = loadPolicy(ctx.policyDir, ctx.familiars);
+  if (!load.ok) {
+    await ctx.ledger.recordDenial(familiar, load.reason!, load.detail!);
+    return json(res, 403, { ok: false, reason: load.reason, detail: load.detail });
+  }
+  const policy = load.policy!;
+
+  if (body.policyDigest && body.policyDigest !== policy.digest) {
+    const detail = 'caller policy digest does not match the authority copy';
+    await ctx.ledger.recordDenial(familiar, 'policy_digest_mismatch', detail);
+    return json(res, 409, { ok: false, reason: 'policy_digest_mismatch', detail });
+  }
+
+  const rejection = load.rejected[familiar];
+  if (rejection) {
+    await ctx.ledger.recordDenial(familiar, rejection.reason, rejection.detail);
+    return json(res, 403, { ok: false, reason: rejection.reason, detail: rejection.detail });
+  }
+
+  const est = estimate({
+    provider: body.provider,
+    model: body.model,
+    inputUnits: Math.max(0, body.inputUnits ?? 0),
+    maxOutputUnits: Math.max(0, body.maxOutputUnits ?? 0),
+  });
+  if (!est) {
+    const detail = `no published price for ${body.provider}/${body.model}`;
+    await ctx.ledger.recordDenial(familiar, 'grant_scope_mismatch', detail);
+    return json(res, 403, { ok: false, reason: 'grant_scope_mismatch', detail });
+  }
+
+  if (!policy.metered.includes(est.actionClass)) {
+    const detail = `action class ${est.actionClass} is not covered by the signed policy`;
+    await ctx.ledger.recordDenial(familiar, 'grant_scope_mismatch', detail);
+    return json(res, 403, { ok: false, reason: 'grant_scope_mismatch', detail });
+  }
+
+  // The grant id is chosen first so the reservation and the grant are one
+  // object from the ledger's point of view. No grant exists without a hold.
+  const grantId = randomUUID();
+  const shadow = policy.mode === 'shadow';
+
+  let reserved;
+  try {
+    reserved = await ctx.ledger.reserve({
+      grantId,
+      familiar,
+      actionClass: est.actionClass,
+      provider: body.provider,
+      model: body.model,
+      maxUsd: est.maxUsd,
+      ttlSeconds: policy.grantTtlSeconds,
+      subBudgetUsd: policy.subBudgets[familiar],
+      force: shadow,
+    });
+  } catch (error) {
+    // Accounting is the gate, not a side effect: a ledger failure denies.
+    return json(res, 503, {
+      ok: false,
+      reason: 'ledger_unavailable',
+      detail: (error as Error).message,
+    });
+  }
+
+  if (!reserved.ok) {
+    return json(res, 402, {
+      ok: false,
+      reason: reserved.reason,
+      detail: reserved.detail,
+      remainingUsd: reserved.remainingUsd,
+    });
+  }
+
+  const grant = mintGrant(ctx.authorityKeyB64u, {
+    grantId,
+    familiar,
+    actionClass: est.actionClass,
+    provider: body.provider,
+    model: body.model,
+    maxUsd: est.maxUsd,
+    maxOutputUnits: est.maxOutputUnits,
+    ttlSeconds: policy.grantTtlSeconds,
+  });
+
+  return json(res, 200, {
+    ok: true,
+    grant,
+    shadowed: reserved.forced === true,
+    remainingUsd: reserved.remainingUsd,
+    gateway: policy.gateway,
+    policyDigest: policy.digest,
+  });
+}
+
+async function handleSettle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ledger: SpendLedger,
+): Promise<void> {
+  const body = await readJson<{
+    grantId?: string;
+    actualUsd?: number;
+    inputUnits?: number;
+    outputUnits?: number;
+  }>(req);
+  if (!body || !body.grantId) {
+    return json(res, 400, { ok: false, reason: 'grant_invalid', detail: 'grantId is required' });
+  }
+  const settled = await ledger.settle({
+    grantId: body.grantId,
+    actualUsd: body.actualUsd ?? 0,
+    inputUnits: body.inputUnits ?? 0,
+    outputUnits: body.outputUnits ?? 0,
+  });
+  return json(res, 200, {
+    ok: settled.ok,
+    receipt: settled.receipt,
+    duplicate: settled.duplicate,
+    overReservation: settled.overReservation,
+    ledger: ledger.snapshot(),
+  });
+}

--- a/packages/bound/src/canonical.ts
+++ b/packages/bound/src/canonical.ts
@@ -1,0 +1,112 @@
+/**
+ * Canonical serialization for `bound:v1` policy documents.
+ *
+ * A policy document is ordinary Markdown with exactly one fenced ```bound
+ * block. Only the block is signed, so prose can be edited freely without
+ * invalidating authority — and editing prose can never grant authority.
+ */
+
+export type BoundValue = string | number | boolean | string[];
+export type BoundBlock = Record<string, BoundValue>;
+
+export type ParseResult =
+  | { ok: true; block: BoundBlock; raw: string }
+  | { ok: false; reason: BoundParseReason; detail: string };
+
+export type BoundParseReason =
+  | 'no_block'
+  | 'multiple_blocks'
+  | 'duplicate_key'
+  | 'bad_syntax'
+  | 'bad_version'
+  | 'missing_field';
+
+const BLOCK_RE = /^```bound[ \t]*\r?\n([\s\S]*?)^```[ \t]*$/gm;
+
+const REQUIRED_FIELDS = ['version', 'scope', 'issued_at'] as const;
+
+function fail(reason: BoundParseReason, detail: string): ParseResult {
+  return { ok: false, reason, detail };
+}
+
+function coerce(raw: string): BoundValue {
+  const trimmed = raw.trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (/^-?\d+(\.\d+)?$/.test(trimmed)) return Number(trimmed);
+  return trimmed;
+}
+
+/** Strip a trailing `# comment` that is not inside a quoted value. */
+function stripComment(line: string): string {
+  const hash = line.indexOf('#');
+  if (hash < 0) return line;
+  // A comment marker must be preceded by whitespace or start the line.
+  if (hash > 0 && !/\s/.test(line[hash - 1]!)) return line;
+  return line.slice(0, hash);
+}
+
+export function extractBlock(markdown: string): ParseResult {
+  BLOCK_RE.lastIndex = 0;
+  const matches = [...markdown.matchAll(BLOCK_RE)];
+  if (matches.length === 0) return fail('no_block', 'no fenced bound block found');
+  if (matches.length > 1) {
+    return fail('multiple_blocks', `${matches.length} bound blocks found, exactly one required`);
+  }
+
+  const raw = matches[0]![1]!;
+  const block: BoundBlock = {};
+  let listKey: string | null = null;
+
+  const lines = raw.split(/\r?\n/);
+  for (const original of lines) {
+    if (original.includes('\t')) return fail('bad_syntax', 'tabs are not permitted');
+    const line = stripComment(original).replace(/\s+$/, '');
+    if (line.trim() === '') continue;
+
+    const listItem = /^\s+-\s+(.+)$/.exec(line);
+    if (listItem) {
+      if (!listKey) return fail('bad_syntax', `list item without a parent key: ${line.trim()}`);
+      (block[listKey] as string[]).push(listItem[1]!.trim());
+      continue;
+    }
+
+    const pair = /^([A-Za-z][A-Za-z0-9_]*):[ \t]*(.*)$/.exec(line);
+    if (!pair) return fail('bad_syntax', `unparsable line: ${line.trim()}`);
+
+    const key = pair[1]!;
+    const value = pair[2]!;
+    if (Object.hasOwn(block, key)) return fail('duplicate_key', `duplicate key: ${key}`);
+
+    if (value.trim() === '') {
+      block[key] = [];
+      listKey = key;
+    } else {
+      block[key] = coerce(value);
+      listKey = null;
+    }
+  }
+
+  if (block.version !== 1) return fail('bad_version', `unsupported version: ${String(block.version)}`);
+  for (const field of REQUIRED_FIELDS) {
+    if (!Object.hasOwn(block, field)) return fail('missing_field', `missing required field: ${field}`);
+  }
+
+  return { ok: true, block, raw };
+}
+
+/** Stable JSON: keys sorted, arrays order-preserving, no insignificant whitespace. */
+export function canonicalJson(block: BoundBlock): string {
+  const keys = Object.keys(block).sort();
+  const parts = keys.map((k) => `${JSON.stringify(k)}:${JSON.stringify(block[k])}`);
+  return `{${parts.join(',')}}`;
+}
+
+/**
+ * Bytes covered by a Val signature. Binding the role prevents a familiar
+ * override from being replayed as the coven-wide policy.
+ */
+export function canonicalBytes(block: BoundBlock, role: string): Buffer {
+  const payload = `bound:v1\n${role}\n${String(block.issued_at)}\n${canonicalJson(block)}`;
+  return Buffer.from(payload, 'utf8');
+}

--- a/packages/bound/src/client.ts
+++ b/packages/bound/src/client.ts
@@ -1,0 +1,138 @@
+/**
+ * BoundClient — the only Bound surface an agent links against.
+ *
+ * A denial is terminal. `spend()` never retries, never falls back to a cheaper
+ * model, and never degrades open: it returns a structured BoundDenied that the
+ * agent reports and moves on from. Free and local work is unaffected because
+ * it never comes through here at all.
+ */
+
+import { postJson } from './http.ts';
+import type { SignedGrant } from './grant.ts';
+
+export interface BoundDenied {
+  ok: false;
+  reason: string;
+  detail: string;
+  remainingUsd?: number;
+}
+
+export interface BoundAllowed<T> {
+  ok: true;
+  result: T;
+  actualUsd: number;
+  grantId: string;
+  remainingUsd: number;
+}
+
+export interface SpendInput {
+  familiar: string;
+  provider: string;
+  model: string;
+  prompt: string;
+  maxOutputTokens: number;
+  /** Optional: prove the caller is looking at the same policy the authority is. */
+  policyDigest?: string;
+}
+
+export interface BoundClientOptions {
+  authorityOrigin: string;
+  gatewayOrigin: string;
+}
+
+export class BoundClient {
+  #authority: string;
+  #gateway: string;
+
+  constructor(options: BoundClientOptions) {
+    this.#authority = options.authorityOrigin.replace(/\/$/, '');
+    this.#gateway = options.gatewayOrigin.replace(/\/$/, '');
+  }
+
+  async requestGrant(input: SpendInput): Promise<
+    | { ok: true; grant: SignedGrant; remainingUsd: number; policyDigest: string }
+    | BoundDenied
+  > {
+    const inputUnits = Math.max(1, Math.ceil(input.prompt.length / 4));
+    const response = await postJson<{
+      ok: boolean;
+      grant?: SignedGrant;
+      reason?: string;
+      detail?: string;
+      remainingUsd?: number;
+      policyDigest?: string;
+    }>(`${this.#authority}/v1/grant`, {
+      familiar: input.familiar,
+      provider: input.provider,
+      model: input.model,
+      inputUnits,
+      maxOutputUnits: input.maxOutputTokens,
+      policyDigest: input.policyDigest,
+    });
+
+    if (!response.body) {
+      return {
+        ok: false,
+        reason: 'authority_unavailable',
+        detail: response.error ?? `authority returned status ${response.status}`,
+      };
+    }
+    if (!response.body.ok || !response.body.grant) {
+      return {
+        ok: false,
+        reason: response.body.reason ?? 'authority_unavailable',
+        detail: response.body.detail ?? 'grant refused',
+        remainingUsd: response.body.remainingUsd,
+      };
+    }
+    return {
+      ok: true,
+      grant: response.body.grant,
+      remainingUsd: response.body.remainingUsd ?? 0,
+      policyDigest: response.body.policyDigest ?? '',
+    };
+  }
+
+  async spend<T = unknown>(input: SpendInput): Promise<BoundAllowed<T> | BoundDenied> {
+    const granted = await this.requestGrant(input);
+    if (!granted.ok) return granted;
+
+    const response = await postJson<{
+      ok: boolean;
+      reason?: string;
+      detail?: string;
+      result?: T;
+      actualUsd?: number;
+      grantId?: string;
+    }>(`${this.#gateway}/v1/proxy`, {
+      grant: granted.grant,
+      provider: input.provider,
+      model: input.model,
+      prompt: input.prompt,
+      maxOutputTokens: input.maxOutputTokens,
+    });
+
+    if (!response.body) {
+      return {
+        ok: false,
+        reason: 'gateway_unavailable',
+        detail: response.error ?? `gateway returned status ${response.status}`,
+      };
+    }
+    if (!response.body.ok) {
+      return {
+        ok: false,
+        reason: response.body.reason ?? 'grant_invalid',
+        detail: response.body.detail ?? 'gateway refused',
+      };
+    }
+
+    return {
+      ok: true,
+      result: response.body.result as T,
+      actualUsd: response.body.actualUsd ?? 0,
+      grantId: response.body.grantId ?? granted.grant.claims.grantId,
+      remainingUsd: granted.remainingUsd,
+    };
+  }
+}

--- a/packages/bound/src/dashboard.ts
+++ b/packages/bound/src/dashboard.ts
@@ -1,0 +1,151 @@
+/** Live dashboard for the local demo. Read-only: it can observe, never authorize. */
+
+import type { ServerResponse } from 'node:http';
+import { html } from './http.ts';
+import type { LedgerState } from './ledger.ts';
+
+type Snapshot = LedgerState & { reservedUsd: number; remainingUsd: number };
+
+interface PolicyView {
+  ok: boolean;
+  reason?: string;
+  detail?: string;
+  policy?: {
+    ceilingUsd: number;
+    mode: string;
+    period: string;
+    subBudgets: Record<string, number>;
+    digest: string;
+    grantTtlSeconds: number;
+  };
+  rejected: Record<string, { reason: string; detail: string }>;
+}
+
+function esc(value: unknown): string {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function usd(value: number): string {
+  return `$${value.toFixed(4)}`;
+}
+
+export function renderDashboard(res: ServerResponse, snapshot: Snapshot, policy: PolicyView): void {
+  const pct =
+    snapshot.ceilingUsd > 0
+      ? Math.min(100, ((snapshot.settledUsd + snapshot.reservedUsd) / snapshot.ceilingUsd) * 100)
+      : 100;
+
+  const policyBanner = policy.ok
+    ? `<div class="ok">Policy verified · mode <b>${esc(policy.policy?.mode)}</b> · digest <code>${esc(
+        policy.policy?.digest.slice(0, 16),
+      )}…</code> · grant TTL ${esc(policy.policy?.grantTtlSeconds)}s</div>`
+    : `<div class="bad">POLICY NOT VERIFIED — all paid actions denied<br><small>${esc(
+        policy.reason,
+      )}: ${esc(policy.detail)}</small></div>`;
+
+  const subBudgets = Object.entries(policy.policy?.subBudgets ?? {})
+    .map(([familiar, cap]) => {
+      const used = snapshot.receipts
+        .filter((r) => r.familiar === familiar)
+        .reduce((sum, r) => sum + r.actualUsd, 0);
+      const rejected = policy.rejected[familiar];
+      return `<tr><td>${esc(familiar)}</td><td>${usd(used)}</td><td>${usd(cap)}</td><td>${
+        rejected ? `<span class="bad-inline">${esc(rejected.reason)}</span>` : 'signed'
+      }</td></tr>`;
+    })
+    .join('');
+
+  const receipts = snapshot.receipts
+    .slice(-12)
+    .reverse()
+    .map(
+      (r) =>
+        `<tr><td>${esc(r.settledAt.slice(11, 19))}</td><td>${esc(r.familiar)}</td><td>${esc(
+          r.provider,
+        )}/${esc(r.model)}</td><td>${esc(r.inputUnits)}→${esc(r.outputUnits)}</td><td>${usd(
+          r.actualUsd,
+        )}</td></tr>`,
+    )
+    .join('');
+
+  const denials = snapshot.denials
+    .slice(-12)
+    .reverse()
+    .map(
+      (d) =>
+        `<tr><td>${esc(d.at.slice(11, 19))}</td><td>${esc(d.familiar)}</td><td><code>${esc(
+          d.reason,
+        )}</code></td><td class="detail">${esc(d.detail)}</td></tr>`,
+    )
+    .join('');
+
+  const page = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>Bound — spend authority</title>
+<meta http-equiv="refresh" content="2">
+<style>
+:root { color-scheme: dark; }
+body { margin:0; padding:32px; background:#0b0b12; color:#e8e6f0;
+  font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; }
+h1 { font-size:22px; margin:0 0 4px; letter-spacing:.02em; }
+h1 span { color:#8b7ee8; }
+h2 { font-size:13px; text-transform:uppercase; letter-spacing:.12em; color:#8a86a3;
+  margin:28px 0 10px; }
+.sub { color:#8a86a3; margin:0 0 20px; }
+.ok, .bad { padding:10px 14px; border-radius:8px; margin-bottom:20px; }
+.ok { background:#12251a; border:1px solid #2c6b45; color:#8ce0ac; }
+.bad { background:#2a1216; border:1px solid #7a2b38; color:#ff9aa8; }
+.bad-inline { color:#ff9aa8; }
+.cards { display:flex; gap:14px; flex-wrap:wrap; }
+.card { flex:1 1 170px; background:#14141f; border:1px solid #262636; border-radius:10px;
+  padding:14px 16px; }
+.card .k { color:#8a86a3; font-size:11px; text-transform:uppercase; letter-spacing:.1em; }
+.card .v { font-size:24px; margin-top:6px; }
+.bar { height:12px; background:#1c1c2a; border-radius:6px; overflow:hidden; margin:18px 0 4px;
+  border:1px solid #262636; }
+.bar i { display:block; height:100%; background:linear-gradient(90deg,#5b4fd6,#b06be0); }
+.bar.full i { background:linear-gradient(90deg,#c0344a,#e0576b); }
+table { width:100%; border-collapse:collapse; }
+td, th { text-align:left; padding:7px 10px; border-bottom:1px solid #1e1e2c; }
+th { color:#8a86a3; font-weight:400; font-size:11px; text-transform:uppercase;
+  letter-spacing:.1em; }
+code { color:#b7a9ff; }
+.detail { color:#8a86a3; }
+.empty { color:#55506b; padding:10px; }
+footer { margin-top:32px; color:#55506b; font-size:12px; }
+</style></head><body>
+<h1>Bound <span>·</span> spend authority</h1>
+<p class="sub">Coven <b>${esc(snapshot.coven)}</b> · period <b>${esc(
+    snapshot.period,
+  )}</b> · this page observes, it cannot authorize.</p>
+${policyBanner}
+<div class="cards">
+  <div class="card"><div class="k">Ceiling</div><div class="v">${usd(snapshot.ceilingUsd)}</div></div>
+  <div class="card"><div class="k">Settled</div><div class="v">${usd(snapshot.settledUsd)}</div></div>
+  <div class="card"><div class="k">Reserved</div><div class="v">${usd(snapshot.reservedUsd)}</div></div>
+  <div class="card"><div class="k">Remaining</div><div class="v">${usd(snapshot.remainingUsd)}</div></div>
+</div>
+<div class="bar${pct >= 100 ? ' full' : ''}"><i style="width:${pct.toFixed(2)}%"></i></div>
+<p class="sub">${pct.toFixed(1)}% of the signed ceiling committed</p>
+
+<h2>Familiar sub-budgets</h2>
+<table><tr><th>Familiar</th><th>Used</th><th>Sub-budget</th><th>Override</th></tr>
+${subBudgets || '<tr><td colspan="4" class="empty">no signed overrides</td></tr>'}</table>
+
+<h2>Receipts (${snapshot.receipts.length})</h2>
+<table><tr><th>Time</th><th>Familiar</th><th>Model</th><th>Units</th><th>Cost</th></tr>
+${receipts || '<tr><td colspan="5" class="empty">no paid actions yet</td></tr>'}</table>
+
+<h2>Denials (${snapshot.denials.length})</h2>
+<table><tr><th>Time</th><th>Familiar</th><th>Reason</th><th>Detail</th></tr>
+${denials || '<tr><td colspan="4" class="empty">nothing denied yet</td></tr>'}</table>
+
+<footer>Refreshes every 2s · JSON at <code>/v1/state</code></footer>
+</body></html>`;
+
+  html(res, 200, page);
+}

--- a/packages/bound/src/gateway.ts
+++ b/packages/bound/src/gateway.ts
@@ -1,0 +1,160 @@
+/**
+ * The Bound Gateway.
+ *
+ * This is the only process that holds a provider credential, and it will not
+ * use it without a valid grant. That single property is what makes the cap a
+ * cap: an agent cannot exceed a budget it has no way to spend against.
+ *
+ * The gateway also clamps requested provider limits down to the grant, so
+ * actual cost cannot exceed the reservation the authority already took.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { json, listen, postJson, readJson, type RunningService } from './http.ts';
+import { NonceGuard, verifyGrant, type SignedGrant } from './grant.ts';
+import { actualCost } from './pricing.ts';
+
+export interface GatewayOptions {
+  /** Authority origin, taken from the signed policy — never from agent input. */
+  authorityOrigin: string;
+  /** Authority grant-verification public key, taken from the signed policy. */
+  authorityPublicKey: string;
+  providerOrigin: string;
+  providerCredential: string;
+  clockSkewSeconds?: number;
+  port?: number;
+}
+
+export interface ProxyRequestBody {
+  grant?: SignedGrant;
+  provider?: string;
+  model?: string;
+  prompt?: string;
+  maxOutputTokens?: number;
+}
+
+/** Shape returned by a metered provider. Never trusted for accounting beyond usage. */
+interface ProviderResult {
+  model: string;
+  output: string;
+  usage: { inputUnits: number; outputUnits: number };
+}
+
+export async function startGateway(options: GatewayOptions): Promise<RunningService> {
+  const nonces = new NonceGuard();
+  const clockSkewSeconds = options.clockSkewSeconds ?? 60;
+
+  return listen(
+    async (req, res, url) => {
+      if (req.method === 'GET' && url.pathname === '/v1/health') {
+        return json(res, 200, { ok: true, service: 'bound-gateway' });
+      }
+      if (req.method !== 'POST' || url.pathname !== '/v1/proxy') {
+        return json(res, 404, { ok: false, reason: 'not_found', detail: url.pathname });
+      }
+      return handleProxy(req, res, options, nonces, clockSkewSeconds);
+    },
+    options.port ?? 8788,
+    'gateway',
+  );
+}
+
+async function handleProxy(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: GatewayOptions,
+  nonces: NonceGuard,
+  clockSkewSeconds: number,
+): Promise<void> {
+  const body = await readJson<ProxyRequestBody>(req);
+  if (!body || !body.provider || !body.model) {
+    return json(res, 400, {
+      ok: false,
+      reason: 'grant_invalid',
+      detail: 'provider and model are required',
+    });
+  }
+
+  const requestedOutputUnits = Math.max(1, body.maxOutputTokens ?? 256);
+
+  const verified = verifyGrant(
+    body.grant,
+    options.authorityPublicKey,
+    { provider: body.provider, model: body.model, requestedOutputUnits },
+    { clockSkewSeconds, nonces },
+  );
+  if (!verified.ok) {
+    return json(res, 403, { ok: false, reason: verified.reason, detail: verified.detail });
+  }
+  const claims = verified.claims;
+
+  // Clamp provider-side limits to the grant. Even a lying client cannot make
+  // the provider produce more units than were reserved.
+  const clampedOutput = Math.min(requestedOutputUnits, claims.maxOutputUnits);
+
+  let providerResponse: ProviderResult | null = null;
+  let providerError: string | null = null;
+
+  try {
+    const response = await fetch(`${options.providerOrigin}/v1/complete`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        // The credential lives here and nowhere an agent can read.
+        authorization: `Bearer ${options.providerCredential}`,
+      },
+      body: JSON.stringify({
+        model: body.model,
+        prompt: body.prompt ?? '',
+        maxOutputTokens: clampedOutput,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      providerError = `provider returned ${response.status}`;
+    } else {
+      providerResponse = (await response.json()) as ProviderResult;
+    }
+  } catch (error) {
+    providerError = (error as Error).message;
+  }
+
+  const usage = providerResponse?.usage ?? { inputUnits: 0, outputUnits: 0 };
+  // Settle even on provider error so the reservation is released rather than
+  // silently held until expiry.
+  const cost = actualCost(body.provider, body.model, usage.inputUnits, usage.outputUnits);
+
+  const settle = await postJson<{ ok: boolean; receipt?: unknown }>(
+    `${options.authorityOrigin}/v1/settle`,
+    {
+      grantId: claims.grantId,
+      actualUsd: cost,
+      inputUnits: usage.inputUnits,
+      outputUnits: usage.outputUnits,
+    },
+  );
+
+  if (!settle.ok) {
+    // Fail closed: if spend cannot be recorded, do not hand back the result.
+    return json(res, 503, {
+      ok: false,
+      reason: 'authority_unavailable',
+      detail: settle.error ?? `settle failed with status ${settle.status}`,
+    });
+  }
+
+  if (providerError) {
+    return json(res, 502, { ok: false, reason: 'provider_error', detail: providerError });
+  }
+
+  return json(res, 200, {
+    ok: true,
+    grantId: claims.grantId,
+    result: providerResponse,
+    actualUsd: cost,
+    clampedOutputUnits: clampedOutput,
+    receipt: settle.body,
+  });
+}
+
+export type { RunningService };

--- a/packages/bound/src/grant.ts
+++ b/packages/bound/src/grant.ts
@@ -1,0 +1,153 @@
+/**
+ * Grants — short-lived, scoped, ed25519-signed spend authorizations.
+ *
+ * Only the authority holds the grant signing key, so an agent can no more mint
+ * a grant than it can mint a policy signature. The gateway verifies the grant
+ * against the authority public key carried in the *signed* policy, which is
+ * why an agent cannot repoint the trust root with an environment variable.
+ */
+
+import { randomUUID, createPrivateKey, sign as edSign, verify as edVerify, createPublicKey } from 'node:crypto';
+import type { DenyReason } from './policy.ts';
+
+export interface GrantClaims {
+  grantId: string;
+  familiar: string;
+  actionClass: string;
+  provider: string;
+  model: string;
+  maxUsd: number;
+  maxOutputUnits: number;
+  nonce: string;
+  iat: number; // epoch seconds
+  exp: number; // epoch seconds
+}
+
+export interface SignedGrant {
+  claims: GrantClaims;
+  sig: string; // base64url over canonical claims
+}
+
+export function canonicalClaims(claims: GrantClaims): Buffer {
+  const keys = Object.keys(claims).sort() as (keyof GrantClaims)[];
+  const body = keys.map((k) => `${JSON.stringify(k)}:${JSON.stringify(claims[k])}`).join(',');
+  return Buffer.from(`bound-grant:v1{${body}}`, 'utf8');
+}
+
+export function mintGrant(
+  privateKeyB64u: string,
+  input: Omit<GrantClaims, 'grantId' | 'nonce' | 'iat' | 'exp'> & {
+    ttlSeconds: number;
+    grantId?: string;
+    now?: Date;
+  },
+): SignedGrant {
+  const now = input.now ?? new Date();
+  const iat = Math.floor(now.getTime() / 1000);
+  const claims: GrantClaims = {
+    grantId: input.grantId ?? randomUUID(),
+    familiar: input.familiar,
+    actionClass: input.actionClass,
+    provider: input.provider,
+    model: input.model,
+    maxUsd: input.maxUsd,
+    maxOutputUnits: input.maxOutputUnits,
+    nonce: randomUUID(),
+    iat,
+    exp: iat + input.ttlSeconds,
+  };
+  const key = createPrivateKey({
+    key: Buffer.from(privateKeyB64u, 'base64url'),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  return { claims, sig: edSign(null, canonicalClaims(claims), key).toString('base64url') };
+}
+
+function publicKeyFromRaw(base64url: string) {
+  const raw = Buffer.from(base64url, 'base64url');
+  if (raw.length !== 32) throw new Error('ed25519 public key must be 32 bytes');
+  return createPublicKey({
+    key: Buffer.concat([Buffer.from('302a300506032b6570032100', 'hex'), raw]),
+    format: 'der',
+    type: 'spki',
+  });
+}
+
+export interface GrantRequestScope {
+  provider: string;
+  model: string;
+  requestedOutputUnits: number;
+}
+
+export type GrantVerifyResult =
+  | { ok: true; claims: GrantClaims }
+  | { ok: false; reason: DenyReason; detail: string };
+
+export class NonceGuard {
+  #seen = new Map<string, number>();
+
+  /** Returns false when the nonce has been used before. */
+  admit(nonce: string, expEpochSeconds: number, now: Date = new Date()): boolean {
+    const nowSec = Math.floor(now.getTime() / 1000);
+    for (const [key, exp] of this.#seen) if (exp <= nowSec) this.#seen.delete(key);
+    if (this.#seen.has(nonce)) return false;
+    this.#seen.set(nonce, expEpochSeconds);
+    return true;
+  }
+}
+
+export function verifyGrant(
+  grant: SignedGrant | null | undefined,
+  authorityPublicKeyB64u: string,
+  scope: GrantRequestScope,
+  options: { clockSkewSeconds: number; nonces: NonceGuard; now?: Date },
+): GrantVerifyResult {
+  if (!grant || !grant.claims || typeof grant.sig !== 'string') {
+    return { ok: false, reason: 'grant_invalid', detail: 'no grant presented' };
+  }
+
+  const now = options.now ?? new Date();
+  const nowSec = Math.floor(now.getTime() / 1000);
+
+  let good = false;
+  try {
+    good = edVerify(
+      null,
+      canonicalClaims(grant.claims),
+      publicKeyFromRaw(authorityPublicKeyB64u),
+      Buffer.from(grant.sig, 'base64url'),
+    );
+  } catch (error) {
+    return { ok: false, reason: 'grant_invalid', detail: (error as Error).message };
+  }
+  if (!good) return { ok: false, reason: 'grant_invalid', detail: 'grant signature does not verify' };
+
+  if (grant.claims.iat > nowSec + options.clockSkewSeconds) {
+    return { ok: false, reason: 'clock_skew', detail: 'grant issued in the future' };
+  }
+  if (grant.claims.exp + options.clockSkewSeconds <= nowSec) {
+    return { ok: false, reason: 'grant_expired', detail: `grant expired at ${grant.claims.exp}` };
+  }
+
+  if (grant.claims.provider !== scope.provider || grant.claims.model !== scope.model) {
+    return {
+      ok: false,
+      reason: 'grant_scope_mismatch',
+      detail: `grant covers ${grant.claims.provider}/${grant.claims.model}, request targets ${scope.provider}/${scope.model}`,
+    };
+  }
+  if (scope.requestedOutputUnits > grant.claims.maxOutputUnits) {
+    return {
+      ok: false,
+      reason: 'grant_scope_mismatch',
+      detail: `requested ${scope.requestedOutputUnits} units exceeds grant limit ${grant.claims.maxOutputUnits}`,
+    };
+  }
+
+  if (!options.nonces.admit(grant.claims.nonce, grant.claims.exp, now)) {
+    return { ok: false, reason: 'grant_replayed', detail: 'grant nonce already used' };
+  }
+
+  return { ok: true, claims: grant.claims };
+}

--- a/packages/bound/src/http.ts
+++ b/packages/bound/src/http.ts
@@ -1,0 +1,101 @@
+/** Tiny shared HTTP helpers. Kept deliberately small; no framework needed. */
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+export type Handler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  url: URL,
+) => Promise<void> | void;
+
+export function json(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'content-length': Buffer.byteLength(payload),
+    'cache-control': 'no-store',
+  });
+  res.end(payload);
+}
+
+export function html(res: ServerResponse, status: number, body: string): void {
+  res.writeHead(status, {
+    'content-type': 'text/html; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+    'cache-control': 'no-store',
+  });
+  res.end(body);
+}
+
+export async function readJson<T>(req: IncomingMessage, limitBytes = 1_000_000): Promise<T | null> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    total += (chunk as Buffer).length;
+    if (total > limitBytes) return null;
+    chunks.push(chunk as Buffer);
+  }
+  if (total === 0) return null;
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+export interface RunningService {
+  server: Server;
+  port: number;
+  origin: string;
+  close: () => Promise<void>;
+}
+
+export function listen(handler: Handler, port: number, name: string): Promise<RunningService> {
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', `http://127.0.0.1`);
+    Promise.resolve(handler(req, res, url)).catch((error: unknown) => {
+      if (!res.headersSent) {
+        json(res, 500, { ok: false, reason: 'internal_error', detail: String(error), service: name });
+      } else {
+        res.end();
+      }
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      const actual = (server.address() as AddressInfo).port;
+      resolve({
+        server,
+        port: actual,
+        origin: `http://127.0.0.1:${actual}`,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+export async function postJson<T>(
+  url: string,
+  body: unknown,
+  timeoutMs = 5000,
+): Promise<{ ok: boolean; status: number; body: T | null; error?: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const parsed = (await response.json().catch(() => null)) as T | null;
+    return { ok: response.ok, status: response.status, body: parsed };
+  } catch (error) {
+    return { ok: false, status: 0, body: null, error: (error as Error).message };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/bound/src/keystore.ts
+++ b/packages/bound/src/keystore.ts
@@ -1,0 +1,85 @@
+/**
+ * Key material lives outside the repository.
+ *
+ * In production the coven signing key is hardware-backed (Secure Enclave or a
+ * hardware token) and Val is the only holder. In this local build it is a
+ * 0600 file in a directory the repo cannot reach, which preserves the property
+ * that matters for the demo: an agent editing repository files cannot produce
+ * a valid signature.
+ */
+
+import { generateKeyPairSync, sign as edSign, createPrivateKey } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface KeyRecord {
+  keyId: string;
+  publicKey: string; // base64url raw 32 bytes
+  privateKey?: string; // base64url raw seed-bearing PKCS8, present only locally
+  createdAt: string;
+}
+
+export function keystoreDir(): string {
+  const override = process.env.BOUND_KEYSTORE;
+  if (override && override.trim() !== '') return override;
+  return join(homedir(), '.coven', 'workspaces', 'familiars', 'cody', '.bound', 'keys');
+}
+
+function keyPath(keyId: string): string {
+  return join(keystoreDir(), `${keyId}.json`);
+}
+
+export function generateKey(keyId: string): KeyRecord {
+  const dir = keystoreDir();
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const rawPublic = publicKey.export({ type: 'spki', format: 'der' }).subarray(-32);
+  const pkcs8 = privateKey.export({ type: 'pkcs8', format: 'der' });
+
+  const record: KeyRecord = {
+    keyId,
+    publicKey: Buffer.from(rawPublic).toString('base64url'),
+    privateKey: Buffer.from(pkcs8).toString('base64url'),
+    createdAt: new Date().toISOString(),
+  };
+
+  writeFileSync(keyPath(keyId), `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+  return record;
+}
+
+export function loadKey(keyId: string): KeyRecord | null {
+  const path = keyPath(keyId);
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, 'utf8')) as KeyRecord;
+}
+
+export function ensureKey(keyId: string): KeyRecord {
+  return loadKey(keyId) ?? generateKey(keyId);
+}
+
+export function listKeys(): KeyRecord[] {
+  const dir = keystoreDir();
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(readFileSync(join(dir, f), 'utf8')) as KeyRecord);
+}
+
+/** Trusted public keys, as the authority and gateway see them. */
+export function trustedKeys(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const key of listKeys()) out[key.keyId] = key.publicKey;
+  return out;
+}
+
+export function signBytes(record: KeyRecord, bytes: Buffer): string {
+  if (!record.privateKey) throw new Error(`key ${record.keyId} has no private half available`);
+  const key = createPrivateKey({
+    key: Buffer.from(record.privateKey, 'base64url'),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  return edSign(null, bytes, key).toString('base64url');
+}

--- a/packages/bound/src/ledger.ts
+++ b/packages/bound/src/ledger.ts
@@ -1,0 +1,298 @@
+/**
+ * SpendLedger — reserve/settle accounting for one (coven, period).
+ *
+ * Every mutation runs through a single serialized queue, so concurrent
+ * reserves cannot race past the ceiling. This is the local stand-in for the
+ * one-per-period Durable Object described in the design.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync, existsSync, renameSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { round6 } from './pricing.ts';
+
+export interface Reservation {
+  grantId: string;
+  familiar: string;
+  actionClass: string;
+  provider: string;
+  model: string;
+  maxUsd: number;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface Receipt {
+  receiptId: string;
+  grantId: string;
+  familiar: string;
+  actionClass: string;
+  provider: string;
+  model: string;
+  actualUsd: number;
+  inputUnits: number;
+  outputUnits: number;
+  settledAt: string;
+}
+
+export interface Denial {
+  denialId: string;
+  familiar: string;
+  reason: string;
+  detail: string;
+  at: string;
+}
+
+export interface LedgerState {
+  coven: string;
+  period: string;
+  ceilingUsd: number;
+  settledUsd: number;
+  reservations: Reservation[];
+  receipts: Receipt[];
+  denials: Denial[];
+}
+
+export type ReserveResult =
+  | { ok: true; reservation: Reservation; remainingUsd: number; forced?: boolean }
+  | { ok: false; reason: 'cap_reached' | 'sub_budget_reached'; detail: string; remainingUsd: number };
+
+export function currentPeriod(now: Date = new Date()): string {
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export class SpendLedger {
+  #state: LedgerState;
+  #path: string | null;
+  #queue: Promise<unknown> = Promise.resolve();
+
+  constructor(options: {
+    coven: string;
+    ceilingUsd: number;
+    period?: string;
+    path?: string | null;
+    now?: Date;
+  }) {
+    const period = options.period ?? currentPeriod(options.now);
+    this.#path = options.path ?? null;
+    this.#state = {
+      coven: options.coven,
+      period,
+      ceilingUsd: options.ceilingUsd,
+      settledUsd: 0,
+      reservations: [],
+      receipts: [],
+      denials: [],
+    };
+
+    if (this.#path && existsSync(this.#path)) {
+      const loaded = JSON.parse(readFileSync(this.#path, 'utf8')) as LedgerState;
+      // Period rollover starts clean: a new month never inherits reservations.
+      if (loaded.period === period && loaded.coven === options.coven) {
+        this.#state = { ...loaded, ceilingUsd: options.ceilingUsd };
+      }
+    }
+    this.#persist();
+  }
+
+  /** Serialize every mutation so concurrent reserves cannot both see headroom. */
+  #run<T>(fn: () => T): Promise<T> {
+    const next = this.#queue.then(fn, fn);
+    this.#queue = next.catch(() => undefined);
+    return next;
+  }
+
+  #persist(): void {
+    if (!this.#path) return;
+    mkdirSync(dirname(this.#path), { recursive: true });
+    const tmp = `${this.#path}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(this.#state, null, 2)}\n`, { mode: 0o600 });
+    renameSync(tmp, this.#path);
+  }
+
+  #expire(nowMs: number): void {
+    if (this.#state.reservations.length === 0) return;
+    this.#state.reservations = this.#state.reservations.filter((r) => r.expiresAt > nowMs);
+  }
+
+  #reservedUsd(): number {
+    return round6(this.#state.reservations.reduce((sum, r) => sum + r.maxUsd, 0));
+  }
+
+  #familiarUsd(familiar: string): number {
+    const settled = this.#state.receipts
+      .filter((r) => r.familiar === familiar)
+      .reduce((sum, r) => sum + r.actualUsd, 0);
+    const reserved = this.#state.reservations
+      .filter((r) => r.familiar === familiar)
+      .reduce((sum, r) => sum + r.maxUsd, 0);
+    return round6(settled + reserved);
+  }
+
+  remainingUsd(now: Date = new Date()): number {
+    this.#expire(now.getTime());
+    return round6(this.#state.ceilingUsd - this.#state.settledUsd - this.#reservedUsd());
+  }
+
+  reserve(input: {
+    grantId: string;
+    familiar: string;
+    actionClass: string;
+    provider: string;
+    model: string;
+    maxUsd: number;
+    ttlSeconds: number;
+    subBudgetUsd?: number;
+    /** Shadow rollout only: record the denial but still issue the hold. */
+    force?: boolean;
+    now?: Date;
+  }): Promise<ReserveResult> {
+    return this.#run(() => {
+      const now = input.now ?? new Date();
+      const nowMs = now.getTime();
+      this.#expire(nowMs);
+
+      const remaining = round6(
+        this.#state.ceilingUsd - this.#state.settledUsd - this.#reservedUsd(),
+      );
+      let forced = false;
+
+      if (input.subBudgetUsd !== undefined) {
+        const familiarUsed = this.#familiarUsd(input.familiar);
+        if (round6(familiarUsed + input.maxUsd) > input.subBudgetUsd) {
+          const detail = `${input.familiar} sub-budget ${input.subBudgetUsd.toFixed(2)} would be exceeded (used ${familiarUsed.toFixed(6)}, requested ${input.maxUsd.toFixed(6)})`;
+          this.#recordDenial(input.familiar, 'sub_budget_reached', detail, now);
+          if (!input.force) {
+            this.#persist();
+            return {
+              ok: false,
+              reason: 'sub_budget_reached',
+              detail,
+              remainingUsd: remaining,
+            } satisfies ReserveResult;
+          }
+          forced = true;
+        }
+      }
+
+      if (round6(input.maxUsd) > remaining) {
+        const detail = `remaining ${remaining.toFixed(6)} USD is below the ${input.maxUsd.toFixed(6)} USD reservation`;
+        this.#recordDenial(input.familiar, 'cap_reached', detail, now);
+        if (!input.force) {
+          this.#persist();
+          return {
+            ok: false,
+            reason: 'cap_reached',
+            detail,
+            remainingUsd: remaining,
+          } satisfies ReserveResult;
+        }
+        forced = true;
+      }
+
+      const reservation: Reservation = {
+        grantId: input.grantId,
+        familiar: input.familiar,
+        actionClass: input.actionClass,
+        provider: input.provider,
+        model: input.model,
+        maxUsd: round6(input.maxUsd),
+        createdAt: nowMs,
+        expiresAt: nowMs + input.ttlSeconds * 1000,
+      };
+      this.#state.reservations.push(reservation);
+      this.#persist();
+      return {
+        ok: true,
+        reservation,
+        remainingUsd: round6(remaining - reservation.maxUsd),
+        forced,
+      } satisfies ReserveResult;
+    });
+  }
+
+  /** Idempotent on grantId: duplicate delivery must not double-charge. */
+  settle(input: {
+    grantId: string;
+    actualUsd: number;
+    inputUnits: number;
+    outputUnits: number;
+    now?: Date;
+  }): Promise<{ ok: true; receipt: Receipt; duplicate: boolean; overReservation: boolean }> {
+    return this.#run(() => {
+      const now = input.now ?? new Date();
+      const existing = this.#state.receipts.find((r) => r.grantId === input.grantId);
+      if (existing) {
+        return { ok: true as const, receipt: existing, duplicate: true, overReservation: false };
+      }
+
+      const index = this.#state.reservations.findIndex((r) => r.grantId === input.grantId);
+      const reservation = index >= 0 ? this.#state.reservations[index]! : null;
+      if (index >= 0) this.#state.reservations.splice(index, 1);
+
+      const actualUsd = round6(Math.max(0, input.actualUsd));
+      const overReservation = reservation ? actualUsd > reservation.maxUsd : false;
+
+      const receipt: Receipt = {
+        receiptId: randomUUID(),
+        grantId: input.grantId,
+        familiar: reservation?.familiar ?? 'unknown',
+        actionClass: reservation?.actionClass ?? 'unknown',
+        provider: reservation?.provider ?? 'unknown',
+        model: reservation?.model ?? 'unknown',
+        actualUsd,
+        inputUnits: input.inputUnits,
+        outputUnits: input.outputUnits,
+        settledAt: now.toISOString(),
+      };
+
+      this.#state.settledUsd = round6(this.#state.settledUsd + actualUsd);
+      this.#state.receipts.push(receipt);
+      if (overReservation) {
+        this.#recordDenial(
+          receipt.familiar,
+          'over_reservation',
+          `actual ${actualUsd} exceeded reservation ${reservation!.maxUsd}`,
+          now,
+        );
+      }
+      this.#persist();
+      return { ok: true as const, receipt, duplicate: false, overReservation };
+    });
+  }
+
+  recordDenial(familiar: string, reason: string, detail: string, now: Date = new Date()): Promise<void> {
+    return this.#run(() => {
+      this.#recordDenial(familiar, reason, detail, now);
+      this.#persist();
+    });
+  }
+
+  #recordDenial(familiar: string, reason: string, detail: string, now: Date): void {
+    this.#state.denials.push({
+      denialId: randomUUID(),
+      familiar,
+      reason,
+      detail,
+      at: now.toISOString(),
+    });
+    if (this.#state.denials.length > 200) this.#state.denials.splice(0, this.#state.denials.length - 200);
+  }
+
+  snapshot(now: Date = new Date()): LedgerState & { reservedUsd: number; remainingUsd: number } {
+    this.#expire(now.getTime());
+    return {
+      ...this.#state,
+      reservations: [...this.#state.reservations],
+      receipts: [...this.#state.receipts],
+      denials: [...this.#state.denials],
+      reservedUsd: this.#reservedUsd(),
+      remainingUsd: round6(this.#state.ceilingUsd - this.#state.settledUsd - this.#reservedUsd()),
+    };
+  }
+}
+
+export function defaultLedgerPath(coven: string, period: string): string {
+  const base = process.env.BOUND_STATE_DIR ?? join(process.cwd(), '.bound-state');
+  return join(base, `${coven}-${period}.json`);
+}

--- a/packages/bound/src/policy.ts
+++ b/packages/bound/src/policy.ts
@@ -1,0 +1,242 @@
+/**
+ * Policy documents: signature verification and effective-policy computation.
+ *
+ * This module performs no I/O. It takes bytes and trusted keys, and returns
+ * results. Every failure path resolves to "no authority", never to a default.
+ */
+
+import { createPublicKey, verify as edVerify, createHash } from 'node:crypto';
+import { canonicalBytes, canonicalJson, extractBlock, type BoundBlock } from './canonical.ts';
+
+export type TrustedKeys = Record<string, string>; // keyId -> base64url raw ed25519 public key
+
+export type DenyReason =
+  | 'policy_missing'
+  | 'policy_unparsable'
+  | 'policy_unsigned'
+  | 'policy_bad_signature'
+  | 'policy_unknown_key'
+  | 'policy_expired'
+  | 'policy_role_mismatch'
+  | 'policy_digest_mismatch'
+  | 'override_unsigned'
+  | 'cap_reached'
+  | 'sub_budget_reached'
+  | 'ledger_unavailable'
+  | 'authority_unavailable'
+  | 'grant_invalid'
+  | 'grant_expired'
+  | 'grant_replayed'
+  | 'grant_scope_mismatch'
+  | 'clock_skew'
+  | 'no_credential'
+  | 'mode_denies';
+
+export interface SignatureTrailer {
+  version: string;
+  alg: string;
+  keyId: string;
+  sig: string;
+}
+
+export interface PolicyDocument {
+  block: BoundBlock;
+  signature: SignatureTrailer | null;
+  role: string;
+}
+
+export type VerifyResult =
+  | { ok: true; policy: PolicyDocument; digest: string }
+  | { ok: false; reason: DenyReason; detail: string };
+
+const SIG_RE = /<!--\s*bound:sig\s+v=(\S+)\s+alg=(\S+)\s+key=(\S+)\s+sig=(\S+)\s*-->/;
+
+export function parseSignature(markdown: string): SignatureTrailer | null {
+  const m = SIG_RE.exec(markdown);
+  if (!m) return null;
+  return { version: m[1]!, alg: m[2]!, keyId: m[3]!, sig: m[4]! };
+}
+
+function rawEd25519PublicKey(base64url: string) {
+  const raw = Buffer.from(base64url, 'base64url');
+  if (raw.length !== 32) throw new Error('ed25519 public key must be 32 bytes');
+  // SPKI prefix for Ed25519.
+  const spki = Buffer.concat([
+    Buffer.from('302a300506032b6570032100', 'hex'),
+    raw,
+  ]);
+  return createPublicKey({ key: spki, format: 'der', type: 'spki' });
+}
+
+export function policyDigest(block: BoundBlock, role: string): string {
+  return createHash('sha256').update(canonicalBytes(block, role)).digest('base64url');
+}
+
+/**
+ * Verify a policy document for a declared role.
+ *
+ * `now` is injected so tests and the authority share one clock discipline.
+ */
+export function verifyDocument(
+  markdown: string | null | undefined,
+  role: string,
+  trusted: TrustedKeys,
+  now: Date = new Date(),
+): VerifyResult {
+  if (markdown === null || markdown === undefined || markdown.trim() === '') {
+    return { ok: false, reason: 'policy_missing', detail: `no document for role ${role}` };
+  }
+
+  const parsed = extractBlock(markdown);
+  if (!parsed.ok) {
+    return { ok: false, reason: 'policy_unparsable', detail: `${parsed.reason}: ${parsed.detail}` };
+  }
+
+  const declaredScope = String(parsed.block.scope);
+  if (declaredScope !== role) {
+    return {
+      ok: false,
+      reason: 'policy_role_mismatch',
+      detail: `document declares scope ${declaredScope}, loaded as ${role}`,
+    };
+  }
+
+  const signature = parseSignature(markdown);
+  if (!signature) {
+    return { ok: false, reason: 'policy_unsigned', detail: `no signature trailer for ${role}` };
+  }
+  if (signature.alg !== 'ed25519' || signature.version !== '1') {
+    return {
+      ok: false,
+      reason: 'policy_bad_signature',
+      detail: `unsupported signature v=${signature.version} alg=${signature.alg}`,
+    };
+  }
+
+  const publicKey = trusted[signature.keyId];
+  if (!publicKey) {
+    return { ok: false, reason: 'policy_unknown_key', detail: `untrusted key id ${signature.keyId}` };
+  }
+
+  let good = false;
+  try {
+    good = edVerify(
+      null,
+      canonicalBytes(parsed.block, role),
+      rawEd25519PublicKey(publicKey),
+      Buffer.from(signature.sig, 'base64url'),
+    );
+  } catch (error) {
+    return {
+      ok: false,
+      reason: 'policy_bad_signature',
+      detail: `verification error: ${(error as Error).message}`,
+    };
+  }
+  if (!good) {
+    return { ok: false, reason: 'policy_bad_signature', detail: `signature does not cover ${role}` };
+  }
+
+  const notAfter = parsed.block.not_after;
+  if (typeof notAfter === 'string' && notAfter !== '') {
+    const expiry = Date.parse(notAfter);
+    if (Number.isNaN(expiry)) {
+      return { ok: false, reason: 'policy_unparsable', detail: `bad not_after: ${notAfter}` };
+    }
+    if (now.getTime() >= expiry) {
+      return { ok: false, reason: 'policy_expired', detail: `policy expired at ${notAfter}` };
+    }
+  }
+
+  return {
+    ok: true,
+    policy: { block: parsed.block, signature, role },
+    digest: policyDigest(parsed.block, role),
+  };
+}
+
+export interface EffectivePolicy {
+  period: string;
+  ceilingUsd: number;
+  mode: 'deny-paid' | 'shadow';
+  metered: string[];
+  authority: string;
+  authorityKey: string;
+  gateway: string;
+  grantTtlSeconds: number;
+  clockSkewSeconds: number;
+  subBudgets: Record<string, number>;
+  digest: string;
+}
+
+export interface OverrideInput {
+  familiar: string;
+  markdown: string | null;
+}
+
+export interface EffectiveResult {
+  policy: EffectivePolicy;
+  /** Familiars whose override failed verification. These get zero paid budget. */
+  rejected: Record<string, { reason: DenyReason; detail: string }>;
+}
+
+function num(block: BoundBlock, key: string, fallback: number): number {
+  const value = block[key];
+  return typeof value === 'number' ? value : fallback;
+}
+
+function str(block: BoundBlock, key: string, fallback: string): string {
+  const value = block[key];
+  return typeof value === 'string' && value !== '' ? value : fallback;
+}
+
+/**
+ * Global plus overrides.
+ *
+ * The global ceiling is a hard clamp applied after merge: no signed override
+ * can raise a familiar above the coven ceiling. An override that fails
+ * verification yields zero budget rather than silently inheriting the global.
+ */
+export function computeEffectivePolicy(
+  globalDoc: PolicyDocument,
+  overrides: OverrideInput[],
+  trusted: TrustedKeys,
+  now: Date = new Date(),
+): EffectiveResult {
+  const g = globalDoc.block;
+  const ceilingUsd = num(g, 'ceiling_usd', 0);
+  const modeRaw = str(g, 'mode', 'deny-paid');
+
+  const policy: EffectivePolicy = {
+    period: str(g, 'period', 'monthly-utc'),
+    ceilingUsd,
+    mode: modeRaw === 'shadow' ? 'shadow' : 'deny-paid',
+    metered: Array.isArray(g.metered) ? (g.metered as string[]) : [],
+    authority: str(g, 'authority', ''),
+    authorityKey: str(g, 'authority_key', '').replace(/^ed25519:/, ''),
+    gateway: str(g, 'gateway', ''),
+    grantTtlSeconds: num(g, 'grant_ttl_seconds', 120),
+    clockSkewSeconds: num(g, 'clock_skew_seconds', 60),
+    subBudgets: {},
+    digest: policyDigest(g, globalDoc.role),
+  };
+
+  const rejected: EffectiveResult['rejected'] = {};
+
+  for (const override of overrides) {
+    const role = `familiar:${override.familiar}`;
+    const verified = verifyDocument(override.markdown, role, trusted, now);
+    if (!verified.ok) {
+      // An unverifiable override is not "ignore and inherit" — it is zero.
+      rejected[override.familiar] = { reason: 'override_unsigned', detail: verified.detail };
+      policy.subBudgets[override.familiar] = 0;
+      continue;
+    }
+    const requested = num(verified.policy.block, 'ceiling_usd', 0);
+    policy.subBudgets[override.familiar] = Math.max(0, Math.min(requested, ceilingUsd));
+  }
+
+  return { policy, rejected };
+}
+
+export { canonicalJson };

--- a/packages/bound/src/pricing.ts
+++ b/packages/bound/src/pricing.ts
@@ -1,0 +1,96 @@
+/**
+ * Pricing and bounded cost estimation.
+ *
+ * Bound reserves the *maximum* an action can cost before it runs, then settles
+ * the actual. Estimation must never understate: the gateway clamps provider
+ * limits to the grant, so an honest estimator plus clamping makes overspend
+ * structurally impossible rather than merely unlikely.
+ */
+
+export type ActionClass =
+  | 'model.tokens'
+  | 'model.images'
+  | 'model.audio'
+  | 'tools.hosted'
+  | 'search.api'
+  | 'compute.render'
+  | 'storage.egress'
+  | 'infra.paid';
+
+export interface UnitPrice {
+  actionClass: ActionClass;
+  /** USD per unit; unit meaning depends on the class. */
+  inputUsdPerUnit: number;
+  outputUsdPerUnit: number;
+  unit: string;
+}
+
+/** Demo catalogue. Real deployments load this from the gateway's provider adapters. */
+export const PRICES: Record<string, UnitPrice> = {
+  'demo-provider/demo-large': {
+    actionClass: 'model.tokens',
+    inputUsdPerUnit: 0.000003,
+    outputUsdPerUnit: 0.000015,
+    unit: 'token',
+  },
+  'demo-provider/demo-small': {
+    actionClass: 'model.tokens',
+    inputUsdPerUnit: 0.0000005,
+    outputUsdPerUnit: 0.0000015,
+    unit: 'token',
+  },
+  'demo-provider/demo-image': {
+    actionClass: 'model.images',
+    inputUsdPerUnit: 0,
+    outputUsdPerUnit: 0.04,
+    unit: 'image',
+  },
+};
+
+export function priceKey(provider: string, model: string): string {
+  return `${provider}/${model}`;
+}
+
+export function lookupPrice(provider: string, model: string): UnitPrice | null {
+  return PRICES[priceKey(provider, model)] ?? null;
+}
+
+export interface EstimateInput {
+  provider: string;
+  model: string;
+  inputUnits: number;
+  maxOutputUnits: number;
+}
+
+export interface Estimate {
+  actionClass: ActionClass;
+  maxUsd: number;
+  maxOutputUnits: number;
+}
+
+export function estimate(input: EstimateInput): Estimate | null {
+  const price = lookupPrice(input.provider, input.model);
+  if (!price) return null;
+  const maxUsd =
+    input.inputUnits * price.inputUsdPerUnit + input.maxOutputUnits * price.outputUsdPerUnit;
+  return {
+    actionClass: price.actionClass,
+    maxUsd: round6(maxUsd),
+    maxOutputUnits: input.maxOutputUnits,
+  };
+}
+
+export function actualCost(
+  provider: string,
+  model: string,
+  inputUnits: number,
+  outputUnits: number,
+): number {
+  const price = lookupPrice(provider, model);
+  if (!price) return 0;
+  return round6(inputUnits * price.inputUsdPerUnit + outputUnits * price.outputUsdPerUnit);
+}
+
+export function round6(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}

--- a/packages/bound/src/provider-stub.ts
+++ b/packages/bound/src/provider-stub.ts
@@ -1,0 +1,59 @@
+/**
+ * Demo metered provider.
+ *
+ * Stands in for a real vendor so the demo spends no real money. It behaves
+ * like one in the way that matters: it refuses to serve without a credential,
+ * and it reports usage the gateway meters.
+ */
+
+import { json, listen, readJson, type RunningService } from './http.ts';
+
+export const DEMO_CREDENTIAL = 'sk-demo-provider-credential-not-a-real-key';
+
+export interface ProviderRequest {
+  model?: string;
+  prompt?: string;
+  maxOutputTokens?: number;
+}
+
+export interface ProviderResponse {
+  model: string;
+  output: string;
+  usage: { inputUnits: number; outputUnits: number };
+}
+
+export async function startProviderStub(port = 0): Promise<RunningService> {
+  return listen(
+    async (req, res, url) => {
+      if (req.method !== 'POST' || url.pathname !== '/v1/complete') {
+        return json(res, 404, { error: 'not_found' });
+      }
+
+      const auth = req.headers.authorization ?? '';
+      if (auth !== `Bearer ${DEMO_CREDENTIAL}`) {
+        // This is what an agent hits when it tries to call the vendor directly.
+        return json(res, 401, { error: 'missing_or_invalid_credential' });
+      }
+
+      const body = await readJson<ProviderRequest>(req);
+      const model = body?.model ?? 'demo-large';
+      const maxOutput = Math.max(1, body?.maxOutputTokens ?? 256);
+      const inputUnits = Math.max(1, Math.ceil((body?.prompt ?? '').length / 4));
+
+      // Deterministic usage keeps demo arithmetic legible.
+      const outputUnits = model === 'demo-image' ? 1 : Math.ceil(maxOutput * 0.9);
+
+      const response: ProviderResponse = {
+        model,
+        output:
+          model === 'demo-image'
+            ? 'data:image/png;base64,<demo-image>'
+            : `demo completion for: ${(body?.prompt ?? '').slice(0, 40)}`,
+        usage: { inputUnits, outputUnits },
+      };
+      return json(res, 200, response);
+    },
+    port,
+    'provider-stub',
+  );
+}

--- a/packages/bound/src/stack.ts
+++ b/packages/bound/src/stack.ts
@@ -1,0 +1,76 @@
+/** Starts the full local Bound stack on loopback: provider stub, gateway, authority. */
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { startAuthority, loadPolicy, discoverFamiliars, type AuthorityHandle } from './authority.ts';
+import { startGateway } from './gateway.ts';
+import { startProviderStub, DEMO_CREDENTIAL } from './provider-stub.ts';
+import type { RunningService } from './http.ts';
+
+export const PACKAGE_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+
+export interface Stack {
+  authority: AuthorityHandle;
+  gateway: RunningService;
+  provider: RunningService;
+  dashboardUrl: string;
+  close: () => Promise<void>;
+}
+
+export interface StackOptions {
+  policyDir?: string;
+  authorityPort?: number;
+  gatewayPort?: number;
+  providerPort?: number;
+  statePath?: string | null;
+}
+
+export async function startStack(options: StackOptions = {}): Promise<Stack> {
+  const policyDir = options.policyDir ?? PACKAGE_ROOT;
+
+  const provider = await startProviderStub(options.providerPort ?? 0);
+  const authority = await startAuthority({
+    policyDir,
+    port: options.authorityPort ?? 0,
+    statePath: options.statePath,
+  });
+
+  const load = loadPolicy(policyDir, discoverFamiliars(policyDir));
+  if (!load.ok) throw new Error(`policy not verified: ${load.reason} — ${load.detail}`);
+
+  // The grant trust root comes from the *signed* policy, not from the process
+  // environment and not from the caller. If the running authority key does not
+  // match the one Val signed, refuse to start rather than trust the running one.
+  const signedAuthorityKey = load.policy!.authorityKey;
+  if (signedAuthorityKey !== authority.publicKey) {
+    await authority.close();
+    await provider.close();
+    throw new Error(
+      `signed policy pins authority key ${signedAuthorityKey} but this authority holds ${authority.publicKey}`,
+    );
+  }
+
+  const gateway = await startGateway({
+    authorityOrigin: authority.origin,
+    authorityPublicKey: signedAuthorityKey,
+    providerOrigin: provider.origin,
+    providerCredential: process.env.BOUND_PROVIDER_CREDENTIAL ?? DEMO_CREDENTIAL,
+    clockSkewSeconds: load.policy!.clockSkewSeconds,
+    port: options.gatewayPort ?? 0,
+  });
+
+  return {
+    authority,
+    gateway,
+    provider,
+    dashboardUrl: authority.origin,
+    close: async () => {
+      await gateway.close();
+      await authority.close();
+      await provider.close();
+    },
+  };
+}
+
+export const DEFAULT_POLICY_DIR = PACKAGE_ROOT;
+export { join };

--- a/packages/bound/test/adversarial.test.ts
+++ b/packages/bound/test/adversarial.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import { runAttacks } from '../demo/attacks.ts';
+import { startStack, PACKAGE_ROOT } from '../src/stack.ts';
+import { BoundClient } from '../src/client.ts';
+
+/**
+ * The whole point of Bound. Every one of these is a way a capable agent might
+ * try to spend past the signed ceiling; every one must deny.
+ */
+test('every documented bypass attempt is denied', { timeout: 180_000 }, async () => {
+  const results = await runAttacks();
+  assert.ok(results.length >= 11, `expected the full suite, got ${results.length}`);
+  for (const result of results) {
+    assert.equal(
+      result.denied,
+      true,
+      `bypass ${result.id} (${result.name}) was NOT denied: ${result.reason} — ${result.detail}`,
+    );
+  }
+});
+
+test('free and local work still succeeds after the cap is reached', { timeout: 120_000 }, async () => {
+  const stack = await startStack({ statePath: null });
+  try {
+    const client = new BoundClient({
+      authorityOrigin: stack.authority.origin,
+      gatewayOrigin: stack.gateway.origin,
+    });
+
+    // Burn the coven ceiling with a familiar that has no sub-budget.
+    let denied: string | null = null;
+    for (let i = 0; i < 60 && denied === null; i += 1) {
+      const outcome = await client.spend({
+        familiar: 'burner',
+        provider: 'demo-provider',
+        model: 'demo-large',
+        prompt: 'burn',
+        maxOutputTokens: 60_000,
+      });
+      if (!outcome.ok) denied = outcome.reason;
+    }
+    assert.equal(denied, 'cap_reached');
+
+    // Free work: no grant, no gateway, no denial.
+    const entries = readdirSync(PACKAGE_ROOT);
+    assert.ok(entries.length > 0);
+
+    // And the ledger never went past the ceiling.
+    const snapshot = stack.authority.ledger.snapshot();
+    assert.ok(
+      snapshot.settledUsd <= snapshot.ceilingUsd,
+      `settled ${snapshot.settledUsd} exceeded ceiling ${snapshot.ceilingUsd}`,
+    );
+  } finally {
+    await stack.close();
+  }
+});
+
+test('a denial is terminal, not a retry loop', { timeout: 120_000 }, async () => {
+  const stack = await startStack({ statePath: null });
+  try {
+    const client = new BoundClient({
+      authorityOrigin: stack.authority.origin,
+      gatewayOrigin: stack.gateway.origin,
+    });
+    // cody carries a signed 10.00 sub-budget in the repo policy.
+    let denials = 0;
+    for (let i = 0; i < 40; i += 1) {
+      const outcome = await client.spend({
+        familiar: 'cody',
+        provider: 'demo-provider',
+        model: 'demo-large',
+        prompt: 'probe',
+        maxOutputTokens: 60_000,
+      });
+      if (!outcome.ok) {
+        denials += 1;
+        assert.equal(outcome.reason, 'sub_budget_reached');
+      }
+    }
+    assert.ok(denials > 0, 'the sub-budget never engaged');
+    const snapshot = stack.authority.ledger.snapshot();
+    const codySpend = snapshot.receipts
+      .filter((r) => r.familiar === 'cody')
+      .reduce((sum, r) => sum + r.actualUsd, 0);
+    assert.ok(codySpend <= 10, `cody spent ${codySpend}, above its 10.00 sub-budget`);
+  } finally {
+    await stack.close();
+  }
+});

--- a/packages/bound/test/canonical.test.ts
+++ b/packages/bound/test/canonical.test.ts
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractBlock, canonicalJson, canonicalBytes } from '../src/canonical.ts';
+
+const VALID = `# BOUNDS.md
+
+Prose here.
+
+\`\`\`bound
+version: 1
+scope: coven
+issued_at: 2026-08-20T00:00:00Z
+ceiling_usd: 25.00
+mode: deny-paid
+metered:
+  - model.tokens
+  - model.images
+\`\`\`
+
+More prose.
+`;
+
+test('parses a well-formed bound block', () => {
+  const result = extractBlock(VALID);
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.block.version, 1);
+  assert.equal(result.block.scope, 'coven');
+  assert.equal(result.block.ceiling_usd, 25);
+  assert.equal(result.block.mode, 'deny-paid');
+  assert.deepEqual(result.block.metered, ['model.tokens', 'model.images']);
+});
+
+test('strips trailing comments but keeps values intact', () => {
+  const result = extractBlock(VALID.replace('mode: deny-paid', 'mode: deny-paid   # only Val'));
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.block.mode, 'deny-paid');
+});
+
+test('editing prose does not change canonical bytes', () => {
+  const a = extractBlock(VALID);
+  const b = extractBlock(VALID.replace('More prose.', 'Completely different prose.'));
+  assert.equal(a.ok && b.ok, true);
+  if (!a.ok || !b.ok) return;
+  assert.equal(
+    canonicalBytes(a.block, 'coven').toString('hex'),
+    canonicalBytes(b.block, 'coven').toString('hex'),
+  );
+});
+
+test('canonical json is key-order independent', () => {
+  const one = canonicalJson({ b: 2, a: 1 });
+  const two = canonicalJson({ a: 1, b: 2 });
+  assert.equal(one, two);
+});
+
+test('canonical bytes bind the role', () => {
+  const parsed = extractBlock(VALID);
+  assert.equal(parsed.ok, true);
+  if (!parsed.ok) return;
+  assert.notEqual(
+    canonicalBytes(parsed.block, 'coven').toString('hex'),
+    canonicalBytes(parsed.block, 'familiar:cody').toString('hex'),
+  );
+});
+
+test('rejects a document with no bound block', () => {
+  const result = extractBlock('# just markdown\n');
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'no_block');
+});
+
+test('rejects two bound blocks', () => {
+  const result = extractBlock(`${VALID}\n${VALID}`);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'multiple_blocks');
+});
+
+test('rejects duplicate keys', () => {
+  const result = extractBlock(VALID.replace('mode: deny-paid', 'scope: familiar:cody'));
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'duplicate_key');
+});
+
+test('rejects tabs and unparsable lines', () => {
+  assert.equal(extractBlock(VALID.replace('mode: deny-paid', '\tmode: x')).ok, false);
+  assert.equal(extractBlock(VALID.replace('mode: deny-paid', 'not a pair')).ok, false);
+});
+
+test('rejects an unsupported version', () => {
+  const result = extractBlock(VALID.replace('version: 1', 'version: 2'));
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'bad_version');
+});
+
+test('rejects a block missing a required field', () => {
+  const result = extractBlock(VALID.replace('issued_at: 2026-08-20T00:00:00Z\n', ''));
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'missing_field');
+});
+
+test('never throws on arbitrary input', () => {
+  const inputs = ['', '```bound\n```', '```bound\n\u0000\n```', '`'.repeat(500), VALID.slice(0, 40)];
+  for (const input of inputs) {
+    assert.doesNotThrow(() => extractBlock(input));
+  }
+});

--- a/packages/bound/test/grant.test.ts
+++ b/packages/bound/test/grant.test.ts
@@ -1,0 +1,158 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { mintGrant, verifyGrant, NonceGuard } from '../src/grant.ts';
+import { estimate, actualCost } from '../src/pricing.ts';
+
+function authorityKeys(): { publicKey: string; privateKey: string } {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    publicKey: Buffer.from(publicKey.export({ type: 'spki', format: 'der' }).subarray(-32)).toString(
+      'base64url',
+    ),
+    privateKey: Buffer.from(privateKey.export({ type: 'pkcs8', format: 'der' })).toString(
+      'base64url',
+    ),
+  };
+}
+
+const KEYS = authorityKeys();
+
+function grant(overrides: Partial<Parameters<typeof mintGrant>[1]> = {}) {
+  return mintGrant(KEYS.privateKey, {
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'demo-provider',
+    model: 'demo-large',
+    maxUsd: 1,
+    maxOutputUnits: 1000,
+    ttlSeconds: 120,
+    ...overrides,
+  });
+}
+
+const SCOPE = { provider: 'demo-provider', model: 'demo-large', requestedOutputUnits: 500 };
+
+test('a freshly minted grant verifies', () => {
+  const result = verifyGrant(grant(), KEYS.publicKey, SCOPE, {
+    clockSkewSeconds: 60,
+    nonces: new NonceGuard(),
+  });
+  assert.equal(result.ok, true);
+});
+
+test('no grant denies', () => {
+  const result = verifyGrant(null, KEYS.publicKey, SCOPE, {
+    clockSkewSeconds: 60,
+    nonces: new NonceGuard(),
+  });
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'grant_invalid');
+});
+
+test('a tampered claim denies', () => {
+  const g = grant();
+  g.claims.maxUsd = 9999;
+  const result = verifyGrant(g, KEYS.publicKey, SCOPE, {
+    clockSkewSeconds: 60,
+    nonces: new NonceGuard(),
+  });
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'grant_invalid');
+});
+
+test('a grant signed by another key denies', () => {
+  const other = authorityKeys();
+  const g = mintGrant(other.privateKey, {
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'demo-provider',
+    model: 'demo-large',
+    maxUsd: 9999,
+    maxOutputUnits: 1e6,
+    ttlSeconds: 120,
+  });
+  const result = verifyGrant(g, KEYS.publicKey, SCOPE, {
+    clockSkewSeconds: 60,
+    nonces: new NonceGuard(),
+  });
+  assert.equal(result.ok, false);
+});
+
+test('an expired grant denies', () => {
+  const g = grant({ ttlSeconds: 1, now: new Date(Date.now() - 600_000) });
+  const result = verifyGrant(g, KEYS.publicKey, SCOPE, {
+    clockSkewSeconds: 60,
+    nonces: new NonceGuard(),
+  });
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'grant_expired');
+});
+
+test('a grant issued far in the future denies on skew', () => {
+  const g = grant({ now: new Date(Date.now() + 600_000) });
+  const result = verifyGrant(g, KEYS.publicKey, SCOPE, {
+    clockSkewSeconds: 60,
+    nonces: new NonceGuard(),
+  });
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'clock_skew');
+});
+
+test('a replayed nonce denies', () => {
+  const nonces = new NonceGuard();
+  const g = grant();
+  assert.equal(verifyGrant(g, KEYS.publicKey, SCOPE, { clockSkewSeconds: 60, nonces }).ok, true);
+  const second = verifyGrant(g, KEYS.publicKey, SCOPE, { clockSkewSeconds: 60, nonces });
+  assert.equal(second.ok, false);
+  if (second.ok) return;
+  assert.equal(second.reason, 'grant_replayed');
+});
+
+test('a different provider or model denies', () => {
+  const nonces = new NonceGuard();
+  const wrongModel = verifyGrant(
+    grant(),
+    KEYS.publicKey,
+    { ...SCOPE, model: 'demo-small' },
+    { clockSkewSeconds: 60, nonces },
+  );
+  assert.equal(wrongModel.ok, false);
+  if (wrongModel.ok) return;
+  assert.equal(wrongModel.reason, 'grant_scope_mismatch');
+});
+
+test('requesting more units than granted denies', () => {
+  const result = verifyGrant(
+    grant({ maxOutputUnits: 100 }),
+    KEYS.publicKey,
+    { ...SCOPE, requestedOutputUnits: 100_000 },
+    { clockSkewSeconds: 60, nonces: new NonceGuard() },
+  );
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'grant_scope_mismatch');
+});
+
+test('estimation is an upper bound on actual cost', () => {
+  const est = estimate({
+    provider: 'demo-provider',
+    model: 'demo-large',
+    inputUnits: 100,
+    maxOutputUnits: 1000,
+  });
+  assert.ok(est);
+  const actual = actualCost('demo-provider', 'demo-large', 100, 900);
+  assert.ok(actual <= est!.maxUsd, `${actual} should not exceed ${est!.maxUsd}`);
+});
+
+test('an unpriced model produces no estimate, therefore no grant', () => {
+  assert.equal(
+    estimate({ provider: 'demo-provider', model: 'not-in-catalogue', inputUnits: 1, maxOutputUnits: 1 }),
+    null,
+  );
+});

--- a/packages/bound/test/ledger.test.ts
+++ b/packages/bound/test/ledger.test.ts
@@ -1,0 +1,173 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SpendLedger, currentPeriod } from '../src/ledger.ts';
+
+function ledger(ceilingUsd = 25): SpendLedger {
+  return new SpendLedger({ coven: 'test', ceilingUsd, path: null });
+}
+
+test('reserve then settle reduces remaining by the actual amount', async () => {
+  const l = ledger();
+  const reserved = await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 5,
+    ttlSeconds: 60,
+  });
+  assert.equal(reserved.ok, true);
+  assert.equal(l.remainingUsd(), 20);
+
+  await l.settle({ grantId: 'g1', actualUsd: 2, inputUnits: 10, outputUnits: 20 });
+  assert.equal(l.remainingUsd(), 23);
+  assert.equal(l.snapshot().settledUsd, 2);
+});
+
+test('concurrent reserves never exceed the ceiling', async () => {
+  const l = ledger(10);
+  const results = await Promise.all(
+    Array.from({ length: 50 }, (_, i) =>
+      l.reserve({
+        grantId: `g${i}`,
+        familiar: `sub-${i}`,
+        actionClass: 'model.tokens',
+        provider: 'p',
+        model: 'm',
+        maxUsd: 1,
+        ttlSeconds: 60,
+      }),
+    ),
+  );
+  const allowed = results.filter((r) => r.ok).length;
+  assert.equal(allowed, 10);
+  assert.ok(l.remainingUsd() >= 0);
+  assert.equal(l.snapshot().reservedUsd, 10);
+});
+
+test('settle is idempotent per grant id', async () => {
+  const l = ledger();
+  await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 5,
+    ttlSeconds: 60,
+  });
+  const first = await l.settle({ grantId: 'g1', actualUsd: 3, inputUnits: 1, outputUnits: 1 });
+  const second = await l.settle({ grantId: 'g1', actualUsd: 3, inputUnits: 1, outputUnits: 1 });
+  assert.equal(first.duplicate, false);
+  assert.equal(second.duplicate, true);
+  assert.equal(second.receipt.receiptId, first.receipt.receiptId);
+  assert.equal(l.snapshot().settledUsd, 3);
+});
+
+test('expired reservations release exactly once', async () => {
+  const l = ledger(10);
+  const t0 = new Date('2026-08-20T00:00:00Z');
+  await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 9,
+    ttlSeconds: 60,
+    now: t0,
+  });
+  assert.equal(l.remainingUsd(t0), 1);
+
+  const later = new Date(t0.getTime() + 61_000);
+  assert.equal(l.remainingUsd(later), 10);
+  assert.equal(l.remainingUsd(later), 10);
+  assert.equal(l.snapshot(later).reservations.length, 0);
+});
+
+test('a familiar sub-budget denies before the coven ceiling', async () => {
+  const l = ledger(25);
+  const first = await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 9,
+    ttlSeconds: 60,
+    subBudgetUsd: 10,
+  });
+  assert.equal(first.ok, true);
+
+  const second = await l.reserve({
+    grantId: 'g2',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 5,
+    ttlSeconds: 60,
+    subBudgetUsd: 10,
+  });
+  assert.equal(second.ok, false);
+  if (second.ok) return;
+  assert.equal(second.reason, 'sub_budget_reached');
+  // Plenty of coven headroom remains — the sub-budget is what stopped it.
+  assert.ok(l.remainingUsd() > 5);
+});
+
+test('a denial is recorded with a reason', async () => {
+  const l = ledger(1);
+  await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 5,
+    ttlSeconds: 60,
+  });
+  const denials = l.snapshot().denials;
+  assert.equal(denials.length, 1);
+  assert.equal(denials[0]!.reason, 'cap_reached');
+});
+
+test('shadow mode records the denial but still issues the hold', async () => {
+  const l = ledger(1);
+  const result = await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 5,
+    ttlSeconds: 60,
+    force: true,
+  });
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.equal(result.forced, true);
+  assert.equal(l.snapshot().denials.length, 1);
+});
+
+test('over-reservation is flagged rather than hidden', async () => {
+  const l = ledger();
+  await l.reserve({
+    grantId: 'g1',
+    familiar: 'cody',
+    actionClass: 'model.tokens',
+    provider: 'p',
+    model: 'm',
+    maxUsd: 1,
+    ttlSeconds: 60,
+  });
+  const settled = await l.settle({ grantId: 'g1', actualUsd: 4, inputUnits: 1, outputUnits: 1 });
+  assert.equal(settled.overReservation, true);
+  assert.ok(l.snapshot().denials.some((d) => d.reason === 'over_reservation'));
+});
+
+test('the period key is UTC month', () => {
+  assert.equal(currentPeriod(new Date('2026-01-31T23:59:59Z')), '2026-01');
+  assert.equal(currentPeriod(new Date('2026-12-01T00:00:00Z')), '2026-12');
+});

--- a/packages/bound/test/policy.test.ts
+++ b/packages/bound/test/policy.test.ts
@@ -1,0 +1,211 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { generateKeyPairSync, sign as edSign, createPrivateKey } from 'node:crypto';
+import { extractBlock, canonicalBytes } from '../src/canonical.ts';
+import { verifyDocument, computeEffectivePolicy } from '../src/policy.ts';
+
+function makeKey(): { id: string; publicKey: string; privateKey: string } {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return {
+    id: 'test-key',
+    publicKey: Buffer.from(publicKey.export({ type: 'spki', format: 'der' }).subarray(-32)).toString(
+      'base64url',
+    ),
+    privateKey: Buffer.from(privateKey.export({ type: 'pkcs8', format: 'der' })).toString(
+      'base64url',
+    ),
+  };
+}
+
+const KEY = makeKey();
+const TRUSTED = { [KEY.id]: KEY.publicKey };
+
+function doc(fields: Record<string, string | number>, role: string, keyId = KEY.id): string {
+  const lines = Object.entries(fields)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join('\n');
+  const body = `# policy\n\n\`\`\`bound\n${lines}\n\`\`\`\n`;
+  const parsed = extractBlock(body);
+  if (!parsed.ok) throw new Error(`fixture unparsable: ${parsed.detail}`);
+  const key = createPrivateKey({
+    key: Buffer.from(KEY.privateKey, 'base64url'),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  const sig = edSign(null, canonicalBytes(parsed.block, role), key).toString('base64url');
+  return `${body}\n<!-- bound:sig v=1 alg=ed25519 key=${keyId} sig=${sig} -->\n`;
+}
+
+const GLOBAL_FIELDS = {
+  version: 1,
+  scope: 'coven',
+  issued_at: '2026-08-20T00:00:00Z',
+  not_after: '2027-08-20T00:00:00Z',
+  ceiling_usd: 25.0,
+  mode: 'deny-paid',
+  authority: 'http://127.0.0.1:8787',
+  authority_key: 'ed25519:abc',
+  gateway: 'http://127.0.0.1:8788',
+  grant_ttl_seconds: 120,
+  clock_skew_seconds: 60,
+};
+
+test('a correctly signed document verifies', () => {
+  const result = verifyDocument(doc(GLOBAL_FIELDS, 'coven'), 'coven', TRUSTED);
+  assert.equal(result.ok, true);
+});
+
+test('a missing document denies', () => {
+  const result = verifyDocument(null, 'coven', TRUSTED);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'policy_missing');
+});
+
+test('a tampered ceiling denies', () => {
+  const tampered = doc(GLOBAL_FIELDS, 'coven').replace('ceiling_usd: 25', 'ceiling_usd: 9999');
+  const result = verifyDocument(tampered, 'coven', TRUSTED);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'policy_bad_signature');
+});
+
+test('a signature for one role does not verify for another', () => {
+  const familiarDoc = doc(
+    { version: 1, scope: 'familiar:cody', issued_at: '2026-08-20T00:00:00Z', ceiling_usd: 10 },
+    'familiar:cody',
+  );
+  // Same bytes, presented as the coven policy.
+  const result = verifyDocument(
+    familiarDoc.replace('scope: familiar:cody', 'scope: coven'),
+    'coven',
+    TRUSTED,
+  );
+  assert.equal(result.ok, false);
+});
+
+test('a document whose declared scope differs from the load role denies', () => {
+  const result = verifyDocument(doc(GLOBAL_FIELDS, 'coven'), 'familiar:cody', TRUSTED);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'policy_role_mismatch');
+});
+
+test('an unsigned document denies', () => {
+  const unsigned = doc(GLOBAL_FIELDS, 'coven').replace(/<!--[\s\S]*?-->/, '');
+  const result = verifyDocument(unsigned, 'coven', TRUSTED);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'policy_unsigned');
+});
+
+test('an unknown key id denies', () => {
+  const result = verifyDocument(doc(GLOBAL_FIELDS, 'coven', 'someone-elses-key'), 'coven', TRUSTED);
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'policy_unknown_key');
+});
+
+test('an expired policy denies', () => {
+  const expired = doc({ ...GLOBAL_FIELDS, not_after: '2026-01-01T00:00:00Z' }, 'coven');
+  const result = verifyDocument(expired, 'coven', TRUSTED, new Date('2026-08-20T00:00:00Z'));
+  assert.equal(result.ok, false);
+  if (result.ok) return;
+  assert.equal(result.reason, 'policy_expired');
+});
+
+function globalPolicy() {
+  const verified = verifyDocument(doc(GLOBAL_FIELDS, 'coven'), 'coven', TRUSTED);
+  assert.equal(verified.ok, true);
+  if (!verified.ok) throw new Error('unreachable');
+  return verified.policy;
+}
+
+test('an absent override inherits the coven ceiling', () => {
+  const { policy } = computeEffectivePolicy(globalPolicy(), [], TRUSTED);
+  assert.equal(policy.ceilingUsd, 25);
+  assert.deepEqual(policy.subBudgets, {});
+});
+
+test('a signed override narrows the familiar', () => {
+  const override = doc(
+    { version: 1, scope: 'familiar:cody', issued_at: '2026-08-20T00:00:00Z', ceiling_usd: 10 },
+    'familiar:cody',
+  );
+  const { policy, rejected } = computeEffectivePolicy(
+    globalPolicy(),
+    [{ familiar: 'cody', markdown: override }],
+    TRUSTED,
+  );
+  assert.equal(policy.subBudgets.cody, 10);
+  assert.deepEqual(rejected, {});
+});
+
+test('an explicit zero override means no paid actions', () => {
+  const override = doc(
+    { version: 1, scope: 'familiar:cody', issued_at: '2026-08-20T00:00:00Z', ceiling_usd: 0 },
+    'familiar:cody',
+  );
+  const { policy } = computeEffectivePolicy(
+    globalPolicy(),
+    [{ familiar: 'cody', markdown: override }],
+    TRUSTED,
+  );
+  assert.equal(policy.subBudgets.cody, 0);
+});
+
+test('an override above the coven ceiling is clamped, never honoured', () => {
+  const override = doc(
+    { version: 1, scope: 'familiar:cody', issued_at: '2026-08-20T00:00:00Z', ceiling_usd: 100000 },
+    'familiar:cody',
+  );
+  const { policy } = computeEffectivePolicy(
+    globalPolicy(),
+    [{ familiar: 'cody', markdown: override }],
+    TRUSTED,
+  );
+  assert.equal(policy.subBudgets.cody, 25);
+});
+
+test('an unsigned override yields zero, not inheritance', () => {
+  const { policy, rejected } = computeEffectivePolicy(
+    globalPolicy(),
+    [{ familiar: 'cody', markdown: '```bound\nversion: 1\nscope: familiar:cody\nissued_at: x\n```' }],
+    TRUSTED,
+  );
+  assert.equal(policy.subBudgets.cody, 0);
+  assert.equal(rejected.cody?.reason, 'override_unsigned');
+});
+
+test('property: no override can raise a familiar above the coven ceiling', () => {
+  const global = globalPolicy();
+  for (const requested of [-100, 0, 0.01, 24.99, 25, 25.01, 1e9, Number.MAX_SAFE_INTEGER]) {
+    const override = doc(
+      {
+        version: 1,
+        scope: 'familiar:probe',
+        issued_at: '2026-08-20T00:00:00Z',
+        ceiling_usd: requested,
+      },
+      'familiar:probe',
+    );
+    const { policy } = computeEffectivePolicy(
+      global,
+      [{ familiar: 'probe', markdown: override }],
+      TRUSTED,
+    );
+    assert.ok(
+      policy.subBudgets.probe! <= policy.ceilingUsd,
+      `requested ${requested} produced ${policy.subBudgets.probe}`,
+    );
+    assert.ok(policy.subBudgets.probe! >= 0);
+  }
+});
+
+test('arbitrary garbage never verifies', () => {
+  const inputs = ['', '?', '```bound```', '<!-- bound:sig v=1 alg=ed25519 key=k sig=z -->'];
+  for (const input of inputs) {
+    const result = verifyDocument(input, 'coven', TRUSTED);
+    assert.equal(result.ok, false);
+  }
+});

--- a/packages/bound/tsconfig.json
+++ b/packages/bound/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["es2023"],
+    "types": ["node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "bin/**/*.ts", "demo/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Problem

`RunItem::ToolResult` correlates to its originating call through `call_id`, but
the runner never enforced that `ToolCall.id` values are unique. A model that
reused an id produced a transcript where no consumer could pair a result with
the call that made it — the ambiguity was silent and unrecoverable after the
fact.

## Change

- Add `RunError::DuplicateToolCallId { agent, call_id }`.
- Track seen call ids for the whole run, seeded from any session history loaded
  at run start, so a duplicate cannot slip in across turns or across a resumed
  conversation.
- Screen the entire model response **before** executing any of its tools.
  Rejecting mid-batch would leave the side effects of earlier calls behind with
  no way to correlate them, so an ambiguous response now runs nothing at all.

## Tests

Three regression tests cover the duplicate arriving in one response, across
turns, and from loaded session history. The first asserts an execution counter
stays at zero, proving no tool ran, and that no `ToolCall` item reached the
transcript.

`bounded_runner_stops_repeated_tool_turns` reused a single id across turns
purely as a loop fixture; each turn now gets a distinct id so it keeps testing
turn bounding rather than the new check.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p coven-agents` — 19 integration + 1 unit test pass
- `cargo test --workspace --locked`
- `python3 scripts/check-secrets.py`, `python3 scripts/check-coven-privacy.py --staged`

Note: the workspace run surfaces a few flaky failures in `coven-daemon`
(`api::tests::handoff_claim_*`, `pty_runner::tests::*`) under parallel load.
They reproduce on the `22b1303` baseline with a *different* set of test names
and all pass in isolation, so they are pre-existing and unrelated to this leaf
crate.
