### PR TITLE
feat(cli): add Copilot CLI provider-owned setup

### DIFF
--- a/crates/coven-cli/src/harness.rs
+++ b/crates/coven-cli/src/harness.rs
@@ -782,7 +782,7 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
         HarnessCommandSpec {
             id: "copilot".to_string(),
             label: "Copilot CLI".to_string(),
-            executable: "copilot".to_string(),
+            executable: crate::setup::copilot::EXECUTABLE.to_string(),
             // Copilot rejects positional prompts outright: non-interactive
             // one-shots are `--prompt <text>` and interactive-with-prompt is
             // `--interactive <text>`. Both ride the `=` form via
@@ -794,7 +794,7 @@ pub fn built_in_harness_specs() -> Vec<HarnessCommandSpec> {
             // non-interactive launches under a PTY — mirror codex's
             // `--color never` hygiene. Interactive launches keep color.
             non_interactive_prompt_prefix_args: vec!["--no-color".to_string()],
-            install_hint: "Install GitHub Copilot CLI with `npm install -g @github/copilot` or `brew install --cask copilot-cli`; if it is already installed, make sure `copilot` is on PATH and run `copilot login` to authenticate, then retry `coven doctor`.".to_string(),
+            install_hint: crate::setup::copilot::INSTALL_GUIDANCE.to_string(),
             source: "bundled".to_string(),
             manifest_path: None,
             // Copilot has no system-prompt flag; identity is injected as a

--- a/crates/coven-cli/src/main.rs
+++ b/crates/coven-cli/src/main.rs
@@ -1522,7 +1522,11 @@ fn run_setup_command(
     verify_only: bool,
     report_json: Option<PathBuf>,
 ) -> Result<()> {
-    let providers = [setup::codex::descriptor(), setup::claude::descriptor()];
+    let providers = [
+        setup::codex::descriptor(),
+        setup::claude::descriptor(),
+        setup::copilot::descriptor(),
+    ];
     let mode = if verify_only {
         setup::SetupMode::VerifyOnly
     } else if verify {

--- a/crates/coven-cli/src/setup/copilot.rs
+++ b/crates/coven-cli/src/setup/copilot.rs
@@ -1,0 +1,9 @@
+use super::{CommandSpec, ProviderDescriptor, ProviderId};
+
+pub const EXECUTABLE: &str = "copilot";
+pub const INSTALL_GUIDANCE: &str = "Install GitHub Copilot CLI with `npm install -g @github/copilot` or `brew install --cask copilot-cli`; if it is already installed, make sure `copilot` is on PATH and run `copilot login` to authenticate, then retry `coven doctor`.";
+
+pub fn descriptor() -> ProviderDescriptor {
+    ProviderDescriptor::new(ProviderId::Copilot, EXECUTABLE, INSTALL_GUIDANCE)
+        .with_login(CommandSpec::new(["login"]))
+}

--- a/crates/coven-cli/src/setup/mod.rs
+++ b/crates/coven-cli/src/setup/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude;
 pub mod codex;
+pub mod copilot;
 mod process;
 
 use std::ffi::{OsStr, OsString};

--- a/crates/coven-cli/tests/setup_cli.rs
+++ b/crates/coven-cli/tests/setup_cli.rs
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 #[path = "../src/setup/mod.rs"]
 mod setup;
 
-use setup::{claude, codex};
+use setup::{claude, codex, copilot};
 use setup::{
     render_human, run_setup, Clock, CommandSpec, Confirmer, ConsentDecision, ConsentRequest,
     ExecutableDiscovery, LaunchRequest, Outcome, ProcessExit, ProcessLauncher, ProviderDescriptor,
@@ -310,6 +310,101 @@ fn claude_provider_handles_missing_declined_and_non_tty_without_launching() -> R
     assert_eq!(launches, 0);
 
     let (outcome, launches, _) = run_claude(
+        FixedTerminal(false),
+        Some("1.2.3"),
+        ConsentDecision::Accepted,
+        LaunchBehavior::exit(0),
+    )?;
+    assert_eq!(outcome, Outcome::NonTty);
+    assert_eq!(launches, 0);
+    Ok(())
+}
+
+#[test]
+fn copilot_provider_launches_exact_login_command() -> Result<()> {
+    let provider = copilot::descriptor();
+    let providers = [provider];
+    let discovery = FakeDiscovery::all_present(&providers, "1.2.3");
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([LaunchBehavior::exit(0)]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&options(Selector::Copilot), &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    assert_eq!(confirmer.requests.len(), 1);
+    assert_eq!(confirmer.requests[0].command, "copilot login");
+    assert_eq!(launcher.launches.len(), 1);
+    assert_eq!(
+        launcher.launches[0].executable,
+        PathBuf::from("/fixture/copilot")
+    );
+    assert_eq!(launcher.launches[0].args, vec![OsString::from("login")]);
+    Ok(())
+}
+
+#[test]
+fn copilot_provider_preserves_failure_and_cancellation_outcomes() -> Result<()> {
+    assert_eq!(
+        run_copilot(
+            FixedTerminal(true),
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::exit(7),
+        )?
+        .0,
+        Outcome::ProviderFailed
+    );
+    assert_eq!(
+        run_copilot(
+            FixedTerminal(true),
+            Some("1.2.3"),
+            ConsentDecision::Accepted,
+            LaunchBehavior::signalled(),
+        )?
+        .0,
+        Outcome::Cancelled
+    );
+    Ok(())
+}
+
+#[test]
+fn copilot_provider_handles_missing_declined_and_non_tty_without_launching() -> Result<()> {
+    let (outcome, launches, rendered) = run_copilot(
+        FixedTerminal(true),
+        None,
+        ConsentDecision::Accepted,
+        LaunchBehavior::exit(0),
+    )?;
+    assert_eq!(outcome, Outcome::NotInstalled);
+    assert_eq!(launches, 0);
+    assert_eq!(
+        rendered,
+        format!(
+            "GitHub Copilot CLI: not_installed\n{}\n",
+            copilot::INSTALL_GUIDANCE
+        )
+    );
+    assert!(rendered.contains("copilot login"));
+
+    let (outcome, launches, _) = run_copilot(
+        FixedTerminal(true),
+        Some("1.2.3"),
+        ConsentDecision::Declined,
+        LaunchBehavior::exit(0),
+    )?;
+    assert_eq!(outcome, Outcome::Declined);
+    assert_eq!(launches, 0);
+
+    let (outcome, launches, _) = run_copilot(
         FixedTerminal(false),
         Some("1.2.3"),
         ConsentDecision::Accepted,
@@ -758,6 +853,97 @@ fn inherited_terminal_and_report_helper() -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+#[test]
+fn copilot_fixture_inherits_terminal_streams_and_records_exact_login() -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp = test_tempdir()?;
+    let fake_copilot = temp.path().join("copilot");
+    let args_path = temp.path().join("args.txt");
+    let stdout_path = temp.path().join("terminal.stdout");
+    let stderr_path = temp.path().join("terminal.stderr");
+    fs::write(
+        &fake_copilot,
+        concat!(
+            "#!/bin/sh\n",
+            "printf '%s\\n' \"$@\" > \"$COVEN_SETUP_ARGS_PATH\"\n",
+            "IFS= read -r line\n",
+            "printf 'copilot-stdout:%s\\n' \"$line\"\n",
+            "printf 'copilot-stderr:%s\\n' \"$line\" >&2\n",
+        ),
+    )?;
+    let mut permissions = fs::metadata(&fake_copilot)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fake_copilot, permissions)?;
+
+    let mut child = Command::new(std::env::current_exe()?)
+        .args([
+            "--exact",
+            "copilot_inherited_terminal_helper",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env("COVEN_SETUP_COPILOT_HELPER", "1")
+        .env("COVEN_SETUP_COPILOT_PATH", &fake_copilot)
+        .env("COVEN_SETUP_ARGS_PATH", &args_path)
+        .stdin(Stdio::piped())
+        .stdout(fs::File::create(&stdout_path)?)
+        .stderr(fs::File::create(&stderr_path)?)
+        .spawn()?;
+    child
+        .stdin
+        .as_mut()
+        .context("helper stdin")?
+        .write_all(b"terminal-input\n")?;
+    drop(child.stdin.take());
+    let status = child.wait()?;
+    assert!(status.success(), "helper failed with {status}");
+
+    assert_eq!(fs::read_to_string(args_path)?, "login\n");
+    assert!(
+        fs::read_to_string(stdout_path)?.contains("copilot-stdout:terminal-input"),
+        "Copilot stdout should remain attached to the inherited terminal"
+    );
+    assert!(
+        fs::read_to_string(stderr_path)?.contains("copilot-stderr:terminal-input"),
+        "Copilot stderr should remain attached to the inherited terminal"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn copilot_inherited_terminal_helper() -> Result<()> {
+    if std::env::var_os("COVEN_SETUP_COPILOT_HELPER").is_none() {
+        return Ok(());
+    }
+    let executable =
+        PathBuf::from(std::env::var_os("COVEN_SETUP_COPILOT_PATH").context("Copilot path")?);
+    let provider = copilot::descriptor();
+    let providers = [provider];
+    let discovery = FixedDiscovery(Some(ResolvedExecutable {
+        path: executable,
+        version: Some("1.2.3".to_owned()),
+    }));
+    let terminal = FixedTerminal(true);
+    let mut confirmer = FakeConfirmer::new([ConsentDecision::Accepted]);
+    let clock = SystemClock::new();
+    let mut launcher = SystemProcessLauncher;
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+
+    let summary = run_setup(&options(Selector::Copilot), &providers, &mut runtime)?;
+
+    assert!(summary.completed());
+    Ok(())
+}
+
 #[test]
 fn report_publication_is_fail_if_exists_atomic_and_redaction_closed() -> Result<()> {
     let temp = test_tempdir()?;
@@ -1000,6 +1186,38 @@ fn run_claude(
         launcher: &mut launcher,
     };
     let summary = run_setup(&options(Selector::Claude), &providers, &mut runtime)?;
+    let mut rendered = Vec::new();
+    render_human(&summary, &mut rendered)?;
+    Ok((
+        summary.results[0].outcome,
+        launcher.launches.len(),
+        String::from_utf8(rendered)?,
+    ))
+}
+
+fn run_copilot(
+    terminal: FixedTerminal,
+    version: Option<&str>,
+    consent: ConsentDecision,
+    behavior: LaunchBehavior,
+) -> Result<(Outcome, usize, String)> {
+    let provider = copilot::descriptor();
+    let providers = [provider];
+    let discovery = FixedDiscovery(version.map(|version| ResolvedExecutable {
+        path: PathBuf::from("fake-copilot"),
+        version: Some(version.to_owned()),
+    }));
+    let mut confirmer = FakeConfirmer::new([consent]);
+    let clock = FakeClock::default();
+    let mut launcher = FakeLauncher::new([behavior]);
+    let mut runtime = SetupRuntime {
+        discovery: &discovery,
+        confirmer: &mut confirmer,
+        terminal: &terminal,
+        clock: &clock,
+        launcher: &mut launcher,
+    };
+    let summary = run_setup(&options(Selector::Copilot), &providers, &mut runtime)?;
     let mut rendered = Vec::new();
     render_human(&summary, &mut rendered)?;
     Ok((


### PR DESCRIPTION
## Context

- Summary: Add consent-aware GitHub Copilot CLI setup with exact `copilot login` behavior and provider-specific fixture coverage.
- Files changed: Copilot setup descriptor, setup registration, shared harness metadata, setup contract tests.
- Closes coven-v041-setup-copilot

## Implementation

- Approach: Reuse the shared setup orchestrator and make Copilot metadata provider-owned.
- User-visible behavior: `coven setup copilot` discovers `copilot`, requests consent, launches `copilot login` with inherited terminal streams, and prints official installation guidance when missing.
- Compatibility notes: No existing provider behavior changes; the harness registry now consumes the same canonical Copilot executable and guidance constants.

## Verification

- [x] `cargo fmt --check`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` (blocked locally by pre-existing Rust 1.95 `clippy::nonminimal_bool` in `crates/coven-relay/src/ws.rs:117`; `cargo clippy -p coven-cli --all-targets -- -D warnings` passes)
- [ ] `cargo test --workspace --locked` (Copilot, setup, Doctor, and smoke suites pass; full local suite hit pre-existing load-sensitive daemon deadline tests that pass individually)
- [x] `python3 scripts/check-secrets.py`
- [x] `python3 scripts/check-coven-privacy.py --staged`
- [x] Copilot fake executable proves exact argv and inherited stdin/stdout/stderr

## Risk and Rollback

- Risk level: Low; additive provider registration following the merged Codex and Claude pattern.
- Rollback plan: Revert this PR to remove Copilot from setup dispatch while retaining existing harness execution support.

## Agent Handoff

- Current state: Ready for CI and review.
- Follow-ups: `coven-v041-parity` owns the later three-harness parity proof.
- Known gaps: None in the Copilot setup scope.