### PR TITLE
fix: harden Unix daemon test fixtures

### DIFF
--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -5300,6 +5300,49 @@ mod tests {
 
     #[cfg(unix)]
     static DAEMON_TERMINATION_TEST_LOCK: Mutex<()> = Mutex::new(());
+    #[cfg(unix)]
+    const MIN_TEST_SOCKET_PATH_MARGIN: usize = 16;
+
+    #[cfg(unix)]
+    fn unix_socket_path_margin(path: &Path) -> usize {
+        let capacity = std::mem::size_of::<libc::sockaddr_un>()
+            - std::mem::offset_of!(libc::sockaddr_un, sun_path);
+        capacity.saturating_sub(path.as_os_str().as_bytes().len() + 1)
+    }
+
+    #[cfg(unix)]
+    fn read_bounded_test_request(stream: &mut UnixStream, deadline: Instant) -> Result<String> {
+        stream.set_nonblocking(false)?;
+        stream.set_read_timeout(Some(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .max(Duration::from_millis(1)),
+        ))?;
+        let mut request = String::new();
+        stream.read_to_string(&mut request)?;
+        Ok(request)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fixture_request_reader_waits_for_a_nonblocking_accepted_stream() -> Result<()> {
+        use std::net::Shutdown;
+
+        let (mut reader, mut writer) = UnixStream::pair()?;
+        reader.set_nonblocking(true)?;
+        let writer = std::thread::spawn(move || -> std::io::Result<()> {
+            std::thread::sleep(Duration::from_millis(25));
+            writer.write_all(b"GET /health HTTP/1.1\r\n\r\n")?;
+            writer.shutdown(Shutdown::Write)
+        });
+
+        let request =
+            read_bounded_test_request(&mut reader, Instant::now() + Duration::from_secs(1));
+        writer.join().expect("delayed request writer")?;
+
+        assert_eq!(request?, "GET /health HTTP/1.1\r\n\r\n");
+        Ok(())
+    }
 
     fn test_daemon_status_socket(coven_home: &Path) -> String {
         daemon_startup_status_socket(coven_home).expect("derive test daemon endpoint")
@@ -9429,7 +9472,7 @@ mod tests {
     #[test]
     fn authenticated_relative_status_is_rewritten_to_the_canonical_socket() -> Result<()> {
         use std::{
-            io::{Read, Write},
+            io::Write,
             os::unix::{fs::PermissionsExt, net::UnixListener},
             time::Instant,
         };
@@ -9453,19 +9496,34 @@ mod tests {
         }
 
         let current_dir = std::fs::canonicalize(std::env::current_dir()?)?;
-        let test_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .ancestors()
-            .nth(2)
-            .expect("workspace root")
-            .join("c");
-        std::fs::create_dir_all(&test_root)?;
         let temp_dir = tempfile::Builder::new()
-            .prefix("")
-            .rand_bytes(2)
-            .tempdir_in(&test_root)?;
-        let coven_home = temp_dir.path().to_path_buf();
+            .prefix("c")
+            .rand_bytes(6)
+            .tempdir()?;
+        let coven_home = std::fs::canonicalize(temp_dir.path())?;
         ensure_private_coven_home(&coven_home)?;
         let socket = daemon_socket_path(&coven_home);
+        assert_eq!(
+            coven_home,
+            std::fs::canonicalize(&coven_home)?,
+            "relative-status fixture must measure and advertise its canonical home"
+        );
+        let workspace = std::fs::canonicalize(
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(2)
+                .expect("workspace root"),
+        )?;
+        assert!(
+            !coven_home.starts_with(&workspace),
+            "relative-status fixture must not inherit checkout depth: {}",
+            coven_home.display()
+        );
+        assert!(
+            unix_socket_path_margin(&socket) >= MIN_TEST_SOCKET_PATH_MARGIN,
+            "relative-status fixture needs at least {MIN_TEST_SOCKET_PATH_MARGIN} bytes of SUN_LEN headroom: {}",
+            socket.display()
+        );
         let listener = UnixListener::bind(&socket)?;
         std::fs::set_permissions(&socket, std::fs::Permissions::from_mode(0o600))?;
         let relative_socket = relative_path(&current_dir, &std::fs::canonicalize(&socket)?)
@@ -9485,8 +9543,7 @@ mod tests {
             loop {
                 match listener.accept() {
                     Ok((mut stream, _)) => {
-                        let mut request = String::new();
-                        stream.read_to_string(&mut request)?;
+                        let request = read_bounded_test_request(&mut stream, deadline)?;
                         assert!(request.starts_with("GET /health HTTP/1.1\r\n"));
                         let body = serde_json::json!({
                             "ok": true,
@@ -9537,7 +9594,7 @@ mod tests {
     #[test]
     fn copied_profile_status_cannot_select_another_profiles_socket() -> Result<()> {
         use std::{
-            io::{Read, Write},
+            io::Write,
             os::unix::{fs::PermissionsExt, net::UnixListener},
             sync::{
                 atomic::{AtomicBool, Ordering},
@@ -9560,8 +9617,7 @@ mod tests {
                     match listener.accept() {
                         Ok((mut stream, _)) => {
                             contacted.store(true, Ordering::Release);
-                            let mut request = String::new();
-                            stream.read_to_string(&mut request)?;
+                            let _request = read_bounded_test_request(&mut stream, deadline)?;
                             let body = serde_json::json!({
                                 "ok": true,
                                 "apiVersion": crate::api::COVEN_API_NAMED_VERSION,

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -5577,9 +5577,10 @@ mod tests {
                 &self,
                 _coven_home: &Path,
                 _status: &DaemonStatus,
-                _deadline: LifecycleDeadline,
+                deadline: LifecycleDeadline,
             ) -> Result<VerifiedStopOutcome> {
-                std::thread::sleep(Duration::from_millis(25));
+                let remaining = deadline.remaining("forcing the test stop deadline to expire")?;
+                std::thread::sleep(remaining.saturating_add(Duration::from_millis(10)));
                 Ok(VerifiedStopOutcome::Exited)
             }
 
@@ -5611,7 +5612,7 @@ mod tests {
         let error = stop_background_server_with_controller_until(
             temp_dir.path(),
             &SlowVerifiedStop,
-            LifecycleDeadline::after(Duration::from_millis(10))?,
+            LifecycleDeadline::after(Duration::from_millis(100))?,
         )
         .expect_err("cleanup must not start after the original stop budget");
 

--- a/crates/coven-cli/src/daemon.rs
+++ b/crates/coven-cli/src/daemon.rs
@@ -9459,7 +9459,10 @@ mod tests {
             .expect("workspace root")
             .join("c");
         std::fs::create_dir_all(&test_root)?;
-        let temp_dir = tempfile::tempdir_in(&test_root)?;
+        let temp_dir = tempfile::Builder::new()
+            .prefix("")
+            .rand_bytes(2)
+            .tempdir_in(&test_root)?;
         let coven_home = temp_dir.path().to_path_buf();
         ensure_private_coven_home(&coven_home)?;
         let socket = daemon_socket_path(&coven_home);

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -2,6 +2,7 @@
 
 use std::{
     fs,
+    os::unix::ffi::OsStrExt,
     path::{Path, PathBuf},
     sync::atomic::{AtomicUsize, Ordering},
 };
@@ -13,6 +14,13 @@ use coven_client::{
 
 const HEALTH: &str = include_str!("../fixtures/health.json");
 const ERROR: &str = include_str!("../fixtures/error.json");
+const MIN_SOCKET_PATH_MARGIN: usize = 16;
+
+fn unix_socket_path_margin(path: &Path) -> usize {
+    let capacity = std::mem::size_of::<libc::sockaddr_un>()
+        - std::mem::offset_of!(libc::sockaddr_un, sun_path);
+    capacity.saturating_sub(path.as_os_str().as_bytes().len() + 1)
+}
 
 struct TestHome {
     path: PathBuf,
@@ -22,20 +30,20 @@ impl TestHome {
     fn new() -> Self {
         static NEXT: AtomicUsize = AtomicUsize::new(0);
 
-        let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .ancestors()
-            .nth(2)
-            .expect("workspace root");
-        let test_root = workspace.join("c");
-        fs::create_dir_all(&test_root).expect("create test root");
+        let test_root = std::env::temp_dir();
         let path = loop {
-            let candidate = test_root.join(format!("{:x}", NEXT.fetch_add(1, Ordering::Relaxed)));
+            let candidate = test_root.join(format!(
+                "c{:x}{:x}",
+                std::process::id(),
+                NEXT.fetch_add(1, Ordering::Relaxed)
+            ));
             match fs::create_dir(&candidate) {
                 Ok(()) => break candidate,
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
                 Err(error) => panic!("create test Coven home: {error}"),
             }
         };
+        let path = fs::canonicalize(path).expect("canonicalize test Coven home");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -49,8 +57,44 @@ impl TestHome {
 impl Drop for TestHome {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.path);
-        let _ = fs::remove_dir(self.path.parent().expect("test root"));
     }
+}
+
+#[test]
+fn dropping_test_home_keeps_the_shared_allocator_base() {
+    let home = TestHome::new();
+    let allocator_base = home.path.parent().expect("allocator base").to_path_buf();
+
+    drop(home);
+
+    assert!(
+        allocator_base.is_dir(),
+        "dropping one owned home must not remove the allocator base"
+    );
+}
+
+#[test]
+fn test_home_socket_path_is_checkout_independent_with_headroom() {
+    let workspace = fs::canonicalize(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .ancestors()
+            .nth(2)
+            .expect("workspace root"),
+    )
+    .expect("canonicalize workspace root");
+    let home = TestHome::new();
+    let socket = home.path.join("coven.sock");
+
+    assert!(
+        !home.path.starts_with(workspace),
+        "test home must not inherit checkout depth: {}",
+        home.path.display()
+    );
+    assert!(
+        unix_socket_path_margin(&socket) >= MIN_SOCKET_PATH_MARGIN,
+        "test socket needs at least {MIN_SOCKET_PATH_MARGIN} bytes of SUN_LEN headroom: {}",
+        socket.display()
+    );
 }
 
 #[cfg(unix)]

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -26,12 +26,16 @@ impl TestHome {
             .ancestors()
             .nth(2)
             .expect("workspace root");
-        let path = workspace.join("c").join(format!(
-            "{:x}{:x}",
-            std::process::id(),
-            NEXT.fetch_add(1, Ordering::Relaxed)
-        ));
-        fs::create_dir_all(&path).expect("create test Coven home");
+        let test_root = workspace.join("c");
+        fs::create_dir_all(&test_root).expect("create test root");
+        let path = loop {
+            let candidate = test_root.join(format!("{:x}", NEXT.fetch_add(1, Ordering::Relaxed)));
+            match fs::create_dir(&candidate) {
+                Ok(()) => break candidate,
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+                Err(error) => panic!("create test Coven home: {error}"),
+            }
+        };
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -1030,6 +1030,16 @@ fn symlinked_ancestor_parent_components_connect_to_the_validated_socket() {
                 }
                 match listener.accept() {
                     Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("configure blocking test stream");
+                        stream
+                            .set_read_timeout(Some(
+                                deadline
+                                    .saturating_duration_since(Instant::now())
+                                    .max(Duration::from_millis(1)),
+                            ))
+                            .expect("bound client request read");
                         let mut request = String::new();
                         stream
                             .read_to_string(&mut request)


### PR DESCRIPTION
## Summary
- allocate short canonical Unix fixture homes outside checkout-dependent paths
- bound reads from accepted fixture sockets so tests cannot hang on inherited nonblocking state
- make the lifecycle deadline fixture expire deterministically under scheduler pressure

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace --locked`
- [x] `python scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`