### PR TITLE
feat(client): reach the daemon's session page cursor

### DIFF
--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -98,6 +98,14 @@ pub(crate) struct ChatEventQuery<'a> {
 pub(crate) const EVENT_PAGE_LIMIT: i64 = 512;
 pub(crate) const EVENT_PAGES_PER_POLL: usize = 8;
 
+/// Sessions requested per `/sessions` round trip. Stays inside the daemon's
+/// 1000-row page ceiling so a page is one bounded response, not a guess.
+pub(crate) const SESSION_PAGE_LIMIT: u16 = 200;
+/// Ceiling on the overlay listing. The overlay renders from memory, so the
+/// listing stops paging here rather than following an unbounded ledger; the
+/// previous single request stopped at 100 without saying so.
+pub(crate) const MAX_LISTED_SESSIONS: usize = 2_000;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ChatEventPage {
     pub(crate) events: Vec<store::EventRecord>,
@@ -152,6 +160,41 @@ pub(crate) fn validated_event_page_cursor(
         anyhow::bail!("daemon event page claimed a continuation without advancing its cursor");
     }
     Ok(cursor)
+}
+
+/// Follow the daemon's `nextCursor` until the session listing is exhausted.
+///
+/// The daemon pages `/sessions` and the previous caller asked for one page of
+/// 100 and dropped the continuation, so a ledger with more sessions than that
+/// simply lost the remainder with no error and no marker. Paging stops at
+/// [`MAX_LISTED_SESSIONS`] because the overlay renders the whole result from
+/// memory.
+pub(crate) fn collect_session_pages<F>(mut fetch: F) -> Result<Vec<store::SessionRecord>>
+where
+    F: FnMut(Option<String>) -> Result<SessionPageResponse>,
+{
+    let mut sessions: Vec<store::SessionRecord> = Vec::new();
+    let mut cursor = None;
+    loop {
+        let page = fetch(cursor.clone())?;
+        let page_len = page.sessions.len();
+        sessions.extend(page.sessions);
+        let Some(next_cursor) = page.next_cursor else {
+            return Ok(sessions);
+        };
+        // A repeated cursor replays the same page forever, and a page that
+        // advertises a continuation without returning a row cannot advance
+        // one either. Both are daemon faults, not empty results.
+        if page_len == 0 || Some(&next_cursor) == cursor.as_ref() {
+            anyhow::bail!(
+                "daemon session page claimed a continuation without advancing its cursor"
+            );
+        }
+        if sessions.len() >= MAX_LISTED_SESSIONS {
+            return Ok(sessions);
+        }
+        cursor = Some(next_cursor);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -484,9 +527,13 @@ impl ChatClient for DaemonChatClient {
     }
 
     fn list_sessions(&mut self) -> Result<Vec<store::SessionRecord>> {
-        let page: SessionPageResponse =
-            self.get_json(ReadEndpoint::Sessions { limit: Some(100) })?;
-        Ok(page.sessions)
+        collect_session_pages(|cursor| {
+            self.get_json(ReadEndpoint::Sessions {
+                limit: Some(SESSION_PAGE_LIMIT),
+                cursor,
+                include_archived: false,
+            })
+        })
     }
 
     fn list_events(&mut self, query: ChatEventQuery<'_>) -> Result<Vec<store::EventRecord>> {
@@ -624,6 +671,110 @@ fn session_title(prompt: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The plain unpaginated listing, used by transport-level tests that care
+    /// about connection reuse rather than about the session page shape.
+    #[cfg(unix)]
+    fn unpaginated_sessions_read() -> ReadEndpoint {
+        ReadEndpoint::Sessions {
+            limit: None,
+            cursor: None,
+            include_archived: false,
+        }
+    }
+
+    fn test_session(id: &str) -> store::SessionRecord {
+        store::SessionRecord {
+            id: id.to_owned(),
+            project_root: "/repo".to_owned(),
+            harness: "codex".to_owned(),
+            title: "Listed".to_owned(),
+            status: "completed".to_owned(),
+            exit_code: Some(0),
+            archived_at: None,
+            created_at: "2026-08-16T00:00:00Z".to_owned(),
+            updated_at: "2026-08-16T00:00:00Z".to_owned(),
+            conversation_id: None,
+            familiar_id: None,
+            execution_binding: None,
+            labels: Vec::new(),
+            visibility: "private".to_owned(),
+            external: false,
+            transcript_path: None,
+        }
+    }
+
+    #[test]
+    fn session_listing_follows_every_daemon_page_cursor() {
+        let mut requested = Vec::new();
+        let sessions = collect_session_pages(|cursor| {
+            requested.push(cursor.clone());
+            Ok(match cursor.as_deref() {
+                None => SessionPageResponse {
+                    sessions: vec![test_session("a"), test_session("b")],
+                    next_cursor: Some("page-2".to_owned()),
+                },
+                Some("page-2") => SessionPageResponse {
+                    sessions: vec![test_session("c")],
+                    next_cursor: None,
+                },
+                other => panic!("unexpected cursor {other:?}"),
+            })
+        })
+        .expect("continuation is followed to exhaustion");
+
+        assert_eq!(requested, vec![None, Some("page-2".to_owned())]);
+        assert_eq!(
+            sessions.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn session_listing_stops_at_the_in_memory_ceiling() {
+        let mut pages = 0_usize;
+        let sessions = collect_session_pages(|_| {
+            pages += 1;
+            Ok(SessionPageResponse {
+                sessions: (0..usize::from(SESSION_PAGE_LIMIT))
+                    .map(|index| test_session(&format!("session-{pages}-{index}")))
+                    .collect(),
+                next_cursor: Some(format!("page-{pages}")),
+            })
+        })
+        .expect("an endless ledger is truncated rather than followed forever");
+
+        assert_eq!(sessions.len(), MAX_LISTED_SESSIONS);
+        assert_eq!(pages, MAX_LISTED_SESSIONS / usize::from(SESSION_PAGE_LIMIT));
+    }
+
+    #[test]
+    fn session_listing_rejects_a_continuation_that_cannot_advance() {
+        let repeated = collect_session_pages(|_| {
+            Ok(SessionPageResponse {
+                sessions: vec![test_session("a")],
+                next_cursor: Some("stuck".to_owned()),
+            })
+        });
+        let empty = collect_session_pages(|_| {
+            Ok(SessionPageResponse {
+                sessions: Vec::new(),
+                next_cursor: Some("page-2".to_owned()),
+            })
+        });
+
+        for error in [
+            repeated.expect_err("a repeated cursor must not replay forever"),
+            empty.expect_err("an empty page cannot carry a continuation"),
+        ] {
+            assert!(
+                error
+                    .to_string()
+                    .contains("claimed a continuation without advancing"),
+                "unexpected error: {error}"
+            );
+        }
+    }
 
     #[test]
     fn event_page_continuation_must_advance_before_another_request() {
@@ -802,7 +953,7 @@ mod tests {
             daemon_client: Some(cached),
             daemon_identity: Some(old_status),
         };
-        let response: Value = client.get_json(ReadEndpoint::Sessions { limit: None })?;
+        let response: Value = client.get_json(unpaginated_sessions_read())?;
 
         assert_eq!(response["source"], "stable");
         assert_eq!(
@@ -996,7 +1147,7 @@ mod tests {
             daemon_client: Some(cached),
             daemon_identity: Some(status),
         };
-        let response: Value = client.get_json(ReadEndpoint::Sessions { limit: None })?;
+        let response: Value = client.get_json(unpaginated_sessions_read())?;
 
         assert_eq!(response["source"], "replacement");
         assert_eq!(
@@ -1073,7 +1224,7 @@ mod tests {
             daemon_client: Some(cached),
             daemon_identity: Some(status),
         };
-        let response = client.get_json::<Value>(ReadEndpoint::Sessions { limit: None });
+        let response = client.get_json::<Value>(unpaginated_sessions_read());
         let (empty_checks, paths) = replacement_server.join().unwrap();
 
         assert_eq!(response?["source"], "replacement");
@@ -1137,7 +1288,7 @@ mod tests {
         };
 
         let error = client
-            .get_json::<Value>(ReadEndpoint::Sessions { limit: None })
+            .get_json::<Value>(unpaginated_sessions_read())
             .expect_err("unchanged incapable daemon must remain unavailable");
         let requests = server.join().unwrap();
 

--- a/crates/coven-cli/src/tui/chat/client.rs
+++ b/crates/coven-cli/src/tui/chat/client.rs
@@ -162,7 +162,7 @@ pub(crate) fn validated_event_page_cursor(
     Ok(cursor)
 }
 
-/// Follow the daemon's `nextCursor` until the session listing is exhausted.
+/// Follow the daemon's `next_cursor` until the session listing is exhausted.
 ///
 /// The daemon pages `/sessions` and the previous caller asked for one page of
 /// 100 and dropped the continuation, so a ledger with more sessions than that

--- a/crates/coven-client/src/http.rs
+++ b/crates/coven-client/src/http.rs
@@ -232,10 +232,27 @@ fn read_path(endpoint: &ReadEndpoint) -> Result<String, ClientError> {
             }
             Ok(format!("/api/v1/sessions/{session_id}"))
         }
-        ReadEndpoint::Sessions { limit } => Ok(limit.map_or_else(
-            || "/api/v1/sessions".to_owned(),
-            |limit| format!("/api/v1/sessions?limit={limit}"),
-        )),
+        ReadEndpoint::Sessions {
+            limit,
+            cursor,
+            include_archived,
+        } => {
+            let mut path = "/api/v1/sessions".to_owned();
+            let mut separator = '?';
+            if let Some(limit) = limit {
+                path.push_str(&format!("{separator}limit={limit}"));
+                separator = '&';
+            }
+            if let Some(cursor) = cursor {
+                validate_session_page_cursor(cursor)?;
+                path.push_str(&format!("{separator}cursor={cursor}"));
+                separator = '&';
+            }
+            if *include_archived {
+                path.push_str(&format!("{separator}includeArchived=true"));
+            }
+            Ok(path)
+        }
         ReadEndpoint::Events {
             session_id,
             after_seq,
@@ -280,6 +297,25 @@ fn validate_session_path_remainder(value: &str) -> Result<(), ClientError> {
     validate_session_request_target_data(value)?;
     if value.contains('?') {
         return Err(ClientError::InvalidRouteParameter("session id"));
+    }
+    Ok(())
+}
+
+/// Reject anything that is not the daemon's own session page cursor.
+///
+/// The daemon issues URL-safe base64 without padding, so a well-formed cursor
+/// is already representable verbatim in the inherited raw `v1` query. Checking
+/// the alphabet keeps a corrupted or hand-composed value from smuggling `&`,
+/// `#`, or whitespace into the request target.
+fn validate_session_page_cursor(value: &str) -> Result<(), ClientError> {
+    if value.is_empty()
+        || !value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        return Err(ClientError::InvalidRouteParameter(
+            "session page cursor is not the daemon's URL-safe base64 cursor",
+        ));
     }
     Ok(())
 }
@@ -337,6 +373,78 @@ mod tests {
                 })
                 .expect("contract-valid external session id"),
                 format!("/api/v1/sessions/{raw}/input")
+            );
+        }
+    }
+
+    #[test]
+    fn session_listing_selects_the_inherited_shape_it_is_asked_for() {
+        let cases = [
+            (None, None, false, "/api/v1/sessions"),
+            (Some(50), None, false, "/api/v1/sessions?limit=50"),
+            (
+                None,
+                Some("Y3Vyc29y"),
+                false,
+                "/api/v1/sessions?cursor=Y3Vyc29y",
+            ),
+            (None, None, true, "/api/v1/sessions?includeArchived=true"),
+            (
+                Some(50),
+                Some("Y3Vyc29y"),
+                true,
+                "/api/v1/sessions?limit=50&cursor=Y3Vyc29y&includeArchived=true",
+            ),
+            (
+                None,
+                Some("Y3Vyc29y"),
+                true,
+                "/api/v1/sessions?cursor=Y3Vyc29y&includeArchived=true",
+            ),
+            (
+                Some(50),
+                None,
+                true,
+                "/api/v1/sessions?limit=50&includeArchived=true",
+            ),
+        ];
+
+        for (limit, cursor, include_archived, expected) in cases {
+            assert_eq!(
+                read_path(&ReadEndpoint::Sessions {
+                    limit,
+                    cursor: cursor.map(str::to_owned),
+                    include_archived,
+                })
+                .expect("contract-valid session listing"),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn session_listing_rejects_a_cursor_outside_the_daemon_alphabet() {
+        for cursor in [
+            "",
+            "cursor value",
+            "cursor&limit=999",
+            "cursor#fragment",
+            "cursor?other=route",
+            "Y3Vyc29y=",
+            "cursor/slash",
+            "cursor+plus",
+            "cursor\nnewline",
+        ] {
+            let error = read_path(&ReadEndpoint::Sessions {
+                limit: None,
+                cursor: Some(cursor.to_owned()),
+                include_archived: false,
+            })
+            .expect_err("unsafe session page cursor was accepted");
+
+            assert!(
+                matches!(error, ClientError::InvalidRouteParameter(_)),
+                "unexpected error for {cursor:?}: {error}"
             );
         }
     }

--- a/crates/coven-client/src/models.rs
+++ b/crates/coven-client/src/models.rs
@@ -31,8 +31,24 @@ pub enum ReadEndpoint {
     Session {
         session_id: String,
     },
+    /// Session listing.
+    ///
+    /// The inherited `v1` route serves two response shapes and the query
+    /// selects between them: with no parameter at all the daemon returns the
+    /// unpaginated `SessionRecord[]`, and any one of `limit`, `cursor`, or
+    /// `includeArchived` switches it to the `{ sessions, nextCursor }`
+    /// envelope. Callers that decode the envelope must therefore set at least
+    /// one of the three, exactly as they already had to for `limit` alone.
     Sessions {
         limit: Option<u16>,
+        /// Opaque page cursor echoed back from a previous page's
+        /// `nextCursor`. It is never composed locally: a caller can only send
+        /// a cursor the daemon just issued, so an older daemon that never
+        /// issues one is never asked to honor one.
+        cursor: Option<String>,
+        /// Include archived sessions. `false` keeps the daemon's default
+        /// `archived_at IS NULL` filter and is not sent on the wire.
+        include_archived: bool,
     },
     Events {
         session_id: String,

--- a/crates/coven-client/src/models.rs
+++ b/crates/coven-client/src/models.rs
@@ -34,15 +34,17 @@ pub enum ReadEndpoint {
     /// Session listing.
     ///
     /// The inherited `v1` route serves two response shapes and the query
-    /// selects between them: with no parameter at all the daemon returns the
-    /// unpaginated `SessionRecord[]`, and any one of `limit`, `cursor`, or
-    /// `includeArchived` switches it to the `{ sessions, nextCursor }`
-    /// envelope. Callers that decode the envelope must therefore set at least
-    /// one of the three, exactly as they already had to for `limit` alone.
+    /// selects between them: the daemon inspects only `limit`, `cursor`, and
+    /// `includeArchived`, and any one of the three switches it to the
+    /// `{ sessions, next_cursor }` envelope, while a query carrying none of
+    /// them returns the unpaginated `SessionRecord[]`. Callers that decode the
+    /// envelope must therefore set at least one of the three, exactly as they
+    /// already had to for `limit` alone. Note the envelope key is snake_case,
+    /// unlike the event envelope's camelCase `nextCursor`.
     Sessions {
         limit: Option<u16>,
         /// Opaque page cursor echoed back from a previous page's
-        /// `nextCursor`. It is never composed locally: a caller can only send
+        /// `next_cursor`. It is never composed locally: a caller can only send
         /// a cursor the daemon just issued, so an older daemon that never
         /// issues one is never asked to honor one.
         cursor: Option<String>,

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -460,7 +460,7 @@ fn a_session_page_read_sends_the_daemon_cursor_and_archive_filter() {
             (
                 "/api/v1/sessions?limit=2&cursor=Y3Vyc29y&includeArchived=true".to_owned(),
                 200,
-                r#"{"sessions":[],"nextCursor":null}"#.to_owned(),
+                r#"{"sessions":[],"next_cursor":null}"#.to_owned(),
             ),
         ],
     );
@@ -477,7 +477,15 @@ fn a_session_page_read_sends_the_daemon_cursor_and_archive_filter() {
         .expect("the paginated envelope is reachable from the typed client");
 
     assert_eq!(page["sessions"], serde_json::json!([]));
-    assert_eq!(page["nextCursor"], serde_json::Value::Null);
+    // `get` rather than `[]`: indexing a missing key also yields `Null`, so an
+    // `assert_eq!(page["next_cursor"], Null)` would pass against a body that
+    // spelled the continuation key any other way — including the camelCase
+    // `nextCursor` of the event envelope, which this route does not emit.
+    assert_eq!(
+        page.get("next_cursor"),
+        Some(&serde_json::Value::Null),
+        "the daemon's snake_case continuation key must survive the typed read"
+    );
     server.join().expect("server thread");
 }
 

--- a/crates/coven-client/tests/health.rs
+++ b/crates/coven-client/tests/health.rs
@@ -180,6 +180,16 @@ fn health_with_capabilities(capabilities: serde_json::Value) -> String {
     health.to_string()
 }
 
+/// The listing with no query at all, which the inherited route answers with
+/// the unpaginated `SessionRecord[]`.
+fn unpaginated_sessions_read() -> ReadEndpoint {
+    ReadEndpoint::Sessions {
+        limit: None,
+        cursor: None,
+        include_archived: false,
+    }
+}
+
 #[test]
 fn lifecycle_client_rejects_non_utf8_home_before_creating_daemon_artifacts() {
     use std::{ffi::OsString, os::unix::ffi::OsStringExt, time::Duration};
@@ -371,7 +381,7 @@ fn missing_sessions_capability_blocks_sessions_but_not_events() {
 
     client.health().expect("health remains a valid v1 response");
     let error = client
-        .get_json::<serde_json::Value>(coven_client::ReadEndpoint::Sessions { limit: None })
+        .get_json::<serde_json::Value>(unpaginated_sessions_read())
         .expect_err("sessions must be blocked before request transmission");
     assert!(
         error.to_string().contains("capabilities.sessions"),
@@ -427,9 +437,74 @@ fn missing_events_capability_blocks_events_but_not_sessions() {
     );
 
     let sessions: serde_json::Value = client
-        .get_json(coven_client::ReadEndpoint::Sessions { limit: None })
+        .get_json(unpaginated_sessions_read())
         .expect("unrelated supported sessions remain usable");
     assert_eq!(sessions["sessions"], serde_json::json!([]));
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn a_session_page_read_sends_the_daemon_cursor_and_archive_filter() {
+    let home = TestHome::new();
+    let health = health_with_capabilities(serde_json::json!({
+        "sessions": true,
+        "events": true,
+        "eventCursor": "sequence",
+        "structuredErrors": true
+    }));
+    let server = serve_responses(
+        &home.path,
+        vec![
+            ("/api/v1/health".to_owned(), 200, health),
+            (
+                "/api/v1/sessions?limit=2&cursor=Y3Vyc29y&includeArchived=true".to_owned(),
+                200,
+                r#"{"sessions":[],"nextCursor":null}"#.to_owned(),
+            ),
+        ],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client.health().expect("health remains a valid v1 response");
+    let page: serde_json::Value = client
+        .get_json(ReadEndpoint::Sessions {
+            limit: Some(2),
+            cursor: Some("Y3Vyc29y".to_owned()),
+            include_archived: true,
+        })
+        .expect("the paginated envelope is reachable from the typed client");
+
+    assert_eq!(page["sessions"], serde_json::json!([]));
+    assert_eq!(page["nextCursor"], serde_json::Value::Null);
+    server.join().expect("server thread");
+}
+
+#[cfg(unix)]
+#[test]
+fn a_session_page_cursor_outside_the_daemon_alphabet_is_never_sent() {
+    let home = TestHome::new();
+    let server = serve_responses(
+        &home.path,
+        vec![("/api/v1/health".to_owned(), 200, HEALTH.to_string())],
+    );
+    let endpoint = DaemonEndpoint::discover(&home.path).expect("discover owner-local socket");
+    let mut client = DaemonClient::new(endpoint);
+
+    client.health().expect("health remains a valid v1 response");
+    let error = client
+        .get_json::<serde_json::Value>(ReadEndpoint::Sessions {
+            limit: None,
+            cursor: Some("cursor&limit=999".to_owned()),
+            include_archived: false,
+        })
+        .expect_err("a forged cursor must be rejected before request transmission");
+
+    assert!(
+        matches!(error, ClientError::InvalidRouteParameter(_)),
+        "unexpected error: {error}"
+    );
     server.join().expect("server thread");
 }
 
@@ -755,7 +830,7 @@ fn a_disappeared_cached_socket_preserves_the_connect_error_contract() {
     fs::remove_file(home.path.join("coven.sock")).expect("remove original daemon endpoint");
 
     let error = client
-        .get_json::<serde_json::Value>(ReadEndpoint::Sessions { limit: None })
+        .get_json::<serde_json::Value>(unpaginated_sessions_read())
         .expect_err("a disappeared endpoint must fail before request bytes");
 
     assert!(matches!(

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -632,17 +632,19 @@ External `running` sessions are not daemon-control targets: `POST /api/v1/sessio
 ## Session list pagination (`v1`)
 
 `GET /api/v1/sessions` serves two response shapes and the query selects between
-them. With no query parameter at all it returns the inherited unpaginated
-`SessionRecord[]`. Any one of `limit`, `cursor`, or `includeArchived` switches
-it to the paginated envelope below. Sessions are ordered newest first by
-`created_at`, then by `id` descending as the tiebreak.
+them. The daemon inspects only `limit`, `cursor`, and `includeArchived`: any one
+of the three switches it to the paginated envelope below, and when none of them
+is present it returns the inherited unpaginated `SessionRecord[]` — so an empty
+query and a query carrying only unrelated parameters both yield the array.
+Sessions are ordered newest first by `created_at`, then by `id` descending as
+the tiebreak.
 
 ### Query parameters
 
 | Parameter        | Required | Description                                                        |
 |------------------|----------|--------------------------------------------------------------------|
 | `limit`          | No       | Sessions per page, 1–1000. Defaults to 100 when the envelope is selected by another parameter. |
-| `cursor`         | No       | Opaque continuation from a previous page's `nextCursor`.           |
+| `cursor`         | No       | Opaque continuation from a previous page's `next_cursor`.          |
 | `includeArchived`| No       | `true` or `false`. Defaults to `false`, which keeps the `archived_at IS NULL` filter. |
 
 An out-of-range `limit`, a non-boolean `includeArchived`, or a cursor the daemon
@@ -656,13 +658,19 @@ cannot decode is a `400 invalid_request`.
     { "id": "session-2", "created_at": "2026-05-09T06:43:00Z" },
     { "id": "session-1", "created_at": "2026-05-09T06:42:00Z" }
   ],
-  "nextCursor": "<opaque page cursor>"
+  "next_cursor": "<opaque page cursor>"
 }
 ```
 
 `sessions` carries full [session records](#session-record-shape-v1); the sample
-above elides their fields. `nextCursor` is `null` on the last page, so a client
-pages until it is absent rather than until a page comes back short.
+above elides their fields. `next_cursor` is `null` on the last page, so a client
+pages until it is `null` rather than until a page comes back short.
+
+Note the key is snake_case, matching the [session record
+shape](#session-record-shape-v1) rather than the camelCase `nextCursor` of the
+[event envelope](#event-record-shape-and-cursor-pagination-v1). A client that
+reads `nextCursor` here decodes nothing, cannot tell that from a genuine last
+page, and silently truncates at the first page.
 
 The cursor is URL-safe base64 without padding, so it is safe to place in a
 query string verbatim, and it is opaque: it encodes the last row's sort key,

--- a/docs/API-CONTRACT.md
+++ b/docs/API-CONTRACT.md
@@ -80,6 +80,14 @@ collide with inherited nested route suffixes (`/handoffs`, `/log`, `/events`,
 or `/artifacts/`) are not exposed by that typed operation. These are inherited
 `v1` routing limitations, not a new id grammar.
 
+The typed session listing carries `limit`, the opaque page `cursor`, and
+`includeArchived`, mirroring the query the daemon already serves (see
+[Session list pagination (`v1`)](#session-list-pagination-v1)). It rejects a
+cursor outside the daemon's URL-safe base64 alphabet before sending, so a
+corrupted or hand-composed value cannot smuggle a separator into the request
+target. Setting none of the three requests the inherited unpaginated array;
+setting any of them requests the envelope.
+
 ## `GET /api/v1/health`
 
 `GET /api/v1/health` returns daemon reachability, the named contract version, coven version, and machine-readable capabilities:
@@ -567,7 +575,8 @@ In `v1`, session responses stay as raw JSON objects using the Rust daemon's snak
 
 Endpoints that return this shape:
 
-- `GET /api/v1/sessions` → `SessionRecord[]`
+- `GET /api/v1/sessions` → `SessionRecord[]` or the paginated envelope, see
+  [Session list pagination (`v1`)](#session-list-pagination-v1)
 - `POST /api/v1/sessions` → `SessionRecord`
 - `POST /api/v1/adopted-sessions` → `SessionRecord`
 - `GET /api/v1/sessions/:id` → `SessionRecord`
@@ -619,6 +628,49 @@ Classify the row kind before interpreting `status`. Synthetic `active` rows can 
 Archive is not a session status. It is stored separately in `archived_at`; archive and summon preserve the existing lifecycle status of every non-running session, including `created` and `idle`.
 
 External `running` sessions are not daemon-control targets: `POST /api/v1/sessions/:id/input` returns `409 session_not_live` because Coven has no owned live runtime, and `POST /api/v1/sessions/:id/kill` returns `422 external_session_not_killable` as documented below.
+
+## Session list pagination (`v1`)
+
+`GET /api/v1/sessions` serves two response shapes and the query selects between
+them. With no query parameter at all it returns the inherited unpaginated
+`SessionRecord[]`. Any one of `limit`, `cursor`, or `includeArchived` switches
+it to the paginated envelope below. Sessions are ordered newest first by
+`created_at`, then by `id` descending as the tiebreak.
+
+### Query parameters
+
+| Parameter        | Required | Description                                                        |
+|------------------|----------|--------------------------------------------------------------------|
+| `limit`          | No       | Sessions per page, 1–1000. Defaults to 100 when the envelope is selected by another parameter. |
+| `cursor`         | No       | Opaque continuation from a previous page's `nextCursor`.           |
+| `includeArchived`| No       | `true` or `false`. Defaults to `false`, which keeps the `archived_at IS NULL` filter. |
+
+An out-of-range `limit`, a non-boolean `includeArchived`, or a cursor the daemon
+cannot decode is a `400 invalid_request`.
+
+### Response envelope
+
+```json
+{
+  "sessions": [
+    { "id": "session-2", "created_at": "2026-05-09T06:43:00Z" },
+    { "id": "session-1", "created_at": "2026-05-09T06:42:00Z" }
+  ],
+  "nextCursor": "<opaque page cursor>"
+}
+```
+
+`sessions` carries full [session records](#session-record-shape-v1); the sample
+above elides their fields. `nextCursor` is `null` on the last page, so a client
+pages until it is absent rather than until a page comes back short.
+
+The cursor is URL-safe base64 without padding, so it is safe to place in a
+query string verbatim, and it is opaque: it encodes the last row's sort key,
+which keeps it stable while rows are inserted ahead of it. Clients must not compose one —
+only echo back what the daemon issued. A daemon old enough to predate this
+envelope answers a `limit` or `cursor` query with the plain array instead, so a
+client that decodes the envelope should treat that as a version mismatch rather
+than an empty page.
 
 ## `POST /api/v1/sessions/external`
 


### PR DESCRIPTION
## Audit first: what the session/event read surface already is

Cave's Chat v1 Phase 2 (`cave-g9d49`, OpenCoven/coven-cave#4835) needs three
canonical reads: list sessions, read one session, and read that session's
events with stable pagination. This started as an audit of whether #760 left
any of them missing. It did not leave much:

**Daemon (`crates/coven-cli/src/api.rs`) — complete.**

| Read | Route | Handler |
|---|---|---|
| List sessions | `GET /api/v1/sessions` | `list_sessions_response`, `api.rs:4291` |
| One session | `GET /api/v1/sessions/:id` | route arm, `api.rs:962` |
| Events | `GET /api/v1/events?sessionId=…` and `GET /api/v1/sessions/:id/events` | `list_session_events`, `api.rs:4557` |

Session paging is real (`store::list_session_page`, `store.rs:2728`): keyset
ordering on `created_at, id` with an opaque URL-safe base64 cursor
(`store.rs:2790`), a 1–1000 `limit`, and `includeArchived`. Event paging is
real too, with a byte-bounded page builder and `nextCursor.afterSeq` /
`hasMore` (`api.rs:4633`).

**Typed client (`crates/coven-client`) — one gap.** `ReadEndpoint` covered
`Session`, `Sessions { limit }`, and `Events { after_seq, limit }`
(`models.rs:29`). Sessions could not express `cursor` or `includeArchived`, so
no `coven-client` caller could ask for a second page. The one in-tree consumer
requested 100 and threw `nextCursor` away
(`tui/chat/client.rs:486`), so a ledger past 100 sessions silently lost the
remainder from the chat overlay.

The v0.4.1 release program (#780) does not schedule this; its `coven-v041-cave`
task is daemon socket/timeout hardening, unrelated.

## What this changes

- `ReadEndpoint::Sessions` carries `cursor` and `include_archived` beside
  `limit`. Setting none of the three still requests the inherited unpaginated
  array, so existing callers are unchanged.
- No capability flag gates the cursor, and deliberately so: a caller can only
  send a cursor the daemon itself just issued, so it is self-gating in a way
  `afterSeq` is not. The client does validate it against the daemon's own
  base64 alphabet before it reaches the request target, so a corrupted or
  hand-composed value cannot smuggle a separator into the inherited raw v1
  query.
- `collect_session_pages` follows `nextCursor` to exhaustion, mirroring the
  existing `consume_event_pages`. It refuses a repeated cursor and a
  continuation on an empty page rather than replaying one forever, and stops at
  a stated ceiling instead of an unstated 100.
- `docs/API-CONTRACT.md` documented this route as `SessionRecord[]` and nothing
  else — the envelope, the query, and the cursor were entirely undocumented. Now
  both shapes are described.

## Known and deliberately out of scope

`afterEventId` is served by the daemon (`api.rs:4572`) and documented as a
compatibility cursor, but `ReadEndpoint::Events` still cannot express it.
`afterSeq` covers Phase 2, and adding the field would churn every `Events`
call site for no current caller.

## Validation

| Check | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p coven-client -p coven-cli --all-targets` | no new findings; nothing on the changed files |
| `cargo test -p coven-client --lib` (Windows) | 64 passed, incl. 2 new path/cursor tests |
| `cargo test -p coven-client --test health` (Linux) | 40 passed, incl. 2 new integration tests |
| `cargo test -p coven-cli --bin coven -- tui::chat::client` | 10 passed, incl. 3 new paging tests |
| `cargo test -p coven-cli --bin coven -- api::tests::` | 363 passed |
| `cargo test -p coven-cli --bin coven` (full) | 2098 passed / 16 failed |

The 16 failures are pre-existing Windows-environment failures, not regressions:
the same modules fail identically on unmodified `origin/main` (`afs::tests`
symlink creation needs a privilege this host does not hold, `daemon::tests`
named-pipe ACL, `maintenance_gate::tests`, `pty_runner::tests`), and the count
varies run to run on the PTY cases. None touch the changed files. The
`coven-client` unix tests are `#![cfg(unix)]` and were compiled and run under
WSL, which is what caught three call sites Windows could not see.

Refs OpenCoven/coven-cave#4835
