### PR TITLE
feat(cli): add Codex provider-owned setup

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -620,7 +620,7 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
         HarnessCommandSpec {
             id: "codex".to_string(),
             label: "Codex".to_string(),
-            executable: "codex".to_string(),
+            executable: crate::setup::codex::EXECUTABLE.to_string(),
             prompt_flag: None,
             interactive_prompt_flag: None,
             interactive_prompt_prefix_args: Vec::new(),
@@ -630,7 +630,7 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
                 "--color".to_string(),
                 "never".to_string(),
             ],
-            install_hint: "Install Codex with `npm install -g @openai/codex` or `brew install --cask codex`; if it is already installed, make sure `codex` is on PATH and run `codex login` or `codex` once to authenticate, then retry `coven doctor`.".to_string(),
+            install_hint: crate::setup::codex::INSTALL_GUIDANCE.to_string(),
             source: "bundled".to_string(),
             manifest_path: None,
             // Codex has no --system-prompt flag; identity is injected as a

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1522,7 +1522,7 @@ fn run_setup_command(
     verify_only: bool,
     report_json: Option<PathBuf>,
 ) -> Result<()> {
-    const PROVIDERS: &[setup::ProviderDescriptor] = &[];
+    let providers = [setup::codex::descriptor()];
     let mode = if verify_only {
         setup::SetupMode::VerifyOnly
     } else if verify {
@@ -1549,7 +1549,7 @@ fn run_setup_command(
         clock: &clock,
         launcher: &mut launcher,
     };
-    let summary = setup::run_setup(&options, PROVIDERS, &mut runtime)?;
+    let summary = setup::run_setup(&options, &providers, &mut runtime)?;
     setup::render_human(&summary, &mut io::stdout().lock())?;
     if summary.completed() {
         Ok(())

--- a/crates/coven-cli/src/setup/codex.rs
+++ b/crates/coven-cli/src/setup/codex.rs
@@ -1,0 +1,9 @@
+use super::{CommandSpec, ProviderDescriptor, ProviderId};
+
+pub const EXECUTABLE: &str = "codex";
+pub const INSTALL_GUIDANCE: &str = "Install Codex with `npm install -g @openai/codex` or `brew install --cask codex`; if it is already installed, make sure `codex` is on PATH and run `codex login` or `codex` once to authenticate, then retry `coven doctor`.";
+
+pub fn descriptor() -> ProviderDescriptor {
+    ProviderDescriptor::new(ProviderId::Codex, EXECUTABLE, INSTALL_GUIDANCE)
+        .with_login(CommandSpec::new(["login"]))
+}

--- a/crates/coven-cli/src/setup/mod.rs
+++ b/crates/coven-cli/src/setup/mod.rs
@@ -1,3 +1,4 @@
+pub mod codex;
 mod process;
 
 use std::ffi::{OsStr, OsString};

--- a/crates/coven-cli/src/setup/mod.rs
+++ b/crates/coven-cli/src/setup/mod.rs
@@ -320,6 +320,7 @@ pub enum SetupError {
     RequiresVerification,
     Rejected,
     PublicationFailed,
+    UnsupportedProvider,
 }
 
 impl fmt::Display for SetupError {
@@ -329,6 +330,9 @@ impl fmt::Display for SetupError {
             Self::RequiresVerification => "setup reports are available only for verification modes",
             Self::Rejected => "setup report failed privacy validation",
             Self::PublicationFailed => "setup report could not be published",
+            Self::UnsupportedProvider => {
+                "the selected setup provider is not available in this build"
+            }
         })
     }
 }
@@ -350,6 +354,12 @@ pub fn run_setup(
     }
 
     let provider_ids = options.selector.providers();
+    if provider_ids
+        .iter()
+        .any(|provider_id| !providers.iter().any(|provider| provider.id == *provider_id))
+    {
+        return Err(SetupError::UnsupportedProvider);
+    }
     let mut results = Vec::with_capacity(provider_ids.len());
     if !runtime.terminal.is_interactive() {
         results.extend(provider_ids.iter().copied().map(|provider| ProviderResult {
@@ -361,19 +371,10 @@ pub fn run_setup(
         }));
     } else {
         for provider_id in provider_ids {
-            let Some(provider) = providers
+            let provider = providers
                 .iter()
                 .find(|provider| provider.id == *provider_id)
-            else {
-                results.push(ProviderResult {
-                    provider: *provider_id,
-                    outcome: Outcome::ProviderFailed,
-                    duration: Duration::ZERO,
-                    version: None,
-                    install_guidance: None,
-                });
-                continue;
-            };
+                .expect("provider registration was validated before setup");
             results.push(run_provider(options, provider, runtime));
         }
     }

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -13,6 +13,7 @@ use anyhow::{Context, Result};
 #[path = "../src/setup/mod.rs"]
 mod setup;
 
+use setup::codex;
 use setup::{
     render_human, run_setup, Clock, CommandSpec, Confirmer, ConsentDecision, ConsentRequest,
     ExecutableDiscovery, LaunchRequest, Outcome, ProcessExit, ProcessLauncher, ProviderDescriptor,
@@ -98,6 +99,97 @@ fn setup_cli_refuses_non_tty_without_waiting_or_launching() -> Result<()> {
         !String::from_utf8_lossy(&output.stderr).contains("Error:"),
         "non-TTY refusal should be a closed setup result, not an internal error"
     );
+    Ok(())
+}
+
+#[test]
+fn codex_provider_launches_exact_login_command() -> Result<()> {
+    let provider = codex::descriptor();
+    let providers = [provider];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0)]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    assert_eq!(confirmer.requests.len(), 1);
+    assert_eq!(confirmer.requests[0].command, "codex login");
+    assert_eq!(launcher.launches.len(), 1);
+    assert_eq!(
+        launcher.launches[0].executable,
+        PathBuf::from("/fixture/codex")
+    );
+    assert_eq!(launcher.launches[0].args, vec![OsString::from("login")]);
+    Ok(())
+}
+
+#[test]
+fn codex_provider_preserves_failure_and_cancellation_outcomes() -> Result<()> {
+    assert_eq!(
+        run_codex(
+            FixedTerminal(true),
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::exit(7),
+        )?
+        .0,
+        Outcome::ProviderFailed
+    );
+    assert_eq!(
+        run_codex(
+            FixedTerminal(true),
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::signalled(),
+        )?
+        .0,
+        Outcome::Cancelled
+    );
+    Ok(())
+}
+
+#[test]
+fn codex_provider_handles_missing_declined_and_non_tty_without_launching() -> Result<()> {
+    let (outcome, launches, rendered) = run_codex(
+        FixedTerminal(true),
+        None,
+        ConsentDecision::Accepted,
+        LaunchBehavior::exit(0),
+    )?;
+    assert_eq!(outcome, Outcome::NotInstalled);
+    assert_eq!(launches, 0);
+    assert_eq!(
+        rendered,
+        format!("Codex: not_installed\n{}\n", codex::INSTALL_GUIDANCE)
+    );
+
+    let (outcome, launches, _) = run_codex(
+        FixedTerminal(true),
+        Some("1.2.3"),
+        ConsentDecision::Declined,
+        LaunchBehavior::exit(0),
+    )?;
+    assert_eq!(outcome, Outcome::Declined);
+    assert_eq!(launches, 0);
+
+    let (outcome, launches, _) = run_codex(
+        FixedTerminal(false),
+        Some("1.2.3"),
+        ConsentDecision::Accepted,
+        LaunchBehavior::exit(0),
+    )?;
+    assert_eq!(outcome, Outcome::NonTty);
+    assert_eq!(launches, 0);
     Ok(())
 }
 
