### PR TITLE
feat: bind mobile QR pairing protocol v2 transcripts

### DIFF
--- a/crates/coven-cli/src/mobile_memory/pairing.rs
+++ b/crates/coven-cli/src/mobile_memory/pairing.rs
@@ -16,6 +16,11 @@ use super::registry::{DeviceRecord, DeviceRegistry, DeviceScope};
 use super::MOBILE_PROTOCOL_VERSION;
 
 const PAIRING_WORDS: &str = include_str!("pairing_words.txt");
+pub const PAIRING_PROTOCOL_MINIMUM_VERSION: u16 = 1;
+pub const PAIRING_PROTOCOL_VERSION: u16 = 2;
+const PAIRING_SCOPE_MEMORY_READ: &str = "memory_read";
+const PAIRING_TRANSCRIPT_V2_DOMAIN: &[u8] = b"COVEN-PAIR/2";
+const PAIRING_OFFER_V2_DOMAIN: &[u8] = b"COVEN-PAIR-OFFER/2";
 
 #[derive(Debug, Clone)]
 pub struct PendingPairing {
@@ -35,6 +40,7 @@ pub struct PendingDevice {
     pub display_name: String,
     pub public_key_x963: String,
     pub app_version: String,
+    pub scopes: Vec<DeviceScope>,
 }
 
 #[derive(Debug, Clone)]
@@ -205,13 +211,16 @@ impl PairingManager {
         let public_key = URL_SAFE_NO_PAD
             .decode(&request.device_public_key)
             .map_err(|_| PairingError::InvalidRequest)?;
-        let transcript = PairingTranscript {
-            protocol_version: request.protocol_version,
-            host_fingerprint,
-            pairing_id,
-            device_public_key: public_key,
-            nonce,
-        };
+        let transcript = PairingTranscript::for_request(
+            &request,
+            PairingOfferV2 {
+                host_fingerprint,
+                pairing_id,
+                nonce,
+                expires_at: pairing.expires_at,
+            },
+            public_key,
+        );
         let transcript_hash = transcript.hash();
         let phrase = derive_pairing_phrase(&transcript);
         pairing.transcript_hash = Some(transcript_hash);
@@ -219,6 +228,7 @@ impl PairingManager {
             display_name: request.device_name,
             public_key_x963: request.device_public_key,
             app_version: request.app_version,
+            scopes: vec![DeviceScope::MemoryRead],
         });
         Ok(EnrolledPairing {
             id: pairing_id,
@@ -335,7 +345,7 @@ impl PairingManager {
             public_key_x963: device.public_key_x963,
             paired_at: now,
             revoked_at: None,
-            scopes: vec![DeviceScope::MemoryRead],
+            scopes: device.scopes,
         };
         self.registry
             .register(record.clone())
@@ -344,7 +354,14 @@ impl PairingManager {
             id: record.id,
             display_name: record.display_name,
             paired_at: record.paired_at,
-            scopes: vec![MobileDeviceScope::MemoryRead],
+            scopes: record
+                .scopes
+                .iter()
+                .filter_map(|scope| match scope {
+                    DeviceScope::MemoryRead => Some(MobileDeviceScope::MemoryRead),
+                    _ => None,
+                })
+                .collect(),
         };
         pairing.device = None;
         pairing.completed = Some(completed.clone());
@@ -355,41 +372,157 @@ impl PairingManager {
     }
 }
 
-struct PairingTranscript {
-    protocol_version: u16,
-    host_fingerprint: [u8; 32],
-    pairing_id: Uuid,
-    device_public_key: Vec<u8>,
-    nonce: [u8; 32],
+#[derive(Debug, Clone)]
+enum PairingTranscript {
+    V1 {
+        protocol_version: u16,
+        host_fingerprint: [u8; 32],
+        pairing_id: Uuid,
+        device_public_key: Vec<u8>,
+        nonce: [u8; 32],
+    },
+    V2 {
+        offer_digest: [u8; 32],
+        protocol_version: u16,
+        supported_minimum: u16,
+        supported_maximum: u16,
+        device_public_key: Vec<u8>,
+        device_name: String,
+        app_version: String,
+    },
 }
 
 impl PairingTranscript {
+    fn for_request(
+        request: &MobilePairingRequest,
+        offer: PairingOfferV2,
+        device_public_key: Vec<u8>,
+    ) -> Self {
+        if request.protocol_version == MOBILE_PROTOCOL_VERSION {
+            Self::V1 {
+                protocol_version: request.protocol_version,
+                host_fingerprint: offer.host_fingerprint,
+                pairing_id: offer.pairing_id,
+                device_public_key,
+                nonce: offer.nonce,
+            }
+        } else {
+            Self::V2 {
+                offer_digest: offer.hash(),
+                protocol_version: request.protocol_version,
+                supported_minimum: request.supported_protocol.minimum,
+                supported_maximum: request.supported_protocol.maximum,
+                device_public_key,
+                device_name: request.device_name.clone(),
+                app_version: request.app_version.clone(),
+            }
+        }
+    }
+
     fn hash(&self) -> [u8; 32] {
         let mut digest = Sha256::new();
-        for field in [
-            self.protocol_version.to_be_bytes().as_slice(),
-            self.host_fingerprint.as_slice(),
-            self.pairing_id.as_bytes(),
-            self.device_public_key.as_slice(),
-            self.nonce.as_slice(),
-        ] {
-            digest.update((field.len() as u32).to_be_bytes());
-            digest.update(field);
+        match self {
+            Self::V1 {
+                protocol_version,
+                host_fingerprint,
+                pairing_id,
+                device_public_key,
+                nonce,
+            } => {
+                let protocol_version = protocol_version.to_be_bytes();
+                for field in [
+                    protocol_version.as_slice(),
+                    host_fingerprint.as_slice(),
+                    pairing_id.as_bytes(),
+                    device_public_key.as_slice(),
+                    nonce.as_slice(),
+                ] {
+                    update_length_prefixed(&mut digest, field);
+                }
+            }
+            Self::V2 {
+                offer_digest,
+                protocol_version,
+                supported_minimum,
+                supported_maximum,
+                device_public_key,
+                device_name,
+                app_version,
+            } => {
+                let protocol_version = protocol_version.to_be_bytes();
+                let supported_minimum = supported_minimum.to_be_bytes();
+                let supported_maximum = supported_maximum.to_be_bytes();
+                for field in [
+                    PAIRING_TRANSCRIPT_V2_DOMAIN,
+                    offer_digest.as_slice(),
+                    protocol_version.as_slice(),
+                    supported_minimum.as_slice(),
+                    supported_maximum.as_slice(),
+                    device_public_key.as_slice(),
+                    device_name.as_bytes(),
+                    app_version.as_bytes(),
+                ] {
+                    update_length_prefixed(&mut digest, field);
+                }
+            }
         }
         digest.finalize().into()
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct PairingOfferV2 {
+    host_fingerprint: [u8; 32],
+    pairing_id: Uuid,
+    nonce: [u8; 32],
+    expires_at: DateTime<Utc>,
+}
+
+impl PairingOfferV2 {
+    fn hash(&self) -> [u8; 32] {
+        let minimum_version = PAIRING_PROTOCOL_MINIMUM_VERSION.to_be_bytes();
+        let maximum_version = PAIRING_PROTOCOL_VERSION.to_be_bytes();
+        let expires_at = self.expires_at.timestamp().to_be_bytes();
+        let mut digest = Sha256::new();
+        for field in [
+            PAIRING_OFFER_V2_DOMAIN,
+            minimum_version.as_slice(),
+            maximum_version.as_slice(),
+            self.host_fingerprint.as_slice(),
+            self.pairing_id.as_bytes(),
+            self.nonce.as_slice(),
+            expires_at.as_slice(),
+            PAIRING_SCOPE_MEMORY_READ.as_bytes(),
+        ] {
+            update_length_prefixed(&mut digest, field);
+        }
+        digest.finalize().into()
+    }
+}
+
+fn update_length_prefixed(digest: &mut Sha256, field: &[u8]) {
+    digest.update((field.len() as u32).to_be_bytes());
+    digest.update(field);
+}
+
 fn validate_pairing_request(request: &MobilePairingRequest) -> Result<(), PairingError> {
-    if request.protocol_version != MOBILE_PROTOCOL_VERSION
-        || request.supported_protocol.minimum > MOBILE_PROTOCOL_VERSION
-        || request.supported_protocol.maximum < MOBILE_PROTOCOL_VERSION
+    let selected_version_supported = request.supported_protocol.minimum <= request.protocol_version
+        && request.supported_protocol.maximum >= request.protocol_version;
+    let supported_version = matches!(
+        request.protocol_version,
+        MOBILE_PROTOCOL_VERSION | PAIRING_PROTOCOL_VERSION
+    );
+    if !supported_version
+        || !selected_version_supported
+        || request.supported_protocol.minimum > request.supported_protocol.maximum
         || request.device_name.is_empty()
         || request.device_name.trim() != request.device_name
         || request.device_name.chars().count() > 80
         || request.device_name.chars().any(char::is_control)
         || request.app_version.is_empty()
         || request.app_version.len() > 64
+        || !request.app_version.is_ascii()
+        || request.app_version.chars().any(char::is_control)
     {
         return Err(PairingError::InvalidRequest);
     }
@@ -431,14 +564,45 @@ pub fn build_pairing_url(
     endpoint: &str,
     host_fingerprint: [u8; 32],
 ) -> Result<String, PairingError> {
+    let endpoint =
+        validate_pairing_endpoint(endpoint)?;
+    let offer = PairingOfferV2 {
+        host_fingerprint,
+        pairing_id: invitation.id,
+        nonce: invitation.nonce,
+        expires_at: invitation.expires_at,
+    };
     let mut url = Url::parse("coven-memory://pair").map_err(|_| PairingError::InvalidRequest)?;
     url.query_pairs_mut()
-        .append_pair("version", &MOBILE_PROTOCOL_VERSION.to_string())
-        .append_pair("endpoint", endpoint)
+        .append_pair("version", &PAIRING_PROTOCOL_VERSION.to_string())
+        .append_pair(
+            "minimumVersion",
+            &PAIRING_PROTOCOL_MINIMUM_VERSION.to_string(),
+        )
+        .append_pair("maximumVersion", &PAIRING_PROTOCOL_VERSION.to_string())
+        .append_pair("pairingId", &invitation.id.to_string())
+        .append_pair("endpoint", endpoint.as_str())
         .append_pair("fingerprint", &URL_SAFE_NO_PAD.encode(host_fingerprint))
         .append_pair("nonce", &URL_SAFE_NO_PAD.encode(invitation.nonce))
-        .append_pair("expires", &invitation.expires_at.timestamp().to_string());
+        .append_pair("expires", &invitation.expires_at.timestamp().to_string())
+        .append_pair("scope", PAIRING_SCOPE_MEMORY_READ)
+        .append_pair("offerDigest", &URL_SAFE_NO_PAD.encode(offer.hash()));
     Ok(url.into())
+}
+
+fn validate_pairing_endpoint(endpoint: &str) -> Result<Url, PairingError> {
+    let mut endpoint = Url::parse(endpoint).map_err(|_| PairingError::InvalidRequest)?;
+    if endpoint.scheme() != "https"
+        || endpoint.host_str().is_none()
+        || !endpoint.username().is_empty()
+        || endpoint.password().is_some()
+        || endpoint.query().is_some()
+        || endpoint.fragment().is_some()
+    {
+        return Err(PairingError::InvalidRequest);
+    }
+    endpoint.set_fragment(None);
+    Ok(endpoint)
 }
 
 pub fn render_pairing_invitation(
@@ -518,6 +682,12 @@ mod tests {
             }
         }
 
+        fn use_v2(&mut self) {
+            self.request.protocol_version = PAIRING_PROTOCOL_VERSION;
+            self.request.supported_protocol.minimum = PAIRING_PROTOCOL_MINIMUM_VERSION;
+            self.request.supported_protocol.maximum = PAIRING_PROTOCOL_VERSION;
+        }
+
         fn enroll(&self) -> EnrolledPairing {
             self.enroll_with_nonce(self.pairing_nonce).unwrap()
         }
@@ -561,13 +731,42 @@ mod tests {
     }
 
     fn synthetic_transcript() -> PairingTranscript {
-        PairingTranscript {
+        PairingTranscript::V1 {
             protocol_version: 1,
             host_fingerprint: [3; 32],
             pairing_id: Uuid::from_u128(1),
             device_public_key: vec![4; 65],
             nonce: [7; 32],
         }
+    }
+
+    fn synthetic_v2_transcript() -> PairingTranscript {
+        PairingTranscript::V2 {
+            offer_digest: [2; 32],
+            protocol_version: 2,
+            supported_minimum: 1,
+            supported_maximum: 2,
+            device_public_key: vec![4; 65],
+            device_name: "Synthetic phone".to_owned(),
+            app_version: "1.0.0".to_owned(),
+        }
+    }
+
+    fn decode_hex(value: &str) -> Vec<u8> {
+        assert_eq!(value.len() % 2, 0);
+        value
+            .as_bytes()
+            .chunks_exact(2)
+            .map(|pair| {
+                let high = char::from(pair[0]).to_digit(16).unwrap();
+                let low = char::from(pair[1]).to_digit(16).unwrap();
+                ((high << 4) | low) as u8
+            })
+            .collect()
+    }
+
+    fn encode_hex(value: &[u8]) -> String {
+        value.iter().map(|byte| format!("{byte:02x}")).collect()
     }
 
     #[test]
@@ -590,6 +789,19 @@ mod tests {
     }
 
     #[test]
+    fn pairing_v2_requires_host_and_device_confirmation() {
+        let mut harness = PairingHarness::new();
+        harness.use_v2();
+        let pending = harness.enroll();
+        assert_eq!(
+            harness.confirm_device(&pending.phrase),
+            PairingProgress::Pending
+        );
+        let device = assert_complete(harness.confirm_host(&pending.phrase), false);
+        assert_eq!(device.scopes, [MobileDeviceScope::MemoryRead]);
+    }
+
+    #[test]
     fn pairing_nonce_is_consumed_on_first_enrollment_attempt() {
         let harness = PairingHarness::new();
         assert_eq!(
@@ -600,6 +812,18 @@ mod tests {
             harness.enroll_with_nonce([7; 32]).unwrap_err(),
             PairingError::PairingConsumed
         );
+    }
+
+    #[test]
+    fn unsupported_pairing_protocol_is_rejected() {
+        let mut harness = PairingHarness::new();
+        harness.request.protocol_version = 3;
+        harness.request.supported_protocol.maximum = 3;
+        assert_eq!(
+            harness.enroll().unwrap_err(),
+            PairingError::InvalidRequest
+        );
+        assert!(harness.devices().is_empty());
     }
 
     #[test]
@@ -743,7 +967,13 @@ mod tests {
             )
             .unwrap();
         let enrolled = manager
-            .enroll(pairing_id, pairing_nonce, request, [3; 32], expired_now)
+            .enroll(
+                pairing_id,
+                pairing_nonce,
+                request,
+                [3; 32],
+                expired_now,
+            )
             .unwrap();
         assert_eq!(
             manager
@@ -836,11 +1066,108 @@ mod tests {
     }
 
     #[test]
-    fn phrase_is_deterministic_for_the_complete_transcript() {
+    fn phrase_is_deterministic_for_the_v1_transcript() {
         let transcript = synthetic_transcript();
         assert_eq!(
             derive_pairing_phrase(&transcript),
             ["athlete", "spatial", "stay", "border", "change", "report"].map(str::to_owned)
+        );
+    }
+
+    #[test]
+    fn pairing_v2_binds_offer_and_client_metadata() {
+        let baseline = synthetic_v2_transcript();
+        let baseline_hash = baseline.hash();
+
+        let mut changed = synthetic_v2_transcript();
+        if let PairingTranscript::V2 { offer_digest, .. } = &mut changed {
+            *offer_digest = [3; 32];
+        }
+        assert_ne!(baseline_hash, changed.hash());
+
+        let mut changed = synthetic_v2_transcript();
+        if let PairingTranscript::V2 { device_name, .. } = &mut changed {
+            device_name.push_str(" other");
+        }
+        assert_ne!(baseline_hash, changed.hash());
+
+        let mut changed = synthetic_v2_transcript();
+        if let PairingTranscript::V2 { app_version, .. } = &mut changed {
+            app_version.push_str("-other");
+        }
+        assert_ne!(baseline_hash, changed.hash());
+    }
+
+    #[test]
+    fn pairing_offer_binds_security_relevant_fields() {
+        let expires_at = DateTime::from_timestamp(1_785_326_700, 0).unwrap();
+        let baseline = PairingOfferV2 {
+            host_fingerprint: [3; 32],
+            pairing_id: Uuid::from_u128(1),
+            nonce: [7; 32],
+            expires_at,
+        };
+        let baseline_hash = baseline.hash();
+
+        let mut changed = baseline;
+        changed.host_fingerprint = [4; 32];
+        assert_ne!(baseline_hash, changed.hash());
+        let mut changed = baseline;
+        changed.pairing_id = Uuid::from_u128(2);
+        assert_ne!(baseline_hash, changed.hash());
+        let mut changed = baseline;
+        changed.nonce = [8; 32];
+        assert_ne!(baseline_hash, changed.hash());
+        let mut changed = baseline;
+        changed.expires_at += Duration::seconds(1);
+        assert_ne!(baseline_hash, changed.hash());
+    }
+
+    #[test]
+    fn portable_pairing_v2_vector_matches_the_contract() {
+        let vector: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/mobile-pairing-v2/transcript-vector.json"
+        ))
+        .unwrap();
+        let host_fingerprint: [u8; 32] = decode_hex(
+            vector["hostFingerprintHex"].as_str().unwrap(),
+        )
+        .try_into()
+        .unwrap();
+        let nonce: [u8; 32] = decode_hex(vector["pairingNonceHex"].as_str().unwrap())
+            .try_into()
+            .unwrap();
+        let offer = PairingOfferV2 {
+            host_fingerprint,
+            pairing_id: Uuid::parse_str(vector["pairingId"].as_str().unwrap()).unwrap(),
+            nonce,
+            expires_at: DateTime::from_timestamp(vector["expiresAtUnix"].as_i64().unwrap(), 0)
+                .unwrap(),
+        };
+        assert_eq!(
+            encode_hex(&offer.hash()),
+            vector["offerDigestHex"].as_str().unwrap()
+        );
+        assert_eq!(vector["requestedScopes"], serde_json::json!(["memory_read"]));
+
+        let transcript = PairingTranscript::V2 {
+            offer_digest: offer.hash(),
+            protocol_version: vector["pairingProtocolVersion"].as_u64().unwrap() as u16,
+            supported_minimum: vector["minimumPairingProtocolVersion"]
+                .as_u64()
+                .unwrap() as u16,
+            supported_maximum: vector["maximumPairingProtocolVersion"]
+                .as_u64()
+                .unwrap() as u16,
+            device_public_key: decode_hex(
+                vector["devicePublicKeyX963Hex"].as_str().unwrap(),
+            ),
+            device_name: vector["deviceName"].as_str().unwrap().to_owned(),
+            app_version: vector["appVersion"].as_str().unwrap().to_owned(),
+        };
+        assert_eq!(
+            encode_hex(&transcript.hash()),
+            vector["transcriptDigestHex"].as_str().unwrap()
         );
     }
 
@@ -852,7 +1179,7 @@ mod tests {
     }
 
     #[test]
-    fn terminal_pairing_output_prints_the_url_once() {
+    fn terminal_pairing_output_prints_a_v2_offer_once() {
         let expires_at = DateTime::from_timestamp(1_785_326_700, 0).unwrap();
         let invitation = PairingInvitation {
             id: Uuid::from_u128(1),
@@ -860,9 +1187,49 @@ mod tests {
             expires_at,
         };
         let url = build_pairing_url(&invitation, "https://192.0.2.1:7443", [3; 32]).unwrap();
+        let parsed = Url::parse(&url).unwrap();
+        let query: HashMap<_, _> = parsed.query_pairs().into_owned().collect();
+        assert_eq!(query["version"], PAIRING_PROTOCOL_VERSION.to_string());
+        assert_eq!(
+            query["minimumVersion"],
+            PAIRING_PROTOCOL_MINIMUM_VERSION.to_string()
+        );
+        assert_eq!(query["pairingId"], invitation.id.to_string());
+        assert_eq!(query["scope"], PAIRING_SCOPE_MEMORY_READ);
+        let expected_offer = PairingOfferV2 {
+            host_fingerprint: [3; 32],
+            pairing_id: invitation.id,
+            nonce: invitation.nonce,
+            expires_at,
+        };
+        assert_eq!(
+            query["offerDigest"],
+            URL_SAFE_NO_PAD.encode(expected_offer.hash())
+        );
+
         let output = render_pairing_invitation(&url, expires_at).unwrap();
         assert_eq!(output.matches(&url).count(), 1);
         assert!(output.contains("Waiting for device"));
         assert!(output.contains("Ctrl-C"));
+    }
+
+    #[test]
+    fn pairing_url_rejects_ambiguous_or_unencrypted_endpoints() {
+        let invitation = PairingInvitation {
+            id: Uuid::from_u128(1),
+            nonce: [7; 32],
+            expires_at: DateTime::from_timestamp(1_785_326_700, 0).unwrap(),
+        };
+        for endpoint in [
+            "http://192.0.2.1:7443",
+            "https://user@192.0.2.1:7443",
+            "https://192.0.2.1:7443?other=value",
+            "https://192.0.2.1:7443#fragment",
+        ] {
+            assert_eq!(
+                build_pairing_url(&invitation, endpoint, [3; 32]).unwrap_err(),
+                PairingError::InvalidRequest
+            );
+        }
     }
 }

--- a/crates/coven-cli/tests/fixtures/mobile-pairing-v2/transcript-vector.json
+++ b/crates/coven-cli/tests/fixtures/mobile-pairing-v2/transcript-vector.json
@@ -1,0 +1,16 @@
+{
+  "fixtureNotice": "SYNTHETIC TEST KEY — NOT A CREDENTIAL",
+  "pairingProtocolVersion": 2,
+  "minimumPairingProtocolVersion": 1,
+  "maximumPairingProtocolVersion": 2,
+  "pairingId": "00000000-0000-0000-0000-000000000001",
+  "hostFingerprintHex": "0303030303030303030303030303030303030303030303030303030303030303",
+  "pairingNonceHex": "0707070707070707070707070707070707070707070707070707070707070707",
+  "expiresAtUnix": 1785326700,
+  "requestedScopes": ["memory_read"],
+  "offerDigestHex": "c71ef974862afd9911afda3af32a128205d861ccf1c124b9abb8c2ae01c97367",
+  "devicePublicKeyX963Hex": "046ff03b949241ce1dadd43519e6960e0a85b41a69a05c328103aa2bce1594ca163c4f753a55bf01dc53f6c0b0c7eee78b40c6ff7d25a96e2282b989cef71c144a",
+  "deviceName": "Synthetic phone",
+  "appVersion": "1.0.0",
+  "transcriptDigestHex": "3011bc63626b5df43504b769356e0558b971b4448970164ffc803946c552ae57"
+}

--- a/docs/design/mobile-pairing-protocol-v2.md
+++ b/docs/design/mobile-pairing-protocol-v2.md
@@ -1,0 +1,131 @@
+# Mobile Pairing Protocol v2
+
+**Status:** implementation contract  
+**Authority:** Coven mobile gateway  
+**Compatibility:** pairing v1 remains accepted; newly rendered QR offers use v2
+
+## Purpose
+
+Pairing v2 hardens the existing QR enrollment flow without replacing its proven transport and confirmation model. The QR introduces a short-lived Coven installation. TLS 1.3 protects the direct connection and the QR-pinned host certificate fingerprint authenticates the endpoint. A transcript-derived six-word phrase confirms that the phone and host observed the same offer and enrollment request before a device grant is persisted.
+
+The QR is not a bearer login credential. A captured offer is useful only during its short invitation window, succeeds at most once, and still requires confirmation on both endpoints.
+
+## Version separation
+
+The existing protected mobile HTTP API remains `COVEN-MEMORY/1` and uses `x-coven-protocol: 1`. Pairing negotiation is a separate version space:
+
+| Value | Meaning |
+| --- | --- |
+| Pairing minimum | `1` |
+| Pairing current/maximum | `2` |
+| Protected mobile API | `1` |
+
+A v1 enrollment keeps its existing transcript byte-for-byte. A v2 enrollment selects pairing protocol `2` only when the client-declared range contains `2`.
+
+## QR offer
+
+The terminal renders a `coven-memory://pair` URL with these query members:
+
+| Member | Contract |
+| --- | --- |
+| `version` | Selected pairing protocol; exactly `2` |
+| `minimumVersion` | Oldest pairing protocol accepted by the host; `1` |
+| `maximumVersion` | Newest pairing protocol accepted by the host; `2` |
+| `pairingId` | Canonical lowercase UUID |
+| `endpoint` | Canonical HTTPS mobile-gateway endpoint; no user info, query, or fragment |
+| `fingerprint` | Unpadded base64url encoding of the 32-byte TLS certificate fingerprint |
+| `nonce` | Unpadded base64url encoding of the 32-byte single-use pairing nonce |
+| `expires` | Signed Unix timestamp in seconds |
+| `scope` | Requested authority; currently exactly `memory_read` |
+| `offerDigest` | Unpadded base64url SHA-256 digest of the canonical offer below |
+
+The endpoint is a routing hint authenticated by the pinned TLS certificate. It is intentionally not included in the offer digest: changing an address without possessing the pinned host private key cannot impersonate the host, while allowing the same installation identity to remain reachable through an equivalent route.
+
+## Canonical offer digest
+
+The offer digest is SHA-256 over length-prefixed fields. For each field, append its byte length as an unsigned 32-bit big-endian integer, then append the field bytes.
+
+Fields, in order:
+
+1. ASCII domain `COVEN-PAIR-OFFER/2`
+2. minimum pairing version as unsigned 16-bit big-endian (`1`)
+3. maximum pairing version as unsigned 16-bit big-endian (`2`)
+4. raw 32-byte host fingerprint
+5. raw 16-byte UUID representation of `pairingId`
+6. raw 32-byte pairing nonce
+7. expiry as signed 64-bit big-endian Unix seconds
+8. UTF-8 scope name `memory_read`
+
+Unknown, duplicate, non-canonical, or malformed URL members must fail closed in clients. Clients must compare the transmitted `offerDigest` to a locally recomputed value before enrollment.
+
+## Enrollment request
+
+The existing JSON request shape remains closed:
+
+```json
+{
+  "protocolVersion": 2,
+  "pairingNonce": "<base64url nonce>",
+  "deviceName": "Val’s iPhone",
+  "devicePublicKey": "<canonical P-256 X9.63 public key>",
+  "appVersion": "1.0.0",
+  "supportedProtocol": {
+    "minimum": 1,
+    "maximum": 2
+  }
+}
+```
+
+Requirements:
+
+- `protocolVersion` is exactly `1` or `2` and lies inside the declared range.
+- v2 clients select `2` only after validating the v2 QR offer.
+- `pairingNonce` decodes canonically to the QR nonce.
+- `devicePublicKey` is a canonical uncompressed 65-byte P-256 X9.63 public key.
+- `deviceName` is non-empty, trimmed, control-character free, and no more than 80 Unicode scalar values.
+- `appVersion` is non-empty ASCII, control-character free, and no more than 64 bytes.
+- The first enrollment attempt consumes the nonce whether the request succeeds or fails.
+
+## Pairing transcript v2
+
+The v2 transcript digest is SHA-256 over the same unsigned 32-bit length-prefixed encoding with these fields:
+
+1. ASCII domain `COVEN-PAIR/2`
+2. raw 32-byte canonical offer digest
+3. selected pairing version as unsigned 16-bit big-endian (`2`)
+4. client minimum pairing version as unsigned 16-bit big-endian
+5. client maximum pairing version as unsigned 16-bit big-endian
+6. raw canonical device public-key bytes
+7. UTF-8 device name
+8. ASCII application version
+
+This binds the host installation, invitation identity, nonce, expiry, requested authority, selected version, supported version range, device key, and human-visible device metadata into one confirmation value.
+
+The first 66 bits of the transcript digest select six words from the existing fixed 2,048-word list. Both endpoints display those words in the same order. Persistence occurs only after both endpoints submit an exact phrase match before the original expiry.
+
+## Completion and retries
+
+- Enrollment changes the invitation from `invited` to `pending confirmation` and consumes the nonce.
+- Either endpoint may confirm first.
+- The authority persists the device record/grant exactly once after both confirmations.
+- Matching retries return the same redacted completed device until the original invitation expires.
+- A wrong phrase before completion destroys the pending pairing.
+- A wrong phrase after completion does not create another device and does not erase the bounded idempotent retry result.
+- Expired pairings are pruned opportunistically and never register a device.
+
+## Security properties
+
+1. Modifying any offer security field changes `offerDigest` and the six-word phrase.
+2. Modifying the device key, selected/range versions, name, or app version changes the phrase.
+3. Pairing v1 vectors remain unchanged for older compatible clients.
+4. A relay or network observer cannot substitute a host without the QR-pinned TLS private key.
+5. Successful pairing creates a key-bound scoped grant, not a reusable bearer credential.
+6. Biometric authorization is outside this transcript: the mobile operating system may gate use of the enrolled private key, while only signatures and assurance evidence reach Coven.
+
+## Portable vector
+
+The canonical synthetic vector lives at:
+
+`crates/coven-cli/tests/fixtures/mobile-pairing-v2/transcript-vector.json`
+
+It contains no live credential. Independent clients should reproduce both `offerDigest` and `transcriptDigest` exactly before interoperating.


### PR DESCRIPTION
## Summary

- preserves pairing protocol v1 byte-for-byte for compatible clients
- makes newly rendered terminal QR offers advertise pairing protocol v2
- binds the host fingerprint, pairing ID, nonce, expiry, version range, and requested `memory_read` authority into a canonical offer digest
- binds the offer digest, selected/range versions, P-256 device key, device name, and app version into the six-word confirmation transcript
- rejects ambiguous or unencrypted pairing endpoints before rendering a QR
- adds adversarial coverage plus a portable cross-client vector and protocol specification

## Compatibility

The protected `COVEN-MEMORY/1` request-signing contract remains unchanged. This PR creates a separate pairing-version space: v1 enrollment remains accepted while new QR offers select v2.

## Security boundary

The direct transport remains TLS 1.3 authenticated by the QR-pinned host certificate fingerprint. This PR hardens the out-of-band offer and enrollment transcript; it does not treat QR knowledge as a durable credential or replace device-key proof of possession.

## Stack

This PR is temporarily based on #791 because successful v2 enrollment issues the key-bound grant introduced there. It will be retargeted to `main` after #791 merges.

## Verification

The complete workspace CI suite is required before merge.

Advances #785
Related architecture: #784
