### PR TITLE
feat(cli): add consent-aware setup orchestration

### DIFF
--- a/crates/coven-cli/build.rs
+++ b/crates/coven-cli/build.rs
@@ -33,14 +33,21 @@ fn main() {
     // declaring it here lets a CI re-run with a different tag re-stamp the
     // binary without `cargo clean`.
     println!("cargo:rerun-if-env-changed=COVEN_BUILD_VERSION");
+    println!("cargo:rerun-if-env-changed=COVEN_BUILD_COMMIT");
     println!("cargo:rerun-if-env-changed=GITHUB_REF_NAME");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
 
     let describe = explicit_build_version()
         .or_else(describe_from_git)
         .or_else(github_ref_name_if_tag)
         .unwrap_or_else(|| format!("{} (unknown source)", env!("CARGO_PKG_VERSION")));
+    let commit = explicit_build_commit()
+        .or_else(commit_from_git)
+        .or_else(github_sha)
+        .unwrap_or_else(|| "unknown".to_owned());
 
     println!("cargo:rustc-env=COVEN_VERSION_DESC={}", describe);
+    println!("cargo:rustc-env=COVEN_BUILD_COMMIT={}", commit);
 }
 
 fn explicit_build_version() -> Option<String> {
@@ -48,6 +55,10 @@ fn explicit_build_version() -> Option<String> {
         .ok()
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
+}
+
+fn explicit_build_commit() -> Option<String> {
+    commit_environment_value("COVEN_BUILD_COMMIT")
 }
 
 fn describe_from_git() -> Option<String> {
@@ -65,6 +76,33 @@ fn describe_from_git() -> Option<String> {
     } else {
         Some(trimmed.to_string())
     }
+}
+
+fn commit_from_git() -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    valid_commit(stdout.trim()).then(|| stdout.trim().to_owned())
+}
+
+fn github_sha() -> Option<String> {
+    commit_environment_value("GITHUB_SHA")
+}
+
+fn commit_environment_value(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_owned())
+        .filter(|value| valid_commit(value))
+}
+
+fn valid_commit(value: &str) -> bool {
+    (7..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
 }
 
 fn github_ref_name_if_tag() -> Option<String> {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1559,11 +1559,7 @@ fn run_setup_command(
 }
 
 fn setup_candidate_commit() -> String {
-    env!("COVEN_VERSION_DESC")
-        .split(|character: char| !character.is_ascii_hexdigit())
-        .find(|segment| (7..=64).contains(&segment.len()))
-        .unwrap_or("unknown")
-        .to_owned()
+    env!("COVEN_BUILD_COMMIT").to_owned()
 }
 
 fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -63,6 +63,7 @@ mod repos_config;
 mod reset;
 mod session_launch;
 mod settings;
+pub mod setup;
 mod state_lock;
 mod store;
 mod stream_json;
@@ -160,6 +161,34 @@ impl Cli {
                 ));
             }
         }
+        if let Some(Command::Setup {
+            verify,
+            verify_only,
+            report_json,
+            ..
+        }) = &self.command
+        {
+            if *verify && *verify_only {
+                let mut command = Cli::command();
+                let setup = command
+                    .find_subcommand_mut("setup")
+                    .expect("derived CLI must contain the setup command");
+                return Err(setup.error(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    "'--verify' cannot be used with '--verify-only'",
+                ));
+            }
+            if report_json.is_some() && !verify && !verify_only {
+                let mut command = Cli::command();
+                let setup = command
+                    .find_subcommand_mut("setup")
+                    .expect("derived CLI must contain the setup command");
+                return Err(setup.error(
+                    clap::error::ErrorKind::MissingRequiredArgument,
+                    "'--report-json' requires '--verify' or '--verify-only'",
+                ));
+            }
+        }
         Ok(self)
     }
 }
