### PR TITLE
fix(agents): reject reused tool call ids

### DIFF
--- a/crates/coven-agents/README.md
+++ b/crates/coven-agents/README.md
@@ -19,6 +19,11 @@ the failure alongside the error, so a failing tool never costs the caller the
 items the run already produced. The runner does not append a failed run's items
 to the session; persisting them is the caller's decision.
 
+Tool call ids must be unique across a run, including call and result ids loaded
+from session history. Results correlate to calls by id, so the runner rejects a
+response that reuses one before running any tool in that response, with
+`RunError::DuplicateToolCallId`.
+
 The crate deliberately does not include an OpenAI client, a daemon command,
 MCP, sandbox execution, voice, or realtime transport. Those are adapters and
 application concerns. Keeping this crate as a workspace leaf also allows it to

--- a/crates/coven-agents/src/error.rs
+++ b/crates/coven-agents/src/error.rs
@@ -74,6 +74,8 @@ pub enum RunError {
     },
     #[error("agent `{agent}` requested unknown tool `{tool}`")]
     UnknownTool { agent: AgentId, tool: String },
+    #[error("agent `{agent}` reused tool call id `{call_id}`")]
+    DuplicateToolCallId { agent: AgentId, call_id: String },
     #[error("tool `{tool}` for agent `{agent}` failed")]
     ToolFailed {
         agent: AgentId,

--- a/crates/coven-agents/src/runner.rs
+++ b/crates/coven-agents/src/runner.rs
@@ -246,6 +246,14 @@ where
             }
             (None, _) => progress.items.clone(),
         };
+        let mut seen_call_ids: BTreeSet<String> = model_items
+            .iter()
+            .filter_map(|item| match item {
+                RunItem::ToolCall { call, .. } => Some(call.id.clone()),
+                RunItem::ToolResult { call_id, .. } => Some(call_id.clone()),
+                _ => None,
+            })
+            .collect();
 
         for turn in 1..=options.max_turns {
             progress.turns = turn;
@@ -453,6 +461,25 @@ where
                 });
                 current = target;
                 continue;
+            }
+
+            // Results correlate to calls by id, so reusing an id makes the
+            // transcript ambiguous. Screen the whole batch before executing
+            // any tool to avoid partial side effects from an invalid response.
+            for action in &response.actions {
+                let ModelAction::ToolCall(call) = action else {
+                    continue;
+                };
+                if !seen_call_ids.insert(call.id.clone()) {
+                    return Err(self.fail(
+                        &current.id,
+                        RunFailureKind::InvalidResponse,
+                        RunError::DuplicateToolCallId {
+                            agent: current.id.clone(),
+                            call_id: call.id.clone(),
+                        },
+                    ));
+                }
             }
 
             for action in response.actions {

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -808,6 +808,58 @@ async fn duplicate_tool_call_ids_in_one_response_execute_no_tools() {
 }
 
 #[tokio::test]
+async fn tool_call_id_reused_across_turns_executes_only_once() {
+    let repeated = || {
+        ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
+            "call-1",
+            "add",
+            json!({}),
+        ))])
+    };
+    let model = Arc::new(QueueModel::new([repeated(), repeated()]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(CountingCallTool {
+            calls: calls.clone(),
+        }));
+    let runner = Runner::new([agent]).unwrap();
+
+    let failure = runner
+        .run("worker", "Add twice.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(failure.turns, 2);
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        failure.new_items.len(),
+        3,
+        "only the first turn's unambiguous call and result are retained, got {:?}",
+        failure.new_items
+    );
+    assert_eq!(
+        failure
+            .new_items
+            .iter()
+            .filter(|item| matches!(item, RunItem::ToolCall { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        failure
+            .new_items
+            .iter()
+            .filter(|item| matches!(item, RunItem::ToolResult { .. }))
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn resumed_history_rejects_reused_tool_call_id() {
     let session = Arc::new(InMemorySession::default());
     session

--- a/crates/coven-agents/tests/runner.rs
+++ b/crates/coven-agents/tests/runner.rs
@@ -110,6 +110,30 @@ impl Tool<()> for CountingDefinitionTool {
     }
 }
 
+struct CountingCallTool {
+    calls: Arc<AtomicUsize>,
+}
+
+#[async_trait]
+impl Tool<()> for CountingCallTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition::new(
+            "add",
+            "Counts executions",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            }),
+        )
+    }
+
+    async fn execute(&self, _arguments: Value, _context: &()) -> Result<Value, BoxError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({ "ok": true }))
+    }
+}
+
 struct RejectInput;
 
 #[async_trait]