@@ -724,6 +816,38 @@ fn run_single(
         launcher: &mut launcher,
     };
     Ok(run_setup(&setup_options, &providers, &mut runtime)?.results[0].outcome)
+}
+
+fn run_codex(
+    terminal: FixedTerminal,
+    version: Option<&str>,
+    consent: ConsentDecision,
+    behavior: LaunchBehavior,
+) -> Result<(Outcome, usize, String)> {
+    let provider = codex::descriptor();
+    let providers = [provider];
+    let discovery = FixedDiscovery(version.map(|version| ResolvedExecutable {
+        path: PathBuf::from("fake-codex"),
+        version: Some(version.to_owned()),
+    }));
+    let mut confirmer = FakeConfirmer::new([consent]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([behavior]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let summary = run_setup(&options(Selector::Codex), &providers, &mut runtime)?;
+    let mut rendered = Vec::new();
+    render_human(&summary, &mut rendered)?;
+    Ok((
+        summary.results[0].outcome,
+        launcher.launches.len(),
+        String::from_utf8(rendered)?,
+    ))
 }
 
 struct FixedTerminal(bool);

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -103,6 +103,32 @@ fn setup_cli_refuses_non_tty_without_waiting_or_launching() -> Result<()> {
 }
 
 #[test]
+fn unregistered_provider_is_rejected_before_runtime_actions() -> Result<()> {
+    let providers = [codex::descriptor()];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let error = run_setup(&options(Selector::Claude), &providers, &mut runtime)
+        .expect_err("an unregistered provider must fail explicitly");
+
+    assert!(matches!(error, SetupError::UnsupportedProvider));
+    assert!(discovery.calls.borrow().is_empty());
+    assert!(confirmer.requests.is_empty());
+    assert!(launcher.launches.is_empty());
+    Ok(())
+}
+
+#[test]
 fn codex_provider_launches_exact_login_command() -> Result<()> {
     let provider = codex::descriptor();
     let providers = [provider];


### PR DESCRIPTION
## Summary
- add the Codex setup descriptor with exact `codex login` argv
- reuse canonical Codex executable and official install guidance in the harness registry
- cover success, failure, cancellation, missing installation, decline, and non-TTY behavior

## Validation
- `cargo fmt --check`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`
- `cargo test -p coven-cli --test setup_cli --test doctor_auth_boundary --test smoke --locked -- --nocapture` (one unrelated daemon permission flake passed on exact rerun)
- `cargo test --workspace --locked`
- `python scripts/check-secrets.py`
- `python3 scripts/check-coven-privacy.py --staged`

## Known baseline
- Workspace Clippy remains blocked by the existing Rust 1.95 `clippy::nonminimal_bool` finding in `crates/coven-relay/src/ws.rs:117`; the changed package passes with `-D warnings`.

Bead: `coven-v041-setup-codex`