### PR TITLE
fix(scripts): teach the secrets guard TypeScript env bindings

### DIFF
--- a/scripts/check-secrets-test.py
+++ b/scripts/check-secrets-test.py
@@ -990,6 +990,70 @@ class SecretGuardExceptionScopeTests(unittest.TestCase):
 
                 self.assertEqual(hits, [])
 
+    def test_typescript_environment_reads_are_safe(self) -> None:
+        cases = [
+            'const token = process.env["REALLY_LONG_SECRET_NAME"];',
+            "const token = process.env['REALLY_LONG_SECRET_NAME'];",
+            "const token = process.env?.REALLY_LONG_SECRET_NAME;",
+            'const token = process.env?.["REALLY_LONG_SECRET_NAME"];',
+            'const token = process.env["REALLY_LONG_SECRET_NAME"]!;',
+            'const token = process.env["REALLY_LONG_SECRET_NAME"].trim();',
+            'const token = process.env["REALLY_LONG_SECRET_NAME"]?.trim();',
+            'const token = process.env["GITHUB_ACCESS_TOKEN"] ?? "";',
+            'const token = process.env["GITHUB_ACCESS_TOKEN"] || "";',
+            'const apiKey = process.env["OPENAI_API_KEY"] as string;',
+            'const secret = Deno.env.get("REALLY_LONG_SECRET_NAME");',
+            'const secret = Deno.env.get("REALLY_LONG_SECRET_NAME")?.trim();',
+            'const secret = Deno.env.get("REALLY_LONG_SECRET_NAME") ?? "";',
+            "const token = Bun.env.REALLY_LONG_SECRET_NAME;",
+            'const token = Bun.env["REALLY_LONG_SECRET_NAME"];',
+            "const apiKey = import.meta.env.VITE_REALLY_LONG_KEY;",
+            'const apiKey = import.meta.env["VITE_REALLY_LONG_KEY"];',
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(
+                    text, "packages/channels/src/config.ts"
+                )
+
+                self.assertEqual(hits, [])
+
+    def test_typescript_environment_reads_reject_literal_payloads(self) -> None:
+        cases = [
+            'const token = process.env["TOKEN"] + "hunter2hunter2hunter2";',
+            'const token = process.env["TOKEN"] ?? "hunter2hunter2hunter2";',
+            'const token = process.env["TOKEN"] || "hunter2hunter2hunter2";',
+            'const token = process.env?.TOKEN ?? "hunter2hunter2hunter2";',
+            'const token = Deno.env.get("TOKEN") ?? "hunter2hunter2hunter2";',
+            'const token = Bun.env.TOKEN ?? "hunter2hunter2hunter2";',
+            (
+                "const apiKey = import.meta.env.VITE_KEY ?? "
+                '"hunter2hunter2hunter2";'
+            ),
+        ]
+
+        for text in cases:
+            with self.subTest(text=text):
+                hits = check_secrets.scan_text(
+                    text, "packages/channels/src/config.ts"
+                )
+
+                self.assertEqual(
+                    hits,
+                    [("packages/channels/src/config.ts", 1, "generic_assignment")],
+                )
+
+    def test_bare_env_object_read_is_not_treated_as_runtime_binding(self) -> None:
+        text = "const token = env.REALLY_LONG_SECRET_NAME;"
+
+        hits = check_secrets.scan_text(text, "packages/channels/src/config.ts")
+
+        self.assertEqual(
+            hits,
+            [("packages/channels/src/config.ts", 1, "generic_assignment")],
+        )
+
     def test_environment_reference_with_appended_value_is_not_safe(self) -> None:
         text = "api_key=${API_KEY}hunter2hunter2hunter2"
 

--- a/scripts/check-secrets.py
+++ b/scripts/check-secrets.py
@@ -66,6 +66,10 @@ RESERVED_EXAMPLE_URL = re.compile(
     r"(?:example\.(?:com|net|org)|[A-Za-z0-9-]+\.(?:example|invalid|localhost|test))"
     r"(?::[0-9]{1,5})?(?:/[^\s\"'<>]*)?"
 )
+# The TypeScript and JavaScript accessors below only vary in how the
+# environment variable *name* is spelled, so none of them can carry a literal
+# secret value. Bare `env.NAME` is deliberately excluded: `env` is an ordinary
+# identifier that any object can bind.
 ENV_SECRET_READ = re.compile(
     r'''(?ix)\b(?:api[_-]?key|secret|token|password|private[_-]?key)\b\s*[:=]\s*
     (?:
@@ -76,7 +80,14 @@ ENV_SECRET_READ = re.compile(
         \)
         |std::env::var\(\s*["'][A-Z0-9_]+["']\s*\)
         |env::var\(\s*["'][A-Z0-9_]+["']\s*\)
-        |process\.env\.[A-Z0-9_]+(?:\.trim\(\)|\?\.trim\(\)|!)?
+        |(?:process\.env|Bun\.env|import\.meta\.env)
+            (?:
+                (?:\.|\?\.)[A-Z0-9_]+
+                |(?:\?\.)?\[\s*["'][A-Z0-9_]+["']\s*\]
+            )
+            (?:\.trim\(\)|\?\.trim\(\)|!)?
+        |Deno\.env\.get\(\s*["'][A-Z0-9_]+["']\s*\)
+            (?:\.trim\(\)|\?\.trim\(\)|!)?
     )'''
 )
 ENV_SECRET_REFERENCE = re.compile(


### PR DESCRIPTION
## Problem

`ENV_SECRET_READ` in `scripts/check-secrets.py` recognized Python, Rust, and exactly one JavaScript shape — dotted `process.env.NAME`. Every other ordinary TypeScript environment read fell through to the `generic_assignment` detector and was reported as a **hardcoded secret**.

Probed against the live guard before changing anything; all of these tripped it:

```ts
const apiKey = process.env["API_KEY"];
const token = process.env?.TOKEN;
const secret = Deno.env.get("SECRET");
const apiKey = import.meta.env.VITE_API_KEY;
const token = Bun.env.TOKEN;
```

There are zero false positives across the 30 tracked `*.ts` files today, so this was **latent** — it would have fired the moment anyone wrote conventional TypeScript. (It already surfaced once while validating an unrelated TS branch.)

## Fix

Accept `process.env`, `Bun.env`, and `import.meta.env` in dotted, optional-chained, and quoted-bracket form, plus `Deno.env.get("NAME")` — keeping the existing `.trim()` / `?.trim()` / `!` suffixes. None of these accessors can carry a literal secret value; only the spelling of the variable *name* differs.

## Kept fail-closed

Bare `env.NAME` (Workers-style bindings) is **deliberately not allowed** — `env` is an ordinary identifier that any object can bind, so accepting it would open a real bypass. A regression test pins that behavior. Literal fallbacks still report:

```ts
const apiKey = process.env.API_KEY ?? "sk-live-realvalue";  // still caught
```

## Verification

| Gate | Result |
| --- | --- |
| `python3 scripts/check-secrets-test.py` | 90 tests OK (was 87) |
| `python3 scripts/check-secrets.py` | passed, exit 0 |
| `python3 scripts/check-coven-privacy.py --files …` | passed, exit 0 |

These are precisely the CI gates for these files (`ci.yml:73,76`). New coverage: 3 tests / 25 cases, including the negative cases above.