@@ -417,14 +441,17 @@ async fn rejected_output_is_not_appended_to_the_session() {
 
 #[tokio::test]
 async fn bounded_runner_stops_repeated_tool_turns() {
-    let repeated_call = || {
+    let repeated_call = |id: &str| {
         ModelResponse::actions(vec![ModelAction::ToolCall(ToolCall::new(
-            "call",
+            id,
             "add",
             json!({ "left": 1, "right": 1 }),
         ))])
     };
-    let model = Arc::new(QueueModel::new([repeated_call(), repeated_call()]));
+    let model = Arc::new(QueueModel::new([
+        repeated_call("call-1"),
+        repeated_call("call-2"),
+    ]));
     let agent = Agent::new("loop", "Loop", "Keep calling.", model).with_tool(Arc::new(AddTool));
     let runner = Runner::new([agent]).unwrap();
     let options = RunOptions {
@@ -725,4 +752,181 @@ async fn tool_failure_after_a_handoff_returns_the_whole_run_transcript() {
         &items[2],
         RunItem::ToolCall { agent, call } if agent.as_str() == "worker" && call.name == "explode"
     ));
+}
+
+#[tokio::test]
+async fn duplicate_tool_call_ids_in_one_response_execute_no_tools() {
+    let model = Arc::new(QueueModel::new([ModelResponse {
+        assistant_message: Some("Adding both.".to_owned()),
+        actions: vec![
+            ModelAction::ToolCall(ToolCall::new("call-1", "add", json!({}))),
+            ModelAction::ToolCall(ToolCall::new("call-1", "add", json!({}))),
+        ],
+    }]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(CountingCallTool {
+            calls: calls.clone(),
+        }));
+    let observer = Arc::new(RecordingObserver::default());
+    let runner = Runner::new([agent])
+        .unwrap()
+        .with_observer(observer.clone());
+
+    let failure = runner
+        .run("worker", "Add twice.", &(), RunOptions::default())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        failure.new_items.len(),
+        2,
+        "the user and assistant messages remain inspectable, got {:?}",
+        failure.new_items
+    );
+    assert!(matches!(
+        &failure.new_items[1],
+        RunItem::AssistantMessage { content, .. } if content == "Adding both."
+    ));
+    assert!(!failure
+        .new_items
+        .iter()
+        .any(|item| matches!(item, RunItem::ToolCall { .. })));
+    assert_paired_lifecycle(&observer.events());
+    assert!(observer.events().iter().any(|event| matches!(
+        event,
+        RunEvent::RunFailed {
+            kind: RunFailureKind::InvalidResponse,
+            ..
+        }
+    )));
+}
+
+#[tokio::test]
+async fn resumed_history_rejects_reused_tool_call_id() {
+    let session = Arc::new(InMemorySession::default());
+    session
+        .append(
+            "conversation-1",
+            &[RunItem::ToolCall {
+                agent: "worker".into(),
+                call: ToolCall::new("call-1", "add", json!({})),
+            }],
+        )
+        .await
+        .unwrap();
+    let model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::ToolCall(ToolCall::new("call-1", "add", json!({}))),
+    ])]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(CountingCallTool {
+            calls: calls.clone(),
+        }));
+    let runner = Runner::new([agent]).unwrap().with_session(session.clone());
+
+    let failure = runner
+        .run(
+            "worker",
+            "Add again.",
+            &(),
+            RunOptions {
+                session_id: Some("conversation-1".to_owned()),
+                ..RunOptions::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(session.items("conversation-1").await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn resumed_result_only_history_rejects_reused_tool_call_id() {
+    let session = Arc::new(InMemorySession::default());
+    session
+        .append(
+            "conversation-1",
+            &[RunItem::ToolResult {
+                agent: "worker".into(),
+                call_id: "call-1".to_owned(),
+                tool: "add".to_owned(),
+                output: json!({ "ok": true }),
+            }],
+        )
+        .await
+        .unwrap();
+    let model = Arc::new(QueueModel::new([ModelResponse::actions(vec![
+        ModelAction::ToolCall(ToolCall::new("call-1", "add", json!({}))),
+    ])]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(CountingCallTool {
+            calls: calls.clone(),
+        }));
+    let runner = Runner::new([agent]).unwrap().with_session(session.clone());
+
+    let failure = runner
+        .run(
+            "worker",
+            "Add again.",
+            &(),
+            RunOptions {
+                session_id: Some("conversation-1".to_owned()),
+                ..RunOptions::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        failure.error,
+        RunError::DuplicateToolCallId { ref call_id, .. } if call_id == "call-1"
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(session.items("conversation-1").await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn unique_tool_call_ids_preserve_tool_execution() {
+    let model = Arc::new(QueueModel::new([
+        ModelResponse::actions(vec![
+            ModelAction::ToolCall(ToolCall::new("call-1", "add", json!({}))),
+            ModelAction::ToolCall(ToolCall::new("call-2", "add", json!({}))),
+        ]),
+        ModelResponse::final_output("Done."),
+    ]));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let agent =
+        Agent::new("worker", "Worker", "Use tools.", model).with_tool(Arc::new(CountingCallTool {
+            calls: calls.clone(),
+        }));
+    let runner = Runner::new([agent]).unwrap();
+
+    let result = runner
+        .run("worker", "Add twice.", &(), RunOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(result.final_output, "Done.");
+    assert_eq!(result.turns, 2);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        result
+            .new_items
+            .iter()
+            .filter(|item| matches!(item, RunItem::ToolResult { .. }))
+            .count(),
+        2
+    );
 }

--- a/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
+++ b/docs/superpowers/specs/2026-08-14-coven-agents-rust-design.md
@@ -87,6 +87,12 @@ Configuration errors are detected before a run. Runtime errors preserve the
 agent, tool, guardrail stage, operation, and source error where applicable.
 Unknown model-requested tools or handoffs fail closed.
 
+Tool call ids must be unique across loaded session history and the current run.
+The seen-id set includes ids from both `ToolCall` and `ToolResult` items because
+results correlate to calls by id. The runner screens a complete model-action
+batch before executing any tool and rejects the whole batch if an id is reused,
+preventing ambiguous transcripts and partial side effects.
+
 Input guardrails are blocking by default. This is safer for a local tool runtime
 because rejected input cannot race with model calls or tool side effects.
 


### PR DESCRIPTION
## Problem

A model could reuse a `ToolCall.id`, producing an ambiguous persisted transcript where results could not be correlated reliably. The original PR #773 also mixed this fix with unrelated Bound work and did not seed IDs from result-only resumed history.

## Change

- reject duplicate tool-call IDs across a run before executing any tool in the ambiguous response batch
- seed seen IDs from both persisted `ToolCall.id` and `ToolResult.call_id` values
- preserve paired run lifecycle and partial-transcript behavior
- document the invariant in the crate README and Rust design
- add regressions for same-batch, cross-turn, ToolCall-history, and result-only-history reuse

This clean branch supersedes the duplicate-ID portion of #773. The unrelated Bound commits remain preserved on the old branch for `coven-v041-bound` and are intentionally excluded here.

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --locked` (117 passed)
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --range origin/main...HEAD`
- `git diff --check origin/main...HEAD`

## Review readiness

- scope: 5 coven-agents files only
- prior review addressed: resumed history seeds both tool calls and tool results
- spec compliance review: approved
- code quality review: approved
