### PR TITLE
test: remove load-sensitive PTY deadline

### DIFF
--- a/crates/coven-cli/src/pty_runner.rs
+++ b/crates/coven-cli/src/pty_runner.rs
@@ -7232,11 +7232,12 @@ exec sleep 10
             env_overrides: Vec::new(),
         };
 
-        let started = Instant::now();
         let outcome =
             stream_codex_json_with_timeout(&command, Duration::from_millis(25), |_| Ok(()))?;
 
-        assert!(started.elapsed() < Duration::from_secs(2));
+        // The terminated outcome proves the activity timeout won while stdin
+        // was blocked. A wall-clock assertion here measures runner load, not
+        // the timeout behavior.
         assert!(outcome
             .error
             .as_deref()


### PR DESCRIPTION
## Summary
- remove the strict two-second wall-clock assertion from the blocked-stdin timeout regression
- retain the behavioral assertion proving the activity timeout terminated the harness
- document why runner elapsed time is not part of the contract

## Validation
- exact regression test passed 20 consecutive runs
- `cargo fmt --check`
- `cargo clippy -p coven-cli --all-targets -- -D warnings`

Closes coven-5ua