@@ -199,6 +228,29 @@ enum Command {
     Doctor {
         #[arg(long, help = "Print checks as JSON (machine-readable)")]
         json: bool,
+    },
+    #[command(about = "Run provider-owned login with explicit consent and direct terminal access")]
+    Setup {
+        #[arg(value_enum, default_value_t = setup::Selector::All)]
+        provider: setup::Selector,
+        #[arg(
+            long,
+            conflicts_with = "verify_only",
+            help = "After login, request separate consent for a bounded provider verification turn"
+        )]
+        verify: bool,
+        #[arg(
+            long,
+            conflicts_with = "verify",
+            help = "Skip login and request consent only for a bounded provider verification turn"
+        )]
+        verify_only: bool,
+        #[arg(
+            long,
+            value_name = "PATH",
+            help = "Atomically write a redacted verification report; the path must not exist"
+        )]
+        report_json: Option<PathBuf>,
     },
     #[command(about = "Report resolved configuration and state paths")]
     Config {
@@ -1119,6 +1171,18 @@ fn main() -> Result<()> {
     // This diagnostic must not create COVEN_HOME through the shared state lock
     // or read settings contents during startup. It is deliberately the one
     // command that runs before normal state initialization.
+    if matches!(&cli.command, Some(Command::Setup { .. })) {
+        match run_cli(cli) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.downcast_ref::<SetupIncomplete>().is_some() => {
+                std::process::exit(1);
+            }
+            Err(error) => {
+                eprintln!("Error: {error:#}");
+                std::process::exit(1);
+            }
+        }
+    }
     if matches!(
         &cli.command,
         Some(Command::Config {
@@ -1170,6 +1234,9 @@ fn main() -> Result<()> {
             eprintln!("{}", cancelled.0);
             std::process::exit(1);
         }
+        if error.downcast_ref::<SetupIncomplete>().is_some() {
+            std::process::exit(1);
+        }
         if let Some(reset_error) = error.downcast_ref::<reset::ResetError>() {
             eprintln!("Error: {reset_error}");
             std::process::exit(reset_error.exit_code());
@@ -1194,6 +1261,17 @@ impl std::fmt::Display for Cancelled {
 
 impl std::error::Error for Cancelled {}
 
+#[derive(Debug)]
+struct SetupIncomplete;
+
+impl std::fmt::Display for SetupIncomplete {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("setup did not complete")
+    }
+}
+
+impl std::error::Error for SetupIncomplete {}
+
 fn run_cli(cli: Cli) -> Result<()> {
     if cli.command.is_none() && !cli.prompt.is_empty() {
         return run_bare_prompt(&cli.prompt);
@@ -1202,6 +1280,12 @@ fn run_cli(cli: Cli) -> Result<()> {
     match cli.command {
         None | Some(Command::Chat) | Some(Command::Tui) => run_shared_interactive_shell(),
         Some(Command::Doctor { json }) => run_doctor(json),
+        Some(Command::Setup {
+            provider,
+            verify,
+            verify_only,
+            report_json,
+        }) => run_setup_command(provider, verify, verify_only, report_json),
         Some(Command::Config {
             command: ConfigCommand::Paths { json },
         }) => {
@@ -1430,6 +1514,56 @@ fn run_cli(cli: Cli) -> Result<()> {
         Some(Command::Acp { args }) => run_engine_passthrough(Some("acp"), &args),
         Some(Command::Code { args }) => run_engine_passthrough(None, &args),
     }
+}
+
+fn run_setup_command(
+    provider: setup::Selector,
+    verify: bool,
+    verify_only: bool,
+    report_json: Option<PathBuf>,
+) -> Result<()> {
+    const PROVIDERS: &[setup::ProviderDescriptor] = &[];
+    let mode = if verify_only {
+        setup::SetupMode::VerifyOnly
+    } else if verify {
+        setup::SetupMode::LoginAndVerify
+    } else {
+        setup::SetupMode::Login
+    };
+    let options = setup::SetupOptions {
+        selector: provider,
+        mode,
+        timeout: Duration::from_secs(300),
+        report_json,
+        candidate_commit: setup_candidate_commit(),
+    };
+    let discovery = setup::SystemExecutableDiscovery::from_environment();
+    let terminal = setup::SystemTerminalState;
+    let mut confirmer = setup::SystemConfirmer;
+    let clock = setup::SystemClock::new();
+    let mut launcher = setup::SystemProcessLauncher;
+    let mut runtime = setup::SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let summary = setup::run_setup(&options, PROVIDERS, &mut runtime)?;
+    setup::render_human(&summary, &mut io::stdout().lock())?;
+    if summary.completed() {
+        Ok(())
+    } else {
+        Err(anyhow::Error::new(SetupIncomplete))
+    }
+}
+
+fn setup_candidate_commit() -> String {
+    env!("COVEN_VERSION_DESC")
+        .split(|character: char| !character.is_ascii_hexdigit())
+        .find(|segment| (7..=64).contains(&segment.len()))
+        .unwrap_or("unknown")
+        .to_owned()
 }
 
 fn run_maintenance_command(command: MaintenanceCommand) -> Result<()> {

--- a/crates/coven-cli/src/setup/mod.rs
+++ b/crates/coven-cli/src/setup/mod.rs
@@ -1,0 +1,773 @@
+mod process;
+
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::fs::{self, OpenOptions};
+use std::io::{self, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use process::{wait_bounded, BoundedProcessResult};
+pub use process::{
+    Clock, LaunchRequest, ProcessExit, ProcessLauncher, RunningProcess, SystemClock,
+    SystemProcessLauncher,
+};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderId {
+    Codex,
+    Claude,
+    Copilot,
+}
+
+impl ProviderId {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Codex => "codex",
+            Self::Claude => "claude",
+            Self::Copilot => "copilot",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Codex => "Codex",
+            Self::Claude => "Claude Code",
+            Self::Copilot => "GitHub Copilot CLI",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum Selector {
+    Codex,
+    Claude,
+    Copilot,
+    All,
+}
+
+impl Selector {
+    fn providers(self) -> &'static [ProviderId] {
+        match self {
+            Self::Codex => &[ProviderId::Codex],
+            Self::Claude => &[ProviderId::Claude],
+            Self::Copilot => &[ProviderId::Copilot],
+            Self::All => &[ProviderId::Codex, ProviderId::Claude, ProviderId::Copilot],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupMode {
+    Login,
+    LoginAndVerify,
+    VerifyOnly,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommandSpec {
+    args: Vec<OsString>,
+}
+
+impl CommandSpec {
+    pub fn new<I, S>(args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        Self {
+            args: args.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderDescriptor {
+    pub id: ProviderId,
+    pub executable: String,
+    pub official_install_guidance: String,
+    login: Option<CommandSpec>,
+    verification: Option<CommandSpec>,
+}
+
+impl ProviderDescriptor {
+    pub fn new(
+        id: ProviderId,
+        executable: impl Into<String>,
+        official_install_guidance: impl Into<String>,
+    ) -> Self {
+        Self {
+            id,
+            executable: executable.into(),
+            official_install_guidance: official_install_guidance.into(),
+            login: None,
+            verification: None,
+        }
+    }
+
+    pub fn with_login(mut self, command: CommandSpec) -> Self {
+        self.login = Some(command);
+        self
+    }
+
+    pub fn with_verification(mut self, command: CommandSpec) -> Self {
+        self.verification = Some(command);
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResolvedExecutable {
+    pub path: PathBuf,
+    pub version: Option<String>,
+}
+
+pub trait ExecutableDiscovery {
+    fn discover(&self, provider: &ProviderDescriptor) -> io::Result<Option<ResolvedExecutable>>;
+}
+
+#[derive(Clone, Debug)]
+pub struct SystemExecutableDiscovery {
+    path: Option<OsString>,
+    pathext: Option<OsString>,
+}
+
+impl SystemExecutableDiscovery {
+    pub fn from_environment() -> Self {
+        Self::from_path(std::env::var_os("PATH"), std::env::var_os("PATHEXT"))
+    }
+
+    pub fn from_path(path: Option<OsString>, pathext: Option<OsString>) -> Self {
+        Self { path, pathext }
+    }
+}
+
+impl ExecutableDiscovery for SystemExecutableDiscovery {
+    fn discover(&self, provider: &ProviderDescriptor) -> io::Result<Option<ResolvedExecutable>> {
+        let executable = Path::new(&provider.executable);
+        if executable.components().count() > 1 {
+            return Ok(
+                executable_is_runnable(executable).then(|| ResolvedExecutable {
+                    path: executable.to_path_buf(),
+                    version: None,
+                }),
+            );
+        }
+        let Some(path) = self.path.as_deref() else {
+            return Ok(None);
+        };
+        for directory in std::env::split_paths(path) {
+            for name in executable_names(&provider.executable, self.pathext.as_deref()) {
+                let candidate = directory.join(name);
+                if executable_is_runnable(&candidate) {
+                    return Ok(Some(ResolvedExecutable {
+                        path: candidate,
+                        version: None,
+                    }));
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupAction {
+    Login,
+    Verification,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConsentRequest {
+    pub provider: ProviderId,
+    pub action: SetupAction,
+    pub command: String,
+    pub notice: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConsentDecision {
+    Accepted,
+    Declined,
+    Cancelled,
+}
+
+pub trait Confirmer {
+    fn confirm(&mut self, request: &ConsentRequest) -> io::Result<ConsentDecision>;
+}
+
+pub struct SystemConfirmer;
+
+impl Confirmer for SystemConfirmer {
+    fn confirm(&mut self, request: &ConsentRequest) -> io::Result<ConsentDecision> {
+        let action = match request.action {
+            SetupAction::Login => "login",
+            SetupAction::Verification => "verification",
+        };
+        let mut stderr = io::stderr().lock();
+        let stdin = io::stdin();
+        loop {
+            writeln!(stderr, "{}", request.notice)?;
+            write!(
+                stderr,
+                "{} {action} will launch `{}` with direct terminal access. Continue? [y/N] ",
+                request.provider.label(),
+                request.command
+            )?;
+            stderr.flush()?;
+            let mut answer = String::new();
+            match stdin.read_line(&mut answer) {
+                Ok(0) => return Ok(ConsentDecision::Cancelled),
+                Ok(_) => match answer.trim().to_ascii_lowercase().as_str() {
+                    "y" | "yes" => return Ok(ConsentDecision::Accepted),
+                    "n" | "no" | "" => return Ok(ConsentDecision::Declined),
+                    _ => continue,
+                },
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => {
+                    return Ok(ConsentDecision::Cancelled);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+}
+
+pub trait TerminalState {
+    fn is_interactive(&self) -> bool;
+}
+
+pub struct SystemTerminalState;
+
+impl TerminalState for SystemTerminalState {
+    fn is_interactive(&self) -> bool {
+        io::stdin().is_terminal() && io::stdout().is_terminal() && io::stderr().is_terminal()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    Completed,
+    NotInstalled,
+    Declined,
+    Cancelled,
+    ProviderFailed,
+    TimedOut,
+    NonTty,
+    VerificationFailed,
+}
+
+#[derive(Clone, Eq, PartialEq)]
+pub struct ProviderResult {
+    pub provider: ProviderId,
+    pub outcome: Outcome,
+    duration: Duration,
+    version: Option<String>,
+    install_guidance: Option<String>,
+}
+
+impl fmt::Debug for ProviderResult {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ProviderResult")
+            .field("provider", &self.provider)
+            .field("outcome", &self.outcome)
+            .field("duration", &self.duration)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SetupSummary {
+    pub results: Vec<ProviderResult>,
+}
+
+impl SetupSummary {
+    pub fn completed(&self) -> bool {
+        !self.results.is_empty()
+            && self
+                .results
+                .iter()
+                .all(|result| result.outcome == Outcome::Completed)
+    }
+}
+
+pub struct SetupOptions {
+    pub selector: Selector,
+    pub mode: SetupMode,
+    pub timeout: Duration,
+    pub report_json: Option<PathBuf>,
+    pub candidate_commit: String,
+}
+
+pub struct SetupRuntime<'a> {
+    pub discovery: &'a dyn ExecutableDiscovery,
+    pub confirmer: &'a mut dyn Confirmer,
+    pub terminal: &'a dyn TerminalState,
+    pub clock: &'a dyn Clock,
+    pub launcher: &'a mut dyn ProcessLauncher,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetupError {
+    Exists,
+    RequiresVerification,
+    Rejected,
+    PublicationFailed,
+}
+
+impl fmt::Display for SetupError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Exists => "setup report destination already exists",
+            Self::RequiresVerification => "setup reports are available only for verification modes",
+            Self::Rejected => "setup report failed privacy validation",
+            Self::PublicationFailed => "setup report could not be published",
+        })
+    }
+}
+
+impl std::error::Error for SetupError {}
+
+pub fn run_setup(
+    options: &SetupOptions,
+    providers: &[ProviderDescriptor],
+    runtime: &mut SetupRuntime<'_>,
+) -> Result<SetupSummary, SetupError> {
+    if let Some(path) = options.report_json.as_deref() {
+        if options.mode == SetupMode::Login {
+            return Err(SetupError::RequiresVerification);
+        }
+        if path.exists() {
+            return Err(SetupError::Exists);
+        }
+    }
+
+    let provider_ids = options.selector.providers();
+    let mut results = Vec::with_capacity(provider_ids.len());
+    if !runtime.terminal.is_interactive() {
+        results.extend(provider_ids.iter().copied().map(|provider| ProviderResult {
+            provider,
+            outcome: Outcome::NonTty,
+            duration: Duration::ZERO,
+            version: None,
+            install_guidance: None,
+        }));
+    } else {
+        for provider_id in provider_ids {
+            let Some(provider) = providers
+                .iter()
+                .find(|provider| provider.id == *provider_id)
+            else {
+                results.push(ProviderResult {
+                    provider: *provider_id,
+                    outcome: Outcome::ProviderFailed,
+                    duration: Duration::ZERO,
+                    version: None,
+                    install_guidance: None,
+                });
+                continue;
+            };
+            results.push(run_provider(options, provider, runtime));
+        }
+    }
+
+    let summary = SetupSummary { results };
+    if let Some(path) = options.report_json.as_deref() {
+        publish_report(path, &summary, &options.candidate_commit)?;
+    }
+    Ok(summary)
+}
+
+pub fn render_human(summary: &SetupSummary, output: &mut dyn Write) -> io::Result<()> {
+    for result in &summary.results {
+        writeln!(
+            output,
+            "{}: {}",
+            result.provider.label(),
+            outcome_name(result.outcome)
+        )?;
+        if result.outcome == Outcome::NotInstalled {
+            if let Some(guidance) = result.install_guidance.as_deref() {
+                writeln!(output, "{guidance}")?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn run_provider(
+    options: &SetupOptions,
+    provider: &ProviderDescriptor,
+    runtime: &mut SetupRuntime<'_>,
+) -> ProviderResult {
+    let provider_started = runtime.clock.now();
+    let executable = match runtime.discovery.discover(provider) {
+        Ok(Some(executable)) => executable,
+        Ok(None) => {
+            return result(
+                provider.id,
+                Outcome::NotInstalled,
+                provider_started,
+                None,
+                Some(provider.official_install_guidance.clone()),
+                runtime.clock,
+            );
+        }
+        Err(_) => {
+            return result(
+                provider.id,
+                Outcome::ProviderFailed,
+                provider_started,
+                None,
+                None,
+                runtime.clock,
+            );
+        }
+    };
+
+    let outcome = match options.mode {
+        SetupMode::Login => run_action(
+            provider,
+            executable.path.as_path(),
+            provider.login.as_ref(),
+            SetupAction::Login,
+            options.timeout,
+            runtime,
+        ),
+        SetupMode::VerifyOnly => run_action(
+            provider,
+            executable.path.as_path(),
+            provider.verification.as_ref(),
+            SetupAction::Verification,
+            options.timeout,
+            runtime,
+        ),
+        SetupMode::LoginAndVerify => {
+            let login = run_action(
+                provider,
+                executable.path.as_path(),
+                provider.login.as_ref(),
+                SetupAction::Login,
+                options.timeout,
+                runtime,
+            );
+            if login == Outcome::Completed {
+                run_action(
+                    provider,
+                    executable.path.as_path(),
+                    provider.verification.as_ref(),
+                    SetupAction::Verification,
+                    options.timeout,
+                    runtime,
+                )
+            } else {
+                login
+            }
+        }
+    };
+    result(
+        provider.id,
+        outcome,
+        provider_started,
+        executable.version,
+        None,
+        runtime.clock,
+    )
+}
+
+fn run_action(
+    provider: &ProviderDescriptor,
+    executable: &Path,
+    command: Option<&CommandSpec>,
+    action: SetupAction,
+    timeout: Duration,
+    runtime: &mut SetupRuntime<'_>,
+) -> Outcome {
+    let Some(command) = command else {
+        return failure_outcome(action);
+    };
+    let consent = ConsentRequest {
+        provider: provider.id,
+        action,
+        command: display_command(&provider.executable, &command.args),
+        notice: match action {
+            SetupAction::Login => {
+                "Coven will hand the terminal directly to the provider-owned login command."
+                    .to_owned()
+            }
+            SetupAction::Verification => {
+                "Verification requires network access and may incur provider usage or cost."
+                    .to_owned()
+            }
+        },
+    };
+    match runtime.confirmer.confirm(&consent) {
+        Ok(ConsentDecision::Accepted) => {}
+        Ok(ConsentDecision::Declined) => return Outcome::Declined,
+        Ok(ConsentDecision::Cancelled) => return Outcome::Cancelled,
+        Err(_) => return Outcome::Cancelled,
+    }
+    let request = LaunchRequest {
+        executable: executable.to_path_buf(),
+        args: command.args.clone(),
+    };
+    let mut process = match runtime.launcher.launch(&request) {
+        Ok(process) => process,
+        Err(_) => return failure_outcome(action),
+    };
+    match wait_bounded(process.as_mut(), runtime.clock, timeout) {
+        Ok(BoundedProcessResult::TimedOut) => Outcome::TimedOut,
+        Ok(BoundedProcessResult::Exited(ProcessExit::Exited(0))) => Outcome::Completed,
+        Ok(BoundedProcessResult::Exited(ProcessExit::Exited(_))) => failure_outcome(action),
+        Ok(BoundedProcessResult::Exited(ProcessExit::Signalled)) => Outcome::Cancelled,
+        Err(_) => failure_outcome(action),
+    }
+}
+
+fn failure_outcome(action: SetupAction) -> Outcome {
+    match action {
+        SetupAction::Login => Outcome::ProviderFailed,
+        SetupAction::Verification => Outcome::VerificationFailed,
+    }
+}
+
+fn result(
+    provider: ProviderId,
+    outcome: Outcome,
+    started: Duration,
+    version: Option<String>,
+    install_guidance: Option<String>,
+    clock: &dyn Clock,
+) -> ProviderResult {
+    ProviderResult {
+        provider,
+        outcome,
+        duration: clock.now().saturating_sub(started),
+        version,
+        install_guidance,
+    }
+}
+
+fn display_command(executable: &str, args: &[OsString]) -> String {
+    std::iter::once(executable.to_owned())
+        .chain(
+            args.iter()
+                .map(|argument| argument.to_string_lossy().into_owned()),
+        )
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn outcome_name(outcome: Outcome) -> &'static str {
+    match outcome {
+        Outcome::Completed => "completed",
+        Outcome::NotInstalled => "not_installed",
+        Outcome::Declined => "declined",
+        Outcome::Cancelled => "cancelled",
+        Outcome::ProviderFailed => "provider_failed",
+        Outcome::TimedOut => "timed_out",
+        Outcome::NonTty => "non_tty",
+        Outcome::VerificationFailed => "verification_failed",
+    }
+}
+
+fn executable_names(executable: &str, pathext: Option<&OsStr>) -> Vec<OsString> {
+    #[cfg(windows)]
+    {
+        let path = Path::new(executable);
+        if path.extension().is_some() {
+            return vec![OsString::from(executable)];
+        }
+        let extensions = pathext
+            .and_then(OsStr::to_str)
+            .unwrap_or(".COM;.EXE;.BAT;.CMD");
+        let mut names = vec![OsString::from(executable)];
+        names.extend(
+            extensions
+                .split(';')
+                .filter(|extension| !extension.is_empty())
+                .map(|extension| OsString::from(format!("{executable}{extension}"))),
+        );
+        names
+    }
+
+    #[cfg(not(windows))]
+    {
+        let _ = pathext;
+        vec![OsString::from(executable)]
+    }
+}
+
+#[cfg(unix)]
+fn executable_is_runnable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    path.metadata()
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn executable_is_runnable(path: &Path) -> bool {
+    path.is_file()
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct SetupReport {
+    schema_version: u32,
+    results: Vec<ReportResult>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ReportResult {
+    harness: ProviderId,
+    version: String,
+    platform: String,
+    candidate_commit: String,
+    duration_ms: u64,
+    exit_class: Outcome,
+    completion: bool,
+}
+
+fn publish_report(
+    destination: &Path,
+    summary: &SetupSummary,
+    candidate_commit: &str,
+) -> Result<(), SetupError> {
+    let report = SetupReport {
+        schema_version: 1,
+        results: summary
+            .results
+            .iter()
+            .map(|result| ReportResult {
+                harness: result.provider,
+                version: result
+                    .version
+                    .clone()
+                    .unwrap_or_else(|| "unknown".to_owned()),
+                platform: format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH),
+                candidate_commit: candidate_commit.to_owned(),
+                duration_ms: result.duration.as_millis().try_into().unwrap_or(u64::MAX),
+                exit_class: result.outcome,
+                completion: result.outcome == Outcome::Completed,
+            })
+            .collect(),
+    };
+    validate_report(&report)?;
+    let bytes = serde_json::to_vec_pretty(&report).map_err(|_| SetupError::Rejected)?;
+    let decoded: SetupReport = serde_json::from_slice(&bytes).map_err(|_| SetupError::Rejected)?;
+    validate_report(&decoded)?;
+
+    let parent = destination.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = destination
+        .file_name()
+        .and_then(OsStr::to_str)
+        .filter(|name| !name.is_empty())
+        .ok_or(SetupError::Rejected)?;
+    let staged = parent.join(format!(".{file_name}.{}.tmp", Uuid::new_v4()));
+    let publish_result = (|| {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&staged)
+            .map_err(|_| SetupError::PublicationFailed)?;
+        file.write_all(&bytes)
+            .map_err(|_| SetupError::PublicationFailed)?;
+        file.sync_all().map_err(|_| SetupError::PublicationFailed)?;
+        drop(file);
+
+        let staged_bytes = fs::read(&staged).map_err(|_| SetupError::PublicationFailed)?;
+        let staged_report: SetupReport =
+            serde_json::from_slice(&staged_bytes).map_err(|_| SetupError::Rejected)?;
+        validate_report(&staged_report)?;
+        atomic_publish_noclobber(&staged, destination)?;
+        if let Ok(directory) = fs::File::open(parent) {
+            let _ = directory.sync_all();
+        }
+        Ok(())
+    })();
+    if publish_result.is_err() {
+        let _ = fs::remove_file(&staged);
+    }
+    publish_result
+}
+
+fn validate_report(report: &SetupReport) -> Result<(), SetupError> {
+    if report.schema_version != 1 || report.results.is_empty() {
+        return Err(SetupError::Rejected);
+    }
+    for result in &report.results {
+        if !safe_report_value(&result.version)
+            || !safe_report_value(&result.platform)
+            || !valid_commit(&result.candidate_commit)
+            || result.completion != (result.exit_class == Outcome::Completed)
+        {
+            return Err(SetupError::Rejected);
+        }
+    }
+    Ok(())
+}
+
+fn safe_report_value(value: &str) -> bool {
+    const FORBIDDEN: &[&str] = &[
+        "oauth",
+        "account",
+        "token",
+        "model",
+        "cookie",
+        "authorization",
+        "bearer",
+    ];
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'+' | b'-'))
+        && !FORBIDDEN
+            .iter()
+            .any(|forbidden| value.to_ascii_lowercase().contains(forbidden))
+}
+
+fn valid_commit(value: &str) -> bool {
+    (7..=64).contains(&value.len()) && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(unix)]
+fn atomic_publish_noclobber(staged: &Path, destination: &Path) -> Result<(), SetupError> {
+    use rustix::fs::{renameat_with, RenameFlags, CWD};
+
+    renameat_with(CWD, staged, CWD, destination, RenameFlags::NOREPLACE).map_err(|error| {
+        if error == rustix::io::Errno::EXIST {
+            SetupError::Exists
+        } else {
+            SetupError::PublicationFailed
+        }
+    })
+}
+
+#[cfg(not(unix))]
+fn atomic_publish_noclobber(staged: &Path, destination: &Path) -> Result<(), SetupError> {
+    if destination.exists() {
+        return Err(SetupError::Exists);
+    }
+    fs::rename(staged, destination).map_err(|error| {
+        if error.kind() == io::ErrorKind::AlreadyExists {
+            SetupError::Exists
+        } else {
+            SetupError::PublicationFailed
+        }
+    })
+}

--- a/crates/coven-cli/src/setup/process.rs
+++ b/crates/coven-cli/src/setup/process.rs
@@ -1,0 +1,273 @@
+use std::ffi::OsString;
+use std::io;
+use std::path::PathBuf;
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LaunchRequest {
+    pub executable: PathBuf,
+    pub args: Vec<OsString>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProcessExit {
+    Exited(i32),
+    Signalled,
+}
+
+pub trait Clock {
+    fn now(&self) -> Duration;
+    fn sleep(&self, duration: Duration);
+}
+
+#[derive(Debug)]
+pub struct SystemClock {
+    origin: Instant,
+}
+
+impl SystemClock {
+    pub fn new() -> Self {
+        Self {
+            origin: Instant::now(),
+        }
+    }
+}
+
+impl Default for SystemClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock for SystemClock {
+    fn now(&self) -> Duration {
+        self.origin.elapsed()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        std::thread::sleep(duration);
+    }
+}
+
+pub trait RunningProcess {
+    fn try_wait(&mut self) -> io::Result<Option<ProcessExit>>;
+    fn terminate_tree(&mut self) -> io::Result<()>;
+    fn wait(&mut self) -> io::Result<ProcessExit>;
+}
+
+pub trait ProcessLauncher {
+    fn launch(&mut self, request: &LaunchRequest) -> io::Result<Box<dyn RunningProcess>>;
+}
+
+pub struct SystemProcessLauncher;
+
+impl ProcessLauncher for SystemProcessLauncher {
+    fn launch(&mut self, request: &LaunchRequest) -> io::Result<Box<dyn RunningProcess>> {
+        let mut command = Command::new(&request.executable);
+        command
+            .args(&request.args)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+
+        let child = command.spawn()?;
+
+        #[cfg(windows)]
+        let (child, job) = {
+            let mut child = child;
+            let job = match windows_job::assign_kill_on_close_job(&child) {
+                Ok(job) => job,
+                Err(error) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(error);
+                }
+            };
+            (child, job)
+        };
+
+        Ok(Box::new(SystemRunningProcess {
+            #[cfg(unix)]
+            process_group: child.id() as libc::pid_t,
+            child,
+            #[cfg(windows)]
+            job,
+        }))
+    }
+}
+
+pub(crate) enum BoundedProcessResult {
+    Exited(ProcessExit),
+    TimedOut,
+}
+
+pub(crate) fn wait_bounded(
+    process: &mut dyn RunningProcess,
+    clock: &dyn Clock,
+    timeout: Duration,
+) -> io::Result<BoundedProcessResult> {
+    let deadline = clock.now().saturating_add(timeout);
+    loop {
+        if let Some(exit) = process.try_wait()? {
+            return Ok(BoundedProcessResult::Exited(exit));
+        }
+        let now = clock.now();
+        if now >= deadline {
+            process.terminate_tree()?;
+            let _ = process.wait()?;
+            return Ok(BoundedProcessResult::TimedOut);
+        }
+        clock.sleep(POLL_INTERVAL.min(deadline.saturating_sub(now)));
+    }
+}
+
+struct SystemRunningProcess {
+    child: Child,
+    #[cfg(unix)]
+    process_group: libc::pid_t,
+    #[cfg(windows)]
+    job: windows_job::Job,
+}
+
+impl RunningProcess for SystemRunningProcess {
+    fn try_wait(&mut self) -> io::Result<Option<ProcessExit>> {
+        self.child
+            .try_wait()
+            .map(|status| status.map(classify_exit))
+    }
+
+    fn terminate_tree(&mut self) -> io::Result<()> {
+        terminate_system_tree(self)
+    }
+
+    fn wait(&mut self) -> io::Result<ProcessExit> {
+        self.child.wait().map(classify_exit)
+    }
+}
+
+#[cfg(unix)]
+fn terminate_system_tree(process: &mut SystemRunningProcess) -> io::Result<()> {
+    signal_process_group(process.process_group, libc::SIGTERM)?;
+    let deadline = Instant::now() + Duration::from_millis(250);
+    while process_group_is_alive(process.process_group) && Instant::now() < deadline {
+        let _ = process.child.try_wait();
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    if process_group_is_alive(process.process_group) {
+        match signal_process_group(process.process_group, libc::SIGKILL) {
+            Ok(()) => {}
+            Err(error) if error.raw_os_error() == Some(libc::EPERM) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn terminate_system_tree(process: &mut SystemRunningProcess) -> io::Result<()> {
+    process.job.terminate()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminate_system_tree(process: &mut SystemRunningProcess) -> io::Result<()> {
+    process.child.kill()
+}
+
+fn classify_exit(status: ExitStatus) -> ProcessExit {
+    match status.code() {
+        Some(code) => ProcessExit::Exited(code),
+        None => ProcessExit::Signalled,
+    }
+}
+
+#[cfg(unix)]
+fn signal_process_group(process_group: libc::pid_t, signal: libc::c_int) -> io::Result<()> {
+    let result = unsafe { libc::kill(-process_group, signal) };
+    if result == 0 {
+        return Ok(());
+    }
+    let error = io::Error::last_os_error();
+    if error.raw_os_error() == Some(libc::ESRCH) {
+        Ok(())
+    } else {
+        Err(error)
+    }
+}
+
+#[cfg(unix)]
+fn process_group_is_alive(process_group: libc::pid_t) -> bool {
+    let result = unsafe { libc::kill(-process_group, 0) };
+    result == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(windows)]
+mod windows_job {
+    use std::io;
+    use std::mem::{size_of, zeroed};
+    use std::os::windows::io::AsRawHandle;
+    use std::process::Child;
+    use std::ptr;
+
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    pub(super) struct Job(HANDLE);
+
+    impl Job {
+        pub(super) fn terminate(&self) -> io::Result<()> {
+            let result = unsafe { TerminateJobObject(self.0, 1) };
+            if result == 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    impl Drop for Job {
+        fn drop(&mut self) {
+            unsafe {
+                CloseHandle(self.0);
+            }
+        }
+    }
+
+    pub(super) fn assign_kill_on_close_job(child: &Child) -> io::Result<Job> {
+        let handle = unsafe { CreateJobObjectW(ptr::null(), ptr::null()) };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let job = Job(handle);
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { zeroed() };
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job.0,
+                JobObjectExtendedLimitInformation,
+                (&raw const limits).cast(),
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if configured == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let assigned = unsafe { AssignProcessToJobObject(job.0, child.as_raw_handle() as HANDLE) };
+        if assigned == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(job)
+    }
+}

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -1,0 +1,928 @@
+use std::cell::{Cell, RefCell};
+use std::collections::VecDeque;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::rc::Rc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+#[path = "../src/setup/mod.rs"]
+mod setup;
+
+use setup::{
+    render_human, run_setup, Clock, CommandSpec, Confirmer, ConsentDecision, ConsentRequest,
+    ExecutableDiscovery, LaunchRequest, Outcome, ProcessExit, ProcessLauncher, ProviderDescriptor,
+    ProviderId, ResolvedExecutable, RunningProcess, Selector, SetupError, SetupMode, SetupOptions,
+    SetupRuntime, SystemClock, SystemExecutableDiscovery, SystemProcessLauncher, TerminalState,
+};
+
+fn coven_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_coven"))
+}
+
+fn test_tempdir() -> Result<tempfile::TempDir> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target/setup-cli-tests");
+    fs::create_dir_all(&root)?;
+    Ok(tempfile::Builder::new().prefix("setup-").tempdir_in(root)?)
+}
+
+fn descriptor(id: ProviderId) -> ProviderDescriptor {
+    ProviderDescriptor::new(
+        id,
+        format!("fake-{}", id.as_str()),
+        "Install this CLI only from its official provider documentation.",
+    )
+    .with_login(CommandSpec::new(["login"]))
+    .with_verification(CommandSpec::new(["verify"]))
+}
+
+fn options(selector: Selector) -> SetupOptions {
+    SetupOptions {
+        selector,
+        mode: SetupMode::Login,
+        timeout: Duration::from_secs(2),
+        report_json: None,
+        candidate_commit: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+    }
+}
+
+#[test]
+fn setup_cli_parses_all_selectors_and_verification_modes() -> Result<()> {
+    for selector in ["codex", "claude", "copilot", "all"] {
+        let output = Command::new(coven_bin())
+            .args(["setup", selector, "--help"])
+            .output()?;
+        assert!(
+            output.status.success(),
+            "selector {selector} was rejected:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let invalid = Command::new(coven_bin())
+        .args(["setup", "other"])
+        .output()?;
+    assert!(!invalid.status.success());
+
+    let conflicting = Command::new(coven_bin())
+        .args(["setup", "codex", "--verify", "--verify-only"])
+        .output()?;
+    assert!(!conflicting.status.success());
+
+    let report_without_verification = Command::new(coven_bin())
+        .args(["setup", "codex", "--report-json", "report.json"])
+        .output()?;
+    assert!(!report_without_verification.status.success());
+    Ok(())
+}
+
+#[test]
+fn setup_cli_refuses_non_tty_without_waiting_or_launching() -> Result<()> {
+    let temp = test_tempdir()?;
+    let output = Command::new(coven_bin())
+        .args(["setup", "codex"])
+        .env("COVEN_HOME", temp.path().join("home"))
+        .stdin(Stdio::null())
+        .output()?;
+
+    assert!(!output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Codex: non_tty"
+    );
+    assert!(
+        !String::from_utf8_lossy(&output.stderr).contains("Error:"),
+        "non-TTY refusal should be a closed setup result, not an internal error"
+    );
+    Ok(())
+}
+
+#[test]
+fn all_discovers_and_confirms_each_provider_once_before_launch() -> Result<()> {
+    let providers = [
+        descriptor(ProviderId::Codex),
+        descriptor(ProviderId::Claude),
+        descriptor(ProviderId::Copilot),
+    ];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([
+        ConsentDecision::Accepted,
+        ConsentDecision::Accepted,
+        ConsentDecision::Accepted,
+    ]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([
+        LaunchBehavior::exit(0),
+        LaunchBehavior::exit(0),
+        LaunchBehavior::exit(0),
+    ]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&options(Selector::All), &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    assert_eq!(
+        summary
+            .results
+            .iter()
+            .map(|result| (result.provider, result.outcome))
+            .collect::<Vec<_>>(),
+        vec![
+            (ProviderId::Codex, Outcome::Completed),
+            (ProviderId::Claude, Outcome::Completed),
+            (ProviderId::Copilot, Outcome::Completed),
+        ]
+    );
+    assert_eq!(
+        discovery.calls.borrow().as_slice(),
+        &[ProviderId::Codex, ProviderId::Claude, ProviderId::Copilot]
+    );
+    assert_eq!(confirmer.requests.len(), 3);
+    assert_eq!(launcher.launches.len(), 3);
+    for ((request, launch), provider) in confirmer.requests.iter().zip(&launcher.launches).zip([
+        ProviderId::Codex,
+        ProviderId::Claude,
+        ProviderId::Copilot,
+    ]) {
+        assert_eq!(request.provider, provider);
+        assert_eq!(request.command, format!("fake-{} login", provider.as_str()));
+        assert_eq!(launch.args, vec![OsString::from("login")]);
+    }
+    Ok(())
+}
+
+#[test]
+fn verification_after_login_requires_a_second_explicit_consent() -> Result<()> {
+    let providers = [descriptor(ProviderId::Codex)];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted, ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0), LaunchBehavior::exit(0)]);
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::LoginAndVerify;
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    assert_eq!(confirmer.requests.len(), 2);
+    assert_eq!(confirmer.requests[0].action, setup::SetupAction::Login);
+    assert_eq!(
+        confirmer.requests[1].action,
+        setup::SetupAction::Verification
+    );
+    assert!(
+        confirmer.requests[1].notice.contains("network access")
+            && confirmer.requests[1].notice.contains("usage or cost"),
+        "verification consent must disclose network and cost: {:?}",
+        confirmer.requests[1]
+    );
+    assert_eq!(launcher.launches.len(), 2);
+    Ok(())
+}
+
+#[test]
+fn missing_executable_prints_only_the_descriptor_official_guidance() -> Result<()> {
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider.clone()];
+    let discovery = FixedDiscovery(None);
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+    let mut rendered = Vec::new();
+    render_human(&summary, &mut rendered)?;
+    assert_eq!(
+        String::from_utf8(rendered)?,
+        concat!(
+            "Codex: not_installed\n",
+            "Install this CLI only from its official provider documentation.\n"
+        )
+    );
+    assert!(confirmer.requests.is_empty());
+    assert!(launcher.launches.is_empty());
+    Ok(())
+}
+
+#[test]
+fn decline_and_non_tty_never_launch_a_provider() -> Result<()> {
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider.clone()];
+
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Declined]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let declined = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+    assert_eq!(declined.results[0].outcome, Outcome::Declined);
+    assert!(launcher.launches.is_empty());
+
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(false);
+    let mut confirmer = FakeConfirmer::new([]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let non_tty = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+    assert_eq!(non_tty.results[0].outcome, Outcome::NonTty);
+    assert!(discovery.calls.borrow().is_empty());
+    assert!(confirmer.requests.is_empty());
+    assert!(launcher.launches.is_empty());
+    Ok(())
+}
+
+#[test]
+fn setup_classifies_the_closed_outcome_set() -> Result<()> {
+    assert_eq!(
+        run_single(
+            SetupMode::Login,
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::exit(0),
+        )?,
+        Outcome::Completed
+    );
+    assert_eq!(
+        run_single(
+            SetupMode::Login,
+            None,
+            ConsentDecision::Accepted,
+            LaunchBehavior::exit(0),
+        )?,
+        Outcome::NotInstalled
+    );
+    assert_eq!(
+        run_single(
+            SetupMode::Login,
+            Some("1.2.3"),
+            ConsentDecision::Declined,
+            LaunchBehavior::exit(0),
+        )?,
+        Outcome::Declined
+    );
+    assert_eq!(
+        run_single(
+            SetupMode::Login,
+            Some("1.2.3"),
+            ConsentDecision::Cancelled,
+            LaunchBehavior::exit(0),
+        )?,
+        Outcome::Cancelled
+    );
+    assert_eq!(
+        run_single(
+            SetupMode::Login,
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::exit(7),
+        )?,
+        Outcome::ProviderFailed
+    );
+    assert_eq!(
+        run_single(
+            SetupMode::Login,
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::signalled(),
+        )?,
+        Outcome::Cancelled
+    );
+    assert_eq!(
+        run_single(
+            SetupMode::VerifyOnly,
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::exit(9),
+        )?,
+        Outcome::VerificationFailed
+    );
+    Ok(())
+}
+
+#[test]
+fn timeout_uses_the_injected_deadline_and_cleans_the_process_tree() -> Result<()> {
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let terminated = Rc::new(Cell::new(false));
+    let mut launcher = FakeLauncher::new([LaunchBehavior::never(Rc::clone(&terminated))]);
+    let mut setup_options = options(Selector::Codex);
+    setup_options.timeout = Duration::from_millis(25);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+
+    assert_eq!(summary.results[0].outcome, Outcome::TimedOut);
+    assert!(terminated.get(), "timed out child tree was not terminated");
+    assert!(clock.now() >= Duration::from_millis(25));
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn system_launcher_timeout_reaps_descendants() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let pid_file = temp.path().join("descendant.pid");
+    let provider = ProviderDescriptor::new(
+        ProviderId::Codex,
+        "sh",
+        "Install the shell from its official source.",
+    )
+    .with_login(CommandSpec::new([
+        "-c",
+        "sleep 30 & child=$!; printf '%s' \"$child\" > \"$1\"; wait \"$child\"",
+        "setup-timeout",
+        pid_file.to_str().context("test path must be valid UTF-8")?,
+    ]));
+    let providers = [provider];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: PathBuf::from("/bin/sh"),
+        version: Some("1.0.0".to_owned()),
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut setup_options = options(Selector::Codex);
+    setup_options.timeout = Duration::from_millis(250);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+    assert_eq!(summary.results[0].outcome, Outcome::TimedOut);
+    let pid = fs::read_to_string(&pid_file)?
+        .trim()
+        .parse::<u32>()
+        .context("descendant pid")?;
+    wait_for_process_exit(pid)?;
+
+    let mode = fs::metadata(temp.path())?.permissions().mode();
+    assert_ne!(mode & 0o700, 0);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn inherited_terminal_io_stays_separate_from_the_redacted_report() -> Result<()> {
+    let temp = test_tempdir()?;
+    let stdout_path = temp.path().join("terminal.stdout");
+    let stderr_path = temp.path().join("terminal.stderr");
+    let report_path = temp.path().join("report.json");
+    let private_path = temp.path().join("private");
+    let mut child = Command::new(std::env::current_exe()?)
+        .args([
+            "--exact",
+            "inherited_terminal_and_report_helper",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("COVEN_SETUP_INHERITED_HELPER", "1")
+        .env("COVEN_SETUP_PRIVATE_PATH", &private_path)
+        .env("COVEN_SETUP_REPORT_PATH", &report_path)
+        .stdin(Stdio::piped())
+        .stdout(fs::File::create(&stdout_path)?)
+        .stderr(fs::File::create(&stderr_path)?)
+        .spawn()?;
+    child
+        .stdin
+        .as_mut()
+        .context("helper stdin")?
+        .write_all(b"terminal-input\n")?;
+    drop(child.stdin.take());
+    let status = child.wait()?;
+    assert!(status.success(), "helper failed with {status}");
+
+    let stdout = fs::read_to_string(stdout_path)?;
+    let stderr = fs::read_to_string(stderr_path)?;
+    assert!(
+        stdout.contains("provider-stdout:terminal-input"),
+        "{stdout:?}"
+    );
+    assert!(
+        stderr.contains(&format!(
+            "oauth account token model {}",
+            private_path.display()
+        )),
+        "{stderr:?}"
+    );
+
+    let report_bytes = fs::read(&report_path)?;
+    let report: serde_json::Value = serde_json::from_slice(&report_bytes)?;
+    assert_eq!(report["schema_version"], 1);
+    assert_eq!(report["results"][0]["harness"], "codex");
+    assert_eq!(report["results"][0]["exit_class"], "completed");
+    assert_eq!(report["results"][0]["completion"], true);
+    let report_text = String::from_utf8(report_bytes)?;
+    for forbidden in [
+        "provider-stdout",
+        "oauth",
+        "account",
+        "token",
+        "model",
+        "\u{1b}",
+    ] {
+        assert!(
+            !report_text.contains(forbidden),
+            "report leaked {forbidden:?}: {report_text}"
+        );
+    }
+    assert!(
+        !report_text.contains(&private_path.to_string_lossy().into_owned()),
+        "report leaked the private path: {report_text}"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn inherited_terminal_and_report_helper() -> Result<()> {
+    if std::env::var_os("COVEN_SETUP_INHERITED_HELPER").is_none() {
+        return Ok(());
+    }
+    let report_path =
+        PathBuf::from(std::env::var_os("COVEN_SETUP_REPORT_PATH").context("report path")?);
+    std::env::var_os("COVEN_SETUP_PRIVATE_PATH").context("private path")?;
+    let provider = ProviderDescriptor::new(
+        ProviderId::Codex,
+        "sh",
+        "Install the shell from its official source.",
+    )
+    .with_verification(CommandSpec::new([
+        "-c",
+        concat!(
+            "IFS= read -r line; ",
+            "printf 'provider-stdout:%s\\n' \"$line\"; ",
+            "printf 'provider-stderr:oauth account token model %s \\033[31m\\n' ",
+            "\"$COVEN_SETUP_PRIVATE_PATH\" >&2"
+        ),
+    ]));
+    let providers = [provider];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: PathBuf::from("/bin/sh"),
+        version: Some("1.2.3".to_owned()),
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    setup_options.report_json = Some(report_path);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+    render_human(&summary, &mut io::stdout().lock())?;
+    assert!(summary.completed());
+    Ok(())
+}
+
+#[test]
+fn report_publication_is_fail_if_exists_atomic_and_redaction_closed() -> Result<()> {
+    let temp = test_tempdir()?;
+    let existing = temp.path().join("existing.json");
+    fs::write(&existing, b"keep-me")?;
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider.clone()];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0)]);
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = SetupMode::VerifyOnly;
+    setup_options.report_json = Some(existing.clone());
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let error = run_setup(&setup_options, &providers, &mut runtime)
+        .expect_err("an existing report must be refused");
+    assert!(matches!(error, SetupError::Exists));
+    assert_eq!(fs::read(&existing)?, b"keep-me");
+    assert!(confirmer.requests.is_empty());
+    assert!(launcher.launches.is_empty());
+
+    let rejected = temp.path().join("rejected.json");
+    let rejected_version = format!(
+        "oauth account token model \u{1b}[31m {}",
+        temp.path().join("private").display()
+    );
+    let discovery = FakeDiscovery::all_present(&providers, &rejected_version);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0)]);
+    setup_options.report_json = Some(rejected.clone());
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let error = run_setup(&setup_options, &providers, &mut runtime)
+        .expect_err("unsafe report data must fail closed");
+    assert!(matches!(error, SetupError::Rejected));
+    assert!(!rejected.exists());
+
+    let published = temp.path().join("published.json");
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0)]);
+    setup_options.report_json = Some(published.clone());
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let summary = run_setup(&setup_options, &providers, &mut runtime)?;
+    assert!(summary.completed());
+    let parsed: serde_json::Value = serde_json::from_slice(&fs::read(&published)?)?;
+    assert_eq!(parsed["results"][0]["version"], "1.2.3");
+    let entries = fs::read_dir(temp.path())?
+        .map(|entry| entry.map(|entry| entry.file_name()))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    assert!(
+        entries
+            .iter()
+            .all(|name| !name.to_string_lossy().contains(".tmp")),
+        "atomic report staging file was left behind: {entries:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()> {
+    let temp = test_tempdir()?;
+    let bin = temp.path().join("bin");
+    fs::create_dir_all(&bin)?;
+    let executable = bin.join(if cfg!(windows) {
+        "fake-cli.exe"
+    } else {
+        "fake-cli"
+    });
+    fs::write(&executable, b"fixture")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755))?;
+    }
+    let path = std::env::join_paths([&bin])?;
+    let discovery = SystemExecutableDiscovery::from_path(Some(path), Some(OsString::from(".EXE")));
+    let _environment_discovery = SystemExecutableDiscovery::from_environment();
+    let _system_confirmer = setup::SystemConfirmer;
+    let _system_terminal = setup::SystemTerminalState;
+    let provider =
+        ProviderDescriptor::new(ProviderId::Codex, "fake-cli", "Official install guidance.");
+    let resolved = discovery
+        .discover(&provider)?
+        .context("executable should be discovered")?;
+    assert_eq!(resolved.path, executable);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&resolved.path, fs::Permissions::from_mode(0o644))?;
+        assert!(discovery.discover(&provider)?.is_none());
+    }
+    Ok(())
+}
+
+#[test]
+fn human_summary_never_echoes_paths_launch_errors_or_terminal_bytes() -> Result<()> {
+    let temp = test_tempdir()?;
+    let private_path = temp.path().join("private");
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: private_path.join("oauth-token"),
+        version: Some("1.2.3".to_owned()),
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([LaunchBehavior::Error(format!(
+        "account token model \u{1b}[31m {}",
+        private_path.display()
+    ))]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let summary = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+    let mut rendered = Vec::new();
+    render_human(&summary, &mut rendered)?;
+    let rendered = String::from_utf8(rendered)?;
+    assert_eq!(rendered, "Codex: provider_failed\n");
+    let debug = format!("{summary:?}");
+    assert!(!debug.contains("oauth-token"), "{debug}");
+    assert!(
+        !debug.contains(&private_path.to_string_lossy().into_owned()),
+        "{debug}"
+    );
+    Ok(())
+}
+
+fn run_single(
+    mode: SetupMode,
+    version: Option<&str>,
+    consent: ConsentDecision,
+    behavior: LaunchBehavior,
+) -> Result<Outcome> {
+    let provider = descriptor(ProviderId::Codex);
+    let providers = [provider];
+    let discovery = FixedDiscovery(version.map(|version| ResolvedExecutable {
+        path: PathBuf::from("fake-codex"),
+        version: Some(version.to_owned()),
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([consent]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([behavior]);
+    let mut setup_options = options(Selector::Codex);
+    setup_options.mode = mode;
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    Ok(run_setup(&setup_options, &providers, &mut runtime)?.results[0].outcome)
+}
+
+struct FixedTerminal(bool);
+
+impl TerminalState for FixedTerminal {
+    fn is_interactive(&self) -> bool {
+        self.0
+    }
+}
+
+struct FixedDiscovery(Option<ResolvedExecutable>);
+
+impl ExecutableDiscovery for FixedDiscovery {
+    fn discover(&self, _provider: &ProviderDescriptor) -> io::Result<Option<ResolvedExecutable>> {
+        Ok(self.0.clone())
+    }
+}
+
+struct FakeDiscovery {
+    entries: Vec<(ProviderId, Option<ResolvedExecutable>)>,
+    calls: RefCell<Vec<ProviderId>>,
+}
+
+impl FakeDiscovery {
+    fn all_present(providers: &[ProviderDescriptor], version: &str) -> Self {
+        Self {
+            entries: providers
+                .iter()
+                .map(|provider| {
+                    (
+                        provider.id,
+                        Some(ResolvedExecutable {
+                            path: PathBuf::from(format!("/fixture/{}", provider.executable)),
+                            version: Some(version.to_owned()),
+                        }),
+                    )
+                })
+                .collect(),
+            calls: RefCell::new(Vec::new()),
+        }
+    }
+}
+
+impl ExecutableDiscovery for FakeDiscovery {
+    fn discover(&self, provider: &ProviderDescriptor) -> io::Result<Option<ResolvedExecutable>> {
+        self.calls.borrow_mut().push(provider.id);
+        Ok(self
+            .entries
+            .iter()
+            .find(|(id, _)| *id == provider.id)
+            .and_then(|(_, executable)| executable.clone()))
+    }
+}
+
+struct FakeConfirmer {
+    decisions: VecDeque<ConsentDecision>,
+    requests: Vec<ConsentRequest>,
+}
+
+impl FakeConfirmer {
+    fn new(decisions: impl IntoIterator<Item = ConsentDecision>) -> Self {
+        Self {
+            decisions: decisions.into_iter().collect(),
+            requests: Vec::new(),
+        }
+    }
+}
+
+impl Confirmer for FakeConfirmer {
+    fn confirm(&mut self, request: &ConsentRequest) -> io::Result<ConsentDecision> {
+        self.requests.push(request.clone());
+        Ok(self
+            .decisions
+            .pop_front()
+            .unwrap_or(ConsentDecision::Cancelled))
+    }
+}
+
+#[derive(Default)]
+struct FakeClock {
+    now: Cell<Duration>,
+}
+
+impl Clock for FakeClock {
+    fn now(&self) -> Duration {
+        self.now.get()
+    }
+
+    fn sleep(&self, duration: Duration) {
+        self.now.set(self.now.get().saturating_add(duration));
+    }
+}
+
+enum LaunchBehavior {
+    Exit {
+        polls_before_exit: usize,
+        exit: ProcessExit,
+        terminated: Rc<Cell<bool>>,
+    },
+    Error(String),
+}
+
+impl LaunchBehavior {
+    fn exit(code: i32) -> Self {
+        Self::Exit {
+            polls_before_exit: 0,
+            exit: ProcessExit::Exited(code),
+            terminated: Rc::new(Cell::new(false)),
+        }
+    }
+
+    fn signalled() -> Self {
+        Self::Exit {
+            polls_before_exit: 0,
+            exit: ProcessExit::Signalled,
+            terminated: Rc::new(Cell::new(false)),
+        }
+    }
+
+    fn never(terminated: Rc<Cell<bool>>) -> Self {
+        Self::Exit {
+            polls_before_exit: usize::MAX,
+            exit: ProcessExit::Signalled,
+            terminated,
+        }
+    }
+}
+
+struct FakeLauncher {
+    behaviors: VecDeque<LaunchBehavior>,
+    launches: Vec<LaunchRequest>,
+}
+
+impl FakeLauncher {
+    fn new(behaviors: impl IntoIterator<Item = LaunchBehavior>) -> Self {
+        Self {
+            behaviors: behaviors.into_iter().collect(),
+            launches: Vec::new(),
+        }
+    }
+}
+
+impl ProcessLauncher for FakeLauncher {
+    fn launch(&mut self, request: &LaunchRequest) -> io::Result<Box<dyn RunningProcess>> {
+        self.launches.push(request.clone());
+        match self
+            .behaviors
+            .pop_front()
+            .unwrap_or_else(|| LaunchBehavior::exit(0))
+        {
+            LaunchBehavior::Exit {
+                polls_before_exit,
+                exit,
+                terminated,
+            } => Ok(Box::new(FakeProcess {
+                polls_before_exit,
+                exit,
+                terminated,
+            })),
+            LaunchBehavior::Error(message) => Err(io::Error::other(message)),
+        }
+    }
+}
+
+struct FakeProcess {
+    polls_before_exit: usize,
+    exit: ProcessExit,
+    terminated: Rc<Cell<bool>>,
+}
+
+impl RunningProcess for FakeProcess {
+    fn try_wait(&mut self) -> io::Result<Option<ProcessExit>> {
+        if self.polls_before_exit == 0 {
+            Ok(Some(self.exit))
+        } else {
+            self.polls_before_exit = self.polls_before_exit.saturating_sub(1);
+            Ok(None)
+        }
+    }
+
+    fn terminate_tree(&mut self) -> io::Result<()> {
+        self.terminated.set(true);
+        Ok(())
+    }
+
+    fn wait(&mut self) -> io::Result<ProcessExit> {
+        Ok(self.exit)
+    }
+}
+
+#[cfg(unix)]
+fn process_is_alive(pid: u32) -> bool {
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn wait_for_process_exit(pid: u32) -> Result<()> {
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    while process_is_alive(pid) {
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for descendant {pid} to exit"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Ok(())
+}

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -643,6 +643,12 @@ fn executable_discovery_is_injectable_and_rejects_non_executables() -> Result<()
     let resolved = discovery
         .discover(&provider)?
         .context("executable should be discovered")?;
+    #[cfg(windows)]
+    assert!(resolved
+        .path
+        .to_string_lossy()
+        .eq_ignore_ascii_case(&executable.to_string_lossy()));
+    #[cfg(not(windows))]
     assert_eq!(resolved.path, executable);
 
     #[cfg(unix)]


### PR DESCRIPTION
## Context

- Bead: `coven-v041-setup-core`
- Implements Task 12 from the merged v0.4.1 release program.
- Provider-specific Codex, Claude Code, and GitHub Copilot CLI descriptors remain intentionally deferred to Tasks 13-15.

## Implementation

- Adds `coven setup codex|claude|copilot|all` parsing with verification/report option validation.
- Adds injectable discovery, confirmation, terminal-state, clock, and process-launch boundaries.
- Preserves direct inherited child stdin/stdout/stderr and obtains separate login/verification consent.
- Classifies the closed result set, including cancellation, provider failure, verification failure, timeout, and non-TTY refusal.
- Adds bounded Unix process-group and Windows Job Object cleanup.
- Publishes verification reports through private adjacent temporary files with validation and atomic no-clobber rename.
- Keeps provider output, launch errors, credentials, terminal control, and private paths out of human summaries and report JSON.

## Verification

- `cargo fmt --check`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- `cargo test -p coven-cli --test setup_cli` — 14 passed
- `cargo test -p coven-cli --test doctor_auth_boundary`
- `cargo test -p coven-cli --test smoke -- --nocapture` — 31 passed
- `cargo test --workspace --locked` — passed on bounded rerun
- `python3 scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`
- Live non-TTY `--verify-only --report-json` produced a redacted atomic report with the candidate commit and no provider launch.

## Reliability note

The first full-workspace run hit the pre-existing load-sensitive `daemon::tests::stop_cleanup_does_not_run_after_the_outer_lifecycle_deadline`. The exact test then passed 6/6 and the full workspace rerun passed. No daemon code is changed here.

## Scope boundary

This PR intentionally supplies no concrete provider command descriptors. Follow-up Beads add each provider through the typed interface; until then interactive setup reports a closed failure rather than invoking an unapproved command. Doctor remains unchanged and offline/hermetic.