### PR TITLE
fix(npm): keep the CLI wrapper's published dependency closure installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,16 +153,25 @@ Install globally:
 ```bash
 npm install -g @opencoven/cli
 coven doctor
+```
+
+The memory dashboard is an opt-in companion on its own release train, so a CLI
+install stays thin and never pulls the dashboard's application dependencies:
+
+```bash
+npm install -g @opencoven/coven-memory-dashboard
 coven memory open
 ```
 
 `coven memory open` starts or reuses the installed local Coven daemon before
-launching the packaged dashboard. It does not require a checkout or running
-development server from the `coven-memory` repository.
+launching that companion. It does not require a checkout or running development
+server from the `coven-memory` repository. Without the companion installed it
+prints the install command above and exits; every other Coven command is
+unaffected.
 
-The core npm wrapper supports Node.js 18 or newer. The optional memory
-dashboard requires Node.js 24 or newer; on an older runtime, only
-`coven memory open` is blocked and prints an upgrade instruction.
+The core npm wrapper supports Node.js 18 or newer. The memory dashboard
+requires Node.js 24 or newer; on an older runtime, only `coven memory open` is
+blocked and prints an upgrade instruction.
 
 **Available npm packages:**
 
@@ -173,7 +182,7 @@ dashboard requires Node.js 24 or newer; on an older runtime, only
 | `@opencoven/cli-macos-x64` | macOS Intel x64                                |
 | `@opencoven/cli-linux-x64` | glibc-based Linux x64 (Alpine unsupported)    |
 | `@opencoven/cli-windows`   | Windows x64                                    |
-| `@opencoven/coven-memory-dashboard` | Optional loopback memory dashboard companion |
+| `@opencoven/coven-memory-dashboard` | Opt-in loopback memory dashboard companion (installed separately) |
 
 ### Build from source (recommended for contributors)
 
@@ -327,9 +336,11 @@ paths directly.
 installed `@opencoven/coven-memory-dashboard` executable. The npm wrapper
 supplies only the installed Node executable and dashboard entrypoint; memory
 data and daemon transport proofs are never passed through the environment.
-Direct native binary installs can place `coven-memory-dashboard` on `PATH` or
-install the package globally. The dashboard requires Node.js 24 or newer; the
-rest of the npm-wrapped CLI remains available on Node.js 18 or newer.
+The companion is not a dependency of the wrapper; install it globally with
+`npm install -g @opencoven/coven-memory-dashboard`, which also puts
+`coven-memory-dashboard` on `PATH` for direct native binary installs. The
+dashboard requires Node.js 24 or newer; the rest of the npm-wrapped CLI remains
+available on Node.js 18 or newer.
 
 Treat the local IPC API as the product contract. Clients may validate for better UX, but the Rust daemon remains the authority boundary.
 

--- a/docs/install/npm.md
+++ b/docs/install/npm.md
@@ -18,19 +18,28 @@ coven doctor
 
 The wrapper exposes the `coven` command and selects the native package for the current platform.
 
-The wrapper also declares `@opencoven/coven-memory-dashboard` as an optional
-companion on its own release train. With optional dependencies enabled, launch
-the packaged loopback-only dashboard with:
+The packaged loopback-only dashboard is a separate opt-in install on its own
+release train. The wrapper stays thin: it depends only on the native binary for
+your platform, so a CLI install never pulls the dashboard's application
+dependencies. Install it when you want `coven memory open`:
 
 ```sh
+npm install -g @opencoven/coven-memory-dashboard
 coven memory open
 ```
+
+Without it, `coven memory open` prints this install instruction and exits; every
+other Coven command is unaffected.
+
+Upgrading from a wrapper older than 0.4.1 removes a dashboard that arrived as an
+implicit dependency, so `coven memory open` stops working until you install the
+companion explicitly with the command above. Nothing else changes.
 
 The wrapper passes only the resolved dashboard entrypoint and the current Node
 executable to the native CLI. It does not put memory content, daemon transport
 proofs, or credentials in the environment.
 
-The core npm wrapper supports Node.js 18 or newer. The optional dashboard
+The core npm wrapper supports Node.js 18 or newer. The dashboard companion
 requires Node.js 24 or newer. On Node.js 18–23, `coven memory open` prints an
 upgrade instruction; list output and every other Coven command remain
 available.
@@ -54,12 +63,11 @@ coven doctor
 
 On Linux, use a glibc-based distribution for the prebuilt package. For Alpine or another musl-based environment, use [Install from source](/install/from-source).
 
-If Coven was installed as a direct native binary, install the dashboard
-executable separately and keep it on `PATH`:
+If Coven was installed as a direct native binary, the dashboard is found on
+`PATH` rather than through the wrapper. The same global install puts it there:
 
 ```sh
 npm install -g @opencoven/coven-memory-dashboard
-coven memory open
 ```
 
 ## Install harness CLIs

