### PR TITLE
feat: add versioned device grants to mobile authority

### DIFF
--- a/crates/coven-cli/src/mobile_memory/auth.rs
+++ b/crates/coven-cli/src/mobile_memory/auth.rs
@@ -9,7 +9,8 @@ use p256::ecdsa::{Signature, VerifyingKey};
 use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
-use super::registry::{DeviceRecord, DeviceRegistry};
+use super::grant::{AssuranceLevel, DeviceScope};
+use super::registry::{DeviceAuthorizationRecord, DeviceRecord, DeviceRegistry};
 use super::MOBILE_REQUEST_WINDOW_SECONDS;
 
 const MAX_REPLAY_ENTRIES: usize = 10_000;
@@ -64,6 +65,14 @@ fn validate_exact_path_and_query(value: &str) -> Result<(), MobileAuthError> {
     Ok(())
 }
 
+fn required_scope(path_and_query: &str) -> Option<DeviceScope> {
+    let path = path_and_query
+        .split_once('?')
+        .map_or(path_and_query, |(path, _)| path);
+    (path == "/api/v1/mobile/memory" || path.starts_with("/api/v1/mobile/memory/"))
+        .then_some(DeviceScope::MemoryRead)
+}
+
 fn decode_32(value: &str) -> Result<[u8; 32], MobileAuthError> {
     if value.len() != 43 {
         return Err(MobileAuthError::InvalidEncoding);
@@ -86,6 +95,9 @@ pub struct MobileRequestAuth {
 
 pub struct VerifiedMobileDevice {
     pub device_id: Uuid,
+    grant_id: Uuid,
+    revocation_epoch: u64,
+    required_scope: Option<DeviceScope>,
 }
 
 pub struct MobileAuthenticator {
@@ -114,7 +126,7 @@ impl MobileAuthenticator {
         self.registry
             .reload()
             .map_err(|_| MobileAuthError::DeviceUnknown)?;
-        let device = self.lookup_device(auth.device_id)?;
+        let authorization = self.lookup_device(auth.device_id)?;
         if now.timestamp().abs_diff(auth.timestamp) > MOBILE_REQUEST_WINDOW_SECONDS as u64 {
             return Err(MobileAuthError::RequestExpired);
         }
@@ -130,11 +142,19 @@ impl MobileAuthenticator {
             &auth.nonce,
             &auth.body_digest,
         )?;
-        verify_signature(&device, &canonical, &auth.signature)?;
+        verify_signature(&authorization.device, &canonical, &auth.signature)?;
+        let required_scope = required_scope(path_and_query);
+        authorization
+            .grant
+            .authorize(required_scope, AssuranceLevel::Possession, now)
+            .map_err(|_| MobileAuthError::DeviceRevoked)?;
         self.insert_nonce(auth.device_id, nonce, now.timestamp())?;
         self.record_rate(auth.device_id, now.timestamp())?;
         Ok(VerifiedMobileDevice {
             device_id: auth.device_id,
+            grant_id: authorization.grant.id,
+            revocation_epoch: authorization.grant.revocation_epoch,
+            required_scope,
         })
     }
 
@@ -145,18 +165,33 @@ impl MobileAuthenticator {
         self.registry
             .reload()
             .map_err(|_| MobileAuthError::DeviceUnknown)?;
-        self.lookup_device(verified.device_id).map(|_| ())
+        let authorization = self.lookup_device(verified.device_id)?;
+        if authorization.grant.id != verified.grant_id
+            || authorization.grant.revocation_epoch != verified.revocation_epoch
+        {
+            return Err(MobileAuthError::DeviceRevoked);
+        }
+        authorization
+            .grant
+            .authorize(
+                verified.required_scope,
+                AssuranceLevel::Possession,
+                Utc::now(),
+            )
+            .map_err(|_| MobileAuthError::DeviceRevoked)
     }
 
-    fn lookup_device(&self, id: Uuid) -> Result<DeviceRecord, MobileAuthError> {
+    fn lookup_device(&self, id: Uuid) -> Result<DeviceAuthorizationRecord, MobileAuthError> {
         match self
             .registry
-            .device(id)
+            .authorization_record(id)
             .map_err(|_| MobileAuthError::DeviceUnknown)?
         {
             None => Err(MobileAuthError::DeviceUnknown),
-            Some(device) if device.revoked_at.is_some() => Err(MobileAuthError::DeviceRevoked),
-            Some(device) => Ok(device),
+            Some(record) if record.device.revoked_at.is_some() => {
+                Err(MobileAuthError::DeviceRevoked)
+            }
+            Some(record) => Ok(record),
         }
     }
 
@@ -242,7 +277,7 @@ mod tests {
             public_key_x963: vector["publicKeyX963"].as_str().unwrap().to_owned(),
             paired_at: Utc::now(),
             revoked_at: None,
-            scopes: vec![super::super::registry::DeviceScope::MemoryRead],
+            scopes: vec![DeviceScope::MemoryRead],
         };
         let canonical = canonical_request(
             vector["method"].as_str().unwrap(),
@@ -284,6 +319,19 @@ mod tests {
     }
 
     #[test]
+    fn protected_memory_routes_require_memory_read_scope() {
+        assert_eq!(
+            required_scope("/api/v1/mobile/memory"),
+            Some(DeviceScope::MemoryRead)
+        );
+        assert_eq!(
+            required_scope("/api/v1/mobile/memory/overview"),
+            Some(DeviceScope::MemoryRead)
+        );
+        assert_eq!(required_scope("/api/v1/mobile/device"), None);
+    }
+
+    #[test]
     fn accepted_nonce_cannot_be_replayed_even_concurrently() {
         let (_temp, authenticator) = authenticator();
         let authenticator = Arc::new(authenticator);
@@ -313,10 +361,51 @@ mod tests {
             .registry
             .register(test_device(device_id))
             .unwrap();
-        let verified = VerifiedMobileDevice { device_id };
+        let authorization = authenticator
+            .registry
+            .authorization_record(device_id)
+            .unwrap()
+            .unwrap();
+        let verified = VerifiedMobileDevice {
+            device_id,
+            grant_id: authorization.grant.id,
+            revocation_epoch: authorization.grant.revocation_epoch,
+            required_scope: Some(DeviceScope::MemoryRead),
+        };
         authenticator
             .registry
             .revoke(device_id, Utc::now() + Duration::seconds(1))
+            .unwrap();
+        assert_eq!(
+            authenticator.ensure_still_active(&verified),
+            Err(MobileAuthError::DeviceRevoked)
+        );
+    }
+
+    #[test]
+    fn changed_grant_loses_a_race_before_response() {
+        let (_temp, authenticator) = authenticator();
+        let device_id = Uuid::from_u128(2);
+        authenticator
+            .registry
+            .register(test_device(device_id))
+            .unwrap();
+        let authorization = authenticator
+            .registry
+            .authorization_record(device_id)
+            .unwrap()
+            .unwrap();
+        let verified = VerifiedMobileDevice {
+            device_id,
+            grant_id: authorization.grant.id,
+            revocation_epoch: authorization.grant.revocation_epoch,
+            required_scope: Some(DeviceScope::MemoryRead),
+        };
+        let mut changed = authorization.grant;
+        changed.revocation_epoch += 1;
+        authenticator
+            .registry
+            .replace_grant(device_id, changed)
             .unwrap();
         assert_eq!(
             authenticator.ensure_still_active(&verified),
@@ -358,7 +447,7 @@ mod tests {
                 .encode(signing_key.public_key().to_encoded_point(false).as_bytes()),
             paired_at: Utc::now(),
             revoked_at: None,
-            scopes: vec![super::super::registry::DeviceScope::MemoryRead],
+            scopes: vec![DeviceScope::MemoryRead],
         }
     }
 }

--- a/crates/coven-cli/src/mobile_memory/grant.rs
+++ b/crates/coven-cli/src/mobile_memory/grant.rs
@@ -1,0 +1,480 @@
+use std::fmt;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+pub const DEVICE_GRANT_VERSION: u16 = 1;
+pub const DEVICE_ACTION_VERSION: u16 = 1;
+const MAX_ACTION_LIFETIME_SECONDS: i64 = 300;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceScope {
+    MemoryRead,
+    SessionMetadataRead,
+    ConversationRead,
+    MessageSend,
+    ToolInvocationRequest,
+    ToolExecutionApprove,
+    SecretsRead,
+    FamiliarMemoryAdmin,
+    DeviceAdmin,
+    IdentityAdmin,
+    MemoryExport,
+    IdentityExport,
+}
+
+impl DeviceScope {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::MemoryRead => "memory_read",
+            Self::SessionMetadataRead => "session_metadata_read",
+            Self::ConversationRead => "conversation_read",
+            Self::MessageSend => "message_send",
+            Self::ToolInvocationRequest => "tool_invocation_request",
+            Self::ToolExecutionApprove => "tool_execution_approve",
+            Self::SecretsRead => "secrets_read",
+            Self::FamiliarMemoryAdmin => "familiar_memory_admin",
+            Self::DeviceAdmin => "device_admin",
+            Self::IdentityAdmin => "identity_admin",
+            Self::MemoryExport => "memory_export",
+            Self::IdentityExport => "identity_export",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssuranceLevel {
+    Possession,
+    RecentUserVerification,
+    FreshUserVerification,
+    FreshBiometric,
+    StepUp,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeviceGrantAudience {
+    LocalCovenAuthority,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantTransportConstraint {
+    AnyAuthenticated,
+    DirectOnly,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DeviceGrantRestrictions {
+    pub transport: GrantTransportConstraint,
+    pub require_fresh_user_verification_for: Vec<DeviceScope>,
+}
+
+impl Default for DeviceGrantRestrictions {
+    fn default() -> Self {
+        Self {
+            transport: GrantTransportConstraint::AnyAuthenticated,
+            require_fresh_user_verification_for: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DeviceGrant {
+    pub version: u16,
+    pub id: Uuid,
+    pub subject_key_id: String,
+    pub audience: DeviceGrantAudience,
+    pub scopes: Vec<DeviceScope>,
+    pub restrictions: DeviceGrantRestrictions,
+    pub minimum_assurance: AssuranceLevel,
+    pub issued_at: DateTime<Utc>,
+    pub not_before: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub revocation_epoch: u64,
+}
+
+impl DeviceGrant {
+    pub fn for_device(
+        device_id: Uuid,
+        public_key_x963: &str,
+        scopes: Vec<DeviceScope>,
+        issued_at: DateTime<Utc>,
+    ) -> Result<Self, GrantError> {
+        let grant = Self {
+            version: DEVICE_GRANT_VERSION,
+            id: Uuid::new_v5(&device_id, b"coven-device-grant-v1"),
+            subject_key_id: subject_key_id(public_key_x963)?,
+            audience: DeviceGrantAudience::LocalCovenAuthority,
+            scopes,
+            restrictions: DeviceGrantRestrictions::default(),
+            minimum_assurance: AssuranceLevel::Possession,
+            issued_at,
+            not_before: issued_at,
+            expires_at: None,
+            revocation_epoch: 0,
+        };
+        grant.validate(public_key_x963)?;
+        Ok(grant)
+    }
+
+    pub fn validate(&self, public_key_x963: &str) -> Result<(), GrantError> {
+        if self.version != DEVICE_GRANT_VERSION {
+            return Err(GrantError::InvalidVersion);
+        }
+        if self.subject_key_id != subject_key_id(public_key_x963)? {
+            return Err(GrantError::SubjectMismatch);
+        }
+        validate_scope_set(&self.scopes)?;
+        validate_scope_set_allow_empty(&self.restrictions.require_fresh_user_verification_for)?;
+        if !self
+            .restrictions
+            .require_fresh_user_verification_for
+            .iter()
+            .all(|scope| self.scopes.binary_search(scope).is_ok())
+        {
+            return Err(GrantError::InvalidRestrictions);
+        }
+        if self.not_before < self.issued_at
+            || self
+                .expires_at
+                .as_ref()
+                .is_some_and(|expires_at| expires_at <= &self.not_before)
+        {
+            return Err(GrantError::InvalidTimeWindow);
+        }
+        Ok(())
+    }
+
+    pub fn authorize(
+        &self,
+        required_scope: Option<DeviceScope>,
+        presented_assurance: AssuranceLevel,
+        now: DateTime<Utc>,
+    ) -> Result<(), GrantError> {
+        if now < self.not_before
+            || self
+                .expires_at
+                .as_ref()
+                .is_some_and(|expires_at| &now >= expires_at)
+        {
+            return Err(GrantError::Inactive);
+        }
+        let required_assurance = match required_scope {
+            Some(scope) => {
+                if self.scopes.binary_search(&scope).is_err() {
+                    return Err(GrantError::ScopeDenied);
+                }
+                if self
+                    .restrictions
+                    .require_fresh_user_verification_for
+                    .binary_search(&scope)
+                    .is_ok()
+                {
+                    self.minimum_assurance
+                        .max(AssuranceLevel::FreshUserVerification)
+                } else {
+                    self.minimum_assurance
+                }
+            }
+            None => self.minimum_assurance,
+        };
+        if presented_assurance < required_assurance {
+            return Err(GrantError::AssuranceRequired);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrantError {
+    InvalidVersion,
+    InvalidSubject,
+    SubjectMismatch,
+    InvalidScopeSet,
+    InvalidRestrictions,
+    InvalidTimeWindow,
+    Inactive,
+    ScopeDenied,
+    AssuranceRequired,
+}
+
+impl fmt::Display for GrantError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidVersion => "unsupported device grant version",
+            Self::InvalidSubject => "device grant subject key id is invalid",
+            Self::SubjectMismatch => "device grant is bound to another key",
+            Self::InvalidScopeSet => "device grant scope set is not canonical",
+            Self::InvalidRestrictions => "device grant restrictions are invalid",
+            Self::InvalidTimeWindow => "device grant time window is invalid",
+            Self::Inactive => "device grant is not active",
+            Self::ScopeDenied => "device grant does not authorize this scope",
+            Self::AssuranceRequired => "device grant requires stronger assurance",
+        })
+    }
+}
+
+impl std::error::Error for GrantError {}
+
+pub fn validate_scope_set(scopes: &[DeviceScope]) -> Result<(), GrantError> {
+    if scopes.is_empty() {
+        return Err(GrantError::InvalidScopeSet);
+    }
+    validate_scope_set_allow_empty(scopes)
+}
+
+fn validate_scope_set_allow_empty(scopes: &[DeviceScope]) -> Result<(), GrantError> {
+    if scopes.windows(2).any(|window| window[0] >= window[1]) {
+        return Err(GrantError::InvalidScopeSet);
+    }
+    Ok(())
+}
+
+fn subject_key_id(public_key_x963: &str) -> Result<String, GrantError> {
+    let key = URL_SAFE_NO_PAD
+        .decode(public_key_x963)
+        .map_err(|_| GrantError::InvalidSubject)?;
+    if URL_SAFE_NO_PAD.encode(&key) != public_key_x963 {
+        return Err(GrantError::InvalidSubject);
+    }
+    Ok(URL_SAFE_NO_PAD.encode(Sha256::digest(key)))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct DeviceActionIntent {
+    pub version: u16,
+    pub scope: DeviceScope,
+    pub operation: String,
+    pub target: String,
+    pub effect_digest: String,
+    pub nonce: String,
+    pub issued_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+impl DeviceActionIntent {
+    pub fn canonical_bytes(&self) -> Result<Vec<u8>, ActionIntentError> {
+        self.validate()?;
+        let issued_at = self.issued_at.to_rfc3339_opts(SecondsFormat::Millis, true);
+        let expires_at = self.expires_at.to_rfc3339_opts(SecondsFormat::Millis, true);
+        let mut encoded = b"COVEN-ACTION/1\0".to_vec();
+        for field in [
+            self.scope.as_str().as_bytes(),
+            self.operation.as_bytes(),
+            self.target.as_bytes(),
+            self.effect_digest.as_bytes(),
+            self.nonce.as_bytes(),
+            issued_at.as_bytes(),
+            expires_at.as_bytes(),
+        ] {
+            encoded.extend_from_slice(&(field.len() as u32).to_be_bytes());
+            encoded.extend_from_slice(field);
+        }
+        Ok(encoded)
+    }
+
+    fn validate(&self) -> Result<(), ActionIntentError> {
+        if self.version != DEVICE_ACTION_VERSION {
+            return Err(ActionIntentError::InvalidVersion);
+        }
+        if self.operation.is_empty()
+            || self.operation.len() > 64
+            || !self.operation.bytes().all(|byte| {
+                byte.is_ascii_lowercase()
+                    || byte.is_ascii_digit()
+                    || matches!(byte, b'.' | b'_' | b'-')
+            })
+        {
+            return Err(ActionIntentError::InvalidOperation);
+        }
+        if self.target.is_empty()
+            || self.target.trim() != self.target
+            || self.target.len() > 512
+            || self.target.chars().any(char::is_control)
+        {
+            return Err(ActionIntentError::InvalidTarget);
+        }
+        validate_canonical_32_byte_base64url(&self.effect_digest)?;
+        validate_canonical_32_byte_base64url(&self.nonce)?;
+        let lifetime = self.expires_at.signed_duration_since(self.issued_at);
+        if lifetime.num_seconds() <= 0 || lifetime.num_seconds() > MAX_ACTION_LIFETIME_SECONDS {
+            return Err(ActionIntentError::InvalidTimeWindow);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionIntentError {
+    InvalidVersion,
+    InvalidOperation,
+    InvalidTarget,
+    InvalidDigest,
+    InvalidTimeWindow,
+}
+
+impl fmt::Display for ActionIntentError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::InvalidVersion => "unsupported action intent version",
+            Self::InvalidOperation => "action intent operation is invalid",
+            Self::InvalidTarget => "action intent target is invalid",
+            Self::InvalidDigest => "action intent digest or nonce is invalid",
+            Self::InvalidTimeWindow => "action intent time window is invalid",
+        })
+    }
+}
+
+impl std::error::Error for ActionIntentError {}
+
+fn validate_canonical_32_byte_base64url(value: &str) -> Result<(), ActionIntentError> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(value)
+        .map_err(|_| ActionIntentError::InvalidDigest)?;
+    if decoded.len() != 32 || URL_SAFE_NO_PAD.encode(decoded) != value {
+        return Err(ActionIntentError::InvalidDigest);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+
+    fn public_key(seed: u8) -> String {
+        let signing_key = p256::SecretKey::from_slice(&[seed; 32]).unwrap();
+        URL_SAFE_NO_PAD.encode(signing_key.public_key().to_encoded_point(false).as_bytes())
+    }
+
+    fn intent() -> DeviceActionIntent {
+        let issued_at = DateTime::from_timestamp(1_785_326_400, 0).unwrap();
+        DeviceActionIntent {
+            version: DEVICE_ACTION_VERSION,
+            scope: DeviceScope::ToolExecutionApprove,
+            operation: "deploy.production".to_owned(),
+            target: "OpenCoven/psyche@synthetic".to_owned(),
+            effect_digest: URL_SAFE_NO_PAD.encode([7_u8; 32]),
+            nonce: URL_SAFE_NO_PAD.encode([9_u8; 32]),
+            issued_at,
+            expires_at: issued_at + Duration::seconds(60),
+        }
+    }
+
+    #[test]
+    fn device_grant_is_bound_to_the_enrolled_key() {
+        let now = Utc::now();
+        let first = public_key(1);
+        let second = public_key(2);
+        let grant = DeviceGrant::for_device(
+            Uuid::from_u128(1),
+            &first,
+            vec![DeviceScope::MemoryRead],
+            now,
+        )
+        .unwrap();
+        grant.validate(&first).unwrap();
+        assert_eq!(grant.validate(&second), Err(GrantError::SubjectMismatch));
+    }
+
+    #[test]
+    fn grant_scope_sets_are_sorted_unique_and_fail_closed() {
+        let now = Utc::now();
+        let key = public_key(3);
+        assert_eq!(
+            DeviceGrant::for_device(
+                Uuid::from_u128(2),
+                &key,
+                vec![DeviceScope::MessageSend, DeviceScope::MemoryRead],
+                now,
+            )
+            .unwrap_err(),
+            GrantError::InvalidScopeSet
+        );
+        assert_eq!(
+            DeviceGrant::for_device(
+                Uuid::from_u128(3),
+                &key,
+                vec![DeviceScope::MemoryRead, DeviceScope::MemoryRead],
+                now,
+            )
+            .unwrap_err(),
+            GrantError::InvalidScopeSet
+        );
+    }
+
+    #[test]
+    fn grant_enforces_scope_time_and_assurance() {
+        let now = Utc::now();
+        let key = public_key(4);
+        let mut grant = DeviceGrant::for_device(
+            Uuid::from_u128(4),
+            &key,
+            vec![DeviceScope::MemoryRead, DeviceScope::ToolExecutionApprove],
+            now,
+        )
+        .unwrap();
+        grant.restrictions.require_fresh_user_verification_for =
+            vec![DeviceScope::ToolExecutionApprove];
+        grant.expires_at = Some(now + Duration::minutes(1));
+        grant.validate(&key).unwrap();
+
+        grant
+            .authorize(
+                Some(DeviceScope::MemoryRead),
+                AssuranceLevel::Possession,
+                now,
+            )
+            .unwrap();
+        assert_eq!(
+            grant.authorize(
+                Some(DeviceScope::ToolExecutionApprove),
+                AssuranceLevel::Possession,
+                now,
+            ),
+            Err(GrantError::AssuranceRequired)
+        );
+        assert_eq!(
+            grant.authorize(
+                Some(DeviceScope::ConversationRead),
+                AssuranceLevel::FreshBiometric,
+                now,
+            ),
+            Err(GrantError::ScopeDenied)
+        );
+        assert_eq!(
+            grant.authorize(
+                Some(DeviceScope::MemoryRead),
+                AssuranceLevel::Possession,
+                now + Duration::minutes(1),
+            ),
+            Err(GrantError::Inactive)
+        );
+    }
+
+    #[test]
+    fn action_intent_canonicalization_binds_every_material_field() {
+        let base = intent();
+        let canonical = base.canonical_bytes().unwrap();
+        let mut changed = base.clone();
+        changed.target.push_str("-other");
+        assert_ne!(canonical, changed.canonical_bytes().unwrap());
+        let mut changed = base.clone();
+        changed.effect_digest = URL_SAFE_NO_PAD.encode([8_u8; 32]);
+        assert_ne!(canonical, changed.canonical_bytes().unwrap());
+        let mut changed = base;
+        changed.expires_at += Duration::seconds(1);
+        assert_ne!(canonical, changed.canonical_bytes().unwrap());
+    }
+}

--- a/crates/coven-cli/src/mobile_memory/mod.rs
+++ b/crates/coven-cli/src/mobile_memory/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod config;
 pub mod contract;
 pub mod gateway;
+pub mod grant;
 pub mod identity;
 pub mod pairing;
 pub mod registry;

--- a/crates/coven-cli/src/mobile_memory/registry.rs
+++ b/crates/coven-cli/src/mobile_memory/registry.rs
@@ -12,9 +12,12 @@ use uuid::Uuid;
 
 use super::config::{atomic_replace_private, ensure_private_mobile_dir, validate_private_file};
 use super::contract::{MobileDeviceScope, MobilePairedDevice};
+pub use super::grant::DeviceScope;
+use super::grant::{AssuranceLevel, DeviceGrant};
 
 pub const DEVICES_FILE: &str = "devices.json";
-const DEVICE_REGISTRY_VERSION: u16 = 1;
+const DEVICE_REGISTRY_VERSION: u16 = 2;
+const LEGACY_DEVICE_REGISTRY_VERSION: u16 = 1;
 const MAX_DEVICE_RECORDS: usize = 128;
 const MAX_DEVICE_NAME_CHARS: usize = 80;
 
@@ -29,22 +32,58 @@ pub struct DeviceRecord {
     pub scopes: Vec<DeviceScope>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum DeviceScope {
-    MemoryRead,
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct GrantedDeviceRecord {
+    device: DeviceRecord,
+    grant: DeviceGrant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceAuthorizationRecord {
+    pub device: DeviceRecord,
+    pub grant: DeviceGrant,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct StoredDeviceRegistry {
     version: u16,
-    devices: Vec<DeviceRecord>,
+    devices: Vec<GrantedDeviceRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct LegacyStoredDeviceRegistry {
+    version: u16,
+    devices: Vec<LegacyDeviceRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct LegacyDeviceRecord {
+    id: Uuid,
+    display_name: String,
+    public_key_x963: String,
+    paired_at: DateTime<Utc>,
+    revoked_at: Option<DateTime<Utc>>,
+    scopes: Vec<LegacyDeviceScope>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum LegacyDeviceScope {
+    MemoryRead,
+}
+
+struct LoadedRegistry {
+    devices: Vec<GrantedDeviceRecord>,
+    migrated: bool,
 }
 
 pub struct DeviceRegistry {
     path: PathBuf,
-    devices: RwLock<Vec<DeviceRecord>>,
+    devices: RwLock<Vec<GrantedDeviceRecord>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -55,16 +94,23 @@ pub struct DeviceStatusRecord {
     pub paired_at: DateTime<Utc>,
     pub revoked_at: Option<DateTime<Utc>>,
     pub scopes: Vec<DeviceScope>,
+    pub grant_id: Uuid,
+    pub minimum_assurance: AssuranceLevel,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub revocation_epoch: u64,
 }
 
 impl DeviceRegistry {
     pub fn load(coven_home: &Path) -> Result<Self> {
         let mobile_dir = ensure_private_mobile_dir(coven_home)?;
         let path = mobile_dir.join(DEVICES_FILE);
-        let devices = read_registry(&path)?;
+        let loaded = read_registry(&path)?;
+        if loaded.migrated {
+            write_registry(&path, &loaded.devices)?;
+        }
         Ok(Self {
             path,
-            devices: RwLock::new(devices),
+            devices: RwLock::new(loaded.devices),
         })
     }
 
@@ -77,16 +123,34 @@ impl DeviceRegistry {
     }
 
     pub fn reload(&self) -> Result<()> {
-        let devices = read_registry(&self.path)?;
+        let loaded = read_registry(&self.path)?;
+        if loaded.migrated {
+            write_registry(&self.path, &loaded.devices)?;
+        }
         *self
             .devices
             .write()
-            .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))? = devices;
+            .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))? = loaded.devices;
         Ok(())
     }
 
     pub fn register(&self, record: DeviceRecord) -> Result<()> {
-        validate_device(&record)?;
+        let grant = DeviceGrant::for_device(
+            record.id,
+            &record.public_key_x963,
+            record.scopes.clone(),
+            record.paired_at,
+        )
+        .context("failed to issue mobile device grant")?;
+        self.register_with_grant(record, grant)
+    }
+
+    pub fn register_with_grant(&self, record: DeviceRecord, grant: DeviceGrant) -> Result<()> {
+        let granted = GrantedDeviceRecord {
+            device: record,
+            grant,
+        };
+        validate_granted_device(&granted)?;
         let mut devices = self
             .devices
             .write()
@@ -94,17 +158,74 @@ impl DeviceRegistry {
         if devices.len() >= MAX_DEVICE_RECORDS {
             bail!("mobile device registry is full");
         }
-        if devices.iter().any(|existing| existing.id == record.id) {
+        if devices
+            .iter()
+            .any(|existing| existing.device.id == granted.device.id)
+        {
             bail!("mobile device id is already registered");
         }
         if devices
             .iter()
-            .any(|existing| existing.public_key_x963 == record.public_key_x963)
+            .any(|existing| existing.device.public_key_x963 == granted.device.public_key_x963)
         {
             bail!("mobile device public key is already registered");
         }
+        if devices
+            .iter()
+            .any(|existing| existing.grant.id == granted.grant.id)
+        {
+            bail!("mobile device grant id is already registered");
+        }
         let mut updated = devices.clone();
-        updated.push(record);
+        updated.push(granted);
+        validate_devices(&updated)?;
+        write_registry(&self.path, &updated)?;
+        *devices = updated;
+        Ok(())
+    }
+
+    pub fn replace_grant(&self, device_id: Uuid, grant: DeviceGrant) -> Result<()> {
+        let mut devices = self
+            .devices
+            .write()
+            .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?;
+        let mut updated = devices.clone();
+        let index = updated
+            .iter()
+            .position(|record| record.device.id == device_id)
+            .context("mobile device is not registered")?;
+        grant
+            .validate(&updated[index].device.public_key_x963)
+            .context("replacement mobile device grant is invalid")?;
+        if grant.revocation_epoch < updated[index].grant.revocation_epoch {
+            bail!("mobile device grant revocation epoch cannot decrease");
+        }
+        if updated
+            .iter()
+            .enumerate()
+            .any(|(other, record)| other != index && record.grant.id == grant.id)
+        {
+            bail!("mobile device grant id is already registered");
+        }
+        updated[index].device.scopes = grant.scopes.clone();
+        updated[index].grant = grant;
+        validate_devices(&updated)?;
+        write_registry(&self.path, &updated)?;
+        *devices = updated;
+        Ok(())
+    }
+
+    pub fn rename(&self, device_id: Uuid, display_name: String) -> Result<()> {
+        let mut devices = self
+            .devices
+            .write()
+            .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?;
+        let mut updated = devices.clone();
+        let device = updated
+            .iter_mut()
+            .find(|record| record.device.id == device_id)
+            .context("mobile device is not registered")?;
+        device.device.display_name = display_name;
         validate_devices(&updated)?;
         write_registry(&self.path, &updated)?;
         *devices = updated;
@@ -117,13 +238,19 @@ impl DeviceRegistry {
             .write()
             .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?;
         let mut updated = devices.clone();
-        let device = updated
+        let record = updated
             .iter_mut()
-            .find(|record| record.id == device_id)
+            .find(|record| record.device.id == device_id)
             .context("mobile device is not registered")?;
-        if device.revoked_at.is_none() {
-            device.revoked_at = Some(revoked_at);
+        if record.device.revoked_at.is_none() {
+            record.device.revoked_at = Some(revoked_at);
+            record.grant.revocation_epoch = record
+                .grant
+                .revocation_epoch
+                .checked_add(1)
+                .context("mobile device revocation epoch overflow")?;
         }
+        validate_devices(&updated)?;
         write_registry(&self.path, &updated)?;
         *devices = updated;
         Ok(())
@@ -145,14 +272,38 @@ impl DeviceRegistry {
             .read()
             .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?
             .iter()
-            .find(|record| record.id == device_id)
-            .cloned())
+            .find(|record| record.device.id == device_id)
+            .map(|record| record.device.clone()))
+    }
+
+    pub fn authorization_record(
+        &self,
+        device_id: Uuid,
+    ) -> Result<Option<DeviceAuthorizationRecord>> {
+        Ok(self
+            .devices
+            .read()
+            .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?
+            .iter()
+            .find(|record| record.device.id == device_id)
+            .map(|record| DeviceAuthorizationRecord {
+                device: record.device.clone(),
+                grant: record.grant.clone(),
+            }))
     }
 
     pub fn active_device(&self, device_id: Uuid) -> Result<Option<DeviceRecord>> {
+        let now = Utc::now();
         Ok(self
-            .device(device_id)?
-            .filter(|record| record.revoked_at.is_none()))
+            .authorization_record(device_id)?
+            .filter(|record| record.device.revoked_at.is_none())
+            .filter(|record| {
+                record
+                    .grant
+                    .authorize(None, AssuranceLevel::Possession, now)
+                    .is_ok()
+            })
+            .map(|record| record.device))
     }
 
     pub fn list_redacted(&self) -> Result<Vec<MobilePairedDevice>> {
@@ -162,14 +313,16 @@ impl DeviceRegistry {
             .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?
             .iter()
             .map(|record| MobilePairedDevice {
-                id: record.id,
-                display_name: record.display_name.clone(),
-                paired_at: record.paired_at,
+                id: record.device.id,
+                display_name: record.device.display_name.clone(),
+                paired_at: record.device.paired_at,
                 scopes: record
+                    .grant
                     .scopes
                     .iter()
-                    .map(|scope| match scope {
-                        DeviceScope::MemoryRead => MobileDeviceScope::MemoryRead,
+                    .filter_map(|scope| match scope {
+                        DeviceScope::MemoryRead => Some(MobileDeviceScope::MemoryRead),
+                        _ => None,
                     })
                     .collect(),
             })
@@ -183,35 +336,101 @@ impl DeviceRegistry {
             .map_err(|_| anyhow::anyhow!("mobile device registry lock poisoned"))?
             .iter()
             .map(|record| DeviceStatusRecord {
-                id: record.id,
-                display_name: record.display_name.clone(),
-                paired_at: record.paired_at,
-                revoked_at: record.revoked_at,
-                scopes: record.scopes.clone(),
+                id: record.device.id,
+                display_name: record.device.display_name.clone(),
+                paired_at: record.device.paired_at,
+                revoked_at: record.device.revoked_at,
+                scopes: record.grant.scopes.clone(),
+                grant_id: record.grant.id,
+                minimum_assurance: record.grant.minimum_assurance,
+                expires_at: record.grant.expires_at,
+                revocation_epoch: record.grant.revocation_epoch,
             })
             .collect())
     }
 }
 
-fn read_registry(path: &Path) -> Result<Vec<DeviceRecord>> {
+fn read_registry(path: &Path) -> Result<LoadedRegistry> {
     match fs::symlink_metadata(path) {
         Ok(_) => validate_private_file(path)?,
-        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(LoadedRegistry {
+                devices: Vec::new(),
+                migrated: false,
+            });
+        }
         Err(error) => {
             return Err(error).with_context(|| format!("failed to inspect {}", path.display()));
         }
     }
     let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
-    let stored: StoredDeviceRegistry = serde_json::from_slice(&bytes)
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
         .with_context(|| format!("failed to parse {}", path.display()))?;
-    if stored.version != DEVICE_REGISTRY_VERSION {
-        bail!("unsupported mobile device registry version");
-    }
-    validate_devices(&stored.devices)?;
-    Ok(stored.devices)
+    let version = value
+        .get("version")
+        .and_then(serde_json::Value::as_u64)
+        .context("mobile device registry omitted a numeric version")?;
+    let version = u16::try_from(version).context("mobile device registry version is out of range")?;
+
+    let loaded = match version {
+        LEGACY_DEVICE_REGISTRY_VERSION => {
+            let stored: LegacyStoredDeviceRegistry = serde_json::from_value(value)
+                .with_context(|| format!("failed to parse {}", path.display()))?;
+            if stored.version != LEGACY_DEVICE_REGISTRY_VERSION {
+                bail!("unsupported mobile device registry version");
+            }
+            LoadedRegistry {
+                devices: stored
+                    .devices
+                    .into_iter()
+                    .map(migrate_legacy_device)
+                    .collect::<Result<Vec<_>>>()?,
+                migrated: true,
+            }
+        }
+        DEVICE_REGISTRY_VERSION => {
+            let stored: StoredDeviceRegistry = serde_json::from_value(value)
+                .with_context(|| format!("failed to parse {}", path.display()))?;
+            if stored.version != DEVICE_REGISTRY_VERSION {
+                bail!("unsupported mobile device registry version");
+            }
+            LoadedRegistry {
+                devices: stored.devices,
+                migrated: false,
+            }
+        }
+        _ => bail!("unsupported mobile device registry version"),
+    };
+    validate_devices(&loaded.devices)?;
+    Ok(loaded)
 }
 
-fn write_registry(path: &Path, devices: &[DeviceRecord]) -> Result<()> {
+fn migrate_legacy_device(record: LegacyDeviceRecord) -> Result<GrantedDeviceRecord> {
+    if record.scopes != [LegacyDeviceScope::MemoryRead] {
+        bail!("legacy mobile device must have exactly the memory_read scope");
+    }
+    let device = DeviceRecord {
+        id: record.id,
+        display_name: record.display_name,
+        public_key_x963: record.public_key_x963,
+        paired_at: record.paired_at,
+        revoked_at: record.revoked_at,
+        scopes: vec![DeviceScope::MemoryRead],
+    };
+    let mut grant = DeviceGrant::for_device(
+        device.id,
+        &device.public_key_x963,
+        device.scopes.clone(),
+        device.paired_at,
+    )
+    .context("failed to migrate legacy mobile device grant")?;
+    if device.revoked_at.is_some() {
+        grant.revocation_epoch = 1;
+    }
+    Ok(GrantedDeviceRecord { device, grant })
+}
+
+fn write_registry(path: &Path, devices: &[GrantedDeviceRecord]) -> Result<()> {
     validate_devices(devices)?;
     let stored = StoredDeviceRegistry {
         version: DEVICE_REGISTRY_VERSION,
@@ -223,24 +442,45 @@ fn write_registry(path: &Path, devices: &[DeviceRecord]) -> Result<()> {
     atomic_replace_private(path, &encoded)
 }
 
-fn validate_devices(devices: &[DeviceRecord]) -> Result<()> {
+fn validate_devices(devices: &[GrantedDeviceRecord]) -> Result<()> {
     if devices.len() > MAX_DEVICE_RECORDS {
         bail!("mobile device registry exceeds the record limit");
     }
-    for (index, device) in devices.iter().enumerate() {
-        validate_device(device)?;
+    for (index, record) in devices.iter().enumerate() {
+        validate_granted_device(record)?;
         if devices[..index]
             .iter()
-            .any(|existing| existing.id == device.id)
+            .any(|existing| existing.device.id == record.device.id)
         {
             bail!("mobile device registry contains duplicate ids");
         }
         if devices[..index]
             .iter()
-            .any(|existing| existing.public_key_x963 == device.public_key_x963)
+            .any(|existing| existing.device.public_key_x963 == record.device.public_key_x963)
         {
             bail!("mobile device registry contains duplicate public keys");
         }
+        if devices[..index]
+            .iter()
+            .any(|existing| existing.grant.id == record.grant.id)
+        {
+            bail!("mobile device registry contains duplicate grant ids");
+        }
+    }
+    Ok(())
+}
+
+fn validate_granted_device(record: &GrantedDeviceRecord) -> Result<()> {
+    validate_device(&record.device)?;
+    record
+        .grant
+        .validate(&record.device.public_key_x963)
+        .context("mobile device grant is invalid")?;
+    if record.device.scopes != record.grant.scopes {
+        bail!("mobile device scopes do not match its grant");
+    }
+    if record.device.revoked_at.is_some() && record.grant.revocation_epoch == 0 {
+        bail!("revoked mobile device must advance its grant revocation epoch");
     }
     Ok(())
 }
@@ -265,9 +505,8 @@ fn validate_device(device: &DeviceRecord) -> Result<()> {
     {
         bail!("mobile device public key is not a canonical P-256 X9.63 key");
     }
-    if device.scopes != [DeviceScope::MemoryRead] {
-        bail!("mobile device must have exactly the memory_read scope");
-    }
+    super::grant::validate_scope_set(&device.scopes)
+        .context("mobile device scope set is invalid")?;
     if device
         .revoked_at
         .is_some_and(|revoked_at| revoked_at < device.paired_at)
@@ -280,7 +519,6 @@ fn validate_device(device: &DeviceRecord) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::Utc;
     use p256::elliptic_curve::sec1::ToEncodedPoint;
 
     fn device(id: Uuid, name: &str) -> DeviceRecord {
@@ -301,37 +539,89 @@ mod tests {
     }
 
     #[test]
-    fn revoked_device_never_authenticates_after_atomic_reload() {
+    fn legacy_registry_migrates_atomically_to_grants() {
+        let temp = tempfile::tempdir().unwrap();
+        let mobile = ensure_private_mobile_dir(temp.path()).unwrap();
+        let path = mobile.join(DEVICES_FILE);
+        let record = device(Uuid::from_u128(7), "Synthetic phone");
+        let legacy = serde_json::json!({
+            "version": 1,
+            "devices": [{
+                "id": record.id,
+                "displayName": record.display_name,
+                "publicKeyX963": record.public_key_x963,
+                "pairedAt": record.paired_at,
+                "revokedAt": null,
+                "scopes": ["memory_read"]
+            }]
+        });
+        atomic_replace_private(
+            &path,
+            format!("{}\n", serde_json::to_string_pretty(&legacy).unwrap()).as_bytes(),
+        )
+        .unwrap();
+
+        let registry = DeviceRegistry::load(temp.path()).unwrap();
+        let authorized = registry.authorization_record(record.id).unwrap().unwrap();
+        assert_eq!(authorized.grant.scopes, [DeviceScope::MemoryRead]);
+        assert_eq!(authorized.grant.revocation_epoch, 0);
+        let migrated: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        assert_eq!(migrated["version"], DEVICE_REGISTRY_VERSION);
+        assert!(migrated["devices"][0].get("grant").is_some());
+    }
+
+    #[test]
+    fn revoked_device_advances_epoch_and_never_authenticates_after_reload() {
         let temp = tempfile::tempdir().unwrap();
         let first = DeviceRegistry::load(temp.path()).unwrap();
         let record = device(Uuid::new_v4(), "Synthetic phone");
         first.register(record.clone()).unwrap();
+        let original_epoch = first
+            .authorization_record(record.id)
+            .unwrap()
+            .unwrap()
+            .grant
+            .revocation_epoch;
 
         let second = DeviceRegistry::load(temp.path()).unwrap();
         second.revoke(record.id, Utc::now()).unwrap();
         first.reload().unwrap();
 
         assert!(first.active_device(record.id).unwrap().is_none());
-        assert!(first
-            .device(record.id)
-            .unwrap()
-            .unwrap()
-            .revoked_at
-            .is_some());
+        let revoked = first.authorization_record(record.id).unwrap().unwrap();
+        assert!(revoked.device.revoked_at.is_some());
+        assert_eq!(revoked.grant.revocation_epoch, original_epoch + 1);
     }
 
     #[test]
-    fn registry_rejects_duplicate_public_keys_and_ids() {
+    fn registry_rejects_duplicate_public_keys_ids_and_grants() {
         let temp = tempfile::tempdir().unwrap();
         let registry = DeviceRegistry::load(temp.path()).unwrap();
         let first = device(Uuid::new_v4(), "Synthetic phone");
         registry.register(first.clone()).unwrap();
 
-        let mut duplicate_id = device(first.id, "Other synthetic phone");
-        assert!(registry.register(duplicate_id.clone()).is_err());
-        duplicate_id.id = Uuid::new_v4();
-        duplicate_id.public_key_x963 = first.public_key_x963;
+        let duplicate_id = device(first.id, "Other synthetic phone");
         assert!(registry.register(duplicate_id).is_err());
+        let mut duplicate_key = device(Uuid::new_v4(), "Other synthetic phone");
+        duplicate_key.public_key_x963 = first.public_key_x963.clone();
+        assert!(registry.register(duplicate_key).is_err());
+
+        let second = device(Uuid::new_v4(), "Second synthetic phone");
+        let mut grant = DeviceGrant::for_device(
+            second.id,
+            &second.public_key_x963,
+            second.scopes.clone(),
+            second.paired_at,
+        )
+        .unwrap();
+        grant.id = registry
+            .authorization_record(first.id)
+            .unwrap()
+            .unwrap()
+            .grant
+            .id;
+        assert!(registry.register_with_grant(second, grant).is_err());
     }
 
     #[test]
@@ -347,7 +637,7 @@ mod tests {
     }
 
     #[test]
-    fn device_status_output_omits_public_keys() {
+    fn device_status_output_omits_public_and_subject_keys() {
         let temp = tempfile::tempdir().unwrap();
         let registry = DeviceRegistry::load(temp.path()).unwrap();
         let record = device(Uuid::new_v4(), "Synthetic phone");
@@ -357,5 +647,24 @@ mod tests {
         assert_eq!(encoded[0]["id"], record.id.to_string());
         assert!(encoded[0].get("publicKeyX963").is_none());
         assert!(encoded[0].get("publicKey").is_none());
+        assert!(encoded[0].get("subjectKeyId").is_none());
+        assert!(encoded[0].get("grantId").is_some());
+    }
+
+    #[test]
+    fn replacement_grant_cannot_decrease_revocation_epoch() {
+        let temp = tempfile::tempdir().unwrap();
+        let registry = DeviceRegistry::load(temp.path()).unwrap();
+        let record = device(Uuid::new_v4(), "Synthetic phone");
+        registry.register(record.clone()).unwrap();
+        let mut grant = registry
+            .authorization_record(record.id)
+            .unwrap()
+            .unwrap()
+            .grant;
+        grant.revocation_epoch = 2;
+        registry.replace_grant(record.id, grant.clone()).unwrap();
+        grant.revocation_epoch = 1;
+        assert!(registry.replace_grant(record.id, grant).is_err());
     }
 }

--- a/crates/coven-cli/src/mobile_memory/registry.rs
+++ b/crates/coven-cli/src/mobile_memory/registry.rs
@@ -370,7 +370,8 @@ fn read_registry(path: &Path) -> Result<LoadedRegistry> {
         .get("version")
         .and_then(serde_json::Value::as_u64)
         .context("mobile device registry omitted a numeric version")?;
-    let version = u16::try_from(version).context("mobile device registry version is out of range")?;
+    let version =
+        u16::try_from(version).context("mobile device registry version is out of range")?;
 
     let loaded = match version {
         LEGACY_DEVICE_REGISTRY_VERSION => {


### PR DESCRIPTION
## Summary

- adds an explicit Rust authority model for device scopes, assurance levels, transport restrictions, expiry, and revocation epochs
- defines canonical exact-action intents so sensitive approvals can bind operation, target, effect digest, nonce, and expiry
- atomically migrates the private device registry from v1 records to v2 records containing key-bound grants
- preserves the existing v1 pairing and request shapes while issuing deterministic grants behind the authority boundary
- re-checks grant identity, revocation epoch, active time window, and route scope before releasing a protected response
- adds migration, key-binding, scope, assurance, expiry, revocation-race, corruption, and privacy tests

## Compatibility

Existing paired devices migrate to a grant with exactly their existing `memory_read` authority. Migration does not widen permissions, rotate the device key, or change the mobile protocol payload. Revoked legacy devices migrate with an advanced revocation epoch.

## Security boundary

Biometrics remain a local platform gate on key use; this PR models the assurance requirement but does not accept an untrusted remote claim that a biometric occurred. Platform adapters and attestable step-up evidence remain follow-up work.

## Verification

The full workspace CI suite is required before merge. No dependency or lockfile changes are introduced.

Advances #786
Related architecture: #784
