### PR TITLE
feat(relay): add admission-controlled bounded mobile rendezvous

### DIFF
--- a/crates/coven-relay/README.md
+++ b/crates/coven-relay/README.md
@@ -1,9 +1,45 @@
 # coven-relay
 
-Stateless WebSocket relay for Hexes — bridges the Coven gateway running on a Mac to iOS Hexes clients.
+`coven-relay` is a bounded, ephemeral WebSocket rendezvous service for OpenCoven devices. It allows a Coven/Psyche host and a mobile client to meet through outbound connections when direct networking is unavailable.
 
-See `docs/specs/2026-05-31-hexes-implementation-plan.md` Track 2 for the full
-implementation roadmap.
+The relay is **not** an OpenCoven identity or authorization authority. It forwards opaque binary frames only. Endpoint authentication, device grants, transcript verification, and application encryption remain end to end between the host and client.
+
+## Protocol v1
+
+Connect to:
+
+```text
+/ws?v=1&room=<ROOM_ID>&role=<host|client>
+Authorization: Bearer <ROOM_CREDENTIAL>
+```
+
+`ROOM_ID` and `ROOM_CREDENTIAL` are separate canonical base64url encodings of 32 random bytes. They are short-lived rendezvous material, not durable device credentials.
+
+The first peer creates an in-memory room. Exactly one `host` and one `client` may occupy that room at a time, and both must present the same credential. Once connected:
+
+- only binary application messages are forwarded;
+- text frames are rejected;
+- ping/pong remains transport-local;
+- no offline buffering or message persistence occurs;
+- bounded channels apply backpressure instead of allowing unbounded memory growth;
+- a peer disconnect closes the remaining peer;
+- idle connections expire;
+- the room is destroyed after both peers disconnect.
+
+Knowing a relay room and credential only permits rendezvous. The tunneled OpenCoven protocol must still authenticate both endpoints and enforce the current device grant.
+
+## Limits
+
+The current server bounds:
+
+- active rooms: 1,024;
+- peers per room: one host and one client;
+- WebSocket message size: 4 MiB;
+- WebSocket frame size: 64 KiB;
+- queued live frames per peer: 32;
+- idle lifetime: 120 seconds.
+
+These defaults are deliberately conservative and may become explicit deployment configuration after production measurements. The relay never logs room credentials or application frames.
 
 ## Running locally
 
@@ -13,15 +49,19 @@ cargo run -p coven-relay
 LISTEN_ADDR=127.0.0.1:9000 cargo run -p coven-relay
 ```
 
-Health check: `curl http://localhost:8080/healthz`
+Health check:
 
-## Deploy
+```sh
+curl http://localhost:8080/healthz
+```
 
-Deployed on Fly.io (`personal` org, region `ord`, hostname `relay.opencoven.dev`).
+## Deployment
+
+The existing Fly.io deployment configuration lives in `deploy/`.
 
 ```sh
 cd crates/coven-relay/deploy
 fly deploy
 ```
 
-Requires `FLY_API_TOKEN` in the environment (or `fly auth login`).
+A production rollout should remain gated until host/mobile clients tunnel the authenticated OpenCoven connection over this broker and integration tests prove that relay compromise cannot read or forge application traffic.

--- a/crates/coven-relay/src/main.rs
+++ b/crates/coven-relay/src/main.rs
@@ -1,11 +1,11 @@
-//! coven-relay — stateless WebSocket relay for Hexes.
+//! coven-relay — bounded opaque WebSocket rendezvous for OpenCoven devices.
 //!
-//! Phase 2A scaffold: minimal Axum WS server with a health endpoint.
-//! Auth + peer routing (2B), offline buffering + APNs (2C), and avatar
-//! serving (2D) are added in subsequent phases.
+//! The relay is deliberately not an OpenCoven authority. It matches two peers
+//! that know the same high-entropy room and token, then forwards binary frames.
+//! Endpoint authentication, grants, and application encryption stay end to end.
 
 use anyhow::Result;