--- a/docs/reference/cli-observe.md
+++ b/docs/reference/cli-observe.md
@@ -36,9 +36,11 @@ table.
 ## coven memory open
 
 `coven memory open` starts or reuses the local Coven daemon, then launches the
-optional `@opencoven/coven-memory-dashboard` companion on a validated loopback
-address. It does not require the dashboard source repository or a separate
-`coven daemon start` step. It does not accept `--json`; `coven memory` and
+opt-in `@opencoven/coven-memory-dashboard` companion on a validated loopback
+address. The companion installs separately from the npm wrapper; when it is
+not installed the command prints the install instruction and exits. It does not
+require the dashboard source repository or a separate `coven daemon start`
+step. It does not accept `--json`; `coven memory` and
 `coven memory --json` retain the read-only list behavior above. The npm wrapper
 requires Node.js 24 or newer for the dashboard only, while other wrapped Coven
 commands continue to support Node.js 18 or newer.

--- a/npm/coven/README.md
+++ b/npm/coven/README.md
@@ -14,15 +14,16 @@ npx @opencoven/cli doctor
 
 The wrapper installs platform-specific native packages through `optionalDependencies` and runs the matching `coven` binary for your OS and CPU. No Rust toolchain is required for end users after a supported package is published.
 
-It also installs `@opencoven/coven-memory-dashboard` as an optional companion.
-`coven memory open` passes only that package's installed entrypoint and the
-current Node executable to the native CLI, which launches the private
-loopback-only dashboard. Existing `coven memory` and `coven memory --json`
-continue to print the memory list.
+`@opencoven/coven-memory-dashboard` is a separate opt-in install, not a
+dependency of this wrapper. When it is present, `coven memory open` passes only
+that package's installed entrypoint and the current Node executable to the
+native CLI, which launches the private loopback-only dashboard; when it is
+absent, the command prints the install instruction. Existing `coven memory` and
+`coven memory --json` continue to print the memory list either way.
 
-The wrapper and native CLI support Node.js 18 or newer. The optional dashboard
-requires Node.js 24 or newer; on Node.js 18–23, `coven memory open` prints an
-upgrade instruction while other Coven commands continue to work.
+The wrapper and native CLI support Node.js 18 or newer. The dashboard requires
+Node.js 24 or newer; on Node.js 18–23, `coven memory open` prints an upgrade
+instruction while other Coven commands continue to work.
 
 ## v0 platform scope
 

--- a/npm/coven/bin/coven.js
+++ b/npm/coven/bin/coven.js
@@ -18,6 +18,13 @@ const platformKey = `${process.platform}-${process.arch}`;
 const packageName = PLATFORM_PACKAGES[platformKey];
 const MEMORY_DASHBOARD_MIN_NODE_MAJOR = 24;
 const WINDOWS_HIDE_NATIVE_WINDOW_ENV = 'COVEN_WINDOWS_HIDE_NATIVE_WINDOW';
+// Wrapper-to-native handoff for `coven memory open`. The wrapper is the only
+// legitimate source of these, so an inherited value is always stale or hostile.
+const MEMORY_DASHBOARD_HANDOFF_ENV = [
+  'COVEN_MEMORY_DASHBOARD_ENTRY',
+  'COVEN_MEMORY_DASHBOARD_NODE',
+  'COVEN_MEMORY_DASHBOARD_BIN'
+];
 const PRINT_NATIVE_BINARY_PATH_ARG = '--print-native-binary-path';
 
 function resolveBinary() {
@@ -106,6 +113,17 @@ for (const name of Object.keys(childEnv)) {
     delete childEnv[name];
   }
 }
+// Same reasoning for the dashboard handoff, and the same case-insensitive
+// sweep. The native CLI launches whatever entrypoint these name, so an
+// inherited value is arbitrary code selected by whoever set it. Clearing them
+// first means the wrapper's own resolution below is the only thing that can
+// populate them; when that resolution fails the native binary sees no handoff
+// and emits its installation error instead of running a stale build.
+for (const name of Object.keys(childEnv)) {
+  if (MEMORY_DASHBOARD_HANDOFF_ENV.includes(name.toUpperCase())) {
+    delete childEnv[name];
+  }
+}
 const opensMemoryDashboard = isMemoryOpenInvocation(args);
 const requestsHelp = args.some((arg) => arg === '--help' || arg === '-h');
 if (
@@ -114,7 +132,7 @@ if (
   !supportsMemoryDashboard(process.versions.node)
 ) {
   console.error(
-    `coven memory open requires Node.js ${MEMORY_DASHBOARD_MIN_NODE_MAJOR} or newer; current Node.js is ${process.versions.node}. Upgrade Node.js and reinstall @opencoven/cli. Other Coven CLI commands continue to support Node.js 18 or newer.`
+    `coven memory open requires Node.js ${MEMORY_DASHBOARD_MIN_NODE_MAJOR} or newer; current Node.js is ${process.versions.node}. Upgrade Node.js, then install the dashboard companion with: npm install -g @opencoven/coven-memory-dashboard. Other Coven CLI commands continue to support Node.js 18 or newer.`
   );
   process.exit(1);
 }
@@ -125,7 +143,9 @@ if (opensMemoryDashboard) {
     );
     childEnv['COVEN_MEMORY_DASHBOARD_NODE'] = process.execPath;
   } catch {
-    // The native binary emits the single actionable installation error.
+    // The default for anyone who has not installed the companion. The
+    // handoff variables stay cleared, so the native binary emits the single
+    // actionable installation error.
   }
 }
 

--- a/npm/coven/package.json
+++ b/npm/coven/package.json
@@ -17,7 +17,6 @@
     "url": "git+https://github.com/OpenCoven/coven.git"
   },
   "optionalDependencies": {
-    "@opencoven/coven-memory-dashboard": "^0.1.0",
     "@opencoven/cli-macos": "0.0.0",
     "@opencoven/cli-macos-x64": "0.0.0",
     "@opencoven/cli-linux-x64": "0.0.0",

--- a/scripts/publish-npm-test.mjs
+++ b/scripts/publish-npm-test.mjs
@@ -4,6 +4,7 @@ import { once } from 'node:events';
 import {
   chmodSync,
   copyFileSync,
+  cpSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -17,9 +18,14 @@ import path from 'node:path';
 import test from 'node:test';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-import { defaultTargetName, isMainModule, targetHelperBinaryName, isOidcContext, nativeTargetNamesForPackageSet, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
+import { assertInstallableDependencies, defaultTargetName, isMainModule, targetHelperBinaryName, isOidcContext, nativeTargetNamesForPackageSet, packageVersionPublished, publishArgs, publishEnv, releaseVersion, targetPackageName, validatePublishToken, validatePublishVersion, wrapperPackageDirName, wrapperPackageNameList, wrapperTextForPackage } from './publish-npm.mjs';
 import { parseReleaseTag } from './release-npm-context.mjs';
 import { platformMatrix } from './release-npm-platform-matrix.mjs';
+
+const WRAPPER_PACKAGE_PATH = new URL(
+  ['..', 'npm', 'coven', 'package.json'].join('/'),
+  import.meta.url
+);
 
 const OIDC_ENV = {
   ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'fake-oidc-token',
@@ -246,18 +252,155 @@ test('defaultTargetName maps win32 x64 to windows', () => {
 });
 
 test('wrapper declares linux x64 native package as an optional dependency', () => {
-  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
-  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  const packageJson = JSON.parse(readFileSync(WRAPPER_PACKAGE_PATH, 'utf8'));
   assert.equal(packageJson.optionalDependencies['@opencoven/cli-linux-x64'], '0.0.0');
 });
 
-test('wrapper keeps the dashboard companion on its independent version', () => {
-  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
-  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
-  assert.equal(
-    packageJson.optionalDependencies['@opencoven/coven-memory-dashboard'],
-    '^0.1.0'
+test('wrapper does not depend on the dashboard companion', () => {
+  // The dashboard is a Next.js application whose own dependency closure is far
+  // larger than the wrapper's, and only `coven memory open` needs it. Depending
+  // on it here put that whole closure into every global CLI install. The
+  // command resolves the companion at run time instead, and the native binary
+  // prints the single actionable install instruction when it is absent.
+  const packageJson = JSON.parse(readFileSync(WRAPPER_PACKAGE_PATH, 'utf8'));
+  for (const field of ['dependencies', 'optionalDependencies', 'peerDependencies']) {
+    assert.equal(
+      packageJson[field]?.['@opencoven/coven-memory-dashboard'],
+      undefined,
+      `dashboard companion must not be declared in ${field}`
+    );
+  }
+});
+
+test('wrapper template is self-consistent at the placeholder version', () => {
+  const packageJson = JSON.parse(readFileSync(WRAPPER_PACKAGE_PATH, 'utf8'));
+  assert.doesNotThrow(() => assertInstallableDependencies(packageJson, '0.0.0'));
+});
+
+test('publish refuses a wrapper dependency npm cannot integrity-check', () => {
+  // These specifiers skip npm's integrity check and need git or a network
+  // fetch, plus credentials, at install time. Only this manifest is in scope:
+  // the specifier that shipped the bug was transitive, reachable because the
+  // wrapper declared the dashboard at all, and is caught below by the pin rule.
+  for (const spec of [
+    'git+https://github.com/OpenCoven/coven-design-system.git#6032f9f4',
+    'ssh://git@github.com/OpenCoven/coven-design-system.git',
+    'github:OpenCoven/coven-design-system',
+    'OpenCoven/coven-design-system',
+    'https://example.invalid/pkg.tgz',
+    'file:../pkg'
+  ]) {
+    assert.throws(
+      () => assertInstallableDependencies({ dependencies: { pkg: spec } }, '0.4.1'),
+      /must be pinned to the release version/,
+      `expected '${spec}' to be refused`
+    );
+  }
+});
+
+test('publish refuses a wrapper dependency left off the release version', () => {
+  // Every installed wrapper dependency is a lockstep-versioned native, so a
+  // surviving range means the placeholder rewrite missed it — which is exactly
+  // how `^0.1.0` shipped. A bare `0.0.0` is the same miss wearing an
+  // exact-looking shape, and resolves to a version that was never published.
+  for (const spec of ['^0.4.1', '~0.4.1', '0.x', 'latest', '*', '0.0.0', '0.4.0']) {
+    assert.throws(
+      () => assertInstallableDependencies({ optionalDependencies: { pkg: spec } }, '0.4.1'),
+      /must be pinned to the release version/,
+      `expected '${spec}' to be refused`
+    );
+  }
+});
+
+test('publish accepts any exact release version, prereleases included', () => {
+  // The rule is equality with the release version, not a version shape, so a
+  // prerelease or build-metadata release passes or fails with the release
+  // itself rather than against a second, divergent shape rule.
+  for (const version of ['0.4.1', '1.0.0-rc.1', '1.0.0+build.5', '999.0.0']) {
+    assert.doesNotThrow(
+      () => assertInstallableDependencies({ optionalDependencies: { pkg: version } }, version),
+      `expected '${version}' to be accepted`
+    );
+  }
+});
+
+test('publish checks every dependency field npm installs from', () => {
+  for (const field of ['dependencies', 'optionalDependencies']) {
+    assert.throws(
+      () =>
+        assertInstallableDependencies(
+          { [field]: { pkg: 'git+https://x.invalid/p.git' } },
+          '0.4.1'
+        ),
+      /must be pinned to the release version/,
+      `expected ${field} to be checked`
+    );
+  }
+  // devDependencies are not installed for a consumer of a published package.
+  assert.doesNotThrow(() =>
+    assertInstallableDependencies(
+      { devDependencies: { pkg: 'git+https://x.invalid/p.git' } },
+      '0.4.1'
+    )
   );
+});
+
+test('publish holds peer dependencies to registry resolution but not to a pin', () => {
+  // Peer ranges are idiomatic and legitimate; a non-registry peer specifier is
+  // not, because npm installs peers and cannot integrity-check those.
+  assert.doesNotThrow(() =>
+    assertInstallableDependencies({ peerDependencies: { pkg: '^3.0.0' } }, '0.4.1')
+  );
+  for (const spec of ['git+https://x.invalid/p.git', 'github:owner/repo', 'file:../p']) {
+    assert.throws(
+      () => assertInstallableDependencies({ peerDependencies: { pkg: spec } }, '0.4.1'),
+      /resolves outside the npm registry/,
+      `expected peer '${spec}' to be refused`
+    );
+  }
+});
+
+test('publish path fails closed on a wrapper dependency npm cannot install', () => {
+  // The unit tests above would all still pass if the call site were deleted.
+  // This drives the real script end to end so the gate is pinned to the publish
+  // path itself, not merely to the exported function.
+  const fixture = mkdtempSync(path.join(tmpdir(), 'coven-publish-gate-'));
+  try {
+    mkdirSync(path.join(fixture, 'scripts'), { recursive: true });
+    copyFileSync(
+      fileURLToPath(new URL('publish-npm.mjs', import.meta.url)),
+      path.join(fixture, 'scripts', 'publish-npm.mjs')
+    );
+    cpSync(
+      fileURLToPath(new URL('../npm/coven', import.meta.url)),
+      path.join(fixture, 'npm', 'coven'),
+      { recursive: true }
+    );
+    const poisoned = path.join(fixture, 'npm', 'coven', 'package.json');
+    const packageJson = JSON.parse(readFileSync(poisoned, 'utf8'));
+    packageJson.dependencies = {
+      '@opencoven/coven-design-system':
+        'git+https://github.com/OpenCoven/coven-design-system.git#6032f9f4'
+    };
+    writeFileSync(poisoned, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+    // --wrapper-only --dry-run reaches writeWrapperPackage and must abort there,
+    // before npm is invoked at all.
+    const result = spawnSync(
+      process.execPath,
+      [path.join(fixture, 'scripts', 'publish-npm.mjs'), '--wrapper-only', '--dry-run'],
+      { encoding: 'utf8', cwd: fixture, env: { ...process.env, COVEN_NPM_VERSION: '0.4.1' } }
+    );
+    assert.notEqual(result.status, 0, 'publish must fail closed on a git dependency');
+    assert.match(
+      result.stderr,
+      /Refusing to publish @opencoven\/cli: dependencies\['@opencoven\/coven-design-system'\]/
+    );
+    // fail() reports a bare actionable line, not an uncaught-throw stack dump.
+    assert.doesNotMatch(result.stderr, /at assertInstallableDependencies/);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
 });
 
 test('wrapper declares the installed dashboard entrypoint handoff', () => {
@@ -433,6 +576,119 @@ test(
   }
 );
 
+test(
+  'wrapper clears an inherited dashboard handoff instead of forwarding it',
+  {
+    skip:
+      process.platform === 'win32' ||
+      !SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`]
+  },
+  () => {
+    // The native CLI launches whatever entrypoint the handoff names, so an
+    // inherited value is arbitrary code chosen by whoever set it. The wrapper
+    // is the only legitimate source. This matters most on the dashboard-absent
+    // path, which is the default for everyone who has not installed the
+    // companion: the wrapper sets nothing there, so anything it failed to clear
+    // would reach the native binary unchallenged.
+    const fixture = mkdtempSync(path.join(tmpdir(), 'coven-wrapper-handoff-env-'));
+    try {
+      const wrapperDir = path.join(fixture, 'wrapper');
+      const wrapperBinDir = path.join(wrapperDir, 'bin');
+      const wrapperPath = path.join(wrapperBinDir, 'coven.js');
+      mkdirSync(wrapperBinDir, { recursive: true });
+      writeFileSync(
+        path.join(wrapperDir, 'package.json'),
+        JSON.stringify({ name: '@opencoven/cli-test', type: 'module' })
+      );
+      copyFileSync(
+        fileURLToPath(new URL('../npm/coven/bin/coven.js', import.meta.url)),
+        wrapperPath
+      );
+
+      const [packageName, binaryName] =
+        SIGNAL_TEST_PACKAGES[`${process.platform}-${process.arch}`];
+      const nativeDir = path.join(wrapperDir, 'node_modules', ...packageName.split('/'));
+      const nativeBinDir = path.join(nativeDir, 'bin');
+      const nativePath = path.join(nativeBinDir, binaryName);
+      mkdirSync(nativeBinDir, { recursive: true });
+      writeFileSync(
+        path.join(nativeDir, 'package.json'),
+        JSON.stringify({ name: packageName, version: '0.0.0' })
+      );
+      writeFileSync(
+        nativePath,
+        [
+          '#!/bin/sh',
+          'printf "%s\\n%s\\n%s\\n" "$COVEN_MEMORY_DASHBOARD_ENTRY" "$COVEN_MEMORY_DASHBOARD_NODE" "$COVEN_MEMORY_DASHBOARD_BIN"',
+          ''
+        ].join('\n')
+      );
+      chmodSync(nativePath, 0o755);
+
+      const inherited = {
+        ...process.env,
+        COVEN_MEMORY_DASHBOARD_ENTRY: '/tmp/attacker-entry.mjs',
+        COVEN_MEMORY_DASHBOARD_NODE: '/tmp/attacker-node',
+        COVEN_MEMORY_DASHBOARD_BIN: '/tmp/attacker-bin'
+      };
+
+      // No dashboard is installed in this fixture, so the wrapper's resolve
+      // fails and it sets no handoff of its own.
+      const absent = spawnSync(process.execPath, [wrapperPath, 'memory', 'open'], {
+        encoding: 'utf8',
+        env: inherited
+      });
+      assert.equal(absent.status, 0, `wrapper exited ${absent.status}: ${absent.stderr}`);
+      assert.equal(
+        absent.stdout,
+        '\n\n\n',
+        'every inherited dashboard handoff variable must be cleared'
+      );
+
+      // A non-dashboard invocation must not carry them either.
+      const unrelated = spawnSync(process.execPath, [wrapperPath, 'doctor'], {
+        encoding: 'utf8',
+        env: inherited
+      });
+      assert.equal(unrelated.status, 0, `wrapper exited ${unrelated.status}`);
+      assert.equal(unrelated.stdout, '\n\n\n');
+
+      // With the companion installed the wrapper supplies its own entry and
+      // Node, and still drops the inherited binary override.
+      const dashboardDir = path.join(
+        wrapperDir,
+        'node_modules',
+        '@opencoven',
+        'coven-memory-dashboard'
+      );
+      const dashboardBinDir = path.join(dashboardDir, 'bin');
+      const dashboardEntry = path.join(dashboardBinDir, 'coven-memory-dashboard.mjs');
+      mkdirSync(dashboardBinDir, { recursive: true });
+      writeFileSync(
+        path.join(dashboardDir, 'package.json'),
+        JSON.stringify({
+          name: '@opencoven/coven-memory-dashboard',
+          version: '0.0.0',
+          type: 'module'
+        })
+      );
+      writeFileSync(dashboardEntry, '');
+
+      const present = spawnSync(process.execPath, [wrapperPath, 'memory', 'open'], {
+        encoding: 'utf8',
+        env: inherited
+      });
+      assert.equal(present.status, 0, `wrapper exited ${present.status}: ${present.stderr}`);
+      const [entry, node, bin] = present.stdout.split('\n');
+      assert.equal(entry, dashboardEntry, 'wrapper must resolve the entry itself');
+      assert.equal(node, process.execPath, 'wrapper must supply its own Node');
+      assert.equal(bin, '', 'inherited binary override must be cleared');
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  }
+);
+
 test('release publishes only the canonical @opencoven/cli wrapper package', () => {
   assert.deepEqual(wrapperPackageNameList(), ['@opencoven/cli']);
   assert.equal(wrapperPackageDirName('@opencoven/cli'), 'coven');
@@ -445,8 +701,7 @@ test('wrapperTextForPackage rewrites @opencoven/cli only when given a different 
 });
 
 test('wrapper declares windows native package as an optional dependency', () => {
-  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
-  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  const packageJson = JSON.parse(readFileSync(WRAPPER_PACKAGE_PATH, 'utf8'));
   assert.equal(packageJson.optionalDependencies['@opencoven/cli-windows'], '0.0.0');
 });
 
@@ -461,8 +716,7 @@ test('wrapper binary maps Intel macOS to the Intel native package', () => {
   const binPath = new URL(['..', 'npm', 'coven', 'bin', 'coven.js'].join('/'), import.meta.url);
   const bin = readFileSync(binPath, 'utf8');
   assert.match(bin, /'darwin-x64': '@opencoven\/cli-macos-x64'/);
-  const packagePath = new URL(['..', 'npm', 'coven', 'package.json'].join('/'), import.meta.url);
-  const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+  const packageJson = JSON.parse(readFileSync(WRAPPER_PACKAGE_PATH, 'utf8'));
   assert.equal(packageJson.optionalDependencies['@opencoven/cli-macos-x64'], '0.0.0');
 });
 

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -53,6 +53,64 @@ const nativePackageSets = {
   'post-intel': ['macos', 'macos-x64', 'linux-x64', 'windows']
 };
 
+// npm installs these into a consumer's dependency tree. `devDependencies` is
+// absent: npm does not install it for a consumer of a published package.
+// `bundleDependencies` is absent too — npm defines it as an array of names, not
+// a spec map, and bundled code ships inside the tarball under the tarball's own
+// integrity hash.
+const LOCKSTEP_DEPENDENCY_FIELDS = ['dependencies', 'optionalDependencies'];
+
+// A specifier npm resolves from somewhere other than the registry, so it
+// carries no integrity hash and needs git or a network fetch at install time.
+// A semver range never contains a slash, which is what separates a bare
+// `owner/repo` GitHub shorthand from a legitimate range.
+const NON_REGISTRY_SPECIFIER =
+  /^(?:git(?:\+[a-z]+)?:|ssh:|https?:|file:|link:|portal:|github:|gitlab:|bitbucket:|gist:)|\//i;
+
+/**
+ * Fail closed on any published dependency npm cannot install from the registry
+ * against an integrity hash.
+ *
+ * Every installed dependency of a published wrapper is a lockstep-versioned
+ * `@opencoven/cli-*` native, so each spec must equal the release version
+ * exactly. That is stronger and simpler than "looks like a version": it also
+ * rejects a `0.0.0` placeholder that escaped the rewrite in
+ * `writeWrapperPackage`, which is exact-shaped but names a version that was
+ * never published. Prerelease and build-metadata versions therefore pass or
+ * fail with the release itself rather than against a separate shape rule.
+ *
+ * Only this package's own manifest is in scope. A transitive git dependency
+ * pulled in by an otherwise well-formed dependency is invisible here; the
+ * defense against that is not declaring dependencies whose own closure is
+ * unaudited.
+ *
+ * `peerDependencies` are legitimately ranges, so they are held only to the
+ * weaker rule that they name something npm can integrity-check.
+ */
+export function assertInstallableDependencies(packageJson, version) {
+  for (const field of LOCKSTEP_DEPENDENCY_FIELDS) {
+    for (const [name, spec] of Object.entries(packageJson[field] ?? {})) {
+      if (spec !== version) {
+        throw new Error(
+          `Refusing to publish ${packageJson.name}: ${field}['${name}'] must be ` +
+            `pinned to the release version ${version}, got '${spec}'. Every ` +
+            `installed dependency of a published package is a lockstep-versioned ` +
+            `native package npm resolves from the registry with an integrity hash.`
+        );
+      }
+    }
+  }
+  for (const [name, spec] of Object.entries(packageJson.peerDependencies ?? {})) {
+    if (NON_REGISTRY_SPECIFIER.test(spec)) {
+      throw new Error(
+        `Refusing to publish ${packageJson.name}: peerDependencies['${name}'] ` +
+          `resolves outside the npm registry ('${spec}'), so npm cannot ` +
+          `integrity-check it and installing it needs credentials.`
+      );
+    }
+  }
+}
+
 if (isMainModule()) {
   main();
 }
@@ -172,6 +230,13 @@ function writePlatformPackage(targetName, target, binaryPath, version) {
     .replaceAll('__OS__', target.os)
     .replaceAll('__CPU__', target.cpu);
 
+  try {
+    // The template declares no dependencies today; the gate is what keeps that
+    // true for the native packages as well as the wrapper.
+    assertInstallableDependencies(JSON.parse(packageJson), version);
+  } catch (error) {
+    fail(error.message);
+  }
   writeFileSync(path.join(outDir, 'package.json'), `${packageJson.trim()}\n`);
   cpSync(path.join(repoRoot, 'npm', 'coven-platform-template', 'README.md'), path.join(outDir, 'README.md'));
   cpSync(binaryPath, path.join(binDir, target.binaryName));
@@ -207,6 +272,13 @@ function writeWrapperPackage(version, packageName = primaryWrapperPackageName, n
         packageJson.optionalDependencies[optionalName] = version;
       }
     }
+  }
+  try {
+    assertInstallableDependencies(packageJson, version);
+  } catch (error) {
+    // Report like every other publish failure: a bare actionable line, not an
+    // uncaught-throw stack dump in the release log.
+    fail(error.message);
   }
   writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
   rewriteWrapperText(path.join(outDir, 'README.md'), packageName);


### PR DESCRIPTION
## Context

- Summary: `npm install -g @opencoven/cli` resolved a `git+https` dependency over `ssh://git@github.com`, skipping npm's integrity check and installing 115 packages for a wrapper that ships three files. This drops the dependency that caused it and adds a fail-closed publish gate.
- Files changed: `npm/coven/package.json`, `npm/coven/bin/coven.js`, `scripts/publish-npm.mjs`, `scripts/publish-npm-test.mjs`, `README.md`, `npm/coven/README.md`, `docs/install/npm.md`, `docs/reference/cli-observe.md`
- Closes #

Reproduced on a clean Windows install:

```
npm warn skipping integrity check for git dependency ssh://git@github.com/OpenCoven/coven-design-system.git
changed 115 packages in 21s
npm warn allow-scripts 2 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   sharp@0.34.5 (install: node install/check.js || npm run build)
npm warn allow-scripts   esbuild@0.25.12 (postinstall: node install.js)
```

The chain: `npm/coven/package.json` declared `@opencoven/coven-memory-dashboard` in `optionalDependencies`; that package is a Next.js application whose runtime `dependencies` include `"@opencoven/coven-design-system": "git+https://github.com/OpenCoven/coven-design-system.git#6032f9f4…"`, and `sharp`/`esbuild` arrive transitively from Next.

## Implementation

Remove the dashboard from the wrapper's `optionalDependencies`, then guard the invariant in the publisher. `assertInstallableDependencies` runs inside `writeWrapperPackage` and `writePlatformPackage`, so the release dry-run (`release-npm.yml:256`) and the real publish both refuse a dependency npm cannot resolve from the registry against an integrity hash.

The rule is **equality with the release version**, not a version shape. Every installed dependency of a published package here is a lockstep-versioned native, so this is the actual invariant, and it is strictly stronger than "looks like a version":

- it catches a `0.0.0` placeholder that escaped the rewrite — exact-*shaped*, but naming a version that was never published;
- it lets a prerelease release pass or fail with the release itself rather than against a second, divergent shape rule (`test-cli-prepublish.mjs:345` explicitly accepts a prerelease `COVEN_NPM_DRY_RUN_VERSION`, which an exact-shape regex would have broken);
- `peerDependencies` are legitimately ranges, so they are held only to the weaker registry-resolution rule.

### User-visible behavior

A global CLI install no longer needs git, GitHub SSH credentials, or the design-system repository, and no longer installs the dashboard's application closure. `coven memory open` is unchanged when the companion is installed; when it is absent the native binary prints its existing actionable instruction (`crates/coven-cli/src/memory_dashboard.rs:93`), after resolving `coven-memory-dashboard` on `PATH`. Every other `coven` command is unaffected either way.

### Two consequences of the removal, fixed here

Both are in scope because this change is what makes them reachable.

1. **The dashboard handoff env vars are now cleared up front.** `COVEN_MEMORY_DASHBOARD_ENTRY` / `_NODE` / `_BIN` were only ever overwritten on the resolve-succeeds path, which was effectively universal before this change. The catch is now the default for anyone without the companion, so an inherited value would survive into the native child by default rather than exceptionally — and the native CLI launches whatever entrypoint it names. The wrapper now applies the same case-insensitive sweep it already applied to `COVEN_WINDOWS_HIDE_NATIVE_WINDOW`, for the same stated reason, and repopulates the variables only from its own resolution. Verified before/after against `origin/main` with a stubbed `child_process`:

   ```
   # origin/main, hostile inherited values
   ENTRY=[/evil.mjs]  NODE=[/evil/node]  BIN=[/evil/bin]
   # this branch
   ENTRY=[<unset>]    NODE=[<unset>]     BIN=[<unset>]
   ```

2. **The Node 18–23 gate named the wrong remedy.** It said "Upgrade Node.js and reinstall `@opencoven/cli`" — reinstalling the wrapper will never install the dashboard now, so a user on Node 18 would upgrade, reinstall as instructed, rerun, and only then hit the real "not installed" error. It now names the companion.

### Docs

The README quickstart ran `coven memory open` directly after installing the CLI, and the direct-native-binary section of the install guide said to keep the executable on `PATH` "instead of installing it globally" — but the global install is what puts it on `PATH`, and is exactly what the native binary's own error tells users to run. Both now name the companion install. An upgrade note records that an implicitly-installed dashboard is pruned on upgrade.

### Compatibility

Users who relied on the dashboard arriving implicitly now install it explicitly with `npm install -g @opencoven/coven-memory-dashboard`. `publish-npm.mjs` only ever rewrote `@opencoven/cli-*` placeholders, so the removed entry was never version-managed — no release coordination needed.

## Verification

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — not run locally; this PR changes no Rust
- [ ] `cargo test --workspace --locked` — not run locally; this PR changes no Rust
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] `python3 scripts/check-api-contract-docs.py`
- [x] Additional manual checks:
  - `node --test scripts/publish-npm-test.mjs scripts/onboarding-docs-test.mjs scripts/cli-docs-test.mjs scripts/pr-readiness-test.mjs` on Linux: **107 tests, 106 pass, 0 fail, 1 skip.**
  - On Windows the same set has one **pre-existing** failure, `Windows wrapper opt-in launches its console-subsystem native child without a console` — it reproduces identically on unmodified `origin/main` on this host and passes on Linux. Unrelated to this change; noted as a follow-up.
  - `COVEN_NPM_VERSION=0.4.1 node scripts/publish-npm.mjs --wrapper-only --dry-run` — exits 0.
  - **Mutation-checked both new load-bearing tests.** Deleting the `assertInstallableDependencies` call site makes `publish path fails closed on a wrapper dependency npm cannot install` fail; deleting the env sweep makes `wrapper clears an inherited dashboard handoff instead of forwarding it` fail. Both pass with the code intact.
  - Negative check: restoring `"@opencoven/coven-memory-dashboard": "^0.1.0"` makes the dry-run exit 1 with `Refusing to publish @opencoven/cli: optionalDependencies['@opencoven/coven-memory-dashboard'] must be pinned to the release version 0.4.1, got '^0.1.0'.`

## Risk and Rollback

- Risk level: low. One dependency removed, one precondition added on the publish path, and one env-scrubbing loop added to the wrapper. The main user-visible risk is someone who expected `coven memory open` to work immediately after a fresh CLI install — that path now prints an install instruction instead of launching, which is the pre-existing behavior for direct native binary installs.
- Rollback plan: revert the commit. The removed entry was not version-managed by the publisher, so no release coordination is needed.

## Agent Handoff

- Current state: complete. Reviewed by four independent agents (publish-gate correctness, removal blast radius, test quality, runtime degradation); all findings addressed or recorded below.
- Corrections to the record from that review:
  - An earlier revision of this PR justified the gate's placement with "`scripts/publish-npm-test.mjs` is not wired into CI". **That was wrong.** It runs via `scripts/test-cli-prepublish.mjs:115-122`, invoked from `ci.yml:345` and `ci.yml:395`. The publisher is still the right home for the gate — it fails closed on the artifact that ships rather than merely observing the source manifest — but the stated reason was false and the commit message has been corrected.
  - The gate reads only this package's own manifest. A transitive git dependency behind an otherwise well-formed dependency is invisible to it; the defense against that is not declaring dependencies whose own closure is unaudited. This is now stated in the code comment and the test.
- Follow-ups:
  - `@opencoven/coven-memory-dashboard` still carries the `git+https` design-system dependency in its own repository, so users who install the companion still hit the integrity warning and still need GitHub credentials. Fixing it there (publish the design system, or vendor the built tokens into the tarball) is the durable fix; this PR only stops the CLI from imposing it on everyone.
  - `Windows wrapper opt-in launches its console-subsystem native child without a console` fails locally on Windows against `origin/main`. Worth its own issue rather than being carried as "known".
  - Separate concern, deliberately not in this diff: on Windows, upgrading while a `coven` daemon is running leaves an orphaned `node_modules/@opencoven/.cli-*` directory per upgrade. npm renames the old tree aside, then cannot delete it because the running process holds the `coven.exe` image lock, and reports `EPERM` as a warning. Stopping the daemon first avoids it; a stale-directory sweep in the wrapper or a `preinstall` daemon stop would fix it properly.
  - `packages/cli/package.json` declares a second manifest also named `@opencoven/cli`. It is not on the publish path and is untouched here, but the new guard covers only `npm/coven/`.
- Known gaps: Rust gates not run locally (no Rust touched); CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