-use axum::{response::IntoResponse, routing::get, Router};
+use axum::{response::IntoResponse, routing::any, routing::get, Router};
 use std::net::SocketAddr;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
@@ -24,9 +24,11 @@ async fn main() -> Result<()> {
         .unwrap_or_else(|_| "0.0.0.0:8080".into())
         .parse()?;
 
+    let relay = ws::RelayState::default();
     let app = Router::new()
         .route("/healthz", get(healthz))
-        .route("/ws", get(ws::handler));
+        .route("/ws", any(ws::handler))
+        .with_state(relay);
 
     info!("coven-relay listening on {addr}");
     let listener = tokio::net::TcpListener::bind(addr).await?;

--- a/crates/coven-relay/src/ws.rs
+++ b/crates/coven-relay/src/ws.rs
@@ -1,14 +1,443 @@
-//! WebSocket handler — Phase 2A stub.
+//! Bounded opaque WebSocket rendezvous.
 //!
-//! Right now this accepts the upgrade and immediately closes. Auth + peer
-//! routing land in Phase 2B.
+//! A room is addressed by a canonical 32-byte base64url identifier and guarded
+//! by a separate canonical 32-byte bearer credential. The first peer creates
+//! the ephemeral room; one `host` and one `client` may be connected at a time.
+//! Only binary application frames are forwarded. The relay does not persist or
+//! interpret them and is not an authentication or authorization authority.
 
-use axum::{extract::WebSocketUpgrade, response::IntoResponse};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 
-pub async fn handler(ws: WebSocketUpgrade) -> impl IntoResponse {
-    ws.on_upgrade(|_socket| async move {
-        // Phase 2B: authenticate bearer token, register peer role (host/client),
-        // fan-out messages between peers sharing the same secret.
-        // Socket drops here, closing the connection cleanly.
+use axum::extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{RawQuery, State};
+use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::Instant;
+
+const RELAY_PROTOCOL_VERSION: &str = "1";
+const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_FRAME_BYTES: usize = 64 * 1024;
+const IDLE_TIMEOUT: Duration = Duration::from_secs(120);
+const DEFAULT_MAX_ROOMS: usize = 1_024;
+const DEFAULT_CHANNEL_CAPACITY: usize = 32;
+
+#[derive(Clone)]
+pub struct RelayState {
+    inner: Arc<Mutex<RelayRegistry>>,
+    next_peer_id: Arc<AtomicU64>,
+    limits: RelayLimits,
+}
+
+impl Default for RelayState {
+    fn default() -> Self {
+        Self::with_limits(RelayLimits {
+            max_rooms: DEFAULT_MAX_ROOMS,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+        })
+    }
+}
+
+impl RelayState {
+    fn with_limits(limits: RelayLimits) -> Self {
+        assert!(limits.max_rooms > 0);
+        assert!(limits.channel_capacity > 0);
+        Self {
+            inner: Arc::new(Mutex::new(RelayRegistry::default())),
+            next_peer_id: Arc::new(AtomicU64::new(1)),
+            limits,
+        }
+    }
+
+    async fn register(
+        &self,
+        room_id: &str,
+        credential: &str,
+        role: PeerRole,
+    ) -> Result<Registration, RegistrationError> {
+        let mut registry = self.inner.lock().await;
+        if !registry.rooms.contains_key(room_id) {
+            if registry.rooms.len() >= self.limits.max_rooms {
+                return Err(RegistrationError::RelayFull);
+            }
+            registry.rooms.insert(
+                room_id.to_owned(),
+                RelayRoom {
+                    credential: credential.to_owned(),
+                    host: None,
+                    client: None,
+                },
+            );
+        }
+
+        let room = registry.rooms.get_mut(room_id).expect("room exists");
+        if !secret_eq(room.credential.as_bytes(), credential.as_bytes()) {
+            return Err(RegistrationError::AuthorizationFailed);
+        }
+        let slot = room.slot_mut(role);
+        if slot.is_some() {
+            return Err(RegistrationError::RoleOccupied);
+        }
+
+        let peer_id = self.next_peer_id.fetch_add(1, Ordering::Relaxed);
+        let (sender, inbox) = mpsc::channel(self.limits.channel_capacity);
+        *slot = Some(ConnectedPeer { id: peer_id, sender });
+        Ok(Registration {
+            room_id: room_id.to_owned(),
+            role,
+            peer_id,
+            inbox,
+        })
+    }
+
+    async fn peer_sender(
+        &self,
+        room_id: &str,
+        role: PeerRole,
+    ) -> Option<mpsc::Sender<Message>> {
+        let registry = self.inner.lock().await;
+        registry
+            .rooms
+            .get(room_id)
+            .and_then(|room| room.peer(role))
+            .map(|peer| peer.sender.clone())
+    }
+
+    async fn unregister(&self, room_id: &str, role: PeerRole, peer_id: u64) {
+        let peer_to_notify = {
+            let mut registry = self.inner.lock().await;
+            let (peer_to_notify, remove_room) = {
+                let Some(room) = registry.rooms.get_mut(room_id) else {
+                    return;
+                };
+                let slot = room.slot_mut(role);
+                if !slot.as_ref().is_some_and(|peer| peer.id == peer_id) {
+                    return;
+                }
+                *slot = None;
+                (
+                    room.peer(role).map(|peer| peer.sender.clone()),
+                    room.host.is_none() && room.client.is_none(),
+                )
+            };
+            if remove_room {
+                registry.rooms.remove(room_id);
+            }
+            peer_to_notify
+        };
+        if let Some(peer) = peer_to_notify {
+            let _ = peer.try_send(close_message(1001, "relay peer disconnected"));
+        }
+    }
+
+    #[cfg(test)]
+    async fn room_count(&self) -> usize {
+        self.inner.lock().await.rooms.len()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RelayLimits {
+    max_rooms: usize,
+    channel_capacity: usize,
+}
+
+#[derive(Default)]
+struct RelayRegistry {
+    rooms: HashMap<String, RelayRoom>,
+}
+
+struct RelayRoom {
+    credential: String,
+    host: Option<ConnectedPeer>,
+    client: Option<ConnectedPeer>,
+}
+
+impl RelayRoom {
+    fn slot_mut(&mut self, role: PeerRole) -> &mut Option<ConnectedPeer> {
+        match role {
+            PeerRole::Host => &mut self.host,
+            PeerRole::Client => &mut self.client,
+        }
+    }
+
+    fn peer(&self, role: PeerRole) -> Option<&ConnectedPeer> {
+        match role {
+            PeerRole::Host => self.client.as_ref(),
+            PeerRole::Client => self.host.as_ref(),
+        }
+    }
+}
+
+struct ConnectedPeer {
+    id: u64,
+    sender: mpsc::Sender<Message>,
+}
+
+struct Registration {
+    room_id: String,
+    role: PeerRole,
+    peer_id: u64,
+    inbox: mpsc::Receiver<Message>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PeerRole {
+    Host,
+    Client,
+}
+
+impl PeerRole {
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "host" => Some(Self::Host),
+            "client" => Some(Self::Client),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegistrationError {
+    RelayFull,
+    AuthorizationFailed,
+    RoleOccupied,
+}
+
+impl RegistrationError {
+    fn close(self) -> (u16, &'static str) {
+        match self {
+            Self::RelayFull => (1013, "relay capacity reached"),
+            Self::AuthorizationFailed => (1008, "relay authorization failed"),
+            Self::RoleOccupied => (1008, "relay role already connected"),
+        }
+    }
+}
+
+struct RelayRequest {
+    room_id: String,
+    credential: String,
+    role: PeerRole,
+}
+
+impl RelayRequest {
+    fn parse(query: Option<&str>, headers: &HeaderMap) -> Result<Self, RequestError> {
+        let query = query.ok_or(RequestError::InvalidQuery)?;
+        let mut version = None;
+        let mut room_id = None;
+        let mut role = None;
+        for pair in query.split('&') {
+            let (name, value) = pair
+                .split_once('=')
+                .ok_or(RequestError::InvalidQuery)?;
+            let target = match name {
+                "v" => &mut version,
+                "room" => &mut room_id,
+                "role" => &mut role,
+                _ => return Err(RequestError::InvalidQuery),
+            };
+            if value.is_empty() || target.replace(value).is_some() {
+                return Err(RequestError::InvalidQuery);
+            }
+        }
+        if version != Some(RELAY_PROTOCOL_VERSION) {
+            return Err(RequestError::ProtocolUnsupported);
+        }
+        let room_id = room_id.ok_or(RequestError::InvalidQuery)?;
+        if !is_canonical_32_byte_base64url(room_id) {
+            return Err(RequestError::InvalidQuery);
+        }
+        let role = role
+            .and_then(PeerRole::parse)
+            .ok_or(RequestError::InvalidQuery)?;
+        Ok(Self {
+            room_id: room_id.to_owned(),
+            credential: bearer_credential(headers)?.to_owned(),
+            role,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequestError {
+    InvalidQuery,
+    ProtocolUnsupported,
+    AuthorizationRequired,
+}
+
+impl RequestError {
+    fn response(self) -> Response {
+        match self {
+            Self::InvalidQuery => (
+                StatusCode::BAD_REQUEST,
+                "invalid relay rendezvous request",
+            )
+                .into_response(),
+            Self::ProtocolUnsupported => (
+                StatusCode::BAD_REQUEST,
+                "unsupported relay protocol version",
+            )
+                .into_response(),
+            Self::AuthorizationRequired => (
+                StatusCode::UNAUTHORIZED,
+                [("www-authenticate", "Bearer")],
+                "relay bearer authorization required",
+            )
+                .into_response(),
+        }
+    }
+}
+
+pub async fn handler(
+    State(state): State<RelayState>,
+    RawQuery(query): RawQuery,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> Response {
+    let request = match RelayRequest::parse(query.as_deref(), &headers) {
+        Ok(request) => request,
+        Err(error) => return error.response(),
+    };
+    ws.max_message_size(MAX_MESSAGE_BYTES)
+        .max_frame_size(MAX_FRAME_BYTES)
+        .on_upgrade(move |socket| serve(socket, state, request))
+}
+
+async fn serve(mut socket: WebSocket, state: RelayState, request: RelayRequest) {
+    let registration = match state
+        .register(&request.room_id, &request.credential, request.role)
+        .await
+    {
+        Ok(registration) => registration,
+        Err(error) => {
+            let (code, reason) = error.close();
+            let _ = socket.send(close_message(code, reason)).await;
+            return;
+        }
+    };
+    let Registration {
+        room_id,
+        role,
+        peer_id,
+        mut inbox,
+    } = registration;
+    relay_loop(&mut socket, &state, &room_id, role, &mut inbox).await;
+    state.unregister(&room_id, role, peer_id).await;
+}
+
+async fn relay_loop(
+    socket: &mut WebSocket,
+    state: &RelayState,
+    room_id: &str,
+    role: PeerRole,
+    inbox: &mut mpsc::Receiver<Message>,
+) {
+    let idle = tokio::time::sleep(IDLE_TIMEOUT);
+    tokio::pin!(idle);
+    loop {
+        tokio::select! {
+            incoming = socket.recv() => {
+                idle.as_mut().reset(Instant::now() + IDLE_TIMEOUT);
+                let Some(Ok(message)) = incoming else { break; };
+                match message {
+                    Message::Binary(payload) => {
+                        if let Err(close) = forward_to_peer(
+                            state, room_id, role, Message::Binary(payload),
+                        ).await {
+                            let _ = socket.send(close).await;
+                            break;
+                        }
+                    }
+                    Message::Text(_) => {
+                        let _ = socket.send(close_message(1003, "binary frames required")).await;
+                        break;
+                    }
+                    Message::Ping(_) | Message::Pong(_) => {}
+                    Message::Close(frame) => {
+                        if let Some(peer) = state.peer_sender(room_id, role).await {
+                            let _ = peer.try_send(Message::Close(frame));
+                        }
+                        break;
+                    }
+                }
+            }
+            outgoing = inbox.recv() => {
+                idle.as_mut().reset(Instant::now() + IDLE_TIMEOUT);
+                let Some(outgoing) = outgoing else { break; };
+                let is_close = matches!(outgoing, Message::Close(_));
+                if socket.send(outgoing).await.is_err() || is_close {
+                    break;
+                }
+            }
+            () = &mut idle => {
+                let _ = socket.send(close_message(1001, "relay idle timeout")).await;
+                break;
+            }
+        }
+    }
+}
+
+async fn forward_to_peer(
+    state: &RelayState,
+    room_id: &str,
+    role: PeerRole,
+    message: Message,
+) -> Result<(), Message> {
+    let peer = state
+        .peer_sender(room_id, role)
+        .await
+        .ok_or_else(|| close_message(1013, "relay peer unavailable"))?;
+    peer.try_send(message).map_err(|error| {
+        if error.is_full() {
+            close_message(1013, "relay backpressure")
+        } else {
+            close_message(1001, "relay peer disconnected")
+        }
     })
 }
+
+fn bearer_credential(headers: &HeaderMap) -> Result<&str, RequestError> {
+    let mut values = headers.get_all(AUTHORIZATION).iter();
+    values
+        .next()
+        .filter(|_| values.next().is_none())
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .filter(|value| is_canonical_32_byte_base64url(value))
+        .ok_or(RequestError::AuthorizationRequired)
+}
+
+fn is_canonical_32_byte_base64url(value: &str) -> bool {
+    value.len() == 43
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+        && value
+            .as_bytes()
+            .last()
+            .is_some_and(|byte| b"AEIMQUYcgkosw048".contains(byte))
+}
+
+fn secret_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    let mut difference = 0_u8;
+    for (left, right) in left.iter().zip(right) {
+        difference |= left ^ right;
+    }
+    difference == 0
+}
+
+fn close_message(code: u16, reason: &'static str) -> Message {
+    Message::Close(Some(CloseFrame {
+        code,
+        reason: reason.into(),
+    }))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/coven-relay/src/ws.rs
+++ b/crates/coven-relay/src/ws.rs
@@ -15,6 +15,7 @@ use axum::extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{RawQuery, State};
 use axum::http::{header::AUTHORIZATION, HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::Instant;
 
@@ -84,7 +85,10 @@ impl RelayState {
 
         let peer_id = self.next_peer_id.fetch_add(1, Ordering::Relaxed);
         let (sender, inbox) = mpsc::channel(self.limits.channel_capacity);
-        *slot = Some(ConnectedPeer { id: peer_id, sender });
+        *slot = Some(ConnectedPeer {
+            id: peer_id,
+            sender,
+        });
         Ok(Registration {
             room_id: room_id.to_owned(),
             role,
@@ -93,11 +97,7 @@ impl RelayState {
         })
     }
 
-    async fn peer_sender(
-        &self,
-        room_id: &str,
-        role: PeerRole,
-    ) -> Option<mpsc::Sender<Message>> {
+    async fn peer_sender(&self, room_id: &str, role: PeerRole) -> Option<mpsc::Sender<Message>> {
         let registry = self.inner.lock().await;
         registry
             .rooms
@@ -230,9 +230,7 @@ impl RelayRequest {
         let mut room_id = None;
         let mut role = None;
         for pair in query.split('&') {
-            let (name, value) = pair
-                .split_once('=')
-                .ok_or(RequestError::InvalidQuery)?;
+            let (name, value) = pair.split_once('=').ok_or(RequestError::InvalidQuery)?;
             let target = match name {
                 "v" => &mut version,
                 "room" => &mut room_id,
@@ -271,11 +269,9 @@ enum RequestError {
 impl RequestError {
     fn response(self) -> Response {
         match self {
-            Self::InvalidQuery => (
-                StatusCode::BAD_REQUEST,
-                "invalid relay rendezvous request",
-            )
-                .into_response(),
+            Self::InvalidQuery => {
+                (StatusCode::BAD_REQUEST, "invalid relay rendezvous request").into_response()
+            }
             Self::ProtocolUnsupported => (
                 StatusCode::BAD_REQUEST,
                 "unsupported relay protocol version",
@@ -390,13 +386,11 @@ async fn forward_to_peer(
         .peer_sender(room_id, role)
         .await
         .ok_or_else(|| close_message(1013, "relay peer unavailable"))?;
-    peer.try_send(message).map_err(|error| {
-        if error.is_full() {
-            close_message(1013, "relay backpressure")
-        } else {
-            close_message(1001, "relay peer disconnected")
-        }
-    })
+    match peer.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(TrySendError::Full(_)) => Err(close_message(1013, "relay backpressure")),
+        Err(TrySendError::Closed(_)) => Err(close_message(1001, "relay peer disconnected")),
+    }
 }
 
 fn bearer_credential(headers: &HeaderMap) -> Result<&str, RequestError> {

--- a/crates/coven-relay/src/ws/tests.rs
+++ b/crates/coven-relay/src/ws/tests.rs
@@ -1,0 +1,241 @@
+use super::*;
+use axum::http::HeaderValue;
+
+fn canonical(seed: char) -> String {
+    let mut value = seed.to_string().repeat(42);
+    value.push('A');
+    value
+}
+
+fn headers(credential: &str) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {credential}")).unwrap(),
+    );
+    headers
+}
+
+#[test]
+fn request_parser_requires_canonical_version_room_role_and_credential() {
+    let room = canonical('A');
+    let credential = canonical('C');
+    let query = format!("role=host&room={room}&v=1");
+    let parsed = RelayRequest::parse(Some(&query), &headers(&credential)).unwrap();
+    assert_eq!(parsed.room_id, room);
+    assert_eq!(parsed.credential, credential);
+    assert_eq!(parsed.role, PeerRole::Host);
+
+    for query in [
+        format!("room={room}&role=host"),
+        format!("v=2&room={room}&role=host"),
+        format!("v=1&room={room}&room={room}&role=host"),
+        format!("v=1&room={room}&role=admin"),
+        "v=1&room=not-base64url&role=host".to_owned(),
+        format!("v=1&room={room}%3d&role=host"),
+        format!("v=1&room={room}&role=host&extra=value"),
+    ] {
+        assert!(RelayRequest::parse(Some(&query), &headers(&credential)).is_err());
+    }
+    assert!(RelayRequest::parse(Some(&query), &HeaderMap::new()).is_err());
+}
+
+#[test]
+fn authorization_header_must_be_unique_and_canonical() {
+    let credential = canonical('D');
+    let mut duplicate = headers(&credential);
+    duplicate.append(
+        AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {credential}")).unwrap(),
+    );
+    assert_eq!(
+        bearer_credential(&duplicate).unwrap_err(),
+        RequestError::AuthorizationRequired
+    );
+
+    let mut malformed = HeaderMap::new();
+    malformed.insert(AUTHORIZATION, HeaderValue::from_static("Basic value"));
+    assert_eq!(
+        bearer_credential(&malformed).unwrap_err(),
+        RequestError::AuthorizationRequired
+    );
+}
+
+#[test]
+fn base64url_validator_rejects_noncanonical_tail_bits() {
+    let canonical = canonical('E');
+    assert!(is_canonical_32_byte_base64url(&canonical));
+    let mut noncanonical = canonical;
+    noncanonical.pop();
+    noncanonical.push('B');
+    assert!(!is_canonical_32_byte_base64url(&noncanonical));
+    assert!(!is_canonical_32_byte_base64url("short"));
+}
+
+#[test]
+fn secret_comparison_checks_length_and_every_byte() {
+    let credential = canonical('F');
+    let other = canonical('G');
+    assert!(secret_eq(credential.as_bytes(), credential.as_bytes()));
+    assert!(!secret_eq(credential.as_bytes(), other.as_bytes()));
+    assert!(!secret_eq(credential.as_bytes(), b"short"));
+}
+
+#[tokio::test]
+async fn room_accepts_one_peer_per_role_with_the_same_credential() {
+    let state = RelayState::with_limits(RelayLimits {
+        max_rooms: 2,
+        channel_capacity: 2,
+    });
+    let room = canonical('H');
+    let credential = canonical('I');
+    let other_credential = canonical('J');
+
+    let host = state
+        .register(&room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    assert_eq!(
+        state
+            .register(&room, &credential, PeerRole::Host)
+            .await
+            .err(),
+        Some(RegistrationError::RoleOccupied)
+    );
+    assert_eq!(
+        state
+            .register(&room, &other_credential, PeerRole::Client)
+            .await
+            .err(),
+        Some(RegistrationError::AuthorizationFailed)
+    );
+    let client = state
+        .register(&room, &credential, PeerRole::Client)
+        .await
+        .unwrap();
+    assert!(state.peer_sender(&room, PeerRole::Host).await.is_some());
+    assert!(state.peer_sender(&room, PeerRole::Client).await.is_some());
+
+    state
+        .unregister(&room, PeerRole::Client, client.peer_id)
+        .await;
+    state
+        .unregister(&room, PeerRole::Host, host.peer_id)
+        .await;
+    assert_eq!(state.room_count().await, 0);
+}
+
+#[tokio::test]
+async fn room_capacity_is_bounded_and_released_after_disconnect() {
+    let state = RelayState::with_limits(RelayLimits {
+        max_rooms: 1,
+        channel_capacity: 1,
+    });
+    let first_room = canonical('K');
+    let second_room = canonical('L');
+    let credential = canonical('M');
+
+    let first = state
+        .register(&first_room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    assert_eq!(
+        state
+            .register(&second_room, &credential, PeerRole::Host)
+            .await
+            .err(),
+        Some(RegistrationError::RelayFull)
+    );
+    state
+        .unregister(&first_room, PeerRole::Host, first.peer_id)
+        .await;
+    let replacement = state
+        .register(&second_room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    state
+        .unregister(&second_room, PeerRole::Host, replacement.peer_id)
+        .await;
+    assert_eq!(state.room_count().await, 0);
+}
+
+#[tokio::test]
+async fn binary_frames_forward_and_backpressure_fails_closed() {
+    let state = RelayState::with_limits(RelayLimits {
+        max_rooms: 1,
+        channel_capacity: 1,
+    });
+    let room = canonical('N');
+    let credential = canonical('O');
+    let host = state
+        .register(&room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    let mut client = state
+        .register(&room, &credential, PeerRole::Client)
+        .await
+        .unwrap();
+
+    forward_to_peer(
+        &state,
+        &room,
+        PeerRole::Host,
+        Message::binary(b"ciphertext".to_vec()),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        client.inbox.recv().await,
+        Some(Message::binary(b"ciphertext".to_vec()))
+    );
+
+    forward_to_peer(
+        &state,
+        &room,
+        PeerRole::Host,
+        Message::binary(b"first".to_vec()),
+    )
+    .await
+    .unwrap();
+    assert!(forward_to_peer(
+        &state,
+        &room,
+        PeerRole::Host,
+        Message::binary(b"second".to_vec()),
+    )
+    .await
+    .is_err());
+
+    state
+        .unregister(&room, PeerRole::Client, client.peer_id)
+        .await;
+    state
+        .unregister(&room, PeerRole::Host, host.peer_id)
+        .await;
+}
+
+#[tokio::test]
+async fn disconnect_notifies_the_remaining_peer() {
+    let state = RelayState::with_limits(RelayLimits {
+        max_rooms: 1,
+        channel_capacity: 2,
+    });
+    let room = canonical('P');
+    let credential = canonical('Q');
+    let mut host = state
+        .register(&room, &credential, PeerRole::Host)
+        .await
+        .unwrap();
+    let client = state
+        .register(&room, &credential, PeerRole::Client)
+        .await
+        .unwrap();
+
+    state
+        .unregister(&room, PeerRole::Client, client.peer_id)
+        .await;
+    assert!(matches!(host.inbox.recv().await, Some(Message::Close(_))));
+    state
+        .unregister(&room, PeerRole::Host, host.peer_id)
+        .await;
+}

--- a/crates/coven-relay/src/ws/tests.rs
+++ b/crates/coven-relay/src/ws/tests.rs
@@ -119,9 +119,7 @@ async fn room_accepts_one_peer_per_role_with_the_same_credential() {
     state
         .unregister(&room, PeerRole::Client, client.peer_id)
         .await;
-    state
-        .unregister(&room, PeerRole::Host, host.peer_id)
-        .await;
+    state.unregister(&room, PeerRole::Host, host.peer_id).await;
     assert_eq!(state.room_count().await, 0);
 }
 
@@ -209,9 +207,7 @@ async fn binary_frames_forward_and_backpressure_fails_closed() {
     state
         .unregister(&room, PeerRole::Client, client.peer_id)
         .await;
-    state
-        .unregister(&room, PeerRole::Host, host.peer_id)
-        .await;
+    state.unregister(&room, PeerRole::Host, host.peer_id).await;
 }
 
 #[tokio::test]
@@ -235,7 +231,5 @@ async fn disconnect_notifies_the_remaining_peer() {
         .unregister(&room, PeerRole::Client, client.peer_id)
         .await;
     assert!(matches!(host.inbox.recv().await, Some(Message::Close(_))));
-    state
-        .unregister(&room, PeerRole::Host, host.peer_id)
-        .await;
+    state.unregister(&room, PeerRole::Host, host.peer_id).await;
 }


### PR DESCRIPTION
## Summary

Adds the relay-first transport foundation for OpenCoven mobile connectivity:

- requires an operator-managed admission credential before a host can create a room
- gives host and client distinct canonical 256-bit room credentials
- prevents clients from creating rooms or occupying the host role
- forwards only opaque text/binary data; endpoint authentication and E2EE remain outside the relay
- bounds active rooms, message size, queue depth, per-peer queued bytes, and global queued bytes
- holds byte-budget permits through the actual WebSocket write
- delivers teardown through a channel independent of the bounded data queue
- applies idle and per-write deadlines so stalled peers cannot pin resources indefinitely
- zeroes in-memory room credentials when a room is removed
- documents WSS, edge rate limiting, credential handling, and relay metadata exposure

## Security boundary

This PR does **not** make relay credentials into OpenCoven identities or device grants. The relay is an opaque rendezvous transport. Hosts and clients must still establish the endpoint-authenticated encrypted pairing/session channel specified by the mobile-device trust architecture merged in #789.

The deployment admission credential is host-only and must never be included in the QR offer. A mobile client receives only its client room credential plus the independent endpoint-authentication material required by the inner protocol.

## Verification

The focused relay tests cover:

- canonical credential parsing
- host-only admitted room creation
- host/client role separation
- duplicate role rejection
- opposite-role forwarding
- per-peer and global queued-byte enforcement
- close delivery while the data queue is full
- stale unregister protection
- room cleanup and capacity bounds

Repository CI remains the merge gate:

```bash
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --locked
python scripts/check-secrets.py
python3 scripts/check-coven-privacy.py --staged
```

## Follow-up scope

This is one implementation increment of #787, not the completion of the entire issue. Remaining work includes endpoint-authenticated pairing over the relay (#785/#786), seamless reconnect/session resumption, revocation propagation, privacy-preserving LAN discovery/direct fallback, and push-assisted wake-up/approval.

Refs #787
